### PR TITLE
fix(opencode): classify reasoning deltas as thinking in stream events

### DIFF
--- a/src/events/adapters/adapters.test.ts
+++ b/src/events/adapters/adapters.test.ts
@@ -1425,6 +1425,56 @@ describe("OpenCodeStreamAdapter", () => {
     expect(events.some((e) => e.type === "stream.thinking.complete" && e.data.sourceKey === "reasoning-1")).toBe(true);
   });
 
+  test("treats message.delta contentType=reasoning as thinking", async () => {
+    const events = collectEvents(bus);
+    const client = createMockClient();
+    const adapterWithClient = new OpenCodeStreamAdapter(bus, "test-session-123", client);
+
+    const stream = mockAsyncStream([{ type: "text", content: "done" }]);
+    const session = createMockSession(stream, client);
+
+    const streamPromise = adapterWithClient.startStreaming(session, "test message", {
+      runId: 42,
+      messageId: "msg-opencode-reasoning-content-type",
+    });
+
+    client.emit("message.delta" as EventType, {
+      type: "message.delta",
+      sessionId: "test-session-123",
+      timestamp: Date.now(),
+      data: {
+        delta: "reasoning via content type",
+        contentType: "reasoning",
+        thinkingSourceKey: "reasoning-content-type-1",
+      },
+    } as AgentEvent<"message.delta">);
+
+    client.emit("message.complete" as EventType, {
+      type: "message.complete",
+      sessionId: "test-session-123",
+      timestamp: Date.now(),
+      data: {
+        message: "",
+      },
+    } as AgentEvent<"message.complete">);
+
+    await streamPromise;
+
+    expect(
+      events.some(
+        (event) => event.type === "stream.thinking.delta"
+          && event.data.sourceKey === "reasoning-content-type-1"
+          && event.data.delta === "reasoning via content type",
+      ),
+    ).toBe(true);
+    expect(
+      events.some(
+        (event) => event.type === "stream.text.delta"
+          && event.data.delta === "reasoning via content type",
+      ),
+    ).toBe(false);
+  });
+
   test("bridges callId-first subagent.start to later Task toolUseId and preserves a single canonical correlation", async () => {
     const events = collectEvents(bus);
     const client = createMockClient();

--- a/src/events/adapters/opencode-adapter.ts
+++ b/src/events/adapters/opencode-adapter.ts
@@ -798,10 +798,13 @@ export class OpenCodeStreamAdapter implements SDKStreamAdapter {
       if (this.abortController?.signal.aborted) return;
 
       const { delta, contentType, thinkingSourceKey } = event.data;
+      const normalizedContentType = typeof contentType === "string"
+        ? contentType.trim().toLowerCase()
+        : "";
 
       if (!delta || delta.length === 0) return;
 
-      if (contentType === "thinking") {
+      if (normalizedContentType === "thinking" || normalizedContentType === "reasoning") {
         const sourceKey = thinkingSourceKey ?? "default";
 
         if (!this.thinkingBlocks.has(sourceKey)) {

--- a/src/sdk/clients/opencode.events.test.ts
+++ b/src/sdk/clients/opencode.events.test.ts
@@ -2072,6 +2072,133 @@ describe("OpenCodeClient event mapping", () => {
     ]);
   });
 
+  test("recognizes reasoning deltas when message.part.delta uses camelCase partId", () => {
+    const client = new OpenCodeClient();
+    const deltas: Array<{
+      sessionId: string;
+      delta?: string;
+      contentType?: string;
+      thinkingSourceKey?: string;
+    }> = [];
+
+    const unsubscribe = client.on("message.delta", (event) => {
+      const data = event.data as {
+        delta?: string;
+        contentType?: string;
+        thinkingSourceKey?: string;
+      };
+      deltas.push({
+        sessionId: event.sessionId,
+        delta: data.delta,
+        contentType: data.contentType,
+        thinkingSourceKey: data.thinkingSourceKey,
+      });
+    });
+
+    (client as unknown as { handleSdkEvent: (event: Record<string, unknown>) => void }).handleSdkEvent({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "reasoning_part_camel",
+          sessionID: "ses_reasoning_camel",
+          messageID: "msg_reasoning_camel",
+          type: "reasoning",
+        },
+      },
+    });
+
+    (client as unknown as { handleSdkEvent: (event: Record<string, unknown>) => void }).handleSdkEvent({
+      type: "message.part.delta",
+      properties: {
+        partId: "reasoning_part_camel",
+        field: "text",
+        sessionID: "ses_reasoning_camel",
+        delta: "camelcase part id reasoning",
+      },
+    });
+
+    unsubscribe();
+
+    expect(deltas).toEqual([
+      {
+        sessionId: "ses_reasoning_camel",
+        delta: "camelcase part id reasoning",
+        contentType: "thinking",
+        thinkingSourceKey: "reasoning_part_camel",
+      },
+    ]);
+  });
+
+  test("ignores message.part.delta updates for non-text fields", () => {
+    const client = new OpenCodeClient();
+    const deltas: string[] = [];
+
+    const unsubscribe = client.on("message.delta", (event) => {
+      const data = event.data as { delta?: string };
+      if (typeof data.delta === "string") {
+        deltas.push(data.delta);
+      }
+    });
+
+    (client as unknown as { handleSdkEvent: (event: Record<string, unknown>) => void }).handleSdkEvent({
+      type: "message.part.delta",
+      properties: {
+        partID: "part_non_text_field",
+        field: "status",
+        sessionID: "ses_non_text_field",
+        delta: "should not emit",
+      },
+    });
+
+    unsubscribe();
+
+    expect(deltas).toEqual([]);
+  });
+
+  test("classifies inline reasoning message.part.delta payloads as thinking", () => {
+    const client = new OpenCodeClient();
+    const deltas: Array<{
+      contentType?: string;
+      thinkingSourceKey?: string;
+      delta?: string;
+    }> = [];
+
+    const unsubscribe = client.on("message.delta", (event) => {
+      const data = event.data as {
+        delta?: string;
+        contentType?: string;
+        thinkingSourceKey?: string;
+      };
+      deltas.push({
+        contentType: data.contentType,
+        thinkingSourceKey: data.thinkingSourceKey,
+        delta: data.delta,
+      });
+    });
+
+    (client as unknown as { handleSdkEvent: (event: Record<string, unknown>) => void }).handleSdkEvent({
+      type: "message.part.delta",
+      properties: {
+        sessionID: "ses_inline_reasoning",
+        delta: "inline reasoning payload",
+        part: {
+          id: "reasoning_inline_1",
+          type: "reasoning",
+        },
+      },
+    });
+
+    unsubscribe();
+
+    expect(deltas).toEqual([
+      {
+        contentType: "thinking",
+        thinkingSourceKey: "reasoning_inline_1",
+        delta: "inline reasoning payload",
+      },
+    ]);
+  });
+
   test("maps agent part to subagent.start with toolCallId from callID", () => {
     const client = new OpenCodeClient();
     const starts: Array<{

--- a/src/sdk/clients/opencode.ts
+++ b/src/sdk/clients/opencode.ts
@@ -1560,9 +1560,13 @@ export class OpenCodeClient implements CodingAgentClient {
         const sessionSubagentState = parentSessionId
           ? this.getSubagentSessionState(parentSessionId)
           : this.createSubagentSessionState();
-        if (part?.type === "text") {
+        const normalizedPartType = typeof part?.type === "string"
+          ? part.type.toLowerCase()
+          : "";
+
+        if (normalizedPartType === "text") {
           // Text streaming is handled entirely by message.part.delta (v2).
-        } else if (part?.type === "reasoning") {
+        } else if (normalizedPartType === "reasoning" || normalizedPartType === "thinking") {
           // Register reasoning part IDs so message.part.delta can route
           // them as "thinking" content; streaming handled by that handler.
           const partId = (part?.id as string) ?? undefined;
@@ -1878,14 +1882,35 @@ export class OpenCodeClient implements CodingAgentClient {
         // v2 SDK sends incremental deltas via a separate event type instead of
         // including `delta` on `message.part.updated`.
         const partDelta = properties?.delta as string | undefined;
-        const partId = properties?.partID as string | undefined;
+        const partRecord = (
+          typeof properties?.part === "object"
+          && properties.part !== null
+          && !Array.isArray(properties.part)
+        )
+          ? properties.part as Record<string, unknown>
+          : undefined;
+        const partId = (
+          (properties?.partID as string | undefined)
+          ?? (properties?.partId as string | undefined)
+          ?? (partRecord?.id as string | undefined)
+        );
+        const field = properties?.field as string | undefined;
+        const inlinePartType = typeof partRecord?.type === "string"
+          ? partRecord.type.toLowerCase()
+          : undefined;
         const deltaSessionId = (properties?.sessionID as string) ?? "";
+        if (field && field !== "text") {
+          break;
+        }
         if (partDelta && partDelta.length > 0) {
-          if (partId && this.reasoningPartIds.has(partId)) {
+          const isReasoningDelta = inlinePartType === "reasoning"
+            || inlinePartType === "thinking"
+            || (partId ? this.reasoningPartIds.has(partId) : false);
+          if (isReasoningDelta) {
             this.emitEvent("message.delta", deltaSessionId, {
               delta: partDelta,
               contentType: "thinking",
-              thinkingSourceKey: partId,
+              thinkingSourceKey: partId ?? "reasoning",
             });
           } else {
             this.emitEvent("message.delta", deltaSessionId, {


### PR DESCRIPTION
## Summary

Fixes the classification of reasoning content from the OpenCode SDK to be properly recognized as thinking deltas in stream events. Previously, only content explicitly marked as "thinking" was classified correctly, while "reasoning" content was treated as regular text deltas.

## Key Changes

- **Enhanced content type detection**: Both `opencode-adapter.ts` and `opencode.ts` now recognize "reasoning" as a synonym for "thinking" content, with case-insensitive matching
- **Improved part type handling**: Added support for camelCase `partId` field in addition to `partID`, and inline part type detection from `message.part.delta` payloads
- **Field filtering**: Added check to ignore non-text field updates in `message.part.delta` events (e.g., status updates)
- **Comprehensive test coverage**: Added tests for:
  - Reasoning content type classification via `contentType` field
  - CamelCase part ID recognition
  - Inline reasoning part detection
  - Non-text field filtering

## Technical Details

### `src/events/adapters/opencode-adapter.ts`
- Normalized `contentType` to lowercase for comparison
- Added "reasoning" to the content type check alongside "thinking"

### `src/sdk/clients/opencode.ts`
- Enhanced `message.part.updated` handler to recognize "reasoning" and "thinking" part types
- Improved `message.part.delta` handler to:
  - Support both `partID` (snake_case) and `partId` (camelCase) field names
  - Detect inline part type from embedded `part` object
  - Filter out non-text field updates
  - Classify reasoning deltas as thinking content with proper source key

This ensures consistent handling of reasoning content across different event types and SDK versions.