### PR TITLE
docs(readme): add migration guide from standalone binary to npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ irm https://raw.githubusercontent.com/flora131/atomic/main/install.ps1 | iex
 ```
 
 
+> [!IMPORTANT]
+> **Migrating from the old standalone binary?** The old version of Atomic was a standalone binary. It is now distributed as an npm package. To migrate:
+>
+> 1. Uninstall the old binary: `atomic uninstall`
+> 2. Uninstall the old workflows package: `bun uninstall -g @bastani/atomic-workflows`
+> 3. Delete the old config directory: `rm -rf ~/.atomic`
+> 4. Remove legacy skill directories: `rm -rf ~/.copilot/skills ~/.opencode/skills`
+> 5. Re-install using any of the install options above
+
 ### 2. Initialize Your Project
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a migration guide to `README.md` for users upgrading from the old standalone binary distribution to the new npm package distribution of Atomic.

## Key Changes

- Added an `[!IMPORTANT]` callout block in the Installation section of `README.md` with a step-by-step migration guide
- Migration steps cover:
  1. Uninstalling the old standalone binary (`atomic uninstall`)
  2. Removing the legacy workflows package (`bun uninstall -g @bastani/atomic-workflows`)
  3. Deleting the old config directory (`~/.atomic`)
  4. Removing legacy skill directories (`~/.copilot/skills`, `~/.opencode/skills`)
  5. Re-installing via the new npm package options

## Migration Notes

This is a documentation-only change. No code was modified. The guide targets existing users of the standalone binary who need to cleanly transition to the npm-based installation.