### PR TITLE
feat(workflow-picker): scrollable inputs and workflow-inputs module

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@bastani/atomic",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.105",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.107",
         "@clack/prompts": "^1.2.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -15,8 +15,6 @@
         "commander": "^14.0.3",
         "ignore": "^7.0.5",
         "react": "^19.2.5",
-        "react-devtools-core": "^7.0.1",
-        "ws": "^8.18.0",
         "yaml": "^2.8.3",
         "zod": "^4.3.6",
       },
@@ -34,7 +32,7 @@
     "lefthook",
   ],
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.105", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-gPn7UEX6WrnIqCclNzfER6Of0mQ1ruxcNe0jrVXR9kOG09qFfaGzd6hy2qr3envCAB/dACkS7UDJoCm4/jg5Dg=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.107", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-zH5CCjvFn4A+RN0LLaqKJYEcGEg2O/Bm+tDpkBGcEKaRZOqwXkKJ2d9JmboALGSxsCAN5K0+uQxPgzk9LhiQzg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.12-3",
+  "version": "0.5.12-4",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",
@@ -71,7 +71,7 @@
     "typescript-language-server": "^5.1.3"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.105",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.107",
     "@clack/prompts": "^1.2.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.2.2",
@@ -81,8 +81,6 @@
     "commander": "^14.0.3",
     "ignore": "^7.0.5",
     "react": "^19.2.5",
