### PR TITLE
chore: prerelease v0.4.23-6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.23-4",
+    "version": "0.4.23-6",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary

Bumps version to 0.4.23-6 for prerelease.

## Changes

- **Version**: Updated from `0.4.23-4` to `0.4.23-6` in `package.json`

## Context

This prerelease follows the merge of PR #350, which fixed tree-sitter worker path injection at compile time. The version skips 0.4.23-5 to maintain consistency with the release sequence.