### PR TITLE
docs(ralph): add troubleshooting for cancelling Ralph and worktree best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ atomic ralph setup -a claude "NEVER run the entire test suite at once with \`pyt
 
 This behavior is intentional—shell interpolation allows powerful patterns like `$(cat prompt.txt)` or variable expansion. When you need literal backticks in prompts, escape them.
 
-**Ralph Continues After Stopping Session:** If you stop a Ralph session (e.g., Ctrl+C or esc) and open a new Claude session, Ralph may automatically resume. This is expected behavior—Ralph is designed to run autonomously until all features are complete or explicitly cancelled. You can still interrupt and give it instructions during execution.
+**Ralph Continues After Stopping Session:** If you stop a Ralph session (e.g., Ctrl+C or esc) and open a new Claude session, Ralph may automatically resume. This is expected behavior—Ralph is designed to run autonomously until an exit condition is met (completion promise / max iterations / all features passing) or it’s explicitly cancelled. You can still interrupt and give it instructions during execution.
 
 To properly stop Ralph:
 


### PR DESCRIPTION
## Summary

Adds comprehensive troubleshooting documentation to clarify Ralph's auto-resume behavior and introduces a best practice for running Ralph in isolated git worktrees to avoid interrupting regular development work.

## Changes

### Troubleshooting Documentation
- **Ralph Auto-Resume Clarification**: Documents that Ralph automatically resumes after stopping a session, which is intentional behavior designed to support autonomous execution until an exit condition is met (completion promise, max iterations, or all features passing)
- **Explicit Cancellation Commands**: Provides clear commands to properly cancel Ralph across all supported agent tools:
  - `claude-code`: `atomic run claude "/ralph:cancel-ralph"`
  - `opencode`: `/ralph:cancel-ralph` in the session
  - `copilot`: `atomic run copilot -i "/ralph:cancel-ralph"`

### Best Practice Addition
- **Git Worktree Workflow**: Recommends running Ralph in a separate git worktree to isolate autonomous execution from the main development workspace
- Includes practical example commands for creating and using a worktree specifically for Ralph sessions

## Why This Matters

Users may be confused or frustrated when Ralph automatically resumes after they stop a session (Ctrl+C or esc). This documentation:

1. **Clarifies Expected Behavior**: Explains that auto-resume is intentional and supports Ralph's autonomous execution model
2. **Provides Clear Solutions**: Offers explicit cancellation commands for all supported agents, eliminating guesswork
3. **Improves Workflow**: Introduces the worktree pattern as a best practice, allowing developers to:
   - Run Ralph autonomously in one worktree
   - Continue regular development in their main workspace
   - Avoid context switching and interruptions

## Documentation Impact

Updates the Troubleshooting section in README.md (lines 635-663) with:
- Clear problem statement and explanation
- Code examples for all agent types
- Best practice recommendation with practical commands
- Link to official git worktree documentation

No breaking changes or migrations required.