### PR TITLE
feat(scm): add Azure DevOps (ADO) support and skills

### DIFF
--- a/.claude/skills/az-commit/SKILL.md
+++ b/.claude/skills/az-commit/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: az-commit
+description: Create well-formatted commits with conventional commit format.
+---
+
+# Smart Git Commit
+
+Create well-formatted commit: $ARGUMENTS
+
+## Current Repository State
+
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits: !`git log --oneline -5`
+- Azure DevOps auth: !`az account show --query "user.name" -o tsv 2>/dev/null || echo "Not authenticated"`
+
+## What This Command Does
+
+1. Checks which files are staged with `git status`
+2. If 0 files are staged, automatically adds all modified and new files with `git add`
+3. Performs a `git diff` to understand what changes are being committed
+4. Analyzes the diff to determine if multiple distinct logical changes are present
+5. If multiple distinct changes are detected, suggests breaking the commit into multiple smaller commits
+6. For each commit (or the single commit if not split), creates a commit message using conventional commit format
+
+## Best Practices for Commits
+
+- Follow the Conventional Commits specification as described below.
+
+# Conventional Commits 1.0.0
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with [SemVer](http://semver.org), by describing the features, fixes, and breaking changes made in commit messages.
+
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements, to communicate intent to the consumers of your library:
+
+1.  **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in Semantic Versioning).
+2.  **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in Semantic Versioning).
+3.  **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or appends a `'!'` after the type/scope, introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic Versioning). A BREAKING CHANGE can be part of commits of any _type_.
+4.  _types_ other than `fix:` and `feat:` are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+5.  _footers_ other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
+
+Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE). A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `'!'` to draw attention to breaking change
+
+```
+feat'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `'!'` to draw attention to breaking change
+
+```
+feat(api)'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with both `'!'` and BREAKING CHANGE footer
+
+```
+chore'!': drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1.  Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `'!'`, and REQUIRED terminal colon and space.
+2.  The type `feat` MUST be used when a commit adds a new feature to your application or library.
+3.  The type `fix` MUST be used when a commit represents a bug fix for your application.
+4.  A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+5.  A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+6.  A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+7.  A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+8.  One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+9.  A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., _BREAKING CHANGE: environment variables now take precedence over config files_.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a `'!'` immediately before the `:`. If `'!'` is used, `BREAKING CHANGE:` MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+14. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: update ref docs_.
+15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+## Why Use Conventional Commits
+
+- Automatically generating CHANGELOGs.
+- Automatically determining a semantic version bump (based on the types of commits landed).
+- Communicating the nature of changes to teammates, the public, and other stakeholders.
+- Triggering build and publish processes.
+- Making it easier for people to contribute to your projects, by allowing them to explore a more structured commit history.
+
+## FAQ
+
+### How should I deal with commit messages in the initial development phase?
+
+We recommend that you proceed as if you've already released the product. Typically _somebody_, even if it's your fellow software developers, is using your software. They'll want to know what's fixed, what breaks etc.
+
+### Are the types in the commit title uppercase or lowercase?
+
+Any casing may be used, but it's best to be consistent.
+
+### What do I do if the commit conforms to more than one of the commit types?
+
+Go back and make multiple commits whenever possible. Part of the benefit of Conventional Commits is its ability to drive us to make more organized commits and PRs.
+
+### Doesn't this discourage rapid development and fast iteration?
+
+It discourages moving fast in a disorganized way. It helps you be able to move fast long term across multiple projects with varied contributors.
+
+### Might Conventional Commits lead developers to limit the type of commits they make because they'll be thinking in the types provided?
+
+Conventional Commits encourages us to make more of certain types of commits such as fixes. Other than that, the flexibility of Conventional Commits allows your team to come up with their own types and change those types over time.
+
+### How does this relate to SemVer?
+
+`fix` type commits should be translated to `PATCH` releases. `feat` type commits should be translated to `MINOR` releases. Commits with `BREAKING CHANGE` in the commits, regardless of type, should be translated to `MAJOR` releases.
+
+### How should I version my extensions to the Conventional Commits Specification, e.g., `@jameswomack/conventional-commit-spec`?
+
+We recommend using SemVer to release your own extensions to this specification (and encourage you to make these extensions'!')
+
+### What do I do if I accidentally use the wrong commit type?
+
+#### When you used a type that's of the spec but not the correct type, e.g., `fix` instead of `feat`
+
+Prior to merging or releasing the mistake, we recommend using `git rebase -i` to edit the commit history. After release, the cleanup will be different according to what tools and processes you use.
+
+#### When you used a type _not_ of the spec, e.g., `feet` instead of `feat`
+
+In a worst case scenario, it's not the end of the world if a commit lands that does not meet the Conventional Commits specification. It simply means that commit will be missed by tools that are based on the spec.
+
+### Do all my contributors need to use the Conventional Commits specification?
+
+No'!' If you use a squash based workflow on Git lead maintainers can clean up the commit messages as they're merged—adding no workload to casual committers. A common workflow for this is to have your git system automatically squash commits from a pull request and present a form for the lead maintainer to enter the proper git commit message for the merge.
+
+### How does Conventional Commits handle revert commits?
+
+Reverting code can be complicated: are you reverting multiple commits? if you revert a feature, should the next release instead be a patch?
+
+Conventional Commits does not make an explicit effort to define revert behavior. Instead we leave it to tooling authors to use the flexibility of _types_ and _footers_ to develop their logic for handling reverts.
+
+One recommendation is to use the `revert` type, and a footer that references the commit SHAs that are being reverted:
+
+```
+revert: let us never again speak of the noodle incident
+
+Refs: 676104e, a215868
+```

--- a/.claude/skills/az-create-pr/SKILL.md
+++ b/.claude/skills/az-create-pr/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: az-create-pr
+description: Commit unstaged changes, push changes, submit an Azure DevOps pull request.
+---
+
+# Create Azure DevOps Pull Request
+
+Commit changes, push to remote, and create an Azure DevOps pull request with a conventional commit-style title and comprehensive description: $ARGUMENTS
+
+## Current Repository State
+
+- Azure DevOps auth: !`az account show --query "user.name" -o tsv 2>/dev/null || echo "NOT_AUTHENTICATED"`
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Default branch: !`az repos show --query "defaultBranch" -o tsv 2>/dev/null | sed 's|refs/heads/||' || git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||' || echo main`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits on this branch: !`git log --oneline -10`
+- Existing PR for branch: !`az repos pr list --source-branch $(git branch --show-current) --status active --query "[0].{id:pullRequestId,title:title}" -o json 2>/dev/null || echo "No existing PR"`
+- Commits ahead of default: !`git log --oneline origin/main..HEAD 2>/dev/null | head -20`
+
+## Prerequisites
+
+If the auth check above shows `NOT_AUTHENTICATED`, stop and print this setup guide:
+
+```
+Azure DevOps CLI is not configured. Run these commands to set up:
+
+  az extension add --name azure-devops
+  az login
+  az devops configure --defaults organization=https://dev.azure.com/<YOUR_ORG> project=<YOUR_PROJECT>
+```
+
+Do NOT proceed with PR creation until authentication is confirmed.
+
+## What This Command Does
+
+1. **Stage and commit changes** using conventional commit format (follow the az-commit skill conventions)
+    - If there are unstaged changes, stage and commit them with appropriate conventional commit messages
+    - If multiple distinct logical changes exist, create separate commits for each
+    - ALWAYS attribute AI-assisted code authorship in commits
+2. **Push the branch** to the remote repository
+    - If the current branch is the default branch (main/master), create a new feature branch first
+    - Use `git push -u origin <branch>` to set upstream tracking
+3. **Analyze all changes** in the branch relative to the base branch
+    - Run `git diff origin/<default-branch>...HEAD` to review the full scope of changes
+    - Read relevant modified files to understand the context and impact of changes
+4. **Generate a PR title** following Conventional Commits format:
+    - Format: `<type>[optional scope]: <description>`
+    - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+    - Use `!` after type/scope for breaking changes: `feat(api)!: change response format`
+    - Keep the title concise (under 72 characters)
+    - For multi-commit PRs, synthesize a higher-level title that captures the overall theme
+5. **Generate a PR description** with the structure defined in the PR Description Template below
+6. **Scan for work item IDs** in branch name and commit messages
+    - Look for patterns like `#1234`, `AB#1234`, or numeric IDs in branch names (e.g., `feature/1234-my-feature`)
+    - These will be passed via `--work-items` flag
+7. **Create or update the pull request**
+    - If no PR exists for this branch: `az repos pr create --title "TITLE" --description "DESCRIPTION" --source-branch <current> --target-branch <default> --draft`
+    - If a PR already exists: `az repos pr update --id <id> --title "TITLE" --description "DESCRIPTION"`
+    - Include `--work-items <ids>` if work item IDs were found
+
+## PR Title Examples
+
+```
+feat(auth): add JWT token refresh endpoint
+fix(ui): resolve layout shift on mobile navigation
+docs: update API reference for v2 endpoints
+refactor(db): migrate from raw SQL to query builder
+feat(api)!: change pagination response format
+chore(deps): bump TypeScript to 5.x
+```
+
+## PR Description Template
+
+Use this structure for the PR body. Omit sections that are not applicable.
+
+```markdown
+## Summary
+
+[1-2 sentence overview of what this PR does and why]
+
+## Changes
+
+- [Key change 1]
+- [Key change 2]
+- [Key change 3]
+
+## Breaking Changes
+
+[Describe what breaks and required migration steps]
+
+## Notes
+
+[Additional context, testing instructions, or deployment considerations]
+```
+
+## Guidelines
+
+- **Respect existing content**: If the PR title already follows conventional commit format, keep it unless it's inaccurate. If a PR already has a meaningful description, enhance it rather than replace it entirely.
+- **Work item references**: If the branch name contains a work item ID (e.g., `feature/1234-add-auth`), include `--work-items 1234` in the create/update command.
+- **Holistic analysis**: The PR title should capture the overall intent of the changes, not just list individual commits.
+- **Single-commit PRs**: The PR title can mirror the commit message.
+- **Multi-commit PRs**: Synthesize a higher-level title that captures the full scope.
+- **Draft by default**: Always create PRs as drafts using `--draft` flag.
+- Use markdown formatting in the description for readability.
+
+## Important Notes
+
+- By default, pre-commit checks (defined in `.pre-commit-config.yaml`) will run to ensure code quality
+    - IMPORTANT: DO NOT SKIP pre-commit checks
+- ALWAYS attribute AI-Assisted Code Authorship in commit messages
+- Always review the diff before generating the title and description to ensure accuracy
+- If `az` CLI is not authenticated or the azure-devops extension is not installed, prompt the user with the setup guide above
+- Use `az repos pr create` (not `gh pr create`) — this is an Azure DevOps repository

