### PR TITLE
chore: bump version to 0.4.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bastani/atomic",
-    "version": "0.4.23-8",
+    "version": "0.4.24",
     "description": "Configuration management CLI for coding agents",
     "type": "module",
     "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary
Bumps version from `0.4.23-8` to `0.4.24`, marking a new stable release of the Atomic CLI.

## Changes
- Updates package version to `0.4.24` in `package.json`
- Graduates from pre-release `0.4.23-8` to stable `0.4.24`

This release includes improvements from the 0.4.23 pre-release cycle, including:
- Provider-aware discovery and config sync alignment (#353)
- Stream event leak prevention (#352)
- Tree-sitter worker path injection fixes (#350)
- Claude Code macOS response handling fixes (#346)

## Test plan
- [x] All tests pass (pre-commit hook verified)
- [x] Type checks pass
- [x] Version bump is the only change in this PR