### PR TITLE
chore(release): bump version to 0.4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.13",
+    "version": "0.4.14",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "MIT",


### PR DESCRIPTION
## Release v0.4.14

This patch release includes a bug fix for Copilot CLI integration to support standalone binary installations.

### What's Changed

* **fix(copilot)**: Support standalone CLI binaries in path resolution (#237)
  - Updated `getBundledCopilotCliPath()` to correctly handle standalone Copilot installations (Homebrew, install script, winget)
  - Previously only worked with npm package installations that use `index.js` wrapper
  - Added guard to check for `.js` extension before wrapping with Node.js
  - Improved error messages with specific installation instructions

### Installation

Standalone binaries are now properly detected and spawned as executables instead of being passed as arguments to Node.js.

**Full Changelog**: https://github.com/flora131/atomic/compare/v0.4.13...v0.4.14