### PR TITLE
chore(release): bump version to v0.5.15-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.14",
+  "version": "0.5.15-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.14` to `0.5.15-0` in preparation for the next release.

## Changes

- `package.json`: version `0.5.14` → `0.5.15-0`

## Test plan

- [x] `bun typecheck` passes
- [x] `bun test` passes (971 tests, 0 failures)