### PR TITLE
chore: release v0.4.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.21",
+    "version": "0.4.22",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary

Version bump to 0.4.22 including recent enhancements and fixes.

## Changes Included

This release includes the following changes since v0.4.21:

- **feat(agents)**: Enhanced research capabilities and PR creation workflow (#314)
- **fix(claude)**: Use `interrupt()` instead of `close()` to preserve session across cancellations (#308)
- **chore**: Update bun package (#309)
- **chore**: Add prerelease branch for testing (#316)
- **hotfix**: Claude model selector improvements (#315)

## Type

Prerelease version bump