### PR TITLE
chore(release): bump version to v0.5.12-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.12-0",
+  "version": "0.5.12-1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.5.12-0` to `v0.5.12-1` as a prerelease patch increment.

## Changes

- `package.json`: version `0.5.12-0` → `0.5.12-1`

## Notes

- Follows the `prerelease/v<major>.<minor>.<patch>-<prerelease>` branch naming convention
- No functional or behavioral changes — version metadata only

## Test plan
- [x] `bun typecheck` passes
- [x] `bun test` passes (965 tests, 0 failures)
- [x] `bun test --coverage` passes