### PR TITLE
perf(skills): use incremental update for global skills on subsequent launches

### DIFF
--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -17,7 +17,7 @@
  *     2. global agent configs    (file copies — no network)
  *     3. @playwright/cli         (bun install -g)
  *     4. @llamaindex/liteparse   (bun install -g)
- *     5. global skills           (bunx skills add ...)
+ *     5. global skills           (bunx skills update … / bunx skills add …)
  *
  * All steps run concurrently using bun (already our runtime) for package
  * installs and `bunx` for CLI tools, avoiding a ~48 s Node.js/npm

--- a/src/services/system/skills.ts
+++ b/src/services/system/skills.ts
@@ -1,18 +1,93 @@
 /**
- * Global skills installation.
+ * Global skills installation and update.
  *
- * Installs bundled agent skills globally via `npx skills`, then removes
- * source-control skill variants so `atomic init` can install them
- * locally per-project based on the user's selected SCM + active agent.
+ * On first install (no skills lockfile), installs all bundled agent skills
+ * globally via `bunx/npx skills add`, then removes source-control skill
+ * variants so `atomic init` can install them locally per-project based on
+ * the user's selected SCM + active agent.
+ *
+ * On subsequent launches (lockfile exists), runs
+ * `bunx/npx skills update [SKILL1] [SKILL2] ...` for all non-SCM bundled
+ * skills — much faster than a clean add each time.
  */
 
+import { join } from "node:path";
+import { homedir } from "node:os";
 import { ALL_SCM_SKILLS } from "../config/index.ts";
 
 const SKILLS_REPO = "https://github.com/flora131/atomic.git";
 const SKILLS_AGENTS = ["claude-code", "opencode", "github-copilot"] as const;
 
+/**
+ * Every skill bundled in `.agents/skills/`, excluding SCM-variant skills.
+ *
+ * Used by the update path (`skills update SKILL1 SKILL2 ...`). When a new
+ * skill is added to or removed from `.agents/skills/`, update this list.
+ */
+const BUNDLED_GLOBAL_SKILLS = [
+  "adapt",
+  "advanced-evaluation",
+  "animate",
+  "arrange",
+  "audit",
+  "bdi-mental-states",
+  "bolder",
+  "bun",
+  "clarify",
+  "colorize",
+  "context-compression",
+  "context-degradation",
+  "context-fundamentals",
+  "context-optimization",
+  "create-spec",
+  "critique",
+  "delight",
+  "distill",
+  "docx",
+  "evaluation",
+  "explain-code",
+  "extract",
+  "filesystem-context",
+  "find-skills",
+  "frontend-design",
+  "harden",
+  "hosted-agents",
+  "impeccable",
+  "init",
+  "layout",
+  "liteparse",
+  "memory-systems",
+  "multi-agent-patterns",
+  "normalize",
+  "onboard",
+  "opentui",
+  "optimize",
+  "overdrive",
+  "pdf",
+  "playwright-cli",
+  "polish",
+  "pptx",
+  "project-development",
+  "prompt-engineer",
+  "quieter",
+  "research-codebase",
+  "shape",
+  "skill-creator",
+  "teach-impeccable",
+  "test-driven-development",
+  "tool-design",
+  "typescript-advanced-types",
+  "typescript-expert",
+  "typescript-react-reviewer",
+  "typeset",
+  "workflow-creator",
+  "xlsx",
+] as const;
+
 interface NpxSkillsResult {
   ok: boolean;
+  /** Full captured stdout — used to parse command output (e.g. `skills list`). */
+  stdout: string;
   /** Tail of captured stderr/stdout — surfaced by the spinner on failure. */
   details: string;
 }
