### PR TITLE
chore(release): bump version to v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.1-0",
+  "version": "0.5.1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.1-0` to the stable release `0.5.1`.

## Changes

- `package.json`: bumped `version` from `0.5.1-0` → `0.5.1`

## Test plan

- [ ] CI passes
- [ ] Verify `version` in `package.json` is `0.5.1`