### PR TITLE
feat(claude-plugin): add hook entry to settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,17 @@
         "repo": "flora131/atomic"
       }
     }
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [[ \"$(uname)\" == MINGW* || \"$(uname)\" == MSYS* || \"$(uname)\" == CYGWIN* ]]; then powershell -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.ps1\"; else \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\"; fi"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Migrates the plugin hook configuration from `plugin.json` to `.claude/settings.json`, centralizing hook management at the repository level instead of the plugin level.

## Key Changes

- **Added** Stop hook configuration to `.claude/settings.json` (lines 21-32)
  - Cross-platform hook execution support (Windows PowerShell and Unix shell)
  - Hook command references `${CLAUDE_PLUGIN_ROOT}` environment variable
  - Executes appropriate stop-hook script based on operating system

## Context

This change follows PR #53 which removed the `hooks` entry from `plugins/ralph/.claude-plugin/plugin.json`. The hook configuration is now managed centrally in the repository's Claude settings, providing better visibility and control over hook execution across the project.

## Technical Details

The Stop hook uses a conditional command to detect the operating system:
- **Windows** (MINGW/MSYS/CYGWIN): Executes PowerShell script `stop-hook.ps1`
- **Unix-based systems**: Executes shell script `stop-hook.sh`

Both scripts are located in `${CLAUDE_PLUGIN_ROOT}/hooks/` directory.