### PR TITLE
chore(release): bump version to v0.5.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.18-0",
+  "version": "0.5.18",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.18-0` to the stable release `0.5.18` in `package.json`.

## Changes

- `package.json`: version `0.5.18-0` → `0.5.18`

## Test plan

- [ ] CI passes
- [ ] On merge, GitHub Release is created and package is published to npm