### PR TITLE
docs(README): add development installation and expand quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,33 @@ We provide the procedures that agents use to work on your project based on softw
 
 ## Quick Start
 
+> **Note:** npm registry publishing is currently in progress. Use the [Development Installation](#development-installation) below until the package is available.
+
 ```bash
-# Using bun (recommended)
+# With installation (recommended)
+# Using bun
+bun add -g @bastani/atomic
+
+# Or using npm
+npm install -g @bastani/atomic
+
+# Without installation
+# Using bun
 bunx @bastani/atomic
 
 # Or using npx
 npx @bastani/atomic
+```
+
+### Development Installation
+
+```bash
+# Clone and install globally
+git clone https://github.com/flora131/atomic.git ~/.atomic
+cd ~/.atomic && bun install && bun link
+
+# Now run from any project
+atomic
 ```
 
 Select your agent. The CLI configures your project automatically.


### PR DESCRIPTION
## Summary

Enhances the README with clearer installation instructions and adds a development installation path for users while npm registry publishing is in progress.

## Key Changes

- **Added npm publishing notice**: Informs users that npm registry publishing is in progress and directs them to use development installation in the meantime
- **Expanded installation options**: 
  - Added `bun add -g` and `npm install -g` for global installation
  - Reorganized quick start section to distinguish between "with installation" and "without installation" methods
  - Maintained existing `bunx` and `npx` usage options
- **New Development Installation section**: 
  - Added instructions for cloning the repo and installing globally via `bun link`
  - Provides clear path for users to test the tool before npm publication

## Impact

Users now have:
- Clear guidance on temporary installation methods during npm publishing
- Multiple installation options based on their preferred package manager
- A straightforward development installation path for early adopters