### PR TITLE
feat(cli): remove default agent and resolve from saved config or init

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "atomic",

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -195,12 +195,16 @@ function handleThemeCommand(args: string): { newTheme: "dark" | "light"; message
  */
 export async function chatCommand(options: ChatCommandOptions = {}): Promise<number> {
   const {
-    agentType = "claude",
+    agentType,
     theme = "dark",
     model,
     workflow = false,
     initialPrompt,
   } = options;
+
+  if (!agentType) {
+    throw new Error("agentType is required — resolve via saved config or init before calling chatCommand");
+  }
 
   // CLI flag takes precedence, then persisted preference
   const effectiveModel = model ?? getModelPreference(agentType);


### PR DESCRIPTION
## Summary

Removes the hardcoded default agent (Claude) from the chat command. Instead, the CLI now resolves the agent from saved configuration or prompts the user via init, ensuring an explicit agent choice every time.

## Key Changes

- **Removed default value** from `--agent` flag in `src/cli.ts:98-99`
- **Agent resolution logic** now follows this priority:
  1. CLI flag (`--agent <name>`)
  2. Saved config (`.atomic/settings.json` - local or global)
  3. Auto-run `init` to prompt user selection
- **Updated help text** to reflect new behavior: "Start chat (uses saved agent or runs init)"
- **Added validation** in `chatCommand` to require explicit `agentType` parameter

## Behavior Changes

### Before
```bash
$ atomic chat              # Silently defaulted to Claude
$ atomic chat -a opencode  # Used OpenCode
```

### After
```bash
$ atomic chat              # Uses saved agent OR runs init to prompt
$ atomic chat -a opencode  # Uses OpenCode (flag takes precedence)
```

## Impact

- **First-time users**: Will be prompted to select an agent during their first `atomic chat` command
- **Existing users**: Will use their previously selected agent from `.atomic/settings.json`
- **Breaking change**: None - existing workflows with explicit `--agent` flags continue to work