### PR TITLE
ci: rename PR description workflow for clarity

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,4 +1,4 @@
-name: PR Description
+name: Claude Code PR Description
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- Renames the GitHub Actions workflow from "PR Description" to "Claude Code PR Description"
- Makes it clearer that this workflow uses Claude Code to generate PR descriptions

## Test plan
- [ ] Verify the workflow still triggers correctly on pull requests
- [ ] Confirm the new name appears correctly in the GitHub Actions UI