### PR TITLE
chore(release): bump version to v0.5.11-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.10",
+  "version": "0.5.11-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.10` to `0.5.11-0` as a prerelease ahead of the `v0.5.11` stable release.

## Changes

- `package.json`: version `0.5.10` → `0.5.11-0`

## Notes

- This is a prerelease version (`-0` suffix) published to npm under the `next` tag
- No functional code changes — version bump only
- Follows the [release workflow](CLAUDE.md#releasing): branch → bump → PR → merge → auto-publish

## Test plan

- [ ] CI passes
- [ ] `package.json` version is `0.5.11-0`