### PR TITLE
fix(build): inject tree-sitter worker path at compile time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,16 +65,16 @@ jobs:
                   mkdir -p dist
 
                   # Linux x64
-                  bun build src/cli.ts --compile --minify --target=bun-linux-x64 --outfile dist/atomic-linux-x64
+                  bun run src/scripts/build-binary.ts --minify --target=bun-linux-x64 --outfile dist/atomic-linux-x64
 
                   # Linux arm64
-                  bun build src/cli.ts --compile --minify --target=bun-linux-arm64 --outfile dist/atomic-linux-arm64
+                  bun run src/scripts/build-binary.ts --minify --target=bun-linux-arm64 --outfile dist/atomic-linux-arm64
 
                   # macOS x64
-                  bun build src/cli.ts --compile --minify --target=bun-darwin-x64 --outfile dist/atomic-darwin-x64
+                  bun run src/scripts/build-binary.ts --minify --target=bun-darwin-x64 --outfile dist/atomic-darwin-x64
 
                   # macOS arm64 (Apple Silicon)
-                  bun build src/cli.ts --compile --minify --target=bun-darwin-arm64 --outfile dist/atomic-darwin-arm64
+                  bun run src/scripts/build-binary.ts --minify --target=bun-darwin-arm64 --outfile dist/atomic-darwin-arm64
 
             - name: Create config archives
               run: |
@@ -124,7 +124,7 @@ jobs:
             - name: Build Windows binary natively
               run: |
                   mkdir dist
-                  bun build src/cli.ts --compile --minify --outfile dist/atomic-windows-x64.exe
+                  bun run src/scripts/build-binary.ts --minify --outfile dist/atomic-windows-x64.exe
 
             - name: Upload Windows artifact
               uses: actions/upload-artifact@v7

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@opentui/react": "^0.1.86",
         "ci-info": "^4.4.0",
         "commander": "^14.0.3",
+        "web-tree-sitter": "0.25.10",
         "zod": "^4.3.6",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ],
     "scripts": {
         "dev": "bun run src/cli.ts",
-        "build": "bun build src/cli.ts --compile --no-compile-autoload-dotenv --no-compile-autoload-bunfig --outfile atomic",
+        "build": "bun run src/scripts/build-binary.ts --outfile atomic",
         "test": "bun test",
         "test:contracts": "bun test src/ui/utils/background-agent-provider-parity.test.ts src/ui/utils/background-agent-runtime-parity.test.ts src/ui/utils/background-agent-acceptance.test.ts src/ui/utils/background-agent-termination-integration.test.ts src/ui/utils/background-agent-keybinding-nonconflict.test.ts src/ui/utils/background-agent-parent-callback.test.ts",
         "typecheck": "tsc --noEmit",
@@ -60,6 +60,7 @@
         "@opentui/react": "^0.1.86",
         "ci-info": "^4.4.0",
         "commander": "^14.0.3",
+        "web-tree-sitter": "0.25.10",
         "zod": "^4.3.6"
     }
 }

