### PR TITLE
feat(orchestrator): add view-mode navigation, compact switcher, and tmux keybindings

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -71,6 +71,8 @@ coveragePathIgnorePatterns = [
   "src/sdk/runtime/theme.ts",
   "src/sdk/components/error-boundary.tsx",
   "src/sdk/components/orchestrator-panel.tsx",
+  "src/sdk/components/compact-switcher.tsx",
+  "src/sdk/components/session-graph-panel.tsx",
   # Workflow runtime I/O (subprocess/SDK/filesystem dependent)
   "src/services/workflows/session.ts",
   "src/services/workflows/graph/nodes.ts",

--- a/research/designs/option3-refined-prototype.html
+++ b/research/designs/option3-refined-prototype.html
@@ -1,0 +1,676 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Atomic — Option 3 Refined</title>
+<style>
+  *, *::before, *::after { box-sizing:border-box; margin:0; padding:0; }
+  :root {
+    --base:#1e1e2e; --mantle:#181825; --crust:#11111b;
+    --surface0:#313244; --surface1:#45475a; --surface2:#585b70;
+    --overlay0:#6c7086; --text:#cdd6f4; --subtext0:#a6adc8;
+    --blue:#89b4fa; --green:#a6e3a1; --red:#f38ba8;
+    --yellow:#f9e2af; --mauve:#cba6f7;
+    --font-mono:'JetBrains Mono','SF Mono','Cascadia Code','Fira Code','Menlo',monospace;
+    --row:20px;
+  }
+  body {
+    background:#0e0e16; color:var(--text);
+    font-family:var(--font-mono); font-size:13px;
+    line-height:var(--row); padding:32px 24px 120px;
+    -webkit-font-smoothing:antialiased;
+  }
+
+  .page-header { max-width:960px; margin:0 auto 40px; }
+  .page-header h1 {
+    font-size:14px; font-weight:600; color:var(--blue);
+    letter-spacing:0.05em; text-transform:uppercase; margin-bottom:8px;
+  }
+  .page-header p { color:var(--subtext0); font-size:12px; line-height:1.6; max-width:680px; }
+
+  .section { max-width:960px; margin:0 auto 48px; }
+  .section-label {
+    font-size:11px; font-weight:600; color:var(--mauve);
+    letter-spacing:0.08em; text-transform:uppercase; margin-bottom:6px;
+  }
+  .section-title { font-size:13px; font-weight:600; color:var(--text); margin-bottom:16px; }
+
+  .interaction-hint {
+    font-size:11px; color:var(--surface2); margin-top:10px; font-style:italic;
+  }
+  .interaction-hint .kh {
+    color:var(--subtext0); font-style:normal;
+    background:var(--surface0); padding:1px 5px; border-radius:3px; font-size:10px;
+  }
+
+  /* ── Keymap reference ──────────────────────── */
+  .keymap {
+    margin-top:24px; padding:16px 20px;
+    background:var(--mantle); border:1px solid var(--surface0); border-radius:8px;
+  }
+  .keymap-title {
+    font-size:11px; font-weight:600; color:var(--surface2);
+    letter-spacing:0.06em; text-transform:uppercase; margin-bottom:10px;
+  }
+  .keymap-cols {
+    display:flex; gap:40px;
+  }
+  .keymap-col { flex:1; }
+  .keymap-col h4 {
+    font-size:11px; font-weight:600; color:var(--subtext0); margin-bottom:6px;
+  }
+  .keymap-row {
+    display:flex; align-items:center; gap:8px;
+    font-size:12px; line-height:1.8;
+  }
+  .keymap-row .km-key {
+    color:var(--text); font-weight:500; min-width:60px;
+  }
+  .keymap-row .km-desc { color:var(--surface2); }
+
+  /* ── Terminal ──────────────────────────────── */
+  .terminal {
+    background:var(--base); border:1px solid var(--surface0);
+    border-radius:8px; overflow:hidden; font-size:13px;
+    line-height:var(--row); position:relative;
+    /* Focus outline when terminal is active */
+    outline:none;
+  }
+  .terminal:focus-within, .terminal.active {
+    border-color:var(--surface1);
+  }
+  .terminal-titlebar {
+    background:var(--mantle); padding:8px 12px;
+    display:flex; align-items:center; gap:8px;
+    border-bottom:1px solid var(--surface0);
+  }
+  .terminal-dot { width:10px; height:10px; border-radius:50%; background:var(--surface1); }
+  .terminal-titlebar-text { font-size:11px; color:var(--surface2); margin-left:4px; }
+  .terminal-body {
+    display:flex; flex-direction:column; min-height:460px; position:relative;
+  }
+
+  /* ── Header ────────────────────────────────── */
+  .header-bar {
+    background:var(--crust); height:var(--row);
+    display:flex; align-items:center; padding:0 8px; flex-shrink:0;
+  }
+  .header-badge {
+    background:var(--mauve); color:var(--crust);
+    font-weight:700; font-size:11px; padding:0 6px;
+    height:16px; display:flex; align-items:center; border-radius:2px;
+  }
+  .header-counts { margin-left:auto; display:flex; gap:10px; font-size:12px; }
+  .count-green { color:var(--green); }
+  .count-yellow { color:var(--yellow); }
+  .count-dim { color:var(--surface2); }
+  .count-red { color:var(--red); }
+
+  /* ── Graph ─────────────────────────────────── */
+  .graph-canvas { flex:1; position:relative; padding:20px 24px; overflow:hidden; }
+  .node-grid { display:flex; flex-direction:column; align-items:center; }
+  .node-row { display:flex; justify-content:center; gap:24px; }
+  .connector-row {
+    display:flex; justify-content:center; height:28px;
+    color:var(--surface1); font-size:13px; line-height:14px;
+    white-space:pre; align-items:center;
+  }
+  .node-card {
+    width:160px; height:52px; border:1px solid var(--surface1); border-radius:6px;
+    display:flex; flex-direction:column; align-items:center; justify-content:center; gap:2px;
+    cursor:pointer; transition:border-color 0.15s, background 0.15s; position:relative;
+  }
+  .node-card .node-name { font-size:12px; font-weight:500; }
+  .node-card .node-meta { font-size:11px; color:var(--subtext0); }
+  .node-card[data-status="running"]  { border-color:var(--yellow); }
+  .node-card[data-status="running"]  .node-name { color:var(--text); }
+  .node-card[data-status="running"]  .node-meta { color:var(--yellow); }
+  .node-card[data-status="complete"] { border-color:var(--green); }
+  .node-card[data-status="complete"] .node-name { color:var(--text); }
+  .node-card[data-status="complete"] .node-meta { color:var(--green); }
+  .node-card[data-status="error"]    { border-color:var(--red); }
+  .node-card[data-status="error"]    .node-name { color:var(--text); }
+  .node-card[data-status="error"]    .node-meta { color:var(--red); }
+  .node-card[data-status="pending"]  { border-color:var(--surface0); }
+  .node-card[data-status="pending"]  .node-name { color:var(--surface2); }
+  .node-card[data-status="pending"]  .node-meta { color:var(--surface2); }
+  .node-card.focused {
+    background:rgba(137,180,250,0.08); border-color:var(--blue);
+    box-shadow:0 0 0 1px rgba(137,180,250,0.15);
+  }
+  .node-card.focused .node-name { color:#fff; }
+
+  /* ── Agent CLI ─────────────────────────────── */
+  .agent-view {
+    flex:1; padding:12px 16px; font-size:12px; line-height:1.7;
+    color:var(--subtext0); overflow:hidden;
+  }
+  .agent-view .prompt { color:var(--blue); }
+  .agent-view .agent-name-label { color:var(--mauve); font-weight:600; }
+  .agent-view .output { color:var(--surface2); }
+  .agent-view .success-text { color:var(--green); }
+  .cursor-block {
+    display:inline-block; width:7px; height:14px; background:var(--text);
+    animation:blink 1s steps(1) infinite; vertical-align:middle; margin-left:2px;
+  }
+  @keyframes blink { 0%,50%{opacity:1;} 51%,100%{opacity:0;} }
+
+  /* ── Statusline ────────────────────────────── */
+  .statusline {
+    background:var(--crust); height:var(--row);
+    display:flex; align-items:center; flex-shrink:0;
+    overflow:hidden; padding:0 4px;
+  }
+  .mode-badge {
+    font-weight:700; font-size:11px; padding:0 6px; height:16px;
+    display:flex; align-items:center; border-radius:2px; flex-shrink:0; margin-left:2px;
+  }
+  .mode-badge.graph { background:var(--blue); color:var(--crust); }
+  .mode-badge.attached { background:var(--surface1); color:var(--text); }
+
+  .breadcrumb {
+    display:flex; align-items:center; margin-left:6px; font-size:12px;
+    flex-shrink:1; min-width:0; overflow:hidden;
+  }
+  .breadcrumb .bc-sep { color:var(--surface2); margin:0 5px; flex-shrink:0; }
+  .breadcrumb .bc-agent { color:var(--text); white-space:nowrap; }
+  .breadcrumb .bc-status { font-size:9px; margin-right:4px; }
+  .breadcrumb .bc-status.running { color:var(--yellow); }
+  .breadcrumb .bc-status.complete { color:var(--green); }
+  .breadcrumb .bc-status.error { color:var(--red); }
+  .breadcrumb .bc-status.pending { color:var(--surface2); }
+  .breadcrumb .bc-pos { color:var(--surface2); font-size:11px; margin-left:6px; flex-shrink:0; }
+
+  .hints {
+    margin-left:auto; padding-right:8px; font-size:12px;
+    color:var(--subtext0); flex-shrink:0; white-space:nowrap; background:var(--crust);
+  }
+  .hints .key { color:var(--text); }
+  .hints .sep { color:var(--surface2); margin:0 3px; }
+
+  /* ── Compact switcher ──────────────────────── */
+  .compact-switcher {
+    position:absolute; bottom:calc(var(--row) + 4px); left:4px;
+    background:var(--mantle); border:1px solid var(--surface1);
+    border-radius:6px; width:260px; z-index:20;
+    overflow:hidden; box-shadow:0 -4px 24px rgba(0,0,0,0.4);
+    animation: pop-in 0.1s ease-out;
+  }
+  @keyframes pop-in {
+    from { opacity:0; transform:translateY(4px); }
+    to   { opacity:1; transform:translateY(0); }
+  }
+  .compact-switcher .sw-header {
+    padding:5px 10px; font-size:10px; color:var(--surface2);
+    border-bottom:1px solid var(--surface0);
+    display:flex; justify-content:space-between;
+  }
+  .compact-switcher .sw-list { padding:3px 0; }
+  .compact-switcher .sw-item {
+    padding:4px 10px; font-size:12px;
+    display:flex; align-items:center; gap:6px;
+    color:var(--subtext0); cursor:default;
+    transition:background 0.06s;
+  }
+  .compact-switcher .sw-item.selected {
+    background:rgba(137,180,250,0.10); color:var(--text);
+  }
+  .compact-switcher .sw-item .sw-dot { font-size:9px; }
+  .compact-switcher .sw-item .sw-dot.running { color:var(--yellow); }
+  .compact-switcher .sw-item .sw-dot.complete { color:var(--green); }
+  .compact-switcher .sw-item .sw-dot.error { color:var(--red); }
+  .compact-switcher .sw-item .sw-dot.pending { color:var(--surface2); }
+  .compact-switcher .sw-item .sw-num {
+    color:var(--surface2); font-size:10px; font-weight:600;
+    width:12px; text-align:right; flex-shrink:0;
+  }
+  .compact-switcher .sw-item .sw-name { flex:1; }
+  .compact-switcher .sw-item .sw-dur { color:var(--surface2); font-size:11px; }
+
+  /* Pulse */
+  @keyframes pulse-dot { 0%,100%{opacity:1;} 50%{opacity:0.4;} }
+  .bc-status.running, .sw-dot.running { animation:pulse-dot 2s ease-in-out infinite; }
+
+  /* Flash on view switch */
+  .view-flash { animation:flash-in 0.12s ease-out; }
+  @keyframes flash-in { from{opacity:0.5;} to{opacity:1;} }
+</style>
+</head>
+<body>
+
+<div class="page-header">
+  <h1>Option 3 — Refined</h1>
+  <p>
+    Full keyboard navigation: arrow keys to navigate the graph, Enter to attach,
+    Esc to return, Tab/Shift+Tab to cycle agents, and <strong>/</strong> to open a compact
+    agent list for direct jumping. Try it below — this is fully interactive.
+  </p>
+</div>
+
+<div class="section">
+  <div class="terminal" id="term" tabindex="0">
+    <div class="terminal-titlebar">
+      <div class="terminal-dot"></div><div class="terminal-dot"></div><div class="terminal-dot"></div>
+      <span class="terminal-titlebar-text" id="titlebar-text">atomic-wf-ralph-a1b2</span>
+    </div>
+    <div class="terminal-body">
+      <!-- Graph view -->
+      <div id="graph-view">
+        <div class="header-bar">
+          <span class="header-badge">Orchestrator</span>
+          <div class="header-counts">
+            <span class="count-green">&#10003; 1</span>
+            <span class="count-yellow">&#9679; 3</span>
+            <span class="count-dim">&#9675; 2</span>
+            <span class="count-red">&#10007; 1</span>
+          </div>
+        </div>
+        <div class="graph-canvas" id="graph-canvas"></div>
+      </div>
+
+      <!-- Agent view -->
+      <div id="agent-view" style="display:none;flex:1;flex-direction:column;">
+        <div class="agent-view" id="agent-content" style="flex:1;"></div>
+      </div>
+
+      <!-- Compact switcher -->
+      <div class="compact-switcher" id="switcher" style="display:none;"></div>
+
+      <!-- Statusline -->
+      <div class="statusline" id="statusline">
+        <span class="mode-badge graph" id="badge">GRAPH</span>
+        <div class="breadcrumb" id="breadcrumb"></div>
+        <div class="hints" id="hints"></div>
+      </div>
+    </div>
+  </div>
+
+  <p class="interaction-hint">
+    Click the terminal to focus it, then use keyboard to navigate.
+    <span class="kh">&uarr;&darr;&larr;&rarr;</span> move focus
+    <span class="kh">Enter</span> attach
+    <span class="kh">Esc</span> back
+    <span class="kh">Tab</span> next agent
+    <span class="kh">/</span> agent list
+  </p>
+
+  <!-- Keymap reference -->
+  <div class="keymap">
+    <div class="keymap-title">Keyboard Reference</div>
+    <div class="keymap-cols">
+      <div class="keymap-col">
+        <h4>Graph view</h4>
+        <div class="keymap-row"><span class="km-key">&uarr; &darr; &larr; &rarr;</span><span class="km-desc">Navigate nodes</span></div>
+        <div class="keymap-row"><span class="km-key">h j k l</span><span class="km-desc">Navigate (vim)</span></div>
+        <div class="keymap-row"><span class="km-key">Enter</span><span class="km-desc">Attach to focused node</span></div>
+        <div class="keymap-row"><span class="km-key">/</span><span class="km-desc">Open agent list</span></div>
+        <div class="keymap-row"><span class="km-key">q</span><span class="km-desc">Quit</span></div>
+      </div>
+      <div class="keymap-col">
+        <h4>Attached view</h4>
+        <div class="keymap-row"><span class="km-key">Esc</span><span class="km-desc">Return to graph</span></div>
+        <div class="keymap-row"><span class="km-key">Tab</span><span class="km-desc">Next agent</span></div>
+        <div class="keymap-row"><span class="km-key">Shift+Tab</span><span class="km-desc">Previous agent</span></div>
+        <div class="keymap-row"><span class="km-key">/</span><span class="km-desc">Open agent list</span></div>
+        <div class="keymap-row"><span class="km-key">q</span><span class="km-desc">Quit</span></div>
+      </div>
+      <div class="keymap-col">
+        <h4>Agent list (/)</h4>
+        <div class="keymap-row"><span class="km-key">&uarr; &darr;</span><span class="km-desc">Select agent</span></div>
+        <div class="keymap-row"><span class="km-key">Enter</span><span class="km-desc">Jump to agent</span></div>
+        <div class="keymap-row"><span class="km-key">Esc</span><span class="km-desc">Close list</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+// ── Data ──────────────────────────────────────
+
+const agents = [
+  { id:"orchestrator",    status:"running",  dur:"5m 02s" },
+  { id:"planner",         status:"complete", dur:"1m 23s" },
+  { id:"frontend-writer", status:"running",  dur:"2m 45s" },
+  { id:"backend-writer",  status:"running",  dur:"3m 12s" },
+  { id:"reviewer",        status:"error",    dur:"0m 43s" },
+  { id:"test-runner",     status:"pending",  dur:"\u2014" },
+  { id:"deploy-agent",    status:"pending",  dur:"\u2014" },
+];
+const icons = { running:"\u25CF", complete:"\u2713", error:"\u2717", pending:"\u25CB" };
+const started = agents.filter(a => a.status !== "pending");
+
+const outputs = {
+  orchestrator:[
+    '<span class="agent-name-label">orchestrator</span> <span class="output">workflow started</span>',
+    '<span class="output">spawning planner...</span>',
+    '<span class="output">spawning deploy-agent...</span>',
+    '&nbsp;',
+    '<span class="prompt">&gt;</span> <span style="color:var(--text)">Coordinating 7 agents for ralph workflow...</span>',
+    '<span class="output">  planner: complete (1m 23s)</span>',
+    '<span class="output">  frontend-writer: running...</span>',
+    '<span class="output">  backend-writer: running...</span>',
+    '<span style="color:var(--red)">  reviewer: error \u2014 lint failed</span>',
+    '&nbsp;',
+    '<span class="prompt">&gt;</span> <span class="cursor-block"></span>',
+  ],
+  planner:[
+    '<span class="agent-name-label">planner</span> <span class="output">session started</span>',
+    '<span class="prompt">&gt;</span> <span style="color:var(--text)">Analyzing codebase structure...</span>',
+    '<span class="output">  found 42 source files, 8 test files</span>',
+    '<span class="output">  identifying change boundaries...</span>',
+    '<span class="success-text">  plan generated: 3 parallel tasks</span>',
+    '&nbsp;',
+    '<span class="success-text">\u2713 session complete (1m 23s)</span>',
+  ],
+  "frontend-writer":[
+    '<span class="agent-name-label">frontend-writer</span> <span class="output">session started</span>',
+    '<span class="prompt">&gt;</span> <span style="color:var(--text)">Implementing UI components...</span>',
+    '<span class="output">  writing src/components/Header.tsx...</span>',
+    '<span class="output">  writing src/components/Sidebar.tsx...</span>',
+    '<span class="output">  writing src/styles/theme.css...</span>',
+    '&nbsp;',
+    '<span class="prompt">&gt;</span> <span class="cursor-block"></span>',
+  ],
+  "backend-writer":[
+    '<span class="agent-name-label">backend-writer</span> <span class="output">session started</span>',
+    '<span class="prompt">&gt;</span> <span style="color:var(--text)">Implementing API endpoints...</span>',
+    '<span class="output">  writing src/routes/api.ts...</span>',
+    '<span class="output">  writing src/middleware/auth.ts...</span>',
+    '<span class="output">  running type checks...</span>',
+    '&nbsp;',
+    '<span class="prompt">&gt;</span> <span class="cursor-block"></span>',
+  ],
+  reviewer:[
+    '<span class="agent-name-label">reviewer</span> <span class="output">session started</span>',
+    '<span class="output">running lint checks on src/...</span>',
+    '&nbsp;',
+    '<span class="prompt">&gt;</span> <span style="color:var(--text)">Reviewing changes in src/index.ts...</span>',
+    '<span class="output">  checking type safety... done</span>',
+    '<span class="output">  checking imports... done</span>',
+    '<span style="color:var(--red)">  error: lint failed at src/index.ts:42</span>',
+    '<span style="color:var(--red)">    Expected semicolon, found newline</span>',
+    '&nbsp;',
+    '<span class="prompt">&gt;</span> <span style="color:var(--text)">Attempting auto-fix...</span>',
+    '<span class="output">  applying prettier...</span>',
+    '<span class="success-text">  fix applied, re-running lint...</span>',
+    '&nbsp;',
+    '<span class="prompt">&gt;</span> <span class="cursor-block"></span>',
+  ],
+  "test-runner":[
+    '<span class="agent-name-label">test-runner</span> <span style="color:var(--surface2)">waiting for backend-writer...</span>',
+  ],
+  "deploy-agent":[
+    '<span class="agent-name-label">deploy-agent</span> <span style="color:var(--surface2)">waiting for all tasks to complete...</span>',
+  ],
+};
+
+// ── Graph spatial positions ───────────────────
+
+const positions = {
+  orchestrator:     { x:2, y:0 },
+  planner:          { x:1, y:1 },
+  "deploy-agent":   { x:3, y:1 },
+  "frontend-writer":{ x:0, y:2 },
+  "backend-writer": { x:1, y:2 },
+  reviewer:         { x:2, y:2 },
+  "test-runner":    { x:1, y:3 },
+};
+
+// ── Build graph ───────────────────────────────
+
+function buildGraph() {
+  const canvas = document.getElementById("graph-canvas");
+  const rows = [
+    [{ id:"orchestrator", status:"running", dur:"5m 02s" }],
+    "fan2",
+    [{ id:"planner", status:"complete", dur:"1m 23s" }, { id:"deploy-agent", status:"pending", dur:"\u2014" }],
+    "fan3",
+    [{ id:"frontend-writer", status:"running", dur:"2m 45s" }, { id:"backend-writer", status:"running", dur:"3m 12s" }, { id:"reviewer", status:"error", dur:"lint failed" }],
+    "single",
+    [{ id:"test-runner", status:"pending", dur:"\u2014" }],
+  ];
+  const grid = document.createElement("div"); grid.className = "node-grid";
+  rows.forEach(row => {
+    if (typeof row === "string") {
+      const c = document.createElement("div"); c.className = "connector-row";
+      if (row === "fan2") c.innerHTML = "\u2502\n\u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510";
+      else if (row === "fan3") { c.innerHTML = "\u2502\n\u250C\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510"; c.style.marginRight = "184px"; }
+      else { c.textContent = "\u2502"; c.style.marginRight = "368px"; }
+      grid.appendChild(c); return;
+    }
+    const nr = document.createElement("div"); nr.className = "node-row";
+    if (row.length === 1 && row[0].id === "test-runner") nr.style.marginRight = "368px";
+    row.forEach(n => {
+      const card = document.createElement("div");
+      card.className = "node-card" + (n.id === "orchestrator" ? " focused" : "");
+      card.dataset.status = n.status; card.dataset.id = n.id;
+      card.innerHTML = `<span class="node-name">${n.id}</span><span class="node-meta">${n.dur}</span>`;
+      card.addEventListener("click", () => {
+        focusNode(n.id);
+        attachTo(n.id);
+      });
+      nr.appendChild(card);
+    });
+    grid.appendChild(nr);
+  });
+  canvas.innerHTML = ""; canvas.appendChild(grid);
+}
+
+// ── State ─────────────────────────────────────
+
+let view = "graph";       // "graph" | "agent"
+let focusedId = "orchestrator";
+let activeId = "";
+let switcherOpen = false;
+let switcherSel = 0;
+
+const GRAPH_HINTS = '<span class="key">\u2191\u2193\u2190\u2192</span> navigate<span class="sep">\u00B7</span><span class="key">\u21B5</span> attach<span class="sep">\u00B7</span><span class="key">/</span> agents<span class="sep">\u00B7</span><span class="key">q</span> quit';
+const ATTACHED_HINTS = '<span class="key">Esc</span> graph<span class="sep">\u00B7</span><span class="key">Tab</span> next<span class="sep">\u00B7</span><span class="key">/</span> agents<span class="sep">\u00B7</span><span class="key">q</span> quit';
+
+// ── View helpers ──────────────────────────────
+
+function focusNode(id) {
+  focusedId = id;
+  document.querySelectorAll(".node-card").forEach(n =>
+    n.classList.toggle("focused", n.dataset.id === id));
+}
+
+function showGraph() {
+  view = "graph"; activeId = "";
+  document.getElementById("graph-view").style.display = "";
+  document.getElementById("agent-view").style.display = "none";
+  document.getElementById("badge").className = "mode-badge graph";
+  document.getElementById("badge").textContent = "GRAPH";
+  document.getElementById("breadcrumb").innerHTML = "";
+  document.getElementById("hints").innerHTML = GRAPH_HINTS;
+  closeSwitcher();
+  focusNode(focusedId);
+}
+
+function attachTo(id) {
+  const a = agents.find(x => x.id === id);
+  if (!a || a.status === "pending") return;
+  view = "agent"; activeId = id; focusedId = id;
+
+  document.getElementById("graph-view").style.display = "none";
+  const av = document.getElementById("agent-view");
+  av.style.display = "flex";
+  av.classList.remove("view-flash"); void av.offsetWidth; av.classList.add("view-flash");
+
+  document.getElementById("agent-content").innerHTML =
+    (outputs[id] || []).map(l => `<div>${l}</div>`).join("");
+
+  document.getElementById("badge").className = "mode-badge attached";
+  document.getElementById("badge").textContent = "ATTACHED";
+
+  const idx = agents.findIndex(x => x.id === id);
+  document.getElementById("breadcrumb").innerHTML =
+    `<span class="bc-sep">\u203A</span>` +
+    `<span class="bc-status ${a.status}">${icons[a.status]}</span>` +
+    `<span class="bc-agent">${a.id}</span>` +
+    `<span class="bc-pos">${idx + 1}/${agents.length}</span>`;
+
+  document.getElementById("hints").innerHTML = ATTACHED_HINTS;
+  closeSwitcher();
+}
+
+function cycleAgent(dir) {
+  if (view !== "agent") return;
+  const curIdx = started.findIndex(a => a.id === activeId);
+  let next = curIdx + dir;
+  if (next < 0) next = started.length - 1;
+  if (next >= started.length) next = 0;
+  attachTo(started[next].id);
+}
+
+// ── Spatial navigation ────────────────────────
+
+function navigate(dir) {
+  const cur = positions[focusedId];
+  if (!cur) return;
+  let best = null, bestDist = Infinity;
+  for (const [id, pos] of Object.entries(positions)) {
+    if (id === focusedId) continue;
+    const dx = pos.x - cur.x, dy = pos.y - cur.y;
+    let valid = false;
+    if (dir === "left"  && dx < 0) valid = true;
+    if (dir === "right" && dx > 0) valid = true;
+    if (dir === "up"    && dy < 0) valid = true;
+    if (dir === "down"  && dy > 0) valid = true;
+    if (!valid) continue;
+    const dist = (dir === "left" || dir === "right")
+      ? Math.abs(dx) + Math.abs(dy) * 3
+      : Math.abs(dy) + Math.abs(dx) * 3;
+    if (dist < bestDist) { bestDist = dist; best = id; }
+  }
+  if (best) focusNode(best);
+}
+
+// ── Compact switcher ──────────────────────────
+
+function openSwitcher() {
+  // Pre-select current agent if attached, or focused node if in graph
+  const currentId = view === "agent" ? activeId : focusedId;
+  switcherSel = agents.findIndex(a => a.id === currentId);
+  if (switcherSel < 0) switcherSel = 0;
+  renderSwitcher();
+  switcherOpen = true;
+}
+
+function renderSwitcher() {
+  const el = document.getElementById("switcher");
+  el.innerHTML = `
+    <div class="sw-header"><span>agents</span><span>\u2191\u2193 select \u00B7 \u21B5 jump \u00B7 Esc close</span></div>
+    <div class="sw-list">${agents.map((a, i) => `
+      <div class="sw-item${i === switcherSel ? ' selected' : ''}" data-idx="${i}">
+        <span class="sw-num">${i + 1}</span>
+        <span class="sw-dot ${a.status}">${icons[a.status]}</span>
+        <span class="sw-name">${a.id}</span>
+        <span class="sw-dur">${a.dur}</span>
+      </div>`).join("")}</div>`;
+  el.style.display = "block";
+
+  // Click handlers
+  el.querySelectorAll(".sw-item").forEach(item => {
+    item.addEventListener("click", () => {
+      const idx = parseInt(item.dataset.idx);
+      closeSwitcher();
+      attachTo(agents[idx].id);
+    });
+  });
+
+  // Scroll selected into view
+  const selected = el.querySelector(".sw-item.selected");
+  if (selected) selected.scrollIntoView({ block: "nearest" });
+}
+
+function closeSwitcher() {
+  document.getElementById("switcher").style.display = "none";
+  switcherOpen = false;
+  switcherSel = 0;
+}
+
+// ── Keyboard ──────────────────────────────────
+
+document.addEventListener("keydown", e => {
+  // Only respond when terminal is focused or page has focus
+  const term = document.getElementById("term");
+
+  // ── Switcher open: intercept all ──
+  if (switcherOpen) {
+    if (e.key === "Escape") { e.preventDefault(); closeSwitcher(); return; }
+    if (e.key === "ArrowUp" || e.key === "k") {
+      e.preventDefault();
+      switcherSel = Math.max(0, switcherSel - 1);
+      renderSwitcher(); return;
+    }
+    if (e.key === "ArrowDown" || e.key === "j") {
+      e.preventDefault();
+      switcherSel = Math.min(agents.length - 1, switcherSel + 1);
+      renderSwitcher(); return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const a = agents[switcherSel];
+      closeSwitcher();
+      if (a) attachTo(a.id);
+      return;
+    }
+    // Number jump within switcher
+    const num = parseInt(e.key);
+    if (num >= 1 && num <= agents.length) {
+      e.preventDefault();
+      closeSwitcher();
+      attachTo(agents[num - 1].id);
+      return;
+    }
+    return;
+  }
+
+  // ── / opens switcher from any view ──
+  if (e.key === "/") {
+    e.preventDefault();
+    openSwitcher();
+    return;
+  }
+
+  // ── Escape: return to graph ──
+  if (e.key === "Escape") {
+    e.preventDefault();
+    if (view === "agent") showGraph();
+    return;
+  }
+
+  // ── Graph view ──
+  if (view === "graph") {
+    if (e.key === "ArrowUp"    || e.key === "k") { e.preventDefault(); navigate("up"); }
+    if (e.key === "ArrowDown"  || e.key === "j") { e.preventDefault(); navigate("down"); }
+    if (e.key === "ArrowLeft"  || e.key === "h") { e.preventDefault(); navigate("left"); }
+    if (e.key === "ArrowRight" || e.key === "l") { e.preventDefault(); navigate("right"); }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      attachTo(focusedId);
+    }
+    return;
+  }
+
+  // ── Attached view ──
+  if (view === "agent") {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      cycleAgent(e.shiftKey ? -1 : 1);
+    }
+  }
+});
+
+// ── Init ──────────────────────────────────────
+
+buildGraph();
+showGraph();
+
+// Auto-focus terminal
+document.getElementById("term").focus();
+</script>
+</body>
+</html>

