### PR TITLE
fix(install): use portable shebang in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Atomic CLI Installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash
 # Usage with version: curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash -s -- v1.0.0


### PR DESCRIPTION
## Summary
Updates the install script shebang to use the more portable `#!/usr/bin/env bash` format instead of `#!/bin/bash`, ensuring the script works on systems where bash is not located at `/bin/bash` (e.g., NixOS, some BSD systems, or custom installations).

## Changes
- Replace `#!/bin/bash` with `#!/usr/bin/env bash` in install.sh:1

## Benefits
- Improved portability across different Unix-like systems
- Follows shell scripting best practices
- No functional changes to the installation logic