### PR TITLE
feat(copilot-cli)!: migrate from prompts to agent system

### DIFF
--- a/.github/agents/cancel-ralph.md
+++ b/.github/agents/cancel-ralph.md
@@ -1,4 +1,5 @@
 ---
+name: cancel-ralph
 description: Cancel active Ralph Wiggum loop
 tools: ["execute", "read"]
 model: claude-opus-4-5

--- a/.github/agents/commit.md
+++ b/.github/agents/commit.md
@@ -1,8 +1,9 @@
 ---
+name: commit
 description: Create well-formatted commits with conventional commit format.
 tools: ["execute", "read", "search"]
 model: claude-opus-4-5
-argument-hint: [message] | --amend
+argument-hint: [message]
 ---
 
 # Smart Git Commit

--- a/.github/agents/create-feature-list.md
+++ b/.github/agents/create-feature-list.md
@@ -1,4 +1,5 @@
 ---
+name: create-feature-list
 description: Create a detailed `research/feature-list.json` and `research/progress.txt` for implementing features or refactors in a codebase from a spec.
 tools: ["edit", "read", "execute"]
 model: claude-opus-4-5

--- a/.github/agents/create-gh-pr.md
+++ b/.github/agents/create-gh-pr.md
@@ -1,4 +1,5 @@
 ---
+name: create-gh-pr
 description: Commit unstaged changes, push changes, submit a pull request.
 tools: ["execute", "search", "read", "agent"]
 model: claude-opus-4-5

--- a/.github/agents/create-spec.md
+++ b/.github/agents/create-spec.md
@@ -1,4 +1,5 @@
 ---
+name: create-spec
 description: Create a detailed execution plan for implementing features or refactors in a codebase by leveraging existing research in the specified `research` directory.
 tools: ["edit", "read", "execute", "search", "agent"]
 model: claude-opus-4-5
@@ -227,7 +228,7 @@ flowchart TB
 
 ### 8.3 Test Plan
 
-- **Unit Tests:** 
+- **Unit Tests:**
 - **Integration Tests:**
 - **End-to-End Tests:**
 

--- a/.github/agents/explain-code.md
+++ b/.github/agents/explain-code.md
@@ -1,4 +1,5 @@
 ---
+name: explain-code
 description: Explain code functionality in detail.
 tools: ["search", "read", "web", "deepwiki/ask_question"]
 model: claude-opus-4-5

--- a/.github/agents/implement-feature.md
+++ b/.github/agents/implement-feature.md
@@ -1,4 +1,5 @@
 ---
+name: implement-feature
 description: Implement a SINGLE feature from `research/feature-list.json` based on the provided execution plan.
 tools: ["execute", "agent", "edit", "search", "read", "web"]
 model: claude-opus-4-5

--- a/.github/agents/ralph-help.md
+++ b/.github/agents/ralph-help.md
@@ -1,4 +1,5 @@
 ---
+name: ralph-help
 description: Explain Ralph Wiggum technique and available commands
 tools: ["read"]
 model: claude-opus-4-5

--- a/.github/agents/ralph-loop.md
+++ b/.github/agents/ralph-loop.md
@@ -1,4 +1,5 @@
 ---
+name: ralph-loop
 description: Start Ralph Wiggum loop in current session
 tools: ["search", "execute", "edit", "read"]
 model: claude-opus-4-5

--- a/.github/agents/research-codebase.md
+++ b/.github/agents/research-codebase.md
@@ -1,4 +1,5 @@
 ---
+name: research-codebase
 description: Document codebase as-is with research directory for historical context
 tools: ["edit", "execute", "read", "search", "agent"]
 model: claude-opus-4-5

--- a/README.md
+++ b/README.md
@@ -115,7 +115,17 @@ Research → Plan (Spec) → Implement (Ralph) → (Debug) → PR
 ### 1. Research the Codebase
 
 ```bash
+# for claude-code
 atomic --agent claude -- /research-codebase "Describe your feature or question"
+
+# for opencode
+atomic --agent opencode -- /research-codebase "Describe your feature or question"
+
+# for copilot
+atomic --agent copilot -- --agent research-codebase "Describe your feature or question"
+```
+
+```bash
 # clear context window before next step
 /clear
 ```
