### PR TITLE
fix(hooks): fix windows path handling in ralph plugin hooks.json

### DIFF
--- a/plugins/ralph/hooks/hooks.json
+++ b/plugins/ralph/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/run.cmd hooks/stop-hook.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/run.cmd\" hooks/stop-hook.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Fixes Windows path handling in the Ralph plugin's stop hook by adding proper quotes around the `run.cmd` path to handle spaces and special characters in the `CLAUDE_PLUGIN_ROOT` environment variable.

## Changes
- Added quotes around `"${CLAUDE_PLUGIN_ROOT}/run.cmd"` in `plugins/ralph/hooks/hooks.json`
- Ensures the command executes correctly on Windows when the plugin root path contains spaces

## Impact
- **Bug fix**: Windows users with spaces in their Claude plugin installation path will no longer experience hook execution failures
- **Cross-platform compatibility**: Improves robustness of path handling across different Windows configurations

## Technical Details
The change wraps the path expansion in quotes to prevent shell interpretation issues:
```diff
- "command": "${CLAUDE_PLUGIN_ROOT}/run.cmd hooks/stop-hook.sh"
+ "command": "\"${CLAUDE_PLUGIN_ROOT}/run.cmd\" hooks/stop-hook.sh"
```

This follows Windows shell best practices for handling paths that may contain whitespace or special characters.