### PR TITLE
fix(ci): force-install cross-platform opentui native bindings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,18 @@ jobs:
 
       - name: Install all platform-specific opentui native bindings
         run: |
-          bun add --optional @opentui/core-darwin-x64@0.1.79 @opentui/core-darwin-arm64@0.1.79 \
-            @opentui/core-linux-x64@0.1.79 @opentui/core-linux-arm64@0.1.79 \
-            @opentui/core-win32-x64@0.1.79 @opentui/core-win32-arm64@0.1.79
+          # Platform packages have os/cpu fields that block install on foreign platforms.
+          # Download and extract tarballs directly to bypass platform checks.
+          OPENTUI_VERSION="0.1.79"
+          for platform in darwin-x64 darwin-arm64 linux-arm64 win32-x64 win32-arm64; do
+            pkg="@opentui/core-${platform}"
+            dest="node_modules/@opentui/core-${platform}"
+            if [ ! -d "$dest" ]; then
+              mkdir -p "$dest"
+              npm pack "${pkg}@${OPENTUI_VERSION}" --pack-destination /tmp 2>/dev/null
+              tar -xzf "/tmp/opentui-core-${platform}-${OPENTUI_VERSION}.tgz" -C "$dest" --strip-components=1
+            fi
+          done
 
       # TODO: Re-enable after fixing failing tests
       # - name: Run tests


### PR DESCRIPTION
## Summary
Fixes cross-platform compilation in the publish workflow by bypassing npm's platform filtering for OpenTUI native bindings. The previous approach using `bun add --optional` failed because platform-specific packages have `os`/`cpu` fields that prevent installation on foreign platforms.

## Changes
- Replaced `bun add --optional` with a custom installation script using `npm pack` + `tar`
- Downloads tarballs for all 5 platform-specific OpenTUI bindings (`darwin-x64`, `darwin-arm64`, `linux-arm64`, `win32-x64`, `win32-arm64`)
- Extracts packages directly into `node_modules/@opentui/core-*`, bypassing platform checks
- Enables `bun build --compile` cross-compilation for all target platforms from a single x64 Linux runner

## Technical Details
The workflow now:
1. Uses `npm pack` to download package tarballs without triggering platform compatibility checks
2. Extracts each tarball directly into the appropriate `node_modules` directory
3. Skips already-installed packages to optimize repeated runs
4. Preserves the version pinning (currently `0.1.79`) for reproducible builds

## Test Plan
- [ ] Verify the publish workflow builds all 5 platform binaries successfully:
  - `atomic-linux-x64`
  - `atomic-linux-arm64`
  - `atomic-darwin-x64`
  - `atomic-darwin-arm64`
  - `atomic-windows-x64.exe`
- [ ] Confirm binaries are uploaded as artifacts and included in GitHub releases