### PR TITLE
chore: prerelease v0.4.22-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.22-3",
+    "version": "0.4.22-4",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary

Prerelease version bump to v0.4.22-4, including bug fixes for clipboard reliability and SDK improvements.

## Changes

- Bump package.json version from `0.4.22-3` to `0.4.22-4`

## Included Fixes

This prerelease includes the following bug fixes:

- **UI**: Improve clipboard reliability across terminals (#320)
- **SDK**: Improve model display accuracy and Copilot event reliability (#325)

## Version Details

- **Previous version**: 0.4.22-3
- **New version**: 0.4.22-4
- **Type**: Prerelease