### PR TITLE
chore(release): bump version to 0.4.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.14",
+    "version": "0.4.15",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "MIT",


### PR DESCRIPTION
## Release v0.4.15

Patch release with a critical fix for Claude Code CLI path resolution in compiled binaries.

### Changes

- **fix(claude)**: Resolve CLI path for compiled binaries (#241)
  - Add `getBundledClaudeCodePath()` function to properly resolve Claude Code CLI executable path
  - Support both npm package installs and standalone binary installs (Homebrew, install script, WinGet)
  - Prevent Claude SDK from resolving to Bun's virtual filesystem path in compiled binaries
  - Update installation URLs to reflect new docs location (code.claude.com)
  - Fixes #240

### Installation Methods Supported

This release ensures proper CLI path resolution for all official Claude Code installation methods:
- Native install (curl/bash, PowerShell/CMD)
- Homebrew (`brew install --cask claude-code`)
- WinGet (`winget install Anthropic.ClaudeCode`)
- npm package (development only)

### Technical Details

The fix implements a two-step resolution strategy:
1. Try `import.meta.resolve` (works in dev mode)
2. Find 'claude' on `$PATH` and resolve symlinks

This approach mirrors the fix previously applied to Copilot CLI path resolution (commit 0545aa9).