### PR TITLE
docs(ralph): clarify loop continuation behavior

### DIFF
--- a/.opencode/command/ralph-help.md
+++ b/.opencode/command/ralph-help.md
@@ -93,7 +93,7 @@ To signal completion, the AI must output a `<promise>` tag:
 <promise>TASK COMPLETE</promise>
 ```
 
-The plugin looks for this specific tag. Without it (or `--max-iterations`), Ralph runs infinitely.
+The plugin looks for this specific tag. Without it (or `--max-iterations`), Ralph runs indefinitely.
 
 ### Self-Reference Mechanism
 

--- a/plugins/ralph/commands/help.md
+++ b/plugins/ralph/commands/help.md
@@ -82,7 +82,7 @@ To signal completion, Claude must output a `<promise>` tag:
 <promise>TASK COMPLETE</promise>
 ```
 
-The stop hook looks for this specific tag. Without it (or `--max-iterations`), Ralph runs infinitely.
+The stop hook looks for this specific tag. Without it (or `--max-iterations`), Ralph runs indefinitely.
 
 ### Self-Reference Mechanism
 

--- a/plugins/ralph/hooks/stop-hook.sh
+++ b/plugins/ralph/hooks/stop-hook.sh
@@ -205,7 +205,7 @@ mv "$TEMP_FILE" "$RALPH_STATE_FILE"
 if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
   SYSTEM_MSG="🔄 Ralph iteration $NEXT_ITERATION | To stop: output <promise>$COMPLETION_PROMISE</promise> (ONLY when statement is TRUE - do not lie to exit!)"
 else
-  SYSTEM_MSG="🔄 Ralph iteration $NEXT_ITERATION | No completion promise set - loop runs infinitely"
+  SYSTEM_MSG="🔄 Ralph iteration $NEXT_ITERATION | No completion promise set - loop runs indefinitely"
 fi
 
 # Output JSON to block the stop and feed prompt back

--- a/plugins/ralph/scripts/setup-ralph-loop.sh
+++ b/plugins/ralph/scripts/setup-ralph-loop.sh
@@ -198,8 +198,8 @@ self-referential loop where you iteratively improve on the same task.
 
 To monitor: head -10 .claude/ralph-loop.local.md
 
-⚠️  WARNING: This loop cannot be stopped manually! It will run infinitely
-    unless you set --max-iterations or --completion-promise.
+⚠️  WARNING: This loop cannot be stopped manually! It will run indefinitely
+    unless you set --max-iterations or --completion-promise or --feature-list.
 
 🔄
 EOF


### PR DESCRIPTION
## Summary
Improves terminology consistency in Ralph loop documentation and messaging by replacing "infinitely" with "indefinitely" to more accurately describe the loop's continuation behavior.

## Key Changes
- **Documentation updates**: Updated help files in both `.opencode/command/ralph-help.md` and `plugins/ralph/commands/help.md` to use "indefinitely" instead of "infinitely"
- **Runtime messaging**: Updated `stop-hook.sh` to display "runs indefinitely" in system messages
- **Setup warnings**: Enhanced warning message in `setup-ralph-loop.sh` to clarify that the loop runs "indefinitely" and explicitly mention `--feature-list` as a stopping condition

## Rationale
The term "indefinitely" is more accurate than "infinitely" because:
- The loop can be stopped through various conditions (max iterations, completion promise, feature list completion)
- "Indefinitely" means "for an unspecified period" while "infinitely" implies "forever without end"
- This terminology better reflects the actual behavior where the loop continues until a stopping condition is met