### PR TITLE
fix(devcontainer): set UTF-8 locale for agent subprocess rendering

### DIFF
--- a/devcontainer-features/src/claude/devcontainer-feature.json
+++ b/devcontainer-features/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "claude",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "name": "Atomic + Claude Code",
   "description": "Installs Atomic CLI with Claude Code agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/devcontainer-features/src/claude/install.sh
+++ b/devcontainer-features/src/claude/install.sh
@@ -128,6 +128,54 @@ fi
 
 echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 
+# ─── Ensure UTF-8 locale for proper Unicode/ASCII art rendering ───────────
+# Agent CLIs (e.g. Copilot) emit Unicode box-drawing / figlet characters.
+# Without a UTF-8 locale the output is garbled when spawned as a Bun
+# subprocess inside the devcontainer.
+if command -v locale-gen >/dev/null 2>&1; then
+    locale-gen en_US.UTF-8 >/dev/null 2>&1 || true
+fi
+
+cat > /etc/profile.d/atomic-locale.sh <<'LOCALE_EOF'
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+LOCALE_EOF
+chmod 644 /etc/profile.d/atomic-locale.sh
+
+# Non-login bash shells
+if [ -f /etc/bash.bashrc ] && ! grep -q 'atomic-locale' /etc/bash.bashrc 2>/dev/null; then
+    cat >> /etc/bash.bashrc <<'BASHRC_LOCALE_EOF'
+
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+BASHRC_LOCALE_EOF
+fi
+
+# Non-login zsh shells
+if [ -f /etc/zsh/zshrc ] && ! grep -q 'atomic-locale' /etc/zsh/zshrc 2>/dev/null; then
+    cat >> /etc/zsh/zshrc <<'ZSHRC_LOCALE_EOF'
+
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+ZSHRC_LOCALE_EOF
+fi
+
+# Fish shells
+if [ -d /etc/fish/conf.d ]; then
+    cat > /etc/fish/conf.d/atomic-locale.fish <<'FISH_LOCALE_EOF'
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+if not set -q LANG
+    set -gx LANG en_US.UTF-8
+end
+if not set -q LC_ALL
+    set -gx LC_ALL en_US.UTF-8
+end
+FISH_LOCALE_EOF
+    chmod 644 /etc/fish/conf.d/atomic-locale.fish
+fi
+
 # ─── Install global CLI tools via bun ──────────────────────────────────────
 # Use bun (already installed) with --trust to allow postinstall lifecycle
 # scripts (e.g. playwright browser downloads).

--- a/devcontainer-features/src/copilot/devcontainer-feature.json
+++ b/devcontainer-features/src/copilot/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "name": "Atomic + Copilot CLI",
   "description": "Installs Atomic CLI with GitHub Copilot agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/devcontainer-features/src/copilot/install.sh
+++ b/devcontainer-features/src/copilot/install.sh
@@ -128,6 +128,54 @@ fi
 
 echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 
+# ─── Ensure UTF-8 locale for proper Unicode/ASCII art rendering ───────────
+# Agent CLIs (e.g. Copilot) emit Unicode box-drawing / figlet characters.
+# Without a UTF-8 locale the output is garbled when spawned as a Bun
+# subprocess inside the devcontainer.
+if command -v locale-gen >/dev/null 2>&1; then
+    locale-gen en_US.UTF-8 >/dev/null 2>&1 || true
+fi
+
+cat > /etc/profile.d/atomic-locale.sh <<'LOCALE_EOF'
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+LOCALE_EOF
+chmod 644 /etc/profile.d/atomic-locale.sh
+
+# Non-login bash shells
+if [ -f /etc/bash.bashrc ] && ! grep -q 'atomic-locale' /etc/bash.bashrc 2>/dev/null; then
+    cat >> /etc/bash.bashrc <<'BASHRC_LOCALE_EOF'
+
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+BASHRC_LOCALE_EOF
+fi
+
+# Non-login zsh shells
+if [ -f /etc/zsh/zshrc ] && ! grep -q 'atomic-locale' /etc/zsh/zshrc 2>/dev/null; then
+    cat >> /etc/zsh/zshrc <<'ZSHRC_LOCALE_EOF'
+
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+ZSHRC_LOCALE_EOF
+fi
+
+# Fish shells
+if [ -d /etc/fish/conf.d ]; then
+    cat > /etc/fish/conf.d/atomic-locale.fish <<'FISH_LOCALE_EOF'
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+if not set -q LANG
+    set -gx LANG en_US.UTF-8
+end
+if not set -q LC_ALL
+    set -gx LC_ALL en_US.UTF-8
+end
+FISH_LOCALE_EOF
+    chmod 644 /etc/fish/conf.d/atomic-locale.fish
+fi
+
 # ─── Install global CLI tools via bun ──────────────────────────────────────
 # Use bun (already installed) with --trust to allow postinstall lifecycle
 # scripts (e.g. playwright browser downloads).

