### PR TITLE
feat(ralph-plugin): remove hooks reference from plugin.json

### DIFF
--- a/plugins/ralph/.claude-plugin/plugin.json
+++ b/plugins/ralph/.claude-plugin/plugin.json
@@ -5,6 +5,5 @@
   "author": {
     "name": "Alex Lavaee",
     "email": "lavaalex3@gmail.com"
-  },
-  "hooks": "./hooks/hooks.json"
+  }
 }


### PR DESCRIPTION
## Summary
Removes the hooks entry from the Ralph plugin's `plugin.json` configuration file. The hooks functionality remains intact in the `hooks/` directory, but the reference in the plugin manifest has been removed.

## Changes
- Removed `"hooks": "./hooks/hooks.json"` from `plugins/ralph/.claude-plugin/plugin.json`
- Hooks directory and files (`hooks.json`, `stop-hook.sh`, `stop-hook.ps1`) remain unchanged

## Context
This change appears to be related to a configuration update, possibly moving away from declarative hook registration in the plugin manifest. The hooks themselves are still present and functional in the `hooks/` directory.