### PR TITLE
fix(picker): wire textarea onContentChange as prop to fix Ctrl+D submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.12-1",
+  "version": "0.5.12-2",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -591,18 +591,14 @@ function TextAreaContent({
     }
   }, [value]);
 
-  // Report changes back to parent via onContentChange.
-  useEffect(() => {
-    const ta = ref.current;
-    if (!ta) return;
-    ta.onContentChange = () => {
-      changeRef.current?.(ta.plainText);
-    };
-    return () => {
-      ta.onContentChange = undefined;
-    };
-  }, [changeRef]);
-
+  // Wire onContentChange as a prop so the reconciler sets it during the
+  // commit phase (via the constructor and setProperty's default branch),
+  // guaranteeing it is active before the textarea can receive key events.
+  // The previous useEffect approach deferred setup as a passive effect
+  // (ConcurrentRoot schedules these via setTimeout) — creating a window
+  // where keystrokes reached the focused textarea before the listener
+  // existed, silently dropping content-change notifications and leaving
+  // fieldValues stale.
   return (
     <textarea
       ref={ref}
@@ -616,6 +612,9 @@ function TextAreaContent({
       placeholderColor={theme.textDim}
       wrapMode="word"
       flexGrow={1}
+      onContentChange={() => {
+        changeRef.current?.(ref.current?.plainText ?? "");
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

Fixes Ctrl+D submission failing for free-form workflows (e.g. `headless-test`) that use the default `text` prompt field. The root cause was a timing race in OpenTUI's ConcurrentRoot reconciler between when the textarea received key events and when its content-change listener was registered.

## Root Cause

The OpenTUI React reconciler uses `ConcurrentRoot`, which schedules `useEffect` (passive effects) asynchronously via `setTimeout` — after the commit phase. However, the textarea's `focused` prop is applied **during** commit via `setProperty`, registering key handlers immediately. This created a window where keystrokes arrived at the focused textarea before `onContentChange` was wired, silently dropping content-change notifications and leaving `fieldValues` stale — so `isFormValid` never became `true` and Ctrl+D could not submit.

## Key Changes

- **`src/sdk/components/workflow-picker-panel.tsx`**: Move `onContentChange` from a `useEffect` assignment to a JSX prop on `<textarea>`, so the reconciler sets it during commit via the `setProperty` default branch — matching how `<input>` wires its `onInput` callback and eliminating the timing window

## Test Plan

- [ ] Verify `bun test tests/sdk/components/workflow-picker-panel.test.tsx` passes (76/76)
- [ ] Install prerelease from npm, run `atomic workflow -a claude`, select `headless-test`, type text, confirm Ctrl+D hint glows and submission works
- [ ] Test structured-input workflows (`hello-world`, `parallel-hello-world`) still work