### PR TITLE
chore(release): bump version to v0.5.0-5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.0-4",
+  "version": "0.5.0-5",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.0-4` to `0.5.0-5`.

## Changes

- Bumped `version` in `package.json` from `0.5.0-4` → `0.5.0-5`

## Test plan

- [x] Version bump applied to `package.json`
- [x] All 661 tests pass
- [x] Type checks pass
- [x] Lint checks pass