### PR TITLE
ci(publish): trigger workflow on release creation instead of push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [created]
 
 permissions:
   contents: write
@@ -102,7 +102,7 @@ jobs:
     needs: build
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for OIDC
 
     steps:
       - name: Checkout repository
@@ -119,10 +119,8 @@ jobs:
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm with provenance
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
Changes the publish workflow to trigger on release creation rather than pushes to the main branch. This provides better control over when packages are published and aligns with the standard release workflow pattern.

## Key Changes
- **Trigger mechanism**: Changed from `push: branches: [main]` to `release: types: [created]`
- **Code quality improvements**:
  - Standardized quote style from single to double quotes for Node.js setup parameters
  - Added clarifying comment for `id-token: write` permission (required for OIDC)
  - Reordered npm publish flags for consistency (`--provenance --access public`)
  - Removed explicit `NODE_AUTH_TOKEN` environment variable (handled automatically via OIDC)

## Benefits
- **Better control**: Packages are only published when explicitly creating a release
- **Safer workflow**: Prevents accidental publishes from direct commits to main
- **Standard practice**: Aligns with common release management patterns
- **OIDC authentication**: Uses trusted publishing with provenance, eliminating the need for long-lived NPM tokens