### PR TITLE
feat(ui): shared Catppuccin palette, gradient progress bars, and streamlined init

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -57,27 +57,53 @@ function Get-Bar {
         [int]$Total,
         [ValidateSet("progress", "success", "error")][string]$State = "progress"
     )
-    $width = 18
+    $width = 30
     $filled = [Math]::Min($width, [int]($Completed * $width / [Math]::Max(1, $Total)))
     $empty  = $width - $filled
-    $fill = switch ($State) {
-        "success" { $script:C_GREEN }
-        "error"   { $script:C_RED }
-        default   { $script:C_BLUE }
+    $bar = ""
+
+    $hasTrueColor = ($env:COLORTERM -eq "truecolor" -or $env:COLORTERM -eq "24bit")
+    if ($hasTrueColor -and $filled -gt 0 -and ($null -eq $env:NO_COLOR -or $env:NO_COLOR -eq "")) {
+        switch ($State) {
+            "success" { $sr=126; $sg=201; $sb=138; $er=166; $eg=227; $eb=161 }
+            "error"   { $sr=224; $sg=108; $sb=136; $er=243; $eg=139; $eb=168 }
+            default   { $sr=242; $sg=196; $sb=120; $er=249; $eg=226; $eb=175 }
+        }
+        for ($i = 0; $i -lt $filled; $i++) {
+            if ($filled -gt 1) {
+                $t = $i / ($filled - 1)
+            } else {
+                $t = 1.0
+            }
+            $r = [int]($sr + ($er - $sr) * $t)
+            $g = [int]($sg + ($eg - $sg) * $t)
+            $b = [int]($sb + ($eb - $sb) * $t)
+            $bar += "`e[38;2;${r};${g};${b}m■"
+        }
+        $bar += "`e[0m"
+    } else {
+        $fill = switch ($State) {
+            "success" { $script:C_GREEN }
+            "error"   { $script:C_RED }
+            default   { $script:C_YELLOW }
+        }
+        $bar = "${fill}$('■' * $filled)${C_RESET}"
     }
-    return "${C_BOLD}${fill}$('█' * $filled)${C_RESET}${C_DIM}$('░' * $empty)${C_RESET}"
+
+    return "${bar}${C_DIM}$('･' * $empty)${C_RESET}"
 }
 
 function Format-Line {
     param(
         [string]$Glyph,
-        [int]$StepNo,
         [int]$Fill,
         [ValidateSet("progress", "success", "error")][string]$State = "progress",
         [string]$Label
     )
     $bar = Get-Bar -Completed $Fill -Total $script:StepTotal -State $State
-    return "  $Glyph  $bar  ${C_DIM}$StepNo/$($script:StepTotal)${C_RESET}  $Label"
+    $pct = if ($script:StepTotal -gt 0) { [int]($Fill * 100 / $script:StepTotal) } else { 0 }
+    $pctStr = $pct.ToString().PadLeft(3)
+    return "  $Glyph  $bar  ${C_DIM}${pctStr}%${C_RESET}  $Label"
 }
 
 # Run a ScriptBlock with a spinner; capture output; surface only on failure.
