### PR TITLE
fix(cli): align intro text using clack log.message

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,7 @@ import {
   isCancel,
   cancel,
   note,
+  log,
 } from "@clack/prompts";
 import { join } from "path";
 import { rm } from "fs/promises";
@@ -57,9 +58,8 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
 
   // Show intro
   intro("Atomic: Automated Procedures and Memory for AI Coding Agents");
-  console.log(
-    "  Enable multi-hour autonomous coding sessions with the Ralph Wiggum\n" +
-      "  Method using research, plan, implement methodology.\n"
+  log.message(
+    "Enable multi-hour autonomous coding sessions with the Ralph Wiggum\nMethod using research, plan, implement methodology."
   );
 
   // Select agent


### PR DESCRIPTION
## Summary
Fixes text alignment in the init command by using the `log.message` utility from `@clack/prompts` instead of `console.log`.

## Changes
- Imported `log` from `@clack/prompts` 
- Replaced `console.log()` with `log.message()` for the intro text (lines 61-63)
- Removed redundant spacing in the message text to let clack handle formatting

## Benefits
- **Consistency**: Aligns with the rest of the CLI which uses clack prompts throughout
- **Better formatting**: `log.message()` provides consistent spacing and alignment with other clack UI elements
- **Cleaner output**: Removes manual spacing adjustments