### PR TITLE
feat(sdk): react-rendered agent footer and deterministic claude session IDs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -269,6 +269,17 @@ Examples:
             process.exit(exitCode);
         });
 
+    // ── Internal: footer renderer (spawned inside agent tmux windows) ──────
+    program
+        .command("_footer", { hidden: true })
+        .description("Internal: render the attached-mode footer for an agent window")
+        .requiredOption("--name <name>", "Agent window name")
+        .action(async (opts: { name: string }) => {
+            const { footerCommand } = await import("./commands/cli/footer.tsx");
+            const exitCode = await footerCommand(opts.name);
+            process.exit(exitCode);
+        });
+
     // ── Completions command ────────────────────────────────────────────────
     program
         .command("completions")
@@ -318,7 +329,8 @@ async function main(): Promise<void> {
             argv.includes("-v") ||
             argv.includes("--help") ||
             argv.includes("-h") ||
-            argv[0] === "completions";
+            argv[0] === "completions" ||
+            argv[0] === "_footer";
 
         if (!isInfoCommand) {
             const { autoSyncIfStale } = await import("./services/system/auto-sync.ts");

--- a/src/commands/cli/footer.tsx
+++ b/src/commands/cli/footer.tsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Internal command that renders the attached-mode footer inside an agent's
+ * tmux window. The executor splits each agent window after creation and
+ * runs `atomic _footer --name <window-name>` in the bottom pane.
+ *
+ * The process blocks indefinitely — tmux kills the pane when the workflow
+ * session is torn down.
+ */
+
+import { createCliRenderer } from "@opentui/core";
+import { createRoot } from "@opentui/react";
+import { resolveTheme } from "../../sdk/runtime/theme.ts";
+import { deriveGraphTheme } from "../../sdk/components/graph-theme.ts";
+import { AttachedStatusline } from "../../sdk/components/attached-statusline.tsx";
+
+export async function footerCommand(name: string): Promise<number> {
+  const renderer = await createCliRenderer({
+    exitOnCtrlC: false,
+  });
+  const theme = deriveGraphTheme(resolveTheme(renderer.themeMode));
+  createRoot(renderer).render(
+    <box
+      width="100%"
+      height="100%"
+      flexDirection="column"
+      justifyContent="flex-end"
+      backgroundColor={theme.background}
+    >
+      <AttachedStatusline name={name} theme={theme} />
+    </box>,
+  );
+
+  await new Promise<void>(() => {});
+  return 0;
+}

--- a/src/sdk/components/attached-statusline.tsx
+++ b/src/sdk/components/attached-statusline.tsx
@@ -1,0 +1,33 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Footer rendered inside each agent tmux window. Lives in a 1-row bottom
+ * pane created by the executor after the agent window is spawned. Mirrors
+ * the orchestrator Statusline style — colored badge on the left, dimmed
+ * keyboard hints on the right.
+ */
+
+import type { GraphTheme } from "./graph-theme.ts";
+
+export function AttachedStatusline({ name, theme }: { name: string; theme: GraphTheme }) {
+  return (
+    <box height={1} flexDirection="row" backgroundColor={theme.backgroundElement}>
+      <box backgroundColor={theme.primary} paddingLeft={1} paddingRight={1} alignItems="center">
+        <text fg={theme.backgroundElement}>
+          <strong>{name}</strong>
+        </text>
+      </box>
+
+      <box flexGrow={1} />
+
+      <box paddingRight={2} alignItems="center">
+        <text>
+          <span fg={theme.text}>ctrl+g</span>
+          <span fg={theme.textMuted}> graph</span>
+          <span fg={theme.textDim}> {"\u00B7"} </span>
+          <span fg={theme.text}>{"ctrl+\\"}</span>
+          <span fg={theme.textMuted}> next</span>
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/src/sdk/components/header.tsx
+++ b/src/sdk/components/header.tsx
@@ -1,8 +1,13 @@
 /** @jsxImportSource @opentui/react */
 
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import type { SessionStatus } from "./orchestrator-panel-types.ts";
-import { useStore, useGraphTheme, useStoreVersion } from "./orchestrator-panel-contexts.ts";
+import {
+  useStore,
+  useGraphTheme,
+  useStoreVersion,
+  TmuxSessionContext,
+} from "./orchestrator-panel-contexts.ts";
 
 function CountBadge({ color, icon, count }: { color: string; icon: string; count: number }) {
   if (count <= 0) return null;
@@ -16,6 +21,7 @@ function CountBadge({ color, icon, count }: { color: string; icon: string; count
 export function Header() {
   const store = useStore();
   const theme = useGraphTheme();
+  const tmuxSession = useContext(TmuxSessionContext);
   const storeVersion = useStoreVersion(store);
 
   const counts = useMemo(() => {
@@ -46,6 +52,14 @@ export function Header() {
           <strong>{badgeText}</strong>
         </span>
       </text>
+
+      {tmuxSession ? (
+        <box paddingLeft={1} alignItems="center">
+          <text fg={theme.text}>
+            <strong>{tmuxSession}</strong>
+          </text>
+        </box>
+      ) : null}
 
       <box flexGrow={1} justifyContent="flex-end" flexDirection="row" gap={2}>
         <CountBadge color={theme.success} icon={"\u2713"} count={counts.complete} />

--- a/src/sdk/components/session-graph-panel.tsx
+++ b/src/sdk/components/session-graph-panel.tsx
@@ -18,18 +18,7 @@ import {
   useRef,
   useContext,
 } from "react";
-import {
-  tmuxRun,
-  TMUX_DEFAULT_STATUS_LEFT,
-  TMUX_DEFAULT_STATUS_LEFT_LENGTH,
-  TMUX_DEFAULT_STATUS_RIGHT,
-  TMUX_DEFAULT_STATUS_RIGHT_LENGTH,
-  TMUX_ATTACHED_STATUS_RIGHT,
-  TMUX_ATTACHED_STATUS_RIGHT_LENGTH,
-  TMUX_ATTACHED_WINDOW_FMT,
-  TMUX_ATTACHED_WINDOW_STYLE,
-  TMUX_ATTACHED_WINDOW_CURRENT_STYLE,
-} from "../runtime/tmux.ts";
+import { tmuxRun } from "../runtime/tmux.ts";
 import {
   useStore,
   useGraphTheme,
@@ -394,47 +383,17 @@ export function SessionGraphPanel() {
   }, [tmuxSession, hasStartedAgent]);
 
   // ── Tmux status bar sync ──────────────────────────────
-  // Attached mode: use tmux's native window list to show agent names
-  // (the current window is highlighted automatically by tmux).
-  // Graph mode: restore the minimal defaults.
+  // The workflow owns its footer: the tmux status bar is hidden for this
+  // session so the React-rendered Statusline is the single source of truth
+  // in both graph and attached modes. Scoped via `-t <tmuxSession>` so other
+  // sessions on the atomic socket (e.g. chat) keep the tmux.conf defaults.
   useEffect(() => {
-    if (store.viewMode === "attached") {
-      tmuxRun(["set", "-g", "status-left", " "]);
-      tmuxRun(["set", "-g", "status-left-length", "1"]);
-      tmuxRun(["set", "-g", "status-right", TMUX_ATTACHED_STATUS_RIGHT]);
-      tmuxRun(["set", "-g", "status-right-length", TMUX_ATTACHED_STATUS_RIGHT_LENGTH]);
-      tmuxRun(["set", "-g", "window-status-format", TMUX_ATTACHED_WINDOW_FMT]);
-      tmuxRun(["set", "-g", "window-status-current-format", TMUX_ATTACHED_WINDOW_FMT]);
-      tmuxRun(["set", "-g", "window-status-style", TMUX_ATTACHED_WINDOW_STYLE]);
-      tmuxRun(["set", "-g", "window-status-current-style", TMUX_ATTACHED_WINDOW_CURRENT_STYLE]);
-      tmuxRun(["set", "-g", "window-status-separator", ""]);
-    } else {
-      tmuxRun(["set", "-g", "status-left", TMUX_DEFAULT_STATUS_LEFT]);
-      tmuxRun(["set", "-g", "status-left-length", TMUX_DEFAULT_STATUS_LEFT_LENGTH]);
-      tmuxRun(["set", "-g", "status-right", TMUX_DEFAULT_STATUS_RIGHT]);
-      tmuxRun(["set", "-g", "status-right-length", TMUX_DEFAULT_STATUS_RIGHT_LENGTH]);
-      tmuxRun(["set", "-gu", "window-status-format"]);
-      tmuxRun(["set", "-gu", "window-status-current-format"]);
-      tmuxRun(["set", "-gu", "window-status-style"]);
-      tmuxRun(["set", "-gu", "window-status-current-style"]);
-      tmuxRun(["set", "-gu", "window-status-separator"]);
-    }
-  }, [store.viewMode]);
-
-  // Restore default tmux status bar on unmount
-  useEffect(() => {
+    const s = tmuxSession;
+    tmuxRun(["set", "-t", s, "status", "off"]);
     return () => {
-      tmuxRun(["set", "-g", "status-left", TMUX_DEFAULT_STATUS_LEFT]);
-      tmuxRun(["set", "-g", "status-left-length", TMUX_DEFAULT_STATUS_LEFT_LENGTH]);
-      tmuxRun(["set", "-g", "status-right", TMUX_DEFAULT_STATUS_RIGHT]);
-      tmuxRun(["set", "-g", "status-right-length", TMUX_DEFAULT_STATUS_RIGHT_LENGTH]);
-      tmuxRun(["set", "-gu", "window-status-format"]);
-      tmuxRun(["set", "-gu", "window-status-current-format"]);
-      tmuxRun(["set", "-gu", "window-status-style"]);
-      tmuxRun(["set", "-gu", "window-status-current-style"]);
-      tmuxRun(["set", "-gu", "window-status-separator"]);
+      tmuxRun(["set", "-tu", s, "status"]);
     };
-  }, []);
+  }, [tmuxSession]);
 
   return (
     <box width="100%" height="100%" flexDirection="column" backgroundColor={theme.background}>
@@ -499,7 +458,7 @@ export function SessionGraphPanel() {
       {/* Compact agent switcher overlay */}
       {switcherOpen ? <CompactSwitcher selectedIndex={switcherSel} /> : null}
 
-      <Statusline focusedNode={focused} attachMsg={attachMsg} />
+      <Statusline attachMsg={attachMsg} />
     </box>
   );
 }

--- a/src/sdk/components/statusline.tsx
+++ b/src/sdk/components/statusline.tsx
@@ -1,14 +1,10 @@
 /** @jsxImportSource @opentui/react */
 
 import { useStore, useGraphTheme, useStoreVersion } from "./orchestrator-panel-contexts.ts";
-import { statusIcon, statusColor } from "./status-helpers.ts";
-import type { LayoutNode } from "./layout.ts";
 
 export function Statusline({
-  focusedNode,
   attachMsg,
 }: {
-  focusedNode: LayoutNode | undefined;
   attachMsg: string;
 }) {
   const store = useStore();
@@ -23,19 +19,6 @@ export function Statusline({
           <strong>GRAPH</strong>
         </text>
       </box>
-
-      {/* Focused node info */}
-      {focusedNode ? (
-        <box backgroundColor="transparent" paddingLeft={1} alignItems="center">
-          <text>
-            <span fg={statusColor(focusedNode.status, theme)}>{statusIcon(focusedNode.status)} </span>
-            <span fg={theme.text}>{focusedNode.name}</span>
-            {focusedNode.error ? (
-              <span fg={theme.error}> {"\u00B7"} {focusedNode.error}</span>
-            ) : null}
-          </text>
-        </box>
-      ) : null}
 
       {store.backgroundTaskCount > 0 ? (
         <box backgroundColor="transparent" paddingLeft={1} alignItems="center">

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -342,32 +342,6 @@ export async function _runHILWatcher(
   }
 }
 
-/**
- * Watch the Claude session JSONL transcript for `AskUserQuestion` HIL events.
- *
- * Uses `fs/promises` `watch()` (inotify/kqueue in Bun) on the session file.
- * On each write, re-reads messages via `getSessionMessages()` and calls
- * `onHIL(true)` when an unresolved `AskUserQuestion` appears or
- * `onHIL(false)` when it is resolved. Only fires on state transitions to
- * avoid redundant callbacks.
- *
- * The loop exits when the provided `AbortSignal` is aborted (e.g. session
- * becomes idle). Individual read errors are silently swallowed so a single
- * corrupt write doesn't kill the watcher.
- */
-async function watchTranscriptForHIL(
-  sessionId: string,
-  signal: AbortSignal,
-  onHIL: (waiting: boolean) => void,
-): Promise<void> {
-  const jsonlPath = `${resolveSessionDir(process.cwd())}/${sessionId}.jsonl`;
-  await _runHILWatcher(
-    watch(jsonlPath, { signal }),
-    () => getSessionMessages(sessionId, { dir: process.cwd(), includeSystemMessages: true }),
-    onHIL,
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -18,7 +18,6 @@
  */
 
 import {
-  listSessions,
   getSessionMessages,
   query as sdkQuery,
   type SessionMessage,
@@ -39,6 +38,9 @@ import {
   attemptSubmitRounds,
 } from "../runtime/tmux.ts";
 import { watch } from "node:fs/promises";
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 
 // ---------------------------------------------------------------------------
 // Session tracking — ensures createClaudeSession is called before claudeQuery
@@ -46,10 +48,24 @@ import { watch } from "node:fs/promises";
 
 /** Per-pane state for Claude sessions. */
 interface PaneState {
-  /** Claude Code's own session ID. Resolved after the first query is sent. */
-  claudeSessionId: string | undefined;
-  /** Session IDs that existed before this pane's Claude instance started. */
-  knownSessionIds: Set<string>;
+  /**
+   * Claude Code's session ID. Pre-generated via `crypto.randomUUID()` in
+   * `createClaudeSession` and passed to `claude --session-id <UUID>` on the
+   * first query, so we know the JSONL filename without polling.
+   */
+  claudeSessionId: string;
+  /** Whether the `claude` CLI has been spawned in this pane yet. */
+  claudeStarted: boolean;
+  /** CLI flags to pass to `claude` when it is spawned on the first query. */
+  chatFlags: string[];
+  /** Timeout in ms waiting for Claude TUI / JSONL file on first spawn. */
+  readyTimeoutMs: number;
+  /**
+   * Workflow session directory (`~/.atomic/sessions/<runId>/<name>-<sid>`).
+   * The first prompt is persisted here as `prompt.txt` so it appears in the
+   * session log alongside `messages.json`, `metadata.json`, etc.
+   */
+  sessionDir: string;
 }
 
 const initializedPanes = new Map<string, PaneState>();
@@ -75,6 +91,11 @@ const DEFAULT_CHAT_FLAGS = [
 export interface ClaudeSessionOptions {
   /** tmux pane ID where Claude should be started */
   paneId: string;
+  /**
+   * Workflow session directory. The first prompt is written here as
+   * `prompt.txt` and Claude is told to read from that path.
+   */
+  sessionDir: string;
   /** CLI flags to pass to the `claude` command (default: ["--allow-dangerously-skip-permissions", "--dangerously-skip-permissions"]) */
   chatFlags?: string[];
   /** Timeout in ms waiting for Claude TUI to be ready (default: 30s) */
@@ -82,11 +103,16 @@ export interface ClaudeSessionOptions {
 }
 
 /**
- * Start Claude Code in a tmux pane with configurable CLI flags.
+ * Initialize per-pane Claude state. Does NOT spawn the `claude` CLI — the
+ * pane is left as a bare shell. The CLI is spawned lazily on the first
+ * `claudeQuery()` call, with the prompt baked into the spawn command:
+ *
+ *     claude [chatFlags] --session-id <UUID> 'Read the prompt in <tmpfile>'
+ *
+ * Pre-generating the session UUID here lets the first query pass it to the
+ * CLI, so we know the JSONL filename up front and can skip discovery polling.
  *
  * Must be called before any `claudeQuery()` calls targeting the same pane.
- * The pane should be a bare shell — `createClaudeSession` sends the `claude`
- * command with the given flags and waits for the TUI to become ready.
  *
  * @example
  * ```typescript
@@ -108,94 +134,89 @@ export interface ClaudeSessionOptions {
 export async function createClaudeSession(options: ClaudeSessionOptions): Promise<void> {
   const {
     paneId,
+    sessionDir,
     chatFlags = DEFAULT_CHAT_FLAGS,
     readyTimeoutMs = 30_000,
   } = options;
 
-  // Snapshot existing Claude sessions BEFORE starting, so we can identify the
-  // new session later by diffing against this set. The directory may not exist
-  // on first run — that's fine, the known set is just empty.
-  let knownSessionIds = new Set<string>();
-  try {
-    const existing = await listSessions({ dir: process.cwd() });
-    knownSessionIds = new Set(existing.map((s) => s.sessionId));
-  } catch {
-    // No session directory yet — all sessions will be "new"
-  }
-
-  const cmd = ["claude", ...chatFlags].join(" ");
-  await sendKeysAndSubmit(paneId, cmd);
-
-  // Give the shell time to exec before polling for TUI readiness
-  await Bun.sleep(1_000);
-  await waitForPaneReady(paneId, readyTimeoutMs);
-
-  // Verify Claude TUI actually rendered — a bare shell or crash won't show
-  // the expected prompt/task indicators
-  const visible = capturePaneVisible(paneId);
-  if (!paneLooksReady(visible) && !paneHasActiveTask(visible)) {
-    throw new Error(
-      "createClaudeSession() timed out waiting for the Claude TUI to start. " +
-      "Verify the `claude` command is installed and the flags are valid.",
-    );
-  }
-
-  // Session ID is resolved lazily in claudeQuery — Claude doesn't write its
-  // session file until it receives the first message.
   initializedPanes.set(paneId, {
-    claudeSessionId: undefined,
-    knownSessionIds,
+    claudeSessionId: randomUUID(),
+    claudeStarted: false,
+    chatFlags,
+    readyTimeoutMs,
+    sessionDir,
   });
 }
 
 /**
- * Find a session ID that isn't in the known set.
- * Returns `undefined` if no new session exists yet.
+ * Spawn `claude` in the pane with the prompt baked in via the Read tool.
+ *
+ * The prompt is written to `${sessionDir}/prompt.txt` so it persists in the
+ * workflow's session log alongside `messages.json`, `metadata.json`, etc.
+ * The argv prompt is `Read the prompt in <path>`, so Claude's first action
+ * is a Read tool call against that file. This sidesteps shell-escaping and
+ * ARG_MAX entirely — the prompt bytes never traverse the shell parser or
+ * the kernel argv cap.
  */
-async function findNewSessionId(
-  knownSessionIds: Set<string>,
-  cwd: string,
-): Promise<string | undefined> {
-  try {
-    const sessions = await listSessions({ dir: cwd });
-    return sessions.find((s) => !knownSessionIds.has(s.sessionId))?.sessionId;
-  } catch {
-    return undefined;
-  }
+async function spawnClaudeWithPrompt(
+  paneId: string,
+  prompt: string,
+  chatFlags: string[],
+  sessionId: string,
+  sessionDir: string,
+  readyTimeoutMs: number,
+): Promise<void> {
+  const promptFile = join(sessionDir, "prompt.txt");
+  writeFileSync(promptFile, prompt, "utf-8");
+
+  // sessionDir is the workflow's `${name}-${sessionId}` directory under
+  // ~/.atomic/sessions — slug-based, so single-quoting is sufficient on
+  // POSIX and PowerShell alike.
+  const argvPrompt = `'Read the prompt in ${promptFile}'`;
+  const cmd = [
+    "claude",
+    ...chatFlags,
+    "--session-id",
+    sessionId,
+    argvPrompt,
+  ].join(" ");
+
+  await sendKeysAndSubmit(paneId, cmd);
+
+  // SDK-native readiness signal: wait for Claude to create its JSONL file
+  // at the known UUID path. No pane scraping, no paneLooksReady check.
+  await waitForSessionFileAt(sessionId, readyTimeoutMs);
 }
 
 /**
- * Watch for a new Claude session JSONL file to appear on disk.
+ * Wait for Claude's JSONL session file at a known UUID-named path to exist.
  *
- * Uses the `fs/promises` `watch()` async iterator (backed by inotify/kqueue
- * in Bun — OS-native, no polling) for instant notification when Claude writes
- * its session file. A `Bun.sleep`-based polling loop runs concurrently to
- * handle the case where the session directory doesn't exist yet (first run).
- *
- * An `AbortController` coordinates the timeout and cleanup across both
- * watchers — whichever detects the session first wins the `Promise.race`,
- * and the abort signal tears down the other.
+ * Because we pass `--session-id <UUID>` to the spawn, the file's exact path
+ * is deterministic — we just need to wait for it to appear. Uses `fs.watch`
+ * for instant OS-native notification (inotify/kqueue in Bun) racing against
+ * a polling fallback that handles the case where the session directory
+ * doesn't exist yet on first run.
  */
-async function waitForSessionFile(
-  knownSessionIds: Set<string>,
+async function waitForSessionFileAt(
+  sessionId: string,
   timeoutMs: number,
-): Promise<string> {
-  const cwd = process.cwd();
-  const sessionDir = resolveSessionDir(cwd);
+): Promise<void> {
+  const sessionDir = resolveSessionDir(process.cwd());
+  const targetPath = `${sessionDir}/${sessionId}.jsonl`;
+
+  if (existsSync(targetPath)) return;
+
   const ac = new AbortController();
   const timeout = setTimeout(() => ac.abort(), timeoutMs);
 
   try {
-    return await Promise.race([
-      // fs.watch — instant OS-native notification (inotify/kqueue in Bun)
-      (async (): Promise<string> => {
+    await Promise.race([
+      // fs.watch — instant OS-native notification when Claude writes the file
+      (async (): Promise<void> => {
         try {
-          for await (const event of watch(sessionDir, {
-            signal: ac.signal,
-          })) {
-            if (event.filename?.endsWith(".jsonl")) {
-              const id = await findNewSessionId(knownSessionIds, cwd);
-              if (id) return id;
+          for await (const event of watch(sessionDir, { signal: ac.signal })) {
+            if (event.filename === `${sessionId}.jsonl` && existsSync(targetPath)) {
+              return;
             }
           }
         } catch (e: unknown) {
@@ -203,14 +224,13 @@ async function waitForSessionFile(
           // Directory doesn't exist yet — let polling handle it
         }
         // Park this branch so polling can win the race
-        return new Promise<string>(() => {});
+        return new Promise<void>(() => {});
       })(),
 
       // Polling fallback — handles directory-not-yet-created case
-      (async (): Promise<string> => {
+      (async (): Promise<void> => {
         while (!ac.signal.aborted) {
-          const id = await findNewSessionId(knownSessionIds, cwd);
-          if (id) return id;
+          if (existsSync(targetPath)) return;
           await Bun.sleep(500);
         }
         throw new DOMException("Aborted", "AbortError");
@@ -219,7 +239,7 @@ async function waitForSessionFile(
   } catch (e: unknown) {
     if (e instanceof DOMException && e.name === "AbortError") {
       throw new Error(
-        "Timed out waiting for Claude to write its session file. " +
+        `Timed out waiting for Claude session file at ${targetPath}. ` +
         "Verify the `claude` command started successfully.",
       );
     }
@@ -545,19 +565,28 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionM
     );
   }
 
-  const normalizedPrompt = normalizeTmuxCapture(prompt).slice(0, 100);
   const dir = process.cwd();
-  let { claudeSessionId } = paneState;
+  const claudeSessionId = paneState.claudeSessionId;
 
-  // Step 1: Wait for pane readiness before sending
-  await waitForPaneReady(paneId, readyTimeoutMs);
-
-  // ── Transcript snapshot (before send) ──
-  // Must be taken BEFORE sending so we get an accurate baseline. On the
-  // first query the session ID is unknown (Claude hasn't written its file
-  // yet), so transcriptBeforeCount stays 0 and we extract all messages.
-  let transcriptBeforeCount = 0;
-  if (claudeSessionId) {
+  // ── First query: spawn `claude --session-id <UUID> 'Read the prompt in <path>'`.
+  // The prompt is delivered via Claude's Read tool on its first turn — no
+  // paste-buffer, no submit retries. Subsequent queries fall through to the
+  // existing paste-buffer flow against the now-running TUI.
+  if (!paneState.claudeStarted) {
+    await spawnClaudeWithPrompt(
+      paneId,
+      prompt,
+      paneState.chatFlags,
+      claudeSessionId,
+      paneState.sessionDir,
+      paneState.readyTimeoutMs,
+    );
+    paneState.claudeStarted = true;
+  } else {
+    // ── Transcript snapshot (before send) ──
+    // Taken BEFORE sending so we get an accurate baseline for slicing the
+    // returned messages to just this turn.
+    let transcriptBeforeCount = 0;
     try {
       const msgs = await getSessionMessages(claudeSessionId, {
         dir,
@@ -567,82 +596,77 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionM
     } catch {
       // Best-effort — 0 means we scan all messages (correct, slightly less efficient)
     }
-  }
 
-  const beforeContent = normalizeTmuxLines(capturePaneScrollback(paneId));
+    const beforeContent = normalizeTmuxLines(capturePaneScrollback(paneId));
+    const normalizedPrompt = normalizeTmuxCapture(prompt).slice(0, 100);
 
-  // Step 2: Send text via paste buffer (atomic, handles large prompts)
-  sendViaPasteBuffer(paneId, prompt);
-  await Bun.sleep(150);
+    // Step 1: Wait for pane readiness before sending
+    await waitForPaneReady(paneId, readyTimeoutMs);
 
-  // Step 3: Submit with per-round capture verification
-  let delivered = await attemptSubmitRounds(paneId, normalizedPrompt, maxSubmitRounds, submitPresses);
+    // Step 2: Send text via paste buffer (atomic, handles large prompts)
+    sendViaPasteBuffer(paneId, prompt);
+    await Bun.sleep(150);
 
-  // Step 4: Adaptive retry — clear line, re-type, re-submit
-  if (!delivered) {
-    const visibleCapture = capturePaneVisible(paneId);
-    const visibleNorm = normalizeTmuxCapture(visibleCapture);
+    // Step 3: Submit with per-round capture verification
+    let delivered = await attemptSubmitRounds(paneId, normalizedPrompt, maxSubmitRounds, submitPresses);
 
-    // Only retry if text is still visible and pane is idle (not mid-task)
-    if (visibleNorm.includes(normalizedPrompt) && !paneHasActiveTask(visibleCapture) && paneLooksReady(visibleCapture)) {
-      sendSpecialKey(paneId, "C-u");
-      await Bun.sleep(80);
-      sendViaPasteBuffer(paneId, prompt);
-      await Bun.sleep(120);
-      delivered = await attemptSubmitRounds(paneId, normalizedPrompt, maxSubmitRounds, submitPresses);
-    }
-  }
+    // Step 4: Adaptive retry — clear line, re-type, re-submit
+    if (!delivered) {
+      const visibleCapture = capturePaneVisible(paneId);
+      const visibleNorm = normalizeTmuxCapture(visibleCapture);
 
-  // Step 5: Final fallback — double C-m nudge + post-submit verification
-  if (!delivered) {
-    sendSpecialKey(paneId, "C-m");
-    await Bun.sleep(120);
-    sendSpecialKey(paneId, "C-m");
-    await Bun.sleep(300);
-
-    const verifyCapture = capturePaneVisible(paneId);
-    if (paneHasActiveTask(verifyCapture)) {
-      delivered = true;
-    } else {
-      delivered = !normalizeTmuxCapture(verifyCapture).includes(normalizedPrompt);
+      // Only retry if text is still visible and pane is idle (not mid-task)
+      if (visibleNorm.includes(normalizedPrompt) && !paneHasActiveTask(visibleCapture) && paneLooksReady(visibleCapture)) {
+        sendSpecialKey(paneId, "C-u");
+        await Bun.sleep(80);
+        sendViaPasteBuffer(paneId, prompt);
+        await Bun.sleep(120);
+        delivered = await attemptSubmitRounds(paneId, normalizedPrompt, maxSubmitRounds, submitPresses);
+      }
     }
 
-    // One more attempt if text is still stuck
+    // Step 5: Final fallback — double C-m nudge + post-submit verification
     if (!delivered) {
       sendSpecialKey(paneId, "C-m");
-      await Bun.sleep(150);
+      await Bun.sleep(120);
       sendSpecialKey(paneId, "C-m");
+      await Bun.sleep(300);
+
+      const verifyCapture = capturePaneVisible(paneId);
+      if (paneHasActiveTask(verifyCapture)) {
+        delivered = true;
+      } else {
+        delivered = !normalizeTmuxCapture(verifyCapture).includes(normalizedPrompt);
+      }
+
+      // One more attempt if text is still stuck
+      if (!delivered) {
+        sendSpecialKey(paneId, "C-m");
+        await Bun.sleep(150);
+        sendSpecialKey(paneId, "C-m");
+      }
     }
+
+    // Wait for response completion via pane idle + transcript read.
+    // HIL detection is integrated into waitForIdle.
+    return await waitForIdle(
+      paneId,
+      claudeSessionId,
+      transcriptBeforeCount,
+      beforeContent,
+      pollIntervalMs,
+      onHIL,
+    );
   }
 
-  // ── Resolve session ID (after send, first query only) ──
-  // Claude doesn't write its session file until it receives the first message.
-  if (!claudeSessionId) {
-    try {
-      claudeSessionId = await waitForSessionFile(
-        paneState.knownSessionIds,
-        readyTimeoutMs,
-      );
-      paneState.claudeSessionId = claudeSessionId;
-    } catch {
-      // Session file not found — output will fall back to pane content
-    }
-  }
-
-  // Step 6: Wait for response completion via pane capture
-  //
-  // Interactive Claude Code sessions don't write idle/result events to the
-  // JSONL. The pane prompt indicator is the only reliable idle signal.
-  // Once idle, output is extracted from the transcript when available.
-  //
-  // HIL detection is integrated into waitForIdle — when the pane looks idle
-  // but the transcript has an unresolved AskUserQuestion, the function
-  // calls onHIL(true) and keeps waiting instead of returning prematurely.
+  // First-query path: wait for Claude to finish the response. The prompt
+  // file lives in the workflow's session dir as `prompt.txt` and is kept
+  // as part of the session log — no cleanup needed.
   return await waitForIdle(
     paneId,
     claudeSessionId,
-    transcriptBeforeCount,
-    beforeContent,
+    0,
+    "",
     pollIntervalMs,
     onHIL,
   );
@@ -674,19 +698,23 @@ export interface ClaudeQueryDefaults {
 export class ClaudeClientWrapper {
   readonly paneId: string;
   private readonly opts: { chatFlags?: string[]; readyTimeoutMs?: number };
+  private readonly sessionDir: string;
 
   constructor(
     paneId: string,
     opts: { chatFlags?: string[]; readyTimeoutMs?: number } = {},
+    sessionDir: string,
   ) {
     this.paneId = paneId;
     this.opts = opts;
+    this.sessionDir = sessionDir;
   }
 
   /** Start the Claude CLI in the tmux pane. Called by the runtime during init. */
   async start(): Promise<void> {
     await createClaudeSession({
       paneId: this.paneId,
+      sessionDir: this.sessionDir,
       chatFlags: this.opts.chatFlags,
       readyTimeoutMs: this.opts.readyTimeoutMs,
     });

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -266,6 +266,34 @@ export function applyContainerEnvDefaults(): void {
   if (bin) process.env.COPILOT_CLI_PATH = bin;
 }
 
+/** Percent of the agent window's vertical space allocated to the React footer pane. */
+const FOOTER_PANE_PERCENT = 5;
+
+/**
+ * Split the agent window so the top pane runs the agent CLI and the bottom
+ * pane runs the React footer (via `atomic _footer`). Allocating a percentage
+ * of the vertical layout — rather than an absolute cell count — lets tmux
+ * enforce its minimum-pane-size constraints and keeps the split readable on
+ * both tall and short terminals.
+ *
+ * Resolves the CLI entrypoint relative to this file (executor.ts lives at
+ * src/sdk/runtime/, so ../../cli.ts is the CLI). `process.argv[1]` points
+ * to executor-entry.ts here — a separate process that has no `_footer`
+ * subcommand — so we can't use it.
+ */
+function spawnAttachedFooter(windowName: string, paneId: string): void {
+  const runtime = process.execPath;
+  if (!runtime) return;
+  const cliPath = join(import.meta.dir, "..", "..", "cli.ts");
+  const cmd = `"${escBash(runtime)}" "${escBash(cliPath)}" _footer --name "${escBash(windowName)}"`;
+  tmux.tmuxRun([
+    "split-window",
+    "-t", paneId,
+    "-v", "-l", `${FOOTER_PANE_PERCENT}%`, "-d",
+    cmd,
+  ]);
+}
+
 function buildPaneCommand(
   agent: AgentType,
   port: number,
@@ -882,6 +910,7 @@ async function initProviderClientAndSession<A extends AgentType>(
   serverUrl: string,
   paneId: string,
   sessionId: string,
+  sessionDir: string,
   clientOpts: StageClientOptions<A>,
   sessionOpts: StageSessionOptions<A>,
   headless = false,
@@ -950,7 +979,7 @@ async function initProviderClientAndSession<A extends AgentType>(
       }
       const claudeClientOpts = clientOpts as StageClientOptions<"claude">;
       const claudeSessionOpts = sessionOpts as StageSessionOptions<"claude">;
-      const client = new ClaudeClientWrapper(paneId, claudeClientOpts);
+      const client = new ClaudeClientWrapper(paneId, claudeClientOpts, sessionDir);
       await client.start();
       const session = new ClaudeSessionWrapper(paneId, sessionId, claudeSessionOpts, onHIL);
       return { client, session } as Result;
@@ -1111,6 +1140,8 @@ function createSessionRunner(
         );
         shared.activeRegistry.set(name, { name, paneId, done: donePromise });
 
+        spawnAttachedFooter(name, paneId);
+
         serverUrl = await waitForServer(shared.agent, port, paneId);
 
         shared.panel.addSession(name, graphParents);
@@ -1231,6 +1262,7 @@ function createSessionRunner(
         serverUrl,
         paneId,
         sessionId,
+        sessionDir,
         clientOpts,
         sessionOpts,
         isHeadless,

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -31,28 +31,6 @@ export type TmuxResult =
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Default status-bar values — must match tmux.conf.
-// Centralised here so restore logic in session-graph-panel stays in sync.
-// ---------------------------------------------------------------------------
-
-export const TMUX_DEFAULT_STATUS_LEFT = " ";
-export const TMUX_DEFAULT_STATUS_LEFT_LENGTH = "10";
-export const TMUX_DEFAULT_STATUS_RIGHT = " #{session_name} | %H:%M ";
-export const TMUX_DEFAULT_STATUS_RIGHT_LENGTH = "60";
-
-// Attached-mode status bar — agent list via tmux window list + shortcut hints.
-// The window-status formats hide window 0 (orchestrator) and style agent names.
-// tmux natively highlights the current window, so no React state sync is needed
-// for agent cycling via Ctrl+\.
-export const TMUX_ATTACHED_STATUS_RIGHT =
-  "#[fg=#cdd6f4]ctrl+g #[fg=#6c7086]graph #[fg=#585b70]\u00b7 #[fg=#cdd6f4]ctrl+\\ #[fg=#6c7086]next ";
-export const TMUX_ATTACHED_STATUS_RIGHT_LENGTH = "40";
-export const TMUX_ATTACHED_WINDOW_FMT =
-  "#{?#{==:#{window_index},0},, #W }";
-export const TMUX_ATTACHED_WINDOW_STYLE = "fg=#6c7086";
-export const TMUX_ATTACHED_WINDOW_CURRENT_STYLE = "fg=#cdd6f4,bold";
-
-// ---------------------------------------------------------------------------
 // Core tmux primitives
 // ---------------------------------------------------------------------------
 

--- a/tests/sdk/components/attached-statusline.test.tsx
+++ b/tests/sdk/components/attached-statusline.test.tsx
@@ -1,0 +1,29 @@
+/** @jsxImportSource @opentui/react */
+
+import { test, expect, describe, afterEach } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { AttachedStatusline } from "../../../src/sdk/components/attached-statusline.tsx";
+import { TEST_THEME } from "./test-helpers.tsx";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+
+afterEach(() => {
+  testSetup?.renderer.destroy();
+  testSetup = null;
+});
+
+describe("AttachedStatusline", () => {
+  test("renders window name badge and keyboard hints", async () => {
+    testSetup = await testRender(
+      <AttachedStatusline name="worker-1" theme={TEST_THEME} />,
+      { width: 80, height: 3 },
+    );
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("worker-1");
+    expect(frame).toContain("ctrl+g");
+    expect(frame).toContain("graph");
+    expect(frame).toContain("ctrl+\\");
+    expect(frame).toContain("next");
+  });
+});

--- a/tests/sdk/components/header.test.tsx
+++ b/tests/sdk/components/header.test.tsx
@@ -87,6 +87,21 @@ describe("Header", () => {
     expect(frame).toContain("\u2713");
   });
 
+  test("shows tmux session name next to badge", async () => {
+    const store = new PanelStore();
+    store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
+
+    testSetup = await testRender(
+      <TestProviders store={store} tmuxSession="atomic-abc123">
+        <Header />
+      </TestProviders>,
+      { width: 80, height: 5 },
+    );
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("atomic-abc123");
+  });
+
   test("shows error count when sessions have errors", async () => {
     const store = new PanelStore();
     store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");

--- a/tests/sdk/components/statusline.test.tsx
+++ b/tests/sdk/components/statusline.test.tsx
@@ -4,7 +4,6 @@ import { test, expect, describe, afterEach } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import { Statusline } from "../../../src/sdk/components/statusline.tsx";
-import type { LayoutNode } from "../../../src/sdk/components/layout.ts";
 import { TestProviders } from "./test-helpers.tsx";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
@@ -14,27 +13,12 @@ afterEach(() => {
   testSetup = null;
 });
 
-function makeLayoutNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
-  return {
-    name: "node",
-    status: "pending",
-    parents: [],
-    startedAt: null,
-    endedAt: null,
-    children: [],
-    depth: 0,
-    x: 0,
-    y: 0,
-    ...overrides,
-  };
-}
-
 describe("Statusline", () => {
   test("renders GRAPH badge", async () => {
     const store = new PanelStore();
     testSetup = await testRender(
       <TestProviders store={store}>
-        <Statusline focusedNode={undefined} attachMsg="" />
+        <Statusline attachMsg="" />
       </TestProviders>,
       { width: 80, height: 5 },
     );
@@ -47,7 +31,7 @@ describe("Statusline", () => {
     const store = new PanelStore();
     testSetup = await testRender(
       <TestProviders store={store}>
-        <Statusline focusedNode={undefined} attachMsg="" />
+        <Statusline attachMsg="" />
       </TestProviders>,
       { width: 80, height: 5 },
     );
@@ -61,7 +45,7 @@ describe("Statusline", () => {
     const store = new PanelStore();
     testSetup = await testRender(
       <TestProviders store={store}>
-        <Statusline focusedNode={undefined} attachMsg={"\u2192 worker-1"} />
+        <Statusline attachMsg={"\u2192 worker-1"} />
       </TestProviders>,
       { width: 80, height: 5 },
     );
@@ -70,56 +54,28 @@ describe("Statusline", () => {
     expect(frame).toContain("worker-1");
   });
 
-  test("shows focused node info", async () => {
+  test("does not render focused node info", async () => {
     const store = new PanelStore();
-    const node = makeLayoutNode({ name: "my-session", status: "running" });
+    store.workflowName = "my-workflow";
+    store.setWorkflowInfo("my-workflow", "claude", [{ name: "worker-1", parents: [] }], "p");
+    store.startSession("worker-1");
     testSetup = await testRender(
       <TestProviders store={store}>
-        <Statusline focusedNode={node} attachMsg="" />
-      </TestProviders>,
-      { width: 80, height: 5 },
-    );
-    await testSetup.renderOnce();
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("my-session");
-    // Status is shown as an icon (●) rather than text label in the redesigned statusline
-    expect(frame).toContain("\u25CF");
-  });
-
-  test("shows error info for errored focused node", async () => {
-    const store = new PanelStore();
-    const node = makeLayoutNode({ name: "broken", status: "error", error: "timeout exceeded" });
-    testSetup = await testRender(
-      <TestProviders store={store}>
-        <Statusline focusedNode={node} attachMsg="" />
+        <Statusline attachMsg="" />
       </TestProviders>,
       { width: 120, height: 5 },
     );
     await testSetup.renderOnce();
     const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("broken");
-    expect(frame).toContain("timeout exceeded");
+    expect(frame).not.toContain("worker-1");
+    expect(frame).not.toContain("my-workflow");
   });
 
-  test("shows quit option when completion is reached", async () => {
-    const store = new PanelStore();
-    store.markCompletionReached();
-    testSetup = await testRender(
-      <TestProviders store={store}>
-        <Statusline focusedNode={undefined} attachMsg="" />
-      </TestProviders>,
-      { width: 80, height: 5 },
-    );
-    await testSetup.renderOnce();
-    const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("quit");
-  });
-
-  test("shows quit option regardless of completion state", async () => {
+  test("shows quit option", async () => {
     const store = new PanelStore();
     testSetup = await testRender(
       <TestProviders store={store}>
-        <Statusline focusedNode={undefined} attachMsg="" />
+        <Statusline attachMsg="" />
       </TestProviders>,
       { width: 80, height: 5 },
     );


### PR DESCRIPTION
## Summary

Redesigns the agent footer to render via React in a dedicated tmux pane, and rewrites the Claude provider session lifecycle to use pre-generated UUIDs and file-based prompt delivery — eliminating shell-escaping issues and the session-diff heuristic.

## Key Changes

### Footer Redesign
- Adds `atomic _footer --name <window>` internal command that renders `AttachedStatusline` in a 1-row bottom pane for each agent window
- New `AttachedStatusline` component: colored name badge with ctrl+g graph and ctrl+backslash next keyboard hints
- Disables the tmux status bar for the workflow session and replaces it with the React-rendered footer
- `Statusline` drops focused-node info (moved to header badge via `TmuxSessionContext`); status-bar restore logic and TMUX constants removed
- Executor now splits each agent window 5% vertically after creation and spawns the footer process in the bottom pane

### Claude Provider - Deterministic Session IDs
- `createClaudeSession` no longer spawns the CLI or polls `listSessions` to discover the session file
- Pre-generates a UUID via `crypto.randomUUID()` on session creation and stores only pane state
- On first `claudeQuery`, writes the prompt to a file and spawns claude with `--session-id <UUID>`, pointing it at the prompt file
- Waits for the deterministic session JSONL file via `fs.watch` + polling, avoiding ARG_MAX and shell-escaping problems
- Subsequent queries fall through to the existing paste-buffer flow

### Cleanup
- Drops unused `watchTranscriptForHIL` wrapper; the underlying `_runHILWatcher` is retained for unit tests

## Tests Added
- `tests/sdk/components/attached-statusline.test.tsx` - new component tests
- `tests/sdk/components/header.test.tsx` - header badge coverage
- `tests/sdk/components/statusline.test.tsx` - updated to reflect removed focused-node rendering
