### PR TITLE
chore(release): bump version to v0.5.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.14-0",
+  "version": "0.5.14",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the `v0.5.14-0` prerelease to the stable `v0.5.14` release by bumping the version in `package.json`.

## Changes

- `package.json`: version `0.5.14-0` → `0.5.14`

## Test plan

- [ ] CI passes
- [ ] Merging this PR triggers the automated GitHub Release and npm publish for `v0.5.14`