### PR TITLE
feat(sdk): add skill invocation tracking, config merging, and UI dedup

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -28,6 +28,7 @@ import {
 } from "../utils/atomic-global-config.ts";
 import { detectInstallationType, getConfigRoot } from "../utils/config-path.ts";
 import { prepareOpenCodeConfigDir } from "../utils/opencode-config.ts";
+import { prepareClaudeConfigDir } from "../utils/claude-config.ts";
 
 // SDK client imports — lazy-loaded per agent to avoid loading all 3 SDKs
 import { createTodoWriteTool } from "../sdk/tools/todo-write.ts";
@@ -84,7 +85,11 @@ async function createClientForAgentType(agentType: AgentType): Promise<CodingAge
     }
     case "opencode": {
       const { createOpenCodeClient } = await import("../sdk/clients/opencode.ts");
-      return createOpenCodeClient({ directory: process.cwd() });
+      return createOpenCodeClient({
+        directory: process.cwd(),
+        port: 0,
+        reuseExistingServer: false,
+      });
     }
     case "copilot": {
       const { createCopilotClient } = await import("../sdk/clients/copilot.ts");
@@ -228,6 +233,13 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
     const mergedConfigDir = await prepareOpenCodeConfigDir({ projectRoot });
     if (mergedConfigDir) {
       process.env.OPENCODE_CONFIG_DIR = mergedConfigDir;
+    }
+  }
+
+  if (agentType === "claude") {
+    const mergedClaudeConfigDir = await prepareClaudeConfigDir();
+    if (mergedClaudeConfigDir) {
+      process.env.CLAUDE_CONFIG_DIR = mergedClaudeConfigDir;
     }
   }
 

--- a/src/sdk/clients/claude.test.ts
+++ b/src/sdk/clients/claude.test.ts
@@ -406,6 +406,90 @@ describe("ClaudeAgentClient observability and parity", () => {
     }
   });
 
