### PR TITLE
fix(workflow-picker): textarea state not propagating in installed package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,6 @@
         "@opentui/react": "^0.1.99",
         "commander": "^14.0.3",
         "ignore": "^7.0.5",
-        "react": "^19.2.5",
         "yaml": "^2.8.3",
         "zod": "^4.3.6",
       },
@@ -25,6 +24,9 @@
         "oxlint": "^1.60.0",
         "typescript": "^6.0.2",
         "typescript-language-server": "^5.1.3",
+      },
+      "peerDependencies": {
+        "react": ">=19.0.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -81,8 +81,10 @@
     "@opentui/react": "^0.1.99",
     "commander": "^14.0.3",
     "ignore": "^7.0.5",
-    "react": "^19.2.5",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0"
   }
 }

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -556,42 +556,56 @@ function EmptyPreview({
 
 const TEXT_FIELD_LINES = 3;
 
-
-const NOOP_CHANGE_REF: React.RefObject<((value: string) => void) | null> = { current: null };
-
 function TextAreaContent({
   value,
   placeholder,
   focused,
-  onChangeRef,
+  onInput,
 }: {
   value: string;
   placeholder: string;
   focused: boolean;
-  onChangeRef?: React.RefObject<((value: string) => void) | null>;
+  onInput: (value: string) => void;
 }) {
   const theme = usePickerTheme();
-  const ref = useRef<TextareaRenderable>(null);
-  const changeRef = onChangeRef ?? NOOP_CHANGE_REF;
+  const instanceRef = useRef<TextareaRenderable | null>(null);
+  const onInputRef = useLatest(onInput);
+  const lastTextRef = useRef(value);
 
-  // Sync external value → textarea when it diverges (e.g. initial value).
+  const refCallback = useCallback((instance: TextareaRenderable | null) => {
+    instanceRef.current = instance;
+  }, []);
+
+  // Sync external value → textarea when it diverges (e.g. initial value
+  // or reset after phase transition).
   useEffect(() => {
-    if (ref.current && ref.current.plainText !== value) {
-      ref.current.setText(value);
+    if (instanceRef.current && instanceRef.current.plainText !== value) {
+      instanceRef.current.setText(value);
+      lastTextRef.current = value;
     }
   }, [value]);
 
-  // Wire onContentChange as a prop so the reconciler sets it during the
-  // commit phase (via the constructor and setProperty's default branch),
-  // guaranteeing it is active before the textarea can receive key events.
-  // The previous useEffect approach deferred setup as a passive effect
-  // (ConcurrentRoot schedules these via setTimeout) — creating a window
-  // where keystrokes reached the focused textarea before the listener
-  // existed, silently dropping content-change notifications and leaving
-  // fieldValues stale.
+  // Detect text changes after each keypress. The native Zig edit buffer's
+  // "content-changed" event is unreliable for propagating to the JS
+  // _contentChangeListener in certain installed environments. Instead,
+  // we hook into useKeyboard (which fires before the textarea processes
+  // the key) and defer the read with queueMicrotask so the textarea has
+  // processed the keystroke by the time we read plainText.
+  useKeyboard(useCallback(() => {
+    queueMicrotask(() => {
+      const inst = instanceRef.current;
+      if (!inst) return;
+      const current = inst.plainText;
+      if (current !== lastTextRef.current) {
+        lastTextRef.current = current;
+        onInputRef.current(current);
+      }
+    });
+  }, []));
+
   return (
     <textarea
-      ref={ref}
+      ref={refCallback}
       initialValue={value}
       placeholder={placeholder}
       focused={focused}
@@ -602,9 +616,6 @@ function TextAreaContent({
       placeholderColor={theme.textDim}
       wrapMode="word"
       flexGrow={1}
-      onContentChange={() => {
-        changeRef.current?.(ref.current?.plainText ?? "");
-      }}
     />
   );
 }
@@ -685,14 +696,12 @@ const Field = memo(function Field({
   value,
   focused,
   onFieldInput,
-  onTextChangeRef,
 }: {
   id?: string;
   field: WorkflowInput;
   value: string;
   focused: boolean;
   onFieldInput: (fieldName: string, value: string) => void;
-  onTextChangeRef?: React.RefObject<((value: string) => void) | null>;
 }) {
   const theme = usePickerTheme();
   const borderCol = focused ? theme.primary : theme.border;
@@ -730,7 +739,7 @@ const Field = memo(function Field({
             value={value}
             placeholder={field.placeholder ?? ""}
             focused={focused}
-            onChangeRef={onTextChangeRef}
+            onInput={onInput}
           />
         ) : field.type === "string" ? (
           <StringContent
@@ -769,7 +778,6 @@ function InputPhase({
   values,
   focusedFieldIdx,
   onFieldInput,
-  onTextChangeRef,
 }: {
   workflow: WorkflowWithMetadata;
   agent: AgentType;
@@ -777,7 +785,6 @@ function InputPhase({
   values: Record<string, string>;
   focusedFieldIdx: number;
   onFieldInput: (fieldName: string, value: string) => void;
-  onTextChangeRef: React.RefObject<((value: string) => void) | null>;
 }) {
   const theme = usePickerTheme();
   const isStructured = workflow.inputs.length > 0;
@@ -924,11 +931,6 @@ function InputPhase({
               value={values[f.name] ?? ""}
               focused={active}
               onFieldInput={onFieldInput}
-              onTextChangeRef={
-                f.type === "text" && active
-                  ? onTextChangeRef
-                  : undefined
-              }
             />
           );
         })}
@@ -1371,16 +1373,6 @@ export function WorkflowPicker({
   }, [currentFields, fieldValues]);
   const isFormValid = invalidFieldIndices.length === 0;
 
-  // Textarea change callback ref — useLatest keeps .current in sync
-  // each render so the textarea effect doesn't need to re-attach.
-  const textChangeRef = useLatest(
-    currentField
-      ? (text: string) => {
-          setFieldValues((prev) => ({ ...prev, [currentField.name]: text }));
-        }
-      : null,
-  );
-
   // Stable callback for field input — the setter is referentially stable.
   const onFieldInput = useCallback(
     (name: string, v: string) => setFieldValues((prev) => ({ ...prev, [name]: v })),
@@ -1466,7 +1458,6 @@ export function WorkflowPicker({
             values={fieldValues}
             focusedFieldIdx={confirmOpen ? -1 : focusedFieldIdx}
             onFieldInput={onFieldInput}
-            onTextChangeRef={textChangeRef}
           />
         ) : null}
 

--- a/src/sdk/runtime/discovery.ts
+++ b/src/sdk/runtime/discovery.ts
@@ -2,10 +2,13 @@
  * Workflow discovery — finds workflow definitions from disk.
  *
  * Workflows are discovered from:
- *   1. .atomic/workflows/<name>/<agent>/index.ts (project-local)
- *   2. ~/.atomic/workflows/<name>/<agent>/index.ts (global)
+ *   1. src/sdk/workflows/builtin/<name>/<agent>/index.ts (SDK-shipped builtins)
+ *   2. .atomic/workflows/<name>/<agent>/index.ts (project-local)
+ *   3. ~/.atomic/workflows/<name>/<agent>/index.ts (global)
  *
- * Project-local workflows take precedence over global ones with the same name.
+ * All three sources use the same scanning function (`discoverFromBaseDir`)
+ * so registration is uniform. Builtin names are reserved — project-local
+ * and global workflows with the same name are dropped during merge.
  */
 
 import { join } from "node:path";
@@ -77,7 +80,7 @@ async function loadWorkflowsGitignore(workflowsDir: string): Promise<ignore.Igno
  */
 async function discoverFromBaseDir(
   baseDir: string,
-  source: "local" | "global",
+  source: "local" | "global" | "builtin",
   agentFilter?: AgentType,
 ): Promise<DiscoveredWorkflow[]> {
   const workflows: DiscoveredWorkflow[] = [];
@@ -91,7 +94,11 @@ async function discoverFromBaseDir(
     return workflows;
   }
 
-  const ig = await loadWorkflowsGitignore(baseDir);
+  // Builtin workflows live inside the SDK source tree — skip .gitignore
+  // handling to avoid writing files into node_modules or the SDK dir.
+  const ig = source === "builtin"
+    ? ignore()
+    : await loadWorkflowsGitignore(baseDir);
 
   for (const wfEntry of workflowEntries) {
     if (!wfEntry.isDirectory()) continue;
@@ -141,41 +148,6 @@ const BUILTIN_WORKFLOWS_DIR = join(
 );
 
 /**
- * Discover built-in workflows shipped as SDK modules.
- *
- * Scans `src/sdk/workflows/builtin/<name>/<agent>/index.ts` for known
- * workflow directories. Returns entries with `source: "builtin"`.
- */
-async function discoverBuiltinWorkflows(
-  agentFilter?: AgentType,
-): Promise<DiscoveredWorkflow[]> {
-  const results: DiscoveredWorkflow[] = [];
-  const agents = agentFilter ? [agentFilter] : AGENTS;
-
-  let workflowEntries;
-  try {
-    workflowEntries = await readdir(BUILTIN_WORKFLOWS_DIR, { withFileTypes: true });
-  } catch {
-    return results;
-  }
-
-  const workflowNames = workflowEntries
-    .filter((d) => d.isDirectory())
-    .map((d) => d.name);
-
-  for (const name of workflowNames) {
-    for (const agent of agents) {
-      const indexPath = join(BUILTIN_WORKFLOWS_DIR, name, agent, "index.ts");
-      if (await Bun.file(indexPath).exists()) {
-        results.push({ name, agent, path: indexPath, source: "builtin" });
-      }
-    }
-  }
-
-  return results;
-}
-
-/**
  * Discover all available workflows from built-in, global, and local sources.
  * Optionally filter by agent.
  *
@@ -221,7 +193,7 @@ export async function discoverWorkflows(
   // reserved by a builtin `ralph` for claude, even when the discovery
   // call was filtered to copilot.
   const [allBuiltins, globalResults, localResults] = await Promise.all([
-    discoverBuiltinWorkflows(),
+    discoverFromBaseDir(BUILTIN_WORKFLOWS_DIR, "builtin"),
     discoverFromBaseDir(globalDir, "global", agentFilter),
     discoverFromBaseDir(localDir, "local", agentFilter),
   ]);


### PR DESCRIPTION
## Summary

Fixes Ctrl+D submission being broken for `type: "text"` workflow input fields (e.g. builtin ralph) when running from an npm-installed package. Users could type into the textarea but `fieldValues` never updated, keeping the form permanently invalid.

## Root Cause

OpenTUI's native Zig edit buffer fires `"content-changed"` events on keystroke, but the JS `_contentChangeListener` callback wired via the `onContentChange` prop was not being invoked in certain installed environments. The native event fired and `handleKeyPress` processed keystrokes correctly (`plainText` updated), but the JS callback never executed — leaving `fieldValues` stale.

## Changes

### `src/sdk/components/workflow-picker-panel.tsx`
- Replace the `onContentChange` prop chain with a `useKeyboard` hook that defers a `queueMicrotask` read of `instance.plainText` after each keypress. By the time the microtask runs, the textarea has processed the keystroke; if the text differs from the last known value, `onInput` fires and updates `fieldValues`.
- Remove the `NOOP_CHANGE_REF` / `textChangeRef` / `onChangeRef` indirection chain — `TextAreaContent` now accepts a plain `onInput` callback.
- Drop the `onTextChangeRef` prop from `Field` and `InputPhase`, simplifying the component tree.

### `src/sdk/runtime/discovery.ts`
- Unify builtin workflow discovery under the existing `discoverFromBaseDir` function by adding `"builtin"` as a valid source type.
- Skip `.gitignore` handling for builtin source (avoids writing into `node_modules` or the SDK directory).
- Remove the now-redundant `discoverBuiltinWorkflows` function.

### `package.json` / `bun.lock`
- Move `react` from `dependencies` to `peerDependencies` (`>=19.0.0`) to prevent duplicate React instances when the package is installed globally.

## Testing

Reproduce by installing the package globally and running a workflow with a `type: "text"` field (e.g. ralph). Typing into the textarea should now enable Ctrl+D submission.