### PR TITLE
fix(auto-sync): retry setup on next launch when any step fails

### DIFF
--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -25,9 +25,9 @@
  *
  * Failures are collected and reported as a summary at the end, but never
  * abort the run — partial setup matches the production installer's
- * "best-effort" semantics. The marker is written after every run (success
- * or partial) so we don't re-attempt the whole setup on every subsequent
- * launch.
+ * "best-effort" semantics. The marker is only written when every step
+ * succeeds; on partial failure the next launch re-runs all steps (they
+ * are idempotent, so re-running already-succeeded steps is harmless).
  */
 
 import { join } from "node:path";
@@ -109,18 +109,21 @@ export async function autoSyncIfStale(): Promise<void> {
     ],
   ]);
 
-  // Always write the marker — partial setup is the production-installer
-  // contract. Re-running the bootstrap installer or `bun update -g
-  // @bastani/atomic` is the recovery path for a failed setup.
-  await markSynced();
+  const failures = results.filter((r) => !r.ok);
+
+  // Only write the marker when every step succeeded. On partial failure
+  // the next launch will re-run all steps — they're idempotent, so
+  // re-running already-succeeded steps is cheap and harmless.
+  if (failures.length === 0) {
+    await markSynced();
+  }
 
   displayBlockBanner();
   printSummary(results);
 
-  const failures = results.filter((r) => !r.ok);
   if (failures.length > 0) {
     console.log(
-      `\n  ${COLORS.dim}Re-run \`bun install -g @bastani/atomic\` after resolving the issues to retry.${COLORS.reset}\n`,
+      `\n  ${COLORS.dim}Setup will retry on next launch. To retry now, re-run your command.${COLORS.reset}\n`,
     );
   } else {
     console.log(


### PR DESCRIPTION
## Summary

Fixes a bug where a partial setup failure was silently marked as complete, preventing automatic retry on subsequent launches. The version marker is now only written when **all** setup steps succeed — on partial failure, the next launch re-runs the full setup (all steps are idempotent, so re-running already-succeeded steps is harmless).

## Key Changes

- **`src/services/system/auto-sync.ts`**: Move `markSynced()` call inside a `failures.length === 0` guard so the `.synced-version` marker is only written on full success
- **Failure message**: Updated from instructing users to manually reinstall (`bun install -g @bastani/atomic`) to informing them that setup will automatically retry on next launch — no manual intervention needed
- **Module docstring**: Updated to document the new write-on-success semantics

## Behavior Before vs. After

| Scenario | Before | After |
|---|---|---|
| All steps succeed | Marker written; setup skipped on next launch ✓ | Same ✓ |
| One or more steps fail | Marker written; partial failures silently ignored ✗ | Marker not written; all steps retry on next launch ✓ |

## Notes

- No breaking changes — this only affects retry behavior when setup is incomplete
- All setup steps (`tmux/psmux`, global agent configs, `@playwright/cli`, `@llamaindex/liteparse`, global skills) are idempotent, making the retry-all-on-failure approach safe and cheap