### PR TITLE
fix(workflows): replace dontAsk with bypassPermissions flags in claude workflows

### DIFF
--- a/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
@@ -85,13 +85,18 @@ import {
 // until Claude reports idle or a result (success, error_max_turns, etc.).
 
 export default defineWorkflow({
-    name: "deep-research-codebase",
-    description:
-      "Deterministic deep codebase research: scout → LOC-driven parallel explorers → aggregator",
-    inputs: [
-      { name: "prompt", type: "text", required: true, description: "research question" },
-    ],
-  })
+  name: "deep-research-codebase",
+  description:
+    "Deterministic deep codebase research: scout → LOC-driven parallel explorers → aggregator",
+  inputs: [
+    {
+      name: "prompt",
+      type: "text",
+      required: true,
+      description: "research question",
+    },
+  ],
+})
   .for<"claude">()
   .run(async (ctx) => {
     // Destructure once so every stage below can close over a bare
@@ -115,7 +120,8 @@ export default defineWorkflow({
       ctx.stage(
         {
           name: "codebase-scout",
-          description: "Map codebase, count LOC, partition for parallel explorers",
+          description:
+            "Map codebase, count LOC, partition for parallel explorers",
         },
         {},
         {},
@@ -175,29 +181,28 @@ export default defineWorkflow({
       ctx.stage(
         {
           name: "research-history",
-          description: "Surface prior research via research-locator + research-analyzer",
+          description:
+            "Surface prior research via research-locator + research-analyzer",
         },
-        {},
+        {
+          chatFlags: [
+            "--allow-dangerously-skip-permissions",
+            "--dangerously-skip-permissions",
+          ],
+        },
         {},
         async (s) => {
           // Dispatches codebase-research-locator → codebase-research-analyzer
           // over the project's research/ directory and outputs a ≤400-word
           // synthesis as prose (no file write — consumed via transcript).
-          await s.session.query(
-            buildHistoryPrompt({ question: prompt, root }),
-          );
+          await s.session.query(buildHistoryPrompt({ question: prompt, root }));
           s.save(s.sessionId);
         },
       ),
     ]);
 
-    const {
-      partitions,
-      explorerCount,
-      scratchDir,
-      totalLoc,
-      totalFiles,
-    } = scout.result;
+    const { partitions, explorerCount, scratchDir, totalLoc, totalFiles } =
+      scout.result;
 
     // Pull both scout transcripts ONCE at the workflow level so every
     // explorer + the aggregator can embed them in their prompts. Both
@@ -229,9 +234,16 @@ export default defineWorkflow({
             name: `explorer-${i}`,
             description: `Explore ${partition
               .map((u) => u.path)
-              .join(", ")} (${partition.reduce((s, u) => s + u.fileCount, 0)} files)`,
+              .join(
+                ", ",
+              )} (${partition.reduce((s, u) => s + u.fileCount, 0)} files)`,
           },
-          {},
+          {
+            chatFlags: [
+              "--allow-dangerously-skip-permissions",
+              "--dangerously-skip-permissions",
+            ],
+          },
           {},
           async (s) => {
             await s.session.query(
@@ -278,9 +290,15 @@ export default defineWorkflow({
     await ctx.stage(
       {
         name: "aggregator",
-        description: "Synthesize explorer findings + history into final research doc",
+        description:
+          "Synthesize explorer findings + history into final research doc",
       },
-      {},
+      {
+        chatFlags: [
+          "--allow-dangerously-skip-permissions",
+          "--dangerously-skip-permissions",
+        ],
+      },
       {},
       async (s) => {
         await s.session.query(

--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -98,19 +98,25 @@ export default defineWorkflow({
 
     for (let iteration = 1; iteration <= MAX_LOOPS; iteration++) {
       // ── Plan ────────────────────────────────────────────────────────────
-      const planner = await ctx.stage(
+      await ctx.stage(
         { name: `planner-${iteration}` },
-        { chatFlags: ["--agent", "planner", "--permission-mode", "dontAsk"] },
+        {
+          chatFlags: [
+            "--agent",
+            "planner",
+            "--allow-dangerously-skip-permissions",
+            "--dangerously-skip-permissions",
+          ],
+        },
         {},
         async (s) => {
-          const result = await s.session.query(
+          await s.session.query(
             buildPlannerPrompt(prompt, {
               iteration,
               debuggerReport: debuggerReport || undefined,
             }),
           );
           s.save(s.sessionId);
-          return extractAssistantText(result, 0);
         },
       );
 
@@ -121,17 +127,13 @@ export default defineWorkflow({
           chatFlags: [
             "--agent",
             "orchestrator",
-            "--permission-mode",
-            "dontAsk",
+            "--allow-dangerously-skip-permissions",
+            "--dangerously-skip-permissions",
           ],
         },
         {},
         async (s) => {
-          await s.session.query(
-            buildOrchestratorPrompt(prompt, {
-              plannerNotes: planner.result,
-            }),
-          );
+          await s.session.query(buildOrchestratorPrompt(prompt));
           s.save(s.sessionId);
         },
       );
@@ -148,7 +150,8 @@ export default defineWorkflow({
           async (s) => {
             const result = await s.session.query(discoveryPrompts.locator, {
               agent: "codebase-locator",
-              permissionMode: "dontAsk",
+              permissionMode: "bypassPermissions",
+              allowDangerouslySkipPermissions: true,
             });
             s.save(s.sessionId);
             return extractAssistantText(result, 0);
@@ -161,7 +164,8 @@ export default defineWorkflow({
           async (s) => {
             const result = await s.session.query(discoveryPrompts.analyzer, {
               agent: "codebase-analyzer",
-              permissionMode: "dontAsk",
+              permissionMode: "bypassPermissions",
+              allowDangerouslySkipPermissions: true,
             });
             s.save(s.sessionId);
             return extractAssistantText(result, 0);
@@ -176,7 +180,8 @@ export default defineWorkflow({
               discoveryPrompts.patternFinder,
               {
                 agent: "codebase-pattern-finder",
-                permissionMode: "dontAsk",
+                permissionMode: "bypassPermissions",
+                allowDangerouslySkipPermissions: true,
               },
             );
             s.save(s.sessionId);
@@ -226,7 +231,12 @@ export default defineWorkflow({
         const debugger_ = await ctx.stage(
           { name: `debugger-${iteration}` },
           {
-            chatFlags: ["--agent", "debugger", "--permission-mode", "dontAsk"],
+            chatFlags: [
+              "--agent",
+              "debugger",
+              "--allow-dangerously-skip-permissions",
+              "--dangerously-skip-permissions",
+            ],
           },
           {},
           async (s) => {


### PR DESCRIPTION
## Summary

Replaces deprecated/incorrect `--permission-mode dontAsk` and `permissionMode: "dontAsk"` permission flags with the correct bypass-permission flags across the `deep-research-codebase` and `ralph` Claude workflow implementations.

## Key Changes

### `deep-research-codebase` workflow
- Added `--allow-dangerously-skip-permissions` and `--dangerously-skip-permissions` chat flags to `research-history`, `explorer-N`, and `aggregator` stages (previously passed no flags)

### `ralph` workflow
- Replaced `--permission-mode dontAsk` with `--allow-dangerously-skip-permissions` / `--dangerously-skip-permissions` for `planner`, `orchestrator`, and `debugger` stages
- Replaced `permissionMode: "dontAsk"` with `permissionMode: "bypassPermissions"` + `allowDangerouslySkipPermissions: true` for `codebase-locator`, `codebase-analyzer`, and `codebase-pattern-finder` query calls
- Removed unused `planner.result` extraction and the `plannerNotes` argument passed to `buildOrchestratorPrompt`

## Notes

- No breaking changes to workflow inputs or outputs
- Formatting-only changes (indentation, line wrapping) are included alongside the permission fixes