### PR TITLE
fix(copilot): detect HIL via elicitation events in workflow UI

### DIFF
--- a/src/sdk/runtime/executor.test.ts
+++ b/src/sdk/runtime/executor.test.ts
@@ -8,6 +8,7 @@ import {
   escBash,
   escPwsh,
   watchCopilotSessionForHIL,
+  watchCopilotSessionForElicitation,
   shouldOverrideCopilotCliPath,
   discoverCopilotBinary,
   applyContainerEnvDefaults,
@@ -528,6 +529,184 @@ describe("watchCopilotSessionForHIL", () => {
 
     expect(session.handlerCount("tool.execution_start")).toBe(0);
     expect(session.handlerCount("tool.execution_complete")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// watchCopilotSessionForElicitation — HIL detection via elicitation events
+// ---------------------------------------------------------------------------
+
+describe("watchCopilotSessionForElicitation", () => {
+  test("fires onHIL(true) on elicitation.requested event", () => {
+    const session = makeMockCopilotSession();
+    const calls: boolean[] = [];
+    const unsubscribe = watchCopilotSessionForElicitation(session, (w) =>
+      calls.push(w),
+    );
+
+    session.dispatch("elicitation.requested", { requestId: "req-1" });
+    expect(calls).toEqual([true]);
+
+    unsubscribe();
+  });
+
+  test("fires onHIL(false) on elicitation.completed with matching requestId", () => {
+    const session = makeMockCopilotSession();
+    const calls: boolean[] = [];
+    const unsubscribe = watchCopilotSessionForElicitation(session, (w) =>
+      calls.push(w),
+    );
+
+    session.dispatch("elicitation.requested", { requestId: "req-1" });
+    expect(calls).toEqual([true]);
+
+    session.dispatch("elicitation.completed", { requestId: "req-1" });
+    expect(calls).toEqual([true, false]);
+
+    unsubscribe();
+  });
+
+  test("only fires onHIL(true) once and onHIL(false) only after last overlapping request completes", () => {
+    const session = makeMockCopilotSession();
+    const calls: boolean[] = [];
+    const unsubscribe = watchCopilotSessionForElicitation(session, (w) =>
+      calls.push(w),
+    );
+
+    session.dispatch("elicitation.requested", { requestId: "req-a" });
+    session.dispatch("elicitation.requested", { requestId: "req-b" });
+    // onHIL(true) fires exactly once on the first request
+    expect(calls).toEqual([true]);
+
+    session.dispatch("elicitation.completed", { requestId: "req-a" });
+    // req-b still active — must not fire onHIL(false) yet
+    expect(calls).toEqual([true]);
+
+    session.dispatch("elicitation.completed", { requestId: "req-b" });
+    expect(calls).toEqual([true, false]);
+
+    unsubscribe();
+  });
+
+  test("ignores elicitation.completed for an unknown requestId", () => {
+    const session = makeMockCopilotSession();
+    const calls: boolean[] = [];
+    const unsubscribe = watchCopilotSessionForElicitation(session, (w) =>
+      calls.push(w),
+    );
+
+    session.dispatch("elicitation.completed", { requestId: "req-unknown" });
+    expect(calls).toEqual([]);
+
+    unsubscribe();
+  });
+
+  test("ignores elicitation.requested payload without a requestId", () => {
+    const session = makeMockCopilotSession();
+    const calls: boolean[] = [];
+    const unsubscribe = watchCopilotSessionForElicitation(session, (w) =>
+      calls.push(w),
+    );
+
+    session.dispatch("elicitation.requested", {});
+    expect(calls).toEqual([]);
+
+    unsubscribe();
+  });
+
+  test("unsubscribe removes both elicitation listeners and subsequent events are not received", () => {
+    const session = makeMockCopilotSession();
+    const calls: boolean[] = [];
+    const unsubscribe = watchCopilotSessionForElicitation(session, (w) =>
+      calls.push(w),
+    );
+
+    expect(session.handlerCount("elicitation.requested")).toBe(1);
+    expect(session.handlerCount("elicitation.completed")).toBe(1);
+
+    unsubscribe();
+
+    expect(session.handlerCount("elicitation.requested")).toBe(0);
+    expect(session.handlerCount("elicitation.completed")).toBe(0);
+
+    // Events fired after unsubscribe must not reach the original handler
+    session.dispatch("elicitation.requested", { requestId: "req-post" });
+    session.dispatch("elicitation.completed", { requestId: "req-post" });
+    expect(calls).toEqual([]);
+  });
+
+  test("MCP-initiated elicitation (non-empty elicitationSource) triggers onHIL(true) and onHIL(false) same as agent-initiated", () => {
+    const session = makeMockCopilotSession();
+    const calls: boolean[] = [];
+    const unsubscribe = watchCopilotSessionForElicitation(session, (w) =>
+      calls.push(w),
+    );
+
+    // Simulate MCP-initiated elicitation with a non-empty elicitationSource
+    session.dispatch("elicitation.requested", {
+      requestId: "req-mcp-1",
+      elicitationSource: "mcp-server://my-tool",
+      message: "Please provide your API key",
+    });
+    expect(calls).toEqual([true]);
+
+    session.dispatch("elicitation.completed", {
+      requestId: "req-mcp-1",
+      action: "accept",
+    });
+    expect(calls).toEqual([true, false]);
+
+    unsubscribe();
+  });
+
+  test("calling unsubscribe twice does not throw", () => {
+    const session = makeMockCopilotSession();
+    const unsubscribe = watchCopilotSessionForElicitation(session, () => {});
+
+    unsubscribe();
+    // Second call must be safe — no throw, no error
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  test("ask_user watcher and elicitation watcher on same session track HIL independently", () => {
+    const session = makeMockCopilotSession();
+    const hilCalls: boolean[] = [];
+    const elicitationCalls: boolean[] = [];
+
+    const unsubHIL = watchCopilotSessionForHIL(session, (w) =>
+      hilCalls.push(w),
+    );
+    const unsubElicitation = watchCopilotSessionForElicitation(session, (w) =>
+      elicitationCalls.push(w),
+    );
+
+    // Fire an ask_user event — only the HIL watcher should see it
+    session.dispatch("tool.execution_start", {
+      toolName: "ask_user",
+      toolCallId: "tc-concurrent",
+    });
+    expect(hilCalls).toEqual([true]);
+    expect(elicitationCalls).toEqual([]);
+
+    // Fire an elicitation event — only the elicitation watcher should see it
+    session.dispatch("elicitation.requested", {
+      requestId: "req-concurrent",
+    });
+    expect(hilCalls).toEqual([true]);
+    expect(elicitationCalls).toEqual([true]);
+
+    // Complete the ask_user — only HIL watcher fires false
+    session.dispatch("tool.execution_complete", { toolCallId: "tc-concurrent" });
+    expect(hilCalls).toEqual([true, false]);
+    expect(elicitationCalls).toEqual([true]);
+
+    // Complete the elicitation — only elicitation watcher fires false
+    session.dispatch("elicitation.completed", { requestId: "req-concurrent" });
+    expect(hilCalls).toEqual([true, false]);
+    expect(elicitationCalls).toEqual([true, false]);
+
+    unsubHIL();
+    unsubElicitation();
   });
 });
 

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -650,6 +650,16 @@ export interface OpenCodeHILEvent {
  * Events for other sessions are silently ignored.  The function returns when
  * the stream is exhausted (i.e. the server closes the connection).
  *
+ * NOTE: OpenCode does not emit any bus event for MCP-server-initiated
+ * elicitation requests — its MCP client never registers an
+ * `ElicitRequestSchema` handler, so such requests are auto-rejected by the
+ * MCP SDK at the protocol layer before reaching any OpenCode-level code.
+ * As a result, the workflow UI **cannot** mark an OpenCode session as
+ * "awaiting input" for MCP elicitation; this is an upstream limitation that
+ * Atomic cannot work around.  If a future OpenCode release surfaces MCP
+ * elicitation as a bus event, extend the switch below (or add a sibling
+ * watcher) to map it onto `onHIL`.
+ *
  * Exported for unit testing.
  */
 export async function watchOpencodeStreamForHIL(
@@ -732,6 +742,50 @@ export function watchCopilotSessionForHIL(
   return () => {
     unsubStart();
     unsubComplete();
+  };
+}
+
+/**
+ * Subscribe to a Copilot session's elicitation events to track HIL state for
+ * `session.ui.elicitation()`, `session.ui.select()`, `session.ui.input()`, and
+ * MCP-server-initiated elicitation requests:
+ *
+ *   - `elicitation.requested`  → `onHIL(true)`  (set transitions empty→non-empty)
+ *   - `elicitation.completed`  → `onHIL(false)` (set transitions non-empty→empty)
+ *
+ * Overlapping elicitation requests are tracked by `requestId` so
+ * `onHIL(false)` only fires after the last in-flight request completes.
+ *
+ * Returns an unsubscribe function that removes both listeners.
+ *
+ * Exported for unit testing.
+ */
+export function watchCopilotSessionForElicitation(
+  session: CopilotHILSessionSurface,
+  onHIL: (waiting: boolean) => void,
+): () => void {
+  const active = new Set<string>();
+  const unsubRequested = session.on("elicitation.requested", (event) => {
+    const data = event.data as { requestId?: string } | undefined;
+    if (data?.requestId) {
+      const wasEmpty = active.size === 0;
+      active.add(data.requestId);
+      if (wasEmpty) onHIL(true);
+    }
+  });
+  const unsubCompleted = session.on("elicitation.completed", (event) => {
+    const data = event.data as { requestId?: string } | undefined;
+    if (
+      data?.requestId &&
+      active.delete(data.requestId) &&
+      active.size === 0
+    ) {
+      onHIL(false);
+    }
+  });
+  return () => {
+    unsubRequested();
+    unsubCompleted();
   };
 }
 
@@ -1198,6 +1252,7 @@ function createSessionRunner(
       // Unsubscribe fn for the Copilot HIL event listeners; invoked in the
       // `finally` block so the handlers are removed when the stage ends.
       let hilUnsubscribe: (() => void) | undefined;
+      let copilotElicitationUnsubscribe: (() => void) | undefined;
 
       if (shared.agent === "copilot") {
         const copilotSession = providerSession as ProviderSession<"copilot">;
@@ -1211,6 +1266,19 @@ function createSessionRunner(
         // is registered, so we can detect HIL via the SDK's event stream and
         // still let the CLI render its native tmux-pane dialog.
         hilUnsubscribe = watchCopilotSessionForHIL(copilotSession, onHIL);
+
+        // Copilot elicitation HIL detection via native SDK events.
+        //
+        // `elicitation.requested` / `elicitation.completed` fire when the
+        // agent calls `session.ui.elicitation()`, `session.ui.select()`,
+        // `session.ui.input()`, or an MCP server issues an elicitation
+        // request.  These events are distinct from the `ask_user` tool and
+        // require a separate watcher so the UI can show the "waiting for
+        // response" indicator in all HIL scenarios.
+        copilotElicitationUnsubscribe = watchCopilotSessionForElicitation(
+          copilotSession,
+          onHIL,
+        );
       }
 
       // ── 12b. OpenCode: SSE event stream for HIL detection ──
@@ -1288,6 +1356,7 @@ function createSessionRunner(
       } finally {
         // ── 14a. Stop background HIL watcher (if any) ──
         hilUnsubscribe?.();
+        copilotElicitationUnsubscribe?.();
 
         // ── 14b. Auto-cleanup provider resources ──
         await cleanupProvider(


### PR DESCRIPTION
## Summary

Adds `watchCopilotSessionForElicitation` to track `elicitation.requested` / `elicitation.completed` event pairs by `requestId`, covering all Copilot HIL scenarios — `session.ui.elicitation()`, `session.ui.select()`, `session.ui.input()`, and MCP-initiated elicitation. The workflow UI now shows \"awaiting input\" for these cases, in addition to the existing `ask_user` tool detection.

## Key Changes

- **New `watchCopilotSessionForElicitation` function** (`executor.ts`): Subscribes to elicitation events on a Copilot session, tracking in-flight requests in a `Set<string>` keyed by `requestId`. Fires `onHIL(true)` when the set transitions empty → non-empty, and `onHIL(false)` only after the last overlapping request completes. Returns an unsubscribe cleanup function.
- **Wired into `createSessionRunner`**: Registered alongside the existing `watchCopilotSessionForHIL` call so both `ask_user` tool events and elicitation events contribute to the UI's HIL indicator. Properly cleaned up in the `finally` block via `copilotElicitationUnsubscribe?.()`.
- **OpenCode limitation documented**: Added a `NOTE` comment in `watchOpencodeStreamForHIL` explaining that OpenCode cannot surface MCP-initiated elicitation as a bus event (upstream limitation — `ElicitRequestSchema` handler is never registered, causing auto-rejection at the MCP SDK layer). Includes guidance for future extension if OpenCode adds support.
- **Comprehensive test coverage** (`executor.test.ts`): 9 new tests covering the full behavioral contract — basic `requested`/`completed` flow, overlapping requests, unknown/malformed `requestId` handling, `unsubscribe` idempotency, MCP-initiated elicitation, and independent co-existence of both watchers on the same session.

## Notes

- No breaking changes. The new watcher is purely additive; existing `ask_user` HIL detection is unchanged.
- OpenCode HIL detection for MCP elicitation remains unsupported and is blocked upstream — documented for future contributors.