### PR TITLE
chore(release): bump version to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Configuration management CLI for coding agents",
   "type": "module",
   "license": "MIT",

--- a/plugins/ralph/.claude-plugin/plugin.json
+++ b/plugins/ralph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Implementation of the Ralph Wiggum technique - continuous self-referential AI loops for interactive iterative development. Run Claude in a while-true loop with the same prompt until task completion.",
   "author": {
     "name": "Alex Lavaee",


### PR DESCRIPTION
## Summary

Patch release bumping version from 0.4.0 to 0.4.1, including Ralph plugin improvements and version synchronization fixes.

## Changes

- **Ralph Plugin Refactor**: Consolidated commands into `opencode.json` for better organization (#116)
- **Version Sync Fix**: Synchronized Ralph plugin version with main project release (#115)
- **Version Bump**: Updated version in both `package.json` and `plugins/ralph/.claude-plugin/plugin.json`

## Details

This release includes two merged PRs:
- #116: `refactor(ralph): consolidate commands into opencode.json`
- #115: `fix(ralph): sync plugin version with project release 0.4.0`

Both changes improve the Ralph plugin structure and maintain version consistency across the project.