### PR TITLE
chore: bump version to 0.4.22-3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.22-2",
+    "version": "0.4.22-3",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary
Increments the package version from `0.4.22-2` to `0.4.22-3` as part of the prerelease workflow.

## Changes
- 📦 Bump `package.json` version: `0.4.22-2` → `0.4.22-3`
- 🔀 Prepared prerelease branch `prerelease/v0.4.22-3` for merging into `main`

## Details
This is a patch-level prerelease version increment for the `@bastani/atomic` package, which is a configuration management CLI for coding agents (Claude, Copilot, OpenCode).

**Type:** Prerelease version bump  
**Impact:** No breaking changes or functional modifications