### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ⚛️ Atomic: Automated Procedures and Memory for AI Coding Agents
 
+[![Run in Smithery](https://smithery.ai/badge/skills/flora131)](https://smithery.ai/skills?ns=flora131&utm_source=github&utm_medium=badge)
+
+
 <p align="center">
   <img src="atomic.png" alt="Atomic" width="200">
 </p>


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/flora131)](https://smithery.ai/skills?ns=flora131&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.