--- a/src/scripts/build-binary.ts
+++ b/src/scripts/build-binary.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+
+import { realpathSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+type BuildOptions = {
+  outfile: string;
+  minify: boolean;
+  target?: string;
+};
+
+function parseCompileTarget(target: string): string {
+  if (!target.startsWith("bun-")) {
+    throw new Error(`Invalid --target ${target}. Expected bun-<os>-<arch>.`);
+  }
+
+  return target;
+}
+
+function parseBuildOptions(argv: string[]): BuildOptions {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      outfile: { type: "string" },
+      target: { type: "string" },
+      minify: { type: "boolean", default: false },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (!values.outfile) {
+    throw new Error("Missing required --outfile <path> argument");
+  }
+
+  return {
+    outfile: values.outfile,
+    target: values.target ? parseCompileTarget(values.target) : undefined,
+    minify: values.minify ?? false,
+  };
+}
+
+function inferTargetOs(target?: string): NodeJS.Platform {
+  if (!target) {
+    return process.platform;
+  }
+
+  const normalizedTarget = target.toLowerCase();
+
+  if (normalizedTarget.includes("windows") || normalizedTarget.includes("win32")) {
+    return "win32";
+  }
+
+  if (normalizedTarget.includes("linux")) {
+    return "linux";
+  }
+
+  if (normalizedTarget.includes("darwin") || normalizedTarget.includes("mac")) {
+    return "darwin";
+  }
+
+  throw new Error(`Unable to infer target OS from --target ${target}`);
+}
+
+function getBunfsRoot(targetOs: NodeJS.Platform): string {
+  return targetOs === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/";
+}
+
+const options = parseBuildOptions(Bun.argv.slice(2));
+
+const projectRoot = process.cwd();
+const parserWorker = realpathSync(resolve(projectRoot, "node_modules/@opentui/core/parser.worker.js"));
+const workerRelativePath = relative(projectRoot, parserWorker).replaceAll("\\", "/");
+const compileTargetOs = inferTargetOs(options.target);
+
+const result = await Bun.build({
+  entrypoints: ["src/cli.ts", parserWorker],
+  minify: options.minify,
+  compile: {
+    outfile: options.outfile,
+    autoloadDotenv: false,
+    autoloadBunfig: false,
+    ...(options.target ? { target: options.target as never } : {}),
+  },
+  define: {
+    OTUI_TREE_SITTER_WORKER_PATH: JSON.stringify(`${getBunfsRoot(compileTargetOs)}${workerRelativePath}`),
+  },
+});
+
+if (!result.success) {
+  for (const log of result.logs) {
+    console.error(log);
+  }
+  process.exit(1);
+}

--- a/src/ui/tree-sitter-assets.binary.test.ts
+++ b/src/ui/tree-sitter-assets.binary.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { join, relative, resolve } from "path";
+import { realpathSync } from "node:fs";
+
+async function runCommand(command: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(command, {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const [stdoutBuffer, stderrBuffer] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  const exitCode = await proc.exited;
+
+  return {
+    stdout: stdoutBuffer,
+    stderr: stderrBuffer,
+    exitCode,
+  };
+}
+
+describe("tree-sitter assets in compiled binaries", () => {
+  let tempDir = "";
+
+  afterAll(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("markdown highlighting initializes in compiled binary", async () => {
+    tempDir = await mkdtemp(join(process.cwd(), ".tmp-tree-sitter-"));
+
+    const scriptPath = join(tempDir, "tree-sitter-binary-check.ts");
+    const binaryPath = join(tempDir, "tree-sitter-binary-check");
+    const treeSitterAssetsPath = join(process.cwd(), "src", "ui", "tree-sitter-assets.ts");
+
+    await writeFile(
+      scriptPath,
+      [
+        `import { initTreeSitterAssets } from ${JSON.stringify(treeSitterAssetsPath)};`,
+        `import { TreeSitterClient, getDataPaths } from "@opentui/core";`,
+        `initTreeSitterAssets();`,
+        `const client = new TreeSitterClient({ dataPath: getDataPaths().globalDataPath });`,
+        `await client.initialize();`,
+        `const result = await client.highlightOnce("# Title\\n\\n- one\\n- two", "markdown");`,
+        `await client.destroy();`,
+        `console.log(JSON.stringify({ hasHighlights: Boolean(result.highlights), error: result.error, warning: result.warning, count: result.highlights?.length ?? 0 }));`,
+      ].join("\n"),
+      "utf8"
+    );
+
+    const parserWorkerPath = realpathSync(
+      resolve(process.cwd(), "node_modules/@opentui/core/parser.worker.js")
+    );
+    const bunfsRoot = process.platform === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/";
+    const workerRelativePath = relative(process.cwd(), parserWorkerPath).replaceAll("\\", "/");
+
+    const build = await Bun.build({
+      entrypoints: [scriptPath, parserWorkerPath],
+      compile: {
+        outfile: binaryPath,
+        autoloadDotenv: false,
+        autoloadBunfig: false,
+      },
+      define: {
+        OTUI_TREE_SITTER_WORKER_PATH: JSON.stringify(`${bunfsRoot}${workerRelativePath}`),
+      },
+    });
+
+    expect(build.success).toBe(true);
+
+    const run = await runCommand([binaryPath]);
+    expect(run.exitCode).toBe(0);
+    expect(run.stderr).not.toContain("TreeSitter worker error");
+
+    const outputLine = run.stdout
+      .trim()
+      .split("\n")
+      .findLast((line) => line.startsWith("{"));
+
+    expect(outputLine).toBeDefined();
+    const parsed = JSON.parse(outputLine ?? "{}");
+    expect(parsed.hasHighlights).toBe(true);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.count).toBeGreaterThan(0);
+  });
+});

--- a/src/ui/tree-sitter-assets.test.ts
+++ b/src/ui/tree-sitter-assets.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { initTreeSitterAssets } from "./tree-sitter-assets.ts";
+
+function withWorkerPathEnv(envPath: string | undefined, callback: () => void): void {
+  const originalEnvPath = process.env.OTUI_TREE_SITTER_WORKER_PATH;
+
+  if (envPath === undefined) {
+    delete process.env.OTUI_TREE_SITTER_WORKER_PATH;
+  } else {
+    process.env.OTUI_TREE_SITTER_WORKER_PATH = envPath;
+  }
+
+  try {
+    callback();
+  } finally {
+    if (originalEnvPath === undefined) {
+      delete process.env.OTUI_TREE_SITTER_WORKER_PATH;
+    } else {
+      process.env.OTUI_TREE_SITTER_WORKER_PATH = originalEnvPath;
+    }
+  }
+}
+
+describe("initTreeSitterAssets worker configuration", () => {
+  test("keeps existing env worker path untouched", () => {
+    withWorkerPathEnv("/tmp/custom-worker.js", () => {
+      initTreeSitterAssets();
+
+      expect(process.env.OTUI_TREE_SITTER_WORKER_PATH).toBe("/tmp/custom-worker.js");
+    });
+  });
+
+  test("uses env fallback when compile-time worker path is unavailable", () => {
+    withWorkerPathEnv(undefined, () => {
+      initTreeSitterAssets();
+
+      expect(process.env.OTUI_TREE_SITTER_WORKER_PATH).toContain("parser.worker.js");
+    });
+  });
+});

--- a/src/ui/tree-sitter-assets.ts
+++ b/src/ui/tree-sitter-assets.ts
@@ -4,12 +4,17 @@
  * When compiled with `bun build --compile`, the `import ... with { type: "file" }`
  * statements in @opentui/core's pre-bundled chunk resolve paths relative to
  * `import.meta.url`, which points to the binary—not the original package location.
- * This module re-imports all Tree-sitter assets so Bun's compiler embeds them in
- * the binary's virtual filesystem ($bunfs), then overrides the default parser
- * paths via `addDefaultParsers()`.
+ * This module re-imports Tree-sitter grammar/query assets so Bun's compiler
+ * embeds them in the binary's virtual filesystem ($bunfs), then overrides
+ * parser paths via `addDefaultParsers()`. The worker path itself is injected
+ * at compile-time by `src/scripts/build-binary.ts` (OpenCode pattern).
  */
 
 import { addDefaultParsers } from "@opentui/core";
+import { resolve } from "path";
+
+declare const OTUI_TREE_SITTER_WORKER_PATH: string;
+
 
 // -- WASM language grammars --------------------------------------------------
 // @ts-expect-error: Bun-specific import attribute for file embedding
@@ -37,9 +42,20 @@ import mdInlineHighlights from "../../node_modules/@opentui/core/assets/markdown
 // @ts-expect-error: Bun-specific import attribute for file embedding
 import zigHighlights from "../../node_modules/@opentui/core/assets/zig/highlights.scm" with { type: "file" };
 
-// -- Parser worker -----------------------------------------------------------
-// @ts-expect-error: Bun-specific import attribute for file embedding
-import parserWorker from "../../node_modules/@opentui/core/parser.worker.js" with { type: "file" };
+function getCompileTimeTreeSitterWorkerPath(): string | undefined {
+  if (
+    typeof OTUI_TREE_SITTER_WORKER_PATH === "undefined" ||
+    OTUI_TREE_SITTER_WORKER_PATH.length === 0
+  ) {
+    return undefined;
+  }
+
+  return OTUI_TREE_SITTER_WORKER_PATH;
+}
+
+function getRuntimeTreeSitterWorkerPath(): string {
+  return resolve(import.meta.dir, "../../node_modules/@opentui/core/parser.worker.js");
+}
 
 /**
  * Override default Tree-sitter parsers with embedded asset paths and set the
@@ -47,9 +63,11 @@ import parserWorker from "../../node_modules/@opentui/core/parser.worker.js" wit
  * (i.e. before `createCliRenderer()` or the first `<markdown>` render).
  */
 export function initTreeSitterAssets(): void {
-  // Point the worker at the embedded file so the TreeSitterClient doesn't try
-  // to resolve it relative to import.meta.url of the @opentui/core bundle.
-  process.env.OTUI_TREE_SITTER_WORKER_PATH = parserWorker;
+  // OpenCode-style binary builds inject OTUI_TREE_SITTER_WORKER_PATH at compile
+  // time. Keep a runtime fallback for local dev/repo installs.
+  if (!process.env.OTUI_TREE_SITTER_WORKER_PATH && !getCompileTimeTreeSitterWorkerPath()) {
+    process.env.OTUI_TREE_SITTER_WORKER_PATH = getRuntimeTreeSitterWorkerPath();
+  }
 
   addDefaultParsers([
     {


### PR DESCRIPTION
## Problem

When compiling Atomic with `bun build --compile`, Tree-sitter syntax highlighting failed in the binary because the file-embedding approach (`import ... with { type: "file" }`) resolved paths relative to `import.meta.url`, which points to the compiled binary rather than the original package location. This caused the parser worker to fail initialization.

## Solution

Replace the file-embedding approach with compile-time path injection using Bun's `define` API, following the pattern used by OpenCode SDK. The worker path is now injected as a compile-time constant pointing to `$bunfs/root/` (Bun's virtual filesystem in compiled binaries), with a runtime fallback for local development.

## Changes

- **Add `src/scripts/build-binary.ts`**: New build wrapper that uses Bun's `define` API to inject `OTUI_TREE_SITTER_WORKER_PATH` pointing to the worker's location in `$bunfs/root/`
- **Update build configuration**: Modified `package.json` build script and all CI workflow build steps to use `build-binary.ts`
- **Refactor `initTreeSitterAssets()`**: Now prefers compile-time constant with runtime fallback for local development
- **Add `web-tree-sitter` dependency**: Required for Tree-sitter functionality
- **Add comprehensive tests**:
  - Unit tests for worker path configuration logic
  - Binary integration test that verifies Tree-sitter highlighting works in compiled binaries

## Testing

The binary integration test (`tree-sitter-assets.binary.test.ts`) compiles a test binary with the new build approach and verifies that markdown highlighting initializes successfully, ensuring the fix works end-to-end.