### PR TITLE
ci: optimize workflow triggers for CI and code review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,18 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "package.json"
+      - "bun.lock"
+      - "tsconfig.json"
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.js"
+      - "**/*.jsx"
 
 jobs:
   typescript-tests:
     name: TypeScript Tests
-    needs: changes
-    if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -2,14 +2,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - "package.json"
-      - "bun.lock"
-      - "tsconfig.json"
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
 
 jobs:
   code-review:


### PR DESCRIPTION
## Summary
Optimizes GitHub Actions workflow triggers to improve CI efficiency and ensure comprehensive code reviews. The CI workflow now only runs when code-related files change, while the code review workflow runs on all PRs regardless of file types.

## Changes
- **CI Workflow** (`.github/workflows/ci.yml`):
  - Added `paths` filter to trigger only on code-related changes (`.ts`, `.tsx`, `.js`, `.jsx`, `package.json`, `bun.lock`, `tsconfig.json`)
  - Removed redundant `needs: changes` dependency and `if` conditional from `typescript-tests` job
  - Simplifies workflow by using workflow-level path filtering instead of job-level conditionals

- **Code Review Workflow** (`.github/workflows/code-review.yml`):
  - Removed `paths` filter to allow Claude to review all PRs, including documentation, configuration, and workflow changes
  - Ensures no PRs bypass automated code review

## Benefits
- **Reduced CI costs**: CI only runs when code changes, saving runner minutes on docs-only PRs
- **Better code coverage**: All PRs get automated review, catching issues in non-code files
- **Simpler configuration**: Cleaner workflow syntax without redundant conditionals

## Test plan
- [x] Verify CI workflow only triggers on code-related file changes
- [x] Verify code review workflow triggers on all PR types
- [x] Confirm no regressions in existing CI behavior