### PR TITLE
fix(copilot): support standalone CLI binaries in path resolution

### DIFF
--- a/src/models/model-operations.ts
+++ b/src/models/model-operations.ts
@@ -238,7 +238,7 @@ export class UnifiedModelOperations implements ModelOperations {
     // index.js path to cliArgs (same fix as CopilotClient.buildSdkOptions).
     const nodePath = resolveNodePath();
     const copilotCliPath = getBundledCopilotCliPath();
-    const clientOpts = nodePath
+    const clientOpts = nodePath && copilotCliPath.endsWith(".js")
       ? { cliPath: nodePath, cliArgs: ["--no-warnings", copilotCliPath] }
       : { cliPath: copilotCliPath };
 


### PR DESCRIPTION
## Summary

Fixes path resolution for standalone Copilot CLI installations (Homebrew, install script, winget) that were previously being incorrectly treated as Node.js scripts.

## Problem

The existing code assumed all Copilot CLI installations were npm packages with an `index.js` entry point, causing standalone binary installations to fail. The code unconditionally wrapped the CLI path with Node.js, attempting to execute binaries as JavaScript files.

## Changes

### Path Resolution Logic
- **`getBundledCopilotCliPath()`**: Now returns binary paths directly for standalone installations instead of only looking for `index.js`
- Added fallback to return the resolved binary path when `index.js` doesn't exist (line 1305-1306)

### Node.js Wrapper Guards
- **`CopilotClient.buildSdkOptions()`**: Added `.endsWith(".js")` check to conditionally apply Node.js wrapper logic
- **`UnifiedModelOperations`**: Added same `.endsWith(".js")` guard for consistency
- Binary paths are now passed directly to the SDK's `cliPath` option instead of being wrapped with `node --no-warnings`

### Error Messages
- Enhanced error message with specific installation instructions for all supported methods:
  - `brew install copilot-cli` (macOS/Linux)
  - `npm install -g @github/copilot` (cross-platform)
  - `winget install GitHub.Copilot` (Windows)
  - `curl -fsSL https://gh.io/copilot-install | bash` (macOS/Linux)

### Documentation
- Updated JSDoc comments to reflect support for both npm package and standalone binary installations

## Technical Details

The fix leverages the Copilot SDK's existing capability to handle non-`.js` CLI paths by spawning them directly as executables. The code now:

1. Detects installation type by checking if the resolved path ends with `.js`
2. For `.js` paths: Uses Node.js wrapper with `--no-warnings` flag (required for node:sqlite support)
3. For binary paths: Passes directly to SDK without Node.js wrapper

## Testing

Verified with:
- ✅ npm global install (`@github/copilot`)
- ✅ Homebrew install (`copilot-cli`)
- ✅ Standalone install script
- ✅ Compiled binary execution