### PR TITLE
chore: bump version to 0.4.21 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.20",
+    "version": "0.4.21",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary

Incremental version bump to prepare for the next release of the Atomic CLI.

## Changes

- Bumped version from `0.4.20` to `0.4.21` in `package.json`

## Context

This is a routine version update following semantic versioning for the `@bastani/atomic` package, which provides configuration management for coding agents (Claude, OpenCode, and Copilot).

---
*Assistant-model: Claude Code*