### PR TITLE
fix(ralph): remove extra quotes in ralph-loop command

### DIFF
--- a/plugins/ralph/commands/ralph-loop.md
+++ b/plugins/ralph/commands/ralph-loop.md
@@ -11,7 +11,7 @@ hide-from-slash-command-tool: "true"
 Execute the setup script to initialize the Ralph loop:
 
 ```!
-"if [[ \"$(uname)\" == MINGW* || \"$(uname)\" == MSYS* || \"$(uname)\" == CYGWIN* ]]; then powershell -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.ps1 $ARGUMENTS\"; else \"${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh $ARGUMENTS\"; fi"
+if [[ "$(uname)" == MINGW* || "$(uname)" == MSYS* || "$(uname)" == CYGWIN* ]]; then powershell -ExecutionPolicy Bypass -File ${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.ps1 $ARGUMENTS; else ${CLAUDE_PLUGIN_ROOT}/scripts/setup-ralph-loop.sh $ARGUMENTS; fi
 ```
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.


### PR DESCRIPTION
## Summary
Fixes the command syntax in `ralph-loop.md` by removing unnecessary outer quotes that were preventing proper command execution.

## Changes
- Removed extraneous double quotes wrapping the entire shell command in the code block
- The command now executes correctly without quote-escaping issues

## Technical Details
The previous version had the entire command wrapped in double quotes, which caused shell parsing issues. This fix ensures the platform detection and script execution logic works as intended for the Ralph Wiggum loop functionality.