### PR TITLE
feat(session): add `atomic session kill` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ atomic session connect <session-name>
 
 # Interactive session picker (fuzzy-search)
 atomic session connect
+
+# Kill a session by name (prompts for confirmation)
+atomic session kill <session-name>
+
+# Kill all sessions in scope (prompts for confirmation)
+atomic session kill
 ```
 
 Session names follow a predictable pattern:
@@ -979,6 +985,7 @@ During `atomic chat`, there is no Atomic-owned TUI — `atomic chat -a <agent>` 
 | `atomic workflow list`          | List available workflows, grouped by source                           |
 | `atomic session list`           | List all running sessions on the atomic tmux socket                   |
 | `atomic session connect [name]` | Attach to a session (interactive picker when no name given)           |
+| `atomic session kill [name]`    | Kill a session by name, or all sessions when no name is given         |
 | `atomic completions <shell>`    | Output shell completion script (bash, zsh, fish, powershell)          |
 | `atomic config set <k> <v>`     | Set configuration values (currently supports `telemetry`)             |
 
@@ -1000,12 +1007,15 @@ The `session` command is available at three levels — scoped or global:
 | ---------------------------------------- | ----------------------------------------------------- |
 | `atomic session list`                    | List all running sessions                             |
 | `atomic session connect [name]`          | Attach to a session (interactive picker when no name) |
+| `atomic session kill [name]`             | Kill a session, or all sessions when no name is given |
 | `atomic chat session list`               | List running chat sessions only                       |
 | `atomic chat session connect [name]`     | Attach to a chat session                              |
+| `atomic chat session kill [name]`        | Kill a chat session, or all chat sessions             |
 | `atomic workflow session list`           | List running workflow sessions only                   |
 | `atomic workflow session connect [name]` | Attach to a workflow session                          |
+| `atomic workflow session kill [name]`    | Kill a workflow session, or all workflow sessions     |
 
-Both `list` and `connect` accept `-a <agent>` (repeatable) to filter by agent backend.
+`list`, `connect`, and `kill` all accept `-a <agent>` (repeatable) to filter by agent backend. `kill` prompts for confirmation before terminating sessions.
 
 ```bash
 atomic session list                      # All sessions
@@ -1013,6 +1023,9 @@ atomic session list -a claude            # Only Claude sessions
 atomic session connect my-session        # Attach by name
 atomic session connect                   # Interactive picker
 atomic chat session list -a copilot      # Chat sessions for Copilot only
