### PR TITLE
chore(release): bump version to v0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.3-1",
+  "version": "0.5.3",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes `v0.5.3` from prerelease to stable by bumping `package.json` from `0.5.3-1` to `0.5.3`.

## Changes in this release

- **feat(install)**: Parallelize setup phases and overhaul progress UI ([#577](https://github.com/flora131/atomic/pull/577))
  - Refactored auto-sync install into two parallel phases (core tools, then npm-dependent tasks) for faster first-run setup
  - Replaced bracketed step counter with an OpenCode-inspired progress bar using Catppuccin colors with true-color/256-color/basic ANSI fallback
  - Extracted block banner into `src/theme/logo.ts`
  - Fixed SDK client option spread order so server URLs always take precedence
- **fix(sdk)**: Add conditional exports and build pipeline for non-Bun consumers ([#575](https://github.com/flora131/atomic/pull/575))

## Test plan

- [x] All 753 tests pass
- [x] Type checks pass
- [x] Lint checks pass