### PR TITLE
chore(release): bump version to v0.5.10-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.9",
+  "version": "0.5.10-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.9` to `0.5.10-0` in preparation for the next release.

## Changes

- `package.json`: version updated from `0.5.9` → `0.5.10-0`

## Test plan

- [x] Version bumped correctly via `bun run src/scripts/bump-version.ts --from-branch`
- [ ] CI passes