### PR TITLE
feat: bundle skills offline and silence auto-sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Get version from package.json
         id: version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
@@ -101,6 +106,9 @@ jobs:
             echo "make_latest=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Bundle configs for release
+        run: bun run src/scripts/bundle-configs.ts "${{ steps.version.outputs.version }}"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -110,3 +118,4 @@ jobs:
           prerelease: ${{ steps.release-type.outputs.is_prerelease == 'true' }}
           make_latest: ${{ steps.release-type.outputs.make_latest }}
           generate_release_notes: true
+          files: atomic-configs-v${{ steps.version.outputs.version }}.zip

--- a/install.ps1
+++ b/install.ps1
@@ -2,8 +2,8 @@
 #
 # Bootstrap installer for systems that don't already have bun. Installs
 # bun (if missing) and then installs atomic from npm via bun. The CLI
-# itself handles tooling deps (Node.js/npm) and global skills on first
-# launch — see src/services/system/auto-sync.ts.
+# silently syncs tooling deps and bundled skills on first launch — see
+# src/services/system/auto-sync.ts.
 #
 # If you already have bun, you can skip this script entirely:
 #   bun install -g @bastani/atomic@latest
@@ -272,6 +272,6 @@ Write-Host "  ${C_GREEN}✓${C_RESET} ${C_BOLD}Atomic installed successfully${C_
 Write-Host ""
 Write-Host "    Get started:  ${C_CYAN}atomic init${C_RESET}"
 Write-Host ""
-Write-Host "    ${C_DIM}Tooling deps and skills will be set up automatically on first launch.${C_RESET}"
+Write-Host "    ${C_DIM}Tooling deps and skills are synced silently on first launch.${C_RESET}"
 Write-Host "    ${C_DIM}To upgrade later: bun update -g @bastani/atomic${C_RESET}"
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,8 @@
 #
 # Bootstrap installer for systems that don't already have bun. Installs
 # bun (if missing) and then installs atomic from npm via bun. The CLI
-# itself handles tooling deps (Node.js/npm) and global skills on first
-# launch — see src/services/system/auto-sync.ts.
+# silently syncs tooling deps and bundled skills on first launch — see
+# src/services/system/auto-sync.ts.
 #
 # If you already have bun, you can skip this script entirely:
 #   bun install -g @bastani/atomic@latest
