### PR TITLE
ci(publish): add support for prerelease branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - "release/**"
+            - "prerelease/**"
     release:
         types: [published]
     workflow_dispatch:
@@ -156,6 +157,17 @@ jobs:
               id: version
               run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
 
+            - name: Determine release type
+              id: release-type
+              run: |
+                  if [[ "${{ github.ref }}" == refs/heads/prerelease/* ]]; then
+                    echo "is_prerelease=true" >> $GITHUB_OUTPUT
+                    echo "make_latest=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "is_prerelease=false" >> $GITHUB_OUTPUT
+                    echo "make_latest=true" >> $GITHUB_OUTPUT
+                  fi
+
             - name: Create checksums
               run: |
                   cd dist
@@ -177,7 +189,8 @@ jobs:
                   tag_name: v${{ steps.version.outputs.version }}
                   name: v${{ steps.version.outputs.version }}
                   draft: false
-                  prerelease: false
+                  prerelease: ${{ steps.release-type.outputs.is_prerelease == 'true' }}
+                  make_latest: ${{ steps.release-type.outputs.make_latest }}
                   generate_release_notes: true
                   files: |
                       dist/atomic-linux-x64


### PR DESCRIPTION
## Summary

Extends the publish workflow to support prerelease versions by adding `prerelease/**` branch support alongside the existing `release/**` branches.

## Key Changes

- **Workflow trigger**: Added `prerelease/**` branches to the push triggers
- **Release type detection**: New step that automatically determines if a release is a prerelease based on the branch name pattern
- **Dynamic release flags**: GitHub releases are now created with appropriate flags:
  - Releases from `prerelease/**` branches → marked as prerelease, not marked as latest
  - Releases from `release/**` branches → marked as stable, set as latest

## Behavior

When pushing to a `prerelease/*` branch:
- ✅ Builds and publishes binaries
- ✅ Creates a GitHub release marked as "prerelease"
- ✅ Does NOT mark the release as "latest" (preventing users from accidentally getting prereleases)

When pushing to a `release/*` branch (existing behavior):
- ✅ Builds and publishes binaries
- ✅ Creates a GitHub release marked as stable
- ✅ Marks the release as "latest"

## Testing

This branch itself serves as a test case for the prerelease workflow functionality.