### PR TITLE
fix(picker): stop keyboard event propagation to prevent textarea interference

### DIFF
--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -1122,11 +1122,15 @@ export function WorkflowPicker({
 
   useKeyboard((key) => {
     if (key.ctrl && key.name === "c") {
+      key.stopPropagation();
       onCancel();
       return;
     }
 
     if (confirmOpenRef.current) {
+      // Consume all keys while the modal is open so focused fields
+      // behind the overlay never see them.
+      key.stopPropagation();
       if (key.name === "y" || key.name === "return") {
         const wf = focusedWfRef.current;
         if (!wf) return;
@@ -1142,20 +1146,24 @@ export function WorkflowPicker({
 
     if (phaseRef.current === "pick") {
       if (key.name === "escape") {
+        key.stopPropagation();
         onCancel();
         return;
       }
       if (key.name === "up" || (key.ctrl && key.name === "k")) {
+        key.stopPropagation();
         setEntryIdx((i: number) => Math.max(0, i - 1));
         return;
       }
       if (key.name === "down" || (key.ctrl && key.name === "j")) {
+        key.stopPropagation();
         setEntryIdx((i: number) =>
           Math.min(entriesRef.current.length - 1, i + 1),
         );
         return;
       }
       if (key.name === "return") {
+        key.stopPropagation();
         const wf = focusedWfRef.current;
         if (wf) {
           const inputs: WorkflowInput[] =
@@ -1181,10 +1189,12 @@ export function WorkflowPicker({
 
     // ── PROMPT phase ──
     if (key.name === "escape") {
+      key.stopPropagation();
       setPhase("pick");
       return;
     }
     if (key.ctrl && key.name === "s") {
+      key.stopPropagation();
       if (!isFormValidRef.current) {
         setFocusedFieldIdx(invalidFieldIndicesRef.current[0]!);
         return;
@@ -1193,6 +1203,7 @@ export function WorkflowPicker({
       return;
     }
     if (key.name === "tab") {
+      key.stopPropagation();
       setFocusedFieldIdx((i: number) => {
         const len = currentFieldsRef.current.length;
         if (len <= 1) return 0;
@@ -1208,6 +1219,7 @@ export function WorkflowPicker({
       const values = field.values ?? [];
       if (values.length === 0) return;
       if (key.name === "left" || key.name === "right") {
+        key.stopPropagation();
         setFieldValues((prev: Record<string, string>) => {
           const cur = prev[field.name] ?? values[0] ?? "";
           const idx = Math.max(0, values.indexOf(cur));
@@ -1223,6 +1235,7 @@ export function WorkflowPicker({
     // (the native <input> fires onSubmit, but we handle it here so
     // the focus-cycling logic stays in one place).
     if (field.type === "string" && key.name === "return") {
+      key.stopPropagation();
       setFocusedFieldIdx((i: number) =>
         Math.min(currentFieldsRef.current.length - 1, i + 1),
       );

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -713,6 +713,21 @@ describe("WorkflowPicker PROMPT keyboard", () => {
     // Default field name is "prompt".
     expect(frame).toContain("prompt");
   });
+
+  test("ctrl+s on free-form workflow with filled prompt opens confirm modal", async () => {
+    const setup = await renderPicker();
+    // Navigate to the freeform workflow (inputs: []).
+    for (let i = 0; i < 3; i++) {
+      await press(setup, (input) => input.pressArrow("down"));
+    }
+    await press(setup, (i) => i.pressEnter());
+    // Type into the DEFAULT_PROMPT_INPUT textarea.
+    await press(setup, (i) => i.typeText("build a dashboard"));
+    await press(setup, (i) => i.pressKey("s", { ctrl: true }));
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("CONFIRM");
+    expect(frame).toContain("submit");
+  });
 });
 
 // ─── Keyboard: CONFIRM phase ─────────────────────


### PR DESCRIPTION
## Summary

Ctrl+S to submit was not working for free-form workflows (e.g. `headless-test`) in the npm-published release. The focused `<textarea>` was re-receiving the Ctrl+S event after `useKeyboard` handled it, interfering with the confirm modal state update in certain runtime environments.

## Key Changes

- **`src/sdk/components/workflow-picker-panel.tsx`**: Added `key.stopPropagation()` for every control key the picker handles exclusively:
  - Ctrl+C / Ctrl+S — cancel and submit
  - Escape — phase transitions
  - Tab / Shift+Tab — field focus cycling
  - Enter — workflow selection and field advancement
  - Up/Down arrows, Ctrl+J/K — list navigation
  - Left/Right arrows — enum value cycling
  - All keys while the CONFIRM modal is open (blanket consume to block focused fields behind the overlay)

- **`tests/sdk/components/workflow-picker-panel.test.tsx`**: Added regression test covering the exact scenario: free-form workflow → type into DEFAULT_PROMPT_INPUT → Ctrl+S → CONFIRM modal appears.

## Root Cause

Free-form workflows use a single `DEFAULT_PROMPT_INPUT` textarea (no structured `WorkflowInput` schema). When `useKeyboard` fired the Ctrl+S handler and called `setConfirmOpen(true)`, the event continued propagating and was processed again by the focused textarea, resetting state before the React re-render completed.

## Testing

Regression test added: `WorkflowPicker PROMPT keyboard > ctrl+s on free-form workflow with filled prompt opens confirm modal`