### PR TITLE
chore(release): bump version to v0.5.1-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.0",
+  "version": "0.5.1-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.0` to `0.5.1-0` in preparation for the next patch release.

## Changes

- `package.json`: version `0.5.0` → `0.5.1-0`

## Notes

This is a prerelease (`-0` suffix). The full `0.5.1` release will follow once changes are validated. After merging into `main`, the GitHub Release will be created automatically and the package will be published to npm.

## Test plan

- [ ] CI passes
- [ ] Version `0.5.1-0` published to npm after merge