### PR TITLE
feat(ralph): improve loop state management and completion detection

### DIFF
--- a/.opencode/command/cancel-ralph.md
+++ b/.opencode/command/cancel-ralph.md
@@ -1,21 +1,45 @@
 ---
-description: Cancel active Ralph Wiggum loop
+description: Cancel the active Ralph Wiggum loop
 agent: build
 model: anthropic/claude-opus-4-5
 ---
 
-# Cancel Ralph
+# Cancel Ralph Loop
 
-Cancel an active Ralph Wiggum loop.
+To cancel the Ralph loop, perform these steps:
 
-## How to Cancel
+1. Check if the Ralph state file exists at `.opencode/ralph-loop.local.md`
 
-Use the `cancel-ralph` tool to stop the current loop.
+2. If the file does NOT exist:
+   - Report: "No active Ralph loop found."
 
-This will:
-1. Check if `.opencode/ralph-loop.local.json` exists
-2. If found, read the current iteration number
-3. Remove the state file
-4. Report: "Cancelled Ralph loop (was at iteration N)"
+3. If the file EXISTS:
+   - Read the file to get the current iteration number from the `iteration:` field in the frontmatter
+   - Read the `feature_list_path:` field (default: "research/feature-list.json")
+   - Check if the feature list file exists and count passing/total features
+   - Delete the file `.opencode/ralph-loop.local.md`
+   - Report: "Cancelled Ralph loop at iteration N" with feature progress if available
 
-If no active loop is found, it will report: "No active Ralph loop found."
+Execute:
+```bash
+if [ -f .opencode/ralph-loop.local.md ]; then
+  ITERATION=$(grep '^iteration:' .opencode/ralph-loop.local.md | sed 's/iteration: *//')
+  FEATURE_LIST_PATH=$(grep '^feature_list_path:' .opencode/ralph-loop.local.md | sed 's/feature_list_path: *//')
+  FEATURE_LIST_PATH="${FEATURE_LIST_PATH:-research/feature-list.json}"
+
+  rm .opencode/ralph-loop.local.md
+
+  echo "Cancelled Ralph loop (was at iteration $ITERATION)"
+
+  # Show feature progress if feature list exists
+  if [ -f "$FEATURE_LIST_PATH" ]; then
+    TOTAL=$(jq 'length' "$FEATURE_LIST_PATH" 2>/dev/null || echo "0")
+    PASSING=$(jq '[.[] | select(.passes == true)] | length' "$FEATURE_LIST_PATH" 2>/dev/null || echo "0")
+    if [ "$TOTAL" -gt 0 ]; then
+      echo "Feature progress: $PASSING / $TOTAL passing"
+    fi
+  fi
+else
+  echo "No active Ralph loop found."
+fi
+```

--- a/.opencode/command/ralph-help.md
+++ b/.opencode/command/ralph-help.md
@@ -1,16 +1,14 @@
 ---
-description: Explain Ralph Wiggum technique and available commands
+description: Explain the Ralph Wiggum technique and available commands
 agent: build
 model: anthropic/claude-opus-4-5
 ---
 
 # Ralph Wiggum Plugin Help
 
-Use the `ralph-help` tool to get detailed documentation about the Ralph Wiggum technique.
+Please explain the following to the user:
 
-## Quick Reference
-
-### What is the Ralph Wiggum Technique?
+## What is the Ralph Wiggum Technique?
 
 The Ralph Wiggum technique is an iterative development methodology based on continuous AI loops, pioneered by Geoffrey Huntley.
 