@@ -132,7 +158,7 @@ function Invoke-Step {
     try {
         while ($job.State -eq 'Running') {
             $f = $frames[$i % 10]
-            $line = Format-Line -Glyph "${C_BLUE}$f${C_RESET}" -StepNo $stepNo -Fill $completed -State "progress" -Label $Label
+            $line = Format-Line -Glyph "${C_BLUE}$f${C_RESET}" -Fill $completed -State "progress" -Label $Label
             [Console]::Write("`r`e[2K$line")
             Start-Sleep -Milliseconds 80
             $i++
@@ -142,11 +168,11 @@ function Invoke-Step {
         [Console]::Write("`r`e[2K")
         if ($succeeded) {
             $script:StepIndex++
-            $line = Format-Line -Glyph "${C_GREEN}✓${C_RESET}" -StepNo $stepNo -Fill $script:StepIndex -State "success" -Label "${C_DIM}$Label${C_RESET}"
+            $line = Format-Line -Glyph "${C_GREEN}✓${C_RESET}" -Fill $script:StepIndex -State "success" -Label "${C_DIM}$Label${C_RESET}"
             Write-Host $line
             return $true
         } else {
-            $line = Format-Line -Glyph "${C_RED}✗${C_RESET}" -StepNo $stepNo -Fill $completed -State "error" -Label $Label
+            $line = Format-Line -Glyph "${C_RED}✗${C_RESET}" -Fill $completed -State "error" -Label $Label
             Write-Host $line
             if (Test-Path $logFile) {
                 Get-Content $logFile -Tail 15 | ForEach-Object {

--- a/install.sh
+++ b/install.sh
@@ -53,45 +53,67 @@ info()  { printf '  %sinfo%s %s\n' "$C_CYAN" "$C_RESET" "$*"; }
 warn()  { printf '  %swarn%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
 error() { printf '  %serror%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; }
 
-# Render a bracketed progress bar at the given completion ratio.
+# Render a slim progress bar with a continuous color gradient.
 #
 # Args: $1 = completed, $2 = total, $3 = state (progress|success|error)
 #
-# The filled segment carries the state colour (blue/green/red). The
-# empty track stays dim so only the active portion telegraphs outcome.
+# Uses true-color per-character gradient (Catppuccin palette) when the
+# terminal supports it; falls back to a single ANSI colour otherwise.
+# The filled segment uses ■ (slim) and the empty track uses ･ (dot).
 render_bar() {
     local completed=$1 total=$2 state=${3:-progress}
-    local width=18
-    local filled=$(( completed * width / total ))
+    local width=30
+    local filled=0
+    (( total > 0 )) && filled=$(( completed * width / total ))
     (( filled > width )) && filled=$width
     local empty=$(( width - filled ))
-    local fill_color
-    case "$state" in
-        success) fill_color="$C_GREEN" ;;
-        error)   fill_color="$C_RED"   ;;
-        *)       fill_color="$C_BLUE"  ;;
-    esac
     local bar="" i
-    for ((i=0; i<filled; i++)); do bar+="█"; done
+
+    if [[ -z "${NO_COLOR:-}" ]] && [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]] && (( filled > 0 )); then
+        local sr sg sb er eg eb
+        case "$state" in
+            success) sr=126 sg=201 sb=138 er=166 eg=227 eb=161 ;;
+            error)   sr=224 sg=108 sb=136 er=243 eg=139 eb=168 ;;
+            *)       sr=242 sg=196 sb=120 er=249 eg=226 eb=175 ;;
+        esac
+        for ((i=0; i<filled; i++)); do
+            if (( filled > 1 )); then
+                local r=$(( sr + (er - sr) * i / (filled - 1) ))
+                local g=$(( sg + (eg - sg) * i / (filled - 1) ))
+                local b=$(( sb + (eb - sb) * i / (filled - 1) ))
+            else
+                local r=$er g=$eg b=$eb
+            fi
+            bar+=$'\033'"[38;2;${r};${g};${b}m■"
+        done
+        bar+=$'\033[0m'
+    else
+        local fill_color
+        case "$state" in
+            success) fill_color="$C_GREEN" ;;
+            error)   fill_color="$C_RED"   ;;
+            *)       fill_color="$C_YELLOW" ;;
+        esac
+        for ((i=0; i<filled; i++)); do bar+="■"; done
+        bar="${fill_color}${bar}${C_RESET}"
+    fi
+
     local rest=""
-    for ((i=0; i<empty; i++)); do rest+="░"; done
-    printf '%s%s%s%s%s%s%s' "$C_BOLD" "$fill_color" "$bar" "$C_RESET" "$C_DIM" "$rest" "$C_RESET"
+    for ((i=0; i<empty; i++)); do rest+="･"; done
+    printf '%s%s%s%s' "$bar" "$C_DIM" "$rest" "$C_RESET"
 }
 
 # Render the full status line (no newline).
 #
-# Args: $1 = glyph, $2 = stepno (1-indexed), $3 = fill (completed count),
-#       $4 = state (progress|success|error), $5 = label
-#
-# `stepno` and `fill` are separate so we can show "step 2/3" in the
-# counter while the bar is still empty (fill=1) during the spinner, and
-# flip to fill=2 only once the step actually succeeds.
+# Args: $1 = glyph, $2 = fill (completed count),
+#       $3 = state (progress|success|error), $4 = label
 render_line() {
-    local glyph=$1 stepno=$2 fill=$3 state=$4 label=$5
-    local bar
+    local glyph=$1 fill=$2 state=$3 label=$4
+    local bar pct=0
     bar=$(render_bar "$fill" "$STEP_TOTAL" "$state")
-    printf '  %s  %s  %s%d/%d%s  %s' \
-        "$glyph" "$bar" "$C_DIM" "$stepno" "$STEP_TOTAL" "$C_RESET" "$label"
+    (( STEP_TOTAL > 0 )) && pct=$(( fill * 100 / STEP_TOTAL ))
+    printf '  %s  %s  %s%3d%%%s  %s' \
+        "$glyph" "$bar" "$C_DIM" "$pct" "$C_RESET" "$label"
 }
 
 # Run a command with a spinner; capture output; surface only on failure.
