### PR TITLE
fix(gitattributes): use LF for polyglot run.cmd scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -58,6 +58,12 @@
 *.cmd      text eol=crlf
 *.ps1      text eol=crlf
 
+# Polyglot scripts (run on both Windows and Unix) need LF
+# These override the *.cmd rule above for specific cross-platform wrappers
+**/run.cmd text eol=lf
+.github/scripts/run.cmd text eol=lf
+plugins/**/run.cmd text eol=lf
+
 # Serialisation
 *.json     text
 *.toml     text


### PR DESCRIPTION
## Summary

Configures Git to use LF line endings for polyglot `run.cmd` wrapper scripts that execute on both Windows and Unix systems.

## Problem

The `run.cmd` files in this repository are polyglot scripts (bash heredoc trick) that work as both Windows batch files and Unix shell scripts. While standard `.cmd` files use CRLF endings on Windows, these polyglot wrappers must use LF endings to function correctly on Unix systems.

Previously, the global `*.cmd text eol=crlf` rule was forcing CRLF endings on all `.cmd` files, breaking the polyglot scripts on Unix.

## Changes

- Added explicit `.gitattributes` rules to override the default `*.cmd` behavior for polyglot wrappers
- Configured LF endings for:
  - `**/run.cmd` (catch-all for any run.cmd in the repo)
  - `.github/scripts/run.cmd` (CI/CD scripts)
  - `plugins/**/run.cmd` (plugin wrappers)

## Technical Details

The polyglot pattern uses a bash heredoc (`: << 'CMDBLOCK'`) to embed Windows batch commands at the top of the file. Windows cmd.exe stops reading at `exit /b`, while Unix shells skip the batch code and execute the shell script below. This pattern requires LF line endings to parse correctly in Unix shells.