+  test("emits skill.invoked from PreToolUse when Claude Skill tool runs", async () => {
+    const client = new ClaudeAgentClient();
+    const invocations: Array<{
+      sessionId: string;
+      skillName?: string;
+      skillPath?: string;
+    }> = [];
+
+    const unsubscribe = client.on("skill.invoked", (event) => {
+      const data = event.data as {
+        skillName?: string;
+        skillPath?: string;
+      };
+      invocations.push({
+        sessionId: event.sessionId,
+        skillName: data.skillName,
+        skillPath: data.skillPath,
+      });
+    });
+
+    try {
+      const privateClient = client as unknown as {
+        registeredHooks: Record<
+          string,
+          Array<
+            (
+              input: Record<string, unknown>,
+              toolUseID: string | undefined,
+              options: { signal: AbortSignal },
+            ) => Promise<{ continue: boolean }>
+          >
+        >;
+        wrapQuery: (
+          queryInstance: null,
+          sessionId: string,
+          config: Record<string, unknown>,
+        ) => { destroy: () => Promise<void> };
+      };
+
+      const wrappedSession = privateClient.wrapQuery(
+        null,
+        "wrapped-session-id",
+        {},
+      );
+      const preToolUseHook = privateClient.registeredHooks.PreToolUse?.[0];
+      expect(preToolUseHook).toBeDefined();
+
+      await preToolUseHook?.(
+        {
+          session_id: "sdk-skill-session",
+          tool_name: "Skill",
+          tool_input: {
+            name: "explain-code",
+            path: "/tmp/skills/explain-code/SKILL.md",
+          },
+        },
+        "skill_tool_use_1",
+        { signal: new AbortController().signal },
+      );
+
+      await preToolUseHook?.(
+        {
+          session_id: "sdk-skill-session",
+          tool_name: "Read",
+          tool_input: { file_path: "README.md" },
+        },
+        "read_tool_use_1",
+        { signal: new AbortController().signal },
+      );
+
+      expect(invocations).toEqual([
+        {
+          sessionId: "wrapped-session-id",
+          skillName: "explain-code",
+          skillPath: "/tmp/skills/explain-code/SKILL.md",
+        },
+      ]);
+
+      await wrappedSession.destroy();
+    } finally {
+      unsubscribe();
+    }
+  });
+
   test("maps child-session tool hooks to subagents when SubagentStart omits tool use IDs", async () => {
     const client = new ClaudeAgentClient();
     const seenParentAgentIds: Array<string | undefined> = [];

--- a/src/sdk/clients/claude.ts
+++ b/src/sdk/clients/claude.ts
@@ -60,6 +60,10 @@ import { loadCopilotAgents } from "../../config/copilot-manual.ts";
 import { existsSync, realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+    extractSkillInvocationFromToolInput,
+    isSkillToolName,
+} from "./skill-invocation.ts";
 
 /**
  * Configuration for Claude SDK native hooks
@@ -129,6 +133,7 @@ function mapEventTypeToHookEvent(eventType: EventType): HookEvent | null {
         "session.start": "SessionStart",
         "session.idle": "SessionEnd",
         "tool.start": "PreToolUse",
+        "skill.invoked": "PreToolUse",
         "tool.complete": "PostToolUse",
         "subagent.start": "SubagentStart",
         "subagent.complete": "SubagentStop",
@@ -2049,6 +2054,38 @@ export class ClaudeAgentClient implements CodingAgentClient {
                     const sessionId = hookSessionId
                         ? this.resolveHookSessionId(hookSessionId)
                         : this.resolveFallbackHookSessionId(resolvedToolUseId);
+
+                    if (eventType === "skill.invoked") {
+                        if (!isSkillToolName(hookInput.tool_name)) {
+                            return { continue: true };
+                        }
+
+                        const skillInvocation =
+                            extractSkillInvocationFromToolInput(
+                                hookInput.tool_input,
+                            );
+                        if (!skillInvocation) {
+                            return { continue: true };
+                        }
+
+                        const skillEvent: AgentEvent<T> = {
+                            type: eventType,
+                            sessionId,
+                            timestamp: new Date().toISOString(),
+                            data: skillInvocation as AgentEvent<T>["data"],
+                        };
+
+                        try {
+                            await handler(skillEvent);
+                        } catch (error) {
+                            console.error(
+                                `Error in hook handler for ${eventType}:`,
+                                error,
+                            );
+                        }
+
+                        return { continue: true };
+                    }
 
                     if (
                         targetHookEvent === "SubagentStart" &&

--- a/src/sdk/clients/opencode.events.test.ts
+++ b/src/sdk/clients/opencode.events.test.ts
@@ -138,6 +138,62 @@ describe("OpenCodeClient event mapping", () => {
     expect(options.clientOptions?.directory).toBe(process.cwd());
   });
 
+  test("starts an isolated server before connecting by default", async () => {
+    const client = new OpenCodeClient();
+    const callOrder: string[] = [];
+    const internal = client as unknown as {
+      spawnServer: () => Promise<boolean>;
+      connect: () => Promise<boolean>;
+      subscribeToSdkEvents: () => Promise<void>;
+      isRunning: boolean;
+    };
+
+    internal.spawnServer = async () => {
+      callOrder.push("spawn");
+      return true;
+    };
+    internal.connect = async () => {
+      callOrder.push("connect");
+      return true;
+    };
+    internal.subscribeToSdkEvents = async () => {
+      callOrder.push("subscribe");
+    };
+
+    await client.start();
+
+    expect(callOrder).toEqual(["spawn", "connect", "subscribe"]);
+    expect(internal.isRunning).toBe(true);
+  });
+
+  test("uses Atomic-managed server path even when reuseExistingServer is true", async () => {
+    const client = new OpenCodeClient({ reuseExistingServer: true });
+    const callOrder: string[] = [];
+    const internal = client as unknown as {
+      spawnServer: () => Promise<boolean>;
+      connect: () => Promise<boolean>;
+      subscribeToSdkEvents: () => Promise<void>;
+      isRunning: boolean;
+    };
+
+    internal.spawnServer = async () => {
+      callOrder.push("spawn");
+      return true;
+    };
+    internal.connect = async () => {
+      callOrder.push("connect");
+      return true;
+    };
+    internal.subscribeToSdkEvents = async () => {
+      callOrder.push("subscribe");
+    };
+
+    await client.start();
+
+    expect(callOrder).toEqual(["spawn", "connect", "subscribe"]);
+    expect(internal.isRunning).toBe(true);
+  });
+
   test("maps session.created info.id to session.start sessionId", () => {
     const client = new OpenCodeClient();
     const sessionStarts: string[] = [];
@@ -1789,6 +1845,95 @@ describe("OpenCodeClient event mapping", () => {
         sessionId: "ses_part_session",
         toolName: "bash",
         toolCallId: "call_tool_1",
+      },
+    ]);
+  });
+
+  test("emits skill.invoked once for native Skill tool lifecycle updates", () => {
+    const client = new OpenCodeClient();
+    const invocations: Array<{
+      sessionId: string;
+      skillName?: string;
+      skillPath?: string;
+    }> = [];
+
+    const unsubscribe = client.on("skill.invoked", (event) => {
+      const data = event.data as {
+        skillName?: string;
+        skillPath?: string;
+      };
+      invocations.push({
+        sessionId: event.sessionId,
+        skillName: data.skillName,
+        skillPath: data.skillPath,
+      });
+    });
+
+    const basePart = {
+      id: "skill_tool_part_1",
+      callID: "skill_tool_call_1",
+      sessionID: "ses_skill_main",
+      messageID: "msg_skill_main",
+      type: "tool",
+      tool: "skill",
+    };
+
+    (client as unknown as { handleSdkEvent: (event: Record<string, unknown>) => void }).handleSdkEvent({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          ...basePart,
+          state: {
+            status: "pending",
+            input: {
+              name: "explain-code",
+              path: "/tmp/skills/explain-code/SKILL.md",
+            },
+          },
+        },
+      },
+    });
+
+    (client as unknown as { handleSdkEvent: (event: Record<string, unknown>) => void }).handleSdkEvent({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          ...basePart,
+          state: {
+            status: "running",
+            input: {
+              name: "explain-code",
+              path: "/tmp/skills/explain-code/SKILL.md",
+            },
+          },
+        },
+      },
+    });
+
+    (client as unknown as { handleSdkEvent: (event: Record<string, unknown>) => void }).handleSdkEvent({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          ...basePart,
+          state: {
+            status: "completed",
+            input: {
+              name: "explain-code",
+              path: "/tmp/skills/explain-code/SKILL.md",
+            },
+            output: "loaded",
+          },
+        },
+      },
+    });
+
+    unsubscribe();
+
+    expect(invocations).toEqual([
+      {
+        sessionId: "ses_skill_main",
+        skillName: "explain-code",
+        skillPath: "/tmp/skills/explain-code/SKILL.md",
       },
     ]);
   });

--- a/src/sdk/clients/opencode.ts
+++ b/src/sdk/clients/opencode.ts
@@ -73,6 +73,12 @@ import {
   incrementRuntimeParityCounter,
   runtimeParityDebug,
 } from "../../workflows/runtime-parity-observability.ts";
+import {
+  extractSkillInvocationFromToolInput,
+  isSkillToolName,
+} from "./skill-invocation.ts";
+import { homedir } from "os";
+import { join } from "path";
 
 // Import the real SDK
 import {
@@ -116,6 +122,7 @@ export interface OpenCodeSdkEvent {
  * Default OpenCode server configuration
  */
 const DEFAULT_OPENCODE_BASE_URL = "http://localhost:4096";
+const ATOMIC_OPENCODE_CONFIG_DIR = join(homedir(), ".atomic", ".opencode");
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_DELAY = 1000;
 const PRE_PROMPT_TERMINAL_SETTLE_MS = 500;
@@ -181,6 +188,14 @@ interface OpenCodeSessionState {
   systemToolsBaseline: number | null;
   compaction: OpenCodeSessionCompactionState;
 }
+
+interface AtomicManagedOpenCodeServerState {
+  url: string;
+  close: () => void;
+  leaseCount: number;
+}
+
+let atomicManagedOpenCodeServer: AtomicManagedOpenCodeServerState | null = null;
 
 function parseOpenCodeSessionStatus(status: unknown): OpenCodeSessionStatus | undefined {
   if (status === "idle" || status === "busy" || status === "retry") {
@@ -655,8 +670,15 @@ export interface OpenCodeClientOptions {
   retryDelay?: number;
   /** Default agent mode for new sessions (default: "build") */
   defaultAgentMode?: OpenCodeAgentMode;
-  /** Auto-start OpenCode server if not running (default: true) */
+  /** Auto-start an Atomic-managed OpenCode server when needed (default: true) */
   autoStart?: boolean;
+  /**
+   * Legacy external-server reuse toggle.
+   *
+   * When true and autoStart is disabled, start() can connect to a pre-existing
+   * non-Atomic OpenCode server at baseUrl.
+   */
+  reuseExistingServer?: boolean;
   /** Port for server when auto-starting (default: 4096) */
   port?: number;
   /** Hostname for server when auto-starting (default: localhost) */
@@ -693,7 +715,6 @@ export class OpenCodeClient implements CodingAgentClient {
   private isConnected = false;
   private currentSessionId: string | null = null;
   private eventSubscriptionController: AbortController | null = null;
-  private serverCloseCallback: (() => void) | null = null;
   private isServerSpawned = false;
   private dispatchServerStop: (() => void) | null = null;
   private readonly sseDiagnosticsCounters: Record<OpenCodeSseDiagnosticsCounter, number> = {
@@ -733,6 +754,7 @@ export class OpenCodeClient implements CodingAgentClient {
    * from assistant-emitted sub-agent lifecycle parts.
    */
   private messageRolesBySession = new Map<string, Map<string, "user" | "assistant">>();
+  private skillInvocationsBySession = new Map<string, Set<string>>();
 
   /**
    * Create a new OpenCodeClient
@@ -881,6 +903,7 @@ export class OpenCodeClient implements CodingAgentClient {
     this.childSessionToParentSession.clear();
     this.reasoningPartIds.clear();
     this.messageRolesBySession.clear();
+    this.skillInvocationsBySession.clear();
 
     this.emitEvent("session.idle", "connection", { reason: "disconnected" });
   }
@@ -1161,6 +1184,7 @@ export class OpenCodeClient implements CodingAgentClient {
     this.activeSessions.delete(sessionId);
     this.sessionStateById.delete(sessionId);
     this.messageRolesBySession.delete(sessionId);
+    this.skillInvocationsBySession.delete(sessionId);
     this.clearSubagentSessionState(sessionId);
     if (this.currentSessionId === sessionId) {
       this.currentSessionId = null;
@@ -1378,6 +1402,50 @@ export class OpenCodeClient implements CodingAgentClient {
     return this.messageRolesBySession.get(sessionId)?.get(messageId);
   }
 
+  private shouldEmitSkillInvocation(
+    sessionId: string,
+    dedupeKey: string,
+  ): boolean {
+    let seen = this.skillInvocationsBySession.get(sessionId);
+    if (!seen) {
+      seen = new Set<string>();
+      this.skillInvocationsBySession.set(sessionId, seen);
+    }
+    if (seen.has(dedupeKey)) {
+      return false;
+    }
+    seen.add(dedupeKey);
+    return true;
+  }
+
+  private maybeEmitSkillInvokedEvent(args: {
+    sessionId: string;
+    toolName: string;
+    toolInput: unknown;
+    toolUseId?: string;
+    toolCallId?: string;
+  }): void {
+    if (!args.sessionId || !isSkillToolName(args.toolName)) {
+      return;
+    }
+
+    const invocation = extractSkillInvocationFromToolInput(args.toolInput);
+    if (!invocation) {
+      return;
+    }
+
+    const dedupeKey =
+      args.toolUseId
+      || args.toolCallId
+      || invocation.skillPath
+      || invocation.skillName;
+    if (!this.shouldEmitSkillInvocation(args.sessionId, dedupeKey)) {
+      return;
+    }
+
+    this.emitEvent("skill.invoked", args.sessionId, invocation);
+  }
+
   /**
    * Handle events from SDK and map to unified event types
    */
@@ -1581,6 +1649,14 @@ export class OpenCodeClient implements CodingAgentClient {
             ? (toolState.metadata as Record<string, unknown>)
             : undefined;
           let agentPartId = sessionSubagentState.childSessionToAgentPart.get(partSessionId);
+
+          this.maybeEmitSkillInvokedEvent({
+            sessionId: parentSessionId || partSessionId,
+            toolName,
+            toolInput,
+            toolUseId: part?.id as string | undefined,
+            toolCallId: part?.callID as string | undefined,
+          });
 
           // --- Child session discovery for sub-agent tools ---
           // When a ToolPart arrives from a session that is NOT the parent
@@ -3075,12 +3151,65 @@ export class OpenCodeClient implements CodingAgentClient {
    * @returns True if server was spawned successfully
    */
   private async spawnServer(): Promise<boolean> {
+    const acquireAtomicServerLease = (state: AtomicManagedOpenCodeServerState): void => {
+      state.leaseCount += 1;
+      this.clientOptions.baseUrl = state.url;
+      this.isServerSpawned = true;
+    };
+
+    const releaseUnhealthyAtomicServer = (): void => {
+      if (!atomicManagedOpenCodeServer) {
+        return;
+      }
+      try {
+        atomicManagedOpenCodeServer.close();
+      } catch {
+        // Ignore cleanup errors and replace with a fresh server.
+      }
+      atomicManagedOpenCodeServer = null;
+    };
+
+    const isAtomicServerHealthy = async (
+      serverUrl: string,
+      directory: string | undefined,
+    ): Promise<boolean> => {
+      try {
+        const tempClient = createSdkClient({
+          baseUrl: serverUrl,
+          directory,
+        });
+        const result = await tempClient.global.health();
+        return !result.error;
+      } catch {
+        return false;
+      }
+    };
+
+    if (this.isServerSpawned && atomicManagedOpenCodeServer) {
+      this.clientOptions.baseUrl = atomicManagedOpenCodeServer.url;
+      return true;
+    }
+
+    if (atomicManagedOpenCodeServer) {
+      const healthy = await isAtomicServerHealthy(
+        atomicManagedOpenCodeServer.url,
+        this.clientOptions.directory,
+      );
+      if (healthy) {
+        acquireAtomicServerLease(atomicManagedOpenCodeServer);
+        return true;
+      }
+      releaseUnhealthyAtomicServer();
+    }
+
     // Parse port from baseUrl
     const url = new URL(this.clientOptions.baseUrl ?? DEFAULT_OPENCODE_BASE_URL);
     const port = this.clientOptions.port ?? parseInt(url.port || "4096", 10);
     const hostname = this.clientOptions.hostname ?? url.hostname ?? "localhost";
 
     try {
+      process.env.OPENCODE_CONFIG_DIR = ATOMIC_OPENCODE_CONFIG_DIR;
+
       const serverOptions: SdkServerOptions = {
         hostname,
         port,
@@ -3088,8 +3217,12 @@ export class OpenCodeClient implements CodingAgentClient {
       };
 
       const { url: serverUrl, close } = await createOpencodeServer(serverOptions);
-      this.serverCloseCallback = close;
-      this.isServerSpawned = true;
+      atomicManagedOpenCodeServer = {
+        url: serverUrl,
+        close,
+        leaseCount: 0,
+      };
+      acquireAtomicServerLease(atomicManagedOpenCodeServer);
 
       // Update baseUrl to the actual server URL
       this.clientOptions.baseUrl = serverUrl;
@@ -3111,23 +3244,27 @@ export class OpenCodeClient implements CodingAgentClient {
     }
 
     const autoStart = this.clientOptions.autoStart !== false;
+    const reuseExistingServer = this.clientOptions.reuseExistingServer === true;
 
-    // First, try to connect to existing server
-    try {
-      await this.connect();
-    } catch (connectionError) {
-      // If autoStart is enabled, try spawning a server
-      if (autoStart) {
-        const spawned = await this.spawnServer();
-        if (spawned) {
-          // Try connecting again
-          await this.connect();
-        } else {
-          throw connectionError;
-        }
-      } else {
-        throw connectionError;
+    if (autoStart) {
+      const spawned = await this.spawnServer();
+      if (!spawned) {
+        throw new Error("Failed to start Atomic-managed OpenCode server");
       }
+
+      try {
+        await this.connect();
+      } catch (error) {
+        this.releaseServerLease();
+        throw error;
+      }
+    } else {
+      if (!reuseExistingServer) {
+        throw new Error(
+          "OpenCode autoStart is disabled. Enable autoStart or set reuseExistingServer to connect to an external server.",
+        );
+      }
+      await this.connect();
     }
 
     // Mark running BEFORE starting SSE so the event loop's while-condition
@@ -3149,16 +3286,7 @@ export class OpenCodeClient implements CodingAgentClient {
     // Disconnect from server
     await this.disconnect();
 
-    // Close spawned server if we started it
-    if (this.serverCloseCallback && this.isServerSpawned) {
-      try {
-        this.serverCloseCallback();
-      } catch {
-        // Ignore errors during cleanup
-      }
-      this.serverCloseCallback = null;
-      this.isServerSpawned = false;
-    }
+    this.releaseServerLease();
 
     // Stop the tool dispatch HTTP server
     if (this.dispatchServerStop) {
@@ -3169,6 +3297,30 @@ export class OpenCodeClient implements CodingAgentClient {
 
     this.eventHandlers.clear();
     this.isRunning = false;
+  }
+
+  private releaseServerLease(): void {
+    if (!this.isServerSpawned) {
+      return;
+    }
+
+    this.isServerSpawned = false;
+
+    if (!atomicManagedOpenCodeServer) {
+      return;
+    }
+
+    atomicManagedOpenCodeServer.leaseCount -= 1;
+    if (atomicManagedOpenCodeServer.leaseCount > 0) {
+      return;
+    }
+
+    try {
+      atomicManagedOpenCodeServer.close();
+    } catch {
+      // Ignore errors during cleanup
+    }
+    atomicManagedOpenCodeServer = null;
   }
 
   /**

--- a/src/sdk/clients/skill-invocation.ts
+++ b/src/sdk/clients/skill-invocation.ts
@@ -1,0 +1,75 @@
+import type { SkillInvokedEventData } from "../types.ts";
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function extractSkillName(input: Record<string, unknown>): string | undefined {
+  const directName = asNonEmptyString(input.name)
+    ?? asNonEmptyString(input.skill)
+    ?? asNonEmptyString(input.skillName)
+    ?? asNonEmptyString(input.skill_name)
+    ?? asNonEmptyString(input.slug);
+  if (directName) {
+    return directName;
+  }
+
+  const nestedSkill = asRecord(input.skill);
+  return nestedSkill
+    ? asNonEmptyString(nestedSkill.name)
+      ?? asNonEmptyString(nestedSkill.skill)
+      ?? asNonEmptyString(nestedSkill.slug)
+    : undefined;
+}
+
+function extractSkillPath(input: Record<string, unknown>): string | undefined {
+  const directPath = asNonEmptyString(input.path)
+    ?? asNonEmptyString(input.skillPath)
+    ?? asNonEmptyString(input.skill_path)
+    ?? asNonEmptyString(input.filePath)
+    ?? asNonEmptyString(input.file_path);
+  if (directPath) {
+    return directPath;
+  }
+
+  const nestedSkill = asRecord(input.skill);
+  return nestedSkill
+    ? asNonEmptyString(nestedSkill.path)
+      ?? asNonEmptyString(nestedSkill.filePath)
+    : undefined;
+}
+
+export function isSkillToolName(toolName: unknown): boolean {
+  return typeof toolName === "string" && toolName.trim().toLowerCase() === "skill";
+}
+
+export function extractSkillInvocationFromToolInput(
+  toolInput: unknown,
+): SkillInvokedEventData | null {
+  const directSkillName = asNonEmptyString(toolInput);
+  if (directSkillName) {
+    return { skillName: directSkillName };
+  }
+
+  const input = asRecord(toolInput);
+  if (!input) {
+    return null;
+  }
+
+  const skillName = extractSkillName(input);
+  if (!skillName) {
+    return null;
+  }
+
+  const skillPath = extractSkillPath(input);
+  return skillPath ? { skillName, skillPath } : { skillName };
+}

--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -159,6 +159,13 @@ import {
   rejectPendingWorkflowInput,
   type WorkflowInputResolver,
 } from "./utils/workflow-input-resolver.ts";
+import {
+  createLoadedSkillTrackingSet,
+  normalizeSessionTrackingKey,
+  normalizeSkillTrackingKey,
+  shouldResetLoadedSkillsForSessionChange,
+  tryTrackLoadedSkill,
+} from "./utils/skill-load-tracking.ts";
 import type {
   Part,
   StreamPartEvent,
@@ -978,6 +985,10 @@ export interface ChatMessage {
   spinnerVerb?: string;
 }
 
+function createLoadedSkillsSetFromMessages(messages: readonly ChatMessage[]): Set<string> {
+  return createLoadedSkillTrackingSet(messages);
+}
+
 /**
  * Tool start event callback signature.
  */
@@ -1299,6 +1310,39 @@ export function createMessage(
     streaming,
     parts,
   };
+}
+
+function appendSkillLoadToLatestAssistantMessage(
+  messages: ChatMessage[],
+  skillLoad: MessageSkillLoad,
+): ChatMessage[] {
+  const normalizedSkillKey = normalizeSkillTrackingKey(skillLoad.skillName);
+  if (normalizedSkillKey.length === 0) {
+    return messages;
+  }
+
+  const lastMsg = messages[messages.length - 1];
+  if (lastMsg && lastMsg.role === "assistant") {
+    const existingLoads = lastMsg.skillLoads ?? [];
+    const hasExistingSkill = existingLoads.some(
+      (existingLoad) => normalizeSkillTrackingKey(existingLoad.skillName) === normalizedSkillKey,
+    );
+    if (hasExistingSkill) {
+      return messages;
+    }
+
+    return [
+      ...messages.slice(0, -1),
+      {
+        ...lastMsg,
+        skillLoads: [...existingLoads, skillLoad],
+      },
+    ];
+  }
+
+  const msg = createMessage("assistant", "");
+  msg.skillLoads = [skillLoad];
+  return [...messages, msg];
 }
 
 function appendUniqueMessagesById(existing: ChatMessage[], incoming: ChatMessage[]): ChatMessage[] {
@@ -1884,10 +1928,42 @@ function getRenderableAssistantParts(
   isLastMessage: boolean,
   hideAskUserQuestion: boolean,
 ): Part[] {
-  let parts = [...(message.parts ?? [])];
+  const skillIndicatorKeys = new Set(
+    (message.skillLoads ?? [])
+      .map((skillLoad) => normalizeSkillTrackingKey(skillLoad.skillName))
+      .filter((key) => key.length > 0),
+  );
+
+  const shouldHideSkillToolIndicator = (toolName: string, input: Record<string, unknown>): boolean => {
+    if (toolName.trim().toLowerCase() !== "skill") {
+      return false;
+    }
+    if (skillIndicatorKeys.size === 0) {
+      return false;
+    }
+    const rawSkillName = typeof input.skill === "string"
+      ? input.skill
+      : (typeof input.name === "string" ? input.name : "");
+    const key = normalizeSkillTrackingKey(rawSkillName);
+    if (key.length === 0) {
+      return true;
+    }
+    return skillIndicatorKeys.has(key);
+  };
+
+  let parts = [...(message.parts ?? [])].filter((part) => {
+    if (part.type !== "tool") {
+      return true;
+    }
+    const toolPart = part as ToolPart;
+    return !shouldHideSkillToolIndicator(toolPart.toolName, toolPart.input);
+  });
 
   // Keep ToolPart state synchronized with the source toolCalls array.
-  parts = syncToolCallsIntoParts(parts, message.toolCalls ?? [], message.timestamp, message.id);
+  const visibleToolCalls = (message.toolCalls ?? []).filter(
+    (toolCall) => !shouldHideSkillToolIndicator(toolCall.toolName, toolCall.input),
+  );
+  parts = syncToolCallsIntoParts(parts, visibleToolCalls, message.timestamp, message.id);
 
   const effectiveParallelAgents = message.parallelAgents;
   if (effectiveParallelAgents && effectiveParallelAgents.length > 0) {
@@ -2549,7 +2625,8 @@ export function ChatApp({
   const [agentAnchorSyncVersion, setAgentAnchorSyncVersion] = useState(0);
   // Incremented when message-window overflow eviction happens.
   // Tracks which skills have been loaded in the current session to avoid duplicate indicators.
-  const loadedSkillsRef = useRef<Set<string>>(new Set());
+  const loadedSkillsRef = useRef<Set<string>>(createLoadedSkillsSetFromMessages(initialMessages));
+  const activeSkillSessionIdRef = useRef<string | null>(null);
   // Ref for scrollbox to enable programmatic scrolling
   const scrollboxRef = useRef<ScrollBoxRenderable>(null);
   // Ref for deferred queue dispatch without circular callback deps
@@ -2581,6 +2658,15 @@ export function ChatApp({
     if (backgroundAgentMessageIdRef.current === messageId) return;
     backgroundAgentMessageIdRef.current = messageId;
     setAgentAnchorSyncVersion((version) => version + 1);
+  }, []);
+
+  const resetLoadedSkillTracking = useCallback((options?: {
+    resetSessionBinding?: boolean;
+  }) => {
+    loadedSkillsRef.current.clear();
+    if (options?.resetSessionBinding) {
+      activeSkillSessionIdRef.current = null;
+    }
   }, []);
 
   const setAgentMessageBinding = useCallback((agentId: string, messageId: string): void => {
@@ -2810,6 +2896,10 @@ export function ChatApp({
     setMessages(next);
   }, []);
 
+  const appendSkillLoadIndicator = useCallback((skillLoad: MessageSkillLoad) => {
+    setMessagesWindowed((prev) => appendSkillLoadToLatestAssistantMessage(prev, skillLoad));
+  }, [setMessagesWindowed]);
+
   const sendBackgroundMessageToAgent = useCallback((content: string) => {
     const trimmed = content.trim();
     if (!trimmed) return;
@@ -2966,6 +3056,7 @@ export function ChatApp({
       }
     } else if (next.status === "completed") {
       setIsAutoCompacting(false);
+      resetLoadedSkillTracking();
       // Compaction succeeded: persist current messages as summary to history buffer,
       // then clear chat and create a fresh streaming message so the active stream
       // continues seamlessly into the new (compacted) context.
@@ -3837,6 +3928,14 @@ export function ChatApp({
   // and Copilot adapters.  Claude sessions never fire these, so the handlers
   // are defensive (guard on isStreamingRef).
   useBusSubscription("stream.session.start", (event) => {
+    const nextSessionId = normalizeSessionTrackingKey(event.sessionId);
+    if (shouldResetLoadedSkillsForSessionChange(activeSkillSessionIdRef.current, nextSessionId)) {
+      resetLoadedSkillTracking();
+    }
+    if (nextSessionId) {
+      activeSkillSessionIdRef.current = nextSessionId;
+    }
+
     if (!isStreamingRef.current) {
       return;
     }
@@ -4710,24 +4809,12 @@ export function ChatApp({
 
   useBusSubscription("stream.skill.invoked", (event) => {
     const { skillName } = event.data;
-    if (loadedSkillsRef.current.has(skillName)) return;
-    loadedSkillsRef.current.add(skillName);
+    if (!tryTrackLoadedSkill(loadedSkillsRef.current, skillName)) return;
     const skillLoad: MessageSkillLoad = {
       skillName,
       status: "loaded",
     };
-    setMessagesWindowed((prev) => {
-      const lastMsg = prev[prev.length - 1];
-      if (lastMsg && lastMsg.role === "assistant") {
-        return [
-          ...prev.slice(0, -1),
-          { ...lastMsg, skillLoads: [...(lastMsg.skillLoads || []), skillLoad] },
-        ];
-      }
-      const msg = createMessage("assistant", "");
-      msg.skillLoads = [skillLoad];
-      return [...prev, msg];
-    });
+    appendSkillLoadIndicator(skillLoad);
   });
 
   // Keep live sub-agent updates anchored to the active streaming message so
@@ -5780,6 +5867,7 @@ Important: Do not add any text before or after the sub-agent's output. Pass thro
         if (onResetSession) {
           await onResetSession();
         }
+        resetLoadedSkillTracking({ resetSessionBinding: true });
         setMessagesWindowed((prev) => {
           appendHistoryBufferAndSync(prev);
           return [];
@@ -5896,7 +5984,7 @@ Important: Do not add any text before or after the sub-agent's output. Pass thro
         backgroundProgressSnapshotRef.current.clear();
         setTranscriptMode(false);
         clearHistoryBufferAndSync();
-        loadedSkillsRef.current.clear();
+        resetLoadedSkillTracking({ resetSessionBinding: true });
         // Reset workflow state on /clear (Copilot only)
         if (agentType === "copilot") {
           setWorkflowSessionDir(null);
@@ -5916,6 +6004,7 @@ Important: Do not add any text before or after the sub-agent's output. Pass thro
       if (result.clearMessages) {
         const shouldResetHistory = result.destroySession || Boolean(result.compactionSummary);
         if (shouldResetHistory) {
+          resetLoadedSkillTracking();
           if (result.compactionSummary) {
             appendCompactionSummaryAndSync(result.compactionSummary);
           } else {
@@ -5991,25 +6080,13 @@ Important: Do not add any text before or after the sub-agent's output. Pass thro
       }
 
       // Track skill load in message for UI indicator (with session-level deduplication)
-      if (result.skillLoaded && !loadedSkillsRef.current.has(result.skillLoaded)) {
-        loadedSkillsRef.current.add(result.skillLoaded);
+      if (result.skillLoaded && tryTrackLoadedSkill(loadedSkillsRef.current, result.skillLoaded)) {
         const skillLoad: MessageSkillLoad = {
           skillName: result.skillLoaded,
           status: result.skillLoadError ? "error" : "loaded",
           errorMessage: result.skillLoadError,
         };
-        setMessagesWindowed((prev) => {
-          const lastMsg = prev[prev.length - 1];
-          if (lastMsg && lastMsg.role === "assistant") {
-            return [
-              ...prev.slice(0, -1),
-              { ...lastMsg, skillLoads: [...(lastMsg.skillLoads || []), skillLoad] },
-            ];
-          }
-          const msg = createMessage("assistant", "");
-          msg.skillLoads = [skillLoad];
-          return [...prev, msg];
-        });
+        appendSkillLoadIndicator(skillLoad);
       }
 
       // Handle exit command

--- a/src/ui/utils/skill-load-tracking.test.ts
+++ b/src/ui/utils/skill-load-tracking.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createLoadedSkillTrackingSet,
+  normalizeSkillTrackingKey,
+  normalizeSessionTrackingKey,
+  shouldResetLoadedSkillsForSessionChange,
+  tryTrackLoadedSkill,
+} from "./skill-load-tracking.ts";
+
+describe("skill-load-tracking", () => {
+  test("normalizes skill names for case-insensitive tracking", () => {
+    expect(normalizeSkillTrackingKey(" Prompt-Engineer ")).toBe("prompt-engineer");
+  });
+
+  test("seeds loaded skill set from existing messages", () => {
+    const loaded = createLoadedSkillTrackingSet([
+      {
+        skillLoads: [
+          { skillName: "prompt-engineer" },
+          { skillName: "  Explain-Code  " },
+        ],
+      },
+      {
+        skillLoads: [{ skillName: "prompt-engineer" }],
+      },
+    ]);
+
+    expect(loaded.has("prompt-engineer")).toBe(true);
+    expect(loaded.has("explain-code")).toBe(true);
+    expect(loaded.size).toBe(2);
+  });
+
+  test("seeds loaded skill set from reconstructed skill-load parts", () => {
+    const loaded = createLoadedSkillTrackingSet([
+      {
+        parts: [
+          {
+            type: "skill-load",
+            skills: [{ skillName: "Prompt-Engineer" }],
+          },
+        ],
+      },
+    ]);
+
+    expect(loaded.has("prompt-engineer")).toBe(true);
+    expect(loaded.size).toBe(1);
+  });
+
+  test("tracks each skill only once", () => {
+    const loaded = new Set<string>();
+
+    expect(tryTrackLoadedSkill(loaded, "prompt-engineer")).toBe(true);
+    expect(tryTrackLoadedSkill(loaded, " Prompt-Engineer ")).toBe(false);
+    expect(tryTrackLoadedSkill(loaded, "")).toBe(false);
+    expect(loaded.size).toBe(1);
+  });
+
+  test("normalizes session tracking keys", () => {
+    expect(normalizeSessionTrackingKey(" session-1 ")).toBe("session-1");
+    expect(normalizeSessionTrackingKey(" ")).toBeNull();
+    expect(normalizeSessionTrackingKey(undefined)).toBeNull();
+  });
+
+  test("resets skill tracking only when session actually changes", () => {
+    expect(shouldResetLoadedSkillsForSessionChange(null, "session-1")).toBe(false);
+    expect(shouldResetLoadedSkillsForSessionChange("session-1", " session-1 ")).toBe(false);
+    expect(shouldResetLoadedSkillsForSessionChange("session-1", "session-2")).toBe(true);
+    expect(shouldResetLoadedSkillsForSessionChange("session-1", null)).toBe(false);
+  });
+});

--- a/src/ui/utils/skill-load-tracking.ts
+++ b/src/ui/utils/skill-load-tracking.ts
@@ -1,0 +1,69 @@
+export interface SkillLoadLike {
+  skillName: string;
+}
+
+export interface SkillLoadPartLike {
+  type: string;
+  skills?: SkillLoadLike[];
+}
+
+export interface SkillLoadMessageLike {
+  skillLoads?: SkillLoadLike[];
+  parts?: SkillLoadPartLike[];
+}
+
+export function normalizeSkillTrackingKey(skillName: string): string {
+  return skillName.trim().toLowerCase();
+}
+
+export function normalizeSessionTrackingKey(sessionId: string | null | undefined): string | null {
+  if (typeof sessionId !== "string") {
+    return null;
+  }
+  const normalized = sessionId.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function shouldResetLoadedSkillsForSessionChange(
+  previousSessionId: string | null | undefined,
+  nextSessionId: string | null | undefined,
+): boolean {
+  const previous = normalizeSessionTrackingKey(previousSessionId);
+  const next = normalizeSessionTrackingKey(nextSessionId);
+  return previous !== null && next !== null && previous !== next;
+}
+
+function collectSkillLoads(message: SkillLoadMessageLike): SkillLoadLike[] {
+  const directSkillLoads = message.skillLoads ?? [];
+  const partSkillLoads = (message.parts ?? [])
+    .filter((part) => part.type === "skill-load")
+    .flatMap((part) => part.skills ?? []);
+  return [...directSkillLoads, ...partSkillLoads];
+}
+
+export function createLoadedSkillTrackingSet(
+  messages: readonly SkillLoadMessageLike[],
+): Set<string> {
+  const loaded = new Set<string>();
+  for (const message of messages) {
+    for (const skill of collectSkillLoads(message)) {
+      const key = normalizeSkillTrackingKey(skill.skillName);
+      if (key.length > 0) {
+        loaded.add(key);
+      }
+    }
+  }
+  return loaded;
+}
+
+export function tryTrackLoadedSkill(
+  loadedSkills: Set<string>,
+  skillName: string,
+): boolean {
+  const key = normalizeSkillTrackingKey(skillName);
+  if (key.length === 0 || loadedSkills.has(key)) {
+    return false;
+  }
+  loadedSkills.add(key);
+  return true;
+}

--- a/src/utils/claude-config.test.ts
+++ b/src/utils/claude-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mkdtemp, mkdir, rm, writeFile, readFile } from "fs/promises";
+import { prepareClaudeConfigDir } from "./claude-config.ts";
+
+describe("prepareClaudeConfigDir", () => {
+  test("returns null when ~/.atomic/.claude is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "atomic-claude-config-"));
+    const homeDir = join(root, "home");
+    const mergedDir = join(root, "merged");
+
+    await mkdir(homeDir, { recursive: true });
+
+    try {
+      const result = await prepareClaudeConfigDir({
+        homeDir,
+        mergedDir,
+      });
+      expect(result).toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("loads ~/.atomic/.claude and overlays ~/.claude", async () => {
+    const root = await mkdtemp(join(tmpdir(), "atomic-claude-config-"));
+    const homeDir = join(root, "home");
+    const mergedDir = join(root, "merged");
+
+    const atomicSkill = join(homeDir, ".atomic", ".claude", "skills", "prompt-engineer", "SKILL.md");
+    const legacySkill = join(homeDir, ".claude", "skills", "prompt-engineer", "SKILL.md");
+    const atomicOnlySkill = join(homeDir, ".atomic", ".claude", "skills", "research-codebase", "SKILL.md");
+
+    await mkdir(join(homeDir, ".atomic", ".claude", "skills", "prompt-engineer"), {
+      recursive: true,
+    });
+    await mkdir(join(homeDir, ".claude", "skills", "prompt-engineer"), {
+      recursive: true,
+    });
+    await mkdir(join(homeDir, ".atomic", ".claude", "skills", "research-codebase"), {
+      recursive: true,
+    });
+
+    await writeFile(atomicSkill, "atomic", "utf-8");
+    await writeFile(legacySkill, "legacy", "utf-8");
+    await writeFile(atomicOnlySkill, "atomic-only", "utf-8");
+
+    try {
+      const result = await prepareClaudeConfigDir({
+        homeDir,
+        mergedDir,
+      });
+      expect(result).toBe(mergedDir);
+
+      const mergedSkill = await readFile(
+        join(mergedDir, "skills", "prompt-engineer", "SKILL.md"),
+        "utf-8",
+      );
+      const mergedAtomicOnlySkill = await readFile(
+        join(mergedDir, "skills", "research-codebase", "SKILL.md"),
+        "utf-8",
+      );
+
+      expect(mergedSkill).toBe("legacy");
+      expect(mergedAtomicOnlySkill).toBe("atomic-only");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/utils/claude-config.ts
+++ b/src/utils/claude-config.ts
@@ -1,0 +1,43 @@
+import { homedir } from "os";
+import { join } from "path";
+import { mkdir, rm } from "fs/promises";
+import { copyDir, pathExists } from "./copy";
+
+export interface PrepareClaudeConfigOptions {
+  homeDir?: string;
+  mergedDir?: string;
+}
+
+/**
+ * Build a merged Claude config directory for CLAUDE_CONFIG_DIR.
+ *
+ * Precedence (low -> high):
+ * 1) ~/.atomic/.claude (Atomic-managed defaults)
+ * 2) ~/.claude (legacy user config)
+ *
+ * @returns merged directory path, or null when ~/.atomic/.claude is missing
+ */
+export async function prepareClaudeConfigDir(
+  options: PrepareClaudeConfigOptions = {},
+): Promise<string | null> {
+  const homeDir = options.homeDir ?? homedir();
+  const atomicBaseDir = join(homeDir, ".atomic", ".claude");
+  const mergedDir =
+    options.mergedDir ?? join(homeDir, ".atomic", ".tmp", "claude-config-merged");
+
+  if (!(await pathExists(atomicBaseDir))) {
+    return null;
+  }
+
+  await rm(mergedDir, { recursive: true, force: true });
+  await mkdir(mergedDir, { recursive: true });
+
+  await copyDir(atomicBaseDir, mergedDir);
+
+  const legacyUserDir = join(homeDir, ".claude");
+  if (await pathExists(legacyUserDir)) {
+    await copyDir(legacyUserDir, mergedDir);
+  }
+
+  return mergedDir;
+}


### PR DESCRIPTION
## Summary

Enhances the Atomic SDK with unified skill invocation tracking, improved configuration management, and streamlined UI for skill loading indicators across Claude, OpenCode, and Copilot agents.

## Key Changes

### Skill Invocation Tracking
- Add shared `skill-invocation.ts` utility for detecting and extracting Skill tool usage across Claude and OpenCode SDKs
- Emit `skill.invoked` events from Claude `PreToolUse` hooks when Skill tool is invoked
- Emit `skill.invoked` events from OpenCode tool part updates with per-session deduplication
- Support flexible skill parameter formats (name, skill, skillName, skill_name, slug) for robust detection

### OpenCode Server Lifecycle
- Refactor OpenCode server management to use Atomic-managed servers with lease counting
- Enable proper multi-client isolation by creating dedicated server instances per client
- Add `reuseExistingServer` option (legacy) for backwards compatibility with external servers
- Store Atomic-managed server state globally to support reference counting and cleanup

### Claude Configuration Merging
- Add `prepareClaudeConfigDir()` utility to merge `~/.atomic/.claude` and `~/.claude` directories
- Support precedence: Atomic defaults (low) → user config (high)
- Set `CLAUDE_CONFIG_DIR` environment variable to merged temporary directory
- Enable centralized Atomic defaults while preserving user customizations

### UI Skill Load Tracking
- Extract `skill-load-tracking.ts` module with session-aware deduplication logic
- Track loaded skills per session to prevent duplicate indicators
- Hide redundant Skill tool call indicators in chat view when skill-load indicator already shown
- Reset tracking on session changes to maintain accuracy across conversations

## Testing

- Added comprehensive tests for skill invocation extraction logic
- Added tests for Claude `skill.invoked` event emission with deduplication
- Added tests for OpenCode `skill.invoked` events from tool parts
- Added tests for skill load tracking deduplication and session management
- Added tests for Claude config directory merging with precedence

## Impact

- **Better observability**: Unified skill invocation tracking across all agent types
- **Cleaner UI**: Eliminates duplicate skill loading indicators in chat
- **Better isolation**: OpenCode clients no longer interfere with each other
- **Flexible configuration**: Users can override Atomic defaults while maintaining baseline config