### PR TITLE
chore(license): switch from MIT to Business Source License 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,114 @@
-MIT License
+Business Source License 1.1
 
-Copyright (c) 2025 Bastani, Inc.
+Parameters
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensor:             Bastani, Inc.
+Licensed Work:        Atomic
+                      The Licensed Work is (c) 2025 Bastani, Inc.
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided that such use does not include offering the
+                      Licensed Work to third parties on a hosted or embedded
+                      basis in a manner that is competitive with Bastani,
+                      Inc.'s products.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+                      A "competitive offering" is a product or service sold
+                      to third parties, including through paid support
+                      arrangements, that significantly overlaps the
+                      capabilities of any Bastani, Inc. commercial product.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+                      "Hosted" means making the functionality of the Licensed
+                      Work available to third parties as a managed service.
+                      "Embedded" means including the source code or
+                      executable code from the Licensed Work in a competitive
+                      product.
+
+                      Internal use of the Licensed Work within your
+                      organization is expressly permitted and is not
+                      considered a competitive offering, regardless of
+                      whether your organization is a for-profit entity.
+
+Change Date:          2030-02-28
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Software,
+please visit: https://atomic.sh/licensing
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.4.19",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
-    "license": "MIT",
+    "license": "BUSL-1.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/flora131/atomic.git"


### PR DESCRIPTION
## Summary

Replace the MIT license with Business Source License 1.1 (BUSL-1.1) to protect against competitive hosted or embedded use while preserving internal and non-production use rights. The license automatically converts to Apache 2.0 on February 28, 2030.

## Changes

- **LICENSE**: Updated from MIT to BUSL-1.1 with the following parameters:
  - Licensor: Bastani, Inc.
  - Licensed Work: Atomic
  - Change Date: 2030-02-28
  - Change License: Apache License, Version 2.0
- **package.json**: Updated license field from MIT to BUSL-1.1

## License Terms

### Permitted Use
- ✅ Internal use within your organization (commercial or non-commercial)
- ✅ Non-production use
- ✅ Production use for non-competitive purposes
- ✅ Modification and redistribution (under same license terms)

### Restricted Use
- ❌ Offering Atomic to third parties as a hosted service in a competitive manner
- ❌ Embedding Atomic in commercial products that compete with Bastani, Inc.'s offerings

A competitive offering is defined as a product or service sold to third parties that significantly overlaps the capabilities of any Bastani, Inc. commercial product.

## Change Date Conversion

On **February 28, 2030**, this license automatically converts to **Apache 2.0**, making Atomic fully open source.

## Additional Information

For alternative licensing arrangements, visit: https://atomic.sh/licensing