### PR TITLE
chore(release): bump version to v0.5.16-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.15",
+  "version": "0.5.16-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.15` to `0.5.16-0` in preparation for the next prerelease.

## Changes

- `package.json`: version `0.5.15` → `0.5.16-0`

## Test plan

- [x] `bun typecheck` passes
- [x] `bun test` passes (971 tests, 0 failures)