### PR TITLE
chore(release): bump version to v0.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.11-0",
+  "version": "0.5.11",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.11-0` to the stable release `0.5.11` by updating `package.json`.

## Changes

- **`package.json`**: Version updated from `0.5.11-0` → `0.5.11`

## Test plan

- [ ] CI passes
- [ ] Version in `package.json` is `0.5.11`
- [ ] Package published to npm as stable release