### PR TITLE
chore(release): bump version to v0.5.7-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.6",
+  "version": "0.5.7-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.6` to `0.5.7-0` as a prerelease ahead of the `v0.5.7` release.

## Changes

- `package.json`: version `0.5.6` → `0.5.7-0`

## Notes

- Version bump generated via `bun run src/scripts/bump-version.ts --from-branch`
- No functional changes; this is a release preparation commit

## Test plan

- [x] `bun typecheck` passes
- [x] `bun test` passes (957 tests, 0 failures)
- [x] Version correctly updated in `package.json`