### PR TITLE
chore(release): bump version to v0.5.3-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.2",
+  "version": "0.5.3-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.2` to `0.5.3-0` as a prerelease ahead of the `0.5.3` stable release.

## Changes

- `package.json`: version `0.5.2` → `0.5.3-0`

## Test plan

- [ ] CI checks pass
- [ ] Version is correct in published package