### PR TITLE
feat(ui): add mouse wheel scroll support to dialog components

### DIFF
--- a/src/ui/components/model-selector-dialog.tsx
+++ b/src/ui/components/model-selector-dialog.tsx
@@ -11,7 +11,7 @@
 
 import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
-import type { KeyEvent, ScrollBoxRenderable } from "@opentui/core";
+import type { KeyEvent, ScrollBoxRenderable, MouseEvent } from "@opentui/core";
 import { useTheme } from "../theme.tsx";
 import type { Model } from "../../models/model-transform.ts";
 import { navigateUp, navigateDown } from "../utils/navigation.ts";
@@ -180,6 +180,18 @@ export function ModelSelectorDialog({
       scrollBox.scrollTo(selectedRow + 1 - listHeight);
     }
   }, [selectedIndex, modelRowOffsets, listHeight]);
+
+  // Translate mouse wheel scroll into selection movement so the highlight follows
+  const handleMouseScroll = useCallback((event: MouseEvent) => {
+    if (reasoningModel) return;
+    const direction = event.scroll?.direction;
+    if (direction === "up") {
+      setSelectedIndex((prev) => navigateUp(prev, flatModels.length));
+    } else if (direction === "down") {
+      setSelectedIndex((prev) => navigateDown(prev, flatModels.length));
+    }
+    event.stopPropagation();
+  }, [flatModels.length, reasoningModel]);
 
   /** Confirm model selection, showing reasoning selector if applicable */
   const confirmModel = useCallback((model: Model) => {
@@ -388,7 +400,8 @@ export function ModelSelectorDialog({
             </text>
           </box>
         ) : (
-          groupedModels.map((group, groupIdx) => {
+          <box flexDirection="column" onMouseScroll={handleMouseScroll}>
+          {groupedModels.map((group, groupIdx) => {
             const isLastGroup = groupIdx === groupedModels.length - 1;
 
             return (
@@ -488,6 +501,8 @@ export function ModelSelectorDialog({
               </box>
             );
           })
+          }
+          </box>
         )}
       </scrollbox>
       <box style={{ paddingLeft: 2, paddingTop: 1 }}>

--- a/src/ui/components/user-question-dialog.tsx
+++ b/src/ui/components/user-question-dialog.tsx
@@ -8,7 +8,7 @@
 
 import React, { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { useKeyboard, useTerminalDimensions } from "@opentui/react";
-import type { KeyEvent, TextareaRenderable, ScrollBoxRenderable } from "@opentui/core";
+import type { KeyEvent, TextareaRenderable, ScrollBoxRenderable, MouseEvent } from "@opentui/core";
 import { useTheme } from "../theme.tsx";
 import { navigateUp, navigateDown } from "../utils/navigation.ts";
 import { PROMPT, STATUS, CONNECTOR } from "../constants/icons.ts";
@@ -177,6 +177,18 @@ export function UserQuestionDialog({
     setIsEditingCustom(false);
     setIsChatAboutThis(false);
   }, [submitAnswer, isChatAboutThis]);
+
+  // Translate mouse wheel scroll into selection movement so the highlight follows
+  const handleMouseScroll = useCallback((event: MouseEvent) => {
+    if (isEditingCustom || isChatAboutThis) return;
+    const direction = event.scroll?.direction;
+    if (direction === "up") {
+      setHighlightedIndex((prev) => navigateUp(prev, optionsCount));
+    } else if (direction === "down") {
+      setHighlightedIndex((prev) => navigateDown(prev, optionsCount));
+    }
+    event.stopPropagation();
+  }, [optionsCount, isEditingCustom, isChatAboutThis]);
 
   useKeyboard(
     useCallback(
@@ -358,6 +370,7 @@ export function UserQuestionDialog({
             scrollX={false}
             marginTop={SPACING.ELEMENT}
           >
+            <box flexDirection="column" onMouseScroll={handleMouseScroll}>
             {allOptions.map((option, index) => {
               const isHighlighted = index === highlightedIndex;
               const isSelected = selectedValues.includes(option.value);
@@ -396,6 +409,7 @@ export function UserQuestionDialog({
                 </React.Fragment>
               );
             })}
+            </box>
           </scrollbox>
           <box marginTop={SPACING.ELEMENT}>
             <text style={{ fg: colors.muted }}>


### PR DESCRIPTION
## Summary

Adds mouse wheel scroll support to dialog components, allowing users to navigate selections using the scroll wheel in addition to keyboard arrows. The highlighted selection now follows scroll gestures for a more intuitive interaction experience.

## Changes

- **ModelSelectorDialog**: Added `onMouseScroll` handler to synchronize selection with mouse wheel events
- **UserQuestionDialog**: Added `onMouseScroll` handler for option navigation
- Imported `MouseEvent` type from `@opentui/core` in both components
- Wrapped dialog content in `<box>` elements to capture scroll events
- Reused existing `navigateUp`/`navigateDown` utilities for consistent wrap-around behavior

## Implementation Details

- Scroll events are translated to selection movements using the same navigation logic as keyboard arrows
- Includes state guards to prevent scrolling during:
  - Reasoning model selection in ModelSelectorDialog
  - Custom text editing in UserQuestionDialog
  - Chat-about-this mode in UserQuestionDialog
- Calls `event.stopPropagation()` to prevent scroll event conflicts

## Files Modified

- `src/ui/components/model-selector-dialog.tsx`
- `src/ui/components/user-question-dialog.tsx`