### PR TITLE
chore(release): bump version to v0.5.2-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.1",
+  "version": "0.5.2-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump to `v0.5.2-0`, cutting a new prerelease to ship the breaking workflow SDK refactor from #572.

## Key Changes

- **Version bump**: `package.json` updated from `0.5.1` → `0.5.2-0`
- Includes workflow SDK hotfix (#572):
  - **refactor(workflow-sdk)!**: Replaced the Bun.plugin source-rewriting resolver with a proper npm dependency model — workflows must now install `@bastani/atomic` as an explicit dependency
  - Moved SDK barrel from `src/sdk/workflows.ts` → `src/sdk/workflows/index.ts`
  - Bundled `ralph` as a built-in workflow under `src/sdk/workflows/builtin/`
  - Added `discoverBuiltinWorkflows()` with local → global → builtin resolution precedence
  - Extracted `executor-entry.ts` to fix Bun dual-module-identity issue
  - Improved error handling in executor (panel notifications, window cleanup on stage failure)
  - Removed `setupWorkflowTypes` service (symlink-based resolution no longer needed)
  - Renamed example workflows: `hello` → `hello-world`, `hello-parallel` → `parallel-hello-world`
  - Updated `workflow-creator` skill docs to enforce clear boundary between Atomic primitives and native SDK imports

## Breaking Changes

> **BREAKING**: Workflows can no longer rely on the implicit SDK resolver to resolve `@bastani/atomic/workflows`. Workflows must have `@bastani/atomic` installed as a direct dependency in their project.

```sh
# In your workflow project directory:
bun add @bastani/atomic
```