### PR TITLE
fix(ralph): sync plugin version with project release 0.4.0

### DIFF
--- a/plugins/ralph/.claude-plugin/plugin.json
+++ b/plugins/ralph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "description": "Implementation of the Ralph Wiggum technique - continuous self-referential AI loops for interactive iterative development. Run Claude in a while-true loop with the same prompt until task completion.",
   "author": {
     "name": "Alex Lavaee",


### PR DESCRIPTION
## Summary
Syncs the Ralph plugin manifest version from `1.0.0` to `0.4.0` to align with the project's current release version.

## Changes
- Updated `plugins/ralph/.claude-plugin/plugin.json` version field from `1.0.0` to `0.4.0`

## Context
The Ralph plugin version was out of sync with the main project version (`0.4.0` in `package.json`). This change ensures version consistency across the monorepo.

## Test plan
- [x] Verify plugin.json shows correct version `0.4.0`
- [ ] Ensure plugin functionality is unaffected by version metadata change