### PR TITLE
chore: prerelease 0.4.23-7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@bastani/atomic",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.66",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.68",
         "@azure/monitor-opentelemetry": "^1.16.0",
         "@clack/prompts": "^1.1.0",
         "@commander-js/extra-typings": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.23-6",
+    "version": "0.4.23-7",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary

Prerelease version 0.4.23-7 with dependency updates.

## Changes

- **Version bump**: 0.4.23-6 → 0.4.23-7
- **Dependency update**: Upgrade @anthropic-ai/claude-agent-sdk from ^0.2.66 to ^0.2.68

## Notes

This is a prerelease version that includes the latest Claude Agent SDK improvements.