### PR TITLE
fix(copilot): resolve standalone CLI when Bun lacks node

### DIFF
--- a/research/web/2026-04-17-bun-global-install-bin-behavior.md
+++ b/research/web/2026-04-17-bun-global-install-bin-behavior.md
@@ -1,0 +1,77 @@
+---
+source_url: https://github.com/oven-sh/bun/tree/main/src/install
+fetched_at: 2026-04-17
+fetch_method: html-parse (GitHub raw + playwright)
+topic: Bun global install bin shim behavior - Windows vs macOS/Linux
+---
+
+# Bun `bun install -g` Bin Behavior
+
+## Key Source Files
+
+- `src/install/bin.zig` — `Linker.linkBinOrCreateShim()`, `createWindowsShim()`, `createSymlink()`
+- `src/install/windows-shim/BinLinkingShim.zig` — Windows `.bunx` file format encoder
+- `src/install/windows-shim/bun_shim_impl.zig` — The pre-compiled `bun_shim_impl.exe` embedded into bun
+- `src/install/PackageManager/PackageManagerOptions.zig` — `openGlobalBinDir()`, env var resolution
+
+## Windows: What gets created in `%USERPROFILE%\.bun\bin\` (or `$BUN_INSTALL\bin\`)
+
+For a package with `"bin": { "copilot": "npm-loader.js" }`, Bun creates TWO files:
+
+1. **`copilot.exe`** — a copy of `bun_shim_impl.exe` (embedded compiled shim, ~13 KB). This is what Windows sees as an executable on PATH.
+2. **`copilot.bunx`** — a binary metadata file encoding:
+   - The relative path to the target `.js` file (in UTF-16)
+   - A "shebang" record indicating how to launch it
+
+For `.js` files, the shebang is set to `"bun run"` (i.e., `run_with_bun`). When `copilot.exe` is invoked, it reads `copilot.bunx` from the same directory and calls `CreateProcessW` to spawn `bun run <path-to-npm-loader.js>`.
+
+**No `.cmd`, `.ps1`, or `.bat` files** are created by Bun. This is explicitly designed to avoid the `Terminate batch job (Y/N)` problem that npm/yarn cmd-shims cause.
+
+Source lines in `bin.zig`:
+```
+// Line 715-786 createWindowsShim():
+abs_bunx_file = abs_dest + ".bunx"   → writes BinLinkingShim metadata
+abs_exe_file  = abs_dest + ".exe"    → writes embedded bun_shim_impl.exe binary
+```
+
+BunExtensions map (`BinLinkingShim.zig` ~line 100):
+```zig
+.{ ".js",  .run_with_bun }   → shebang = "bun run"
+.{ ".mjs", .run_with_bun }
+.{ ".cjs", .run_with_bun }
+.{ ".ts",  .run_with_bun }
+.{ ".cmd", .run_with_cmd }   → shebang = "cmd /c"
+.{ ".bat", .run_with_cmd }
+.{ ".ps1", .run_with_powershell } → shebang = "powershell -ExecutionPolicy Bypass -File"
+```
+
+## macOS and Linux: What gets created in `~/.bun/bin/`
+
+The non-Windows path in `bin.zig` calls `createSymlink()` (line ~597):
+- Creates a **symlink** named after the bin entry (e.g., `copilot`) pointing to the actual JS file in `node_modules` (global store)
+- Also calls `chmod 0777` on the target to make it executable
+- Normalizes `\r\n` shebangs to `\n` in the target file (`tryNormalizeShebang`)
+
+The symlink points to the actual target file — Bun does NOT create a wrapper shell script. Execution relies on the shebang line in the JS file (e.g., `#!/usr/bin/env bun` or `#!/usr/bin/env node`).
+
+## Env Vars That Override the Bin Directory
+
+From `PackageManagerOptions.zig` `openGlobalBinDir()`:
+
+1. `$BUN_INSTALL_BIN` — direct override of bin directory (highest priority)
+2. `bunfig.toml` `global_bin_dir` field
+3. `$BUN_INSTALL/bin` — if `$BUN_INSTALL` is set
+4. `$XDG_CACHE_HOME/.bun/bin` OR `$HOME/.bun/bin` — default fallback
+
+On Windows, the same logic applies: `$BUN_INSTALL\bin` or `$USERPROFILE\.bun\bin`.
+
+Global package store dir (NOT the bin dir): `$BUN_INSTALL_GLOBAL_DIR` > `$BUN_INSTALL/install/global` > `$XDG_CACHE_HOME/.bun/install/global` > `$HOME/.bun/install/global`
+
+## Summary for PATH Helper
+
+When writing a cross-platform helper to locate `copilot` binary:
+
+- **Windows**: Look for `copilot.exe` (not `copilot` or `copilot.bunx`) in the bin dir. The `.exe` is the launcher.
+- **macOS/Linux**: Look for `copilot` (symlink, no extension) in the bin dir.
+- **Bin dir resolution**: Check `$BUN_INSTALL_BIN` first, then `$BUN_INSTALL/bin`, then `$HOME/.bun/bin` (or `$XDG_CACHE_HOME/.bun/bin`).
+- Do not rely solely on hardcoded `~/.bun/bin` — use the env var chain above. The bin dir is always on PATH after normal Bun install.