-    "react-devtools-core": "^7.0.1",
-    "ws": "^8.18.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   }

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -391,7 +391,7 @@ async function runPickerMode(
 
 /**
  * Execute a workflow selected via the picker. The picker already stores
- * free-form prompts under the `prompt` key (via `DEFAULT_PROMPT_INPUT`),
+ * free-form prompts under the canonical `prompt` key,
  * so we can hand the inputs record straight through — no split between
  * "prompt" and "structured inputs" is needed.
  */

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -30,6 +30,7 @@ import {
   createCliRenderer,
   type CliRenderer,
   type KeyEvent,
+  type ScrollBoxRenderable,
   type TextareaRenderable,
 } from "@opentui/core";
 import {
@@ -42,6 +43,11 @@ import { useLatest } from "./hooks.ts";
 import { resolveTheme, type TerminalTheme } from "../runtime/theme.ts";
 import type { AgentType, WorkflowInput } from "../types.ts";
 import type { WorkflowWithMetadata } from "../runtime/discovery.ts";
+import {
+  DEFAULT_PROMPT_FIELDS,
+  isFreeformPromptSchema,
+  normalizePickerInputs,
+} from "../workflow-inputs.ts";
 import { ErrorBoundary } from "./error-boundary.tsx";
 
 // ─── Theme ──────────────────────────────────────
@@ -116,19 +122,6 @@ export interface WorkflowPickerResult {
   /** Populated form values, one per declared input (or { prompt } for free-form). */
   inputs: Record<string, string>;
 }
-
-/** Fallback field used when a workflow has no structured input schema. */
-const DEFAULT_PROMPT_INPUT: WorkflowInput = {
-  name: "prompt",
-  type: "text",
-  required: true,
-  description: "what do you want this workflow to do?",
-  placeholder: "describe your task…",
-};
-
-/** Stable single-element array for free-form workflows — avoids allocating
- *  a new `[DEFAULT_PROMPT_INPUT]` on every useMemo recomputation. */
-const DEFAULT_FIELDS: WorkflowInput[] = [DEFAULT_PROMPT_INPUT];
 
 // ─── Helpers ────────────────────────────────────
 
@@ -477,8 +470,7 @@ const Preview = memo(function Preview({
   wf: WorkflowWithMetadata;
 }) {
   const theme = usePickerTheme();
-  const args: readonly WorkflowInput[] =
-    wf.inputs.length > 0 ? wf.inputs : DEFAULT_FIELDS;
+  const args = normalizePickerInputs(wf.inputs);
 
   return (
     <box
@@ -690,12 +682,14 @@ function EnumContent({
 }
 
 const Field = memo(function Field({
+  id,
   field,
   value,
   focused,
   onFieldInput,
   onTextChangeRef,
 }: {
+  id?: string;
   field: WorkflowInput;
   value: string;
   focused: boolean;
@@ -719,7 +713,7 @@ const Field = memo(function Field({
   );
 
   return (
-    <box flexDirection="column">
+    <box id={id} flexDirection="column">
       <box
         border
         borderStyle="rounded"
@@ -788,7 +782,55 @@ function InputPhase({
   onTextChangeRef: React.RefObject<((value: string) => void) | null>;
 }) {
   const theme = usePickerTheme();
-  const isStructured = workflow.inputs.length > 0;
+  const isStructured = !isFreeformPromptSchema(workflow.inputs);
+  const scrollboxRef = useRef<ScrollBoxRenderable>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  // Auto-scroll to keep the focused field visible.
+  // Sync scrollTop immediately so the visibility check below
+  // marks the field as visible on the same render pass.
+  useEffect(() => {
+    const sb = scrollboxRef.current;
+    const field = fields[focusedFieldIdx];
+    if (!sb || !field) return;
+    sb.scrollChildIntoView(`field-${field.name}`);
+    setScrollTop(sb.scrollTop);
+  }, [focusedFieldIdx, fields]);
+
+  // Sync scrollTop on every OpenTUI render frame via renderBefore.
+  // This replaces a polling timer — it fires at the renderer's native
+  // frame rate so the focused field defocuses within one frame of
+  // scrolling out of view, preventing the terminal cursor from
+  // bleeding into the fixed header above.
+  const syncScrollFrame = useCallback(function (this: unknown) {
+    const sb = scrollboxRef.current;
+    if (!sb) return;
+    setScrollTop((prev) => {
+      const cur = sb.scrollTop;
+      return cur !== prev ? cur : prev;
+    });
+  }, []);
+
+  // The bordered content box (where the cursor lives) must be fully
+  // inside the viewport. If even one row is clipped the field loses
+  // focus so the cursor can never land in a clipped row.
+  const isFocusedFieldVisible = useMemo(() => {
+    const sb = scrollboxRef.current;
+    if (!sb) return true;
+    const vpH = sb.viewport.height;
+    if (vpH <= 0) return true;
+    let y = 0;
+    for (let i = 0; i < fields.length; i++) {
+      const f = fields[i]!;
+      const inputH = f.type === "text" ? TEXT_FIELD_LINES + 2 : 3;
+      if (i === focusedFieldIdx) {
+        return y >= scrollTop && y + inputH <= scrollTop + vpH;
+      }
+      // Caption row (1) + spacer row (1) below the bordered box.
+      y += inputH + 2;
+    }
+    return true;
+  }, [fields, focusedFieldIdx, scrollTop]);
 
   return (
     <box
@@ -839,7 +881,7 @@ function InputPhase({
       <box flexDirection="row" height={1}>
         <text>
           <span fg={theme.textDim}>
-            <strong>{isStructured ? "INPUTS" : "PROMPT"}</strong>
+            <strong>INPUTS</strong>
           </span>
         </text>
         <box flexGrow={1} />
@@ -851,20 +893,48 @@ function InputPhase({
       </box>
       <box height={1} />
 
-      {fields.map((f, i) => (
-        <Field
-          key={f.name}
-          field={f}
-          value={values[f.name] ?? ""}
-          focused={i === focusedFieldIdx}
-          onFieldInput={onFieldInput}
-          onTextChangeRef={
-            f.type === "text" && i === focusedFieldIdx
-              ? onTextChangeRef
-              : undefined
-          }
-        />
-      ))}
+      <scrollbox
+        ref={scrollboxRef}
+        scrollY
+        viewportCulling
+        flexGrow={1}
+        renderBefore={syncScrollFrame}
+        style={{
+          rootOptions: {
+            backgroundColor: "transparent",
+            border: false,
+          },
+          contentOptions: {
+            flexDirection: "column",
+          },
+          verticalScrollbarOptions: {
+            showArrows: false,
+            trackOptions: {
+              foregroundColor: theme.border,
+              backgroundColor: theme.backgroundElement,
+            },
+          },
+        }}
+      >
+        {fields.map((f, i) => {
+          const active = i === focusedFieldIdx && isFocusedFieldVisible;
+          return (
+            <Field
+              key={f.name}
+              id={`field-${f.name}`}
+              field={f}
+              value={values[f.name] ?? ""}
+              focused={active}
+              onFieldInput={onFieldInput}
+              onTextChangeRef={
+                f.type === "text" && active
+                  ? onTextChangeRef
+                  : undefined
+              }
+            />
+          );
+        })}
+      </scrollbox>
     </box>
   );
 }
@@ -1171,10 +1241,7 @@ function usePickerKeyboard(state: PickerKeyboardState): void {
       key.stopPropagation();
       const wf = focusedWfRef.current;
       if (wf) {
-        const inputs: readonly WorkflowInput[] =
-          wf.inputs.length > 0
-            ? wf.inputs
-            : DEFAULT_FIELDS;
+        const inputs = normalizePickerInputs(wf.inputs);
         const initial: Record<string, string> = {};
         for (const f of inputs) {
           initial[f.name] =
@@ -1290,9 +1357,10 @@ export function WorkflowPicker({
   const focusedWf = entries[clampedEntryIdx]?.workflow;
 
   const currentFields = useMemo<readonly WorkflowInput[]>(
-    () => focusedWf && focusedWf.inputs.length > 0
-      ? focusedWf.inputs
-      : DEFAULT_FIELDS,
+    () =>
+      focusedWf
+        ? normalizePickerInputs(focusedWf.inputs)
+        : DEFAULT_PROMPT_FIELDS,
     [focusedWf],
   );
   const currentField = currentFields[focusedFieldIdx];

--- a/src/sdk/runtime/discovery.ts
+++ b/src/sdk/runtime/discovery.ts
@@ -13,6 +13,7 @@ import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import ignore from "ignore";
 import type { AgentType, WorkflowInput } from "../types.ts";
+import { normalizePickerInputs } from "../workflow-inputs.ts";
 import { WorkflowLoader } from "./loader.ts";
 
 export interface DiscoveredWorkflow {
@@ -288,12 +289,12 @@ export async function findWorkflow(
 export interface WorkflowWithMetadata extends DiscoveredWorkflow {
   /** Workflow description, empty string when none was declared. */
   description: string;
-  /** Declared input schema, empty array for free-form workflows. */
+  /** Picker-ready input schema; free-form workflows materialize a prompt field. */
   inputs: readonly WorkflowInput[];
 }
 
 /**
- * Load metadata (description + inputs) for a batch of discovered workflows.
+ * Load metadata (description + picker-ready inputs) for a batch of discovered workflows.
  *
  * Workflows that fail to import are **skipped silently** so one broken
  * entry can never prevent the picker from rendering. Callers that need
@@ -311,7 +312,7 @@ export async function loadWorkflowsMetadata(
       return {
         ...wf,
         description: loaded.value.definition.description,
-        inputs: loaded.value.definition.inputs,
+        inputs: normalizePickerInputs(loaded.value.definition.inputs),
       };
     }),
   );
@@ -319,5 +320,4 @@ export async function loadWorkflowsMetadata(
     (r): r is WorkflowWithMetadata => r !== null,
   );
 }
-
 

--- a/src/sdk/workflow-inputs.ts
+++ b/src/sdk/workflow-inputs.ts
@@ -1,0 +1,54 @@
+import type { WorkflowInput } from "./types.ts";
+
+/** Canonical free-form prompt field used by the interactive picker. */
+export const DEFAULT_PROMPT_INPUT: Readonly<WorkflowInput> = Object.freeze({
+  name: "prompt",
+  type: "text",
+  required: true,
+  description: "what do you want this workflow to do?",
+  placeholder: "describe your task…",
+});
+
+/** Stable single-field schema for free-form workflows. */
+export const DEFAULT_PROMPT_FIELDS: readonly WorkflowInput[] = Object.freeze([
+  DEFAULT_PROMPT_INPUT,
+]);
+
+/**
+ * Materialize the picker-facing input schema.
+ *
+ * Runtime workflow definitions keep `inputs: []` for free-form workflows so
+ * the CLI can preserve positional-prompt semantics. The interactive picker,
+ * however, benefits from a single normalized shape where every workflow has at
+ * least one field to render.
+ */
+export function normalizePickerInputs(
+  inputs: readonly WorkflowInput[],
+): readonly WorkflowInput[] {
+  return inputs.length > 0 ? inputs : DEFAULT_PROMPT_FIELDS;
+}
+
+/**
+ * Whether a picker-facing schema represents the canonical free-form prompt.
+ *
+ * This accepts both the raw `[]` runtime shape and the normalized
+ * `[DEFAULT_PROMPT_INPUT]` picker shape so callers can treat both as the same
+ * conceptual "free-form prompt" mode.
+ */
+export function isFreeformPromptSchema(
+  inputs: readonly WorkflowInput[],
+): boolean {
+  if (inputs.length === 0) return true;
+  if (inputs.length !== 1) return false;
+
+  const field = inputs[0];
+  return (
+    field?.name === DEFAULT_PROMPT_INPUT.name &&
+    field.type === DEFAULT_PROMPT_INPUT.type &&
+    field.required === DEFAULT_PROMPT_INPUT.required &&
+    field.description === DEFAULT_PROMPT_INPUT.description &&
+    field.placeholder === DEFAULT_PROMPT_INPUT.placeholder &&
+    field.default === DEFAULT_PROMPT_INPUT.default &&
+    field.values === DEFAULT_PROMPT_INPUT.values
+  );
+}

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../src/sdk/components/workflow-picker-panel.tsx";
 import type { WorkflowWithMetadata } from "../../../src/sdk/runtime/discovery.ts";
 import type { WorkflowInput } from "../../../src/sdk/types.ts";
+import { DEFAULT_PROMPT_FIELDS } from "../../../src/sdk/workflow-inputs.ts";
 
 // ─── Keyboard input helpers ───────────────────────
 //
@@ -134,7 +135,7 @@ const WORKFLOWS: WorkflowWithMetadata[] = [
     name: "freeform",
     source: "builtin",
     description: "freeform prompt",
-    inputs: [],
+    inputs: DEFAULT_PROMPT_FIELDS,
   }),
 ];
 
@@ -750,8 +751,8 @@ describe("WorkflowPicker PROMPT keyboard", () => {
     }
     await press(setup, (i) => i.pressEnter());
     const frame = setup.captureCharFrame();
-    // Free-form shows "PROMPT" header (isStructured = false).
-    expect(frame).toContain("PROMPT");
+    // Free-form uses the same INPUTS section label as structured workflows.
+    expect(frame).toContain("INPUTS");
     // Default field name is "prompt".
     expect(frame).toContain("prompt");
   });
@@ -763,12 +764,38 @@ describe("WorkflowPicker PROMPT keyboard", () => {
       await press(setup, (input) => input.pressArrow("down"));
     }
     await press(setup, (i) => i.pressEnter());
-    // Type into the DEFAULT_PROMPT_INPUT textarea.
+    // Type into the normalized default prompt textarea.
     await press(setup, (i) => i.typeText("build a dashboard"));
     await press(setup, (i) => i.pressKey("d", { ctrl: true }));
     const frame = setup.captureCharFrame();
     expect(frame).toContain("CONFIRM");
     expect(frame).toContain("submit");
+  });
+
+  test("short terminal: fields remain navigable via tab and the focused field is visible", async () => {
+    // A many-field workflow at a very constrained height (15 rows) —
+    // the scrollbox should keep the focused field visible instead of
+    // clumping all fields together.
+    const manyFields: WorkflowInput[] = [
+      { name: "a", type: "string", required: true },
+      { name: "b", type: "string", required: false },
+      { name: "c", type: "string", required: false },
+      { name: "d", type: "string", required: false },
+      { name: "e", type: "string", required: false },
+    ];
+    const workflows = [
+      makeWorkflow({ name: "many", source: "local", inputs: manyFields }),
+    ];
+    const setup = await renderAndEnterPrompt({ workflows, height: 15 });
+    // Tab through fields — each should remain navigable without crash.
+    for (let i = 0; i < 4; i++) {
+      await press(setup, (input) => input.pressTab());
+    }
+    const frame = setup.captureCharFrame();
+    // After 4 tabs we should be on the last field (5 / 5).
+    expect(frame).toContain("5 / 5");
+    // The PROMPT status badge should still be visible.
+    expect(frame).toContain("PROMPT");
   });
 });
 

--- a/tests/sdk/runtime/discovery.test.ts
+++ b/tests/sdk/runtime/discovery.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import {
   discoverWorkflows,
   findWorkflow,
+  loadWorkflowsMetadata,
   WorkflowLoader,
   WORKFLOWS_GITIGNORE,
 } from "../../../src/sdk/workflows/index.ts";
@@ -384,5 +385,44 @@ export default defineWorkflow({ name: "report-test" })
 
     expect(result.ok).toBe(true);
     expect(stages).toEqual(["resolve", "validate", "load"]);
+  });
+});
+
+describe("loadWorkflowsMetadata", () => {
+  test("materializes the default prompt field for free-form workflows", async () => {
+    const workflowDir = join(
+      tempDir,
+      ".atomic",
+      "workflows",
+      "picker-freeform",
+      "copilot",
+    );
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, "index.ts"),
+      `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({ name: "picker-freeform" })
+  .run(async () => {})
+  .compile();
+`,
+    );
+
+    const discovered = await discoverWorkflows(tempDir, "copilot");
+    const metadata = await loadWorkflowsMetadata(
+      discovered.filter((wf) => wf.name === "picker-freeform"),
+    );
+
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]!.inputs).toEqual([
+      {
+        name: "prompt",
+        type: "text",
+        required: true,
+        description: "what do you want this workflow to do?",
+        placeholder: "describe your task…",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Introduces a scrollable input panel in the workflow picker for workflows with many fields, and extracts input normalization logic into a dedicated `workflow-inputs.ts` module.

## Key Changes

### New `src/sdk/workflow-inputs.ts` module
- `normalizePickerInputs()` — materializes a default `prompt` field for free-form (no-input) workflows so every picker entry has at least one renderable field
- `isFreeformPromptSchema()` — detects both the raw `[]` runtime shape and the normalized `[DEFAULT_PROMPT_INPUT]` picker shape as the same conceptual free-form mode
- Frozen `DEFAULT_PROMPT_INPUT` and `DEFAULT_PROMPT_FIELDS` constants (eliminates per-render allocations)

### Scrollable input panel in `workflow-picker-panel.tsx`
- Wraps picker input fields in a `<scrollbox>` with `scrollY` and `viewportCulling` enabled
- Auto-scrolls to keep the focused field visible via `scrollChildIntoView`
- Syncs scroll position on every renderer frame (`renderBefore`) to prevent cursor bleed when a field scrolls out of the viewport
- `isFocusedFieldVisible` guard suppresses focus rendering for fully clipped fields
- Adds `id` prop to `Field` for scroll targeting
- Unifies the section label to `INPUTS` for both free-form and structured workflows

### `discovery.ts`
- Normalizes inputs via `normalizePickerInputs()` at the metadata-load layer so `WorkflowWithMetadata.inputs` is always picker-ready

### Dependency cleanup
- Bumped `@anthropic-ai/claude-agent-sdk` from `0.2.105` → `0.2.107`
- Removed unused `react-devtools-core` and `ws` dependencies

## Tests
- `tests/sdk/runtime/discovery.test.ts`: verifies `loadWorkflowsMetadata` materializes the default prompt field for free-form workflows
- `tests/sdk/components/workflow-picker-panel.test.tsx`: adds scrollbox navigation test with a 5-field workflow at a constrained 15-row terminal height; updates existing test to expect the unified `INPUTS` label