### PR TITLE
feat(workflow-sdk)!: replace ctx.session() with ctx.stage() and auto-infer graph topology

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -1,34 +1,34 @@
 ---
 name: workflow-creator
-description: Create custom multi-agent workflows for Atomic CLI using the defineWorkflow().run().compile() API with ctx.session() for dynamic session spawning. Applies context engineering principles (context-fundamentals, context-degradation, context-compression, context-optimization), architectural patterns (multi-agent-patterns, memory-systems, tool-design, filesystem-context, hosted-agents), quality assurance (evaluation, advanced-evaluation), and design methodology (project-development, bdi-mental-states) to produce robust, context-aware workflows. Workflows live at .atomic/workflows/<name>/<agent>/index.ts. Trigger when users want to create workflows, build agent pipelines, define multi-stage automations, set up review loops, connect coding agents, or mention .atomic/workflows/, defineWorkflow, or agent task sequences.
+description: Create custom multi-agent workflows for Atomic CLI using the defineWorkflow().run().compile() API with ctx.stage(opts, clientOpts, sessionOpts, callback) for dynamic session spawning with auto-init/cleanup. Applies context engineering principles (context-fundamentals, context-degradation, context-compression, context-optimization), architectural patterns (multi-agent-patterns, memory-systems, tool-design, filesystem-context, hosted-agents), quality assurance (evaluation, advanced-evaluation), and design methodology (project-development, bdi-mental-states) to produce robust, context-aware workflows. Workflows live at .atomic/workflows/<name>/<agent>/index.ts. Trigger when users want to create workflows, build agent pipelines, define multi-stage automations, set up review loops, connect coding agents, or mention .atomic/workflows/, defineWorkflow, or agent task sequences.
 ---
 
 # Workflow Creator
 
-You are a workflow architect specializing in the Atomic CLI `defineWorkflow().run().compile()` API. Your role is to translate user intent into well-structured workflow files that orchestrate multiple coding agent sessions using **programmatic SDK code** — Claude Agent SDK, Copilot SDK, and OpenCode SDK. Sessions are spawned dynamically via `ctx.session()` inside the `.run()` callback, using native TypeScript control flow (loops, conditionals, `Promise.all()`) for orchestration.
+You are a workflow architect specializing in the Atomic CLI `defineWorkflow().run().compile()` API. Your role is to translate user intent into well-structured workflow files that orchestrate multiple coding agent sessions using **programmatic SDK code** — Claude Agent SDK, Copilot SDK, and OpenCode SDK. Sessions are spawned dynamically via `ctx.stage(opts, clientOpts, sessionOpts, callback)` inside the `.run()` callback, using native TypeScript control flow (loops, conditionals, `Promise.all()`) for orchestration. The runtime auto-creates the SDK client and session, injects them as `s.client` and `s.session`, runs the callback, then auto-cleans up.
 
 You also serve as a **context engineering advisor**, applying principles from a suite of design skills to make informed architectural decisions about session structure, data flow, prompt composition, and quality assurance. Use these skills to elevate workflows beyond simple pipelines into robust, context-aware systems that respect token budgets, prevent degradation, and produce verifiable results.
 
 ## Reference Files
 
-Load the topic-specific reference files from `references/` as needed. Start with `getting-started.md` for a quick-start example, then consult the others based on the task:
+Load the topic-specific reference files from `references/` based on priority. **Always load Tier 1 files.** Load Tier 2-3 files when the task requires that topic.
 
-| File | When to load |
-|---|---|
-| `getting-started.md` | Always — quick-start example, SDK exports, and `SessionContext` reference |
-| `failure-modes.md` | **Before shipping any multi-session workflow** — catalogue of silent failures across Claude / Copilot / OpenCode with wrong-vs-right patterns, plus a pre-ship design checklist |
-| `agent-sessions.md` | Creating agent sessions with SDK calls: Claude `query()` / `claudeQuery()`, Copilot `CopilotClient`, OpenCode `createOpencodeClient()` |
-| `computation-and-validation.md` | Deterministic computation, response parsing, validation, file I/O inside `run()` |
-| `user-input.md` | Collecting user input: Claude `canUseTool`, Copilot `onElicitationRequest`, OpenCode TUI control |
-| `control-flow.md` | Loops (`for`/`while`), conditionals (`if`/`else`), early termination, retry patterns |
-| `state-and-data-flow.md` | Data flow between sessions: `s.save()`, `s.transcript()`, `s.getMessages()`, file persistence |
-| `session-config.md` | Per-SDK configuration: model, tools, permissions, hooks, structured output |
-| `discovery-and-verification.md` | File discovery, `export default`, provider validation, TypeScript config |
+| Tier | File | When to load |
+|---|---|---|
+| **1** | `getting-started.md` | **Always** — quick-start examples for all 3 SDKs, SDK exports, `SessionContext` reference |
+| **1** | `failure-modes.md` | **Always for multi-session workflows** — 15 catalogued failures (silent + loud) with wrong-vs-right patterns and a pre-ship design checklist |
+| **2** | `agent-sessions.md` | When writing SDK calls — `s.session.query()` (Claude), `s.session.sendAndWait()` (Copilot), `s.client.session.prompt()` (OpenCode); includes critical pitfalls on timeouts and session lifecycle |
+| **2** | `control-flow.md` | When using loops, conditionals, parallel execution, or review/fix patterns |
+| **2** | `state-and-data-flow.md` | When passing data between sessions — `s.save()`, `s.transcript()`, `s.getMessages()`, file persistence, transcript compression |
+| **3** | `computation-and-validation.md` | When adding deterministic computation, response parsing, validation, quality gates, or file I/O |
+| **3** | `session-config.md` | When configuring model, tools, permissions, hooks, or structured output per SDK |
+| **3** | `user-input.md` | When collecting user input mid-workflow — Claude `canUseTool`, Copilot `onElicitationRequest`, OpenCode TUI control |
+| **3** | `discovery-and-verification.md` | When setting up workflow file structure, validation, or TypeScript config |
 
 ## Information Flow Is a First-Class Design Concern
 
 **A workflow is an information flow problem, not a sequence of prompts.**
-Before you write a single `ctx.session()` call, answer these three questions
+Before you write a single `ctx.stage()` call, answer these three questions
 for every session boundary in your workflow:
 
 1. **What context does this session need to succeed?** The original user
@@ -49,10 +49,10 @@ them is the #1 cause of broken multi-agent workflows:
 
 | Lifecycle state | Context visible to the model | When it happens |
 |---|---|---|
-| **Fresh** | **Nothing** — empty conversation | `createSession()` / `session.create()` |
-| **Continued** | Everything sent so far in this session | Additional turns on the same live session |
-| **Resumed** | Everything persisted from the prior session of the SAME agent | `resumeSession(id)` / reusing `sessionID` |
-| **Closed** | Gone from the live client; possibly persisted on disk | `disconnect()` / `client.stop()` |
+| **Fresh** | **Nothing** — empty conversation | Each new `ctx.stage()` call — the runtime creates a new session |
+| **Continued** | Everything sent so far in this session | Additional turns within the same stage callback |
+| **Resumed** | Everything persisted from the prior session of the SAME agent | Reusing a `sessionID` from a prior stage |
+| **Closed** | Gone from the live client; possibly persisted on disk | Runtime auto-cleanup after the stage callback returns |
 
 **Closing a session and creating a new one wipes all in-session context.**
 The new session knows *only* what you put in its first prompt. This is the
@@ -60,12 +60,7 @@ Copilot/OpenCode multi-agent failure mode — planner → orchestrator → revie
 pipelines where the next stage runs in a fresh session and has no idea what
 the prior stage produced.
 
-Claude is different: the `claudeQuery`/`createClaudeSession` pattern uses a
-single persistent tmux pane, so every turn accumulates in the same
-conversation. Sub-agent dispatch via `@"agent-name (agent)"` still shares
-pane scrollback with the parent. But for Copilot and OpenCode, **every
-`createSession` is a fresh conversation** — you must explicitly forward
-context across the boundary.
+Claude is different: the runtime reuses a single persistent tmux pane, so every turn within a stage accumulates in the same conversation. Sub-agent dispatch via `@"agent-name (agent)"` still shares pane scrollback with the parent. But for Copilot and OpenCode, **every `ctx.stage()` is a fresh conversation** — you must explicitly forward context across the boundary.
 
 ### Three ways to carry context across a session boundary
 
@@ -129,46 +124,17 @@ When designing workflows, consult these skills to make informed architectural de
 | Task-model fit validation | `project-development` | Scoping a new workflow — validates whether the task is viable for agent automation before designing execution |
 | Deliberative reasoning | `bdi-mental-states` | Building agents that need explainable reasoning chains or formal cognitive models — BDI architecture for belief-desire-intention state tracking |
 
-### Skill Application by Workflow Phase
-
-**Planning phase** (before writing code):
-- `project-development` — Is this task viable for agent automation? What's the expected cost?
-- `multi-agent-patterns` — Should this be one session or many? What coordination topology? **Critical for Copilot/OpenCode** because every session boundary is a context boundary.
-- `context-fundamentals` — How much context does each session need? What's the token budget? Which parts are load-bearing?
-
-**Session design phase** (structuring `run()` callbacks and prompts):
-- `context-fundamentals` — Position critical information at start/end of prompts, not middle. Understand what "context" actually means for each session.
-- `context-degradation` — Add compaction triggers for loops; isolate unrelated concerns into separate sessions; detect lost-in-middle and poisoning early.
-- `context-compression` — Summarize prior transcripts before injecting into the next session; preserve file paths and key decisions.
-- `tool-design` — Design clear tool contracts; consolidate overlapping tools.
-- `filesystem-context` — Use file-based scratch pads for intermediate state; load context on demand instead of pre-loading.
-
-**Cross-session data flow phase** (the phase that breaks Copilot/OpenCode workflows silently):
-- `context-fundamentals` — Decide what **must** survive each session boundary before you write the handoff code.
-- `context-compression` — **Mandatory** when forwarding large prior-stage output into a fresh session; naive forwarding will blow the context window.
-- `filesystem-context` — Offload large outputs to files; pass `{ path }` references instead of inlining full content; let the next session read selectively.
-- `memory-systems` — Choose persistence layer: in-memory variables for intra-session, `s.save()` for intra-workflow, files/DB for cross-workflow, vector stores for semantic retrieval.
-- `multi-agent-patterns` — Choose the coordination topology: supervisor, peer-to-peer, swarm. Each has different handoff protocols and different context-loss characteristics.
-
-**Runtime context management phase** (once the workflow is running):
-- `context-optimization` — Apply compaction when context grows past safe thresholds; mask verbose tool outputs; use cache-friendly prompt ordering. Reach for SDK-level compaction (`/compact`, programmatic helpers) before resorting to "start a new session" — the latter loses all in-session reasoning.
-- `context-degradation` — Diagnose when a long-running session starts producing worse output; decide whether to compact, clear, or split.
-
-**Quality assurance phase** (adding review/validation):
-- `evaluation` — Define success rubrics; test outcomes not execution paths.
-- `advanced-evaluation` — Use pairwise comparison for subjective quality; mitigate position and length bias in judge prompts.
-
 ## How Workflows Work
 
-A workflow is a TypeScript file with a single `.run()` callback that orchestrates agent sessions dynamically. Inside the callback, you call `ctx.session()` to spawn sessions — each gets its own tmux window and graph node. You use **native TypeScript** for all control flow: `for` loops, `if`/`else` branching, `Promise.all()` for parallelism, and `try`/`catch` for error handling.
+A workflow is a TypeScript file with a single `.run()` callback that orchestrates agent sessions dynamically. Inside the callback, you call `ctx.stage()` to spawn sessions — each gets its own tmux window and graph node. You use **native TypeScript** for all control flow: `for` loops, `if`/`else` branching, `Promise.all()` for parallelism, and `try`/`catch` for error handling.
 
 ```ts
 import { defineWorkflow } from "@bastani/atomic/workflows";
 
-export default defineWorkflow({ name: "my-workflow", description: "..." })
+export default defineWorkflow<"claude">({ name: "my-workflow", description: "..." })
   .run(async (ctx) => {
-    const step1 = await ctx.session({ name: "step-1" }, async (s) => { /* SDK code */ });
-    await ctx.session({ name: "step-2" }, async (s) => { /* SDK code */ });
+    const step1 = await ctx.stage({ name: "step-1" }, {}, {}, async (s) => { /* s.client, s.session */ });
+    await ctx.stage({ name: "step-2" }, {}, {}, async (s) => { /* s.client, s.session */ });
   })
   .compile();
 ```
@@ -184,12 +150,24 @@ Global workflows: `~/.atomic/workflows/<name>/<agent>/index.ts`
 
 ### Two context levels
 
-| Context | Available in | Has `serverUrl`/`paneId`/`save`? | Purpose |
+| Context | Available in | Has `client`/`session`/`paneId`/`save`? | Purpose |
 |---------|-------------|----------------------------------|---------|
 | `WorkflowContext` (`ctx`) | `.run(async (ctx) => ...)` | No | Orchestration: spawn sessions, read transcripts |
-| `SessionContext` (`s`) | `ctx.session(opts, async (s) => ...)` | Yes | Agent work: connect SDK clients, send prompts, save output |
+| `SessionContext` (`s`) | `ctx.stage(opts, clientOpts, sessionOpts, async (s) => ...)` | Yes | Agent work: use `s.client` and `s.session` for SDK calls, save output |
 
-The `WorkflowContext` is the orchestrator — it spawns sessions and reads transcripts. The `SessionContext` is the worker — it has the agent server URL, tmux pane, and save function. Both contexts can spawn nested sessions via `session()` and read prior transcripts via `transcript()`.
+The `WorkflowContext` is the orchestrator — it spawns sessions and reads transcripts. The `SessionContext` is the worker — it has the pre-initialized client and session, tmux pane, and save function. Both contexts can spawn nested sessions via `stage()` and read prior transcripts via `transcript()`.
+
+### Structural Rules
+
+These are hard constraints enforced by the builder, loader, and runtime. Violating any of them will prevent the workflow from compiling, loading, or executing correctly:
+
+1. **`.run()` required** — the builder must have a `.run(async (ctx) => { ... })` call.
+2. **`.compile()` required** — the chain must end with `.compile()`.
+3. **`export default` required** — workflow files must use `export default` for discovery.
+4. **Unique session names** — every `ctx.stage()` call must use a unique `name` across the workflow run.
+5. **Completed-only reads** — `transcript()` and `getMessages()` only access sessions whose callback has returned and saves have flushed. Attempting to read a still-running session throws.
+6. **Graph topology is auto-inferred** — the runtime derives parent-child edges from `await`/`Promise.all` patterns. Sequential `await` creates a chain; `Promise.all([...])` branches from the same parent; a stage awaited after `Promise.all` resolves receives all parallel stages as parents. No explicit dependency declarations are needed or supported.
+7. **Do not manually create clients or sessions** — the runtime auto-creates `s.client` and `s.session` from `clientOpts` and `sessionOpts`. Do not call `new CopilotClient(...)`, `createOpencodeClient(...)`, `createClaudeSession(...)`, or `claudeQuery({ paneId, ... })` directly. Use `s.session.query()`, `s.session.sendAndWait()`, and `s.client.session.prompt()` instead.
 
 ## Concept-to-Code Mapping
 
@@ -197,17 +175,17 @@ Every workflow pattern maps directly to TypeScript code:
 
 | Workflow Concept | Programmatic Pattern |
 |---|---|
-| Agent session (send prompt, get response) | `ctx.session({ name }, async (s) => { /* SDK calls using s.serverUrl, s.paneId */ })` |
-| Sequential execution | `await ctx.session(...)` followed by `await ctx.session(...)` |
-| Parallel execution | `Promise.all([ctx.session(...), ctx.session(...)])` |
-| Conditional branching | `if (...) { await ctx.session({ name: "fix" }, ...) }` |
-| Bounded loops with visible graph nodes | `for (let i = 1; i <= N; i++) { await ctx.session({ name: \`step-\${i}\` }, ...) }` |
-| Explicit dependency between sessions | `ctx.session({ name: "b", dependsOn: ["a"] }, ...)` — renders `b` as a child of `a` AND blocks `b` until `a` finishes (see Key Patterns §"Explicit Dependency Chains") |
-| Return data from session | `const h = await ctx.session(opts, async (s) => { return value; }); h.result` |
+| Agent session (send prompt, get response) | `ctx.stage({ name }, {}, {}, async (s) => { /* use s.client, s.session */ })` |
+| Sequential execution | `await ctx.stage(...)` followed by `await ctx.stage(...)` |
+| Parallel execution | `Promise.all([ctx.stage(...), ctx.stage(...)])` |
+| Conditional branching | `if (...) { await ctx.stage({ name: "fix" }, {}, {}, ...) }` |
+| Bounded loops with visible graph nodes | `for (let i = 1; i <= N; i++) { await ctx.stage({ name: \`step-\${i}\` }, {}, {}, ...) }` |
+| Sequential dependency (auto-inferred) | `await ctx.stage({ name: "a" }, ...); await ctx.stage({ name: "b" }, ...)` — the runtime infers `a → b` from the `await` ordering |
+| Return data from session | `const h = await ctx.stage(opts, {}, {}, async (s) => { return value; }); h.result` |
 | Data flow between sessions | `s.save()` to persist → `s.transcript(handle)` or `s.transcript("name")` to retrieve |
 | Deterministic computation (no LLM) | Plain TypeScript inside `.run()` or inside a session callback |
-| Subagent orchestration | Claude: `@"agent (agent)"` prefix; Copilot: `createSession({ agent })`; OpenCode: `prompt({ agent })` |
-| Per-session configuration | SDK-specific: Claude `claudeQuery({ options })`, Copilot `createSession({ ... })`, OpenCode `session.create({ config })` |
+| Subagent orchestration | Claude: `@"agent (agent)"` prefix in prompt; Copilot: pass `{ agent: "planner" }` as sessionOpts; OpenCode: pass `agent` in `s.client.session.prompt()` |
+| Per-session configuration | Pass `clientOpts` (2nd arg) and `sessionOpts` (3rd arg) to `ctx.stage()` — auto-forwarded to client/session creation |
 | Response data extraction | Parse SDK responses directly; return extracted data from the session callback |
 
 ## Authoring Process
@@ -218,11 +196,11 @@ Map the user's intent to sessions and patterns:
 
 | Question | Maps to |
 |----------|---------|
-| What are the distinct steps? | Each step → `ctx.session()` call |
-| Can any steps run in parallel? | `Promise.all([ctx.session(...), ...])` |
+| What are the distinct steps? | Each step → `ctx.stage()` call |
+| Can any steps run in parallel? | `Promise.all([ctx.stage(...), ...])` |
 | Does any step need deterministic computation? | Plain TypeScript inside `.run()` or session callback |
-| Do any steps need to repeat? | `for`/`while` loop with `ctx.session()` inside |
-| Are there conditional paths? | `if`/`else` wrapping `ctx.session()` calls |
+| Do any steps need to repeat? | `for`/`while` loop with `ctx.stage()` inside |
+| Are there conditional paths? | `if`/`else` wrapping `ctx.stage()` calls |
 | What data flows between steps? | `s.save()` → `s.transcript(handle)` / `s.getMessages(handle)` |
 | Does the workflow need user input? | SDK-specific user input APIs (see `user-input.md`) |
 | Do any steps need a specific model? | SDK-specific session config (see `session-config.md`) |
@@ -245,13 +223,15 @@ Then apply **design advisory checks** — these catch architectural issues befor
 
 ### 2. Choose the Target Agent
 
-Workflows are per-SDK. Decide which agent SDK to target:
+Workflows are per-SDK. Pass a type parameter to `defineWorkflow<"agent">()` to narrow all context types and get correct `s.client` / `s.session` types:
 
-| Agent | SDK Import | Primary API |
-|-------|-----------|-------------|
-| Claude | `claudeQuery` from `@bastani/atomic/workflows` | `createClaudeSession()` → `claudeQuery({ paneId, prompt })` — automates Claude TUI via tmux |
-| Copilot | `CopilotClient` from `@github/copilot-sdk` | `client.createSession()` → `session.sendAndWait({ prompt }, SEND_TIMEOUT_MS)` (explicit timeout is mandatory — default is 60s and throws; see `references/agent-sessions.md`) |
-| OpenCode | `createOpencodeClient` from `@opencode-ai/sdk/v2` | `client.session.create()` → `client.session.prompt({ ... })` |
+| Agent | `defineWorkflow` type | Primary API (inside callback) |
+|-------|----------------------|-------------------------------|
+| Claude | `defineWorkflow<"claude">` | `s.session.query(prompt)` — wraps `claudeQuery({ paneId, prompt })`, auto-manages tmux pane |
+| Copilot | `defineWorkflow<"copilot">` | `s.session.sendAndWait({ prompt }, SEND_TIMEOUT_MS)` — explicit timeout is mandatory (default 60s throws; see `references/agent-sessions.md`) |
+| OpenCode | `defineWorkflow<"opencode">` | `s.client.session.prompt({ sessionID: s.session.id, parts: [...] })` |
+
+No direct imports of `CopilotClient`, `createOpencodeClient`, or `createClaudeSession` are needed — the runtime manages client/session lifecycle automatically.
 
 If you need cross-agent support, create one workflow file per agent under `.atomic/workflows/<name>/<agent>/index.ts`. Use shared helper modules for SDK-agnostic logic (prompts, parsing, validation) in a sibling directory like `.atomic/workflows/<name>/helpers/`.
 
@@ -261,31 +241,34 @@ If you need cross-agent support, create one workflow file per agent under `.atom
 
 ```ts
 // .atomic/workflows/my-workflow/claude/index.ts