--- a/research/designs/option3-refined-prototype.html
+++ b/research/designs/option3-refined-prototype.html
@@ -338,6 +338,7 @@ const agents = [
 ];
 const icons = { running:"\u25CF", complete:"\u2713", error:"\u2717", pending:"\u25CB" };
 const started = agents.filter(a => a.status !== "pending");
+const subagents = started.filter(a => a.id !== "orchestrator");
 
 const outputs = {
   orchestrator:[
@@ -511,12 +512,12 @@ function attachTo(id) {
   document.getElementById("badge").className = "mode-badge attached";
   document.getElementById("badge").textContent = "ATTACHED";
 
-  const idx = agents.findIndex(x => x.id === id);
+  const subIdx = subagents.findIndex(x => x.id === id);
   document.getElementById("breadcrumb").innerHTML =
     `<span class="bc-sep">\u203A</span>` +
     `<span class="bc-status ${a.status}">${icons[a.status]}</span>` +
     `<span class="bc-agent">${a.id}</span>` +
-    `<span class="bc-pos">${idx + 1}/${agents.length}</span>`;
+    `<span class="bc-pos">${subIdx + 1}/${subagents.length}</span>`;
 
   document.getElementById("hints").innerHTML = ATTACHED_HINTS;
   closeSwitcher();
@@ -524,12 +525,12 @@ function attachTo(id) {
 
 function cycleAgent(dir) {
   if (view !== "agent") return;
-  const curIdx = started.findIndex(a => a.id === activeId);
+  const curIdx = subagents.findIndex(a => a.id === activeId);
+  if (curIdx < 0) return;
   let next = curIdx + dir;
-  if (next < 0) next = started.length - 1;
-  if (next >= started.length) next = 0;
-  // attachTo handles orchestrator → graph automatically
-  attachTo(started[next].id);
+  if (next < 0) next = subagents.length - 1;
+  if (next >= subagents.length) next = 0;
+  attachTo(subagents[next].id);
 }
 
 // ── Spatial navigation ────────────────────────

--- a/research/designs/option3-refined-prototype.html
+++ b/research/designs/option3-refined-prototype.html
@@ -243,8 +243,9 @@
   <h1>Option 3 — Refined</h1>
   <p>
     Full keyboard navigation: arrow keys to navigate the graph, Enter to attach,
-    Esc to return, Tab/Shift+Tab to cycle agents, and <strong>/</strong> to open a compact
-    agent list for direct jumping. Try it below — this is fully interactive.
+    Tab/Shift+Tab to cycle agents, <strong>g</strong> to jump straight back to graph,
+    and <strong>/</strong> to open a compact agent list for direct jumping.
+    No Esc key — avoids interrupting running agents. Try it below.
   </p>
 </div>
 
@@ -290,7 +291,6 @@
     Click the terminal to focus it, then use keyboard to navigate.
     <span class="kh">&uarr;&darr;&larr;&rarr;</span> move focus
     <span class="kh">Enter</span> attach
-    <span class="kh">Esc</span> back
     <span class="kh">Tab</span> next agent
     <span class="kh">/</span> agent list
   </p>
@@ -309,9 +309,9 @@
       </div>
       <div class="keymap-col">
         <h4>Attached view</h4>
-        <div class="keymap-row"><span class="km-key">Esc</span><span class="km-desc">Return to graph</span></div>
-        <div class="keymap-row"><span class="km-key">Tab</span><span class="km-desc">Next agent</span></div>
+        <div class="keymap-row"><span class="km-key">Tab</span><span class="km-desc">Next agent (wraps to graph)</span></div>
         <div class="keymap-row"><span class="km-key">Shift+Tab</span><span class="km-desc">Previous agent</span></div>
+        <div class="keymap-row"><span class="km-key">g</span><span class="km-desc">Back to graph</span></div>
         <div class="keymap-row"><span class="km-key">/</span><span class="km-desc">Open agent list</span></div>
         <div class="keymap-row"><span class="km-key">q</span><span class="km-desc">Quit</span></div>
       </div>
@@ -319,7 +319,6 @@
         <h4>Agent list (/)</h4>
         <div class="keymap-row"><span class="km-key">&uarr; &darr;</span><span class="km-desc">Select agent</span></div>
         <div class="keymap-row"><span class="km-key">Enter</span><span class="km-desc">Jump to agent</span></div>
-        <div class="keymap-row"><span class="km-key">Esc</span><span class="km-desc">Close list</span></div>
       </div>
     </div>
   </div>
@@ -466,7 +465,7 @@ let switcherOpen = false;
 let switcherSel = 0;
 
 const GRAPH_HINTS = '<span class="key">\u2191\u2193\u2190\u2192</span> navigate<span class="sep">\u00B7</span><span class="key">\u21B5</span> attach<span class="sep">\u00B7</span><span class="key">/</span> agents<span class="sep">\u00B7</span><span class="key">q</span> quit';
-const ATTACHED_HINTS = '<span class="key">Esc</span> graph<span class="sep">\u00B7</span><span class="key">Tab</span> next<span class="sep">\u00B7</span><span class="key">/</span> agents<span class="sep">\u00B7</span><span class="key">q</span> quit';
+const ATTACHED_HINTS = '<span class="key">Tab</span> next<span class="sep">\u00B7</span><span class="key">S-Tab</span> prev<span class="sep">\u00B7</span><span class="key">g</span> graph<span class="sep">\u00B7</span><span class="key">/</span> agents<span class="sep">\u00B7</span><span class="key">q</span> quit';
 
 // ── View helpers ──────────────────────────────
 
@@ -491,6 +490,14 @@ function showGraph() {
 function attachTo(id) {
   const a = agents.find(x => x.id === id);
   if (!a || a.status === "pending") return;
+
+  // Orchestrator = the graph view (it's the same tmux window in reality)
+  if (id === "orchestrator") {
+    focusedId = "orchestrator";
+    showGraph();
+    return;
+  }
+
   view = "agent"; activeId = id; focusedId = id;
 
   document.getElementById("graph-view").style.display = "none";
@@ -521,6 +528,7 @@ function cycleAgent(dir) {
   let next = curIdx + dir;
   if (next < 0) next = started.length - 1;
   if (next >= started.length) next = 0;
+  // attachTo handles orchestrator → graph automatically
   attachTo(started[next].id);
 }
 
@@ -635,13 +643,6 @@ document.addEventListener("keydown", e => {
     return;
   }
 
-  // ── Escape: return to graph ──
-  if (e.key === "Escape") {
-    e.preventDefault();
-    if (view === "agent") showGraph();
-    return;
-  }
-
   // ── Graph view ──
   if (view === "graph") {
     if (e.key === "ArrowUp"    || e.key === "k") { e.preventDefault(); navigate("up"); }
@@ -660,6 +661,10 @@ document.addEventListener("keydown", e => {
     if (e.key === "Tab") {
       e.preventDefault();
       cycleAgent(e.shiftKey ? -1 : 1);
+    }
+    if (e.key === "g") {
+      e.preventDefault();
+      showGraph();
     }
   }
 });

--- a/src/sdk/components/compact-switcher.tsx
+++ b/src/sdk/components/compact-switcher.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * CompactSwitcher — a lightweight popup that lists all agents for quick
+ * direct-jump navigation. Opened with "/" from any view mode.
+ */
+
+import { useStore, useGraphTheme, useStoreVersion } from "./orchestrator-panel-contexts.ts";
+import { statusIcon, statusColor, fmtDuration } from "./status-helpers.ts";
+import { lerpColor } from "./color-utils.ts";
+
+export interface CompactSwitcherProps {
+  selectedIndex: number;
+}
+
+export function CompactSwitcher({ selectedIndex }: CompactSwitcherProps) {
+  const store = useStore();
+  const theme = useGraphTheme();
+  useStoreVersion(store);
+
+  const agents = store.sessions;
+  const headerHint = "\u2191\u2193 select \u00B7 \u21B5 jump \u00B7 Esc close";
+
+  return (
+    <box
+      position="absolute"
+      bottom={1}
+      left={0}
+      width={44}
+      border
+      borderStyle="rounded"
+      borderColor={theme.borderActive}
+      backgroundColor={theme.backgroundElement}
+      flexDirection="column"
+    >
+      {/* Header */}
+      <box height={1} flexDirection="row" paddingLeft={1} paddingRight={1}>
+        <text fg={theme.textDim}>agents</text>
+        <box flexGrow={1} />
+        <text fg={theme.textDim}>{headerHint}</text>
+      </box>
+
+      {/* Agent list */}
+      {agents.map((agent, i) => {
+        const isSelected = i === selectedIndex;
+        const icon = statusIcon(agent.status);
+        const iconColor = statusColor(agent.status, theme);
+        const duration =
+          agent.startedAt !== null
+            ? fmtDuration((agent.endedAt ?? Date.now()) - agent.startedAt)
+            : "\u2014";
+
+        return (
+          <box
+            key={agent.name}
+            height={1}
+            flexDirection="row"
+            paddingLeft={1}
+            paddingRight={1}
+            backgroundColor={isSelected ? lerpColor(theme.backgroundElement, theme.primary, 0.12) : theme.backgroundElement}
+          >
+            <text>
+              <span fg={theme.textDim}>{String(i + 1).padStart(2)} </span>
+              <span fg={iconColor}>{icon} </span>
+              <span fg={isSelected ? theme.text : theme.textMuted}>{agent.name}</span>
+            </text>
+            <box flexGrow={1} />
+            <text fg={theme.textDim}>{duration}</text>
+          </box>
+        );
+      })}
+    </box>
+  );
+}

--- a/src/sdk/components/orchestrator-panel-store.test.ts
+++ b/src/sdk/components/orchestrator-panel-store.test.ts
@@ -714,4 +714,128 @@ describe("PanelStore", () => {
       expect(store.sessions.find((s) => s.name === "s3")!.parents).toEqual(["s2"]);
     });
   });
+
+  // ── setViewMode ────────────────────────────────────────────────────────────
+
+  describe("setViewMode", () => {
+    test("defaults to graph mode with empty active agent", () => {
+      expect(store.viewMode).toBe("graph");
+      expect(store.activeAgentId).toBe("");
+    });
+
+    test("switches to attached mode with agent ID", () => {
+      store.setViewMode("attached", "worker-1");
+      expect(store.viewMode).toBe("attached");
+      expect(store.activeAgentId).toBe("worker-1");
+    });
+
+    test("switches back to graph mode and clears active agent", () => {
+      store.setViewMode("attached", "worker-1");
+      store.setViewMode("graph");
+      expect(store.viewMode).toBe("graph");
+      expect(store.activeAgentId).toBe("");
+    });
+
+    test("increments version by exactly 1", () => {
+      const before = store.version;
+      store.setViewMode("attached", "worker-1");
+      expect(store.version).toBe(before + 1);
+    });
+
+    test("notifies subscribers", () => {
+      const listener = mock(() => {});
+      store.subscribe(listener);
+      store.setViewMode("attached", "worker-1");
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test("attached without agent ID clears active agent", () => {
+      store.setViewMode("attached");
+      expect(store.viewMode).toBe("attached");
+      expect(store.activeAgentId).toBe("");
+    });
+  });
+
+  // ── getSubagents ───────────────────────────────────────────────────────────
+
+  describe("getSubagents", () => {
+    beforeEach(() => {
+      store.setWorkflowInfo("wf", "claude", [
+        { name: "planner", parents: [] },
+        { name: "writer", parents: ["planner"] },
+        { name: "reviewer", parents: ["writer"] },
+      ], "prompt");
+    });
+
+    test("returns empty when all non-orchestrator sessions are pending", () => {
+      expect(store.getSubagents()).toEqual([]);
+    });
+
+    test("excludes orchestrator from subagent list", () => {
+      store.startSession("planner");
+      const subs = store.getSubagents();
+      expect(subs.every((s) => s.name !== "orchestrator")).toBe(true);
+    });
+
+    test("includes running and completed sessions", () => {
+      store.startSession("planner");
+      store.completeSession("planner");
+      store.startSession("writer");
+      const subs = store.getSubagents();
+      expect(subs.map((s) => s.name)).toEqual(["planner", "writer"]);
+    });
+
+    test("includes errored sessions", () => {
+      store.startSession("planner");
+      store.failSession("planner", "timeout");
+      const subs = store.getSubagents();
+      expect(subs.map((s) => s.name)).toEqual(["planner"]);
+    });
+
+    test("excludes pending sessions", () => {
+      store.startSession("planner");
+      const subs = store.getSubagents();
+      expect(subs.map((s) => s.name)).toEqual(["planner"]);
+      expect(subs.some((s) => s.name === "writer")).toBe(false);
+      expect(subs.some((s) => s.name === "reviewer")).toBe(false);
+    });
+  });
+
+  // ── getActiveAgentIndex ────────────────────────────────────────────────────
+
+  describe("getActiveAgentIndex", () => {
+    beforeEach(() => {
+      store.setWorkflowInfo("wf", "claude", [
+        { name: "planner", parents: [] },
+        { name: "writer", parents: ["planner"] },
+        { name: "reviewer", parents: ["writer"] },
+      ], "prompt");
+      store.startSession("planner");
+      store.startSession("writer");
+    });
+
+    test("returns -1 when no agent is active", () => {
+      expect(store.getActiveAgentIndex()).toBe(-1);
+    });
+
+    test("returns correct index for first subagent", () => {
+      store.setViewMode("attached", "planner");
+      expect(store.getActiveAgentIndex()).toBe(0);
+    });
+
+    test("returns correct index for second subagent", () => {
+      store.setViewMode("attached", "writer");
+      expect(store.getActiveAgentIndex()).toBe(1);
+    });
+
+    test("returns -1 for orchestrator (not a subagent)", () => {
+      store.setViewMode("attached", "orchestrator");
+      expect(store.getActiveAgentIndex()).toBe(-1);
+    });
+
+    test("returns -1 for non-existent agent", () => {
+      store.setViewMode("attached", "nonexistent");
+      expect(store.getActiveAgentIndex()).toBe(-1);
+    });
+  });
 });

--- a/src/sdk/components/orchestrator-panel-store.ts
+++ b/src/sdk/components/orchestrator-panel-store.ts
@@ -126,7 +126,7 @@ export class PanelStore {
 
   /**
    * Return non-orchestrator agents that have started (not pending).
-   * These are the agents Tab/Shift+Tab cycles through.
+   * Used for the tmux status bar agent count and active-agent index.
    */
   getSubagents(): SessionData[] {
     return this.sessions.filter(

--- a/src/sdk/components/orchestrator-panel-store.ts
+++ b/src/sdk/components/orchestrator-panel-store.ts
@@ -1,7 +1,7 @@
 // ─── State Store ──────────────────────────────────
 // Bridges the imperative OrchestratorPanel API with the React component tree.
 
-import type { SessionData, SessionStatus, PanelSession } from "./orchestrator-panel-types.ts";
+import type { SessionData, SessionStatus, PanelSession, ViewMode } from "./orchestrator-panel-types.ts";
 
 type Listener = () => void;
 
@@ -16,6 +16,11 @@ export class PanelStore {
   completionReached = false;
   exitResolve: (() => void) | null = null;
   abortResolve: (() => void) | null = null;
+
+  /** Current view mode — graph overview or attached to a specific agent. */
+  viewMode: ViewMode = "graph";
+  /** ID of the agent currently attached to (only meaningful when viewMode === "attached"). */
+  activeAgentId = "";
 
   private listeners = new Set<Listener>();
 
@@ -106,6 +111,36 @@ export class PanelStore {
       orch.endedAt = Date.now();
     }
     this.emit();
+  }
+
+  /**
+   * Switch between graph and attached view modes.
+   * When switching to "attached", provide the agent ID to attach to.
+   * Switching to "graph" clears the active agent.
+   */
+  setViewMode(mode: ViewMode, agentId?: string): void {
+    this.viewMode = mode;
+    this.activeAgentId = mode === "attached" && agentId ? agentId : "";
+    this.emit();
+  }
+
+  /**
+   * Return non-orchestrator agents that have started (not pending).
+   * These are the agents Tab/Shift+Tab cycles through.
+   */
+  getSubagents(): SessionData[] {
+    return this.sessions.filter(
+      (s) => s.name !== "orchestrator" && s.status !== "pending",
+    );
+  }
+
+  /**
+   * Return the 0-based index of the active agent within the subagent list,
+   * or -1 if not found.
+   */
+  getActiveAgentIndex(): number {
+    const subs = this.getSubagents();
+    return subs.findIndex((s) => s.name === this.activeAgentId);
   }
 
   /** Safely invoke exitResolve at most once, guarding against rapid repeated calls. */

--- a/src/sdk/components/orchestrator-panel-types.ts
+++ b/src/sdk/components/orchestrator-panel-types.ts
@@ -2,6 +2,8 @@
 
 export type SessionStatus = "pending" | "running" | "complete" | "error";
 
+export type ViewMode = "graph" | "attached";
+
 export interface PanelSession {
   name: string;
   parents: string[];

--- a/src/sdk/components/session-graph-panel.tsx
+++ b/src/sdk/components/session-graph-panel.tsx
@@ -18,7 +18,14 @@ import {
   useRef,
   useContext,
 } from "react";
-import { tmuxRun } from "../runtime/tmux.ts";
+import {
+  tmuxRun,
+  escapeTmuxFormat,
+  TMUX_DEFAULT_STATUS_LEFT,
+  TMUX_DEFAULT_STATUS_LEFT_LENGTH,
+  TMUX_DEFAULT_STATUS_RIGHT,
+  TMUX_DEFAULT_STATUS_RIGHT_LENGTH,
+} from "../runtime/tmux.ts";
 import {
   useStore,
   useGraphTheme,
@@ -380,8 +387,8 @@ export function SessionGraphPanel() {
 
   useEffect(() => {
     if (store.viewMode === "attached" && store.activeAgentId) {
-      const name = store.activeAgentId;
-      const left = `#[bg=#6c7086,fg=#1e1e2e,bold] ATTACHED #[default] #[fg=#7f849c]\u203a #[fg=#cdd6f4]${name} #[fg=#7f849c]${activeAgentIdx + 1}/${subagentCount}`;
+      const safeName = escapeTmuxFormat(store.activeAgentId);
+      const left = `#[bg=#6c7086,fg=#1e1e2e,bold] ATTACHED #[default] #[fg=#7f849c]\u203a #[fg=#cdd6f4]${safeName} #[fg=#7f849c]${activeAgentIdx + 1}/${subagentCount}`;
       const right = `#[fg=#7f849c]Graph: #[fg=#cdd6f4]ctrl+g #[fg=#7f849c]| Next: #[fg=#cdd6f4]ctrl+\\ `;
 
       tmuxRun(["set", "-g", "status-left", left]);
@@ -389,21 +396,21 @@ export function SessionGraphPanel() {
       tmuxRun(["set", "-g", "status-right", right]);
       tmuxRun(["set", "-g", "status-right-length", "40"]);
     } else {
-      // Graph mode: restore defaults from tmux.conf
-      tmuxRun(["set", "-g", "status-left", " "]);
-      tmuxRun(["set", "-g", "status-left-length", "10"]);
-      tmuxRun(["set", "-g", "status-right", " #{session_name} | %H:%M "]);
-      tmuxRun(["set", "-g", "status-right-length", "60"]);
+      // Graph mode: restore defaults (constants from tmux.ts match tmux.conf)
+      tmuxRun(["set", "-g", "status-left", TMUX_DEFAULT_STATUS_LEFT]);
+      tmuxRun(["set", "-g", "status-left-length", TMUX_DEFAULT_STATUS_LEFT_LENGTH]);
+      tmuxRun(["set", "-g", "status-right", TMUX_DEFAULT_STATUS_RIGHT]);
+      tmuxRun(["set", "-g", "status-right-length", TMUX_DEFAULT_STATUS_RIGHT_LENGTH]);
     }
   }, [store.viewMode, store.activeAgentId, activeAgentIdx, subagentCount]);
 
   // Restore default tmux status bar on unmount
   useEffect(() => {
     return () => {
-      tmuxRun(["set", "-g", "status-left", " "]);
-      tmuxRun(["set", "-g", "status-left-length", "10"]);
-      tmuxRun(["set", "-g", "status-right", " #{session_name} | %H:%M "]);
-      tmuxRun(["set", "-g", "status-right-length", "60"]);
+      tmuxRun(["set", "-g", "status-left", TMUX_DEFAULT_STATUS_LEFT]);
+      tmuxRun(["set", "-g", "status-left-length", TMUX_DEFAULT_STATUS_LEFT_LENGTH]);
+      tmuxRun(["set", "-g", "status-right", TMUX_DEFAULT_STATUS_RIGHT]);
+      tmuxRun(["set", "-g", "status-right-length", TMUX_DEFAULT_STATUS_RIGHT_LENGTH]);
     };
   }, []);
 

--- a/src/sdk/components/session-graph-panel.tsx
+++ b/src/sdk/components/session-graph-panel.tsx
@@ -273,13 +273,6 @@ export function SessionGraphPanel() {
       navigate("down");
       return;
     }
-    if (key.name === "tab") {
-      // Tab: attach to first available subagent
-      const subs = store.getSubagents();
-      if (subs.length > 0) doAttach(subs[0]!.name);
-      return;
-    }
-
     // Enter: attach to focused node's tmux window
     if (key.name === "return") {
       doAttach(focusedIdRef.current);

--- a/src/sdk/components/session-graph-panel.tsx
+++ b/src/sdk/components/session-graph-panel.tsx
@@ -227,13 +227,6 @@ export function SessionGraphPanel() {
         if (agent) doAttach(agent.name);
         return;
       }
-      // Number keys 1-9 for direct jump
-      const num = parseInt(key.sequence ?? "", 10);
-      if (num >= 1 && num <= store.sessions.length) {
-        closeSwitcher();
-        doAttach(store.sessions[num - 1]!.name);
-        return;
-      }
       return; // Swallow all other keys while switcher is open
     }
 

--- a/src/sdk/components/session-graph-panel.tsx
+++ b/src/sdk/components/session-graph-panel.tsx
@@ -34,6 +34,7 @@ import { NodeCard } from "./node-card.tsx";
 import { Edge } from "./edge.tsx";
 import { Header } from "./header.tsx";
 import { Statusline } from "./statusline.tsx";
+import { CompactSwitcher } from "./compact-switcher.tsx";
 
 /** Interval (ms) between pulse animation frames — ~60fps feel. */
 const PULSE_INTERVAL_MS = 60;
@@ -76,6 +77,10 @@ export function SessionGraphPanel() {
   const [focusedId, setFocusedId] = useState("");
   const focusedIdRef = useRef(focusedId);
   focusedIdRef.current = focusedId;
+
+  // Compact switcher state
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+  const [switcherSel, setSwitcherSel] = useState(0);
 
   // Update focus when sessions first appear
   useEffect(() => {
@@ -123,14 +128,39 @@ export function SessionGraphPanel() {
       const session = store.sessions.find((s) => s.name === id);
       if (!session || session.status === "pending") return;
 
+      // Orchestrator = the graph view itself
+      if (id === "orchestrator") {
+        store.setViewMode("graph");
+        return;
+      }
+
       if (attachTimerRef.current) clearTimeout(attachTimerRef.current);
       setAttachMsg(`\u2192 ${n.name}`);
       attachTimerRef.current = setTimeout(() => setAttachMsg(""), ATTACH_MSG_DISPLAY_MS);
 
+      setFocusedId(id);
+      store.setViewMode("attached", id);
       tmuxRun(["switch-client", "-t", `${tmuxSession}:${n.name}`]);
     },
     [layout.map, tmuxSession, store.sessions],
   );
+
+  const returnToGraph = useCallback(() => {
+    store.setViewMode("graph");
+  }, []);
+
+  const openSwitcher = useCallback(() => {
+    // Pre-select the current agent or focused node
+    const currentId = store.viewMode === "attached" ? store.activeAgentId : focusedIdRef.current;
+    const idx = store.sessions.findIndex((s) => s.name === currentId);
+    setSwitcherSel(Math.max(0, idx));
+    setSwitcherOpen(true);
+  }, []);
+
+  const closeSwitcher = useCallback(() => {
+    setSwitcherOpen(false);
+    setSwitcherSel(0);
+  }, []);
 
   // Spatial navigation
   const navigate = useCallback(
@@ -172,18 +202,61 @@ export function SessionGraphPanel() {
     [focusedId, layout.map, nodeList],
   );
 
-  // gg double-tap tracking
+  // gg double-tap tracking (graph mode only)
   const lastKeyRef = useRef({ key: "", time: 0 });
 
-  // Keyboard handling
+  // Keyboard handling — with Ctrl+G return-to-graph and auto-reset
   useKeyboard((key) => {
-    // Ctrl+C or q: quit the workflow (abort if running, exit if completed)
+    // ── Switcher open: intercept all keys ──
+    if (switcherOpen) {
+      if (key.name === "escape") {
+        closeSwitcher();
+        return;
+      }
+      if (key.name === "up" || key.name === "k") {
+        setSwitcherSel((s) => Math.max(0, s - 1));
+        return;
+      }
+      if (key.name === "down" || key.name === "j") {
+        setSwitcherSel((s) => Math.min(store.sessions.length - 1, s + 1));
+        return;
+      }
+      if (key.name === "return") {
+        const agent = store.sessions[switcherSel];
+        closeSwitcher();
+        if (agent) doAttach(agent.name);
+        return;
+      }
+      // Number keys 1-9 for direct jump
+      const num = parseInt(key.sequence ?? "", 10);
+      if (num >= 1 && num <= store.sessions.length) {
+        closeSwitcher();
+        doAttach(store.sessions[num - 1]!.name);
+        return;
+      }
+      return; // Swallow all other keys while switcher is open
+    }
+
+    // ── Global: Ctrl+C or q quits ──
     if ((key.ctrl && key.name === "c") || key.name === "q") {
       store.requestQuit();
       return;
     }
 
-    // Arrow keys + hjkl navigation
+    // ── Auto-reset: receiving keys while "attached" means user returned to the orchestrator window ──
+    if (store.viewMode === "attached") {
+      returnToGraph();
+      // Fall through to process the key in graph mode
+    }
+
+    // ── / opens agent switcher ──
+    if (key.sequence === "/") {
+      openSwitcher();
+      return;
+    }
+
+    // ── Graph view navigation ──
+    // Arrow keys + hjkl
     if (key.name === "left" || key.name === "h") {
       navigate("left");
       return;
@@ -201,7 +274,9 @@ export function SessionGraphPanel() {
       return;
     }
     if (key.name === "tab") {
-      navigate(key.shift ? "left" : "right");
+      // Tab: attach to first available subagent
+      const subs = store.getSubagents();
+      if (subs.length > 0) doAttach(subs[0]!.name);
       return;
     }
 
@@ -289,6 +364,63 @@ export function SessionGraphPanel() {
     }
   }, [focusedId, focused, termW, termH, padX, padY, viewportH, layout.rowH]);
 
+  // ── Detect return to graph via Ctrl+G ─────────────────
+  // Ctrl+G is bound at the tmux level (select-window -t :0), so tmux
+  // swallows the key and the React app never receives it.  Poll the
+  // active window index while attached; when window 0 becomes active
+  // again we know the user returned and can reset viewMode immediately.
+  useEffect(() => {
+    if (store.viewMode !== "attached") return;
+
+    const check = () => {
+      const result = tmuxRun([
+        "display-message", "-t", tmuxSession, "-p", "#{window_index}",
+      ]);
+      if (result.ok && result.stdout.trim() === "0") {
+        store.setViewMode("graph");
+      }
+    };
+
+    const id = setInterval(check, 300);
+    return () => clearInterval(id);
+  }, [store.viewMode, tmuxSession]);
+
+  // ── Tmux status bar sync ──────────────────────────────
+  // When attached, the orchestrator panel is hidden (user views the agent's
+  // tmux window). Mirror the status line hints into tmux's own status bar
+  // so navigation keys remain discoverable.
+  const subagentCount = store.getSubagents().length;
+  const activeAgentIdx = store.getActiveAgentIndex();
+
+  useEffect(() => {
+    if (store.viewMode === "attached" && store.activeAgentId) {
+      const name = store.activeAgentId;
+      const left = `#[bg=#6c7086,fg=#1e1e2e,bold] ATTACHED #[default] #[fg=#7f849c]\u203a #[fg=#cdd6f4]${name} #[fg=#7f849c]${activeAgentIdx + 1}/${subagentCount}`;
+      const right = `#[fg=#7f849c]Graph: #[fg=#cdd6f4]ctrl+g #[fg=#7f849c]| Next: #[fg=#cdd6f4]ctrl+\\ `;
+
+      tmuxRun(["set", "-g", "status-left", left]);
+      tmuxRun(["set", "-g", "status-left-length", "50"]);
+      tmuxRun(["set", "-g", "status-right", right]);
+      tmuxRun(["set", "-g", "status-right-length", "40"]);
+    } else {
+      // Graph mode: restore defaults from tmux.conf
+      tmuxRun(["set", "-g", "status-left", " "]);
+      tmuxRun(["set", "-g", "status-left-length", "10"]);
+      tmuxRun(["set", "-g", "status-right", " #{session_name} | %H:%M "]);
+      tmuxRun(["set", "-g", "status-right-length", "60"]);
+    }
+  }, [store.viewMode, store.activeAgentId, activeAgentIdx, subagentCount]);
+
+  // Restore default tmux status bar on unmount
+  useEffect(() => {
+    return () => {
+      tmuxRun(["set", "-g", "status-left", " "]);
+      tmuxRun(["set", "-g", "status-left-length", "10"]);
+      tmuxRun(["set", "-g", "status-right", " #{session_name} | %H:%M "]);
+      tmuxRun(["set", "-g", "status-right-length", "60"]);
+    };
+  }, []);
+
   return (
     <box width="100%" height="100%" flexDirection="column" backgroundColor={theme.background}>
       <Header />
@@ -348,6 +480,9 @@ export function SessionGraphPanel() {
           </box>
         </box>
       </scrollbox>
+
+      {/* Compact agent switcher overlay */}
+      {switcherOpen ? <CompactSwitcher selectedIndex={switcherSel} /> : null}
 
       <Statusline focusedNode={focused} attachMsg={attachMsg} />
     </box>

--- a/src/sdk/components/statusline.tsx
+++ b/src/sdk/components/statusline.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/react */
 
-import { useGraphTheme } from "./orchestrator-panel-contexts.ts";
-import { statusIcon, statusColor, statusLabel } from "./status-helpers.ts";
+import { useStore, useGraphTheme, useStoreVersion } from "./orchestrator-panel-contexts.ts";
+import { statusIcon, statusColor } from "./status-helpers.ts";
 import type { LayoutNode } from "./layout.ts";
 
 export function Statusline({
@@ -11,24 +11,25 @@ export function Statusline({
   focusedNode: LayoutNode | undefined;
   attachMsg: string;
 }) {
+  const store = useStore();
   const theme = useGraphTheme();
-  const ni = focusedNode ? statusIcon(focusedNode.status) : "";
-  const nc = focusedNode ? statusColor(focusedNode.status, theme) : theme.textDim;
+  useStoreVersion(store);
 
   return (
     <box height={1} flexDirection="row" backgroundColor={theme.backgroundElement}>
+      {/* Mode badge — always GRAPH since this bar is only visible in the orchestrator window */}
       <box backgroundColor={theme.primary} paddingLeft={1} paddingRight={1} alignItems="center">
         <text fg={theme.backgroundElement}>
           <strong>GRAPH</strong>
         </text>
       </box>
 
+      {/* Focused node info */}
       {focusedNode ? (
-        <box backgroundColor="transparent" paddingLeft={1} paddingRight={1} alignItems="center">
+        <box backgroundColor="transparent" paddingLeft={1} alignItems="center">
           <text>
-            <span fg={nc}>{ni} </span>
+            <span fg={statusColor(focusedNode.status, theme)}>{statusIcon(focusedNode.status)} </span>
             <span fg={theme.text}>{focusedNode.name}</span>
-            <span fg={theme.textMuted}> {"\u00B7"} {statusLabel(focusedNode.status)}</span>
             {focusedNode.error ? (
               <span fg={theme.error}> {"\u00B7"} {focusedNode.error}</span>
             ) : null}
@@ -38,6 +39,7 @@ export function Statusline({
 
       <box flexGrow={1} />
 
+      {/* Navigation hints — always graph-mode (tmux status bar handles attached-mode hints) */}
       <box paddingRight={2} alignItems="center">
         {attachMsg ? (
           <text fg={theme.text}>
@@ -45,11 +47,14 @@ export function Statusline({
           </text>
         ) : (
           <text>
-            <span fg={theme.text}>{"\u2191"} {"\u2193"} {"\u2190"} {"\u2192"}</span>
+            <span fg={theme.text}>{"\u2191\u2193\u2190\u2192"}</span>
             <span fg={theme.textMuted}> navigate</span>
             <span fg={theme.textDim}> {"\u00B7"} </span>
             <span fg={theme.text}>{"\u21B5"}</span>
             <span fg={theme.textMuted}> attach</span>
+            <span fg={theme.textDim}> {"\u00B7"} </span>
+            <span fg={theme.text}>/</span>
+            <span fg={theme.textMuted}> agents</span>
             <span fg={theme.textDim}> {"\u00B7"} </span>
             <span fg={theme.text}>q</span>
             <span fg={theme.textMuted}> quit</span>

--- a/src/sdk/runtime/tmux.conf
+++ b/src/sdk/runtime/tmux.conf
@@ -43,6 +43,13 @@ bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
 bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
+# ── Atomic workflow navigation (prefix-free) ──────────────
+# Ctrl+G: jump straight back to the graph (window 0) from any agent window
+bind -n C-g select-window -t :0
+
+# Ctrl+\: cycle to next agent window from anywhere
+bind -n C-\\ next-window
+
 # Escape exits copy-mode (clear selection first if one exists, otherwise cancel)
 bind-key -T copy-mode-vi Escape if-shell -F "#{selection_present}" "send-keys -X clear-selection" "send-keys -X cancel"
 

--- a/src/sdk/runtime/tmux.conf
+++ b/src/sdk/runtime/tmux.conf
@@ -21,6 +21,8 @@ set -g focus-events on
 setw -g aggressive-resize on
 
 # Status bar — minimal
+# These defaults are mirrored by TMUX_DEFAULT_STATUS_* constants in tmux.ts.
+# Keep both in sync when changing.
 set -g status-left " "
 set -g status-right " #{session_name} | %H:%M "
 set -g status-right-length 60

--- a/src/sdk/runtime/tmux.conf
+++ b/src/sdk/runtime/tmux.conf
@@ -46,6 +46,15 @@ bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
 bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
 # ── Atomic workflow navigation (prefix-free) ──────────────
+# These bindings use `bind -n` (root table) so they work without a prefix key.
+# They only apply inside Atomic's isolated tmux server (-L atomic) and do NOT
+# affect the user's regular tmux or shell sessions.
+#
+# NOTE: Ctrl+\ overrides the default SIGQUIT signal.  Agent CLIs running in
+# these panes will not receive SIGQUIT via Ctrl+\.  Use `kill -QUIT <pid>` if
+# needed.  The integrated agents (Claude Code, OpenCode, Copilot CLI) use
+# Ctrl+C for interrupts and are not affected.
+
 # Ctrl+G: jump straight back to the graph (window 0) from any agent window
 bind -n C-g select-window -t :0
 

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -170,6 +170,9 @@ export function createSession(
   }
   args.push(initialCommand);
   const paneId = tmux(args);
+  // Reload config into the running server so keybindings are always current
+  // (tmux only loads -f on first server start; source-file updates a running server).
+  tmuxRun(["source-file", CONFIG_PATH]);
   return paneId || tmux(["list-panes", "-t", sessionName, "-F", "#{pane_id}"]).split("\n")[0]!;
 }
 

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -23,6 +23,29 @@ const CONFIG_PATH = join(import.meta.dir, "tmux.conf");
 // Core tmux primitives
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Default status-bar values — must match tmux.conf.
+// Centralised here so restore logic in session-graph-panel stays in sync.
+// ---------------------------------------------------------------------------
+
+export const TMUX_DEFAULT_STATUS_LEFT = " ";
+export const TMUX_DEFAULT_STATUS_LEFT_LENGTH = "10";
+export const TMUX_DEFAULT_STATUS_RIGHT = " #{session_name} | %H:%M ";
+export const TMUX_DEFAULT_STATUS_RIGHT_LENGTH = "60";
+
+/**
+ * Escape a string for safe interpolation into tmux format strings.
+ * Replaces `#` with `##` to prevent tmux from interpreting `#[...]`
+ * as style directives or `#(...)` as shell command expansions.
+ */
+export function escapeTmuxFormat(value: string): string {
+  return value.replace(/#/g, "##");
+}
+
+// ---------------------------------------------------------------------------
+// Core tmux primitives
+// ---------------------------------------------------------------------------
+
 /** Cached resolved multiplexer binary path. Resolved once on first use. */
 let resolvedMuxBinary: string | null | undefined; // undefined = not yet resolved
 

--- a/tests/sdk/components/session-graph-panel.test.tsx
+++ b/tests/sdk/components/session-graph-panel.test.tsx
@@ -168,31 +168,6 @@ describe("SessionGraphPanel", () => {
       expect(frame).toContain("orchestrator");
     });
 
-    test("tab moves focus right", async () => {
-      const store = createPopulatedStore();
-      const setup = await renderPanel(store);
-
-      setup.mockInput.pressTab();
-      await setup.renderOnce();
-
-      const frame = setup.captureCharFrame();
-      expect(frame).toContain("worker-1");
-    });
-
-    test("shift+tab moves focus left", async () => {
-      const store = createPopulatedStore();
-      const setup = await renderPanel(store);
-
-      // First move right, then shift-tab back
-      setup.mockInput.pressTab();
-      await setup.renderOnce();
-      setup.mockInput.pressTab({ shift: true });
-      await setup.renderOnce();
-
-      const frame = setup.captureCharFrame();
-      expect(frame).toContain("orchestrator");
-    });
-
     test("G (shift+g) moves to deepest node", async () => {
       const store = createPopulatedStore();
       const setup = await renderPanel(store);

--- a/tests/sdk/components/statusline.test.tsx
+++ b/tests/sdk/components/statusline.test.tsx
@@ -82,7 +82,8 @@ describe("Statusline", () => {
     await testSetup.renderOnce();
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("my-session");
-    expect(frame).toContain("running");
+    // Status is shown as an icon (●) rather than text label in the redesigned statusline
+    expect(frame).toContain("\u25CF");
   });
 
   test("shows error info for errored focused node", async () => {


### PR DESCRIPTION
## Summary

Adds full keyboard navigation between the orchestrator graph view and attached agent views, a compact agent-switcher popup (`/`), and prefix-free tmux keybindings (`Ctrl+G`, `Ctrl+\`) for navigating the multi-agent workflow from any window.

## Key Changes

### View Mode State (`orchestrator-panel-types.ts`, `orchestrator-panel-store.ts`)
- Added `ViewMode` type (`"graph" | "attached"`) to `orchestrator-panel-types.ts`
- `PanelStore` gains `viewMode` / `activeAgentId` state plus `setViewMode()`, `getSubagents()`, and `getActiveAgentIndex()` methods

### Orchestrator Navigation (`session-graph-panel.tsx`)
- **Auto-reset**: any key received while `viewMode === "attached"` (i.e. user returned to the orchestrator tmux window) automatically resets to graph mode
- Polls active tmux window index every 300ms to detect `Ctrl+G` graph-return (tmux swallows the key before React sees it)
- `Enter` on the orchestrator node stays in / returns to graph mode instead of switching windows
- Removed `Tab`/`Shift+Tab` graph-grid cycling (now handled at the tmux level)
- Syncs navigation hints into the tmux status bar while in attached mode; restores defaults on unmount

### Compact Switcher (`compact-switcher.tsx`)
- New `CompactSwitcher` popup component, opened with `/` from any view
- Lists all agents with status icons, numbering, and elapsed duration
- `↑`/`↓` or `j`/`k` to navigate, `Enter` to attach, `Esc` to close
- Pre-selects the currently active or focused agent when opened

### Tmux Keybindings (`tmux.conf`, `tmux.ts`)
- `Ctrl+G` — jump straight back to graph (window 0) from any agent window (prefix-free)
- `Ctrl+\` — cycle to the next agent window (prefix-free); note: overrides the default SIGQUIT signal
- `tmux.ts` now runs `source-file` after session creation so keybindings are always current in a running server
- Exported `TMUX_DEFAULT_STATUS_*` constants and `escapeTmuxFormat()` to keep status-bar sync centralized

### Statusline (`statusline.tsx`)
- Shows focused node status as icon (`●`/`✓`/`✗`/`○`) instead of a text label
- Adds `/` agents hint to the navigation bar
- Removes `Tab`/`Shift+Tab` hints (no longer applicable)

### Tests & Config
- New tests for `setViewMode`, `getSubagents`, `getActiveAgentIndex` in `orchestrator-panel-store.test.ts`
- Removed `Tab`/`Shift+Tab` graph-navigation tests from `session-graph-panel.test.tsx`
- Updated `statusline.test.tsx` to assert icon-based status rendering (`●`) instead of text label
- Excluded new UI components (`compact-switcher.tsx`, `session-graph-panel.tsx`) from coverage in `bunfig.toml`

### Design Prototype
- Added `research/designs/option3-refined-prototype.html` — interactive single-file prototype demonstrating the full keyboard UX (graph nav, attach, switcher, breadcrumb statusline)

## Notes

- `Ctrl+\` overrides the default SIGQUIT signal. Agent CLIs in these panes will not receive SIGQUIT via `Ctrl+\`. The integrated agents (Claude Code, OpenCode, Copilot CLI) use `Ctrl+C` for interrupts and are unaffected.
- The prefix-free bindings only apply inside Atomic's isolated tmux server (`-L atomic`) and do not affect the user's regular tmux sessions.