### PR TITLE
chore(release): bump version to v0.5.17-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "@bastani/atomic",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.108",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.111",
         "@clack/prompts": "^1.2.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.2.2",
-        "@opencode-ai/sdk": "^1.4.3",
+        "@opencode-ai/sdk": "^1.4.6",
         "@opentui/core": "^0.1.99",
         "@opentui/react": "^0.1.99",
         "commander": "^14.0.3",
@@ -20,13 +20,13 @@
       "devDependencies": {
         "@types/bun": "^1.3.12",
         "@types/react": "^19.2.14",
-        "lefthook": "^2.1.5",
+        "lefthook": "^2.1.6",
         "oxlint": "^1.60.0",
         "typescript": "^6.0.2",
         "typescript-language-server": "^5.1.3",
       },
       "peerDependencies": {
-        "react": ">=19.0.0",
+        "react": "^19.2.5",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.16",
+  "version": "0.5.17-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.16` to `0.5.17-0` as a prerelease ahead of the `v0.5.17` stable release.

## Changes

- `package.json`: version `0.5.16` → `0.5.17-0`

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes prerelease to npm after merge