### PR TITLE
chore(release): bump version to v0.5.4-0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Note: There are three main coding agents used in this repository: OpenCode, Clau
 
 ### Bumping Versions
 
-Use the `bump-version.ts` script to update the version across all tracked files (`package.json` and `packages/workflow-sdk/package.json`):
+Use the `bump-version.ts` script to update the version across all tracked files (`package.json`):
 
 ```sh
 # Explicit version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.3",
+  "version": "0.5.4-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.5.3` to `v0.5.4-0` (prerelease) and fixes a stale documentation reference. Merging this PR will trigger the automated GitHub Release creation and npm publish workflow.

## Changes

- `package.json`: version `0.5.3` → `0.5.4-0`
- `CLAUDE.md`: remove stale reference to `packages/workflow-sdk/package.json` in the bump-version docs (that package no longer exists as a separate tracked file)

## Test plan

- [ ] CI checks pass
- [ ] Release workflow publishes `0.5.4-0` to npm with the `prerelease` dist-tag