### PR TITLE
chore(release): bump version to v0.5.6-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.5",
+  "version": "0.5.6-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.5` → `0.5.6-0` in preparation for the next minor release.

## Changes

- `package.json`: version updated from `0.5.5` to `0.5.6-0`

## Test plan

- [ ] CI passes
- [ ] Version is correctly reflected in `package.json`