### PR TITLE
fix(package.json): revert version from 1.0.1 to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Configuration management CLI for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Reverts the package version from `1.0.1` back to `1.0.0` in package.json.

## Changes
- **package.json**: Version downgraded from `1.0.1` → `1.0.0`

## Context
This change resets the version number, likely to re-establish the correct versioning baseline before the next npm publish workflow.