### PR TITLE
chore(release): bump version to v0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `0.5.7-0` to the stable `0.5.7` release by updating the version field in `package.json`.

## Changes

- `package.json`: `0.5.7-0` → `0.5.7`

## What's in v0.5.7

Changes included since `v0.5.6`:

- **fix(cli)**: fix zsh completions and eliminate Node.js/npm startup bottleneck (#596)
- **fix(ux)**: use tmux native window list for attached-mode status bar (#595)
- **refactor(ux)**: remove dead code from pre-native-window-list implementation (#594)
- **perf(ux)**: defer tmux window polling until an agent starts
- **docs(readme)**: update workflow list from flag to subcommand (#593)

## Test plan

- [ ] CI passes
- [ ] Version is correctly set to `0.5.7` in `package.json`
- [ ] Merge triggers automated GitHub Release and npm publish