### PR TITLE
hotfix(dev-containers): remove default firewall

### DIFF
--- a/.devcontainer/claude/devcontainer.json
+++ b/.devcontainer/claude/devcontainer.json
@@ -85,6 +85,7 @@
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  // uncomment the following line to enable firewall initialization
+  // "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
   "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
This pull request makes a small change to the `.devcontainer/claude/devcontainer.json` file, commenting out the `postStartCommand` that initializes the firewall. A comment was added to indicate how to re-enable the firewall initialization if needed.