@@ -21,17 +19,106 @@ while :; do
 done
 ```
 
-The same prompt is fed to the AI repeatedly. The "self-referential" aspect comes from the AI seeing its own previous work in files and git history.
+The same prompt is fed to the AI repeatedly. The "self-referential" aspect comes from the AI seeing its own previous work in the files and git history, not from feeding output back as input.
 
-### Available Commands
+**Each iteration:**
+1. AI receives the SAME prompt
+2. Works on the task, modifying files
+3. Completes its response
+4. Plugin intercepts idle state and feeds the same prompt again
+5. AI sees its previous work in the files
+6. Iteratively improves until completion
 
-| Command         | Description                                |
-| --------------- | ------------------------------------------ |
-| `/ralph-loop`   | Start a Ralph loop in your current session |
-| `/cancel-ralph` | Cancel an active Ralph loop                |
-| `/ralph-help`   | Show this help                             |
+The technique is described as "deterministically bad in an undeterministic world" - failures are predictable, enabling systematic improvement through prompt tuning.
 
-### When to Use Ralph
+## Available Commands
+
+### /ralph-loop [PROMPT] [OPTIONS]
+
+Start a Ralph loop in your current session.
+
+**Usage:**
+```
+/ralph-loop                                    (uses /implement-feature, runs until all features pass)
+/ralph-loop --max-iterations 20                (uses /implement-feature with iteration limit)
+/ralph-loop --feature-list specs/features.json (use custom feature list path)
+/ralph-loop "Refactor the cache layer" --max-iterations 20
+/ralph-loop "Add tests" --completion-promise "TESTS COMPLETE"
+```
+
+**Options:**
+- `--max-iterations <n>` - Max iterations before auto-stop (default: 0 for unlimited)
+- `--completion-promise <text>` - Promise phrase to signal completion
+- `--feature-list <path>` - Path to feature list JSON (default: research/feature-list.json)
+
+**Stopping conditions:**
+- `--max-iterations` limit reached
+- `--completion-promise` detected in output
+- All features in `--feature-list` are passing (when max_iterations = 0)
+- Manual cancellation with `/cancel-ralph`
+
+**How it works:**
+1. Creates `.opencode/ralph-loop.local.md` state file in project root
+2. You work on the task (default: /implement-feature)
+3. When you finish responding, the plugin intercepts
+4. Same prompt fed back
+5. You see your previous work
+6. Continues until completion condition met
+
+---
+
+### /cancel-ralph
+
+Cancel an active Ralph loop (removes the loop state file).
+
+**Usage:**
+```
+/cancel-ralph
+```
+
+**How it works:**
+- Checks for active loop state file
+- Removes `.opencode/ralph-loop.local.md`
+- Reports cancellation with iteration count
+
+---
+
+## Key Concepts
+
+### Completion Promises
+
+To signal completion, the AI must output a `<promise>` tag:
+
+```
+<promise>TASK COMPLETE</promise>
+```
+
+The plugin looks for this specific tag. Without it (or `--max-iterations`), Ralph runs infinitely.
+
+### Self-Reference Mechanism
+
+The "loop" doesn't mean the AI talks to itself. It means:
+- Same prompt repeated
+- AI's work persists in files
+- Each iteration sees previous attempts
+- Builds incrementally toward goal
+
+## Example
+
+### Interactive Bug Fix
+
+```
+/ralph-loop "Fix the token refresh logic in auth.ts. Output <promise>FIXED</promise> when all tests pass." --completion-promise "FIXED" --max-iterations 10
+```
+
+You'll see Ralph:
+- Attempt fixes
+- Run tests
+- See failures
+- Iterate on solution
+- In your current session
+
+## When to Use Ralph
 
 **Good for:**
 - Well-defined tasks with clear success criteria
@@ -43,8 +130,9 @@ The same prompt is fed to the AI repeatedly. The "self-referential" aspect comes
 - Tasks requiring human judgment or design decisions
 - One-shot operations
 - Tasks with unclear success criteria
+- Debugging production issues (use targeted debugging instead)
 
-### Learn More
+## Learn More
 
 - Original technique: https://ghuntley.com/ralph/
 - Ralph Orchestrator: https://github.com/mikeyobrien/ralph-orchestrator

--- a/.opencode/command/ralph-loop.md
+++ b/.opencode/command/ralph-loop.md
@@ -1,54 +1,113 @@
 ---
-description: Start Ralph Wiggum loop in current session
+description: Start a Ralph Wiggum loop for iterative development
 agent: build
 model: anthropic/claude-opus-4-5
 ---
 
 # Ralph Loop Command
 
-Start a Ralph Wiggum loop - a self-referential AI loop that repeats the same prompt until completion.
+You are starting a Ralph Wiggum loop. This is an iterative development technique where you work on the same task repeatedly, seeing your previous work in files and git history.
 
-## Arguments
+## Setup Instructions
 
-$ARGUMENTS
+Execute the following steps to initialize the Ralph loop:
 
-## How to Start
+1. Parse the arguments from: `$ARGUMENTS`
 
-Use the `ralph-loop` tool with the following parameters:
-- `prompt`: The prompt to repeat each iteration (default: /implement-feature)
-- `max_iterations`: Maximum iterations before auto-stop (0 = unlimited)
-- `completion_promise`: Promise phrase to signal completion (e.g., 'DONE')
-- `feature_list`: Path to feature list JSON (default: research/feature-list.json)
+   Arguments format: `<PROMPT> [--max-iterations N] [--completion-promise TEXT] [--feature-list PATH]`
 
-## Examples
+   - Extract the main prompt (everything that isn't a flag or flag value)
+   - Extract `--max-iterations` value if provided (default: 0 for unlimited)
+   - Extract `--completion-promise` value if provided (default: null)
+   - Extract `--feature-list` value if provided (default: "research/feature-list.json")
+
+2. Create the state file at `.opencode/ralph-loop.local.md` (in the project root) with this exact format:
+
+```markdown
+---
+active: true
+iteration: 1
+max_iterations: <MAX_ITERATIONS_VALUE>
+completion_promise: <COMPLETION_PROMISE_VALUE_OR_null>
+feature_list_path: <FEATURE_LIST_PATH_VALUE>
+started_at: "<CURRENT_ISO_TIMESTAMP>"
+---
+
+<THE_PROMPT_TEXT>
+```
+
+   If no custom prompt is provided, use the default prompt:
+   ```
+   /implement-feature
+
+   <EXTREMELY_IMPORTANT>
+   - Implement features incrementally, make small changes each iteration.
+     - Only work on the SINGLE highest priority feature at a time.
+     - Use the `feature-list.json` file if it is provided to you as a guide otherwise create your own `feature-list.json` based on the task.
+   - If a completion promise is set, you may ONLY output it when the statement is completely and unequivocally TRUE. Do not output false promises to escape the loop, even if you think you're stuck or should exit for other reasons. The loop is designed to continue until genuine completion.
+   </EXTREMELY_IMPORTANT>
+   ```
+
+   **IMPORTANT**: If using the default prompt and the feature list file does NOT exist, output an error and do NOT create the state file:
+   ```
+   Error: Feature list not found at: <FEATURE_LIST_PATH>
+
+   The default /implement-feature prompt requires a feature list to work.
+
+   To fix this, either:
+     1. Create the feature list: /create-feature-list
+     2. Specify a different path: --feature-list <path>
+     3. Use a custom prompt instead
+   ```
+
+3. Output the activation message:
 
 ```