@@ -129,7 +151,7 @@ run_step() {
     while kill -0 "$pid" 2>/dev/null; do
         local f="${frames[i % 10]}"
         printf '\r\033[2K'
-        render_line "${C_BLUE}${f}${C_RESET}" "$stepno" "$completed" "progress" "$label"
+        render_line "${C_BLUE}${f}${C_RESET}" "$completed" "progress" "$label"
         i=$((i + 1))
         sleep 0.08
     done
@@ -139,12 +161,12 @@ run_step() {
     printf '\r\033[2K'
     if [[ "$rc" == "0" ]]; then
         STEP_INDEX=$((STEP_INDEX + 1))
-        render_line "${C_GREEN}✓${C_RESET}" "$stepno" "$STEP_INDEX" "success" "${C_DIM}${label}${C_RESET}"
+        render_line "${C_GREEN}✓${C_RESET}" "$STEP_INDEX" "success" "${C_DIM}${label}${C_RESET}"
         printf '\n\033[?25h'  # newline + show cursor
         rm -f "$log"
         return 0
     else
-        render_line "${C_RED}✗${C_RESET}" "$stepno" "$completed" "error" "$label"
+        render_line "${C_RED}✗${C_RESET}" "$completed" "error" "$label"
         printf '\n\033[?25h'
         if [[ -s "$log" ]]; then
             # Indent and dim the final ~15 lines of captured output

--- a/src/commands/cli/init/index.ts
+++ b/src/commands/cli/init/index.ts
@@ -1,5 +1,8 @@
 /**
  * Init command - Interactive setup flow for atomic CLI
+ *
+ * Uses Catppuccin Mocha palette for visual hierarchy and brand alignment.
+ * All color output respects the NO_COLOR environment variable.
  */
 
 import {
@@ -45,6 +48,7 @@ import {
   hasProjectOnboardingFiles,
 } from "./onboarding.ts";
 import { displayBlockBanner } from "@/theme/logo.ts";
+import { createPainter } from "@/theme/colors.ts";
 
 /**
  * Thrown when the user cancels an interactive prompt during init.
@@ -91,6 +95,7 @@ export {
  */
 export async function initCommand(options: InitOptions = {}): Promise<void> {
   const { showBanner = true, configNotFoundMessage, callerHandlesExit = false } = options;
+  const paint = createPainter();
 
   /** Exit-or-throw helper: when a caller (e.g. chatCommand auto-init) sets
    *  `callerHandlesExit`, we throw so the caller can handle the cancellation.
@@ -107,30 +112,23 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     displayBlockBanner();
   }
 
-  // Show intro
-  intro("Atomic: Automated Procedures and Memory for AI Coding Agents");
-  log.message(
-    "Enable multi-hour autonomous coding sessions with the Ralph Wiggum\nMethod using research, plan, implement methodology."
-  );
+  intro(paint("accent", "Configure agent skills & source control", { bold: true }));
 
-  // Show config not found message if provided (after intro, before agent selection)
   if (configNotFoundMessage) {
     log.info(configNotFoundMessage);
   }
 
-  // Select agent
+  // ── Agent selection ────────────────────────────────────────────────
   let agentKey: AgentKey;
 
   if (options.preSelectedAgent) {
-    // Pre-selected agent - validate and skip selection prompt
     if (!isValidAgent(options.preSelectedAgent)) {
       cancel(`Unknown agent: ${options.preSelectedAgent}`);
       exitOrThrow(1, `Unknown agent: ${options.preSelectedAgent}`);
     }
     agentKey = options.preSelectedAgent;
-    log.info(`Configuring ${AGENT_CONFIG[agentKey].name}...`);
+    log.info(`${paint("accent", "→")} Agent: ${paint("text", AGENT_CONFIG[agentKey].name, { bold: true })}`);
   } else {
-    // Interactive selection
     const agentKeys = getAgentKeys();
     const agentOptions = agentKeys.map((key) => ({
       value: key,
@@ -139,12 +137,12 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     }));
 
     const selectedAgent = await select({
-      message: "Select a coding agent to configure:",
+      message: "Which coding agent?",
       options: agentOptions,
     });
 
     if (isCancel(selectedAgent)) {
-      cancel("Operation cancelled.");
+      cancel("Cancelled.");
       exitOrThrow(0);
     }
 
@@ -152,104 +150,87 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   }
   const agent = AGENT_CONFIG[agentKey];
   const targetDir = process.cwd();
-
-  // Auto-confirm mode for CI/testing
   const autoConfirm = options.yes ?? false;
 
-  // Select source control type (after agent selection)
+  // ── SCM selection ──────────────────────────────────────────────────
   let scmType: SourceControlType;
 
   if (options.preSelectedScm) {
-    // Pre-selected SCM - validate and skip selection prompt
     if (!isValidScm(options.preSelectedScm)) {
       cancel(`Unknown source control: ${options.preSelectedScm}`);
       exitOrThrow(1, `Unknown source control: ${options.preSelectedScm}`);
     }
     scmType = options.preSelectedScm;
-    log.info(`Using ${SCM_CONFIG[scmType].displayName} for source control...`);
+    log.info(`${paint("accent", "→")} SCM: ${paint("text", SCM_CONFIG[scmType].displayName, { bold: true })}`);
   } else if (autoConfirm) {
-    // Auto-confirm mode defaults to GitHub
     scmType = "github";
-    log.info("Defaulting to GitHub/Git for source control...");
+    log.info(`${paint("accent", "→")} SCM: ${paint("text", "GitHub / Git", { bold: true })} ${paint("dim", "(default)")}`);
   } else {
-    // Interactive selection
     const scmOptions = getScmKeys().map((key) => ({
       value: key,
       label: SCM_CONFIG[key].displayName,
-      hint: `Uses ${SCM_CONFIG[key].cliTool} + ${SCM_CONFIG[key].reviewSystem}`,
+      hint: `${SCM_CONFIG[key].cliTool} + ${SCM_CONFIG[key].reviewSystem}`,
     }));
 
     const selectedScm = await select({
-      message: "Select your source control system:",
+      message: "Which source control?",
       options: scmOptions,
     });
 
     if (isCancel(selectedScm)) {
-      cancel("Operation cancelled.");
+      cancel("Cancelled.");
       exitOrThrow(0);
     }
 
     scmType = selectedScm as SourceControlType;
   }
 
-  // Show Phabricator configuration warning if Sapling is selected
+  // Sapling-specific warning
   if (scmType === "sapling") {
     const arcconfigPath = join(targetDir, ".arcconfig");
     const hasArcconfig = await pathExists(arcconfigPath);
 
     if (!hasArcconfig) {
       log.warn(
-        "Note: Sapling + Phabricator requires .arcconfig in your repository root.\n" +
-          "See: https://www.phacility.com/phabricator/ for Phabricator setup."
+        `Sapling + Phabricator requires ${paint("text", ".arcconfig", { bold: true })} in your repo root.\n` +
+        `${paint("dim", "See: https://www.phacility.com/phabricator/")}`
       );
     }
   }
 
-  // Confirm directory
-  let confirmDir: boolean | symbol = true;
-  if (!autoConfirm) {
-    confirmDir = await confirm({
-      message: `Configure ${agent.name} source control skills in ${targetDir}?`,
-      initialValue: true,
-    });
-
-    if (isCancel(confirmDir)) {
-      cancel("Operation cancelled.");
-      exitOrThrow(0);
-    }
-
-    if (!confirmDir) {
-      cancel("Operation cancelled.");
-      exitOrThrow(0);
-    }
-  }
-
-  // Check if folder already exists
+  // ── Preflight summary ──────────────────────────────────────────────
   const targetFolder = join(targetDir, agent.folder);
   const folderExists = await pathExists(targetFolder);
+  const configAction = folderExists ? "update" : "create";
 
-  if (folderExists && !autoConfirm) {
-    const update = await confirm({
-      message: `${agent.folder} already exists. Update source control skills?`,
+  if (!autoConfirm) {
+    const summaryLines = [
+      `${paint("dim", "Agent")}   ${paint("text", agent.name, { bold: true })}`,
+      `${paint("dim", "SCM")}     ${paint("text", SCM_CONFIG[scmType].displayName, { bold: true })}`,
+      `${paint("dim", "Target")}  ${paint("text", targetDir)}`,
+      `${paint("dim", "Action")}  ${paint(folderExists ? "warning" : "success", configAction)}`,
+    ];
+    note(summaryLines.join("\n"), paint("accent", "Setup", { bold: true }));
+
+    const shouldProceed = await confirm({
+      message: folderExists
+        ? `${agent.folder} exists — update source control skills?`
+        : "Proceed with setup?",
       initialValue: true,
-      active: "Yes, update",
-      inactive: "No, cancel",
     });
 
-    if (isCancel(update)) {
-      cancel("Operation cancelled.");
-      exitOrThrow(0);
-    }
-
-    if (!update) {
-      cancel("Operation cancelled. Existing config preserved.");
+    if (isCancel(shouldProceed) || !shouldProceed) {
+      cancel("Cancelled.");
       exitOrThrow(0);
     }
   }
 
-  // Configure source control skills with spinner
+  // ── Configure ──────────────────────────────────────────────────────
   const s = spinner();
-  s.start("Configuring source control skills...");
+  s.start("Configuring skills…");
+
+  let skillsInstalled = false;
+  let skillsSkipReason = "";
 
   try {
     const configRoot = getConfigRoot();
@@ -289,7 +270,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     });
     upsertTrustedWorkspacePath(resolve(targetDir), agentKey);
 
-    s.stop("Source control skills configured successfully!");
+    s.stop(paint("success", "✓", { bold: true }) + " Skills configured");
 
     // Install SCM-specific skill variants locally for the active agent via
     // `npx skills add` (best-effort: a failure is surfaced as a warning).
@@ -303,7 +284,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       const skillsLabel = skillsToInstall.join(", ");
       const skillsSpinner = spinner();
       skillsSpinner.start(
-        `Installing ${skillsLabel} locally for ${agent.name}...`,
+        `Installing ${paint("text", skillsLabel, { bold: true })}…`,
       );
       const skillsResult = await installLocalScmSkills({
         scmType,
@@ -311,39 +292,60 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
         cwd: targetDir,
       });
       if (skillsResult.success) {
+        skillsInstalled = true;
         skillsSpinner.stop(
-          `Installed ${skillsLabel} locally for ${agent.name}`,
+          paint("success", "✓", { bold: true }) + ` ${skillsLabel} installed`,
         );
       } else {
+        skillsSkipReason = skillsResult.details;
         skillsSpinner.stop(
-          `Skipped local ${skillsLabel} install (${skillsResult.details})`,
+          paint("warning", "○") + ` ${skillsLabel} skipped ${paint("dim", `(${skillsResult.details})`)}`,
         );
       }
     }
   } catch (error) {
-    s.stop("Failed to configure source control skills");
+    s.stop(paint("error", "✗", { bold: true }) + " Configuration failed");
     console.error(
       error instanceof Error ? error.message : "Unknown error occurred"
     );
     exitOrThrow(1, error instanceof Error ? error.message : "Unknown error occurred");
   }
 
-  // Check for WSL on Windows
+  // ── WSL warning ────────────────────────────────────────────────────
   if (isWindows() && !isWslInstalled()) {
-    note(
-      `WSL is not installed. Some scripts may require WSL.\n` +
-        `Install WSL: ${WSL_INSTALL_URL}`,
-      "Warning"
+    log.warn(
+      `WSL not detected. Some scripts may require it.\n` +
+      `${paint("dim", WSL_INSTALL_URL)}`
     );
   }
 
-  // Success message
-  note(
-    `${agent.name} source control skills configured in ${agent.folder}/skills\n\n` +
-      `Selected workflow: ${SCM_CONFIG[scmType].displayName}\n\n` +
-      `Run '${agent.cmd}' to start the agent.`,
-    "Success"
+  // ── Summary ────────────────────────────────────────────────────────
+  const resultLines: string[] = [];
+  resultLines.push(
+    `${paint("success", "✓")} ${agent.name} skills ${paint("dim", "→")} ${paint("text", agent.folder + "/skills")}`,
+  );
+  resultLines.push(
+    `${paint("success", "✓")} SCM workflow ${paint("dim", "→")} ${paint("text", SCM_CONFIG[scmType].displayName)}`,
   );
 
-  outro("You're all set!");
+  if (import.meta.dir.includes("node_modules")) {
+    if (skillsInstalled) {
+      resultLines.push(
+        `${paint("success", "✓")} Local skills installed`,
+      );
+    } else {
+      resultLines.push(
+        `${paint("warning", "○")} Local skills skipped ${paint("dim", skillsSkipReason ? `(${skillsSkipReason})` : "")}`,
+      );
+    }
+  }
+
+  resultLines.push("");
+  resultLines.push(
+    `${paint("accent", "→")} Run ${paint("text", agent.cmd, { bold: true })} to start the agent`,
+  );
+
+  note(resultLines.join("\n"), paint("success", "Ready", { bold: true }));
+
+  outro(paint("dim", "Happy coding ⚛"));
 }

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -7,8 +7,8 @@
  */
 
 import { AGENT_CONFIG, type AgentKey } from "@/services/config/index.ts";
-import { COLORS } from "@/theme/colors.ts";
-import { isCommandInstalled, supportsColor, supportsTrueColor } from "@/services/system/detect.ts";
+import { COLORS, createPainter, type PaletteKey } from "@/theme/colors.ts";
+import { isCommandInstalled } from "@/services/system/detect.ts";
 import { ensureTmuxInstalled, ensureBunInstalled } from "../../lib/spawn.ts";
 import {
   isTmuxInstalled,
@@ -149,31 +149,6 @@ export async function workflowCommand(options: {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Workflow list rendering
-//
-// Catppuccin Mocha palette rendered via 24-bit ANSI, with graceful fallback
-// to basic ANSI on legacy terminals and plain text when colour is disabled.
-// Hex values mirror src/sdk/runtime/theme.ts so the CLI output and the TUI
-// speak one visual language.
-// ---------------------------------------------------------------------------
-
-type PaletteKey = "text" | "dim" | "accent" | "success" | "mauve";
-
-const PALETTE: Record<PaletteKey, readonly [number, number, number]> = {
-  text:    [205, 214, 244], // #cdd6f4 — primary text
-  dim:     [127, 132, 156], // #7f849c — secondary text
-  accent:  [137, 180, 250], // #89b4fa — blue accent
-  success: [166, 227, 161], // #a6e3a1 — green (local source)
-  mauve:   [203, 166, 247], // #cba6f7 — mauve (global source)
-};
-
-interface PaintOptions {
-  bold?: boolean;
-}
-
-type Paint = (key: PaletteKey, text: string, opts?: PaintOptions) => string;
-
 /** Stable agent sort order; keeps output deterministic across runs. */
 const AGENT_ORDER: readonly AgentType[] = ["claude", "opencode", "copilot"];
 /** Display names shown as provider sub-headings; honours proper branding. */
@@ -196,39 +171,6 @@ const SOURCE_COLORS: Record<DiscoveredWorkflow["source"], PaletteKey> = {
   global: "mauve",
   builtin: "accent",
 };
-
-/**
- * Build a colour-aware painter for the current terminal.
- * Truecolor terminals get the full Catppuccin palette; legacy terminals
- * degrade to basic ANSI; NO_COLOR emits plain text. The optional `bold`
- * flag adds weight contrast — essential for typographic hierarchy in a
- * monospace medium where size and family are fixed.
- */
-function createPainter(): Paint {
-  if (supportsTrueColor()) {
-    return (key, text, opts) => {
-      const [r, g, b] = PALETTE[key];
-      const sgr = opts?.bold
-        ? `\x1b[1;38;2;${r};${g};${b}m`
-        : `\x1b[38;2;${r};${g};${b}m`;
-      return `${sgr}${text}\x1b[0m`;
-    };
-  }
-  if (supportsColor()) {
-    const ANSI: Record<PaletteKey, string> = {
-      text:    "",
-      dim:     "\x1b[2m",
-      accent:  "\x1b[34m",
-      success: "\x1b[32m",
-      mauve:   "\x1b[35m",
-    };
-    return (key, text, opts) => {
-      const weight = opts?.bold ? "\x1b[1m" : "";
-      return `${weight}${ANSI[key]}${text}\x1b[0m`;
-    };
-  }
-  return (_key, text) => text;
-}
 
 /**
  * Render `atomic workflow --list` output as a printable string.

--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -90,7 +90,7 @@ export async function autoSyncIfStale(): Promise<void> {
   if (stored === VERSION) return;
 
   console.log(
-    `\n  ${COLORS.dim}Setting up atomic ${COLORS.reset}${COLORS.bold}v${VERSION}${COLORS.reset}${COLORS.dim}…${COLORS.reset}\n`,
+    `\n  ${COLORS.dim}Setting up atomic ${COLORS.reset}${COLORS.bold}v${VERSION}${COLORS.reset}${COLORS.dim}…${COLORS.reset}`,
   );
 
   // Steps are split into two parallel phases:

--- a/src/services/system/install-ui.ts
+++ b/src/services/system/install-ui.ts
@@ -3,12 +3,12 @@
  *
  * Renders an OpenCode-inspired single-line progress bar:
  *
- *     ⠋ ■■■■■■■■■■■■■■■■■■････････････  50%  tmux / psmux
+ *     ⠋  ■■■■■■■■■■■■■■■■■■････････････  50%  tmux / psmux
  *
- * where the braille spinner is provided by `@clack/prompts` and the bar
- * uses Catppuccin Mocha accent colors (Blue for progress, Green for
- * success, Red for error) with true-color → 256-color → basic ANSI
- * fallback.
+ * The braille spinner animates in-place via a setInterval loop and the
+ * bar uses Catppuccin Mocha accent colors (Yellow for progress, Green
+ * for success, Red for error) with a per-character true-color gradient
+ * that falls back gracefully through 256-color → basic ANSI.
  *
  * Steps are grouped into **phases**. Steps within a phase run in parallel
  * (via `Promise.all`); phases themselves run sequentially so later phases
@@ -23,7 +23,6 @@
  * library, just what auto-sync needs to stop being visually noisy.
  */
 
-import { spinner } from "@clack/prompts";
 import { COLORS } from "@/theme/colors.ts";
 import {
   supportsTrueColor,
@@ -36,9 +35,9 @@ const BAR_EMPTY = "･";
 
 /**
  * Semantic bar states mapped to Catppuccin Mocha colors:
- *   progress → Blue  #89b4fa (accent; "in flight")
- *   success  → Green #a6e3a1 (universal "completed")
- *   error    → Red   #f38ba8 (universal "failed")
+ *   progress → Yellow #f9e2af (warm accent; "in flight")
+ *   success  → Green  #a6e3a1 (universal "completed")
+ *   error    → Red    #f38ba8 (universal "failed")
  *
  * The empty track stays dim regardless — only the filled portion carries
  * the status signal, which keeps the bar legible while still telegraphing
@@ -50,12 +49,12 @@ function fillColor(state: BarState): string {
   if (supportsTrueColor()) {
     switch (state) {
       case "success":
-        return "\x1b[38;2;166;227;161m"; // Catppuccin Green #a6e3a1
+        return "\x1b[38;2;166;227;161m"; // Catppuccin Green  #a6e3a1
       case "error":
-        return "\x1b[38;2;243;139;168m"; // Catppuccin Red   #f38ba8
+        return "\x1b[38;2;243;139;168m"; // Catppuccin Red    #f38ba8
       case "progress":
       default:
-        return "\x1b[38;2;137;180;250m"; // Catppuccin Blue  #89b4fa
+        return "\x1b[38;2;249;226;175m"; // Catppuccin Yellow #f9e2af
     }
   }
   if (supports256Color()) {
@@ -66,7 +65,7 @@ function fillColor(state: BarState): string {
         return "\x1b[38;5;211m";
       case "progress":
       default:
-        return "\x1b[38;5;111m";
+        return "\x1b[38;5;222m";
     }
   }
   switch (state) {
@@ -76,11 +75,36 @@ function fillColor(state: BarState): string {
       return COLORS.red;
     case "progress":
     default:
-      return COLORS.blue;
+      return COLORS.yellow;
   }
 }
 
-/** Render a progress bar: colored filled ■ + dim empty ･ */
+type RGB = [number, number, number];
+
+/**
+ * Gradient endpoints for the filled bar segment. Each state interpolates
+ * from a slightly deeper/warmer tone (left) to the full Catppuccin
+ * accent (right), producing a smooth continuous color gradient.
+ */
+function gradientEndpoints(state: BarState): { start: RGB; end: RGB } {
+  switch (state) {
+    case "success":
+      return { start: [126, 201, 138], end: [166, 227, 161] };
+    case "error":
+      return { start: [224, 108, 136], end: [243, 139, 168] };
+    case "progress":
+    default:
+      return { start: [242, 196, 120], end: [249, 226, 175] };
+  }
+}
+
+/**
+ * Render a progress bar: gradient-filled ■ + dim empty ･
+ *
+ * In true-color mode each filled character gets its own interpolated RGB
+ * value, producing a smooth continuous gradient. Falls back to a single
+ * solid color on 256-color or basic ANSI terminals.
+ */
 function renderBar(
   completed: number,
   total: number,
@@ -90,14 +114,25 @@ function renderBar(
   const ratio = Math.max(0, Math.min(1, completed / safeTotal));
   const filled = Math.round(ratio * BAR_WIDTH);
   const empty = BAR_WIDTH - filled;
-  return (
-    fillColor(state) +
-    BAR_FILLED.repeat(filled) +
-    COLORS.reset +
-    COLORS.dim +
-    BAR_EMPTY.repeat(empty) +
-    COLORS.reset
-  );
+
+  let filledStr = "";
+  if (filled > 0) {
+    if (supportsTrueColor()) {
+      const { start, end } = gradientEndpoints(state);
+      for (let i = 0; i < filled; i++) {
+        const t = filled > 1 ? i / (filled - 1) : 1;
+        const r = Math.round(start[0] + (end[0] - start[0]) * t);
+        const g = Math.round(start[1] + (end[1] - start[1]) * t);
+        const b = Math.round(start[2] + (end[2] - start[2]) * t);
+        filledStr += `\x1b[38;2;${r};${g};${b}m${BAR_FILLED}`;
+      }
+      filledStr += COLORS.reset;
+    } else {
+      filledStr = fillColor(state) + BAR_FILLED.repeat(filled) + COLORS.reset;
+    }
+  }
+
+  return filledStr + COLORS.dim + BAR_EMPTY.repeat(empty) + COLORS.reset;
 }
 
 function formatLine(
@@ -130,6 +165,8 @@ export interface Step {
 /** A phase is a group of steps that run in parallel. */
 export type Phase = Step[];
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 /**
  * Runs phases of async steps with a single persistent spinner line
  * showing stepped progress. Steps within each phase run in parallel;
@@ -144,18 +181,39 @@ export type Phase = Step[];
 export async function runSteps(phases: Phase[]): Promise<StepResult[]> {
   const total = phases.reduce((n, phase) => n + phase.length, 0);
   const results: StepResult[] = [];
-  const s = spinner();
   let completed = 0;
+  let frameIdx = 0;
+  let currentLabel = phases[0]?.[0]?.label ?? "";
+  let animating = true;
 
-  // Start with 0/total so the user sees the bar immediately.
-  s.start(formatLine(0, total, phases[0]?.[0]?.label ?? ""));
+  const isTTY = process.stdout.isTTY ?? false;
+
+  if (isTTY) process.stdout.write("\x1b[?25l"); // hide cursor
+
+  // Restore cursor on unexpected exit so the terminal isn't left broken.
+  const restoreCursor = () => {
+    if (isTTY) process.stdout.write("\x1b[?25h");
+  };
+  process.once("SIGINT", restoreCursor);
+  process.once("SIGTERM", restoreCursor);
+
+  // Animate the braille spinner + progress bar in-place (80 ms/frame).
+  const interval = isTTY
+    ? setInterval(() => {
+        if (!animating) return;
+        const frame = SPINNER_FRAMES[frameIdx % SPINNER_FRAMES.length];
+        const line = formatLine(completed, total, currentLabel);
+        process.stdout.write(
+          `\r\x1b[2K  ${COLORS.blue}${frame}${COLORS.reset}  ${line}`,
+        );
+        frameIdx++;
+      }, 80)
+    : null;
 
   for (const phase of phases) {
-    // Show all in-flight labels for this phase.
     const inFlight = new Set(phase.map((step) => step.label));
-    s.message(formatLine(completed, total, [...inFlight].join(", ")));
+    currentLabel = [...inFlight].join(", ");
 
-    // Run every step in this phase concurrently.
     const phaseResults = await Promise.all(
       phase.map(async (step): Promise<StepResult> => {
         try {
@@ -163,9 +221,7 @@ export async function runSteps(phases: Phase[]): Promise<StepResult[]> {
           completed++;
           inFlight.delete(step.label);
           if (inFlight.size > 0) {
-            s.message(
-              formatLine(completed, total, [...inFlight].join(", ")),
-            );
+            currentLabel = [...inFlight].join(", ");
           }
           return { label: step.label, ok: true };
         } catch (error) {
@@ -174,9 +230,7 @@ export async function runSteps(phases: Phase[]): Promise<StepResult[]> {
           completed++;
           inFlight.delete(step.label);
           if (inFlight.size > 0) {
-            s.message(
-              formatLine(completed, total, [...inFlight].join(", ")),
-            );
+            currentLabel = [...inFlight].join(", ");
           }
           return { label: step.label, ok: false, error: message };
         }
@@ -186,16 +240,32 @@ export async function runSteps(phases: Phase[]): Promise<StepResult[]> {
     results.push(...phaseResults);
   }
 
-  // Stop with a filled bar + final label. Bar color flips to the
-  // universal status colors: green when every step succeeded, red when
-  // any step failed.
+  // Stop animation and render the final line.
+  animating = false;
+  if (interval) clearInterval(interval);
+  process.removeListener("SIGINT", restoreCursor);
+  process.removeListener("SIGTERM", restoreCursor);
+
   const okCount = results.filter((r) => r.ok).length;
   const allOk = okCount === total;
   const finalState: BarState = allOk ? "success" : "error";
+  const glyph = allOk
+    ? `${fillColor("success")}✓${COLORS.reset}`
+    : `${fillColor("error")}✗${COLORS.reset}`;
   const finalLabel = allOk
     ? `${fillColor("success")}Setup complete${COLORS.reset}`
     : `${fillColor("error")}Setup finished with errors${COLORS.reset}`;
-  s.stop(formatLine(total, total, finalLabel, finalState));
+
+  if (isTTY) {
+    process.stdout.write(
+      `\r\x1b[2K  ${glyph}  ${formatLine(total, total, finalLabel, finalState)}\n`,
+    );
+    process.stdout.write("\x1b[?25h"); // show cursor
+  } else {
+    console.log(
+      `  ${glyph}  ${formatLine(total, total, finalLabel, finalState)}`,
+    );
+  }
 
   return results;
 }

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,4 +1,4 @@
-import { supportsColor } from "@/services/system/detect.ts";
+import { supportsColor, supportsTrueColor } from "@/services/system/detect.ts";
 
 /**
  * ANSI color and formatting codes for CLI output
@@ -25,3 +25,65 @@ const NO_COLORS = {
 } as const;
 
 export const COLORS = supportsColor() ? ANSI_CODES : NO_COLORS;
+
+// ---------------------------------------------------------------------------
+// Catppuccin Mocha palette — shared across all CLI commands
+//
+// Truecolor terminals get the full palette via 24-bit ANSI SGR; legacy
+// terminals degrade to basic ANSI; NO_COLOR emits plain text.
+// Hex values mirror .impeccable.md and src/sdk/runtime/theme.ts.
+// ---------------------------------------------------------------------------
+
+export type PaletteKey = "text" | "dim" | "accent" | "success" | "error" | "warning" | "mauve";
+
+export const PALETTE: Record<PaletteKey, readonly [number, number, number]> = {
+  text:    [205, 214, 244], // #cdd6f4
+  dim:     [127, 132, 156], // #7f849c (Overlay1)
+  accent:  [137, 180, 250], // #89b4fa (Blue)
+  success: [166, 227, 161], // #a6e3a1 (Green)
+  error:   [243, 139, 168], // #f38ba8 (Red)
+  warning: [249, 226, 175], // #f9e2af (Yellow)
+  mauve:   [203, 166, 247], // #cba6f7 (Mauve)
+};
+
+export interface PaintOptions {
+  bold?: boolean;
+}
+
+export type Paint = (key: PaletteKey, text: string, opts?: PaintOptions) => string;
+
+/**
+ * Build a colour-aware painter for the current terminal.
+ *
+ * Truecolor terminals get the full Catppuccin palette; legacy terminals
+ * degrade to basic ANSI; NO_COLOR emits plain text. The optional `bold`
+ * flag adds weight contrast — essential for typographic hierarchy in a
+ * monospace medium where size and family are fixed.
+ */
+export function createPainter(): Paint {
+  if (supportsTrueColor()) {
+    return (key, text, opts) => {
+      const [r, g, b] = PALETTE[key];
+      const sgr = opts?.bold
+        ? `\x1b[1;38;2;${r};${g};${b}m`
+        : `\x1b[38;2;${r};${g};${b}m`;
+      return `${sgr}${text}\x1b[0m`;
+    };
+  }
+  if (supportsColor()) {
+    const ANSI: Record<PaletteKey, string> = {
+      text:    "",
+      dim:     "\x1b[2m",
+      accent:  "\x1b[34m",
+      success: "\x1b[32m",
+      error:   "\x1b[31m",
+      warning: "\x1b[33m",
+      mauve:   "\x1b[35m",
+    };
+    return (key, text, opts) => {
+      const weight = opts?.bold ? "\x1b[1m" : "";
+      return `${weight}${ANSI[key]}${text}\x1b[0m`;
+    };
+  }
+  return (_key, text) => text;
+}


### PR DESCRIPTION
## Summary

Unifies the CLI's color system under a single shared Catppuccin Mocha palette and overhauls the install progress bar UI with true-color per-character gradients, wider bars, and percentage-based progress indicators across all platforms.

## Key Changes

### Shared Theme System (`src/theme/colors.ts`)
- Add `PALETTE`, `PaletteKey`, and `createPainter()` — a single Catppuccin Mocha color source shared across all CLI commands
- `createPainter()` degrades gracefully: 24-bit true-color → basic ANSI → plain text (respects `NO_COLOR`)

### Install Progress UI (`install-ui.ts`, `install.sh`, `install.ps1`)
- Replace `@clack/prompts` spinner with a custom `setInterval`-based braille spinner for tighter in-place rendering control
- Per-character true-color gradient across the filled bar segment (interpolates from a deeper tone to the full Catppuccin accent)
- Bar width widened 18 → 30 columns; glyphs changed from `█`/`░` → `■`/`･`
- Progress indicator changed from step counters (`2/4`) to percentages (`50%`)
- In-progress bar color changed Blue → Yellow (`#f9e2af`) to distinguish from the accent used in surrounding text
- Cursor hidden during animation and restored on `SIGINT`/`SIGTERM`

### Init Command (`src/commands/cli/init/index.ts`)
- Adopts `createPainter()` for consistent typographic hierarchy and brand alignment
- Consolidates two-step confirm flow into a single preflight summary note + one proceed/cancel prompt
- Tightened microcopy throughout: shorter prompt labels, concise status messages, `outro` updated to `"Happy coding ⚛"`