### PR TITLE
fix(claude-plugin): fix YAML indentation and command path syntax

### DIFF
--- a/plugins/ralph/commands/ralph-loop.md
+++ b/plugins/ralph/commands/ralph-loop.md
@@ -5,10 +5,10 @@ allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/run.cmd:*)"]
 hide-from-slash-command-tool: "true"
 model: opus
 hooks:
-    Stop:
-        - hooks:
-          - type: command
-            command: "${CLAUDE_PLUGIN_ROOT}/run.cmd hooks/stop-hook.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "${CLAUDE_PLUGIN_ROOT}/run.cmd hooks/stop-hook.sh"
 ---
 
 # Ralph Loop Command
@@ -16,7 +16,7 @@ hooks:
 Execute the setup script to initialize the Ralph loop:
 
 ```!
-"${CLAUDE_PLUGIN_ROOT}/run.cmd scripts/setup-ralph-loop.sh" $ARGUMENTS
+${CLAUDE_PLUGIN_ROOT}/run.cmd scripts/setup-ralph-loop.sh $ARGUMENTS
 ```
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.


### PR DESCRIPTION
## Summary
Fixes YAML formatting issues in the ralph-loop command configuration that could cause parsing errors and incorrect command execution.

## Changes
- **Fixed YAML indentation**: Corrected the nested structure of the Stop hook configuration (lines 7-11)
- **Removed unnecessary quotes**: Changed command path from quoted string to unquoted to ensure proper environment variable expansion: `"${CLAUDE_PLUGIN_ROOT}/run.cmd ..."` → `${CLAUDE_PLUGIN_ROOT}/run.cmd ...`

## Technical Details
The YAML indentation was inconsistent, with the `Stop:` hook improperly nested. The quotes around the command path in the script block could potentially interfere with proper `${CLAUDE_PLUGIN_ROOT}` variable expansion in some shell environments.

## Files Changed
- `plugins/ralph/commands/ralph-loop.md`: Fixed YAML frontmatter and command syntax