--- a/.github/skills/az-commit/SKILL.md
+++ b/.github/skills/az-commit/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: az-commit
+description: Create well-formatted commits with conventional commit format.
+---
+
+# Smart Git Commit
+
+Create well-formatted commit: $ARGUMENTS
+
+## Current Repository State
+
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits: !`git log --oneline -5`
+- Azure DevOps auth: !`az account show --query "user.name" -o tsv 2>/dev/null || echo "Not authenticated"`
+
+## What This Command Does
+
+1. Checks which files are staged with `git status`
+2. If 0 files are staged, automatically adds all modified and new files with `git add`
+3. Performs a `git diff` to understand what changes are being committed
+4. Analyzes the diff to determine if multiple distinct logical changes are present
+5. If multiple distinct changes are detected, suggests breaking the commit into multiple smaller commits
+6. For each commit (or the single commit if not split), creates a commit message using conventional commit format
+
+## Best Practices for Commits
+
+- Follow the Conventional Commits specification as described below.
+
+# Conventional Commits 1.0.0
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with [SemVer](http://semver.org), by describing the features, fixes, and breaking changes made in commit messages.
+
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements, to communicate intent to the consumers of your library:
+
+1.  **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in Semantic Versioning).
+2.  **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in Semantic Versioning).
+3.  **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or appends a `'!'` after the type/scope, introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic Versioning). A BREAKING CHANGE can be part of commits of any _type_.
+4.  _types_ other than `fix:` and `feat:` are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+5.  _footers_ other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
+
+Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE). A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `'!'` to draw attention to breaking change
+
+```
+feat'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `'!'` to draw attention to breaking change
+
+```
+feat(api)'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with both `'!'` and BREAKING CHANGE footer
+
+```
+chore'!': drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1.  Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `'!'`, and REQUIRED terminal colon and space.
+2.  The type `feat` MUST be used when a commit adds a new feature to your application or library.
+3.  The type `fix` MUST be used when a commit represents a bug fix for your application.
+4.  A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+5.  A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+6.  A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+7.  A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+8.  One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+9.  A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., _BREAKING CHANGE: environment variables now take precedence over config files_.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a `'!'` immediately before the `:`. If `'!'` is used, `BREAKING CHANGE:` MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+14. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: update ref docs_.
+15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+## Why Use Conventional Commits
+
+- Automatically generating CHANGELOGs.
+- Automatically determining a semantic version bump (based on the types of commits landed).
+- Communicating the nature of changes to teammates, the public, and other stakeholders.
+- Triggering build and publish processes.
+- Making it easier for people to contribute to your projects, by allowing them to explore a more structured commit history.
+
+## FAQ
+
+### How should I deal with commit messages in the initial development phase?
+
+We recommend that you proceed as if you've already released the product. Typically _somebody_, even if it's your fellow software developers, is using your software. They'll want to know what's fixed, what breaks etc.
+
+### Are the types in the commit title uppercase or lowercase?
+
+Any casing may be used, but it's best to be consistent.
+
+### What do I do if the commit conforms to more than one of the commit types?
+
+Go back and make multiple commits whenever possible. Part of the benefit of Conventional Commits is its ability to drive us to make more organized commits and PRs.
+
+### Doesn't this discourage rapid development and fast iteration?
+
+It discourages moving fast in a disorganized way. It helps you be able to move fast long term across multiple projects with varied contributors.
+
+### Might Conventional Commits lead developers to limit the type of commits they make because they'll be thinking in the types provided?
+
+Conventional Commits encourages us to make more of certain types of commits such as fixes. Other than that, the flexibility of Conventional Commits allows your team to come up with their own types and change those types over time.
+
+### How does this relate to SemVer?
+
+`fix` type commits should be translated to `PATCH` releases. `feat` type commits should be translated to `MINOR` releases. Commits with `BREAKING CHANGE` in the commits, regardless of type, should be translated to `MAJOR` releases.
+
+### How should I version my extensions to the Conventional Commits Specification, e.g., `@jameswomack/conventional-commit-spec`?
+
+We recommend using SemVer to release your own extensions to this specification (and encourage you to make these extensions'!')
+
+### What do I do if I accidentally use the wrong commit type?
+
+#### When you used a type that's of the spec but not the correct type, e.g., `fix` instead of `feat`
+
+Prior to merging or releasing the mistake, we recommend using `git rebase -i` to edit the commit history. After release, the cleanup will be different according to what tools and processes you use.
+
+#### When you used a type _not_ of the spec, e.g., `feet` instead of `feat`
+
+In a worst case scenario, it's not the end of the world if a commit lands that does not meet the Conventional Commits specification. It simply means that commit will be missed by tools that are based on the spec.
+
+### Do all my contributors need to use the Conventional Commits specification?
+
+No'!' If you use a squash based workflow on Git lead maintainers can clean up the commit messages as they're merged—adding no workload to casual committers. A common workflow for this is to have your git system automatically squash commits from a pull request and present a form for the lead maintainer to enter the proper git commit message for the merge.
+
+### How does Conventional Commits handle revert commits?
+
+Reverting code can be complicated: are you reverting multiple commits? if you revert a feature, should the next release instead be a patch?
+
+Conventional Commits does not make an explicit effort to define revert behavior. Instead we leave it to tooling authors to use the flexibility of _types_ and _footers_ to develop their logic for handling reverts.
+
+One recommendation is to use the `revert` type, and a footer that references the commit SHAs that are being reverted:
+
+```
+revert: let us never again speak of the noodle incident
+
+Refs: 676104e, a215868
+```

--- a/.github/skills/az-create-pr/SKILL.md
+++ b/.github/skills/az-create-pr/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: az-create-pr
+description: Commit unstaged changes, push changes, submit an Azure DevOps pull request.
+---
+
+# Create Azure DevOps Pull Request
+
+Commit changes, push to remote, and create an Azure DevOps pull request with a conventional commit-style title and comprehensive description: $ARGUMENTS
+
+## Current Repository State
+
+- Azure DevOps auth: !`az account show --query "user.name" -o tsv 2>/dev/null || echo "NOT_AUTHENTICATED"`
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Default branch: !`az repos show --query "defaultBranch" -o tsv 2>/dev/null | sed 's|refs/heads/||' || git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||' || echo main`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits on this branch: !`git log --oneline -10`
+- Existing PR for branch: !`az repos pr list --source-branch $(git branch --show-current) --status active --query "[0].{id:pullRequestId,title:title}" -o json 2>/dev/null || echo "No existing PR"`
+- Commits ahead of default: !`git log --oneline origin/main..HEAD 2>/dev/null | head -20`
+
+## Prerequisites
+
+If the auth check above shows `NOT_AUTHENTICATED`, stop and print this setup guide:
+
+```
+Azure DevOps CLI is not configured. Run these commands to set up:
+
+  az extension add --name azure-devops
+  az login
+  az devops configure --defaults organization=https://dev.azure.com/<YOUR_ORG> project=<YOUR_PROJECT>
+```
+
+Do NOT proceed with PR creation until authentication is confirmed.
+
+## What This Command Does
+
+1. **Stage and commit changes** using conventional commit format (follow the az-commit skill conventions)
+    - If there are unstaged changes, stage and commit them with appropriate conventional commit messages
+    - If multiple distinct logical changes exist, create separate commits for each
+    - ALWAYS attribute AI-assisted code authorship in commits
+2. **Push the branch** to the remote repository
+    - If the current branch is the default branch (main/master), create a new feature branch first
+    - Use `git push -u origin <branch>` to set upstream tracking
+3. **Analyze all changes** in the branch relative to the base branch
+    - Run `git diff origin/<default-branch>...HEAD` to review the full scope of changes
+    - Read relevant modified files to understand the context and impact of changes
+4. **Generate a PR title** following Conventional Commits format:
+    - Format: `<type>[optional scope]: <description>`
+    - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+    - Use `!` after type/scope for breaking changes: `feat(api)!: change response format`
+    - Keep the title concise (under 72 characters)
+    - For multi-commit PRs, synthesize a higher-level title that captures the overall theme
+5. **Generate a PR description** with the structure defined in the PR Description Template below
+6. **Scan for work item IDs** in branch name and commit messages
+    - Look for patterns like `#1234`, `AB#1234`, or numeric IDs in branch names (e.g., `feature/1234-my-feature`)
+    - These will be passed via `--work-items` flag
+7. **Create or update the pull request**
+    - If no PR exists for this branch: `az repos pr create --title "TITLE" --description "DESCRIPTION" --source-branch <current> --target-branch <default> --draft`
+    - If a PR already exists: `az repos pr update --id <id> --title "TITLE" --description "DESCRIPTION"`
+    - Include `--work-items <ids>` if work item IDs were found
+
+## PR Title Examples
+
+```
+feat(auth): add JWT token refresh endpoint
+fix(ui): resolve layout shift on mobile navigation
+docs: update API reference for v2 endpoints
+refactor(db): migrate from raw SQL to query builder
+feat(api)!: change pagination response format
+chore(deps): bump TypeScript to 5.x
+```
+
+## PR Description Template
+
+Use this structure for the PR body. Omit sections that are not applicable.
+
+```markdown
+## Summary
+
+[1-2 sentence overview of what this PR does and why]
+
+## Changes
+
+- [Key change 1]
+- [Key change 2]
+- [Key change 3]
+
+## Breaking Changes
+
+[Describe what breaks and required migration steps]
+
+## Notes
+
+[Additional context, testing instructions, or deployment considerations]
+```
+
+## Guidelines
+
+- **Respect existing content**: If the PR title already follows conventional commit format, keep it unless it's inaccurate. If a PR already has a meaningful description, enhance it rather than replace it entirely.
+- **Work item references**: If the branch name contains a work item ID (e.g., `feature/1234-add-auth`), include `--work-items 1234` in the create/update command.
+- **Holistic analysis**: The PR title should capture the overall intent of the changes, not just list individual commits.
+- **Single-commit PRs**: The PR title can mirror the commit message.
+- **Multi-commit PRs**: Synthesize a higher-level title that captures the full scope.
+- **Draft by default**: Always create PRs as drafts using `--draft` flag.
+- Use markdown formatting in the description for readability.
+
+## Important Notes
+
+- By default, pre-commit checks (defined in `.pre-commit-config.yaml`) will run to ensure code quality
+    - IMPORTANT: DO NOT SKIP pre-commit checks
+- ALWAYS attribute AI-Assisted Code Authorship in commit messages
+- Always review the diff before generating the title and description to ensure accuracy
+- If `az` CLI is not authenticated or the azure-devops extension is not installed, prompt the user with the setup guide above
+- Use `az repos pr create` (not `gh pr create`) — this is an Azure DevOps repository

