### PR TITLE
feat(claude-plugin): add hook entry to Ralph plugin config

### DIFF
--- a/plugins/ralph/.claude-plugin/plugin.json
+++ b/plugins/ralph/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "Alex Lavaee",
     "email": "lavaalex3@gmail.com"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Summary
Adds hooks configuration to the Ralph plugin's `plugin.json` to enable stop hook functionality for managing self-referential AI loops.

## Key Changes
- Added `"hooks": "./hooks/hooks.json"` entry to `plugins/ralph/.claude-plugin/plugin.json`
- Links the plugin configuration to the existing hooks file that contains stop hook logic
- Enables the Ralph plugin to properly register and execute stop hooks that prevent infinite loops

## Context
The Ralph Wiggum plugin implements continuous self-referential AI loops for iterative development. This hook entry allows the plugin to register stop conditions that can interrupt the loop when needed, providing better control over the loop execution lifecycle.