### PR TITLE
fix(cli): fix zsh completions and eliminate Node.js/npm startup bottleneck

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/common-utils": {},
-    "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
     "ghcr.io/devcontainers-extra/features/tmux-apt-get:1": {},
     "ghcr.io/devcontainers-extra/features/bun:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},

--- a/devcontainer-features/src/claude/devcontainer-feature.json
+++ b/devcontainer-features/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "claude",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "name": "Atomic + Claude Code",
   "description": "Installs Atomic CLI with Claude Code agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",
@@ -13,7 +13,6 @@
     }
   },
   "dependsOn": {
-    "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
     "ghcr.io/devcontainers-extra/features/tmux-apt-get:1": {},
     "ghcr.io/devcontainers-extra/features/bun:1": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}

--- a/devcontainer-features/src/claude/install.sh
+++ b/devcontainer-features/src/claude/install.sh
@@ -81,21 +81,10 @@ chmod 644 /etc/profile.d/atomic-path.sh
 
 echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 
-# ─── Install global npm CLI tools ───────────────────────────────────────────
-# Source NVM (installed by the dependent node feature) so npm resolves to the
-# NVM-managed binary, then fix group permissions so the non-root container user
-# (already in the `nvm` group) can install packages later without permission errors.
-# This mirrors how devcontainers/features/node installs pnpm.
-NVM_DIR="${NVM_DIR:-"/usr/local/share/nvm"}"
-echo "Installing global npm CLI tools..."
-if [ -s "${NVM_DIR}/nvm.sh" ]; then
-    (. "${NVM_DIR}/nvm.sh" && npm install -g @playwright/cli @llamaindex/liteparse) 2>&1 \
-        && { echo "✓ Global npm CLI tools installed"; chmod -R g+rw "${NVM_DIR}/versions" 2>/dev/null || true; } \
-        || echo "⚠ Some global npm CLI tools failed to install (non-fatal)"
-else
-    npm install -g @playwright/cli @llamaindex/liteparse 2>&1 \
-        && echo "✓ Global npm CLI tools installed" \
-        || echo "⚠ Some global npm CLI tools failed to install (non-fatal)"
-fi
-command -v playwright >/dev/null && echo "✓ playwright available"
-command -v lit >/dev/null && echo "✓ liteparse (lit) available"
+# ─── Install global CLI tools via bun ──────────────────────────────────────
+# Use bun (already installed) with --trust to allow postinstall lifecycle
+# scripts (e.g. playwright browser downloads).
+echo "Installing global CLI tools..."
+su - "${REMOTE_USER}" -c "bun install -g --trust @playwright/cli@latest @llamaindex/liteparse@latest" 2>&1 \
+    && echo "✓ Global CLI tools installed" \
+    || echo "⚠ Some global CLI tools failed to install (non-fatal)"

--- a/devcontainer-features/src/copilot/devcontainer-feature.json
+++ b/devcontainer-features/src/copilot/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "name": "Atomic + Copilot CLI",
   "description": "Installs Atomic CLI with GitHub Copilot agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",
