### PR TITLE
feat(claude-plugin): add atomic-plugins marketplace and enable ralph plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,16 @@
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "extraKnownMarketplaces": {
+    "atomic-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "flora131/atomic"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ralph@atomic-plugins": true
+  }
 }


### PR DESCRIPTION
## Summary

Configures Claude Code to recognize the atomic-plugins marketplace and enables the ralph plugin for autonomous implementation loops.

## Key Changes

- Added `extraKnownMarketplaces` configuration pointing to the `flora131/atomic` GitHub repository as the `atomic-plugins` marketplace
- Enabled the `ralph@atomic-plugins` plugin in Claude Code settings
- This allows users to access Ralph commands (`/ralph:ralph-loop`, `/ralph:cancel-ralph`, `/ralph:help`) for multi-hour autonomous coding sessions

## Context

The Ralph plugin implements the [Ralph Wiggum Method](https://ghuntley.com/ralph/) for continuous self-referential AI loops, enabling overnight feature implementation. By registering this marketplace, Claude Code can discover and load the ralph plugin from the atomic repository.

## Files Modified

- `.claude/settings.json` - Added marketplace configuration and enabled ralph plugin