### PR TITLE
chore(release): bump version to v0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.6-0",
+  "version": "0.5.6",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.6-0` to the stable release `0.5.6` by updating the version field in `package.json`.

## Changes

- Bumps `package.json` version from `0.5.6-0` to `0.5.6`

## Test plan

- [x] All 967 tests pass
- [x] Typecheck passes
- [x] Lint passes