-/ralph-loop                                    # Uses /implement-feature, runs until all features pass
-/ralph-loop --max-iterations 20                # With iteration limit
-/ralph-loop "Build a todo API" --completion-promise "DONE" --max-iterations 20
+Ralph loop activated!
+
+Iteration: 1
+Max iterations: <N or "unlimited">
+Completion promise: <TEXT or "none">
+Feature list: <FEATURE_LIST_PATH>
+
+The Ralph plugin will now monitor for session idle events. When you complete
+your response, the same prompt will be fed back to continue the loop.
+
+To stop the loop:
+- Output <promise>YOUR_PROMISE</promise> if a completion promise is set
+- Wait for max iterations to be reached
+- All features in feature-list.json are passing (when max_iterations = 0)
+- Run /cancel-ralph to cancel manually
 ```
 
-## How It Works
+4. If a completion promise is set, display this critical warning:
 
-1. Creates state file at `.opencode/ralph-loop.local.json`
-2. You work on the task
-3. When session goes idle, plugin detects it
-4. Same prompt fed back via `session.promptAsync`
-5. You see your previous work in files
-6. Continues until:
-   - Max iterations reached
-   - `<promise>PHRASE</promise>` detected in output
-   - All features in feature list are passing (when max_iterations = 0)
+```
+CRITICAL - Ralph Loop Completion Promise
 
-## Stopping the Loop
+To complete this loop, output this EXACT text:
+  <promise>YOUR_PROMISE_HERE</promise>
 
-To signal completion, output: `<promise>YOUR_PHRASE</promise>`
+STRICT REQUIREMENTS:
+  - Use <promise> XML tags EXACTLY as shown above
+  - The statement MUST be completely and unequivocally TRUE
+  - Do NOT output false statements to exit the loop
+  - Do NOT lie even if you think you should exit
 
-CRITICAL: Only output the promise when the statement is completely and unequivocally TRUE. Do not lie to exit the loop.
+IMPORTANT: Even if you believe you're stuck or the task is impossible,
+you MUST NOT output a false promise. The loop continues until the
+promise is GENUINELY TRUE.
+```
 
-## Monitoring
+5. Now begin working on the task from the prompt. The Ralph plugin will automatically continue feeding you the same prompt when you complete your response.
 
-Check current iteration:
-```bash
-cat .opencode/ralph-loop.local.json | jq '.iteration'
+## Example Usage
+
+```
+/ralph-loop                                    (uses /implement-feature, runs until all features pass)
+/ralph-loop --max-iterations 20                (uses /implement-feature with iteration limit)
+/ralph-loop --feature-list specs/features.json (use custom feature list path)
+/ralph-loop Build a REST API for todos --completion-promise "DONE" --max-iterations 20
+/ralph-loop Fix the auth bug --max-iterations 10
+/ralph-loop Refactor the cache layer
 ```

