### PR TITLE
chore(release): bump version to v0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.4-0",
+  "version": "0.5.4",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `v0.5.4-0` to the stable release `v0.5.4` by updating the version field in `package.json`.

## Changes

- `package.json`: bumps `version` from `0.5.4-0` → `0.5.4`

## Test plan

- [ ] CI passes on the release branch
- [ ] Merge triggers the automated GitHub Release for `v0.5.4`
- [ ] Package published to npm with provenance