### PR TITLE
feat(workflows): structured inputs, interactive picker, and new builtin

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-creator
-description: Create custom multi-agent workflows for Atomic CLI using the defineWorkflow().run().compile() API with ctx.stage(opts, clientOpts, sessionOpts, callback) for dynamic session spawning with auto-init/cleanup. Applies context engineering principles (context-fundamentals, context-degradation, context-compression, context-optimization), architectural patterns (multi-agent-patterns, memory-systems, tool-design, filesystem-context, hosted-agents), quality assurance (evaluation, advanced-evaluation), and design methodology (project-development, bdi-mental-states) to produce robust, context-aware workflows. Workflows live at .atomic/workflows/<name>/<agent>/index.ts. Trigger when users want to create workflows, build agent pipelines, define multi-stage automations, set up review loops, connect coding agents, or mention .atomic/workflows/, defineWorkflow, or agent task sequences.
+description: Create custom multi-agent workflows for Atomic CLI using the defineWorkflow().run().compile() API with ctx.stage(opts, clientOpts, sessionOpts, callback) for dynamic session spawning with auto-init/cleanup. Workflows can declare structured input schemas (string/text/enum fields) that the CLI materialises as `--<field>=<value>` flags and the interactive picker (`atomic workflow -a <agent>`) renders as a form; free-form workflows receive their positional prompt under `ctx.inputs.prompt`. Applies context engineering principles (context-fundamentals, context-degradation, context-compression, context-optimization), architectural patterns (multi-agent-patterns, memory-systems, tool-design, filesystem-context, hosted-agents), quality assurance (evaluation, advanced-evaluation), and design methodology (project-development, bdi-mental-states) to produce robust, context-aware workflows. Workflows live at .atomic/workflows/<name>/<agent>/index.ts. Trigger when users want to create workflows, build agent pipelines, define multi-stage automations, set up review loops, connect coding agents, declare workflow inputs, or mention .atomic/workflows/, defineWorkflow, ctx.inputs, the atomic workflow picker, or agent task sequences.
 ---
 
 # Workflow Creator
@@ -17,12 +17,13 @@ Load the topic-specific reference files from `references/` based on priority. **
 |---|---|---|
 | **1** | `getting-started.md` | **Always** — quick-start examples for all 3 SDKs, SDK exports, `SessionContext` reference |
 | **1** | `failure-modes.md` | **Always for multi-session workflows** — 15 catalogued failures (silent + loud) with wrong-vs-right patterns and a pre-ship design checklist |
+| **1** | `workflow-inputs.md` | **Always when declaring structured inputs or documenting how a workflow is invoked** — `WorkflowInput` schema, field-type selection, picker + CLI flag semantics, builtin-protection rules, invocation cheat sheet |
 | **2** | `agent-sessions.md` | When writing SDK calls — `s.session.query()` (Claude), `s.session.sendAndWait()` (Copilot), `s.client.session.prompt()` (OpenCode); includes critical pitfalls on timeouts and session lifecycle |
 | **2** | `control-flow.md` | When using loops, conditionals, parallel execution, or review/fix patterns |
 | **2** | `state-and-data-flow.md` | When passing data between sessions — `s.save()`, `s.transcript()`, `s.getMessages()`, file persistence, transcript compression |
 | **3** | `computation-and-validation.md` | When adding deterministic computation, response parsing, validation, quality gates, or file I/O |
 | **3** | `session-config.md` | When configuring model, tools, permissions, hooks, or structured output per SDK |
-| **3** | `user-input.md` | When collecting user input mid-workflow — Claude `canUseTool`, Copilot `onElicitationRequest`, OpenCode TUI control |
+| **3** | `user-input.md` | When collecting user input **mid-workflow** (not at invocation time) — Claude `canUseTool`, Copilot `onElicitationRequest`, OpenCode TUI control. For invocation-time inputs, see `workflow-inputs.md`. |
 | **3** | `discovery-and-verification.md` | When setting up workflow file structure, validation, or TypeScript config |
 
 ## Information Flow Is a First-Class Design Concern
@@ -178,10 +179,70 @@ Discovery sources (highest precedence first):
 
 | Context | Available in | Has `client`/`session`/`paneId`/`save`? | Purpose |
 |---------|-------------|----------------------------------|---------|
-| `WorkflowContext` (`ctx`) | `.run(async (ctx) => ...)` | No | Orchestration: spawn sessions, read transcripts |
-| `SessionContext` (`s`) | `ctx.stage(opts, clientOpts, sessionOpts, async (s) => ...)` | Yes | Agent work: use `s.client` and `s.session` for SDK calls, save output |
+| `WorkflowContext` (`ctx`) | `.run(async (ctx) => ...)` | No | Orchestration: spawn sessions, read transcripts, read `ctx.inputs` |
+| `SessionContext` (`s`) | `ctx.stage(opts, clientOpts, sessionOpts, async (s) => ...)` | Yes | Agent work: use `s.client` and `s.session` for SDK calls, save output, read `s.inputs` |
 
-The `WorkflowContext` is the orchestrator — it spawns sessions and reads transcripts. The `SessionContext` is the worker — it has the pre-initialized client and session, tmux pane, and save function. Both contexts can spawn nested sessions via `stage()` and read prior transcripts via `transcript()`.
+The `WorkflowContext` is the orchestrator — it spawns sessions and reads transcripts. The `SessionContext` is the worker — it has the pre-initialized client and session, tmux pane, and save function. Both contexts can spawn nested sessions via `stage()` and read prior transcripts via `transcript()`. Both expose the same `inputs: Record<string, string>` field — populated identically from whichever invocation surface the user chose.
+
+### Declared inputs: one API, three invocation surfaces
+
+Workflows receive user data exclusively through `ctx.inputs` (and `s.inputs` inside stage callbacks). The invocation surface — positional CLI prompt, structured CLI flags, or the interactive picker — is a CLI concern; by the time your workflow code runs, the runtime has already normalised everything into a `Record<string, string>`.
+
+You have two choices when defining a workflow:
+
+**Free-form** — no schema. The positional CLI prompt lands under the reserved `prompt` key. Read it via `ctx.inputs.prompt ?? ""`.
+
+```ts
+defineWorkflow<"claude">({ name: "answer", description: "Single-turn answer" })
+  .run(async (ctx) => {
+    // Destructure once so every stage can close over a bare string.
+    const prompt = ctx.inputs.prompt ?? "";
+    await ctx.stage({ name: "answer" }, {}, {}, async (s) => {
+      await s.session.query(prompt);
+      s.save(s.sessionId);
+    });
+  })
+  .compile();
+```
+
+**Structured** — declare an `inputs` array on `defineWorkflow`. The CLI materialises one `--<field>=<value>` flag per entry, validates required fields + enum membership before launching anything, and the interactive picker renders a form from the same schema.
+
+```ts
+defineWorkflow<"claude">({
+    name: "gen-spec",
+    description: "Convert a research doc into an execution spec",
+    inputs: [
+      { name: "research_doc", type: "string", required: true, description: "path to the research doc" },
+      {
+        name: "focus",
+        type: "enum",
+        required: true,
+        values: ["minimal", "standard", "exhaustive"],
+        default: "standard",
+      },
+      { name: "notes", type: "text", description: "extra guidance (optional)" },
+    ],
+  })
+  .run(async (ctx) => {
+    const { research_doc, focus } = ctx.inputs;
+    const notes = ctx.inputs.notes ?? "";
+    // ... use the fields to build prompts, paths, etc.
+  })
+  .compile();
+```
+
+Three field types are supported: `string` (single-line), `text` (multi-line), `enum` (fixed set of values). **Load `references/workflow-inputs.md` for the full schema shape, validation rules, invocation cheat sheet, and the free-form-vs-structured decision guide.**
+
+### Invocation surfaces
+
+| Surface | Command | When the user reaches for it |
+|---|---|---|
+| Named, free-form prompt | `atomic workflow -n hello -a claude "fix the bug"` | Scripted runs of free-form workflows; the positional prompt lands in `ctx.inputs.prompt` |
+| Named, structured flags | `atomic workflow -n gen-spec -a claude --research_doc=notes.md --focus=standard` | Scripted runs of structured workflows; one `--<name>=<value>` per declared input |
+| Interactive picker | `atomic workflow -a claude` | Discovery. Shows a fuzzy-filterable list, then renders a form (free-form gets a single `prompt` field; structured gets one field per declared input) |
+| List | `atomic workflow -l` | Browsing everything available, grouped by source (local / global / builtin) |
+
+**Builtin workflows are reserved.** A local or global workflow with the same name as a builtin (e.g. `ralph`) cannot shadow the builtin at resolution time — `atomic workflow -n ralph -a claude` always resolves to the SDK copy. Pick distinct names for your own workflows and you'll never hit this.
 
 ### Structural Rules
 
@@ -274,13 +335,17 @@ export default defineWorkflow<"claude">({
     description: "Two-step pipeline",
   })
   .run(async (ctx) => {
+    // Free-form workflow — destructure the positional prompt once so
+    // every stage below can close over a bare string.
+    const prompt = ctx.inputs.prompt ?? "";
+
     const analyze = await ctx.stage(
       { name: "analyze", description: "Analyze the codebase" },
       {},
       {},
       async (s) => {
         // s.session is a ClaudeSessionWrapper — auto-created by the runtime
-        const result = await s.session.query(s.userPrompt);
+        const result = await s.session.query(prompt);
         s.save(s.sessionId);
         return result.output;
       },
@@ -322,13 +387,18 @@ export default defineWorkflow<"copilot">({
     description: "Two-step pipeline",
   })
   .run(async (ctx) => {
+    // `userPromptText` rather than `prompt` because Copilot's
+    // sendAndWait uses `{ prompt: ... }` as an object key — the local
+    // name avoids visual collision inside those send calls.
+    const userPromptText = ctx.inputs.prompt ?? "";
+
     const analyze = await ctx.stage(
       { name: "analyze", description: "Analyze the codebase" },
       {},
       {},
       async (s) => {
         // s.session is a CopilotSession — auto-created by the runtime
-        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+        await s.session.sendAndWait({ prompt: userPromptText }, SEND_TIMEOUT_MS);
         s.save(await s.session.getMessages());
       },
     );
@@ -363,6 +433,8 @@ export default defineWorkflow<"opencode">({
     description: "Two-step pipeline",
   })
   .run(async (ctx) => {
+    const prompt = ctx.inputs.prompt ?? "";
+
     const analyze = await ctx.stage(
       { name: "analyze", description: "Analyze the codebase" },
       {},
@@ -371,7 +443,7 @@ export default defineWorkflow<"opencode">({
         // s.client is OpencodeClient; s.session is the Session data object
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
-          parts: [{ type: "text", text: s.userPrompt }],
+          parts: [{ type: "text", text: prompt }],
         });
         s.save(result.data!);
       },
@@ -405,9 +477,27 @@ bunx tsc --noEmit --pretty false
 
 ### 5. Test the Workflow
 
+For free-form workflows, pass the prompt as a positional argument:
+
 ```bash
 atomic workflow -n <workflow-name> -a <agent> "<your prompt>"
 ```
+
+For structured workflows, pass one `--<field>=<value>` flag per declared input (both `--foo=bar` and `--foo bar` forms work):
+
+```bash
+atomic workflow -n <workflow-name> -a <agent> \
+  --research_doc=notes.md \
+  --focus=standard
+```
+
+To discover workflows interactively without remembering flag names, launch the picker:
+
+```bash
+atomic workflow -a <agent>
+```
+
+The picker is scoped to `<agent>` — it shows every workflow compatible with that backend, grouped by source (local / global / builtin), with a fuzzy filter and a form rendered from each workflow's declared schema.
 
 ## Key Patterns
 
@@ -430,6 +520,7 @@ Loops run at the workflow level, spawning a new graph node per iteration so user
 ```ts
 defineWorkflow<"claude">({ name: "review-fix", description: "Iterative review and fix" })
   .run(async (ctx) => {
+    const prompt = ctx.inputs.prompt ?? "";
     const MAX_CYCLES = 10;
     let consecutiveClean = 0;
 
@@ -437,7 +528,7 @@ defineWorkflow<"claude">({ name: "review-fix", description: "Iterative review an
       // Each iteration spawns a visible graph node
       const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
         // s.session is auto-created by the runtime
-        const result = await s.session.query(buildReviewPrompt(s.userPrompt));
+        const result = await s.session.query(buildReviewPrompt(prompt));
         s.save(s.sessionId);
         return result.output;
       });
@@ -452,7 +543,7 @@ defineWorkflow<"claude">({ name: "review-fix", description: "Iterative review an
 
       // Conditionally spawn a fix session
       await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
-        await s.session.query(buildFixSpecFromReview(parsed, s.userPrompt));
+        await s.session.query(buildFixSpecFromReview(parsed, prompt));
         s.save(s.sessionId);
       });
     }
@@ -479,9 +570,11 @@ await ctx.stage({ name: "guided-implementation" }, {}, {}, async (s) => {
 
 ```ts
 .run(async (ctx) => {
+  const prompt = ctx.inputs.prompt ?? "";
+
   const triage = await ctx.stage({ name: "triage" }, {}, {}, async (s) => {
     const result = await s.session.query(
-      `Classify this as "bug", "feature", or "question":\n${s.userPrompt}`,
+      `Classify this as "bug", "feature", or "question":\n${prompt}`,
     );
     s.save(s.sessionId);
     return result.output.toLowerCase();
@@ -532,8 +625,10 @@ export default defineWorkflow<"claude">({
     description: "describe → [summarize-a, summarize-b] → merge",
   })
   .run(async (ctx) => {
+    const prompt = ctx.inputs.prompt ?? "";
+
     const describe = await ctx.stage({ name: "describe" }, {}, {}, async (s) => {
-      await s.session.query(s.userPrompt);
+      await s.session.query(prompt);
       s.save(s.sessionId);
     });
 
@@ -610,12 +705,14 @@ These three primitives compose to express any DAG topology through ordinary Type
 
 Delegate to named sub-agents within a session. Each SDK has its own mechanism:
 
+Assume `const prompt = ctx.inputs.prompt ?? "";` is pulled out at the top of each workflow's `.run()` callback (free-form convention) — every example below closes over it.
+
 **Claude** — prefix the prompt with `@"agent-name (agent)"`:
 
 ```ts
 await ctx.stage({ name: "plan-and-execute" }, {}, {}, async (s) => {
   // s.session is auto-created; query() passes the prompt directly to the Claude TUI
-  await s.session.query(`@"planner (agent)" Create a plan for: ${s.userPrompt}`);
+  await s.session.query(`@"planner (agent)" Create a plan for: ${prompt}`);
   await s.session.query(`@"orchestrator (agent)" Execute the plan above.`);
   s.save(s.sessionId);
 });
@@ -628,7 +725,7 @@ const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
 await ctx.stage({ name: "plan" }, {}, { agent: "planner" }, async (s) => {
   // s.session is a CopilotSession created with agent: "planner"
-  await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 ```
@@ -640,7 +737,7 @@ await ctx.stage({ name: "plan" }, {}, { title: "plan" }, async (s) => {
   // s.client is OpencodeClient; s.session is the Session data object
   const result = await s.client.session.prompt({
     sessionID: s.session.id,
-    parts: [{ type: "text", text: s.userPrompt }],
+    parts: [{ type: "text", text: prompt }],
     agent: "planner",
   });
   s.save(result.data!);
@@ -672,10 +769,13 @@ export function buildPlanPrompt(spec: string): string {
 // .atomic/workflows/my-workflow/claude/index.ts
 import { buildPlanPrompt } from "../helpers/prompts.ts";
 // ...
-await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
-  await s.session.query(buildPlanPrompt(s.userPrompt));
-  s.save(s.sessionId);
-});
+.run(async (ctx) => {
+  const prompt = ctx.inputs.prompt ?? "";
+  await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
+    await s.session.query(buildPlanPrompt(prompt));
+    s.save(s.sessionId);
+  });
+})
 ```
 
 ### Context-Aware Transcript Handoff
@@ -696,7 +796,7 @@ Use the filesystem as a coordination layer instead of inlining large data into p
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `userPrompt` | `string` | The original user prompt from the CLI invocation |
+| `inputs` | `Record<string, string>` | Structured inputs for this run. Free-form workflows store their positional prompt under `inputs.prompt`; structured workflows store one key per declared input. See `references/workflow-inputs.md`. |
 | `agent` | `AgentType` | Which agent is running (`"claude"`, `"copilot"`, or `"opencode"`) |
 | `stage(opts, clientOpts, sessionOpts, fn)` | `<T>(opts: SessionRunOptions, clientOpts: StageClientOptions<A>, sessionOpts: StageSessionOptions<A>, fn: (s: SessionContext<A>) => Promise<T>) => Promise<SessionHandle<T>>` | Spawn a session — runtime auto-creates client+session, runs callback, auto-cleans up |
 | `transcript(ref)` | `(ref: SessionRef) => Promise<Transcript>` | Get a completed session's transcript |
@@ -708,7 +808,7 @@ Use the filesystem as a coordination layer instead of inlining large data into p
 |-------|------|-------------|
 | `client` | `ProviderClient<A>` | Pre-created SDK client — managed by the runtime; type resolves to the native SDK client for your agent |
 | `session` | `ProviderSession<A>` | Pre-created session — managed by the runtime; type resolves to the native SDK session for your agent |
-| `userPrompt` | `string` | The original user prompt from the CLI invocation |
+| `inputs` | `Record<string, string>` | Same inputs record as `WorkflowContext.inputs`, forwarded into every stage so session callbacks can read the values without closing over the outer `ctx` |
 | `agent` | `AgentType` | Which agent is running |
 | `paneId` | `string` | tmux pane ID for this session |
 | `sessionId` | `string` | Session UUID |

--- a/.agents/skills/workflow-creator/references/agent-sessions.md
+++ b/.agents/skills/workflow-creator/references/agent-sessions.md
@@ -24,7 +24,7 @@ import { defineWorkflow } from "@bastani/atomic/workflows";
       // s.session — session wrapper (ready to accept queries via s.session.query())
 
       // Send queries — Claude maintains conversation context across calls
-      const result = await s.session.query(s.userPrompt);
+      const result = await s.session.query((s.inputs.prompt ?? ""));
       // result.output contains the captured response text
 
       // Save transcript
@@ -62,7 +62,7 @@ export default defineWorkflow<"claude">({ name: "implement" })
       {},
       {},
       async (s) => {
-        const result = await s.session.query(s.userPrompt);
+        const result = await s.session.query((s.inputs.prompt ?? ""));
         // result.output contains the captured response text
         s.save(s.sessionId);
       },
@@ -101,7 +101,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 .run(async (ctx) => {
   await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
     const result = query({
-      prompt: s.userPrompt,
+      prompt: (s.inputs.prompt ?? ""),
       options: {
         model: "claude-opus-4-6",
         effort: "high",
@@ -191,7 +191,7 @@ Invoke named sub-agents by prefixing the prompt with `@"agent-name (agent)"`. Th
 .run(async (ctx) => {
   await ctx.stage({ name: "plan-and-implement" }, {}, {}, async (s) => {
     // Delegate to the "planner" agent
-    await s.session.query(`@"planner (agent)" Create a plan for: ${s.userPrompt}`);
+    await s.session.query(`@"planner (agent)" Create a plan for: ${(s.inputs.prompt ?? "")}`);
 
     // Delegate to the "orchestrator" agent
     await s.session.query(`@"orchestrator (agent)" Execute the plan above.`);
@@ -223,7 +223,7 @@ export default defineWorkflow<"copilot">({ name: "implement" })
         // s.client — CopilotClient (already started by runtime)
         // s.session — CopilotSession (already created, foreground session set)
 
-        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+        await s.session.sendAndWait({ prompt: (s.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
 
         s.save(await s.session.getMessages());
       },
@@ -310,7 +310,7 @@ provider-specific escape hatches, not the default stage-to-stage handoff path.
 // Buggy — the orchestrator session is fresh and knows NOTHING about
 // what the planner just produced, because createSession() started a
 // brand-new conversation.
-await runAgent("planner", buildPlannerPrompt(ctx.userPrompt));
+await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
 await runAgent("orchestrator", buildOrchestratorPrompt());
 // ↑ orchestrator only sees buildOrchestratorPrompt() — no planner output,
 //   no original user spec, no context.
@@ -335,10 +335,10 @@ async function runAgent(agent: string, prompt: string): Promise<string> {
 }
 
 // Correct — forward the planner's output into the orchestrator prompt
-const plannerNotes = await runAgent("planner", buildPlannerPrompt(ctx.userPrompt));
+const plannerNotes = await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
 await runAgent(
   "orchestrator",
-  buildOrchestratorPrompt(ctx.userPrompt, { plannerNotes }),
+  buildOrchestratorPrompt((ctx.inputs.prompt ?? ""), { plannerNotes }),
 );
 ```
 
@@ -446,7 +446,7 @@ await ctx.stage(
     },
   }, // sessionOpts
   async (s) => {
-    await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+    await s.session.sendAndWait({ prompt: (s.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
     s.save(await s.session.getMessages());
   },
 );
@@ -473,7 +473,7 @@ await ctx.stage(
   {},
   { tools: [myTool] },
   async (s) => {
-    await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+    await s.session.sendAndWait({ prompt: (s.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
     s.save(await s.session.getMessages());
   },
 );
@@ -530,7 +530,7 @@ const SEND_TIMEOUT_MS = 30 * 60 * 1000; // planner can take a while
     {},
     { agent: "planner" }, // sessionOpts — binds the session to the "planner" agent
     async (s) => {
-      await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+      await s.session.sendAndWait({ prompt: (s.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
       s.save(await s.session.getMessages());
     },
   );
@@ -558,7 +558,7 @@ export default defineWorkflow<"opencode">({ name: "implement" })
 
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
-          parts: [{ type: "text", text: s.userPrompt }],
+          parts: [{ type: "text", text: (s.inputs.prompt ?? "") }],
         });
 
         s.save(result.data!);
@@ -598,19 +598,19 @@ substitute the OpenCode API equivalents:
 ```ts
 // Buggy — orchestrator session is fresh; it has no idea what the planner
 // produced because we created a brand-new session for it.
-await runAgent("planner-1", "planner", buildPlannerPrompt(ctx.userPrompt));
+await runAgent("planner-1", "planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
 await runAgent("orchestrator-1", "orchestrator", buildOrchestratorPrompt());
 
 // Correct — capture planner output and forward it into orchestrator prompt
 const plannerNotes = await runAgent(
   "planner-1",
   "planner",
-  buildPlannerPrompt(ctx.userPrompt),
+  buildPlannerPrompt((ctx.inputs.prompt ?? "")),
 );
 await runAgent(
   "orchestrator-1",
   "orchestrator",
-  buildOrchestratorPrompt(ctx.userPrompt, { plannerNotes }),
+  buildOrchestratorPrompt((ctx.inputs.prompt ?? ""), { plannerNotes }),
 );
 ```
 
@@ -707,7 +707,7 @@ function extractResponseText(
 // Usage inside a ctx.stage callback:
 const result = await s.client.session.prompt({
   sessionID: s.session.id,
-  parts: [{ type: "text", text: s.userPrompt }],
+  parts: [{ type: "text", text: (s.inputs.prompt ?? "") }],
 });
 const text = extractResponseText(result.data!.parts);
 ```
@@ -737,7 +737,7 @@ Pass the `agent` parameter to `s.client.session.prompt()` to route a prompt to a
       // Route the prompt to the "planner" agent
       const result = await s.client.session.prompt({
         sessionID: s.session.id,
-        parts: [{ type: "text", text: s.userPrompt }],
+        parts: [{ type: "text", text: (s.inputs.prompt ?? "") }],
         agent: "planner",
       });
 

--- a/.agents/skills/workflow-creator/references/computation-and-validation.md
+++ b/.agents/skills/workflow-creator/references/computation-and-validation.md
@@ -201,7 +201,7 @@ Add automated quality checkpoints using evaluation rubrics. This pattern applies
 ```ts
 .run(async (ctx) => {
   const impl = await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
-    await s.session.query(s.userPrompt);
+    await s.session.query((s.inputs.prompt ?? ""));
     s.save(s.sessionId);
   });
 

--- a/.agents/skills/workflow-creator/references/control-flow.md
+++ b/.agents/skills/workflow-creator/references/control-flow.md
@@ -20,7 +20,7 @@ Run a triage session first, then branch at the `.run()` level to spawn a purpose
   // Step 1: Classify the request
   const triage = await ctx.stage({ name: "triage" }, {}, {}, async (s) => {
     const result = await s.session.query(
-      `Classify this as "bug", "feature", or "question": ${ctx.userPrompt}`,
+      `Classify this as "bug", "feature", or "question": ${(ctx.inputs.prompt ?? "")}`,
     );
     s.save(s.sessionId);
     return result.output.toLowerCase();
@@ -56,7 +56,7 @@ When the branching logic is simple and you want the agent to retain full context
 .run(async (ctx) => {
   await ctx.stage({ name: "triage-and-act" }, {}, {}, async (s) => {
     const triageResult = await s.session.query(
-      `Classify this as "bug", "feature", or "question": ${ctx.userPrompt}`,
+      `Classify this as "bug", "feature", or "question": ${(ctx.inputs.prompt ?? "")}`,
     );
 
     const classification = triageResult.output.toLowerCase();
@@ -133,7 +133,7 @@ The inter-session pattern is the right fit here: every review and every fix beco
   for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
     // Each review is a visible graph node
     const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
-      const result = await s.session.query(buildReviewPrompt(ctx.userPrompt));
+      const result = await s.session.query(buildReviewPrompt((ctx.inputs.prompt ?? "")));
       s.save(s.sessionId);
       return result.output;
     });
@@ -152,8 +152,8 @@ The inter-session pattern is the right fit here: every review and every fix beco
     consecutiveClean = 0;
 
     const fixPrompt = parsed
-      ? buildFixSpecFromReview(parsed, ctx.userPrompt)
-      : buildFixSpecFromRawReview(reviewRaw, ctx.userPrompt);
+      ? buildFixSpecFromReview(parsed, (ctx.inputs.prompt ?? ""))
+      : buildFixSpecFromRawReview(reviewRaw, (ctx.inputs.prompt ?? ""));
 
     // Each fix is also a visible graph node
     await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
@@ -182,7 +182,7 @@ const SEND_TIMEOUT_MS = 30 * 60 * 1000;
   for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
     const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
       await s.session.sendAndWait(
-        { prompt: buildReviewPrompt(ctx.userPrompt) },
+        { prompt: buildReviewPrompt((ctx.inputs.prompt ?? "")) },
         SEND_TIMEOUT_MS,
       );
       const reviewRaw = getAssistantText(await s.session.getMessages()); // see failure-modes.md §F1
@@ -202,8 +202,8 @@ const SEND_TIMEOUT_MS = 30 * 60 * 1000;
     consecutiveClean = 0;
 
     const fixPrompt = parsed
-      ? buildFixSpecFromReview(parsed, ctx.userPrompt)
-      : buildFixSpecFromRawReview(reviewRaw, ctx.userPrompt);
+      ? buildFixSpecFromReview(parsed, (ctx.inputs.prompt ?? ""))
+      : buildFixSpecFromRawReview(reviewRaw, (ctx.inputs.prompt ?? ""));
 
     await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
       await s.session.sendAndWait(
@@ -326,11 +326,11 @@ Within a single session callback, each SDK call adds to the conversation context
 .run(async (ctx) => {
   await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
     try {
-      await s.session.query(ctx.userPrompt);
+      await s.session.query((ctx.inputs.prompt ?? ""));
     } catch (error) {
       // Retry with simpler prompt
       await s.session.query(
-        `The previous attempt failed. Please try a simpler approach: ${ctx.userPrompt}`,
+        `The previous attempt failed. Please try a simpler approach: ${(ctx.inputs.prompt ?? "")}`,
       );
     }
     s.save(s.sessionId);
@@ -359,7 +359,7 @@ async function retryWithBackoff<T>(
 
 .run(async (ctx) => {
   await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
-    await retryWithBackoff(() => s.session.query(ctx.userPrompt));
+    await retryWithBackoff(() => s.session.query((ctx.inputs.prompt ?? "")));
     s.save(s.sessionId);
   });
 })
@@ -373,7 +373,7 @@ Combine loops, conditionals, and inter-session data passing. Session callbacks r
 .run(async (ctx) => {
   // Step 1: Analyse — result is available as a typed handle
   const analysisHandle = await ctx.stage({ name: "analyze" }, {}, {}, async (s) => {
-    const result = await s.session.query(`Analyse the task: ${ctx.userPrompt}`);
+    const result = await s.session.query(`Analyse the task: ${(ctx.inputs.prompt ?? "")}`);
     s.save(s.sessionId);
     return result.output;
   });

--- a/.agents/skills/workflow-creator/references/discovery-and-verification.md
+++ b/.agents/skills/workflow-creator/references/discovery-and-verification.md
@@ -124,7 +124,7 @@ This catches:
 
 ## Testing
 
-Test a workflow by running it:
+Run a free-form workflow by passing the prompt as a positional argument:
 
 ```bash
 atomic workflow -n <workflow-name> -a <agent> "<your prompt>"
@@ -133,4 +133,18 @@ atomic workflow -n <workflow-name> -a <agent> "<your prompt>"
 Where:
 - `-n` / `--name` — workflow name (matches directory name)
 - `-a` / `--agent` — target agent (`claude`, `copilot`, or `opencode`)
-- The quoted string is the user prompt passed as `ctx.userPrompt`
+- The quoted string is the user prompt, which the runtime stores under `ctx.inputs.prompt` so workflow authors can read it via `ctx.inputs.prompt ?? ""`
+
+Run a workflow with declared inputs by passing one `--<field>=<value>` flag per entry in its schema:
+
+```bash
+atomic workflow -n <workflow-name> -a <agent> --field_a=value --field_b=value
+```
+
+Or discover and run any workflow interactively through the picker:
+
+```bash
+atomic workflow -a <agent>
+```
+
+See `workflow-inputs.md` for the full `WorkflowInput` schema shape, validation rules, and picker behaviour.

--- a/.agents/skills/workflow-creator/references/failure-modes.md
+++ b/.agents/skills/workflow-creator/references/failure-modes.md
@@ -238,7 +238,7 @@ does NOT apply to `s.session.query()`.)
 ### ❌ Wrong
 
 ```ts
-await runAgent("planner", buildPlannerPrompt(ctx.userPrompt));
+await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
 // orchestrator is a fresh session — it has no idea what the planner produced
 await runAgent("orchestrator", buildOrchestratorPrompt());
 ```
@@ -246,10 +246,10 @@ await runAgent("orchestrator", buildOrchestratorPrompt());
 ### ✅ Right — explicit handoff
 
 ```ts
-const plannerNotes = await runAgent("planner", buildPlannerPrompt(ctx.userPrompt));
+const plannerNotes = await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
 await runAgent(
   "orchestrator",
-  buildOrchestratorPrompt(ctx.userPrompt, { plannerNotes }),
+  buildOrchestratorPrompt((ctx.inputs.prompt ?? ""), { plannerNotes }),
 );
 ```
 
@@ -510,7 +510,7 @@ initialized.
 // OLD — no longer needed; the runtime handles session initialization
 await ctx.stage({ name: "..." }, {}, {}, async (s) => {
   // Manual init was required before the runtime managed lifecycle
-  await s.session.query(ctx.userPrompt);
+  await s.session.query((ctx.inputs.prompt ?? ""));
   s.save(s.sessionId);
 });
 ```
@@ -519,7 +519,7 @@ await ctx.stage({ name: "..." }, {}, {}, async (s) => {
 
 ```ts
 await ctx.stage({ name: "..." }, {}, {}, async (s) => {
-  const result = await s.session.query(ctx.userPrompt);
+  const result = await s.session.query((ctx.inputs.prompt ?? ""));
   s.save(s.sessionId);
 });
 ```

--- a/.agents/skills/workflow-creator/references/getting-started.md
+++ b/.agents/skills/workflow-creator/references/getting-started.md
@@ -19,12 +19,16 @@ export default defineWorkflow<"claude">({
     description: "A two-session pipeline",
   })
   .run(async (ctx) => {
+    // Free-form workflow: the positional CLI prompt lands under
+    // `inputs.prompt`. Destructure once and close over it in stages.
+    const prompt = ctx.inputs.prompt ?? "";
+
     const describe = await ctx.stage(
       { name: "describe", description: "Ask Claude to describe the project" },
       {},
       {},
       async (s) => {
-        await s.session.query(s.userPrompt);
+        await s.session.query(prompt);
         s.save(s.sessionId);
       },
     );
@@ -65,12 +69,17 @@ export default defineWorkflow<"copilot">({
     description: "A two-session pipeline",
   })
   .run(async (ctx) => {
+    // `userPromptText` rather than `prompt` because Copilot's
+    // sendAndWait uses `{ prompt: ... }` as an object key — the local
+    // name avoids visual collision inside those send calls.
+    const userPromptText = ctx.inputs.prompt ?? "";
+
     const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
       {},
       {},
       async (s) => {
-        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+        await s.session.sendAndWait({ prompt: userPromptText }, SEND_TIMEOUT_MS);
         s.save(await s.session.getMessages());
       },
     );
@@ -105,6 +114,8 @@ export default defineWorkflow<"opencode">({
     description: "A two-session pipeline",
   })
   .run(async (ctx) => {
+    const prompt = ctx.inputs.prompt ?? "";
+
     const describe = await ctx.stage(
       { name: "describe", description: "Ask the agent to describe the project" },
       {},
@@ -112,7 +123,7 @@ export default defineWorkflow<"opencode">({
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
-          parts: [{ type: "text", text: s.userPrompt }],
+          parts: [{ type: "text", text: prompt }],
         });
         s.save(result.data!);
       },
@@ -211,7 +222,7 @@ The Atomic runtime provides `s.client` and `s.session` with types resolved from 
 |-------|------|-------------|
 | `client` | `ProviderClient<A>` | Pre-created SDK client (auto-managed by runtime) |
 | `session` | `ProviderSession<A>` | Pre-created provider session (auto-managed by runtime) |
-| `userPrompt` | `string` | Original user prompt from CLI invocation |
+| `inputs` | `Record<string, string>` | Structured inputs for this run. Free-form workflows read `s.inputs.prompt`; structured workflows read their declared field names. See `workflow-inputs.md`. |
 | `agent` | `AgentType` | Which agent is running |
 | `transcript(ref)` | `(ref: SessionRef) => Promise<Transcript>` | Get prior session's transcript as `{ path, content }` |
 | `getMessages(ref)` | `(ref: SessionRef) => Promise<SavedMessage[]>` | Get prior session's raw native messages |
@@ -225,9 +236,10 @@ The Atomic runtime provides `s.client` and `s.session` with types resolved from 
 
 | File | Topic |
 |---|---|
+| `workflow-inputs.md` | Declaring the `inputs: WorkflowInput[]` schema, the free-form vs structured decision, CLI flag + picker invocation surfaces, builtin protection |
 | `agent-sessions.md` | Creating agent sessions with SDK calls per provider |
 | `computation-and-validation.md` | Deterministic computation, parsing, validation inside `run()` |
-| `user-input.md` | Collecting user input with per-SDK APIs |
+| `user-input.md` | Collecting user input **mid-workflow** (for invocation-time inputs, see `workflow-inputs.md`) |
 | `control-flow.md` | Loops, conditionals, early termination in plain TypeScript |
 | `state-and-data-flow.md` | Data flow between sessions, transcripts, persistence |
 | `session-config.md` | Per-SDK session configuration: model, tools, permissions, hooks |

--- a/.agents/skills/workflow-creator/references/session-config.md
+++ b/.agents/skills/workflow-creator/references/session-config.md
@@ -27,7 +27,7 @@ await ctx.stage({ name: "..." }, {}, {
   timeoutMs: 5 * 60 * 1000,     // 5 minutes per query (default)
   pollIntervalMs: 1_000,         // Poll interval for output
 }, async (s) => {
-  await s.session.query(ctx.userPrompt);
+  await s.session.query((ctx.inputs.prompt ?? ""));
   s.save(s.sessionId);
 });
 ```
@@ -38,7 +38,7 @@ await ctx.stage({ name: "..." }, {}, {
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
 const result = query({
-  prompt: ctx.userPrompt,
+  prompt: (ctx.inputs.prompt ?? ""),
   options: {
     // Model selection
     model: "claude-opus-4-6",         // Full model ID or alias ("opus", "sonnet", "haiku")
@@ -117,7 +117,7 @@ Hooks intercept tool usage, session events, and context management. The `hooks` 
 
 ```ts
 const result = query({
-  prompt: ctx.userPrompt,
+  prompt: (ctx.inputs.prompt ?? ""),
   options: {
     hooks: {
       PreToolUse: [{
@@ -207,7 +207,7 @@ await ctx.stage({ name: "plan" }, {}, {
   // Advanced
   infiniteSessions: true,             // Auto-manage context via compaction
 }, async (s) => {
-  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt: (ctx.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 ```
@@ -217,7 +217,7 @@ await ctx.stage({ name: "plan" }, {}, {
 ```ts
 // Approve everything (autonomous) — this is the default
 await ctx.stage({ name: "plan" }, {}, { onPermissionRequest: approveAll }, async (s) => {
-  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt: (ctx.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 
@@ -237,7 +237,7 @@ await ctx.stage({ name: "plan" }, {}, {
     }
   },
 }, async (s) => {
-  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt: (ctx.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 ```
@@ -281,7 +281,7 @@ await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
   // Basic prompt
   const result = await s.client.session.prompt({
     sessionID: s.session.id,
-    parts: [{ type: "text", text: ctx.userPrompt }],
+    parts: [{ type: "text", text: (ctx.inputs.prompt ?? "") }],
   });
 
   // Structured output

--- a/.agents/skills/workflow-creator/references/state-and-data-flow.md
+++ b/.agents/skills/workflow-creator/references/state-and-data-flow.md
@@ -110,7 +110,7 @@ Use closures and variables for state within a single session:
 
     for (let cycle = 0; cycle < 10; cycle++) {
       const result = await s.session.query(
-        buildReviewPrompt(ctx.userPrompt, priorOutput),
+        buildReviewPrompt((ctx.inputs.prompt ?? ""), priorOutput),
       );
 
       // Accumulate findings
@@ -128,7 +128,7 @@ Use closures and variables for state within a single session:
       consecutiveClean = 0;
 
       // Apply fix
-      const fixResult = await s.session.query(buildFixSpec(review, ctx.userPrompt));
+      const fixResult = await s.session.query(buildFixSpec(review, (ctx.inputs.prompt ?? "")));
       priorOutput = fixResult.output;
     }
 
@@ -339,7 +339,7 @@ Use the filesystem as a coordination layer instead of inlining large data into p
 ```ts
 .run(async (ctx) => {
   await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
-    await s.session.query(`Create a plan for: ${s.userPrompt}\n\nWrite it to plan.md.`);
+    await s.session.query(`Create a plan for: ${(s.inputs.prompt ?? "")}\n\nWrite it to plan.md.`);
     s.save(s.sessionId);
   });
 

--- a/.agents/skills/workflow-creator/references/user-input.md
+++ b/.agents/skills/workflow-creator/references/user-input.md
@@ -1,6 +1,8 @@
-# User Input
+# User Input (mid-workflow)
 
-Collecting user input mid-workflow is achieved through SDK-specific APIs. This is the programmatic equivalent of `.askUserQuestion()`.
+This reference covers **mid-workflow** user interaction — pausing a running stage to ask the user a question, approve a permission, or confirm a decision. It's the programmatic equivalent of `.askUserQuestion()`.
+
+For **invocation-time** inputs (the values the user supplies when they launch the workflow from the CLI or the picker), see `workflow-inputs.md` instead. Invocation-time inputs are declared on `defineWorkflow({ inputs: [...] })` and arrive in `ctx.inputs` before any stage starts — the workflow author reads them via `ctx.inputs.<name>`.
 
 ## Claude
 
@@ -38,7 +40,7 @@ Allow the agent to ask the user questions by including `AskUserQuestion` in `all
 
 ```ts
 const result = query({
-  prompt: ctx.userPrompt,
+  prompt: (ctx.inputs.prompt ?? ""),
   options: {
     allowedTools: ["Read", "Write", "Edit", "Bash", "AskUserQuestion"],
   },
@@ -50,7 +52,7 @@ const result = query({
 For interactive sessions, use streaming mode to feed user input:
 
 ```ts
-const q = query({ prompt: ctx.userPrompt, options: { ... } });
+const q = query({ prompt: (ctx.inputs.prompt ?? ""), options: { ... } });
 
 // Feed additional input while the agent is running
 q.streamInput("Here's the additional context you asked for...");
@@ -75,7 +77,7 @@ await ctx.stage({ name: "plan" }, {}, {
     return answer;
   },
 }, async (s) => {
-  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt: (ctx.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 ```
@@ -95,7 +97,7 @@ await ctx.stage({ name: "plan" }, {}, {
     };
   },
 }, async (s) => {
-  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt: (ctx.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 ```
@@ -110,7 +112,7 @@ import { approveAll } from "@github/copilot-sdk";
 
 // Explicit (same as the default):
 await ctx.stage({ name: "plan" }, {}, { onPermissionRequest: approveAll }, async (s) => {
-  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt: (ctx.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 ```
@@ -129,7 +131,7 @@ await ctx.stage({ name: "plan" }, {}, {
     return { kind: "approved" };
   },
 }, async (s) => {
-  await s.session.sendAndWait({ prompt: ctx.userPrompt }, SEND_TIMEOUT_MS);
+  await s.session.sendAndWait({ prompt: (ctx.inputs.prompt ?? "") }, SEND_TIMEOUT_MS);
   s.save(await s.session.getMessages());
 });
 ```

--- a/.agents/skills/workflow-creator/references/workflow-inputs.md
+++ b/.agents/skills/workflow-creator/references/workflow-inputs.md
@@ -1,0 +1,271 @@
+# Workflow Inputs
+
+Workflows collect structured data from the user at invocation time through
+a single uniform API: `ctx.inputs` (and `s.inputs` inside stage
+callbacks). This reference covers how the inputs pipe works, when to
+declare a schema vs. rely on the free-form fallback, and how values
+reach the workflow from the CLI and the interactive picker.
+
+## The inputs pipe
+
+Every workflow run receives a `Record<string, string>` of inputs. The
+runtime populates it from whichever invocation surface the user chose:
+
+| Surface | How values are supplied | How they land in `ctx.inputs` |
+|---|---|---|
+| **Named run, positional** — `atomic workflow -n hello -a claude "fix the bug"` | A single positional prompt string | `{ prompt: "fix the bug" }` |
+| **Named run, structured** — `atomic workflow -n gen-spec -a claude --research_doc=notes.md --focus=standard` | One `--<field>=<value>` flag per declared input | `{ research_doc: "notes.md", focus: "standard" }` |
+| **Interactive picker** — `atomic workflow -a claude` | The user fills in a form rendered from the declared schema (or the default `prompt` field if the workflow is free-form) | Whatever the user typed, keyed by field name |
+
+Workflow code is the same either way — it always reads
+`ctx.inputs.<name>`. The invocation surface is a CLI concern, not a
+workflow concern.
+
+## Reading inputs
+
+For free-form workflows (no declared schema), the positional prompt
+lands under the reserved `prompt` key. Destructure it once at the top of
+`.run()` so every stage can close over a bare string:
+
+```ts
+defineWorkflow<"claude">({ name: "answer", description: "Single-turn answer" })
+  .run(async (ctx) => {
+    const prompt = ctx.inputs.prompt ?? "";
+
+    await ctx.stage({ name: "answer" }, {}, {}, async (s) => {
+      await s.session.query(prompt);
+      s.save(s.sessionId);
+    });
+  })
+  .compile();
+```
+
+For structured workflows, read each declared field by name. Pull them
+out of `ctx.inputs` once for readability and so downstream stages can
+close over locals:
+
+```ts
+defineWorkflow<"claude">({
+    name: "gen-spec",
+    description: "Convert a research doc into a detailed execution spec",
+    inputs: [
+      { name: "research_doc", type: "string", required: true },
+      {
+        name: "focus",
+        type: "enum",
+        required: true,
+        values: ["minimal", "standard", "exhaustive"],
+        default: "standard",
+      },
+      { name: "notes", type: "text" },
+    ],
+  })
+  .run(async (ctx) => {
+    const { research_doc, focus } = ctx.inputs;
+    const notes = ctx.inputs.notes ?? "";
+
+    await ctx.stage({ name: "write-spec" }, {}, {}, async (s) => {
+      await s.session.query(
+        `Read ${research_doc} and produce a ${focus} spec.` +
+          (notes ? `\n\nExtra guidance:\n${notes}` : ""),
+      );
+      s.save(s.sessionId);
+    });
+  })
+  .compile();
+```
+
+The nullish coalescing on `notes` handles the optional field case —
+declared-but-unset inputs resolve to `undefined` unless they have a
+`default`.
+
+## Declaring an input schema
+
+Pass an `inputs` array to `defineWorkflow({ ... })`. Each entry is a
+`WorkflowInput`:
+
+```ts
+interface WorkflowInput {
+  /** Field name — becomes the CLI flag (`--<name>`) and form label. */
+  name: string;
+  /** Input kind: string | text | enum */
+  type: "string" | "text" | "enum";
+  /** Whether the field must be non-empty before the workflow can run. */
+  required?: boolean;
+  /** Short description shown as the field caption. */
+  description?: string;
+  /** Placeholder shown when the field is empty. */
+  placeholder?: string;
+  /** Default value — enums use this to pick their initial value. */
+  default?: string;
+  /** Allowed values — required when `type` is `"enum"`. */
+  values?: string[];
+}
+```
+
+### Picking a field type
+
+| Type | Use when | Picker renders as | Example |
+|---|---|---|---|
+| `string` | Short single-line values — identifiers, file paths, branch names | Single-row text input | `research_doc: "notes.md"` |
+| `text` | Longer free-form prose — specs, prompts, extra context | Multi-row text area | `spec: "Build a..."` |
+| `enum` | A fixed set of allowed values | Radio-button row | `focus: "standard" \| "minimal" \| "exhaustive"` |
+
+Rule of thumb: use `enum` whenever there's a closed set of options — it
+gives users discoverable choices instead of making them remember magic
+strings, and the CLI will reject invalid values at parse time.
+
+### Validation enforced by the runtime
+
+The `defineWorkflow` builder validates the schema at compile time and
+rejects authoring mistakes immediately — you won't discover them in
+production:
+
+- **Input names must be valid CLI flag tails** — start with a letter,
+  then letters/digits/underscores/dashes. `1bad` is rejected because
+  `--1bad` isn't a parseable flag.
+- **Enum inputs must declare `values`** — an enum with no choices is
+  always invalid.
+- **Enum `default` must be in `values`** — prevents drift between the
+  default and the allowed set.
+- **No duplicate names** — two inputs with the same `name` shadow each
+  other and are rejected.
+
+At invocation time, the CLI does a second pass to catch runtime errors
+before spinning up any tmux session:
+
+- **Required fields must be non-empty** (whitespace-only strings are
+  treated as empty). Missing required fields produce a clear
+  `Missing required input --<name>` error and exit non-zero.
+- **Enum values must be in the allowed list.** `--focus=bogus` produces
+  `Invalid value for --focus: "bogus". Expected one of: minimal, standard, exhaustive.`
+- **Unknown flags are rejected.** A `--random_flag=value` that isn't in
+  the schema produces `Unknown input --random_flag` with the valid
+  flag list appended.
+
+This validation runs before any workflow code, so a malformed
+invocation can never reach your `.run()` callback in a half-filled
+state.
+
+## Free-form vs structured: when to use which
+
+Choose **free-form** (no `inputs` field on `defineWorkflow`) when:
+
+- The workflow takes a single unstructured request that varies widely
+  in phrasing — "find the bug", "build me a chart", "refactor the auth
+  module".
+- You want the simplest possible CLI surface.
+- The workflow's first LLM call will do its own intent extraction from
+  the raw prompt.
+
+Read the prompt via `ctx.inputs.prompt ?? ""`.
+
+Choose **structured** (declared `inputs: [...]`) when:
+
+- Several distinct fields are always needed — a file path + a focus
+  level + optional notes, for example.
+- You want the picker to show a real form (each field, its type, and
+  any validation cues) instead of a single blob text area.
+- You want the CLI to reject bad inputs before spawning a workflow —
+  e.g. a nonexistent enum value.
+- You want the invocation to be scriptable and auditable — flag-based
+  invocation reads cleanly in CI.
+
+Structured workflows can also include a `prompt` field in their schema
+if they need both a free-form request AND structured parameters. The
+`prompt` key is not magic for structured workflows — it's just a
+conventional name. You only get "positional maps to `prompt`" behavior
+when the workflow has no schema at all.
+
+## The interactive picker
+
+`atomic workflow -a <agent>` (no `-n`) launches the interactive
+picker. The picker:
+
+1. Discovers all workflows compatible with `<agent>` across local,
+   global, and builtin sources.
+2. Loads each workflow's metadata (description + declared inputs).
+3. Shows a Telescope-style fuzzy list. The user types to filter,
+   arrows to navigate, ↵ to lock in a selection.
+4. Renders the selected workflow's form. Free-form workflows get a
+   single `prompt` text field; structured workflows get one field
+   per declared input with type-specific rendering.
+5. Validates required fields on ⌃s. If any are empty, focus jumps to
+   the first invalid field and the run button stays disabled.
+6. Confirms with a y/n modal, then tears down the picker and hands
+   off to the workflow executor — same live-run surface users see
+   when they invoke the workflow with `-n` directly.
+
+The picker is the preferred discovery path for users who don't
+remember flag names. Structured workflows benefit the most from it
+because the form teaches the schema as the user fills it in.
+
+## Builtin protection
+
+Builtin workflows (the ones shipped inside the SDK — currently `ralph`)
+are **reserved**. A local or global workflow with the same name will
+not shadow the builtin at resolution time. This prevents a user from
+accidentally redefining the canonical version of a workflow in a way
+that confuses teammates or breaks automation.
+
+You'll still see shadowed local/global workflows in
+`atomic workflow -l` output so the collision is visible, but running
+`atomic workflow -n ralph -a claude` will always land on the builtin.
+
+The practical implication: **don't name a new workflow the same as a
+builtin**. Pick a distinct name and you'll never hit this.
+
+## Invocation cheat sheet
+
+```bash
+# List everything, grouped by source
+atomic workflow -l
+
+# Launch the picker for a pinned agent
+atomic workflow -a claude
+
+# Free-form, positional prompt
+atomic workflow -n hello -a claude "hello world"
+
+# Structured, one flag per field
+atomic workflow -n gen-spec -a claude \
+  --research_doc=research/docs/2026-04-11-auth.md \
+  --focus=standard \
+  --notes="pay special attention to session token storage"
+
+# Structured, long-form flag value (= form)
+atomic workflow -n gen-spec -a claude --focus standard --research_doc notes.md
+```
+
+Both `--flag=value` and `--flag value` forms are accepted. Short flags
+(`-x value`) are NOT parsed as structured inputs — only long-form
+`--<name>` flags resolve against the schema.
+
+## Pitfalls
+
+### Don't expect `inputs.prompt` on structured workflows
+
+A structured workflow that doesn't declare a `prompt` field will have
+`ctx.inputs.prompt === undefined`. The CLI also rejects a positional
+prompt for structured workflows outright — if you try
+`atomic workflow -n gen-spec -a claude "some text"` you'll get:
+
+> Error: workflow 'gen-spec' takes structured inputs — pass them as
+> `--<name>=<value>` flags instead of a positional prompt.
+
+If your workflow wants both a free-form prompt AND structured fields,
+declare `prompt` as a `text` input explicitly in the schema.
+
+### Don't rename inputs across workflow versions
+
+Declared input names are part of the workflow's public API — they map
+directly to `--<name>` flags and field identifiers in the picker.
+Renaming a field is a breaking change for any script that invokes the
+workflow. If you need to rename, add the new name alongside the old,
+migrate callers, then remove the old name in a later change.
+
+### Don't put secrets in `default`
+
+Defaults are visible in the picker and printed in CLI errors. They're
+fine for values like `"standard"` but not for API keys or auth tokens.
+Read those from environment variables inside the workflow instead.

--- a/.atomic/workflows/hello-world/claude/index.ts
+++ b/.atomic/workflows/hello-world/claude/index.ts
@@ -1,16 +1,53 @@
 import { defineWorkflow } from "@bastani/atomic/workflows";
 
+/**
+ * Build the greeting prompt from the structured inputs. The picker and
+ * CLI flag parser both populate `ctx.inputs` — this workflow exercises
+ * the full structured-input pipeline end to end.
+ */
+function buildHelloPrompt(inputs: Record<string, string>): string {
+  const greeting = inputs.greeting ?? "Hello";
+  const style = inputs.style ?? "casual";
+  const notes = inputs.notes?.trim() ?? "";
+  const base = `${greeting} Please respond with a ${style} hello-world greeting.`;
+  return notes ? `${base}\n\nAdditional guidance:\n${notes}` : base;
+}
+
 export default defineWorkflow<"claude">({
     name: "hello-world",
     description: "A simple single-session hello world workflow",
+    inputs: [
+      {
+        name: "greeting",
+        type: "string",
+        required: true,
+        description: "the opening phrase the agent should echo back",
+        placeholder: "Hello, world!",
+      },
+      {
+        name: "style",
+        type: "enum",
+        required: true,
+        description: "tone of the response",
+        values: ["formal", "casual", "robotic"],
+        default: "casual",
+      },
+      {
+        name: "notes",
+        type: "text",
+        description: "extra guidance for the agent (optional)",
+        placeholder: "anything you want to add…",
+      },
+    ],
   })
   .run(async (ctx) => {
+    const prompt = buildHelloPrompt(ctx.inputs);
     await ctx.stage(
       { name: "hello", description: "Say hello to the world" },
       {},
       {},
       async (s) => {
-        await s.session.query(s.userPrompt);
+        await s.session.query(prompt);
         s.save(s.sessionId);
       },
     );

--- a/.atomic/workflows/hello-world/copilot/index.ts
+++ b/.atomic/workflows/hello-world/copilot/index.ts
@@ -2,17 +2,54 @@ import { defineWorkflow } from "@bastani/atomic/workflows";
 
 const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
+/**
+ * Build the greeting prompt from the structured inputs. The picker and
+ * CLI flag parser both populate `ctx.inputs` — this workflow exercises
+ * the full structured-input pipeline end to end.
+ */
+function buildHelloPrompt(inputs: Record<string, string>): string {
+  const greeting = inputs.greeting ?? "Hello";
+  const style = inputs.style ?? "casual";
+  const notes = inputs.notes?.trim() ?? "";
+  const base = `${greeting} Please respond with a ${style} hello-world greeting.`;
+  return notes ? `${base}\n\nAdditional guidance:\n${notes}` : base;
+}
+
 export default defineWorkflow<"copilot">({
     name: "hello-world",
     description: "A simple single-session hello world workflow",
+    inputs: [
+      {
+        name: "greeting",
+        type: "string",
+        required: true,
+        description: "the opening phrase the agent should echo back",
+        placeholder: "Hello, world!",
+      },
+      {
+        name: "style",
+        type: "enum",
+        required: true,
+        description: "tone of the response",
+        values: ["formal", "casual", "robotic"],
+        default: "casual",
+      },
+      {
+        name: "notes",
+        type: "text",
+        description: "extra guidance for the agent (optional)",
+        placeholder: "anything you want to add…",
+      },
+    ],
   })
   .run(async (ctx) => {
+    const prompt = buildHelloPrompt(ctx.inputs);
     await ctx.stage(
       { name: "hello", description: "Say hello to the world" },
       {},
       {},
       async (s) => {
-        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+        await s.session.sendAndWait({ prompt }, SEND_TIMEOUT_MS);
         s.save(await s.session.getMessages());
       },
     );

--- a/.atomic/workflows/hello-world/opencode/index.ts
+++ b/.atomic/workflows/hello-world/opencode/index.ts
@@ -1,10 +1,47 @@
 import { defineWorkflow } from "@bastani/atomic/workflows";
 
+/**
+ * Build the greeting prompt from the structured inputs. The picker and
+ * CLI flag parser both populate `ctx.inputs` — this workflow exercises
+ * the full structured-input pipeline end to end.
+ */
+function buildHelloPrompt(inputs: Record<string, string>): string {
+  const greeting = inputs.greeting ?? "Hello";
+  const style = inputs.style ?? "casual";
+  const notes = inputs.notes?.trim() ?? "";
+  const base = `${greeting} Please respond with a ${style} hello-world greeting.`;
+  return notes ? `${base}\n\nAdditional guidance:\n${notes}` : base;
+}
+
 export default defineWorkflow<"opencode">({
     name: "hello-world",
     description: "A simple single-session hello world workflow",
+    inputs: [
+      {
+        name: "greeting",
+        type: "string",
+        required: true,
+        description: "the opening phrase the agent should echo back",
+        placeholder: "Hello, world!",
+      },
+      {
+        name: "style",
+        type: "enum",
+        required: true,
+        description: "tone of the response",
+        values: ["formal", "casual", "robotic"],
+        default: "casual",
+      },
+      {
+        name: "notes",
+        type: "text",
+        description: "extra guidance for the agent (optional)",
+        placeholder: "anything you want to add…",
+      },
+    ],
   })
   .run(async (ctx) => {
+    const prompt = buildHelloPrompt(ctx.inputs);
     await ctx.stage(
       { name: "hello", description: "Say hello to the world" },
       {},
@@ -12,7 +49,7 @@ export default defineWorkflow<"opencode">({
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
-          parts: [{ type: "text", text: s.userPrompt }],
+          parts: [{ type: "text", text: prompt }],
         });
         s.save(result.data!);
       },

--- a/.atomic/workflows/parallel-hello-world/claude/index.ts
+++ b/.atomic/workflows/parallel-hello-world/claude/index.ts
@@ -1,16 +1,41 @@
 import { defineWorkflow } from "@bastani/atomic/workflows";
 
+/** Compose the initial greeting prompt from the structured inputs. */
+function buildGreetPrompt(inputs: Record<string, string>): string {
+  const topic = inputs.topic ?? "the world";
+  const tone = inputs.tone ?? "warm";
+  return `Write a short ${tone} greeting about "${topic}".`;
+}
+
 export default defineWorkflow<"claude">({
     name: "parallel-hello-world",
     description: "Parallel hello world: greet → [formal, casual] → merge",
+    inputs: [
+      {
+        name: "topic",
+        type: "string",
+        required: true,
+        description: "what the greeting should be about",
+        placeholder: "a new project launch",
+      },
+      {
+        name: "tone",
+        type: "enum",
+        required: true,
+        description: "overall tone of the seed greeting",
+        values: ["warm", "neutral", "cold"],
+        default: "warm",
+      },
+    ],
   })
   .run(async (ctx) => {
+    const seedPrompt = buildGreetPrompt(ctx.inputs);
     const greet = await ctx.stage(
       { name: "greet", description: "Generate a greeting topic" },
       {},
       {},
       async (s) => {
-        await s.session.query(s.userPrompt);
+        await s.session.query(seedPrompt);
         s.save(s.sessionId);
       },
     );

--- a/.atomic/workflows/parallel-hello-world/copilot/index.ts
+++ b/.atomic/workflows/parallel-hello-world/copilot/index.ts
@@ -2,17 +2,42 @@ import { defineWorkflow } from "@bastani/atomic/workflows";
 
 const SEND_TIMEOUT_MS = 30 * 60 * 1000;
 
+/** Compose the initial greeting prompt from the structured inputs. */
+function buildGreetPrompt(inputs: Record<string, string>): string {
+  const topic = inputs.topic ?? "the world";
+  const tone = inputs.tone ?? "warm";
+  return `Write a short ${tone} greeting about "${topic}".`;
+}
+
 export default defineWorkflow<"copilot">({
     name: "parallel-hello-world",
     description: "Parallel hello world: greet → [formal, casual] → merge",
+    inputs: [
+      {
+        name: "topic",
+        type: "string",
+        required: true,
+        description: "what the greeting should be about",
+        placeholder: "a new project launch",
+      },
+      {
+        name: "tone",
+        type: "enum",
+        required: true,
+        description: "overall tone of the seed greeting",
+        values: ["warm", "neutral", "cold"],
+        default: "warm",
+      },
+    ],
   })
   .run(async (ctx) => {
+    const seedPrompt = buildGreetPrompt(ctx.inputs);
     const greet = await ctx.stage(
       { name: "greet", description: "Generate a greeting topic" },
       {},
       {},
       async (s) => {
-        await s.session.sendAndWait({ prompt: s.userPrompt }, SEND_TIMEOUT_MS);
+        await s.session.sendAndWait({ prompt: seedPrompt }, SEND_TIMEOUT_MS);
         s.save(await s.session.getMessages());
       },
     );

--- a/.atomic/workflows/parallel-hello-world/opencode/index.ts
+++ b/.atomic/workflows/parallel-hello-world/opencode/index.ts
@@ -1,10 +1,35 @@
 import { defineWorkflow } from "@bastani/atomic/workflows";
 
+/** Compose the initial greeting prompt from the structured inputs. */
+function buildGreetPrompt(inputs: Record<string, string>): string {
+  const topic = inputs.topic ?? "the world";
+  const tone = inputs.tone ?? "warm";
+  return `Write a short ${tone} greeting about "${topic}".`;
+}
+
 export default defineWorkflow<"opencode">({
     name: "parallel-hello-world",
     description: "Parallel hello world: greet → [formal, casual] → merge",
+    inputs: [
+      {
+        name: "topic",
+        type: "string",
+        required: true,
+        description: "what the greeting should be about",
+        placeholder: "a new project launch",
+      },
+      {
+        name: "tone",
+        type: "enum",
+        required: true,
+        description: "overall tone of the seed greeting",
+        values: ["warm", "neutral", "cold"],
+        default: "warm",
+      },
+    ],
   })
   .run(async (ctx) => {
+    const seedPrompt = buildGreetPrompt(ctx.inputs);
     const greet = await ctx.stage(
       { name: "greet", description: "Generate a greeting topic" },
       {},
@@ -12,7 +37,7 @@ export default defineWorkflow<"opencode">({
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
-          parts: [{ type: "text", text: s.userPrompt }],
+          parts: [{ type: "text", text: seedPrompt }],
         });
         s.save(result.data!);
       },

--- a/.atomic/workflows/tsconfig.json
+++ b/.atomic/workflows/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "paths": {
+      "@bastani/atomic/workflows": ["../../src/sdk/workflows/index.ts"],
+      "@bastani/atomic": ["../../src/sdk/index.ts"]
+    }
+  },
+  "include": ["**/*.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -167,11 +167,16 @@ export default defineWorkflow<"claude">({
   description: "Research -> Implement -> Review",
 })
   .run(async (ctx) => {
+    // Free-form workflows receive their positional prompt under
+    // `ctx.inputs.prompt`. Destructure it once so every stage below
+    // can close over a bare string.
+    const prompt = ctx.inputs.prompt ?? "";
+
     const research = await ctx.stage(
       { name: "research", description: "Analyze the codebase" },
       {}, {},
       async (s) => {
-        await s.session.query(`/research-codebase ${s.userPrompt}`);
+        await s.session.query(`/research-codebase ${prompt}`);
         s.save(s.sessionId);
       },
     );
@@ -250,11 +255,13 @@ export default defineWorkflow<"claude">({
   description: "Two-session pipeline: describe -> summarize",
 })
   .run(async (ctx) => {
+    const prompt = ctx.inputs.prompt ?? "";
+
     const describe = await ctx.stage(
       { name: "describe", description: "Ask Claude to describe the project" },
       {}, {},
       async (s) => {
-        await s.session.query(s.userPrompt);
+        await s.session.query(prompt);
         s.save(s.sessionId);
       },
     );
@@ -287,10 +294,12 @@ export default defineWorkflow<"claude">({
   description: "describe -> [summarize-a, summarize-b] -> merge",
 })
   .run(async (ctx) => {
+    const prompt = ctx.inputs.prompt ?? "";
+
     const describe = await ctx.stage(
       { name: "describe" }, {}, {},
       async (s) => {
-        await s.session.query(s.userPrompt);
+        await s.session.query(prompt);
         s.save(s.sessionId);
       },
     );
@@ -322,6 +331,71 @@ export default defineWorkflow<"claude">({
 
 </details>
 
+<details>
+<summary>Example: Structured-input workflow (declared schema + CLI flag validation)</summary>
+
+Declare an `inputs` array on `defineWorkflow` and the CLI materialises one `--<field>=<value>` flag per entry. Required fields, enum membership, and unknown-flag rejection are all validated before any tmux session is spawned. The interactive picker (`atomic workflow -a <agent>`) renders the same schema as a form.
+
+```ts
+// .atomic/workflows/gen-spec/claude/index.ts
+import { defineWorkflow } from "@bastani/atomic/workflows";
+
+export default defineWorkflow<"claude">({
+  name: "gen-spec",
+  description: "Convert a research doc into an execution spec",
+  inputs: [
+    {
+      name: "research_doc",
+      type: "string",
+      required: true,
+      description: "path to the research doc",
+      placeholder: "research/docs/2026-04-11-auth.md",
+    },
+    {
+      name: "focus",
+      type: "enum",
+      required: true,
+      description: "how aggressively to scope the spec",
+      values: ["minimal", "standard", "exhaustive"],
+      default: "standard",
+    },
+    {
+      name: "notes",
+      type: "text",
+      description: "extra guidance for the spec writer (optional)",
+    },
+  ],
+})
+  .run(async (ctx) => {
+    // Read each declared field by name.
+    const { research_doc, focus } = ctx.inputs;
+    const notes = ctx.inputs.notes ?? "";
+
+    await ctx.stage({ name: "write-spec" }, {}, {}, async (s) => {
+      await s.session.query(
+        `Read ${research_doc} and produce a ${focus} spec.` +
+          (notes ? `\n\nExtra guidance:\n${notes}` : ""),
+      );
+      s.save(s.sessionId);
+    });
+  })
+  .compile();
+```
+
+Run it either way:
+
+```bash
+# Named + flags (scriptable; CI-friendly)
+atomic workflow -n gen-spec -a claude \
+  --research_doc=research/docs/2026-04-11-auth.md \
+  --focus=standard
+
+# Picker (fuzzy-search the workflow list, then fill the form)
+atomic workflow -a claude
+```
+
+</details>
+
 **Key capabilities:**
 
 | Capability                   | Description                                                                          |
@@ -330,6 +404,8 @@ export default defineWorkflow<"claude">({
 | **Native TypeScript control flow** | Use `for`, `if/else`, `Promise.all()`, `try/catch` — no framework DSL needed |
 | **Session return values**    | Session callbacks can return data: `const h = await ctx.stage(...); h.result`      |
 | **Transcript passing**       | Access prior session output via handle (`s.transcript(handle)`) or name (`s.transcript("name")`) |
+| **Declared input schemas**   | Add an `inputs: [...]` array to `defineWorkflow()` and the CLI materialises `--<field>=<value>` flags with built-in validation (required fields, enum membership, unknown flags) |
+| **Interactive picker**       | `atomic workflow -a <agent>` launches a fuzzy-searchable picker that renders each workflow's input schema as a form — no flag-memorisation required |
 | **Nested sub-sessions**      | Call `s.stage()` inside a session callback to spawn child sessions — visible as nested nodes in the graph |
 | **Auto-inferred graph**      | Graph topology auto-inferred from `await`/`Promise.all` patterns — no annotations needed               |
 | **Provider-agnostic**        | Write raw SDK code for Claude, Copilot, or OpenCode inside each session callback     |
@@ -368,7 +444,7 @@ Use your workflow-creator skill to create a workflow that plans, implements, and
 
 | Property                | Type                      | Description                                                    |
 | ----------------------- | ------------------------- | -------------------------------------------------------------- |
-| `ctx.userPrompt`        | `string`                  | Original user prompt from the CLI invocation                   |
+| `ctx.inputs`            | `Record<string, string>`  | Structured inputs for this run. Free-form workflows store their positional prompt under `ctx.inputs.prompt`; workflows with a declared `inputs` schema store one key per declared field |
 | `ctx.agent`             | `AgentType`               | Which agent is running (`"claude"`, `"copilot"`, `"opencode"`) |
 | `ctx.stage(opts, clientOpts, sessionOpts, fn)` | `Promise<SessionHandle<T>>` | Spawn a session — returns handle with `name`, `id`, `result` |
 | `ctx.transcript(ref)`   | `Promise<Transcript>`     | Get a completed session's transcript (`{ path, content }`)     |
@@ -380,7 +456,7 @@ Use your workflow-creator skill to create a workflow that plans, implements, and
 | ----------------------- | ------------------------- | -------------------------------------------------------------- |
 | `s.client`              | `ProviderClient<A>`       | Pre-created SDK client (auto-managed by runtime)               |
 | `s.session`             | `ProviderSession<A>`      | Pre-created provider session (auto-managed by runtime)         |
-| `s.userPrompt`          | `string`                  | Original user prompt from the CLI invocation                   |
+| `s.inputs`              | `Record<string, string>`  | Same inputs record as `ctx.inputs`, forwarded into every stage so session callbacks can read values without closing over the outer `ctx` |
 | `s.agent`               | `AgentType`               | Which agent is running                                         |
 | `s.paneId`              | `string`                  | tmux pane ID for this session                                  |
 | `s.sessionId`           | `string`                  | Session UUID                                                   |
@@ -750,12 +826,35 @@ atomic chat -a claude --verbose              # Forward --verbose to claude
 
 #### `atomic workflow` Flags
 
-| Flag                 | Description                                                         |
-| -------------------- | ------------------------------------------------------------------- |
-| `-n, --name <name>`  | Workflow name (matches directory under `.atomic/workflows/<name>/`) |
-| `-a, --agent <name>` | Agent: `claude`, `opencode`, `copilot`                              |
-| `-l, --list`         | List available workflows                                            |
-| `[prompt...]`        | Prompt for the workflow                                             |
+| Flag                       | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `-n, --name <name>`        | Workflow name (matches directory under `.atomic/workflows/<name>/`) |
+| `-a, --agent <name>`       | Agent: `claude`, `opencode`, `copilot`                              |
+| `-l, --list`               | List available workflows, grouped by source                         |
+| `--<field>=<value>`        | Structured input for workflows that declare an `inputs` schema (also accepts `--<field> <value>`) |
+| `[prompt...]`               | Positional prompt for free-form workflows (rejected on workflows with a declared schema) |
+
+The workflow command supports four invocation shapes:
+
+```bash
+# 1. List every workflow available to you, grouped by source
+atomic workflow -l
+
+# 2. Launch the interactive picker for an agent (no -n) — fuzzy-search
+#    the list, fill the form rendered from the workflow's declared inputs,
+#    and confirm with y/n
+atomic workflow -a claude
+
+# 3. Run a free-form workflow with a positional prompt
+atomic workflow -n ralph -a claude "build a REST API for user management"
+
+# 4. Run a structured-input workflow with one --<field> flag per declared input
+atomic workflow -n gen-spec -a claude \
+  --research_doc=research/docs/2026-04-11-auth.md \
+  --focus=standard
+```
+
+Workflows that declare an `inputs: WorkflowInput[]` schema get CLI flag validation for free — missing required fields and invalid enum values are rejected before any tmux session is spawned, with error messages that spell out the expected flag set. Workflows that don't declare a schema still accept a single positional prompt, which the runtime stores under `ctx.inputs.prompt`. **Builtin workflows (like `ralph`) are reserved names** — a local or global workflow with the same name will not shadow a builtin at resolution time.
 
 ### Atomic-Provided Skills (invokable from any agent chat)
 

--- a/research/designs/tsconfig.json
+++ b/research/designs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.tsx"]
+}

--- a/research/designs/workflow-picker-tui.tsx
+++ b/research/designs/workflow-picker-tui.tsx
@@ -1,0 +1,1614 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Atomic — Workflow Picker TUI
+ *
+ * OpenTUI React prototype of the interactive picker that appears when
+ * `atomic workflow -a <agent>` is invoked without a workflow name. The
+ * picker is strictly agent-scoped: the backend comes from the `-a`
+ * flag at launch and cannot be changed from within the UI, matching
+ * how `atomic chat -a <agent>` behaves. Demonstrates:
+ *
+ *   1. Telescope-style fuzzy picker — type to filter, arrows to navigate,
+ *      subsequence matching against both name and description
+ *   2. Structured argument preview — each workflow's input schema is
+ *      rendered as a form in the right pane; freeform workflows fall
+ *      back to a single `prompt` field
+ *   3. Two-phase flow with a confirm modal — PICK → PROMPT, with a
+ *      locked-in workflow chip once the user commits to a selection and
+ *      a centered "ready to run" modal overlay on ⌃s that shows the
+ *      fully-composed shell invocation before submission.
+ *
+ * The confirm modal prints the equivalent shell invocation, so the
+ * picker teaches the CLI flags as a side effect of using it.
+ *
+ * Run:   bun run research/designs/workflow-picker-tui.tsx -a <agent>
+ *        (default agent is "copilot" if -a is omitted)
+ * Exit:  esc (in pick phase) · ctrl-c (anywhere)
+ *
+ * Design: Catppuccin Mocha · rounded borders · Neovim-style statusline
+ */
+
+import { createCliRenderer } from "@opentui/core";
+import {
+  createRoot,
+  useKeyboard,
+  useRenderer,
+} from "@opentui/react";
+import { useState, useEffect, useMemo } from "react";
+
+// ─── Theme ──────────────────────────────────────
+
+interface PickerTheme {
+  background: string;
+  backgroundPanel: string;
+  backgroundElement: string;
+  surface: string;
+  text: string;
+  textMuted: string;
+  textDim: string;
+  primary: string;
+  success: string;
+  error: string;
+  warning: string;
+  info: string;
+  mauve: string;
+  border: string;
+  borderActive: string;
+}
+
+// Background ladder — three shades below/around the base:
+//   backgroundElement #11111b  — deepest, for RECESSED surfaces
+//                                 (unfocused form fields, cursor hiding)
+//   backgroundPanel   #181825  — subtly darker than base
+//                                 (focused form field bg, locked-in chip)
+//   background        #1e1e2e  — Catppuccin Base (main body)
+//   surface           #313244  — Catppuccin Surface0, RAISED panel
+//                                 (header bar, statusline bar; same as
+//                                  the production orchestrator panel's
+//                                  `theme.backgroundElement`)
+const theme: PickerTheme = {
+  background:        "#1e1e2e",
+  backgroundPanel:   "#181825",
+  backgroundElement: "#11111b",
+  surface:           "#313244",
+  text:              "#cdd6f4",
+  textMuted:         "#a6adc8",
+  textDim:           "#585b70",
+  primary:           "#89b4fa", // blue   — primary UI
+  success:           "#a6e3a1", // green  — local workflows, success state
+  error:             "#f38ba8", // red    — errors
+  warning:           "#f9e2af", // yellow — warnings
+  info:              "#89dceb", // sky    — builtin workflows, informational
+  mauve:             "#cba6f7", // purple — global workflows
+  border:            "#313244",
+  borderActive:      "#45475a",
+};
+
+// ─── Types ──────────────────────────────────────
+
+type AgentType = "claude" | "copilot" | "opencode";
+type Source = "local" | "global" | "builtin";
+type Phase = "pick" | "prompt";
+
+// Structured-input schema — the long-term shape of proposal #5, where
+// `defineWorkflow` accepts an `inputs` object and the CLI materialises
+// a field per input. Workflows that omit `inputs` fall back to the
+// single free-form prompt field via DEFAULT_PROMPT_INPUT.
+type FieldType = "text" | "string" | "enum";
+
+interface WorkflowInput {
+  name: string;
+  type: FieldType;
+  required?: boolean;
+  description?: string;
+  placeholder?: string;
+  default?: string;
+  values?: string[]; // enum only
+}
+
+interface Workflow {
+  name: string;
+  description: string;
+  source: Source;
+  agents: AgentType[];
+  inputs?: WorkflowInput[];
+}
+
+// Fallback field used when a workflow has no structured input schema.
+// Keeps the prompt phase renderer uniform — always a non-empty field list.
+const DEFAULT_PROMPT_INPUT: WorkflowInput = {
+  name: "prompt",
+  type: "text",
+  required: true,
+  description: "what do you want this workflow to do?",
+  placeholder: "describe your task…",
+};
+
+// ─── Mock Data ──────────────────────────────────
+// In the real picker these come from discoverWorkflows() + a
+// ~/.atomic/state.json file that tracks last-used per workflow.
+
+const WORKFLOWS: Workflow[] = [
+  {
+    name: "deep-research-codebase",
+    description:
+      "Deterministic deep codebase research: scout → LOC-driven parallel explorers → aggregator.",
+    source: "local",
+    agents: ["copilot"],
+  },
+  {
+    name: "generate-spec",
+    description:
+      "Convert research docs into detailed execution specs with file paths and test plans.",
+    source: "local",
+    agents: ["claude", "copilot"],
+    inputs: [
+      {
+        name: "research_doc",
+        type: "string",
+        required: true,
+        description: "path to the research doc to convert",
+        placeholder: "research/docs/2026-04-11-auth.md",
+      },
+      {
+        name: "focus",
+        type: "enum",
+        required: true,
+        description: "how aggressively to scope the spec",
+        values: ["minimal", "standard", "exhaustive"],
+        default: "standard",
+      },
+      {
+        name: "notes",
+        type: "text",
+        description: "extra guidance for the spec writer (optional)",
+        placeholder: "anything the research doc doesn't already cover…",
+      },
+    ],
+  },
+  {
+    name: "refactor-planner",
+    description:
+      "Plan multi-file refactors with cross-module impact analysis and rollback guidance.",
+    source: "local",
+    agents: ["claude"],
+    inputs: [
+      {
+        name: "target_dir",
+        type: "string",
+        required: true,
+        description: "directory rooted in the repo to analyse",
+        placeholder: "src/middleware/auth",
+      },
+      {
+        name: "goal",
+        type: "text",
+        required: true,
+        description: "what the refactor should achieve",
+        placeholder: "migrate legacy session tokens to HMAC scheme, preserving…",
+      },
+      {
+        name: "strategy",
+        type: "enum",
+        required: true,
+        description: "how to stage the rollout",
+        values: ["incremental", "full-rewrite", "parallel"],
+        default: "incremental",
+      },
+    ],
+  },
+  {
+    name: "code-review",
+    description:
+      "Run a PR diff through every installed agent backend, then reconcile disagreements.",
+    source: "global",
+    agents: ["claude", "opencode", "copilot"],
+    inputs: [
+      {
+        name: "pr_ref",
+        type: "string",
+        required: true,
+        description: "PR number, branch, or git ref",
+        placeholder: "anomalyco/atomic#580",
+      },
+      {
+        name: "depth",
+        type: "enum",
+        required: true,
+        description: "how deeply to analyse each hunk",
+        values: ["quick", "thorough"],
+        default: "thorough",
+      },
+    ],
+  },
+  {
+    name: "doc-writer",
+    description:
+      "Generate or update API docs from source, preserving prior prose where still accurate.",
+    source: "global",
+    agents: ["claude", "opencode"],
+  },
+  {
+    name: "hello-world",
+    description: "Minimal two-stage demo workflow — useful for validating SDK setups.",
+    source: "builtin",
+    agents: ["claude", "opencode", "copilot"],
+  },
+];
+
+// Agent install state — in the real picker this would be
+// isCommandInstalled(AGENT_CONFIG[agent].cmd) per backend.
+const INSTALLED_AGENTS: Record<AgentType, boolean> = {
+  claude: true,
+  copilot: true,
+  opencode: false, // demo: shows a "not installed" agent gracefully
+};
+
+// Pinned agent for this session. In production this comes from the
+// `atomic workflow -a <agent>` flag; in the demo we parse process.argv
+// ourselves. The value is a module-level constant — the picker does
+// not expose any in-UI way to change it, matching how
+// `atomic chat -a <agent>` behaves.
+const VALID_AGENTS: readonly AgentType[] = ["claude", "copilot", "opencode"];
+const DEFAULT_AGENT: AgentType = "copilot";
+
+function parseAgentFromArgv(): AgentType {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const flag = args[i];
+    if (flag === "-a" || flag === "--agent") {
+      const val = args[i + 1];
+      if (!val) {
+        console.error(
+          `Missing value for ${flag}. Usage: -a <${VALID_AGENTS.join("|")}>`,
+        );
+        process.exit(1);
+      }
+      if (!(VALID_AGENTS as readonly string[]).includes(val)) {
+        console.error(
+          `Unknown agent "${val}". Valid: ${VALID_AGENTS.join(", ")}`,
+        );
+        process.exit(1);
+      }
+      return val as AgentType;
+    }
+  }
+  return DEFAULT_AGENT;
+}
+
+const CURRENT_AGENT: AgentType = parseAgentFromArgv();
+
+// ─── Helpers ────────────────────────────────────
+
+const SOURCE_DISPLAY: Record<Source, string> = {
+  local: "local",
+  global: "global",
+  builtin: "builtin",
+};
+
+// Directory hint shown in parentheses next to each source label —
+// matches the copy used by `atomic workflow -l` so users see the
+// same wording in both surfaces.
+const SOURCE_DIR: Record<Source, string> = {
+  local: ".atomic/workflows",
+  global: "~/.atomic/workflows",
+  builtin: "built-in",
+};
+
+const SOURCE_COLOR: Record<Source, keyof PickerTheme> = {
+  local: "success",
+  global: "mauve",
+  builtin: "info",
+};
+
+// Subsequence fuzzy match — Telescope-style. Returns a score (lower =
+// better) or null for no match. Adjacent matches are rewarded; jumps over
+// non-matching characters are penalized proportionally to the gap.
+function fuzzyMatch(query: string, target: string): number | null {
+  if (query === "") return 0;
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let ti = 0;
+  let score = 0;
+  let prev = -2;
+  for (let qi = 0; qi < q.length; qi++) {
+    let found = -1;
+    while (ti < t.length) {
+      if (t[ti] === q[qi]) { found = ti; break; }
+      ti++;
+    }
+    if (found === -1) return null;
+    score += found === prev + 1 ? 1 : 4 + (found - prev);
+    prev = found;
+    ti++;
+  }
+  return score;
+}
+
+// ─── List Building ──────────────────────────────
+
+interface ListEntry {
+  workflow: Workflow;
+  section: Source;
+}
+
+interface ListRow {
+  kind: "section" | "entry";
+  source?: Source; // present on section headers
+  entry?: ListEntry;
+}
+
+function buildEntries(query: string, agent: AgentType): ListEntry[] {
+  type Scored = { wf: Workflow; score: number };
+  const scored: Scored[] = [];
+  for (const wf of WORKFLOWS) {
+    // Scope filter — the picker only shows workflows compatible with
+    // the agent the user currently has selected in the sidebar.
+    if (!wf.agents.includes(agent)) continue;
+
+    // Match against both name (primary) and description (secondary, +2
+    // penalty so name matches always win ties).
+    const nameScore = fuzzyMatch(query, wf.name);
+    const descScore = fuzzyMatch(query, wf.description);
+    const best =
+      nameScore !== null && descScore !== null
+        ? Math.min(nameScore, descScore + 2)
+        : nameScore !== null
+        ? nameScore
+        : descScore !== null
+        ? descScore + 2
+        : null;
+    if (best !== null) scored.push({ wf, score: best });
+  }
+
+  // Empty query: grouped by source. Non-empty query: flat score-sorted.
+  if (query === "") {
+    const rest: ListEntry[] = [];
+    for (const source of ["local", "global", "builtin"] as Source[]) {
+      const group = scored
+        .filter((s) => s.wf.source === source)
+        .sort((a, b) => a.wf.name.localeCompare(b.wf.name));
+      for (const s of group) rest.push({ workflow: s.wf, section: source });
+    }
+    return rest;
+  }
+
+  scored.sort((a, b) => a.score - b.score);
+  return scored.map<ListEntry>((s) => ({ workflow: s.wf, section: s.wf.source }));
+}
+
+function buildRows(entries: ListEntry[], query: string): ListRow[] {
+  const rows: ListRow[] = [];
+  if (query === "") {
+    let lastSection: string | null = null;
+    for (const e of entries) {
+      if (e.section !== lastSection) {
+        rows.push({ kind: "section", source: e.section });
+        lastSection = e.section;
+      }
+      rows.push({ kind: "entry", entry: e });
+    }
+  } else {
+    for (const e of entries) rows.push({ kind: "entry", entry: e });
+  }
+  return rows;
+}
+
+// ─── Components ─────────────────────────────────
+
+// Section header with a leading mauve indicator bar. The colored glyph
+// gives ALL-CAPS labels real weight against the preview body so they
+// don't blend into the surrounding dim text.
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <box height={1} flexDirection="row">
+      <text>
+        <span fg={theme.mauve}>▎ </span>
+        <span fg={theme.textMuted}><strong>{label}</strong></span>
+      </text>
+    </box>
+  );
+}
+
+
+function FilterBar({
+  query,
+  count,
+  cursorOn,
+}: {
+  query: string;
+  count: number;
+  cursorOn: boolean;
+}) {
+  return (
+    <box
+      height={3}
+      border
+      borderStyle="rounded"
+      borderColor={theme.borderActive}
+      backgroundColor={theme.backgroundPanel}
+      flexDirection="row"
+      paddingLeft={2}
+      paddingRight={2}
+      alignItems="center"
+    >
+      <text><span fg={theme.primary}><strong>❯ </strong></span></text>
+      <text>
+        <span fg={theme.text}>{query}</span>
+        <span fg={cursorOn ? theme.text : theme.backgroundPanel}>▋</span>
+      </text>
+      <box flexGrow={1} />
+      <text>
+        <span fg={theme.text}>{count}</span>
+        <span fg={theme.textDim}> {count === 1 ? "match" : "matches"}</span>
+      </text>
+    </box>
+  );
+}
+
+function WorkflowList({
+  rows,
+  focusedEntryIdx,
+}: {
+  rows: ListRow[];
+  focusedEntryIdx: number;
+}) {
+  if (rows.length === 0) {
+    return (
+      <box paddingLeft={2} paddingTop={2}>
+        <text><span fg={theme.textDim}>no matches</span></text>
+      </box>
+    );
+  }
+
+  let entryCounter = -1;
+  return (
+    <box flexDirection="column">
+      {rows.map((row, i) => {
+        if (row.kind === "section") {
+          const src = row.source!;
+          return (
+            <box
+              key={`s${i}`}
+              height={2}
+              paddingTop={1}
+              paddingLeft={2}
+            >
+              <text>
+                <span fg={theme[SOURCE_COLOR[src]]}>
+                  {SOURCE_DISPLAY[src]}
+                </span>
+                <span fg={theme.textDim}>
+                  {" (" + SOURCE_DIR[src] + ")"}
+                </span>
+              </text>
+            </box>
+          );
+        }
+        entryCounter++;
+        const isFocused = entryCounter === focusedEntryIdx;
+        const wf = row.entry!.workflow;
+
+        return (
+          <box
+            key={`e${i}`}
+            height={1}
+            flexDirection="row"
+            backgroundColor={isFocused ? theme.border : "transparent"}
+            paddingLeft={1}
+            paddingRight={2}
+          >
+            <text>
+              <span fg={isFocused ? theme.primary : theme.textDim}>
+                {isFocused ? "▸ " : "  "}
+              </span>
+              <span fg={isFocused ? theme.text : theme.textMuted}>
+                {wf.name}
+              </span>
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}
+
+// A single argument shown in the preview pane. Three-row layout:
+//
+//   Row 1 — name (left) | type · required|optional (right)
+//   Row 2 — description (muted)
+//   Row 3 — enum values list (only for `type: "enum"`)
+//
+// `required` flips the right-hand tag between warning-yellow ("required")
+// and textDim ("optional") so the eye can scan down a form and find the
+// mandatory fields immediately.
+function ArgumentRow({ field }: { field: WorkflowInput }) {
+  const isRequired = field.required ?? false;
+  const tagCol = isRequired ? theme.warning : theme.textDim;
+  const tagLabel = isRequired ? "required" : "optional";
+  const showEnumValues =
+    field.type === "enum" && field.values && field.values.length > 0;
+
+  return (
+    <box flexDirection="column" paddingLeft={2} paddingRight={2}>
+      {/* Row 1: name + type · required */}
+      <box flexDirection="row" height={1}>
+        <text>
+          <span fg={theme.text}>{field.name}</span>
+        </text>
+        <box flexGrow={1} />
+        <text>
+          <span fg={theme.textDim}>{field.type}</span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={tagCol}>{tagLabel}</span>
+        </text>
+      </box>
+
+      {/* Row 2: description */}
+      {field.description ? (
+        <box height={1}>
+          <text><span fg={theme.textMuted}>{field.description}</span></text>
+        </box>
+      ) : null}
+
+      {/* Row 3: enum values, joined with mid-dots */}
+      {showEnumValues ? (
+        <box height={1}>
+          <text>
+            <span fg={theme.textDim}>{field.values!.join("  ·  ")}</span>
+          </text>
+        </box>
+      ) : null}
+
+      {/* Gap between args */}
+      <box height={1} />
+    </box>
+  );
+}
+
+function Preview({ wf }: { wf: Workflow }) {
+  // Every workflow has at least one argument to show. Structured
+  // workflows use their declared inputs; everything else falls back to
+  // DEFAULT_PROMPT_INPUT so users still see a clear "prompt — text —
+  // required" row.
+  const args: WorkflowInput[] =
+    wf.inputs && wf.inputs.length > 0 ? wf.inputs : [DEFAULT_PROMPT_INPUT];
+
+  return (
+    <box
+      flexDirection="column"
+      paddingLeft={3}
+      paddingRight={3}
+      paddingTop={1}
+    >
+      {/* Name */}
+      <text>
+        <span fg={theme.text}><strong>{wf.name}</strong></span>
+      </text>
+
+      <box height={1} />
+
+      {/* Source — matches the `atomic workflow -l` label + dim dir hint */}
+      <text>
+        <span fg={theme[SOURCE_COLOR[wf.source]]}>
+          {SOURCE_DISPLAY[wf.source]}
+        </span>
+        <span fg={theme.textDim}>
+          {" (" + SOURCE_DIR[wf.source] + ")"}
+        </span>
+      </text>
+
+      <box height={2} />
+
+      {/* Description */}
+      <text><span fg={theme.textMuted}>{wf.description}</span></text>
+
+      <box height={2} />
+
+      {/* ARGUMENTS — the mauve ▎ indicator bar gives the section label
+          real weight against the preview body. */}
+      <SectionLabel label="ARGUMENTS" />
+      <box height={1} />
+      {args.map((f) => (
+        <ArgumentRow key={f.name} field={f} />
+      ))}
+    </box>
+  );
+}
+
+function EmptyPreview({ query }: { query: string }) {
+  return (
+    <box
+      flexDirection="column"
+      paddingLeft={3}
+      paddingRight={3}
+      paddingTop={3}
+    >
+      <text>
+        <span fg={theme.textMuted}>No workflows match </span>
+        <span fg={theme.text}>"{query}"</span>
+      </text>
+      <box height={2} />
+      <text><span fg={theme.textDim}>Press backspace to widen your search, or</span></text>
+      <box height={2} />
+      <text><span fg={theme.textDim}>create a new one at</span></text>
+      <box height={1} />
+      <box paddingLeft={2}>
+        <text><span fg={theme.primary}>.atomic/workflows/&lt;name&gt;/&lt;agent&gt;/index.ts</span></text>
+      </box>
+    </box>
+  );
+}
+
+// ─── Field renderers ────────────────────────────
+// One per FieldType. Each takes a `focused` flag so the input chrome
+// (border, cursor, placeholder) adapts to which field is being edited.
+
+const TEXT_FIELD_LINES = 3;
+
+// When a focused field is empty, we want the cursor to sit *on* the
+// first character of the placeholder — so typing replaces the
+// placeholder starting at the insertion point, not after it. This
+// renders the first char of the placeholder (or a space if the
+// placeholder itself is empty) with inverted fg/bg while the cursor
+// is blinking on, and as plain dim text while it's off — producing
+// a block-cursor effect that matches huh/noice/readline conventions.
+function PlaceholderWithCursor({
+  placeholder,
+  cursorShown,
+  bgCol,
+}: {
+  placeholder: string;
+  cursorShown: boolean;
+  bgCol: string;
+}) {
+  // Graceful fallback so the cursor still renders when a field has
+  // no placeholder text defined at all.
+  const effective = placeholder.length > 0 ? placeholder : " ";
+  const first = effective.slice(0, 1);
+  const rest = effective.slice(1);
+
+  return (
+    <text>
+      <span
+        fg={cursorShown ? theme.surface : theme.textDim}
+        bg={cursorShown ? theme.primary : bgCol}
+      >
+        {first}
+      </span>
+      <span fg={theme.textDim}>{rest}</span>
+    </text>
+  );
+}
+
+function TextAreaContent({
+  value,
+  placeholder,
+  focused,
+  cursorOn,
+  lines,
+  bgCol,
+}: {
+  value: string;
+  placeholder: string;
+  focused: boolean;
+  cursorOn: boolean;
+  lines: number;
+  bgCol: string;
+}) {
+  const textLines = value.split("\n");
+  // Scroll with content so the cursor line stays visible even when the
+  // user has typed more than `lines` rows.
+  const start = Math.max(0, textLines.length - lines);
+  const visible: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    visible.push(textLines[start + i] ?? "");
+  }
+  const cursorLine = Math.min(lines - 1, textLines.length - 1 - start);
+  const isEmpty = value === "";
+  const cursorShown = focused && cursorOn;
+
+  return (
+    <box flexDirection="column">
+      {visible.map((line, i) => {
+        // Empty + first line: placeholder with the cursor overlapping
+        // its first character (the insertion point).
+        if (isEmpty && i === 0) {
+          return (
+            <box key={i} height={1}>
+              <PlaceholderWithCursor
+                placeholder={placeholder}
+                cursorShown={cursorShown}
+                bgCol={bgCol}
+              />
+            </box>
+          );
+        }
+        // Non-empty line: text + trailing cursor on the cursor line.
+        const showCursorHere = cursorShown && !isEmpty && i === cursorLine;
+        return (
+          <box key={i} height={1}>
+            <text>
+              <span fg={theme.text}>{line}</span>
+              <span fg={showCursorHere ? theme.primary : bgCol}>▋</span>
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}
+
+function StringContent({
+  value,
+  placeholder,
+  focused,
+  cursorOn,
+  bgCol,
+}: {
+  value: string;
+  placeholder: string;
+  focused: boolean;
+  cursorOn: boolean;
+  bgCol: string;
+}) {
+  const isEmpty = value === "";
+  const cursorShown = focused && cursorOn;
+
+  // Empty: cursor overlaps first char of placeholder at the
+  // insertion point — so the first keystroke replaces the
+  // placeholder instead of pushing a cursor past it.
+  if (isEmpty) {
+    return (
+      <box height={1} flexDirection="row">
+        <PlaceholderWithCursor
+          placeholder={placeholder}
+          cursorShown={cursorShown}
+          bgCol={bgCol}
+        />
+      </box>
+    );
+  }
+
+  // Non-empty: standard line-input layout with cursor after the value.
+  return (
+    <box height={1} flexDirection="row">
+      <text>
+        <span fg={theme.text}>{value}</span>
+        <span fg={cursorShown ? theme.primary : bgCol}>▋</span>
+      </text>
+    </box>
+  );
+}
+
+function EnumContent({
+  values,
+  selected,
+  focused,
+}: {
+  values: string[];
+  selected: string;
+  focused: boolean;
+}) {
+  return (
+    <box height={1} flexDirection="row">
+      {values.map((v, i) => {
+        const isSelected = v === selected;
+        const marker = isSelected ? "●" : "○";
+        const markerColor = isSelected
+          ? focused ? theme.primary : theme.success
+          : theme.textDim;
+        const textColor = isSelected
+          ? focused ? theme.text : theme.textMuted
+          : theme.textDim;
+        return (
+          <box
+            key={v}
+            flexDirection="row"
+            paddingLeft={i > 0 ? 3 : 0}
+            height={1}
+          >
+            <text>
+              <span fg={markerColor}>{marker} </span>
+              <span fg={textColor}>{v}</span>
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}
+
+function Field({
+  field,
+  value,
+  focused,
+  cursorOn,
+}: {
+  field: WorkflowInput;
+  value: string;
+  focused: boolean;
+  cursorOn: boolean;
+}) {
+  // Focused fields light up with the primary accent and a slightly
+  // warmer panel background — an unambiguous "edit me" signal.
+  const borderCol = focused ? theme.primary : theme.border;
+  const bgCol = focused ? theme.backgroundPanel : theme.backgroundElement;
+
+  // Fixed row heights per type — string/enum are single-row, text is
+  // multi-row so paragraphs have room to breathe.
+  const boxHeight = field.type === "text" ? TEXT_FIELD_LINES + 2 : 3;
+
+  // Caption: type · required|optional · description — dim, single line,
+  // sits directly under the field so the form scans cleanly top-to-bottom.
+  const tagCol = field.required ? theme.warning : theme.textDim;
+  const tagLabel = field.required ? "required" : "optional";
+  const captionDesc = field.description ? "  ·  " + field.description : "";
+
+  return (
+    <box flexDirection="column">
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={borderCol}
+        backgroundColor={bgCol}
+        flexDirection="column"
+        paddingLeft={2}
+        paddingRight={2}
+        height={boxHeight}
+        justifyContent={field.type === "text" ? "flex-start" : "center"}
+        title={` ${field.name} `}
+        titleAlignment="left"
+      >
+        {field.type === "text" ? (
+          <TextAreaContent
+            value={value}
+            placeholder={field.placeholder ?? ""}
+            focused={focused}
+            cursorOn={cursorOn}
+            lines={TEXT_FIELD_LINES}
+            bgCol={bgCol}
+          />
+        ) : field.type === "string" ? (
+          <StringContent
+            value={value}
+            placeholder={field.placeholder ?? ""}
+            focused={focused}
+            cursorOn={cursorOn}
+            bgCol={bgCol}
+          />
+        ) : field.type === "enum" ? (
+          <EnumContent
+            values={field.values ?? []}
+            selected={value}
+            focused={focused}
+          />
+        ) : null}
+      </box>
+
+      {/* Caption row directly under the box */}
+      <box paddingLeft={2} paddingRight={2} height={1}>
+        <text>
+          <span fg={theme.textDim}>{field.type}</span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={tagCol}>{tagLabel}</span>
+          <span fg={theme.textDim}>{captionDesc}</span>
+        </text>
+      </box>
+
+      {/* Gap between fields */}
+      <box height={1} />
+    </box>
+  );
+}
+
+function InputPhase({
+  workflow,
+  agent,
+  fields,
+  values,
+  focusedFieldIdx,
+  cursorOn,
+}: {
+  workflow: Workflow;
+  agent: AgentType;
+  fields: WorkflowInput[];
+  values: Record<string, string>;
+  focusedFieldIdx: number;
+  cursorOn: boolean;
+}) {
+  const isStructured = workflow.inputs !== undefined && workflow.inputs.length > 0;
+
+  return (
+    <box
+      flexDirection="column"
+      paddingLeft={3}
+      paddingRight={3}
+      paddingTop={2}
+      flexGrow={1}
+    >
+      {/* Locked-in workflow chip — the visual commitment to the selection */}
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={theme.border}
+        backgroundColor={theme.backgroundPanel}
+        flexDirection="column"
+        paddingLeft={2}
+        paddingRight={2}
+        paddingTop={1}
+        paddingBottom={1}
+      >
+        <text>
+          <span fg={theme.primary}><strong>▸ </strong></span>
+          <span fg={theme.text}><strong>{workflow.name}</strong></span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={theme.mauve}>{agent}</span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={theme[SOURCE_COLOR[workflow.source]]}>
+            {SOURCE_DISPLAY[workflow.source]}
+          </span>
+          <span fg={theme.textDim}>
+            {" (" + SOURCE_DIR[workflow.source] + ")"}
+          </span>
+        </text>
+        <box height={1} />
+        <text><span fg={theme.textMuted}>{workflow.description}</span></text>
+      </box>
+
+      <box height={2} />
+
+      {/* Section label — shows a field count for structured forms, or
+          just "prompt" for the free-form fallback. */}
+      <box flexDirection="row" height={1}>
+        <text>
+          <span fg={theme.textDim}>
+            <strong>{isStructured ? "INPUTS" : "PROMPT"}</strong>
+          </span>
+        </text>
+        <box flexGrow={1} />
+        <text>
+          <span fg={theme.textDim}>
+            {isStructured
+              ? `${focusedFieldIdx + 1} / ${fields.length}`
+              : ""}
+          </span>
+        </text>
+      </box>
+      <box height={1} />
+
+      {/* One Field per input — for free-form workflows, there's a single
+          text field bound to DEFAULT_PROMPT_INPUT. */}
+      {fields.map((f, i) => (
+        <Field
+          key={f.name}
+          field={f}
+          value={values[f.name] ?? ""}
+          focused={i === focusedFieldIdx}
+          cursorOn={cursorOn}
+        />
+      ))}
+    </box>
+  );
+}
+
+// ConfirmModal — centered overlay shown when the user hits ⌃s in the
+// prompt phase. Displays the fully-composed shell invocation so users
+// can sanity-check the flags (and copy them out via terminal text
+// selection) before committing.
+//
+// PRODUCTION INTEGRATION:
+// In the real Atomic CLI, accepting this modal should:
+//   1. Invoke the workflow runner with { workflow, agent, inputs:
+//      fieldValues } — see src/commands/cli/workflow.ts for the entry
+//      point that `atomic workflow <name> -a <agent> ...` already uses.
+//   2. Tear down the picker renderer and hand control to the workflow's
+//      live run view, the same surface `atomic workflow <name>` lands
+//      on when flags are passed directly on the command line.
+// Neither hook is wired up at the prototype layer — the demo just
+// destroys the renderer on confirm, and the `// TODO(prod):` callsite
+// below marks where the real trigger + navigation belongs.
+function ConfirmModal({
+  workflow,
+  agent,
+  fields,
+  values,
+}: {
+  workflow: Workflow;
+  agent: AgentType;
+  fields: WorkflowInput[];
+  values: Record<string, string>;
+}) {
+  const isStructured = workflow.inputs !== undefined && workflow.inputs.length > 0;
+
+  // Shorten a single value for display on one line. Long text fields
+  // get truncated with an ellipsis so the command preview stays readable.
+  function shortVal(v: string): string {
+    const trimmed = v.replace(/\n/g, " ").trim();
+    if (trimmed.length > 48) return trimmed.slice(0, 45) + "…";
+    return trimmed;
+  }
+
+  // Free-form fallback: pull the single prompt value from DEFAULT_PROMPT_INPUT.
+  const promptText = values[DEFAULT_PROMPT_INPUT.name] ?? "";
+  const promptShort = shortVal(promptText) || "your question…";
+
+  return (
+    // Full-screen absolute overlay container. No backdrop fill — the
+    // InputPhase stays faintly visible around the card, giving the
+    // modal a "floating panel over a still form" feel rather than a
+    // hard page transition.
+    <box
+      position="absolute"
+      left={0}
+      top={0}
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      zIndex={100}
+    >
+      {/* The modal card — sized to content, centered both axes. */}
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={theme.success}
+        backgroundColor={theme.backgroundPanel}
+        flexDirection="column"
+        paddingLeft={3}
+        paddingRight={3}
+        paddingTop={1}
+        paddingBottom={1}
+        title=" ready to run "
+        titleAlignment="center"
+      >
+        <text>
+          <span fg={theme.success}><strong>✓ </strong></span>
+          <span fg={theme.text}><strong>command composed</strong></span>
+        </text>
+
+        <box height={1} />
+
+        <box paddingLeft={2} flexDirection="column">
+          <text>
+            <span fg={theme.textMuted}>atomic workflow </span>
+            <span fg={theme.text}>{workflow.name}</span>
+            <span fg={theme.textMuted}>{" \\"}</span>
+          </text>
+          <text>
+            <span fg={theme.textMuted}>  -a </span>
+            <span fg={theme.text}>{agent}</span>
+            <span fg={theme.textMuted}>{" \\"}</span>
+          </text>
+          {isStructured ? (
+            <box flexDirection="column">
+              {fields.map((f, i) => {
+                const last = i === fields.length - 1;
+                const val = shortVal(values[f.name] ?? "") || `<${f.type}>`;
+                return (
+                  <text key={f.name}>
+                    <span fg={theme.textMuted}>  --</span>
+                    <span fg={theme.text}>{f.name}</span>
+                    <span fg={theme.textMuted}>="</span>
+                    <span fg={theme.text}>{val}</span>
+                    <span fg={theme.textMuted}>"</span>
+                    <span fg={theme.textDim}>{last ? "" : " \\"}</span>
+                  </text>
+                );
+              })}
+            </box>
+          ) : (
+            <text>
+              <span fg={theme.textMuted}>  "</span>
+              <span fg={theme.text}>{promptShort}</span>
+              <span fg={theme.textMuted}>"</span>
+            </text>
+          )}
+        </box>
+
+        <box height={1} />
+
+        {/* Prompt + key legend — the modal's own footer. The globally
+            mapped keys here are duplicated in the Statusline hints so
+            users scanning either surface find the same answer. esc
+            still cancels silently since it costs nothing to support,
+            but it's not advertised — y/n is the documented path. */}
+        <text>
+          <span fg={theme.textDim}>submit and run this workflow?  </span>
+          <span fg={theme.success}><strong>y</strong></span>
+          <span fg={theme.textDim}> submit  ·  </span>
+          <span fg={theme.error}><strong>n</strong></span>
+          <span fg={theme.textDim}> cancel</span>
+        </text>
+      </box>
+    </box>
+  );
+}
+
+// Per-agent brand color used as the Header pill background. The pill
+// *is* the session identity badge — its contents and hue together
+// answer "which backend am I targeting right now?" at a glance.
+const AGENT_PILL_COLOR: Record<AgentType, keyof PickerTheme> = {
+  claude: "warning", // amber — Anthropic-adjacent
+  copilot: "success", // green — GitHub-adjacent
+  opencode: "mauve",  // purple — leaves the warm slots for the other two
+};
+
+function Header({
+  phase,
+  confirmOpen,
+  selectedAgent,
+  scopedCount,
+}: {
+  phase: Phase;
+  confirmOpen: boolean;
+  selectedAgent: AgentType;
+  scopedCount: number;
+}) {
+  // When the confirm modal is open we shift the breadcrumb to "confirm"
+  // so the header reflects the active surface, even though the
+  // underlying phase is still "prompt".
+  const phaseLabel = confirmOpen
+    ? "confirm"
+    : phase === "pick"
+    ? "select"
+    : "compose";
+  const pillBg = theme[AGENT_PILL_COLOR[selectedAgent]];
+
+  return (
+    <box
+      height={1}
+      backgroundColor={theme.surface}
+      flexDirection="row"
+      paddingRight={2}
+      alignItems="center"
+    >
+      {/* Identity pill — shows the backend this session is pinned to,
+          with a per-agent background hue so the badge is recognisable
+          at a glance. Rendered in all caps to match the PICK / PROMPT
+          / DONE mode pill in the statusline. Fixed at launch from the
+          `-a` flag; not selectable from within the UI. */}
+      <text>
+        <span fg={theme.surface} bg={pillBg}>
+          <strong>{" " + selectedAgent.toUpperCase() + " "}</strong>
+        </span>
+      </text>
+      <text><span fg={theme.textDim}>{"  workflow  "}</span></text>
+      <text><span fg={theme.textMuted}>›</span></text>
+      <text><span fg={theme.textDim}>{"  " + phaseLabel}</span></text>
+      <box flexGrow={1} />
+      {/* Right side: workflow count for the currently-selected agent. */}
+      <text>
+        <span fg={theme.textDim}>
+          {scopedCount + (scopedCount === 1 ? " workflow" : " workflows")}
+        </span>
+      </text>
+    </box>
+  );
+}
+
+function Statusline({
+  phase,
+  confirmOpen,
+  hints,
+  focusedWf,
+}: {
+  phase: Phase;
+  confirmOpen: boolean;
+  // `dim: true` fades the key to textDim so callers can mark a hint as
+  // visually disabled — used to signal that ⌃s is currently blocked
+  // by unfilled required fields.
+  hints: { key: string; label: string; dim?: boolean }[];
+  focusedWf: Workflow | undefined;
+}) {
+  const modeLabel = confirmOpen
+    ? "CONFIRM"
+    : phase === "pick"
+    ? "PICK"
+    : "PROMPT";
+  const modeColor = confirmOpen
+    ? theme.mauve
+    : phase === "pick"
+    ? theme.primary
+    : theme.success;
+
+  return (
+    <box height={1} flexDirection="row" backgroundColor={theme.surface}>
+      <box
+        backgroundColor={modeColor}
+        paddingLeft={1}
+        paddingRight={1}
+        alignItems="center"
+      >
+        <text fg={theme.surface}><strong>{modeLabel}</strong></text>
+      </box>
+
+      {focusedWf ? (
+        <box paddingLeft={1} paddingRight={1} alignItems="center">
+          <text>
+            <span fg={theme.text}>{focusedWf.name}</span>
+          </text>
+        </box>
+      ) : null}
+
+      <box flexGrow={1} />
+
+      <box paddingRight={2} alignItems="center" flexDirection="row">
+        {hints.map((h, i) => (
+          <box key={i} flexDirection="row">
+            {i > 0 ? (
+              <text><span fg={theme.textDim}>{"  ·  "}</span></text>
+            ) : null}
+            <text>
+              <span fg={h.dim ? theme.textDim : theme.text}>{h.key}</span>
+              <span fg={h.dim ? theme.textDim : theme.textMuted}>
+                {" " + h.label}
+              </span>
+            </text>
+          </box>
+        ))}
+      </box>
+    </box>
+  );
+}
+
+// ─── Validation ─────────────────────────────────
+
+// A field is valid when it's optional, or required + non-empty. Enum
+// fields are always seeded with a default or the first value on phase
+// transition, so in practice they can't be empty — but we check
+// defensively anyway. Text and string fields are validated after
+// trimming whitespace so a form of spaces alone doesn't slip through.
+function isFieldValid(field: WorkflowInput, value: string): boolean {
+  if (!field.required) return true;
+  if (field.type === "enum") return value !== "";
+  return value.trim() !== "";
+}
+
+// ─── App ────────────────────────────────────────
+
+function WorkflowPicker() {
+  const renderer = useRenderer();
+
+  const [phase, setPhase] = useState<Phase>("pick");
+  const [query, setQuery] = useState("");
+  const [entryIdx, setEntryIdx] = useState(0);
+  // Structured form state: one value per field, plus the currently
+  // focused field index. Initialized on phase transition from "pick".
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
+  const [focusedFieldIdx, setFocusedFieldIdx] = useState(0);
+  // Confirm modal visibility — opens on ⌃s in the prompt phase, closes
+  // on n/esc (cancel) or y/enter (submit; in prod, this is where the
+  // workflow is actually triggered — see ConfirmModal's doc comment).
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Blinking cursor — Neovim's default rate is ~530ms half-period.
+  const [cursorTick, setCursorTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setCursorTick((c: number) => (c + 1) % 2), 530);
+    return () => clearInterval(id);
+  }, []);
+  const cursorOn = cursorTick === 0;
+
+  // The agent is pinned for the whole session — no state, no
+  // dependency on anything reactive. `buildEntries` still takes it
+  // as a parameter so the scope filter is explicit.
+  const entries = useMemo(
+    () => buildEntries(query, CURRENT_AGENT),
+    [query],
+  );
+  const rows = useMemo(() => buildRows(entries, query), [entries, query]);
+
+  // Clamp the focused index whenever the filter shrinks the list.
+  useEffect(() => {
+    if (entryIdx >= entries.length) {
+      setEntryIdx(Math.max(0, entries.length - 1));
+    }
+  }, [entries.length, entryIdx]);
+
+  const focusedWf = entries[entryIdx]?.workflow;
+
+  // Resolve the active field list per render. For structured workflows
+  // this is `workflow.inputs`; for free-form, a one-element list with
+  // DEFAULT_PROMPT_INPUT — keeping the form renderer uniform.
+  const currentFields: WorkflowInput[] =
+    focusedWf?.inputs && focusedWf.inputs.length > 0
+      ? focusedWf.inputs
+      : [DEFAULT_PROMPT_INPUT];
+  const currentField = currentFields[focusedFieldIdx];
+
+  // Validation — the list of indices of required fields that are still
+  // empty. Users can cycle through these freely with tab/shift+tab,
+  // but ⌃s is blocked until the list is empty, so a half-filled form
+  // can never reach the confirm modal.
+  const invalidFieldIndices = useMemo(() => {
+    const out: number[] = [];
+    for (let i = 0; i < currentFields.length; i++) {
+      const f = currentFields[i]!;
+      const v = fieldValues[f.name] ?? "";
+      if (!isFieldValid(f, v)) out.push(i);
+    }
+    return out;
+  }, [currentFields, fieldValues]);
+  const isFormValid = invalidFieldIndices.length === 0;
+
+  // Keyboard handling — branches on phase, with the confirm modal
+  // intercepting all input while visible.
+  useKeyboard((key) => {
+    if (key.ctrl && key.name === "c") {
+      renderer.destroy();
+      return;
+    }
+
+    // ── CONFIRM MODAL (overlay) ──
+    // When the modal is open it owns the keyboard: y/enter commits,
+    // n/esc cancels, everything else is swallowed so the user can't
+    // keep typing into the (now-hidden) form fields.
+    if (confirmOpen) {
+      if (key.name === "y" || key.name === "return") {
+        // TODO(prod): this is where the real CLI should trigger the
+        // workflow and navigate to its live run view. Concretely:
+        //
+        //   await runWorkflow({
+        //     workflow: focusedWf,
+        //     agent: CURRENT_AGENT,
+        //     inputs: fieldValues,
+        //   });
+        //   // then hand control to the workflow run surface, the
+        //   // same one `atomic workflow <name> -a <agent>` lands on
+        //   // when flags are passed directly on the command line.
+        //
+        // Neither hook is wired at the prototype layer, so for now
+        // we just tear down the picker renderer on submit.
+        renderer.destroy();
+        return;
+      }
+      if (key.name === "n" || key.name === "escape") {
+        setConfirmOpen(false);
+        return;
+      }
+      return;
+    }
+
+    if (phase === "pick") {
+      if (key.name === "escape") {
+        renderer.destroy();
+        return;
+      }
+      if (key.name === "up" || (key.ctrl && key.name === "k")) {
+        setEntryIdx((i: number) => Math.max(0, i - 1));
+        return;
+      }
+      if (key.name === "down" || (key.ctrl && key.name === "j")) {
+        setEntryIdx((i: number) => Math.min(entries.length - 1, i + 1));
+        return;
+      }
+      if (key.name === "return") {
+        if (focusedWf) {
+          // Seed fieldValues from the schema so enum fields start on
+          // their default and the rest start empty. This is the only
+          // place fieldValues is initialized — phase returns to "pick"
+          // always go back through this handler to re-seed.
+          const inputs: WorkflowInput[] =
+            focusedWf.inputs && focusedWf.inputs.length > 0
+              ? focusedWf.inputs
+              : [DEFAULT_PROMPT_INPUT];
+          const initial: Record<string, string> = {};
+          for (const f of inputs) {
+            initial[f.name] =
+              f.default ??
+              (f.type === "enum" ? f.values?.[0] ?? "" : "");
+          }
+          setFieldValues(initial);
+          setFocusedFieldIdx(0);
+          setPhase("prompt");
+        }
+        return;
+      }
+      if (key.name === "backspace") {
+        setQuery((q: string) => q.slice(0, -1));
+        return;
+      }
+      // Printable characters feed the filter input.
+      if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+        const c = key.sequence;
+        if (c >= " " && c <= "~") setQuery((q: string) => q + c);
+      }
+      return;
+    }
+
+    // ── PROMPT phase ──
+    if (key.name === "escape") {
+      setPhase("pick");
+      return;
+    }
+    if (key.ctrl && key.name === "s") {
+      // Block submission while any required field is empty. Jump focus
+      // to the first invalid field so the user sees exactly where the
+      // problem is — the modal never opens, so there's no way to run a
+      // workflow with missing required inputs.
+      if (!isFormValid) {
+        setFocusedFieldIdx(invalidFieldIndices[0]!);
+        return;
+      }
+      setConfirmOpen(true);
+      return;
+    }
+    // Tab / Shift-Tab cycles between fields, wrapping around at the
+    // ends so multi-field forms feel like a proper loop — the common
+    // expectation in TUI forms (huh, dialog, gum) and web forms alike.
+    if (key.name === "tab") {
+      setFocusedFieldIdx((i: number) => {
+        const len = currentFields.length;
+        if (len <= 1) return 0;
+        return key.shift ? (i - 1 + len) % len : (i + 1) % len;
+      });
+      return;
+    }
+    if (!currentField) return;
+
+    // Enum fields: ← → cycles values, ignores text input.
+    if (currentField.type === "enum") {
+      const values = currentField.values ?? [];
+      if (values.length === 0) return;
+      if (key.name === "left" || key.name === "right") {
+        setFieldValues((prev: Record<string, string>) => {
+          const cur = prev[currentField.name] ?? values[0] ?? "";
+          const idx = Math.max(0, values.indexOf(cur));
+          const delta = key.name === "left" ? -1 : 1;
+          const nextIdx = (idx + delta + values.length) % values.length;
+          return { ...prev, [currentField.name]: values[nextIdx] ?? "" };
+        });
+      }
+      return;
+    }
+
+    // Text/string fields accept printable input.
+    if (key.name === "return") {
+      if (currentField.type === "text") {
+        setFieldValues((prev: Record<string, string>) => ({
+          ...prev,
+          [currentField.name]: (prev[currentField.name] ?? "") + "\n",
+        }));
+      } else {
+        // string: advance to next field on Enter
+        setFocusedFieldIdx((i: number) =>
+          Math.min(currentFields.length - 1, i + 1),
+        );
+      }
+      return;
+    }
+    if (key.name === "backspace") {
+      setFieldValues((prev: Record<string, string>) => ({
+        ...prev,
+        [currentField.name]: (prev[currentField.name] ?? "").slice(0, -1),
+      }));
+      return;
+    }
+    if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+      const c = key.sequence;
+      if (c >= " " && c <= "~") {
+        setFieldValues((prev: Record<string, string>) => ({
+          ...prev,
+          [currentField.name]: (prev[currentField.name] ?? "") + c,
+        }));
+      }
+    }
+  });
+
+  // Footer hints — compact, action-first. The confirm-modal hints take
+  // priority over the underlying phase's hints while the modal is open.
+  const pickHints = [
+    { key: "↑↓", label: "navigate" },
+    { key: "↵", label: "select" },
+    { key: "esc", label: "quit" },
+  ];
+  // When the form is invalid, the ⌃s hint is dimmed to signal that
+  // submission is currently blocked. The key still "exists" — hitting
+  // it just jumps focus to the first invalid field instead of opening
+  // the modal — so we fade it rather than hide it.
+  const promptHints = [
+    { key: "tab", label: "to navigate forward" },
+    { key: "shift+tab", label: "to navigate backward" },
+    { key: "ctrl+s", label: "to run", dim: !isFormValid },
+  ];
+  const confirmHints = [
+    { key: "y", label: "submit" },
+    { key: "n", label: "cancel" },
+  ];
+
+  const hints = confirmOpen
+    ? confirmHints
+    : phase === "pick"
+    ? pickHints
+    : promptHints;
+
+  return (
+    // `position="relative"` on the root establishes the positioning
+    // context for the ConfirmModal's absolute overlay — without this,
+    // the modal's `left/top/width/height` resolve against the terminal
+    // viewport rather than the app root.
+    <box
+      position="relative"
+      width="100%"
+      height="100%"
+      flexDirection="column"
+      backgroundColor={theme.background}
+    >
+      <Header
+        phase={phase}
+        confirmOpen={confirmOpen}
+        selectedAgent={CURRENT_AGENT}
+        scopedCount={
+          WORKFLOWS.filter((w) => w.agents.includes(CURRENT_AGENT)).length
+        }
+      />
+
+      {phase === "pick" ? (
+        <box
+          flexGrow={1}
+          flexDirection="row"
+          paddingLeft={2}
+          paddingRight={2}
+          paddingTop={1}
+        >
+          {/* Left sidebar — filter + list. The selected agent is now
+              advertised by the pill in the Header, not here. */}
+          <box width={36} flexDirection="column">
+            <FilterBar
+              query={query}
+              count={entries.length}
+              cursorOn={cursorOn}
+            />
+            <box height={1} />
+            <WorkflowList rows={rows} focusedEntryIdx={entryIdx} />
+          </box>
+          {/* Divider — a single column of darker surface */}
+          <box width={1} backgroundColor={theme.border} />
+          {/* Preview column — takes all remaining width */}
+          <box flexGrow={1} flexDirection="column">
+            {focusedWf ? (
+              <Preview wf={focusedWf} />
+            ) : (
+              <EmptyPreview query={query} />
+            )}
+          </box>
+        </box>
+      ) : phase === "prompt" && focusedWf ? (
+        <InputPhase
+          workflow={focusedWf}
+          agent={CURRENT_AGENT}
+          fields={currentFields}
+          values={fieldValues}
+          focusedFieldIdx={focusedFieldIdx}
+          cursorOn={cursorOn}
+        />
+      ) : null}
+
+      <Statusline
+        phase={phase}
+        confirmOpen={confirmOpen}
+        hints={hints}
+        focusedWf={focusedWf}
+      />
+
+      {/* Confirm modal — rendered last so it sits above the Header,
+          InputPhase, and Statusline in document order. zIndex={100} on
+          the overlay container reinforces the stacking for good
+          measure. */}
+      {confirmOpen && focusedWf ? (
+        <ConfirmModal
+          workflow={focusedWf}
+          agent={CURRENT_AGENT}
+          fields={currentFields}
+          values={fieldValues}
+        />
+      ) : null}
+    </box>
+  );
+}
+
+// ─── Entry ──────────────────────────────────────
+
+const renderer = await createCliRenderer({ exitOnCtrlC: false });
+createRoot(renderer).render(<WorkflowPicker />);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,20 +127,42 @@ Examples:
         });
 
     // Add workflow command
+    //
+    // Two shapes are supported behind a single command:
+    //   1. `atomic workflow -a <agent>`                 — interactive picker
+    //   2. `atomic workflow -n <name> -a <agent> ...`   — named run with
+    //       either a positional prompt (free-form workflows) or
+    //       `--<field>=<value>` flags (structured-input workflows).
+    //
+    // `allowUnknownOption` + `allowExcessArguments` give us both: unknown
+    // flags and positional tokens land in `cmd.args`, which we forward
+    // as `passthroughArgs` so the command layer can parse them against
+    // the workflow's declared schema.
     program
         .command("workflow")
         .description("Run a multi-session agent workflow")
         .option("-n, --name <name>", "Workflow name (matches directory under .atomic/workflows/<name>/)")
         .option("-a, --agent <name>", `Agent to use (${agentChoices})`)
         .option("-l, --list", "List available workflows")
-        .argument("[prompt...]", "Prompt for the workflow")
-        .action(async (promptParts, localOpts) => {
+        .allowUnknownOption()
+        .allowExcessArguments(true)
+        .addHelpText(
+            "after",
+            `
+Examples:
+  $ atomic workflow -l                              List available workflows
+  $ atomic workflow -a claude                       Open the interactive picker
+  $ atomic workflow -n ralph -a claude "fix bug"    Run a free-form workflow
+  $ atomic workflow -n gen-spec -a claude --research_doc=notes.md --focus=standard
+                                                    Run a structured-input workflow`,
+        )
+        .action(async (localOpts, cmd) => {
             const { workflowCommand } = await import("@/commands/cli/workflow.ts");
             const exitCode = await workflowCommand({
                 name: localOpts.name,
                 agent: localOpts.agent,
-                prompt: promptParts.length > 0 ? promptParts.join(" ") : undefined,
                 list: localOpts.list,
+                passthroughArgs: cmd.args,
             });
             process.exit(exitCode);
         });

--- a/src/commands/cli/workflow-command.test.ts
+++ b/src/commands/cli/workflow-command.test.ts
@@ -1,0 +1,757 @@
+/**
+ * Integration-style tests for `workflowCommand` — the CLI entry point that
+ * wires list/picker/named-mode branching together. Three modules are stubbed:
+ * the workflows SDK (executor + tmux probe + discovery), the system detector
+ * (command-presence checks), and the spawn helpers (best-effort installers).
+ * Every one of these is a side-effectful dependency — tmux spawn, disk I/O,
+ * agent CLI spawn — and replacing them with controlled fakes lets us hit the
+ * CLI's error/success branches without actually touching the real system.
+ *
+ * Two patterns make this file work:
+ *
+ *   1. `mock.module(…)` replaces each dependency module BEFORE the first
+ *      dynamic `import("./workflow.ts")` so the module-under-test binds to
+ *      the mocked references. Top-level await is required — a static import
+ *      would hoist above the mocks and defeat them.
+ *
+ *   2. Every test runs against a fresh `mkdtemp`ed cwd plumbed through the
+ *      `cwd` option. That lets us control which workflows the command sees
+ *      without touching the repo's own `.atomic/workflows` tree.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  mock,
+} from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import * as realWorkflows from "@/sdk/workflows/index.ts";
+import * as realDetect from "@/services/system/detect.ts";
+import * as realSpawn from "../../lib/spawn.ts";
+import type {
+  WorkflowDefinition,
+  WorkflowRunOptions,
+  DiscoveredWorkflow,
+} from "@/sdk/workflows/index.ts";
+
+// Capture original function references BEFORE `mock.module` replaces the
+// module exports. `import * as realWorkflows` gives a LIVE namespace — after
+// mock.module rebinds the exports, `realWorkflows.discoverWorkflows` would
+// resolve to our own mock and a pass-through would recurse infinitely. These
+// constants lock in the real implementations so pass-through defaults work.
+const realDiscoverWorkflows = realWorkflows.discoverWorkflows;
+const realLoadWorkflowsMetadata = realWorkflows.loadWorkflowsMetadata;
+const realIsCommandInstalled = realDetect.isCommandInstalled;
+
+// ─── Dependency mocks ───────────────────────────────────────────────────────
+// Every mock is a wrapper around the real implementation by default so
+// unrelated tests that don't care about a given mock still see the real
+// behaviour. Tests override specific mocks via `mockImplementationOnce` (or a
+// longer-lived `mockImplementation` inside a describe block) to exercise
+// failure branches. `beforeEach` resets everything to the default pass-through.
+
+const executeWorkflowMock =
+  mock<(opts: WorkflowRunOptions) => Promise<void>>(async () => {});
+
+// Default: real discovery so the filesystem-level branches still work.
+const discoverWorkflowsMock = mock<typeof realWorkflows.discoverWorkflows>(
+  (...args) => realDiscoverWorkflows(...args),
+);
+
+// Default: real metadata load — supports the picker branches that need
+// compiled metadata from a real workflow on disk.
+const loadWorkflowsMetadataMock = mock<
+  typeof realWorkflows.loadWorkflowsMetadata
+>((...args) => realLoadWorkflowsMetadata(...args));
+
+// Default: pretend tmux is installed. The test env has it, but we want the
+// coverage test to be deterministic regardless of host config — if the host
+// removed tmux we'd still want these tests to cover the happy path.
+const isTmuxInstalledMock =
+  mock<typeof realWorkflows.isTmuxInstalled>(() => true);
+
+// Default: real presence check. Tests override for the agent-missing branch.
+const isCommandInstalledMock = mock<typeof realDetect.isCommandInstalled>(
+  (cmd) => realIsCommandInstalled(cmd),
+);
+
+// Default: no-op so the best-effort installer branch in runPrereqChecks
+// doesn't try to actually install tmux/bun on the test machine.
+const ensureTmuxInstalledMock = mock<typeof realSpawn.ensureTmuxInstalled>(
+  async () => {},
+);
+const ensureBunInstalledMock = mock<typeof realSpawn.ensureBunInstalled>(
+  async () => {},
+);
+
+mock.module("@/sdk/workflows/index.ts", () => ({
+  ...realWorkflows,
+  executeWorkflow: executeWorkflowMock,
+  discoverWorkflows: discoverWorkflowsMock,
+  loadWorkflowsMetadata: loadWorkflowsMetadataMock,
+  isTmuxInstalled: isTmuxInstalledMock,
+}));
+mock.module("@/services/system/detect.ts", () => ({
+  ...realDetect,
+  isCommandInstalled: isCommandInstalledMock,
+}));
+mock.module("../../lib/spawn.ts", () => ({
+  ...realSpawn,
+  ensureTmuxInstalled: ensureTmuxInstalledMock,
+  ensureBunInstalled: ensureBunInstalledMock,
+}));
+
+// Dynamic import — must happen AFTER `mock.module` so the module-under-test
+// binds to the mocked dependencies. Top-level await is fine under Bun.
+const { workflowCommand } = await import("./workflow.ts");
+
+// ─── Output capture ─────────────────────────────────────────────────────────
+// The CLI writes error banners to stderr via `console.error`, success content
+// to stdout via `process.stdout.write`. Wrap both so tests can snapshot the
+// emitted text without leaking it into the test runner's own output.
+
+interface CapturedOutput {
+  stdout: string;
+  stderr: string;
+  restore: () => void;
+}
+
+function captureOutput(): CapturedOutput {
+  const captured: CapturedOutput = {
+    stdout: "",
+    stderr: "",
+    restore: () => {},
+  };
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const originalConsoleWarn = console.warn;
+
+  // Typed as never so the loose commander signature doesn't widen.
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stdout +=
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  console.error = (...args: unknown[]) => {
+    captured.stderr += args.map((a) => String(a)).join(" ") + "\n";
+  };
+  console.log = (...args: unknown[]) => {
+    captured.stdout += args.map((a) => String(a)).join(" ") + "\n";
+  };
+  console.warn = (...args: unknown[]) => {
+    captured.stderr += args.map((a) => String(a)).join(" ") + "\n";
+  };
+
+  captured.restore = () => {
+    process.stdout.write = originalStdoutWrite;
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+  };
+  return captured;
+}
+
+// ─── Colour handling ────────────────────────────────────────────────────────
+// `NO_COLOR` flips both COLORS (module load time) and createPainter (call
+// time) into plain-text mode so assertions can match against readable
+// substrings rather than SGR escape noise. COLORS is baked at module load
+// so the env var must already be set by the time workflow.ts gets imported.
+
+let originalNoColor: string | undefined;
+beforeAll(() => {
+  originalNoColor = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+});
+afterAll(() => {
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+});
+
+// ─── Temp workspace plumbing ────────────────────────────────────────────────
+// Each test gets a fresh cwd so one test's workflows can't leak into another.
+// The actual workflow files live under `.atomic/workflows/<name>/<agent>/index.ts`
+// — matching the layout that `discoverWorkflows` scans.
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "atomic-workflow-cmd-test-"));
+  // Reset every mock to its default pass-through / no-op so tests are
+  // independent — no leftover state from prior overrides. `mockClear` wipes
+  // call history; `mockImplementation` replaces the queued implementation
+  // (including anything set via `mockImplementationOnce`) with the default.
+  executeWorkflowMock.mockClear();
+  executeWorkflowMock.mockImplementation(async () => {});
+  discoverWorkflowsMock.mockClear();
+  discoverWorkflowsMock.mockImplementation((...args) =>
+    realDiscoverWorkflows(...args),
+  );
+  loadWorkflowsMetadataMock.mockClear();
+  loadWorkflowsMetadataMock.mockImplementation((...args) =>
+    realLoadWorkflowsMetadata(...args),
+  );
+  isTmuxInstalledMock.mockClear();
+  isTmuxInstalledMock.mockImplementation(() => true);
+  isCommandInstalledMock.mockClear();
+  isCommandInstalledMock.mockImplementation((cmd) => realIsCommandInstalled(cmd));
+  ensureTmuxInstalledMock.mockClear();
+  ensureTmuxInstalledMock.mockImplementation(async () => {});
+  ensureBunInstalledMock.mockClear();
+  ensureBunInstalledMock.mockImplementation(async () => {});
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+/**
+ * Write a real workflow file that compiles through `defineWorkflow()`.
+ * Tests import a real SDK so the module under test sees a live
+ * `WorkflowDefinition`, not a mock shape — this keeps the coverage
+ * line-level on `runNamedMode`'s resolution of the compiled definition.
+ */
+async function writeCompiledWorkflow(
+  opts: {
+    name: string;
+    agent: "claude" | "copilot" | "opencode";
+    source?: string;
+  },
+): Promise<string> {
+  const dir = join(tempDir, ".atomic", "workflows", opts.name, opts.agent);
+  await mkdir(dir, { recursive: true });
+  const filePath = join(dir, "index.ts");
+  const defaultBody =
+    opts.source ??
+    `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({ name: "${opts.name}" })
+  .run(async () => {})
+  .compile();
+`;
+  await writeFile(filePath, defaultBody);
+  return filePath;
+}
+
+// ─── List mode ──────────────────────────────────────────────────────────────
+
+describe("workflowCommand --list", () => {
+  test("prints the rendered list and returns 0", async () => {
+    await writeCompiledWorkflow({ name: "alpha", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      list: true,
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    // Singular noun because only our one workflow is filtered in, and builtins
+    // discovered via `{ merge: false }` may still show up — so assert on the
+    // name we wrote instead of a count.
+    expect(cap.stdout).toContain("alpha");
+    expect(cap.stdout).toContain("run: atomic workflow -n <name> -a <agent>");
+  });
+
+  test("filters by the provided agent", async () => {
+    await writeCompiledWorkflow({ name: "claude-only", agent: "claude" });
+    await writeCompiledWorkflow({ name: "copilot-only", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      list: true,
+      agent: "claude",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(cap.stdout).toContain("claude-only");
+    expect(cap.stdout).not.toContain("copilot-only");
+  });
+
+  test("renders the empty state when no workflows exist and no agent filter is set", async () => {
+    // No agent filter + a fresh tempdir means `discoverWorkflows` only
+    // returns builtins for whichever agents exist on disk; to exercise
+    // the real empty-state branch we filter to an agent with no builtin
+    // coverage for the tempdir — `opencode` has builtins too, so instead
+    // point at an empty workflows directory.
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      list: true,
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    // Either the builtin ralph shows up or we get the "no workflows" banner.
+    // We only need to verify the code path completes and writes *something*.
+    expect(cap.stdout.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── Agent validation ──────────────────────────────────────────────────────
+
+describe("workflowCommand agent validation", () => {
+  test("missing agent returns 1 and logs a targeted error", async () => {
+    const cap = captureOutput();
+    const code = await workflowCommand({ cwd: tempDir });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("Missing agent");
+  });
+
+  test("unknown agent returns 1 and lists valid agents", async () => {
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      agent: "bogus-agent",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("Unknown agent");
+    // Error helper lists valid agents — spot-check one.
+    expect(cap.stderr).toContain("claude");
+  });
+});
+
+// ─── Picker mode error paths ───────────────────────────────────────────────
+
+describe("workflowCommand picker mode", () => {
+  test("rejects passthrough args in picker mode", async () => {
+    // No `-n` means picker mode; any extra args are ambiguous (would the
+    // user want them fed into the picker's form, or straight through?), so
+    // the command bails early rather than guessing.
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      agent: "copilot",
+      passthroughArgs: ["oops", "--mode=fast"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("unexpected arguments");
+    // The hint points the user at the right place.
+    expect(cap.stderr).toContain("-n <name>");
+  });
+});
+
+// ─── Named mode error paths ────────────────────────────────────────────────
+
+describe("workflowCommand named-mode error paths", () => {
+  test("unknown workflow name returns 1 and lists available options", async () => {
+    // Seed one workflow so the "Available" section renders.
+    await writeCompiledWorkflow({ name: "real-one", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "does-not-exist",
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("does-not-exist");
+    expect(cap.stderr).toContain("not found");
+    // Lists the real workflow we wrote so users can copy-paste a valid name.
+    expect(cap.stderr).toContain("real-one");
+    // executeWorkflow should never be called on the error path.
+    expect(executeWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  test("parse errors in passthrough args abort before loading", async () => {
+    await writeCompiledWorkflow({ name: "parse-err", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "parse-err",
+      agent: "copilot",
+      // Trailing --flag with no value is the canonical parse error.
+      passthroughArgs: ["--orphan"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("--orphan");
+    expect(executeWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  test("load errors from WorkflowLoader surface cleanly", async () => {
+    // Write a workflow file that lacks `.compile()` — the loader treats
+    // this as a hard error and the CLI must return 1 rather than crash.
+    await writeCompiledWorkflow({
+      name: "broken",
+      agent: "copilot",
+      source: `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({ name: "broken" })
+  .run(async () => {});
+// intentionally missing .compile()
+`,
+    });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "broken",
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("not compiled");
+    expect(executeWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  test("free-form workflow rejects stray --flags", async () => {
+    // A workflow with no declared `inputs` takes a positional prompt; any
+    // `--<name>` flag is definitionally wrong because there's nothing for
+    // it to bind to.
+    await writeCompiledWorkflow({ name: "free-form", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "free-form",
+      agent: "copilot",
+      passthroughArgs: ["--mode=fast"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("no declared inputs");
+    expect(cap.stderr).toContain("--mode");
+    expect(executeWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  test("structured workflow rejects positional prompt tokens", async () => {
+    await writeCompiledWorkflow({
+      name: "structured",
+      agent: "copilot",
+      source: `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({
+  name: "structured",
+  inputs: [
+    { name: "topic", type: "string", required: true },
+  ],
+})
+  .run(async () => {})
+  .compile();
+`,
+    });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "structured",
+      agent: "copilot",
+      // Positional-only invocation is ambiguous against a structured
+      // schema, so the command refuses to guess.
+      passthroughArgs: ["just", "a", "prompt"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("structured inputs");
+    expect(cap.stderr).toContain("--topic");
+    expect(executeWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  test("structured workflow surfaces schema validation errors", async () => {
+    await writeCompiledWorkflow({
+      name: "validated",
+      agent: "copilot",
+      source: `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({
+  name: "validated",
+  inputs: [
+    { name: "topic", type: "string", required: true },
+  ],
+})
+  .run(async () => {})
+  .compile();
+`,
+    });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "validated",
+      agent: "copilot",
+      // Empty flag set — required `topic` is missing.
+      passthroughArgs: [],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("--topic");
+    expect(executeWorkflowMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Named mode success paths (via mocked executor) ────────────────────────
+
+describe("workflowCommand named-mode success paths", () => {
+  test("free-form workflow runs through the executor with the prompt as input", async () => {
+    await writeCompiledWorkflow({ name: "runs", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "runs",
+      agent: "copilot",
+      passthroughArgs: ["fix", "the", "bug"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock).toHaveBeenCalledTimes(1);
+    const call = executeWorkflowMock.mock.calls[0]![0];
+    expect(call.agent).toBe("copilot");
+    // Free-form prompt is threaded under the `prompt` key so workflow
+    // authors can read `ctx.inputs.prompt` uniformly.
+    expect(call.inputs).toEqual({ prompt: "fix the bug" });
+    expect((call.definition as WorkflowDefinition).name).toBe("runs");
+  });
+
+  test("free-form workflow with no prompt forwards an empty inputs record", async () => {
+    await writeCompiledWorkflow({ name: "silent", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "silent",
+      agent: "copilot",
+      passthroughArgs: [],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock).toHaveBeenCalledTimes(1);
+    expect(executeWorkflowMock.mock.calls[0]![0].inputs).toEqual({});
+  });
+
+  test("structured workflow resolves flags and calls executor with merged inputs", async () => {
+    await writeCompiledWorkflow({
+      name: "struct-run",
+      agent: "copilot",
+      source: `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({
+  name: "struct-run",
+  inputs: [
+    { name: "topic", type: "string", required: true },
+    { name: "depth", type: "enum", values: ["shallow", "deep"], default: "shallow" },
+  ],
+})
+  .run(async () => {})
+  .compile();
+`,
+    });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "struct-run",
+      agent: "copilot",
+      passthroughArgs: ["--topic=authz", "--depth=deep"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock).toHaveBeenCalledTimes(1);
+    expect(executeWorkflowMock.mock.calls[0]![0].inputs).toEqual({
+      topic: "authz",
+      depth: "deep",
+    });
+  });
+
+  test("runLoadedWorkflow surfaces executor failures as exit code 1", async () => {
+    await writeCompiledWorkflow({ name: "boom", agent: "copilot" });
+
+    executeWorkflowMock.mockImplementationOnce(async () => {
+      throw new Error("tmux is on fire");
+    });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "boom",
+      agent: "copilot",
+      passthroughArgs: ["try", "it"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("Workflow failed");
+    expect(cap.stderr).toContain("tmux is on fire");
+  });
+
+  test("runLoadedWorkflow stringifies non-Error throwns", async () => {
+    await writeCompiledWorkflow({ name: "non-err", agent: "copilot" });
+
+    executeWorkflowMock.mockImplementationOnce(async () => {
+      // Thrown value is a plain string — the catch branch falls back to
+      // `String(error)` rather than reading `.message`.
+      throw "raw string failure";
+    });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "non-err",
+      agent: "copilot",
+      passthroughArgs: [],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("raw string failure");
+  });
+});
+
+// ─── Prereq checks (runPrereqChecks) ───────────────────────────────────────
+
+describe("workflowCommand prereq checks", () => {
+  test("missing agent CLI returns 1 with an install hint", async () => {
+    // `isCommandInstalled` is the first gate in runPrereqChecks — when it
+    // returns false for the agent binary, the command errors out before
+    // ever touching tmux or bun.
+    isCommandInstalledMock.mockImplementation((cmd) => cmd !== "claude");
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "anything",
+      agent: "claude",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("'claude' is not installed");
+    expect(cap.stderr).toContain("Install it from");
+  });
+
+  test("missing tmux attempts installer then errors when still absent", async () => {
+    // Force tmux to never appear even after the installer runs. The
+    // installer itself resolves cleanly, so we exercise the post-installer
+    // recheck + error-branch combination.
+    isTmuxInstalledMock.mockImplementation(() => false);
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "anything",
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(ensureTmuxInstalledMock).toHaveBeenCalledTimes(1);
+    // Platform-specific message — both tmux and psmux acceptable.
+    expect(cap.stderr).toMatch(/(tmux|psmux) is not installed/);
+  });
+
+  test("best-effort tmux installer errors are swallowed", async () => {
+    // Even if the installer throws, runPrereqChecks falls through to a
+    // second `isTmuxInstalled()` check — if that still says false, we
+    // return the same error. The installer failure itself must not
+    // propagate.
+    isTmuxInstalledMock.mockImplementation(() => false);
+    ensureTmuxInstalledMock.mockImplementationOnce(async () => {
+      throw new Error("installer crashed");
+    });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "anything",
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    // The crash message never surfaces — the catch block just swallows it.
+    expect(cap.stderr).not.toContain("installer crashed");
+    expect(cap.stderr).toMatch(/(tmux|psmux) is not installed/);
+  });
+});
+
+// ─── Picker mode discovery branches ────────────────────────────────────────
+
+describe("workflowCommand picker discovery branches", () => {
+  test("returns 1 when discovery finds zero workflows", async () => {
+    // Picker mode without any workflows on disk — the CLI should explain
+    // where to put a new workflow rather than render an empty picker.
+    discoverWorkflowsMock.mockImplementationOnce(async () => []);
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("No workflows found");
+    expect(cap.stderr).toContain(".atomic/workflows/<name>/copilot/index.ts");
+  });
+
+  test("returns 1 when every discovered workflow fails to load metadata", async () => {
+    // Discovery found entries but metadata load returned nothing — that's
+    // the "all workflows on disk are broken" branch. We fake a single
+    // discovered entry and then make the metadata loader drop it.
+    const fakeEntry: DiscoveredWorkflow = {
+      name: "broken",
+      agent: "copilot",
+      source: "local",
+      path: join(tempDir, ".atomic/workflows/broken/copilot/index.ts"),
+    };
+    discoverWorkflowsMock.mockImplementationOnce(async () => [fakeEntry]);
+    loadWorkflowsMetadataMock.mockImplementationOnce(async () => []);
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("All discovered workflows failed to load");
+  });
+});
+
+// Note on the picker success path: the branches that actually open the
+// interactive picker (runPickerMode lines after the "no workflows found" and
+// "all failed to load" guards, plus all of runResolvedSelection) are not
+// covered from this file. Exercising them requires mocking
+// `WorkflowPickerPanel`, which is a side-effectful class that spins up a
+// real CliRenderer on stdin/stdout. Mocking it process-wide via mock.module
+// leaks into the WorkflowPickerPanel's own unit tests (they share the same
+// bun test process) and breaks them — the same live-binding issue that
+// mock.module has with other consumers in the suite. Rather than fight the
+// tooling, we accept a small amount of uncovered code in the picker success
+// path; the remaining coverage comfortably clears the per-file threshold.

--- a/src/commands/cli/workflow.test.ts
+++ b/src/commands/cli/workflow.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect } from "bun:test";
+import {
+  parsePassthroughArgs,
+  validateInputsAgainstSchema,
+  resolveInputs,
+} from "./workflow.ts";
+import type { WorkflowInput } from "@/sdk/workflows/index.ts";
+
+// ─── parsePassthroughArgs ──────────────────────────────────────────────────
+
+describe("parsePassthroughArgs", () => {
+  test("parses --name=value flag pairs", () => {
+    const out = parsePassthroughArgs(["--foo=bar", "--baz=qux"]);
+    expect(out.flags).toEqual({ foo: "bar", baz: "qux" });
+    expect(out.positional).toEqual([]);
+    expect(out.errors).toEqual([]);
+  });
+
+  test("parses --name value flag pairs", () => {
+    const out = parsePassthroughArgs(["--foo", "bar", "--baz", "qux"]);
+    expect(out.flags).toEqual({ foo: "bar", baz: "qux" });
+    expect(out.errors).toEqual([]);
+  });
+
+  test("preserves values containing equals signs", () => {
+    const out = parsePassthroughArgs(["--query=key=value"]);
+    expect(out.flags).toEqual({ query: "key=value" });
+  });
+
+  test("collects positional tokens separately", () => {
+    const out = parsePassthroughArgs(["fix", "the", "bug"]);
+    expect(out.positional).toEqual(["fix", "the", "bug"]);
+    expect(out.flags).toEqual({});
+  });
+
+  test("returns an error when a flag has no value", () => {
+    const out = parsePassthroughArgs(["--foo"]);
+    expect(out.errors.length).toBe(1);
+    expect(out.errors[0]).toContain("--foo");
+  });
+
+  test("treats a trailing --flag --other as a missing value", () => {
+    // Second `--other` looks like a flag so the parser should not
+    // silently consume it as the first flag's value.
+    const out = parsePassthroughArgs(["--foo", "--other=x"]);
+    expect(out.errors.length).toBe(1);
+    expect(out.flags).toEqual({ other: "x" });
+  });
+
+  test("handles mixed positional and flag tokens", () => {
+    const out = parsePassthroughArgs([
+      "run",
+      "--mode=fast",
+      "now",
+      "--retries",
+      "3",
+    ]);
+    expect(out.positional).toEqual(["run", "now"]);
+    expect(out.flags).toEqual({ mode: "fast", retries: "3" });
+    expect(out.errors).toEqual([]);
+  });
+});
+
+// ─── validateInputsAgainstSchema ───────────────────────────────────────────
+
+const schema: WorkflowInput[] = [
+  {
+    name: "research_doc",
+    type: "string",
+    required: true,
+    description: "path",
+  },
+  {
+    name: "focus",
+    type: "enum",
+    required: true,
+    values: ["minimal", "standard", "exhaustive"],
+    default: "standard",
+  },
+  {
+    name: "notes",
+    type: "text",
+  },
+];
+
+describe("validateInputsAgainstSchema", () => {
+  test("passes when all required fields are present", () => {
+    const errors = validateInputsAgainstSchema(
+      { research_doc: "notes.md", focus: "standard" },
+      schema,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test("accepts an omitted enum with a declared default", () => {
+    // `focus` has a default of "standard", so omission should be OK.
+    const errors = validateInputsAgainstSchema(
+      { research_doc: "notes.md" },
+      schema,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test("flags a missing required string input", () => {
+    const errors = validateInputsAgainstSchema(
+      { focus: "standard" },
+      schema,
+    );
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("--research_doc");
+  });
+
+  test("rejects required strings that are whitespace only", () => {
+    const errors = validateInputsAgainstSchema(
+      { research_doc: "   ", focus: "standard" },
+      schema,
+    );
+    expect(errors[0]).toContain("--research_doc");
+  });
+
+  test("rejects enum values that are not in the allowed list", () => {
+    const errors = validateInputsAgainstSchema(
+      { research_doc: "notes.md", focus: "bogus" },
+      schema,
+    );
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("bogus");
+    expect(errors[0]).toContain("minimal");
+  });
+
+  test("flags unknown inputs", () => {
+    const errors = validateInputsAgainstSchema(
+      {
+        research_doc: "notes.md",
+        focus: "standard",
+        bogus: "hello",
+      },
+      schema,
+    );
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("--bogus");
+  });
+});
+
+// ─── resolveInputs ─────────────────────────────────────────────────────────
+
+describe("resolveInputs", () => {
+  test("fills in declared defaults", () => {
+    const out = resolveInputs({ research_doc: "notes.md" }, schema);
+    expect(out.research_doc).toBe("notes.md");
+    expect(out.focus).toBe("standard");
+    // `notes` has no default — should be absent, not empty-string.
+    expect(out.notes).toBeUndefined();
+  });
+
+  test("prefers provided values over defaults", () => {
+    const out = resolveInputs(
+      { research_doc: "notes.md", focus: "exhaustive" },
+      schema,
+    );
+    expect(out.focus).toBe("exhaustive");
+  });
+
+  test("falls back to the first enum value when no default and no input", () => {
+    const enumOnly: WorkflowInput[] = [
+      {
+        name: "mode",
+        type: "enum",
+        required: true,
+        values: ["a", "b", "c"],
+      },
+    ];
+    expect(resolveInputs({}, enumOnly)).toEqual({ mode: "a" });
+  });
+
+  test("ignores unknown provided keys", () => {
+    const out = resolveInputs(
+      { research_doc: "notes.md", bogus: "hello" },
+      schema,
+    );
+    expect(out.bogus).toBeUndefined();
+  });
+});

--- a/src/commands/cli/workflow.test.ts
+++ b/src/commands/cli/workflow.test.ts
@@ -1,10 +1,27 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import {
   parsePassthroughArgs,
   validateInputsAgainstSchema,
   resolveInputs,
+  renderWorkflowList,
 } from "./workflow.ts";
 import type { WorkflowInput } from "@/sdk/workflows/index.ts";
+import type { DiscoveredWorkflow } from "@/sdk/workflows/index.ts";
+
+// ─── Colour handling ────────────────────────────────────────────────────────
+// The renderer emits ANSI sequences when the host terminal claims truecolor
+// support. Force `NO_COLOR=1` for this file so renderWorkflowList assertions
+// can match on plain-text output rather than brittle SGR escapes. Restore the
+// prior value on teardown so other suites in the same run are unaffected.
+let originalNoColor: string | undefined;
+beforeAll(() => {
+  originalNoColor = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+});
+afterAll(() => {
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+});
 
 // ─── parsePassthroughArgs ──────────────────────────────────────────────────
 
@@ -37,6 +54,17 @@ describe("parsePassthroughArgs", () => {
     const out = parsePassthroughArgs(["--foo"]);
     expect(out.errors.length).toBe(1);
     expect(out.errors[0]).toContain("--foo");
+  });
+
+  test("flags an empty flag name when `--=value` slips through", () => {
+    // `--=foo` tokenises to body="=foo", splits at the first `=`,
+    // and yields an empty name. The parser rejects this so users see
+    // "did you mean --name=foo?" rather than silently accepting a
+    // nameless entry in the flags record.
+    const out = parsePassthroughArgs(["--=foo"]);
+    expect(out.errors.length).toBe(1);
+    expect(out.errors[0]).toContain("Malformed flag");
+    expect(out.flags).toEqual({});
   });
 
   test("treats a trailing --flag --other as a missing value", () => {
@@ -139,6 +167,105 @@ describe("validateInputsAgainstSchema", () => {
     );
     expect(errors.length).toBe(1);
     expect(errors[0]).toContain("--bogus");
+  });
+
+  test("flags a required enum that resolves to empty when no values are declared", () => {
+    // Pathological but reachable: a declared enum with an empty
+    // `values` array and no default falls through to value==="" in the
+    // resolver, which should trip the enum-specific required-input
+    // error branch rather than the generic string-required branch.
+    const brokenSchema: WorkflowInput[] = [
+      { name: "mode", type: "enum", required: true, values: [] },
+    ];
+    const errors = validateInputsAgainstSchema({}, brokenSchema);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("--mode");
+    expect(errors[0]).toContain("expected one of:");
+  });
+});
+
+// ─── renderWorkflowList ────────────────────────────────────────────────────
+
+function wf(
+  name: string,
+  agent: DiscoveredWorkflow["agent"],
+  source: DiscoveredWorkflow["source"],
+): DiscoveredWorkflow {
+  return {
+    name,
+    agent,
+    source,
+    path: `/tmp/fake/${source}/${name}/${agent}/index.ts`,
+  };
+}
+
+describe("renderWorkflowList", () => {
+  test("renders an empty-state stanza when no workflows are available", () => {
+    const out = renderWorkflowList([]);
+    expect(out).toContain("no workflows found");
+    // Teaches the user where to drop a new workflow.
+    expect(out).toContain(".atomic/workflows/<name>/<agent>/index.ts");
+  });
+
+  test("uses singular 'workflow' for a count of exactly one", () => {
+    const out = renderWorkflowList([wf("only", "claude", "local")]);
+    // Must say "1 workflow", never "1 workflows".
+    expect(out).toMatch(/\b1 workflow\b/);
+    expect(out).not.toMatch(/\b1 workflows\b/);
+    expect(out).toContain("only");
+  });
+
+  test("groups entries by source → provider and sorts names", () => {
+    const workflows: DiscoveredWorkflow[] = [
+      wf("zebra", "claude", "local"),
+      wf("apple", "claude", "local"),
+      wf("middle", "opencode", "local"),
+      wf("personal", "claude", "global"),
+      wf("shipped", "copilot", "builtin"),
+    ];
+    const out = renderWorkflowList(workflows);
+
+    // Count uses plural noun.
+    expect(out).toMatch(/\b5 workflows\b/);
+
+    // Section headings appear with friendly directory hints.
+    expect(out).toContain("local");
+    expect(out).toContain(".atomic/workflows");
+    expect(out).toContain("global");
+    expect(out).toContain("~/.atomic/workflows");
+    expect(out).toContain("builtin");
+    expect(out).toContain("built-in");
+
+    // Provider sub-headings are present with branded names.
+    expect(out).toContain("Claude");
+    expect(out).toContain("OpenCode");
+    expect(out).toContain("Copilot CLI");
+
+    // Run-hint footer is appended.
+    expect(out).toContain("run: atomic workflow -n <name> -a <agent>");
+
+    // Local/Claude names are sorted alphabetically: apple before zebra.
+    const appleIdx = out.indexOf("apple");
+    const zebraIdx = out.indexOf("zebra");
+    expect(appleIdx).toBeGreaterThanOrEqual(0);
+    expect(zebraIdx).toBeGreaterThan(appleIdx);
+
+    // Source ordering: local before global before builtin.
+    const localIdx = out.indexOf("local");
+    const globalIdx = out.indexOf("global");
+    const builtinIdx = out.indexOf("builtin");
+    expect(localIdx).toBeLessThan(globalIdx);
+    expect(globalIdx).toBeLessThan(builtinIdx);
+  });
+
+  test("omits provider sub-groups that have no entries for a given source", () => {
+    // Only a copilot workflow exists, so the local stanza should render a
+    // single "Copilot CLI" sub-heading — never "Claude" or "OpenCode".
+    const out = renderWorkflowList([wf("alone", "copilot", "local")]);
+    expect(out).toContain("Copilot CLI");
+    expect(out).not.toContain("Claude");
+    expect(out).not.toContain("OpenCode");
+    expect(out).toContain("alone");
   });
 });
 

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -2,8 +2,11 @@
  * Workflow CLI command
  *
  * Usage:
- *   atomic workflow -n <name> -a <agent> <prompt>
- *   atomic workflow --list
+ *   atomic workflow -a <agent>                     interactive picker
+ *   atomic workflow -n <name> -a <agent> <prompt>  free-form workflow
+ *   atomic workflow -n <name> -a <agent> --<field>=<value> ...
+ *                                                  structured-input workflow
+ *   atomic workflow --list                         list discoverable workflows
  */
 
 import { AGENT_CONFIG, type AgentKey } from "@/services/config/index.ts";
@@ -14,64 +17,248 @@ import {
   isTmuxInstalled,
   discoverWorkflows,
   findWorkflow,
+  loadWorkflowsMetadata,
   executeWorkflow,
   WorkflowLoader,
   resetMuxBinaryCache,
 } from "@/sdk/workflows/index.ts";
-import type { AgentType, DiscoveredWorkflow } from "@/sdk/workflows/index.ts";
+import type {
+  AgentType,
+  DiscoveredWorkflow,
+  WorkflowInput,
+  WorkflowWithMetadata,
+} from "@/sdk/workflows/index.ts";
+import { WorkflowPickerPanel } from "@/sdk/components/workflow-picker-panel.tsx";
+
+// ─── Flag parser ────────────────────────────────────────────────────────────
+
+/**
+ * Split commander's passthrough arg list into structured input flags and
+ * positional tokens (the latter get joined to form the free-form prompt).
+ *
+ * Accepts both `--name=value` and `--name value` forms, mirroring the
+ * conventions users already know from native agent CLIs. Flags whose
+ * values parse-fail (e.g. a trailing `--foo` with nothing after it) are
+ * returned as errors so the caller can print a clear usage hint rather
+ * than swallowing the mistake.
+ *
+ * Short flags (`-x value`) are treated as unknown and left in the
+ * positional bucket — we only recognise long-form `--<name>` flags as
+ * structured inputs.
+ */
+export function parsePassthroughArgs(args: string[]): {
+  flags: Record<string, string>;
+  positional: string[];
+  errors: string[];
+} {
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+  const errors: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i]!;
+    if (tok.startsWith("--")) {
+      const body = tok.slice(2);
+      const eq = body.indexOf("=");
+      if (eq >= 0) {
+        const name = body.slice(0, eq);
+        const value = body.slice(eq + 1);
+        if (name === "") {
+          errors.push(`Malformed flag "${tok}" — expected --<name>=<value>.`);
+          continue;
+        }
+        flags[name] = value;
+      } else {
+        const next = args[i + 1];
+        if (next === undefined || next.startsWith("-")) {
+          errors.push(
+            `Missing value for --${body}. Use --${body}=<value> or --${body} <value>.`,
+          );
+          continue;
+        }
+        flags[body] = next;
+        i++;
+      }
+    } else {
+      positional.push(tok);
+    }
+  }
+
+  return { flags, positional, errors };
+}
+
+// ─── Validation ─────────────────────────────────────────────────────────────
+
+/**
+ * Validate a set of CLI-provided input values against a workflow's
+ * declared schema. Returns a list of human-readable error strings — the
+ * caller should print each on its own line and exit non-zero if any are
+ * returned.
+ */
+export function validateInputsAgainstSchema(
+  inputs: Record<string, string>,
+  schema: readonly WorkflowInput[],
+): string[] {
+  const errors: string[] = [];
+  const known = new Set(schema.map((i) => i.name));
+
+  for (const field of schema) {
+    const raw = inputs[field.name];
+    const value =
+      raw === undefined || raw === ""
+        ? field.default ?? (field.type === "enum" ? field.values?.[0] ?? "" : "")
+        : raw;
+
+    if (field.required) {
+      if (field.type === "enum") {
+        if (value === "") {
+          errors.push(
+            `Missing required input --${field.name} (expected one of: ${(field.values ?? []).join(", ")}).`,
+          );
+        }
+      } else if (value.trim() === "") {
+        errors.push(`Missing required input --${field.name}.`);
+      }
+    }
+
+    if (field.type === "enum" && value !== "") {
+      const allowed = field.values ?? [];
+      if (!allowed.includes(value)) {
+        errors.push(
+          `Invalid value for --${field.name}: "${value}". ` +
+            `Expected one of: ${allowed.join(", ")}.`,
+        );
+      }
+    }
+  }
+
+  for (const name of Object.keys(inputs)) {
+    if (!known.has(name)) {
+      errors.push(
+        `Unknown input --${name}. ` +
+          `Valid inputs: ${schema.length > 0 ? schema.map((i) => `--${i.name}`).join(", ") : "(none — this workflow takes a free-form prompt)"}.`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Merge CLI-provided values with schema defaults so the executor sees a
+ * fully-resolved inputs record. Defaults for enum fields fall back to the
+ * first declared value when no explicit default is set. Unknown keys are
+ * dropped — validation has already flagged them.
+ */
+export function resolveInputs(
+  provided: Record<string, string>,
+  schema: readonly WorkflowInput[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const field of schema) {
+    const raw = provided[field.name];
+    if (raw !== undefined && raw !== "") {
+      out[field.name] = raw;
+    } else if (field.default !== undefined) {
+      out[field.name] = field.default;
+    } else if (field.type === "enum" && field.values && field.values.length > 0) {
+      out[field.name] = field.values[0]!;
+    }
+  }
+  return out;
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────────
 
 export async function workflowCommand(options: {
   name?: string;
   agent?: string;
-  prompt?: string;
   list?: boolean;
+  /**
+   * Everything commander parked in `cmd.args` — a mix of positional
+   * prompt tokens and unknown `--<name>` flags that the
+   * {@link parsePassthroughArgs} helper splits apart.
+   */
+  passthroughArgs?: string[];
 }): Promise<number> {
-  // List mode
+  const passthroughArgs = options.passthroughArgs ?? [];
+
+  // ── List mode ──
+  // `merge: false` keeps local and global entries independent so the
+  // list can show both copies of a non-reserved name when they coexist
+  // on disk. Reserved builtin names are already filtered out of both
+  // merge modes inside `discoverWorkflows`, so shadowed local/global
+  // workflows never reach the renderer.
   if (options.list) {
-    const workflows = await discoverWorkflows(undefined, options.agent as AgentType | undefined);
+    const workflows = await discoverWorkflows(
+      undefined,
+      options.agent as AgentType | undefined,
+      { merge: false },
+    );
     process.stdout.write(renderWorkflowList(workflows));
     return 0;
   }
 
-  // Run mode — validate inputs
-  if (!options.name) {
-    console.error(`${COLORS.red}Error: Missing workflow name. Use -n <name>.${COLORS.reset}`);
-    return 1;
-  }
-
+  // ── Agent validation (required for every non-list branch) ──
   if (!options.agent) {
-    console.error(`${COLORS.red}Error: Missing agent. Use -a <agent>.${COLORS.reset}`);
+    console.error(
+      `${COLORS.red}Error: Missing agent. Use -a <agent>.${COLORS.reset}`,
+    );
     return 1;
   }
 
   const validAgents = Object.keys(AGENT_CONFIG);
   if (!validAgents.includes(options.agent)) {
-    console.error(`${COLORS.red}Error: Unknown agent '${options.agent}'.${COLORS.reset}`);
+    console.error(
+      `${COLORS.red}Error: Unknown agent '${options.agent}'.${COLORS.reset}`,
+    );
     console.error(`Valid agents: ${validAgents.join(", ")}`);
     return 1;
   }
-
   const agent = options.agent as AgentKey;
 
-  // Check agent CLI is installed
+  // ── Preflight checks (shared between picker and named modes) ──
+  const preflightCode = await runPrereqChecks(agent);
+  if (preflightCode !== 0) return preflightCode;
+
+  // ── Picker mode: -a <agent>, no -n ──
+  if (!options.name) {
+    return runPickerMode(agent, passthroughArgs);
+  }
+
+  // ── Named mode: -n <name> -a <agent> [args...] ──
+  return runNamedMode(options.name, agent, passthroughArgs);
+}
+
+// ─── Shared helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Verify that the agent CLI, tmux (or psmux on Windows), and bun are all
+ * installed. Attempts best-effort installs for the latter two and
+ * returns a non-zero exit code if any check still fails afterwards.
+ */
+async function runPrereqChecks(agent: AgentKey): Promise<number> {
   if (!isCommandInstalled(AGENT_CONFIG[agent].cmd)) {
-    console.error(`${COLORS.red}Error: '${AGENT_CONFIG[agent].cmd}' is not installed.${COLORS.reset}`);
+    console.error(
+      `${COLORS.red}Error: '${AGENT_CONFIG[agent].cmd}' is not installed.${COLORS.reset}`,
+    );
     console.error(`Install it from: ${AGENT_CONFIG[agent].install_url}`);
     return 1;
   }
 
-  // Ensure tmux/psmux is installed
   if (!isTmuxInstalled()) {
     console.log("Terminal multiplexer not found. Installing...");
     try {
       await ensureTmuxInstalled();
       resetMuxBinaryCache();
     } catch {
-      // Installation attempt failed — fall through to check below
+      // Fall through to the check below — best effort.
     }
     if (!isTmuxInstalled()) {
       const isWin = process.platform === "win32";
-      console.error(`${COLORS.red}Error: ${isWin ? "psmux" : "tmux"} is not installed.${COLORS.reset}`);
+      console.error(
+        `${COLORS.red}Error: ${isWin ? "psmux" : "tmux"} is not installed.${COLORS.reset}`,
+      );
       console.error(
         isWin
           ? "Install psmux: https://github.com/psmux/psmux#installation"
@@ -81,43 +268,183 @@ export async function workflowCommand(options: {
     }
   }
 
-  // Ensure bun is installed (required for workflow execution)
   if (!Bun.which("bun")) {
     console.log("Bun runtime not found. Installing...");
     try {
       await ensureBunInstalled();
     } catch {
-      // Installation attempt failed — fall through to check below
+      // Best effort — fall through to the check below.
     }
     if (!Bun.which("bun")) {
-      console.error(`${COLORS.red}Error: bun is not installed.${COLORS.reset}`);
+      console.error(
+        `${COLORS.red}Error: bun is not installed.${COLORS.reset}`,
+      );
       console.error("Install bun: https://bun.sh");
       return 1;
     }
   }
 
+  return 0;
+}
+
+/**
+ * Run the given workflow definition through the executor, catching any
+ * execution errors so the CLI can exit with a non-zero code instead of
+ * letting an unhandled promise rejection bubble to `main()`.
+ *
+ * Free-form workflows ride the same `inputs` pipe — their positional
+ * prompt is stored under `inputs.prompt`, so workflow authors read it
+ * via `ctx.inputs.prompt ?? ""` whether or not the workflow declares
+ * a schema.
+ */
+async function runLoadedWorkflow(args: {
+  definition: Parameters<typeof executeWorkflow>[0]["definition"];
+  agent: AgentKey;
+  inputs: Record<string, string>;
+  workflowFile: string;
+}): Promise<number> {
+  try {
+    await executeWorkflow({
+      definition: args.definition,
+      agent: args.agent,
+      inputs: args.inputs,
+      workflowFile: args.workflowFile,
+    });
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`${COLORS.red}Workflow failed: ${message}${COLORS.reset}`);
+    return 1;
+  }
+}
+
+// ─── Picker mode ────────────────────────────────────────────────────────────
+
+/**
+ * Show the interactive picker, then hand off to the executor if the
+ * user confirms a selection. Passthrough args are rejected here — the
+ * picker already surfaces the same UI for typing values, so letting CLI
+ * flags leak through would create two conflicting sources of truth.
+ */
+async function runPickerMode(
+  agent: AgentKey,
+  passthroughArgs: string[],
+): Promise<number> {
+  if (passthroughArgs.length > 0) {
+    console.error(
+      `${COLORS.red}Error: unexpected arguments for the interactive picker: ${passthroughArgs.join(" ")}${COLORS.reset}`,
+    );
+    console.error(
+      `Pass workflow-specific flags only alongside -n <name>, or remove them to launch the picker.`,
+    );
+    return 1;
+  }
+
+  const discovered = await discoverWorkflows(undefined, agent);
+  if (discovered.length === 0) {
+    console.error(
+      `${COLORS.red}No workflows found for agent '${agent}'.${COLORS.reset}`,
+    );
+    console.error(
+      `Create one at: .atomic/workflows/<name>/${agent}/index.ts`,
+    );
+    return 1;
+  }
+
+  const metadata = await loadWorkflowsMetadata(discovered);
+  if (metadata.length === 0) {
+    console.error(
+      `${COLORS.red}All discovered workflows failed to load. Check the files under .atomic/workflows/ and ~/.atomic/workflows/.${COLORS.reset}`,
+    );
+    return 1;
+  }
+
+  // Stable sort so the picker list order is deterministic.
+  metadata.sort((a, b) => a.name.localeCompare(b.name));
+
+  const panel = await WorkflowPickerPanel.create({ agent, workflows: metadata });
+  let result;
+  try {
+    result = await panel.waitForSelection();
+  } finally {
+    panel.destroy();
+  }
+
+  if (!result) {
+    return 0;
+  }
+
+  return runResolvedSelection(result.workflow, agent, result.inputs);
+}
+
+/**
+ * Execute a workflow selected via the picker. The picker already stores
+ * free-form prompts under the `prompt` key (via `DEFAULT_PROMPT_INPUT`),
+ * so we can hand the inputs record straight through — no split between
+ * "prompt" and "structured inputs" is needed.
+ */
+async function runResolvedSelection(
+  workflow: WorkflowWithMetadata,
+  agent: AgentKey,
+  inputs: Record<string, string>,
+): Promise<number> {
+  const loaded = await WorkflowLoader.loadWorkflow(workflow, {
+    warn(warnings) {
+      for (const w of warnings) {
+        console.warn(`⚠ [${w.rule}] ${w.message}`);
+      }
+    },
+    error(stage, _error, message) {
+      console.error(`${COLORS.red}Error (${stage}): ${message}${COLORS.reset}`);
+    },
+  });
+  if (!loaded.ok) return 1;
+
+  return runLoadedWorkflow({
+    definition: loaded.value.definition,
+    agent,
+    inputs,
+    workflowFile: workflow.path,
+  });
+}
+
+// ─── Named mode ─────────────────────────────────────────────────────────────
+
+async function runNamedMode(
+  name: string,
+  agent: AgentKey,
+  passthroughArgs: string[],
+): Promise<number> {
   // Find the workflow
-  const discovered = await findWorkflow(options.name, agent);
+  const discovered = await findWorkflow(name, agent);
 
   if (!discovered) {
-    console.error(`${COLORS.red}Error: Workflow '${options.name}' not found for agent '${agent}'.${COLORS.reset}`);
+    console.error(
+      `${COLORS.red}Error: Workflow '${name}' not found for agent '${agent}'.${COLORS.reset}`,
+    );
     console.error(`\nExpected location:`);
-    console.error(`  .atomic/workflows/${options.name}/${agent}/index.ts  ${COLORS.dim}(local)${COLORS.reset}`);
-    console.error(`  ~/.atomic/workflows/${options.name}/${agent}/index.ts ${COLORS.dim}(global)${COLORS.reset}`);
+    console.error(
+      `  .atomic/workflows/${name}/${agent}/index.ts  ${COLORS.dim}(local)${COLORS.reset}`,
+    );
+    console.error(
+      `  ~/.atomic/workflows/${name}/${agent}/index.ts ${COLORS.dim}(global)${COLORS.reset}`,
+    );
 
     const available = await discoverWorkflows(undefined, agent);
     if (available.length > 0) {
       console.error(`\nAvailable ${agent} workflows:`);
       for (const wf of available) {
-        console.error(`  ${COLORS.dim}•${COLORS.reset} ${wf.name} ${COLORS.dim}(${wf.source})${COLORS.reset}`);
+        console.error(
+          `  ${COLORS.dim}•${COLORS.reset} ${wf.name} ${COLORS.dim}(${wf.source})${COLORS.reset}`,
+        );
       }
     }
 
     return 1;
   }
 
-  // Load workflow through the pipeline: resolve → validate → load.
-  // External workflows must have `@bastani/atomic` installed as a dependency.
+  // Load workflow so we can read the declared input schema before
+  // trusting any passthrough values.
   const result = await WorkflowLoader.loadWorkflow(discovered, {
     warn(warnings) {
       for (const w of warnings) {
@@ -129,24 +456,79 @@ export async function workflowCommand(options: {
     },
   });
 
-  if (!result.ok) {
+  if (!result.ok) return 1;
+  const definition = result.value.definition;
+
+  // Parse passthrough args into typed flags + positional tokens. The
+  // parser intentionally rejects only obviously-broken flags (e.g.
+  // `--foo` with nothing after it) — unknown flag names are surfaced
+  // later, in validateInputsAgainstSchema, so we can show the valid
+  // flag list alongside the error.
+  const { flags, positional, errors: parseErrors } =
+    parsePassthroughArgs(passthroughArgs);
+  if (parseErrors.length > 0) {
+    for (const e of parseErrors) {
+      console.error(`${COLORS.red}Error: ${e}${COLORS.reset}`);
+    }
     return 1;
   }
 
-  // Execute
-  try {
-    await executeWorkflow({
-      definition: result.value.definition,
+  const isStructured = definition.inputs.length > 0;
+
+  if (isStructured) {
+    // Positional args are ambiguous for structured workflows — users
+    // must go through `--<name>` flags so the executor has a typed
+    // record to validate against.
+    if (positional.length > 0) {
+      console.error(
+        `${COLORS.red}Error: workflow '${definition.name}' takes structured inputs — ` +
+          `pass them as --<name>=<value> flags instead of a positional prompt.${COLORS.reset}`,
+      );
+      console.error(
+        `Expected flags: ${definition.inputs.map((i) => `--${i.name}`).join(", ")}`,
+      );
+      return 1;
+    }
+    const validationErrors = validateInputsAgainstSchema(flags, definition.inputs);
+    if (validationErrors.length > 0) {
+      for (const e of validationErrors) {
+        console.error(`${COLORS.red}Error: ${e}${COLORS.reset}`);
+      }
+      return 1;
+    }
+    const resolvedInputs = resolveInputs(flags, definition.inputs);
+    return runLoadedWorkflow({
+      definition,
       agent,
-      prompt: options.prompt ?? "",
+      inputs: resolvedInputs,
       workflowFile: discovered.path,
     });
-    return 0;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`${COLORS.red}Workflow failed: ${message}${COLORS.reset}`);
+  }
+
+  // Free-form workflows: reject stray --<flag> flags outright, since
+  // they have no schema to validate against.
+  if (Object.keys(flags).length > 0) {
+    console.error(
+      `${COLORS.red}Error: workflow '${definition.name}' has no declared inputs — unknown flags: ${Object.keys(flags).map((n) => `--${n}`).join(", ")}.${COLORS.reset}`,
+    );
+    console.error(
+      `Pass your request as a positional prompt: atomic workflow -n ${definition.name} -a ${agent} "your prompt"`,
+    );
     return 1;
   }
+
+  // Free-form workflows store their single prompt under the `prompt`
+  // key so workflow authors can read `ctx.inputs.prompt` uniformly.
+  // An empty positional list stays as an empty inputs record and
+  // `ctx.inputs.prompt` stays undefined.
+  const prompt = positional.join(" ");
+  const inputs: Record<string, string> = prompt === "" ? {} : { prompt };
+  return runLoadedWorkflow({
+    definition,
+    agent,
+    inputs,
+    workflowFile: discovered.path,
+  });
 }
 
 /** Stable agent sort order; keeps output deterministic across runs. */
@@ -165,11 +547,14 @@ const SOURCE_DIRS: Record<DiscoveredWorkflow["source"], string> = {
   global: "~/.atomic/workflows",
   builtin: "built-in",
 };
-/** Section heading colour per source — preserves the source-type semantic. */
+/** Section heading colour per source — three distinct hues so each
+ *  source reads at a glance. `accent` (blue) is deliberately reserved
+ *  for the agent-provider sub-headings nested inside each section, so
+ *  builtin uses the new `info` (sky) key to avoid a clash. */
 const SOURCE_COLORS: Record<DiscoveredWorkflow["source"], PaletteKey> = {
-  local: "success",
-  global: "mauve",
-  builtin: "accent",
+  local: "success", // green — project-scoped, "yours"
+  global: "mauve",  // purple — user-scoped, personal
+  builtin: "info",  // sky    — ships with atomic, foundational
 };
 
 /**

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -180,8 +180,16 @@ export async function workflowCommand(options: {
    * {@link parsePassthroughArgs} helper splits apart.
    */
   passthroughArgs?: string[];
+  /**
+   * Project root used for workflow discovery. Defaults to
+   * `process.cwd()` in production; tests inject a temp dir so they
+   * can control which workflows are visible without touching the
+   * real filesystem.
+   */
+  cwd?: string;
 }): Promise<number> {
   const passthroughArgs = options.passthroughArgs ?? [];
+  const cwd = options.cwd;
 
   // ── List mode ──
   // `merge: false` keeps local and global entries independent so the
@@ -191,7 +199,7 @@ export async function workflowCommand(options: {
   // workflows never reach the renderer.
   if (options.list) {
     const workflows = await discoverWorkflows(
-      undefined,
+      cwd,
       options.agent as AgentType | undefined,
       { merge: false },
     );
@@ -223,11 +231,11 @@ export async function workflowCommand(options: {
 
   // ── Picker mode: -a <agent>, no -n ──
   if (!options.name) {
-    return runPickerMode(agent, passthroughArgs);
+    return runPickerMode(agent, passthroughArgs, cwd);
   }
 
   // ── Named mode: -n <name> -a <agent> [args...] ──
-  return runNamedMode(options.name, agent, passthroughArgs);
+  return runNamedMode(options.name, agent, passthroughArgs, cwd);
 }
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────
@@ -329,6 +337,7 @@ async function runLoadedWorkflow(args: {
 async function runPickerMode(
   agent: AgentKey,
   passthroughArgs: string[],
+  cwd: string | undefined,
 ): Promise<number> {
   if (passthroughArgs.length > 0) {
     console.error(
@@ -340,7 +349,7 @@ async function runPickerMode(
     return 1;
   }
 
-  const discovered = await discoverWorkflows(undefined, agent);
+  const discovered = await discoverWorkflows(cwd, agent);
   if (discovered.length === 0) {
     console.error(
       `${COLORS.red}No workflows found for agent '${agent}'.${COLORS.reset}`,
@@ -414,9 +423,10 @@ async function runNamedMode(
   name: string,
   agent: AgentKey,
   passthroughArgs: string[],
+  cwd: string | undefined,
 ): Promise<number> {
   // Find the workflow
-  const discovered = await findWorkflow(name, agent);
+  const discovered = await findWorkflow(name, agent, cwd);
 
   if (!discovered) {
     console.error(
@@ -430,7 +440,7 @@ async function runNamedMode(
       `  ~/.atomic/workflows/${name}/${agent}/index.ts ${COLORS.dim}(global)${COLORS.reset}`,
     );
 
-    const available = await discoverWorkflows(undefined, agent);
+    const available = await discoverWorkflows(cwd, agent);
     if (available.length > 0) {
       console.error(`\nAvailable ${agent} workflows:`);
       for (const wf of available) {
@@ -580,8 +590,11 @@ const SOURCE_COLORS: Record<DiscoveredWorkflow["source"], PaletteKey> = {
  *       <name>
  *
  *   run: atomic workflow -n <name> -a <agent>
+ *
+ * Exported for testing — the pure-function shape makes coverage for the
+ * renderer trivial without spinning up a full CLI invocation.
  */
-function renderWorkflowList(workflows: DiscoveredWorkflow[]): string {
+export function renderWorkflowList(workflows: DiscoveredWorkflow[]): string {
   const paint = createPainter();
   const lines: string[] = [];
 

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -1,0 +1,1454 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * WorkflowPickerPanel — interactive TUI for `atomic workflow -a <agent>`.
+ *
+ * Telescope-style fuzzy picker with a two-phase flow:
+ *
+ *   1. PICK   — filter workflows scoped to the current agent, navigate with
+ *               ↑/↓ or ⌃j/⌃k, press ↵ to lock in a selection.
+ *   2. PROMPT — fill the workflow's declared input schema (one field per
+ *               declared `WorkflowInput`). Free-form workflows fall back to
+ *               a single `prompt` text field.
+ *
+ * Pressing ⌃s in the prompt phase validates required fields and opens a
+ * CONFIRM modal that shows the fully-composed shell command before
+ * submission. y/↵ confirms, n/esc cancels back to the form.
+ *
+ * Lifecycle:
+ *
+ *   const panel = await WorkflowPickerPanel.create({ agent, workflows });
+ *   const result = await panel.waitForSelection();
+ *   panel.destroy();
+ *   if (result) await executeWorkflow({ ... });
+ *
+ * `waitForSelection()` resolves with `null` if the user exits without
+ * committing (esc in PICK phase, or ⌃c anywhere) and with a
+ * `{ workflow, inputs }` record if they confirm the run.
+ */
+
+import { createCliRenderer, type CliRenderer } from "@opentui/core";
+import {
+  createRoot,
+  useKeyboard,
+  type Root,
+} from "@opentui/react";
+import { useState, useEffect, useMemo } from "react";
+import { resolveTheme, type TerminalTheme } from "../runtime/theme.ts";
+import type { AgentType, WorkflowInput } from "../types.ts";
+import type { WorkflowWithMetadata } from "../runtime/discovery.ts";
+import { ErrorBoundary } from "./error-boundary.tsx";
+
+// ─── Theme ──────────────────────────────────────
+// The picker uses a slightly extended palette vs. the base terminal theme:
+// an `info` (sky) hue for built-in workflows and a `mauve` hue for global
+// ones — the same distinctions `atomic workflow -l` already draws. The
+// rest is sourced from {@link resolveTheme} so light/dark mode tracks the
+// orchestrator panel.
+interface PickerTheme {
+  background: string;
+  backgroundPanel: string;
+  backgroundElement: string;
+  surface: string;
+  text: string;
+  textMuted: string;
+  textDim: string;
+  primary: string;
+  success: string;
+  error: string;
+  warning: string;
+  info: string;
+  mauve: string;
+  border: string;
+  borderActive: string;
+}
+
+function buildPickerTheme(base: TerminalTheme): PickerTheme {
+  // For dark mode the prototype values track Catppuccin Mocha. For light
+  // mode we derive muted variants from the base palette — the specific
+  // extras (`info`, `mauve`, the three-level background ladder) have no
+  // direct entries in `TerminalTheme`, so we pick close-enough Catppuccin
+  // values to keep the picker visually consistent with the orchestrator.
+  const isDark = base.bg !== "#eff1f5";
+  return {
+    background: base.bg,
+    backgroundPanel: isDark ? "#181825" : "#e6e9ef",
+    backgroundElement: isDark ? "#11111b" : "#dce0e8",
+    surface: base.surface,
+    text: base.text,
+    textMuted: isDark ? "#a6adc8" : "#5c5f77",
+    textDim: base.dim,
+    primary: base.accent,
+    success: base.success,
+    error: base.error,
+    warning: base.warning,
+    info: isDark ? "#89dceb" : "#04a5e5",
+    mauve: isDark ? "#cba6f7" : "#8839ef",
+    border: base.borderDim,
+    borderActive: base.border,
+  };
+}
+
+// ─── Types ──────────────────────────────────────
+
+type Source = "local" | "global" | "builtin";
+type Phase = "pick" | "prompt";
+
+/** The payload the picker resolves with on successful submission. */
+export interface WorkflowPickerResult {
+  /** The workflow the user committed to running. */
+  workflow: WorkflowWithMetadata;
+  /** Populated form values, one per declared input (or { prompt } for free-form). */
+  inputs: Record<string, string>;
+}
+
+/** Fallback field used when a workflow has no structured input schema. */
+const DEFAULT_PROMPT_INPUT: WorkflowInput = {
+  name: "prompt",
+  type: "text",
+  required: true,
+  description: "what do you want this workflow to do?",
+  placeholder: "describe your task…",
+};
+
+// ─── Helpers ────────────────────────────────────
+
+const SOURCE_DISPLAY: Record<Source, string> = {
+  local: "local",
+  global: "global",
+  builtin: "builtin",
+};
+
+const SOURCE_DIR: Record<Source, string> = {
+  local: ".atomic/workflows",
+  global: "~/.atomic/workflows",
+  builtin: "built-in",
+};
+
+const SOURCE_COLOR: Record<Source, keyof PickerTheme> = {
+  local: "success",
+  global: "mauve",
+  builtin: "info",
+};
+
+/**
+ * Subsequence fuzzy match — Telescope-style. Returns a score (lower =
+ * better) or null for no match. Adjacent matches are rewarded; jumps over
+ * non-matching characters are penalized proportionally to the gap.
+ */
+function fuzzyMatch(query: string, target: string): number | null {
+  if (query === "") return 0;
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let ti = 0;
+  let score = 0;
+  let prev = -2;
+  for (let qi = 0; qi < q.length; qi++) {
+    let found = -1;
+    while (ti < t.length) {
+      if (t[ti] === q[qi]) {
+        found = ti;
+        break;
+      }
+      ti++;
+    }
+    if (found === -1) return null;
+    score += found === prev + 1 ? 1 : 4 + (found - prev);
+    prev = found;
+    ti++;
+  }
+  return score;
+}
+
+// ─── List Building ──────────────────────────────
+
+interface ListEntry {
+  workflow: WorkflowWithMetadata;
+  section: Source;
+}
+
+interface ListRow {
+  kind: "section" | "entry";
+  source?: Source;
+  entry?: ListEntry;
+}
+
+function buildEntries(
+  query: string,
+  workflows: WorkflowWithMetadata[],
+): ListEntry[] {
+  type Scored = { wf: WorkflowWithMetadata; score: number };
+  const scored: Scored[] = [];
+  for (const wf of workflows) {
+    const nameScore = fuzzyMatch(query, wf.name);
+    const descScore = fuzzyMatch(query, wf.description);
+    const best =
+      nameScore !== null && descScore !== null
+        ? Math.min(nameScore, descScore + 2)
+        : nameScore !== null
+          ? nameScore
+          : descScore !== null
+            ? descScore + 2
+            : null;
+    if (best !== null) scored.push({ wf, score: best });
+  }
+
+  if (query === "") {
+    const rest: ListEntry[] = [];
+    for (const source of ["local", "global", "builtin"] as Source[]) {
+      const group = scored
+        .filter((s) => s.wf.source === source)
+        .sort((a, b) => a.wf.name.localeCompare(b.wf.name));
+      for (const s of group) rest.push({ workflow: s.wf, section: source });
+    }
+    return rest;
+  }
+
+  scored.sort((a, b) => a.score - b.score);
+  return scored.map<ListEntry>((s) => ({
+    workflow: s.wf,
+    section: s.wf.source,
+  }));
+}
+
+function buildRows(entries: ListEntry[], query: string): ListRow[] {
+  const rows: ListRow[] = [];
+  if (query === "") {
+    let lastSection: string | null = null;
+    for (const e of entries) {
+      if (e.section !== lastSection) {
+        rows.push({ kind: "section", source: e.section });
+        lastSection = e.section;
+      }
+      rows.push({ kind: "entry", entry: e });
+    }
+  } else {
+    for (const e of entries) rows.push({ kind: "entry", entry: e });
+  }
+  return rows;
+}
+
+// ─── Validation ─────────────────────────────────
+
+function isFieldValid(field: WorkflowInput, value: string): boolean {
+  if (!field.required) return true;
+  if (field.type === "enum") return value !== "";
+  return value.trim() !== "";
+}
+
+// ─── Components ─────────────────────────────────
+
+function SectionLabel({
+  theme,
+  label,
+}: {
+  theme: PickerTheme;
+  label: string;
+}) {
+  return (
+    <box height={1} flexDirection="row">
+      <text>
+        <span fg={theme.mauve}>▎ </span>
+        <span fg={theme.textMuted}>
+          <strong>{label}</strong>
+        </span>
+      </text>
+    </box>
+  );
+}
+
+function FilterBar({
+  theme,
+  query,
+}: {
+  theme: PickerTheme;
+  query: string;
+}) {
+  return (
+    <box
+      height={3}
+      border
+      borderStyle="rounded"
+      borderColor={theme.borderActive}
+      backgroundColor={theme.backgroundPanel}
+      flexDirection="row"
+      paddingLeft={2}
+      paddingRight={2}
+      alignItems="center"
+    >
+      <text>
+        <span fg={theme.primary}>
+          <strong>❯ </strong>
+        </span>
+      </text>
+      <text>
+        <span fg={theme.text}>{query}</span>
+        {/* Solid full-cell caret. Rendered as a space with a coloured
+            background so the cursor thickness stays stable — the
+            previous `▋` half-block halved in width compared to the
+            highlighted-char placeholder cursor. */}
+        <span bg={theme.primary}> </span>
+      </text>
+    </box>
+  );
+}
+
+function WorkflowList({
+  theme,
+  rows,
+  focusedEntryIdx,
+}: {
+  theme: PickerTheme;
+  rows: ListRow[];
+  focusedEntryIdx: number;
+}) {
+  if (rows.length === 0) {
+    return (
+      <box paddingLeft={2} paddingTop={2}>
+        <text>
+          <span fg={theme.textDim}>no matches</span>
+        </text>
+      </box>
+    );
+  }
+
+  let entryCounter = -1;
+  return (
+    <box flexDirection="column">
+      {rows.map((row, i) => {
+        if (row.kind === "section") {
+          const src = row.source!;
+          return (
+            <box
+              key={`s${i}`}
+              height={2}
+              paddingTop={1}
+              paddingLeft={2}
+            >
+              <text>
+                <span fg={theme[SOURCE_COLOR[src]]}>
+                  {SOURCE_DISPLAY[src]}
+                </span>
+                <span fg={theme.textDim}>
+                  {" (" + SOURCE_DIR[src] + ")"}
+                </span>
+              </text>
+            </box>
+          );
+        }
+        entryCounter++;
+        const isFocused = entryCounter === focusedEntryIdx;
+        const wf = row.entry!.workflow;
+
+        return (
+          <box
+            key={`e${i}`}
+            height={1}
+            flexDirection="row"
+            backgroundColor={isFocused ? theme.border : "transparent"}
+            paddingLeft={1}
+            paddingRight={2}
+          >
+            <text>
+              <span fg={isFocused ? theme.primary : theme.textDim}>
+                {isFocused ? "▸ " : "  "}
+              </span>
+              <span fg={isFocused ? theme.text : theme.textMuted}>
+                {wf.name}
+              </span>
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}
+
+function ArgumentRow({
+  theme,
+  field,
+}: {
+  theme: PickerTheme;
+  field: WorkflowInput;
+}) {
+  const isRequired = field.required ?? false;
+  const tagCol = isRequired ? theme.warning : theme.textDim;
+  const tagLabel = isRequired ? "required" : "optional";
+  const showEnumValues =
+    field.type === "enum" && field.values && field.values.length > 0;
+
+  return (
+    <box flexDirection="column" paddingLeft={2} paddingRight={2}>
+      <box flexDirection="row" height={1}>
+        <text>
+          <span fg={theme.text}>{field.name}</span>
+        </text>
+        <box flexGrow={1} />
+        <text>
+          <span fg={theme.textDim}>{field.type}</span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={tagCol}>{tagLabel}</span>
+        </text>
+      </box>
+
+      {field.description ? (
+        <box height={1}>
+          <text>
+            <span fg={theme.textMuted}>{field.description}</span>
+          </text>
+        </box>
+      ) : null}
+
+      {showEnumValues ? (
+        <box height={1}>
+          <text>
+            <span fg={theme.textDim}>{field.values!.join("  ·  ")}</span>
+          </text>
+        </box>
+      ) : null}
+
+      <box height={1} />
+    </box>
+  );
+}
+
+function Preview({
+  theme,
+  wf,
+}: {
+  theme: PickerTheme;
+  wf: WorkflowWithMetadata;
+}) {
+  const args: WorkflowInput[] =
+    wf.inputs.length > 0 ? [...wf.inputs] : [DEFAULT_PROMPT_INPUT];
+
+  return (
+    <box
+      flexDirection="column"
+      paddingLeft={3}
+      paddingRight={3}
+      paddingTop={1}
+    >
+      <text>
+        <span fg={theme.text}>
+          <strong>{wf.name}</strong>
+        </span>
+      </text>
+
+      <box height={1} />
+
+      <text>
+        <span fg={theme[SOURCE_COLOR[wf.source as Source]]}>
+          {SOURCE_DISPLAY[wf.source as Source]}
+        </span>
+        <span fg={theme.textDim}>
+          {" (" + SOURCE_DIR[wf.source as Source] + ")"}
+        </span>
+      </text>
+
+      <box height={2} />
+
+      <text>
+        <span fg={theme.textMuted}>
+          {wf.description || "(no description)"}
+        </span>
+      </text>
+
+      <box height={2} />
+
+      <SectionLabel theme={theme} label="ARGUMENTS" />
+      <box height={1} />
+      {args.map((f) => (
+        <ArgumentRow key={f.name} theme={theme} field={f} />
+      ))}
+    </box>
+  );
+}
+
+function EmptyPreview({
+  theme,
+  query,
+}: {
+  theme: PickerTheme;
+  query: string;
+}) {
+  return (
+    <box
+      flexDirection="column"
+      paddingLeft={3}
+      paddingRight={3}
+      paddingTop={3}
+    >
+      <text>
+        <span fg={theme.textMuted}>No workflows match </span>
+        <span fg={theme.text}>"{query}"</span>
+      </text>
+      <box height={2} />
+      <text>
+        <span fg={theme.textDim}>
+          Press backspace to widen your search, or
+        </span>
+      </text>
+      <box height={2} />
+      <text>
+        <span fg={theme.textDim}>create a new one at</span>
+      </text>
+      <box height={1} />
+      <box paddingLeft={2}>
+        <text>
+          <span fg={theme.primary}>
+            .atomic/workflows/&lt;name&gt;/&lt;agent&gt;/index.ts
+          </span>
+        </text>
+      </box>
+    </box>
+  );
+}
+
+// ─── Field renderers ────────────────────────────
+
+const TEXT_FIELD_LINES = 3;
+
+/**
+ * Render a placeholder with a solid full-cell caret overlapping its
+ * first character. The caret is a full cell wide — same thickness as
+ * the trailing-caret cell used for typed text — so switching between
+ * "empty" and "has input" states never visually halves the cursor.
+ *
+ * When the field is not focused, the placeholder renders plain dim
+ * text without the caret highlight.
+ */
+function PlaceholderWithCursor({
+  theme,
+  placeholder,
+  focused,
+}: {
+  theme: PickerTheme;
+  placeholder: string;
+  focused: boolean;
+}) {
+  const effective = placeholder.length > 0 ? placeholder : " ";
+  const first = effective.slice(0, 1);
+  const rest = effective.slice(1);
+
+  if (!focused) {
+    return (
+      <text>
+        <span fg={theme.textDim}>{effective}</span>
+      </text>
+    );
+  }
+
+  return (
+    <text>
+      <span fg={theme.surface} bg={theme.primary}>
+        {first}
+      </span>
+      <span fg={theme.textDim}>{rest}</span>
+    </text>
+  );
+}
+
+function TextAreaContent({
+  theme,
+  value,
+  placeholder,
+  focused,
+  lines,
+}: {
+  theme: PickerTheme;
+  value: string;
+  placeholder: string;
+  focused: boolean;
+  lines: number;
+}) {
+  const textLines = value.split("\n");
+  const start = Math.max(0, textLines.length - lines);
+  const visible: string[] = [];
+  for (let i = 0; i < lines; i++) {
+    visible.push(textLines[start + i] ?? "");
+  }
+  const cursorLine = Math.min(lines - 1, textLines.length - 1 - start);
+  const isEmpty = value === "";
+
+  return (
+    <box flexDirection="column">
+      {visible.map((line, i) => {
+        if (isEmpty && i === 0) {
+          return (
+            <box key={i} height={1}>
+              <PlaceholderWithCursor
+                theme={theme}
+                placeholder={placeholder}
+                focused={focused}
+              />
+            </box>
+          );
+        }
+        // Trailing caret on the active line. Rendered as a
+        // background-coloured space so the cell width matches the
+        // placeholder-overlap caret exactly — no thickness change
+        // between empty and typed states.
+        const showCursorHere = focused && !isEmpty && i === cursorLine;
+        return (
+          <box key={i} height={1}>
+            <text>
+              <span fg={theme.text}>{line}</span>
+              {showCursorHere ? <span bg={theme.primary}> </span> : null}
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}
+
+function StringContent({
+  theme,
+  value,
+  placeholder,
+  focused,
+}: {
+  theme: PickerTheme;
+  value: string;
+  placeholder: string;
+  focused: boolean;
+}) {
+  const isEmpty = value === "";
+
+  if (isEmpty) {
+    return (
+      <box height={1} flexDirection="row">
+        <PlaceholderWithCursor
+          theme={theme}
+          placeholder={placeholder}
+          focused={focused}
+        />
+      </box>
+    );
+  }
+
+  return (
+    <box height={1} flexDirection="row">
+      <text>
+        <span fg={theme.text}>{value}</span>
+        {focused ? <span bg={theme.primary}> </span> : null}
+      </text>
+    </box>
+  );
+}
+
+function EnumContent({
+  theme,
+  values,
+  selected,
+  focused,
+}: {
+  theme: PickerTheme;
+  values: string[];
+  selected: string;
+  focused: boolean;
+}) {
+  return (
+    <box height={1} flexDirection="row">
+      {values.map((v, i) => {
+        const isSelected = v === selected;
+        const marker = isSelected ? "●" : "○";
+        const markerColor = isSelected
+          ? focused
+            ? theme.primary
+            : theme.success
+          : theme.textDim;
+        const textColor = isSelected
+          ? focused
+            ? theme.text
+            : theme.textMuted
+          : theme.textDim;
+        return (
+          <box
+            key={v}
+            flexDirection="row"
+            paddingLeft={i > 0 ? 3 : 0}
+            height={1}
+          >
+            <text>
+              <span fg={markerColor}>{marker} </span>
+              <span fg={textColor}>{v}</span>
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}
+
+function Field({
+  theme,
+  field,
+  value,
+  focused,
+}: {
+  theme: PickerTheme;
+  field: WorkflowInput;
+  value: string;
+  focused: boolean;
+}) {
+  const borderCol = focused ? theme.primary : theme.border;
+  const bgCol = focused ? theme.backgroundPanel : theme.backgroundElement;
+
+  const boxHeight = field.type === "text" ? TEXT_FIELD_LINES + 2 : 3;
+
+  const tagCol = field.required ? theme.warning : theme.textDim;
+  const tagLabel = field.required ? "required" : "optional";
+  const captionDesc = field.description ? "  ·  " + field.description : "";
+
+  return (
+    <box flexDirection="column">
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={borderCol}
+        backgroundColor={bgCol}
+        flexDirection="column"
+        paddingLeft={2}
+        paddingRight={2}
+        height={boxHeight}
+        justifyContent={field.type === "text" ? "flex-start" : "center"}
+        title={` ${field.name} `}
+        titleAlignment="left"
+      >
+        {field.type === "text" ? (
+          <TextAreaContent
+            theme={theme}
+            value={value}
+            placeholder={field.placeholder ?? ""}
+            focused={focused}
+            lines={TEXT_FIELD_LINES}
+          />
+        ) : field.type === "string" ? (
+          <StringContent
+            theme={theme}
+            value={value}
+            placeholder={field.placeholder ?? ""}
+            focused={focused}
+          />
+        ) : field.type === "enum" ? (
+          <EnumContent
+            theme={theme}
+            values={field.values ?? []}
+            selected={value}
+            focused={focused}
+          />
+        ) : null}
+      </box>
+
+      <box paddingLeft={2} paddingRight={2} height={1}>
+        <text>
+          <span fg={theme.textDim}>{field.type}</span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={tagCol}>{tagLabel}</span>
+          <span fg={theme.textDim}>{captionDesc}</span>
+        </text>
+      </box>
+
+      <box height={1} />
+    </box>
+  );
+}
+
+function InputPhase({
+  theme,
+  workflow,
+  agent,
+  fields,
+  values,
+  focusedFieldIdx,
+}: {
+  theme: PickerTheme;
+  workflow: WorkflowWithMetadata;
+  agent: AgentType;
+  fields: WorkflowInput[];
+  values: Record<string, string>;
+  focusedFieldIdx: number;
+}) {
+  const isStructured = workflow.inputs.length > 0;
+
+  return (
+    <box
+      flexDirection="column"
+      paddingLeft={3}
+      paddingRight={3}
+      paddingTop={2}
+      flexGrow={1}
+    >
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={theme.border}
+        backgroundColor={theme.backgroundPanel}
+        flexDirection="column"
+        paddingLeft={2}
+        paddingRight={2}
+        paddingTop={1}
+        paddingBottom={1}
+      >
+        <text>
+          <span fg={theme.primary}>
+            <strong>▸ </strong>
+          </span>
+          <span fg={theme.text}>
+            <strong>{workflow.name}</strong>
+          </span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={theme.mauve}>{agent}</span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={theme[SOURCE_COLOR[workflow.source as Source]]}>
+            {SOURCE_DISPLAY[workflow.source as Source]}
+          </span>
+          <span fg={theme.textDim}>
+            {" (" + SOURCE_DIR[workflow.source as Source] + ")"}
+          </span>
+        </text>
+        <box height={1} />
+        <text>
+          <span fg={theme.textMuted}>
+            {workflow.description || "(no description)"}
+          </span>
+        </text>
+      </box>
+
+      <box height={2} />
+
+      <box flexDirection="row" height={1}>
+        <text>
+          <span fg={theme.textDim}>
+            <strong>{isStructured ? "INPUTS" : "PROMPT"}</strong>
+          </span>
+        </text>
+        <box flexGrow={1} />
+        <text>
+          <span fg={theme.textDim}>
+            {isStructured ? `${focusedFieldIdx + 1} / ${fields.length}` : ""}
+          </span>
+        </text>
+      </box>
+      <box height={1} />
+
+      {fields.map((f, i) => (
+        <Field
+          key={f.name}
+          theme={theme}
+          field={f}
+          value={values[f.name] ?? ""}
+          focused={i === focusedFieldIdx}
+        />
+      ))}
+    </box>
+  );
+}
+
+function ConfirmModal({
+  theme,
+  workflow,
+  agent,
+}: {
+  theme: PickerTheme;
+  workflow: WorkflowWithMetadata;
+  agent: AgentType;
+}) {
+  return (
+    <box
+      position="absolute"
+      left={0}
+      top={0}
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      zIndex={100}
+    >
+      <box
+        border
+        borderStyle="rounded"
+        borderColor={theme.success}
+        backgroundColor={theme.backgroundPanel}
+        flexDirection="column"
+        paddingLeft={3}
+        paddingRight={3}
+        paddingTop={1}
+        paddingBottom={1}
+        title=" ready to run "
+        titleAlignment="center"
+      >
+        {/* Header — the form the user just filled in already shows the
+            workflow name, agent, and field values, so the modal stays
+            minimal and focuses on the submit/cancel question rather
+            than restating the full invocation. */}
+        <text>
+          <span fg={theme.success}>
+            <strong>✓ </strong>
+          </span>
+          <span fg={theme.text}>
+            <strong>{workflow.name}</strong>
+          </span>
+          <span fg={theme.textDim}>{"  ·  "}</span>
+          <span fg={theme.mauve}>{agent}</span>
+        </text>
+
+        <box height={1} />
+
+        <text>
+          <span fg={theme.textDim}>
+            submit and run this workflow?{"  "}
+          </span>
+          <span fg={theme.success}>
+            <strong>y</strong>
+          </span>
+          <span fg={theme.textDim}> submit  ·  </span>
+          <span fg={theme.error}>
+            <strong>n</strong>
+          </span>
+          <span fg={theme.textDim}> cancel</span>
+        </text>
+      </box>
+    </box>
+  );
+}
+
+// Per-agent brand color used as the Header pill background.
+const AGENT_PILL_COLOR: Record<AgentType, keyof PickerTheme> = {
+  claude: "warning",
+  copilot: "success",
+  opencode: "mauve",
+};
+
+function Header({
+  theme,
+  phase,
+  confirmOpen,
+  selectedAgent,
+  scopedCount,
+}: {
+  theme: PickerTheme;
+  phase: Phase;
+  confirmOpen: boolean;
+  selectedAgent: AgentType;
+  scopedCount: number;
+}) {
+  const phaseLabel = confirmOpen
+    ? "confirm"
+    : phase === "pick"
+      ? "select"
+      : "compose";
+  const pillBg = theme[AGENT_PILL_COLOR[selectedAgent]];
+
+  return (
+    <box
+      height={1}
+      backgroundColor={theme.surface}
+      flexDirection="row"
+      paddingRight={2}
+      alignItems="center"
+    >
+      <text>
+        <span fg={theme.surface} bg={pillBg}>
+          <strong>{" " + selectedAgent.toUpperCase() + " "}</strong>
+        </span>
+      </text>
+      <text>
+        <span fg={theme.textDim}>{"  workflow  "}</span>
+      </text>
+      <text>
+        <span fg={theme.textMuted}>›</span>
+      </text>
+      <text>
+        <span fg={theme.textDim}>{"  " + phaseLabel}</span>
+      </text>
+      <box flexGrow={1} />
+      <text>
+        <span fg={theme.textDim}>
+          {scopedCount + (scopedCount === 1 ? " workflow" : " workflows")}
+        </span>
+      </text>
+    </box>
+  );
+}
+
+function Statusline({
+  theme,
+  phase,
+  confirmOpen,
+  hints,
+  focusedWf,
+}: {
+  theme: PickerTheme;
+  phase: Phase;
+  confirmOpen: boolean;
+  hints: { key: string; label: string; dim?: boolean }[];
+  focusedWf: WorkflowWithMetadata | undefined;
+}) {
+  const modeLabel = confirmOpen
+    ? "CONFIRM"
+    : phase === "pick"
+      ? "PICK"
+      : "PROMPT";
+  const modeColor = confirmOpen
+    ? theme.mauve
+    : phase === "pick"
+      ? theme.primary
+      : theme.success;
+
+  return (
+    <box height={1} flexDirection="row" backgroundColor={theme.surface}>
+      <box
+        backgroundColor={modeColor}
+        paddingLeft={1}
+        paddingRight={1}
+        alignItems="center"
+      >
+        <text fg={theme.surface}>
+          <strong>{modeLabel}</strong>
+        </text>
+      </box>
+
+      {focusedWf ? (
+        <box paddingLeft={1} paddingRight={1} alignItems="center">
+          <text>
+            <span fg={theme.text}>{focusedWf.name}</span>
+          </text>
+        </box>
+      ) : null}
+
+      <box flexGrow={1} />
+
+      <box paddingRight={2} alignItems="center" flexDirection="row">
+        {hints.map((h, i) => (
+          <box key={i} flexDirection="row">
+            {i > 0 ? (
+              <text>
+                <span fg={theme.textDim}>{"  ·  "}</span>
+              </text>
+            ) : null}
+            <text>
+              <span fg={h.dim ? theme.textDim : theme.text}>{h.key}</span>
+              <span fg={h.dim ? theme.textDim : theme.textMuted}>
+                {" " + h.label}
+              </span>
+            </text>
+          </box>
+        ))}
+      </box>
+    </box>
+  );
+}
+
+// ─── App ────────────────────────────────────────
+
+interface PickerAppProps {
+  theme: PickerTheme;
+  agent: AgentType;
+  workflows: WorkflowWithMetadata[];
+  onSubmit: (result: WorkflowPickerResult) => void;
+  onCancel: () => void;
+}
+
+function WorkflowPicker({
+  theme,
+  agent,
+  workflows,
+  onSubmit,
+  onCancel,
+}: PickerAppProps) {
+  const [phase, setPhase] = useState<Phase>("pick");
+  const [query, setQuery] = useState("");
+  const [entryIdx, setEntryIdx] = useState(0);
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
+  const [focusedFieldIdx, setFocusedFieldIdx] = useState(0);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Note: the cursor is rendered as a steady full-cell block rather
+  // than a blinking caret. Blinking was causing the caret cell to
+  // flash visibly every 530ms, which read as a "text block flashing"
+  // bug on top of the already-jarring thickness change that used to
+  // happen when switching between placeholder and typed-text cursors.
+  // Both issues go away with a stable caret.
+
+  const entries = useMemo(() => buildEntries(query, workflows), [query, workflows]);
+  const rows = useMemo(() => buildRows(entries, query), [entries, query]);
+
+  useEffect(() => {
+    if (entryIdx >= entries.length) {
+      setEntryIdx(Math.max(0, entries.length - 1));
+    }
+  }, [entries.length, entryIdx]);
+
+  const focusedWf = entries[entryIdx]?.workflow;
+
+  const currentFields: WorkflowInput[] =
+    focusedWf && focusedWf.inputs.length > 0
+      ? [...focusedWf.inputs]
+      : [DEFAULT_PROMPT_INPUT];
+  const currentField = currentFields[focusedFieldIdx];
+
+  const invalidFieldIndices = useMemo(() => {
+    const out: number[] = [];
+    for (let i = 0; i < currentFields.length; i++) {
+      const f = currentFields[i]!;
+      const v = fieldValues[f.name] ?? "";
+      if (!isFieldValid(f, v)) out.push(i);
+    }
+    return out;
+  }, [currentFields, fieldValues]);
+  const isFormValid = invalidFieldIndices.length === 0;
+
+  useKeyboard((key) => {
+    if (key.ctrl && key.name === "c") {
+      onCancel();
+      return;
+    }
+
+    if (confirmOpen) {
+      if (key.name === "y" || key.name === "return") {
+        if (!focusedWf) return;
+        onSubmit({ workflow: focusedWf, inputs: { ...fieldValues } });
+        return;
+      }
+      if (key.name === "n" || key.name === "escape") {
+        setConfirmOpen(false);
+        return;
+      }
+      return;
+    }
+
+    if (phase === "pick") {
+      if (key.name === "escape") {
+        onCancel();
+        return;
+      }
+      if (key.name === "up" || (key.ctrl && key.name === "k")) {
+        setEntryIdx((i: number) => Math.max(0, i - 1));
+        return;
+      }
+      if (key.name === "down" || (key.ctrl && key.name === "j")) {
+        setEntryIdx((i: number) =>
+          Math.min(entries.length - 1, i + 1),
+        );
+        return;
+      }
+      if (key.name === "return") {
+        if (focusedWf) {
+          const inputs: WorkflowInput[] =
+            focusedWf.inputs.length > 0
+              ? [...focusedWf.inputs]
+              : [DEFAULT_PROMPT_INPUT];
+          const initial: Record<string, string> = {};
+          for (const f of inputs) {
+            initial[f.name] =
+              f.default ??
+              (f.type === "enum" ? (f.values?.[0] ?? "") : "");
+          }
+          setFieldValues(initial);
+          setFocusedFieldIdx(0);
+          setPhase("prompt");
+        }
+        return;
+      }
+      if (key.name === "backspace") {
+        setQuery((q: string) => q.slice(0, -1));
+        return;
+      }
+      if (
+        key.sequence &&
+        key.sequence.length === 1 &&
+        !key.ctrl &&
+        !key.meta
+      ) {
+        const c = key.sequence;
+        if (c >= " " && c <= "~") setQuery((q: string) => q + c);
+      }
+      return;
+    }
+
+    // ── PROMPT phase ──
+    if (key.name === "escape") {
+      setPhase("pick");
+      return;
+    }
+    if (key.ctrl && key.name === "s") {
+      if (!isFormValid) {
+        setFocusedFieldIdx(invalidFieldIndices[0]!);
+        return;
+      }
+      setConfirmOpen(true);
+      return;
+    }
+    if (key.name === "tab") {
+      setFocusedFieldIdx((i: number) => {
+        const len = currentFields.length;
+        if (len <= 1) return 0;
+        return key.shift ? (i - 1 + len) % len : (i + 1) % len;
+      });
+      return;
+    }
+    if (!currentField) return;
+
+    if (currentField.type === "enum") {
+      const values = currentField.values ?? [];
+      if (values.length === 0) return;
+      if (key.name === "left" || key.name === "right") {
+        setFieldValues((prev: Record<string, string>) => {
+          const cur = prev[currentField.name] ?? values[0] ?? "";
+          const idx = Math.max(0, values.indexOf(cur));
+          const delta = key.name === "left" ? -1 : 1;
+          const nextIdx = (idx + delta + values.length) % values.length;
+          return { ...prev, [currentField.name]: values[nextIdx] ?? "" };
+        });
+      }
+      return;
+    }
+
+    if (key.name === "return") {
+      if (currentField.type === "text") {
+        setFieldValues((prev: Record<string, string>) => ({
+          ...prev,
+          [currentField.name]: (prev[currentField.name] ?? "") + "\n",
+        }));
+      } else {
+        setFocusedFieldIdx((i: number) =>
+          Math.min(currentFields.length - 1, i + 1),
+        );
+      }
+      return;
+    }
+    if (key.name === "backspace") {
+      setFieldValues((prev: Record<string, string>) => ({
+        ...prev,
+        [currentField.name]: (prev[currentField.name] ?? "").slice(0, -1),
+      }));
+      return;
+    }
+    if (
+      key.sequence &&
+      key.sequence.length === 1 &&
+      !key.ctrl &&
+      !key.meta
+    ) {
+      const c = key.sequence;
+      if (c >= " " && c <= "~") {
+        setFieldValues((prev: Record<string, string>) => ({
+          ...prev,
+          [currentField.name]: (prev[currentField.name] ?? "") + c,
+        }));
+      }
+    }
+  });
+
+  const pickHints = [
+    { key: "↑↓", label: "navigate" },
+    { key: "↵", label: "select" },
+    { key: "esc", label: "quit" },
+  ];
+  const promptHints = [
+    { key: "tab", label: "to navigate forward" },
+    { key: "shift+tab", label: "to navigate backward" },
+    { key: "ctrl+s", label: "to run", dim: !isFormValid },
+  ];
+  const confirmHints = [
+    { key: "y", label: "submit" },
+    { key: "n", label: "cancel" },
+  ];
+
+  const hints = confirmOpen
+    ? confirmHints
+    : phase === "pick"
+      ? pickHints
+      : promptHints;
+
+  return (
+    <box
+      position="relative"
+      width="100%"
+      height="100%"
+      flexDirection="column"
+      backgroundColor={theme.background}
+    >
+      <Header
+        theme={theme}
+        phase={phase}
+        confirmOpen={confirmOpen}
+        selectedAgent={agent}
+        scopedCount={workflows.length}
+      />
+
+      {phase === "pick" ? (
+        <box
+          flexGrow={1}
+          flexDirection="row"
+          paddingLeft={2}
+          paddingRight={2}
+          paddingTop={1}
+        >
+          <box width={36} flexDirection="column">
+            <FilterBar theme={theme} query={query} />
+            <box height={1} />
+            <WorkflowList
+              theme={theme}
+              rows={rows}
+              focusedEntryIdx={entryIdx}
+            />
+          </box>
+          <box width={1} backgroundColor={theme.border} />
+          <box flexGrow={1} flexDirection="column">
+            {focusedWf ? (
+              <Preview theme={theme} wf={focusedWf} />
+            ) : (
+              <EmptyPreview theme={theme} query={query} />
+            )}
+          </box>
+        </box>
+      ) : phase === "prompt" && focusedWf ? (
+        <InputPhase
+          theme={theme}
+          workflow={focusedWf}
+          agent={agent}
+          fields={currentFields}
+          values={fieldValues}
+          focusedFieldIdx={focusedFieldIdx}
+        />
+      ) : null}
+
+      <Statusline
+        theme={theme}
+        phase={phase}
+        confirmOpen={confirmOpen}
+        hints={hints}
+        focusedWf={focusedWf}
+      />
+
+      {confirmOpen && focusedWf ? (
+        <ConfirmModal theme={theme} workflow={focusedWf} agent={agent} />
+      ) : null}
+    </box>
+  );
+}
+
+// ─── Public class API ──────────────────────────
+
+export interface WorkflowPickerPanelOptions {
+  agent: AgentType;
+  /** Pre-loaded workflows to show. Must already be filtered to `agent`. */
+  workflows: WorkflowWithMetadata[];
+}
+
+/**
+ * Imperative shell around the React picker tree — mirrors the
+ * {@link OrchestratorPanel} lifecycle so both panels can be used
+ * interchangeably by the CLI command layer.
+ */
+export class WorkflowPickerPanel {
+  private renderer: CliRenderer;
+  private root: Root;
+  private destroyed = false;
+  private resolveSelection: ((r: WorkflowPickerResult | null) => void) | null =
+    null;
+  private selectionPromise: Promise<WorkflowPickerResult | null>;
+
+  private constructor(
+    renderer: CliRenderer,
+    options: WorkflowPickerPanelOptions,
+  ) {
+    this.renderer = renderer;
+    this.selectionPromise = new Promise((resolve) => {
+      this.resolveSelection = resolve;
+    });
+
+    const theme = buildPickerTheme(resolveTheme(renderer.themeMode));
+    this.root = createRoot(renderer);
+    this.root.render(
+      <ErrorBoundary
+        fallback={(err) => (
+          <box
+            width="100%"
+            height="100%"
+            justifyContent="center"
+            alignItems="center"
+            backgroundColor={theme.background}
+          >
+            <text>
+              <span fg={theme.error}>
+                {`Fatal render error: ${err.message}`}
+              </span>
+            </text>
+          </box>
+        )}
+      >
+        <WorkflowPicker
+          theme={theme}
+          agent={options.agent}
+          workflows={options.workflows}
+          onSubmit={(result) => this.handleSubmit(result)}
+          onCancel={() => this.handleCancel()}
+        />
+      </ErrorBoundary>,
+    );
+  }
+
+  /**
+   * Create a new WorkflowPickerPanel. Initialises a CLI renderer and
+   * mounts the interactive tree. The caller should `await
+   * waitForSelection()` and then call `destroy()` regardless of outcome.
+   */
+  static async create(
+    options: WorkflowPickerPanelOptions,
+  ): Promise<WorkflowPickerPanel> {
+    const renderer = await createCliRenderer({
+      exitOnCtrlC: false,
+      exitSignals: [
+        "SIGTERM",
+        "SIGQUIT",
+        "SIGABRT",
+        "SIGHUP",
+        "SIGPIPE",
+        "SIGBUS",
+        "SIGFPE",
+      ],
+    });
+    return new WorkflowPickerPanel(renderer, options);
+  }
+
+  /**
+   * Resolve with the user's selection once they confirm, or `null` if
+   * they exit the picker without committing. Idempotent — subsequent
+   * calls return the same promise.
+   */
+  waitForSelection(): Promise<WorkflowPickerResult | null> {
+    return this.selectionPromise;
+  }
+
+  /** Tear down the CLI renderer. Idempotent. */
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    // Ensure anyone still awaiting the selection promise is released.
+    if (this.resolveSelection) {
+      this.resolveSelection(null);
+      this.resolveSelection = null;
+    }
+    try {
+      this.renderer.destroy();
+    } catch {}
+  }
+
+  private handleSubmit(result: WorkflowPickerResult): void {
+    if (this.resolveSelection) {
+      this.resolveSelection(result);
+      this.resolveSelection = null;
+    }
+  }
+
+  private handleCancel(): void {
+    if (this.resolveSelection) {
+      this.resolveSelection(null);
+      this.resolveSelection = null;
+    }
+  }
+}

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -44,7 +44,7 @@ import { ErrorBoundary } from "./error-boundary.tsx";
 // ones — the same distinctions `atomic workflow -l` already draws. The
 // rest is sourced from {@link resolveTheme} so light/dark mode tracks the
 // orchestrator panel.
-interface PickerTheme {
+export interface PickerTheme {
   background: string;
   backgroundPanel: string;
   backgroundElement: string;
@@ -62,7 +62,7 @@ interface PickerTheme {
   borderActive: string;
 }
 
-function buildPickerTheme(base: TerminalTheme): PickerTheme {
+export function buildPickerTheme(base: TerminalTheme): PickerTheme {
   // For dark mode the prototype values track Catppuccin Mocha. For light
   // mode we derive muted variants from the base palette — the specific
   // extras (`info`, `mauve`, the three-level background ladder) have no
@@ -135,7 +135,7 @@ const SOURCE_COLOR: Record<Source, keyof PickerTheme> = {
  * better) or null for no match. Adjacent matches are rewarded; jumps over
  * non-matching characters are penalized proportionally to the gap.
  */
-function fuzzyMatch(query: string, target: string): number | null {
+export function fuzzyMatch(query: string, target: string): number | null {
   if (query === "") return 0;
   const q = query.toLowerCase();
   const t = target.toLowerCase();
@@ -172,7 +172,7 @@ interface ListRow {
   entry?: ListEntry;
 }
 
-function buildEntries(
+export function buildEntries(
   query: string,
   workflows: WorkflowWithMetadata[],
 ): ListEntry[] {
@@ -210,7 +210,7 @@ function buildEntries(
   }));
 }
 
-function buildRows(entries: ListEntry[], query: string): ListRow[] {
+export function buildRows(entries: ListEntry[], query: string): ListRow[] {
   const rows: ListRow[] = [];
   if (query === "") {
     let lastSection: string | null = null;
@@ -229,7 +229,7 @@ function buildRows(entries: ListEntry[], query: string): ListRow[] {
 
 // ─── Validation ─────────────────────────────────
 
-function isFieldValid(field: WorkflowInput, value: string): boolean {
+export function isFieldValid(field: WorkflowInput, value: string): boolean {
   if (!field.required) return true;
   if (field.type === "enum") return value !== "";
   return value.trim() !== "";
@@ -1051,7 +1051,7 @@ interface PickerAppProps {
   onCancel: () => void;
 }
 
-function WorkflowPicker({
+export function WorkflowPicker({
   theme,
   agent,
   workflows,
@@ -1412,6 +1412,14 @@ export class WorkflowPickerPanel {
         "SIGFPE",
       ],
     });
+    return new WorkflowPickerPanel(renderer, options);
+  }
+
+  /** Create with an externally-provided renderer (e.g. a test renderer). */
+  static createWithRenderer(
+    renderer: CliRenderer,
+    options: WorkflowPickerPanelOptions,
+  ): WorkflowPickerPanel {
     return new WorkflowPickerPanel(renderer, options);
   }
 

--- a/src/sdk/define-workflow.test.ts
+++ b/src/sdk/define-workflow.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import { defineWorkflow, WorkflowBuilder } from "./define-workflow.ts";
+import type { WorkflowInput } from "./types.ts";
 
 describe("defineWorkflow", () => {
   test("returns a WorkflowBuilder", () => {
@@ -41,6 +42,106 @@ describe("WorkflowBuilder.compile()", () => {
       .run(async () => {})
       .compile();
     expect(def.__brand).toBe("WorkflowDefinition");
+  });
+
+  test("defaults inputs to an empty array when none are declared", () => {
+    const def = defineWorkflow({ name: "test" })
+      .run(async () => {})
+      .compile();
+    expect(def.inputs).toEqual([]);
+  });
+
+  test("preserves declared inputs in order", () => {
+    const def = defineWorkflow({
+      name: "gen-spec",
+      inputs: [
+        {
+          name: "research_doc",
+          type: "string",
+          required: true,
+          description: "path",
+        },
+        {
+          name: "focus",
+          type: "enum",
+          required: true,
+          values: ["minimal", "standard", "exhaustive"],
+          default: "standard",
+        },
+      ],
+    })
+      .run(async () => {})
+      .compile();
+    expect(def.inputs).toHaveLength(2);
+    expect(def.inputs[0]?.name).toBe("research_doc");
+    expect(def.inputs[1]?.name).toBe("focus");
+    expect(def.inputs[1]?.type).toBe("enum");
+  });
+
+  test("freezes declared inputs to prevent downstream mutation", () => {
+    const def = defineWorkflow({
+      name: "test",
+      inputs: [{ name: "foo", type: "string" }],
+    })
+      .run(async () => {})
+      .compile();
+    expect(() => {
+      (def.inputs as unknown as WorkflowInput[])[0]!.name = "bar";
+    }).toThrow();
+  });
+
+  test("rejects enum inputs with no values", () => {
+    expect(() =>
+      defineWorkflow({
+        name: "bad",
+        inputs: [{ name: "mode", type: "enum" }],
+      })
+        .run(async () => {})
+        .compile(),
+    ).toThrow("declares no `values`");
+  });
+
+  test("rejects enum defaults outside the allowed values", () => {
+    expect(() =>
+      defineWorkflow({
+        name: "bad",
+        inputs: [
+          {
+            name: "mode",
+            type: "enum",
+            values: ["a", "b"],
+            default: "c",
+          },
+        ],
+      })
+        .run(async () => {})
+        .compile(),
+    ).toThrow(/not one of its declared values/);
+  });
+
+  test("rejects input names that are not valid CLI flag tails", () => {
+    expect(() =>
+      defineWorkflow({
+        name: "bad",
+        inputs: [{ name: "1bad", type: "string" }],
+      })
+        .run(async () => {})
+        .compile(),
+    ).toThrow(/invalid/);
+  });
+
+  test("rejects duplicate input names", () => {
+    expect(() =>
+      defineWorkflow({
+        name: "bad",
+        inputs: [
+          { name: "foo", type: "string" },
+          { name: "foo", type: "string" },
+        ],
+      })
+        .run(async () => {})
+        .compile(),
+    ).toThrow(/duplicate input name/);
   });
 
   test("preserves name and description", () => {

--- a/src/sdk/define-workflow.ts
+++ b/src/sdk/define-workflow.ts
@@ -10,7 +10,49 @@
  *     .compile()
  */
 
-import type { AgentType, WorkflowOptions, WorkflowContext, WorkflowDefinition } from "./types.ts";
+import type {
+  AgentType,
+  WorkflowOptions,
+  WorkflowContext,
+  WorkflowDefinition,
+  WorkflowInput,
+} from "./types.ts";
+
+/**
+ * Validate a single declared workflow input, throwing on authoring
+ * mistakes that would otherwise surface as confusing runtime errors
+ * inside the picker or the flag parser.
+ */
+function validateWorkflowInput(input: WorkflowInput, workflowName: string): void {
+  if (!input.name || input.name.trim() === "") {
+    throw new Error(
+      `Workflow "${workflowName}" has an input with an empty name.`,
+    );
+  }
+  if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(input.name)) {
+    throw new Error(
+      `Workflow "${workflowName}" input "${input.name}" has an invalid ` +
+        `name — must start with a letter and contain only letters, ` +
+        `digits, underscores, and dashes (so it can be used as a ` +
+        `\`--${input.name}\` CLI flag).`,
+    );
+  }
+  if (input.type === "enum") {
+    if (!Array.isArray(input.values) || input.values.length === 0) {
+      throw new Error(
+        `Workflow "${workflowName}" input "${input.name}" is an enum but ` +
+          `declares no \`values\`.`,
+      );
+    }
+    if (input.default !== undefined && !input.values.includes(input.default)) {
+      throw new Error(
+        `Workflow "${workflowName}" input "${input.name}" has a default ` +
+          `"${input.default}" that is not one of its declared values: ` +
+          `${input.values.join(", ")}.`,
+      );
+    }
+  }
+}
 
 /**
  * Chainable workflow builder. Records the run callback,
@@ -61,10 +103,28 @@ export class WorkflowBuilder<A extends AgentType = AgentType> {
 
     const runFn = this.runFn;
 
+    // Freeze the declared inputs so consumers can read the schema without
+    // worrying that picker or executor code has mutated it upstream.
+    const declaredInputs = this.options.inputs ?? [];
+    const seen = new Set<string>();
+    for (const input of declaredInputs) {
+      validateWorkflowInput(input, this.options.name);
+      if (seen.has(input.name)) {
+        throw new Error(
+          `Workflow "${this.options.name}" has duplicate input name "${input.name}".`,
+        );
+      }
+      seen.add(input.name);
+    }
+    const inputs = Object.freeze(
+      declaredInputs.map((i) => Object.freeze({ ...i })),
+    ) as readonly WorkflowInput[];
+
     return {
       __brand: "WorkflowDefinition" as const,
       name: this.options.name,
       description: this.options.description ?? "",
+      inputs,
       run: runFn,
     };
   }
@@ -90,7 +150,7 @@ export class WorkflowBuilder<A extends AgentType = AgentType> {
  *       {},
  *       async (s) => {
  *         // s.client: CopilotClient, s.session: CopilotSession
- *         await s.session.sendAndWait({ prompt: s.userPrompt });
+ *         await s.session.sendAndWait({ prompt: s.inputs.prompt ?? "" });
  *         s.save(await s.session.getMessages());
  *       },
  *     );

--- a/src/sdk/runtime/discovery.ts
+++ b/src/sdk/runtime/discovery.ts
@@ -13,7 +13,8 @@ import { readdir, writeFile } from "fs/promises";
 import { existsSync, readdirSync } from "fs";
 import { homedir } from "os";
 import ignore from "ignore";
-import type { AgentType } from "../types.ts";
+import type { AgentType, WorkflowInput } from "../types.ts";
+import { WorkflowLoader } from "./loader.ts";
 
 export interface DiscoveredWorkflow {
   name: string;
@@ -175,30 +176,88 @@ function discoverBuiltinWorkflows(
 
 /**
  * Discover all available workflows from built-in, global, and local sources.
- * Optionally filter by agent. Precedence: local > global > builtin.
+ * Optionally filter by agent.
+ *
+ * **Merge precedence:** `builtin > local > global`.
+ *
+ * Builtin names are **strictly reserved** — a user-defined local or
+ * global workflow whose name matches any built-in workflow is dropped
+ * entirely from discovery. It will not be registered, returned from
+ * `findWorkflow`, appear in the interactive picker, or show up in
+ * `atomic workflow -l`. This protects SDK-shipped workflows (e.g.
+ * `ralph`) from being silently overridden or even visibly "competing
+ * with" a user's own definition, which would otherwise be confusing
+ * when someone tries to run the canonical version.
+ *
+ * Reservation is by **name only**, across all agents: if a builtin
+ * defines `ralph` for any agent, a local `ralph` for any other agent is
+ * also dropped. Local still overrides global for every non-builtin
+ * name, so project-scoped customisation of user-scoped workflows
+ * continues to work.
+ *
+ * By default, the result is **merged by precedence** — if a workflow is
+ * defined in both local and global sources, only the higher-precedence
+ * entry is returned. This is the right shape for `findWorkflow`, which
+ * needs the single resolved entry per (name, agent) pair.
+ *
+ * Pass `{ merge: false }` to get the **unmerged** result — local and
+ * global contribute their entries independently, so `--list` can show
+ * both a local and a global copy of the same workflow when they coexist
+ * on disk. (Builtin reservation still applies in both modes.)
  */
 export async function discoverWorkflows(
   projectRoot: string = process.cwd(),
-  agentFilter?: AgentType
+  agentFilter?: AgentType,
+  options: { merge?: boolean } = {},
 ): Promise<DiscoveredWorkflow[]> {
+  const { merge = true } = options;
+
   const localDir = getLocalWorkflowsDir(projectRoot);
   const globalDir = getGlobalWorkflowsDir();
 
-  const builtinResults = discoverBuiltinWorkflows(agentFilter);
+  // Collect ALL builtin names (ignoring agentFilter) so reservation is
+  // name-based across every agent: a local `ralph` for copilot is still
+  // reserved by a builtin `ralph` for claude, even when the discovery
+  // call was filtered to copilot.
+  const allBuiltins = discoverBuiltinWorkflows();
+  const reservedNames = new Set<string>(allBuiltins.map((w) => w.name));
+  const builtinResults = agentFilter
+    ? allBuiltins.filter((w) => w.agent === agentFilter)
+    : allBuiltins;
+
   const [globalResults, localResults] = await Promise.all([
     discoverFromBaseDir(globalDir, "global", agentFilter),
     discoverFromBaseDir(localDir, "local", agentFilter),
   ]);
 
-  // Merge with precedence: builtin (lowest) → global → local (highest)
+  // Drop any local/global workflow whose name matches a reserved
+  // builtin. This happens BEFORE both merge and unmerged code paths so
+  // reserved names never leak into `findWorkflow`, the picker, or
+  // `--list` — there is exactly one canonical entry per reserved name,
+  // the SDK-shipped one.
+  const filteredGlobal = globalResults.filter((w) => !reservedNames.has(w.name));
+  const filteredLocal = localResults.filter((w) => !reservedNames.has(w.name));
+
+  if (!merge) {
+    // Unmerged: keep local and global independent so `--list` can show
+    // both copies of a non-reserved name when they coexist. Order lowest
+    // → highest precedence so callers that want the winning entry can
+    // take the last one by (agent, name).
+    return [...filteredGlobal, ...filteredLocal, ...builtinResults];
+  }
+
+  // Merge with precedence: global (lowest) → local → builtin (highest).
+  // Builtin is layered last as a belt-and-braces guarantee — though
+  // reserved-name filtering above already makes this overwrite
+  // impossible in practice.
   const byKey = new Map<string, DiscoveredWorkflow>();
+  for (const wf of filteredGlobal) {
+    byKey.set(`${wf.agent}/${wf.name}`, wf);
+  }
+  for (const wf of filteredLocal) {
+    byKey.set(`${wf.agent}/${wf.name}`, wf);
+  }
   for (const wf of builtinResults) {
-    byKey.set(`${wf.agent}/${wf.name}`, wf);
-  }
-  for (const wf of globalResults) {
-    byKey.set(`${wf.agent}/${wf.name}`, wf);
-  }
-  for (const wf of localResults) {
     byKey.set(`${wf.agent}/${wf.name}`, wf);
   }
 
@@ -215,6 +274,50 @@ export async function findWorkflow(
 ): Promise<DiscoveredWorkflow | null> {
   const all = await discoverWorkflows(projectRoot, agent);
   return all.find((w) => w.name === name) ?? null;
+}
+
+/**
+ * A discovered workflow enriched with the metadata the picker needs to
+ * render it: the human description and the declared input schema.
+ *
+ * Populated by {@link loadWorkflowsMetadata}, which runs each discovered
+ * workflow through {@link WorkflowLoader.loadWorkflow} and extracts just
+ * the display-relevant fields — the full compiled definition is
+ * discarded after extraction so re-imports during execution are cheap.
+ */
+export interface WorkflowWithMetadata extends DiscoveredWorkflow {
+  /** Workflow description, empty string when none was declared. */
+  description: string;
+  /** Declared input schema, empty array for free-form workflows. */
+  inputs: readonly WorkflowInput[];
+}
+
+/**
+ * Load metadata (description + inputs) for a batch of discovered workflows.
+ *
+ * Workflows that fail to import are **skipped silently** so one broken
+ * entry can never prevent the picker from rendering. Callers that need
+ * to surface load errors (e.g. `atomic workflow -n broken`) should use
+ * {@link WorkflowLoader.loadWorkflow} directly — that path produces
+ * structured error reports.
+ */
+export async function loadWorkflowsMetadata(
+  discovered: DiscoveredWorkflow[],
+): Promise<WorkflowWithMetadata[]> {
+  const results = await Promise.all(
+    discovered.map(async (wf): Promise<WorkflowWithMetadata | null> => {
+      const loaded = await WorkflowLoader.loadWorkflow(wf);
+      if (!loaded.ok) return null;
+      return {
+        ...wf,
+        description: loaded.value.definition.description,
+        inputs: loaded.value.definition.inputs,
+      };
+    }),
+  );
+  return results.filter(
+    (r): r is WorkflowWithMetadata => r !== null,
+  );
 }
 
 

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -90,8 +90,13 @@ export interface WorkflowRunOptions {
   definition: WorkflowDefinition;
   /** Agent type */
   agent: AgentType;
-  /** The user's prompt */
-  prompt: string;
+  /**
+   * Structured inputs for this run. Free-form workflows model their
+   * single positional prompt as `{ prompt: "..." }` so workflow
+   * authors can read `ctx.inputs.prompt` uniformly regardless of
+   * whether the workflow declares a schema. Empty record is valid.
+   */
+  inputs?: Record<string, string>;
   /** Absolute path to the workflow's index.ts file (from discovery) */
   workflowFile: string;
   /** Project root (defaults to cwd) */
@@ -253,6 +258,31 @@ export function escPwsh(s: string): string {
     .replace(/\r/g, "`r");
 }
 
+/**
+ * Decode the ATOMIC_WF_INPUTS env var (base64-encoded JSON) into a
+ * `Record<string, string>`. Returns an empty record when the variable
+ * is missing, malformed, or does not decode to a string-map object —
+ * structured inputs are optional, so a corrupt payload must never
+ * prevent free-form workflows from running.
+ */
+export function parseInputsEnv(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const decoded = Buffer.from(raw, "base64").toString("utf-8");
+    const parsed: unknown = JSON.parse(decoded);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 // ============================================================================
 // Entry point called by the CLI command
 // ============================================================================
@@ -269,7 +299,7 @@ export async function executeWorkflow(
   const {
     definition,
     agent,
-    prompt,
+    inputs = {},
     workflowFile,
     projectRoot = process.cwd(),
   } = options;
@@ -289,13 +319,20 @@ export async function executeWorkflow(
   const launcherPath = join(sessionsBaseDir, `orchestrator.${launcherExt}`);
   const logPath = join(sessionsBaseDir, "orchestrator.log");
 
+  // Inputs are passed through as base64-encoded JSON so long multiline
+  // text values survive shell quoting without any further escaping.
+  // Free-form workflows ride the same pipe — their single positional
+  // prompt is stored under the `prompt` key so workflow authors always
+  // read the user's prompt via `ctx.inputs.prompt`.
+  const inputsB64 = Buffer.from(JSON.stringify(inputs)).toString("base64");
+
   const launcherScript = isWin
     ? [
         `Set-Location "${escPwsh(projectRoot)}"`,
         `$env:ATOMIC_WF_ID = "${escPwsh(workflowRunId)}"`,
         `$env:ATOMIC_WF_TMUX = "${escPwsh(tmuxSessionName)}"`,
         `$env:ATOMIC_WF_AGENT = "${escPwsh(agent)}"`,
-        `$env:ATOMIC_WF_PROMPT = "${escPwsh(Buffer.from(prompt).toString("base64"))}"`,
+        `$env:ATOMIC_WF_INPUTS = "${escPwsh(inputsB64)}"`,
         `$env:ATOMIC_WF_FILE = "${escPwsh(workflowFile)}"`,
         `$env:ATOMIC_WF_CWD = "${escPwsh(projectRoot)}"`,
         `bun run "${escPwsh(thisFile)}" 2>"${escPwsh(logPath)}"`,
@@ -306,7 +343,7 @@ export async function executeWorkflow(
         `export ATOMIC_WF_ID="${escBash(workflowRunId)}"`,
         `export ATOMIC_WF_TMUX="${escBash(tmuxSessionName)}"`,
         `export ATOMIC_WF_AGENT="${escBash(agent)}"`,
-        `export ATOMIC_WF_PROMPT="${escBash(Buffer.from(prompt).toString("base64"))}"`,
+        `export ATOMIC_WF_INPUTS="${escBash(inputsB64)}"`,
         `export ATOMIC_WF_FILE="${escBash(workflowFile)}"`,
         `export ATOMIC_WF_CWD="${escBash(projectRoot)}"`,
         `bun run "${escBash(thisFile)}" 2>"${escBash(logPath)}"`,
@@ -428,7 +465,13 @@ interface SharedRunnerState {
   tmuxSessionName: string;
   sessionsBaseDir: string;
   agent: AgentType;
-  prompt: string;
+  /**
+   * Structured inputs for this workflow run. Free-form workflows use
+   * `{ prompt: "..." }`; structured workflows use their declared field
+   * names. Workflow authors read both shapes via `ctx.inputs` — and
+   * specifically via `ctx.inputs.prompt` for the free-form case.
+   */
+  inputs: Record<string, string>;
   panel: OrchestratorPanel;
   /** Sessions that have been spawned (for name uniqueness + cleanup). */
   activeRegistry: Map<string, ActiveSession>;
@@ -748,10 +791,14 @@ function createSessionRunner(
         );
 
       // ── 13. Construct SessionContext ──
+      // Free-form workflows read their prompt via `s.inputs.prompt`;
+      // structured workflows read their declared fields the same way.
+      // A single uniform access pattern means workflow code never has
+      // to branch on "is this workflow structured or free-form".
       const ctx: SessionContext = {
         client: providerClient as SessionContext["client"],
         session: providerSession as SessionContext["session"],
-        userPrompt: shared.prompt,
+        inputs: shared.inputs,
         agent: shared.agent,
         sessionDir,
         paneId,
@@ -837,12 +884,11 @@ export async function runOrchestrator(): Promise<void> {
     "ATOMIC_WF_ID",
     "ATOMIC_WF_TMUX",
     "ATOMIC_WF_AGENT",
-    "ATOMIC_WF_PROMPT",
     "ATOMIC_WF_FILE",
     "ATOMIC_WF_CWD",
   ] as const;
   for (const key of requiredEnvVars) {
-    if (!process.env[key]) {
+    if (process.env[key] === undefined) {
       throw new Error(`Missing required environment variable: ${key}`);
     }
   }
@@ -850,9 +896,15 @@ export async function runOrchestrator(): Promise<void> {
   const workflowRunId = process.env.ATOMIC_WF_ID!;
   const tmuxSessionName = process.env.ATOMIC_WF_TMUX!;
   const agent = process.env.ATOMIC_WF_AGENT! as AgentType;
-  const prompt = Buffer.from(process.env.ATOMIC_WF_PROMPT!, "base64").toString(
-    "utf-8",
-  );
+  // ATOMIC_WF_INPUTS carries the full input payload. Free-form
+  // workflows store their single positional prompt under the `prompt`
+  // key so workflow authors always read it via `ctx.inputs.prompt`.
+  // An unset, missing, or malformed payload falls back to an empty
+  // record so `ctx.inputs.prompt` gracefully becomes `undefined`.
+  const inputs = parseInputsEnv(process.env.ATOMIC_WF_INPUTS);
+  // A bare prompt string is still useful for the panel header and the
+  // session-dir metadata.json — both just want something displayable.
+  const prompt = inputs.prompt ?? "";
   const workflowFile = process.env.ATOMIC_WF_FILE!;
   const cwd = process.env.ATOMIC_WF_CWD!;
 
@@ -887,7 +939,7 @@ export async function runOrchestrator(): Promise<void> {
     tmuxSessionName,
     sessionsBaseDir,
     agent,
-    prompt,
+    inputs,
     panel,
     activeRegistry: new Map(),
     completedRegistry: new Map(),
@@ -936,7 +988,7 @@ export async function runOrchestrator(): Promise<void> {
     const sessionRunner = createSessionRunner(shared, "orchestrator");
 
     const workflowCtx: WorkflowContext = {
-      userPrompt: prompt,
+      inputs,
       agent,
       stage: sessionRunner as WorkflowContext["stage"],
       transcript: async (ref: SessionRef): Promise<Transcript> => {

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -95,6 +95,44 @@ export type {
   ClaudeQueryDefaults,
 };
 
+// ─── Workflow input schemas ─────────────────────────────────────────────────
+
+/**
+ * Supported field types for a workflow's declared inputs.
+ *
+ * - `"string"` — single-line free-form input (short values, identifiers, paths)
+ * - `"text"`   — multi-line free-form input (long prose, prompts, specs)
+ * - `"enum"`   — one of a fixed list of allowed `values`
+ */
+export type WorkflowInputType = "string" | "text" | "enum";
+
+/**
+ * A declared input for a workflow. When a workflow provides an `inputs`
+ * array, the CLI materialises one `--<name>` flag per input (and the
+ * interactive picker renders one field per input) so users can pass
+ * structured values rather than a single free-form prompt.
+ *
+ * Leaving `inputs` unset (or empty) signals that the workflow consumes a
+ * single free-form prompt instead — the legacy
+ * `atomic workflow -n <name> -a <agent> "prompt"` form.
+ */
+export interface WorkflowInput {
+  /** Field name — also the CLI flag (`--<name>`) and form field identifier. */
+  name: string;
+  /** Input kind — see {@link WorkflowInputType}. */
+  type: WorkflowInputType;
+  /** Whether the field must be non-empty before the workflow can run. */
+  required?: boolean;
+  /** Short human description shown as the field caption. */
+  description?: string;
+  /** Placeholder text shown when the field is empty. */
+  placeholder?: string;
+  /** Default value pre-filled into the field. Enums use this to pick their initial value. */
+  default?: string;
+  /** Allowed values — required when `type` is `"enum"`. */
+  values?: string[];
+}
+
 // ─── Core types ─────────────────────────────────────────────────────────────
 
 /**
@@ -169,8 +207,16 @@ export interface SessionContext<A extends AgentType = AgentType> {
   client: ProviderClient<A>;
   /** Provider-specific session (auto-created by runtime) */
   session: ProviderSession<A>;
-  /** The original user prompt from the CLI invocation */
-  userPrompt: string;
+  /**
+   * Structured inputs for this workflow run. Populated from CLI flags
+   * (`--<name>=<value>`) or the interactive picker.
+   *
+   * Free-form workflows (no declared `inputs` schema) receive their
+   * single positional prompt under the `prompt` key — so
+   * `s.inputs.prompt` is the canonical way to read the user's prompt
+   * regardless of whether the workflow is structured or free-form.
+   */
+  inputs: Record<string, string>;
   /** Which agent is running */
   agent: A;
   /**
@@ -212,8 +258,16 @@ export interface SessionContext<A extends AgentType = AgentType> {
  * Does not have session-specific fields (paneId, save, etc.).
  */
 export interface WorkflowContext<A extends AgentType = AgentType> {
-  /** The original user prompt from the CLI invocation */
-  userPrompt: string;
+  /**
+   * Structured inputs for this workflow run. Populated from CLI flags
+   * (`--<name>=<value>`) or the interactive picker.
+   *
+   * Free-form workflows (no declared `inputs` schema) receive their
+   * single positional prompt under the `prompt` key — so
+   * `ctx.inputs.prompt` is the canonical way to read the user's prompt
+   * regardless of whether the workflow is structured or free-form.
+   */
+  inputs: Record<string, string>;
   /** Which agent is running */
   agent: A;
   /**
@@ -248,6 +302,13 @@ export interface WorkflowOptions {
   name: string;
   /** Human-readable description */
   description?: string;
+  /**
+   * Optional declared inputs. When provided, the CLI materialises one
+   * `--<name>` flag per entry and the interactive picker renders one form
+   * field per entry. Leave unset to keep the workflow free-form (a single
+   * positional prompt argument).
+   */
+  inputs?: WorkflowInput[];
 }
 
 /**
@@ -257,6 +318,8 @@ export interface WorkflowDefinition<A extends AgentType = AgentType> {
   readonly __brand: "WorkflowDefinition";
   readonly name: string;
   readonly description: string;
+  /** Declared input schema — empty array for free-form workflows. */
+  readonly inputs: readonly WorkflowInput[];
   /** The workflow's entry point. Called by the executor with a WorkflowContext. */
   readonly run: (ctx: WorkflowContext<A>) => Promise<void>;
 }

--- a/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
@@ -1,0 +1,294 @@
+/**
+ * deep-research-codebase / claude
+ *
+ * A deterministically-orchestrated, distributed version of the
+ * `research-codebase` skill. The research-codebase skill spawns
+ * codebase-locator / codebase-analyzer / codebase-pattern-finder /
+ * codebase-research-locator / codebase-research-analyzer /
+ * codebase-online-researcher sub-agents on the fly via LLM judgment;
+ * this workflow spawns the same agents on a deterministic schedule
+ * driven by the codebase's lines of code.
+ *
+ * Topology:
+ *
+ *           ┌─→ codebase-scout
+ *   parent ─┤
+ *           └─→ research-history
+ *                     │
+ *                     ▼
+ *   ┌──────────────────────────────────────────────────┐
+ *   │  explorer-1   explorer-2   ...   explorer-N      │   (Promise.all)
+ *   └──────────────────────────────────────────────────┘
+ *                     │
+ *                     ▼
+ *                aggregator
+ *
+ * Stage 1a — codebase-scout
+ *   Pure-TypeScript: lists files (git ls-files), counts LOC (batched wc -l),
+ *   renders a depth-bounded ASCII tree, and bin-packs directories into N
+ *   partitions where N is determined by the LOC heuristic. Then makes one
+ *   short LLM call to produce an architectural orientation that primes the
+ *   downstream explorers. Returns structured data via `handle.result` and
+ *   the agent's prose via `ctx.transcript(handle)`.
+ *
+ * Stage 1b — research-history (parallel sibling of scout)
+ *   Dispatches the codebase-research-locator and codebase-research-analyzer
+ *   sub-agents over the project's existing research/ directory to surface
+ *   prior decisions, completed investigations, and unresolved questions.
+ *   Output is consumed via session transcript (≤400 words) and feeds into
+ *   the aggregator as supplementary context.
+ *
+ * Stage 2 — explorer-1..N (parallel; depends on scout + history)
+ *   Each explorer is a coordinator that dispatches specialized sub-agents
+ *   over its assigned partition (single LOC-balanced slice of the codebase):
+ *     - codebase-locator       → finds relevant files in the partition
+ *     - codebase-analyzer      → documents how the most relevant files work
+ *     - codebase-pattern-finder → finds existing pattern examples
+ *     - codebase-online-researcher → (conditional) external library docs
+ *   The explorer never reads files directly — it orchestrates specialists
+ *   and writes a synthesized findings document to a known scratch path.
+ *
+ * Stage 3 — aggregator
+ *   Reads each explorer's scratch file by path (file-based handoff to keep
+ *   the aggregator's own context lean — we deliberately do NOT inline N
+ *   transcripts into the prompt). Folds in the research-history overview
+ *   as supplementary context. Synthesizes a single research document at
+ *   research/docs/YYYY-MM-DD-<slug>.md.
+ *
+ * Context-engineering decisions are documented at each stage below.
+ */
+
+import { defineWorkflow } from "../../../index.ts";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  getCodebaseRoot,
+  partitionUnits,
+  scoutCodebase,
+} from "../helpers/scout.ts";
+import {
+  calculateExplorerCount,
+  explainHeuristic,
+} from "../helpers/heuristic.ts";
+import {
+  buildAggregatorPrompt,
+  buildExplorerPrompt,
+  buildHistoryPrompt,
+  buildScoutPrompt,
+  slugifyPrompt,
+} from "../helpers/prompts.ts";
+
+export default defineWorkflow<"claude">({
+    name: "deep-research-codebase",
+    description:
+      "Deterministic deep codebase research: scout → LOC-driven parallel explorers → aggregator",
+  })
+  .run(async (ctx) => {
+    // Free-form workflows receive their positional prompt under
+    // `inputs.prompt`; destructure once so every stage below can close
+    // over a bare `prompt` string without re-reaching into ctx.inputs.
+    const prompt = ctx.inputs.prompt ?? "";
+    const root = getCodebaseRoot();
+    const startedAt = new Date();
+    const isoDate = startedAt.toISOString().slice(0, 10);
+    const slug = slugifyPrompt(prompt);
+
+    // ── Stages 1a + 1b: codebase-scout ∥ research-history ──────────────────
+    // Run the codebase scout (deterministic compute + brief LLM orientation)
+    // in parallel with the research-history scout (sub-agent dispatch over
+    // the project's prior research docs). Both must complete before any
+    // explorer starts, since:
+    //   - explorers depend on `scout.result.partitions`
+    //   - aggregator depends on the history transcript
+    // Promise.all gives us the cleanest auto-inferred graph topology:
+    // parent → [scout, history] → [explorer-1..N] → aggregator.
+    const [scout, history] = await Promise.all([
+      ctx.stage(
+        {
+          name: "codebase-scout",
+          description: "Map codebase, count LOC, partition for parallel explorers",
+        },
+        {},
+        {},
+        async (s) => {
+          // 1. Deterministic scouting.
+          const data = scoutCodebase(root);
+          if (data.units.length === 0) {
+            throw new Error(
+              `deep-research-codebase: scout found no source files under ${root}. ` +
+                `Run from inside a code repository or check the CODE_EXTENSIONS list.`,
+            );
+          }
+
+          // 2. Heuristic decides explorer count (capped by available units).
+          const targetCount = calculateExplorerCount(data.totalLoc);
+          const partitions = partitionUnits(data.units, targetCount);
+          const actualCount = partitions.length;
+
+          // 3. Scratch directory for explorer outputs (timestamped to avoid
+          //    collisions across runs).
+          const scratchDir = path.join(
+            root,
+            "research",
+            "docs",
+            `.deep-research-${startedAt.getTime()}`,
+          );
+          await mkdir(scratchDir, { recursive: true });
+
+          // 4. Short LLM call: architectural orientation for downstream
+          //    explorers. The prompt explicitly forbids the agent from
+          //    answering the research question — its only job here is to
+          //    orient.
+          await s.session.query(
+            buildScoutPrompt({
+              question: prompt,
+              tree: data.tree,
+              totalLoc: data.totalLoc,
+              totalFiles: data.totalFiles,
+              explorerCount: actualCount,
+              partitionPreview: partitions,
+            }),
+          );
+          s.save(s.sessionId);
+
+          return {
+            root,
+            totalLoc: data.totalLoc,
+            totalFiles: data.totalFiles,
+            tree: data.tree,
+            partitions,
+            explorerCount: actualCount,
+            scratchDir,
+            heuristicNote: explainHeuristic(data.totalLoc, actualCount),
+          };
+        },
+      ),
+      ctx.stage(
+        {
+          name: "research-history",
+          description: "Surface prior research via research-locator + research-analyzer",
+        },
+        {},
+        {},
+        async (s) => {
+          // Dispatches codebase-research-locator → codebase-research-analyzer
+          // over the project's research/ directory and outputs a ≤400-word
+          // synthesis as prose (no file write — consumed via transcript).
+          await s.session.query(
+            buildHistoryPrompt({ question: prompt, root }),
+          );
+          s.save(s.sessionId);
+        },
+      ),
+    ]);
+
+    const {
+      partitions,
+      explorerCount,
+      scratchDir,
+      totalLoc,
+      totalFiles,
+    } = scout.result;
+
+    // Pull both scout transcripts ONCE at the workflow level so every
+    // explorer + the aggregator can embed them in their prompts. Both
+    // stages have already completed by this point (we're past Promise.all),
+    // so these reads are safe (F13).
+    const scoutOverview = (await ctx.transcript(scout)).content;
+    const historyOverview = (await ctx.transcript(history)).content;
+
+    // ── Stage 2: parallel explorers ────────────────────────────────────────
+    // Each explorer is a separate tmux pane / Claude session, running
+    // concurrently via Promise.all. Each one receives:
+    //   - the original research question (top + bottom of prompt)
+    //   - the scout's architectural overview
+    //   - its OWN partition (never the full file list)
+    //   - the absolute path to its scratch file
+    //
+    // Information flow choices:
+    //   • We deliberately do not pass other explorers' work — they run in
+    //     parallel and forward-only data flow is enforced by the runtime
+    //     (F13). Cross-cutting happens in the aggregator.
+    //   • We pass the partition via closure capture, not by parsing
+    //     scout transcripts — strongly typed and lossless.
+    const explorerHandles = await Promise.all(
+      partitions.map((partition, idx) => {
+        const i = idx + 1;
+        const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
+        return ctx.stage(
+          {
+            name: `explorer-${i}`,
+            description: `Explore ${partition
+              .map((u) => u.path)
+              .join(", ")} (${partition.reduce((s, u) => s + u.fileCount, 0)} files)`,
+          },
+          {},
+          {},
+          async (s) => {
+            await s.session.query(
+              buildExplorerPrompt({
+                question: prompt,
+                index: i,
+                total: explorerCount,
+                partition,
+                scoutOverview,
+                scratchPath,
+                root,
+              }),
+            );
+            s.save(s.sessionId);
+
+            // Returning structured metadata lets the aggregator stage reach
+            // each explorer's scratch path without re-parsing transcripts.
+            return { index: i, scratchPath, partition };
+          },
+        );
+      }),
+    );
+
+    // ── Stage 3: aggregator ────────────────────────────────────────────────
+    // Synthesizes explorer findings into the final research document at
+    // research/docs/YYYY-MM-DD-<slug>.md.
+    //
+    // Information flow choice:
+    //   • The aggregator reads explorer findings via FILE PATHS, not by
+    //     embedding all N transcripts in its prompt. This keeps its
+    //     context lean (filesystem-context skill) and lets the agent
+    //     selectively re-read source files when explorers contradict
+    //     each other.
+    //   • The aggregator only sees the scout overview (short) plus a
+    //     manifest of explorer scratch paths — token cost stays roughly
+    //     constant in N rather than growing linearly.
+    const finalPath = path.join(
+      root,
+      "research",
+      "docs",
+      `${isoDate}-${slug}.md`,
+    );
+
+    await ctx.stage(
+      {
+        name: "aggregator",
+        description: "Synthesize explorer findings + history into final research doc",
+      },
+      {},
+      {},
+      async (s) => {
+        await s.session.query(
+          buildAggregatorPrompt({
+            question: prompt,
+            totalLoc,
+            totalFiles,
+            explorerCount,
+            explorerFiles: explorerHandles.map((h) => h.result),
+            finalPath,
+            scoutOverview,
+            historyOverview,
+          }),
+        );
+        s.save(s.sessionId);
+      },
+    );
+  })
+  .compile();

--- a/src/sdk/workflows/builtin/deep-research-codebase/copilot/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/copilot/index.ts
@@ -1,0 +1,276 @@
+/**
+ * deep-research-codebase / copilot
+ *
+ * Copilot replica of the Claude deep-research-codebase workflow. The Claude
+ * version dispatches specialist sub-agents (codebase-locator, codebase-
+ * analyzer, etc.) inside a single explorer session via `@"name (agent)"`
+ * syntax — a Claude-specific feature. Copilot sessions are bound to a single
+ * agent for their entire lifetime, so we keep the SAME graph topology
+ * (scout ∥ history → explorer-1..N → aggregator) but drive each explorer
+ * through the locate → analyze → patterns → synthesize sequence inline using
+ * the default agent's built-in file tools.
+ *
+ * Topology (identical to Claude version):
+ *
+ *           ┌─→ codebase-scout
+ *   parent ─┤
+ *           └─→ research-history
+ *                     │
+ *                     ▼
+ *   ┌──────────────────────────────────────────────────┐
+ *   │  explorer-1   explorer-2   ...   explorer-N      │   (Promise.all)
+ *   └──────────────────────────────────────────────────┘
+ *                     │
+ *                     ▼
+ *                aggregator
+ *
+ * Copilot-specific concerns baked in:
+ *
+ *  • F10 — every `sendAndWait` passes an explicit 30-minute timeout. The SDK
+ *    default is 60 seconds; a timeout THROWS and aborts the entire stage.
+ *    Explorers can easily exceed 60s on large partitions.
+ *
+ *  • F5 — every `ctx.stage()` call is a FRESH session with no memory of prior
+ *    stages. We forward the scout overview, history overview, and partition
+ *    assignment explicitly into each explorer's first prompt. The aggregator
+ *    gets the same plus the explorer scratch file paths.
+ *
+ *  • F9 — `s.save()` receives `SessionEvent[]` via `s.session.getMessages()`
+ *    (Copilot's correct shape). Passing anything else breaks downstream
+ *    `transcript()` reads.
+ *
+ *  • F6 — every prompt explicitly requires trailing prose AFTER any tool
+ *    call, so `transcript()` is never empty. A Copilot turn whose final
+ *    message is a tool call produces an empty assistant.message terminator
+ *    (F1); trailing prose is our insurance.
+ */
+
+import { defineWorkflow } from "../../../index.ts";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  getCodebaseRoot,
+  partitionUnits,
+  scoutCodebase,
+} from "../helpers/scout.ts";
+import {
+  calculateExplorerCount,
+  explainHeuristic,
+} from "../helpers/heuristic.ts";
+import {
+  buildAggregatorPrompt,
+  buildExplorerPromptGeneric,
+  buildHistoryPromptGeneric,
+  buildScoutPrompt,
+  slugifyPrompt,
+} from "../helpers/prompts.ts";
+
+// ── Timeouts ────────────────────────────────────────────────────────────────
+// Every sendAndWait call passes one of these explicitly — never relying on
+// the 60-second default (F10). Pick generously; a hung session still surfaces
+// as a clear error rather than silently breaking downstream stages.
+const SCOUT_TIMEOUT_MS = 15 * 60 * 1000; // 15 min — short orientation call
+const HISTORY_TIMEOUT_MS = 20 * 60 * 1000; // 20 min — reads research/ docs
+const EXPLORER_TIMEOUT_MS = 45 * 60 * 1000; // 45 min — multi-step locate/analyze
+const AGGREGATOR_TIMEOUT_MS = 45 * 60 * 1000; // 45 min — reads N explorer reports
+
+export default defineWorkflow<"copilot">({
+    name: "deep-research-codebase",
+    description:
+      "Deterministic deep codebase research: scout → LOC-driven parallel explorers → aggregator",
+  })
+  .run(async (ctx) => {
+    // Free-form workflows receive their positional prompt under
+    // `inputs.prompt`; destructure once so every stage below can close
+    // over a bare `prompt` string without re-reaching into ctx.inputs.
+    const prompt = ctx.inputs.prompt ?? "";
+    const root = getCodebaseRoot();
+    const startedAt = new Date();
+    const isoDate = startedAt.toISOString().slice(0, 10);
+    const slug = slugifyPrompt(prompt);
+
+    // ── Stages 1a + 1b: codebase-scout ∥ research-history ──────────────────
+    const [scout, history] = await Promise.all([
+      ctx.stage(
+        {
+          name: "codebase-scout",
+          description: "Map codebase, count LOC, partition for parallel explorers",
+        },
+        {},
+        {},
+        async (s) => {
+          // 1. Deterministic scouting (pure TypeScript — no LLM).
+          const data = scoutCodebase(root);
+          if (data.units.length === 0) {
+            throw new Error(
+              `deep-research-codebase: scout found no source files under ${root}. ` +
+                `Run from inside a code repository or check the CODE_EXTENSIONS list.`,
+            );
+          }
+
+          // 2. Heuristic decides explorer count (capped by available units).
+          const targetCount = calculateExplorerCount(data.totalLoc);
+          const partitions = partitionUnits(data.units, targetCount);
+          const actualCount = partitions.length;
+
+          // 3. Scratch directory for explorer outputs (timestamped to avoid
+          //    collisions across runs).
+          const scratchDir = path.join(
+            root,
+            "research",
+            "docs",
+            `.deep-research-${startedAt.getTime()}`,
+          );
+          await mkdir(scratchDir, { recursive: true });
+
+          // 4. Short LLM call: architectural orientation for downstream
+          //    explorers. The prompt forbids the agent from answering the
+          //    research question — its only job here is to orient.
+          await s.session.sendAndWait(
+            {
+              prompt: buildScoutPrompt({
+                question: prompt,
+                tree: data.tree,
+                totalLoc: data.totalLoc,
+                totalFiles: data.totalFiles,
+                explorerCount: actualCount,
+                partitionPreview: partitions,
+              }),
+            },
+            SCOUT_TIMEOUT_MS,
+          );
+          // F9: Copilot takes SessionEvent[], not a session ID.
+          s.save(await s.session.getMessages());
+
+          return {
+            root,
+            totalLoc: data.totalLoc,
+            totalFiles: data.totalFiles,
+            tree: data.tree,
+            partitions,
+            explorerCount: actualCount,
+            scratchDir,
+            heuristicNote: explainHeuristic(data.totalLoc, actualCount),
+          };
+        },
+      ),
+      ctx.stage(
+        {
+          name: "research-history",
+          description: "Surface prior research from research/ directory",
+        },
+        {},
+        {},
+        async (s) => {
+          // The generic history prompt drives a single default-agent session
+          // through locate → analyze → synthesize inline, instead of Claude's
+          // sub-agent dispatch.
+          await s.session.sendAndWait(
+            { prompt: buildHistoryPromptGeneric({ question: prompt, root }) },
+            HISTORY_TIMEOUT_MS,
+          );
+          s.save(await s.session.getMessages());
+        },
+      ),
+    ]);
+
+    const {
+      partitions,
+      explorerCount,
+      scratchDir,
+      totalLoc,
+      totalFiles,
+    } = scout.result;
+
+    // Pull both scout transcripts ONCE at the workflow level so every
+    // explorer + the aggregator can embed them in their prompts (F5). Both
+    // stages have completed here (we're past Promise.all), so these reads
+    // are safe (F13).
+    const scoutOverview = (await ctx.transcript(scout)).content;
+    const historyOverview = (await ctx.transcript(history)).content;
+
+    // ── Stage 2: parallel explorers ────────────────────────────────────────
+    // Each explorer is a separate Copilot session, running concurrently via
+    // Promise.all. Because the session is fresh (F5), every piece of context
+    // it needs — question, architectural orientation, historical context,
+    // partition assignment, scratch path — is injected into the first prompt
+    // via buildExplorerPromptGeneric.
+    const explorerHandles = await Promise.all(
+      partitions.map((partition, idx) => {
+        const i = idx + 1;
+        const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
+        return ctx.stage(
+          {
+            name: `explorer-${i}`,
+            description: `Explore ${partition
+              .map((u) => u.path)
+              .join(", ")} (${partition.reduce((s, u) => s + u.fileCount, 0)} files)`,
+          },
+          {},
+          {},
+          async (s) => {
+            await s.session.sendAndWait(
+              {
+                prompt: buildExplorerPromptGeneric({
+                  question: prompt,
+                  index: i,
+                  total: explorerCount,
+                  partition,
+                  scoutOverview,
+                  historyOverview,
+                  scratchPath,
+                  root,
+                }),
+              },
+              EXPLORER_TIMEOUT_MS,
+            );
+            s.save(await s.session.getMessages());
+
+            // Returning structured metadata lets the aggregator stage reach
+            // each explorer's scratch path without re-parsing transcripts.
+            return { index: i, scratchPath, partition };
+          },
+        );
+      }),
+    );
+
+    // ── Stage 3: aggregator ────────────────────────────────────────────────
+    // Reads explorer findings via FILE PATHS (filesystem-context skill) to
+    // keep the aggregator's own context lean — we deliberately do NOT inline
+    // N transcripts into the prompt. Token cost stays roughly constant in N.
+    const finalPath = path.join(
+      root,
+      "research",
+      "docs",
+      `${isoDate}-${slug}.md`,
+    );
+
+    await ctx.stage(
+      {
+        name: "aggregator",
+        description: "Synthesize explorer findings + history into final research doc",
+      },
+      {},
+      {},
+      async (s) => {
+        await s.session.sendAndWait(
+          {
+            prompt: buildAggregatorPrompt({
+              question: prompt,
+              totalLoc,
+              totalFiles,
+              explorerCount,
+              explorerFiles: explorerHandles.map((h) => h.result),
+              finalPath,
+              scoutOverview,
+              historyOverview,
+            }),
+          },
+          AGGREGATOR_TIMEOUT_MS,
+        );
+        s.save(await s.session.getMessages());
+      },
+    );
+  })
+  .compile();

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/heuristic.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/heuristic.ts
@@ -1,0 +1,38 @@
+/**
+ * Determine how many parallel explorer sub-agents to spawn for the
+ * deep-research-codebase workflow, based on lines of code in the codebase.
+ *
+ * The heuristic balances coverage against coordination overhead:
+ *   - Too few explorers leave parts of the codebase under-investigated.
+ *   - Too many explorers flood the aggregator with redundant findings,
+ *     burn tokens on coordination, and exhaust tmux/process budgets.
+ *
+ * Tier choices were anchored to the rough sizes of common project shapes:
+ *
+ *   <    5,000 LOC →  2 explorers   scripts, single-purpose tools
+ *   <   25,000 LOC →  3 explorers   small libraries, CLI utilities
+ *   <  100,000 LOC →  5 explorers   medium applications
+ *   <  500,000 LOC →  7 explorers   large applications, small monorepos
+ *   <2,000,000 LOC →  9 explorers   large monorepos
+ *   ≥2,000,000 LOC → 12 explorers   massive monorepos (hard cap)
+ *
+ * The hard cap of 12 prevents runaway parallelism: each explorer is a
+ * Claude tmux pane plus an LLM session, so the cost grows linearly in
+ * tokens, processes, and walltime as well as in aggregator context.
+ */
+export function calculateExplorerCount(loc: number): number {
+  if (!Number.isFinite(loc) || loc <= 0) return 2;
+  if (loc < 5_000) return 2;
+  if (loc < 25_000) return 3;
+  if (loc < 100_000) return 5;
+  if (loc < 500_000) return 7;
+  if (loc < 2_000_000) return 9;
+  return 12;
+}
+
+/** Human-readable rationale for the heuristic decision — surfaced in logs/prompts. */
+export function explainHeuristic(loc: number, count: number): string {
+  return `Codebase: ${loc.toLocaleString()} LOC → spawning ${count} parallel explorer${
+    count === 1 ? "" : "s"
+  }.`;
+}

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/prompts.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/prompts.ts
@@ -1,0 +1,816 @@
+/**
+ * Prompt builders for the deep-research-codebase workflow.
+ *
+ * Context-engineering principles applied throughout:
+ *   - Position-aware placement: the research question is repeated at the
+ *     TOP and BOTTOM of every prompt (recall is 85-95% at the edges and
+ *     drops to 76-82% in the middle — see context-fundamentals).
+ *   - Informativity over exhaustiveness: each explorer prompt contains
+ *     only that explorer's partition, never the full file list.
+ *   - Explicit trailing commentary (F6): every prompt asks the agent to
+ *     produce a short text summary AFTER any tool/file output, so the
+ *     transcript is not empty when downstream stages read it.
+ *   - File-based handoff (filesystem-context skill): explorer findings
+ *     are written to disk and the aggregator reads them by path, instead
+ *     of inlining N transcripts into the aggregator's prompt.
+ *   - Documentarian role: every prompt explicitly forbids critique or
+ *     improvement suggestions; we are recording what exists.
+ */
+
+import path from "node:path";
+import type { PartitionUnit } from "./scout.ts";
+
+const DOCUMENTARIAN_DISCLAIMER =
+  "You are a documentarian, not a critic. Document what EXISTS — do not " +
+  "propose improvements, identify issues, or suggest refactors. Focus on " +
+  "concrete file paths, line numbers, and how things actually work.";
+
+/** Slugify the user's prompt for use in the final research filename. */
+export function slugifyPrompt(prompt: string): string {
+  const slug = prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 6)
+    .join("-")
+    .substring(0, 60);
+  return slug || "research";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stage 1 — codebase-scout
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildScoutPrompt(opts: {
+  question: string;
+  tree: string;
+  totalLoc: number;
+  totalFiles: number;
+  explorerCount: number;
+  partitionPreview: PartitionUnit[][];
+}): string {
+  const partitionPreview = opts.partitionPreview
+    .map((bin, i) => {
+      const dirs = bin.map((u) => `\`${u.path}/\``).join(", ");
+      const loc = bin.reduce((s, u) => s + u.loc, 0);
+      return `  ${i + 1}. ${dirs} — ${loc.toLocaleString()} LOC`;
+    })
+    .join("\n");
+
+  return [
+    `<RESEARCH_QUESTION>`,
+    opts.question,
+    `</RESEARCH_QUESTION>`,
+    ``,
+    `<CONTEXT>`,
+    `You are the codebase scout for the deep-research-codebase workflow. The`,
+    `workflow has already computed the codebase layout deterministically:`,
+    ``,
+    `- Total source files: ${opts.totalFiles.toLocaleString()}`,
+    `- Total LOC: ${opts.totalLoc.toLocaleString()}`,
+    `- Explorers to spawn: ${opts.explorerCount} (chosen by LOC heuristic)`,
+    ``,
+    `Pre-computed partition assignments (${opts.explorerCount} explorers):`,
+    partitionPreview,
+    ``,
+    `Compact directory tree (depth 3, ≤200 entries):`,
+    "```",
+    opts.tree,
+    "```",
+    `</CONTEXT>`,
+    ``,
+    `<TASK>`,
+    `Read the tree above and produce a brief architectural orientation that`,
+    `will help the ${opts.explorerCount} parallel explorer sub-agents understand the`,
+    `layout BEFORE they dive into their assigned partitions.`,
+    ``,
+    `Cover, in ≤300 words:`,
+    `  1. The repo's overall shape (monorepo vs single package, polyglot or not)`,
+    `  2. The 3-5 most important top-level directories and what each contains`,
+    `  3. Architectural boundaries / layering you can see from the tree`,
+    `  4. Where entry points or main modules likely live`,
+    ``,
+    `Do NOT attempt to answer the research question yet — your job is`,
+    `orientation for downstream explorers, not investigation. You may use`,
+    `Read/Glob/Grep sparingly to verify your guesses about a few key files,`,
+    `but keep the output short.`,
+    `</TASK>`,
+    ``,
+    `<CONSTRAINTS>`,
+    DOCUMENTARIAN_DISCLAIMER,
+    `Stay under 300 words. No bullet lists longer than 5 items.`,
+    `End with a short prose paragraph (NOT a tool call) so this transcript`,
+    `has content for downstream stages to read.`,
+    `</CONSTRAINTS>`,
+    ``,
+    `<RESEARCH_QUESTION_REMINDER>`,
+    opts.question,
+    `</RESEARCH_QUESTION_REMINDER>`,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stage 2 — explorer-N
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildExplorerPrompt(opts: {
+  question: string;
+  index: number;
+  total: number;
+  partition: PartitionUnit[];
+  scoutOverview: string;
+  scratchPath: string;
+  root: string;
+}): string {
+  const assignmentLines = opts.partition
+    .map((u) => {
+      const abs = path.join(opts.root, u.path);
+      return `  - \`${abs}/\` (${u.fileCount} files, ${u.loc.toLocaleString()} LOC)`;
+    })
+    .join("\n");
+
+  // Comma-separated absolute dir list — used in subagent dispatch prompts as
+  // an unambiguous scope constraint that the locator/pattern-finder can pass
+  // straight to Glob.
+  const dirListAbs = opts.partition
+    .map((u) => `\`${path.join(opts.root, u.path)}\``)
+    .join(", ");
+
+  const orientation = opts.scoutOverview.trim().length > 0
+    ? opts.scoutOverview.trim()
+    : "(scout overview unavailable — proceed without)";
+
+  return [
+    `<RESEARCH_QUESTION>`,
+    opts.question,
+    `</RESEARCH_QUESTION>`,
+    ``,
+    `<YOUR_IDENTITY>`,
+    `You are explorer ${opts.index} of ${opts.total}. You are a COORDINATOR — your`,
+    `job is to dispatch specialized research sub-agents and synthesize their`,
+    `findings. You do NOT use Read/Glob/Grep yourself; you orchestrate the`,
+    `specialists. The codebase has been partitioned across ${opts.total} parallel`,
+    `explorers — you are responsible for your assigned slice. Other explorers`,
+    `are simultaneously covering the rest.`,
+    `</YOUR_IDENTITY>`,
+    ``,
+    `<ARCHITECTURAL_ORIENTATION>`,
+    `The codebase scout produced this overview to help you orient before dispatch:`,
+    ``,
+    orientation,
+    `</ARCHITECTURAL_ORIENTATION>`,
+    ``,
+    `<YOUR_ASSIGNMENT>`,
+    `Your assigned directories (DO NOT search outside these — other explorers`,
+    `cover the rest):`,
+    ``,
+    assignmentLines,
+    `</YOUR_ASSIGNMENT>`,
+    ``,
+    `<RESEARCH_PROTOCOL>`,
+    `Execute these steps IN ORDER. Each numbered step must complete before the`,
+    `next begins. Use the exact \`@"name (agent)"\` dispatch syntax shown below.`,
+    ``,
+    `── STEP 1 — Locate relevant files (codebase-locator) ──`,
+    ``,
+    `Dispatch the codebase-locator. Constrain it strictly to your assigned dirs:`,
+    ``,
+    `  @"codebase-locator (agent)" CRITICAL: search ONLY within these directories`,
+    `  (do not search elsewhere): ${dirListAbs}.`,
+    ``,
+    `  Find files in those directories that relate to this research question:`,
+    `  "${opts.question}"`,
+    ``,
+    `  Categorize results by purpose: implementation, tests, types, config,`,
+    `  examples, docs. Return absolute paths grouped by category.`,
+    ``,
+    `── STEP 2 — Analyze the most relevant files (codebase-analyzer) ──`,
+    ``,
+    `Pick the 5-10 most relevant IMPLEMENTATION files from STEP 1's output and`,
+    `dispatch the codebase-analyzer:`,
+    ``,
+    `  @"codebase-analyzer (agent)" Document how the following files work as`,
+    `  they relate to the research question "${opts.question}":`,
+    `  <list the files you picked, one per line>`,
+    ``,
+    `  Cover control flow, data flow, key abstractions, and any external`,
+    `  dependencies. Use file:line references throughout. Do NOT critique or`,
+    `  suggest improvements — describe what exists.`,
+    ``,
+    `── STEP 3 — Find existing patterns (codebase-pattern-finder) ──`,
+    ``,
+    `Dispatch the pattern-finder, scoped to your dirs:`,
+    ``,
+    `  @"codebase-pattern-finder (agent)" CRITICAL: search ONLY within these`,
+    `  directories: ${dirListAbs}.`,
+    ``,
+    `  Find existing code patterns related to "${opts.question}" inside those`,
+    `  directories. Return concrete code snippets with file:line references.`,
+    ``,
+    `── STEP 4 — External documentation research (CONDITIONAL) ──`,
+    ``,
+    `ONLY run this step IF Step 2 surfaced external library or dependency`,
+    `usage that is CENTRAL to answering the research question. Otherwise SKIP.`,
+    ``,
+    `If applicable, dispatch:`,
+    ``,
+    `  @"codebase-online-researcher (agent)" Research the documentation for`,
+    `  <library/dependency name> as it relates to: "${opts.question}".`,
+    ``,
+    `  Return links and concrete findings. The agent should follow the`,
+    `  token-efficient fetch order described in its instructions.`,
+    ``,
+    `── STEP 5 — Synthesize and write findings ──`,
+    ``,
+    `Combine the outputs from Steps 1-4 into a single markdown document and`,
+    `use the Write tool to write it to:`,
+    ``,
+    `  ${opts.scratchPath}`,
+    ``,
+    `Use the OUTPUT_FORMAT below.`,
+    ``,
+    `── STEP 6 — Brief summary ──`,
+    ``,
+    `As your final response (after the Write tool call), output a 2-3 sentence`,
+    `prose summary of what you found. This is REQUIRED so the aggregator can`,
+    `index your report and the transcript is not empty.`,
+    `</RESEARCH_PROTOCOL>`,
+    ``,
+    `<OUTPUT_FORMAT>`,
+    `The file at \`${opts.scratchPath}\` must be a markdown document with these`,
+    `sections, in this order. Each section should reflect what the corresponding`,
+    `sub-agent returned:`,
+    ``,
+    `# Explorer ${opts.index} Findings`,
+    ``,
+    `## Scope`,
+    `One-line description of which directories you covered.`,
+    ``,
+    `## Overview`,
+    `1-2 paragraph synthesis of all sub-agent findings as they relate to the`,
+    `research question.`,
+    ``,
+    `## Files in Scope`,
+    `From codebase-locator (Step 1). Categorized list with absolute paths.`,
+    ``,
+    `## How It Works`,
+    `From codebase-analyzer (Step 2). Control flow, data flow, key abstractions,`,
+    `with file:line references throughout.`,
+    ``,
+    `## Patterns`,
+    `From codebase-pattern-finder (Step 3). Concrete code examples with`,
+    `file:line refs.`,
+    ``,
+    `## External References`,
+    `From codebase-online-researcher (Step 4) — INCLUDE ONLY if Step 4 ran.`,
+    `Otherwise omit this section. Include links the online researcher returned.`,
+    ``,
+    `## Cross-References`,
+    `Files OUTSIDE your assigned directories that other explorers should check,`,
+    `with a 1-line note on why each is relevant.`,
+    ``,
+    `## File Index`,
+    `Bulleted list of every file the sub-agents touched, each with a 1-line`,
+    `description of what's in it.`,
+    `</OUTPUT_FORMAT>`,
+    ``,
+    `<CONSTRAINTS>`,
+    DOCUMENTARIAN_DISCLAIMER,
+    `Use file:line references throughout — concrete, not abstract.`,
+    `Do NOT investigate directories outside your assignment, even via sub-agents.`,
+    `Do NOT skip Steps 1-3 or 5-6. Step 4 is the only optional step.`,
+    `Do NOT use Read/Glob/Grep directly — coordinate via sub-agents only.`,
+    `End your turn with the required 2-3 sentence prose summary AFTER writing`,
+    `the file (do not end on a tool call).`,
+    `</CONSTRAINTS>`,
+    ``,
+    `<RESEARCH_QUESTION_REMINDER>`,
+    opts.question,
+    `</RESEARCH_QUESTION_REMINDER>`,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stage 1b — research-history (parallel sibling of codebase-scout)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The research-history scout dispatches specialized sub-agents to surface
+ * historical context from the project's `research/` directory:
+ *   - codebase-research-locator → finds prior research docs about the topic
+ *   - codebase-research-analyzer → extracts key insights from the most
+ *     relevant docs
+ *
+ * Output is consumed via session transcript (not file write) — kept short
+ * (≤400 words) so the aggregator can embed it cheaply.
+ */
+export function buildHistoryPrompt(opts: {
+  question: string;
+  root: string;
+}): string {
+  return [
+    `<RESEARCH_QUESTION>`,
+    opts.question,
+    `</RESEARCH_QUESTION>`,
+    ``,
+    `<YOUR_IDENTITY>`,
+    `You are the research-history scout for the deep-research-codebase`,
+    `workflow. You run in parallel with the codebase-scout. Your job is to`,
+    `surface relevant historical context from the project's existing research`,
+    `directory using specialized sub-agents — NOT to investigate the live`,
+    `codebase (the explorers will do that).`,
+    `</YOUR_IDENTITY>`,
+    ``,
+    `<RESEARCH_PROTOCOL>`,
+    `Execute these steps in order:`,
+    ``,
+    `── STEP 1 — Locate prior research documents ──`,
+    ``,
+    `Dispatch the research-locator sub-agent:`,
+    ``,
+    `  @"codebase-research-locator (agent)" Locate research documents related`,
+    `  to: "${opts.question}". Search the \`${path.join(opts.root, "research")}\``,
+    `  directory and any sibling research directories. Return categorized`,
+    `  document paths (docs/, tickets/, notes/, etc.) with 1-line summaries.`,
+    ``,
+    `If no research/ directory exists or no relevant docs are found, note`,
+    `that explicitly and SKIP STEP 2.`,
+    ``,
+    `── STEP 2 — Extract insights from the most relevant documents ──`,
+    ``,
+    `Pick the 3-5 MOST relevant documents from STEP 1 and dispatch the`,
+    `research-analyzer:`,
+    ``,
+    `  @"codebase-research-analyzer (agent)" Extract key insights from these`,
+    `  documents as they relate to the research question "${opts.question}":`,
+    `  <list the doc paths you picked>`,
+    ``,
+    `  Filter out noise. Focus on prior decisions, completed investigations,`,
+    `  and unresolved questions that bear on the current research question.`,
+    ``,
+    `── STEP 3 — Synthesize ──`,
+    ``,
+    `Output a 200-400 word synthesis of historical context as your final`,
+    `prose response. Cover:`,
+    `  - Key prior decisions on related topics`,
+    `  - Past investigations and their conclusions`,
+    `  - Open questions from prior research`,
+    `  - Document paths the aggregator should reference (with brief notes)`,
+    ``,
+    `If no relevant history exists, output a single sentence saying so.`,
+    ``,
+    `Do NOT write any files — your output is consumed via session transcript.`,
+    `</RESEARCH_PROTOCOL>`,
+    ``,
+    `<CONSTRAINTS>`,
+    DOCUMENTARIAN_DISCLAIMER,
+    `Stay under 400 words total in your final synthesis.`,
+    `Do NOT investigate live source files — that's the explorers' job.`,
+    `End with the prose synthesis (do not end on a tool call).`,
+    `</CONSTRAINTS>`,
+    ``,
+    `<RESEARCH_QUESTION_REMINDER>`,
+    opts.question,
+    `</RESEARCH_QUESTION_REMINDER>`,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Generic variants (Copilot / OpenCode)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The Claude variants above use `@"name (agent)"` sub-agent dispatch, which is
+// a Claude-specific feature. Copilot and OpenCode sessions are bound to a
+// single agent for the lifetime of the session, so replicating the specialist
+// pattern would require spawning separate child sessions for each specialist —
+// a linear blow-up in session count that is not worth the context-isolation
+// benefit for a partition-scoped explorer.
+//
+// Instead, these generic variants guide a single default-agent session through
+// the same conceptual steps (locate → analyze → patterns → synthesize) using
+// its own built-in file tools. The graph topology remains identical to the
+// Claude version: scout ∥ history → explorer-1..N → aggregator.
+
+/**
+ * Generic explorer prompt (Copilot / OpenCode). Drives a single default-agent
+ * session through the locate → analyze → patterns → synthesize sequence using
+ * built-in tools directly, instead of Claude's sub-agent dispatch.
+ */
+export function buildExplorerPromptGeneric(opts: {
+  question: string;
+  index: number;
+  total: number;
+  partition: PartitionUnit[];
+  scoutOverview: string;
+  historyOverview: string;
+  scratchPath: string;
+  root: string;
+}): string {
+  const assignmentLines = opts.partition
+    .map((u) => {
+      const abs = path.join(opts.root, u.path);
+      return `  - \`${abs}/\` (${u.fileCount} files, ${u.loc.toLocaleString()} LOC)`;
+    })
+    .join("\n");
+
+  const dirListAbs = opts.partition
+    .map((u) => `\`${path.join(opts.root, u.path)}\``)
+    .join(", ");
+
+  const orientation = opts.scoutOverview.trim().length > 0
+    ? opts.scoutOverview.trim()
+    : "(scout overview unavailable — proceed without)";
+
+  const history = opts.historyOverview.trim().length > 0
+    ? opts.historyOverview.trim()
+    : "(no historical research surfaced)";
+
+  return [
+    `<RESEARCH_QUESTION>`,
+    opts.question,
+    `</RESEARCH_QUESTION>`,
+    ``,
+    `<YOUR_IDENTITY>`,
+    `You are explorer ${opts.index} of ${opts.total} in a deep-research workflow.`,
+    `The codebase has been partitioned across ${opts.total} parallel explorers —`,
+    `you are responsible for ONE assigned slice. Other explorers are`,
+    `simultaneously investigating the rest. You are a documentarian, not a`,
+    `critic: record what EXISTS, do not propose improvements.`,
+    ``,
+    `Your session is fresh — it was created specifically for this task. Every`,
+    `piece of context you need is in this prompt; nothing carries over from the`,
+    `scout or from other explorers. Treat this prompt as your complete briefing.`,
+    `</YOUR_IDENTITY>`,
+    ``,
+    `<ARCHITECTURAL_ORIENTATION>`,
+    `The codebase scout produced this overview to help you orient:`,
+    ``,
+    orientation,
+    `</ARCHITECTURAL_ORIENTATION>`,
+    ``,
+    `<HISTORICAL_CONTEXT>`,
+    `Prior research surfaced by the research-history scout (supplementary —`,
+    `live findings you produce below take precedence):`,
+    ``,
+    history,
+    `</HISTORICAL_CONTEXT>`,
+    ``,
+    `<YOUR_ASSIGNMENT>`,
+    `Your assigned directories (DO NOT search outside these — other explorers`,
+    `cover the rest):`,
+    ``,
+    assignmentLines,
+    `</YOUR_ASSIGNMENT>`,
+    ``,
+    `<RESEARCH_PROTOCOL>`,
+    `Execute these steps IN ORDER using your built-in file tools (read, grep,`,
+    `glob, shell). Each step must complete before the next begins.`,
+    ``,
+    `── STEP 1 — Locate relevant files ──`,
+    ``,
+    `Use grep / glob to find files within ONLY these directories:`,
+    `${dirListAbs}`,
+    ``,
+    `that relate to the research question. CRITICAL: restrict every search to`,
+    `the directories listed above — do not wander into the rest of the codebase.`,
+    ``,
+    `Categorize what you find by purpose:`,
+    `  - Implementation (core logic)`,
+    `  - Tests (unit / integration / e2e)`,
+    `  - Types / interfaces`,
+    `  - Configuration`,
+    `  - Examples / fixtures`,
+    `  - Documentation`,
+    ``,
+    `Record absolute paths grouped by category. Do NOT read file contents yet.`,
+    ``,
+    `── STEP 2 — Analyze the most relevant implementation files ──`,
+    ``,
+    `Pick the 5-10 MOST relevant implementation files from STEP 1 and read them`,
+    `in full. For each file, document:`,
+    `  - Its role (what it does, why it exists)`,
+    `  - Key abstractions, types, and functions with \`file.ts:line\` references`,
+    `  - Control flow and data flow as they relate to the research question`,
+    `  - External dependencies it uses (libraries, other modules)`,
+    ``,
+    `Use file:line references throughout — never abstract descriptions.`,
+    ``,
+    `── STEP 3 — Find existing patterns ──`,
+    ``,
+    `Search (within your assigned directories only) for concrete code patterns`,
+    `related to the research question. Return snippets with \`file.ts:line\``,
+    `references so the aggregator can cite them directly.`,
+    ``,
+    `── STEP 4 — External documentation (CONDITIONAL) ──`,
+    ``,
+    `ONLY run this step IF Step 2 surfaced external library usage that is`,
+    `CENTRAL to answering the research question. Otherwise skip it entirely.`,
+    ``,
+    `If applicable, use your web-fetch / web-search tools to pull focused`,
+    `documentation excerpts for the relevant library, tied back to how your`,
+    `assigned files use it. Return links and concrete findings only — no`,
+    `general tutorials.`,
+    ``,
+    `── STEP 5 — Synthesize and write findings ──`,
+    ``,
+    `Combine the outputs from Steps 1-4 into a single markdown document and`,
+    `write it to this path using your write / edit tool:`,
+    ``,
+    `  ${opts.scratchPath}`,
+    ``,
+    `Use the OUTPUT_FORMAT below. This file is the ONLY way your findings`,
+    `reach the aggregator — be complete and precise.`,
+    ``,
+    `── STEP 6 — Brief prose summary (REQUIRED) ──`,
+    ``,
+    `AFTER writing the file, output a 2-3 sentence prose summary as your final`,
+    `textual response. This is required for two reasons:`,
+    `  1. The aggregator uses it as an index of your report`,
+    `  2. If your session ends on a tool call with no trailing prose, the`,
+    `     downstream handoff will be empty and the aggregator will miss your`,
+    `     contribution entirely.`,
+    `</RESEARCH_PROTOCOL>`,
+    ``,
+    `<OUTPUT_FORMAT>`,
+    `The file at \`${opts.scratchPath}\` must be a markdown document with these`,
+    `sections, in this order:`,
+    ``,
+    `# Explorer ${opts.index} Findings`,
+    ``,
+    `## Scope`,
+    `One-line description of which directories you covered.`,
+    ``,
+    `## Overview`,
+    `1-2 paragraph synthesis of your findings as they relate to the research`,
+    `question.`,
+    ``,
+    `## Files in Scope`,
+    `From Step 1. Categorized list with absolute paths.`,
+    ``,
+    `## How It Works`,
+    `From Step 2. Control flow, data flow, key abstractions, with \`file.ts:line\``,
+    `references throughout.`,
+    ``,
+    `## Patterns`,
+    `From Step 3. Concrete code examples with \`file.ts:line\` references.`,
+    ``,
+    `## External References`,
+    `From Step 4 — INCLUDE ONLY if Step 4 ran. Otherwise omit this section.`,
+    ``,
+    `## Cross-References`,
+    `Files OUTSIDE your assigned directories that other explorers should check,`,
+    `with a 1-line note on why each is relevant.`,
+    ``,
+    `## File Index`,
+    `Bulleted list of every file you touched, each with a 1-line description.`,
+    `</OUTPUT_FORMAT>`,
+    ``,
+    `<CONSTRAINTS>`,
+    DOCUMENTARIAN_DISCLAIMER,
+    `Use file:line references throughout — concrete, not abstract.`,
+    `Do NOT investigate directories outside your assignment.`,
+    `Do NOT skip Steps 1-3 or 5-6. Step 4 is the only optional step.`,
+    `End your turn with the required 2-3 sentence prose summary AFTER writing`,
+    `the file — do NOT end on a tool call, or your findings will be lost to the`,
+    `aggregator.`,
+    `</CONSTRAINTS>`,
+    ``,
+    `<RESEARCH_QUESTION_REMINDER>`,
+    opts.question,
+    `</RESEARCH_QUESTION_REMINDER>`,
+  ].join("\n");
+}
+
+/**
+ * Generic research-history prompt (Copilot / OpenCode). A single default-agent
+ * session searches the project's research/ directory using its own file tools,
+ * instead of dispatching Claude's codebase-research-locator / analyzer
+ * sub-agents.
+ */
+export function buildHistoryPromptGeneric(opts: {
+  question: string;
+  root: string;
+}): string {
+  const researchDir = path.join(opts.root, "research");
+
+  return [
+    `<RESEARCH_QUESTION>`,
+    opts.question,
+    `</RESEARCH_QUESTION>`,
+    ``,
+    `<YOUR_IDENTITY>`,
+    `You are the research-history scout for the deep-research-codebase`,
+    `workflow. You run in parallel with the codebase-scout. Your job is to`,
+    `surface relevant historical context from the project's existing research`,
+    `directory (${researchDir}) — NOT to investigate the live codebase (the`,
+    `explorers will do that).`,
+    `</YOUR_IDENTITY>`,
+    ``,
+    `<RESEARCH_PROTOCOL>`,
+    `Execute these steps in order using your built-in file tools (read, grep,`,
+    `glob, shell):`,
+    ``,
+    `── STEP 1 — Locate prior research documents ──`,
+    ``,
+    `Search \`${researchDir}\` (and any sibling research directories that exist)`,
+    `for documents related to the research question. Look for:`,
+    `  - Research docs (research/docs/, research/*.md)`,
+    `  - Decision records / ADRs`,
+    `  - Tickets, notes, or RFCs about related topics`,
+    ``,
+    `If no research/ directory exists at all, note that explicitly and SKIP`,
+    `to the final synthesis step with a single-sentence "no history" output.`,
+    ``,
+    `── STEP 2 — Extract insights from the most relevant documents ──`,
+    ``,
+    `Pick the 3-5 MOST relevant documents from STEP 1 and read them. For each,`,
+    `extract:`,
+    `  - Prior decisions that bear on the current question`,
+    `  - Completed investigations and their conclusions`,
+    `  - Open questions or unresolved threads`,
+    ``,
+    `Filter out noise — skip anything that isn't directly relevant.`,
+    ``,
+    `── STEP 3 — Synthesize ──`,
+    ``,
+    `Output a 200-400 word synthesis of historical context as your final`,
+    `prose response. Cover:`,
+    `  - Key prior decisions on related topics`,
+    `  - Past investigations and their conclusions`,
+    `  - Open questions from prior research`,
+    `  - Document paths the aggregator should reference (with brief notes)`,
+    ``,
+    `If no relevant history exists, output a single sentence saying so.`,
+    ``,
+    `Do NOT write any files — your output is consumed via session transcript.`,
+    `Your final assistant message must contain the synthesis as prose. If you`,
+    `end on a tool call with no trailing text, the aggregator will see nothing.`,
+    `</RESEARCH_PROTOCOL>`,
+    ``,
+    `<CONSTRAINTS>`,
+    DOCUMENTARIAN_DISCLAIMER,
+    `Stay under 400 words total in your final synthesis.`,
+    `Do NOT investigate live source files — that's the explorers' job.`,
+    `End with the prose synthesis (do not end on a tool call).`,
+    `</CONSTRAINTS>`,
+    ``,
+    `<RESEARCH_QUESTION_REMINDER>`,
+    opts.question,
+    `</RESEARCH_QUESTION_REMINDER>`,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stage 3 — aggregator
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildAggregatorPrompt(opts: {
+  question: string;
+  totalLoc: number;
+  totalFiles: number;
+  explorerCount: number;
+  explorerFiles: { index: number; scratchPath: string; partition: PartitionUnit[] }[];
+  finalPath: string;
+  scoutOverview: string;
+  historyOverview: string;
+}): string {
+  const explorerSummary = opts.explorerFiles
+    .map((e) => {
+      const dirs = e.partition.map((u) => `\`${u.path}/\``).join(", ");
+      return `- **Explorer ${e.index}** → \`${e.scratchPath}\`\n  Covered: ${dirs}`;
+    })
+    .join("\n");
+
+  const orientation = opts.scoutOverview.trim().length > 0
+    ? opts.scoutOverview.trim()
+    : "(scout overview unavailable)";
+
+  const history = opts.historyOverview.trim().length > 0
+    ? opts.historyOverview.trim()
+    : "(no historical research surfaced)";
+
+  return [
+    `<RESEARCH_QUESTION>`,
+    opts.question,
+    `</RESEARCH_QUESTION>`,
+    ``,
+    `<YOUR_IDENTITY>`,
+    `You are the aggregator. ${opts.explorerCount} parallel explorer sub-agents`,
+    `have completed their investigations of the codebase`,
+    `(${opts.totalLoc.toLocaleString()} LOC across ${opts.totalFiles.toLocaleString()} source files),`,
+    `and a parallel research-history scout has surveyed the project's prior`,
+    `research documents. Each explorer wrote a detailed findings file. Your`,
+    `job is to synthesize these findings — together with historical context —`,
+    `into a single comprehensive research document that answers the question.`,
+    `</YOUR_IDENTITY>`,
+    ``,
+    `<ARCHITECTURAL_ORIENTATION>`,
+    orientation,
+    `</ARCHITECTURAL_ORIENTATION>`,
+    ``,
+    `<HISTORICAL_CONTEXT>`,
+    `The research-history scout dispatched codebase-research-locator and`,
+    `codebase-research-analyzer over the project's research/ directory. Their`,
+    `synthesis (use as supplementary context — live findings take precedence):`,
+    ``,
+    history,
+    `</HISTORICAL_CONTEXT>`,
+    ``,
+    `<EXPLORER_REPORTS>`,
+    `Read each explorer's findings file in full. Each file has the same`,
+    `structure (Scope / Overview / Files in Scope / How It Works / Patterns /`,
+    `External References / Cross-References / File Index). The findings`,
+    `inside each file were produced by codebase-locator, codebase-analyzer,`,
+    `codebase-pattern-finder, and (sometimes) codebase-online-researcher`,
+    `sub-agents — they are LIVE evidence and take precedence over history.`,
+    ``,
+    explorerSummary,
+    `</EXPLORER_REPORTS>`,
+    ``,
+    `<TASK>`,
+    `1. Read EVERY explorer findings file in full, one at a time, using the`,
+    `   Read tool with no offset or limit.`,
+    `2. Synthesize the findings into a unified research document.`,
+    `3. Cross-reference: identify connections between findings from different`,
+    `   explorers, especially via the "Cross-References" sections.`,
+    `4. Integrate historical context where it adds value — but live findings`,
+    `   from the explorers are the primary source of truth. If history and`,
+    `   live findings disagree, trust the live findings.`,
+    `5. Resolve any remaining contradictions by re-reading the underlying`,
+    `   source files directly.`,
+    `6. Write the final research document to: \`${opts.finalPath}\``,
+    `7. After writing the file, output a ≤200-word executive summary as your`,
+    `   final prose response so this transcript has content.`,
+    `</TASK>`,
+    ``,
+    `<OUTPUT_FORMAT>`,
+    `The file at \`${opts.finalPath}\` must follow this structure:`,
+    ``,
+    "```markdown",
+    `---`,
+    `date: <today's date YYYY-MM-DD HH:MM:SS TZ — run \`date '+%Y-%m-%d %H:%M:%S %Z'\`>`,
+    `researcher: deep-research-codebase workflow`,
+    `git_commit: <run \`git rev-parse --verify HEAD\`>`,
+    `branch: <run \`git branch --show-current\`>`,
+    `repository: <repo name from \`basename \\$(git rev-parse --show-toplevel)\`>`,
+    `topic: "<the original research question>"`,
+    `tags: [research, codebase, deep-research]`,
+    `status: complete`,
+    `last_updated: <today's date YYYY-MM-DD>`,
+    `---`,
+    ``,
+    `# Research: <short title>`,
+    ``,
+    `## Research Question`,
+    `<verbatim original question>`,
+    ``,
+    `## Executive Summary`,
+    `3-5 paragraph high-level answer with concrete evidence.`,
+    ``,
+    `## Detailed Findings`,
+    ``,
+    `### <Component / Area 1>`,
+    `Description with file:line references.`,
+    ``,
+    `### <Component / Area 2>`,
+    `...`,
+    ``,
+    `## Architecture & Patterns`,
+    `Cross-cutting patterns observed across multiple components.`,
+    ``,
+    `## Code References`,
+    `- \`path/to/file.ts:123\` — what's there`,
+    ``,
+    `## Historical Context (from research/)`,
+    `Relevant insights from prior research documents, with paths. Omit this`,
+    `section entirely if the research-history scout found nothing.`,
+    ``,
+    `## Open Questions`,
+    `Areas needing further investigation.`,
+    ``,
+    `## Methodology`,
+    `Generated by the deep-research-codebase workflow with ${opts.explorerCount} parallel`,
+    `explorers covering ${opts.totalFiles.toLocaleString()} source files`,
+    `(${opts.totalLoc.toLocaleString()} LOC). Each explorer dispatched the`,
+    `codebase-locator, codebase-analyzer, codebase-pattern-finder, and (when`,
+    `applicable) codebase-online-researcher sub-agents over its assigned`,
+    `partition. A parallel research-history scout dispatched`,
+    `codebase-research-locator and codebase-research-analyzer over the`,
+    `project's prior research documents.`,
+    "```",
+    `</OUTPUT_FORMAT>`,
+    ``,
+    `<CONSTRAINTS>`,
+    DOCUMENTARIAN_DISCLAIMER,
+    `Prefer concrete file:line references over abstract descriptions.`,
+    `Do NOT skim explorer reports — read each one in full.`,
+    `If two explorers contradict each other, re-read the underlying source files.`,
+    `End with the required ≤200-word executive summary AFTER writing the file.`,
+    `</CONSTRAINTS>`,
+    ``,
+    `<RESEARCH_QUESTION_REMINDER>`,
+    opts.question,
+    `</RESEARCH_QUESTION_REMINDER>`,
+  ].join("\n");
+}

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
@@ -1,0 +1,334 @@
+/**
+ * Codebase scout: deterministic helpers for the deep-research-codebase workflow.
+ *
+ * Responsibilities:
+ *   1. Discover the codebase root (git toplevel, falling back to cwd).
+ *   2. List all source files, respecting .gitignore when in a git repo.
+ *   3. Count lines of code per file using batched `wc -l`.
+ *   4. Render a compact directory tree (depth-bounded) for prompt context.
+ *   5. Build "partition units" by aggregating LOC at depth-1, then drilling
+ *      down on any unit that is too large to live in a single explorer.
+ *   6. Bin-pack partition units into N balanced groups (largest-first).
+ *
+ * Everything here is pure TypeScript + child_process — no LLM calls.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/** Source-file extensions we treat as "code" for LOC accounting. */
+const CODE_EXTENSIONS = new Set<string>([
+  // Web / TS / JS
+  "ts", "tsx", "js", "jsx", "mjs", "cjs",
+  "vue", "svelte", "astro",
+  // Systems
+  "c", "cc", "cpp", "cxx", "h", "hpp", "rs", "go", "zig",
+  // JVM / .NET
+  "java", "kt", "kts", "scala", "groovy", "cs", "fs",
+  // Scripting
+  "py", "rb", "php", "pl", "lua", "sh", "bash", "zsh", "fish",
+  // Mobile
+  "swift", "m", "mm",
+  // Functional / niche
+  "ex", "exs", "erl", "elm", "hs", "ml", "clj", "cljs", "edn",
+  "r", "jl", "dart", "nim",
+  // Schemas / DSLs that materially shape behavior
+  "sql", "graphql", "proto",
+]);
+
+/** Directories we always exclude even when not using git ls-files. */
+const FIND_IGNORE_PATTERNS = [
+  "node_modules", ".git", "dist", "build", "out",
+  ".next", ".nuxt", ".turbo", ".vercel", ".cache",
+  "target", "vendor", "__pycache__", ".venv", "venv", "coverage",
+];
+
+/** Per-file LOC + path. */
+export type FileStats = { path: string; loc: number };
+
+/**
+ * A "partition unit" is the atomic chunk of work that gets bin-packed into
+ * an explorer. It is always one directory (possibly drilled down to depth 2)
+ * with all of the code files that live anywhere underneath it.
+ */
+export type PartitionUnit = {
+  /** Repo-relative path, e.g. "src/cli" or "packages/foo/src". */
+  path: string;
+  loc: number;
+  fileCount: number;
+  /** Repo-relative file paths inside this unit (full recursive listing). */
+  files: string[];
+};
+
+export type CodebaseScout = {
+  /** Absolute path to the repository root. */
+  root: string;
+  totalLoc: number;
+  totalFiles: number;
+  /** Compact rendered directory tree (depth-bounded) for prompt context. */
+  tree: string;
+  /** Partition units, sorted by LOC descending. */
+  units: PartitionUnit[];
+};
+
+/** Resolve the project root. Prefers `git rev-parse --show-toplevel`. */
+export function getCodebaseRoot(): string {
+  const r = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (r.status === 0 && r.stdout) {
+    return r.stdout.trim();
+  }
+  return process.cwd();
+}
+
+function isCodeFile(p: string): boolean {
+  const dot = p.lastIndexOf(".");
+  if (dot < 0 || dot === p.length - 1) return false;
+  const ext = p.slice(dot + 1).toLowerCase();
+  return CODE_EXTENSIONS.has(ext);
+}
+
+/** List all files in the repository. Prefers git ls-files (respects .gitignore). */
+function listAllFiles(root: string): string[] {
+  const git = spawnSync("git", ["ls-files"], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (git.status === 0 && git.stdout) {
+    return git.stdout.split("\n").filter((l) => l.length > 0);
+  }
+
+  // Fallback: shell out to find with the standard ignore patterns.
+  const args: string[] = [".", "-type", "f"];
+  for (const pattern of FIND_IGNORE_PATTERNS) {
+    args.push("-not", "-path", `*/${pattern}/*`);
+  }
+  const find = spawnSync("find", args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (find.status === 0 && find.stdout) {
+    return find.stdout
+      .split("\n")
+      .map((p) => p.replace(/^\.\//, ""))
+      .filter((p) => p.length > 0);
+  }
+  return [];
+}
+
+/**
+ * Count lines for a batch of files using `wc -l`. Output format:
+ *   "  N filename"
+ *   "  N total"   (when more than one file is passed)
+ *
+ * We batch to avoid command-line length limits.
+ */
+function countLines(root: string, files: string[]): Map<string, number> {
+  const result = new Map<string, number>();
+  if (files.length === 0) return result;
+
+  const BATCH = 200;
+  for (let i = 0; i < files.length; i += BATCH) {
+    const batch = files.slice(i, i + BATCH);
+    const r = spawnSync("wc", ["-l", "--", ...batch], {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (!r.stdout) continue;
+    for (const line of r.stdout.split("\n")) {
+      const m = line.match(/^\s*(\d+)\s+(.+)$/);
+      // Regex groups are typed `string | undefined` under strict mode even
+      // when the whole match succeeded — guard explicitly.
+      const countStr = m?.[1];
+      const filename = m?.[2]?.trim();
+      if (countStr === undefined || filename === undefined) continue;
+      if (filename === "total") continue;
+      result.set(filename, parseInt(countStr, 10));
+    }
+  }
+  return result;
+}
+
+/** Group file stats by directory at the given depth (1-indexed). */
+function aggregateAtDepth(files: FileStats[], depth: number): PartitionUnit[] {
+  const map = new Map<string, PartitionUnit>();
+  for (const f of files) {
+    const parts = f.path.split("/");
+    const key = parts.length >= depth
+      ? parts.slice(0, depth).join("/")
+      : (parts.slice(0, parts.length - 1).join("/") || "(root)");
+    let cur = map.get(key);
+    if (!cur) {
+      cur = { path: key, loc: 0, fileCount: 0, files: [] };
+      map.set(key, cur);
+    }
+    cur.loc += f.loc;
+    cur.fileCount += 1;
+    cur.files.push(f.path);
+  }
+  return [...map.values()];
+}
+
+/**
+ * Build candidate partition units. Starts at depth 1 and drills down on any
+ * unit that is too large (> 20% of total LOC) to balance partitions better.
+ * A single drill-down pass is enough for typical codebases — we deliberately
+ * do not recurse to keep behavior predictable.
+ */
+function buildPartitionUnits(files: FileStats[]): PartitionUnit[] {
+  if (files.length === 0) return [];
+
+  const totalLoc = files.reduce((s, f) => s + f.loc, 0);
+  const drillThreshold = Math.max(Math.floor(totalLoc * 0.2), 1);
+
+  const units = aggregateAtDepth(files, 1);
+
+  // Drill down on oversized units (single pass).
+  for (let i = 0; i < units.length; i++) {
+    const unit = units[i];
+    // noUncheckedIndexedAccess makes units[i] possibly undefined; we know
+    // it's defined because i < units.length, but TS can't prove that.
+    if (unit === undefined) continue;
+    if (unit.loc <= drillThreshold) continue;
+    const subFiles = files.filter((f) =>
+      f.path === unit.path || f.path.startsWith(unit.path + "/"),
+    );
+    const subUnits = aggregateAtDepth(subFiles, 2);
+    if (subUnits.length > 1) {
+      units.splice(i, 1, ...subUnits);
+      i += subUnits.length - 1;
+    }
+  }
+
+  return units.sort((a, b) => b.loc - a.loc);
+}
+
+/**
+ * Render a compact, depth-bounded ASCII tree of the codebase. Used as prompt
+ * context for the scout's architectural-overview LLM call.
+ *
+ * - `maxDepth`: how many directory levels to descend before stopping.
+ * - `maxLines`: hard cap on output lines; we append "└── ..." if exceeded.
+ *
+ * Only directories show recursive file counts; leaf files appear as bare names.
+ */
+function renderTree(files: string[], maxDepth = 3, maxLines = 200): string {
+  type Node = { children: Map<string, Node>; isFile: boolean; fileCount: number };
+  const root: Node = { children: new Map(), isFile: false, fileCount: 0 };
+
+  for (const file of files) {
+    const parts = file.split("/");
+    let cur = root;
+    cur.fileCount += 1;
+    for (let i = 0; i < parts.length && i < maxDepth; i++) {
+      const part = parts[i];
+      if (part === undefined) continue; // unreachable in practice
+      let child = cur.children.get(part);
+      if (!child) {
+        child = { children: new Map(), isFile: false, fileCount: 0 };
+        cur.children.set(part, child);
+      }
+      child.fileCount += 1;
+      cur = child;
+      if (i === parts.length - 1) cur.isFile = true;
+    }
+  }
+
+  const lines: string[] = [];
+  let truncated = false;
+
+  function walk(node: Node, prefix: string): void {
+    if (truncated) return;
+    const entries = [...node.children.entries()].sort((a, b) => {
+      const aIsDir = a[1].children.size > 0;
+      const bIsDir = b[1].children.size > 0;
+      if (aIsDir !== bIsDir) return aIsDir ? -1 : 1;
+      return a[0].localeCompare(b[0]);
+    });
+    for (let i = 0; i < entries.length; i++) {
+      if (lines.length >= maxLines) {
+        lines.push(prefix + "└── ...");
+        truncated = true;
+        return;
+      }
+      const entry = entries[i];
+      if (entry === undefined) continue; // unreachable in practice
+      const [name, child] = entry;
+      const last = i === entries.length - 1;
+      const branch = last ? "└── " : "├── ";
+      const isDir = child.children.size > 0;
+      const label = isDir ? `${name}/  (${child.fileCount} files)` : name;
+      lines.push(prefix + branch + label);
+      walk(child, prefix + (last ? "    " : "│   "));
+      if (truncated) return;
+    }
+  }
+
+  walk(root, "");
+  return lines.join("\n");
+}
+
+/**
+ * Run the full scout: list files, count LOC, render tree, build partition units.
+ */
+export function scoutCodebase(root: string): CodebaseScout {
+  const allPaths = listAllFiles(root);
+  const codePaths = allPaths.filter(isCodeFile);
+  const locMap = countLines(root, codePaths);
+
+  const fileStats: FileStats[] = codePaths.map((p) => ({
+    path: p,
+    loc: locMap.get(p) ?? 0,
+  }));
+
+  const totalLoc = fileStats.reduce((s, f) => s + f.loc, 0);
+  const totalFiles = fileStats.length;
+  const treeSource = allPaths.length > 0 ? allPaths : codePaths;
+  const tree = renderTree(treeSource, 3, 200);
+  const units = buildPartitionUnits(fileStats);
+
+  return { root, totalLoc, totalFiles, tree, units };
+}
+
+/**
+ * Bin-pack partition units into `count` balanced groups. Greedy
+ * largest-first: assign each unit to the currently-lightest bin.
+ *
+ * If there are fewer units than requested bins, the result has exactly
+ * `units.length` non-empty bins (we never return empty bins).
+ */
+export function partitionUnits(
+  units: PartitionUnit[],
+  count: number,
+): PartitionUnit[][] {
+  if (units.length === 0) return [];
+  const n = Math.max(1, Math.min(count, units.length));
+  const bins: PartitionUnit[][] = Array.from({ length: n }, () => []);
+  const totals: number[] = Array.from({ length: n }, () => 0);
+
+  const sorted = [...units].sort((a, b) => b.loc - a.loc);
+  for (const u of sorted) {
+    let minIdx = 0;
+    let minTotal = totals[0] ?? 0;
+    for (let i = 1; i < n; i++) {
+      const t = totals[i] ?? 0;
+      if (t < minTotal) {
+        minIdx = i;
+        minTotal = t;
+      }
+    }
+    const bin = bins[minIdx];
+    if (bin === undefined) continue; // unreachable: minIdx ∈ [0, n)
+    bin.push(u);
+    totals[minIdx] = minTotal + u.loc;
+  }
+
+  return bins;
+}

--- a/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
@@ -1,0 +1,284 @@
+/**
+ * deep-research-codebase / opencode
+ *
+ * OpenCode replica of the Claude deep-research-codebase workflow. The Claude
+ * version dispatches specialist sub-agents (codebase-locator, codebase-
+ * analyzer, etc.) inside a single explorer session via `@"name (agent)"`
+ * syntax — a Claude-specific feature. OpenCode sessions are bound to a
+ * single agent for their lifetime, so we keep the SAME graph topology
+ * (scout ∥ history → explorer-1..N → aggregator) but drive each explorer
+ * through the locate → analyze → patterns → synthesize sequence inline using
+ * the default agent's built-in file tools.
+ *
+ * Topology (identical to Claude version):
+ *
+ *           ┌─→ codebase-scout
+ *   parent ─┤
+ *           └─→ research-history
+ *                     │
+ *                     ▼
+ *   ┌──────────────────────────────────────────────────┐
+ *   │  explorer-1   explorer-2   ...   explorer-N      │   (Promise.all)
+ *   └──────────────────────────────────────────────────┘
+ *                     │
+ *                     ▼
+ *                aggregator
+ *
+ * OpenCode-specific concerns baked in:
+ *
+ *  • F5 — every `ctx.stage()` call is a FRESH session with no memory of
+ *    prior stages. We forward the scout overview, history overview, and
+ *    partition assignment explicitly into each explorer's first prompt.
+ *
+ *  • F9 — `s.save()` receives the `{ info, parts }` payload from
+ *    `s.client.session.prompt()` via `result.data!`. Passing the full
+ *    `result` (with its wrapping) or raw `result.data.parts` breaks
+ *    downstream `transcript()` reads.
+ *
+ *  • F6 — every prompt explicitly requires trailing prose AFTER any tool
+ *    call so the rendered transcript has content. OpenCode's `parts` array
+ *    mixes text/tool/reasoning/file parts; without trailing text the
+ *    transcript extractor returns an empty string.
+ *
+ *  • F3 — transcript extraction relies on the runtime's text-only rendering
+ *    of `result.data.parts`. The helpers call `ctx.transcript(handle)` which
+ *    returns `{ path, content }` where content is already text-filtered.
+ */
+
+import { defineWorkflow } from "../../../index.ts";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  getCodebaseRoot,
+  partitionUnits,
+  scoutCodebase,
+} from "../helpers/scout.ts";
+import {
+  calculateExplorerCount,
+  explainHeuristic,
+} from "../helpers/heuristic.ts";
+import {
+  buildAggregatorPrompt,
+  buildExplorerPromptGeneric,
+  buildHistoryPromptGeneric,
+  buildScoutPrompt,
+  slugifyPrompt,
+} from "../helpers/prompts.ts";
+
+export default defineWorkflow<"opencode">({
+    name: "deep-research-codebase",
+    description:
+      "Deterministic deep codebase research: scout → LOC-driven parallel explorers → aggregator",
+  })
+  .run(async (ctx) => {
+    // Free-form workflows receive their positional prompt under
+    // `inputs.prompt`; destructure once so every stage below can close
+    // over a bare `prompt` string without re-reaching into ctx.inputs.
+    const prompt = ctx.inputs.prompt ?? "";
+    const root = getCodebaseRoot();
+    const startedAt = new Date();
+    const isoDate = startedAt.toISOString().slice(0, 10);
+    const slug = slugifyPrompt(prompt);
+
+    // ── Stages 1a + 1b: codebase-scout ∥ research-history ──────────────────
+    const [scout, history] = await Promise.all([
+      ctx.stage(
+        {
+          name: "codebase-scout",
+          description: "Map codebase, count LOC, partition for parallel explorers",
+        },
+        {},
+        { title: "codebase-scout" },
+        async (s) => {
+          // 1. Deterministic scouting (pure TypeScript — no LLM).
+          const data = scoutCodebase(root);
+          if (data.units.length === 0) {
+            throw new Error(
+              `deep-research-codebase: scout found no source files under ${root}. ` +
+                `Run from inside a code repository or check the CODE_EXTENSIONS list.`,
+            );
+          }
+
+          // 2. Heuristic decides explorer count (capped by available units).
+          const targetCount = calculateExplorerCount(data.totalLoc);
+          const partitions = partitionUnits(data.units, targetCount);
+          const actualCount = partitions.length;
+
+          // 3. Scratch directory for explorer outputs (timestamped to avoid
+          //    collisions across runs).
+          const scratchDir = path.join(
+            root,
+            "research",
+            "docs",
+            `.deep-research-${startedAt.getTime()}`,
+          );
+          await mkdir(scratchDir, { recursive: true });
+
+          // 4. Short LLM call: architectural orientation for downstream
+          //    explorers. The prompt forbids the agent from answering the
+          //    research question — its only job here is to orient.
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
+            parts: [
+              {
+                type: "text",
+                text: buildScoutPrompt({
+                  question: prompt,
+                  tree: data.tree,
+                  totalLoc: data.totalLoc,
+                  totalFiles: data.totalFiles,
+                  explorerCount: actualCount,
+                  partitionPreview: partitions,
+                }),
+              },
+            ],
+          });
+          // F9: OpenCode takes the unwrapped { info, parts } object.
+          s.save(result.data!);
+
+          return {
+            root,
+            totalLoc: data.totalLoc,
+            totalFiles: data.totalFiles,
+            tree: data.tree,
+            partitions,
+            explorerCount: actualCount,
+            scratchDir,
+            heuristicNote: explainHeuristic(data.totalLoc, actualCount),
+          };
+        },
+      ),
+      ctx.stage(
+        {
+          name: "research-history",
+          description: "Surface prior research from research/ directory",
+        },
+        {},
+        { title: "research-history" },
+        async (s) => {
+          // The generic history prompt drives a single default-agent session
+          // through locate → analyze → synthesize inline, instead of Claude's
+          // sub-agent dispatch.
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
+            parts: [
+              {
+                type: "text",
+                text: buildHistoryPromptGeneric({
+                  question: prompt,
+                  root,
+                }),
+              },
+            ],
+          });
+          s.save(result.data!);
+        },
+      ),
+    ]);
+
+    const {
+      partitions,
+      explorerCount,
+      scratchDir,
+      totalLoc,
+      totalFiles,
+    } = scout.result;
+
+    // Pull both scout transcripts ONCE at the workflow level so every
+    // explorer + the aggregator can embed them in their prompts (F5). Both
+    // stages have completed here (we're past Promise.all), so these reads
+    // are safe (F13).
+    const scoutOverview = (await ctx.transcript(scout)).content;
+    const historyOverview = (await ctx.transcript(history)).content;
+
+    // ── Stage 2: parallel explorers ────────────────────────────────────────
+    // Each explorer is a separate OpenCode session, running concurrently via
+    // Promise.all. Because the session is fresh (F5), every piece of context
+    // it needs — question, architectural orientation, historical context,
+    // partition assignment, scratch path — is injected into the first prompt
+    // via buildExplorerPromptGeneric.
+    const explorerHandles = await Promise.all(
+      partitions.map((partition, idx) => {
+        const i = idx + 1;
+        const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
+        return ctx.stage(
+          {
+            name: `explorer-${i}`,
+            description: `Explore ${partition
+              .map((u) => u.path)
+              .join(", ")} (${partition.reduce((s, u) => s + u.fileCount, 0)} files)`,
+          },
+          {},
+          { title: `explorer-${i}` },
+          async (s) => {
+            const result = await s.client.session.prompt({
+              sessionID: s.session.id,
+              parts: [
+                {
+                  type: "text",
+                  text: buildExplorerPromptGeneric({
+                    question: prompt,
+                    index: i,
+                    total: explorerCount,
+                    partition,
+                    scoutOverview,
+                    historyOverview,
+                    scratchPath,
+                    root,
+                  }),
+                },
+              ],
+            });
+            s.save(result.data!);
+
+            // Returning structured metadata lets the aggregator stage reach
+            // each explorer's scratch path without re-parsing transcripts.
+            return { index: i, scratchPath, partition };
+          },
+        );
+      }),
+    );
+
+    // ── Stage 3: aggregator ────────────────────────────────────────────────
+    // Reads explorer findings via FILE PATHS (filesystem-context skill) to
+    // keep the aggregator's own context lean — we deliberately do NOT inline
+    // N transcripts into the prompt. Token cost stays roughly constant in N.
+    const finalPath = path.join(
+      root,
+      "research",
+      "docs",
+      `${isoDate}-${slug}.md`,
+    );
+
+    await ctx.stage(
+      {
+        name: "aggregator",
+        description: "Synthesize explorer findings + history into final research doc",
+      },
+      {},
+      { title: "aggregator" },
+      async (s) => {
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
+          parts: [
+            {
+              type: "text",
+              text: buildAggregatorPrompt({
+                question: prompt,
+                totalLoc,
+                totalFiles,
+                explorerCount,
+                explorerFiles: explorerHandles.map((h) => h.result),
+                finalPath,
+                scoutOverview,
+                historyOverview,
+              }),
+            },
+          ],
+        });
+        s.save(result.data!);
+      },
+    );
+  })
+  .compile();

--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -37,6 +37,10 @@ export default defineWorkflow<"claude">({
     "Plan → orchestrate → review → debug loop with bounded iteration",
 })
   .run(async (ctx) => {
+    // Free-form workflows receive their positional prompt under
+    // `inputs.prompt`; destructure once so every stage below can close
+    // over a bare `prompt` string without re-reaching into ctx.inputs.
+    const prompt = ctx.inputs.prompt ?? "";
     let consecutiveClean = 0;
     let debuggerReport = "";
 
@@ -51,7 +55,7 @@ export default defineWorkflow<"claude">({
           await s.session.query(
             asAgentCall(
               "planner",
-              buildPlannerPrompt(s.userPrompt, {
+              buildPlannerPrompt(prompt, {
                 iteration,
                 debuggerReport: debuggerReport || undefined,
               }),
@@ -72,7 +76,7 @@ export default defineWorkflow<"claude">({
           await s.session.query(
             asAgentCall(
               "orchestrator",
-              buildOrchestratorPrompt(s.userPrompt),
+              buildOrchestratorPrompt(prompt),
             ),
           );
           s.save(s.sessionId);
@@ -91,7 +95,7 @@ export default defineWorkflow<"claude">({
           const result = await s.session.query(
             asAgentCall(
               "reviewer",
-              buildReviewPrompt(s.userPrompt, { gitStatus, iteration }),
+              buildReviewPrompt(prompt, { gitStatus, iteration }),
             ),
           );
           s.save(s.sessionId);
@@ -118,7 +122,7 @@ export default defineWorkflow<"claude">({
             const result = await s.session.query(
               asAgentCall(
                 "reviewer",
-                buildReviewPrompt(s.userPrompt, {
+                buildReviewPrompt(prompt, {
                   gitStatus,
                   iteration,
                   isConfirmationPass: true,

--- a/src/sdk/workflows/builtin/ralph/copilot/index.ts
+++ b/src/sdk/workflows/builtin/ralph/copilot/index.ts
@@ -73,6 +73,12 @@ export default defineWorkflow<"copilot">({
     "Plan → orchestrate → review → debug loop with bounded iteration",
 })
   .run(async (ctx) => {
+    // Free-form workflows receive their positional prompt under
+    // `inputs.prompt`; destructure once so every stage below can close
+    // over a bare `userPromptText` without re-reaching into ctx.inputs.
+    // (Named `userPromptText` rather than `prompt` to avoid confusion
+    // with the `prompt:` object key used in the Copilot send call.)
+    const userPromptText = ctx.inputs.prompt ?? "";
     let consecutiveClean = 0;
     let debuggerReport = "";
 
@@ -86,7 +92,7 @@ export default defineWorkflow<"copilot">({
         async (s) => {
           await s.session.sendAndWait(
             {
-              prompt: buildPlannerPrompt(s.userPrompt, {
+              prompt: buildPlannerPrompt(userPromptText, {
                 iteration,
                 debuggerReport: debuggerReport || undefined,
               }),
@@ -109,7 +115,7 @@ export default defineWorkflow<"copilot">({
         async (s) => {
           await s.session.sendAndWait(
             {
-              prompt: buildOrchestratorPrompt(s.userPrompt, {
+              prompt: buildOrchestratorPrompt(userPromptText, {
                 plannerNotes: planner.result,
               }),
             },
@@ -130,7 +136,7 @@ export default defineWorkflow<"copilot">({
         async (s) => {
           await s.session.sendAndWait(
             {
-              prompt: buildReviewPrompt(s.userPrompt, {
+              prompt: buildReviewPrompt(userPromptText, {
                 gitStatus,
                 iteration,
               }),
@@ -161,7 +167,7 @@ export default defineWorkflow<"copilot">({
           async (s) => {
             await s.session.sendAndWait(
               {
-                prompt: buildReviewPrompt(s.userPrompt, {
+                prompt: buildReviewPrompt(userPromptText, {
                   gitStatus,
                   iteration,
                   isConfirmationPass: true,

--- a/src/sdk/workflows/builtin/ralph/opencode/index.ts
+++ b/src/sdk/workflows/builtin/ralph/opencode/index.ts
@@ -42,6 +42,10 @@ export default defineWorkflow<"opencode">({
     "Plan → orchestrate → review → debug loop with bounded iteration",
 })
   .run(async (ctx) => {
+    // Free-form workflows receive their positional prompt under
+    // `inputs.prompt`; destructure once so every stage below can close
+    // over a bare `prompt` string without re-reaching into ctx.inputs.
+    const prompt = ctx.inputs.prompt ?? "";
     let consecutiveClean = 0;
     let debuggerReport = "";
 
@@ -58,7 +62,7 @@ export default defineWorkflow<"opencode">({
             parts: [
               {
                 type: "text",
-                text: buildPlannerPrompt(s.userPrompt, {
+                text: buildPlannerPrompt(prompt, {
                   iteration,
                   debuggerReport: debuggerReport || undefined,
                 }),
@@ -84,7 +88,7 @@ export default defineWorkflow<"opencode">({
             parts: [
               {
                 type: "text",
-                text: buildOrchestratorPrompt(s.userPrompt, {
+                text: buildOrchestratorPrompt(prompt, {
                   plannerNotes: planner.result,
                 }),
               },
@@ -109,7 +113,7 @@ export default defineWorkflow<"opencode">({
             parts: [
               {
                 type: "text",
-                text: buildReviewPrompt(s.userPrompt, {
+                text: buildReviewPrompt(prompt, {
                   gitStatus,
                   iteration,
                 }),
@@ -143,7 +147,7 @@ export default defineWorkflow<"opencode">({
               parts: [
                 {
                   type: "text",
-                  text: buildReviewPrompt(s.userPrompt, {
+                  text: buildReviewPrompt(prompt, {
                     gitStatus,
                     iteration,
                     isConfirmationPass: true,

--- a/src/sdk/workflows/index.ts
+++ b/src/sdk/workflows/index.ts
@@ -20,6 +20,8 @@ export type {
   WorkflowContext,
   WorkflowOptions,
   WorkflowDefinition,
+  WorkflowInput,
+  WorkflowInputType,
   StageClientOptions,
   StageSessionOptions,
   ProviderClient,
@@ -89,9 +91,13 @@ export {
   AGENTS,
   discoverWorkflows,
   findWorkflow,
+  loadWorkflowsMetadata,
   WORKFLOWS_GITIGNORE,
 } from "../runtime/discovery.ts";
-export type { DiscoveredWorkflow } from "../runtime/discovery.ts";
+export type {
+  DiscoveredWorkflow,
+  WorkflowWithMetadata,
+} from "../runtime/discovery.ts";
 
 // Runtime — workflow loader pipeline
 export { WorkflowLoader } from "../runtime/loader.ts";

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -34,7 +34,7 @@ export const COLORS = supportsColor() ? ANSI_CODES : NO_COLORS;
 // Hex values mirror .impeccable.md and src/sdk/runtime/theme.ts.
 // ---------------------------------------------------------------------------
 
-export type PaletteKey = "text" | "dim" | "accent" | "success" | "error" | "warning" | "mauve";
+export type PaletteKey = "text" | "dim" | "accent" | "success" | "error" | "warning" | "mauve" | "info";
 
 export const PALETTE: Record<PaletteKey, readonly [number, number, number]> = {
   text:    [205, 214, 244], // #cdd6f4
@@ -44,6 +44,7 @@ export const PALETTE: Record<PaletteKey, readonly [number, number, number]> = {
   error:   [243, 139, 168], // #f38ba8 (Red)
   warning: [249, 226, 175], // #f9e2af (Yellow)
   mauve:   [203, 166, 247], // #cba6f7 (Mauve)
+  info:    [137, 220, 235], // #89dceb (Sky)
 };
 
 export interface PaintOptions {
@@ -79,6 +80,7 @@ export function createPainter(): Paint {
       error:   "\x1b[31m",
       warning: "\x1b[33m",
       mauve:   "\x1b[35m",
+      info:    "\x1b[36m",
     };
     return (key, text, opts) => {
       const weight = opts?.bold ? "\x1b[1m" : "";

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -1,0 +1,915 @@
+/** @jsxImportSource @opentui/react */
+
+import { test, expect, describe, afterEach } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { createTestRenderer } from "@opentui/core/testing";
+import { act } from "react";
+import {
+  WorkflowPicker,
+  WorkflowPickerPanel,
+  buildEntries,
+  buildPickerTheme,
+  buildRows,
+  fuzzyMatch,
+  isFieldValid,
+  type PickerTheme,
+  type WorkflowPickerResult,
+} from "@/sdk/components/workflow-picker-panel.tsx";
+import type { WorkflowWithMetadata } from "@/sdk/runtime/discovery.ts";
+import type { WorkflowInput } from "@/sdk/types.ts";
+
+// ─── Keyboard input helpers ───────────────────────
+//
+// OpenTUI's stdin parser holds lone `\x1B` bytes pending, waiting for
+// either a follow-up byte or a timeout to disambiguate a bare escape
+// key from the start of an escape sequence. In tests that never
+// advance the clock, we need to force-flush the parser explicitly.
+// We also wrap every input action in React's `act()` so the resulting
+// state updates are committed before the next `renderOnce()` captures
+// a frame.
+
+type TestSetup = Awaited<ReturnType<typeof testRender>>;
+
+function flushPendingInput(setup: TestSetup) {
+  // stdinParser is public on CliRenderer (no underscore).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const r = setup.renderer as any;
+  r.stdinParser?.flushTimeout?.(Number.POSITIVE_INFINITY);
+  r.drainStdinParser?.();
+}
+
+async function press(
+  setup: TestSetup,
+  action: (input: TestSetup["mockInput"]) => void | Promise<void>,
+) {
+  await act(async () => {
+    await action(setup.mockInput);
+    flushPendingInput(setup);
+  });
+  await setup.renderOnce();
+}
+
+// ─── Fixtures ─────────────────────────────────────
+
+function makeWorkflow(
+  overrides: Partial<WorkflowWithMetadata> = {},
+): WorkflowWithMetadata {
+  return {
+    name: "wf",
+    agent: "claude",
+    path: "/tmp/wf",
+    source: "local",
+    description: "",
+    inputs: [],
+    ...overrides,
+  };
+}
+
+const TEST_DARK_BASE = {
+  bg: "#1e1e2e",
+  surface: "#313244",
+  selection: "#45475a",
+  border: "#6c7086",
+  borderDim: "#585b70",
+  accent: "#89b4fa",
+  text: "#cdd6f4",
+  dim: "#7f849c",
+  success: "#a6e3a1",
+  error: "#f38ba8",
+  warning: "#f9e2af",
+};
+
+const TEST_LIGHT_BASE = {
+  bg: "#eff1f5",
+  surface: "#ccd0da",
+  selection: "#bcc0cc",
+  border: "#9ca0b0",
+  borderDim: "#acb0be",
+  accent: "#1e66f5",
+  text: "#4c4f69",
+  dim: "#8c8fa1",
+  success: "#40a02b",
+  error: "#d20f39",
+  warning: "#df8e1d",
+};
+
+const TEST_THEME: PickerTheme = buildPickerTheme(TEST_DARK_BASE);
+
+// A catalog with one workflow from each source plus a free-form one.
+const WORKFLOWS: WorkflowWithMetadata[] = [
+  makeWorkflow({
+    name: "ralph",
+    source: "local",
+    description: "run ralph loop",
+    inputs: [
+      {
+        name: "task",
+        type: "text",
+        required: true,
+        description: "the task",
+        placeholder: "what to do",
+      },
+      {
+        name: "mode",
+        type: "enum",
+        required: true,
+        values: ["fast", "slow"],
+        default: "fast",
+      },
+      { name: "notes", type: "string", required: false },
+    ],
+  }),
+  makeWorkflow({
+    name: "deep-research",
+    source: "global",
+    description: "deep research",
+    inputs: [
+      { name: "question", type: "string", required: true, placeholder: "ask" },
+    ],
+  }),
+  makeWorkflow({
+    name: "freeform",
+    source: "builtin",
+    description: "freeform prompt",
+    inputs: [],
+  }),
+];
+
+// ─── Lifecycle ────────────────────────────────────
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+
+afterEach(() => {
+  testSetup?.renderer.destroy();
+  testSetup = null;
+});
+
+async function renderPicker(
+  opts: {
+    workflows?: WorkflowWithMetadata[];
+    onSubmit?: (r: WorkflowPickerResult) => void;
+    onCancel?: () => void;
+    width?: number;
+    height?: number;
+    kittyKeyboard?: boolean;
+  } = {},
+) {
+  const onSubmit = opts.onSubmit ?? (() => {});
+  const onCancel = opts.onCancel ?? (() => {});
+  testSetup = await testRender(
+    <WorkflowPicker
+      theme={TEST_THEME}
+      agent="claude"
+      workflows={opts.workflows ?? WORKFLOWS}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    />,
+    {
+      width: opts.width ?? 120,
+      height: opts.height ?? 40,
+      // Kitty mode lets `pressKey("j", { ctrl: true })` emit distinct
+      // `ctrl+j` key events instead of being flattened to "\n" which
+      // the standard keypress parser reports as return.
+      kittyKeyboard: opts.kittyKeyboard ?? false,
+    },
+  );
+  await testSetup.renderOnce();
+  return testSetup;
+}
+
+// ─── Pure helper unit tests ───────────────────────
+
+describe("fuzzyMatch", () => {
+  test("returns 0 for empty query", () => {
+    expect(fuzzyMatch("", "anything")).toBe(0);
+  });
+
+  test("returns null when no subsequence match", () => {
+    expect(fuzzyMatch("xyz", "hello")).toBeNull();
+  });
+
+  test("matches contiguous prefix cheaply", () => {
+    const score = fuzzyMatch("hel", "hello");
+    expect(score).not.toBeNull();
+    expect(score!).toBeLessThan(20);
+  });
+
+  test("penalises gaps between matched characters", () => {
+    // "ab" should match both "ab" and "a_____b" but the latter scores higher
+    // (higher = worse).
+    const tight = fuzzyMatch("ab", "ab")!;
+    const loose = fuzzyMatch("ab", "a-----b")!;
+    expect(tight).toBeLessThan(loose);
+  });
+
+  test("case insensitive", () => {
+    expect(fuzzyMatch("ABC", "abcdef")).not.toBeNull();
+    expect(fuzzyMatch("abc", "ABCDEF")).not.toBeNull();
+  });
+});
+
+describe("isFieldValid", () => {
+  test("optional field is always valid", () => {
+    const f: WorkflowInput = { name: "n", type: "string", required: false };
+    expect(isFieldValid(f, "")).toBe(true);
+    expect(isFieldValid(f, "  ")).toBe(true);
+  });
+
+  test("required string/text invalid when only whitespace", () => {
+    const f: WorkflowInput = { name: "n", type: "string", required: true };
+    expect(isFieldValid(f, "")).toBe(false);
+    expect(isFieldValid(f, "   ")).toBe(false);
+    expect(isFieldValid(f, "x")).toBe(true);
+  });
+
+  test("required text treats newline-only as invalid", () => {
+    const f: WorkflowInput = { name: "n", type: "text", required: true };
+    expect(isFieldValid(f, "\n")).toBe(false);
+    expect(isFieldValid(f, "content\n")).toBe(true);
+  });
+
+  test("required enum invalid when empty string", () => {
+    const f: WorkflowInput = {
+      name: "mode",
+      type: "enum",
+      required: true,
+      values: ["a", "b"],
+    };
+    expect(isFieldValid(f, "")).toBe(false);
+    // Enum fields don't trim — any non-empty selection is valid.
+    expect(isFieldValid(f, "a")).toBe(true);
+  });
+});
+
+describe("buildEntries", () => {
+  test("empty query groups workflows by source in canonical order", () => {
+    const entries = buildEntries("", WORKFLOWS);
+    const sections = entries.map((e) => e.section);
+    // local should come before global which should come before builtin.
+    expect(sections).toEqual(["local", "global", "builtin"]);
+  });
+
+  test("empty query sorts alphabetically within a source", () => {
+    const workflows = [
+      makeWorkflow({ name: "zebra", source: "local" }),
+      makeWorkflow({ name: "alpha", source: "local" }),
+      makeWorkflow({ name: "mango", source: "local" }),
+    ];
+    const entries = buildEntries("", workflows);
+    expect(entries.map((e) => e.workflow.name)).toEqual([
+      "alpha",
+      "mango",
+      "zebra",
+    ]);
+  });
+
+  test("non-empty query sorts by score regardless of source", () => {
+    const entries = buildEntries("ralph", WORKFLOWS);
+    expect(entries.length).toBeGreaterThan(0);
+    // "ralph" should match the ralph workflow first.
+    expect(entries[0]!.workflow.name).toBe("ralph");
+  });
+
+  test("query that matches description only still returns the entry", () => {
+    const workflows = [
+      makeWorkflow({
+        name: "wf-a",
+        description: "does unique-marker thing",
+      }),
+    ];
+    const entries = buildEntries("unique-marker", workflows);
+    expect(entries).toHaveLength(1);
+  });
+
+  test("query with no match returns empty", () => {
+    const entries = buildEntries("qqqqqq", WORKFLOWS);
+    expect(entries).toHaveLength(0);
+  });
+
+  test("name match scored strictly better than description-only match", () => {
+    // Two workflows, one matches in name, one matches in description.
+    const workflows = [
+      makeWorkflow({ name: "abc", description: "irrelevant" }),
+      makeWorkflow({ name: "other", description: "abc here" }),
+    ];
+    const entries = buildEntries("abc", workflows);
+    // The name-match should sort first.
+    expect(entries[0]!.workflow.name).toBe("abc");
+  });
+});
+
+describe("buildRows", () => {
+  test("empty query inserts section headers for each source transition", () => {
+    const entries = buildEntries("", WORKFLOWS);
+    const rows = buildRows(entries, "");
+    const sectionRows = rows.filter((r) => r.kind === "section");
+    expect(sectionRows).toHaveLength(3);
+    expect(sectionRows.map((r) => r.source)).toEqual([
+      "local",
+      "global",
+      "builtin",
+    ]);
+  });
+
+  test("non-empty query emits no section rows", () => {
+    const entries = buildEntries("ralph", WORKFLOWS);
+    const rows = buildRows(entries, "ralph");
+    expect(rows.every((r) => r.kind === "entry")).toBe(true);
+  });
+
+  test("empty entries yields empty rows", () => {
+    expect(buildRows([], "")).toEqual([]);
+  });
+});
+
+describe("buildPickerTheme", () => {
+  test("produces distinct dark-mode info/mauve for Mocha base", () => {
+    const theme = buildPickerTheme(TEST_DARK_BASE);
+    expect(theme.backgroundPanel).toBe("#181825");
+    expect(theme.backgroundElement).toBe("#11111b");
+    expect(theme.info).toBe("#89dceb");
+    expect(theme.mauve).toBe("#cba6f7");
+  });
+
+  test("produces light-mode values when base.bg is Latte base", () => {
+    const theme = buildPickerTheme(TEST_LIGHT_BASE);
+    expect(theme.backgroundPanel).toBe("#e6e9ef");
+    expect(theme.backgroundElement).toBe("#dce0e8");
+    expect(theme.info).toBe("#04a5e5");
+    expect(theme.mauve).toBe("#8839ef");
+  });
+
+  test("forwards base colors into matching theme slots", () => {
+    const theme = buildPickerTheme(TEST_DARK_BASE);
+    expect(theme.background).toBe(TEST_DARK_BASE.bg);
+    expect(theme.surface).toBe(TEST_DARK_BASE.surface);
+    expect(theme.text).toBe(TEST_DARK_BASE.text);
+    expect(theme.primary).toBe(TEST_DARK_BASE.accent);
+  });
+});
+
+// ─── React component rendering ────────────────────
+
+describe("WorkflowPicker rendering", () => {
+  test("renders header with agent pill and workflow count", async () => {
+    const setup = await renderPicker();
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("CLAUDE");
+    expect(frame).toContain("workflow");
+    // Three workflows in the catalog.
+    expect(frame).toContain("3 workflows");
+  });
+
+  test("header shows singular when exactly one workflow", async () => {
+    const setup = await renderPicker({
+      workflows: [makeWorkflow({ name: "solo", source: "local" })],
+    });
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("1 workflow");
+    expect(frame).not.toContain("1 workflows");
+  });
+
+  test("renders PICK mode badge initially", async () => {
+    const setup = await renderPicker();
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("PICK");
+  });
+
+  test("renders workflow names in list", async () => {
+    const setup = await renderPicker();
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("ralph");
+    expect(frame).toContain("deep-research");
+    expect(frame).toContain("freeform");
+  });
+
+  test("renders source section labels", async () => {
+    const setup = await renderPicker();
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("local");
+    expect(frame).toContain("global");
+    expect(frame).toContain("builtin");
+  });
+
+  test("renders preview for the focused workflow", async () => {
+    const setup = await renderPicker();
+    const frame = setup.captureCharFrame();
+    // Focus starts on the first entry which (alphabetically within local)
+    // is "ralph" — its description should appear in the preview pane.
+    expect(frame).toContain("run ralph loop");
+    expect(frame).toContain("ARGUMENTS");
+  });
+
+  test("renders navigation hints in statusline", async () => {
+    const setup = await renderPicker();
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("navigate");
+    expect(frame).toContain("select");
+    expect(frame).toContain("quit");
+  });
+
+  test("renders 'no matches' with empty workflow list", async () => {
+    const setup = await renderPicker({ workflows: [] });
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("no matches");
+  });
+
+  test("empty workflow list renders the empty preview hint", async () => {
+    const setup = await renderPicker({ workflows: [] });
+    const frame = setup.captureCharFrame();
+    // EmptyPreview shows the `.atomic/workflows/...` hint.
+    expect(frame).toContain(".atomic/workflows");
+  });
+});
+
+// ─── Keyboard: PICK phase ─────────────────────────
+
+describe("WorkflowPicker PICK keyboard", () => {
+  test("escape calls onCancel", async () => {
+    let cancelled = false;
+    const setup = await renderPicker({
+      onCancel: () => {
+        cancelled = true;
+      },
+    });
+    await press(setup, (i) => i.pressEscape());
+    expect(cancelled).toBe(true);
+  });
+
+  test("ctrl+c calls onCancel", async () => {
+    let cancelled = false;
+    const setup = await renderPicker({
+      onCancel: () => {
+        cancelled = true;
+      },
+    });
+    await press(setup, (i) => i.pressCtrlC());
+    expect(cancelled).toBe(true);
+  });
+
+  test("arrow down moves focus to next entry", async () => {
+    const setup = await renderPicker();
+    await press(setup, (i) => i.pressArrow("down"));
+    // The focused preview switches from ralph to deep-research.
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("deep research");
+  });
+
+  test("arrow up is clamped at 0", async () => {
+    const setup = await renderPicker();
+    // Try to move up from the top — should stay at 0 without throwing.
+    await press(setup, (i) => i.pressArrow("up"));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("run ralph loop");
+  });
+
+  test("ctrl+j moves focus down like arrow down", async () => {
+    // Kitty keyboard mode is required for the parser to report the raw
+    // key as `ctrl+j` instead of collapsing it onto `return` (CR/LF).
+    const setup = await renderPicker({ kittyKeyboard: true });
+    await press(setup, (i) => i.pressKey("j", { ctrl: true }));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("deep research");
+  });
+
+  test("ctrl+k moves focus up like arrow up", async () => {
+    const setup = await renderPicker({ kittyKeyboard: true });
+    await press(setup, (i) => i.pressArrow("down"));
+    await press(setup, (i) => i.pressKey("k", { ctrl: true }));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("run ralph loop");
+  });
+
+  test("arrow down clamps at bottom of list", async () => {
+    const setup = await renderPicker();
+    for (let i = 0; i < 10; i++) {
+      await press(setup, (input) => input.pressArrow("down"));
+    }
+    const frame = setup.captureCharFrame();
+    // After over-scrolling, we should sit on the last workflow (freeform).
+    expect(frame).toContain("freeform prompt");
+  });
+
+  test("typing printable characters builds the query", async () => {
+    const setup = await renderPicker();
+    await press(setup, (i) => i.typeText("ralph"));
+    const frame = setup.captureCharFrame();
+    // The query should appear in the filter bar.
+    expect(frame).toContain("ralph");
+    expect(frame).not.toContain("no matches");
+  });
+
+  test("typing a query that matches nothing shows no matches", async () => {
+    const setup = await renderPicker();
+    await press(setup, (i) => i.typeText("qqqq"));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("no matches");
+    expect(frame).toContain('"qqqq"');
+  });
+
+  test("backspace removes last query character", async () => {
+    const setup = await renderPicker();
+    await press(setup, (i) => i.typeText("qqqq"));
+    // Confirm the "no matches" state before backspacing.
+    expect(setup.captureCharFrame()).toContain("no matches");
+    for (let i = 0; i < 6; i++) {
+      await press(setup, (input) => input.pressBackspace());
+    }
+    const frame = setup.captureCharFrame();
+    expect(frame).not.toContain("no matches");
+    expect(frame).toContain("run ralph loop");
+  });
+
+  test("enter transitions to prompt phase", async () => {
+    const setup = await renderPicker();
+    await press(setup, (i) => i.pressEnter());
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("PROMPT");
+    expect(frame).toContain("INPUTS");
+  });
+
+  test("enter with no focused workflow (empty list) is a no-op", async () => {
+    const setup = await renderPicker({ workflows: [] });
+    await press(setup, (i) => i.pressEnter());
+    // Still in PICK phase.
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("PICK");
+  });
+});
+
+// ─── Keyboard: PROMPT phase ───────────────────────
+
+async function renderAndEnterPrompt(
+  opts: Parameters<typeof renderPicker>[0] = {},
+) {
+  const setup = await renderPicker(opts);
+  await press(setup, (i) => i.pressEnter());
+  return setup;
+}
+
+describe("WorkflowPicker PROMPT keyboard", () => {
+  test("escape returns to pick phase", async () => {
+    const setup = await renderAndEnterPrompt();
+    await press(setup, (i) => i.pressEscape());
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("PICK");
+  });
+
+  test("ctrl+c still calls onCancel from prompt phase", async () => {
+    let cancelled = false;
+    const setup = await renderAndEnterPrompt({
+      onCancel: () => {
+        cancelled = true;
+      },
+    });
+    await press(setup, (i) => i.pressCtrlC());
+    expect(cancelled).toBe(true);
+  });
+
+  test("tab cycles focus forward through fields", async () => {
+    const setup = await renderAndEnterPrompt();
+    await press(setup, (i) => i.pressTab());
+    const frame = setup.captureCharFrame();
+    // ralph has 3 inputs; pos indicator should move to "2 / 3".
+    expect(frame).toContain("2 / 3");
+  });
+
+  test("shift+tab cycles focus backward through fields", async () => {
+    const setup = await renderAndEnterPrompt();
+    await press(setup, (i) => i.pressTab({ shift: true }));
+    const frame = setup.captureCharFrame();
+    // Shift-tab from field 0 wraps to last (field 3 → "3 / 3").
+    expect(frame).toContain("3 / 3");
+  });
+
+  test("tab is a no-op when there is only one field", async () => {
+    const workflows = [
+      makeWorkflow({
+        name: "one-field",
+        source: "local",
+        inputs: [{ name: "only", type: "string", required: true }],
+      }),
+    ];
+    const setup = await renderAndEnterPrompt({ workflows });
+    await press(setup, (i) => i.pressTab());
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("1 / 1");
+  });
+
+  test("typing in a text field appends characters", async () => {
+    const setup = await renderAndEnterPrompt();
+    // Field 0 is the "task" text field.
+    await press(setup, (i) => i.typeText("hello"));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("hello");
+  });
+
+  test("return in a text field inserts a newline", async () => {
+    const setup = await renderAndEnterPrompt();
+    await press(setup, (i) => i.typeText("line1"));
+    await press(setup, (i) => i.pressEnter());
+    await press(setup, (i) => i.typeText("line2"));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("line1");
+    expect(frame).toContain("line2");
+    // Still on field 1 of 3 (no field advance).
+    expect(frame).toContain("1 / 3");
+  });
+
+  test("backspace removes last char from a text field", async () => {
+    const setup = await renderAndEnterPrompt();
+    await press(setup, (i) => i.typeText("abc"));
+    await press(setup, (i) => i.pressBackspace());
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("ab");
+  });
+
+  test("return on string field advances focus", async () => {
+    // A workflow with two string fields — return should jump from field 0 to field 1.
+    const workflows = [
+      makeWorkflow({
+        name: "two-strings",
+        source: "local",
+        inputs: [
+          { name: "a", type: "string", required: true },
+          { name: "b", type: "string", required: true },
+        ],
+      }),
+    ];
+    const setup = await renderAndEnterPrompt({ workflows });
+    await press(setup, (i) => i.pressEnter());
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("2 / 2");
+  });
+
+  test("enum field: right arrow cycles value forward", async () => {
+    // ralph has an enum "mode" with ["fast","slow"] at index 1.
+    const setup = await renderAndEnterPrompt();
+    // Advance focus to field idx 1 (the enum).
+    await press(setup, (i) => i.pressTab());
+    await press(setup, (i) => i.pressArrow("right"));
+    // Now the selected enum should have rotated from "fast" → "slow".
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("slow");
+  });
+
+  test("enum field: left arrow cycles value backward (wraps)", async () => {
+    const setup = await renderAndEnterPrompt();
+    await press(setup, (i) => i.pressTab());
+    await press(setup, (i) => i.pressArrow("left"));
+    const frame = setup.captureCharFrame();
+    // "fast" → left wraps back to "slow".
+    expect(frame).toContain("slow");
+  });
+
+  test("enum field with empty values array is a no-op on arrow", async () => {
+    const workflows = [
+      makeWorkflow({
+        name: "empty-enum",
+        source: "local",
+        inputs: [
+          { name: "choice", type: "enum", required: false, values: [] },
+        ],
+      }),
+    ];
+    const setup = await renderAndEnterPrompt({ workflows });
+    await press(setup, (i) => i.pressArrow("right"));
+    // Should not crash; frame should still render.
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("empty-enum");
+  });
+
+  test("ctrl+s with invalid required text field stays in PROMPT mode", async () => {
+    const setup = await renderAndEnterPrompt();
+    // Nothing has been typed into the required text field — form invalid.
+    await press(setup, (i) => i.pressKey("s", { ctrl: true }));
+    const frame = setup.captureCharFrame();
+    // Still on PROMPT mode, not CONFIRM.
+    expect(frame).toContain("PROMPT");
+    expect(frame).not.toContain("CONFIRM");
+  });
+
+  test("ctrl+s with all required fields filled opens the confirm modal", async () => {
+    const setup = await renderAndEnterPrompt();
+    // Fill the required text field "task".
+    await press(setup, (i) => i.typeText("do something"));
+    await press(setup, (i) => i.pressKey("s", { ctrl: true }));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("CONFIRM");
+    expect(frame).toContain("submit");
+  });
+
+  test("free-form workflow seeds a DEFAULT prompt field", async () => {
+    const setup = await renderPicker();
+    // Move down past ralph (local) and deep-research (global) to freeform
+    // (the builtin entry).
+    for (let i = 0; i < 3; i++) {
+      await press(setup, (input) => input.pressArrow("down"));
+    }
+    await press(setup, (i) => i.pressEnter());
+    const frame = setup.captureCharFrame();
+    // Free-form shows "PROMPT" header (isStructured = false).
+    expect(frame).toContain("PROMPT");
+    // Default field name is "prompt".
+    expect(frame).toContain("prompt");
+  });
+});
+
+// ─── Keyboard: CONFIRM phase ─────────────────────
+
+async function renderInConfirm(
+  opts: Parameters<typeof renderPicker>[0] = {},
+) {
+  const setup = await renderAndEnterPrompt(opts);
+  await press(setup, (i) => i.typeText("task text"));
+  await press(setup, (i) => i.pressKey("s", { ctrl: true }));
+  return setup;
+}
+
+describe("WorkflowPicker CONFIRM keyboard", () => {
+  test("y submits with current inputs", async () => {
+    let result: WorkflowPickerResult | null = null;
+    const setup = await renderInConfirm({
+      onSubmit: (r) => {
+        result = r;
+      },
+    });
+    await press(setup, (i) => i.pressKey("y"));
+    expect(result).not.toBeNull();
+    expect(result!.workflow.name).toBe("ralph");
+    expect(result!.inputs.task).toContain("task text");
+  });
+
+  test("return also submits", async () => {
+    let submitted = false;
+    const setup = await renderInConfirm({
+      onSubmit: () => {
+        submitted = true;
+      },
+    });
+    await press(setup, (i) => i.pressEnter());
+    expect(submitted).toBe(true);
+  });
+
+  test("n cancels the confirm back to prompt", async () => {
+    const setup = await renderInConfirm();
+    await press(setup, (i) => i.pressKey("n"));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("PROMPT");
+    expect(frame).not.toContain("CONFIRM");
+  });
+
+  test("escape cancels the confirm back to prompt", async () => {
+    const setup = await renderInConfirm();
+    await press(setup, (i) => i.pressEscape());
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("PROMPT");
+  });
+
+  test("unrelated keys in confirm phase are ignored", async () => {
+    const setup = await renderInConfirm();
+    await press(setup, (i) => i.pressKey("x"));
+    const frame = setup.captureCharFrame();
+    // Still in CONFIRM.
+    expect(frame).toContain("CONFIRM");
+  });
+
+  test("ctrl+c in confirm still calls onCancel", async () => {
+    let cancelled = false;
+    const setup = await renderInConfirm({
+      onCancel: () => {
+        cancelled = true;
+      },
+    });
+    await press(setup, (i) => i.pressCtrlC());
+    expect(cancelled).toBe(true);
+  });
+});
+
+// ─── Imperative class ────────────────────────────
+
+describe("WorkflowPickerPanel class", () => {
+  let panel: WorkflowPickerPanel | null = null;
+  let coreSetup: Awaited<ReturnType<typeof createTestRenderer>> | null = null;
+
+  afterEach(() => {
+    panel?.destroy();
+    panel = null;
+    coreSetup?.renderer.destroy();
+    coreSetup = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  async function createPanel() {
+    coreSetup = await createTestRenderer({ width: 120, height: 40 });
+    // Match what `testRender` does so useEffect-backed subscriptions (like
+    // `useKeyboard`) flush synchronously during construction — without
+    // this, the keyboard listener isn't attached in time for subsequent
+    // mockInput events.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    act(() => {
+      panel = WorkflowPickerPanel.createWithRenderer(coreSetup!.renderer, {
+        agent: "claude",
+        workflows: WORKFLOWS,
+      });
+    });
+    return panel!;
+  }
+
+  test("createWithRenderer returns an instance without throwing", async () => {
+    const p = await createPanel();
+    expect(p).toBeInstanceOf(WorkflowPickerPanel);
+  });
+
+  test("waitForSelection returns a pending promise", async () => {
+    const p = await createPanel();
+    const promise = p.waitForSelection();
+    expect(promise).toBeInstanceOf(Promise);
+
+    let resolved = false;
+    promise.then(() => {
+      resolved = true;
+    });
+    await Bun.sleep(5);
+    expect(resolved).toBe(false);
+  });
+
+  test("waitForSelection is idempotent — same promise on subsequent calls", async () => {
+    const p = await createPanel();
+    const a = p.waitForSelection();
+    const b = p.waitForSelection();
+    expect(a).toBe(b);
+  });
+
+  test("destroy resolves a pending selection with null", async () => {
+    const p = await createPanel();
+    const promise = p.waitForSelection();
+    p.destroy();
+    panel = null;
+    const result = await promise;
+    expect(result).toBeNull();
+  });
+
+  test("destroy is idempotent", async () => {
+    const p = await createPanel();
+    p.destroy();
+    expect(() => p.destroy()).not.toThrow();
+    panel = null;
+  });
+
+  test("createWithRenderer with empty workflow list still mounts", async () => {
+    coreSetup = await createTestRenderer({ width: 120, height: 40 });
+    panel = WorkflowPickerPanel.createWithRenderer(coreSetup.renderer, {
+      agent: "opencode",
+      workflows: [],
+    });
+    expect(panel).toBeInstanceOf(WorkflowPickerPanel);
+  });
+
+  async function pressOnCore(fn: () => void | Promise<void>) {
+    await act(async () => {
+      await fn();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const r = coreSetup!.renderer as any;
+      r.stdinParser?.flushTimeout?.(Number.POSITIVE_INFINITY);
+      r.drainStdinParser?.();
+    });
+    await coreSetup!.renderOnce();
+  }
+
+  test("handleCancel: esc from PICK resolves selection with null", async () => {
+    const p = await createPanel();
+    const selection = p.waitForSelection();
+    await pressOnCore(() => coreSetup!.mockInput.pressEscape());
+    const result = await selection;
+    expect(result).toBeNull();
+    // Prevent afterEach from double-destroying after handleCancel.
+    panel = null;
+    p.destroy();
+  });
+
+  test("handleSubmit: driving the full pick→prompt→confirm→y flow resolves with payload", async () => {
+    const p = await createPanel();
+    const selection = p.waitForSelection();
+
+    // PICK → press enter to lock in ralph.
+    await pressOnCore(() => coreSetup!.mockInput.pressEnter());
+    // PROMPT → fill the required text field.
+    await pressOnCore(() => coreSetup!.mockInput.typeText("via class"));
+    // Ctrl-s → open CONFIRM modal.
+    await pressOnCore(() =>
+      coreSetup!.mockInput.pressKey("s", { ctrl: true }),
+    );
+    // y → submit.
+    await pressOnCore(() => coreSetup!.mockInput.pressKey("y"));
+
+    const result = await selection;
+    expect(result).not.toBeNull();
+    expect(result!.workflow.name).toBe("ralph");
+    expect(result!.inputs.task).toContain("via class");
+    panel = null;
+    p.destroy();
+  });
+});

--- a/tests/sdk/runtime/discovery.test.ts
+++ b/tests/sdk/runtime/discovery.test.ts
@@ -169,7 +169,10 @@ describe("built-in workflow discovery", () => {
     expect(ralphAgents).toEqual(["claude", "copilot", "opencode"]);
   });
 
-  test("local workflow overrides built-in with same name", async () => {
+  test("built-in workflow is NOT shadowed by a local with the same name", async () => {
+    // Builtin names are reserved — a user-defined local workflow must
+    // never win at merge time, even when it exists on disk. This
+    // protects SDK-shipped workflows from being silently overridden.
     const dir = join(tempDir, ".atomic", "workflows", "ralph", "claude");
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, "index.ts"), "export default {};");
@@ -177,7 +180,59 @@ describe("built-in workflow discovery", () => {
     const results = await discoverWorkflows(tempDir, "claude");
     const ralph = results.find((r) => r.name === "ralph");
     expect(ralph).toBeDefined();
-    expect(ralph!.source).toBe("local");
+    expect(ralph!.source).toBe("builtin");
+  });
+
+  test("reserved builtin names are dropped from unmerged discovery", async () => {
+    // `--list` uses `{ merge: false }`, but reserved builtin names must
+    // still filter out user-defined local/global workflows of the same
+    // name so nothing shadowed ever appears in the list. Users should
+    // see exactly one `ralph` entry — the SDK-shipped one — even if
+    // they have a local copy sitting on disk under the reserved name.
+    const dir = join(tempDir, ".atomic", "workflows", "ralph", "claude");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "index.ts"), "export default {};");
+
+    const results = await discoverWorkflows(tempDir, "claude", { merge: false });
+    const ralphEntries = results.filter((r) => r.name === "ralph");
+    expect(ralphEntries).toHaveLength(1);
+    expect(ralphEntries[0]!.source).toBe("builtin");
+  });
+
+  test("reservation is name-based across all agents", async () => {
+    // Ralph ships for every agent, so a local copilot ralph is reserved
+    // even when discovery is filtered to copilot specifically. The
+    // reservation lives at the NAME level, not the (name, agent) level,
+    // so a user can never register any variant of a reserved name.
+    const dir = join(tempDir, ".atomic", "workflows", "ralph", "copilot");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "index.ts"), "export default {};");
+
+    const merged = await discoverWorkflows(tempDir, "copilot");
+    const mergedRalph = merged.filter((r) => r.name === "ralph");
+    expect(mergedRalph).toHaveLength(1);
+    expect(mergedRalph[0]!.source).toBe("builtin");
+
+    const unmerged = await discoverWorkflows(tempDir, "copilot", {
+      merge: false,
+    });
+    const unmergedRalph = unmerged.filter((r) => r.name === "ralph");
+    expect(unmergedRalph).toHaveLength(1);
+    expect(unmergedRalph[0]!.source).toBe("builtin");
+  });
+
+  test("findWorkflow never resolves a reserved name to a local entry", async () => {
+    // Sanity check: the named-mode CLI path goes through `findWorkflow`,
+    // which internally calls discoverWorkflows in merged mode. With
+    // reserved-name filtering, a local ralph/claude must still resolve
+    // to the builtin — never to the user's file.
+    const dir = join(tempDir, ".atomic", "workflows", "ralph", "claude");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "index.ts"), "export default {};");
+
+    const resolved = await findWorkflow("ralph", "claude", tempDir);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.source).toBe("builtin");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a structured `inputs` schema to `defineWorkflow`, an interactive TUI picker for workflow discovery, and a new `deep-research-codebase` builtin workflow. Includes comprehensive test coverage for both the picker component and CLI entry point.

## Key Changes

### Structured Workflow Inputs
- `defineWorkflow` now accepts an optional `inputs` schema with `string`, `text`, and `enum` field types
- CLI materializes one `--<field>=<value>` flag per schema entry, validates required fields and enum membership before spawning any session, and rejects unknown flags with a usage hint
- Free-form workflows continue to accept a positional prompt funnelled through the reserved `prompt` key
- `SessionContext`/`WorkflowContext` expose `inputs: Record<string, string>` replacing the legacy `userPrompt` field
- Orchestrator env switches from `ATOMIC_WF_PROMPT` to a base64-encoded `ATOMIC_WF_INPUTS` JSON record to safely handle multiline values

### Interactive Workflow Picker
- `atomic workflow -a <agent>` (without `-n`) now opens a full TUI picker instead of erroring on missing name
- Picker supports fuzzy search, per-field form prompts, and a confirmation screen before execution
- Discovery gains an unmerged mode so `--list` can show local and global copies of the same workflow name side-by-side
- Builtin workflow names are strictly reserved — user-defined workflows can never shadow SDK builtins at resolution, in the picker, or in `--list`

### New `deep-research-codebase` Builtin
- Deterministically-orchestrated, distributed codebase research workflow
- Topology: parent → `[codebase-scout ∥ research-history]` → `[explorer-1..N in parallel]` → aggregator
- Scout uses `git ls-files` + LOC counting to bin-pack directories into LOC-balanced partitions, driving explorer count from a heuristic rather than model judgment
- Ships for all three agents (Claude, Copilot, OpenCode) with shared helpers under `helpers/` (scout, heuristic, prompts)
- Writes output to `research/docs/YYYY-MM-DD-<slug>.md`

### Tests
- New `workflow-picker-panel.test.tsx`: covers pure helpers (`fuzzyMatch`, `isFieldValid`, `buildEntries`, `buildRows`, `buildPickerTheme`), full PICK → PROMPT → CONFIRM → SUBMIT flow, and the imperative `WorkflowPickerPanel` class via `createWithRenderer`
- New `workflow-command.test.ts`: mock-based integration tests for list/picker/named mode branches, agent validation, prereq checks, and executor success/failure paths
- Expanded `workflow.test.ts`: additional edge cases for `parsePassthroughArgs` and `validateInputsAgainstSchema`

### Documentation & SDK
- `workflow-creator` skill and reference docs updated to cover schema shape, invocation surfaces, and free-form vs structured decision guide
- New `workflow-inputs.md` reference document
- Example workflows (`hello-world`, `parallel-hello-world`, `ralph`) migrated to `ctx.inputs` API

## Breaking Changes

- `SessionContext.userPrompt` / `WorkflowContext.userPrompt` is replaced by `ctx.inputs.prompt` — existing workflows using `userPrompt` must migrate to `ctx.inputs.prompt`
- `ATOMIC_WF_PROMPT` env var is replaced by `ATOMIC_WF_INPUTS` (base64-encoded JSON) in the orchestrator payload