### PR TITLE
docs(license): update README to reflect BSL 1.1 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,7 +774,7 @@ See [DEV_SETUP.md](DEV_SETUP.md) for development setup, testing guidelines, and 
 
 ## License
 
-MIT
+Business Source License 1.1
 
 ## Credits
 


### PR DESCRIPTION
## Summary

Updates the README.md to reflect the project's transition from MIT to Business Source License 1.1, completing the license change initiated in #290.

## Changes

- Updated the License section in README.md from "MIT" to "Business Source License 1.1"
- Aligns documentation with the actual LICENSE file

## License Information

The project now uses the **Business Source License 1.1** (BSL 1.1):

- **Permitted Use**: Internal use within your organization, including for-profit entities, is fully permitted
- **Production Use**: Allowed, except for competitive hosted or embedded offerings that overlap with Bastani, Inc.'s commercial products
- **Change Date**: 2030-02-28 - the license will automatically convert to Apache License 2.0
- **Non-OSI License**: BSL 1.1 is not an Open Source license, but will become one on the Change Date

This license allows broad usage while preventing direct commercial competition with the licensor's products.