### PR TITLE
docs: fix broken links to coding agent documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Select your agent. The CLI configures your project automatically.
 
 - [bun](https://bun.sh/docs/installation) or [node.js](https://nodejs.org/en/download/) installed
 - Coding agent installed:
-  - [Claude Code](https://docs.anthropic.com/en/docs/claude/setup)
+  - [Claude Code](https://code.claude.com/docs/en/quickstart)
   - [OpenCode](https://opencode.ai)
-  - [GitHub Copilot CLI](https://github.com/github/copilot)
+  - [GitHub Copilot CLI](https://github.com/features/copilot/cli)
 
 ---
 


### PR DESCRIPTION
## Summary
Updates broken documentation links in the Prerequisites section to point to the correct current URLs for Claude Code and GitHub Copilot CLI.

## Changes
- **Claude Code**: Updated link from outdated `/docs/claude/setup` to current quickstart page at `code.claude.com/docs/en/quickstart`
- **GitHub Copilot CLI**: Updated link from repository page to the official features page at `github.com/features/copilot/cli`

## Impact
Users will now be directed to the correct, active documentation pages when setting up prerequisites for using Atomic.