### PR TITLE
chore(release): bump version to v0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.5-0",
+  "version": "0.5.5",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",
@@ -56,7 +56,9 @@
     "lint:fix": "oxlint --config=oxlint.json --fix src",
     "prepare": "lefthook install || true"
   },
-  "trustedDependencies": ["lefthook"],
+  "trustedDependencies": [
+    "lefthook"
+  ],
   "devDependencies": {
     "@types/bun": "^1.3.12",
     "@types/react": "^19.2.14",


### PR DESCRIPTION
## Summary

Promotes the prerelease version \`0.5.5-0\` to the stable release \`0.5.5\`.

## Changes

- **`package.json`**: Version bumped from \`0.5.5-0\` → \`0.5.5\`
- **`package.json`**: Minor formatting fix — expanded \`trustedDependencies\` array to multi-line style

## Test plan

- [x] All 880 tests pass
- [x] Type checks pass
- [x] Lint passes