### PR TITLE
chore(release): bump version to v0.5.9-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.9-0",
+  "version": "0.5.9-1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the prerelease version from `0.5.9-0` to `0.5.9-1` in `package.json`.

## Changes

- `package.json`: version `0.5.9-0` → `0.5.9-1`

## Test plan

- [x] Version bump script ran successfully
- [x] All 957 tests pass with 0 failures