-import { defineWorkflow, createClaudeSession, claudeQuery } from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
-export default defineWorkflow({
+export default defineWorkflow<"claude">({
     name: "my-workflow",
     description: "Two-step pipeline",
   })
   .run(async (ctx) => {
-    const analyze = await ctx.session(
+    const analyze = await ctx.stage(
       { name: "analyze", description: "Analyze the codebase" },
+      {},
+      {},
       async (s) => {
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({ paneId: s.paneId, prompt: s.userPrompt });
+        // s.session is a ClaudeSessionWrapper — auto-created by the runtime
+        const result = await s.session.query(s.userPrompt);
         s.save(s.sessionId);
+        return result.output;
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "implement", description: "Implement based on analysis" },
+      {},
+      {},
       async (s) => {
         const analysis = await s.transcript(analyze);
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({
-          paneId: s.paneId,
-          prompt: `Based on this analysis:\n${analysis.content}\n\nImplement the changes.`,
-        });
+        await s.session.query(
+          `Based on this analysis:\n${analysis.content}\n\nImplement the changes.`,
+        );
         s.save(s.sessionId);
       },
     );
@@ -299,55 +282,44 @@ export default defineWorkflow({
 > SDK default is only 60 seconds and a timeout **throws** — it aborts the
 > session callback and propagates out. See the Copilot "Critical pitfall"
 > section in `references/agent-sessions.md` for the full explanation.
+> `onPermissionRequest: approveAll` is the default when not specified in sessionOpts.
 
 ```ts
 // .atomic/workflows/my-workflow/copilot/index.ts
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { CopilotClient, approveAll } from "@github/copilot-sdk";
 
 // Explicit timeout per sendAndWait call — see Copilot pitfall in agent-sessions.md
 const SEND_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
-export default defineWorkflow({
+export default defineWorkflow<"copilot">({
     name: "my-workflow",
     description: "Two-step pipeline",
   })
   .run(async (ctx) => {
-    const analyze = await ctx.session(
+    const analyze = await ctx.stage(
       { name: "analyze", description: "Analyze the codebase" },
+      {},
+      {},
       async (s) => {
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-
-        await session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
-        s.save(await session.getMessages());
-
-        await session.disconnect();
-        await client.stop();
+        // s.session is a CopilotSession — auto-created by the runtime
+        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+        s.save(await s.session.getMessages());
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "implement", description: "Implement based on analysis" },
+      {},
+      {},
       async (s) => {
         const analysis = await s.transcript(analyze);
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-
-        await session.sendAndWait(
+        await s.session.sendAndWait(
           {
             prompt: `Based on this analysis:\n${analysis.content}\n\nImplement the changes.`,
           },
           SEND_TIMEOUT_MS,
         );
-        s.save(await session.getMessages());
-
-        await session.disconnect();
-        await client.stop();
+        s.save(await s.session.getMessages());
       },
     );
   })
@@ -359,38 +331,34 @@ export default defineWorkflow({
 ```ts
 // .atomic/workflows/my-workflow/opencode/index.ts
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { createOpencodeClient } from "@opencode-ai/sdk/v2";
 
-export default defineWorkflow({
+export default defineWorkflow<"opencode">({
     name: "my-workflow",
     description: "Two-step pipeline",
   })
   .run(async (ctx) => {
-    const analyze = await ctx.session(
+    const analyze = await ctx.stage(
       { name: "analyze", description: "Analyze the codebase" },
+      {},
+      { title: "analyze" },
       async (s) => {
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
-        const session = await client.session.create({ title: "analyze" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
+        // s.client is OpencodeClient; s.session is the Session data object
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
           parts: [{ type: "text", text: s.userPrompt }],
         });
         s.save(result.data!);
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "implement", description: "Implement based on analysis" },
+      {},
+      { title: "implement" },
       async (s) => {
         const analysis = await s.transcript(analyze);
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
-        const session = await client.session.create({ title: "implement" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
           parts: [{
             type: "text",
             text: `Based on this analysis:\n${analysis.content}\n\nImplement the changes.`,
@@ -420,11 +388,11 @@ atomic workflow -n <workflow-name> -a <agent> "<your prompt>"
 ### Linear Pipeline
 
 ```ts
-defineWorkflow({ name: "pipeline", description: "Sequential pipeline" })
+defineWorkflow<"claude">({ name: "pipeline", description: "Sequential pipeline" })
   .run(async (ctx) => {
-    const plan = await ctx.session({ name: "plan" }, async (s) => { /* plan */ });
-    const execute = await ctx.session({ name: "execute" }, async (s) => { /* execute */ });
-    await ctx.session({ name: "verify" }, async (s) => { /* verify */ });
+    const plan = await ctx.stage({ name: "plan" }, {}, {}, async (s) => { /* s.session.query(...) */ });
+    const execute = await ctx.stage({ name: "execute" }, {}, {}, async (s) => { /* s.session.query(...) */ });
+    await ctx.stage({ name: "verify" }, {}, {}, async (s) => { /* s.session.query(...) */ });
   })
   .compile();
 ```
@@ -434,19 +402,16 @@ defineWorkflow({ name: "pipeline", description: "Sequential pipeline" })
 Loops run at the workflow level, spawning a new graph node per iteration so users can see progress in real time. Each iteration gets its own tmux window:
 
 ```ts
-defineWorkflow({ name: "review-fix", description: "Iterative review and fix" })
+defineWorkflow<"claude">({ name: "review-fix", description: "Iterative review and fix" })
   .run(async (ctx) => {
     const MAX_CYCLES = 10;
     let consecutiveClean = 0;
 
     for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
       // Each iteration spawns a visible graph node
-      const review = await ctx.session({ name: `review-${cycle}` }, async (s) => {
-        await createClaudeSession({ paneId: s.paneId });
-        const result = await claudeQuery({
-          paneId: s.paneId,
-          prompt: buildReviewPrompt(s.userPrompt),
-        });
+      const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
+        // s.session is auto-created by the runtime
+        const result = await s.session.query(buildReviewPrompt(s.userPrompt));
         s.save(s.sessionId);
         return result.output;
       });
@@ -460,12 +425,8 @@ defineWorkflow({ name: "review-fix", description: "Iterative review and fix" })
       consecutiveClean = 0;
 
       // Conditionally spawn a fix session
-      await ctx.session({ name: `fix-${cycle}` }, async (s) => {
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({
-          paneId: s.paneId,
-          prompt: buildFixSpecFromReview(parsed, s.userPrompt),
-        });
+      await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
+        await s.session.query(buildFixSpecFromReview(parsed, s.userPrompt));
         s.save(s.sessionId);
       });
     }
@@ -475,16 +436,15 @@ defineWorkflow({ name: "review-fix", description: "Iterative review and fix" })
 
 ### Intra-Session Multi-Turn (within one session)
 
-Multiple SDK calls within a single `ctx.session()` share the same agent context. Use this when turns build on each other and don't need separate graph nodes:
+Multiple SDK calls within a single `ctx.stage()` share the same agent context. Use this when turns build on each other and don't need separate graph nodes:
 
 ```ts
-await ctx.session({ name: "guided-implementation" }, async (s) => {
-  await createClaudeSession({ paneId: s.paneId });
-  // Claude remembers all prior turns within the same pane
-  await claudeQuery({ paneId: s.paneId, prompt: "Step 1: Set up the project structure." });
-  await claudeQuery({ paneId: s.paneId, prompt: "Step 2: Implement the core logic." });
-  await claudeQuery({ paneId: s.paneId, prompt: "Step 3: Add error handling." });
-  await claudeQuery({ paneId: s.paneId, prompt: "Step 4: Write tests." });
+await ctx.stage({ name: "guided-implementation" }, {}, {}, async (s) => {
+  // s.session is auto-created; Claude remembers all prior turns within the same pane
+  await s.session.query("Step 1: Set up the project structure.");
+  await s.session.query("Step 2: Implement the core logic.");
+  await s.session.query("Step 3: Add error handling.");
+  await s.session.query("Step 4: Write tests.");
   s.save(s.sessionId);
 });
 ```
@@ -493,23 +453,21 @@ await ctx.session({ name: "guided-implementation" }, async (s) => {
 
 ```ts
 .run(async (ctx) => {
-  const triage = await ctx.session({ name: "triage" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    const result = await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Classify this as "bug", "feature", or "question":\n${s.userPrompt}`,
-    });
+  const triage = await ctx.stage({ name: "triage" }, {}, {}, async (s) => {
+    const result = await s.session.query(
+      `Classify this as "bug", "feature", or "question":\n${s.userPrompt}`,
+    );
     s.save(s.sessionId);
     return result.output.toLowerCase();
   });
 
   // Conditional session spawning — only the relevant branch appears in the graph
   if (triage.result.includes("bug")) {
-    await ctx.session({ name: "fix-bug" }, async (s) => { /* ... */ });
+    await ctx.stage({ name: "fix-bug" }, {}, {}, async (s) => { /* ... */ });
   } else if (triage.result.includes("feature")) {
-    await ctx.session({ name: "implement-feature" }, async (s) => { /* ... */ });
+    await ctx.stage({ name: "implement-feature" }, {}, {}, async (s) => { /* ... */ });
   } else {
-    await ctx.session({ name: "answer-question" }, async (s) => { /* ... */ });
+    await ctx.stage({ name: "answer-question" }, {}, {}, async (s) => { /* ... */ });
   }
 })
 ```
@@ -518,12 +476,12 @@ await ctx.session({ name: "guided-implementation" }, async (s) => {
 
 ```ts
 .run(async (ctx) => {
-  const research = await ctx.session({ name: "research" }, async (s) => {
-    // ... perform research ...
+  const research = await ctx.stage({ name: "research" }, {}, {}, async (s) => {
+    // ... perform research using s.session ...
     s.save(s.sessionId);
   });
 
-  await ctx.session({ name: "synthesize" }, async (s) => {
+  await ctx.stage({ name: "synthesize" }, {}, {}, async (s) => {
     // Read prior session's output (handle-based — recommended)
     const transcript = await s.transcript(research);
     // Use as rendered text:
@@ -541,49 +499,42 @@ await ctx.session({ name: "guided-implementation" }, async (s) => {
 Use `Promise.all()` for concurrent execution. Each parallel session gets its own tmux window and graph node:
 
 ```ts
-import { defineWorkflow, createClaudeSession, claudeQuery } from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
-export default defineWorkflow({
+export default defineWorkflow<"claude">({
     name: "parallel-demo",
     description: "describe → [summarize-a, summarize-b] → merge",
   })
   .run(async (ctx) => {
-    const describe = await ctx.session({ name: "describe" }, async (s) => {
-      await createClaudeSession({ paneId: s.paneId });
-      await claudeQuery({ paneId: s.paneId, prompt: s.userPrompt });
+    const describe = await ctx.stage({ name: "describe" }, {}, {}, async (s) => {
+      await s.session.query(s.userPrompt);
       s.save(s.sessionId);
     });
 
     // Parallel: both sessions run concurrently
     const [summarizeA, summarizeB] = await Promise.all([
-      ctx.session({ name: "summarize-a" }, async (s) => {
+      ctx.stage({ name: "summarize-a" }, {}, {}, async (s) => {
         const research = await s.transcript(describe);
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({
-          paneId: s.paneId,
-          prompt: `Read ${research.path} and summarize it in 2-3 bullet points.`,
-        });
+        await s.session.query(
+          `Read ${research.path} and summarize it in 2-3 bullet points.`,
+        );
         s.save(s.sessionId);
       }),
-      ctx.session({ name: "summarize-b" }, async (s) => {
+      ctx.stage({ name: "summarize-b" }, {}, {}, async (s) => {
         const research = await s.transcript(describe);
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({
-          paneId: s.paneId,
-          prompt: `Read ${research.path} and summarize it in a single sentence.`,
-        });
+        await s.session.query(
+          `Read ${research.path} and summarize it in a single sentence.`,
+        );
         s.save(s.sessionId);
       }),
     ]);
 
-    await ctx.session({ name: "merge" }, async (s) => {
+    await ctx.stage({ name: "merge" }, {}, {}, async (s) => {
       const bullets = await s.transcript(summarizeA);
       const oneliner = await s.transcript(summarizeB);
-      await createClaudeSession({ paneId: s.paneId });
-      await claudeQuery({
-        paneId: s.paneId,
-        prompt: `Combine:\n\n## Bullets\n${bullets.content}\n\n## One-liner\n${oneliner.content}`,
-      });
+      await s.session.query(
+        `Combine:\n\n## Bullets\n${bullets.content}\n\n## One-liner\n${oneliner.content}`,
+      );
       s.save(s.sessionId);
     });
   })
@@ -592,32 +543,42 @@ export default defineWorkflow({
 
 **Constraint:** `transcript()` only reads from sessions that have completed (callback returned + saves flushed). A session running in parallel can read a *prior* session's output but not a sibling that's still running.
 
-### Explicit Dependency Chains (`dependsOn`)
+### Graph Topology: Auto-Inferred from `await`/`Promise.all` Patterns
 
-By default, every top-level `ctx.session()` attaches to the root `orchestrator` node in the graph, so a `.run()` block like `await ctx.session({ name: "planner" }); await ctx.session({ name: "worker" })` renders both sessions as *siblings under orchestrator* — even though `worker` only makes sense after `planner` finishes. The JavaScript `await` orders them correctly at runtime, but the graph loses that fact: users see a fan-out when the real topology is a chain.
+The runtime automatically infers the workflow graph topology from the JavaScript control flow — no explicit dependency declarations are needed.
 
-`SessionRunOptions.dependsOn` fixes this by declaring which sessions a new session is the successor of. It serves two purposes at once:
-
-1. **Graph rendering** — each name in `dependsOn` becomes a parent edge, so the layout algorithm draws real topology (chains, fan-ins) instead of sibling-under-root.
-2. **Runtime ordering** — at spawn time, the runtime awaits each named dep's completion before starting. If any dep failed, the dependent fails fast with a clear error instead of racing or hanging. This makes `Promise.all([...])` patterns safe: kick off several sessions concurrently and let `dependsOn` serialize only the edges that actually need to be serial.
+**Sequential (`await`):** Each awaited `ctx.stage()` call creates a parent-child edge from the previous stage. Two sequential awaits produce a real chain in the graph:
 
 ```ts
-// ❌ Siblings under orchestrator — graph is misleading
-await ctx.session({ name: "planner" }, async (s) => { /* ... */ });
-await ctx.session({ name: "worker"  }, async (s) => { /* ... */ });
-
-// ✅ A real chain in the graph AND enforced ordering
-await ctx.session({ name: "planner" }, async (s) => { /* ... */ });
-await ctx.session({ name: "worker", dependsOn: ["planner"] }, async (s) => { /* ... */ });
+// ✅ Graph infers: orchestrator → planner → worker
+await ctx.stage({ name: "planner" }, {}, {}, async (s) => { /* ... */ });
+await ctx.stage({ name: "worker" }, {}, {}, async (s) => { /* ... */ });
 ```
 
-**Rules:**
-- Every name in `dependsOn` must refer to a session that has already been spawned (active or completed) when the dependent session is created. Unknown names throw immediately.
-- A session cannot depend on itself.
-- `dependsOn` and `await` are complementary. Use `await` when your JavaScript already serializes the calls (simple sequential flows). Add `dependsOn` when you also want the graph to tell the truth, or when you fan out with `Promise.all(...)` and need one branch to wait on another.
-- When `dependsOn` is omitted, the session keeps the default parent (the enclosing scope — `orchestrator` at the top level, the enclosing session for `s.session()`).
+**Parallel (`Promise.all`):** Sessions passed to `Promise.all([...])` branch from the same parent and run concurrently — the runtime gives each a sibling edge from the enclosing scope:
 
-**Pattern: "previous stage" chain in a loop.** For iterative workflows where each stage is the successor of the last, track the previous session's name in a local variable so every `ctx.session()` can wire itself as a successor. See `references/control-flow.md` §"Explicit dependency chains" for the ralph-style example.
+```ts
+// ✅ Graph infers: orchestrator → [summarize-a, summarize-b] (parallel siblings)
+const [a, b] = await Promise.all([
+  ctx.stage({ name: "summarize-a" }, {}, {}, async (s) => { /* ... */ }),
+  ctx.stage({ name: "summarize-b" }, {}, {}, async (s) => { /* ... */ }),
+]);
+```
+
+**Fan-in:** A stage awaited after a `Promise.all` resolves automatically receives all parallel stages as parents — the graph draws a merge node:
+
+```ts
+// ✅ Graph infers: [summarize-a, summarize-b] → merge
+const [a, b] = await Promise.all([
+  ctx.stage({ name: "summarize-a" }, {}, {}, async (s) => { /* ... */ }),
+  ctx.stage({ name: "summarize-b" }, {}, {}, async (s) => { /* ... */ }),
+]);
+await ctx.stage({ name: "merge" }, {}, {}, async (s) => { /* ... */ });
+```
+
+**Nested sub-sessions:** `s.stage()` inside a callback automatically becomes a child of the enclosing session — no declaration needed.
+
+These three primitives compose to express any DAG topology through ordinary TypeScript, keeping workflow code readable and the graph accurate without any extra metadata.
 
 ### Sub-Agent Orchestration
 
@@ -626,59 +587,36 @@ Delegate to named sub-agents within a session. Each SDK has its own mechanism:
 **Claude** — prefix the prompt with `@"agent-name (agent)"`:
 
 ```ts
-await ctx.session({ name: "plan-and-execute" }, async (s) => {
-  await createClaudeSession({ paneId: s.paneId });
-  await claudeQuery({
-    paneId: s.paneId,
-    prompt: `@"planner (agent)" Create a plan for: ${s.userPrompt}`,
-  });
-  await claudeQuery({
-    paneId: s.paneId,
-    prompt: `@"orchestrator (agent)" Execute the plan above.`,
-  });
+await ctx.stage({ name: "plan-and-execute" }, {}, {}, async (s) => {
+  // s.session is auto-created; query() passes the prompt directly to the Claude TUI
+  await s.session.query(`@"planner (agent)" Create a plan for: ${s.userPrompt}`);
+  await s.session.query(`@"orchestrator (agent)" Execute the plan above.`);
   s.save(s.sessionId);
 });
 ```
 
-**Copilot** — pass `agent` to `createSession()`. Remember the explicit
-`sendAndWait` timeout — the planner sub-agent is a prime example of work
-that exceeds Copilot's 60s default and silently breaks downstream stages
-(see `references/agent-sessions.md`):
+**Copilot** — pass `{ agent: "planner" }` as the sessionOpts (3rd arg). The runtime creates the session with `agent: "planner"` automatically. Remember the explicit `sendAndWait` timeout — the planner sub-agent is a prime example of work that exceeds Copilot's 60s default and silently breaks downstream stages (see `references/agent-sessions.md`):
 
 ```ts
 const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
-await ctx.session({ name: "plan" }, async (s) => {
-  const client = new CopilotClient({ cliUrl: s.serverUrl });
-  await client.start();
-
-  const plannerSession = await client.createSession({
-    agent: "planner",
-    onPermissionRequest: approveAll,
-  });
-  await client.setForegroundSessionId(plannerSession.sessionId);
-  await plannerSession.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
-
-  s.save(await plannerSession.getMessages());
-  await plannerSession.disconnect();
-  await client.stop();
+await ctx.stage({ name: "plan" }, {}, { agent: "planner" }, async (s) => {
+  // s.session is a CopilotSession created with agent: "planner"
+  await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 ```
 
-**OpenCode** — pass `agent` to `session.prompt()`:
+**OpenCode** — pass `agent` to `s.client.session.prompt()`:
 
 ```ts
-await ctx.session({ name: "plan" }, async (s) => {
-  const client = createOpencodeClient({ baseUrl: s.serverUrl });
-  const session = await client.session.create({ title: "plan" });
-  await client.tui.selectSession({ sessionID: session.data!.id });
-
-  const result = await client.session.prompt({
-    sessionID: session.data!.id,
+await ctx.stage({ name: "plan" }, {}, { title: "plan" }, async (s) => {
+  // s.client is OpencodeClient; s.session is the Session data object
+  const result = await s.client.session.prompt({
+    sessionID: s.session.id,
     parts: [{ type: "text", text: s.userPrompt }],
     agent: "planner",
   });
-
   s.save(result.data!);
 });
 ```
@@ -708,114 +646,23 @@ export function buildPlanPrompt(spec: string): string {
 // .atomic/workflows/my-workflow/claude/index.ts
 import { buildPlanPrompt } from "../helpers/prompts.ts";
 // ...
-await claudeQuery({ paneId: s.paneId, prompt: buildPlanPrompt(s.userPrompt) });
-```
-
-### Context-Aware Transcript Handoff
-
-When passing transcripts between sessions, compress at the boundary to prevent downstream context degradation. Use structured summaries that preserve actionable information while dropping verbose tool output (applies `context-compression` + `context-degradation`):
-
-```ts
-// helpers/compression.ts
-export function compressTranscript(content: string, maxTokenEstimate: number = 4000): string {
-  // Rough estimate: 1 token ≈ 4 chars
-  const maxChars = maxTokenEstimate * 4;
-  if (content.length <= maxChars) return content;
-
-  // Preserve first and last sections (recency + primacy bias)
-  const headSize = Math.floor(maxChars * 0.4);
-  const tailSize = Math.floor(maxChars * 0.4);
-  const head = content.slice(0, headSize);
-  const tail = content.slice(-tailSize);
-
-  return `${head}\n\n[... ${content.length - headSize - tailSize} chars compressed ...]\n\n${tail}`;
-}
-```
-
-```ts
-await ctx.session({ name: "synthesize" }, async (s) => {
-  const research = await s.transcript("research");
-  // Compress before injecting into prompt to stay within token budget
-  const compressed = compressTranscript(research.content, 4000);
-  await createClaudeSession({ paneId: s.paneId });
-  await claudeQuery({
-    paneId: s.paneId,
-    prompt: `Synthesize this research:\n${compressed}`,
-  });
+await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
+  await s.session.query(buildPlanPrompt(s.userPrompt));
   s.save(s.sessionId);
 });
 ```
 
+### Context-Aware Transcript Handoff
+
+When passing large transcripts between sessions, compress at the boundary to prevent context degradation. See `state-and-data-flow.md` §"Context-Aware Transcript Handoff" for the compression helper pattern and usage example. Applies `context-compression` + `context-degradation`.
+
 ### Quality Gate with LLM-as-Judge
 
-Add automated quality checkpoints using evaluation rubrics. This pattern applies `evaluation` + `advanced-evaluation`:
-
-```ts
-.run(async (ctx) => {
-  const impl = await ctx.session({ name: "implement" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    await claudeQuery({ paneId: s.paneId, prompt: s.userPrompt });
-    s.save(s.sessionId);
-  });
-
-  await ctx.session({ name: "quality-gate" }, async (s) => {
-    const implTranscript = await s.transcript(impl);
-    await createClaudeSession({ paneId: s.paneId });
-    const result = await claudeQuery({
-      paneId: s.paneId,
-      prompt: `You are a code quality judge. Score this implementation 1-5 for:
-- **Correctness**: Does it solve the stated problem?
-- **Completeness**: Are edge cases handled?
-- **Style**: Does it follow project conventions?
-
-## Implementation to judge
-${implTranscript.content}
-
-Respond with JSON: { "correctness": N, "completeness": N, "style": N, "pass": boolean, "issues": [...] }`,
-    });
-
-    const scores = JSON.parse(
-      result.output.match(/\`\`\`json\s*\n([\s\S]*?)\n\`\`\`/)?.[1] ?? result.output,
-    );
-
-    if (!scores.pass) {
-      await claudeQuery({
-        paneId: s.paneId,
-        prompt: `Fix these quality issues:\n${scores.issues.join("\n")}`,
-      });
-    }
-
-    s.save(s.sessionId);
-  });
-})
-```
+Add automated quality checkpoints using evaluation rubrics. See `computation-and-validation.md` §"Quality Gate with LLM-as-Judge" for the full pattern with scoring, JSON parsing, and conditional fix loops. Applies `evaluation` + `advanced-evaluation`.
 
 ### File-Based Coordination with Scratch Pad
 
-Use the filesystem as a coordination layer instead of inlining large data into prompts. This applies `filesystem-context`:
-
-```ts
-.run(async (ctx) => {
-  await ctx.session({ name: "plan" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Create a plan for: ${s.userPrompt}\n\nWrite it to plan.md.`,
-    });
-    s.save(s.sessionId);
-  });
-
-  await ctx.session({ name: "execute" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    // Reference the file by path — lets the agent read selectively
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Read plan.md and implement each task. Mark tasks done as you go.`,
-    });
-    s.save(s.sessionId);
-  });
-})
-```
+Use the filesystem as a coordination layer instead of inlining large data into prompts. See `state-and-data-flow.md` §"File-Based Coordination" for the pattern. Applies `filesystem-context`.
 
 ## API Reference
 
@@ -825,7 +672,7 @@ Use the filesystem as a coordination layer instead of inlining large data into p
 |-------|------|-------------|
 | `userPrompt` | `string` | The original user prompt from the CLI invocation |
 | `agent` | `AgentType` | Which agent is running (`"claude"`, `"copilot"`, or `"opencode"`) |
-| `session(opts, fn)` | `<T>(opts: SessionRunOptions, fn: (s: SessionContext) => Promise<T>) => Promise<SessionHandle<T>>` | Spawn a session with its own tmux window and graph node |
+| `stage(opts, clientOpts, sessionOpts, fn)` | `<T>(opts: SessionRunOptions, clientOpts: StageClientOptions<A>, sessionOpts: StageSessionOptions<A>, fn: (s: SessionContext<A>) => Promise<T>) => Promise<SessionHandle<T>>` | Spawn a session — runtime auto-creates client+session, runs callback, auto-cleans up |
 | `transcript(ref)` | `(ref: SessionRef) => Promise<Transcript>` | Get a completed session's transcript |
 | `getMessages(ref)` | `(ref: SessionRef) => Promise<SavedMessage[]>` | Get a completed session's raw native messages |
 
@@ -833,7 +680,8 @@ Use the filesystem as a coordination layer instead of inlining large data into p
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `serverUrl` | `string` | The agent's server URL (Copilot `--ui-server` / OpenCode built-in server) |
+| `client` | `ProviderClient<A>` | Pre-created SDK client (`CopilotClient` / `OpencodeClient` / `ClaudeClientWrapper`) — managed by the runtime |
+| `session` | `ProviderSession<A>` | Pre-created session (`CopilotSession` / `OpencodeSession` / `ClaudeSessionWrapper`) — managed by the runtime |
 | `userPrompt` | `string` | The original user prompt from the CLI invocation |
 | `agent` | `AgentType` | Which agent is running |
 | `paneId` | `string` | tmux pane ID for this session |
@@ -842,17 +690,16 @@ Use the filesystem as a coordination layer instead of inlining large data into p
 | `save` | `SaveTranscript` | Save this session's output for subsequent sessions |
 | `transcript(ref)` | `(ref: SessionRef) => Promise<Transcript>` | Get a completed session's transcript |
 | `getMessages(ref)` | `(ref: SessionRef) => Promise<SavedMessage[]>` | Get a completed session's raw native messages |
-| `session(opts, fn)` | `<T>(...) => Promise<SessionHandle<T>>` | Spawn a nested sub-session (child of this session in the graph) |
+| `stage(opts, clientOpts, sessionOpts, fn)` | `<T>(...) => Promise<SessionHandle<T>>` | Spawn a nested sub-session (child of this session in the graph) |
 
-### `SessionRunOptions` (first argument to `ctx.session()` / `s.session()`)
+### `SessionRunOptions` (first argument to `ctx.stage()` / `s.stage()`)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | `string` | **Required.** Unique name across the workflow run — also the tmux window title and graph label |
 | `description` | `string?` | Human-readable description — saved to session metadata |
-| `dependsOn` | `string[]?` | Names of sessions this one depends on. Each becomes a parent edge in the graph AND blocks the new session from starting until every named dep has finished. Unknown names throw at spawn time. Leave undefined to attach to the default parent (enclosing scope). See Key Patterns §"Explicit Dependency Chains" |
 
-### `SessionHandle<T>` (returned by `ctx.session()`)
+### `SessionHandle<T>` (returned by `ctx.stage()`)
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -863,19 +710,9 @@ Use the filesystem as a coordination layer instead of inlining large data into p
 ### `s.save()` — Provider-Specific
 
 - **Claude**: `s.save(s.sessionId)` — pass the session ID; transcript is auto-read
-- **Copilot**: `s.save(await session.getMessages())` — pass `SessionEvent[]`
-- **OpenCode**: `s.save(result.data!)` — pass the `{ info, parts }` response object
+- **Copilot**: `s.save(await s.session.getMessages())` — pass `SessionEvent[]` from the pre-created session
+- **OpenCode**: `s.save(result.data!)` — pass the `{ info, parts }` response object from `s.client.session.prompt()`
 
 ### `s.transcript(ref)` — Rendered Text
 
 Accepts a `SessionHandle` (recommended) or session name string. Returns `{ path: string, content: string }` — the file path on disk and the rendered assistant text. Use `content` for embedding in prompts, or `path` for file-based triggers.
-
-## Structural Rules
-
-1. **`.run()` required** — the builder must have a `.run(async (ctx) => { ... })` call.
-2. **`.compile()` required** — the chain must end with `.compile()`.
-3. **`export default` required** — workflow files must use `export default` for discovery.
-4. **Unique session names** — every `ctx.session()` call must use a unique `name` across the workflow run.
-5. **Completed-only reads** — `transcript()` and `getMessages()` only access sessions whose callback has returned and saves have flushed. Attempting to read a still-running session throws.
-6. **Claude lifecycle** — `createClaudeSession({ paneId: s.paneId })` must be called before any `claudeQuery()` in each session.
-7. **`dependsOn` must reference spawned sessions** — every name in `dependsOn` must refer to a session that has already been created (active or completed). Unknown names, and self-references, throw at spawn time. If a dep fails, the dependent fails with the same error.

--- a/.agents/skills/workflow-creator/references/agent-sessions.md
+++ b/.agents/skills/workflow-creator/references/agent-sessions.md
@@ -1,79 +1,91 @@
 # Agent Sessions
 
-Each `ctx.session()` call inside a workflow's `.run()` callback creates an isolated agent session. The session callback receives `s` (a `SessionContext`) which scopes all session-specific operations. This is the programmatic equivalent of defining agent stages — you have full access to every SDK feature.
+Each `ctx.stage()` call inside a workflow's `.run()` callback creates an isolated agent session. The runtime auto-initializes the provider client and session before invoking your callback — the callback receives `s` (a `SessionContext`) with `s.client` (the pre-created SDK client) and `s.session` (the pre-created session) ready to use. Auto-cleanup (disconnect, stop) is handled by the runtime after the callback completes. This is the programmatic equivalent of defining agent stages — you have full access to every SDK feature through `s.client` and `s.session`.
+
+`ctx.stage()` takes four arguments: `ctx.stage(stageOpts, clientOpts, sessionOpts, callback)`.
 
 ## Claude Agent SDK
 
-Claude runs as a full interactive TUI in a tmux pane. You must call `createClaudeSession()` to start the TUI before sending queries with `claudeQuery()`.
+Claude runs as a full interactive TUI in a tmux pane. The runtime auto-starts the Claude CLI (via `s.client`) and creates a session wrapper (`s.session`) before the callback runs. Pass CLI flags via `clientOpts` (2nd arg) and query defaults via `sessionOpts` (3rd arg).
 
 ### Session lifecycle
 
 ```ts
-import { defineWorkflow, createClaudeSession, claudeQuery, clearClaudeSession } from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
 // ...
 .run(async (ctx) => {
-  await ctx.session({ name: "implement", description: "Implement the feature" }, async (s) => {
-    // 1. Start Claude TUI in the pane (required before claudeQuery)
-    await createClaudeSession({ paneId: s.paneId });
+  await ctx.stage(
+    { name: "implement", description: "Implement the feature" },
+    {}, // clientOpts: chatFlags and readyTimeoutMs go here
+    {}, // sessionOpts: query defaults (timeoutMs, pollIntervalMs, etc.) go here
+    async (s) => {
+      // s.client — ClaudeClientWrapper (Claude CLI already started by runtime)
+      // s.session — ClaudeSessionWrapper (ready to accept queries)
 
-    // 2. Send queries — Claude maintains conversation context across calls
-    const result = await claudeQuery({
-      paneId: s.paneId,
-      prompt: ctx.userPrompt,
-    });
-    // result.output contains the captured response text
+      // Send queries — Claude maintains conversation context across calls
+      const result = await s.session.query(s.userPrompt);
+      // result.output contains the captured response text
 
-    // 3. Save transcript
-    s.save(s.sessionId);
-  });
+      // Save transcript
+      s.save(s.sessionId);
+    },
+  );
 })
 ```
 
-`createClaudeSession()` sends the `claude` command with permission flags, waits for the TUI to render, and registers the pane. If `claudeQuery()` is called without a prior `createClaudeSession()` on the same pane, it throws an error.
+The runtime handles:
+1. Starting the Claude CLI in the tmux pane (equivalent to the old `createClaudeSession()`)
+2. Creating a `ClaudeSessionWrapper` bound to the pane
+3. Auto-cleanup via `clearClaudeSession` after the callback
 
-Options:
-- `paneId` — tmux pane ID (from `s.paneId`)
+Client options (2nd arg to `ctx.stage()`):
 - `chatFlags` — CLI flags (default: `["--allow-dangerously-skip-permissions", "--dangerously-skip-permissions"]`)
 - `readyTimeoutMs` — timeout waiting for TUI readiness (default: 30s)
 
-`clearClaudeSession(paneId)` removes a pane from the initialized set. Call it when a Claude session is killed or no longer needed.
+Session options (3rd arg to `ctx.stage()`), applied as defaults to every `s.session.query()` call:
+- `timeoutMs` — timeout waiting for Claude to finish responding (default: 300s)
+- `pollIntervalMs` — polling interval (default: 2000ms)
+- `submitPresses` — C-m presses per submit round (default: 1)
+- `maxSubmitRounds` — max submit rounds (default: 6)
+- `readyTimeoutMs` — timeout waiting for pane readiness before sending (default: 30s)
 
-### Basic usage with `claudeQuery()`
+### Basic usage with `s.session.query()`
 
 ```ts
-import { defineWorkflow, createClaudeSession, claudeQuery } from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
-// ...
-.run(async (ctx) => {
-  await ctx.session({ name: "implement", description: "Implement the feature" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    const result = await claudeQuery({
-      paneId: s.paneId,
-      prompt: ctx.userPrompt,
-    });
-    // result.output contains the captured response text
-    s.save(s.sessionId);
-  });
-})
+export default defineWorkflow<"claude">({ name: "implement" })
+  .run(async (ctx) => {
+    await ctx.stage(
+      { name: "implement", description: "Implement the feature" },
+      {},
+      {},
+      async (s) => {
+        const result = await s.session.query(s.userPrompt);
+        // result.output contains the captured response text
+        s.save(s.sessionId);
+      },
+    );
+  })
+  .compile();
 ```
 
-`claudeQuery()` sends text to the Claude pane, verifies delivery, retries if needed, and waits for output stabilization. Returns `{ output: string }`.
+`s.session.query(prompt)` sends text to the Claude pane, verifies delivery, retries if needed, and waits for output stabilization. Returns `{ output: string }`.
 
 ### Multi-turn conversations
 
-Claude maintains conversation context across calls within the same pane. Send multiple prompts in one session for multi-turn conversations:
+Claude maintains conversation context across calls within the same pane. Call `s.session.query()` multiple times in one stage for multi-turn conversations:
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "implement" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
+  await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
     // Turn 1: Plan
-    await claudeQuery({ paneId: s.paneId, prompt: "Plan the implementation." });
+    await s.session.query("Plan the implementation.");
     // Turn 2: Execute (Claude remembers the plan)
-    await claudeQuery({ paneId: s.paneId, prompt: "Now implement the plan." });
+    await s.session.query("Now implement the plan.");
     // Turn 3: Verify
-    await claudeQuery({ paneId: s.paneId, prompt: "Run the tests." });
+    await s.session.query("Run the tests.");
     s.save(s.sessionId);
   });
 })
@@ -87,9 +99,9 @@ For programmatic control beyond tmux automation, the Claude Agent SDK provides `
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
 .run(async (ctx) => {
-  await ctx.session({ name: "implement" }, async (s) => {
+  await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
     const result = query({
-      prompt: ctx.userPrompt,
+      prompt: s.userPrompt,
       options: {
         model: "claude-opus-4-6",
         effort: "high",
@@ -171,26 +183,18 @@ const result = query({ prompt: "Continue...", options: { resume: sessionId } });
 const result = query({ prompt: "Try a different approach", options: { resume: sessionId, forkSession: true } });
 ```
 
-### Sub-agent delegation via `claudeQuery()`
+### Sub-agent delegation via `s.session.query()`
 
-When using `claudeQuery()`, invoke named sub-agents by prefixing the prompt with `@"agent-name (agent)"`. The agent must be defined in `.claude/agents/`:
+Invoke named sub-agents by prefixing the prompt with `@"agent-name (agent)"`. The agent must be defined in `.claude/agents/`:
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "plan-and-implement" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-
+  await ctx.stage({ name: "plan-and-implement" }, {}, {}, async (s) => {
     // Delegate to the "planner" agent
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `@"planner (agent)" Create a plan for: ${ctx.userPrompt}`,
-    });
+    await s.session.query(`@"planner (agent)" Create a plan for: ${s.userPrompt}`);
 
     // Delegate to the "orchestrator" agent
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `@"orchestrator (agent)" Execute the plan above.`,
-    });
+    await s.session.query(`@"orchestrator (agent)" Execute the plan above.`);
 
     s.save(s.sessionId);
   });
@@ -199,34 +203,33 @@ When using `claudeQuery()`, invoke named sub-agents by prefixing the prompt with
 
 ## Copilot SDK
 
-Copilot uses a client-server architecture. `CopilotClient` manages the CLI server, and `CopilotSession` handles individual conversations.
+Copilot uses a client-server architecture. The runtime auto-creates a `CopilotClient` (as `s.client`) and a `CopilotSession` (as `s.session`) before invoking your callback. Auto-cleanup (`session.disconnect()` and `client.stop()`) is handled by the runtime after the callback completes.
 
 ### Basic usage
 
 ```ts
-import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
 // Always pass an explicit timeout to sendAndWait — see the pitfall note below.
 const SEND_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
-.run(async (ctx) => {
-  await ctx.session({ name: "implement" }, async (s) => {
-    const client = new CopilotClient({ cliUrl: s.serverUrl });
-    await client.start();
+export default defineWorkflow<"copilot">({ name: "implement" })
+  .run(async (ctx) => {
+    await ctx.stage(
+      { name: "implement" },
+      {}, // clientOpts: CopilotClientOptions (excluding cliUrl, which is auto-injected)
+      {}, // sessionOpts: CopilotSessionConfig (model, agent, tools, hooks, etc.)
+      async (s) => {
+        // s.client — CopilotClient (already started by runtime)
+        // s.session — CopilotSession (already created, foreground session set)
 
-    const session = await client.createSession({
-      onPermissionRequest: approveAll,
-    });
-    await client.setForegroundSessionId(session.sessionId);
+        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
 
-    await session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
-
-    s.save(await session.getMessages());
-
-    await session.disconnect();
-    await client.stop();
-  });
-})
+        s.save(await s.session.getMessages());
+      },
+    );
+  })
+  .compile();
 ```
 
 ### Critical pitfall: `sendAndWait` has a 60-second default timeout
@@ -403,41 +406,42 @@ needs its own explicit timeout.
 const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
 .run(async (ctx) => {
-  await ctx.session({ name: "implement" }, async (s) => {
-    const client = new CopilotClient({ cliUrl: s.serverUrl });
-    await client.start();
-    const session = await client.createSession({ onPermissionRequest: approveAll });
-    await client.setForegroundSessionId(session.sessionId);
-
+  await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
     // Turn 1
-    await session.sendAndWait({ prompt: "Plan the implementation." }, SEND_TIMEOUT_MS);
+    await s.session.sendAndWait({ prompt: "Plan the implementation." }, SEND_TIMEOUT_MS);
     // Turn 2
-    await session.sendAndWait({ prompt: "Now implement the plan." }, SEND_TIMEOUT_MS);
+    await s.session.sendAndWait({ prompt: "Now implement the plan." }, SEND_TIMEOUT_MS);
     // Turn 3
-    await session.sendAndWait({ prompt: "Run the tests." }, SEND_TIMEOUT_MS);
+    await s.session.sendAndWait({ prompt: "Run the tests." }, SEND_TIMEOUT_MS);
 
-    s.save(await session.getMessages());
-    await session.disconnect();
-    await client.stop();
+    s.save(await s.session.getMessages());
   });
 })
 ```
 
 ### Session configuration
 
+Pass session config options as the 3rd arg to `ctx.stage()` (`sessionOpts`). These are forwarded to `client.createSession()`:
+
 ```ts
-const session = await client.createSession({
-  model: "claude-sonnet-4.6",
-  reasoningEffort: "high",
-  systemMessage: "You are a security auditor...",
-  tools: [defineTool({ ... })],
-  onPermissionRequest: approveAll,
-  onUserInputRequest: (request) => { /* handle user input */ },
-  hooks: {
-    onPreToolUse: (event) => { /* before tool execution */ },
-    onPostToolUse: (event) => { /* after tool execution */ },
+await ctx.stage(
+  { name: "audit" },
+  {}, // clientOpts
+  {
+    model: "claude-sonnet-4.6",
+    reasoningEffort: "high",
+    systemMessage: "You are a security auditor...",
+    onUserInputRequest: (request) => { /* handle user input */ },
+    hooks: {
+      onPreToolUse: (event) => { /* before tool execution */ },
+      onPostToolUse: (event) => { /* after tool execution */ },
+    },
+  }, // sessionOpts
+  async (s) => {
+    await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+    s.save(await s.session.getMessages());
   },
-});
+);
 ```
 
 ### Custom tools
@@ -455,10 +459,16 @@ const myTool = defineTool({
   },
 });
 
-const session = await client.createSession({
-  tools: [myTool],
-  onPermissionRequest: approveAll,
-});
+// Pass tools via sessionOpts (3rd arg to ctx.stage())
+await ctx.stage(
+  { name: "implement" },
+  {},
+  { tools: [myTool] },
+  async (s) => {
+    await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+    s.save(await s.session.getMessages());
+  },
+);
 ```
 
 ### Extracting response text
@@ -489,67 +499,65 @@ function getAssistantText(messages: SessionEvent[]): string {
 ### Streaming events
 
 ```ts
-session.on("assistant.message_delta", (event) => {
+// s.session is the CopilotSession — subscribe to events directly
+s.session.on("assistant.message_delta", (event) => {
   process.stdout.write(event.data.content);
 });
 
-session.on("assistant.reasoning_delta", (event) => {
+s.session.on("assistant.reasoning_delta", (event) => {
   // Access reasoning output
 });
 ```
 
 ### Sub-agent delegation
 
-Pass the `agent` parameter to `createSession()` to bind a session to a named sub-agent:
+Pass the `agent` parameter in `sessionOpts` (3rd arg to `ctx.stage()`) to bind the session to a named sub-agent:
 
 ```ts
 const SEND_TIMEOUT_MS = 30 * 60 * 1000; // planner can take a while
 
 .run(async (ctx) => {
-  await ctx.session({ name: "plan" }, async (s) => {
-    const client = new CopilotClient({ cliUrl: s.serverUrl });
-    await client.start();
-
-    // Create a session bound to the "planner" agent
-    const session = await client.createSession({
-      agent: "planner",
-      onPermissionRequest: approveAll,
-    });
-    await client.setForegroundSessionId(session.sessionId);
-
-    await session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
-
-    s.save(await session.getMessages());
-    await session.disconnect();
-    await client.stop();
-  });
+  await ctx.stage(
+    { name: "plan" },
+    {},
+    { agent: "planner" }, // sessionOpts — binds the session to the "planner" agent
+    async (s) => {
+      await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+      s.save(await s.session.getMessages());
+    },
+  );
 })
 ```
 
 ## OpenCode SDK
 
-OpenCode uses a client-server model. `createOpencodeClient()` connects to a running server.
+OpenCode uses a client-server model. The runtime auto-creates an `OpencodeClient` (as `s.client`) and an OpenCode session (as `s.session`) before invoking your callback. Use `s.client.session.prompt({ sessionID: s.session.id, ... })` to send prompts.
 
 ### Basic usage
 
 ```ts
-import { createOpencodeClient } from "@opencode-ai/sdk/v2";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
-.run(async (ctx) => {
-  await ctx.session({ name: "implement" }, async (s) => {
-    const client = createOpencodeClient({ baseUrl: s.serverUrl });
+export default defineWorkflow<"opencode">({ name: "implement" })
+  .run(async (ctx) => {
+    await ctx.stage(
+      { name: "implement" },
+      {}, // clientOpts: directory, experimental_workspaceID
+      { title: "implement" }, // sessionOpts: title, parentID, workspaceID
+      async (s) => {
+        // s.client — OpencodeClient (already connected)
+        // s.session — OpenCode Session (already created, TUI selected)
 
-    const session = await client.session.create({ title: "implement" });
-    await client.tui.selectSession({ sessionID: session.data!.id });
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
+          parts: [{ type: "text", text: s.userPrompt }],
+        });
 
-    const result = await client.session.prompt({
-      sessionID: session.data!.id,
-      parts: [{ type: "text", text: ctx.userPrompt }],
-    });
-
-    s.save(result.data!);
-  });
-})
+        s.save(result.data!);
+      },
+    );
+  })
+  .compile();
 ```
 
 ### Critical pitfall: session lifecycle controls what context is available
@@ -571,10 +579,10 @@ substitute the OpenCode API equivalents:
 
 | Concept | Copilot API | OpenCode API |
 |---|---|---|
-| Create fresh session | `client.createSession({ agent })` | `client.session.create({ title })` + `agent` on `session.prompt()` |
-| Send a turn | `session.sendAndWait({ prompt }, timeout)` | `client.session.prompt({ sessionID, parts })` |
-| Close / disconnect | `session.disconnect()` / `client.stop()` | session lifecycle managed via server; no explicit disconnect in typical flow |
-| Resume prior session | `client.resumeSession(sessionId)` | Reuse the same `sessionID` with `client.session.prompt()` — the server retains history |
+| Fresh session (auto-created) | `s.session` (runtime creates via `createSession`) | `s.session` (runtime creates via `session.create`) |
+| Send a turn | `s.session.sendAndWait({ prompt }, timeout)` | `s.client.session.prompt({ sessionID: s.session.id, parts })` |
+| Close / disconnect | Auto-handled by runtime | session lifecycle managed via server; no explicit disconnect in typical flow |
+| Resume prior session | `s.client.resumeSession(sessionId)` | Reuse the same `sessionID` with `s.client.session.prompt()` — the server retains history |
 | Extract final text | `getAssistantText(messages)` (see `failure-modes.md` §F1) | `extractResponseText(result.data!.parts)` |
 
 **Multi-agent handoff example (applies the same pattern as Copilot):**
@@ -609,28 +617,24 @@ identically here; the only thing that changes is the method names.
 
 ### Multi-turn conversations
 
-Send multiple prompts to the same session:
+Send multiple prompts to the same session using `s.client.session.prompt()` with `s.session.id`:
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "multi-turn" }, async (s) => {
-    const client = createOpencodeClient({ baseUrl: s.serverUrl });
-    const session = await client.session.create({ title: "multi-turn" });
-    await client.tui.selectSession({ sessionID: session.data!.id });
-
+  await ctx.stage({ name: "multi-turn" }, {}, { title: "multi-turn" }, async (s) => {
     // Turn 1
-    await client.session.prompt({
-      sessionID: session.data!.id,
+    await s.client.session.prompt({
+      sessionID: s.session.id,
       parts: [{ type: "text", text: "Plan the implementation." }],
     });
     // Turn 2
-    await client.session.prompt({
-      sessionID: session.data!.id,
+    await s.client.session.prompt({
+      sessionID: s.session.id,
       parts: [{ type: "text", text: "Now implement the plan." }],
     });
     // Turn 3
-    const result = await client.session.prompt({
-      sessionID: session.data!.id,
+    const result = await s.client.session.prompt({
+      sessionID: s.session.id,
       parts: [{ type: "text", text: "Run the tests." }],
     });
 
@@ -642,8 +646,9 @@ Send multiple prompts to the same session:
 ### Structured output
 
 ```ts
-const result = await client.session.prompt({
-  sessionID: session.data!.id,
+// Inside a ctx.stage callback:
+const result = await s.client.session.prompt({
+  sessionID: s.session.id,
   parts: [{ type: "text", text: "List all API endpoints as JSON" }],
   format: {
     type: "json_schema",
@@ -666,14 +671,15 @@ const result = await client.session.prompt({
 Inject context into a session without triggering a response:
 
 ```ts
-await client.session.prompt({
-  sessionID: session.data!.id,
+// Inside a ctx.stage callback:
+await s.client.session.prompt({
+  sessionID: s.session.id,
   parts: [{ type: "text", text: "Here is the background context..." }],
   noReply: true,
 });
 // Now send the actual prompt
-const result = await client.session.prompt({
-  sessionID: session.data!.id,
+const result = await s.client.session.prompt({
+  sessionID: s.session.id,
   parts: [{ type: "text", text: "Based on the context, implement..." }],
 });
 ```
@@ -690,14 +696,19 @@ function extractResponseText(
     .join("\n");
 }
 
-// Usage:
+// Usage inside a ctx.stage callback:
+const result = await s.client.session.prompt({
+  sessionID: s.session.id,
+  parts: [{ type: "text", text: s.userPrompt }],
+});
 const text = extractResponseText(result.data!.parts);
 ```
 
 ### Event streaming
 
 ```ts
-const unsubscribe = await client.event.subscribe((event) => {
+// Inside a ctx.stage callback:
+const unsubscribe = await s.client.event.subscribe((event) => {
   if (event.type === "session.updated") {
     console.log("Session updated:", event.data);
   }
@@ -706,23 +717,24 @@ const unsubscribe = await client.event.subscribe((event) => {
 
 ### Sub-agent delegation
 
-Pass the `agent` parameter to `session.prompt()` to route a prompt to a named sub-agent:
+Pass the `agent` parameter to `s.client.session.prompt()` to route a prompt to a named sub-agent:
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "plan" }, async (s) => {
-    const client = createOpencodeClient({ baseUrl: s.serverUrl });
-    const session = await client.session.create({ title: "plan" });
-    await client.tui.selectSession({ sessionID: session.data!.id });
+  await ctx.stage(
+    { name: "plan" },
+    {},
+    { title: "plan" },
+    async (s) => {
+      // Route the prompt to the "planner" agent
+      const result = await s.client.session.prompt({
+        sessionID: s.session.id,
+        parts: [{ type: "text", text: s.userPrompt }],
+        agent: "planner",
+      });
 
-    // Route the prompt to the "planner" agent
-    const result = await client.session.prompt({
-      sessionID: session.data!.id,
-      parts: [{ type: "text", text: ctx.userPrompt }],
-      agent: "planner",
-    });
-
-    s.save(result.data!);
-  });
+      s.save(result.data!);
+    },
+  );
 })
 ```

--- a/.agents/skills/workflow-creator/references/computation-and-validation.md
+++ b/.agents/skills/workflow-creator/references/computation-and-validation.md
@@ -2,34 +2,26 @@
 
 Deterministic computation — validation, data transforms, file I/O, API calls — is written as plain TypeScript inside `.run()` or session callbacks. No LLM session is needed. This is the programmatic equivalent of a `.tool()` node.
 
-> **Note:** All Claude examples below assume `createClaudeSession({ paneId: s.paneId })` is called at the start of each session callback before any `claudeQuery()` calls.
-
 ## Inline computation
 
 Any TypeScript code inside a session callback that doesn't call an SDK prompt function is deterministic computation:
 
 ```ts
-await ctx.session({ name: "validate-and-fix", description: "Validate, then fix if needed" }, async (s) => {
+await ctx.stage({ name: "validate-and-fix", description: "Validate, then fix if needed" }, {}, {}, async (s) => {
   // Step 1: Deterministic — parse prior session's output
   const messages = await s.getMessages("planner");
   const planText = extractText(messages);
   const plan = JSON.parse(planText);
 
   // Step 2: Deterministic — validate the plan
-  const isValid = plan.tasks?.length > 0 && plan.tasks.every((t: any) => t.id && t.description);
+  const isValid = plan.tasks?.length > 0 && plan.tasks.every((t: { id: string; description: string }) => t.id && t.description);
 
   if (!isValid) {
     // Step 3: Agent session — ask the agent to fix the plan
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: "The plan is invalid. Please create a valid plan with tasks.",
-    });
+    await s.session.query("The plan is invalid. Please create a valid plan with tasks.");
   } else {
     // Step 4: Agent session — execute the valid plan
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Execute this plan:\n${JSON.stringify(plan.tasks)}`,
-    });
+    await s.session.query(`Execute this plan:\n${JSON.stringify(plan.tasks)}`);
   }
 
   s.save(s.sessionId);
@@ -42,16 +34,16 @@ Each SDK returns responses in different formats. Use helpers to extract text:
 
 ### Claude
 
-`claudeQuery()` returns `{ output: string }` — the captured pane text.
+`s.session.query()` returns `{ output: string, delivered: boolean }` — the captured response text.
 
 ```ts
-const result = await claudeQuery({ paneId: s.paneId, prompt: "..." });
+const result = await s.session.query("...");
 const text = result.output; // Already a string
 ```
 
 ### Copilot
 
-`session.getMessages()` returns `SessionEvent[]`. Concatenate every
+`s.session.getMessages()` returns `SessionEvent[]`. Concatenate every
 top-level assistant turn's non-empty content — picking only `.at(-1)` is a
 silent-failure trap. See `failure-modes.md` §F1 / §F2 for the full
 explanation.
@@ -72,7 +64,7 @@ function getAssistantText(messages: SessionEvent[]): string {
 }
 
 // Usage:
-const messages = await session.getMessages();
+const messages = await s.session.getMessages();
 const text = getAssistantText(messages);
 ```
 
@@ -149,7 +141,7 @@ Read and write files directly in `run()`:
 import { readFile, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 
-// Inside a ctx.session() callback:
+// Inside a ctx.stage() callback:
 async (s) => {
   // Write to session directory
   const outputDir = join(s.sessionDir, "artifacts");
@@ -166,16 +158,13 @@ async (s) => {
 Make HTTP requests for external integrations:
 
 ```ts
-// Inside a ctx.session() callback:
+// Inside a ctx.stage() callback:
 async (s) => {
   const response = await fetch("https://api.example.com/data");
   const data = await response.json();
 
   // Use the data in a prompt
-  await claudeQuery({
-    paneId: s.paneId,
-    prompt: `Process this data:\n${JSON.stringify(data)}`,
-  });
+  await s.session.query(`Process this data:\n${JSON.stringify(data)}`);
   s.save(s.sessionId);
 },
 ```
@@ -185,7 +174,7 @@ async (s) => {
 Transform data between sessions:
 
 ```ts
-// Inside a ctx.session() callback:
+// Inside a ctx.stage() callback:
 async (s) => {
   const raw = await s.getMessages("planner");
 
@@ -200,10 +189,45 @@ async (s) => {
   tasks.sort((a, b) => b.priority - a.priority);
 
   // Pass to agent
-  await claudeQuery({
-    paneId: s.paneId,
-    prompt: `Execute these tasks in order:\n${JSON.stringify(tasks)}`,
-  });
+  await s.session.query(`Execute these tasks in order:\n${JSON.stringify(tasks)}`);
   s.save(s.sessionId);
 },
+```
+
+## Quality Gate with LLM-as-Judge
+
+Add automated quality checkpoints using evaluation rubrics. This pattern applies `evaluation` + `advanced-evaluation`:
+
+```ts
+.run(async (ctx) => {
+  const impl = await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
+    await s.session.query(s.userPrompt);
+    s.save(s.sessionId);
+  });
+
+  await ctx.stage({ name: "quality-gate" }, {}, {}, async (s) => {
+    const implTranscript = await s.transcript(impl);
+    const result = await s.session.query(
+      `You are a code quality judge. Score this implementation 1-5 for:
+- **Correctness**: Does it solve the stated problem?
+- **Completeness**: Are edge cases handled?
+- **Style**: Does it follow project conventions?
+
+## Implementation to judge
+${implTranscript.content}
+
+Respond with JSON: { "correctness": N, "completeness": N, "style": N, "pass": boolean, "issues": [...] }`,
+    );
+
+    const scores = JSON.parse(
+      result.output.match(/\`\`\`json\s*\n([\s\S]*?)\n\`\`\`/)?.[1] ?? result.output,
+    );
+
+    if (!scores.pass) {
+      await s.session.query(`Fix these quality issues:\n${scores.issues.join("\n")}`);
+    }
+
+    s.save(s.sessionId);
+  });
+})
 ```

--- a/.agents/skills/workflow-creator/references/control-flow.md
+++ b/.agents/skills/workflow-creator/references/control-flow.md
@@ -4,8 +4,8 @@ Control flow in workflows is plain TypeScript inside `.run()`. Use `if`/`else` f
 
 There are two levels where control flow can live:
 
-- **Intra-session**: multiple SDK calls within one `ctx.session()` callback — the agent remembers context across all of them.
-- **Inter-session**: loops/conditionals at the `.run()` level that spawn multiple `ctx.session()` calls — each iteration becomes its own visible graph node in the UI.
+- **Intra-session**: multiple SDK calls within one `ctx.stage()` callback — the agent remembers context across all of them.
+- **Inter-session**: loops/conditionals at the `.run()` level that spawn multiple `ctx.stage()` calls — each iteration becomes its own visible graph node in the UI.
 
 Prefer inter-session control flow when you want the workflow graph to reflect what actually happened at runtime.
 
@@ -18,12 +18,10 @@ Run a triage session first, then branch at the `.run()` level to spawn a purpose
 ```ts
 .run(async (ctx) => {
   // Step 1: Classify the request
-  const triage = await ctx.session({ name: "triage" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    const result = await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Classify this as "bug", "feature", or "question": ${ctx.userPrompt}`,
-    });
+  const triage = await ctx.stage({ name: "triage" }, {}, {}, async (s) => {
+    const result = await s.session.query(
+      `Classify this as "bug", "feature", or "question": ${ctx.userPrompt}`,
+    );
     s.save(s.sessionId);
     return result.output.toLowerCase();
   });
@@ -32,21 +30,18 @@ Run a triage session first, then branch at the `.run()` level to spawn a purpose
 
   // Step 2: Branch — each path spawns its own session
   if (classification.includes("bug")) {
-    await ctx.session({ name: "fix-bug" }, async (s) => {
-      await createClaudeSession({ paneId: s.paneId });
-      await claudeQuery({ paneId: s.paneId, prompt: "Diagnose and fix the bug described above." });
+    await ctx.stage({ name: "fix-bug" }, {}, {}, async (s) => {
+      await s.session.query("Diagnose and fix the bug described above.");
       s.save(s.sessionId);
     });
   } else if (classification.includes("feature")) {
-    await ctx.session({ name: "implement-feature" }, async (s) => {
-      await createClaudeSession({ paneId: s.paneId });
-      await claudeQuery({ paneId: s.paneId, prompt: "Design and implement the feature described above." });
+    await ctx.stage({ name: "implement-feature" }, {}, {}, async (s) => {
+      await s.session.query("Design and implement the feature described above.");
       s.save(s.sessionId);
     });
   } else {
-    await ctx.session({ name: "answer-question" }, async (s) => {
-      await createClaudeSession({ paneId: s.paneId });
-      await claudeQuery({ paneId: s.paneId, prompt: "Research and answer the question above." });
+    await ctx.stage({ name: "answer-question" }, {}, {}, async (s) => {
+      await s.session.query("Research and answer the question above.");
       s.save(s.sessionId);
     });
   }
@@ -59,22 +54,19 @@ When the branching logic is simple and you want the agent to retain full context
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "triage-and-act" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-
-    const triageResult = await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Classify this as "bug", "feature", or "question": ${ctx.userPrompt}`,
-    });
+  await ctx.stage({ name: "triage-and-act" }, {}, {}, async (s) => {
+    const triageResult = await s.session.query(
+      `Classify this as "bug", "feature", or "question": ${ctx.userPrompt}`,
+    );
 
     const classification = triageResult.output.toLowerCase();
 
     if (classification.includes("bug")) {
-      await claudeQuery({ paneId: s.paneId, prompt: "Diagnose and fix the bug described above." });
+      await s.session.query("Diagnose and fix the bug described above.");
     } else if (classification.includes("feature")) {
-      await claudeQuery({ paneId: s.paneId, prompt: "Design and implement the feature described above." });
+      await s.session.query("Design and implement the feature described above.");
     } else {
-      await claudeQuery({ paneId: s.paneId, prompt: "Research and answer the question above." });
+      await s.session.query("Research and answer the question above.");
     }
 
     s.save(s.sessionId);
@@ -93,12 +85,8 @@ Each iteration spawns its own session, so the graph shows exactly how many passe
   const MAX_ITERATIONS = 5;
 
   for (let i = 1; i <= MAX_ITERATIONS; i++) {
-    const iteration = await ctx.session({ name: `refine-${i}` }, async (s) => {
-      await createClaudeSession({ paneId: s.paneId });
-      const result = await claudeQuery({
-        paneId: s.paneId,
-        prompt: `Iteration ${i}: Improve the implementation.`,
-      });
+    const iteration = await ctx.stage({ name: `refine-${i}` }, {}, {}, async (s) => {
+      const result = await s.session.query(`Iteration ${i}: Improve the implementation.`);
       s.save(s.sessionId);
       return result.output;
     });
@@ -116,15 +104,11 @@ When the agent must remember every prior iteration's output to make progress, ke
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "iterative-refinement" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
+  await ctx.stage({ name: "iterative-refinement" }, {}, {}, async (s) => {
     const MAX_ITERATIONS = 5;
 
     for (let i = 0; i < MAX_ITERATIONS; i++) {
-      const result = await claudeQuery({
-        paneId: s.paneId,
-        prompt: `Iteration ${i + 1}: Improve the implementation.`,
-      });
+      const result = await s.session.query(`Iteration ${i + 1}: Improve the implementation.`);
 
       if (result.output.includes("LGTM") || result.output.includes("no issues")) {
         break;
@@ -148,12 +132,8 @@ The inter-session pattern is the right fit here: every review and every fix beco
 
   for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
     // Each review is a visible graph node
-    const review = await ctx.session({ name: `review-${cycle}` }, async (s) => {
-      await createClaudeSession({ paneId: s.paneId });
-      const result = await claudeQuery({
-        paneId: s.paneId,
-        prompt: buildReviewPrompt(ctx.userPrompt),
-      });
+    const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
+      const result = await s.session.query(buildReviewPrompt(ctx.userPrompt));
       s.save(s.sessionId);
       return result.output;
     });
@@ -176,12 +156,8 @@ The inter-session pattern is the right fit here: every review and every fix beco
       : buildFixSpecFromRawReview(reviewRaw, ctx.userPrompt);
 
     // Each fix is also a visible graph node
-    await ctx.session({ name: `fix-${cycle}` }, async (s) => {
-      await createClaudeSession({ paneId: s.paneId });
-      await claudeQuery({
-        paneId: s.paneId,
-        prompt: fixPrompt || "Fix any remaining issues.",
-      });
+    await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
+      await s.session.query(fixPrompt || "Fix any remaining issues.");
       s.save(s.sessionId);
     });
   }
@@ -204,21 +180,14 @@ const SEND_TIMEOUT_MS = 30 * 60 * 1000;
   let consecutiveClean = 0;
 
   for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
-    const review = await ctx.session({ name: `review-${cycle}` }, async (s) => {
-      const client = new CopilotClient({ cliUrl: s.serverUrl });
-      await client.start();
-      const session = await client.createSession({ onPermissionRequest: approveAll });
-      await client.setForegroundSessionId(session.sessionId);
-
-      await session.sendAndWait(
+    const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
+      await s.session.sendAndWait(
         { prompt: buildReviewPrompt(ctx.userPrompt) },
         SEND_TIMEOUT_MS,
       );
-      const reviewRaw = getAssistantText(await session.getMessages()); // see failure-modes.md §F1
+      const reviewRaw = getAssistantText(await s.session.getMessages()); // see failure-modes.md §F1
 
-      s.save(await session.getMessages());
-      await session.disconnect();
-      await client.stop();
+      s.save(await s.session.getMessages());
       return reviewRaw;
     });
 
@@ -236,137 +205,101 @@ const SEND_TIMEOUT_MS = 30 * 60 * 1000;
       ? buildFixSpecFromReview(parsed, ctx.userPrompt)
       : buildFixSpecFromRawReview(reviewRaw, ctx.userPrompt);
 
-    await ctx.session({ name: `fix-${cycle}` }, async (s) => {
-      const client = new CopilotClient({ cliUrl: s.serverUrl });
-      await client.start();
-      const session = await client.createSession({ onPermissionRequest: approveAll });
-      await client.setForegroundSessionId(session.sessionId);
-
-      await session.sendAndWait(
+    await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
+      await s.session.sendAndWait(
         { prompt: fixPrompt || "Fix remaining issues." },
         SEND_TIMEOUT_MS,
       );
 
-      s.save(await session.getMessages());
-      await session.disconnect();
-      await client.stop();
+      s.save(await s.session.getMessages());
     });
   }
 })
 ```
 
-## Explicit dependency chains (`dependsOn`)
+## Graph topology: auto-inferred from `await`/`Promise.all`
 
-`SessionRunOptions.dependsOn` lets a session declare which prior sessions it's a successor of. It has two effects, and both matter:
+The runtime automatically infers the workflow graph topology from the JavaScript control flow. No explicit dependency declarations are needed or supported — the graph always reflects the actual execution structure.
 
-1. **Graph rendering** — each name becomes a parent edge, so the workflow graph draws a real chain (or fan-in) instead of making every top-level `ctx.session()` a sibling under `orchestrator`.
-2. **Runtime ordering** — the runtime awaits each named dep before starting. In `Promise.all([...])` patterns, this lets you fan out concurrently and still serialize the edges that matter. If a dep failed, the dependent fails fast with a clear error.
+### Sequential (`await`): `a → b` edge
 
-Use `dependsOn` whenever the default behavior (every top-level session shown as a sibling under orchestrator) misrepresents what the workflow actually does. The classic case: an iterative loop where each stage depends on the previous one.
-
-### Why this exists: the sibling-under-root problem
-
-Without `dependsOn`, every top-level `ctx.session()` attaches to `orchestrator`. Two sequential awaits produce a graph that looks like *parallel siblings* even though the JavaScript is strictly sequential:
+Each sequential `await ctx.stage(...)` produces a parent-child edge from the previous stage. The graph draws a real chain:
 
 ```ts
-// ❌ Graph shows planner and worker as siblings under orchestrator.
-// The await runs them in order, but the graph loses that information —
-// users can't tell at a glance which stage happened first.
+// ✅ Graph infers: orchestrator → planner → worker
 .run(async (ctx) => {
-  await ctx.session({ name: "planner" }, async (s) => { /* ... */ });
-  await ctx.session({ name: "worker"  }, async (s) => { /* ... */ });
+  await ctx.stage({ name: "planner" }, {}, {}, async (s) => { /* ... */ });
+  await ctx.stage({ name: "worker"  }, {}, {}, async (s) => { /* ... */ });
 })
 ```
 
+### Parallel (`Promise.all`): both branch from same parent
+
+Sessions passed to `Promise.all([...])` branch from the same parent and run concurrently. The runtime gives each a sibling edge from the enclosing scope:
+
 ```ts
-// ✅ Graph shows orchestrator → planner → worker as a chain.
+// ✅ Graph infers: orchestrator → [summarize-a, summarize-b] (parallel siblings)
 .run(async (ctx) => {
-  await ctx.session({ name: "planner" }, async (s) => { /* ... */ });
-  await ctx.session(
-    { name: "worker", dependsOn: ["planner"] },
-    async (s) => { /* ... */ },
-  );
+  const [a, b] = await Promise.all([
+    ctx.stage({ name: "summarize-a" }, {}, {}, async (s) => { /* ... */ }),
+    ctx.stage({ name: "summarize-b" }, {}, {}, async (s) => { /* ... */ }),
+  ]);
 })
 ```
 
-### Pattern: "previous stage" chain in a loop
+### Fan-in: stage after `Promise.all` gets all parallel stages as parents
 
-When every stage in a loop is the successor of the last, thread a local `prevStage` variable through each `ctx.session()` call. This is the pattern used by the bundled `ralph` workflow (`.atomic/workflows/ralph/*/index.ts`) — every iteration's planner depends on the previous iteration's debugger, every orchestrator depends on the planner just above it, and so on. The whole multi-iteration pipeline renders as one long spine instead of a mess of siblings:
+A stage awaited after a `Promise.all` resolves automatically receives all parallel stages as parents — the graph draws a merge node:
 
 ```ts
+// ✅ Graph infers: orchestrator → A → [B, C] → D (fan-in merge)
 .run(async (ctx) => {
-  // Track the most recent session so the next stage can wire itself
-  // as a successor. `depsOn()` just returns [prevStage] or undefined.
-  let prevStage: string | undefined;
-  const depsOn = (): string[] | undefined =>
-    prevStage ? [prevStage] : undefined;
+  await ctx.stage({ name: "A" }, {}, {}, async (s) => { /* ... */ });
 
+  await Promise.all([
+    ctx.stage({ name: "B" }, {}, {}, async (s) => { /* ... */ }),
+    ctx.stage({ name: "C" }, {}, {}, async (s) => { /* ... */ }),
+  ]);
+
+  // D receives B and C as parents — rendered as a merge node.
+  await ctx.stage({ name: "D" }, {}, {}, async (s) => { /* ... */ });
+})
+```
+
+### Nested sub-sessions: child of the enclosing session
+
+`s.stage()` inside a callback automatically becomes a child of the enclosing session — no declaration needed:
+
+```ts
+await ctx.stage({ name: "outer" }, {}, {}, async (s) => {
+  // inner is a child of outer in the graph automatically
+  await s.stage({ name: "inner" }, {}, {}, async (s2) => { /* ... */ });
+});
+```
+
+### Pattern: iterative loop chains
+
+In iterative loops each stage is naturally the successor of the last because `await` serializes them within the loop body. The graph renders as a chain by default:
+
+```ts
+// ✅ Graph infers a spine: planner-1 → worker-1 → planner-2 → worker-2 → ...
+.run(async (ctx) => {
   for (let i = 1; i <= MAX_LOOPS; i++) {
-    const plannerName = `planner-${i}`;
-    await ctx.session(
-      { name: plannerName, dependsOn: depsOn() },
-      async (s) => { /* ... */ },
-    );
-    prevStage = plannerName;
+    await ctx.stage({ name: `planner-${i}` }, {}, {}, async (s) => { /* ... */ });
+    await ctx.stage({ name: `worker-${i}` }, {}, {}, async (s) => { /* ... */ });
 
-    const workerName = `worker-${i}`;
-    await ctx.session(
-      { name: workerName, dependsOn: depsOn() },
-      async (s) => { /* ... */ },
-    );
-    prevStage = workerName;
-
-    // Conditionally appended stages still update prevStage so the next
-    // iteration's first stage picks up wherever the chain left off.
     if (needsReview) {
-      const reviewerName = `reviewer-${i}`;
-      await ctx.session(
-        { name: reviewerName, dependsOn: depsOn() },
-        async (s) => { /* ... */ },
-      );
-      prevStage = reviewerName;
+      await ctx.stage({ name: `reviewer-${i}` }, {}, {}, async (s) => { /* ... */ });
     }
   }
 })
 ```
 
-**Why the helper function instead of an inline array?** The helper returns `undefined` on the first iteration (no prior stage exists yet) and `[prevStage]` thereafter. Passing `undefined` makes the first session fall back to the default parent — no special-case branching in the loop body.
+Each iteration's stages form a natural chain because each `await` follows the previous one. Conditional stages fit in seamlessly — the graph reflects whatever path was actually executed.
 
-### Pattern: parallel fan-out with a gating dep
+### Note on data flow vs. topology
 
-`dependsOn` is the only way to make `Promise.all([...])` patterns respect "B must wait for A" without serializing the whole group. The runtime awaits each dep's completion promise before starting the dependent session, so B sits idle until A finishes while C runs alongside A.
-
-```ts
-.run(async (ctx) => {
-  // Gate: A must run first; B and C can run in parallel after A.
-  await ctx.session({ name: "A" }, async (s) => { /* ... */ });
-
-  await Promise.all([
-    ctx.session(
-      { name: "B", dependsOn: ["A"] },
-      async (s) => { /* ... */ },
-    ),
-    ctx.session(
-      { name: "C", dependsOn: ["A"] },
-      async (s) => { /* ... */ },
-    ),
-  ]);
-
-  // D waits for BOTH B and C (fan-in) — renders as a merge node.
-  await ctx.session(
-    { name: "D", dependsOn: ["B", "C"] },
-    async (s) => { /* ... */ },
-  );
-})
-```
-
-Because `A` finished before the `Promise.all`, the `dependsOn: ["A"]` check resolves immediately for both `B` and `C` — they start concurrently. `D` waits for both to settle. If either `B` or `C` throws, `D` gets the same error instead of hanging.
-
-### When NOT to use `dependsOn`
-
-- **When siblings really are siblings.** If you have two independent top-level sessions that genuinely don't depend on each other and you *want* the graph to show them as parallel work under orchestrator, don't add `dependsOn`. It's not a style — it's a dependency declaration.
-- **For nested sub-sessions inside a callback.** `s.session()` already declares parentage via its enclosing scope: the nested session is a child of the outer session automatically. Adding `dependsOn` there is redundant.
-- **Instead of `s.transcript()`.** `dependsOn` controls execution order and graph edges, not data flow. If B needs to *read* A's output, use `s.transcript(aHandle)` — that still requires `await ctx.session(a)` to have completed, which `dependsOn` (or a simple await) guarantees.
+Graph topology (parent-child edges) is inferred from control flow. Data flow between sessions is separate: use `s.transcript(handle)` to read a prior session's saved output. The two concerns are independent — you do not need explicit dependency declarations to access another session's transcript; you just need that session's `await` to have completed before you read it.
 
 ## Multi-turn conversations
 
@@ -374,13 +307,12 @@ Within a single session callback, each SDK call adds to the conversation context
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "guided-implementation" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    // Claude remembers all prior turns within the same pane
-    await claudeQuery({ paneId: s.paneId, prompt: "Step 1: Set up the project structure." });
-    await claudeQuery({ paneId: s.paneId, prompt: "Step 2: Implement the core logic." });
-    await claudeQuery({ paneId: s.paneId, prompt: "Step 3: Add error handling." });
-    await claudeQuery({ paneId: s.paneId, prompt: "Step 4: Write tests." });
+  await ctx.stage({ name: "guided-implementation" }, {}, {}, async (s) => {
+    // The session remembers all prior turns within the same callback
+    await s.session.query("Step 1: Set up the project structure.");
+    await s.session.query("Step 2: Implement the core logic.");
+    await s.session.query("Step 3: Add error handling.");
+    await s.session.query("Step 4: Write tests.");
     s.save(s.sessionId);
   });
 })
@@ -392,16 +324,14 @@ Within a single session callback, each SDK call adds to the conversation context
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "implement" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
+  await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
     try {
-      await claudeQuery({ paneId: s.paneId, prompt: ctx.userPrompt });
+      await s.session.query(ctx.userPrompt);
     } catch (error) {
       // Retry with simpler prompt
-      await claudeQuery({
-        paneId: s.paneId,
-        prompt: `The previous attempt failed. Please try a simpler approach: ${ctx.userPrompt}`,
-      });
+      await s.session.query(
+        `The previous attempt failed. Please try a simpler approach: ${ctx.userPrompt}`,
+      );
     }
     s.save(s.sessionId);
   });
@@ -428,11 +358,8 @@ async function retryWithBackoff<T>(
 }
 
 .run(async (ctx) => {
-  await ctx.session({ name: "implement" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    await retryWithBackoff(() =>
-      claudeQuery({ paneId: s.paneId, prompt: ctx.userPrompt })
-    );
+  await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
+    await retryWithBackoff(() => s.session.query(ctx.userPrompt));
     s.save(s.sessionId);
   });
 })
@@ -445,9 +372,8 @@ Combine loops, conditionals, and inter-session data passing. Session callbacks r
 ```ts
 .run(async (ctx) => {
   // Step 1: Analyse — result is available as a typed handle
-  const analysisHandle = await ctx.session({ name: "analyze" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    const result = await claudeQuery({ paneId: s.paneId, prompt: `Analyse the task: ${ctx.userPrompt}` });
+  const analysisHandle = await ctx.stage({ name: "analyze" }, {}, {}, async (s) => {
+    const result = await s.session.query(`Analyse the task: ${ctx.userPrompt}`);
     s.save(s.sessionId);
     return result.output;
   });
@@ -457,16 +383,14 @@ Combine loops, conditionals, and inter-session data passing. Session callbacks r
 
   // Step 2: Iterative implementation — each pass is a graph node
   for (let i = 1; i <= maxIterations; i++) {
-    const impl = await ctx.session({ name: `implement-${i}` }, async (s) => {
+    const impl = await ctx.stage({ name: `implement-${i}` }, {}, {}, async (s) => {
       // Pass the analysis transcript into this session
       const analysis = await s.transcript(analysisHandle);
-      await createClaudeSession({ paneId: s.paneId });
-      const result = await claudeQuery({
-        paneId: s.paneId,
-        prompt: i === 1
+      const result = await s.session.query(
+        i === 1
           ? `Implement based on:\n${analysis.content}`
           : "Continue improving the implementation.",
-      });
+      );
       s.save(s.sessionId);
       return result.output;
     });

--- a/.agents/skills/workflow-creator/references/discovery-and-verification.md
+++ b/.agents/skills/workflow-creator/references/discovery-and-verification.md
@@ -36,18 +36,18 @@ Local workflows override global ones with the same name. The `<agent>` subdirect
 
 ## Export format
 
-Every workflow file must use `export default` with a compiled workflow:
+Every workflow file must use `export default` with a compiled workflow. Pass the agent type as a generic parameter to `defineWorkflow` for precise `s.client` and `s.session` types. `ctx.stage()` takes four positional arguments: stage options, client init options, session create options, and the callback.
 
 ```ts
 import { defineWorkflow } from "@bastani/atomic/workflows";
 
-export default defineWorkflow({
+export default defineWorkflow<"claude">({
     name: "my-workflow",
     description: "What this workflow does",
   })
   .run(async (ctx) => {
-    await ctx.session({ name: "step-1" }, async (s) => { /* ... */ });
-    await ctx.session({ name: "step-2" }, async (s) => { /* ... */ });
+    await ctx.stage({ name: "step-1" }, {}, {}, async (s) => { /* ... */ });
+    await ctx.stage({ name: "step-2" }, {}, {}, async (s) => { /* ... */ });
   })
   .compile();
 ```
@@ -63,15 +63,15 @@ The `WorkflowBuilder` enforces these rules at definition time:
 1. **Non-empty workflow** — `.compile()` throws if no `.run()` call was made
 2. **Required workflow name** — `defineWorkflow()` throws if `name` is empty
 
-Session name uniqueness is enforced at runtime when `ctx.session()` is called — duplicate names within the same workflow run will throw.
+Session name uniqueness is enforced at runtime when `ctx.stage()` is called — duplicate names within the same workflow run will throw.
 
 ### Provider validation warnings
 
 The SDK includes regex-based validation for all three providers:
 
-- **Claude** (`validateClaudeWorkflow`): Warns if the workflow uses `claudeQuery` without a corresponding `createClaudeSession` call
-- **Copilot** (`validateCopilotWorkflow`): Warns if the workflow doesn't use `s.serverUrl` for `CopilotClient` or doesn't call `setForegroundSessionId()`
-- **OpenCode** (`validateOpenCodeWorkflow`): Warns if the workflow doesn't use `s.serverUrl` for `createOpencodeClient` or doesn't call `tui.selectSession()`
+- **Claude** (`validateClaudeWorkflow`): Warns on direct `createClaudeSession` or `claudeQuery` usage — the runtime now handles init/cleanup automatically. Use `s.session.query(prompt)` instead.
+- **Copilot** (`validateCopilotWorkflow`): Warns on manual `new CopilotClient` or `client.createSession()` usage — the runtime auto-creates and cleans up the client and session. Use `s.client` and `s.session` instead. Pass session config as the third argument to `ctx.stage()`.
+- **OpenCode** (`validateOpenCodeWorkflow`): Warns on manual `createOpencodeClient()` or `client.session.create()` usage — the runtime auto-creates the client and session. Use `s.client` and `s.session` instead. Pass client config as the second argument and session config as the third argument to `ctx.stage()`.
 
 These are non-blocking warnings — the workflow will still load.
 
@@ -129,6 +129,9 @@ This catches:
 - Wrong session callback signatures
 - Missing required fields (`name`)
 - SDK type mismatches (e.g., passing wrong types to `s.save()`)
+- Incorrect provider-specific method calls (e.g., calling `s.session.query()` in a Copilot workflow)
+
+**Note on generic type parameter:** Using `defineWorkflow<"claude">()`, `defineWorkflow<"copilot">()`, or `defineWorkflow<"opencode">()` narrows `s.client` and `s.session` to the correct provider types throughout the `.run()` callback and all `ctx.stage()` callbacks. Without the type parameter, `s.client` and `s.session` resolve to a union of all provider types, which requires type guards to use provider-specific methods.
 
 ## Testing
 

--- a/.agents/skills/workflow-creator/references/failure-modes.md
+++ b/.agents/skills/workflow-creator/references/failure-modes.md
@@ -33,17 +33,17 @@ Silent failures are catalogued first below. Loud failures are grouped at the end
 | [F1](#f1-copilot-getlastassistanttext-returns-empty-string) | Copilot: `getLastAssistantText` returns empty string | Copilot | silent |
 | [F2](#f2-copilot-sub-agent-messages-pollute-getmessages-stream) | Copilot: sub-agent messages pollute `getMessages()` stream | Copilot | silent |
 | [F3](#f3-opencode-result-parts-contain-non-text-parts) | OpenCode: `result.data.parts` contains non-text parts | OpenCode | silent |
-| [F4](#f4-claudequery-output-includes-tui-scrollback-not-just-the-last-turn) | Claude: `claudeQuery.output` includes TUI scrollback, not just the last turn | Claude | silent |
+| [F4](#f4-claudequery-output-includes-tui-scrollback-not-just-the-last-turn) | Claude: `s.session.query()` output includes TUI scrollback, not just the last turn | Claude | silent |
 | [F5](#f5-fresh-session-wipes-prior-stage-context) | Fresh session wipes prior stage context | Copilot, OpenCode | silent |
 | [F6](#f6-planner-prompts-that-dont-request-trailing-commentary-produce-empty-handoffs) | Planner prompts that don't request trailing commentary produce empty handoffs | all | silent |
 | [F7](#f7-continued-sessions-accumulate-state-across-loop-iterations) | Continued sessions accumulate state across loop iterations (lost-in-middle) | all | silent |
 | [F8](#f8-fenced-block-parsers-break-when-the-model-adds-prose) | Fenced-block parsers break when the model adds prose before/after | all | silent |
 | [F9](#f9-ssave-receives-the-wrong-shape) | `s.save()` receives the wrong shape for the SDK | all | silent |
 | [F10](#f10-copilot-sendandwait-default-60s-timeout-throws) | Copilot: `sendAndWait` default 60s timeout throws | Copilot | loud |
-| [F11](#f11-claudequery-without-prior-createclaudesession-throws) | Claude: `claudeQuery` without prior `createClaudeSession` throws | Claude | loud |
+| [F11](#f11-claudequery-without-prior-createclaudesession-throws-resolved-by-runtime) | ~~Claude: `claudeQuery` without prior `createClaudeSession` throws~~ (resolved by runtime) | Claude | N/A |
 | [F12](#f12-resume-session-tries-to-swap-agents) | Resume session tries to swap agents | Copilot, OpenCode | loud |
 | [F13](#f13-parallel-siblings-read-each-others-transcripts) | Parallel siblings read each other's transcripts | all | loud |
-| [F14](#f14-forgetting-to-await-ctxsession) | Forgetting to `await` `ctx.session()` | all | silent |
+| [F14](#f14-forgetting-to-await-ctxstage) | Forgetting to `await` `ctx.stage()` | all | silent |
 | [F15](#f15-using-a-pending-sessionhandle-before-completion) | Using a pending `SessionHandle` before completion | all | silent |
 
 ---
@@ -175,17 +175,18 @@ function extractResponseText(
 
 ---
 
-## F4. Claude: `claudeQuery.output` includes TUI scrollback, not just the last turn
+## F4. Claude: `s.session.query()` output includes TUI scrollback, not just the last turn
 
 **Symptom.** Parsers matching "the last fenced JSON block" pick up an old
 turn's JSON because the captured output contains multiple turns of scrollback.
 
-**Root cause.** `claudeQuery()` captures the tmux pane's visible scrollback
-after output stabilizes — it's not a scoped "this call's response only"
-string. Earlier sub-agent output, prior-turn assistant text, and even the
-user's own prompt echo all end up in `result.output`.
+**Root cause.** `s.session.query()` wraps `claudeQuery()`, which captures the
+tmux pane's visible scrollback after output stabilizes — it's not a scoped
+"this call's response only" string. Earlier sub-agent output, prior-turn
+assistant text, and even the user's own prompt echo all end up in
+`result.output`.
 
-**Affected SDKs.** Claude (tmux-based `claudeQuery`).
+**Affected SDKs.** Claude (tmux-based query).
 
 ### ❌ Wrong
 
@@ -233,7 +234,7 @@ put in its first prompt.
 
 **Affected SDKs.** Copilot, OpenCode. (Claude's tmux pane model is
 different — context accumulates in the same pane, so this failure mode
-does NOT apply to `claudeQuery`.)
+does NOT apply to `s.session.query()`.)
 
 ### ❌ Wrong
 
@@ -333,11 +334,12 @@ vulnerable because the scrollback captures every intermediate turn.
 ### ❌ Wrong — unbounded loop on a single session
 
 ```ts
-await createClaudeSession({ paneId });
-for (let i = 0; i < 20; i++) {
-  await claudeQuery({ paneId, prompt: buildReviewPrompt() });
-  await claudeQuery({ paneId, prompt: buildFixPrompt() });
-}
+await ctx.stage({ name: "review-loop" }, {}, {}, async (s) => {
+  for (let i = 0; i < 20; i++) {
+    await s.session.query(buildReviewPrompt());
+    await s.session.query(buildFixPrompt());
+  }
+});
 ```
 
 ### ✅ Right — compact or reset between iterations
@@ -353,17 +355,19 @@ Options, in order of preference:
    lose the in-session reasoning but gain a clean context window.
 
 ```ts
-const MAX_TURNS_BEFORE_COMPACT = 10;
-let turnsSinceCompact = 0;
+await ctx.stage({ name: "review-loop" }, {}, {}, async (s) => {
+  const MAX_TURNS_BEFORE_COMPACT = 10;
+  let turnsSinceCompact = 0;
 
-for (let i = 0; i < MAX_ITERATIONS; i++) {
-  if (turnsSinceCompact >= MAX_TURNS_BEFORE_COMPACT) {
-    await claudeQuery({ paneId, prompt: "/compact" });
-    turnsSinceCompact = 0;
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    if (turnsSinceCompact >= MAX_TURNS_BEFORE_COMPACT) {
+      await s.session.query("/compact");
+      turnsSinceCompact = 0;
+    }
+    await s.session.query(buildReviewPrompt());
+    turnsSinceCompact += 1;
   }
-  await claudeQuery({ paneId, prompt: buildReviewPrompt() });
-  turnsSinceCompact += 1;
-}
+});
 ```
 
 **Consult.** `context-degradation`, `context-compression`, `context-optimization`.
@@ -444,7 +448,7 @@ expects, and the runtime doesn't type-check the argument beyond "anything".
 | SDK | Correct argument |
 |---|---|
 | Claude | `s.save(s.sessionId)` — pass the session ID; the runtime reads the transcript file |
-| Copilot | `s.save(await session.getMessages())` — pass `SessionEvent[]` |
+| Copilot | `s.save(await s.session.getMessages())` — pass `SessionEvent[]` |
 | OpenCode | `s.save(result.data!)` — pass the `{ info, parts }` object |
 
 ### ❌ Wrong
@@ -454,9 +458,9 @@ expects, and the runtime doesn't type-check the argument beyond "anything".
 s.save(result.output);
 
 // Copilot — saves an empty array if called before sendAndWait
-s.save(await session.getMessages());
+s.save(await s.session.getMessages());
 // Or saves one message object instead of the array
-s.save((await session.getMessages()).at(-1));
+s.save((await s.session.getMessages()).at(-1));
 
 // OpenCode — missing the data unwrap
 s.save(result);
@@ -477,7 +481,7 @@ log the length. A 0-length or JSON-that-isn't-prose signature = F9.
 ## F10. Copilot: `sendAndWait` default 60s timeout throws
 
 **Symptom.** `Timeout after 60000ms waiting for session.idle`. Every
-subsequent `ctx.session()` call never executes — the throw propagates out of
+subsequent `ctx.stage()` call never executes — the throw propagates out of
 `run()` and halts the workflow.
 
 **Full write-up.** `agent-sessions.md` §"Critical pitfall: `sendAndWait` has
@@ -487,29 +491,38 @@ a 60-second default timeout".
 
 ```ts
 const SEND_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
-await session.sendAndWait({ prompt }, SEND_TIMEOUT_MS);
+await s.session.sendAndWait({ prompt }, SEND_TIMEOUT_MS);
 ```
 
 ---
 
-## F11. Claude: `claudeQuery` without prior `createClaudeSession` throws
+## F11. ~~Claude: `claudeQuery` without prior `createClaudeSession` throws~~ (resolved by runtime)
 
-**Symptom.** Exception at the first `claudeQuery` call in a session.
+This failure mode is now handled automatically by the runtime. When using
+`s.session.query()`, the runtime calls `createClaudeSession()` during stage
+initialization before the user callback runs. Manual `createClaudeSession`
+calls are no longer needed — `s.client` and `s.session` arrive fully
+initialized.
 
-**Fix.** Always call `createClaudeSession({ paneId: s.paneId })` as the
-first line inside each Claude-backed `ctx.session()` callback:
+**Previously required (now unnecessary):**
 
 ```ts
-await ctx.session({ name: "..." }, async (s) => {
-  await createClaudeSession({ paneId: s.paneId });
+// OLD — no longer needed
+await ctx.stage({ name: "..." }, async (s) => {
+  await createClaudeSession({ paneId: s.paneId }); // ← runtime does this now
   await claudeQuery({ paneId: s.paneId, prompt: ctx.userPrompt });
   s.save(s.sessionId);
 });
 ```
 
-If a Claude session is killed mid-workflow, call
-`clearClaudeSession(paneId)` to remove the pane from the initialized set
-before recreating it.
+**Current pattern:**
+
+```ts
+await ctx.stage({ name: "..." }, {}, {}, async (s) => {
+  const result = await s.session.query(ctx.userPrompt);
+  s.save(s.sessionId);
+});
+```
 
 ---
 
@@ -534,7 +547,7 @@ throws or returns empty.
 
 **Root cause.** `s.transcript()` only exposes **prior completed sessions** —
 ones whose callback has returned and whose saves have flushed. Sessions
-launched concurrently via `Promise.all([ctx.session(...), ctx.session(...)])` run
+launched concurrently via `Promise.all([ctx.stage(...), ctx.stage(...)])` run
 at the same time; forward-only data flow is enforced.
 
 **Fix.** Restructure to either a linear chain, a "fan-out, then merge"
@@ -543,19 +556,19 @@ shared state (files, DB) if siblings genuinely need to coordinate.
 
 ```ts
 // Fan-out → merge
-await ctx.session({ name: "describe" }, async (s) => { /* ... */ });
+await ctx.stage({ name: "describe" }, {}, {}, async (s) => { /* ... */ });
 
 await Promise.all([
-  ctx.session({ name: "summarize-a" }, async (s) => {
+  ctx.stage({ name: "summarize-a" }, {}, {}, async (s) => {
     const d = await s.transcript("describe"); // OK — prior completed session
     // s.transcript("summarize-b") would fail here — sibling not yet complete
   }),
-  ctx.session({ name: "summarize-b" }, async (s) => {
+  ctx.stage({ name: "summarize-b" }, {}, {}, async (s) => {
     const d = await s.transcript("describe"); // OK — prior completed session
   }),
 ]);
 
-await ctx.session({ name: "merge" }, async (s) => {
+await ctx.stage({ name: "merge" }, {}, {}, async (s) => {
   const a = await s.transcript("summarize-a"); // OK — prior completed session
   const b = await s.transcript("summarize-b"); // OK — prior completed session
 });
@@ -563,7 +576,7 @@ await ctx.session({ name: "merge" }, async (s) => {
 
 ---
 
-## F14. Forgetting to `await` `ctx.session()`
+## F14. Forgetting to `await` `ctx.stage()`
 
 **Symptom.** A session runs (its tmux window opens, the agent does work)
 but the orchestrator doesn't wait for it. Subsequent sessions that depend
@@ -571,7 +584,7 @@ on its output via `transcript()` or `getMessages()` see empty or missing
 data. The workflow may finish "successfully" before the session's callback
 has returned.
 
-**Root cause.** `ctx.session()` returns a `Promise<SessionHandle<T>>`.
+**Root cause.** `ctx.stage()` returns a `Promise<SessionHandle<T>>`.
 Without `await`, the session is spawned but the `.run()` callback continues
 immediately. The session's save never reaches the `completedRegistry`
 before downstream code tries to read it.
@@ -583,13 +596,13 @@ SDK-specific.
 
 ```ts
 // Missing await — session fires but orchestrator doesn't wait
-ctx.session({ name: "research" }, async (s) => {
+ctx.stage({ name: "research" }, {}, {}, async (s) => {
   // ... agent work ...
   s.save(s.sessionId);
 });
 
 // This runs before "research" completes
-await ctx.session({ name: "synthesize" }, async (s) => {
+await ctx.stage({ name: "synthesize" }, {}, {}, async (s) => {
   const r = await s.transcript("research"); // empty or throws
 });
 ```
@@ -597,12 +610,12 @@ await ctx.session({ name: "synthesize" }, async (s) => {
 ### ✅ Right
 
 ```ts
-await ctx.session({ name: "research" }, async (s) => {
+await ctx.stage({ name: "research" }, {}, {}, async (s) => {
   // ... agent work ...
   s.save(s.sessionId);
 });
 
-await ctx.session({ name: "synthesize" }, async (s) => {
+await ctx.stage({ name: "synthesize" }, {}, {}, async (s) => {
   const r = await s.transcript("research"); // works
 });
 ```
@@ -620,7 +633,7 @@ this at compile time.
 `s.transcript(handle)` throws / returns empty even though the session
 eventually completes.
 
-**Root cause.** `ctx.session()` returns a `SessionHandle<T>` whose
+**Root cause.** `ctx.stage()` returns a `SessionHandle<T>` whose
 `.result` is only populated after the callback returns. If you store the
 promise but access the handle before awaiting it, the result field is
 not yet set and the session is not in the `completedRegistry`.
@@ -631,8 +644,8 @@ not yet set and the session is not in the `completedRegistry`.
 
 ```ts
 // Start both but access handles before awaiting
-const handleA = ctx.session({ name: "a" }, async (s) => { /* ... */ return 42; });
-const handleB = ctx.session({ name: "b" }, async (s) => {
+const handleA = ctx.stage({ name: "a" }, {}, {}, async (s) => { /* ... */ return 42; });
+const handleB = ctx.stage({ name: "b" }, {}, {}, async (s) => {
   // handleA is a Promise, not a resolved SessionHandle
   const transcript = await s.transcript(handleA); // fails
 });
@@ -642,9 +655,9 @@ const handleB = ctx.session({ name: "b" }, async (s) => {
 
 ```ts
 // Await first, then use the resolved handle
-const handleA = await ctx.session({ name: "a" }, async (s) => { /* ... */ return 42; });
+const handleA = await ctx.stage({ name: "a" }, {}, {}, async (s) => { /* ... */ return 42; });
 
-await ctx.session({ name: "b" }, async (s) => {
+await ctx.stage({ name: "b" }, {}, {}, async (s) => {
   const transcript = await s.transcript(handleA); // works — handleA is resolved
   console.log(handleA.result); // 42
 });
@@ -655,13 +668,13 @@ all promises resolve:
 
 ```ts
 const [a, b] = await Promise.all([
-  ctx.session({ name: "a" }, async (s) => { /* ... */ return "x"; }),
-  ctx.session({ name: "b" }, async (s) => { /* ... */ return "y"; }),
+  ctx.stage({ name: "a" }, {}, {}, async (s) => { /* ... */ return "x"; }),
+  ctx.stage({ name: "b" }, {}, {}, async (s) => { /* ... */ return "y"; }),
 ]);
 // a.result === "x", b.result === "y"
 ```
 
-**Detection.** TypeScript's type system helps — `ctx.session()` returns
+**Detection.** TypeScript's type system helps — `ctx.stage()` returns
 `Promise<SessionHandle<T>>`, not `SessionHandle<T>` directly. If you're
 accessing `.result` without awaiting, the type will be `Promise`, not `T`.
 
@@ -671,15 +684,14 @@ accessing `.result` without awaiting, the type will be `Promise`, not `T`.
 
 Before shipping a multi-session workflow, walk the list:
 
-- [ ] Every `session.sendAndWait` call passes an explicit timeout (F10)
+- [ ] Every `s.session.sendAndWait` call passes an explicit timeout (F10)
 - [ ] Every fresh-session handoff forwards context explicitly (F5)
 - [ ] Every prompt whose output feeds a downstream stage explicitly requests trailing commentary (F6)
 - [ ] Response-text extraction uses the per-SDK correct pattern (F1-F4)
 - [ ] Structured-output parsers extract the LAST fenced block, not the first (F8)
-- [ ] `s.save()` receives the per-SDK correct shape (F9)
+- [ ] `s.save()` receives the per-SDK correct shape — Copilot uses `s.session.getMessages()` (F9)
 - [ ] Loops over 10 iterations have a compaction / reset strategy (F7)
 - [ ] Parallel groups only read from prior completed sessions, never siblings (F13)
-- [ ] Every `ctx.session()` call is `await`ed (F14)
+- [ ] Every `ctx.stage()` call is `await`ed (F14)
 - [ ] `SessionHandle` values are only used after the promise resolves (F15)
-- [ ] Claude-backed sessions start with `createClaudeSession` (F11)
 - [ ] Resume is only used within the same agent role (F12)

--- a/.agents/skills/workflow-creator/references/getting-started.md
+++ b/.agents/skills/workflow-creator/references/getting-started.md
@@ -4,37 +4,40 @@ This guide covers the basics of creating workflows with the `defineWorkflow().ru
 
 ## Quick-start example
 
-Use `defineWorkflow().run(callback).compile()` to define your workflow. Inside the `.run()` callback, use `ctx.session()` to spawn agent sessions dynamically. Each session gets its own tmux window and graph node. Use native TypeScript control flow (`for`, `if`, `Promise.all()`) for orchestration.
+Use `defineWorkflow<"agent">().run(callback).compile()` to define your workflow. Inside the `.run()` callback, use `ctx.stage()` to spawn agent sessions dynamically. Each session gets its own tmux window and graph node. Use native TypeScript control flow (`for`, `if`, `Promise.all()`) for orchestration.
+
+The runtime manages the full session lifecycle automatically — it creates the client, creates the session, runs your callback, then cleans up. You never need to manually disconnect or stop anything.
 
 ### Claude
 
 ```ts
 // .atomic/workflows/my-workflow/claude/index.ts
-import { defineWorkflow, createClaudeSession, claudeQuery } from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
-export default defineWorkflow({
+export default defineWorkflow<"claude">({
     name: "my-workflow",
     description: "A two-session pipeline",
   })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask Claude to describe the project" },
+      {},
+      {},
       async (s) => {
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({ paneId: s.paneId, prompt: ctx.userPrompt });
+        await s.session.query(s.userPrompt);
         s.save(s.sessionId);
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "summarize", description: "Summarize the previous session's output" },
+      {},
+      {},
       async (s) => {
         const research = await s.transcript(describe);
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({
-          paneId: s.paneId,
-          prompt: `Read ${research.path} and summarize it in 2-3 bullet points.`,
-        });
+        await s.session.query(
+          `Read ${research.path} and summarize it in 2-3 bullet points.`,
+        );
         s.save(s.sessionId);
       },
     );
@@ -53,47 +56,38 @@ explicit, generous timeout. See the "Critical pitfall" section in
 ```ts
 // .atomic/workflows/my-workflow/copilot/index.ts
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { CopilotClient, approveAll } from "@github/copilot-sdk";
 
 // Explicit 30-minute timeout — required; see agent-sessions.md pitfall note.
 const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
-export default defineWorkflow({
+export default defineWorkflow<"copilot">({
     name: "my-workflow",
     description: "A two-session pipeline",
   })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
+      {},
+      {},
       async (s) => {
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-        await session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
-        s.save(await session.getMessages());
-        await session.disconnect();
-        await client.stop();
+        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+        s.save(await s.session.getMessages());
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "summarize", description: "Summarize the previous session's output" },
+      {},
+      {},
       async (s) => {
         const research = await s.transcript(describe);
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-        await session.sendAndWait(
+        await s.session.sendAndWait(
           {
             prompt: `Summarize the following in 2-3 bullet points:\n\n${research.content}`,
           },
           SEND_TIMEOUT_MS,
         );
-        s.save(await session.getMessages());
-        await session.disconnect();
-        await client.stop();
+        s.save(await s.session.getMessages());
       },
     );
   })
@@ -105,36 +99,33 @@ export default defineWorkflow({
 ```ts
 // .atomic/workflows/my-workflow/opencode/index.ts
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { createOpencodeClient } from "@opencode-ai/sdk/v2";
 
-export default defineWorkflow({
+export default defineWorkflow<"opencode">({
     name: "my-workflow",
     description: "A two-session pipeline",
   })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
+      {},
+      { title: "describe" },
       async (s) => {
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
-        const session = await client.session.create({ title: "describe" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
-          parts: [{ type: "text", text: ctx.userPrompt }],
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
+          parts: [{ type: "text", text: s.userPrompt }],
         });
         s.save(result.data!);
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "summarize", description: "Summarize the previous session's output" },
+      {},
+      { title: "summarize" },
       async (s) => {
         const research = await s.transcript(describe);
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
-        const session = await client.session.create({ title: "summarize" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
           parts: [{ type: "text", text: `Summarize the following in 2-3 bullet points:\n\n${research.content}` }],
         });
         s.save(result.data!);
@@ -153,13 +144,13 @@ Sessions are spawned dynamically, so you can use loops, conditionals, and `Promi
 ```ts
 // Parallel sessions
 const [a, b] = await Promise.all([
-  ctx.session({ name: "task-a" }, async (s) => { /* ... */ }),
-  ctx.session({ name: "task-b" }, async (s) => { /* ... */ }),
+  ctx.stage({ name: "task-a" }, {}, {}, async (s) => { /* ... */ }),
+  ctx.stage({ name: "task-b" }, {}, {}, async (s) => { /* ... */ }),
 ]);
 
 // Loop with dynamic sessions
 for (let i = 1; i <= maxIterations; i++) {
-  const result = await ctx.session({ name: `step-${i}` }, async (s) => {
+  const result = await ctx.stage({ name: `step-${i}` }, {}, {}, async (s) => {
     // ... do work ...
     return someValue; // available as result.result
   });
@@ -168,7 +159,7 @@ for (let i = 1; i <= maxIterations; i++) {
 
 // Conditional sessions
 if (needsReview) {
-  await ctx.session({ name: "review" }, async (s) => { /* ... */ });
+  await ctx.stage({ name: "review" }, {}, {}, async (s) => { /* ... */ });
 }
 ```
 
@@ -177,7 +168,7 @@ if (needsReview) {
 The SDK (`@bastani/atomic/workflows`) exports everything you need for workflow authoring:
 
 **Builder:**
-- `defineWorkflow` — entry point, returns a chainable `WorkflowBuilder`
+- `defineWorkflow` — entry point, accepts an optional type parameter (`"claude"`, `"copilot"`, `"opencode"`) for type narrowing; returns a chainable `WorkflowBuilder`
 - `WorkflowBuilder` — the builder class (rarely needed directly)
 
 **Types** (import with `import type`):
@@ -185,9 +176,16 @@ The SDK (`@bastani/atomic/workflows`) exports everything you need for workflow a
 - `Transcript` — `{ path: string, content: string }` from `ctx.transcript()`
 - `SavedMessage` — union of provider-specific message types
 - `SaveTranscript` — overloaded save function type
-- `SessionContext` — the context object passed to `ctx.session()` callbacks
-- `SessionHandle<T>` — returned by `ctx.session()`, carries `{ name, id, result }`
-- `SessionRunOptions` — `{ name, description?, dependsOn? }` for `ctx.session()` first argument
+- `SessionContext` — the context object passed to `ctx.stage()` callbacks
+- `SessionHandle<T>` — returned by `ctx.stage()`, carries `{ name, id, result }`
+- `SessionRunOptions` — `{ name, description? }` for `ctx.stage()` first argument
+- `StageClientOptions<A>` — provider-specific client init options for `ctx.stage()` second argument
+- `StageSessionOptions<A>` — provider-specific session create options for `ctx.stage()` third argument
+- `ProviderClient<A>` — the `s.client` type, resolved by agent type
+- `ProviderSession<A>` — the `s.session` type, resolved by agent type
+- `ClaudeClientWrapper` — synthetic client wrapper for Claude stages
+- `ClaudeSessionWrapper` — synthetic session wrapper for Claude stages (exposes `s.session.query()`)
+- `ClaudeQueryDefaults` — per-stage query defaults (timeouts, poll interval) for Claude sessions
 - `SessionRef` — `string | SessionHandle<unknown>` for transcript/message lookups
 - `WorkflowContext` — top-level context passed to `.run()` callback
 - `WorkflowOptions` — `{ name, description? }` workflow metadata
@@ -199,12 +197,10 @@ The SDK (`@bastani/atomic/workflows`) exports everything you need for workflow a
 - `ClaudeSessionMessage` — from `@anthropic-ai/claude-agent-sdk`
 
 **Provider helpers:**
-- `createClaudeSession` — start Claude TUI in a tmux pane; must be called before `claudeQuery()`
-- `claudeQuery` — send a prompt to Claude TUI via tmux send-keys
-- `clearClaudeSession` — remove a pane from the initialized set (cleanup)
-- `validateClaudeWorkflow` — static validation for Claude workflow source files
-- `validateCopilotWorkflow` — regex-based Copilot usage checks
-- `validateOpenCodeWorkflow` — regex-based OpenCode usage checks
+- `validateClaudeWorkflow` — static validation for Claude workflow source files; warns on direct `createClaudeSession` or `claudeQuery` usage
+- `validateCopilotWorkflow` — static validation for Copilot workflow source files; warns on manual `new CopilotClient` or `client.createSession()` usage
+- `validateOpenCodeWorkflow` — static validation for OpenCode workflow source files; warns on manual `createOpencodeClient()` or `client.session.create()` usage
+- `createClaudeSession`, `claudeQuery`, `clearClaudeSession` — low-level tmux helpers; still exported for advanced use but not needed in typical workflows (use `s.session.query()` instead)
 
 **Runtime utilities:**
 - tmux helpers: `createSession`, `createWindow`, `createPane`, `sendKeysAndSubmit`, `capturePane`, etc.
@@ -216,7 +212,8 @@ The SDK (`@bastani/atomic/workflows`) exports everything you need for workflow a
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `serverUrl` | `string` | Agent's server URL (Copilot / OpenCode) |
+| `client` | `ProviderClient<A>` | Pre-created SDK client (auto-managed by runtime) |
+| `session` | `ProviderSession<A>` | Pre-created provider session (auto-managed by runtime) |
 | `userPrompt` | `string` | Original user prompt from CLI invocation |
 | `agent` | `AgentType` | Which agent is running |
 | `transcript(ref)` | `(ref: SessionRef) => Promise<Transcript>` | Get prior session's transcript as `{ path, content }` |
@@ -225,7 +222,7 @@ The SDK (`@bastani/atomic/workflows`) exports everything you need for workflow a
 | `sessionDir` | `string` | Path to session storage directory |
 | `paneId` | `string` | tmux pane ID |
 | `sessionId` | `string` | Session UUID |
-| `session(opts, fn)` | `<T>(...) => Promise<SessionHandle<T>>` | Spawn a nested sub-session (child of this session in the graph) |
+| `stage(opts, clientOpts, sessionOpts, fn)` | `<T>(...) => Promise<SessionHandle<T>>` | Spawn a nested sub-session (child of this session in the graph) |
 
 ## Reference files
 
@@ -241,4 +238,4 @@ The SDK (`@bastani/atomic/workflows`) exports everything you need for workflow a
 
 ## Type safety
 
-The SDK is typed with **no `unknown` or `any`**. `SessionContext` fields are precisely typed, and native SDK types are re-exported for convenience. Use `import type` for type-only imports.
+The SDK is typed with **no `unknown` or `any`**. `SessionContext` fields are precisely typed, and native SDK types are re-exported for convenience. Use `import type` for type-only imports. Use the `defineWorkflow<"agent">()` type parameter to narrow `s.client` and `s.session` to the correct provider types.

--- a/.agents/skills/workflow-creator/references/session-config.md
+++ b/.agents/skills/workflow-creator/references/session-config.md
@@ -1,24 +1,35 @@
 # Session Configuration
 
-Each SDK has its own configuration options for controlling model selection, tools, permissions, hooks, and structured output. Configure these within each session callback.
+Each SDK has its own configuration options for controlling model selection, tools, permissions, hooks, and structured output. Pass these via `clientOpts` (2nd arg to `ctx.stage()`) and `sessionOpts` (3rd arg to `ctx.stage()`). The runtime uses them to create the client and session automatically — no manual client or session creation needed.
 
 ## Claude Agent SDK
 
-### `createClaudeSession()` options
+### Client options (`clientOpts` — 2nd arg to `ctx.stage()`)
 
-Start the Claude TUI in a tmux pane. Must be called before any `claudeQuery()` on the same pane:
+These correspond to `createClaudeSession()` options and control how the Claude
+TUI pane is started:
 
 ```ts
-import { createClaudeSession } from "@bastani/atomic/workflows";
-
-// Default flags (skip all permissions)
-await createClaudeSession({ paneId: s.paneId });
-
-// Custom CLI flags
-await createClaudeSession({
-  paneId: s.paneId,
+await ctx.stage({ name: "..." }, {
   chatFlags: ["--model", "opus", "--dangerously-skip-permissions"],
   readyTimeoutMs: 60_000,  // Wait up to 60s for TUI (default: 30s)
+}, {}, async (s) => {
+  // s.client and s.session are ready
+});
+```
+
+### Session options (`sessionOpts` — 3rd arg to `ctx.stage()`)
+
+These are `ClaudeQueryDefaults` and set defaults for every `s.session.query()`
+call inside the callback (`timeoutMs`, `pollIntervalMs`, etc.):
+
+```ts
+await ctx.stage({ name: "..." }, {}, {
+  timeoutMs: 5 * 60 * 1000,     // 5 minutes per query (default)
+  pollIntervalMs: 1_000,         // Poll interval for output
+}, async (s) => {
+  await s.session.query(ctx.userPrompt);
+  s.save(s.sessionId);
 });
 ```
 
@@ -85,20 +96,21 @@ const result = query({
 });
 ```
 
-### `claudeQuery()` options
+### `s.session.query()` usage
 
-The `claudeQuery()` helper sends text to a tmux pane. Requires `createClaudeSession()` to have been called first on the same pane:
+`s.session.query()` is the runtime wrapper around `claudeQuery()`. It uses
+the pane ID from `s.paneId` automatically. Call it inside the stage callback:
 
 ```ts
-import { createClaudeSession, claudeQuery } from "@bastani/atomic/workflows";
-
-await createClaudeSession({ paneId: s.paneId });
-const result = await claudeQuery({
-  paneId: s.paneId,       // tmux pane ID (from SessionContext)
-  prompt: "Your prompt",  // Text to send
+await ctx.stage({ name: "..." }, {}, {}, async (s) => {
+  const result = await s.session.query("Your prompt");
+  // result.output — captured response text
+  s.save(s.sessionId);
 });
-// result.output — captured response text
 ```
+
+The query defaults (timeout, poll interval) can be configured via `sessionOpts`
+as shown above.
 
 ### Claude hooks
 
@@ -146,12 +158,16 @@ const result = query({
 
 ## Copilot SDK
 
-### `createSession()` options
+### Session options (`sessionOpts` — 3rd arg to `ctx.stage()`)
+
+All `client.createSession()` options are passed as `sessionOpts`. The runtime
+forwards them to `client.createSession()`. `onPermissionRequest` defaults to
+`approveAll` when not specified.
 
 ```ts
-import { CopilotClient, approveAll, defineTool } from "@github/copilot-sdk";
+import { approveAll, defineTool } from "@github/copilot-sdk";
 
-const session = await client.createSession({
+await ctx.stage({ name: "plan" }, {}, {
   // Model selection
   model: "claude-sonnet-4.6",
   reasoningEffort: "high",
@@ -169,8 +185,8 @@ const session = await client.createSession({
     }),
   ],
 
-  // Permissions (required)
-  onPermissionRequest: approveAll,    // Or custom handler
+  // Permissions (defaults to approveAll if omitted)
+  onPermissionRequest: approveAll,
 
   // User input
   onUserInputRequest: async (request) => {
@@ -191,133 +207,150 @@ const session = await client.createSession({
 
   // Advanced
   infiniteSessions: true,             // Auto-manage context via compaction
-  provider: {                          // Custom provider config
-    name: "my-provider",
-    baseUrl: "https://api.example.com",
-    apiKey: "...",
-  },
+}, async (s) => {
+  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 ```
 
 ### Copilot permission modes
 
 ```ts
-// Approve everything (autonomous)
-const session = await client.createSession({
-  onPermissionRequest: approveAll,
+// Approve everything (autonomous) — this is the default
+await ctx.stage({ name: "plan" }, {}, { onPermissionRequest: approveAll }, async (s) => {
+  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 
 // Custom permission handler
-const session = await client.createSession({
+await ctx.stage({ name: "plan" }, {}, {
   onPermissionRequest: async (request) => {
     // request.kind: "shell" | "write" | "read" | "mcp" | "custom-tool" | "url" | "memory" | "hook"
     switch (request.kind) {
       case "shell":
-        // Inspect command before approving
         return request.command?.includes("rm")
           ? { kind: "denied-permanently", reason: "Dangerous" }
           : { kind: "approved" };
       case "write":
-        // Allow all file writes
         return { kind: "approved" };
       default:
         return { kind: "approved" };
     }
   },
+}, async (s) => {
+  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 ```
 
 ## OpenCode SDK
 
-### Client creation
+### Client options (`clientOpts` — 2nd arg to `ctx.stage()`)
+
+The `baseUrl` is auto-injected by the runtime. Pass any additional client
+options (such as `directory`) via `clientOpts`:
 
 ```ts
-import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk/v2";
-
-// Option 1: Start server + client (standalone)
-const opencode = await createOpencode({
-  hostname: "localhost",
-  port: 3000,
-  config: {
-    // Inline config overrides opencode.json
-  },
+await ctx.stage({ name: "..." }, {
+  directory: "/path/to/project",   // Override working directory
+}, {}, async (s) => {
+  // s.client is the OpencodeClient, already connected
 });
+```
 
-// Option 2: Client-only (connect to existing server — typical for workflows)
-const client = createOpencodeClient({
-  baseUrl: s.serverUrl,   // From SessionContext
+### Session options (`sessionOpts` — 3rd arg to `ctx.stage()`)
+
+These are forwarded to `client.session.create()`. Use them to set a title,
+parentID, or workspaceID for the session:
+
+```ts
+await ctx.stage({ name: "..." }, {}, {
+  title: "Feature implementation",
+  parentID: "parent-session-id",
+  workspaceID: "workspace-id",
+}, async (s) => {
+  // s.session is the created OpencodeSession, s.session.id is the session ID
 });
 ```
 
 ### Session prompting
 
+Use `s.client` and `s.session.id` inside the callback:
+
 ```ts
-// Basic prompt
-const result = await client.session.prompt({
-  sessionID: session.data!.id,
-  parts: [{ type: "text", text: "Your prompt" }],
-});
+await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
+  // Basic prompt
+  const result = await s.client.session.prompt({
+    sessionID: s.session.id,
+    parts: [{ type: "text", text: ctx.userPrompt }],
+  });
 
-// Structured output
-const result = await client.session.prompt({
-  sessionID: session.data!.id,
-  parts: [{ type: "text", text: "List endpoints as JSON" }],
-  format: {
-    type: "json_schema",
-    schema: { type: "object", properties: { endpoints: { type: "array" } } },
-    retryCount: 3,
-  },
-});
+  // Structured output
+  const structured = await s.client.session.prompt({
+    sessionID: s.session.id,
+    parts: [{ type: "text", text: "List endpoints as JSON" }],
+    format: {
+      type: "json_schema",
+      schema: { type: "object", properties: { endpoints: { type: "array" } } },
+      retryCount: 3,
+    },
+  });
 
-// No-reply context injection
-await client.session.prompt({
-  sessionID: session.data!.id,
-  parts: [{ type: "text", text: "Background context..." }],
-  noReply: true,
+  // No-reply context injection
+  await s.client.session.prompt({
+    sessionID: s.session.id,
+    parts: [{ type: "text", text: "Background context..." }],
+    noReply: true,
+  });
+
+  s.save(result.data!);
 });
 ```
 
 ### OpenCode session management
 
 ```ts
-// Create session
-const session = await client.session.create({ title: "my-session" });
+await ctx.stage({ name: "..." }, {}, {}, async (s) => {
+  // Select session in TUI (auto-called by runtime, but can be called again)
+  await s.client.tui.selectSession({ sessionID: s.session.id });
 
-// Select session in TUI
-await client.tui.selectSession({ sessionID: session.data!.id });
+  // Fork session
+  await s.client.session.fork({ sessionID: s.session.id, messageID: "..." });
 
-// Fork session
-await client.session.fork({ sessionID: session.data!.id, messageID: "..." });
+  // Abort
+  await s.client.session.abort({ sessionID: s.session.id });
 
-// Abort
-await client.session.abort({ sessionID: session.data!.id });
-
-// Session messages
-const messages = await client.session.messages({ sessionID: session.data!.id });
+  // Session messages
+  const messages = await s.client.session.messages({ sessionID: s.session.id });
+});
 ```
 
 ### OpenCode event streaming
 
 ```ts
-const unsubscribe = await client.event.subscribe((event) => {
-  switch (event.type) {
-    case "session.updated":
-      console.log("Session updated");
-      break;
-    case "message.created":
-      console.log("New message");
-      break;
-  }
+await ctx.stage({ name: "..." }, {}, {}, async (s) => {
+  const unsubscribe = await s.client.event.subscribe((event) => {
+    switch (event.type) {
+      case "session.updated":
+        console.log("Session updated");
+        break;
+      case "message.created":
+        console.log("New message");
+        break;
+    }
+  });
 });
 ```
 
 ### OpenCode permissions
 
 ```ts
-// Handle permission requests
-await client.session.permission({
-  sessionID: session.data!.id,
-  permissionID: "...",
-  approved: true,
+await ctx.stage({ name: "..." }, {}, {}, async (s) => {
+  // Handle permission requests
+  await s.client.session.permission({
+    sessionID: s.session.id,
+    permissionID: "...",
+    approved: true,
+  });
 });
 ```

--- a/.agents/skills/workflow-creator/references/state-and-data-flow.md
+++ b/.agents/skills/workflow-creator/references/state-and-data-flow.md
@@ -2,8 +2,6 @@
 
 Data flows between sessions via `s.save()` (in the producing session) and `transcript()` / `getMessages()` (in consuming sessions or at the `.run()` level). Within a session, use plain TypeScript variables. This is the programmatic equivalent of `globalState` and reducers.
 
-> **Note:** All Claude examples below assume `createClaudeSession({ paneId: s.paneId })` is called at the start of each session callback before any `claudeQuery()` calls.
-
 ## Between sessions: `s.save()` → `transcript()` / `getMessages()`
 
 **Completion rule:** `transcript()` and `getMessages()` can only access data from sessions whose callbacks have already returned (i.e., sessions in the `completedRegistry`). In a `Promise.all()` group, sibling sessions cannot read each other's output — only sessions that completed before the group started are available.
@@ -17,7 +15,7 @@ Each SDK has its own save pattern:
 s.save(s.sessionId);
 
 // Copilot — pass SessionEvent[] from getMessages()
-s.save(await session.getMessages());
+s.save(await s.session.getMessages());
 
 // OpenCode — pass response { info, parts } from session.prompt()
 s.save(result.data!);
@@ -29,31 +27,23 @@ s.save(result.data!);
 - `path` — absolute file path to the transcript on disk
 - `content` — extracted assistant text, ready to embed in prompts
 
-Pass the session handle returned by a prior `ctx.session()` call (handle-based, recommended). The string name `s.transcript("name")` also works when no handle is in scope.
+Pass the session handle returned by a prior `ctx.stage()` call (handle-based, recommended). The string name `s.transcript("name")` also works when no handle is in scope.
 
 ```ts
 .run(async (ctx) => {
-  const researchHandle = await ctx.session({ name: "research" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
-    await claudeQuery({ paneId: s.paneId, prompt: "Research the topic." });
+  const researchHandle = await ctx.stage({ name: "research" }, {}, {}, async (s) => {
+    await s.session.query("Research the topic.");
     s.save(s.sessionId);
   });
 
-  await ctx.session({ name: "synthesize" }, async (s) => {
+  await ctx.stage({ name: "synthesize" }, {}, {}, async (s) => {
     const research = await s.transcript(researchHandle);
-    await createClaudeSession({ paneId: s.paneId });
 
     // Use rendered text in a prompt
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Synthesize this research:\n${research.content}`,
-    });
+    await s.session.query(`Synthesize this research:\n${research.content}`);
 
     // Or reference the file path (useful for Claude file triggers)
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Read ${research.path} and summarize the key findings.`,
-    });
+    await s.session.query(`Read ${research.path} and summarize the key findings.`);
 
     s.save(s.sessionId);
   });
@@ -66,12 +56,12 @@ Pass the session handle returned by a prior `ctx.session()` call (handle-based, 
 
 ```ts
 .run(async (ctx) => {
-  const researchHandle = await ctx.session({ name: "research" }, async (s) => {
+  const researchHandle = await ctx.stage({ name: "research" }, {}, {}, async (s) => {
     // ... research work ...
     s.save(s.sessionId);
   });
 
-  await ctx.session({ name: "analyze-results" }, async (s) => {
+  await ctx.stage({ name: "analyze-results" }, {}, {}, async (s) => {
     const messages = await s.getMessages(researchHandle);
 
     // messages is SavedMessage[], where each entry is:
@@ -96,7 +86,7 @@ Session callbacks can return a value directly. The handle exposes it via `.resul
 
 ```ts
 .run(async (ctx) => {
-  const planHandle = await ctx.session({ name: "plan" }, async (s) => {
+  const planHandle = await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
     // ... planning work ...
     return { taskCount: 5, priority: "high" };
   });
@@ -112,18 +102,16 @@ Use closures and variables for state within a single session:
 
 ```ts
 .run(async (ctx) => {
-  await ctx.session({ name: "review-fix" }, async (s) => {
-    await createClaudeSession({ paneId: s.paneId });
+  await ctx.stage({ name: "review-fix" }, {}, {}, async (s) => {
     // Local state — plain variables
     let consecutiveClean = 0;
     let priorOutput = "";
     const findings: string[] = [];
 
     for (let cycle = 0; cycle < 10; cycle++) {
-      const result = await claudeQuery({
-        paneId: s.paneId,
-        prompt: buildReviewPrompt(ctx.userPrompt, priorOutput),
-      });
+      const result = await s.session.query(
+        buildReviewPrompt(ctx.userPrompt, priorOutput),
+      );
 
       // Accumulate findings
       const review = parseReviewResult(result.output);
@@ -140,10 +128,7 @@ Use closures and variables for state within a single session:
       consecutiveClean = 0;
 
       // Apply fix
-      const fixResult = await claudeQuery({
-        paneId: s.paneId,
-        prompt: buildFixSpec(review, ctx.userPrompt),
-      });
+      const fixResult = await s.session.query(buildFixSpec(review, ctx.userPrompt));
       priorOutput = fixResult.output;
     }
 
@@ -163,11 +148,11 @@ import { readFile, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 
 .run(async (ctx) => {
-  await ctx.session({ name: "plan" }, async (s) => {
+  await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
     // ... plan session ...
   });
 
-  await ctx.session({ name: "generate-report" }, async (s) => {
+  await ctx.stage({ name: "generate-report" }, {}, {}, async (s) => {
     // Write artifacts to session directory
     const artifactDir = join(s.sessionDir, "artifacts");
     await mkdir(artifactDir, { recursive: true });
@@ -262,32 +247,28 @@ Session A → s.save() → Session B reads via s.transcript(handleA)
 
 ```ts
 .run(async (ctx) => {
-  const researchHandle = await ctx.session({ name: "research" }, async (s) => {
+  const researchHandle = await ctx.stage({ name: "research" }, {}, {}, async (s) => {
     // ... research work ...
     s.save(s.sessionId);
   });
-  const analysisHandle = await ctx.session({ name: "analysis" }, async (s) => {
+  const analysisHandle = await ctx.stage({ name: "analysis" }, {}, {}, async (s) => {
     // ... analysis work ...
     s.save(s.sessionId);
   });
-  const feedbackHandle = await ctx.session({ name: "feedback" }, async (s) => {
+  const feedbackHandle = await ctx.stage({ name: "feedback" }, {}, {}, async (s) => {
     // ... feedback work ...
     s.save(s.sessionId);
   });
 
-  await ctx.session({ name: "merge" }, async (s) => {
+  await ctx.stage({ name: "merge" }, {}, {}, async (s) => {
     const research = await s.transcript(researchHandle);
     const analysis = await s.transcript(analysisHandle);
     const userFeedback = await s.transcript(feedbackHandle);
-    await createClaudeSession({ paneId: s.paneId });
 
-    await claudeQuery({
-      paneId: s.paneId,
-      prompt: `Combine these inputs:
+    await s.session.query(`Combine these inputs:
 Research: ${research.content}
 Analysis: ${analysis.content}
-Feedback: ${userFeedback.content}`,
-    });
+Feedback: ${userFeedback.content}`);
     s.save(s.sessionId);
   });
 })
@@ -299,16 +280,16 @@ Each session can read all prior completed steps (but not parallel siblings):
 
 ```ts
 .run(async (ctx) => {
-  const h1 = await ctx.session({ name: "session-1" }, async (s) => {
+  const h1 = await ctx.stage({ name: "session-1" }, {}, {}, async (s) => {
     // ...
     s.save(s.sessionId);
   });
-  const h2 = await ctx.session({ name: "session-2" }, async (s) => {
+  const h2 = await ctx.stage({ name: "session-2" }, {}, {}, async (s) => {
     // ...
     s.save(s.sessionId);
   });
 
-  await ctx.session({ name: "session-3" }, async (s) => {
+  await ctx.stage({ name: "session-3" }, {}, {}, async (s) => {
     // Read from any prior completed session via its handle
     const s1 = await s.transcript(h1);
     const s2 = await s.transcript(h2);
@@ -316,6 +297,56 @@ Each session can read all prior completed steps (but not parallel siblings):
     // Combine and process
     const combined = `${s1.content}\n${s2.content}`;
     // ...
+  });
+})
+```
+
+## Context-Aware Transcript Handoff
+
+When passing transcripts between sessions, compress at the boundary to prevent downstream context degradation. Use structured summaries that preserve actionable information while dropping verbose tool output (applies `context-compression` + `context-degradation`):
+
+```ts
+// helpers/compression.ts
+export function compressTranscript(content: string, maxTokenEstimate: number = 4000): string {
+  // Rough estimate: 1 token ≈ 4 chars
+  const maxChars = maxTokenEstimate * 4;
+  if (content.length <= maxChars) return content;
+
+  // Preserve first and last sections (recency + primacy bias)
+  const headSize = Math.floor(maxChars * 0.4);
+  const tailSize = Math.floor(maxChars * 0.4);
+  const head = content.slice(0, headSize);
+  const tail = content.slice(-tailSize);
+
+  return `${head}\n\n[... ${content.length - headSize - tailSize} chars compressed ...]\n\n${tail}`;
+}
+```
+
+```ts
+await ctx.stage({ name: "synthesize" }, {}, {}, async (s) => {
+  const research = await s.transcript("research");
+  // Compress before injecting into prompt to stay within token budget
+  const compressed = compressTranscript(research.content, 4000);
+  await s.session.query(`Synthesize this research:\n${compressed}`);
+  s.save(s.sessionId);
+});
+```
+
+## File-Based Coordination
+
+Use the filesystem as a coordination layer instead of inlining large data into prompts. This applies `filesystem-context`:
+
+```ts
+.run(async (ctx) => {
+  await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
+    await s.session.query(`Create a plan for: ${s.userPrompt}\n\nWrite it to plan.md.`);
+    s.save(s.sessionId);
+  });
+
+  await ctx.stage({ name: "execute" }, {}, {}, async (s) => {
+    // Reference the file by path — lets the agent read selectively
+    await s.session.query(`Read plan.md and implement each task. Mark tasks done as you go.`);
+    s.save(s.sessionId);
   });
 })
 ```

--- a/.agents/skills/workflow-creator/references/user-input.md
+++ b/.agents/skills/workflow-creator/references/user-input.md
@@ -11,7 +11,7 @@ The Claude Agent SDK provides a `canUseTool` callback for runtime approval and u
 ```ts
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
-// Inside a ctx.session() callback:
+// Inside a ctx.stage() callback:
 async (s) => {
   const result = query({
     prompt: "Implement the feature, but ask me before making any database changes.",
@@ -58,19 +58,25 @@ q.streamInput("Here's the additional context you asked for...");
 
 ## Copilot
 
+Session callbacks (`onUserInputRequest`, `onElicitationRequest`,
+`onPermissionRequest`) are passed as `sessionOpts` — the third argument to
+`ctx.stage()`. The runtime forwards them to `client.createSession()`.
+`onPermissionRequest` defaults to `approveAll` when not specified.
+
 ### Via `onUserInputRequest`
 
 Handle `ask_user` tool requests from the agent:
 
 ```ts
-const session = await client.createSession({
-  onPermissionRequest: approveAll,
+await ctx.stage({ name: "plan" }, {}, {
   onUserInputRequest: async (request) => {
     // request.question contains the agent's question
-    // Return the user's answer
     const answer = await promptUser(request.question);
     return answer;
   },
+}, async (s) => {
+  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 ```
 
@@ -79,28 +85,33 @@ const session = await client.createSession({
 For form-style UI with structured options:
 
 ```ts
-const session = await client.createSession({
+await ctx.stage({ name: "plan" }, {}, {
   onPermissionRequest: approveAll,
   onElicitationRequest: async (request) => {
     // request contains form fields and options
-    // Return structured response
     return {
       action: "submit",
       values: { strategy: "conservative", confirm: true },
     };
   },
+}, async (s) => {
+  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 ```
 
 ### Programmatic approval
 
-For fully autonomous workflows, use `approveAll` to skip all permission prompts:
+For fully autonomous workflows, use `approveAll` to skip all permission prompts.
+This is the **default** when `onPermissionRequest` is not specified in `sessionOpts`:
 
 ```ts
 import { approveAll } from "@github/copilot-sdk";
 
-const session = await client.createSession({
-  onPermissionRequest: approveAll,
+// Explicit (same as the default):
+await ctx.stage({ name: "plan" }, {}, { onPermissionRequest: approveAll }, async (s) => {
+  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 ```
 
@@ -109,7 +120,7 @@ const session = await client.createSession({
 For fine-grained control over permissions:
 
 ```ts
-const session = await client.createSession({
+await ctx.stage({ name: "plan" }, {}, {
   onPermissionRequest: async (request) => {
     // request.kind: "shell" | "write" | "read" | "mcp" | "custom-tool" | "url" | "memory" | "hook"
     if (request.kind === "shell" && request.command?.includes("rm -rf")) {
@@ -117,27 +128,29 @@ const session = await client.createSession({
     }
     return { kind: "approved" };
   },
+}, async (s) => {
+  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  s.save(await s.session.getMessages());
 });
 ```
 
 ## OpenCode
+
+The `s.client` and `s.session` are auto-created by the runtime. Use them
+directly — no manual client creation needed.
 
 ### Via TUI control endpoints
 
 OpenCode uses TUI control endpoints for user interaction:
 
 ```ts
-import { createOpencodeClient } from "@opencode-ai/sdk/v2";
-
-// Inside a ctx.session() callback:
+// Inside a ctx.stage() callback:
 async (s) => {
-  const client = createOpencodeClient({ baseUrl: s.serverUrl });
-
   // Wait for the next TUI control request
-  const controlRequest = await client.tui.next();
+  const controlRequest = await s.client.tui.next();
 
   // Respond to the control request
-  await client.tui.response({
+  await s.client.tui.response({
     requestID: controlRequest.data!.id,
     response: "User's answer here",
   });
@@ -149,16 +162,19 @@ async (s) => {
 Handle permission requests programmatically:
 
 ```ts
-// Subscribe to events and handle permission requests
-const unsubscribe = await client.event.subscribe((event) => {
-  if (event.type === "permission.requested") {
-    client.session.permission({
-      sessionID: event.sessionID,
-      permissionID: event.permissionID,
-      approved: true,
-    });
-  }
-});
+// Inside a ctx.stage() callback:
+async (s) => {
+  // Subscribe to events and handle permission requests
+  const unsubscribe = await s.client.event.subscribe((event) => {
+    if (event.type === "permission.requested") {
+      s.client.session.permission({
+        sessionID: event.sessionID,
+        permissionID: event.permissionID,
+        approved: true,
+      });
+    }
+  });
+},
 ```
 
 ## Combining user input with control flow
@@ -166,19 +182,18 @@ const unsubscribe = await client.event.subscribe((event) => {
 Use user input results in conditional logic:
 
 ```ts
-// Inside a ctx.session() callback:
+// Inside a ctx.stage() callback (Claude example):
 async (s) => {
   // Get the plan from a previous session
   const plan = await s.transcript("plan");
-  await createClaudeSession({ paneId: s.paneId });
 
   // Ask the user (implementation depends on which SDK you're using)
   const approved = await getUserApproval(`Approve this plan?\n${plan.content}`);
 
   if (approved) {
-    await claudeQuery({ paneId: s.paneId, prompt: "Execute the plan." });
+    await s.session.query("Execute the plan.");
   } else {
-    await claudeQuery({ paneId: s.paneId, prompt: "Revise the plan." });
+    await s.session.query("Revise the plan.");
   }
 
   s.save(s.sessionId);

--- a/.atomic/workflows/hello-parallel/claude/index.ts
+++ b/.atomic/workflows/hello-parallel/claude/index.ts
@@ -8,58 +8,55 @@
  * Run: atomic workflow -n hello-parallel -a claude "describe this project"
  */
 
-import { defineWorkflow, createClaudeSession, claudeQuery } from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
-export default defineWorkflow({
+export default defineWorkflow<"claude">({
   name: "hello-parallel",
   description: "Parallel Claude demo: describe → [summarize-a, summarize-b] → merge",
 })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask Claude to describe the project" },
+      {},
+      {},
       async (s) => {
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({ paneId: s.paneId, prompt: s.userPrompt });
+        await s.session.query(s.userPrompt);
         s.save(s.sessionId);
       },
     );
 
     const [summarizeA, summarizeB] = await Promise.all([
-      ctx.session(
+      ctx.stage(
         { name: "summarize-a", description: "Summarize the description as bullet points" },
+        {},
+        {},
         async (s) => {
           const research = await s.transcript(describe);
-          await createClaudeSession({ paneId: s.paneId });
-          await claudeQuery({
-            paneId: s.paneId,
-            prompt: `Read ${research.path} and summarize it in 2-3 bullet points.`,
-          });
+          await s.session.query(`Read ${research.path} and summarize it in 2-3 bullet points.`);
           s.save(s.sessionId);
         },
       ),
-      ctx.session(
+      ctx.stage(
         { name: "summarize-b", description: "Summarize the description as a one-liner" },
+        {},
+        {},
         async (s) => {
           const research = await s.transcript(describe);
-          await createClaudeSession({ paneId: s.paneId });
-          await claudeQuery({
-            paneId: s.paneId,
-            prompt: `Read ${research.path} and summarize it in a single sentence.`,
-          });
+          await s.session.query(`Read ${research.path} and summarize it in a single sentence.`);
           s.save(s.sessionId);
         },
       ),
     ]);
 
-    await ctx.session(
+    await ctx.stage(
       { name: "merge", description: "Merge both summaries into a final output" },
+      {},
+      {},
       async (s) => {
         const bullets = await s.transcript(summarizeA);
         const oneliner = await s.transcript(summarizeB);
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({
-          paneId: s.paneId,
-          prompt: [
+        await s.session.query(
+          [
             "Combine the following two summaries into one concise paragraph:",
             "",
             "## Bullet points",
@@ -68,7 +65,7 @@ export default defineWorkflow({
             "## One-liner",
             oneliner.content,
           ].join("\n"),
-        });
+        );
         s.save(s.sessionId);
       },
     );

--- a/.atomic/workflows/hello-parallel/copilot/index.ts
+++ b/.atomic/workflows/hello-parallel/copilot/index.ts
@@ -9,7 +9,6 @@
  */
 
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { CopilotClient, approveAll } from "@github/copilot-sdk";
 
 /**
  * `CopilotSession.sendAndWait` defaults to a 60s timeout and THROWS on
@@ -18,89 +17,71 @@ import { CopilotClient, approveAll } from "@github/copilot-sdk";
  */
 const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
-export default defineWorkflow({
+export default defineWorkflow<"copilot">({
   name: "hello-parallel",
   description: "Parallel Copilot demo: describe → [summarize-a, summarize-b] → merge",
 })
   .run(async (ctx) => {
     // Sequential: describe
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
+      {},
+      {},
       async (s) => {
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
+        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
 
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-        await session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
-
-        s.save(await session.getMessages());
-        await session.disconnect();
-        await client.stop();
+        s.save(await s.session.getMessages());
       },
     );
 
     // Parallel: summarize-a + summarize-b
     const [summarizeA, summarizeB] = await Promise.all([
-      ctx.session(
+      ctx.stage(
         { name: "summarize-a", description: "Summarize the description as bullet points" },
+        {},
+        {},
         async (s) => {
           const research = await s.transcript(describe);
 
-          const client = new CopilotClient({ cliUrl: s.serverUrl });
-          await client.start();
-
-          const session = await client.createSession({ onPermissionRequest: approveAll });
-          await client.setForegroundSessionId(session.sessionId);
-          await session.sendAndWait(
+          await s.session.sendAndWait(
             {
               prompt: `Summarize the following in 2-3 bullet points:\n\n${research.content}`,
             },
             SEND_TIMEOUT_MS,
           );
 
-          s.save(await session.getMessages());
-          await session.disconnect();
-          await client.stop();
+          s.save(await s.session.getMessages());
         },
       ),
-      ctx.session(
+      ctx.stage(
         { name: "summarize-b", description: "Summarize the description as a one-liner" },
+        {},
+        {},
         async (s) => {
           const research = await s.transcript(describe);
 
-          const client = new CopilotClient({ cliUrl: s.serverUrl });
-          await client.start();
-
-          const session = await client.createSession({ onPermissionRequest: approveAll });
-          await client.setForegroundSessionId(session.sessionId);
-          await session.sendAndWait(
+          await s.session.sendAndWait(
             {
               prompt: `Summarize the following in a single sentence:\n\n${research.content}`,
             },
             SEND_TIMEOUT_MS,
           );
 
-          s.save(await session.getMessages());
-          await session.disconnect();
-          await client.stop();
+          s.save(await s.session.getMessages());
         },
       ),
     ]);
 
     // Sequential: merge
-    await ctx.session(
+    await ctx.stage(
       { name: "merge", description: "Merge both summaries into a final output" },
+      {},
+      {},
       async (s) => {
         const bullets = await s.transcript(summarizeA);
         const oneliner = await s.transcript(summarizeB);
 
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
-
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-        await session.sendAndWait(
+        await s.session.sendAndWait(
           {
             prompt: [
               "Combine the following two summaries into one concise paragraph:",
@@ -115,9 +96,7 @@ export default defineWorkflow({
           SEND_TIMEOUT_MS,
         );
 
-        s.save(await session.getMessages());
-        await session.disconnect();
-        await client.stop();
+        s.save(await s.session.getMessages());
       },
     );
   })

--- a/.atomic/workflows/hello-parallel/opencode/index.ts
+++ b/.atomic/workflows/hello-parallel/opencode/index.ts
@@ -9,23 +9,19 @@
  */
 
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { createOpencodeClient } from "@opencode-ai/sdk/v2";
 
-export default defineWorkflow({
+export default defineWorkflow<"opencode">({
   name: "hello-parallel",
   description: "Parallel OpenCode demo: describe → [summarize-a, summarize-b] → merge",
 })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
+      {},
+      { title: "describe" },
       async (s) => {
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
-
-        const session = await client.session.create({ title: "describe" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
           parts: [{ type: "text", text: s.userPrompt }],
         });
 
@@ -34,17 +30,15 @@ export default defineWorkflow({
     );
 
     const [summarizeA, summarizeB] = await Promise.all([
-      ctx.session(
+      ctx.stage(
         { name: "summarize-a", description: "Summarize the description as bullet points" },
+        {},
+        { title: "summarize-a" },
         async (s) => {
           const research = await s.transcript(describe);
-          const client = createOpencodeClient({ baseUrl: s.serverUrl });
 
-          const session = await client.session.create({ title: "summarize-a" });
-          await client.tui.selectSession({ sessionID: session.data!.id });
-
-          const result = await client.session.prompt({
-            sessionID: session.data!.id,
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
             parts: [
               {
                 type: "text",
@@ -56,17 +50,15 @@ export default defineWorkflow({
           s.save(result.data!);
         },
       ),
-      ctx.session(
+      ctx.stage(
         { name: "summarize-b", description: "Summarize the description as a one-liner" },
+        {},
+        { title: "summarize-b" },
         async (s) => {
           const research = await s.transcript(describe);
-          const client = createOpencodeClient({ baseUrl: s.serverUrl });
 
-          const session = await client.session.create({ title: "summarize-b" });
-          await client.tui.selectSession({ sessionID: session.data!.id });
-
-          const result = await client.session.prompt({
-            sessionID: session.data!.id,
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
             parts: [
               {
                 type: "text",
@@ -80,18 +72,16 @@ export default defineWorkflow({
       ),
     ]);
 
-    await ctx.session(
+    await ctx.stage(
       { name: "merge", description: "Merge both summaries into a final output" },
+      {},
+      { title: "merge" },
       async (s) => {
         const bullets = await s.transcript(summarizeA);
         const oneliner = await s.transcript(summarizeB);
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
 
-        const session = await client.session.create({ title: "merge" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
           parts: [
             {
               type: "text",

--- a/.atomic/workflows/hello/claude/index.ts
+++ b/.atomic/workflows/hello/claude/index.ts
@@ -8,32 +8,31 @@
  * Run: atomic workflow -n hello -a claude "describe this project"
  */
 
-import { defineWorkflow, createClaudeSession, claudeQuery } from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
-export default defineWorkflow({
+export default defineWorkflow<"claude">({
   name: "hello",
   description: "Two-session Claude demo: describe → summarize",
 })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask Claude to describe the project" },
+      {},
+      {},
       async (s) => {
-        await createClaudeSession({ paneId: s.paneId });
-        await claudeQuery({ paneId: s.paneId, prompt: s.userPrompt });
+        await s.session.query(s.userPrompt);
         s.save(s.sessionId);
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "summarize", description: "Summarize the previous session's output" },
+      {},
+      {},
       async (s) => {
-        await createClaudeSession({ paneId: s.paneId });
         const research = await s.transcript(describe);
 
-        await claudeQuery({
-          paneId: s.paneId,
-          prompt: `Read ${research.path} and summarize it in 2-3 bullet points.`,
-        });
+        await s.session.query(`Read ${research.path} and summarize it in 2-3 bullet points.`);
         s.save(s.sessionId);
       },
     );

--- a/.atomic/workflows/hello/copilot/index.ts
+++ b/.atomic/workflows/hello/copilot/index.ts
@@ -8,7 +8,6 @@
  */
 
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { CopilotClient, approveAll } from "@github/copilot-sdk";
 
 /**
  * `CopilotSession.sendAndWait` defaults to a 60s timeout and THROWS on
@@ -17,51 +16,37 @@ import { CopilotClient, approveAll } from "@github/copilot-sdk";
  */
 const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
-export default defineWorkflow({
+export default defineWorkflow<"copilot">({
   name: "hello",
   description: "Two-session Copilot demo: describe → summarize",
 })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
+      {},
+      {},
       async (s) => {
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
+        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
 
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-
-        await session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
-
-        s.save(await session.getMessages());
-
-        await session.disconnect();
-        await client.stop();
+        s.save(await s.session.getMessages());
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "summarize", description: "Summarize the previous session's output" },
+      {},
+      {},
       async (s) => {
         const research = await s.transcript(describe);
 
-        const client = new CopilotClient({ cliUrl: s.serverUrl });
-        await client.start();
-
-        const session = await client.createSession({ onPermissionRequest: approveAll });
-        await client.setForegroundSessionId(session.sessionId);
-
-        await session.sendAndWait(
+        await s.session.sendAndWait(
           {
             prompt: `Summarize the following in 2-3 bullet points:\n\n${research.content}`,
           },
           SEND_TIMEOUT_MS,
         );
 
-        s.save(await session.getMessages());
-
-        await session.disconnect();
-        await client.stop();
+        s.save(await s.session.getMessages());
       },
     );
   })

--- a/.atomic/workflows/hello/opencode/index.ts
+++ b/.atomic/workflows/hello/opencode/index.ts
@@ -8,23 +8,19 @@
  */
 
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { createOpencodeClient } from "@opencode-ai/sdk/v2";
 
-export default defineWorkflow({
+export default defineWorkflow<"opencode">({
   name: "hello",
   description: "Two-session OpenCode demo: describe → summarize",
 })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
+      {},
+      { title: "describe" },
       async (s) => {
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
-
-        const session = await client.session.create({ title: "describe" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
           parts: [{ type: "text", text: s.userPrompt }],
         });
 
@@ -32,17 +28,15 @@ export default defineWorkflow({
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "summarize", description: "Summarize the previous session's output" },
+      {},
+      { title: "summarize" },
       async (s) => {
         const research = await s.transcript(describe);
-        const client = createOpencodeClient({ baseUrl: s.serverUrl });
 
-        const session = await client.session.create({ title: "summarize" });
-        await client.tui.selectSession({ sessionID: session.data!.id });
-
-        const result = await client.session.prompt({
-          sessionID: session.data!.id,
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
           parts: [
             {
               type: "text",

--- a/.atomic/workflows/ralph/claude/index.ts
+++ b/.atomic/workflows/ralph/claude/index.ts
@@ -10,11 +10,7 @@
  * Run: atomic workflow -n ralph -a claude "<your spec>"
  */
 
-import {
-  defineWorkflow,
-  createClaudeSession,
-  claudeQuery,
-} from "@bastani/atomic/workflows";
+import { defineWorkflow } from "@bastani/atomic/workflows";
 
 import {
   buildPlannerPrompt,
@@ -35,7 +31,7 @@ function asAgentCall(agentName: string, prompt: string): string {
   return `@"${agentName} (agent)" ${prompt}`;
 }
 
-export default defineWorkflow({
+export default defineWorkflow<"claude">({
   name: "ralph",
   description:
     "Plan → orchestrate → review → debug loop with bounded iteration",
@@ -43,73 +39,66 @@ export default defineWorkflow({
   .run(async (ctx) => {
     let consecutiveClean = 0;
     let debuggerReport = "";
-    // Track the most recent session so the next stage can declare it as a
-    // dependency — this chains planner → orchestrator → reviewer → [confirm]
-    // → [debugger] → next planner in the graph instead of showing every
-    // stage as an independent sibling under the root.
-    let prevStage: string | undefined;
-    const depsOn = (): string[] | undefined =>
-      prevStage ? [prevStage] : undefined;
 
     for (let iteration = 1; iteration <= MAX_LOOPS; iteration++) {
       // ── Plan ────────────────────────────────────────────────────────────
       const plannerName = `planner-${iteration}`;
-      await ctx.session(
-        { name: plannerName, dependsOn: depsOn() },
+      await ctx.stage(
+        { name: plannerName },
+        {},
+        {},
         async (s) => {
-          await createClaudeSession({ paneId: s.paneId });
-          await claudeQuery({
-            paneId: s.paneId,
-            prompt: asAgentCall(
+          await s.session.query(
+            asAgentCall(
               "planner",
               buildPlannerPrompt(s.userPrompt, {
                 iteration,
                 debuggerReport: debuggerReport || undefined,
               }),
             ),
-          });
+          );
           s.save(s.sessionId);
         },
       );
-      prevStage = plannerName;
+
 
       // ── Orchestrate ─────────────────────────────────────────────────────
       const orchName = `orchestrator-${iteration}`;
-      await ctx.session(
-        { name: orchName, dependsOn: depsOn() },
+      await ctx.stage(
+        { name: orchName },
+        {},
+        {},
         async (s) => {
-          await createClaudeSession({ paneId: s.paneId });
-          await claudeQuery({
-            paneId: s.paneId,
-            prompt: asAgentCall(
+          await s.session.query(
+            asAgentCall(
               "orchestrator",
               buildOrchestratorPrompt(s.userPrompt),
             ),
-          });
+          );
           s.save(s.sessionId);
         },
       );
-      prevStage = orchName;
+
 
       // ── Review (first pass) ─────────────────────────────────────────────
       let gitStatus = await safeGitStatusS();
       const reviewerName = `reviewer-${iteration}`;
-      const review = await ctx.session(
-        { name: reviewerName, dependsOn: depsOn() },
+      const review = await ctx.stage(
+        { name: reviewerName },
+        {},
+        {},
         async (s) => {
-          await createClaudeSession({ paneId: s.paneId });
-          const result = await claudeQuery({
-            paneId: s.paneId,
-            prompt: asAgentCall(
+          const result = await s.session.query(
+            asAgentCall(
               "reviewer",
               buildReviewPrompt(s.userPrompt, { gitStatus, iteration }),
             ),
-          });
+          );
           s.save(s.sessionId);
           return result.output;
         },
       );
-      prevStage = reviewerName;
+
 
       let reviewRaw = review.result;
       let parsed = parseReviewResult(reviewRaw);
@@ -121,13 +110,13 @@ export default defineWorkflow({
         // Confirmation pass — re-run reviewer only
         gitStatus = await safeGitStatusS();
         const confirmName = `reviewer-${iteration}-confirm`;
-        const confirm = await ctx.session(
-          { name: confirmName, dependsOn: depsOn() },
+        const confirm = await ctx.stage(
+          { name: confirmName },
+          {},
+          {},
           async (s) => {
-            await createClaudeSession({ paneId: s.paneId });
-            const result = await claudeQuery({
-              paneId: s.paneId,
-              prompt: asAgentCall(
+            const result = await s.session.query(
+              asAgentCall(
                 "reviewer",
                 buildReviewPrompt(s.userPrompt, {
                   gitStatus,
@@ -135,12 +124,12 @@ export default defineWorkflow({
                   isConfirmationPass: true,
                 }),
               ),
-            });
+            );
             s.save(s.sessionId);
             return result.output;
           },
         );
-        prevStage = confirmName;
+
 
         reviewRaw = confirm.result;
         parsed = parseReviewResult(reviewRaw);
@@ -158,25 +147,25 @@ export default defineWorkflow({
       // ── Debug (only if findings remain AND another iteration is allowed) ─
       if (hasActionableFindings(parsed, reviewRaw) && iteration < MAX_LOOPS) {
         const debuggerName = `debugger-${iteration}`;
-        const debugger_ = await ctx.session(
-          { name: debuggerName, dependsOn: depsOn() },
+        const debugger_ = await ctx.stage(
+          { name: debuggerName },
+          {},
+          {},
           async (s) => {
-            await createClaudeSession({ paneId: s.paneId });
-            const result = await claudeQuery({
-              paneId: s.paneId,
-              prompt: asAgentCall(
+            const result = await s.session.query(
+              asAgentCall(
                 "debugger",
                 buildDebuggerReportPrompt(parsed, reviewRaw, {
                   iteration,
                   gitStatus,
                 }),
               ),
-            });
+            );
             s.save(s.sessionId);
             return result.output;
           },
         );
-        prevStage = debuggerName;
+
         debuggerReport = extractMarkdownBlock(debugger_.result);
       }
     }

--- a/.atomic/workflows/ralph/copilot/index.ts
+++ b/.atomic/workflows/ralph/copilot/index.ts
@@ -11,7 +11,6 @@
  */
 
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { CopilotClient, approveAll } from "@github/copilot-sdk";
 import type { SessionEvent } from "@github/copilot-sdk";
 
 import {
@@ -68,7 +67,7 @@ function getAssistantText(messages: SessionEvent[]): string {
     .join("\n\n");
 }
 
-export default defineWorkflow({
+export default defineWorkflow<"copilot">({
   name: "ralph",
   description:
     "Plan → orchestrate → review → debug loop with bounded iteration",
@@ -76,28 +75,16 @@ export default defineWorkflow({
   .run(async (ctx) => {
     let consecutiveClean = 0;
     let debuggerReport = "";
-    // Track the most recent session so the next stage can declare it as a
-    // dependency — this chains planner → orchestrator → reviewer → [confirm]
-    // → [debugger] → next planner in the graph instead of showing every
-    // stage as an independent sibling under the root.
-    let prevStage: string | undefined;
-    const depsOn = (): string[] | undefined =>
-      prevStage ? [prevStage] : undefined;
 
     for (let iteration = 1; iteration <= MAX_LOOPS; iteration++) {
       // ── Plan ──────────────────────────────────────────────────────────
       const plannerName = `planner-${iteration}`;
-      const planner = await ctx.session(
-        { name: plannerName, dependsOn: depsOn() },
+      const planner = await ctx.stage(
+        { name: plannerName },
+        {},
+        { agent: "planner" },
         async (s) => {
-          const client = new CopilotClient({ cliUrl: s.serverUrl });
-          await client.start();
-          const session = await client.createSession({
-            agent: "planner",
-            onPermissionRequest: approveAll,
-          });
-          await client.setForegroundSessionId(session.sessionId);
-          await session.sendAndWait(
+          await s.session.sendAndWait(
             {
               prompt: buildPlannerPrompt(s.userPrompt, {
                 iteration,
@@ -106,28 +93,21 @@ export default defineWorkflow({
             },
             AGENT_SEND_TIMEOUT_MS,
           );
-          const messages = await session.getMessages();
+          const messages = await s.session.getMessages();
           s.save(messages);
-          await session.disconnect();
-          await client.stop();
           return getAssistantText(messages);
         },
       );
-      prevStage = plannerName;
+
 
       // ── Orchestrate ───────────────────────────────────────────────────
       const orchName = `orchestrator-${iteration}`;
-      await ctx.session(
-        { name: orchName, dependsOn: depsOn() },
+      await ctx.stage(
+        { name: orchName },
+        {},
+        { agent: "orchestrator" },
         async (s) => {
-          const client = new CopilotClient({ cliUrl: s.serverUrl });
-          await client.start();
-          const session = await client.createSession({
-            agent: "orchestrator",
-            onPermissionRequest: approveAll,
-          });
-          await client.setForegroundSessionId(session.sessionId);
-          await session.sendAndWait(
+          await s.session.sendAndWait(
             {
               prompt: buildOrchestratorPrompt(s.userPrompt, {
                 plannerNotes: planner.result,
@@ -135,27 +115,20 @@ export default defineWorkflow({
             },
             AGENT_SEND_TIMEOUT_MS,
           );
-          s.save(await session.getMessages());
-          await session.disconnect();
-          await client.stop();
+          s.save(await s.session.getMessages());
         },
       );
-      prevStage = orchName;
+
 
       // ── Review (first pass) ───────────────────────────────────────────
       let gitStatus = await safeGitStatusS();
       const reviewerName = `reviewer-${iteration}`;
-      const review = await ctx.session(
-        { name: reviewerName, dependsOn: depsOn() },
+      const review = await ctx.stage(
+        { name: reviewerName },
+        {},
+        { agent: "reviewer" },
         async (s) => {
-          const client = new CopilotClient({ cliUrl: s.serverUrl });
-          await client.start();
-          const session = await client.createSession({
-            agent: "reviewer",
-            onPermissionRequest: approveAll,
-          });
-          await client.setForegroundSessionId(session.sessionId);
-          await session.sendAndWait(
+          await s.session.sendAndWait(
             {
               prompt: buildReviewPrompt(s.userPrompt, {
                 gitStatus,
@@ -164,14 +137,12 @@ export default defineWorkflow({
             },
             AGENT_SEND_TIMEOUT_MS,
           );
-          const messages = await session.getMessages();
+          const messages = await s.session.getMessages();
           s.save(messages);
-          await session.disconnect();
-          await client.stop();
           return getAssistantText(messages);
         },
       );
-      prevStage = reviewerName;
+
 
       let reviewRaw = review.result;
       let parsed = parseReviewResult(reviewRaw);
@@ -183,17 +154,12 @@ export default defineWorkflow({
         // Confirmation pass — re-run reviewer only
         gitStatus = await safeGitStatusS();
         const confirmName = `reviewer-${iteration}-confirm`;
-        const confirm = await ctx.session(
-          { name: confirmName, dependsOn: depsOn() },
+        const confirm = await ctx.stage(
+          { name: confirmName },
+          {},
+          { agent: "reviewer" },
           async (s) => {
-            const client = new CopilotClient({ cliUrl: s.serverUrl });
-            await client.start();
-            const session = await client.createSession({
-              agent: "reviewer",
-              onPermissionRequest: approveAll,
-            });
-            await client.setForegroundSessionId(session.sessionId);
-            await session.sendAndWait(
+            await s.session.sendAndWait(
               {
                 prompt: buildReviewPrompt(s.userPrompt, {
                   gitStatus,
@@ -203,14 +169,12 @@ export default defineWorkflow({
               },
               AGENT_SEND_TIMEOUT_MS,
             );
-            const messages = await session.getMessages();
+            const messages = await s.session.getMessages();
             s.save(messages);
-            await session.disconnect();
-            await client.stop();
             return getAssistantText(messages);
           },
         );
-        prevStage = confirmName;
+
 
         reviewRaw = confirm.result;
         parsed = parseReviewResult(reviewRaw);
@@ -228,17 +192,12 @@ export default defineWorkflow({
       // ── Debug (only if findings remain AND another iteration is allowed) ─
       if (hasActionableFindings(parsed, reviewRaw) && iteration < MAX_LOOPS) {
         const debuggerName = `debugger-${iteration}`;
-        const debugger_ = await ctx.session(
-          { name: debuggerName, dependsOn: depsOn() },
+        const debugger_ = await ctx.stage(
+          { name: debuggerName },
+          {},
+          { agent: "debugger" },
           async (s) => {
-            const client = new CopilotClient({ cliUrl: s.serverUrl });
-            await client.start();
-            const session = await client.createSession({
-              agent: "debugger",
-              onPermissionRequest: approveAll,
-            });
-            await client.setForegroundSessionId(session.sessionId);
-            await session.sendAndWait(
+            await s.session.sendAndWait(
               {
                 prompt: buildDebuggerReportPrompt(parsed, reviewRaw, {
                   iteration,
@@ -247,14 +206,12 @@ export default defineWorkflow({
               },
               AGENT_SEND_TIMEOUT_MS,
             );
-            const messages = await session.getMessages();
+            const messages = await s.session.getMessages();
             s.save(messages);
-            await session.disconnect();
-            await client.stop();
             return getAssistantText(messages);
           },
         );
-        prevStage = debuggerName;
+
         debuggerReport = extractMarkdownBlock(debugger_.result);
       }
     }

--- a/.atomic/workflows/ralph/opencode/index.ts
+++ b/.atomic/workflows/ralph/opencode/index.ts
@@ -11,7 +11,6 @@
  */
 
 import { defineWorkflow } from "@bastani/atomic/workflows";
-import { createOpencodeClient } from "@opencode-ai/sdk/v2";
 
 import {
   buildPlannerPrompt,
@@ -37,7 +36,7 @@ function extractResponseText(
     .join("\n");
 }
 
-export default defineWorkflow({
+export default defineWorkflow<"opencode">({
   name: "ralph",
   description:
     "Plan → orchestrate → review → debug loop with bounded iteration",
@@ -45,27 +44,17 @@ export default defineWorkflow({
   .run(async (ctx) => {
     let consecutiveClean = 0;
     let debuggerReport = "";
-    // Track the most recent session so the next stage can declare it as a
-    // dependency — this chains planner → orchestrator → reviewer → [confirm]
-    // → [debugger] → next planner in the graph instead of showing every
-    // stage as an independent sibling under the root.
-    let prevStage: string | undefined;
-    const depsOn = (): string[] | undefined =>
-      prevStage ? [prevStage] : undefined;
 
     for (let iteration = 1; iteration <= MAX_LOOPS; iteration++) {
       // ── Plan ────────────────────────────────────────────────────────────
       const plannerName = `planner-${iteration}`;
-      const planner = await ctx.session(
-        { name: plannerName, dependsOn: depsOn() },
+      const planner = await ctx.stage(
+        { name: plannerName },
+        {},
+        { title: `planner-${iteration}` },
         async (s) => {
-          const client = createOpencodeClient({ baseUrl: s.serverUrl });
-          const session = await client.session.create({
-            title: `planner-${iteration}`,
-          });
-          await client.tui.selectSession({ sessionID: session.data!.id });
-          const result = await client.session.prompt({
-            sessionID: session.data!.id,
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
             parts: [
               {
                 type: "text",
@@ -81,20 +70,17 @@ export default defineWorkflow({
           return extractResponseText(result.data!.parts);
         },
       );
-      prevStage = plannerName;
+
 
       // ── Orchestrate ─────────────────────────────────────────────────────
       const orchName = `orchestrator-${iteration}`;
-      await ctx.session(
-        { name: orchName, dependsOn: depsOn() },
+      await ctx.stage(
+        { name: orchName },
+        {},
+        { title: `orchestrator-${iteration}` },
         async (s) => {
-          const client = createOpencodeClient({ baseUrl: s.serverUrl });
-          const session = await client.session.create({
-            title: `orchestrator-${iteration}`,
-          });
-          await client.tui.selectSession({ sessionID: session.data!.id });
-          const result = await client.session.prompt({
-            sessionID: session.data!.id,
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
             parts: [
               {
                 type: "text",
@@ -108,21 +94,18 @@ export default defineWorkflow({
           s.save(result.data!);
         },
       );
-      prevStage = orchName;
+
 
       // ── Review (first pass) ─────────────────────────────────────────────
       let gitStatus = await safeGitStatusS();
       const reviewerName = `reviewer-${iteration}`;
-      const review = await ctx.session(
-        { name: reviewerName, dependsOn: depsOn() },
+      const review = await ctx.stage(
+        { name: reviewerName },
+        {},
+        { title: `reviewer-${iteration}` },
         async (s) => {
-          const client = createOpencodeClient({ baseUrl: s.serverUrl });
-          const session = await client.session.create({
-            title: `reviewer-${iteration}`,
-          });
-          await client.tui.selectSession({ sessionID: session.data!.id });
-          const result = await client.session.prompt({
-            sessionID: session.data!.id,
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
             parts: [
               {
                 type: "text",
@@ -138,7 +121,7 @@ export default defineWorkflow({
           return extractResponseText(result.data!.parts);
         },
       );
-      prevStage = reviewerName;
+
 
       let reviewRaw = review.result;
       let parsed = parseReviewResult(reviewRaw);
@@ -150,16 +133,13 @@ export default defineWorkflow({
         // Confirmation pass — re-run reviewer only
         gitStatus = await safeGitStatusS();
         const confirmName = `reviewer-${iteration}-confirm`;
-        const confirm = await ctx.session(
-          { name: confirmName, dependsOn: depsOn() },
+        const confirm = await ctx.stage(
+          { name: confirmName },
+          {},
+          { title: `reviewer-${iteration}-confirm` },
           async (s) => {
-            const client = createOpencodeClient({ baseUrl: s.serverUrl });
-            const session = await client.session.create({
-              title: `reviewer-${iteration}-confirm`,
-            });
-            await client.tui.selectSession({ sessionID: session.data!.id });
-            const result = await client.session.prompt({
-              sessionID: session.data!.id,
+            const result = await s.client.session.prompt({
+              sessionID: s.session.id,
               parts: [
                 {
                   type: "text",
@@ -176,7 +156,7 @@ export default defineWorkflow({
             return extractResponseText(result.data!.parts);
           },
         );
-        prevStage = confirmName;
+
 
         reviewRaw = confirm.result;
         parsed = parseReviewResult(reviewRaw);
@@ -194,16 +174,13 @@ export default defineWorkflow({
       // ── Debug (only if findings remain AND another iteration is allowed) ─
       if (hasActionableFindings(parsed, reviewRaw) && iteration < MAX_LOOPS) {
         const debuggerName = `debugger-${iteration}`;
-        const debugger_ = await ctx.session(
-          { name: debuggerName, dependsOn: depsOn() },
+        const debugger_ = await ctx.stage(
+          { name: debuggerName },
+          {},
+          { title: `debugger-${iteration}` },
           async (s) => {
-            const client = createOpencodeClient({ baseUrl: s.serverUrl });
-            const session = await client.session.create({
-              title: `debugger-${iteration}`,
-            });
-            await client.tui.selectSession({ sessionID: session.data!.id });
-            const result = await client.session.prompt({
-              sessionID: session.data!.id,
+            const result = await s.client.session.prompt({
+              sessionID: s.session.id,
               parts: [
                 {
                   type: "text",
@@ -219,7 +196,7 @@ export default defineWorkflow({
             return extractResponseText(result.data!.parts);
           },
         );
-        prevStage = debuggerName;
+
         debuggerReport = extractMarkdownBlock(debugger_.result);
       }
     }

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.4.0"
+    "@opencode-ai/plugin": "1.4.3"
   }
 }

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ export default defineWorkflow({
   description: "Two-session Claude demo: describe → summarize",
 })
   .run(async (ctx) => {
-    const describe = await ctx.session(
+    const describe = await ctx.stage(
       { name: "describe", description: "Ask Claude to describe the project" },
       async (s) => {
         await createClaudeSession({ paneId: s.paneId });
@@ -252,7 +252,7 @@ export default defineWorkflow({
       },
     );
 
-    await ctx.session(
+    await ctx.stage(
       { name: "summarize", description: "Summarize the previous session's output" },
       async (s) => {
         const research = await s.transcript(describe);
@@ -274,12 +274,12 @@ export default defineWorkflow({
 
 | Capability                   | Description                                                                          |
 | ---------------------------- | ------------------------------------------------------------------------------------ |
-| **Dynamic session spawning** | Call `ctx.session()` to spawn sessions at runtime — each gets its own tmux window and graph node |
+| **Dynamic session spawning** | Call `ctx.stage()` to spawn sessions at runtime — each gets its own tmux window and graph node |
 | **Native TypeScript control flow** | Use `for`, `if/else`, `Promise.all()`, `try/catch` — no framework DSL needed |
-| **Session return values**    | Session callbacks can return data: `const h = await ctx.session(...); h.result`      |
+| **Session return values**    | Session callbacks can return data: `const h = await ctx.stage(...); h.result`      |
 | **Transcript passing**       | Access prior session output via handle (`s.transcript(handle)`) or name (`s.transcript("name")`) |
-| **Nested sub-sessions**      | Call `s.session()` inside a session callback to spawn child sessions — visible as nested nodes in the graph |
-| **Dependency tracking**      | Use `dependsOn: ["name"]` to declare session ordering — the runtime waits and the graph shows the edges |
+| **Nested sub-sessions**      | Call `s.stage()` inside a session callback to spawn child sessions — visible as nested nodes in the graph |
+| **Auto-inferred graph**      | Graph topology auto-inferred from `await`/`Promise.all` patterns — no annotations needed               |
 | **Provider-agnostic**        | Write raw SDK code for Claude, Copilot, or OpenCode inside each session callback     |
 | **Live graph visualization** | Sessions appear in the TUI graph as they're spawned — loops and conditionals are visible in real time |
 
@@ -306,7 +306,7 @@ Use your workflow-creator skill to create a workflow that plans, implements, and
 | ----------------------- | ------------------------- | -------------------------------------------------------------- |
 | `ctx.userPrompt`        | `string`                  | Original user prompt from the CLI invocation                   |
 | `ctx.agent`             | `AgentType`               | Which agent is running (`"claude"`, `"copilot"`, `"opencode"`) |
-| `ctx.session(opts, fn)` | `Promise<SessionHandle<T>>` | Spawn a session — returns handle with `name`, `id`, `result` |
+| `ctx.stage(opts, fn)` | `Promise<SessionHandle<T>>` | Spawn a session — returns handle with `name`, `id`, `result` |
 | `ctx.transcript(ref)`   | `Promise<Transcript>`     | Get a completed session's transcript (`{ path, content }`)     |
 | `ctx.getMessages(ref)`  | `Promise<SavedMessage[]>` | Get a completed session's raw native messages                  |
 
@@ -323,7 +323,7 @@ Use your workflow-creator skill to create a workflow that plans, implements, and
 | `s.save(messages)`      | `SaveTranscript`          | Save this session's output for subsequent sessions             |
 | `s.transcript(ref)`     | `Promise<Transcript>`     | Get a completed session's transcript                           |
 | `s.getMessages(ref)`    | `Promise<SavedMessage[]>` | Get a completed session's raw native messages                  |
-| `s.session(opts, fn)`   | `Promise<SessionHandle<T>>` | Spawn a nested sub-session (child in the graph)              |
+| `s.stage(opts, fn)`   | `Promise<SessionHandle<T>>` | Spawn a nested sub-session (child in the graph)              |
 
 #### Session Options (`SessionRunOptions`)
 
@@ -331,17 +331,8 @@ Use your workflow-creator skill to create a workflow that plans, implements, and
 | ------------- | ---------- | ----------------------------------------------------------------------------- |
 | `name`        | `string`   | Unique session name within the workflow run                                   |
 | `description` | `string?`  | Human-readable description shown in the graph                                 |
-| `dependsOn`   | `string[]?`| Names of sessions that must complete before this one starts (creates graph edges) |
 
-`dependsOn` is useful when spawning sessions with `Promise.all()` — it lets the runtime enforce ordering while still allowing parallel spawning of independent sessions:
-
-```ts
-await Promise.all([
-  ctx.session({ name: "migrate-db" }, async (s) => { /* ... */ }),
-  ctx.session({ name: "seed-data", dependsOn: ["migrate-db"] }, async (s) => { /* ... */ }),
-  ctx.session({ name: "gen-types", dependsOn: ["migrate-db"] }, async (s) => { /* ... */ }),
-]);
-```
+The runtime auto-infers parent-child edges from execution order: sequential `await` creates a chain, while `Promise.all` creates parallel fan-out/fan-in — no annotations needed.
 
 #### Saving Transcripts
 
@@ -654,7 +645,7 @@ Skills are auto-invoked when relevant — `test-driven-development` activates be
 
 During `atomic workflow` execution, Atomic renders a live orchestrator panel built on [OpenTUI](https://github.com/anomalyco/opentui) on top of the workflow's tmux session graph. It shows:
 
-- **Session graph** — Nodes for each `.session()` call with status (pending, running, completed, failed) and edges for sequential / parallel dependencies
+- **Session graph** — Nodes for each `.stage()` call with status (pending, running, completed, failed) and edges for sequential / parallel dependencies
 - **Task list tracking** — Ralph's decomposed task list with dependency arrows, updated in real time as workers complete tasks
 - **Pane previews** — Thumbnail of each tmux pane so you can see what every agent is doing without switching contexts
 - **Transcript passing visibility** — Highlights `s.save()` / `s.transcript()` handoffs as they happen between sessions

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -89,6 +89,7 @@ coveragePathIgnorePatterns = [
   # System utilities (I/O-heavy)
   "src/services/system/download.ts",
   "src/services/system/file-lock.ts",
+  "src/services/system/workflows.ts",
   "src/lib/spawn.ts",
   "src/lib/ui/clipboard.ts",
   "src/lib/ui/mention-parsing.ts",

--- a/research/web/2026-04-10-nodejs-fs-rm-windows-junction-behavior.md
+++ b/research/web/2026-04-10-nodejs-fs-rm-windows-junction-behavior.md
@@ -1,0 +1,244 @@
+---
+source_url: multiple (Node.js/node, libuv/libuv, microsoft/STL, oven-sh/bun source + GitHub issues)
+fetched_at: 2026-04-10
+fetch_method: html-parse (raw GitHub URLs)
+topic: Node.js fs.rm / fs.promises.rm behavior with Windows NTFS junctions
+---
+
+# Node.js `fs.rm` + Windows NTFS Junctions: Complete Research
+
+## Summary
+
+`fs.rm(path, { recursive: true })` on a Windows NTFS junction is **safe** in all current Node.js versions — it removes only the junction entry itself, not the contents of the target directory. However, the code path differs by version, and there have been related bugs. Bun has had confirmed bugs on this front.
+
+---
+
+## Node.js Implementation Paths by Version
+
+### Node.js v14–v22 (all LTS): Async `fs.rm` / `fs.promises.rm` — JS rimraf path
+
+File: `lib/internal/fs/rimraf.js`
+
+The async and promise `rm` always use `rimraf()` (in all Node.js versions including v23+):
+
+```
+rimraf(path) →
+  lstat(path) →
+    if stats.isDirectory() → _rmdir() → rmdir() → if ENOTEMPTY → _rmchildren()
+    else → unlink(path)
+```
+
+**Junction behavior via libuv `lstat`:**
+
+From `libuv/libuv/src/win/fs.c` — `fs__stat_assign_statbuf()`:
+
+```c
+if (do_lstat && (stat_info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
+  statbuf->st_mode |= S_IFLNK;  // ← junction gets S_IFLNK, NOT S_IFDIR
+}
+```
+
+For a standard NTFS junction pointing to `\??\C:\...`, libuv `lstat` returns `S_IFLNK` (symlink mode). So:
+
+- `stats.isDirectory()` = **false**
+- `stats.isSymbolicLink()` = **true**
+- rimraf calls `unlink(path)` — removes just the junction
+
+**libuv `unlink` on a junction** (from `fs__unlink_rmdir()`):
+
+Opens with `FILE_FLAG_OPEN_REPARSE_POINT` (does not follow). If target has `FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT` and `readlink_handle()` succeeds (valid junction), deletion via `FILE_DISPOSITION_DELETE` is allowed. The junction entry is deleted, target is untouched.
+
+**Conclusion (async path, all Node.js versions):** Safe — removes only the junction.
+
+---
+
+### Node.js v14–v22: Sync `fs.rmSync` — JS rimrafSync path
+
+`lib/fs.js` (v22.x):
+
+```js
+function rmSync(path, options) {
+  lazyLoadRimraf();
+  return rimrafSync(getValidatedPath(path), validateRmOptionsSync(path, options, false));
+}
+```
+
+`rimrafSync` calls `lstatSync` → same libuv path → junction gets `S_IFLNK` → `isDirectory()` = false → `_unlinkSync(path)` → removes just the junction.
+
+**Conclusion (sync path, v14–v22):** Safe.
+
+---
+
+### Node.js v23+ (including v24, v25): Sync `fs.rmSync` — Native C++ path
+
+Introduced by PR [#53617](https://github.com/nodejs/node/pull/53617), merged 2024-07-18, first in Node.js 23.0.0 (released 2024-10-16).
+
+`lib/fs.js` (v23+):
+
+```js
+function rmSync(path, options) {
+  const opts = validateRmOptionsSync(path, options, false);
+  return binding.rmSync(getValidatedPath(path), opts.maxRetries, opts.recursive, opts.retryDelay);
+}
+```
+
+Native C++ (`src/node_file.cc`):
+
+```cpp
+auto file_status = std::filesystem::symlink_status(file_path, error);
+// ...
+if (recursive) {
+  std::filesystem::remove_all(file_path, error);
+} else {
+  std::filesystem::remove(file_path, error);
+}
+```
+
+**Key: MSVC STL `symlink_status` for junctions returns `file_type::junction`** (not `file_type::directory`, not `file_type::symlink`).
+
+From `microsoft/STL/stl/inc/filesystem`:
+```cpp
+if (_Stats._Reparse_point_tag == __std_fs_reparse_tag::_Mount_point) {
+  this->type(file_type::junction);  // ← distinct type!
+  return;
+}
+```
+
+So `is_directory()` on a junction = **false** → the EISDIR guard is not triggered.
+
+**`std::filesystem::remove_all` on a junction** (MSVC STL `stl/inc/filesystem`):
+
+```cpp
+uintmax_t remove_all(const path& _Path, error_code& _Ec) {
+  const auto _First_remove_result = __std_fs_remove(_Path.c_str());
+  // ...
+  if (_First_remove_result._Error == __std_win_error::_Directory_not_empty) {
+    _Remove_all_dir(_Path, _Ec, _Removed_count);  // Only called if dir is not empty
+  }
+}
+```
+
+`__std_fs_remove` opens with `FILE_FLAG_OPEN_REPARSE_POINT` (no follow) and deletes the entry directly. A junction is an atomic entry — `__std_fs_remove` succeeds immediately without returning `_Directory_not_empty`. `_Remove_all_dir` is never called. Target directory is untouched.
+
+**Conclusion (sync path, v23+):** Safe.
+
+**Caveat (fixed):** There was a bug in v24.12.0 (PR [#61020](https://github.com/nodejs/node/issues/61020)) where `rmSync` used `std::filesystem::status()` instead of `symlink_status()`, which follows symlinks. This caused broken symlinks/junctions to silently fail (no-op). Fixed in PR [#61040](https://github.com/nodejs/node/pull/61040), merged 2025-12-23. This was a no-op bug (wouldn't delete), not a data-destruction bug.
+
+---
+
+## Summary Table
+
+| Node.js Version | `fs.rm` (async) | `fs.promises.rm` | `fs.rmSync` |
+|---|---|---|---|
+| v14–v22 | rimraf/libuv lstat → unlink ✅ | rimrafPromises ✅ | rimrafSync/libuv lstat → unlinkSync ✅ |
+| v23+ | rimraf/libuv lstat → unlink ✅ | rimrafPromises ✅ | native C++ std::filesystem::remove_all ✅ |
+
+In all cases: **junction is removed, target directory contents are untouched.**
+
+---
+
+## Bun's Implementation and Bugs
+
+### Bun `fs.rm` (Node.js-compat)
+
+Source: `src/bun.js/node/node_fs.zig`, `NodeFS.rm()`:
+
+```zig
+pub fn rm(this: *NodeFS, args: Arguments.Rm, _: Flavor) Maybe(Return.Rm) {
+  if (args.recursive) {
+    zigDeleteTree(std.fs.cwd(), args.path.slice(), .file) catch |err| { ... };
+    return .success;
+  }
+  // non-recursive: std.posix.unlinkZ
+}
+```
+
+**`zigDeleteTree` with `.file` kind hint:**
+1. Calls `zigDeleteTreeOpenInitialSubpath(self, sub_path, .file)` with `treat_as_dir = false`
+2. First tries `deleteFile(sub_path)` (which is `std.posix.unlinkZ`)
+3. If that returns `error.IsDir`, sets `treat_as_dir = true`, then tries `openDir(sub_path, {no_follow: true})`
+
+**Problem:** On Windows, `openDir` with `no_follow: true` still opens junction directories and iterates their **target** contents. This is a known Windows kernel behavior: even with `FILE_OPEN_REPARSE_POINT`, `NtQueryDirectoryFile` on a junction handle can dereference the junction for directory listing.
+
+### Confirmed Bun Bug
+
+Issue [#27233](https://github.com/oven-sh/bun/issues/27233) — "Windows: bun rm -f \<folder\> crashes (panic: invalid enum value) when folder contains a JUNCTION"
+
+- **Crash**: Junction inside a directory caused `deleteFile` to be called with `FILE_NON_DIRECTORY_FILE`, Windows returned `STATUS_NOT_A_DIRECTORY`, unhandled errno caused panic.
+- **Data destruction risk**: PR [#27251](https://github.com/oven-sh/bun/pull/27251) explicitly states: "rm -rf incorrectly recursing into junctions/directory symlinks and **deleting the target directory's contents**"
+- **Status**: As of April 2026, PRs [#27245](https://github.com/oven-sh/bun/pull/27245) and [#27251](https://github.com/oven-sh/bun/pull/27251) are still **open** (not merged).
+
+**Bun `fs.rm({ recursive: true })` on a Windows junction is potentially unsafe as of Bun v1.3.9+ — it may follow the junction and delete the target's contents, or panic.**
+
+For the **shell** `$\`rm -rf\``, the same crash was confirmed.
+
+---
+
+## Safe Junction Removal on Windows
+
+### Option 1: `fs.unlink` (safest — libuv path, all versions)
+
+`fs.unlink` / `fs.promises.unlink` calls libuv `fs__unlink` → `fs__unlink_rmdir(isrmdir=false)`:
+- Opens with `FILE_FLAG_OPEN_REPARSE_POINT` (does not follow)
+- Checks `FILE_ATTRIBUTE_REPARSE_POINT` — if it's a valid symlink/junction, allows deletion
+- Deletes the junction entry atomically
+
+**Limitation:** `fs.unlink` on a non-symlink directory returns `EPERM` on POSIX. On Windows it also rejects plain directories (non-reparse-point). So it is safe to use for junctions specifically.
+
+```ts
+import { unlink } from 'node:fs/promises';
+await unlink(junctionPath); // Safe on Windows, removes only the junction
+```
+
+### Option 2: `fs.rm(path, { recursive: false })` (Node.js only, not Bun-safe)
+
+Without `recursive: true`, `fs.rmSync` in v23+ uses `std::filesystem::remove()` (not `remove_all`). On a junction this still removes the junction safely since `__std_fs_remove` opens with `OPEN_REPARSE_POINT`.
+
+But this is equivalent to `unlink` with extra overhead, and `force: true` may suppress the error if the junction is already gone.
+
+### Recommended Pattern (cross-platform, cross-runtime safe)
+
+```ts
+import fs from 'node:fs/promises';
+
+async function removeJunctionSafely(junctionPath: string): Promise<void> {
+  try {
+    // Check it's actually a symlink/junction (lstat doesn't follow)
+    const stat = await fs.lstat(junctionPath);
+    if (stat.isSymbolicLink()) {
+      await fs.unlink(junctionPath);
+    } else {
+      // It's already a real directory or file — handle differently
+      await fs.rm(junctionPath, { recursive: true, force: true });
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+```
+
+### Why `fs.unlink` is safer than `fs.rm` for junctions
+
+| Method | Mechanism | Junction safety |
+|---|---|---|
+| `fs.unlink` | libuv → `FILE_OPEN_REPARSE_POINT` + `DELETE` | Always safe — removes junction only |
+| `fs.rm({ recursive: false })` | rimraf → unlink (v14–22) or native remove (v23+) | Safe in Node.js; uncertain in Bun |
+| `fs.rm({ recursive: true })` | rimraf → unlink (v14–22) or remove_all (v23+) | Safe in Node.js; **unsafe in Bun** |
+| `fs.rmdir` | libuv → rmdir (for directories) | Works on junctions but semantically odd |
+
+---
+
+## References
+
+- Node.js `lib/internal/fs/rimraf.js`: https://github.com/nodejs/node/blob/main/lib/internal/fs/rimraf.js
+- Node.js `src/node_file.cc` (RmSync): https://github.com/nodejs/node/blob/main/src/node_file.cc
+- PR #53617 — moved rmSync to C++: https://github.com/nodejs/node/pull/53617
+- PR #61040 — fix broken symlinks in rmSync: https://github.com/nodejs/node/pull/61040
+- Issue #61020 — rmSync broken symlink bug in v24.12.0: https://github.com/nodejs/node/issues/61020
+- libuv `src/win/fs.c`: https://github.com/libuv/libuv/blob/v1.x/src/win/fs.c
+- MSVC STL `stl/inc/filesystem`: https://github.com/microsoft/STL/blob/main/stl/inc/filesystem
+- MSVC STL `stl/src/filesystem.cpp`: https://github.com/microsoft/STL/blob/main/stl/src/filesystem.cpp
+- Bun issue #27233 — junction rm crash: https://github.com/oven-sh/bun/issues/27233
+- Bun PR #27245 — fix junction dir_iterator: https://github.com/oven-sh/bun/pull/27245
+- Bun PR #27251 — fix shell rm on junctions: https://github.com/oven-sh/bun/pull/27251
+- Bun `src/bun.js/node/node_fs.zig`: https://github.com/oven-sh/bun/blob/main/src/bun.js/node/node_fs.zig

--- a/src/sdk/define-workflow.ts
+++ b/src/sdk/define-workflow.ts
@@ -2,25 +2,25 @@
  * Workflow Builder — defines a workflow with a single `.run()` entry point.
  *
  * Usage:
- *   defineWorkflow({ name: "my-workflow", description: "..." })
+ *   defineWorkflow<"copilot">({ name: "my-workflow", description: "..." })
  *     .run(async (ctx) => {
- *       await ctx.session({ name: "research" }, async (s) => { ... });
- *       await ctx.session({ name: "plan" }, async (s) => { ... });
+ *       await ctx.stage({ name: "research" }, {}, {}, async (s) => { ... });
+ *       await ctx.stage({ name: "plan" }, {}, {}, async (s) => { ... });
  *     })
  *     .compile()
  */
 
-import type { WorkflowOptions, WorkflowContext, WorkflowDefinition } from "./types.ts";
+import type { AgentType, WorkflowOptions, WorkflowContext, WorkflowDefinition } from "./types.ts";
 
 /**
  * Chainable workflow builder. Records the run callback,
  * then .compile() seals it into a WorkflowDefinition.
  */
-export class WorkflowBuilder {
+export class WorkflowBuilder<A extends AgentType = AgentType> {
   /** @internal Brand for detection across package boundaries */
   readonly __brand = "WorkflowBuilder" as const;
   private readonly options: WorkflowOptions;
-  private runFn: ((ctx: WorkflowContext) => Promise<void>) | null = null;
+  private runFn: ((ctx: WorkflowContext<A>) => Promise<void>) | null = null;
 
   constructor(options: WorkflowOptions) {
     this.options = options;
@@ -29,12 +29,12 @@ export class WorkflowBuilder {
   /**
    * Set the workflow's entry point.
    *
-   * The callback receives a {@link WorkflowContext} with `session()` for
+   * The callback receives a {@link WorkflowContext} with `stage()` for
    * spawning agent sessions, and `transcript()` / `getMessages()` for
    * reading completed session outputs. Use native TypeScript control flow
    * (loops, conditionals, `Promise.all()`) for orchestration.
    */
-  run(fn: (ctx: WorkflowContext) => Promise<void>): this {
+  run(fn: (ctx: WorkflowContext<A>) => Promise<void>): this {
     if (this.runFn) {
       throw new Error("run() can only be called once per workflow.");
     }
@@ -51,7 +51,7 @@ export class WorkflowBuilder {
    * After calling compile(), the returned object is consumed by the
    * Atomic CLI runtime.
    */
-  compile(): WorkflowDefinition {
+  compile(): WorkflowDefinition<A> {
     if (!this.runFn) {
       throw new Error(
         `Workflow "${this.options.name}" has no run callback. ` +
@@ -73,29 +73,45 @@ export class WorkflowBuilder {
 /**
  * Entry point for defining a workflow.
  *
+ * Pass a type parameter to narrow all context types to a specific agent:
+ *
  * @example
  * ```typescript
  * import { defineWorkflow } from "@bastani/atomic/workflows";
  *
- * export default defineWorkflow({
+ * export default defineWorkflow<"copilot">({
  *   name: "hello",
  *   description: "Two-session demo",
  * })
  *   .run(async (ctx) => {
- *     const describe = await ctx.session({ name: "describe" }, async (s) => {
- *       // ... agent SDK code using s.serverUrl, s.paneId, s.save() ...
- *     });
- *     await ctx.session({ name: "summarize" }, async (s) => {
- *       const research = await s.transcript(describe);
- *       // ...
- *     });
+ *     const describe = await ctx.stage(
+ *       { name: "describe" },
+ *       {},
+ *       {},
+ *       async (s) => {
+ *         // s.client: CopilotClient, s.session: CopilotSession
+ *         await s.session.sendAndWait({ prompt: s.userPrompt });
+ *         s.save(await s.session.getMessages());
+ *       },
+ *     );
+ *     await ctx.stage(
+ *       { name: "summarize" },
+ *       {},
+ *       {},
+ *       async (s) => {
+ *         const research = await s.transcript(describe);
+ *         // ...
+ *       },
+ *     );
  *   })
  *   .compile();
  * ```
  */
-export function defineWorkflow(options: WorkflowOptions): WorkflowBuilder {
+export function defineWorkflow<A extends AgentType = AgentType>(
+  options: WorkflowOptions,
+): WorkflowBuilder<A> {
   if (!options.name || options.name.trim() === "") {
     throw new Error("Workflow name is required.");
   }
-  return new WorkflowBuilder(options);
+  return new WorkflowBuilder<A>(options);
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -25,6 +25,10 @@ export type {
   WorkflowContext,
   WorkflowOptions,
   WorkflowDefinition,
+  StageClientOptions,
+  StageSessionOptions,
+  ProviderClient,
+  ProviderSession,
 } from "./types.ts";
 
 // Workflow SDK (also available as atomic/workflows subpath)

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -284,6 +284,92 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<ClaudeQu
 }
 
 // ---------------------------------------------------------------------------
+// Synthetic wrappers — uniform s.client / s.session API for Claude stages
+// ---------------------------------------------------------------------------
+
+/**
+ * Default query options the user can set per-stage via the `sessionOpts` arg.
+ * These become defaults for every `s.session.query()` call within that stage.
+ */
+export interface ClaudeQueryDefaults {
+  /** Timeout in ms waiting for Claude to finish responding (default: 300s) */
+  timeoutMs?: number;
+  /** Polling interval in ms (default: 2000) */
+  pollIntervalMs?: number;
+  /** Number of C-m presses per submit round (default: 1) */
+  submitPresses?: number;
+  /** Max submit rounds if text isn't consumed (default: 6) */
+  maxSubmitRounds?: number;
+  /** Timeout in ms waiting for pane to be ready before sending (default: 30s) */
+  readyTimeoutMs?: number;
+}
+
+/**
+ * Synthetic client wrapper for Claude stages.
+ * Auto-starts the Claude CLI in the tmux pane during `start()`.
+ */
+export class ClaudeClientWrapper {
+  readonly paneId: string;
+  private readonly opts: { chatFlags?: string[]; readyTimeoutMs?: number };
+
+  constructor(
+    paneId: string,
+    opts: { chatFlags?: string[]; readyTimeoutMs?: number } = {},
+  ) {
+    this.paneId = paneId;
+    this.opts = opts;
+  }
+
+  /** Start the Claude CLI in the tmux pane. Called by the runtime during init. */
+  async start(): Promise<void> {
+    await createClaudeSession({
+      paneId: this.paneId,
+      chatFlags: this.opts.chatFlags,
+      readyTimeoutMs: this.opts.readyTimeoutMs,
+    });
+  }
+
+  /** Noop — cleanup is handled by the runtime via `clearClaudeSession`. */
+  async stop(): Promise<void> {}
+}
+
+/**
+ * Synthetic session wrapper for Claude stages.
+ * Wraps `claudeQuery()` so users call `s.session.query(prompt)`.
+ */
+export class ClaudeSessionWrapper {
+  readonly paneId: string;
+  readonly sessionId: string;
+  private readonly defaults: ClaudeQueryDefaults;
+
+  constructor(
+    paneId: string,
+    sessionId: string,
+    defaults: ClaudeQueryDefaults = {},
+  ) {
+    this.paneId = paneId;
+    this.sessionId = sessionId;
+    this.defaults = defaults;
+  }
+
+  /** Send a prompt to Claude and wait for the response. */
+  async query(
+    prompt: string,
+    opts?: Partial<ClaudeQueryDefaults>,
+  ): Promise<ClaudeQueryResult> {
+    return claudeQuery({
+      paneId: this.paneId,
+      prompt,
+      ...this.defaults,
+      ...opts,
+    });
+  }
+
+  /** Noop — for API symmetry with CopilotSession.disconnect(). */
+  async disconnect(): Promise<void> {}
+}
+
+// ---------------------------------------------------------------------------
 // Static source validation
 // ---------------------------------------------------------------------------
 
@@ -295,21 +381,28 @@ export interface ClaudeValidationWarning {
 /**
  * Validate a Claude workflow source file for common mistakes.
  *
- * Checks that `createClaudeSession` is called when `claudeQuery` is used,
- * paralleling the validation patterns for Copilot and OpenCode workflows.
+ * Warns on direct usage of createClaudeSession/claudeQuery — the runtime
+ * now handles init/cleanup automatically via s.client and s.session.
  */
 export function validateClaudeWorkflow(source: string): ClaudeValidationWarning[] {
   const warnings: ClaudeValidationWarning[] = [];
 
+  if (/\bcreateClaudeSession\b/.test(source)) {
+    warnings.push({
+      rule: "claude/manual-session",
+      message:
+        "Manual createClaudeSession() call detected. The runtime auto-starts the Claude CLI — " +
+        "use s.session.query() instead of claudeQuery(). Pass chatFlags via the second arg to ctx.stage().",
+    });
+  }
+
   if (/\bclaudeQuery\b/.test(source)) {
-    if (!/\bcreateClaudeSession\b/.test(source)) {
-      warnings.push({
-        rule: "claude/create-session",
-        message:
-          "Could not verify that createClaudeSession is called before claudeQuery(). " +
-          "Call createClaudeSession({ paneId: s.paneId }) to start the Claude CLI before sending queries.",
-      });
-    }
+    warnings.push({
+      rule: "claude/manual-query",
+      message:
+        "Direct claudeQuery() call detected. Use s.session.query(prompt) instead — " +
+        "it wraps claudeQuery with the correct paneId.",
+    });
   }
 
   return warnings;

--- a/src/sdk/providers/copilot.ts
+++ b/src/sdk/providers/copilot.ts
@@ -1,9 +1,8 @@
 /**
  * Copilot workflow source validation.
  *
- * Checks that Copilot workflow source files follow required patterns:
- * - `cliUrl` is wired to the session context's `serverUrl`
- * - `setForegroundSessionId` is called after creating a session
+ * Checks that Copilot workflow source files use the runtime-managed
+ * `s.client` and `s.session` instead of manual SDK client creation.
  */
 
 export interface CopilotValidationWarning {
@@ -17,28 +16,22 @@ export interface CopilotValidationWarning {
 export function validateCopilotWorkflow(source: string): CopilotValidationWarning[] {
   const warnings: CopilotValidationWarning[] = [];
 
-  if (/\bCopilotClient\b/.test(source)) {
-    // Accept any identifier before .serverUrl (e.g., s.serverUrl, ctx.serverUrl)
-    // or a destructured `serverUrl` variable
-    if (!/cliUrl\s*:\s*(?:\w+\.serverUrl|serverUrl)/.test(source)) {
-      warnings.push({
-        rule: "copilot/cli-url",
-        message:
-          "Could not verify that CopilotClient is created with { cliUrl: s.serverUrl }. " +
-          "This is required to connect to the workflow's agent pane.",
-      });
-    }
+  if (/\bnew\s+CopilotClient\b/.test(source)) {
+    warnings.push({
+      rule: "copilot/manual-client",
+      message:
+        "Manual CopilotClient creation detected. Use s.client instead — " +
+        "the runtime auto-creates and cleans up the client.",
+    });
   }
 
-  if (/\bcreateSession\b/.test(source)) {
-    if (!/\bsetForegroundSessionId\b/.test(source)) {
-      warnings.push({
-        rule: "copilot/foreground-session",
-        message:
-          "Could not verify that setForegroundSessionId is called after createSession(). " +
-          "Call client.setForegroundSessionId(session.sessionId) so the TUI displays the workflow session.",
-      });
-    }
+  if (/\bclient\.createSession\b/.test(source)) {
+    warnings.push({
+      rule: "copilot/manual-session",
+      message:
+        "Manual createSession() call detected. Use s.session instead — " +
+        "the runtime auto-creates the session. Pass session config as the third arg to ctx.stage().",
+    });
   }
 
   return warnings;

--- a/src/sdk/providers/opencode.ts
+++ b/src/sdk/providers/opencode.ts
@@ -1,9 +1,8 @@
 /**
  * OpenCode workflow source validation.
  *
- * Checks that OpenCode workflow source files follow required patterns:
- * - `baseUrl` is wired to the session context's `serverUrl`
- * - `tui.selectSession` is called after creating a session
+ * Checks that OpenCode workflow source files use the runtime-managed
+ * `s.client` and `s.session` instead of manual SDK client creation.
  */
 
 export interface OpenCodeValidationWarning {
@@ -18,27 +17,21 @@ export function validateOpenCodeWorkflow(source: string): OpenCodeValidationWarn
   const warnings: OpenCodeValidationWarning[] = [];
 
   if (/\bcreateOpencodeClient\b/.test(source)) {
-    // Accept any identifier before .serverUrl (e.g., s.serverUrl, ctx.serverUrl)
-    // or a destructured `serverUrl` variable
-    if (!/baseUrl\s*:\s*(?:\w+\.serverUrl|serverUrl)/.test(source)) {
-      warnings.push({
-        rule: "opencode/base-url",
-        message:
-          "Could not verify that createOpencodeClient is called with { baseUrl: s.serverUrl }. " +
-          "This is required to connect to the workflow's agent pane.",
-      });
-    }
+    warnings.push({
+      rule: "opencode/manual-client",
+      message:
+        "Manual createOpencodeClient() call detected. Use s.client instead — " +
+        "the runtime auto-creates the client. Pass client config as the second arg to ctx.stage().",
+    });
   }
 
-  if (/\bsession\.create\b/.test(source)) {
-    if (!/\btui\.selectSession\b/.test(source)) {
-      warnings.push({
-        rule: "opencode/select-session",
-        message:
-          "Could not verify that tui.selectSession is called after session.create(). " +
-          "Call client.tui.selectSession({ sessionID }) so the TUI displays the workflow session.",
-      });
-    }
+  if (/\bclient\.session\.create\b/.test(source)) {
+    warnings.push({
+      rule: "opencode/manual-session",
+      message:
+        "Manual client.session.create() call detected. Use s.session instead — " +
+        "the runtime auto-creates the session. Pass session config as the third arg to ctx.stage().",
+    });
   }
 
   return warnings;

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -7,7 +7,7 @@
  *    `bun run executor.ts --run <args>`
  * 3. The CLI then attaches to the tmux session (user sees it live)
  * 4. The orchestrator pane calls `definition.run(workflowCtx)` — the
- *    user's callback uses `ctx.session()` to spawn agent sessions
+ *    user's callback uses `ctx.stage()` to spawn agent sessions
  */
 
 import { join, resolve } from "path";
@@ -24,6 +24,8 @@ import type {
   Transcript,
   SavedMessage,
   SaveTranscript,
+  StageClientOptions,
+  StageSessionOptions,
 } from "../types.ts";
 import type { SessionEvent } from "@github/copilot-sdk";
 import type { SessionPromptResponse } from "@opencode-ai/sdk/v2";
@@ -31,8 +33,13 @@ import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk";
 import * as tmux from "./tmux.ts";
 import { getMuxBinary } from "./tmux.ts";
 import { WorkflowLoader } from "./loader.ts";
-import { clearClaudeSession } from "../providers/claude.ts";
+import {
+  clearClaudeSession,
+  ClaudeClientWrapper,
+  ClaudeSessionWrapper,
+} from "../providers/claude.ts";
 import { OrchestratorPanel } from "./panel.tsx";
+import { GraphFrontierTracker } from "./graph-inference.ts";
 
 /** Maximum time (ms) to wait for an agent's server to become reachable. */
 const SERVER_WAIT_TIMEOUT_MS = 60_000;
@@ -98,11 +105,7 @@ interface SessionResult {
 interface ActiveSession {
   name: string;
   paneId: string;
-  /**
-   * Settles when the session finishes. Resolves on success, rejects with the
-   * callback's error on failure. Dependent sessions awaiting via `dependsOn`
-   * block on this promise.
-   */
+  /** Settles when the session finishes. Resolves on success, rejects on failure. */
   done: Promise<void>;
 }
 
@@ -410,7 +413,7 @@ function resolveRef(ref: SessionRef): string {
 }
 
 // ============================================================================
-// Session runner — implements ctx.session() lifecycle
+// Session runner — implements ctx.stage() lifecycle
 // ============================================================================
 
 /** Shared state passed to session runners by the orchestrator. */
@@ -427,23 +430,118 @@ interface SharedRunnerState {
 }
 
 /**
- * Create a `ctx.session()` function bound to a parent name for graph edges.
+ * Create the provider-specific client and session for a stage.
+ * Called by the session runner after server readiness is confirmed.
+ */
+async function initProviderClientAndSession(
+  agent: AgentType,
+  serverUrl: string,
+  paneId: string,
+  sessionId: string,
+  clientOpts: StageClientOptions<AgentType>,
+  sessionOpts: StageSessionOptions<AgentType>,
+): Promise<{ client: unknown; session: unknown }> {
+  switch (agent) {
+    case "copilot": {
+      const { CopilotClient, approveAll } = await import("@github/copilot-sdk");
+      const copilotClientOpts = clientOpts as StageClientOptions<"copilot">;
+      const copilotSessionOpts = sessionOpts as StageSessionOptions<"copilot">;
+      const client = new CopilotClient({ cliUrl: serverUrl, ...copilotClientOpts });
+      await client.start();
+      const session = await client.createSession({
+        onPermissionRequest: approveAll,
+        ...copilotSessionOpts,
+      });
+      await client.setForegroundSessionId(session.sessionId);
+      return { client, session };
+    }
+    case "opencode": {
+      const { createOpencodeClient } = await import("@opencode-ai/sdk/v2");
+      const ocClientOpts = clientOpts as StageClientOptions<"opencode">;
+      const ocSessionOpts = sessionOpts as StageSessionOptions<"opencode">;
+      const client = createOpencodeClient({ baseUrl: serverUrl, ...ocClientOpts });
+      const sessionResult = await client.session.create(ocSessionOpts);
+      await client.tui.selectSession({ sessionID: sessionResult.data!.id });
+      return { client, session: sessionResult.data! };
+    }
+    case "claude": {
+      const claudeClientOpts = clientOpts as StageClientOptions<"claude">;
+      const claudeSessionOpts = sessionOpts as StageSessionOptions<"claude">;
+      const client = new ClaudeClientWrapper(paneId, claudeClientOpts);
+      await client.start();
+      const session = new ClaudeSessionWrapper(paneId, sessionId, claudeSessionOpts);
+      return { client, session };
+    }
+  }
+}
+
+/**
+ * Clean up provider-specific resources after a stage callback completes.
+ * Errors are silently caught — cleanup must not mask callback errors.
+ */
+async function cleanupProvider(
+  agent: AgentType,
+  providerClient: unknown,
+  providerSession: unknown,
+  paneId: string,
+): Promise<void> {
+  switch (agent) {
+    case "copilot": {
+      const { CopilotSession: CopilotSessionClass } = await import("@github/copilot-sdk");
+      try {
+        if (providerSession instanceof CopilotSessionClass) {
+          await providerSession.disconnect();
+        }
+      } catch {}
+      try {
+        const { CopilotClient: CopilotClientClass } = await import("@github/copilot-sdk");
+        if (providerClient instanceof CopilotClientClass) {
+          await providerClient.stop();
+        }
+      } catch {}
+      break;
+    }
+    case "opencode":
+      // Stateless HTTP client — no cleanup needed
+      break;
+    case "claude":
+      clearClaudeSession(paneId);
+      break;
+  }
+}
+
+/**
+ * Create a `ctx.stage()` function bound to a parent name for graph edges.
+ *
+ * Graph topology is auto-inferred from JavaScript's execution order:
+ * - **Sequential** (`await`): the completed stage is in the frontier when the
+ *   next stage spawns → parent-child edge.
+ * - **Parallel** (`Promise.all`): both calls fire in the same synchronous
+ *   frame → frontier is empty for the second call → sibling edges.
+ * - **Fan-in**: after `Promise.all` resolves, all parallel stages are in the
+ *   frontier → the next stage depends on all of them.
+ *
  * The returned function manages the full session lifecycle:
- * spawn → run callback → flush saves → complete/error → cleanup.
+ * spawn → init client/session → run callback → flush saves → cleanup → complete/error.
  */
 function createSessionRunner(
   shared: SharedRunnerState,
   parentName: string,
 ): <T = void>(
   options: SessionRunOptions,
+  clientOpts: StageClientOptions<AgentType>,
+  sessionOpts: StageSessionOptions<AgentType>,
   run: (ctx: SessionContext) => Promise<T>,
 ) => Promise<SessionHandle<T>> {
+  const graphTracker = new GraphFrontierTracker(parentName);
+
   return async <T = void>(
     options: SessionRunOptions,
+    clientOpts: StageClientOptions<AgentType>,
+    sessionOpts: StageSessionOptions<AgentType>,
     run: (ctx: SessionContext) => Promise<T>,
   ): Promise<SessionHandle<T>> => {
     const { name } = options;
-    const deps = options.dependsOn ?? [];
 
     // ── 1. Validate name uniqueness (synchronous, before any await) ──
     if (!name || name.trim() === "") {
@@ -453,23 +551,8 @@ function createSessionRunner(
       throw new Error(`Duplicate session name: "${name}"`);
     }
 
-    // ── 2. Validate dependsOn (synchronous, before any await) ──
-    if (deps.length > 0) {
-      if (deps.includes(name)) {
-        throw new Error(`Session "${name}" cannot depend on itself.`);
-      }
-      const unknown = deps.filter(
-        (d) =>
-          !shared.activeRegistry.has(d) && !shared.completedRegistry.has(d),
-      );
-      if (unknown.length > 0) {
-        throw new Error(
-          `Session "${name}" dependsOn unknown session(s): ${unknown.join(
-            ", ",
-          )}. Dependencies must be spawned before the dependent session.`,
-        );
-      }
-    }
+    // ── 2. Auto-infer graph parents from frontier (synchronous) ──
+    const graphParents = graphTracker.onSpawn();
 
     // ── 3. Create done promise so dependent sessions can await this one ──
     let resolveDone!: () => void;
@@ -487,22 +570,8 @@ function createSessionRunner(
 
     const sessionId = generateId();
     let paneId = "";
-    // Graph parents: explicit deps if provided, otherwise the enclosing scope.
-    const graphParents = deps.length > 0 ? [...deps] : [parentName];
 
     try {
-      // ── 5. Wait for dependsOn sessions to finish ──
-      // Active deps block; completed deps resolve immediately. If a dep
-      // rejects (its session failed), this throws and aborts the dependent.
-      if (deps.length > 0) {
-        await Promise.all(
-          deps.map((d) => {
-            const active = shared.activeRegistry.get(d);
-            if (active) return active.done;
-            return Promise.resolve();
-          }),
-        );
-      }
 
       // ── 6. Allocate port ──
       const port = await getRandomPort();
@@ -652,9 +721,21 @@ function createSessionRunner(
         return JSON.parse(raw) as SavedMessage[];
       };
 
-      // ── 12. Construct SessionContext ──
+      // ── 12. Auto-create provider client and session ──
+      const { client: providerClient, session: providerSession } =
+        await initProviderClientAndSession(
+          shared.agent,
+          serverUrl,
+          paneId,
+          sessionId,
+          clientOpts,
+          sessionOpts,
+        );
+
+      // ── 13. Construct SessionContext ──
       const ctx: SessionContext = {
-        serverUrl,
+        client: providerClient as SessionContext["client"],
+        session: providerSession as SessionContext["session"],
         userPrompt: shared.prompt,
         agent: shared.agent,
         sessionDir,
@@ -663,7 +744,7 @@ function createSessionRunner(
         save,
         transcript: transcriptFn,
         getMessages: getMessagesFn,
-        session: createSessionRunner(shared, name),
+        stage: createSessionRunner(shared, name) as SessionContext["stage"],
       };
 
       // ── Write session metadata ──
@@ -684,7 +765,7 @@ function createSessionRunner(
         ),
       );
 
-      // ── 13. Run user callback ──
+      // ── 14. Run user callback ──
       let callbackResult: T;
       try {
         callbackResult = await run(ctx);
@@ -697,27 +778,29 @@ function createSessionRunner(
         );
         shared.panel.sessionError(name, message);
         throw error;
+      } finally {
+        // ── 14a. Auto-cleanup provider resources ──
+        await cleanupProvider(shared.agent, providerClient, providerSession, paneId);
       }
 
-      // ── 14. Mark session complete ──
+      // ── 15. Mark session complete ──
       shared.panel.sessionSuccess(name);
       const result: SessionResult = { name, sessionId, sessionDir, paneId };
       shared.completedRegistry.set(name, result);
       shared.activeRegistry.delete(name);
       resolveDone();
 
+      // Update frontier so the next stage in this scope chains from us.
+      graphTracker.onSettle(name);
       return { name, id: sessionId, result: callbackResult! };
     } catch (error) {
-      // Ensure the done promise settles and the active entry is cleared so
-      // dependents fail fast instead of hanging forever on a ghost dep.
+      // Ensure the done promise settles and the active entry is cleared.
       shared.activeRegistry.delete(name);
       rejectDone(error);
+      // Update frontier even on failure — if the caller catches and
+      // continues, the next stage should still chain from this one.
+      graphTracker.onSettle(name);
       throw error;
-    } finally {
-      // ── 15. Cleanup (Claude session state) ──
-      if (shared.agent === "claude" && paneId) {
-        clearClaudeSession(paneId);
-      }
     }
   };
 }
@@ -831,7 +914,7 @@ async function runOrchestrator(): Promise<void> {
     const workflowCtx: WorkflowContext = {
       userPrompt: prompt,
       agent,
-      session: sessionRunner,
+      stage: sessionRunner as WorkflowContext["stage"],
       transcript: async (ref: SessionRef): Promise<Transcript> => {
         const refName = resolveRef(ref);
         const prev = shared.completedRegistry.get(refName);

--- a/src/sdk/runtime/graph-inference.ts
+++ b/src/sdk/runtime/graph-inference.ts
@@ -1,0 +1,50 @@
+/**
+ * Frontier-based graph inference for workflow stage topology.
+ *
+ * Automatically infers parent-child edges from JavaScript's execution order:
+ * - **Sequential** (`await`): completed stages are in the frontier when the
+ *   next stage spawns → parent-child edge.
+ * - **Parallel** (`Promise.all`): both calls fire in the same synchronous
+ *   frame → frontier is empty for the second call → sibling edges.
+ * - **Fan-in**: after `Promise.all` resolves, all parallel stages are in the
+ *   frontier → the next stage depends on all of them.
+ */
+export class GraphFrontierTracker {
+  /**
+   * Stages that completed since the last stage was spawned in this scope.
+   * When non-empty at spawn time, the new stage is sequential (depends on frontier).
+   */
+  private frontier: string[] = [];
+
+  /**
+   * The parent set for the current parallel batch — a snapshot of the frontier
+   * at the point the first sibling consumed it.
+   */
+  private parallelAncestors: string[];
+
+  constructor(parentName: string) {
+    this.parallelAncestors = [parentName];
+  }
+
+  /**
+   * Called synchronously when a new stage is spawned.
+   * Returns the inferred graph parents for this stage.
+   */
+  onSpawn(): string[] {
+    if (this.frontier.length > 0) {
+      // Sequential: previous stage(s) completed → new wave
+      this.parallelAncestors = [...this.frontier];
+      this.frontier = [];
+    }
+    // Parallel sibling, first stage, or sequential → same ancestors
+    return [...this.parallelAncestors];
+  }
+
+  /**
+   * Called when a stage settles (completes or fails).
+   * Adds the stage to the frontier so the next spawn can chain from it.
+   */
+  onSettle(name: string): void {
+    this.frontier.push(name);
+  }
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -8,8 +8,94 @@ import type { SessionEvent } from "@github/copilot-sdk";
 import type { SessionPromptResponse } from "@opencode-ai/sdk/v2";
 import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk";
 
+// Provider SDK types for the type maps
+import type {
+  CopilotClient,
+  CopilotClientOptions,
+  CopilotSession,
+  SessionConfig as CopilotSessionConfig,
+} from "@github/copilot-sdk";
+import type {
+  OpencodeClient,
+  Session as OpencodeSession,
+} from "@opencode-ai/sdk/v2";
+import type {
+  ClaudeClientWrapper,
+  ClaudeSessionWrapper,
+  ClaudeQueryDefaults,
+} from "./providers/claude.ts";
+
 /** Supported agent types */
 export type AgentType = "copilot" | "opencode" | "claude";
+
+// ─── Provider type maps ─────────────────────────────────────────────────────
+
+/**
+ * Maps each agent to the client init options the user passes to `ctx.stage()`.
+ * Auto-injected fields (`cliUrl`, `baseUrl`, `paneId`) are omitted.
+ */
+type ClientOptionsMap = {
+  opencode: { directory?: string; experimental_workspaceID?: string };
+  copilot: Omit<CopilotClientOptions, "cliUrl">;
+  claude: { chatFlags?: string[]; readyTimeoutMs?: number };
+};
+
+/**
+ * Maps each agent to the session create options the user passes to `ctx.stage()`.
+ * - OpenCode: `client.session.create()` body params
+ * - Copilot: `client.createSession()` config (onPermissionRequest defaults to approveAll)
+ * - Claude: `claudeQuery()` defaults for subsequent queries
+ */
+type SessionOptionsMap = {
+  opencode: {
+    parentID?: string;
+    title?: string;
+    workspaceID?: string;
+  };
+  copilot: Partial<CopilotSessionConfig>;
+  claude: ClaudeQueryDefaults;
+};
+
+/** Maps each agent to the `s.client` type provided in the stage callback. */
+type ClientMap = {
+  opencode: OpencodeClient;
+  copilot: CopilotClient;
+  claude: ClaudeClientWrapper;
+};
+
+/** Maps each agent to the `s.session` type provided in the stage callback. */
+type SessionMap = {
+  opencode: OpencodeSession;
+  copilot: CopilotSession;
+  claude: ClaudeSessionWrapper;
+};
+
+/** Client init options for `ctx.stage()`, resolved by agent type. */
+export type StageClientOptions<A extends AgentType> = ClientOptionsMap[A];
+
+/** Session create options for `ctx.stage()`, resolved by agent type. */
+export type StageSessionOptions<A extends AgentType> = SessionOptionsMap[A];
+
+/** The `s.client` type in a stage callback, resolved by agent type. */
+export type ProviderClient<A extends AgentType> = ClientMap[A];
+
+/** The `s.session` type in a stage callback, resolved by agent type. */
+export type ProviderSession<A extends AgentType> = SessionMap[A];
+
+// Re-export provider types for convenience
+export type {
+  CopilotClient,
+  CopilotClientOptions,
+  CopilotSession,
+  CopilotSessionConfig,
+  OpencodeClient,
+  OpencodeSession,
+  ClaudeClientWrapper,
+  ClaudeSessionWrapper,
+  ClaudeQueryDefaults,
+};
+
+// ─── Core types ─────────────────────────────────────────────────────────────
 
 /**
  * A transcript from a completed session.
@@ -34,7 +120,7 @@ export type SavedMessage =
 /**
  * Save native message objects from the provider SDK.
  *
- * - **Copilot**: `s.save(await session.getMessages())`
+ * - **Copilot**: `s.save(await s.session.getMessages())`
  * - **OpenCode**: `s.save(result.data)` — the full `{ info, parts }` response
  * - **Claude**: `s.save(sessionId)` — auto-reads via `getSessionMessages()`
  */
@@ -51,7 +137,7 @@ export interface SaveTranscript {
 export type SessionRef = string | SessionHandle<unknown>;
 
 /**
- * Handle returned by `ctx.session()`. Used for type-safe transcript references
+ * Handle returned by `ctx.stage()`. Used for type-safe transcript references
  * and carries the callback's return value.
  */
 export interface SessionHandle<T = void> {
@@ -64,45 +150,29 @@ export interface SessionHandle<T = void> {
 }
 
 /**
- * Options for spawning a session via `ctx.session()`.
+ * Options for spawning a session via `ctx.stage()`.
  */
 export interface SessionRunOptions {
   /** Unique name for this session (used for transcript references and graph display) */
   name: string;
   /** Human-readable description */
   description?: string;
-  /**
-   * Names of sessions this one depends on. Serves two purposes:
-   *
-   * 1. **Graph rendering** — each named session becomes a parent edge in the
-   *    graph, so chains and fan-ins show up as real topology instead of
-   *    sibling-under-root.
-   * 2. **Runtime ordering** — at spawn time, the runtime waits for every
-   *    named dep to finish before starting. This makes dependency-driven
-   *    `Promise.all([...])` patterns safe: you can kick off many sessions
-   *    concurrently and let `dependsOn` serialize only the edges that matter.
-   *
-   * Each name must refer to a session that has already been spawned (either
-   * active or completed) at the time the dependent session is created.
-   * Unknown names throw a clear error.
-   *
-   * When omitted, the session falls back to the default parent (the
-   * enclosing `ctx.session()` scope, or `orchestrator` at the top level).
-   */
-  dependsOn?: string[];
 }
 
 /**
  * Context provided to each session's callback.
- * Created by `ctx.session(opts, fn)` — the callback receives this as its argument.
+ * Created by `ctx.stage(opts, clientOpts, sessionOpts, fn)` — the callback
+ * receives this as its argument with pre-initialized `client` and `session`.
  */
-export interface SessionContext {
-  /** The agent's server URL (Copilot --ui-server / OpenCode built-in server) */
-  serverUrl: string;
+export interface SessionContext<A extends AgentType = AgentType> {
+  /** Provider-specific SDK client (auto-created by runtime) */
+  client: ProviderClient<A>;
+  /** Provider-specific session (auto-created by runtime) */
+  session: ProviderSession<A>;
   /** The original user prompt from the CLI invocation */
   userPrompt: string;
   /** Which agent is running */
-  agent: AgentType;
+  agent: A;
   /**
    * Get a completed session's transcript as rendered text.
    * Accepts a SessionHandle (recommended) or session name string.
@@ -129,29 +199,34 @@ export interface SessionContext {
    * The sub-session is a child of this session in the graph.
    * The callback's return value is available as `handle.result`.
    */
-  session<T = void>(
+  stage<T = void>(
     options: SessionRunOptions,
-    run: (ctx: SessionContext) => Promise<T>,
+    clientOpts: StageClientOptions<A>,
+    sessionOpts: StageSessionOptions<A>,
+    run: (ctx: SessionContext<A>) => Promise<T>,
   ): Promise<SessionHandle<T>>;
 }
 
 /**
  * Top-level context provided to the workflow's `.run()` callback.
- * Does not have session-specific fields (serverUrl, paneId, save, etc.).
+ * Does not have session-specific fields (paneId, save, etc.).
  */
-export interface WorkflowContext {
+export interface WorkflowContext<A extends AgentType = AgentType> {
   /** The original user prompt from the CLI invocation */
   userPrompt: string;
   /** Which agent is running */
-  agent: AgentType;
+  agent: A;
   /**
    * Spawn a session with its own tmux window and graph node.
-   * The runtime manages the full lifecycle: start → run callback → complete/error.
-   * The callback's return value is available as `handle.result`.
+   * The runtime manages the full lifecycle: create client → create session →
+   * run callback → cleanup. The callback's return value is available as
+   * `handle.result`.
    */
-  session<T = void>(
+  stage<T = void>(
     options: SessionRunOptions,
-    run: (ctx: SessionContext) => Promise<T>,
+    clientOpts: StageClientOptions<A>,
+    sessionOpts: StageSessionOptions<A>,
+    run: (ctx: SessionContext<A>) => Promise<T>,
   ): Promise<SessionHandle<T>>;
   /**
    * Get a completed session's transcript as rendered text.
@@ -178,10 +253,10 @@ export interface WorkflowOptions {
 /**
  * A compiled workflow definition — the sealed output of defineWorkflow().compile().
  */
-export interface WorkflowDefinition {
+export interface WorkflowDefinition<A extends AgentType = AgentType> {
   readonly __brand: "WorkflowDefinition";
   readonly name: string;
   readonly description: string;
   /** The workflow's entry point. Called by the executor with a WorkflowContext. */
-  readonly run: (ctx: WorkflowContext) => Promise<void>;
+  readonly run: (ctx: WorkflowContext<A>) => Promise<void>;
 }

--- a/src/sdk/workflows.ts
+++ b/src/sdk/workflows.ts
@@ -2,7 +2,7 @@
  * atomic/workflows
  *
  * Workflow SDK for defining dynamic agent workflows.
- * Workflows use defineWorkflow().run().compile() with ctx.session()
+ * Workflows use defineWorkflow().run().compile() with ctx.stage()
  * for spawning agent sessions using native TypeScript control flow.
  */
 
@@ -20,6 +20,19 @@ export type {
   WorkflowContext,
   WorkflowOptions,
   WorkflowDefinition,
+  StageClientOptions,
+  StageSessionOptions,
+  ProviderClient,
+  ProviderSession,
+  CopilotClient,
+  CopilotClientOptions,
+  CopilotSession,
+  CopilotSessionConfig,
+  OpencodeClient,
+  OpencodeSession,
+  ClaudeClientWrapper,
+  ClaudeSessionWrapper,
+  ClaudeQueryDefaults,
 } from "./types.ts";
 
 // Re-export native SDK types for convenience

--- a/src/services/system/workflows.ts
+++ b/src/services/system/workflows.ts
@@ -14,7 +14,7 @@
  */
 
 import { join, sep } from "path";
-import { readdir, rm } from "fs/promises";
+import { lstat, readdir, rm, symlink, unlink } from "fs/promises";
 import { homedir } from "os";
 import {
   copyDir,
@@ -44,6 +44,41 @@ function isSafeEntryName(name: string): boolean {
  */
 function packageRoot(): string {
   return join(import.meta.dir, "..", "..", "..");
+}
+
+/**
+ * Safely remove a symlink or junction before re-creating it.
+ *
+ * On Windows, Bun's `rm({ recursive: true })` follows NTFS junctions and
+ * can delete the **target directory's contents** (oven-sh/bun#27233).
+ * `unlink` is safe: it opens with `FILE_FLAG_OPEN_REPARSE_POINT` and
+ * removes only the link entry, never following it.
+ *
+ * Falls back to `rm` only when the path is a real directory (not a link),
+ * which can happen if a previous version created the path as a plain copy
+ * instead of a symlink.
+ */
+async function removeLinkOrDir(path: string): Promise<void> {
+  try {
+    const stats = await lstat(path);
+    if (stats.isSymbolicLink()) {
+      await unlink(path);
+    } else if (stats.isDirectory()) {
+      await rm(path, { recursive: true, force: true });
+    } else {
+      await unlink(path);
+    }
+  } catch (error: unknown) {
+    // ENOENT — path doesn't exist; nothing to remove.
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return;
+    }
+    throw error;
+  }
 }
 
 /** Honors ATOMIC_SETTINGS_HOME so tests can point at a temp dir. */
@@ -102,4 +137,104 @@ export async function installGlobalWorkflows(): Promise<void> {
       await copyDir(src, dest);
     }
   }
+
+  // ── Type-resolution setup for workflow authors ─────────────────────
+  //
+  // The bundled tsconfig.json uses relative `paths` that only resolve
+  // correctly inside the package's own directory tree. Once the files
+  // are copied to `~/.atomic/workflows/`, those relative paths break.
+  //
+  // Strategy: symlink `node_modules/@bastani/atomic` in the destination
+  // back to the running package root.  TypeScript's standard module
+  // resolution then finds `@bastani/atomic/workflows` (and its
+  // transitive deps) automatically — no `paths` override needed.
+  //
+  // If symlink creation fails (permissions, unsupported FS), we fall
+  // back to a tsconfig with an absolute `paths` entry pointing at the
+  // package's SDK source.  Either way the workflow author gets types
+  // with zero manual configuration.
+  await setupWorkflowTypes(destRoot);
 }
+
+/**
+ * Wire up TypeScript type resolution for a global workflows directory.
+ *
+ * Creates a `node_modules/@bastani/atomic` symlink → the installed
+ * package root and generates a tsconfig.json that lets standard module
+ * resolution do the work. Falls back to absolute `paths` in the
+ * tsconfig if symlinking isn't possible.
+ */
+export async function setupWorkflowTypes(destRoot: string): Promise<void> {
+  const pkgRoot = packageRoot();
+  let usedSymlink = false;
+
+  // 1. Symlink the package itself
+  try {
+    const scopeDir = join(destRoot, "node_modules", "@bastani");
+    await ensureDir(scopeDir);
+
+    const link = join(scopeDir, "atomic");
+    await removeLinkOrDir(link);
+
+    // Junctions on Windows need no elevated privileges.
+    const type = process.platform === "win32" ? "junction" : "dir";
+    await symlink(pkgRoot, link, type);
+    usedSymlink = true;
+  } catch {
+    // Swallow — falls back to paths-based tsconfig below.
+  }
+
+  // 2. Symlink @types/bun so `Bun.*` APIs have types in workflows
+  try {
+    const bunTypes = join(pkgRoot, "node_modules", "@types", "bun");
+    if (await pathExists(bunTypes)) {
+      const typesDir = join(destRoot, "node_modules", "@types");
+      await ensureDir(typesDir);
+
+      const link = join(typesDir, "bun");
+      await removeLinkOrDir(link);
+
+      const type = process.platform === "win32" ? "junction" : "dir";
+      await symlink(bunTypes, link, type);
+    }
+  } catch {
+    // Best effort — Bun APIs in workflows lack types but runtime is fine.
+  }
+
+  // 3. Generate a clean tsconfig for the destination
+  const compilerOptions: Record<string, unknown> = {
+    target: "ESNext",
+    module: "ESNext",
+    moduleResolution: "bundler",
+    allowImportingTsExtensions: true,
+    noEmit: true,
+    verbatimModuleSyntax: true,
+    strict: true,
+    skipLibCheck: true,
+    types: ["bun"],
+  };
+
+  if (!usedSymlink) {
+    // Fallback: absolute paths so TypeScript can still resolve the SDK
+    // source from the installed package location.
+    compilerOptions.paths = {
+      "@bastani/atomic": [join(pkgRoot, "src", "sdk", "index.ts")],
+      "@bastani/atomic/workflows": [join(pkgRoot, "src", "sdk", "workflows.ts")],
+    };
+  }
+
+  const tsconfig = { compilerOptions, include: GLOBAL_TSCONFIG_INCLUDE };
+
+  await Bun.write(
+    join(destRoot, "tsconfig.json"),
+    JSON.stringify(tsconfig, null, 2) + "\n",
+  );
+}
+
+/** Include globs shared by every generated global workflows tsconfig. */
+const GLOBAL_TSCONFIG_INCLUDE = [
+  "**/claude/**/*.ts",
+  "**/copilot/**/*.ts",
+  "**/opencode/**/*.ts",
+  "**/helpers/**/*.ts",
+];

--- a/tests/lib/path-root-guard.test.ts
+++ b/tests/lib/path-root-guard.test.ts
@@ -1,0 +1,117 @@
+import {
+  test,
+  expect,
+  describe,
+  beforeAll,
+  afterAll,
+} from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  isPathWithinRoot,
+  assertPathWithinRoot,
+  assertRealPathWithinRoot,
+} from "@/lib/path-root-guard.ts";
+
+// ---------------------------------------------------------------------------
+// isPathWithinRoot
+// ---------------------------------------------------------------------------
+
+describe("isPathWithinRoot", () => {
+  test("returns true when candidate equals root", () => {
+    expect(isPathWithinRoot("/a/b", "/a/b")).toBe(true);
+  });
+
+  test("returns true for a direct child", () => {
+    expect(isPathWithinRoot("/a/b", "/a/b/c")).toBe(true);
+  });
+
+  test("returns true for a deeply nested child", () => {
+    expect(isPathWithinRoot("/a", "/a/b/c/d/e")).toBe(true);
+  });
+
+  test("returns false for a parent directory", () => {
+    expect(isPathWithinRoot("/a/b/c", "/a/b")).toBe(false);
+  });
+
+  test("returns false for a sibling directory", () => {
+    expect(isPathWithinRoot("/a/b", "/a/c")).toBe(false);
+  });
+
+  test("returns false when .. escapes root", () => {
+    expect(isPathWithinRoot("/a/b", "/a/b/c/../../d")).toBe(false);
+  });
+
+  test("returns true when .. resolves within root", () => {
+    expect(isPathWithinRoot("/a/b", "/a/b/c/../c/d")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertPathWithinRoot
+// ---------------------------------------------------------------------------
+
+describe("assertPathWithinRoot", () => {
+  test("does not throw for path within root", () => {
+    expect(() =>
+      assertPathWithinRoot("/a/b", "/a/b/c", "Source"),
+    ).not.toThrow();
+  });
+
+  test("throws for path outside root", () => {
+    expect(() =>
+      assertPathWithinRoot("/a/b", "/a/c", "Source"),
+    ).toThrow("Source escapes allowed root: /a/c");
+  });
+
+  test("includes the label and candidate in the error", () => {
+    expect(() =>
+      assertPathWithinRoot("/x", "/y/z", "CustomLabel"),
+    ).toThrow(/CustomLabel escapes allowed root: \/y\/z/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertRealPathWithinRoot
+// ---------------------------------------------------------------------------
+
+describe("assertRealPathWithinRoot", () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "prg-test-"));
+    await mkdir(join(tmpDir, "sub"), { recursive: true });
+    await writeFile(join(tmpDir, "sub", "file.txt"), "content");
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("resolves and returns the real path for a file within root", async () => {
+    const result = await assertRealPathWithinRoot(
+      tmpDir,
+      join(tmpDir, "sub", "file.txt"),
+      "Test",
+    );
+    expect(result).toEndWith("file.txt");
+  });
+
+  test("throws for a real path that resolves outside root", async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), "prg-outside-"));
+    await writeFile(join(outsideDir, "out.txt"), "x");
+
+    try {
+      await expect(
+        assertRealPathWithinRoot(
+          tmpDir,
+          join(outsideDir, "out.txt"),
+          "Escape",
+        ),
+      ).rejects.toThrow(/Escape resolves outside allowed root/);
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/sdk/components/layout.test.ts
+++ b/tests/sdk/components/layout.test.ts
@@ -166,14 +166,14 @@ describe("computeLayout", () => {
     expect(result.map["b"]!.x).toBe(result.map["c"]!.x);
   });
 
-  // ── dependsOn-style ralph chain ──────────────────────────────────────────
+  // ── Auto-inferred ralph chain ────────────────────────────────────────────
   //
-  // When the executor wires up `dependsOn`, the parents array on each
-  // SessionData ends up pointing at the prior stage instead of the root
-  // "orchestrator". These tests assert that the layout treats that shape
-  // as a linear chain (not a fan-out of siblings under the root), which is
-  // the visual behavior users see after the fix.
-  describe("ralph-style dependsOn chain", () => {
+  // The executor's frontier tracker auto-infers parent-child edges from
+  // `await`/`Promise.all` patterns. For sequential `await` chains (like
+  // ralph), each stage's parents array points at the prior stage instead
+  // of the root "orchestrator". These tests assert that the layout treats
+  // that shape as a linear chain (not a fan-out of siblings under the root).
+  describe("auto-inferred ralph chain", () => {
     test("single-iteration chain: plan → orch → review → debug", () => {
       const result = computeLayout([
         makeSession("orchestrator"),

--- a/tests/sdk/runtime/graph-inference.test.ts
+++ b/tests/sdk/runtime/graph-inference.test.ts
@@ -1,0 +1,205 @@
+import { test, expect, describe } from "bun:test";
+import { GraphFrontierTracker } from "@/sdk/runtime/graph-inference.ts";
+
+describe("GraphFrontierTracker", () => {
+  test("first stage gets the scope parent", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+  });
+
+  test("sequential chain: each stage depends on the previous", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a");
+
+    // await ctx.stage("b")
+    expect(t.onSpawn()).toEqual(["a"]);
+    t.onSettle("b");
+
+    // await ctx.stage("c")
+    expect(t.onSpawn()).toEqual(["b"]);
+    t.onSettle("c");
+  });
+
+  test("parallel fan-out: siblings share the same parent", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a");
+
+    // Promise.all([ctx.stage("b"), ctx.stage("c")])
+    // Both spawn synchronously before either settles
+    expect(t.onSpawn()).toEqual(["a"]); // b
+    expect(t.onSpawn()).toEqual(["a"]); // c — frontier was cleared, uses parallelAncestors
+  });
+
+  test("fan-in: stage after Promise.all depends on all parallel stages", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a");
+
+    // Promise.all([ctx.stage("b"), ctx.stage("c")])
+    t.onSpawn(); // b
+    t.onSpawn(); // c
+    t.onSettle("b");
+    t.onSettle("c");
+
+    // await ctx.stage("merge")
+    expect(t.onSpawn()).toEqual(["b", "c"]);
+  });
+
+  test("hello-parallel: describe → [summarize-a, summarize-b] → merge", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("describe")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("describe");
+
+    // Promise.all([ctx.stage("summarize-a"), ctx.stage("summarize-b")])
+    expect(t.onSpawn()).toEqual(["describe"]); // summarize-a
+    expect(t.onSpawn()).toEqual(["describe"]); // summarize-b
+    t.onSettle("summarize-a");
+    t.onSettle("summarize-b");
+
+    // await ctx.stage("merge")
+    expect(t.onSpawn()).toEqual(["summarize-a", "summarize-b"]);
+  });
+
+  test("ralph loop: sequential chain across iterations", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // Iteration 1
+    expect(t.onSpawn()).toEqual(["orchestrator"]); // planner-1
+    t.onSettle("planner-1");
+
+    expect(t.onSpawn()).toEqual(["planner-1"]); // orchestrator-1
+    t.onSettle("orchestrator-1");
+
+    expect(t.onSpawn()).toEqual(["orchestrator-1"]); // reviewer-1
+    t.onSettle("reviewer-1");
+
+    // Iteration 2
+    expect(t.onSpawn()).toEqual(["reviewer-1"]); // planner-2
+    t.onSettle("planner-2");
+
+    expect(t.onSpawn()).toEqual(["planner-2"]); // orchestrator-2
+    t.onSettle("orchestrator-2");
+  });
+
+  test("conditional skip: skipped stage is invisible to tracker", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a");
+
+    // if (false) await ctx.stage("b")  — skipped, nothing happens
+
+    // await ctx.stage("c")
+    expect(t.onSpawn()).toEqual(["a"]);
+  });
+
+  test("failed stage: still chains to next if caller catches", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")  — runs and fails
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a"); // called even on failure
+
+    // Caller catches, continues
+    // await ctx.stage("b")
+    expect(t.onSpawn()).toEqual(["a"]);
+  });
+
+  test("non-stage awaits are invisible", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a");
+
+    // await fetchSomething()  — not a stage, no tracker interaction
+
+    // await ctx.stage("b")
+    expect(t.onSpawn()).toEqual(["a"]);
+  });
+
+  test("nested scopes get independent trackers", () => {
+    const outer = new GraphFrontierTracker("orchestrator");
+    const inner = new GraphFrontierTracker("outer-stage");
+
+    // Outer scope
+    expect(outer.onSpawn()).toEqual(["orchestrator"]); // outer-stage
+    outer.onSettle("outer-stage");
+
+    // Inner scope (inside outer-stage callback)
+    expect(inner.onSpawn()).toEqual(["outer-stage"]); // inner-a
+    inner.onSettle("inner-a");
+    expect(inner.onSpawn()).toEqual(["inner-a"]); // inner-b
+
+    // Outer scope continues
+    expect(outer.onSpawn()).toEqual(["outer-stage"]);
+  });
+
+  test("diamond pattern: sequential → parallel → fan-in → parallel → fan-in", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a");
+
+    // Promise.all([ctx.stage("b"), ctx.stage("c")])
+    expect(t.onSpawn()).toEqual(["a"]); // b
+    expect(t.onSpawn()).toEqual(["a"]); // c
+    t.onSettle("b");
+    t.onSettle("c");
+
+    // Promise.all([ctx.stage("d"), ctx.stage("e")])
+    expect(t.onSpawn()).toEqual(["b", "c"]); // d
+    expect(t.onSpawn()).toEqual(["b", "c"]); // e
+    t.onSettle("d");
+    t.onSettle("e");
+
+    // await ctx.stage("f")
+    expect(t.onSpawn()).toEqual(["d", "e"]);
+  });
+
+  test("three-way parallel fan-out", () => {
+    const t = new GraphFrontierTracker("root");
+
+    expect(t.onSpawn()).toEqual(["root"]); // a
+    t.onSettle("a");
+
+    // Promise.all([ctx.stage("b"), ctx.stage("c"), ctx.stage("d")])
+    expect(t.onSpawn()).toEqual(["a"]); // b
+    expect(t.onSpawn()).toEqual(["a"]); // c
+    expect(t.onSpawn()).toEqual(["a"]); // d
+    t.onSettle("b");
+    t.onSettle("c");
+    t.onSettle("d");
+
+    // await ctx.stage("merge")
+    expect(t.onSpawn()).toEqual(["b", "c", "d"]);
+  });
+
+  test("fire-and-forget: concurrent stages are siblings", () => {
+    const t = new GraphFrontierTracker("orchestrator");
+
+    // await ctx.stage("a")
+    expect(t.onSpawn()).toEqual(["orchestrator"]);
+    t.onSettle("a");
+
+    // const bPromise = ctx.stage("b")  — not awaited
+    expect(t.onSpawn()).toEqual(["a"]); // b
+
+    // await ctx.stage("c")  — c spawns before b settles
+    expect(t.onSpawn()).toEqual(["a"]); // c — parallel with b
+
+    // Both are concurrent siblings from "a"
+  });
+});

--- a/tests/sdk/runtime/workflow-types.test.ts
+++ b/tests/sdk/runtime/workflow-types.test.ts
@@ -1,0 +1,83 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { mkdtemp, rm, readlink, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import { existsSync, lstatSync } from "fs";
+import { setupWorkflowTypes } from "@/services/system/workflows.ts";
+
+describe("setupWorkflowTypes", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "atomic-wf-types-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("creates @bastani/atomic symlink in node_modules", async () => {
+    await setupWorkflowTypes(tempDir);
+
+    const symlinkPath = join(tempDir, "node_modules", "@bastani", "atomic");
+    expect(existsSync(symlinkPath)).toBe(true);
+
+    const stats = lstatSync(symlinkPath);
+    expect(stats.isSymbolicLink()).toBe(true);
+
+    // Symlink target should contain a package.json with name @bastani/atomic
+    const pkgJson = JSON.parse(
+      await readFile(join(symlinkPath, "package.json"), "utf-8"),
+    );
+    expect(pkgJson.name).toBe("@bastani/atomic");
+  });
+
+  test("generates tsconfig.json without paths when symlink succeeds", async () => {
+    await setupWorkflowTypes(tempDir);
+
+    const tsconfig = JSON.parse(
+      await readFile(join(tempDir, "tsconfig.json"), "utf-8"),
+    );
+
+    expect(tsconfig.compilerOptions.moduleResolution).toBe("bundler");
+    expect(tsconfig.compilerOptions.strict).toBe(true);
+    expect(tsconfig.compilerOptions.paths).toBeUndefined();
+    expect(tsconfig.include).toBeArrayOfSize(4);
+  });
+
+  test("is idempotent — second call replaces stale symlinks", async () => {
+    await setupWorkflowTypes(tempDir);
+    await setupWorkflowTypes(tempDir);
+
+    const symlinkPath = join(tempDir, "node_modules", "@bastani", "atomic");
+    expect(existsSync(symlinkPath)).toBe(true);
+
+    const stats = lstatSync(symlinkPath);
+    expect(stats.isSymbolicLink()).toBe(true);
+  });
+
+  test("symlink target points to the package root", async () => {
+    await setupWorkflowTypes(tempDir);
+
+    const symlinkPath = join(tempDir, "node_modules", "@bastani", "atomic");
+    const target = await readlink(symlinkPath);
+
+    // The target should contain src/sdk/workflows.ts (the SDK barrel)
+    const workflowsSrc = join(target, "src", "sdk", "workflows.ts");
+    expect(existsSync(workflowsSrc)).toBe(true);
+  });
+
+  test("tsconfig include globs cover all agent directories", async () => {
+    await setupWorkflowTypes(tempDir);
+
+    const tsconfig = JSON.parse(
+      await readFile(join(tempDir, "tsconfig.json"), "utf-8"),
+    );
+
+    const includes: string[] = tsconfig.include;
+    expect(includes).toContain("**/claude/**/*.ts");
+    expect(includes).toContain("**/copilot/**/*.ts");
+    expect(includes).toContain("**/opencode/**/*.ts");
+    expect(includes).toContain("**/helpers/**/*.ts");
+  });
+});

--- a/tests/services/system/copy.test.ts
+++ b/tests/services/system/copy.test.ts
@@ -1,0 +1,369 @@
+import {
+  test,
+  expect,
+  describe,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import {
+  mkdtemp,
+  rm,
+  mkdir,
+  writeFile,
+  readFile,
+  stat,
+  symlink,
+} from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  ensureDir,
+  ensureDirSync,
+  normalizePath,
+  isPathSafe,
+  copyFile,
+  shouldExclude,
+  copyDir,
+  copyDirNonDestructive,
+  pathExists,
+  isDirectory,
+  isFileEmpty,
+} from "@/services/system/copy.ts";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "copy-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// normalizePath
+// ---------------------------------------------------------------------------
+
+describe("normalizePath", () => {
+  test("converts backslashes to forward slashes", () => {
+    expect(normalizePath("a\\b\\c")).toBe("a/b/c");
+  });
+
+  test("leaves forward slashes unchanged", () => {
+    expect(normalizePath("a/b/c")).toBe("a/b/c");
+  });
+
+  test("handles empty string", () => {
+    expect(normalizePath("")).toBe("");
+  });
+
+  test("handles mixed separators", () => {
+    expect(normalizePath("a\\b/c\\d")).toBe("a/b/c/d");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPathSafe
+// ---------------------------------------------------------------------------
+
+describe("isPathSafe", () => {
+  test("returns true for a child path", () => {
+    expect(isPathSafe("/base", "child")).toBe(true);
+  });
+
+  test("returns false for path traversal", () => {
+    expect(isPathSafe("/base", "../escape")).toBe(false);
+  });
+
+  test("returns true for current directory", () => {
+    expect(isPathSafe("/base", ".")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldExclude
+// ---------------------------------------------------------------------------
+
+describe("shouldExclude", () => {
+  test("excludes by exact name match", () => {
+    expect(shouldExclude("path/node_modules", "node_modules", ["node_modules"])).toBe(true);
+  });
+
+  test("excludes when relative path starts with exclusion", () => {
+    expect(shouldExclude("vendor/lib", "lib", ["vendor"])).toBe(true);
+  });
+
+  test("excludes by exact relative path match", () => {
+    expect(shouldExclude("vendor/lib", "lib", ["vendor/lib"])).toBe(true);
+  });
+
+  test("does not exclude non-matching paths", () => {
+    expect(shouldExclude("src/utils", "utils", ["vendor"])).toBe(false);
+  });
+
+  test("normalizes Windows paths for comparison", () => {
+    expect(shouldExclude("vendor\\lib", "lib", ["vendor"])).toBe(true);
+  });
+
+  test("returns false for empty exclude list", () => {
+    expect(shouldExclude("any/path", "path", [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureDir
+// ---------------------------------------------------------------------------
+
+describe("ensureDir", () => {
+  test("creates a new directory", async () => {
+    const dir = join(tmpDir, "new-dir");
+    await ensureDir(dir);
+    const stats = await stat(dir);
+    expect(stats.isDirectory()).toBe(true);
+  });
+
+  test("succeeds for an existing directory", async () => {
+    const dir = join(tmpDir, "existing");
+    await mkdir(dir);
+    await expect(ensureDir(dir)).resolves.toBeUndefined();
+  });
+
+  test("creates nested directories", async () => {
+    const dir = join(tmpDir, "a", "b", "c");
+    await ensureDir(dir);
+    const stats = await stat(dir);
+    expect(stats.isDirectory()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureDirSync
+// ---------------------------------------------------------------------------
+
+describe("ensureDirSync", () => {
+  test("creates a new directory synchronously", () => {
+    const dir = join(tmpDir, "sync-dir");
+    ensureDirSync(dir);
+    expect(() => ensureDirSync(dir)).not.toThrow();
+  });
+
+  test("creates nested directories synchronously", () => {
+    const dir = join(tmpDir, "sync-a", "sync-b");
+    ensureDirSync(dir);
+    expect(() => ensureDirSync(dir)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// copyFile
+// ---------------------------------------------------------------------------
+
+describe("copyFile", () => {
+  test("copies file content to destination", async () => {
+    const src = join(tmpDir, "source.txt");
+    const dest = join(tmpDir, "dest.txt");
+    await writeFile(src, "hello world");
+    await copyFile(src, dest);
+    expect(await readFile(dest, "utf-8")).toBe("hello world");
+  });
+
+  test("is a no-op when src and dest resolve to the same path", async () => {
+    const file = join(tmpDir, "same.txt");
+    await writeFile(file, "original");
+    await copyFile(file, file);
+    expect(await readFile(file, "utf-8")).toBe("original");
+  });
+
+  test("throws a descriptive error for non-existent source", async () => {
+    const src = join(tmpDir, "missing.txt");
+    const dest = join(tmpDir, "dest.txt");
+    await expect(copyFile(src, dest)).rejects.toThrow(/Failed to copy/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pathExists
+// ---------------------------------------------------------------------------
+
+describe("pathExists", () => {
+  test("returns true for an existing file", async () => {
+    const file = join(tmpDir, "exists.txt");
+    await writeFile(file, "x");
+    expect(await pathExists(file)).toBe(true);
+  });
+
+  test("returns true for an existing directory", async () => {
+    expect(await pathExists(tmpDir)).toBe(true);
+  });
+
+  test("returns false for a non-existent path", async () => {
+    expect(await pathExists(join(tmpDir, "nope"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDirectory
+// ---------------------------------------------------------------------------
+
+describe("isDirectory", () => {
+  test("returns true for a directory", async () => {
+    expect(await isDirectory(tmpDir)).toBe(true);
+  });
+
+  test("returns false for a file", async () => {
+    const file = join(tmpDir, "file.txt");
+    await writeFile(file, "x");
+    expect(await isDirectory(file)).toBe(false);
+  });
+
+  test("returns false for a non-existent path", async () => {
+    expect(await isDirectory(join(tmpDir, "nope"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFileEmpty
+// ---------------------------------------------------------------------------
+
+describe("isFileEmpty", () => {
+  test("returns true for a 0-byte file", async () => {
+    const file = join(tmpDir, "empty.txt");
+    await writeFile(file, "");
+    expect(await isFileEmpty(file)).toBe(true);
+  });
+
+  test("returns true for a whitespace-only file", async () => {
+    const file = join(tmpDir, "ws.txt");
+    await writeFile(file, "   \n  \t  ");
+    expect(await isFileEmpty(file)).toBe(true);
+  });
+
+  test("returns false for a file with content", async () => {
+    const file = join(tmpDir, "content.txt");
+    await writeFile(file, "hello");
+    expect(await isFileEmpty(file)).toBe(false);
+  });
+
+  test("returns true for a non-existent file", async () => {
+    expect(await isFileEmpty(join(tmpDir, "nope"))).toBe(true);
+  });
+
+  test("returns false for a large file with content", async () => {
+    const file = join(tmpDir, "large.txt");
+    await writeFile(file, "x".repeat(2048));
+    expect(await isFileEmpty(file)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// copyDir
+// ---------------------------------------------------------------------------
+
+describe("copyDir", () => {
+  test("copies a directory recursively", async () => {
+    const src = join(tmpDir, "src");
+    const dest = join(tmpDir, "dest");
+
+    await mkdir(join(src, "sub"), { recursive: true });
+    await writeFile(join(src, "a.txt"), "aaa");
+    await writeFile(join(src, "sub", "b.txt"), "bbb");
+
+    await copyDir(src, dest);
+
+    expect(await readFile(join(dest, "a.txt"), "utf-8")).toBe("aaa");
+    expect(await readFile(join(dest, "sub", "b.txt"), "utf-8")).toBe("bbb");
+  });
+
+  test("respects the exclude option", async () => {
+    const src = join(tmpDir, "src");
+    const dest = join(tmpDir, "dest");
+
+    await mkdir(join(src, "keep"), { recursive: true });
+    await mkdir(join(src, "skip"), { recursive: true });
+    await writeFile(join(src, "keep", "a.txt"), "keep");
+    await writeFile(join(src, "skip", "b.txt"), "skip");
+
+    await copyDir(src, dest, { exclude: ["skip"] });
+
+    expect(await pathExists(join(dest, "keep", "a.txt"))).toBe(true);
+    expect(await pathExists(join(dest, "skip"))).toBe(false);
+  });
+
+  test("skips opposite-platform scripts by default", async () => {
+    const src = join(tmpDir, "src");
+    const dest = join(tmpDir, "dest");
+
+    await mkdir(src, { recursive: true });
+    await writeFile(join(src, "setup.sh"), "#!/bin/sh\necho hi");
+    await writeFile(join(src, "setup.ps1"), "Write-Host hi");
+
+    await copyDir(src, dest);
+
+    if (process.platform !== "win32") {
+      expect(await pathExists(join(dest, "setup.sh"))).toBe(true);
+      expect(await pathExists(join(dest, "setup.ps1"))).toBe(false);
+    }
+  });
+
+  test("can disable opposite-script skipping", async () => {
+    const src = join(tmpDir, "src");
+    const dest = join(tmpDir, "dest");
+
+    await mkdir(src, { recursive: true });
+    await writeFile(join(src, "setup.sh"), "#!/bin/sh");
+    await writeFile(join(src, "setup.ps1"), "Write-Host");
+
+    await copyDir(src, dest, { skipOppositeScripts: false });
+
+    expect(await pathExists(join(dest, "setup.sh"))).toBe(true);
+    expect(await pathExists(join(dest, "setup.ps1"))).toBe(true);
+  });
+
+  test("dereferences symlinks into regular files", async () => {
+    const src = join(tmpDir, "src");
+    const dest = join(tmpDir, "dest");
+
+    await mkdir(src, { recursive: true });
+    await writeFile(join(src, "real.txt"), "linked content");
+    await symlink(join(src, "real.txt"), join(src, "link.txt"));
+
+    await copyDir(src, dest);
+
+    expect(await readFile(join(dest, "link.txt"), "utf-8")).toBe(
+      "linked content",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// copyDirNonDestructive
+// ---------------------------------------------------------------------------
+
+describe("copyDirNonDestructive", () => {
+  test("does not overwrite existing files", async () => {
+    const src = join(tmpDir, "src");
+    const dest = join(tmpDir, "dest");
+
+    await mkdir(src, { recursive: true });
+    await mkdir(dest, { recursive: true });
+    await writeFile(join(src, "a.txt"), "new");
+    await writeFile(join(dest, "a.txt"), "old");
+
+    await copyDirNonDestructive(src, dest);
+
+    expect(await readFile(join(dest, "a.txt"), "utf-8")).toBe("old");
+  });
+
+  test("copies files that do not exist at destination", async () => {
+    const src = join(tmpDir, "src");
+    const dest = join(tmpDir, "dest");
+
+    await mkdir(src, { recursive: true });
+    await mkdir(dest, { recursive: true });
+    await writeFile(join(src, "new.txt"), "new content");
+
+    await copyDirNonDestructive(src, dest);
+
+    expect(await readFile(join(dest, "new.txt"), "utf-8")).toBe("new content");
+  });
+});

--- a/tests/services/system/detect.test.ts
+++ b/tests/services/system/detect.test.ts
@@ -1,0 +1,244 @@
+import {
+  test,
+  expect,
+  describe,
+  afterEach,
+  beforeEach,
+} from "bun:test";
+import {
+  isCommandInstalled,
+  getCommandPath,
+  getCommandVersion,
+  isWindows,
+  isMacOS,
+  isLinux,
+  getScriptExtension,
+  getOppositeScriptExtension,
+  isWslInstalled,
+  supportsColor,
+  supportsTrueColor,
+  supports256Color,
+} from "@/services/system/detect.ts";
+
+// ---------------------------------------------------------------------------
+// Platform detection
+// ---------------------------------------------------------------------------
+
+describe("platform detection", () => {
+  test("isLinux matches process.platform", () => {
+    expect(isLinux()).toBe(process.platform === "linux");
+  });
+
+  test("isWindows matches process.platform", () => {
+    expect(isWindows()).toBe(process.platform === "win32");
+  });
+
+  test("isMacOS matches process.platform", () => {
+    expect(isMacOS()).toBe(process.platform === "darwin");
+  });
+
+  test("exactly one platform flag is true", () => {
+    const flags = [isLinux(), isWindows(), isMacOS()];
+    expect(flags.filter(Boolean).length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Script extensions
+// ---------------------------------------------------------------------------
+
+describe("script extensions", () => {
+  test("getScriptExtension returns .sh on non-Windows", () => {
+    if (process.platform !== "win32") {
+      expect(getScriptExtension()).toBe(".sh");
+    }
+  });
+
+  test("getOppositeScriptExtension returns .ps1 on non-Windows", () => {
+    if (process.platform !== "win32") {
+      expect(getOppositeScriptExtension()).toBe(".ps1");
+    }
+  });
+
+  test("extensions are complementary", () => {
+    const ext = getScriptExtension();
+    const opposite = getOppositeScriptExtension();
+    expect(ext).not.toBe(opposite);
+    expect([".sh", ".ps1"]).toContain(ext);
+    expect([".sh", ".ps1"]).toContain(opposite);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Command detection
+// ---------------------------------------------------------------------------
+
+describe("isCommandInstalled", () => {
+  test("returns true for a known command (ls)", () => {
+    expect(isCommandInstalled("ls")).toBe(true);
+  });
+
+  test("returns false for a non-existent command", () => {
+    expect(isCommandInstalled("__no_such_cmd_xyzzy__")).toBe(false);
+  });
+});
+
+describe("getCommandPath", () => {
+  test("returns an absolute path for a known command", () => {
+    const p = getCommandPath("ls");
+    expect(p).not.toBeNull();
+    expect(p!.startsWith("/")).toBe(true);
+  });
+
+  test("returns null for a non-existent command", () => {
+    expect(getCommandPath("__no_such_cmd_xyzzy__")).toBeNull();
+  });
+});
+
+describe("getCommandVersion", () => {
+  test("returns a version string for bun", () => {
+    const version = getCommandVersion("bun");
+    expect(version).not.toBeNull();
+    expect(version!).toContain(".");
+  });
+
+  test("returns null for a non-existent command", () => {
+    expect(getCommandVersion("__no_such_cmd_xyzzy__")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WSL detection
+// ---------------------------------------------------------------------------
+
+describe("isWslInstalled", () => {
+  test("returns false on non-Windows", () => {
+    if (process.platform !== "win32") {
+      expect(isWslInstalled()).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Color support
+// ---------------------------------------------------------------------------
+
+describe("supportsColor", () => {
+  const origNoColor = process.env.NO_COLOR;
+
+  afterEach(() => {
+    if (origNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = origNoColor;
+    }
+  });
+
+  test("returns false when NO_COLOR is set", () => {
+    process.env.NO_COLOR = "1";
+    expect(supportsColor()).toBe(false);
+  });
+
+  test("returns true when NO_COLOR is unset", () => {
+    delete process.env.NO_COLOR;
+    expect(supportsColor()).toBe(true);
+  });
+});
+
+describe("supportsTrueColor", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ["NO_COLOR", "COLORTERM", "TERM_PROGRAM", "TERM"]) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  test("returns false when NO_COLOR is set", () => {
+    process.env.NO_COLOR = "";
+    expect(supportsTrueColor()).toBe(false);
+  });
+
+  test("returns true when COLORTERM is truecolor", () => {
+    process.env.COLORTERM = "truecolor";
+    expect(supportsTrueColor()).toBe(true);
+  });
+
+  test("returns true when COLORTERM is 24bit", () => {
+    process.env.COLORTERM = "24bit";
+    expect(supportsTrueColor()).toBe(true);
+  });
+
+  test("returns false for Apple_Terminal", () => {
+    process.env.TERM_PROGRAM = "Apple_Terminal";
+    expect(supportsTrueColor()).toBe(false);
+  });
+
+  test("returns true for known truecolor terminals", () => {
+    for (const term of ["iTerm.app", "hyper", "WezTerm", "alacritty", "kitty", "ghostty"]) {
+      process.env.TERM_PROGRAM = term;
+      expect(supportsTrueColor()).toBe(true);
+    }
+  });
+
+  test("returns true when TERM contains 24bit", () => {
+    process.env.TERM = "xterm-24bit";
+    expect(supportsTrueColor()).toBe(true);
+  });
+
+  test("returns true when TERM contains direct", () => {
+    process.env.TERM = "xterm-direct";
+    expect(supportsTrueColor()).toBe(true);
+  });
+
+  test("returns false when no truecolor indicators present", () => {
+    expect(supportsTrueColor()).toBe(false);
+  });
+});
+
+describe("supports256Color", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ["TERM", "NO_COLOR", "COLORTERM", "TERM_PROGRAM"]) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  test("returns true when TERM includes 256color", () => {
+    process.env.TERM = "xterm-256color";
+    expect(supports256Color()).toBe(true);
+  });
+
+  test("returns true when supportsTrueColor is true", () => {
+    process.env.COLORTERM = "truecolor";
+    expect(supports256Color()).toBe(true);
+  });
+
+  test("returns false with basic TERM and no truecolor", () => {
+    process.env.TERM = "xterm";
+    expect(supports256Color()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the `ctx.session()` API with `ctx.stage()`, which auto-initializes provider-specific clients and sessions before the callback runs. Graph topology (sequential, parallel, fan-in) is now automatically inferred from JavaScript execution order via a frontier tracker, removing the need for manual `dependsOn` declarations.

## Key Changes

### Breaking Changes

- **`ctx.session()` → `ctx.stage()`**: The stage callback now receives pre-initialized `s.client` and `s.session` (provider SDK objects) instead of `s.serverUrl`. New signature:
  ```ts
  ctx.stage({ name }, clientOpts, sessionOpts, async (s) => { ... })
  ```
- **`dependsOn` removed**: `SessionRunOptions.dependsOn` is gone. Graph edges are inferred automatically.
- **`serverUrl` removed from `SessionContext`**: Use `s.client` / `s.session` directly.

### New Features

- **Auto-init provider clients/sessions** (`executor.ts`): The runtime creates and tears down provider-specific SDK objects (CopilotClient, OpenCode client, ClaudeClientWrapper) around each stage callback, with cleanup in a `finally` block.
- **Frontier-based graph inference** (`graph-inference.ts`): New `GraphFrontierTracker` class automatically determines parent-child vs. sibling edges from JS execution order — `await` produces sequential edges, `Promise.all` produces parallel/fan-in edges.
- **Type-safe agent generics**: `WorkflowContext<A>`, `SessionContext<A>`, `WorkflowDefinition<A>`, and `WorkflowBuilder<A>` are now generic over `AgentType`, giving narrowed `client`/`session`/`agent` types within callbacks.
- **Provider type maps** (`types.ts`): Exported `StageClientOptions<A>`, `StageSessionOptions<A>`, `ProviderClient<A>`, `ProviderSession<A>` resolve to the correct SDK types per agent.
- **Global workflow type resolution** (`workflows.ts`): `installGlobalWorkflows` now calls `setupWorkflowTypes`, which symlinks `node_modules/@bastani/atomic` (and `@types/bun`) into the destination and generates a `tsconfig.json` — zero-config TypeScript for workflow authors.

### Other Changes

- Updated all example workflows (`.atomic/workflows/`) to the new `ctx.stage()` API
- Updated `workflow-creator` skill docs and references
- Added unit tests for `GraphFrontierTracker`, `path-root-guard`, `detect`, and `copy` modules
- Excluded `src/services/system/workflows.ts` from test coverage (I/O-heavy)
- Bumped `@opencode-ai/plugin` to 1.4.3

## Migration

```ts
// Before
ctx.session({ name: "step" }, async (s) => {
  await createClaudeSession({ paneId: s.paneId });
  await claudeQuery({ paneId: s.paneId, prompt: s.userPrompt });
});

// After
defineWorkflow<"claude">({ ... })
  .run(async (ctx) => {
    ctx.stage({ name: "step" }, {}, {}, async (s) => {
      await s.session.query(s.userPrompt); // s.session: ClaudeSessionWrapper
    });
  });
```