### PR TITLE
chore(release): bump version to v0.5.14-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.13",
+  "version": "0.5.14-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.13` to `0.5.14-0` (prerelease), triggering automated GitHub Release creation and npm publish upon merge.

## Changes

- `package.json`: version `0.5.13` → `0.5.14-0`

## Test plan

- [ ] CI passes
- [ ] Release workflow creates the `v0.5.14-0` prerelease tag
- [ ] Package is published to npm as `@bastani/atomic@0.5.14-0`