### PR TITLE
chore(release): bump version to v0.5.8-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.7",
+  "version": "0.5.8-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.7` to `0.5.8-0` in preparation for the `v0.5.8` prerelease.

## Changes

- **`package.json`**: Version updated from `0.5.7` → `0.5.8-0`

## Test plan

- [x] `bun test` passes (957 tests, 0 failures)
- [x] Version bump verified in `package.json`