### PR TITLE
chore(release): bump version to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.0-5",
+  "version": "0.5.0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the `0.5.0-5` prerelease to the stable `0.5.0` release by updating the version in `package.json`.

## Changes

- `package.json`: `0.5.0-5` → `0.5.0`

## Test plan
- [x] All 661 tests pass
- [x] TypeScript typecheck passes
- [x] Lint passes