### PR TITLE
fix(opencode): route native skill invocations through command API

### DIFF
--- a/.claude/skills/research-codebase/SKILL.md
+++ b/.claude/skills/research-codebase/SKILL.md
@@ -16,7 +16,8 @@ The user's research question/request is: **$ARGUMENTS**
 
 - OPTIMIZE the user's research question request using your prompt-engineer skill and confirm that the your refined question captures the user's intent BEFORE proceeding using the `AskUserQuestion` tool.
 - After research is complete and the research artifact(s) are generated, provide an executive summary of the research and path to the research document(s) to the user, and ask if they have any follow-up questions or need clarification.
-  </EXTREMELY_IMPORTANT>
+
+</EXTREMELY_IMPORTANT>
 
 1. **Read any directly mentioned files first:**
     - If the user mentions specific files (tickets, docs, or other notes), read them FULLY first

--- a/.github/skills/research-codebase/SKILL.md
+++ b/.github/skills/research-codebase/SKILL.md
@@ -16,7 +16,8 @@ The user's research question/request is: **$ARGUMENTS**
 
 - OPTIMIZE the user's research question request using your prompt-engineer skill and confirm that the your refined question captures the user's intent BEFORE proceeding using the `AskUserQuestion` tool.
 - After research is complete and the research artifact(s) are generated, provide an executive summary of the research and path to the research document(s) to the user, and ask if they have any follow-up questions or need clarification.
-  </EXTREMELY_IMPORTANT>
+
+</EXTREMELY_IMPORTANT>
 
 1. **Read any directly mentioned files first:**
     - If the user mentions specific files (tickets, docs, or other notes), read them FULLY first

--- a/.opencode/skills/research-codebase/SKILL.md
+++ b/.opencode/skills/research-codebase/SKILL.md
@@ -16,7 +16,8 @@ The user's research question/request is: **$ARGUMENTS**
 
 - OPTIMIZE the user's research question request using your prompt-engineer skill and confirm that the your refined question captures the user's intent BEFORE proceeding using the `AskUserQuestion` tool.
 - After research is complete and the research artifact(s) are generated, provide an executive summary of the research and path to the research document(s) to the user, and ask if they have any follow-up questions or need clarification.
-  </EXTREMELY_IMPORTANT>
+
+</EXTREMELY_IMPORTANT>
 
 1. **Read any directly mentioned files first:**
     - If the user mentions specific files (tickets, docs, or other notes), read them FULLY first