@@ -13,7 +13,6 @@
     }
   },
   "dependsOn": {
-    "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
     "ghcr.io/devcontainers-extra/features/tmux-apt-get:1": {},
     "ghcr.io/devcontainers-extra/features/bun:1": {},
     "ghcr.io/devcontainers/features/copilot-cli:1": {}

--- a/devcontainer-features/src/copilot/install.sh
+++ b/devcontainer-features/src/copilot/install.sh
@@ -81,21 +81,10 @@ chmod 644 /etc/profile.d/atomic-path.sh
 
 echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 
-# ─── Install global npm CLI tools ───────────────────────────────────────────
-# Source NVM (installed by the dependent node feature) so npm resolves to the
-# NVM-managed binary, then fix group permissions so the non-root container user
-# (already in the `nvm` group) can install packages later without permission errors.
-# This mirrors how devcontainers/features/node installs pnpm.
-NVM_DIR="${NVM_DIR:-"/usr/local/share/nvm"}"
-echo "Installing global npm CLI tools..."
-if [ -s "${NVM_DIR}/nvm.sh" ]; then
-    (. "${NVM_DIR}/nvm.sh" && npm install -g @playwright/cli @llamaindex/liteparse) 2>&1 \
-        && { echo "✓ Global npm CLI tools installed"; chmod -R g+rw "${NVM_DIR}/versions" 2>/dev/null || true; } \
-        || echo "⚠ Some global npm CLI tools failed to install (non-fatal)"
-else
-    npm install -g @playwright/cli @llamaindex/liteparse 2>&1 \
-        && echo "✓ Global npm CLI tools installed" \
-        || echo "⚠ Some global npm CLI tools failed to install (non-fatal)"
-fi
-command -v playwright >/dev/null && echo "✓ playwright available"
-command -v lit >/dev/null && echo "✓ liteparse (lit) available"
+# ─── Install global CLI tools via bun ──────────────────────────────────────
+# Use bun (already installed) with --trust to allow postinstall lifecycle
+# scripts (e.g. playwright browser downloads).
+echo "Installing global CLI tools..."
+su - "${REMOTE_USER}" -c "bun install -g --trust @playwright/cli@latest @llamaindex/liteparse@latest" 2>&1 \
+    && echo "✓ Global CLI tools installed" \
+    || echo "⚠ Some global CLI tools failed to install (non-fatal)"

--- a/devcontainer-features/src/opencode/devcontainer-feature.json
+++ b/devcontainer-features/src/opencode/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "name": "Atomic + OpenCode",
   "description": "Installs Atomic CLI with OpenCode agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",
@@ -13,7 +13,6 @@
     }
   },
   "dependsOn": {
-    "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
     "ghcr.io/devcontainers-extra/features/tmux-apt-get:1": {},
     "ghcr.io/devcontainers-extra/features/bun:1": {},
     "ghcr.io/devcontainers-extra/features/opencode:1": {}

--- a/devcontainer-features/src/opencode/install.sh
+++ b/devcontainer-features/src/opencode/install.sh
@@ -81,21 +81,10 @@ chmod 644 /etc/profile.d/atomic-path.sh
 
 echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 
-# ─── Install global npm CLI tools ───────────────────────────────────────────
-# Source NVM (installed by the dependent node feature) so npm resolves to the
-# NVM-managed binary, then fix group permissions so the non-root container user
-# (already in the `nvm` group) can install packages later without permission errors.
-# This mirrors how devcontainers/features/node installs pnpm.
-NVM_DIR="${NVM_DIR:-"/usr/local/share/nvm"}"
-echo "Installing global npm CLI tools..."
-if [ -s "${NVM_DIR}/nvm.sh" ]; then
-    (. "${NVM_DIR}/nvm.sh" && npm install -g @playwright/cli @llamaindex/liteparse) 2>&1 \
-        && { echo "✓ Global npm CLI tools installed"; chmod -R g+rw "${NVM_DIR}/versions" 2>/dev/null || true; } \
-        || echo "⚠ Some global npm CLI tools failed to install (non-fatal)"
-else
-    npm install -g @playwright/cli @llamaindex/liteparse 2>&1 \
-        && echo "✓ Global npm CLI tools installed" \
-        || echo "⚠ Some global npm CLI tools failed to install (non-fatal)"
-fi
-command -v playwright >/dev/null && echo "✓ playwright available"
-command -v lit >/dev/null && echo "✓ liteparse (lit) available"
+# ─── Install global CLI tools via bun ──────────────────────────────────────
+# Use bun (already installed) with --trust to allow postinstall lifecycle
+# scripts (e.g. playwright browser downloads).
+echo "Installing global CLI tools..."
+su - "${REMOTE_USER}" -c "bun install -g --trust @playwright/cli@latest @llamaindex/liteparse@latest" 2>&1 \
+    && echo "✓ Global CLI tools installed" \
+    || echo "⚠ Some global CLI tools failed to install (non-fatal)"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -327,7 +327,8 @@ async function main(): Promise<void> {
             argv.includes("--version") ||
             argv.includes("-v") ||
             argv.includes("--help") ||
-            argv.includes("-h");
+            argv.includes("-h") ||
+            argv[0] === "completions";
 
         if (!isInfoCommand) {
             const { autoSyncIfStale } = await import("./services/system/auto-sync.ts");

--- a/src/completions/zsh.ts
+++ b/src/completions/zsh.ts
@@ -140,5 +140,5 @@ _atomic_session() {
     esac
 }
 
-_atomic "$@"
+compdef _atomic atomic
 `;

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -99,228 +99,19 @@ export interface EnsureOptions {
 }
 
 /**
- * Ensure npm is installed, attempting to install Node.js via available system
- * package managers when missing.
- *
- * No-op when npm is already on PATH.
- */
-
-
-async function installNodeViaFnm(quiet: boolean): Promise<boolean> {
-  const inherit = !quiet;
-  // Install fnm if not present.
-  if (!Bun.which("fnm")) {
-    let installed = false;
-    // macOS: prefer Homebrew
-    if (process.platform === "darwin" && Bun.which("brew")) {
-      const brew = await runCommand(
-        [Bun.which("brew")!, "install", "fnm"],
-        { inherit },
-      );
-      installed = brew.success;
-    }
-    // Windows: prefer winget
-    if (!installed && process.platform === "win32" && Bun.which("winget")) {
-      const winget = await runCommand(
-        [Bun.which("winget")!, "install", "Schniz.fnm"],
-        { inherit },
-      );
-      if (winget.success) {
-        // Refresh PATH — winget installs to a location on the user PATH.
-        const userPath = process.env.LOCALAPPDATA
-          ? join(process.env.LOCALAPPDATA, "Microsoft", "WinGet", "Links")
-          : null;
-        if (userPath) prependPath(userPath);
-      }
-      installed = winget.success;
-    }
-    // Linux / fallback: use the curl installer (requires a shell)
-    if (!installed) {
-      const shell = Bun.which("bash") ?? Bun.which("sh");
-      if (!shell) return false;
-
-      const curl = await runCommand(
-        [shell, "-lc", "curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell"],
-        { inherit },
-      );
-      if (!curl.success) return false;
-
-      // Add fnm to PATH for the current session.
-      const home = getHomeDir() ?? "/tmp";
-      const fnmDir = process.env.FNM_DIR ?? join(home, ".local", "share", "fnm");
-      prependPath(fnmDir);
-      // Some systems install to ~/.fnm instead
-      prependPath(join(home, ".fnm"));
-    }
-  }
-
-  const fnmPath = Bun.which("fnm");
-  if (!fnmPath) return false;
-
-  // Install LTS Node.js via fnm.
-  const fnmInstall = await runCommand(
-    [fnmPath, "install", "--lts"],
-    { inherit },
-  );
-  if (!fnmInstall.success) return false;
-
-  // Activate the installed version by adding its bin dir to PATH.
-  const envShell = process.platform === "win32" ? "cmd" : "bash";
-  const envProc = Bun.spawn({
-    cmd: [fnmPath, "env", "--shell", envShell],
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [envOutput, envExitCode] = await Promise.all([
-    new Response(envProc.stdout).text(),
-    envProc.exited,
-  ]);
-  if (envExitCode === 0) {
-    if (process.platform === "win32") {
-      // cmd output: SET "PATH=C:\...\fnm_multishells\...;..."
-      const pathMatch = envOutput.match(/SET "PATH=([^"]+?)"/i);
-      if (pathMatch?.[1]) {
-        const firstEntry = pathMatch[1].split(";")[0];
-        if (firstEntry) prependPath(firstEntry);
-      }
-    } else {
-      // bash output: export PATH="/.../fnm_multishells/...:..."
-      const pathMatch = envOutput.match(/export PATH="([^"]+?):/);
-      if (pathMatch?.[1]) {
-        prependPath(pathMatch[1]);
-      }
-    }
-  }
-
-  return !!Bun.which("node");
-}
-
-export async function ensureNpmInstalled(options: EnsureOptions = {}): Promise<void> {
-  const quiet = options.quiet ?? false;
-  const inherit = !quiet;
-
-  if (Bun.which("npm")) {
-    return;
-  }
-
-  // Buffer captured failure output so a thrown error can surface the tail
-  // through the spinner summary. Only populated when `quiet` is set.
-  let capturedDetails = "";
-  const record = (result: SpawnResult) => {
-    if (quiet && !result.success && result.details) {
-      capturedDetails = result.details;
-    }
-  };
-
-  // Preferred: install via fnm (no root required, works on all platforms).
-  if (await installNodeViaFnm(quiet)) {
-    return;
-  }
-
-  if (process.platform === "win32") {
-    // Fallback: direct Node.js installation via Windows package managers.
-    if (Bun.which("winget")) {
-      record(
-        await runCommand(
-          [
-            "winget",
-            "install",
-            "--id",
-            "OpenJS.NodeJS.LTS",
-            "-e",
-            "--silent",
-            "--accept-source-agreements",
-            "--accept-package-agreements",
-          ],
-          { inherit },
-        ),
-      );
-    } else if (Bun.which("choco")) {
-      record(
-        await runCommand(
-          ["choco", "install", "nodejs-lts", "-y", "--no-progress"],
-          { inherit },
-        ),
-      );
-    } else if (Bun.which("scoop")) {
-      record(
-        await runCommand(["scoop", "install", "nodejs-lts"], { inherit }),
-      );
-    }
-
-    const programFiles = process.env.ProgramFiles;
-    if (programFiles) {
-      prependPath(join(programFiles, "nodejs"));
-    }
-    if (Bun.which("npm")) return;
-    throw new Error(
-      capturedDetails || "Could not install Node.js on Windows (no supported package manager found).",
-    );
-  }
-
-  const shell = Bun.which("bash") ?? Bun.which("sh");
-  if (!shell) {
-    throw new Error("Neither bash nor sh is available to install Node.js.");
-  }
-
-  // Fallback: Homebrew, NodeSource, then system package managers.
-  const installers = [
-    'if command -v brew >/dev/null 2>&1; then brew install node && brew link --overwrite node 2>/dev/null; fi',
-    'if command -v apt-get >/dev/null 2>&1; then SUDO=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"; $SUDO apt-get update && $SUDO apt-get install -y nodejs npm; fi',
-    'if command -v dnf >/dev/null 2>&1; then if command -v sudo >/dev/null 2>&1; then sudo dnf install -y nodejs npm; elif [ "$(id -u)" -eq 0 ]; then dnf install -y nodejs npm; fi; fi',
-    'if command -v yum >/dev/null 2>&1; then if command -v sudo >/dev/null 2>&1; then sudo yum install -y nodejs npm; elif [ "$(id -u)" -eq 0 ]; then yum install -y nodejs npm; fi; fi',
-    'if command -v pacman >/dev/null 2>&1; then if command -v sudo >/dev/null 2>&1; then sudo pacman -Sy --noconfirm nodejs npm; elif [ "$(id -u)" -eq 0 ]; then pacman -Sy --noconfirm nodejs npm; fi; fi',
-    'if command -v zypper >/dev/null 2>&1; then if command -v sudo >/dev/null 2>&1; then sudo zypper --non-interactive install nodejs npm; elif [ "$(id -u)" -eq 0 ]; then zypper --non-interactive install nodejs npm; fi; fi',
-    'if command -v apk >/dev/null 2>&1; then if command -v sudo >/dev/null 2>&1; then sudo apk add --no-cache nodejs npm; elif [ "$(id -u)" -eq 0 ]; then apk add --no-cache nodejs npm; fi; fi',
-  ];
-
-  for (const script of installers) {
-    if (Bun.which("npm")) {
-      return;
-    }
-    record(await runCommand([shell, "-lc", script], { inherit }));
-    if (Bun.which("npm")) {
-      return;
-    }
-  }
-
-  throw new Error(
-    capturedDetails || "Could not install Node.js — no supported package manager succeeded.",
-  );
-}
-
-/**
- * Upgrade npm to the latest version.
- * Falls back to installing Node.js/npm if it is not yet present.
- */
-export async function upgradeNpm(): Promise<void> {
-  const npmPath = Bun.which("npm");
-  if (!npmPath) {
-    await ensureNpmInstalled();
-    return;
-  }
-  const result = await runCommand([npmPath, "install", "-g", "npm@latest"]);
-  if (!result.success) {
-    const hint =
-      result.details?.includes("EACCES") || result.details?.includes("permission")
-        ? "\nIf this is a permissions issue, try: sudo npm install -g npm@latest"
-        : "";
-    throw new Error(`npm self-upgrade failed: ${result.details}${hint}`);
-  }
-}
-
-/**
- * Upgrade a global npm package to the latest version.
+ * Install a global package via bun. Uses `--trust` to allow postinstall
+ * lifecycle scripts (required by packages like @playwright/cli).
  */
 export async function upgradeGlobalPackage(pkg: string): Promise<void> {
   const versionedPkg = pkg.includes("@latest") ? pkg : `${pkg}@latest`;
-  const npmPath = Bun.which("npm");
-  if (npmPath) {
-    const result = await runCommand([npmPath, "install", "-g", versionedPkg]);
-    if (result.success) return;
-    throw new Error(`Failed to upgrade ${pkg}: npm: ${result.details}`);
+  const bunPath = Bun.which("bun");
+  if (!bunPath) {
+    throw new Error(`bun is not available to install ${pkg}.`);
   }
-  throw new Error(`npm is not available to upgrade ${pkg}.`);
+  const result = await runCommand([bunPath, "install", "-g", "--trust", versionedPkg]);
+  if (!result.success) {
+    throw new Error(`Failed to install ${pkg}: ${result.details}`);
+  }
 }
 
 /** Upgrade @playwright/cli to the latest version globally. */
@@ -455,11 +246,6 @@ export async function ensureBunInstalled(): Promise<void> {
       if (result.success && Bun.which("bun")) return;
     }
 
-    const npmPath = Bun.which("npm");
-    if (npmPath) {
-      const result = await runCommand([npmPath, "install", "-g", "bun"], { inherit: true });
-      if (result.success && Bun.which("bun")) return;
-    }
     return;
   }
 

--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -11,19 +11,18 @@
  * comparing the bundled `VERSION` constant against a marker file at
  * `~/.atomic/.synced-version`. On a mismatch we run the same setup the
  * production bootstrap installers (`install.sh` / `install.ps1`) provide,
- * grouped into two parallel phases:
+ * as a single parallel phase:
  *
- *   Phase 1 (parallel — no inter-dependencies):
- *     1. Node.js / npm           (installed via fnm, no system pkg-mgr)
- *     2. tmux / psmux            (terminal multiplexer for `chat` / `workflow`)
- *     3. global agent configs    (file copies — no network)
+ *     1. tmux / psmux            (terminal multiplexer for `chat` / `workflow`)
+ *     2. global agent configs    (file copies — no network)
+ *     3. @playwright/cli         (bun install -g)
+ *     4. @llamaindex/liteparse   (bun install -g)
+ *     5. global skills           (bunx skills add ...)
  *
- *   Phase 2 (parallel — all need npm from Phase 1):
- *     4. @playwright/cli         (npm install -g)
- *     5. @llamaindex/liteparse   (npm install -g)
- *     6. global skills           (npx skills add ...)
+ * All steps run concurrently using bun (already our runtime) for package
+ * installs and `bunx` for CLI tools, avoiding a ~48 s Node.js/npm
+ * download via fnm that previously gated Phase 2.
  *
- * Steps within each phase run concurrently; phases run sequentially.
  * Failures are collected and reported as a summary at the end, but never
  * abort the run — partial setup matches the production installer's
  * "best-effort" semantics. The marker is written after every run (success
@@ -36,7 +35,6 @@ import { homedir } from "node:os";
 import { VERSION } from "../../version.ts";
 import { COLORS } from "../../theme/colors.ts";
 import {
-  ensureNpmInstalled,
   ensureTmuxInstalled,
   upgradePlaywrightCli,
   upgradeLiteparse,
@@ -93,33 +91,21 @@ export async function autoSyncIfStale(): Promise<void> {
     `\n  ${COLORS.dim}Setting up atomic ${COLORS.reset}${COLORS.bold}v${VERSION}${COLORS.reset}${COLORS.dim}…${COLORS.reset}`,
   );
 
-  // Steps are split into two parallel phases:
-  //
-  //  Phase 1 — core tools + file copies (no inter-dependencies):
-  //    npm is installed via fnm (not a system package manager), so it
-  //    won't contend with tmux's apt-get/dnf install. Agent config
-  //    copies are pure file I/O with no network or npm dependency.
-  //
-  //  Phase 2 — npm-dependent tasks (run after Phase 1):
-  //    @playwright/cli, @llamaindex/liteparse, and `npx skills` all
-  //    need npm/npx. They install independent packages, so they can
-  //    run concurrently.
+  // All steps run in a single parallel phase. bun (already our runtime)
+  // handles global package installs and `bunx` execution, so there is no
+  // need to install Node.js/npm first — eliminating a ~48 s fnm download
+  // that previously dominated the loading screen.
   //
   // Each step's failure is caught inside `runSteps` (not thrown), so
   // subsequent steps still run even if one fails — matches install.sh's
   // best-effort contract.
   const results = await runSteps([
-    // Phase 1 — parallel
     [
-      { label: "Node.js / npm",        fn: () => ensureNpmInstalled({ quiet: true }) },
       { label: "tmux / psmux",         fn: () => ensureTmuxInstalled({ quiet: true }) },
       { label: "global agent configs", fn: installGlobalAgents },
-    ],
-    // Phase 2 — parallel, after Phase 1
-    [
-      { label: "@playwright/cli",       fn: upgradePlaywrightCli },
+      { label: "@playwright/cli",      fn: upgradePlaywrightCli },
       { label: "@llamaindex/liteparse", fn: upgradeLiteparse },
-      { label: "global skills",         fn: installGlobalSkills },
+      { label: "global skills",        fn: installGlobalSkills },
     ],
   ]);
 

--- a/src/services/system/install-ui.ts
+++ b/src/services/system/install-ui.ts
@@ -11,10 +11,9 @@
  * that falls back gracefully through 256-color → basic ANSI.
  *
  * Steps are grouped into **phases**. Steps within a phase run in parallel
- * (via `Promise.all`); phases themselves run sequentially so later phases
- * can depend on earlier ones (e.g. npm must be available before
- * `npm install -g` tasks). The progress bar advances and the label
- * updates in real-time as individual steps complete within a phase.
+ * (via `Promise.all`); phases themselves run sequentially. The progress
+ * bar advances and the label updates in real-time as individual steps
+ * complete within a phase.
  *
  * A final summary (✓/✗ per step) is printed after all steps finish, and
  * any captured stderr/stdout from a failed step is shown beneath it.

--- a/src/services/system/skills.ts
+++ b/src/services/system/skills.ts
@@ -18,15 +18,20 @@ interface NpxSkillsResult {
 }
 
 async function runNpxSkills(args: string[]): Promise<NpxSkillsResult> {
-  const npxPath = Bun.which("npx");
-  if (!npxPath) {
-    return { ok: false, details: "npx not found on PATH" };
+  // Prefer bunx (already available as our runtime) over npx to avoid
+  // depending on a full Node.js/npm installation.
+  const runner = Bun.which("bunx") ?? Bun.which("npx");
+  if (!runner) {
+    return { ok: false, details: "neither bunx nor npx found on PATH" };
   }
 
   // Capture stdout/stderr so the outer spinner UI owns terminal output and
-  // can surface the tail of any failure. `npx skills add` is otherwise
-  // very chatty.
-  const proc = Bun.spawn([npxPath, "--yes", "skills", ...args], {
+  // can surface the tail of any failure.
+  const isBunx = runner.endsWith("bunx");
+  const cmd = isBunx
+    ? [runner, "skills", ...args]
+    : [runner, "--yes", "skills", ...args];
+  const proc = Bun.spawn(cmd, {
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
## Summary

Fixes broken zsh shell completions and removes the ~48s Node.js/npm installation bottleneck from the startup auto-sync flow by migrating all global package management from npm to bun.

## Key Changes

### Bug Fixes
- **zsh completions**: Replace `_atomic "$@"` with `compdef _atomic atomic` in the generated completion script for correct zsh completion registration
- **completions command**: Skip auto-sync during `atomic completions` invocations so tab-completion does not trigger the setup flow

### Performance
- **Startup time**: Remove the two-phase auto-sync (Phase 1: install Node.js/npm via fnm ~48s, Phase 2: npm-dependent installs) and collapse to a single parallel phase — bun is already available as the runtime
- All `@playwright/cli`, `@llamaindex/liteparse`, and `skills` installs now run concurrently on startup with no blocking Node.js download

### Refactor
- **`src/lib/spawn.ts`**: Delete `ensureNpmInstalled`, `upgradeNpm`, and `installNodeViaFnm` (~210 lines removed); `upgradeGlobalPackage` now uses `bun install -g --trust`
- **`src/services/system/skills.ts`**: Use `bunx` (falling back to `npx`) for running the `skills` CLI tool
- **Devcontainer features** (claude, copilot, opencode v1.0.10 → v1.0.11): Drop `ghcr.io/devcontainers/features/node:1` dependency; replace NVM/npm global install script with `bun install -g --trust`
- **`.devcontainer/devcontainer.json`**: Remove Node.js devcontainer feature