### PR TITLE
chore(release): bump version to v0.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.15-0",
+  "version": "0.5.15",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `v0.5.15-0` to the stable `v0.5.15` release by bumping the version in `package.json`.

## Changes

- `package.json`: version `0.5.15-0` → `0.5.15`

## Test plan

- [x] All 971 tests pass
- [x] Type checks pass
- [x] Lint checks pass (no matching staged files)