### PR TITLE
fix(sdk): serialize queries after abort to prevent race conditions

### DIFF
--- a/src/sdk/clients/claude.ts
+++ b/src/sdk/clients/claude.ts
@@ -102,6 +102,8 @@ interface ClaudeSessionState {
     systemToolsBaseline: number | null;
     /** Whether per-turn usage events were emitted from message_delta during streaming */
     hasEmittedStreamingUsage: boolean;
+    /** In-flight abort gate used to serialize new queries after interrupts */
+    pendingAbortPromise: Promise<void> | null;
 }
 
 interface StreamIntegrityCounters {
@@ -686,6 +688,59 @@ export class ClaudeAgentClient implements CodingAgentClient {
             systemToolsBaseline:
                 persisted?.systemToolsBaseline ?? this.probeSystemToolsBaseline,
             hasEmittedStreamingUsage: false,
+            pendingAbortPromise: null,
+        };
+
+        const waitForPendingAbort = async (): Promise<void> => {
+            const pendingAbort = state.pendingAbortPromise;
+            if (!pendingAbort) {
+                return;
+            }
+            try {
+                await pendingAbort;
+            } catch {
+                // If abort fails, do not block subsequent user turns.
+            }
+        };
+
+        const runAbortWithLock = (): Promise<void> => {
+            if (state.pendingAbortPromise) {
+                return state.pendingAbortPromise;
+            }
+
+            const abortPromise = (async () => {
+                // Prefer graceful interruption so the underlying Claude Code
+                // session remains reusable for the next turn. Force-close only
+                // as a fallback for runtimes that do not expose interrupt().
+                const activeQuery = state.query as
+                    | (Query & {
+                          interrupt?: () => Promise<void>;
+                      })
+                    | null;
+                if (!activeQuery) {
+                    return;
+                }
+
+                if (typeof activeQuery.interrupt === "function") {
+                    try {
+                        await activeQuery.interrupt();
+                        return;
+                    } catch {
+                        // Fall through to force-close fallback.
+                    }
+                }
+
+                activeQuery.close();
+            })();
+
+            state.pendingAbortPromise = abortPromise;
+            void abortPromise.finally(() => {
+                if (state.pendingAbortPromise === abortPromise) {
+                    state.pendingAbortPromise = null;
+                }
+            });
+
+            return abortPromise;
         };
 
         this.sessions.set(sessionId, state);
@@ -697,6 +752,7 @@ export class ClaudeAgentClient implements CodingAgentClient {
                 if (state.isClosed) {
                     throw new Error("Session is closed");
                 }
+                await waitForPendingAbort();
                 this.emitRuntimeSelection(sessionId, "send");
 
                 // Build options with resume if we have an SDK session ID
@@ -818,6 +874,7 @@ export class ClaudeAgentClient implements CodingAgentClient {
                         if (state.isClosed) {
                             throw new Error("Session is closed");
                         }
+                        await waitForPendingAbort();
                         state.hasEmittedStreamingUsage = false;
                         emitRuntimeSelection();
                         const options: Options = {
@@ -1147,6 +1204,7 @@ export class ClaudeAgentClient implements CodingAgentClient {
                 if (state.isClosed) {
                     throw new Error("Session is closed");
                 }
+                await waitForPendingAbort();
                 this.emitRuntimeSelection(sessionId, "summarize");
 
                 // Send /compact as a prompt to the Claude Agents SDK
@@ -1202,6 +1260,7 @@ export class ClaudeAgentClient implements CodingAgentClient {
                 if (state.isClosed) {
                     return null;
                 }
+                await waitForPendingAbort();
 
                 let statusQuery: Query | null = null;
                 let shouldClose = false;
@@ -1244,48 +1303,11 @@ export class ClaudeAgentClient implements CodingAgentClient {
             },
 
             abort: async (): Promise<void> => {
-                // Prefer graceful interruption so the underlying Claude Code
-                // session remains reusable for the next turn. Force-close only
-                // as a fallback for runtimes that do not expose interrupt().
-                const activeQuery = state.query as
-                    | (Query & {
-                          interrupt?: () => Promise<void>;
-                      })
-                    | null;
-                if (!activeQuery) {
-                    return;
-                }
-                if (typeof activeQuery.interrupt === "function") {
-                    try {
-                        await activeQuery.interrupt();
-                        return;
-                    } catch {
-                        // Fall through to force-close fallback.
-                    }
-                }
-                activeQuery.close();
+                await runAbortWithLock();
             },
 
             abortBackgroundAgents: async (): Promise<void> => {
-                // Prefer graceful interruption to avoid poisoning the next
-                // resumed turn after background/foreground cancellation.
-                const activeQuery = state.query as
-                    | (Query & {
-                          interrupt?: () => Promise<void>;
-                      })
-                    | null;
-                if (!activeQuery) {
-                    return;
-                }
-                if (typeof activeQuery.interrupt === "function") {
-                    try {
-                        await activeQuery.interrupt();
-                        return;
-                    } catch {
-                        // Fall through to force-close fallback.
-                    }
-                }
-                activeQuery.close();
+                await runAbortWithLock();
             },
 
             destroy: async (): Promise<void> => {


### PR DESCRIPTION
## Summary

Introduces an abort gate mechanism to prevent race conditions where new queries could start while previous abort/interrupt operations are still in progress. This ensures safe serialization of operations and prevents the Claude Agent SDK session from entering an inconsistent state.

## Problem

Previously, there was a race condition where:
- A user could abort an in-flight query via `abort()` or `abortBackgroundAgents()`
- While the abort was still tearing down the query, a new `send()`, `stream()`, `summarize()`, or `getStatus()` call could begin
- This could cause the session to enter an inconsistent state or leave resources improperly cleaned up

## Solution

### Core Changes

- **Added abort gate**: New `pendingAbortPromise` field in `ClaudeSessionState` tracks any in-flight abort operation
- **Serialization helper**: `waitForPendingAbort()` ensures all query methods wait for pending aborts to complete before proceeding
- **Shared abort logic**: `runAbortWithLock()` deduplicates the abort implementation and ensures only one abort runs at a time

### Implementation Details

1. **`runAbortWithLock()`**: Manages the abort lifecycle
   - Returns existing promise if abort already in progress (deduplication)
   - Attempts graceful interrupt via `query.interrupt()` first
   - Falls back to force-close with `query.close()` if interrupt unavailable/fails
   - Automatically clears `pendingAbortPromise` when complete

2. **Query method protection**: Modified `send()`, `stream()`, `summarize()`, and `getStatus()` to call `waitForPendingAbort()` before proceeding

3. **Code deduplication**: Both `abort()` and `abortBackgroundAgents()` now simply call `runAbortWithLock()`, eliminating ~40 lines of duplicated code

## Benefits

- ✅ Prevents race conditions between abort and subsequent queries
- ✅ Ensures session state consistency
- ✅ Reduces code duplication (DRY principle)
- ✅ Maintains graceful interrupt behavior with force-close fallback
- ✅ Non-blocking: failed aborts don't prevent subsequent user turns