### PR TITLE
chore(mcp): switch to GitHub Copilot MCP server and sync dev skills from .agents

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
-    "gh_grep": {
+    "github": {
       "type": "http",
-      "url": "https://mcp.grep.app"
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": { "Authorization": "Bearer YOUR_GITHUB_PAT" }
     }
   }
 }

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -2,9 +2,10 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": "allow",
   "mcp": {
-    "gh_grep": {
+    "github": {
       "type": "remote",
-      "url": "https://mcp.grep.app"
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": { "Authorization": "Bearer YOUR_GITHUB_PAT" }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     ".opencode/agents",
     ".opencode/opencode.json",
     ".github/agents",
-    ".github/lsp.json"
+    ".github/lsp.json",
+    ".mcp.json"
   ],
   "scripts": {
     "dev": "bun run src/cli.ts",

--- a/src/commands/cli/init/index.ts
+++ b/src/commands/cli/init/index.ts
@@ -18,7 +18,6 @@ import {
 } from "../../../services/config/index.ts";
 import { pathExists } from "../../../services/system/copy.ts";
 import { getConfigRoot } from "../../../services/config/config-path.ts";
-import { getTemplateAgentFolder } from "../../../services/config/atomic-global-config.ts";
 import { upsertTrustedWorkspacePath } from "../../../services/config/settings.ts";
 import { applyManagedOnboardingFiles } from "./onboarding.ts";
 import { installLocalScmSkills, syncProjectScmSkills } from "./scm.ts";
@@ -86,11 +85,12 @@ export async function ensureProjectSetup(
             cwd: projectRoot,
           });
         } else {
-          // Source checkout: copy from bundled templates
-          const templateFolder = getTemplateAgentFolder(agentKey);
+          // Source checkout (e.g. `bun run dev`): copy from the canonical
+          // `.agents/skills` directory so prompt edits in-repo flow through
+          // to the target project without needing a publish or git push.
           await syncProjectScmSkills({
             scmType: detectedScm,
-            sourceSkillsDir: join(configRoot, templateFolder, "skills"),
+            sourceSkillsDir: join(configRoot, ".agents", "skills"),
             targetSkillsDir: join(
               projectRoot,
               AGENT_CONFIG[agentKey].folder,

--- a/src/services/config/definitions.ts
+++ b/src/services/config/definitions.ts
@@ -88,13 +88,7 @@ export const AGENT_CONFIG: Record<AgentKey, AgentConfig> = {
     install_url:
       "https://github.com/github/copilot-cli?tab=readme-ov-file#installation",
     exclude: ["workflows", "dependabot.yml"],
-    onboarding_files: [
-      {
-        source: ".mcp.json",
-        destination: ".mcp.json",
-        merge: true,
-      },
-    ],
+    onboarding_files: [],
   },
 };
 


### PR DESCRIPTION
## Summary

Replaces the `gh_grep` MCP integration (mcp.grep.app) with the official GitHub Copilot MCP server, and fixes dev-mode skill syncing to read directly from the in-repo `.agents/skills` directory.

## Key Changes

- **MCP server swap** (`.mcp.json`, `.opencode/opencode.json`): Replace `gh_grep` with a `github` entry pointing to `https://api.githubcopilot.com/mcp`, authenticated via a Bearer PAT header placeholder (`YOUR_GITHUB_PAT`).
- **Bundle `.mcp.json`** (`package.json`): Add `.mcp.json` to the published package `files` list so consumers receive the Copilot MCP config out of the box.
- **Remove redundant onboarding copy** (`src/services/config/definitions.ts`): Empty out `copilot.onboarding_files` — the project-level `.mcp.json` is now the canonical source, so per-project templating is no longer needed.
- **Fix dev-mode skill path** (`src/commands/cli/init/index.ts`): In `ensureProjectSetup`, source skills from `.agents/skills` directly instead of the bundled template folder. This lets prompt edits made in-repo flow through to target projects immediately, without a publish or `git push`.

## Migration Notes

Users who have an existing `.mcp.json` or `opencode.json` with the old `gh_grep` entry should replace it with:

```json
"github": {
  "type": "http",
  "url": "https://api.githubcopilot.com/mcp",
  "headers": { "Authorization": "Bearer <YOUR_GITHUB_PAT>" }
}
```