--- a/src/events/adapters/opencode-adapter.ts
+++ b/src/events/adapters/opencode-adapter.ts
@@ -190,7 +190,7 @@ export class OpenCodeStreamAdapter implements SDKStreamAdapter {
     message: string,
     options: StreamAdapterOptions,
   ): Promise<void> {
-    const { runId, messageId, agent, runtimeFeatureFlags, abortSignal } = options;
+    const { runId, messageId, agent, runtimeFeatureFlags, abortSignal, skillCommand } = options;
 
     // Clean up any existing subscriptions from a previous startStreaming() call
     // to prevent subscription accumulation on re-entry without dispose()
@@ -474,7 +474,11 @@ export class OpenCodeStreamAdapter implements SDKStreamAdapter {
           : undefined;
 
         try {
-          await session.sendAsync(message, dispatchOptions);
+          if (skillCommand) {
+            await session.command!(skillCommand.name, skillCommand.args, dispatchOptions);
+          } else {
+            await session.sendAsync(message, dispatchOptions);
+          }
         } catch (error) {
           if (!isDispatchAbortError(error)) {
             throw error;

--- a/src/events/adapters/types.ts
+++ b/src/events/adapters/types.ts
@@ -50,4 +50,6 @@ export interface StreamAdapterOptions {
   knownAgentNames?: string[];
   /** Runtime contract feature-flag overrides (Task #1 scaffolding) */
   runtimeFeatureFlags?: WorkflowRuntimeFeatureFlagOverrides;
+  /** Structured skill/slash-command for OpenCode session.command() dispatch */
+  skillCommand?: { name: string; args: string };
 }

--- a/src/sdk/clients/opencode.ts
+++ b/src/sdk/clients/opencode.ts
@@ -2431,6 +2431,40 @@ export class OpenCodeClient implements CodingAgentClient {
         }
       },
 
+      command: async (
+        commandName: string,
+        args: string,
+        options?: { agent?: string; abortSignal?: AbortSignal },
+      ): Promise<void> => {
+        if (sessionState.isClosed) {
+          throw new Error("Session is closed");
+        }
+        if (!client.sdkClient) {
+          throw new Error("Client not connected");
+        }
+
+        const resolvedModel = client.activePromptModel ?? initialPromptModel;
+        const modelString = resolvedModel
+          ? `${resolvedModel.providerID}/${resolvedModel.modelID}`
+          : undefined;
+
+        const result = await client.sdkClient.session.command(
+          {
+            sessionID: sessionId,
+            directory: client.clientOptions.directory,
+            agent: agentMode,
+            model: modelString,
+            command: commandName,
+            arguments: args,
+          },
+          options?.abortSignal ? { signal: options.abortSignal } : undefined,
+        );
+
+        if (result?.error) {
+          throw new Error(extractOpenCodeErrorMessage(result.error));
+        }
+      },
+
       stream: (
         message: string,
         options?: { agent?: string; abortSignal?: AbortSignal },

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -309,6 +309,20 @@ export interface Session {
   destroy(): Promise<void>;
 
   /**
+   * Send a structured slash-command to the session.
+   * Only implemented by OpenCode (maps to POST /session/{id}/command).
+   * Other clients should omit this; callers fall back to sendAsync/stream.
+   * @param commandName - The command name (without leading slash)
+   * @param args - The command arguments string
+   * @param options - Optional dispatch options (abort signal, agent override)
+   */
+  command?(
+    commandName: string,
+    args: string,
+    options?: { agent?: string; abortSignal?: AbortSignal },
+  ): Promise<void>;
+
+  /**
    * Abort any ongoing work in the session.
    * Optional - only supported by some SDKs (e.g., Copilot).
    * When supported, this cancels in-flight agent work including sub-agent invocations.

--- a/src/ui/commands/registry.ts
+++ b/src/ui/commands/registry.ts
@@ -38,6 +38,8 @@ export interface StreamMessageOptions {
   agent?: string;
   /** Marks this stream as @agent-only so completion can be finalized without SDK onComplete. */
   isAgentOnlyStream?: boolean;
+  /** Structured skill/slash-command dispatch. When set, OpenCode uses session.command() instead of promptAsync(). */
+  skillCommand?: { name: string; args: string };
 }
 
 /**

--- a/src/ui/commands/skill-commands.ts
+++ b/src/ui/commands/skill-commands.ts
@@ -637,6 +637,7 @@ function dispatchNativeSkillInvocation(
 ): CommandResult {
     context.sendSilentMessage(
         buildSkillInvocationMessage(skillName, skillArgs),
+        { skillCommand: { name: skillName, args: skillArgs } },
     );
     return { success: true, skillLoaded: skillName };
 }

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -19,7 +19,7 @@ import {
 import { ThemeProvider, darkTheme, type Theme } from "./theme.tsx";
 import { AppErrorBoundary } from "./components/error-exit-screen.tsx";
 import { initTreeSitterAssets } from "./tree-sitter-assets.ts";
-import { initializeCommandsAsync, globalRegistry } from "./commands/index.ts";
+import { initializeCommandsAsync } from "./commands/index.ts";
 import { EventBusProvider } from "../events/event-bus-provider.tsx";
 import type {
   CodingAgentClient,
@@ -44,57 +44,6 @@ import { attachDebugSubscriber } from "../events/debug-subscriber.ts";
 import { cleanupMcpBridgeScripts } from "../sdk/tools/opencode-mcp-bridge.ts";
 
 const FLUSH_FRAME_MS = 16;
-
-/**
- * Build a system prompt section describing all registered capabilities.
- * Includes slash commands, skills, and sub-agents so the model is aware
- * of them and they count toward the system/tools token baseline.
- */
-function buildCapabilitiesSystemPrompt(): string {
-  const allCommands = globalRegistry.all();
-  if (allCommands.length === 0) return "";
-
-  const sections: string[] = [];
-
-  const builtins = allCommands.filter((c) => c.category === "builtin");
-  if (builtins.length > 0) {
-    const lines = builtins.map((c) => {
-      const hint = c.argumentHint ? ` ${c.argumentHint}` : "";
-      return `  /${c.name}${hint} - ${c.description}`;
-    });
-    sections.push(`Slash Commands:\n${lines.join("\n")}`);
-  }
-
-  const skills = allCommands.filter((c) => c.category === "skill");
-  if (skills.length > 0) {
-    const lines = skills.map((c) => {
-      const hint = c.argumentHint ? ` ${c.argumentHint}` : "";
-      return `  /${c.name}${hint} - ${c.description}`;
-    });
-    sections.push(
-      `Skills (invoke with /skill-name):\n${lines.join("\n")}\n\n` +
-        `Note: Skills listed above are user-invocable via slash commands. ` +
-        `To load a skill yourself, use the Skill tool instead of outputting a slash command.`,
-    );
-  }
-
-  const agents = allCommands.filter((c) => c.category === "agent");
-  if (agents.length > 0) {
-    const lines = agents.map((c) => {
-      const hint = c.argumentHint ? ` ${c.argumentHint}` : "";
-      return `  /${c.name}${hint} - ${c.description}`;
-    });
-    sections.push(`Sub-Agents (invoke with /agent-name):\n${lines.join("\n")}`);
-  }
-
-  const workflows = allCommands.filter((c) => c.category === "workflow");
-  if (workflows.length > 0) {
-    const lines = workflows.map((c) => `  /${c.name} - ${c.description}`);
-    sections.push(`Workflows:\n${lines.join("\n")}`);
-  }
-
-  return sections.join("\n\n");
-}
 
 // ============================================================================
 // TYPES
@@ -455,7 +404,7 @@ export async function startChatUI(
    */
   async function handleStreamMessage(
     content: string,
-    options?: { agent?: string }
+    options?: { agent?: string; skillCommand?: { name: string; args: string } }
   ): Promise<void> {
     const pendingAbort = state.pendingAbortPromise;
     if (pendingAbort) {
@@ -526,6 +475,7 @@ export async function startChatUI(
         abortSignal: state.streamAbortController?.signal,
         agent: options?.agent,
         knownAgentNames,
+        skillCommand: options?.skillCommand,
       });
 
       state.messageCount++;
@@ -653,19 +603,6 @@ export async function startChatUI(
       initializeCommandsAsync({ providerDiscoveryPlan }),
       clientStartPromise ?? Promise.resolve(),
     ]);
-
-    // Enhance session config with capabilities system prompt so the model
-    // knows about all available slash commands, skills, and sub-agents.
-    // This also ensures they count toward the system/tools token baseline.
-    const capabilitiesPrompt = buildCapabilitiesSystemPrompt();
-    if (capabilitiesPrompt) {
-      const existing = sessionConfig?.systemPrompt ?? "";
-      if (sessionConfig) {
-        sessionConfig.systemPrompt = existing
-          ? `${existing}\n\n${capabilitiesPrompt}`
-          : capabilitiesPrompt;
-      }
-    }
 
     // Ensure Tree-sitter WASM/SCM assets are embedded and reachable in
     // compiled binaries ($bunfs) before any renderer or <markdown> component


### PR DESCRIPTION
Routes native skill invocations through OpenCode's structured session.command() API instead of sending them as prompt text. This ensures skill execution follows the SDK's command contract and removes redundant capability prompt injection from UI startup.

Key changes:
- Added optional command() method to Session interface 
- Implemented command() in OpenCode client to call session.command() API
- Added skillCommand metadata to option interfaces for propagation
- Modified OpenCodeStreamAdapter to route skills through session.command()
- Updated skill dispatch to pass structured command metadata
- Removed buildCapabilitiesSystemPrompt() function and injection logic
- Fixed formatting in research-codebase skill files

Benefits:
- Correct API usage aligned with OpenCode SDK command contract
- Reduced token overhead from eliminated capabilities prompt
- Better type safety with structured command metadata
- Clearer separation between prompt messages and command invocations