+atomic session kill my-session           # Kill one session by name
+atomic session kill                      # Kill all sessions (with confirmation)
+atomic workflow session kill -a claude   # Kill all Claude workflow sessions
 ```
 
 #### `atomic chat` Flags

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@
  *   atomic workflow session connect <id>      Attach to a session
  *   atomic session list                       List all running sessions
  *   atomic session connect [id]               Interactive session picker
+ *   atomic session kill [id]                  Kill a session (or all when no id)
  *   atomic config set <key> <value>           Set configuration value
  *   atomic --version                          Show version
  *   atomic --help                             Show help
@@ -77,6 +78,22 @@ function addSessionSubcommand(parent: Command, scope: "chat" | "workflow" | "all
             }
         });
 
+    sessionCmd
+        .command("kill")
+        .description("Kill a running session (omit id to kill all)")
+        .argument("[session_id]", "Session name to kill (omit to kill all)")
+        .option(
+            "-a, --agent <name>",
+            `Filter by agent backend (${Object.keys(AGENT_CONFIG).join(", ")}); repeatable`,
+            collectAgent,
+            [] as string[],
+        )
+        .action(async (sessionId, localOpts) => {
+            const { sessionKillCommand } = await import("./commands/cli/session.ts");
+            const exitCode = await sessionKillCommand(sessionId, localOpts.agent, scope);
+            process.exit(exitCode);
+        });
+
     return sessionCmd;
 }
 
@@ -131,7 +148,8 @@ Examples:
   $ atomic chat -a opencode                         Start OpenCode interactively
   $ atomic chat -a claude "fix the bug"             Claude with initial prompt
   $ atomic chat session list                        List running sessions
-  $ atomic chat session connect <id>                Attach to a session`,
+  $ atomic chat session connect <id>                Attach to a session
+  $ atomic chat session kill [id]                   Kill a chat session (or all)`,
         )
         .action(async (localOpts, cmd) => {
             const validAgents = Object.keys(AGENT_CONFIG);
@@ -201,7 +219,8 @@ Examples:
   $ atomic workflow -n gen-spec -a claude --research_doc=notes.md --focus=standard
                                                     Run a structured-input workflow
   $ atomic workflow session list                    List running sessions
-  $ atomic workflow session connect <id>            Attach to a session`,
+  $ atomic workflow session connect <id>            Attach to a session
+  $ atomic workflow session kill [id]               Kill a workflow session (or all)`,
         )
         .action(async (localOpts, cmd) => {
             const { workflowCommand } = await import("./commands/cli/workflow.ts");

--- a/src/commands/cli/session.test.ts
+++ b/src/commands/cli/session.test.ts
@@ -6,6 +6,7 @@ import {
   sessionListCommand,
   sessionConnectCommand,
   sessionPickerCommand,
+  sessionKillCommand,
 } from "./session.ts";
 import type { SessionDeps } from "./session.ts";
 import type { TmuxSession } from "../../sdk/runtime/tmux.ts";
@@ -287,6 +288,9 @@ const tmuxMocks = {
   spawnMuxAttach: mock(() => ({ exited: Promise.resolve(0) }) as never),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   select: mock<(...args: any[]) => Promise<string | symbol>>(() => Promise.resolve("my-session")),
+  killSession: mock<(name: string) => void>(() => {}),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  confirm: mock<(...args: any[]) => Promise<boolean | symbol>>(() => Promise.resolve(true)),
   isCancel: ((v: unknown) => typeof v === "symbol") as SessionDeps["isCancel"],
 };
 
@@ -305,6 +309,8 @@ function resetTmuxMocks(): void {
   tmuxMocks.detachAndAttachAtomic.mockReset();
   tmuxMocks.spawnMuxAttach.mockReset().mockReturnValue({ exited: Promise.resolve(0) } as never);
   tmuxMocks.select.mockReset().mockResolvedValue("my-session");
+  tmuxMocks.killSession.mockReset();
+  tmuxMocks.confirm.mockReset().mockResolvedValue(true);
 }
 
 // ─── sessionListCommand ─────────────────────────────────────────────────
@@ -487,5 +493,222 @@ describe("sessionPickerCommand", () => {
     const code = await sessionPickerCommand([], "all", makeDeps());
     expect(code).toBe(0);
     expect(tmuxMocks.spawnMuxAttach).not.toHaveBeenCalled();
+  });
+});
+
+// ─── sessionKillCommand ──────────────────────────────────────────────────
+
+describe("sessionKillCommand", () => {
+  beforeEach(resetTmuxMocks);
+
+  // (a) tmux not installed → stdout "no sessions running" + "tmux is not installed", return 0
+  test("returns 0 with 'no sessions' when tmux is not installed", async () => {
+    tmuxMocks.isTmuxInstalled.mockReturnValue(false);
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((c: string) => { chunks.push(c); return true; }) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(undefined, [], "all", makeDeps());
+      expect(code).toBe(0);
+      const output = chunks.join("");
+      expect(output).toContain("no sessions running");
+      expect(output).toContain("tmux is not installed");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (b) named id, session not in scope → stderr error, return 1
+  test("returns 1 with error when named session does not exist", async () => {
+    // listSessions returns empty, so the target won't be found
+    tmuxMocks.listSessions.mockReturnValue([]);
+    const chunks: string[] = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = ((c: string) => { chunks.push(c); return true; }) as typeof process.stderr.write;
+    try {
+      const code = await sessionKillCommand("ghost-session", [], "all", makeDeps());
+      expect(code).toBe(1);
+      const output = chunks.join("");
+      expect(output).toContain("ghost-session");
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  // (c) named id, session exists but is out of scope → return 1
+  test("returns 1 when named session exists but is out of scope", async () => {
+    const now = new Date().toISOString();
+    // listSessions has a chat session, but we request scope=workflow
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "atomic-chat-claude-aaa11111", windows: 1, created: now, attached: false, type: "chat" as const, agent: "claude" },
+    ]);
+    const chunks: string[] = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = ((c: string) => { chunks.push(c); return true; }) as typeof process.stderr.write;
+    try {
+      const code = await sessionKillCommand("atomic-chat-claude-aaa11111", [], "workflow", makeDeps());
+      expect(code).toBe(1);
+      const output = chunks.join("");
+      expect(output).toContain("atomic-chat-claude-aaa11111");
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  // (d) named id found, user confirms → killSession called, return 0
+  test("prompts and calls killSession on confirm for named session", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "target-session", windows: 1, created: now, attached: false, type: "chat" as const },
+    ]);
+    tmuxMocks.confirm.mockResolvedValue(true);
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((c: string) => { chunks.push(c); return true; }) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand("target-session", [], "all", makeDeps());
+      expect(code).toBe(0);
+      expect(tmuxMocks.killSession).toHaveBeenCalledTimes(1);
+      expect(tmuxMocks.killSession).toHaveBeenCalledWith("target-session");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (e) named id found, user declines → killSession NOT called, return 0
+  test("does NOT call killSession when user declines named kill", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "target-session", windows: 1, created: now, attached: false, type: "chat" as const },
+    ]);
+    tmuxMocks.confirm.mockResolvedValue(false);
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand("target-session", [], "all", makeDeps());
+      expect(code).toBe(0);
+      expect(tmuxMocks.killSession).not.toHaveBeenCalled();
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (f) named id found, user cancels (symbol) → killSession NOT called, return 0
+  test("does NOT call killSession when user cancels named kill", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "target-session", windows: 1, created: now, attached: false, type: "chat" as const },
+    ]);
+    tmuxMocks.confirm.mockResolvedValue(Symbol("cancel"));
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand("target-session", [], "all", makeDeps());
+      expect(code).toBe(0);
+      expect(tmuxMocks.killSession).not.toHaveBeenCalled();
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (g) omitted id, no sessions → empty state on stdout, return 0, confirm NOT called
+  test("omitted id with no sessions prints empty state and returns 0 without prompt", async () => {
+    tmuxMocks.listSessions.mockReturnValue([]);
+    const chunks: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((c: string) => { chunks.push(c); return true; }) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(undefined, [], "all", makeDeps());
+      expect(code).toBe(0);
+      const output = chunks.join("");
+      expect(output).toContain("no sessions running");
+      expect(tmuxMocks.confirm).not.toHaveBeenCalled();
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (h) omitted id, N sessions, user confirms → killSession called for each, return 0
+  test("omitted id prompts and kills all sessions on confirm", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "session-a", windows: 1, created: now, attached: false, type: "chat" as const, agent: "claude" },
+      { name: "session-b", windows: 1, created: now, attached: false, type: "workflow" as const, agent: "opencode" },
+      { name: "session-c", windows: 1, created: now, attached: false, type: "chat" as const, agent: "copilot" },
+    ]);
+    tmuxMocks.confirm.mockResolvedValue(true);
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(undefined, [], "all", makeDeps());
+      expect(code).toBe(0);
+      expect(tmuxMocks.killSession).toHaveBeenCalledTimes(3);
+      expect(tmuxMocks.killSession).toHaveBeenCalledWith("session-a");
+      expect(tmuxMocks.killSession).toHaveBeenCalledWith("session-b");
+      expect(tmuxMocks.killSession).toHaveBeenCalledWith("session-c");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (i) scope=chat, only chat sessions killed when id omitted
+  test("scope=chat only kills chat sessions when id omitted", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "chat-session", windows: 1, created: now, attached: false, type: "chat" as const, agent: "claude" },
+      { name: "wf-session", windows: 1, created: now, attached: false, type: "workflow" as const, agent: "opencode" },
+    ]);
+    tmuxMocks.confirm.mockResolvedValue(true);
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(undefined, [], "chat", makeDeps());
+      expect(code).toBe(0);
+      expect(tmuxMocks.killSession).toHaveBeenCalledTimes(1);
+      expect(tmuxMocks.killSession).toHaveBeenCalledWith("chat-session");
+      expect(tmuxMocks.killSession).not.toHaveBeenCalledWith("wf-session");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (j) scope=workflow, only workflow sessions killed when id omitted
+  test("scope=workflow only kills workflow sessions when id omitted", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "chat-session", windows: 1, created: now, attached: false, type: "chat" as const, agent: "claude" },
+      { name: "wf-session", windows: 1, created: now, attached: false, type: "workflow" as const, agent: "opencode" },
+    ]);
+    tmuxMocks.confirm.mockResolvedValue(true);
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(undefined, [], "workflow", makeDeps());
+      expect(code).toBe(0);
+      expect(tmuxMocks.killSession).toHaveBeenCalledTimes(1);
+      expect(tmuxMocks.killSession).toHaveBeenCalledWith("wf-session");
+      expect(tmuxMocks.killSession).not.toHaveBeenCalledWith("chat-session");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (k) user declines kill-all → killSession NOT called
+  test("does NOT kill any sessions when user declines kill-all", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "session-x", windows: 1, created: now, attached: false, type: "chat" as const },
+      { name: "session-y", windows: 1, created: now, attached: false, type: "workflow" as const },
+    ]);
+    tmuxMocks.confirm.mockResolvedValue(false);
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(undefined, [], "all", makeDeps());
+      expect(code).toBe(0);
+      expect(tmuxMocks.killSession).not.toHaveBeenCalled();
+    } finally {
+      process.stdout.write = origWrite;
+    }
   });
 });

--- a/src/commands/cli/session.ts
+++ b/src/commands/cli/session.ts
@@ -7,7 +7,7 @@
  * tmux directly.
  */
 
-import { select, isCancel, cancel } from "@clack/prompts";
+import { select, confirm, isCancel, cancel } from "@clack/prompts";
 import { createPainter, type PaletteKey } from "../../theme/colors.ts";
 import {
   listSessions as _listSessions,
@@ -18,6 +18,7 @@ import {
   switchClient as _switchClient,
   spawnMuxAttach as _spawnMuxAttach,
   detachAndAttachAtomic as _detachAndAttachAtomic,
+  killSession as _killSession,
   SOCKET_NAME,
 } from "../../sdk/workflows/index.ts";
 import type { TmuxSession, SessionType } from "../../sdk/runtime/tmux.ts";
@@ -36,8 +37,11 @@ export interface SessionDeps {
   switchClient: (name: string) => void;
   spawnMuxAttach: (name: string) => Subprocess;
   detachAndAttachAtomic: (name: string) => void;
+  killSession: (name: string) => void;
   /** Prompt function for the session picker — defaults to @clack/prompts select. */
   select: typeof select;
+  /** Prompt function for yes/no confirmations — defaults to @clack/prompts confirm. */
+  confirm: typeof confirm;
   isCancel: typeof isCancel;
 }
 
@@ -51,7 +55,9 @@ const defaultDeps: SessionDeps = {
   switchClient: _switchClient,
   spawnMuxAttach: _spawnMuxAttach,
   detachAndAttachAtomic: _detachAndAttachAtomic,
+  killSession: _killSession,
   select,
+  confirm,
   isCancel,
 };
 
@@ -262,4 +268,114 @@ export async function sessionPickerCommand(agents: string[] = [], scope: Session
   }
 
   return sessionConnectCommand(selected as string, deps);
+}
+
+// ─── Session kill command ────────────────────────────────────────────────────
+
+/**
+ * Kill a named session or all sessions matching the given scope and agents.
+ *
+ * - If `sessionId` is provided: confirm and kill that one session.
+ * - If `sessionId` is omitted: confirm and kill all sessions in scope.
+ */
+export async function sessionKillCommand(
+  sessionId: string | undefined,
+  agents: string[] = [],
+  scope: SessionScope = "all",
+  deps: SessionDeps = defaultDeps,
+): Promise<number> {
+  const paint = createPainter();
+
+  if (!deps.isTmuxInstalled()) {
+    process.stdout.write(
+      "\n  " + paint("text", "no sessions running", { bold: true }) +
+      "\n\n  " + paint("dim", "tmux is not installed") + "\n\n",
+    );
+    return 0;
+  }
+
+  // ── Named kill path ───────────────────────────────────────────────────────
+  if (sessionId !== undefined) {
+    const inScope = filterByScope(deps.listSessions(), scope);
+    const target = inScope.find((s) => s.name === sessionId);
+
+    if (!target) {
+      const scopeLabel = scope === "all" ? "" : ` in ${scope} scope`;
+      process.stderr.write(
+        paint("error", `Error: session '${sessionId}' not found${scopeLabel}.`) + "\n",
+      );
+      if (inScope.length > 0) {
+        process.stderr.write(
+          "\n" + paint("dim", "Available sessions:") + "\n",
+        );
+        for (const s of inScope) {
+          process.stderr.write(
+            "  " + paint("dim", "○") + " " + paint("text", s.name) + "\n",
+          );
+        }
+        process.stderr.write("\n");
+      }
+      return 1;
+    }
+
+    const answer = await deps.confirm({
+      message: `Kill session '${sessionId}'?`,
+      initialValue: false,
+    });
+
+    if (deps.isCancel(answer)) {
+      cancel("Cancelled.");
+      return 0;
+    }
+
+    if (answer === true) {
+      deps.killSession(sessionId);
+      process.stdout.write(
+        "\n  " + paint("success", "✓") + " killed " + paint("text", sessionId) + "\n\n",
+      );
+      return 0;
+    }
+
+    // answer === false
+    process.stdout.write(
+      "\n  " + paint("dim", "Cancelled.") + "\n\n",
+    );
+    return 0;
+  }
+
+  // ── Kill-all path ─────────────────────────────────────────────────────────
+  const targets = filterByAgent(filterByScope(deps.listSessions(), scope), agents);
+
+  if (targets.length === 0) {
+    process.stdout.write(renderSessionList([]));
+    return 0;
+  }
+
+  const noun = targets.length === 1 ? "session" : "sessions";
+  const scopePrefix = scope === "all" ? "" : `${scope} `;
+  const answer = await deps.confirm({
+    message: `Kill all ${targets.length} ${scopePrefix}${noun}?`,
+    initialValue: false,
+  });
+
+  if (deps.isCancel(answer)) {
+    cancel("Cancelled.");
+    return 0;
+  }
+
+  if (answer === true) {
+    for (const t of targets) {
+      deps.killSession(t.name);
+    }
+    process.stdout.write(
+      "\n  " + paint("success", "✓") + " killed " + paint("text", String(targets.length)) + " " + paint("dim", noun) + "\n\n",
+    );
+    return 0;
+  }
+
+  // answer === false
+  process.stdout.write(
+    "\n  " + paint("dim", "Cancelled.") + "\n\n",
+  );
+  return 0;
 }

--- a/src/completions/bash.ts
+++ b/src/completions/bash.ts
@@ -58,7 +58,7 @@ _atomic_completions() {
                 COMPREPLY=( $(compgen -W "session -a --agent -h --help" -- "$cur") )
             elif [[ "$cmd2" == "session" ]]; then
                 if [[ -z "$cmd3" ]]; then
-                    COMPREPLY=( $(compgen -W "list connect -h --help" -- "$cur") )
+                    COMPREPLY=( $(compgen -W "list connect kill -h --help" -- "$cur") )
                 else
                     COMPREPLY=( $(compgen -W "-a --agent -h --help" -- "$cur") )
                 fi
@@ -71,7 +71,7 @@ _atomic_completions() {
                 COMPREPLY=( $(compgen -W "-a --agent -h --help" -- "$cur") )
             elif [[ "$cmd2" == "session" ]]; then
                 if [[ -z "$cmd3" ]]; then
-                    COMPREPLY=( $(compgen -W "list connect -h --help" -- "$cur") )
+                    COMPREPLY=( $(compgen -W "list connect kill -h --help" -- "$cur") )
                 else
                     COMPREPLY=( $(compgen -W "-a --agent -h --help" -- "$cur") )
                 fi
@@ -79,7 +79,7 @@ _atomic_completions() {
             ;;
         session)
             if [[ -z "$cmd2" ]]; then
-                COMPREPLY=( $(compgen -W "list connect -h --help" -- "$cur") )
+                COMPREPLY=( $(compgen -W "list connect kill -h --help" -- "$cur") )
             else
                 COMPREPLY=( $(compgen -W "-a --agent -h --help" -- "$cur") )
             fi

--- a/src/completions/fish.ts
+++ b/src/completions/fish.ts
@@ -56,7 +56,7 @@ end
 
 function __atomic_needs_subcmd_of
     __atomic_using_cmd $argv
-    and not __fish_seen_subcommand_from list connect set
+    and not __fish_seen_subcommand_from list connect kill set
 end
 
 # ── Global options ──────────────────────────────────────────────────────────
@@ -86,10 +86,12 @@ complete -c atomic -n '__atomic_using_cmd chat; and not __fish_seen_subcommand_f
 complete -c atomic -n '__atomic_using_cmd chat; and not __fish_seen_subcommand_from session' -a session -d 'Manage running chat sessions'
 
 # chat session
-complete -c atomic -n '__atomic_using_cmd chat session; and not __fish_seen_subcommand_from list connect' -a list -d 'List running sessions'
-complete -c atomic -n '__atomic_using_cmd chat session; and not __fish_seen_subcommand_from list connect' -a connect -d 'Attach to a running session'
+complete -c atomic -n '__atomic_using_cmd chat session; and not __fish_seen_subcommand_from list connect kill' -a list -d 'List running sessions'
+complete -c atomic -n '__atomic_using_cmd chat session; and not __fish_seen_subcommand_from list connect kill' -a connect -d 'Attach to a running session'
+complete -c atomic -n '__atomic_using_cmd chat session; and not __fish_seen_subcommand_from list connect kill' -a kill -d 'Kill a running session (omit id to kill all)'
 complete -c atomic -n '__atomic_using_cmd chat session list' -s a -l agent -d 'Filter by agent' -r -a "$agents"
 complete -c atomic -n '__atomic_using_cmd chat session connect' -s a -l agent -d 'Filter by agent' -r -a "$agents"
+complete -c atomic -n '__atomic_using_cmd chat session kill' -s a -l agent -d 'Filter by agent' -r -a "$agents"
 
 # ── workflow ────────────────────────────────────────────────────────────────
 
@@ -102,17 +104,21 @@ complete -c atomic -n '__atomic_using_cmd workflow; and not __fish_seen_subcomma
 complete -c atomic -n '__atomic_using_cmd workflow list' -s a -l agent -d 'Filter by agent' -r -a "$agents"
 
 # workflow session
-complete -c atomic -n '__atomic_using_cmd workflow session; and not __fish_seen_subcommand_from list connect' -a list -d 'List running sessions'
-complete -c atomic -n '__atomic_using_cmd workflow session; and not __fish_seen_subcommand_from list connect' -a connect -d 'Attach to a running session'
+complete -c atomic -n '__atomic_using_cmd workflow session; and not __fish_seen_subcommand_from list connect kill' -a list -d 'List running sessions'
+complete -c atomic -n '__atomic_using_cmd workflow session; and not __fish_seen_subcommand_from list connect kill' -a connect -d 'Attach to a running session'
+complete -c atomic -n '__atomic_using_cmd workflow session; and not __fish_seen_subcommand_from list connect kill' -a kill -d 'Kill a running session (omit id to kill all)'
 complete -c atomic -n '__atomic_using_cmd workflow session list' -s a -l agent -d 'Filter by agent' -r -a "$agents"
 complete -c atomic -n '__atomic_using_cmd workflow session connect' -s a -l agent -d 'Filter by agent' -r -a "$agents"
+complete -c atomic -n '__atomic_using_cmd workflow session kill' -s a -l agent -d 'Filter by agent' -r -a "$agents"
 
 # ── session (top-level) ────────────────────────────────────────────────────
 
-complete -c atomic -n '__atomic_using_cmd session; and not __fish_seen_subcommand_from list connect' -a list -d 'List running sessions'
-complete -c atomic -n '__atomic_using_cmd session; and not __fish_seen_subcommand_from list connect' -a connect -d 'Attach to a running session'
+complete -c atomic -n '__atomic_using_cmd session; and not __fish_seen_subcommand_from list connect kill' -a list -d 'List running sessions'
+complete -c atomic -n '__atomic_using_cmd session; and not __fish_seen_subcommand_from list connect kill' -a connect -d 'Attach to a running session'
+complete -c atomic -n '__atomic_using_cmd session; and not __fish_seen_subcommand_from list connect kill' -a kill -d 'Kill a running session (omit id to kill all)'
 complete -c atomic -n '__atomic_using_cmd session list' -s a -l agent -d 'Filter by agent' -r -a "$agents"
 complete -c atomic -n '__atomic_using_cmd session connect' -s a -l agent -d 'Filter by agent' -r -a "$agents"
+complete -c atomic -n '__atomic_using_cmd session kill' -s a -l agent -d 'Filter by agent' -r -a "$agents"
 
 # ── config ──────────────────────────────────────────────────────────────────
 

--- a/src/completions/powershell.ts
+++ b/src/completions/powershell.ts
@@ -96,6 +96,7 @@ Register-ArgumentCompleter -Native -CommandName atomic -ScriptBlock {
                             $completions = @(
                                 @{ text = 'list';    tip = 'List running sessions' }
                                 @{ text = 'connect'; tip = 'Attach to a running session' }
+                                @{ text = 'kill';    tip = 'Kill a running session (omit id to kill all)' }
                             )
                         } else {
                             $completions = @(
@@ -125,6 +126,7 @@ Register-ArgumentCompleter -Native -CommandName atomic -ScriptBlock {
                             $completions = @(
                                 @{ text = 'list';    tip = 'List running sessions' }
                                 @{ text = 'connect'; tip = 'Attach to a running session' }
+                                @{ text = 'kill';    tip = 'Kill a running session (omit id to kill all)' }
                             )
                         } else {
                             $completions = @(
@@ -139,6 +141,7 @@ Register-ArgumentCompleter -Native -CommandName atomic -ScriptBlock {
                         $completions = @(
                             @{ text = 'list';    tip = 'List running sessions' }
                             @{ text = 'connect'; tip = 'Attach to a running session' }
+                            @{ text = 'kill';    tip = 'Kill a running session (omit id to kill all)' }
                         )
                     } else {
                         $completions = @(

--- a/src/completions/zsh.ts
+++ b/src/completions/zsh.ts
@@ -125,12 +125,13 @@ _atomic_session() {
             local -a subs=(
                 'list:List running sessions'
                 'connect:Attach to a running session'
+                'kill:Kill a running session (omit id to kill all)'
             )
             _describe 'subcommand' subs
             ;;
         subargs)
             case "\${words[1]}" in
-                list|connect)
+                list|connect|kill)
                     _arguments \\
                         '*'{-a,--agent}'[Filter by agent]:agent:(claude opencode copilot)' \\
                         '(-h --help)'{-h,--help}'[Show help]'


### PR DESCRIPTION
## Summary

Adds a `kill` subcommand to `atomic session`, `atomic chat session`, and `atomic workflow session` that terminates one named session or all sessions in scope after a confirmation prompt.

## Key Changes

- **New `sessionKillCommand`** in `src/commands/cli/session.ts` — handles both single-session and kill-all flows with `@clack/prompts` confirmation
- **CLI wiring** in `src/cli.ts` — `kill [session_id]` subcommand added under all three session groups; respects `-a/--agent` filter
- **Error UX** — prints available sessions to stderr when a named target is not found; returns exit code `1`
- **Shell completions** updated for bash, zsh, fish, and PowerShell
- **README** updated with `kill` subcommand examples
- **Tests** — 220+ lines of new test coverage in `session.test.ts` covering tmux-not-installed, named session not found, out-of-scope, confirmed kill, and cancel paths

## Notes

No breaking changes. All existing `session list` and `session connect` behaviour is unchanged.