### PR TITLE
feat(install): add --prerelease flag to install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,25 @@ iex "& { $(irm https://raw.githubusercontent.com/flora131/atomic/main/install.ps
 </details>
 
 <details>
+<summary>Install a prerelease version</summary>
+
+> **⚠️ Warning:** Prerelease versions are unstable and may contain breaking changes, incomplete features, or bugs. Use them for testing and feedback only — not in production workflows.
+
+**macOS / Linux:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash -s -- --prerelease
+```
+
+**Windows PowerShell:**
+
+```powershell
+iex "& { $(irm https://raw.githubusercontent.com/flora131/atomic/main/install.ps1) } -Prerelease"
+```
+
+</details>
+
+<details>
 <summary>Custom install directory</summary>
 
 **macOS / Linux:**

--- a/install.ps1
+++ b/install.ps1
@@ -1,13 +1,15 @@
 # Atomic CLI Installer for Windows
 # Usage: irm https://raw.githubusercontent.com/flora131/atomic/main/install.ps1 | iex
 # Usage with version: iex "& { $(irm https://raw.githubusercontent.com/flora131/atomic/main/install.ps1) } -Version v1.0.0"
+# Usage prerelease: iex "& { $(irm https://raw.githubusercontent.com/flora131/atomic/main/install.ps1) } -Prerelease"
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '')]
 param(
     [String]$Version = "latest",
     [String]$InstallDir = "",
-    [Switch]$NoPathUpdate = $false
+    [Switch]$NoPathUpdate = $false,
+    [Switch]$Prerelease = $false
 )
 
 $ErrorActionPreference = 'Stop'
@@ -166,14 +168,27 @@ $null = New-Item -ItemType Directory -Force -Path $DataDir
 if ($Version -eq "latest") {
     Write-Info "Fetching latest version..."
     try {
-        $Release = Invoke-RestMethod "https://api.github.com/repos/${GithubRepo}/releases/latest"
+        if ($Prerelease) {
+            $Releases = Invoke-RestMethod "https://api.github.com/repos/${GithubRepo}/releases"
+            $Release = $Releases | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1
+            if (-not $Release) {
+                Write-Err "No prerelease found"
+                exit 1
+            }
+        } else {
+            $Release = Invoke-RestMethod "https://api.github.com/repos/${GithubRepo}/releases/latest"
+        }
         $Version = $Release.tag_name
     } catch {
         Write-Err "Failed to fetch latest version: $_"
         exit 1
     }
 }
-Write-Info "Installing version: $Version"
+if ($Prerelease -and $Version -ne "latest") {
+    Write-Info "Installing prerelease: $Version"
+} else {
+    Write-Info "Installing version: $Version"
+}
 
 # Setup URLs
 $BaseUrl = "https://github.com/${GithubRepo}/releases/download/${Version}"

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 # Atomic CLI Installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash
 # Usage with version: curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash -s -- v1.0.0
+# Usage prerelease: curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash -s -- --prerelease
 
 set -euo pipefail
 
@@ -244,15 +245,32 @@ sync_global_agent_configs() {
     fi
 }
 
-# Get latest version
+# Get latest version (stable or prerelease)
 get_latest_version() {
-    curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" |
-        grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    local prerelease="${1:-false}"
+    if [[ "$prerelease" == "true" ]]; then
+        curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases" |
+            grep -E '"tag_name"|"prerelease"' | paste - - |
+            grep '"prerelease": true' | head -1 |
+            sed -E 's/.*"tag_name": "([^"]+)".*/\1/'
+    else
+        curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" |
+            grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+    fi
 }
 
 # Main installation
 main() {
-    local version="${1:-}"
+    local version="" prerelease="false"
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --prerelease) prerelease="true"; shift ;;
+            *) version="$1"; shift ;;
+        esac
+    done
+
     local platform download_url checksums_url config_url tmp_dir
 
     # Check dependencies
@@ -265,8 +283,15 @@ main() {
 
     # Get version
     if [[ -z "$version" ]]; then
-        version=$(get_latest_version)
-        info "Latest version: $version"
+        version=$(get_latest_version "$prerelease")
+        if [[ -z "$version" ]]; then
+            error "No ${prerelease:+pre}release found"
+        fi
+        if [[ "$prerelease" == "true" ]]; then
+            info "Latest prerelease: $version"
+        else
+            info "Latest version: $version"
+        fi
     fi
 
     # Setup directories


### PR DESCRIPTION
## Summary

Add a `--prerelease` flag to both `install.sh` and `install.ps1` so testers can install the latest GitHub prerelease binary. Default behavior is unchanged — only stable releases are installed without the flag.

## Changes

- **install.sh**: Add `--prerelease` flag and argument parser; `get_latest_version()` queries `/releases` API filtering for prereleases when the flag is set
- **install.ps1**: Add `-Prerelease` switch parameter with equivalent logic using `Invoke-RestMethod`
- **README.md**: Add "Install a prerelease version" section under Advanced Installation with instability warning

## Notes

- The default install path continues using GitHub's `/releases/latest` endpoint, which guarantees only stable (non-prerelease, non-draft) releases
- The `--prerelease` flag can be combined with a specific version tag, in which case the flag is ignored and the specified version is installed directly