### PR TITLE
docs(readme): fix incorrect agent names in ralph-loop examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,13 @@ Or, use `/ralph:ralph-loop` for autonomous mode to enable multi-hour autonomous 
 
 ```bash
 # for claude-code
-atomic --agent claude -- /ralph:ralph-loop
+atomic --agent claude-code -- /ralph:ralph-loop
 
 # for opencode
-atomic --agent opencode -- /ralph-loop
+atomic --agent opencode -- /ralph:ralph-loop
 
-# for copilot
-atomic --agent copilot -- --agent ralph-loop
+# for copilot-cli
+atomic --agent copilot-cli -- /ralph:ralph-loop
 ```
 
 ### 5. Debugging


### PR DESCRIPTION
## Summary

Fixed incorrect agent identifiers in the ralph-loop autonomous mode examples that referenced non-existent agents. Updated documentation to use the correct agent names that are actually available in the codebase.

## Changes

- **Fixed agent name**: Changed `claude` → `claude-code` to match the actual agent identifier
- **Fixed agent name**: Changed `copilot` → `copilot-cli` to match the actual agent identifier  
- **Fixed command syntax**: Updated opencode example to use `/ralph:ralph-loop` (was missing the `/ralph:` prefix)
- **Fixed command syntax**: Updated copilot-cli example to use `/ralph:ralph-loop` (was incorrectly using `--agent ralph-loop`)

## Impact

Users following the README examples will now be able to successfully run ralph-loop in autonomous mode without encountering "agent not found" errors. All three agent examples now use consistent and correct syntax.