### PR TITLE
chore(release): bump version to v0.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.8-0",
+  "version": "0.5.8",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.8-0` to the stable release `0.5.8` in `package.json`.

## Changes

- **`package.json`**: Bumped `version` field from `0.5.8-0` to `0.5.8`

## Test plan

- [ ] CI passes
- [ ] `package.json` version is `0.5.8`
- [ ] npm publish triggers on merge to `main`