### PR TITLE
chore(release): bump version to v0.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.10-0",
+  "version": "0.5.10",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes v0.5.10-0 prerelease to stable v0.5.10, finalizing the Copilot SDK API migration from `sendAndWait()` to `send()`.

## Changes in this release

- **refactor(sdk,workflows):** Migrate Copilot session API from `sendAndWait()` to `send()` across all workflows, skills, and documentation
- **Simplified builtin workflows:** Reduced boilerplate in `ralph` and `deep-research-codebase` Copilot workflow implementations
- **Updated example workflows:** `hello-world` and `parallel-hello-world` examples updated for the new API

## Test plan
- [x] All 957 tests pass
- [x] Typecheck passes
- [x] Lint passes