### PR TITLE
fix(sdk,setup): fix ./workflows export and bun install -g concurrent race

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       "bun": "./src/sdk/index.ts",
       "types": "./dist/sdk/index.d.ts"
     },
+    "./workflows": {
+      "bun": "./src/sdk/workflows/index.ts",
+      "types": "./dist/sdk/workflows/index.d.ts"
+    },
     "./*": {
       "bun": "./src/sdk/*",
       "types": "./dist/sdk/*"

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -99,29 +99,31 @@ export interface EnsureOptions {
 }
 
 /**
- * Install a global package via bun. Uses `--trust` to allow postinstall
- * lifecycle scripts (required by packages like @playwright/cli).
+ * Install one or more global packages via a single `bun install -g` call.
+ * Uses `--trust` to allow postinstall lifecycle scripts (required by
+ * packages like @playwright/cli).
+ *
+ * Combining multiple packages into one invocation is important: Bun's
+ * global linker is not safe to run concurrently — two parallel
+ * `bun install -g` processes race to create the same symlinks in the
+ * shared global store, causing EEXIST errors for transitive deps that
+ * both packages (or the already-installed @bastani/atomic) share.
  */
-export async function upgradeGlobalPackage(pkg: string): Promise<void> {
-  const versionedPkg = pkg.includes("@latest") ? pkg : `${pkg}@latest`;
+export async function upgradeGlobalPackages(pkgs: string[]): Promise<void> {
   const bunPath = Bun.which("bun");
   if (!bunPath) {
-    throw new Error(`bun is not available to install ${pkg}.`);
+    throw new Error(`bun is not available to install ${pkgs.join(", ")}.`);
   }
-  const result = await runCommand([bunPath, "install", "-g", "--trust", versionedPkg]);
+  const versioned = pkgs.map((p) => (p.includes("@latest") ? p : `${p}@latest`));
+  const result = await runCommand([bunPath, "install", "-g", "--trust", ...versioned]);
   if (!result.success) {
-    throw new Error(`Failed to install ${pkg}: ${result.details}`);
+    throw new Error(`Failed to install ${pkgs.join(", ")}: ${result.details}`);
   }
 }
 
-/** Upgrade @playwright/cli to the latest version globally. */
-export async function upgradePlaywrightCli(): Promise<void> {
-  return upgradeGlobalPackage("@playwright/cli");
-}
-
-/** Upgrade @llamaindex/liteparse to the latest version globally. */
-export async function upgradeLiteparse(): Promise<void> {
-  return upgradeGlobalPackage("@llamaindex/liteparse");
+/** Upgrade @playwright/cli and @llamaindex/liteparse globally in one pass. */
+export async function upgradeGlobalToolPackages(): Promise<void> {
+  return upgradeGlobalPackages(["@playwright/cli", "@llamaindex/liteparse"]);
 }
 
 /**

--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -36,8 +36,7 @@ import { VERSION } from "../../version.ts";
 import { COLORS } from "../../theme/colors.ts";
 import {
   ensureTmuxInstalled,
-  upgradePlaywrightCli,
-  upgradeLiteparse,
+  upgradeGlobalToolPackages,
 } from "../../lib/spawn.ts";
 import { installGlobalAgents } from "./agents.ts";
 import { installGlobalSkills } from "./skills.ts";
@@ -101,11 +100,10 @@ export async function autoSyncIfStale(): Promise<void> {
   // best-effort contract.
   const results = await runSteps([
     [
-      { label: "tmux / psmux",         fn: () => ensureTmuxInstalled({ quiet: true }) },
-      { label: "global agent configs", fn: installGlobalAgents },
-      { label: "@playwright/cli",      fn: upgradePlaywrightCli },
-      { label: "@llamaindex/liteparse", fn: upgradeLiteparse },
-      { label: "global skills",        fn: installGlobalSkills },
+      { label: "tmux / psmux",          fn: () => ensureTmuxInstalled({ quiet: true }) },
+      { label: "global agent configs",  fn: installGlobalAgents },
+      { label: "global tool packages",  fn: upgradeGlobalToolPackages },
+      { label: "global skills",         fn: installGlobalSkills },
     ],
   ]);
 


### PR DESCRIPTION
## Summary

Fixes two independent bugs: custom workflows failing to load in the workflow picker, and an EEXIST race condition during global package installation at setup.

## Changes

### Fix: `./workflows` subpath export (`package.json`)

The wildcard `"./*"` export entry mapped `@bastani/atomic/workflows` to the **directory** `./src/sdk/workflows` rather than the **file** `./src/sdk/workflows/index.ts`. Package exports do not perform index-file resolution, so every custom workflow's `import { defineWorkflow } from "@bastani/atomic/workflows"` silently failed at runtime, causing `loadWorkflowsMetadata` to drop all custom workflows.

**Fix:** Add an explicit `"./workflows"` export entry pointing directly to `./src/sdk/workflows/index.ts`.

### Fix: Concurrent `bun install -g` EEXIST race (`src/lib/spawn.ts`, `src/services/system/auto-sync.ts`)

Two separate concurrent `bun install -g` calls (one for `@playwright/cli`, one for `@llamaindex/liteparse`) raced to symlink shared transitive deps (`@github/copilot-darwin-arm64`, `@anthropic-ai/sdk`) in the global store, causing EEXIST errors.

**Fix:** Merge `upgradePlaywrightCli` and `upgradeLiteparse` into a single `upgradeGlobalToolPackages` function that passes both packages in one `bun install -g` invocation — one linker pass, no race.

## Key Files Changed

- `package.json` — explicit `./workflows` subpath export
- `src/lib/spawn.ts` — `upgradeGlobalPackages(pkgs: string[])` + `upgradeGlobalToolPackages()`
- `src/services/system/auto-sync.ts` — consolidated install step