### PR TITLE
chore(release): bump version to v0.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.9-1",
+  "version": "0.5.9",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.9-1` to stable release `0.5.9` by updating `package.json`.

## Changes

- `package.json`: bumped `version` from `0.5.9-1` to `0.5.9`

## Test plan

- [x] Typecheck passes
- [x] All 957 tests pass