### PR TITLE
fix(ui): embed tree-sitter assets for compiled binary builds

### DIFF
--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./chat.tsx";
 import { ThemeProvider, darkTheme, type Theme } from "./theme.tsx";
 import { AppErrorBoundary } from "./components/error-exit-screen.tsx";
+import { initTreeSitterAssets } from "./tree-sitter-assets.ts";
 import { initializeCommandsAsync, globalRegistry } from "./commands/index.ts";
 import { EventBusProvider } from "../events/event-bus-provider.tsx";
 import type {
@@ -633,6 +634,11 @@ export async function startChatUI(
           : capabilitiesPrompt;
       }
     }
+
+    // Ensure Tree-sitter WASM/SCM assets are embedded and reachable in
+    // compiled binaries ($bunfs) before any renderer or <markdown> component
+    // triggers syntax highlighting.
+    initTreeSitterAssets();
 
     // Create the CLI renderer with:
     // - mouse tracking ENABLED for scroll-wheel support in scrollboxes and

--- a/src/ui/tree-sitter-assets.ts
+++ b/src/ui/tree-sitter-assets.ts
@@ -1,0 +1,98 @@
+/**
+ * Tree-sitter Asset Embedding for Binary Builds
+ *
+ * When compiled with `bun build --compile`, the `import ... with { type: "file" }`
+ * statements in @opentui/core's pre-bundled chunk resolve paths relative to
+ * `import.meta.url`, which points to the binary—not the original package location.
+ * This module re-imports all Tree-sitter assets so Bun's compiler embeds them in
+ * the binary's virtual filesystem ($bunfs), then overrides the default parser
+ * paths via `addDefaultParsers()`.
+ */
+
+import { addDefaultParsers } from "@opentui/core";
+
+// -- WASM language grammars --------------------------------------------------
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import jsWasm from "../../node_modules/@opentui/core/assets/javascript/tree-sitter-javascript.wasm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import tsWasm from "../../node_modules/@opentui/core/assets/typescript/tree-sitter-typescript.wasm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import mdWasm from "../../node_modules/@opentui/core/assets/markdown/tree-sitter-markdown.wasm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import mdInlineWasm from "../../node_modules/@opentui/core/assets/markdown_inline/tree-sitter-markdown_inline.wasm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import zigWasm from "../../node_modules/@opentui/core/assets/zig/tree-sitter-zig.wasm" with { type: "file" };
+
+// -- SCM highlight / injection queries ---------------------------------------
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import jsHighlights from "../../node_modules/@opentui/core/assets/javascript/highlights.scm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import tsHighlights from "../../node_modules/@opentui/core/assets/typescript/highlights.scm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import mdHighlights from "../../node_modules/@opentui/core/assets/markdown/highlights.scm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import mdInjections from "../../node_modules/@opentui/core/assets/markdown/injections.scm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import mdInlineHighlights from "../../node_modules/@opentui/core/assets/markdown_inline/highlights.scm" with { type: "file" };
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import zigHighlights from "../../node_modules/@opentui/core/assets/zig/highlights.scm" with { type: "file" };
+
+// -- Parser worker -----------------------------------------------------------
+// @ts-expect-error: Bun-specific import attribute for file embedding
+import parserWorker from "../../node_modules/@opentui/core/parser.worker.js" with { type: "file" };
+
+/**
+ * Override default Tree-sitter parsers with embedded asset paths and set the
+ * worker path. Must be called before any TreeSitterClient is initialised
+ * (i.e. before `createCliRenderer()` or the first `<markdown>` render).
+ */
+export function initTreeSitterAssets(): void {
+  // Point the worker at the embedded file so the TreeSitterClient doesn't try
+  // to resolve it relative to import.meta.url of the @opentui/core bundle.
+  process.env.OTUI_TREE_SITTER_WORKER_PATH = parserWorker;
+
+  addDefaultParsers([
+    {
+      filetype: "javascript",
+      wasm: jsWasm,
+      queries: { highlights: [jsHighlights] },
+    },
+    {
+      filetype: "typescript",
+      wasm: tsWasm,
+      queries: { highlights: [tsHighlights] },
+    },
+    {
+      filetype: "markdown",
+      wasm: mdWasm,
+      queries: {
+        highlights: [mdHighlights],
+        injections: [mdInjections],
+      },
+      injectionMapping: {
+        nodeTypes: {
+          inline: "markdown_inline",
+          pipe_table_cell: "markdown_inline",
+        },
+        infoStringMap: {
+          javascript: "javascript",
+          js: "javascript",
+          typescript: "typescript",
+          ts: "typescript",
+          markdown: "markdown",
+          md: "markdown",
+        },
+      },
+    },
+    {
+      filetype: "markdown_inline",
+      wasm: mdInlineWasm,
+      queries: { highlights: [mdInlineHighlights] },
+    },
+    {
+      filetype: "zig",
+      wasm: zigWasm,
+      queries: { highlights: [zigHighlights] },
+    },
+  ]);
+}


### PR DESCRIPTION
## Summary

Fixes syntax highlighting in compiled binaries by ensuring all Tree-sitter WASM grammars, SCM query files, and the parser worker are embedded in the binary's virtual filesystem ($bunfs).

## Problem

When Atomic CLI is compiled with `bun build --compile`, the `import ... with { type: "file" }` statements in `@opentui/core`'s pre-bundled chunk resolve paths relative to `import.meta.url`, which points to the compiled binary rather than the original `node_modules` location. This causes syntax highlighting to fail because the Tree-sitter assets cannot be found at runtime.

## Solution

Created a new `tree-sitter-assets.ts` module that re-imports all Tree-sitter assets using Bun's `import ... with { type: "file" }` syntax, which instructs the compiler to embed these files in $bunfs. The module then overrides the default parser paths via `addDefaultParsers()` and sets the worker path via the `OTUI_TREE_SITTER_WORKER_PATH` environment variable.

## Key Changes

- **New file**: `src/ui/tree-sitter-assets.ts`
  - Imports all WASM language grammars (JavaScript, TypeScript, Markdown, Markdown inline, Zig)
  - Imports all SCM highlight and injection query files
  - Imports the Tree-sitter parser worker
  - Exports `initTreeSitterAssets()` function that:
    - Sets `OTUI_TREE_SITTER_WORKER_PATH` environment variable
    - Calls `addDefaultParsers()` with embedded asset paths
    - Configures injection mapping for markdown code blocks

- **Updated**: `src/ui/index.ts`
  - Calls `initTreeSitterAssets()` in `startChatUI()` before the CLI renderer is created
  - Ensures syntax highlighting is properly initialized before any `<markdown>` component renders

## Supported Languages

Syntax highlighting now works in compiled binaries for:
- JavaScript (`.js`)
- TypeScript (`.ts`)
- Markdown (`.md`) with code block injection support
- Zig (`.zig`)

## Impact

Users installing the compiled binary distribution will now see properly highlighted code in the TUI, matching the behavior of the non-compiled version.