@@ -269,7 +269,7 @@ main() {
     printf '\n  %s✓%s %sAtomic installed successfully%s\n\n' \
         "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_RESET"
     printf '    Get started:  %satomic init%s\n\n' "$C_CYAN" "$C_RESET"
-    printf '    %sTooling deps and skills will be set up automatically on first launch.%s\n' \
+    printf '    %sTooling deps and skills are synced silently on first launch.%s\n' \
         "$C_DIM" "$C_RESET"
     printf '    %sTo upgrade later: bun update -g @bastani/atomic%s\n\n' \
         "$C_DIM" "$C_RESET"

--- a/package.json
+++ b/package.json
@@ -41,9 +41,8 @@
   },
   "files": [
     "src",
-    "dist",
-    "tsconfig.json",
     "assets/settings.schema.json",
+    ".agents/skills",
     ".claude/agents",
     ".opencode/agents",
     ".github/agents",

--- a/src/commands/cli/init/index.ts
+++ b/src/commands/cli/init/index.ts
@@ -244,7 +244,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     // Best-effort template copy: source checkouts still carry the bundled
     // gh-*/sl-* skill templates, but binary and npm installs no longer do
     // (they live in the skills CLI repo). `installLocalScmSkills` below
-    // handles the binary/npm case by invoking `npx skills add` — so a zero
+    // handles the binary/npm case by invoking `bunx skills add` — so a zero
     // copy here is not an error, just a signal that the template isn't
     // bundled for this install type.
     await syncProjectScmSkills({
@@ -273,7 +273,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     s.stop(paint("success", "✓", { bold: true }) + " Skills configured");
 
     // Install SCM-specific skill variants locally for the active agent via
-    // `npx skills add` (best-effort: a failure is surfaced as a warning).
+    // `bunx skills add` (best-effort: a failure is surfaced as a warning).
     //
     // Source checkouts already have the bundled skills on disk and the
     // template-copy above has placed the selected variants into `targetDir`;

--- a/src/commands/cli/init/scm.ts
+++ b/src/commands/cli/init/scm.ts
@@ -113,7 +113,7 @@ export async function syncProjectScmSkills(options: SyncProjectScmSkillsOptions)
   return copiedCount;
 }
 
-/** Skills-CLI agent identifiers (match `npx skills -a <value>`). */
+/** Skills-CLI agent identifiers (match `bunx skills -a <value>`). */
 const SKILLS_AGENT_BY_KEY: Record<AgentKey, string> = {
   claude: "claude-code",
   opencode: "opencode",
@@ -125,7 +125,7 @@ const SKILLS_REPO = "https://github.com/flora131/atomic.git";
 export interface InstallLocalScmSkillsOptions {
   scmType: SourceControlType;
   agentKey: AgentKey;
-  /** The directory to run `npx skills add` in (the project root). */
+  /** The directory to run `bunx skills add` in (the project root). */
   cwd: string;
 }
 
@@ -139,7 +139,7 @@ export interface InstallLocalScmSkillsResult {
 
 /**
  * Install the SCM skill variants (e.g. `gh-commit`, `gh-create-pr` for
- * GitHub) locally into the current project via `npx skills add`. The `-g`
+ * GitHub) locally into the current project via `bunx skills add`. The `-g`
  * flag is intentionally omitted so the skills are installed per-project
  * (in the given `cwd`).
  *
@@ -157,9 +157,9 @@ export async function installLocalScmSkills(
 
   const skills = SCM_SKILLS_BY_TYPE[scmType];
 
-  const npxPath = Bun.which("npx");
-  if (!npxPath) {
-    return { success: false, skills, details: "npx not found on PATH" };
+  const bunxPath = Bun.which("bunx");
+  if (!bunxPath) {
+    return { success: false, skills, details: "bunx not found on PATH" };
   }
 
   const agentFlag = SKILLS_AGENT_BY_KEY[agentKey];
@@ -168,8 +168,7 @@ export async function installLocalScmSkills(
   try {
     const proc = Bun.spawn({
       cmd: [
-        npxPath,
-        "--yes",
+        bunxPath,
         "skills",
         "add",
         SKILLS_REPO,

--- a/src/scripts/bundle-configs.ts
+++ b/src/scripts/bundle-configs.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env bun
+/**
+ * Bundle global configs for a release.
+ *
+ * Installs curated skills globally, copies bundled agent definitions to
+ * each agent's global config root, and packages everything into a zip
+ * archive suitable for attaching to a GitHub Release.
+ *
+ * Usage:
+ *   bun run src/scripts/bundle-configs.ts <version> [output-dir]
+ *
+ * <version>     Semver string (e.g. 0.4.47 or 0.4.47-0).
+ * [output-dir]  Directory for the zip file. Defaults to $GITHUB_WORKSPACE
+ *               or the current directory.
+ */
+
+import { $ } from "bun";
+import { cpSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "../..");
+const HOME = homedir();
+
+/** Source repo for the global skills install. */
+const SKILLS_REPO = "https://github.com/flora131/atomic.git";
+
+/** Skills excluded from the global install (VCS-specific commit/PR helpers). */
+const EXCLUDED_SKILLS = [
+  "gh-commit",
+  "gh-create-pr",
+  "sl-commit",
+  "sl-submit-diff",
+];
+
+/** Agent CLI flags accepted by `bunx skills`. */
+const AGENT_FLAGS = ["claude-code", "opencode", "github-copilot"];
+
+/**
+ * Local config root (in repo) → global root (~/) for each agent.
+ * Copilot uses `.github` locally but `.copilot` globally.
+ */
+const AGENT_ROOTS = {
+  claude: { local: ".claude", global: ".claude" },
+  opencode: { local: ".opencode", global: ".opencode" },
+  copilot: { local: ".github", global: ".copilot" },
+} as const;
+
+/** Paths included in the zip archive (relative to $HOME). */
+const ZIP_INCLUDES = [
+  ".agents/skills",
+  ".claude/agents",
+  ".claude/skills",
+  ".opencode/agents",
+  ".copilot/agents",
+  ".copilot/lsp-config.json",
+];
+
+// ── Steps ──────────────────────────────────────────────────────────────────
+
+async function installGlobalSkills(): Promise<void> {
+  console.log("Installing global skills…");
+
+  const agentArgs = AGENT_FLAGS.flatMap((a) => ["-a", a]);
+
+  await $`bunx skills add ${SKILLS_REPO} --skill "*" -g ${agentArgs} -y`;
+
+  const removeArgs = EXCLUDED_SKILLS.flatMap((s) => ["--skill", s]);
+  await $`bunx skills remove ${removeArgs} -g ${agentArgs} -y`;
+}
+
+async function copyBundledAgents(): Promise<void> {
+  console.log("Copying bundled agents to global roots…");
+
+  for (const [agent, { local, global: globalDir }] of Object.entries(
+    AGENT_ROOTS,
+  )) {
+    const src = join(ROOT, local, "agents");
+    const dest = join(HOME, globalDir, "agents");
+
+    mkdirSync(dest, { recursive: true });
+    cpSync(src, dest, { recursive: true });
+    console.log(`  ${agent}: ${src} → ${dest}`);
+  }
+
+  const lspSrc = join(ROOT, ".github", "lsp.json");
+  if (existsSync(lspSrc)) {
+    const lspDest = join(HOME, AGENT_ROOTS.copilot.global, "lsp-config.json");
+    cpSync(lspSrc, lspDest);
+    console.log(`  copilot: lsp.json → ${lspDest}`);
+  }
+}
+
+async function packageZip(
+  version: string,
+  outputDir: string,
+): Promise<string> {
+  const zipName = `atomic-configs-v${version}.zip`;
+  const zipPath = resolve(outputDir, zipName);
+
+  console.log(`Packaging ${zipName}…`);
+  await $`cd ${HOME} && zip -r ${zipPath} ${ZIP_INCLUDES} -x '*.DS_Store'`.quiet();
+  console.log(`  → ${zipPath}`);
+
+  return zipPath;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const version = process.argv[2]?.replace(/^v/, "");
+  const outputDir = process.argv[3] ?? process.env.GITHUB_WORKSPACE ?? ".";
+
+  if (!version) {
+    console.error(
+      "Usage: bun run src/scripts/bundle-configs.ts <version> [output-dir]",
+    );
+    process.exit(1);
+  }
+
+  await installGlobalSkills();
+  await copyBundledAgents();
+  await packageZip(version, outputDir);
+
+  console.log("\nDone.");
+}
+
+main();

--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -11,37 +11,29 @@
  * comparing the bundled `VERSION` constant against a marker file at
  * `~/.atomic/.synced-version`. On a mismatch we run the same setup the
  * production bootstrap installers (`install.sh` / `install.ps1`) provide,
- * as a single parallel phase:
+ * silently in the background:
  *
  *     1. tmux / psmux            (terminal multiplexer for `chat` / `workflow`)
  *     2. global agent configs    (file copies — no network)
  *     3. @playwright/cli         (bun install -g)
  *     4. @llamaindex/liteparse   (bun install -g)
- *     5. global skills           (bunx skills add ...)
+ *     5. global skills           (file copies from bundled .agents/skills)
  *
- * All steps run concurrently using bun (already our runtime) for package
- * installs and `bunx` for CLI tools, avoiding a ~48 s Node.js/npm
- * download via fnm that previously gated Phase 2.
- *
- * Failures are collected and reported as a summary at the end, but never
- * abort the run — partial setup matches the production installer's
- * "best-effort" semantics. The marker is only written when every step
- * succeeds; on partial failure the next launch re-runs all steps (they
- * are idempotent, so re-running already-succeeded steps is harmless).
+ * All steps run silently. The only user-facing loading bar lives in the
+ * bootstrap installers (install.sh / install.ps1). Failures are swallowed;
+ * the marker is only written when every step succeeds, so the next launch
+ * retries (all steps are idempotent).
  */
 
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { VERSION } from "../../version.ts";
-import { COLORS } from "../../theme/colors.ts";
 import {
   ensureTmuxInstalled,
   upgradeGlobalToolPackages,
 } from "../../lib/spawn.ts";
 import { installGlobalAgents } from "./agents.ts";
 import { installGlobalSkills } from "./skills.ts";
-import { runSteps, printSummary } from "./install-ui.ts";
-import { displayBlockBanner } from "../../theme/logo.ts";
 
 /** Path to the version marker. Honors ATOMIC_SETTINGS_HOME for tests. */
 function syncMarkerPath(): string {
@@ -71,9 +63,24 @@ export async function markSynced(): Promise<void> {
 }
 
 /**
+ * Run a step silently, returning whether it succeeded.
+ */
+async function silentStep(fn: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await fn();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Sync tooling deps, bundled agents, and global skills if the marker
  * doesn't match the bundled VERSION. No-op in dev checkouts and when the
  * marker already matches the current version.
+ *
+ * Runs entirely silently — no spinner, no progress bar, no banner. The
+ * only loading UI lives in the bootstrap installers (install.sh / install.ps1).
  */
 export async function autoSyncIfStale(): Promise<void> {
   if (!isInstalledPackage()) return;
@@ -86,46 +93,19 @@ export async function autoSyncIfStale(): Promise<void> {
 
   if (stored === VERSION) return;
 
-  console.log(
-    `\n  ${COLORS.dim}Setting up atomic ${COLORS.reset}${COLORS.bold}v${VERSION}${COLORS.reset}${COLORS.dim}…${COLORS.reset}`,
-  );
-
-  // All steps run in a single parallel phase. bun (already our runtime)
-  // handles global package installs and `bunx` execution, so there is no
-  // need to install Node.js/npm first — eliminating a ~48 s fnm download
-  // that previously dominated the loading screen.
-  //
-  // Each step's failure is caught inside `runSteps` (not thrown), so
-  // subsequent steps still run even if one fails — matches install.sh's
-  // best-effort contract.
-  const results = await runSteps([
-    [
-      { label: "tmux / psmux",          fn: () => ensureTmuxInstalled({ quiet: true }) },
-      { label: "global agent configs",  fn: installGlobalAgents },
-      { label: "global tool packages",  fn: upgradeGlobalToolPackages },
-      { label: "global skills",         fn: installGlobalSkills },
-    ],
+  // All steps run in parallel and silently. Failures are swallowed so the
+  // CLI can proceed. The marker is only written when every step succeeds;
+  // on partial failure the next launch retries (all steps are idempotent).
+  const results = await Promise.all([
+    silentStep(() => ensureTmuxInstalled({ quiet: true })),
+    silentStep(installGlobalAgents),
+    silentStep(upgradeGlobalToolPackages),
+    silentStep(installGlobalSkills),
   ]);
 
-  const failures = results.filter((r) => !r.ok);
+  const allOk = results.every(Boolean);
 
-  // Only write the marker when every step succeeded. On partial failure
-  // the next launch will re-run all steps — they're idempotent, so
-  // re-running already-succeeded steps is cheap and harmless.
-  if (failures.length === 0) {
+  if (allOk) {
     await markSynced();
-  }
-
-  displayBlockBanner();
-  printSummary(results);
-
-  if (failures.length > 0) {
-    console.log(
-      `\n  ${COLORS.dim}Setup will retry on next launch. To retry now, re-run your command.${COLORS.reset}\n`,
-    );
-  } else {
-    console.log(
-      `\n  ${COLORS.dim}Learn more at ${COLORS.reset}${COLORS.blue}https://deepwiki.com/flora131/atomic${COLORS.reset}\n`,
-    );
   }
 }

--- a/src/services/system/skills.ts
+++ b/src/services/system/skills.ts
@@ -1,77 +1,73 @@
 /**
  * Global skills installation.
  *
- * Installs bundled agent skills globally via `npx skills`, then removes
- * source-control skill variants so `atomic init` can install them
- * locally per-project based on the user's selected SCM + active agent.
+ * Copies bundled agent skills from the installed package into the
+ * provider-native global skill roots, mirroring the merge-copy approach
+ * used by {@link installGlobalAgents} for agent configs.
+ *
+ * Previously this ran `npx skills add <repo>` at runtime, which cloned
+ * the entire git repo on every version bump.  Now the skills ship inside
+ * the npm package (`.agents/skills/`) and are copied locally — no network
+ * required, no `npx`/`bunx` dependency.
+ *
+ * SCM-variant skills (gh-commit, gh-create-pr, sl-commit, sl-submit-diff)
+ * are excluded from the global install; `atomic init` installs them
+ * per-project based on the user's selected SCM + active agent.
  */
 
+import { join } from "node:path";
+import { homedir } from "node:os";
 import { ALL_SCM_SKILLS } from "../config/index.ts";
+import { copyDir, pathExists } from "./copy.ts";
 
-const SKILLS_REPO = "https://github.com/flora131/atomic.git";
-const SKILLS_AGENTS = ["claude-code", "opencode", "github-copilot"] as const;
-
-interface NpxSkillsResult {
-  ok: boolean;
-  /** Tail of captured stderr/stdout — surfaced by the spinner on failure. */
-  details: string;
+/**
+ * Locate the package root by walking up from this module. Both in installed
+ * (`<pkg>/src/services/system/skills.ts`) and dev checkout layouts the
+ * package root is three directories up.
+ */
+function packageRoot(): string {
+  return join(import.meta.dir, "..", "..", "..");
 }
 
-async function runNpxSkills(args: string[]): Promise<NpxSkillsResult> {
-  // Prefer bunx (already available as our runtime) over npx to avoid
-  // depending on a full Node.js/npm installation.
-  const runner = Bun.which("bunx") ?? Bun.which("npx");
-  if (!runner) {
-    return { ok: false, details: "neither bunx nor npx found on PATH" };
-  }
-
-  // Capture stdout/stderr so the outer spinner UI owns terminal output and
-  // can surface the tail of any failure.
-  const isBunx = runner.endsWith("bunx");
-  const cmd = isBunx
-    ? [runner, "skills", ...args]
-    : [runner, "--yes", "skills", ...args];
-  const proc = Bun.spawn(cmd, {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stderr, stdout, exitCode] = await Promise.all([
-    new Response(proc.stderr).text(),
-    new Response(proc.stdout).text(),
-    proc.exited,
-  ]);
-  const details = (stderr.trim() || stdout.trim()).slice(-800);
-  return { ok: exitCode === 0, details };
+/** Honors ATOMIC_SETTINGS_HOME so tests can point at a temp dir. */
+function homeRoot(): string {
+  return process.env.ATOMIC_SETTINGS_HOME ?? homedir();
 }
 
+/**
+ * Global skill directories keyed by provider.
+ *
+ * From CLAUDE.md:
+ *   - `~/.agents/skills` for OpenCode and Copilot CLI
+ *   - `~/.claude/skills` for Claude Code
+ */
+const SKILL_DEST_DIRS = [
+  ".agents/skills",
+  ".claude/skills",
+] as const;
+
+/** The set of SCM skill names to exclude from global installation. */
+const SCM_SKILL_SET = new Set<string>(ALL_SCM_SKILLS);
+
+/**
+ * Copy bundled skills to the global skill directories, excluding
+ * SCM-variant skills that are installed per-project by `atomic init`.
+ */
 export async function installGlobalSkills(): Promise<void> {
-  const agentFlags = SKILLS_AGENTS.flatMap((agent) => ["-a", agent]);
+  const src = join(packageRoot(), ".agents", "skills");
 
-  const addResult = await runNpxSkills([
-    "add",
-    SKILLS_REPO,
-    "--skill",
-    "*",
-    "-g",
-    ...agentFlags,
-    "-y",
-  ]);
-  if (!addResult.ok) {
-    throw new Error(`npx skills add failed: ${addResult.details}`);
+  if (!(await pathExists(src))) {
+    throw new Error(`Bundled skills missing at ${src}`);
   }
 
-  const removeSkillFlags = ALL_SCM_SKILLS.flatMap((skill) => [
-    "--skill",
-    skill,
-  ]);
-  const removeResult = await runNpxSkills([
-    "remove",
-    ...removeSkillFlags,
-    "-g",
-    ...agentFlags,
-    "-y",
-  ]);
-  if (!removeResult.ok) {
-    throw new Error(`npx skills remove failed: ${removeResult.details}`);
-  }
+  const home = homeRoot();
+
+  // Build the exclusion list from SCM skill names
+  const exclude = [...SCM_SKILL_SET];
+
+  await Promise.all(
+    SKILL_DEST_DIRS.map((rel) =>
+      copyDir(src, join(home, rel), { exclude }),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary

Ships agent skills inside the npm package (`.agents/skills/`) and copies them into global skill directories at first launch, removing the runtime `bunx skills add <git-repo>` network dependency. Auto-sync now runs entirely silently in the background with no user-facing UI.

## Key Changes

### Skills: offline bundling
- **`package.json`**: Adds `.agents/skills` to npm `files`; removes `dist` and `tsconfig.json`
- **`src/services/system/skills.ts`**: Replaces `bunx skills add <repo>` (live git clone) with a local `copyDir` from the bundled package path — zero network I/O at first launch
- **`src/scripts/bundle-configs.ts`** *(new)*: Build-time script that installs curated global skills, copies bundled agent definitions for all three providers, and packages everything into `atomic-configs-v<version>.zip` for the GitHub Release

### Auto-sync: silent execution
- **`src/services/system/auto-sync.ts`**: Removes all user-facing output (banner, spinner, progress summary); steps run concurrently via `Promise.all` with errors swallowed by a `silentStep` wrapper
- Failure handling remains best-effort: the version marker is only written when every step succeeds, so partial failures trigger a transparent retry on next launch

### npx → bunx migration
- **`src/commands/cli/init/scm.ts`**: Replaces `npx`/`npx --yes` with `bunx` when invoking the `skills` CLI for per-project SCM skill installs; drops the `--yes` flag (not needed by `bunx`)
- Updates all related comments and docstrings throughout the init flow

### CI
- **`.github/workflows/publish.yml`**: Adds a Bun setup step and a `bundle-configs.ts` run step before the release; attaches the generated `.zip` to the GitHub Release artifact

### Installer messaging
- **`install.sh`** / **`install.ps1`**: Updates post-install footer text to reflect the silent sync behavior

## Migration Notes

No action required. Skills previously installed via a live git clone at first launch are now copied from the bundled package, producing the same result faster and without a network dependency. SCM-variant skills (`gh-commit`, `gh-create-pr`, `sl-commit`, `sl-submit-diff`) continue to be installed per-project by `atomic init`.