### PR TITLE
docs: add table of contents and shell backtick troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ This approach highlights the best of SDLC and gets you 40-60% of the way there s
 
 ---
 
+## Table of Contents
+
+- [Set up Atomic](#set-up-atomic)
+- [The Flywheel](#the-flywheel)
+- [How It Works](#how-it-works)
+- [The Workflow](#the-workflow)
+- [Commands, Agents, and Skills](#commands-agents-and-skills)
+- [Supported Coding Agents](#supported-coding-agents)
+- [Autonomous Execution (Ralph)](#autonomous-execution-ralph)
+- [Updating Atomic](#updating-atomic)
+- [Uninstalling Atomic](#uninstalling-atomic)
+- [Telemetry](#telemetry)
+- [Troubleshooting](#troubleshooting)
+- [FAQ](#faq)
+- [License](#license)
+- [Credits](#credits)
+
+---
+
 ## Set up Atomic
 
 > Install Atomic and start using it with your preferred AI coding agent.
@@ -599,6 +618,19 @@ git config --global user.email "you@example.com"
 **Windows Command Resolution:** If agents fail to spawn on Windows, ensure the agent CLI is in your PATH. Atomic uses `Bun.which()` to resolve command paths, which handles Windows `.cmd`, `.exe`, and `.bat` extensions automatically.
 
 **File Preservation:** When re-running `atomic init`, your custom `CLAUDE.md` and `AGENTS.md` files are preserved by default. Use `--force` to overwrite all files including `CLAUDE.md`/`AGENTS.md`.
+
+**Shell Interprets Backticks as Commands:** When passing prompts to Atomic CLI commands, your shell (bash/zsh) interprets backticks (`` ` ``) as command substitution before Atomic receives the input. This causes commands like `` `pytest` `` in your prompt to be executed by the shell, resulting in errors like `zsh: command not found: pytest`.
+
+```bash
+# Problem:
+atomic ralph setup -a claude "NEVER run the entire test suite at once with `pytest`."
+# Error: zsh: command not found: pytest
+
+# Solution: Escape backticks with backslash
+atomic ralph setup -a claude "NEVER run the entire test suite at once with \`pytest\`."
+```
+
+This behavior is intentional—shell interpolation allows powerful patterns like `$(cat prompt.txt)` or variable expansion. When you need literal backticks in prompts, escape them.
 
 ---
 


### PR DESCRIPTION
## Summary

Improves README navigation and documentation by adding a table of contents and addressing a common shell command issue.

## Key Changes

- **Added Table of Contents**: Comprehensive TOC with links to all major sections (Set up Atomic, The Flywheel, How It Works, Commands/Agents/Skills, Troubleshooting, FAQ, etc.) for easier navigation of the lengthy README
- **Added Troubleshooting Entry**: Documents shell backtick interpretation issue that occurs when passing prompts with backticks to Atomic CLI commands
  - Explains why commands like `` `pytest` `` in prompts cause `command not found` errors
  - Provides solution: escape backticks with backslash (`\`pytest\``)
  - Clarifies this is intentional shell behavior, not a bug

## Notes

The PR title mentioned FAQ updates, but the FAQ section remains unchanged in this PR. Only the TOC and Troubleshooting sections were modified.