### PR TITLE
fix(ci): remove unsupported Windows ARM64 target and add manual trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -50,9 +56,6 @@ jobs:
           # Windows x64
           bun build src/index.ts --compile --minify --target=bun-windows-x64 --outfile dist/atomic-windows-x64.exe
 
-          # Windows arm64
-          bun build src/index.ts --compile --minify --target=bun-windows-arm64 --outfile dist/atomic-windows-arm64.exe
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
@@ -97,7 +100,6 @@ jobs:
             dist/atomic-darwin-x64
             dist/atomic-darwin-arm64
             dist/atomic-windows-x64.exe
-            dist/atomic-windows-arm64.exe
             dist/checksums.txt
 
   # publish-npm:


### PR DESCRIPTION
## Summary
Fixes the CI workflow by removing the unsupported Windows ARM64 binary target and adds the ability to manually trigger releases.

## Changes
- **Removed Windows ARM64 binary compilation** - Bun does not currently support the `bun-windows-arm64` target, which was causing workflow failures
- **Added `workflow_dispatch` trigger** - Enables manual workflow runs with a configurable tag input for ad-hoc releases
- **Updated release artifacts list** - Removed Windows ARM64 binary from the files uploaded to GitHub releases

## Impact
- ✅ CI workflow should now complete successfully without ARM64 Windows build errors
- ✅ Maintainers can manually trigger releases without creating a GitHub release first
- 📦 Windows users on x64 can still download binaries (ARM64 Windows support pending Bun upstream support)

## Test Plan
- [x] Workflow should now complete successfully without Windows ARM64 build errors