### PR TITLE
docs(readme): fix ralph command syntax in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,16 +424,16 @@ The loop exits when **any** of these conditions are met:
 
 ```bash
 # Default: implement features until all pass
-/ralph-loop
+/ralph:ralph-loop
 
 # Limit iterations
-/ralph-loop --max-iterations 20
+/ralph:ralph-loop --max-iterations 20
 
 # Custom prompt with completion promise
-/ralph-loop "Build a todo API" --completion-promise "DONE" --max-iterations 20
+/ralph:ralph-loop "Build a todo API" --completion-promise "DONE" --max-iterations 20
 
 # Custom feature list path
-/ralph-loop --feature-list specs/my-features.json
+/ralph:ralph-loop --feature-list specs/my-features.json
 ```
 
 ---


### PR DESCRIPTION
## Summary
Corrected the command syntax in the Ralph Loop examples section to match the proper namespace format.

## Changes
- Updated all example commands from `/ralph-loop` to `/ralph:ralph-loop`
- Updated all example commands from `/ralph-loop --max-iterations` to `/ralph:ralph-loop --max-iterations`
- Updated all example commands from `/ralph-loop --feature-list` to `/ralph:ralph-loop --feature-list`

## Context
The examples section was using the incorrect command syntax without the `ralph:` namespace prefix. The commands table at the beginning of the section correctly showed `/ralph:ralph-loop`, but the examples below were inconsistent with this format.

This ensures users copy the correct command syntax when following the documentation.