### PR TITLE
build(sdk): ship dist/ with .d.ts declarations and exclude test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.12",
+  "version": "0.5.13-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",
@@ -41,6 +41,7 @@
   },
   "files": [
     "src",
+    "dist",
     "assets/settings.schema.json",
     ".agents/skills",
     ".claude/agents",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,5 +8,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/sdk"]
+  "include": ["src/sdk"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Ships `dist/` in the published package so TypeScript consumers can resolve types from the `exports` map, and excludes `*.test.ts` files from the declaration build to keep the package clean. Bumps version to `v0.5.13-0`.

## Changes

- **`package.json`**: Added `dist` to the `files` array so declaration files are included when publishing; bumped version to `0.5.13-0`
- **`tsconfig.build.json`**: Added `exclude: ["src/**/*.test.ts"]` to prevent test files from generating `.test.d.ts` artifacts in `dist/`

## Why

The `exports` map already referenced `./dist/sdk/index.d.ts` for the `types` field, but `dist/` was never listed in `files`, so TypeScript consumers would get unresolved type errors after installing the package.

## Test plan

- [x] `bun run build` succeeds
- [x] `bun typecheck` passes
- [x] `bun test` passes (via pre-commit hook)
- [x] `bun pm pack --dry-run` confirms `dist/sdk/index.d.ts` is included
- [x] No `*.test.d.ts` files in `dist/`