--- a/devcontainer-features/src/opencode/devcontainer-feature.json
+++ b/devcontainer-features/src/opencode/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "name": "Atomic + OpenCode",
   "description": "Installs Atomic CLI with OpenCode agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/devcontainer-features/src/opencode/install.sh
+++ b/devcontainer-features/src/opencode/install.sh
@@ -128,6 +128,54 @@ fi
 
 echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 
+# ─── Ensure UTF-8 locale for proper Unicode/ASCII art rendering ───────────
+# Agent CLIs (e.g. Copilot) emit Unicode box-drawing / figlet characters.
+# Without a UTF-8 locale the output is garbled when spawned as a Bun
+# subprocess inside the devcontainer.
+if command -v locale-gen >/dev/null 2>&1; then
+    locale-gen en_US.UTF-8 >/dev/null 2>&1 || true
+fi
+
+cat > /etc/profile.d/atomic-locale.sh <<'LOCALE_EOF'
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+LOCALE_EOF
+chmod 644 /etc/profile.d/atomic-locale.sh
+
+# Non-login bash shells
+if [ -f /etc/bash.bashrc ] && ! grep -q 'atomic-locale' /etc/bash.bashrc 2>/dev/null; then
+    cat >> /etc/bash.bashrc <<'BASHRC_LOCALE_EOF'
+
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+BASHRC_LOCALE_EOF
+fi
+
+# Non-login zsh shells
+if [ -f /etc/zsh/zshrc ] && ! grep -q 'atomic-locale' /etc/zsh/zshrc 2>/dev/null; then
+    cat >> /etc/zsh/zshrc <<'ZSHRC_LOCALE_EOF'
+
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+ZSHRC_LOCALE_EOF
+fi
+
+# Fish shells
+if [ -d /etc/fish/conf.d ]; then
+    cat > /etc/fish/conf.d/atomic-locale.fish <<'FISH_LOCALE_EOF'
+# atomic-locale: ensure UTF-8 for agent CLI Unicode rendering
+if not set -q LANG
+    set -gx LANG en_US.UTF-8
+end
+if not set -q LC_ALL
+    set -gx LC_ALL en_US.UTF-8
+end
+FISH_LOCALE_EOF
+    chmod 644 /etc/fish/conf.d/atomic-locale.fish
+fi
+
 # ─── Install global CLI tools via bun ──────────────────────────────────────
 # Use bun (already installed) with --trust to allow postinstall lifecycle
 # scripts (e.g. playwright browser downloads).


### PR DESCRIPTION
## Summary

Sets `en_US.UTF-8` locale across all devcontainer feature install scripts to fix garbled Unicode/ASCII art output when agent CLIs are spawned as Bun subprocesses.

**Root cause:** Devcontainers default to `POSIX`/`C` locale. Agent CLIs (Claude Code, Copilot, OpenCode) emit Unicode box-drawing characters and figlet ASCII art. When Bun spawns these as subprocesses, multi-byte UTF-8 characters are garbled because the subprocess inherits the `POSIX` locale rather than the terminal's UTF-8 setting. Running the CLI directly in the shell works because the terminal profile sets UTF-8 — but that profile is not sourced for programmatic subprocess invocations.

## Changes

- Generates `en_US.UTF-8` locale via `locale-gen` when available (no-op if already present)
- Injects locale defaults into all shell entry points so subprocesses inherit UTF-8:
  - **Login shells**: `/etc/profile.d/atomic-locale.sh`
  - **Non-login bash**: `/etc/bash.bashrc`
  - **Non-login zsh**: `/etc/zsh/zshrc`
  - **Fish**: `/etc/fish/conf.d/atomic-locale.fish`
- Uses `${LANG:-en_US.UTF-8}` / `set -q` guards to preserve any user-defined locale
- Bumps all three devcontainer features (`claude`, `copilot`, `opencode`) from `1.0.12` → `1.0.13`

## Test plan

- [ ] Rebuild each devcontainer and verify `locale` outputs `LANG=en_US.UTF-8` and `LC_ALL=en_US.UTF-8`
- [ ] Run `atomic chat` inside the devcontainer and confirm figlet ASCII art renders correctly (no garbled box-drawing characters)
- [ ] Set a custom `LANG` before rebuilding and verify it is not overridden by the install script