### PR TITLE
chore(release): bump version to v0.5.12-5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.12-4",
+  "version": "0.5.12-5",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version to `0.5.12-5` prerelease, picking up the type-safe workflow inputs feature landed in #635.

## Changes

- `package.json`: version `0.5.12-4` → `0.5.12-5`

## Test plan

- [ ] Verify `version` in `package.json` is `0.5.12-5`
- [ ] Confirm CI passes
- [ ] Confirm npm publish succeeds after merge