### PR TITLE
chore(release): bump version to v0.5.3-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.3-0",
+  "version": "0.5.3-1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the prerelease version from `v0.5.3-0` to `v0.5.3-1` in `package.json`.

## Changes

- `package.json`: version `0.5.3-0` → `0.5.3-1`

## Test plan

- [x] Typecheck passes
- [x] All 753 tests pass