### PR TITLE
chore(release): bump version to v0.5.9-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.8",
+  "version": "0.5.9-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.8` to `0.5.9-0` in preparation for the upcoming `v0.5.9` release.

## Changes

- `package.json`: version `0.5.8` → `0.5.9-0`

## Test plan

- [ ] Verify `package.json` version is `0.5.9-0`
- [ ] CI passes and npm prerelease publish succeeds