### PR TITLE
fix(claude): use interrupt() instead of close() to preserve session across cancellations

### DIFF
--- a/src/events/adapters/adapters.test.ts
+++ b/src/events/adapters/adapters.test.ts
@@ -1564,8 +1564,8 @@ describe("ClaudeStreamAdapter", () => {
       messageId: "msg-2",
     });
 
-    // Should have session.start + 2 delta events + 1 complete event
-    expect(events.length).toBe(4);
+    // Should have session.start + 2 delta events + 1 complete event + 1 idle
+    expect(events.length).toBe(5);
 
     const deltaEvents = events.filter((e) => e.type === "stream.text.delta");
     expect(deltaEvents.length).toBe(2);
@@ -1628,7 +1628,7 @@ describe("ClaudeStreamAdapter", () => {
     expect(thinkingCompleteEvents[0].data.durationMs).toBe(500);
   });
 
-  test("publishes session idle events from SDK client", async () => {
+  test("publishes session idle from stream completion and ignores client idle events", async () => {
     const events = collectEvents(bus);
     const client = createMockClient();
 
@@ -1641,7 +1641,8 @@ describe("ClaudeStreamAdapter", () => {
       messageId: "msg-2",
     });
 
-    // Ignore events from other sessions.
+    // Client-level idle events are ignored for Claude to prevent stale
+    // previous-run idle markers from being reassigned to the active run.
     client.emit("session.idle" as EventType, {
       type: "session.idle",
       sessionId: "other-session",
@@ -1660,8 +1661,68 @@ describe("ClaudeStreamAdapter", () => {
 
     const idleEvents = events.filter((e) => e.type === "stream.session.idle");
     expect(idleEvents.length).toBe(1);
-    expect(idleEvents[0].data.reason).toBe("completed");
+    expect(idleEvents[0].data.reason).toBe("generator-complete");
     expect(idleEvents[0].runId).toBe(100);
+  });
+
+  test("ignores stale client idle emitted after an interrupted run", async () => {
+    const events = collectEvents(bus);
+    const client = createMockClient();
+
+    const streams: Array<AsyncGenerator<AgentMessage>> = [
+      (async function* interruptedRun(): AsyncGenerator<AgentMessage> {
+        yield { type: "text", content: "partial" };
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        yield { type: "text", content: "late" };
+      })(),
+      (async function* nextRun(): AsyncGenerator<AgentMessage> {
+        yield { type: "text", content: "second-run" };
+      })(),
+    ];
+
+    const session = {
+      id: "test-session-123",
+      stream: mock(() => streams.shift()!),
+      __client: client,
+    } as unknown as Session;
+
+    const firstAbort = new AbortController();
+    const firstRun = adapter.startStreaming(session, "first", {
+      runId: 200,
+      messageId: "msg-first",
+      abortSignal: firstAbort.signal,
+    });
+    firstAbort.abort();
+    await firstRun;
+
+    const secondRun = adapter.startStreaming(session, "second", {
+      runId: 201,
+      messageId: "msg-second",
+    });
+
+    // Simulate a late idle signal from the interrupted first run arriving
+    // while the second run is active.
+    client.emit("session.idle" as EventType, {
+      type: "session.idle",
+      sessionId: "test-session-123",
+      timestamp: Date.now(),
+      data: { reason: "completed" },
+    } as AgentEvent<"session.idle">);
+
+    await secondRun;
+
+    const secondRunEvents = events.filter((event) => event.runId === 201);
+    const secondRunDelta = secondRunEvents.filter((event) => event.type === "stream.text.delta");
+    expect(secondRunDelta.length).toBe(1);
+    expect(secondRunDelta[0].data.delta).toBe("second-run");
+
+    const secondRunComplete = secondRunEvents.find((event) => event.type === "stream.text.complete");
+    expect(secondRunComplete).toBeDefined();
+    expect(secondRunComplete?.data.fullText).toBe("second-run");
+
+    const secondRunIdle = secondRunEvents.filter((event) => event.type === "stream.session.idle");
+    expect(secondRunIdle.length).toBe(1);
+    expect(secondRunIdle[0].data.reason).toBe("generator-complete");
   });
 
   test("publishes session error on stream error", async () => {
@@ -1771,8 +1832,8 @@ describe("ClaudeStreamAdapter", () => {
       messageId: "msg-2",
     });
 
-    // Should only have session.start, text delta, and text complete events
-    expect(events.length).toBe(3);
+    // Should only have session.start, text delta, text.complete, and session.idle events
+    expect(events.length).toBe(4);
     expect(events.some((e) => e.type === "stream.text.delta")).toBe(true);
     expect(events.some((e) => e.type === "stream.text.complete")).toBe(true);
   });
@@ -1793,10 +1854,13 @@ describe("ClaudeStreamAdapter", () => {
       messageId: "msg-2",
     });
 
-    // Complete event should be the last event
+    // Session idle should be the last event after text completion
     const lastEvent = events[events.length - 1];
-    expect(lastEvent.type).toBe("stream.text.complete");
-    expect(lastEvent.data.fullText).toBe("First Second");
+    const completeEvent = events.find((e) => e.type === "stream.text.complete");
+    expect(completeEvent).toBeDefined();
+    expect(completeEvent?.data.fullText).toBe("First Second");
+    expect(lastEvent.type).toBe("stream.session.idle");
+    expect(lastEvent.data.reason).toBe("generator-complete");
   });
 
   test("publishes tool start events from stream (tool_use)", async () => {

--- a/src/events/adapters/claude-adapter.ts
+++ b/src/events/adapters/claude-adapter.ts
@@ -46,7 +46,6 @@ import type {
   Session,
   AgentMessage,
   EventHandler,
-  SessionIdleEventData,
   SessionErrorEventData,
   SessionInfoEventData,
   SessionWarningEventData,
@@ -180,7 +179,7 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
     message: string,
     options: StreamAdapterOptions,
   ): Promise<void> {
-    const { runId, messageId, agent, runtimeFeatureFlags } = options;
+    const { runId, messageId, agent, runtimeFeatureFlags, abortSignal } = options;
 
     // Clean up any existing subscriptions from a previous startStreaming() call
     // to prevent subscription accumulation on re-entry without dispose()
@@ -188,6 +187,14 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
 
     // Create abort controller for cancellation
     this.abortController = new AbortController();
+    const forwardExternalAbort = () => {
+      this.abortController?.abort();
+    };
+    if (abortSignal?.aborted) {
+      forwardExternalAbort();
+    } else if (abortSignal) {
+      abortSignal.addEventListener("abort", forwardExternalAbort, { once: true });
+    }
 
     // Reset text accumulator
     this.textAccumulator = "";
@@ -258,12 +265,6 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
         this.createSubagentUpdateHandler(runId),
       );
       this.unsubscribers.push(unsubAgentUpdate);
-
-      const unsubIdle = client.on(
-        "session.idle",
-        this.createSessionIdleHandler(runId),
-      );
-      this.unsubscribers.push(unsubIdle);
 
       const unsubSessionError = client.on(
         "session.error",
@@ -357,6 +358,8 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
       this.unsubscribers.push(unsubSessionCompaction);
     }
 
+    let streamCompletionReason: "generator-complete" | "aborted" | "error" = "generator-complete";
+
     try {
       // Retry loop for transient failures (429, 503, ECONNRESET, etc.)
       let lastError: unknown = null;
@@ -369,17 +372,23 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
           for await (const chunk of stream) {
             // Check for cancellation
             if (this.abortController.signal.aborted) {
+              streamCompletionReason = "aborted";
               break;
             }
 
             this.processStreamChunk(chunk, runId, messageId);
           }
 
+          const wasAborted = this.abortController.signal.aborted;
+
           // Publish stream.text.complete event if we accumulated any text
-          if (this.textAccumulator.length > 0) {
+          // and this run was not interrupted.
+          if (!wasAborted && this.textAccumulator.length > 0) {
             this.publishTextComplete(runId, messageId);
           }
-          this.publishSyntheticAgentComplete(runId, true);
+          if (!wasAborted) {
+            this.publishSyntheticAgentComplete(runId, true);
+          }
 
           // Stream completed successfully — exit retry loop
           lastError = null;
@@ -388,7 +397,10 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
           lastError = error;
 
           // Don't retry aborted requests
-          if (this.abortController?.signal.aborted) break;
+          if (this.abortController?.signal.aborted) {
+            streamCompletionReason = "aborted";
+            break;
+          }
 
           const classified = classifyError(error);
           if (!classified.isRetryable || attempt >= DEFAULT_MAX_RETRIES) break;
@@ -419,27 +431,26 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
       if (lastError) throw lastError;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
+      if (this.abortController?.signal.aborted) {
+        streamCompletionReason = "aborted";
+      }
       // Handle stream errors
       if (this.abortController && !this.abortController.signal.aborted) {
+        streamCompletionReason = "error";
         this.publishSessionError(runId, error);
-        // Publish session.idle after error so the UI can finalize
-        // (matches OpenCode adapter pattern for consistent state transitions)
-        const idleEvent: BusEvent<"stream.session.idle"> = {
-          type: "stream.session.idle",
-          sessionId: this.sessionId,
-          runId,
-          timestamp: Date.now(),
-          data: { reason: "error" },
-        };
-        this.bus.publish(idleEvent);
       }
       this.publishSyntheticAgentComplete(runId, false, errorMessage);
     } finally {
+      if (abortSignal) {
+        abortSignal.removeEventListener("abort", forwardExternalAbort);
+      }
       if (this.abortController?.signal.aborted) {
+        streamCompletionReason = "aborted";
         this.publishSyntheticAgentComplete(runId, false, "Tool execution aborted");
       }
       // Force-complete any tools still pending/running — prevents orphaned tool state
       this.cleanupOrphanedTools(runId);
+      this.publishSessionIdle(runId, streamCompletionReason);
       // Keep subscriptions until dispose() so delayed hook events can complete tools.
     }
   }
@@ -1513,28 +1524,6 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
     };
   }
 
-  private createSessionIdleHandler(
-    runId: number,
-  ): EventHandler<"session.idle"> {
-    return (event) => {
-      if (event.sessionId !== this.sessionId) {
-        return;
-      }
-
-      const data = event.data as SessionIdleEventData;
-      const busEvent: BusEvent<"stream.session.idle"> = {
-        type: "stream.session.idle",
-        sessionId: this.sessionId,
-        runId,
-        timestamp: Date.now(),
-        data: {
-          reason: typeof data.reason === "string" ? data.reason : undefined,
-        },
-      };
-      this.bus.publish(busEvent);
-    };
-  }
-
   private publishSessionStart(runId: number): void {
     const event: BusEvent<"stream.session.start"> = {
       type: "stream.session.start",
@@ -1542,6 +1531,20 @@ export class ClaudeStreamAdapter implements SDKStreamAdapter {
       runId,
       timestamp: Date.now(),
       data: {},
+    };
+    this.bus.publish(event);
+  }
+
+  private publishSessionIdle(
+    runId: number,
+    reason: "generator-complete" | "aborted" | "error",
+  ): void {
+    const event: BusEvent<"stream.session.idle"> = {
+      type: "stream.session.idle",
+      sessionId: this.sessionId,
+      runId,
+      timestamp: Date.now(),
+      data: { reason },
     };
     this.bus.publish(event);
   }

--- a/src/sdk/clients/claude.interrupt-resume-regression.test.ts
+++ b/src/sdk/clients/claude.interrupt-resume-regression.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let queryCallCount = 0;
+let interruptCalls = 0;
+let closeCalls = 0;
+let forceClosed = false;
+let releaseFirstRun: (() => void) | null = null;
+let resolveFirstQueryStarted: (() => void) | null = null;
+let firstQueryStarted: Promise<void> = Promise.resolve();
+let resolveFirstRunBlocked: (() => void) | null = null;
+let firstRunBlocked: Promise<void> = Promise.resolve();
+const capturedOptions: Array<Record<string, unknown> | undefined> = [];
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+    query: ({
+        options,
+    }: {
+        prompt: string;
+        options?: Record<string, unknown>;
+    }) => {
+        queryCallCount += 1;
+        const callNumber = queryCallCount;
+        capturedOptions.push(options);
+
+        if (callNumber === 1) {
+            resolveFirstQueryStarted?.();
+        }
+
+        return {
+            async *[Symbol.asyncIterator]() {
+                if (callNumber === 2 && forceClosed) {
+                    throw new Error("Claude Code process exited with code 1");
+                }
+
+                const sdkSessionId = "sdk-interrupt-regression";
+                yield {
+                    type: "system",
+                    subtype: "init",
+                    model: "claude-3-5-sonnet-20241022",
+                    session_id: sdkSessionId,
+                };
+
+                yield {
+                    type: "stream_event",
+                    event: {
+                        type: "content_block_delta",
+                        delta: {
+                            type: "text_delta",
+                            text: callNumber === 1 ? "first" : "second",
+                        },
+                    },
+                    session_id: sdkSessionId,
+                };
+
+                if (callNumber === 1) {
+                    await new Promise<void>((resolve) => {
+                        releaseFirstRun = resolve;
+                        resolveFirstRunBlocked?.();
+                    });
+                }
+
+                yield {
+                    type: "result",
+                    subtype: "success",
+                    usage: { input_tokens: 1, output_tokens: 1 },
+                    session_id: sdkSessionId,
+                };
+            },
+            interrupt: async () => {
+                interruptCalls += 1;
+                releaseFirstRun?.();
+                releaseFirstRun = null;
+            },
+            close: () => {
+                closeCalls += 1;
+                forceClosed = true;
+                releaseFirstRun?.();
+                releaseFirstRun = null;
+            },
+            mcpServerStatus: async () => [],
+            supportedModels: async () => [],
+        };
+    },
+    createSdkMcpServer: () => ({
+        close: () => {
+            return;
+        },
+    }),
+}));
+
+describe("ClaudeAgentClient interrupt resume regression", () => {
+    beforeEach(() => {
+        queryCallCount = 0;
+        interruptCalls = 0;
+        closeCalls = 0;
+        forceClosed = false;
+        releaseFirstRun = null;
+        capturedOptions.length = 0;
+        firstQueryStarted = new Promise<void>((resolve) => {
+            resolveFirstQueryStarted = resolve;
+        });
+        firstRunBlocked = new Promise<void>((resolve) => {
+            resolveFirstRunBlocked = resolve;
+        });
+    });
+
+    test("interrupting a run does not poison the next resumed stream", async () => {
+        const { ClaudeAgentClient } = await import("./claude.ts");
+        const client = new ClaudeAgentClient();
+
+        const privateClient = client as unknown as {
+            buildSdkOptions: (
+                config: Record<string, unknown>,
+                sessionId?: string,
+            ) => Record<string, unknown>;
+            wrapQuery: (
+                queryInstance: null,
+                sessionId: string,
+                config: Record<string, unknown>,
+            ) => {
+                stream: (message: string) => AsyncIterable<{
+                    type: string;
+                    content?: unknown;
+                }>;
+                abort: () => Promise<void>;
+                destroy: () => Promise<void>;
+            };
+        };
+
+        privateClient.buildSdkOptions = () => ({});
+        const session = privateClient.wrapQuery(null, "interrupt-session", {});
+
+        const firstRunChunks: string[] = [];
+        const firstRunPromise = (async () => {
+            for await (const chunk of session.stream("first run")) {
+                if (chunk.type === "text" && typeof chunk.content === "string") {
+                    firstRunChunks.push(chunk.content);
+                }
+            }
+        })();
+
+        await firstQueryStarted;
+        await firstRunBlocked;
+        await session.abort();
+        await firstRunPromise;
+
+        const secondRunChunks: string[] = [];
+        for await (const chunk of session.stream("second run")) {
+            if (chunk.type === "text" && typeof chunk.content === "string") {
+                secondRunChunks.push(chunk.content);
+            }
+        }
+
+        expect(firstRunChunks.join("")).toBe("first");
+        expect(secondRunChunks.join("")).toBe("second");
+        expect(interruptCalls).toBe(1);
+        expect(closeCalls).toBe(0);
+        expect(capturedOptions[1]?.resume).toBe("sdk-interrupt-regression");
+
+        await session.destroy();
+    });
+});

--- a/src/sdk/clients/claude.ts
+++ b/src/sdk/clients/claude.ts
@@ -1240,18 +1240,48 @@ export class ClaudeAgentClient implements CodingAgentClient {
             },
 
             abort: async (): Promise<void> => {
-                // Close the active query to terminate in-flight SDK work
-                // (including sub-agent invocations). The session remains
-                // reusable for subsequent queries via resume.
-                state.query?.close();
+                // Prefer graceful interruption so the underlying Claude Code
+                // session remains reusable for the next turn. Force-close only
+                // as a fallback for runtimes that do not expose interrupt().
+                const activeQuery = state.query as
+                    | (Query & {
+                          interrupt?: () => Promise<void>;
+                      })
+                    | null;
+                if (!activeQuery) {
+                    return;
+                }
+                if (typeof activeQuery.interrupt === "function") {
+                    try {
+                        await activeQuery.interrupt();
+                        return;
+                    } catch {
+                        // Fall through to force-close fallback.
+                    }
+                }
+                activeQuery.close();
             },
 
             abortBackgroundAgents: async (): Promise<void> => {
-                // Close the active query to terminate background agents.
-                // The Claude SDK manages sub-agents internally within the
-                // query; closing it terminates all in-flight work including
-                // background sub-agent invocations.
-                state.query?.close();
+                // Prefer graceful interruption to avoid poisoning the next
+                // resumed turn after background/foreground cancellation.
+                const activeQuery = state.query as
+                    | (Query & {
+                          interrupt?: () => Promise<void>;
+                      })
+                    | null;
+                if (!activeQuery) {
+                    return;
+                }
+                if (typeof activeQuery.interrupt === "function") {
+                    try {
+                        await activeQuery.interrupt();
+                        return;
+                    } catch {
+                        // Fall through to force-close fallback.
+                    }
+                }
+                activeQuery.close();
             },
 
             destroy: async (): Promise<void> => {


### PR DESCRIPTION
## Summary

Fixes a critical regression where aborting a Claude Code run would poison the underlying session, causing subsequent resumed turns to fail with "Claude Code process exited with code 1".

**Key changes:**
- Replace `query.close()` with `query.interrupt()` in `abort()` and `abortBackgroundAgents()` so the underlying Claude Code session remains reusable for subsequent resumed turns, falling back to `close()` only when `interrupt()` is unavailable
- Move `session.idle` emission from an SDK client event listener (which could fire stale idle signals from previous runs) to a deterministic `publishSessionIdle()` call in the stream's `finally` block with typed completion reasons (`generator-complete`, `aborted`, `error`)
- Forward external `abortSignal` into the adapter's internal `AbortController` and suppress `text-complete`/`agent-complete` events when the stream was interrupted

**Why this matters:**
Using `close()` terminates the entire Claude Code process, requiring a full restart for the next query. The new `interrupt()` method gracefully pauses execution while keeping the session alive, enabling instant resumption without process overhead. This significantly improves user experience when canceling long-running operations or background agents.

**Additional improvements:**
- Eliminates race conditions where stale `session.idle` events from interrupted runs could be incorrectly attributed to the active run
- Ensures completion events are only published for runs that actually completed (not interrupted runs)
- Provides more accurate completion state tracking with explicit `aborted`, `error`, and `generator-complete` reasons

## Test plan

- [x] New regression test (`claude.interrupt-resume-regression.test.ts`) verifies that interrupting a run uses `interrupt()` instead of `close()` and the next resumed stream works correctly without throwing "Claude Code process exited" errors
- [x] New adapter test (`ignores stale client idle emitted after an interrupted run`) verifies stale idle signals from a previous run are not reassigned to the active run
- [x] Updated existing adapter tests to account for deterministic idle event emission in the `finally` block
- [x] All 2698 tests pass