--- a/.github/skills/gh-commit/SKILL.md
+++ b/.github/skills/gh-commit/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: gh-commit
+description: Create well-formatted commits with conventional commit format.
+---
+
+# Smart Git Commit
+
+Create well-formatted commit: $ARGUMENTS
+
+## Current Repository State
+
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits: !`git log --oneline -5`
+
+## What This Command Does
+
+1. Checks which files are staged with `git status`
+2. If 0 files are staged, automatically adds all modified and new files with `git add`
+3. Performs a `git diff` to understand what changes are being committed
+4. Analyzes the diff to determine if multiple distinct logical changes are present
+5. If multiple distinct changes are detected, suggests breaking the commit into multiple smaller commits
+6. For each commit (or the single commit if not split), creates a commit message using conventional commit format
+
+## Best Practices for Commits
+
+- Follow the Conventional Commits specification as described below.
+
+# Conventional Commits 1.0.0
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with [SemVer](http://semver.org), by describing the features, fixes, and breaking changes made in commit messages.
+
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements, to communicate intent to the consumers of your library:
+
+1.  **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in Semantic Versioning).
+2.  **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in Semantic Versioning).
+3.  **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or appends a `'!'` after the type/scope, introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic Versioning). A BREAKING CHANGE can be part of commits of any _type_.
+4.  _types_ other than `fix:` and `feat:` are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+5.  _footers_ other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
+
+Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE). A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `'!'` to draw attention to breaking change
+
+```
+feat'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `'!'` to draw attention to breaking change
+
+```
+feat(api)'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with both `'!'` and BREAKING CHANGE footer
+
+```
+chore'!': drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1.  Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `'!'`, and REQUIRED terminal colon and space.
+2.  The type `feat` MUST be used when a commit adds a new feature to your application or library.
+3.  The type `fix` MUST be used when a commit represents a bug fix for your application.
+4.  A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+5.  A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+6.  A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+7.  A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+8.  One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+9.  A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., _BREAKING CHANGE: environment variables now take precedence over config files_.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a `'!'` immediately before the `:`. If `'!'` is used, `BREAKING CHANGE:` MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+14. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: update ref docs._
+15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+## Why Use Conventional Commits
+
+- Automatically generating CHANGELOGs.
+- Automatically determining a semantic version bump (based on the types of commits landed).
+- Communicating the nature of changes to teammates, the public, and other stakeholders.
+- Triggering build and publish processes.
+- Making it easier for people to contribute to your projects, by allowing them to explore a more structured commit history.
+
+## FAQ
+
+### How should I deal with commit messages in the initial development phase?
+
+We recommend that you proceed as if you've already released the product. Typically _somebody_, even if it's your fellow software developers, is using your software. They'll want to know what's fixed, what breaks etc.
+
+### Are the types in the commit title uppercase or lowercase?
+
+Any casing may be used, but it's best to be consistent.
+
+### What do I do if the commit conforms to more than one of the commit types?
+
+Go back and make multiple commits whenever possible. Part of the benefit of Conventional Commits is its ability to drive us to make more organized commits and PRs.
+
+### Doesn't this discourage rapid development and fast iteration?
+
+It discourages moving fast in a disorganized way. It helps you be able to move fast long term across multiple projects with varied contributors.
+
+### Might Conventional Commits lead developers to limit the type of commits they make because they'll be thinking in the types provided?
+
+Conventional Commits encourages us to make more of certain types of commits such as fixes. Other than that, the flexibility of Conventional Commits allows your team to come up with their own types and change those types over time.
+
+### How does this relate to SemVer?
+
+`fix` type commits should be translated to `PATCH` releases. `feat` type commits should be translated to `MINOR` releases. Commits with `BREAKING CHANGE` in the commits, regardless of type, should be translated to `MAJOR` releases.
+
+### How should I version my extensions to the Conventional Commits Specification, e.g. `@jameswomack/conventional-commit-spec`?
+
+We recommend using SemVer to release your own extensions to this specification (and encourage you to make these extensions'!')
+
+### What do I do if I accidentally use the wrong commit type?
+
+#### When you used a type that's of the spec but not the correct type, e.g. `fix` instead of `feat`
+
+Prior to merging or releasing the mistake, we recommend using `git rebase -i` to edit the commit history. After release, the cleanup will be different according to what tools and processes you use.
+
+#### When you used a type _not_ of the spec, e.g. `feet` instead of `feat`
+
+In a worst case scenario, it's not the end of the world if a commit lands that does not meet the Conventional Commits specification. It simply means that commit will be missed by tools that are based on the spec.
+
+### Do all my contributors need to use the Conventional Commits specification?
+
+No'!' If you use a squash based workflow on Git lead maintainers can clean up the commit messages as they're merged—adding no workload to casual committers. A common workflow for this is to have your git system automatically squash commits from a pull request and present a form for the lead maintainer to enter the proper git commit message for the merge.
+
+### How does Conventional Commits handle revert commits?
+
+Reverting code can be complicated: are you reverting multiple commits? if you revert a feature, should the next release instead be a patch?
+
+Conventional Commits does not make an explicit effort to define revert behavior. Instead we leave it to tooling authors to use the flexibility of _types_ and _footers_ to develop their logic for handling reverts.
+
+One recommendation is to use the `revert` type, and a footer that references the commit SHAs that are being reverted:
+
+```
+revert: let us never again speak of the noodle incident
+
+Refs: 676104e, a215868
+```
+
+### Attributing AI-Assisted Code Authorship
+
+When using AI tools to generate code, it can be beneficial to maintain transparency about authorship for accountability, code review, and auditing purposes. This can be done easily by using Git trailers that append structured metadata to the end of commit messages.
+
+This can be done by appending one or more custom trailers in the commit message, such as:
+
+```
+Assistant-model: Claude Code
+```
+
+Because most Git tooling expects `Co-authored-by` trailers to be formatted as email addresses, you should use a different trailer key to avoid confusion and to distinguish authorship from assistance.
+
+Trailers can be added manually at the end of a commit message, or by using the `git commit` command with the `--trailer` option:
+
+```
+git commit --message "Implement feature" --trailer "Assistant-model: Claude Code"
+```
+
+Trailers can be displayed using the [pretty formats](https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-trailersoptions) option to `git log` command. For example, for a formatted history showing the hash, author name, and assistant models used for each commit:
+
+```
+git log --color --pretty=format:"%C(yellow)%h%C(reset) %C(blue)%an%C(reset) [%C(magenta)%(trailers:key=Assistant-model,valueonly=true,separator=%x2C)%C(reset)] %s%C(bold cyan)%d%C(reset)"
+```
+
+```
+2100e6c Author [Claude Code] Test commit 4 (HEAD -> work-item-8)
+7120221 Author [Claude Code] Test commit 3
+ea03d91 Author [] Test commit 2
+f93fd8e Author [Claude Code] Test commit 1
+dde0159 Claude Code [] Test work item (#7) (origin/main, origin/HEAD)
+```
+
+## Important Notes
+
+- By default, pre-commit checks (defined in `.pre-commit-config.yaml`) will run to ensure code quality
+    - IMPORTANT: DO NOT SKIP pre-commit checks
+- ALWAYS attribute AI-Assisted Code Authorship
+- If specific files are already staged, the command will only commit those files
+- If no files are staged, it will automatically stage all modified and new files
+- The commit message will be constructed based on the changes detected
+- Before committing, the command will review the diff to identify if multiple commits would be more appropriate
+- If suggesting multiple commits, it will help you stage and commit the changes separately
+- Always reviews the commit diff to ensure the message matches the changes

--- a/.github/skills/gh-create-pr/SKILL.md
+++ b/.github/skills/gh-create-pr/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: gh-create-pr
+description: Commit unstaged changes, push changes, submit a pull request.
+---
+
+# Create Pull Request
+
+Commit changes, push to remote, and create a pull request with a conventional commit-style title and comprehensive description: $ARGUMENTS
+
+## Current Repository State
+
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Default branch: !`git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||' || echo main`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits on this branch: !`git log --oneline -10`
+- Existing PR for branch: !`gh pr view --json number,title,body 2>/dev/null || echo "No existing PR"`
+
+## What This Command Does
+
+1. **Stage and commit changes** using conventional commit format (follow the gh-commit skill conventions)
+    - If there are unstaged changes, stage and commit them with appropriate conventional commit messages
+    - If multiple distinct logical changes exist, create separate commits for each
+    - ALWAYS attribute AI-assisted code authorship in commits
+2. **Push the branch** to the remote repository
+    - If the current branch is the default branch (main/master), create a new feature branch first
+    - Use `git push -u origin <branch>` to set upstream tracking
+3. **Analyze all changes** in the branch relative to the base branch
+    - Run `git diff origin/<default-branch>...HEAD` to review the full scope of changes
+    - Read relevant modified files to understand the context and impact of changes
+4. **Generate a PR title** following Conventional Commits format:
+    - Format: `<type>[optional scope]: <description>`
+    - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+    - Use `!` after type/scope for breaking changes: `feat(api)!: change response format`
+    - Keep the title concise (under 72 characters)
+    - For multi-commit PRs, synthesize a higher-level title that captures the overall theme
+5. **Generate a PR description** with the structure defined in the PR Description Template below
+6. **Create or update the pull request**
+    - If no PR exists for this branch: `gh pr create --title "TITLE" --body "DESCRIPTION"`
+    - If a PR already exists: `gh pr edit <number> --title "TITLE" --body "DESCRIPTION"`
+
+## PR Title Examples
+
+```
+feat(auth): add JWT token refresh endpoint
+fix(ui): resolve layout shift on mobile navigation
+docs: update API reference for v2 endpoints
+refactor(db): migrate from raw SQL to query builder
+feat(api)!: change pagination response format
+chore(deps): bump TypeScript to 5.x
+```
+
+## PR Description Template
+
+Use this structure for the PR body. Omit sections that are not applicable.
+
+```markdown
+## Summary
+
+[1-2 sentence overview of what this PR does and why]
+
+## Changes
+
+- [Key change 1]
+- [Key change 2]
+- [Key change 3]
+
+## Breaking Changes
+
+[Describe what breaks and required migration steps]
+
+## Notes
+
+[Additional context, testing instructions, or deployment considerations]
+```
+
+## Guidelines
+
+- **Respect existing content**: If the PR title already follows conventional commit format, keep it unless it's inaccurate. If a PR already has a meaningful description, enhance it rather than replace it entirely.
+- **Issue references**: If the branch name contains an issue number (e.g., `feat/123-add-auth`), reference it in the description with `Closes #123` or `Refs #123`.
+- **Holistic analysis**: The PR title should capture the overall intent of the changes, not just list individual commits.
+- **Single-commit PRs**: The PR title can mirror the commit message.
+- **Multi-commit PRs**: Synthesize a higher-level title that captures the full scope.
+- Use markdown formatting in the description for readability.
+
+## Important Notes
+
+- By default, pre-commit checks (defined in `.pre-commit-config.yaml`) will run to ensure code quality
+    - IMPORTANT: DO NOT SKIP pre-commit checks
+- ALWAYS attribute AI-Assisted Code Authorship in commit messages
+- Always review the diff before generating the title and description to ensure accuracy
+- If `gh` CLI is not authenticated, prompt the user to run `gh auth login` first

--- a/.opencode/skills/az-commit/SKILL.md
+++ b/.opencode/skills/az-commit/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: az-commit
+description: Create well-formatted commits with conventional commit format.
+---
+
+# Smart Git Commit
+
+Create well-formatted commit: $ARGUMENTS
+
+## Current Repository State
+
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits: !`git log --oneline -5`
+- Azure DevOps auth: !`az account show --query "user.name" -o tsv 2>/dev/null || echo "Not authenticated"`
+
+## What This Command Does
+
+1. Checks which files are staged with `git status`
+2. If 0 files are staged, automatically adds all modified and new files with `git add`
+3. Performs a `git diff` to understand what changes are being committed
+4. Analyzes the diff to determine if multiple distinct logical changes are present
+5. If multiple distinct changes are detected, suggests breaking the commit into multiple smaller commits
+6. For each commit (or the single commit if not split), creates a commit message using conventional commit format
+
+## Best Practices for Commits
+
+- Follow the Conventional Commits specification as described below.
+
+# Conventional Commits 1.0.0
+
+## Summary
+
+The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with [SemVer](http://semver.org), by describing the features, fixes, and breaking changes made in commit messages.
+
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements, to communicate intent to the consumers of your library:
+
+1.  **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in Semantic Versioning).
+2.  **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in Semantic Versioning).
+3.  **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:`, or appends a `'!'` after the type/scope, introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in Semantic Versioning). A BREAKING CHANGE can be part of commits of any _type_.
+4.  _types_ other than `fix:` and `feat:` are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+5.  _footers_ other than `BREAKING CHANGE: <description>` may be provided and follow a convention similar to [git trailer format](https://git-scm.com/docs/git-interpret-trailers).
+
+Additional types are not mandated by the Conventional Commits specification, and have no implicit effect in Semantic Versioning (unless they include a BREAKING CHANGE). A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with `'!'` to draw attention to breaking change
+
+```
+feat'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with scope and `'!'` to draw attention to breaking change
+
+```
+feat(api)'!': send an email to the customer when a product is shipped
+```
+
+### Commit message with both `'!'` and BREAKING CHANGE footer
+
+```
+chore'!': drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+### Commit message with no body
+
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+
+```
+feat(lang): add Polish language
+```
+
+### Commit message with multi-paragraph body and multiple footers
+
+```
+fix: prevent racing of requests
+
+Introduce a request id and a reference to latest request. Dismiss
+incoming responses other than from latest request.
+
+Remove timeouts which were used to mitigate the racing issue but are
+obsolete now.
+
+Reviewed-by: Z
+Refs: #123
+```
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1.  Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `'!'`, and REQUIRED terminal colon and space.
+2.  The type `feat` MUST be used when a commit adds a new feature to your application or library.
+3.  The type `fix` MUST be used when a commit represents a bug fix for your application.
+4.  A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+5.  A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string_.
+6.  A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+7.  A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+8.  One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the [git trailer convention](https://git-scm.com/docs/git-interpret-trailers)).
+9.  A footer's token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
+10. A footer's value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., _BREAKING CHANGE: environment variables now take precedence over config files_.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a `'!'` immediately before the `:`. If `'!'` is used, `BREAKING CHANGE:` MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+14. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., _docs: update ref docs_.
+15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+## Why Use Conventional Commits
+
+- Automatically generating CHANGELOGs.
+- Automatically determining a semantic version bump (based on the types of commits landed).
+- Communicating the nature of changes to teammates, the public, and other stakeholders.
+- Triggering build and publish processes.
+- Making it easier for people to contribute to your projects, by allowing them to explore a more structured commit history.
+
+## FAQ
+
+### How should I deal with commit messages in the initial development phase?
+
+We recommend that you proceed as if you've already released the product. Typically _somebody_, even if it's your fellow software developers, is using your software. They'll want to know what's fixed, what breaks etc.
+
+### Are the types in the commit title uppercase or lowercase?
+
+Any casing may be used, but it's best to be consistent.
+
+### What do I do if the commit conforms to more than one of the commit types?
+
+Go back and make multiple commits whenever possible. Part of the benefit of Conventional Commits is its ability to drive us to make more organized commits and PRs.
+
+### Doesn't this discourage rapid development and fast iteration?
+
+It discourages moving fast in a disorganized way. It helps you be able to move fast long term across multiple projects with varied contributors.
+
+### Might Conventional Commits lead developers to limit the type of commits they make because they'll be thinking in the types provided?
+
+Conventional Commits encourages us to make more of certain types of commits such as fixes. Other than that, the flexibility of Conventional Commits allows your team to come up with their own types and change those types over time.
+
+### How does this relate to SemVer?
+
+`fix` type commits should be translated to `PATCH` releases. `feat` type commits should be translated to `MINOR` releases. Commits with `BREAKING CHANGE` in the commits, regardless of type, should be translated to `MAJOR` releases.
+
+### How should I version my extensions to the Conventional Commits Specification, e.g., `@jameswomack/conventional-commit-spec`?
+
+We recommend using SemVer to release your own extensions to this specification (and encourage you to make these extensions'!')
+
+### What do I do if I accidentally use the wrong commit type?
+
+#### When you used a type that's of the spec but not the correct type, e.g., `fix` instead of `feat`
+
+Prior to merging or releasing the mistake, we recommend using `git rebase -i` to edit the commit history. After release, the cleanup will be different according to what tools and processes you use.
+
+#### When you used a type _not_ of the spec, e.g., `feet` instead of `feat`
+
+In a worst case scenario, it's not the end of the world if a commit lands that does not meet the Conventional Commits specification. It simply means that commit will be missed by tools that are based on the spec.
+
+### Do all my contributors need to use the Conventional Commits specification?
+
+No'!' If you use a squash based workflow on Git lead maintainers can clean up the commit messages as they're merged—adding no workload to casual committers. A common workflow for this is to have your git system automatically squash commits from a pull request and present a form for the lead maintainer to enter the proper git commit message for the merge.
+
+### How does Conventional Commits handle revert commits?
+
+Reverting code can be complicated: are you reverting multiple commits? if you revert a feature, should the next release instead be a patch?
+
+Conventional Commits does not make an explicit effort to define revert behavior. Instead we leave it to tooling authors to use the flexibility of _types_ and _footers_ to develop their logic for handling reverts.
+
+One recommendation is to use the `revert` type, and a footer that references the commit SHAs that are being reverted:
+
+```
+revert: let us never again speak of the noodle incident
+
+Refs: 676104e, a215868
+```

--- a/.opencode/skills/az-create-pr/SKILL.md
+++ b/.opencode/skills/az-create-pr/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: az-create-pr
+description: Commit unstaged changes, push changes, submit an Azure DevOps pull request.
+---
+
+# Create Azure DevOps Pull Request
+
+Commit changes, push to remote, and create an Azure DevOps pull request with a conventional commit-style title and comprehensive description: $ARGUMENTS
+
+## Current Repository State
+
+- Azure DevOps auth: !`az account show --query "user.name" -o tsv 2>/dev/null || echo "NOT_AUTHENTICATED"`
+- Git status: !`git status --porcelain`
+- Current branch: !`git branch --show-current`
+- Default branch: !`az repos show --query "defaultBranch" -o tsv 2>/dev/null | sed 's|refs/heads/||' || git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||' || echo main`
+- Staged changes: !`git diff --cached --stat`
+- Unstaged changes: !`git diff --stat`
+- Recent commits on this branch: !`git log --oneline -10`
+- Existing PR for branch: !`az repos pr list --source-branch $(git branch --show-current) --status active --query "[0].{id:pullRequestId,title:title}" -o json 2>/dev/null || echo "No existing PR"`
+- Commits ahead of default: !`git log --oneline origin/main..HEAD 2>/dev/null | head -20`
+
+## Prerequisites
+
+If the auth check above shows `NOT_AUTHENTICATED`, stop and print this setup guide:
+
+```
+Azure DevOps CLI is not configured. Run these commands to set up:
+
+  az extension add --name azure-devops
+  az login
+  az devops configure --defaults organization=https://dev.azure.com/<YOUR_ORG> project=<YOUR_PROJECT>
+```
+
+Do NOT proceed with PR creation until authentication is confirmed.
+
+## What This Command Does
+
+1. **Stage and commit changes** using conventional commit format (follow the az-commit skill conventions)
+    - If there are unstaged changes, stage and commit them with appropriate conventional commit messages
+    - If multiple distinct logical changes exist, create separate commits for each
+    - ALWAYS attribute AI-assisted code authorship in commits
+2. **Push the branch** to the remote repository
+    - If the current branch is the default branch (main/master), create a new feature branch first
+    - Use `git push -u origin <branch>` to set upstream tracking
+3. **Analyze all changes** in the branch relative to the base branch
+    - Run `git diff origin/<default-branch>...HEAD` to review the full scope of changes
+    - Read relevant modified files to understand the context and impact of changes
+4. **Generate a PR title** following Conventional Commits format:
+    - Format: `<type>[optional scope]: <description>`
+    - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+    - Use `!` after type/scope for breaking changes: `feat(api)!: change response format`
+    - Keep the title concise (under 72 characters)
+    - For multi-commit PRs, synthesize a higher-level title that captures the overall theme
+5. **Generate a PR description** with the structure defined in the PR Description Template below
+6. **Scan for work item IDs** in branch name and commit messages
+    - Look for patterns like `#1234`, `AB#1234`, or numeric IDs in branch names (e.g., `feature/1234-my-feature`)
+    - These will be passed via `--work-items` flag
+7. **Create or update the pull request**
+    - If no PR exists for this branch: `az repos pr create --title "TITLE" --description "DESCRIPTION" --source-branch <current> --target-branch <default> --draft`
+    - If a PR already exists: `az repos pr update --id <id> --title "TITLE" --description "DESCRIPTION"`
+    - Include `--work-items <ids>` if work item IDs were found
+
+## PR Title Examples
+
+```
+feat(auth): add JWT token refresh endpoint
+fix(ui): resolve layout shift on mobile navigation
+docs: update API reference for v2 endpoints
+refactor(db): migrate from raw SQL to query builder
+feat(api)!: change pagination response format
+chore(deps): bump TypeScript to 5.x
+```
+
+## PR Description Template
+
+Use this structure for the PR body. Omit sections that are not applicable.
+
+```markdown
+## Summary
+
+[1-2 sentence overview of what this PR does and why]
+
+## Changes
+
+- [Key change 1]
+- [Key change 2]
+- [Key change 3]
+
+## Breaking Changes
+
+[Describe what breaks and required migration steps]
+
+## Notes
+
+[Additional context, testing instructions, or deployment considerations]
+```
+
+## Guidelines
+
+- **Respect existing content**: If the PR title already follows conventional commit format, keep it unless it's inaccurate. If a PR already has a meaningful description, enhance it rather than replace it entirely.
+- **Work item references**: If the branch name contains a work item ID (e.g., `feature/1234-add-auth`), include `--work-items 1234` in the create/update command.
+- **Holistic analysis**: The PR title should capture the overall intent of the changes, not just list individual commits.
+- **Single-commit PRs**: The PR title can mirror the commit message.
+- **Multi-commit PRs**: Synthesize a higher-level title that captures the full scope.
+- **Draft by default**: Always create PRs as drafts using `--draft` flag.
+- Use markdown formatting in the description for readability.
+
+## Important Notes
+
+- By default, pre-commit checks (defined in `.pre-commit-config.yaml`) will run to ensure code quality
+    - IMPORTANT: DO NOT SKIP pre-commit checks
+- ALWAYS attribute AI-Assisted Code Authorship in commit messages
+- Always review the diff before generating the title and description to ensure accuracy
+- If `az` CLI is not authenticated or the azure-devops extension is not installed, prompt the user with the setup guide above
+- Use `az repos pr create` (not `gh pr create`) — this is an Azure DevOps repository

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
+    }
+  }
+}