@@ -125,7 +135,17 @@ atomic --agent claude -- /research-codebase "Describe your feature or question"
 ### 2. Create a Specification
 
 ```bash
+# for claude-code
 atomic --agent claude -- /create-spec [research-path]
+
+# for opencode
+atomic --agent opencode -- /create-spec [research-path]
+
+# for copilot
+atomic --agent copilot -- --agent create-spec [research-path]
+```
+
+```bash
 # clear context window before next step
 /clear
 ```
@@ -135,7 +155,17 @@ atomic --agent claude -- /create-spec [research-path]
 ### 3. Break Into Features
 
 ```bash
+# for claude-code
 atomic --agent claude -- /create-feature-list [spec-path]
+
+# for opencode
+atomic --agent opencode -- /create-feature-list [spec-path]
+
+# for copilot
+atomic --agent copilot -- --agent create-feature-list [spec-path]
+```
+
+```bash
 # clear context window before next step
 /clear
 ```
@@ -151,7 +181,17 @@ atomic --agent claude -- /create-feature-list [spec-path]
 ### 4. Implement Features
 
 ```bash
+# for claude-code
 atomic --agent claude -- /implement-feature
+
+# for opencode
+atomic --agent opencode -- /implement-feature
+
+# for copilot
+atomic --agent copilot -- --agent implement-feature
+```
+
+```bash
 # clear context window before next feature implementation
 /clear
 ```
