### PR TITLE
chore(license): update copyright holder to Bastani, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Flora
+Copyright (c) 2025 Bastani, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Updates the copyright holder in the MIT License from "Flora" to "Bastani, Inc." to reflect the proper organizational ownership.

## Changes

- Updated `LICENSE` file copyright line from "Copyright (c) 2025 Flora" to "Copyright (c) 2025 Bastani, Inc."

## Notes

This is purely an administrative update to reflect proper copyright ownership. The MIT License terms and permissions remain unchanged.