### PR TITLE
chore(release): bump version to v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.2-0",
+  "version": "0.5.2",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `0.5.2-0` to the stable `0.5.2` release by updating the version in `package.json`.

## Changes

- `package.json`: version `0.5.2-0` → `0.5.2`

## Test plan

- [ ] CI passes
- [ ] Version is correctly set in `package.json`