### PR TITLE
fix(claude): route ralph reviewer via session and sync global settings

### DIFF
--- a/.agents/skills/workflow-creator/references/agent-sessions.md
+++ b/.agents/skills/workflow-creator/references/agent-sessions.md
@@ -99,7 +99,9 @@ Claude maintains conversation context across calls within the same pane. Call `s
 
 ### Advanced: Claude Agent SDK `query()` API
 
-For programmatic control beyond tmux automation, the Claude Agent SDK provides `query()`:
+For programmatic control beyond tmux automation, the Claude Agent SDK provides `query()`. **Do not call it from inside a non-headless `ctx.stage()`** — that spawns a TUI in a tmux pane that goes unused while the SDK runs in-process (see `failure-modes.md` §F17). Either set `headless: true` on the stage and pass SDK options through `s.session.query(prompt, options)` (the headless wrapper forwards them to `query()`), or use the interactive TUI route below with `chatFlags: ["--agent", "<name>", ...]` plus `s.session.query(prompt)`.
+
+The example below is reference for the SDK option surface — in real workflow code, prefer `s.session.query()` so the runtime, not your callback, decides which transport to use:
 
 ```ts
 import { query } from "@anthropic-ai/claude-agent-sdk";

--- a/.agents/skills/workflow-creator/references/failure-modes.md
+++ b/.agents/skills/workflow-creator/references/failure-modes.md
@@ -46,6 +46,7 @@ Silent failures are catalogued first below. Loud failures are grouped at the end
 | [F14](#f14-forgetting-to-await-ctxstage) | Forgetting to `await` `ctx.stage()` | all | silent |
 | [F15](#f15-using-a-pending-sessionhandle-before-completion) | Using a pending `SessionHandle` before completion | all | silent |
 | [F16](#f16-headless-stage-errors-are-invisible-in-the-graph) | Headless stage errors are invisible in the graph | all | silent |
+| [F17](#f17-claude-importing-sdk-query-inside-a-non-headless-stage) | Claude: importing the SDK `query()` inside a non-headless stage (anti-pattern) | Claude | silent |
 
 ---
 
@@ -713,6 +714,144 @@ full error for each failed headless stage.
 
 ---
 
+## F17. Claude: importing the SDK `query()` inside a non-headless stage
+
+**Symptom.** A reviewer / extractor / structured-output stage shows up in
+the workflow graph as a tmux pane, but the pane sits idle on the Claude
+welcome screen for the entire stage duration. The stage still produces a
+result — but the visible session never moved. CPU and token cost double:
+two Claude processes ran, one in the pane (idle) and one in-process (the
+SDK call that actually did the work).
+
+**Root cause.** The stage was registered without `headless: true`, so the
+runtime spawned an interactive Claude TUI in a tmux pane and bound
+`s.session` to it. The callback ignored that and called
+`query()` from `@anthropic-ai/claude-agent-sdk` directly:
+
+```ts
+import { query } from "@anthropic-ai/claude-agent-sdk";
+// ...
+ctx.stage({ name: "review" }, {}, {}, async (s) => {
+  for await (const msg of query({ prompt, options: { outputFormat: ... } })) { /* ... */ }
+});
+```
+
+That import bypasses `s.session` entirely. The runtime cannot route the
+SDK call through the TUI it just started, so:
+
+1. The visible pane never receives a prompt — the user sees a blank Claude
+   session in the graph.
+2. A second Claude process spins up in the orchestrator process to service
+   the SDK call. Both processes count against rate limits and token spend.
+3. Idle detection on the pane never fires because no prompt was ever sent;
+   the runtime relies on session-state events that won't arrive, and stage
+   completion happens only because the callback returned (not because the
+   pane finished work).
+
+The runtime exposes exactly two routes for an SDK feature:
+
+| You want to use… | Stage shape | Code in callback |
+|---|---|---|
+| `outputFormat`, custom `agents`, `maxBudgetUsd`, etc. **without** a visible pane | `{ headless: true }` | `s.session.query(prompt, sdkOptions)` — wraps `HeadlessClaudeSessionWrapper.query()` which forwards `options` to the SDK |
+| The visible TUI with a sub-agent | omit `headless` and pass `chatFlags: ["--agent", "<name>", ...]` | `s.session.query(prompt)` — sends through tmux send-keys |
+
+The one option that does **not** exist is "visible pane + in-process SDK call".
+That combination is always wrong — pick one route or the other.
+
+**Affected SDKs.** Claude only. Copilot and OpenCode don't expose a
+parallel "import the bare SDK" foot-gun in this codebase.
+
+### ❌ Wrong — visible pane + bypassed-SDK call
+
+```ts
+import { query as claudeSdkQuery } from "@anthropic-ai/claude-agent-sdk";
+
+await ctx.stage({ name: "review" }, {}, {}, async (s) => {
+  // Visible TUI was started, but we're ignoring it.
+  for await (const msg of claudeSdkQuery({
+    prompt: reviewPrompt,
+    options: {
+      outputFormat: { type: "json_schema", schema: REVIEW_SCHEMA },
+    },
+  })) {
+    if (msg.type === "result") { /* ... */ }
+  }
+  s.save(s.sessionId);
+});
+```
+
+### ✅ Right (a) — visible TUI with sub-agent + chatFlags
+
+When you want the user to watch the review happen, run the sub-agent in
+the pane via `--agent` and parse JSON out of the assistant text. The
+prompt should enumerate the schema fields so the model emits matching
+JSON; a tolerant parser (last-fenced-block + last-balanced-object
+fallback, F8) handles any prose the model adds:
+
+```ts
+await ctx.stage(
+  { name: "review" },
+  { chatFlags: ["--agent", "reviewer", "--allow-dangerously-skip-permissions", "--dangerously-skip-permissions"] },
+  {},
+  async (s) => {
+    const messages = await s.session.query(reviewPrompt);
+    s.save(s.sessionId);
+    return parseReviewResult(extractAssistantText(messages, 0));
+  },
+);
+```
+
+This is the pattern used by `src/sdk/workflows/builtin/ralph/claude/index.ts`
+for its planner, orchestrator, reviewer, and debugger stages.
+
+### ✅ Right (b) — headless stage with SDK options via `s.session.query()`
+
+When you don't need the pane (e.g. background data gathering), set
+`headless: true` and pass SDK options as the second argument to
+`s.session.query()`. The runtime uses `HeadlessClaudeSessionWrapper`,
+which calls the SDK's `query()` in-process and exposes the full options
+surface (`agent`, `outputFormat`, `permissionMode`, `maxBudgetUsd`, etc.):
+
+```ts
+await ctx.stage(
+  { name: "review", headless: true },
+  {}, {},
+  async (s) => {
+    const messages = await s.session.query(reviewPrompt, {
+      agent: "reviewer",
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+    });
+    s.save(s.sessionId);
+    return extractAssistantText(messages, 0);
+  },
+);
+```
+
+> **Note on `--json-schema`.** The CLI's `--json-schema` flag requires
+> `-p` (print mode) and therefore can't be passed via `chatFlags` to the
+> interactive TUI. If you need SDK-validated structured output, use route
+> (b) — set `headless: true` and pass `outputFormat: { type: "json_schema", schema }`
+> in the `s.session.query()` options. Pair (a)'s visible TUI with a
+> tolerant JSON parser instead. (Note: `s.session.query()`'s headless
+> wrapper currently returns `SessionMessage[]` and discards the SDK
+> result event's `structured_output` field — for now, parse JSON out of
+> the assistant text either way.)
+
+**Detection.**
+1. Grep your workflow for `from "@anthropic-ai/claude-agent-sdk"` —
+   `query`, `tool`, `createSdkMcpServer` and similar imports inside a
+   `.run()` callback are the smell. Workflow code should import from
+   `@bastani/atomic/workflows` and access the SDK exclusively through
+   `s.client` and `s.session`.
+2. Watch the workflow run. If a visible pane shows the Claude welcome
+   screen for the entire duration of a stage and never receives a prompt,
+   you have F17.
+3. Cost monitoring. F17 roughly doubles the Claude process count — if
+   stage spend looks 2× a single run, audit imports.
+
+---
+
 ## Design checklist
 
 Before shipping a multi-session workflow, walk the list:
@@ -729,3 +868,4 @@ Before shipping a multi-session workflow, walk the list:
 - [ ] `SessionHandle` values are only used after the promise resolves (F15)
 - [ ] If provider-level resume/fork is used at all, it stays within the same agent role (F12)
 - [ ] Headless stage callbacks include descriptive error context so failures can be diagnosed without a graph node (F16)
+- [ ] Claude stages never import `query` (or other entry points) from `@anthropic-ai/claude-agent-sdk` directly — go through `s.session.query()` so the runtime routes to the TUI (interactive) or the SDK (headless) consistently (F17)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
     "CLAUDE_CODE_NO_FLICKER": "1"
   },
   "includeCoAuthoredBy": false,
+  "skipDangerousModePermissionPrompt": true,
   "permissions": {
     "defaultMode": "bypassPermissions"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
     "lefthook",
   ],
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.108", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-B6DDuzuguNu2P2rzVcEf0P0hKwEWqqwoXU9UsmYONFuTOHIqfvK8d8oDBwPCctQ/fG7nnJOf796RNAb/ZXM+Zg=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.111", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-DwXyJpVL8JXB8L2toSw1by7uIt1p8hPGi0P+hqr5tL+Ae7DcK9O3tUd6XcGown3LZ49zNCUAIpqX3wDmOhqp0Q=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
@@ -156,7 +156,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.4.3", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.4.6", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-sQaVfEfQW3m3DeCVlurSTUjgIYdIk+gIfOys51MVFYzJHw+FyjjuAt7EKKA+LeZU5AiWGlpkIRa1rJo5KWMXCw=="],
 
     "@opentui/core": ["@opentui/core@0.1.99", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.99", "@opentui/core-darwin-x64": "0.1.99", "@opentui/core-linux-arm64": "0.1.99", "@opentui/core-linux-x64": "0.1.99", "@opentui/core-win32-arm64": "0.1.99", "@opentui/core-win32-x64": "0.1.99", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-I3+AEgGzqNWIpWX9g2WOscSPwtQDNOm4KlBjxBWCZjLxkF07u77heWXF7OiAdhKLtNUW6TFiyt6yznqAZPdG3A=="],
 
@@ -380,27 +380,27 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
-    "lefthook": ["lefthook@2.1.5", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.5", "lefthook-darwin-x64": "2.1.5", "lefthook-freebsd-arm64": "2.1.5", "lefthook-freebsd-x64": "2.1.5", "lefthook-linux-arm64": "2.1.5", "lefthook-linux-x64": "2.1.5", "lefthook-openbsd-arm64": "2.1.5", "lefthook-openbsd-x64": "2.1.5", "lefthook-windows-arm64": "2.1.5", "lefthook-windows-x64": "2.1.5" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-yB9IFWurFllusbPZqvG0EavTmpNXPya2MuO7Li7YT78xAj3uCQ3AgmW9TVUbTTsSMhsegbiAMRpwfEk2TP1P0A=="],
+    "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
 
-    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VITTaw8PxxyE26gkZ8UcwIa5ZrWnKNRGLeeSrqri40cQdXvLTEoMq2tjjw7eiL9UcB0waRReDdzydevy9GOPUQ=="],
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ=="],
 
-    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-AvtjYiW0BSGHBGrdvL313seUymrW9FxI+6JJwJ+ZSaa2sH81etrTB0wAwlH1L9VfFwK9+gWvatZBvLfF3L4fPw=="],
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ=="],
 
-    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-mXjJwe8jKGWGiBYUxfQY1ab3Nn5NhafqT9q3KJz8m5joGGQj4JD0cbWxF1nVBLBWsDGbWZRZunTCMGcIScT2bQ=="],
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA=="],
 
-    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-exD69dCjc1K45BxatDPGoH4NmEvgLKPm4kJLOWn1fTeHRKZwWiFPwnjknEoG2OemlCDHmCU++5X40kMEG0WBlA=="],
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg=="],
 
-    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-57TDKC5ewWpsCLZQKIJMHumFEObYKVundmPpiWhX491hINRZYYOL/26yrnVnNcidThRzTiTC+HLcuplLcaXtbA=="],
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g=="],
 
-    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-bqK3LrAB5l5YaCaoHk6qRWlITrGWzP4FbwRxA31elbxjd0wgNWZ2Sn3zEfSEcxz442g7/PPkEwqqsTx0kSFzpg=="],
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw=="],
 
-    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.5", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-5aSwK7vV3A6t0w9PnxCMiVjQlcvopBP50BtmnnLnNJyAYHnFbZ0Baq5M0WkE9IsUkWSux0fe6fd0jDkuG711MA=="],
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A=="],
 
-    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Y+pPdDuENJ8qWnUgL02xxhpjblc0WnwXvWGfqnl3WZrAgHzQpwx3G6469RID/wlNVdHYAlw3a8UkFSMYsTzXvA=="],
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg=="],
 
-    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-2PlcFBjTzJaMufw0c28kfhB/0zmaRCU0TRPPsil/HU2YNOExod4upPGLk9qjgsOmb2YVWFz6zq6u7+D1yqmzTQ=="],
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
 
-    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-yiAh8qxml6uqy10jDxOdN9fOQpyLxBFY1fgCEAhn7sVJYmJKRhjqSBwZX6LG5MQjzr29KStrIdw7TR3lf3rT7Q=="],
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 

--- a/package.json
+++ b/package.json
@@ -68,17 +68,17 @@
   "devDependencies": {
     "@types/bun": "^1.3.12",
     "@types/react": "^19.2.14",
-    "lefthook": "^2.1.5",
+    "lefthook": "^2.1.6",
     "oxlint": "^1.60.0",
     "typescript": "^6.0.2",
     "typescript-language-server": "^5.1.3"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.108",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.111",
     "@clack/prompts": "^1.2.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.2.2",
-    "@opencode-ai/sdk": "^1.4.3",
+    "@opencode-ai/sdk": "^1.4.6",
     "@opentui/core": "^0.1.99",
     "@opentui/react": "^0.1.99",
     "commander": "^14.0.3",
@@ -87,6 +87,6 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "react": ">=19.0.0"
+    "react": "^19.2.5"
   }
 }

--- a/src/commands/cli/init/onboarding.ts
+++ b/src/commands/cli/init/onboarding.ts
@@ -1,7 +1,21 @@
 import { join } from "node:path";
+import { homedir } from "node:os";
 import { AGENT_CONFIG, type AgentKey } from "../../../services/config/index.ts";
 import { pathExists } from "../../../services/system/copy.ts";
 import { syncJsonFile } from "../../../lib/merge.ts";
+
+/**
+ * Resolve an onboarding destination path. A leading `~/` is expanded to
+ * the user's home directory so providers can target global config roots
+ * (e.g. `~/.claude/settings.json`); anything else resolves against the
+ * project root.
+ */
+function resolveDestination(destination: string, projectRoot: string): string {
+  if (destination === "~" || destination.startsWith("~/")) {
+    return join(homedir(), destination.slice(1));
+  }
+  return join(projectRoot, destination);
+}
 
 export async function applyManagedOnboardingFiles(
   agentKey: AgentKey,
@@ -16,7 +30,10 @@ export async function applyManagedOnboardingFiles(
       continue;
     }
 
-    const destinationPath = join(projectRoot, managedFile.destination);
+    const destinationPath = resolveDestination(
+      managedFile.destination,
+      projectRoot,
+    );
     await syncJsonFile(sourcePath, destinationPath, managedFile.merge);
   }
 }
