### PR TITLE
chore(release): bump version to v0.5.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.16-0",
+  "version": "0.5.16",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `v0.5.16-0` to the stable release `v0.5.16` by updating the version in `package.json`.

## Changes

- **`package.json`**: Version bumped from `0.5.16-0` → `0.5.16`

## Test plan

- [ ] CI passes
- [ ] Version in `package.json` is `0.5.16`
- [ ] Package published to npm as `@bastani/atomic@0.5.16`