@@ -168,7 +208,14 @@ Repeat until all features pass.
 Or, use `/ralph:ralph-loop` for autonomous mode to enable multi-hour autonomous coding sessions. More in [Ralph Section](#autonomous-execution-ralph):
 
 ```bash
+# for claude-code
 atomic --agent claude -- /ralph:ralph-loop
+
+# for opencode
+atomic --agent opencode -- /ralph-loop
+
+# for copilot
+atomic --agent copilot -- --agent ralph-loop
 ```
 
 ### 5. Debugging
@@ -180,19 +227,40 @@ If something breaks during implementation that the agent did not catch, you can 
 First, generate a debugging report:
 
 ```bash
+# for claude-code
 atomic --agent claude -- "Use the debugging agent to create a debugging report for [insert error message here]."
+
+# for opencode
+atomic --agent opencode -- "Use the debugging agent to create a debugging report for [insert error message here]."
+
+# for copilot
+atomic --agent copilot -- "Use the debugging agent to create a debugging report for [insert error message here]."
 ```
 
 Then, use the debugging report to guide your agent:
 
 ```bash
+# for claude-code
 atomic --agent claude -- "Follow the debugging report above to resolve the issue."
+
+# for opencode
+atomic --agent opencode -- "Follow the debugging report above to resolve the issue."
+
+# for copilot
+atomic --agent copilot -- "Follow the debugging report above to resolve the issue."
 ```
 
 ### 6. Create Pull Request
 
 ```bash
+# for claude-code
 atomic --agent claude -- /create-gh-pr
+
+# for opencode
+atomic --agent opencode -- /create-gh-pr
+
+# for copilot
+atomic --agent copilot -- --agent create-gh-pr
 ```
 
 ---
@@ -243,11 +311,11 @@ Domain knowledge applied during work. These are automatically invoked when relev
 
 ## Supported Coding Agents
 
-| Agent              | CLI Command                  | Folder       | Context File |
-| ------------------ | ---------------------------- | ------------ | ------------ |
-| Claude Code        | `atomic --agent claude` | `.claude/`   | `CLAUDE.md`  |
-| OpenCode           | `atomic --agent opencode`    | `.opencode/` | `AGENTS.md`  |
-| GitHub Copilot CLI | `atomic --agent copilot` | `.github/`   | `AGENTS.md`  |
+| Agent              | CLI Command               | Folder       | Context File |
+| ------------------ | ------------------------- | ------------ | ------------ |
+| Claude Code        | `atomic --agent claude`   | `.claude/`   | `CLAUDE.md`  |
+| OpenCode           | `atomic --agent opencode` | `.opencode/` | `AGENTS.md`  |
+| GitHub Copilot CLI | `atomic --agent copilot`  | `.github/`   | `AGENTS.md`  |
 
 > **Note:** Use `--` to separate atomic flags from agent arguments. Everything after `--` is passed directly to the agent:
 > ```bash

--- a/src/commands/run-agent.ts
+++ b/src/commands/run-agent.ts
@@ -97,7 +97,11 @@ export async function runAgentCommand(
   }
 
   // Build the command with flags and user-provided arguments
-  const cmd = [agent.cmd, ...agent.additional_flags, ...agentArgs];
+  // Replace "." with actual cwd for flags like --add-dir
+  const flags = agent.additional_flags.map((flag) =>
+    flag === "." ? process.cwd() : flag
+  );
+  const cmd = [agent.cmd, ...flags, ...agentArgs];
 
   if (isDebug) {
     console.error(`[atomic:debug] Spawning command: ${cmd.join(" ")}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,7 @@ export const AGENT_CONFIG: Record<AgentKey, AgentConfig> = {
   copilot: {
     name: "GitHub Copilot CLI",
     cmd: "copilot",
-    additional_flags: ["--allow-all-tools", "--allow-all-paths"],
+    additional_flags: ["--add-dir", ".", "--yolo", "--disable-builtin-mcps"],
     folder: ".github",
     install_url:
       "https://github.com/github/copilot-cli?tab=readme-ov-file#installation",


### PR DESCRIPTION
## Summary

This PR migrates GitHub Copilot CLI from the legacy prompts system to the new agent architecture, aligning it with the standardized agent system used across all supported coding agents (Claude Code, OpenCode, and Copilot CLI).

## Key Changes

### Structural Changes
- **Renamed directory**: `.github/prompts/` → `.github/agents/`
- **File extension change**: `.prompt.md` → `.md` for all agent definitions
- **Added `name` field**: All agent files now include a `name` frontmatter field for proper identification

### Affected Agents
- `cancel-ralph` - Cancel active Ralph Wiggum loop
- `commit` - Create well-formatted conventional commits
- `create-feature-list` - Generate feature lists from specs
- `create-gh-pr` - Create GitHub pull requests
- `create-spec` - Create detailed execution plans
- `explain-code` - Explain code functionality
- `implement-feature` - Implement features from feature list
- `ralph-help` - Ralph Wiggum help documentation
- `ralph-loop` - Start autonomous Ralph Wiggum loop
- `research-codebase` - Document and research codebase

### Configuration Updates
- **Updated `src/config.ts`**: Enhanced Copilot CLI flags
  - Added `--add-dir .` to specify current directory
  - Added `--yolo` flag for automatic confirmations
  - Added `--disable-builtin-mcps` to avoid conflicts
  - Fixed flag interpolation to resolve `.` to actual `process.cwd()`
- **Updated `src/commands/run-agent.ts`**: Added logic to resolve `.` flag to actual working directory

### Documentation
- **Updated `README.md`**: Added comprehensive examples showing command usage across all three agents (Claude Code, OpenCode, and Copilot CLI) for consistency and clarity

## Breaking Changes

⚠️ **The directory structure has changed from `.github/prompts/` to `.github/agents/`**

Users who have:
- Custom automation referencing the old `prompts` directory
- Scripts that depend on `.prompt.md` file extensions

Will need to update their paths and references accordingly.

## Migration Impact

This change standardizes the agent invocation pattern:
- **Before**: `atomic --agent copilot -- /research-codebase`
- **After**: `atomic --agent copilot -- --agent research-codebase`

The new pattern aligns with Copilot CLI's native agent system, providing better integration and consistency across all supported coding agents.