### PR TITLE
chore(release): bump version to v0.5.9-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.8",
+  "version": "0.5.9-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.8` to `0.5.9-0` in preparation for the next prerelease.

## Key Changes

- Updated `package.json` version from `0.5.8` → `0.5.9-0`

## Notes

This is a prerelease version bump. Once merged to `main`, a GitHub Release will be automatically created and the version will be published to npm.