--- a/assets/settings.schema.json
+++ b/assets/settings.schema.json
@@ -14,7 +14,11 @@
     },
     "scm": {
       "type": "string",
-      "enum": ["github", "sapling"],
+      "enum": [
+        "github",
+        "sapling",
+        "azure-devops"
+      ],
       "description": "Selected source control management system."
     },
     "lastUpdated": {
@@ -26,21 +30,43 @@
       "type": "object",
       "description": "Model preferences keyed by agent type.",
       "properties": {
-        "claude": { "type": "string", "description": "Model ID for Claude Code." },
-        "opencode": { "type": "string", "description": "Model ID for OpenCode." },
-        "copilot": { "type": "string", "description": "Model ID for GitHub Copilot." }
+        "claude": {
+          "type": "string",
+          "description": "Model ID for Claude Code."
+        },
+        "opencode": {
+          "type": "string",
+          "description": "Model ID for OpenCode."
+        },
+        "copilot": {
+          "type": "string",
+          "description": "Model ID for GitHub Copilot."
+        }
       },
-      "additionalProperties": { "type": "string" }
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "reasoningEffort": {
       "type": "object",
       "description": "Reasoning effort level keyed by agent type.",
       "properties": {
-        "claude": { "type": "string", "description": "Reasoning effort for Claude Code." },
-        "opencode": { "type": "string", "description": "Reasoning effort for OpenCode." },
-        "copilot": { "type": "string", "description": "Reasoning effort for GitHub Copilot." }
+        "claude": {
+          "type": "string",
+          "description": "Reasoning effort for Claude Code."
+        },
+        "opencode": {
+          "type": "string",
+          "description": "Reasoning effort for OpenCode."
+        },
+        "copilot": {
+          "type": "string",
+          "description": "Reasoning effort for GitHub Copilot."
+        }
       },
-      "additionalProperties": { "type": "string" }
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "prerelease": {
       "type": "boolean",
@@ -52,7 +78,10 @@
       "description": "Globally trusted workspaces that have completed provider onboarding through 'atomic init'.",
       "items": {
         "type": "object",
-        "required": ["workspacePath", "provider"],
+        "required": [
+          "workspacePath",
+          "provider"
+        ],
         "properties": {
           "workspacePath": {
             "type": "string",
@@ -60,7 +89,11 @@
           },
           "provider": {
             "type": "string",
-            "enum": ["claude", "opencode", "copilot"],
+            "enum": [
+              "claude",
+              "opencode",
+              "copilot"
+            ],
             "description": "Provider initialized for the trusted workspace."
           }
         },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@
  *   atomic                          Interactive setup (same as 'atomic init')
  *   atomic init                     Interactive setup with agent selection
  *   atomic init -a <agent>          Setup specific agent (skip selection)
- *   atomic init -s <scm>             Setup specific SCM (github, sapling)
+ *   atomic init -s <scm>             Setup specific SCM (github, sapling, azure-devops)
  *   atomic chat -a <agent>          Start interactive chat with an agent
  *   atomic config set <key> <value> Set configuration value
  *   atomic update                   Self-update to latest version

--- a/src/commands/cli/init/index.ts
+++ b/src/commands/cli/init/index.ts
@@ -302,7 +302,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     if (!hasArcconfig) {
       log.warn(
         "Note: Sapling + Phabricator requires .arcconfig in your repository root.\n" +
-          "See: https://www.phacility.com/phabricator/ for Phabricator setup."
+        "See: https://www.phacility.com/phabricator/ for Phabricator setup."
       );
     }
   }
@@ -369,7 +369,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     const targetSkillsDir = join(targetFolder, "skills");
 
     // Best-effort template copy: source checkouts still carry the bundled
-    // gh-*/sl-* skill templates, but binary and npm installs no longer do
+    // gh-*/sl-*/az-* skill templates, but binary and npm installs no longer do
     // (they live in the skills CLI repo). `installLocalScmSkills` below
     // handles the binary/npm case by invoking `npx skills add` — so a zero
     // copy here is not an error, just a signal that the template isn't
@@ -438,7 +438,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   if (isWindows() && !isWslInstalled()) {
     note(
       `WSL is not installed. Some scripts may require WSL.\n` +
-        `Install WSL: ${WSL_INSTALL_URL}`,
+      `Install WSL: ${WSL_INSTALL_URL}`,
       "Warning"
     );
   }
@@ -446,8 +446,8 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   // Success message
   note(
     `${agent.name} source control skills configured in ${agent.folder}/skills\n\n` +
-      `Selected workflow: ${SCM_CONFIG[scmType].displayName}\n\n` +
-      `Run '${agent.cmd}' to start the agent.`,
+    `Selected workflow: ${SCM_CONFIG[scmType].displayName}\n\n` +
+    `Run '${agent.cmd}' to start the agent.`,
     "Success"
   );
 

--- a/src/commands/cli/init/scm.ts
+++ b/src/commands/cli/init/scm.ts
@@ -4,17 +4,18 @@ import { copyFile, pathExists, ensureDir } from "@/services/system/copy.ts";
 import { getOppositeScriptExtension } from "@/services/system/detect.ts";
 import type { AgentKey, SourceControlType } from "@/services/config/index.ts";
 
-export const SCM_PREFIX_BY_TYPE: Record<SourceControlType, "gh-" | "sl-"> = {
+export const SCM_PREFIX_BY_TYPE: Record<SourceControlType, "gh-" | "sl-" | "az-"> = {
   github: "gh-",
   sapling: "sl-",
+  "azure-devops": "az-",
 };
 
-export function getScmPrefix(scmType: SourceControlType): "gh-" | "sl-" {
+export function getScmPrefix(scmType: SourceControlType): "gh-" | "sl-" | "az-" {
   return SCM_PREFIX_BY_TYPE[scmType];
 }
 
 export function isManagedScmEntry(name: string): boolean {
-  return name.startsWith("gh-") || name.startsWith("sl-");
+  return name.startsWith("gh-") || name.startsWith("sl-") || name.startsWith("az-");
 }
 
 export interface ReconcileScmVariantsOptions {
@@ -132,7 +133,7 @@ export interface InstallLocalScmSkillsResult {
 }
 
 /**
- * Install the SCM skill variants (gh-* or sl-*) locally into the current
+ * Install the SCM skill variants (gh-*, sl-*, or az-*) locally into the current
  * project via `npx skills add`. The `-g` flag is intentionally omitted so
  * the skills are installed per-project (in the given `cwd`).
  *

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -11,7 +11,7 @@
  * When running from an installed package (i.e. somewhere inside
  * `node_modules/`) we also install all bundled skills globally via
  * `npx skills add` and then remove the source-control skill variants
- * (`gh-*` / `sl-*`) globally so `atomic init` can install them locally
+ * (`gh-*` / `sl-*` / `az-*`) globally so `atomic init` can install them locally
  * per-project based on the user's selected SCM + active agent.
  *
  * Source-repo installs (`bun install` on a cloned checkout) skip the global
@@ -44,6 +44,8 @@ const SCM_SKILLS_TO_REMOVE_GLOBALLY = [
   "gh-create-pr",
   "sl-commit",
   "sl-submit-diff",
+  "az-commit",
+  "az-create-pr",
 ] as const;
 
 async function runNpxSkills(args: string[]): Promise<boolean> {

--- a/src/services/config/definitions.ts
+++ b/src/services/config/definitions.ts
@@ -104,11 +104,10 @@ export function getAgentKeys(): AgentKey[] {
  */
 
 /** Supported source control types */
-export type SourceControlType = "github" | "sapling";
-// Future: | 'azure-devops'
+export type SourceControlType = "github" | "sapling" | "azure-devops";
 
 /** SCM keys for iteration */
-const SCM_KEYS = ["github", "sapling"] as const;
+const SCM_KEYS = ["github", "sapling", "azure-devops"] as const;
 
 export interface ScmConfig {
   /** Internal identifier */
@@ -148,6 +147,16 @@ export const SCM_CONFIG: Record<SourceControlType, ScmConfig> = {
     detectDir: ".sl",
     reviewCommandFile: "submit-diff.md",
     requiredConfigFiles: [".arcconfig", "~/.arcrc"],
+  },
+  "azure-devops": {
+    name: "azure-devops",
+    displayName: "Azure DevOps / Git",
+    cliTool: "git",
+    reviewTool: "az repos",
+    reviewSystem: "azure-devops",
+    detectDir: ".git",
+    reviewCommandFile: "create-az-pr.md",
+    requiredConfigFiles: ["~/.azure/azureProfile.json"],
   },
 };
 

--- a/src/services/config/settings.ts
+++ b/src/services/config/settings.ts
@@ -14,7 +14,7 @@ import { join, dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { SETTINGS_SCHEMA_URL } from "@/services/config/settings-schema.ts";
 import { ensureDirSync } from "@/services/system/copy.ts";
-import type { AgentKey } from "@/services/config/definitions.ts";
+import type { AgentKey, SourceControlType } from "@/services/config/definitions.ts";
 
 export interface TrustedPathEntry {
   workspacePath: string;
@@ -23,7 +23,7 @@ export interface TrustedPathEntry {
 
 interface AtomicSettings {
   $schema?: string;
-  scm?: "github" | "sapling";
+  scm?: SourceControlType;
   version?: number;
   lastUpdated?: string;
   model?: Record<string, string>; // agentType -> modelId


### PR DESCRIPTION
## Summary
Adds native support for Azure DevOps (ADO) as a Source Control Management (SCM) system alongside GitHub and Sapling. This enables developers to use the `atomic` CLI to initialize ADO workspaces and leverage new `az-commit` and `az-create-pr` skills across Claude, OpenCode, and GitHub Copilot agents.

## Changes
- **Azure DevOps Skills:** Added `az-commit` and `az-create-pr` skills to `.claude`, `.github`, and `.opencode` skill directories. These utilize the Azure CLI (`az repos`) to automatically formulate conventional commits, push branches, and create draft pull requests in ADO.
- **GitHub Skills Update:** Added/updated the equivalent `gh-commit` and `gh-create-pr` skills in the `.github` directory to ensure parity across SCM templates.
- **SCM Configuration:** Updated `SCM_CONFIG` in `src/services/config/definitions.ts` to fully integrate `azure-devops`. It is now recognized alongside `github` and `sapling`, mapping `az repos` as the review tool and requiring `~/.azure/azureProfile.json` for validation.
- **CLI & Initialization Pipeline:** - Updated `atomic init` CLI options to accept `-s azure-devops`.
  - Expanded `SCM_PREFIX_BY_TYPE` and prefix detection in `init/scm.ts` to correctly handle `az-` file variants.
  - Added the new `az-` skills to the global cleanup list in `postinstall.ts` to ensure local workspace overrides work as intended.
- **Settings Schema Validation:** Updated `assets/settings.schema.json` and `src/services/config/settings.ts` to allow `azure-devops` as a valid SCM enum.
- **Tooling:** Added a `deepwiki` MCP server configuration to `.vscode/mcp.json`.