### PR TITLE
chore(release): bump version to v0.5.18-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.17",
+  "version": "0.5.18-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.17` to `0.5.18-0` in preparation for the next release cut.

## Changes

- `package.json`: version `0.5.17` → `0.5.18-0`

## Test plan

- [ ] CI passes on the PR.
- [ ] Merging triggers the GitHub Release and npm publish for `v0.5.18-0`.