@@ -22,7 +97,7 @@ async function runNpxSkills(args: string[]): Promise<NpxSkillsResult> {
   // depending on a full Node.js/npm installation.
   const runner = Bun.which("bunx") ?? Bun.which("npx");
   if (!runner) {
-    return { ok: false, details: "neither bunx nor npx found on PATH" };
+    return { ok: false, stdout: "", details: "neither bunx nor npx found on PATH" };
   }
 
   // Capture stdout/stderr so the outer spinner UI owns terminal output and
@@ -34,6 +109,7 @@ async function runNpxSkills(args: string[]): Promise<NpxSkillsResult> {
   const proc = Bun.spawn(cmd, {
     stdout: "pipe",
     stderr: "pipe",
+    env: { ...process.env, DISABLE_TELEMETRY: "1" },
   });
   const [stderr, stdout, exitCode] = await Promise.all([
     new Response(proc.stderr).text(),
@@ -41,25 +117,65 @@ async function runNpxSkills(args: string[]): Promise<NpxSkillsResult> {
     proc.exited,
   ]);
   const details = (stderr.trim() || stdout.trim()).slice(-800);
-  return { ok: exitCode === 0, details };
+  return { ok: exitCode === 0, stdout, details };
+}
+
+/**
+ * True when the skills CLI lockfile exists, indicating skills have been
+ * installed at least once (possibly for a different project).
+ */
+async function skillsLockExists(): Promise<boolean> {
+  const xdgState = process.env.XDG_STATE_HOME;
+  const lockPath = xdgState
+    ? join(xdgState, "skills", ".skill-lock.json")
+    : join(homedir(), ".agents", ".skill-lock.json");
+  return Bun.file(lockPath).exists();
+}
+
+/**
+ * True when Atomic's bundled skills are already installed globally.
+ * Runs `skills list -g` and regex-matches the output for bundled names.
+ */
+async function hasBundledSkillsInstalled(): Promise<boolean> {
+  const listResult = await runNpxSkills(["list", "-g"]);
+  if (!listResult.ok) return false;
+
+  const output = listResult.stdout;
+  return BUNDLED_GLOBAL_SKILLS.some((skill) =>
+    new RegExp(`\\b${skill}\\b`).test(output),
+  );
 }
 
 export async function installGlobalSkills(): Promise<void> {
   const agentFlags = SKILLS_AGENTS.flatMap((agent) => ["-a", agent]);
 
-  const addResult = await runNpxSkills([
-    "add",
-    SKILLS_REPO,
-    "--skill",
-    "*",
-    "-g",
-    ...agentFlags,
-    "-y",
-  ]);
-  if (!addResult.ok) {
-    throw new Error(`npx skills add failed: ${addResult.details}`);
+  if ((await skillsLockExists()) && (await hasBundledSkillsInstalled())) {
+    // Incremental update — much faster than a clean add.
+    const updateResult = await runNpxSkills([
+      "update",
+      ...BUNDLED_GLOBAL_SKILLS,
+    ]);
+    if (!updateResult.ok) {
+      throw new Error(`skills update failed: ${updateResult.details}`);
+    }
+  } else {
+    // First install — full add from the repo.
+    const addResult = await runNpxSkills([
+      "add",
+      SKILLS_REPO,
+      "--skill",
+      "*",
+      "-g",
+      ...agentFlags,
+      "-y",
+    ]);
+    if (!addResult.ok) {
+      throw new Error(`skills add failed: ${addResult.details}`);
+    }
   }
 
+  // Remove SCM skills from global scope so `atomic init` can install
+  // them locally per-project based on the user's selected SCM.
   const removeSkillFlags = ALL_SCM_SKILLS.flatMap((skill) => [
     "--skill",
     skill,
@@ -72,6 +188,6 @@ export async function installGlobalSkills(): Promise<void> {
     "-y",
   ]);
   if (!removeResult.ok) {
-    throw new Error(`npx skills remove failed: ${removeResult.details}`);
+    throw new Error(`skills remove failed: ${removeResult.details}`);
   }
 }


### PR DESCRIPTION
## Summary

Optimizes repeated Atomic launches by switching global skill sync from a full `skills add` (slow, network-heavy) to `skills update` when skills are already installed. First-install behavior is fully preserved.

## Key Changes

- **Two-phase detection** before deciding which path to take:
  - `skillsLockExists()` — checks for the skills CLI lockfile (`~/.agents/.skill-lock.json` or `$XDG_STATE_HOME/skills/.skill-lock.json`)
  - `hasBundledSkillsInstalled()` — runs `skills list -g` and regex-matches output against the bundled skill list
- **Incremental update path**: when both conditions are true, runs `skills update <skill1> <skill2> ...` for all non-SCM bundled skills — significantly faster than cloning the repo and running a full `add`
- **First-install fallback**: full `skills add --skill '*' -g` from the repo is preserved for when no lockfile or skills are detected
- **`BUNDLED_GLOBAL_SKILLS` constant** — explicit static list of all globally-installed skills (excluding SCM variants), used to build the `update` command args
- **`stdout` capture** added to `NpxSkillsResult` so `hasBundledSkillsInstalled()` can parse `skills list` output
- **`DISABLE_TELEMETRY=1`** passed to all `bunx/npx skills` invocations
- Updated `auto-sync.ts` comment to reflect the dual-path behavior

## Notes

- No breaking changes — the first-install path is identical to before
- SCM skill removal after install is unchanged; it still runs after whichever install path is taken