### PR TITLE
ci(publish): enable npm publishing in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v0.1.0)'
+        description: "Tag to release (e.g., v0.1.0)"
         required: true
         type: string
 
@@ -131,31 +131,31 @@ jobs:
             dist/atomic-config.zip
             dist/checksums.txt
 
-  # publish-npm:
-  #   name: Publish to npm
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   permissions:
-  #     contents: read
-  #     id-token: write # Required for OIDC provenance
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC provenance
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v6
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-  #     - name: Setup Bun
-  #       uses: oven-sh/setup-bun@v2
-  #       with:
-  #         version: latest
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          version: latest
 
-  #     - name: Install dependencies
-  #       run: bun ci
+      - name: Install dependencies
+        run: bun ci
 
-  #     - name: Setup Node.js for npm publish
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: "lts/*"
-  #         registry-url: "https://registry.npmjs.org"
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          registry-url: "https://registry.npmjs.org"
 
-  #     - name: Publish to npm with provenance
-  #       run: npm publish --provenance --access public
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
Enables automated npm package publishing to the npm registry as part of the release workflow. The `publish-npm` job was previously commented out and is now active.

## Key Changes
- **Uncommented npm publish job**: Activates the `publish-npm` job in `.github/workflows/publish.yml`
- **OIDC provenance support**: Maintains secure publishing with OIDC provenance attestation
- **Workflow integration**: npm publishing runs in parallel with binary releases after successful builds
- **Minor formatting**: Standardizes quote style in workflow configuration (single to double quotes)

## Technical Details
The npm publish job:
- Runs on Ubuntu with the latest Bun runtime
- Requires successful completion of the `build` job
- Uses Node.js LTS for npm publishing
- Publishes with `--provenance` flag for supply chain security
- Publishes with `--access public` for the scoped `@bastani/atomic` package

This enables users to install the CLI via npm:
```bash
npm install -g @bastani/atomic
```

In addition to the existing binary installation method.