### PR TITLE
feat(claude-plugin): add marketplace config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,16 @@
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "enabledPlugins": {
+    "ralph@atomic-plugins": true
+  },
+  "extraKnownMarketplaces": {
+    "atomic-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "flora131/atomic"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Configures Claude Code plugin marketplace to enable the Ralph Wiggum plugin from the atomic-plugins marketplace hosted in this repository.

## Key Changes
- **Added plugin enablement**: Enables `ralph@atomic-plugins` plugin in Claude Code settings
- **Configured custom marketplace**: Adds `atomic-plugins` as a known marketplace sourced from the `flora131/atomic` GitHub repository
- **Updated settings**: Modified `.claude/settings.json` to include plugin and marketplace configurations

## Context
The Ralph Wiggum plugin (located in `plugins/ralph/`) implements the Ralph Wiggum technique for continuous self-referential AI loops. This configuration makes the plugin discoverable and usable through Claude Code's plugin system by:
1. Registering the repository as a plugin marketplace
2. Enabling the ralph plugin from that marketplace

## Technical Details
The configuration adds two new sections to `.claude/settings.json`:
- `enabledPlugins`: Activates the ralph plugin
- `extraKnownMarketplaces`: Registers the atomic-plugins marketplace pointing to this GitHub repo