### PR TITLE
chore: bump version to v0.4.22-5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.22-4",
+    "version": "0.4.22-5",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.4.22-4` to `0.4.22-5` for the next prerelease following the merge of new SDK features.

## Changes

- Updated `version` in `package.json` from `0.4.22-4` to `0.4.22-5`

## Context

This version bump follows the merge of PR #328, which added:
- Skill invocation tracking
- Configuration merging capabilities  
- UI deduplication improvements

## Related PRs

- #328 - feat(sdk): add skill invocation tracking, config merging, and UI dedup