### PR TITLE
fix(ci): install all platform opentui bindings for cross-compilation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
+      - name: Install all platform-specific opentui native bindings
+        run: |
+          bun add --optional @opentui/core-darwin-x64@0.1.79 @opentui/core-darwin-arm64@0.1.79 \
+            @opentui/core-linux-x64@0.1.79 @opentui/core-linux-arm64@0.1.79 \
+            @opentui/core-win32-x64@0.1.79 @opentui/core-win32-arm64@0.1.79
+
       # TODO: Re-enable after fixing failing tests
       # - name: Run tests
       #   run: bun test


### PR DESCRIPTION
## Summary
Fixes build failures when cross-compiling binaries for multiple platforms in the publish workflow. The workflow now installs all platform-specific `@opentui/core-*` native bindings before running `bun build --compile` for each target platform.

## Problem
When using `bun build --compile --target=bun-<platform>-<arch>` to cross-compile for non-host platforms, Bun resolves dynamic imports like `@opentui/core-${platform}-${arch}` at build time (not runtime). The build was failing with:
```
Could not resolve: "@opentui/core-linux-arm64/index.ts"
```
because only the host platform's native bindings were installed by default.

## Solution
- Explicitly install all 6 platform-specific native bindings as optional dependencies before the build step:
  - `@opentui/core-darwin-x64@0.1.79`
  - `@opentui/core-darwin-arm64@0.1.79`
  - `@opentui/core-linux-x64@0.1.79`
  - `@opentui/core-linux-arm64@0.1.79`
  - `@opentui/core-win32-x64@0.1.79`
  - `@opentui/core-win32-arm64@0.1.79`

This ensures the bundler can resolve all platform imports when compiling for each target.

## Test plan
- [ ] Publish workflow successfully builds all 5 platform binaries (Linux x64/arm64, macOS x64/arm64, Windows x64)
- [ ] No "Could not resolve" errors during cross-compilation
- [ ] Resulting binaries contain the correct native modules for their target platforms