### PR TITLE
fix(ci): trigger publish workflow on release published event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary
Changed the GitHub Actions publish workflow trigger from `created` to `published` event. This ensures the workflow runs when a draft release is published, not when the draft is initially created.

## Changes
- Updated `.github/workflows/publish.yml` trigger from `release.types: [created]` to `release.types: [published]`

## Why
When creating releases as drafts first (for review), the `created` event fires immediately when the draft is created. The workflow should only run when the release is actually published to avoid:
- Premature npm package publication
- Unnecessary binary builds for draft releases
- Publishing incomplete or unreviewed releases

## Impact
- Draft releases can now be created and reviewed before triggering the publish workflow
- The workflow (binary builds, npm publish, GitHub release) only runs when releases are published