@@ -32,7 +49,7 @@ export async function hasProjectOnboardingFiles(
 
   const checks = await Promise.all(
     onboardingFiles.map((managedFile) =>
-      pathExists(join(projectRoot, managedFile.destination))
+      pathExists(resolveDestination(managedFile.destination, projectRoot))
     ),
   );
   return checks.every(Boolean);

--- a/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
@@ -187,12 +187,7 @@ export default defineWorkflow({
           description:
             "Surface prior research via research-locator + research-analyzer",
         },
-        {
-          chatFlags: [
-            "--allow-dangerously-skip-permissions",
-            "--dangerously-skip-permissions",
-          ],
-        },
+        {},
         {},
         async (s) => {
           // Dispatches codebase-research-locator → codebase-research-analyzer
@@ -243,12 +238,7 @@ export default defineWorkflow({
                 ", ",
               )} (${partition.reduce((s, u) => s + u.fileCount, 0)} files)`,
           },
-          {
-            chatFlags: [
-              "--allow-dangerously-skip-permissions",
-              "--dangerously-skip-permissions",
-            ],
-          },
+          {},
           {},
           async (s) => {
             await s.session.query(
@@ -298,12 +288,7 @@ export default defineWorkflow({
         description:
           "Synthesize explorer findings + history into final research doc",
       },
-      {
-        chatFlags: [
-          "--allow-dangerously-skip-permissions",
-          "--dangerously-skip-permissions",
-        ],
-      },
+      {},
       {},
       async (s) => {
         await s.session.query(

--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -7,15 +7,18 @@
  *   - {@link MAX_LOOPS} iterations have completed, OR
  *   - Two parallel reviewer passes both return zero findings.
  *
- * The reviewer stages use the Claude Agent SDK's structured output
- * (`outputFormat`) to guarantee the review result matches the
- * {@link ReviewResultSchema} — no manual JSON parsing required.
+ * The reviewer stages run the `reviewer` sub-agent in a visible TUI via the
+ * `--agent reviewer` chatFlag, then parse the JSON review out of the
+ * assistant text with {@link parseReviewResult}. The prompt enumerates the
+ * {@link ReviewResultSchema} fields so the model emits matching JSON. We
+ * deliberately avoid invoking the Claude Agent SDK's `query()` from inside a
+ * non-headless stage — that would spawn a TUI pane that goes unused while
+ * the SDK runs in-process (see workflow-creator skill, failure-modes F17).
  *
  * Run: atomic workflow -n ralph -a claude "<your spec>"
  */
 
 import { defineWorkflow, extractAssistantText } from "../../../index.ts";
-import { query as claudeSdkQuery } from "@anthropic-ai/claude-agent-sdk";
 
 import {
   buildPlannerPrompt,
@@ -24,10 +27,8 @@ import {
   buildReviewPrompt,
   buildDebuggerReportPrompt,
   extractMarkdownBlock,
-  filterActionable,
+  parseReviewResult,
   mergeReviewResults,
-  REVIEW_RESULT_JSON_SCHEMA,
-  type ReviewResult,
   type StructuredReviewResult,
 } from "../helpers/prompts.ts";
 import { hasActionableFindings } from "../helpers/review.ts";
@@ -41,41 +42,13 @@ const MAX_LOOPS = 10;
 // timeout is needed.
 
 /**
- * Run the Claude Agent SDK's `query()` with structured output and collect
- * the result. Returns a {@link StructuredReviewResult} with the SDK-validated
- * structured output (when available) and the raw text fallback.
+ * Extract a {@link StructuredReviewResult} from the reviewer TUI's assistant
+ * text. {@link parseReviewResult} tolerates surrounding prose and fenced
+ * code blocks; the prompt instructs the model to emit JSON matching
+ * {@link ReviewResultSchema}.
  */
-async function queryWithStructuredOutput(
-  prompt: string,
-): Promise<StructuredReviewResult> {
-  let structured: ReviewResult | null = null;
-  let raw = "";
-
-  for await (const msg of claudeSdkQuery({
-    prompt,
-    options: {
-      outputFormat: {
-        type: "json_schema",
-        schema: REVIEW_RESULT_JSON_SCHEMA,
-      },
-    },
-  })) {
-    if (msg.type === "result") {
-      raw = String((msg as Record<string, unknown>).result ?? "");
-      if (
-        msg.subtype === "success" &&
-        (msg as Record<string, unknown>).structured_output
-      ) {
-        structured = (msg as Record<string, unknown>)
-          .structured_output as ReviewResult;
-      }
-    }
-  }
-
-  return {
-    structured: structured ? filterActionable(structured) : null,
-    raw,
-  };
+function extractReview(rawText: string): StructuredReviewResult {
+  return { structured: parseReviewResult(rawText), raw: rawText };
 }
 
 export default defineWorkflow({
@@ -206,17 +179,34 @@ export default defineWorkflow({
         discoveryContext,
       });
 
+      const reviewerChatFlags = [
+        "--agent",
+        "reviewer",
+        "--allow-dangerously-skip-permissions",
+        "--dangerously-skip-permissions",
+      ];
+
       const [reviewA, reviewB] = await Promise.all([
-        ctx.stage({ name: `reviewer-${iteration}-a` }, {}, {}, async (s) => {
-          const result = await queryWithStructuredOutput(reviewPrompt);
-          s.save(s.sessionId);
-          return result;
-        }),
-        ctx.stage({ name: `reviewer-${iteration}-b` }, {}, {}, async (s) => {
-          const result = await queryWithStructuredOutput(reviewPrompt);
-          s.save(s.sessionId);
-          return result;
-        }),
+        ctx.stage(
+          { name: `reviewer-${iteration}-a` },
+          { chatFlags: reviewerChatFlags },
+          {},
+          async (s) => {
+            const result = await s.session.query(reviewPrompt);
+            s.save(s.sessionId);
+            return extractReview(extractAssistantText(result, 0));
+          },
+        ),
+        ctx.stage(
+          { name: `reviewer-${iteration}-b` },
+          { chatFlags: reviewerChatFlags },
+          {},
+          async (s) => {
+            const result = await s.session.query(reviewPrompt);
+            s.save(s.sessionId);
+            return extractReview(extractAssistantText(result, 0));
+          },
+        ),
       ]);
 
       const merged = mergeReviewResults(reviewA.result, reviewB.result);

--- a/src/services/config/definitions.ts
+++ b/src/services/config/definitions.ts
@@ -54,6 +54,11 @@ export const AGENT_CONFIG: Record<AgentKey, AgentConfig> = {
         destination: ".claude/settings.json",
         merge: true,
       },
+      {
+        source: ".claude/settings.json",
+        destination: "~/.claude/settings.json",
+        merge: true,
+      },
     ],
   },
   opencode: {


### PR DESCRIPTION
## Summary

Fixes the F17 anti-pattern in the Ralph workflow where reviewer stages spawned a visible TUI pane but bypassed it via a direct `query()` import, causing two Claude processes to run simultaneously. Also syncs local `.claude/settings.json` to `~/.claude/settings.json` during onboarding so dangerous-skip permissions apply globally, eliminating redundant per-stage `chatFlags`.

## Key Changes

### Ralph workflow (`src/sdk/workflows/builtin/ralph/claude/index.ts`)
- Removed direct `query()` import from `@anthropic-ai/claude-agent-sdk` (F17 anti-pattern)
- Reviewer stages now pass `--agent reviewer` via `chatFlags` and call `s.session.query()`, routing through the visible TUI
- Replaced `queryWithStructuredOutput()` (SDK-based) with `extractReview()` + `parseReviewResult()` (tolerant text parser)
- Imports `parseReviewResult` from prompts helpers instead of the removed `filterActionable`/`REVIEW_RESULT_JSON_SCHEMA`

### Global settings sync (`src/services/config/definitions.ts`, `src/commands/cli/init/onboarding.ts`)
- Onboarding now resolves `~/` prefixes in managed-file destinations, enabling global config targets
- Added managed file entry to sync `.claude/settings.json` → `~/.claude/settings.json` (merged) so `bypassPermissions` and `skipDangerousModePermissionPrompt` apply to all Claude Code sessions
- Deep-research workflow drops per-stage `--allow-dangerously-skip-permissions`/`--dangerously-skip-permissions` chatFlags that are now redundant

### Documentation (`.agents/skills/workflow-creator/references/`)
- Added **F17** to failure-modes reference: comprehensive description of the visible-pane + in-process-SDK anti-pattern with wrong/right code examples and detection steps
- Updated agent-sessions reference to warn against calling `query()` inside non-headless stages and prefer `s.session.query()`

### Dependency bumps
- `@anthropic-ai/claude-agent-sdk`: `0.2.108` → `0.2.111`
- `@opencode-ai/sdk`: `1.4.3` → `1.4.6`
- `lefthook`: `2.1.5` → `2.1.6`

## Migration Notes

No breaking changes. If you have workflow stages that import `query` from `@anthropic-ai/claude-agent-sdk` directly inside a `.run()` callback, migrate to one of the two correct patterns documented in F17:
- **Visible TUI**: pass `chatFlags: ["--agent", "<name>", ...]` and call `s.session.query(prompt)`
- **Headless**: set `headless: true` on the stage and call `s.session.query(prompt, sdkOptions)`