### PR TITLE
chore: prerelease v0.4.23-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.23-3",
+    "version": "0.4.23-4",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary

Bumps version to `0.4.23-4` for prerelease.

## Changes

- Updated version in `package.json` from `0.4.23-3` to `0.4.23-4`

## Type

This is a prerelease version bump with no functional changes.