--- a/.opencode/plugin/ralph.ts
+++ b/.opencode/plugin/ralph.ts
@@ -1,108 +1,43 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs"
+import { join } from "path"
+
 /**
  * Ralph Wiggum Plugin for OpenCode
  *
  * Implementation of the Ralph Wiggum technique - continuous self-referential AI loops
- * for interactive iterative development. Runs the AI in a while-true loop with the
- * same prompt until task completion.
+ * for iterative development. Named after Ralph Wiggum from The Simpsons, embodying
+ * the philosophy of persistent iteration despite setbacks.
  *
- * Original technique: https://ghuntley.com/ralph/
+ * Core concept: Feed the same prompt repeatedly, letting the AI see its previous work
+ * in files and git history, creating a self-referential feedback loop.
+ *
+ * Based on: https://ghuntley.com/ralph/
  */
-
-import { Plugin, tool } from "@opencode-ai/plugin"
-import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from "fs"
-import { join } from "path"
 
 interface RalphState {
   active: boolean
   iteration: number
-  max_iterations: number
-  completion_promise: string | null
-  feature_list_path: string
-  started_at: string
+  maxIterations: number
+  completionPromise: string | null
+  featureListPath: string
+  startedAt: string
   prompt: string
 }
 
-const RALPH_STATE_FILE = ".opencode/ralph-loop.local.json"
-
-function readRalphState(directory: string): RalphState | null {
-  const statePath = join(directory, RALPH_STATE_FILE)
-  if (!existsSync(statePath)) {
-    return null
-  }
-  try {
-    const content = readFileSync(statePath, "utf-8")
-    return JSON.parse(content) as RalphState
-  } catch {
-    return null
-  }
+interface Feature {
+  category: string
+  description: string
+  steps: string[]
+  passes: boolean
 }
 
-function writeRalphState(directory: string, state: RalphState): void {
-  const statePath = join(directory, RALPH_STATE_FILE)
-  const dir = join(directory, ".opencode")
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
-  writeFileSync(statePath, JSON.stringify(state, null, 2))
-}
-
-function deleteRalphState(directory: string): void {
-  const statePath = join(directory, RALPH_STATE_FILE)
-  if (existsSync(statePath)) {
-    unlinkSync(statePath)
-  }
-}
-
-function testAllFeaturesPassing(directory: string, featureListPath: string): { passing: boolean; message: string } {
-  const fullPath = join(directory, featureListPath)
-  if (!existsSync(fullPath)) {
-    return { passing: false, message: `Feature list not found at: ${featureListPath}` }
-  }
-
-  try {
-    const content = readFileSync(fullPath, "utf-8")
-    const features = JSON.parse(content) as Array<{ passes?: boolean }>
-
-    const total = features.length
-    if (total === 0) {
-      return { passing: false, message: "Feature list is empty" }
-    }
-
-    const passingCount = features.filter((f) => f.passes === true).length
-    const failing = total - passingCount
-
-    return {
-      passing: failing === 0,
-      message: `Feature Progress: ${passingCount} / ${total} passing (${failing} remaining)`,
-    }
-  } catch {
-    return { passing: false, message: `Failed to parse feature list: ${featureListPath}` }
-  }
-}
-
-export const RalphPlugin: Plugin = async ({ project, client, $, directory, worktree }) => {
-  console.log("[Ralph] Plugin initialized")
-
-  return {
-    tool: {
-      // Custom tool: ralph-loop - Start a Ralph loop
-      "ralph-loop": tool({
-        description:
-          "Start a Ralph Wiggum loop. Runs the AI in a self-referential loop with the same prompt until completion.",
-        args: {
-          prompt: tool.schema.string().optional().describe("The prompt to repeat each iteration (default: /implement-feature)"),
-          max_iterations: tool.schema.number().optional().describe("Maximum iterations before auto-stop (0 = unlimited)"),
-          completion_promise: tool.schema.string().optional().describe("Promise phrase to signal completion (e.g., 'DONE')"),
-          feature_list: tool.schema.string().optional().describe("Path to feature list JSON (default: research/feature-list.json)"),
-        },
-        async execute(args) {
-          const maxIterations = args.max_iterations || 0
-          const completionPromise = args.completion_promise || null
-          const featureListPath = args.feature_list || "research/feature-list.json"
-
-          // Default prompt includes /implement-feature and critical instructions
-          // Users can fully override by providing their own prompt
-          const DEFAULT_PROMPT = `/implement-feature
+// Default values - keep in sync with plugins/ralph/scripts/setup-ralph-loop.sh
+const STATE_FILE = ".opencode/ralph-loop.local.md"
+const DEFAULT_MAX_ITERATIONS = 0
+const DEFAULT_COMPLETION_PROMISE = null
+const DEFAULT_FEATURE_LIST_PATH = "research/feature-list.json"
+const DEFAULT_PROMPT = `/implement-feature
 
 <EXTREMELY_IMPORTANT>
 - Implement features incrementally, make small changes each iteration.
@@ -111,189 +46,247 @@ export const RalphPlugin: Plugin = async ({ project, client, $, directory, workt
 - If a completion promise is set, you may ONLY output it when the statement is completely and unequivocally TRUE. Do not output false promises to escape the loop, even if you think you're stuck or should exit for other reasons. The loop is designed to continue until genuine completion.
 </EXTREMELY_IMPORTANT>`
 
-          const fullPrompt = args.prompt || DEFAULT_PROMPT
+function parseRalphState(directory: string): RalphState | null {
+  const statePath = join(directory, STATE_FILE)
 
-          // Check if using default /implement-feature and feature list is missing
-          if (!args.prompt && !existsSync(join(directory, featureListPath))) {
-            return `Error: Feature list not found at: ${featureListPath}
+  if (!existsSync(statePath)) {
+    return null
+  }
 
-The default /implement-feature prompt requires a feature list. Either:
-1. Create the feature list: /create-feature-list
-2. Specify a different path with feature_list parameter
-3. Use a custom prompt instead`
-          }
+  try {
+    const content = readFileSync(statePath, "utf-8")
 
-          const state: RalphState = {
-            active: true,
-            iteration: 1,
-            max_iterations: maxIterations,
-            completion_promise: completionPromise,
-            feature_list_path: featureListPath,
-            started_at: new Date().toISOString(),
-            prompt: fullPrompt,
-          }
+    // Parse YAML frontmatter
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+    if (!frontmatterMatch) {
+      return null
+    }
 
-          writeRalphState(directory, state)
+    const [, frontmatter, prompt] = frontmatterMatch
 
-          return `🔄 Ralph loop activated!
+    // Parse frontmatter values
+    const getValue = (key: string): string | null => {
+      const match = frontmatter.match(new RegExp(`^${key}:\\s*(.*)$`, "m"))
+      if (!match) return null
+      // Remove surrounding quotes if present
+      return match[1].replace(/^["'](.*)["']$/, "$1")
+    }
 
-Iteration: 1
-Max iterations: ${maxIterations > 0 ? maxIterations : "unlimited"}
-Completion promise: ${completionPromise ? `${completionPromise} (ONLY output when TRUE - do not lie!)` : "none (runs based on feature list or forever)"}
+    const active = getValue("active") === "true"
+    const iteration = parseInt(getValue("iteration") || "1", 10)
+    const maxIterations = parseInt(getValue("max_iterations") || String(DEFAULT_MAX_ITERATIONS), 10)
+    const completionPromise = getValue("completion_promise")
+    const featureListPath = getValue("feature_list_path") || DEFAULT_FEATURE_LIST_PATH
+    const startedAt = getValue("started_at") || new Date().toISOString()
 
-The loop will continue until:
-${maxIterations > 0 ? `• Max iterations (${maxIterations}) reached\n` : ""}${completionPromise ? `• <promise>${completionPromise}</promise> detected in output\n` : ""}${maxIterations === 0 ? `• All features in ${featureListPath} are passing\n` : ""}
-State file: ${RALPH_STATE_FILE}
-
-Prompt: ${args.prompt ? `custom: ${args.prompt}` : `default:\n${DEFAULT_PROMPT}`}`
-        },
-      }),
-
-      // Custom tool: cancel-ralph - Cancel an active Ralph loop
-      "cancel-ralph": tool({
-        description: "Cancel an active Ralph Wiggum loop",
-        args: {},
-        async execute() {
-          const state = readRalphState(directory)
-
-          if (!state) {
-            return "No active Ralph loop found."
-          }
-
-          const iteration = state.iteration
-          deleteRalphState(directory)
-
-          return `Cancelled Ralph loop (was at iteration ${iteration})`
-        },
-      }),
-
-      // Custom tool: ralph-help - Explain the technique
-      "ralph-help": tool({
-        description: "Explain the Ralph Wiggum technique and available commands",
-        args: {},
-        async execute() {
-          return `# Ralph Wiggum Technique
-
-## What is it?
-The Ralph Wiggum technique is an iterative development methodology based on continuous AI loops, pioneered by Geoffrey Huntley.
-
-**Core concept:**
-\`\`\`bash
-while :; do
-  cat PROMPT.md | opencode --continue
-done
-\`\`\`
-
-Each iteration:
-1. AI receives the SAME prompt
-2. Works on the task, modifying files
-3. Session goes idle
-4. Plugin sends the same prompt again
-5. AI sees its previous work in files
-6. Iteratively improves until completion
-
-## Available Tools
-
-### ralph-loop
-Start a loop with: \`ralph-loop\` tool
-- prompt: The prompt to repeat (default: /implement-feature)
-- max_iterations: Max iterations (0 = unlimited)
-- completion_promise: Promise phrase to signal completion
-- feature_list: Path to feature list JSON
-
-### cancel-ralph
-Cancel an active loop with: \`cancel-ralph\` tool
-
-### Completion Promises
-To signal completion, output: \`<promise>YOUR_PHRASE</promise>\`
-
-## When to Use
-**Good for:**
-- Well-defined tasks with clear success criteria
-- Iterative development with self-correction
-- Greenfield projects
-
-**Not good for:**
-- Tasks requiring human judgment
-- One-shot operations
-- Unclear success criteria
-
-## Learn More
-- Original: https://ghuntley.com/ralph/
-- Ralph Orchestrator: https://github.com/mikeyobrien/ralph-orchestrator`
-        },
-      }),
-    },
-
-    // Event hook to handle session.idle and continue the loop
-    event: async ({ event }) => {
-      // Check if this is a session.idle event
-      if (event.type !== "session.idle") {
-        return
-      }
-
-      const state = readRalphState(directory)
-      if (!state || !state.active) {
-        return
-      }
-
-      console.log(`[Ralph] Session idle detected at iteration ${state.iteration}`)
-
-      // Check max iterations
-      if (state.max_iterations > 0 && state.iteration >= state.max_iterations) {
-        console.log(`[Ralph] Max iterations (${state.max_iterations}) reached`)
-        deleteRalphState(directory)
-        return
-      }
-
-      // Check feature list (only when max_iterations = 0)
-      if (state.max_iterations === 0) {
-        const featureCheck = testAllFeaturesPassing(directory, state.feature_list_path)
-        console.log(`[Ralph] ${featureCheck.message}`)
-        if (featureCheck.passing) {
-          console.log("[Ralph] All features passing! Exiting loop.")
-          deleteRalphState(directory)
-          return
-        }
-      }
-
-      // Increment iteration
-      const nextIteration = state.iteration + 1
-      state.iteration = nextIteration
-      writeRalphState(directory, state)
-
-      // Build system message
-      let systemMsg = `🔄 Ralph iteration ${nextIteration}`
-      if (state.completion_promise) {
-        systemMsg += ` | To stop: output <promise>${state.completion_promise}</promise> (ONLY when statement is TRUE - do not lie!)`
-      }
-
-      console.log(`[Ralph] ${systemMsg}`)
-
-      // Send the same prompt back using the client
-      // @ts-ignore - session types may vary
-      const sessionID = event.properties?.sessionID || event.sessionID
-
-      if (sessionID && client?.session?.promptAsync) {
-        try {
-          await client.session.promptAsync({
-            path: { id: sessionID },
-            body: {
-              parts: [
-                { type: "text", text: systemMsg },
-                { type: "text", text: state.prompt },
-              ],
-            },
-          })
-          console.log("[Ralph] Sent prompt for next iteration")
-        } catch (err) {
-          console.error("[Ralph] Failed to send prompt:", err)
-        }
-      } else {
-        console.log("[Ralph] Could not send prompt - client or sessionID not available")
-      }
-    },
+    return {
+      active,
+      iteration,
+      maxIterations,
+      completionPromise:
+        completionPromise === "null" || !completionPromise
+          ? DEFAULT_COMPLETION_PROMISE
+          : completionPromise,
+      featureListPath,
+      startedAt,
+      prompt: prompt.trim() || DEFAULT_PROMPT,
+    }
+  } catch {
+    return null
   }
 }
 
-export default RalphPlugin
+function writeRalphState(directory: string, state: RalphState): void {
+  const statePath = join(directory, STATE_FILE)
+
+  const completionPromiseYaml =
+    state.completionPromise === null ? "null" : `"${state.completionPromise}"`
+
+  const content = `---
+active: ${state.active}
+iteration: ${state.iteration}
+max_iterations: ${state.maxIterations}
+completion_promise: ${completionPromiseYaml}
+feature_list_path: ${state.featureListPath}
+started_at: "${state.startedAt}"
+---
+
+${state.prompt}
+`
+
+  writeFileSync(statePath, content, "utf-8")
+}
+
+function deleteRalphState(directory: string): boolean {
+  const statePath = join(directory, STATE_FILE)
+
+  if (existsSync(statePath)) {
+    unlinkSync(statePath)
+    return true
+  }
+  return false
+}
+
+/**
+ * Check if all features in feature-list.json are passing
+ * Returns { allPassing: boolean, total: number, passing: number, failing: number }
+ */
+function checkAllFeaturesPassing(
+  directory: string,
+  featureListPath: string
+): { allPassing: boolean; total: number; passing: number; failing: number } | null {
+  const fullPath = join(directory, featureListPath)
+
+  if (!existsSync(fullPath)) {
+    return null
+  }
+
+  try {
+    const content = readFileSync(fullPath, "utf-8")
+    const features: Feature[] = JSON.parse(content)
+
+    if (!Array.isArray(features) || features.length === 0) {
+      return null
+    }
+
+    const total = features.length
+    const passing = features.filter((f) => f.passes === true).length
+    const failing = total - passing
+
+    return {
+      allPassing: failing === 0,
+      total,
+      passing,
+      failing,
+    }
+  } catch {
+    return null
+  }
+}
+
+function checkCompletionPromise(text: string, promise: string): boolean {
+  // Extract text from <promise> tags
+  const promiseMatch = text.match(/<promise>([\s\S]*?)<\/promise>/)
+  if (!promiseMatch) return false
+
+  // Normalize whitespace and compare
+  const promiseText = promiseMatch[1].trim().replace(/\s+/g, " ")
+  return promiseText === promise
+}
+
+export const RalphPlugin: Plugin = async ({ directory, client, $ }) => {
+  return {
+    /**
+     * Handle session idle event - this is when the AI has finished responding
+     * and would normally wait for user input. In Ralph mode, we intercept this
+     * to continue the loop.
+     */
+    event: async ({ event }) => {
+      if (event.type !== "session.idle") return
+
+      const state = parseRalphState(directory)
+      if (!state || !state.active) return
+
+      // Get the last assistant message to check for completion
+      // We need to check if the completion promise was output
+      if (state.completionPromise) {
+        try {
+          // Use the SDK to get session messages
+          const session = await client.session.get({ id: event.properties.sessionID })
+          if (session.messages && session.messages.length > 0) {
+            // Find the last assistant message
+            const lastAssistantMsg = [...session.messages]
+              .reverse()
+              .find((m) => m.role === "assistant")
+
+            if (lastAssistantMsg) {
+              // Extract text content from message parts
+              const textContent = lastAssistantMsg.parts
+                ?.filter((p: any) => p.type === "text")
+                .map((p: any) => p.text)
+                .join("\n")
+
+              if (textContent && checkCompletionPromise(textContent, state.completionPromise)) {
+                // Completion promise detected - stop the loop
+                deleteRalphState(directory)
+                await client.app.log({
+                  service: "ralph-plugin",
+                  level: "info",
+                  message: `Ralph loop completed: detected <promise>${state.completionPromise}</promise>`,
+                })
+                return
+              }
+            }
+          }
+        } catch (err) {
+          // If we can't check messages, continue the loop
+          await client.app.log({
+            service: "ralph-plugin",
+            level: "warn",
+            message: `Could not check for completion promise: ${err}`,
+          })
+        }
+      }
+
+      // Check max iterations
+      if (state.maxIterations > 0 && state.iteration >= state.maxIterations) {
+        deleteRalphState(directory)
+        await client.app.log({
+          service: "ralph-plugin",
+          level: "info",
+          message: `Ralph loop stopped: max iterations (${state.maxIterations}) reached`,
+        })
+        return
+      }
+
+      // Check if all features are passing (only when max_iterations = 0, i.e., infinite mode)
+      const featureStatus = checkAllFeaturesPassing(directory, state.featureListPath)
+      if (state.maxIterations === 0 && featureStatus?.allPassing) {
+        deleteRalphState(directory)
+        await client.app.log({
+          service: "ralph-plugin",
+          level: "info",
+          message: `Ralph loop completed: All ${featureStatus.total} features passing!`,
+        })
+        return
+      }
+
+      // Continue the loop - increment iteration and feed prompt back
+      const nextIteration = state.iteration + 1
+      writeRalphState(directory, {
+        ...state,
+        iteration: nextIteration,
+      })
+
+      // Build the continuation message
+      let systemMsg = `Ralph iteration ${nextIteration}`
+      if (featureStatus) {
+        systemMsg += ` | Features: ${featureStatus.passing}/${featureStatus.total} passing`
+      }
+      if (state.completionPromise) {
+        systemMsg += ` | To stop: output <promise>${state.completionPromise}</promise> (ONLY when TRUE)`
+      } else if (state.maxIterations > 0) {
+        systemMsg += ` / ${state.maxIterations}`
+      } else if (!featureStatus) {
+        systemMsg += ` | No completion promise set - loop runs until cancelled`
+      }
+
+      // Log the iteration
+      await client.app.log({
+        service: "ralph-plugin",
+        level: "info",
+        message: systemMsg,
+      })
+
+      // Append the prompt back to continue the session
+      // The prompt includes a marker showing the iteration
+      const continuationPrompt = `[${systemMsg}]\n\n${state.prompt}`
+
+      // Use session.send to continue the conversation
+      await client.session.send({
+        id: event.properties.sessionID,
+        text: continuationPrompt,
+      })
+    },
+  }
+}

--- a/plugins/ralph/commands/ralph-loop.md
+++ b/plugins/ralph/commands/ralph-loop.md
@@ -1,6 +1,6 @@
 ---
 description: "Start Ralph Loop in current session"
-argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT]"
+argument-hint: "PROMPT [--max-iterations N] [--completion-promise TEXT] [--feature-list PATH]"
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/run.cmd:*)"]
 hide-from-slash-command-tool: "true"
 model: opus
@@ -15,5 +15,3 @@ ${CLAUDE_PLUGIN_ROOT}/run.cmd scripts/setup-ralph-loop.sh $ARGUMENTS
 ```
 
 Please work on the task. When you try to exit, the Ralph loop will feed the SAME PROMPT back to you for the next iteration. You'll see your previous work in files and git history, allowing you to iterate and improve.
-
-CRITICAL RULE: If a completion promise is set, you may ONLY output it when the statement is completely and unequivocally TRUE. Do not output false promises to escape the loop, even if you think you're stuck or should exit for other reasons. The loop is designed to continue until genuine completion.


### PR DESCRIPTION
## Summary

Significantly improves the Ralph Wiggum loop implementation with better state management, enhanced completion detection, and clearer documentation for the iterative development technique.

## Key Changes

### State Management
- **Migrated state file format** from JSON (`.opencode/ralph-loop.local.json`) to Markdown with YAML frontmatter (`.opencode/ralph-loop.local.md`)
- Improved state parsing with proper frontmatter extraction and validation
- Better handling of null values for completion promises
- More robust state file creation and deletion

### Completion Detection
- **Enhanced completion promise detection** using proper XML tag parsing (`<promise>...</promise>`)
- Added session message inspection to detect completion promises in AI output
- Improved feature list checking with detailed progress tracking (passing/total/failing counts)
- Better error handling when checking session messages

### Plugin Architecture
- Refactored from tool-based to event-driven architecture using `session.idle` events
- Switched from `session.promptAsync` to `session.send` for loop continuation
- Added comprehensive logging using `client.app.log` for better observability
- Cleaner separation of concerns between state management and loop logic

### Documentation
- **Expanded `/ralph-help`** command with detailed explanations of:
  - The Ralph Wiggum technique and its philosophy
  - All available commands with usage examples
  - Completion promises and self-reference mechanisms
  - When to use (and not use) Ralph loops
- **Improved `/ralph-loop`** command documentation with:
  - Step-by-step setup instructions
  - Clearer argument parsing and validation
  - Better error messages for missing feature lists
  - More explicit completion promise warnings
- **Enhanced `/cancel-ralph`** command with feature progress reporting

### Developer Experience
- More informative iteration messages showing feature progress
- Better error messages and validation
- Clearer warnings about completion promise requirements
- Improved loop status reporting with feature counts

## Breaking Changes

- State file location changed from `.opencode/ralph-loop.local.json` to `.opencode/ralph-loop.local.md`
- Existing Ralph loops in progress will need to be cancelled and restarted

## Technical Details

- Uses YAML frontmatter for structured metadata in the state file
- Implements proper XML tag parsing for completion promises
- Leverages OpenCode SDK's session inspection capabilities
- Maintains backward compatibility with default prompt and feature list paths