### PR TITLE
chore: bump version to 0.1.0 for initial pre-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Configuration management CLI for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bumps package version from 1.0.0 to 0.1.0 in preparation for the initial pre-release of the atomic CLI.

## Changes
- Updated version field in package.json from `1.0.0` to `0.1.0`

## Context
This version number better reflects the early-stage nature of the project as it approaches its first public release. The 0.1.0 version signals that the tool is functional but still in active development.

## Test plan
- [x] Version updated in package.json