### PR TITLE
chore(release): bump version to v0.5.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.17-0",
+  "version": "0.5.17",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes `v0.5.17-0` prerelease to `v0.5.17` stable release by updating `package.json`.

## Changes

- `package.json`: `0.5.17-0` → `0.5.17`

## Test plan

- [ ] CI passes
- [ ] GitHub Release is created automatically after merge
- [ ] Package published to npm with provenance