--- a/src/sdk/runtime/executor-entry.ts
+++ b/src/sdk/runtime/executor-entry.ts
@@ -8,7 +8,9 @@
  * library module that can be safely re-exported from the SDK barrel.
  */
 
-import { runOrchestrator } from "./executor.ts";
+import { runOrchestrator, applyContainerEnvDefaults } from "./executor.ts";
+
+applyContainerEnvDefaults();
 
 runOrchestrator().catch((err) => {
   console.error("Fatal:", err);

--- a/src/sdk/runtime/executor.test.ts
+++ b/src/sdk/runtime/executor.test.ts
@@ -573,6 +573,25 @@ describe("discoverCopilotBinary / shouldOverrideCopilotCliPath", () => {
     expect(discoverCopilotBinary()).toBeUndefined();
   });
 
+  test("returns undefined when PATH is unset", () => {
+    delete process.env.PATH;
+    expect(discoverCopilotBinary()).toBeUndefined();
+  });
+
+  test("returns undefined when PATH is empty", () => {
+    process.env.PATH = "";
+    expect(discoverCopilotBinary()).toBeUndefined();
+  });
+
+  test("skips non-executable files named 'copilot' on Unix", () => {
+    if (process.platform === "win32") return;
+    const p = join(sandbox, "copilot");
+    writeFileSync(p, "not executable");
+    chmodSync(p, 0o644);
+    process.env.PATH = sandbox;
+    expect(discoverCopilotBinary()).toBeUndefined();
+  });
+
   test("shouldOverrideCopilotCliPath: false when COPILOT_CLI_PATH is user-set", () => {
     putExe(sandbox, "copilot");
     process.env.PATH = sandbox;
@@ -589,10 +608,17 @@ describe("discoverCopilotBinary / shouldOverrideCopilotCliPath", () => {
 
   test("shouldOverrideCopilotCliPath: true when bun + copilot but no node", () => {
     putExe(sandbox, "copilot");
+    // Sandboxing PATH to a dir without `node` is what makes this test
+    // deterministic regardless of the host's installed toolchain.
     process.env.PATH = sandbox;
     // We're running this test under Bun, so process.versions.bun is set
     expect(!!process.versions.bun).toBe(true);
     expect(shouldOverrideCopilotCliPath()).toBe(true);
+  });
+
+  test("shouldOverrideCopilotCliPath: false when PATH is unset", () => {
+    delete process.env.PATH;
+    expect(shouldOverrideCopilotCliPath()).toBe(false);
   });
 
   test("applyContainerEnvDefaults sets COPILOT_CLI_PATH when override is needed", () => {

--- a/src/sdk/runtime/executor.test.ts
+++ b/src/sdk/runtime/executor.test.ts
@@ -1,10 +1,16 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   renderMessagesToText,
   hasContent,
   escBash,
   escPwsh,
   watchCopilotSessionForHIL,
+  shouldOverrideCopilotCliPath,
+  discoverCopilotBinary,
+  applyContainerEnvDefaults,
   type CopilotHILSessionSurface,
 } from "./executor.ts";
 import type { SavedMessage } from "../types.ts";
@@ -522,5 +528,85 @@ describe("watchCopilotSessionForHIL", () => {
 
     expect(session.handlerCount("tool.execution_start")).toBe(0);
     expect(session.handlerCount("tool.execution_complete")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Copilot CLI path discovery (Bun-without-node containers)
+// ---------------------------------------------------------------------------
+
+describe("discoverCopilotBinary / shouldOverrideCopilotCliPath", () => {
+  let sandbox: string;
+  let savedPath: string | undefined;
+  let savedCliPath: string | undefined;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), "atomic-cli-probe-"));
+    savedPath = process.env.PATH;
+    savedCliPath = process.env.COPILOT_CLI_PATH;
+    delete process.env.COPILOT_CLI_PATH;
+  });
+
+  afterEach(() => {
+    if (savedPath === undefined) delete process.env.PATH;
+    else process.env.PATH = savedPath;
+    if (savedCliPath === undefined) delete process.env.COPILOT_CLI_PATH;
+    else process.env.COPILOT_CLI_PATH = savedCliPath;
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  function putExe(dir: string, name: string, contents = "#!/bin/sh\necho $0"): string {
+    const p = join(dir, name);
+    writeFileSync(p, contents);
+    chmodSync(p, 0o755);
+    return p;
+  }
+
+  test("finds an executable 'copilot' on PATH", () => {
+    const bin = putExe(sandbox, "copilot");
+    process.env.PATH = sandbox;
+    expect(discoverCopilotBinary()).toBe(bin);
+  });
+
+  test("returns undefined when no copilot on PATH", () => {
+    process.env.PATH = sandbox;
+    expect(discoverCopilotBinary()).toBeUndefined();
+  });
+
+  test("shouldOverrideCopilotCliPath: false when COPILOT_CLI_PATH is user-set", () => {
+    putExe(sandbox, "copilot");
+    process.env.PATH = sandbox;
+    process.env.COPILOT_CLI_PATH = "/somewhere/else/copilot";
+    expect(shouldOverrideCopilotCliPath()).toBe(false);
+  });
+
+  test("shouldOverrideCopilotCliPath: false when node is also on PATH (SDK default works)", () => {
+    putExe(sandbox, "copilot");
+    putExe(sandbox, "node");
+    process.env.PATH = sandbox;
+    expect(shouldOverrideCopilotCliPath()).toBe(false);
+  });
+
+  test("shouldOverrideCopilotCliPath: true when bun + copilot but no node", () => {
+    putExe(sandbox, "copilot");
+    process.env.PATH = sandbox;
+    // We're running this test under Bun, so process.versions.bun is set
+    expect(!!process.versions.bun).toBe(true);
+    expect(shouldOverrideCopilotCliPath()).toBe(true);
+  });
+
+  test("applyContainerEnvDefaults sets COPILOT_CLI_PATH when override is needed", () => {
+    const bin = putExe(sandbox, "copilot");
+    process.env.PATH = sandbox;
+    applyContainerEnvDefaults();
+    expect(process.env.COPILOT_CLI_PATH).toBe(bin);
+  });
+
+  test("applyContainerEnvDefaults does NOT overwrite user-set COPILOT_CLI_PATH", () => {
+    putExe(sandbox, "copilot");
+    process.env.PATH = sandbox;
+    process.env.COPILOT_CLI_PATH = "/custom/copilot";
+    applyContainerEnvDefaults();
+    expect(process.env.COPILOT_CLI_PATH).toBe("/custom/copilot");
   });
 });

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -17,6 +17,7 @@
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { writeFile } from "node:fs/promises";
+import { statSync } from "node:fs";
 import type {
   WorkflowDefinition,
   WorkflowContext,
@@ -180,6 +181,73 @@ async function getRandomPort(): Promise<number> {
   throw new Error(
     `Failed to acquire a random port after ${MAX_RETRIES} attempts (last: ${lastPort})`,
   );
+}
+
+/**
+ * Resolve a non-JS Copilot CLI binary on PATH.
+ *
+ * Under Bun, `@github/copilot-sdk` spawns its bundled JS entry via `node`
+ * (see `getNodeExecPath` in the SDK). If `node` isn't installed — common in
+ * minimal containers — the spawn fails silently with ENOENT and the SDK's
+ * write to the child's stdin surfaces as "Cannot call write after a stream
+ * was destroyed" from vscode-jsonrpc. Pointing the SDK at a standalone
+ * `copilot` binary (the npm-installed ELF executable) sidesteps the
+ * node-vs-bun problem because the SDK execs it directly when the path does
+ * not end in `.js`.
+ *
+ * Returns undefined if no suitable binary is found.
+ */
+export function discoverCopilotBinary(): string | undefined {
+  const pathVar = process.env.PATH;
+  if (!pathVar) return undefined;
+  const exe = process.platform === "win32" ? "copilot.exe" : "copilot";
+  const sep = process.platform === "win32" ? ";" : ":";
+  for (const dir of pathVar.split(sep)) {
+    if (!dir) continue;
+    const candidate = join(dir, exe);
+    if (candidate.endsWith(".js")) continue;
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {}
+  }
+  return undefined;
+}
+
+/**
+ * True when we need to override the SDK's default CLI path — i.e. running
+ * under Bun, the user hasn't set COPILOT_CLI_PATH, and `node` is not
+ * available to execute the SDK's bundled JS entry.
+ */
+export function shouldOverrideCopilotCliPath(): boolean {
+  if (!process.versions.bun) return false;
+  if (process.env.COPILOT_CLI_PATH) return false;
+  return discoverCopilotBinary() !== undefined && !isNodeOnPath();
+}
+
+function isNodeOnPath(): boolean {
+  const pathVar = process.env.PATH;
+  if (!pathVar) return false;
+  const exe = process.platform === "win32" ? "node.exe" : "node";
+  const sep = process.platform === "win32" ? ";" : ":";
+  for (const dir of pathVar.split(sep)) {
+    if (!dir) continue;
+    try {
+      if (statSync(join(dir, exe)).isFile()) return true;
+    } catch {}
+  }
+  return false;
+}
+
+/**
+ * Set safe env defaults for the orchestrator process before any SDK is
+ * loaded. Must be called exactly once, as early as possible — headless
+ * Copilot stages spawn the CLI as a subprocess and inherit this env.
+ */
+export function applyContainerEnvDefaults(): void {
+  if (shouldOverrideCopilotCliPath()) {
+    const bin = discoverCopilotBinary();
+    if (bin) process.env.COPILOT_CLI_PATH = bin;
+  }
 }
 
 function buildPaneCommand(

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -17,7 +17,7 @@
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { writeFile } from "node:fs/promises";
-import { statSync } from "node:fs";
+import { statSync, accessSync, constants as fsConstants } from "node:fs";
 import type {
   WorkflowDefinition,
   WorkflowContext,
@@ -200,15 +200,17 @@ async function getRandomPort(): Promise<number> {
 export function discoverCopilotBinary(): string | undefined {
   const pathVar = process.env.PATH;
   if (!pathVar) return undefined;
+  // Windows: only `copilot.exe` is probed. Bun's global install writes a
+  // real `.exe` shim, so this covers the Bun-container scenario this guard
+  // exists for. Pre-existing npm-installed shims (`copilot.cmd`/`.ps1`)
+  // aren't handled — the entire override is gated on `process.versions.bun`.
   const exe = process.platform === "win32" ? "copilot.exe" : "copilot";
   const sep = process.platform === "win32" ? ";" : ":";
   for (const dir of pathVar.split(sep)) {
     if (!dir) continue;
     const candidate = join(dir, exe);
-    if (candidate.endsWith(".js")) continue;
-    try {
-      if (statSync(candidate).isFile()) return candidate;
-    } catch {}
+    if (!isExecutableFile(candidate)) continue;
+    return candidate;
   }
   return undefined;
 }
@@ -217,11 +219,25 @@ export function discoverCopilotBinary(): string | undefined {
  * True when we need to override the SDK's default CLI path — i.e. running
  * under Bun, the user hasn't set COPILOT_CLI_PATH, and `node` is not
  * available to execute the SDK's bundled JS entry.
+ *
+ * Pure predicate on the current env; safe to call repeatedly.
  */
 export function shouldOverrideCopilotCliPath(): boolean {
   if (!process.versions.bun) return false;
   if (process.env.COPILOT_CLI_PATH) return false;
-  return discoverCopilotBinary() !== undefined && !isNodeOnPath();
+  if (isNodeOnPath()) return false;
+  return discoverCopilotBinary() !== undefined;
+}
+
+function isExecutableFile(path: string): boolean {
+  try {
+    if (!statSync(path).isFile()) return false;
+    if (process.platform === "win32") return true;
+    accessSync(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isNodeOnPath(): boolean {
@@ -231,23 +247,23 @@ function isNodeOnPath(): boolean {
   const sep = process.platform === "win32" ? ";" : ":";
   for (const dir of pathVar.split(sep)) {
     if (!dir) continue;
-    try {
-      if (statSync(join(dir, exe)).isFile()) return true;
-    } catch {}
+    if (isExecutableFile(join(dir, exe))) return true;
   }
   return false;
 }
 
 /**
  * Set safe env defaults for the orchestrator process before any SDK is
- * loaded. Must be called exactly once, as early as possible — headless
- * Copilot stages spawn the CLI as a subprocess and inherit this env.
+ * loaded. Idempotent — subsequent calls no-op once `COPILOT_CLI_PATH`
+ * is set. Call as early as possible so headless Copilot subprocesses
+ * inherit the resolved env.
  */
 export function applyContainerEnvDefaults(): void {
-  if (shouldOverrideCopilotCliPath()) {
-    const bin = discoverCopilotBinary();
-    if (bin) process.env.COPILOT_CLI_PATH = bin;
-  }
+  if (!process.versions.bun) return;
+  if (process.env.COPILOT_CLI_PATH) return;
+  if (isNodeOnPath()) return;
+  const bin = discoverCopilotBinary();
+  if (bin) process.env.COPILOT_CLI_PATH = bin;
 }
 
 function buildPaneCommand(


### PR DESCRIPTION
## Summary

Fixes a crash in headless Copilot stages when running under Bun in minimal containers that lack a `node` binary. When `@github/copilot-sdk` can't spawn its bundled JS entry via `node`, the JSON-RPC transport writes to a dead stdin and surfaces as `Cannot call write after a stream was destroyed`.

## Root Cause

`@github/copilot-sdk`'s `getNodeExecPath()` returns the literal string `"node"` when the parent process is Bun. In containers without `node` installed, the subsequent `spawn("node", ...)` fails with `ENOENT`, silently killing the JSON-RPC subprocess.

## Key Changes

- **`src/sdk/runtime/executor.ts`** — adds four helpers:
  - `discoverCopilotBinary()` *(exported)* — walks `PATH` for a non-`.js` `copilot` / `copilot.exe` binary (cross-platform)
  - `shouldOverrideCopilotCliPath()` *(exported)* — returns `true` only when: running under Bun **and** `COPILOT_CLI_PATH` is unset **and** `node` is absent **and** a standalone `copilot` binary exists
  - `applyContainerEnvDefaults()` *(exported)* — sets `COPILOT_CLI_PATH` to the discovered binary when the override is needed; no-op otherwise
  - `isNodeOnPath()` / `isExecutableFile()` *(private)* — cross-platform PATH probing utilities
- **`src/sdk/runtime/executor-entry.ts`** — calls `applyContainerEnvDefaults()` once at orchestrator startup so all child stages (including headless Copilot) inherit the correct env
- **`src/sdk/runtime/executor.test.ts`** — full test coverage for discovery, override logic, and idempotent env application
- **`research/web/2026-04-17-bun-global-install-bin-behavior.md`** — research note documenting Bun's global bin shim behavior (Windows `.exe` shim, macOS/Linux symlink) that informed the cross-platform detection strategy

## Behavior

| Scenario | Effect |
|---|---|
| `node` is on PATH | No-op — SDK default path works fine |
| User set `COPILOT_CLI_PATH` | No-op — user's value is preserved |
| Bun + no `node` + `copilot` on PATH | Sets `COPILOT_CLI_PATH` to the discovered binary |
| Windows | Searches for `copilot.exe` (Bun's `-g` install writes a real `.exe` shim) |

## Notes

- The SDK skips its `node` shim when `cliPath` does not end in `.js`, so pointing it at the standalone binary is sufficient
- `applyContainerEnvDefaults()` is idempotent — subsequent calls are no-ops once `COPILOT_CLI_PATH` is set
- No changes to public API surface; new helpers are exported only for testability