### PR TITLE
chore(release): bump version to 0.4.2 and improve cross-platform compatibility

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,24 +7,13 @@
     "defaultMode": "bypassPermissions"
   },
   "enableAllProjectMcpServers": true,
-  "extraKnownMarketplaces": {
-    "atomic-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "flora131/atomic"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "ralph@atomic-plugins": true
-  },
   "hooks": {
     "SessionEnd": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "bun run \"${CLAUDE_PROJECT_DIR}/.claude/hooks/telemetry-stop.ts\"",
+            "command": "bun run .claude/hooks/telemetry-stop.ts",
             "timeout": 30
           }
         ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Configuration management CLI for coding agents",
   "type": "module",
   "license": "MIT",

--- a/plugins/ralph/.claude-plugin/plugin.json
+++ b/plugins/ralph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Implementation of the Ralph Wiggum technique - continuous self-referential AI loops for interactive iterative development. Run Claude in a while-true loop with the same prompt until task completion.",
   "author": {
     "name": "Alex Lavaee",

--- a/plugins/ralph/hooks/hooks.json
+++ b/plugins/ralph/hooks/hooks.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "rm -f \"${CLAUDE_PROJECT_DIR}/.claude/ralph-loop.local.md\""
+            "command": "bun -e \"require('fs').rmSync(process.env.CLAUDE_PROJECT_DIR+'/.claude/ralph-loop.local.md',{force:true})\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
Release version 0.4.2 with cross-platform compatibility improvements and cleanup of unused plugin marketplace configuration.

## Changes
- **Version bump**: Update version to 0.4.2 in `package.json` and ralph plugin
- **Cross-platform compatibility**: Replace `rm -f` with bun-based file removal for Windows support in ralph plugin cleanup hook
- **Hook simplification**: Remove `${CLAUDE_PROJECT_DIR}` prefix from hook command paths (bun resolves relative paths correctly)
- **Configuration cleanup**: Remove unused `extraKnownMarketplaces` and `enabledPlugins` configuration from `.claude/settings.json`

## Technical Details
The ralph plugin SessionEnd hook now uses a cross-platform Node.js command via bun for file deletion instead of the Unix-specific `rm -f` command.

## Test Plan
- [ ] Verify version displays correctly with `atomic --version`
- [ ] Test hooks execute properly on both Unix and Windows systems
- [ ] Confirm ralph plugin loads and cleanup works correctly
- [ ] Verify telemetry-stop hook executes with simplified path