### PR TITLE
refactor(config): remove trustedPaths from global settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,20 +1073,16 @@ Resolution order:
   "$schema": "https://raw.githubusercontent.com/flora131/atomic/main/assets/settings.schema.json",
   "version": 1,
   "scm": "github",
-  "lastUpdated": "2026-04-09T12:00:00.000Z",
-  "trustedPaths": [
-    { "workspacePath": "/home/you/project", "provider": "claude" }
-  ]
+  "lastUpdated": "2026-04-09T12:00:00.000Z"
 }
 ```
 
-| Field          | Type   | Description                                                                             |
-| -------------- | ------ | --------------------------------------------------------------------------------------- |
-| `$schema`      | string | JSON Schema URL for editor autocomplete                                                 |
-| `version`      | number | Config schema version (currently `1`)                                                   |
-| `scm`          | string | Source control: `github` or `sapling`                                                   |
-| `lastUpdated`  | string | ISO 8601 timestamp of the last update                                                   |
-| `trustedPaths` | array  | Workspaces that have completed provider onboarding; atomic skips re-prompting for these |
+| Field         | Type   | Description                               |
+| ------------- | ------ | ----------------------------------------- |
+| `$schema`     | string | JSON Schema URL for editor autocomplete   |
+| `version`     | number | Config schema version (currently `1`)     |
+| `scm`         | string | Source control: `github` or `sapling`     |
+| `lastUpdated` | string | ISO 8601 timestamp of the last update     |
 
 > Model selection and reasoning effort are managed by each underlying agent CLI (e.g. Claude Code's `/model`), not Atomic. Atomic's chat command spawns the agent's native TUI — use the agent's own controls.
 

--- a/assets/settings.schema.json
+++ b/assets/settings.schema.json
@@ -22,26 +22,6 @@
       "format": "date-time",
       "description": "ISO 8601 timestamp of the last configuration update."
     },
-    "trustedPaths": {
-      "type": "array",
-      "description": "Globally trusted workspaces that have completed provider onboarding through 'atomic init'.",
-      "items": {
-        "type": "object",
-        "required": ["workspacePath", "provider"],
-        "properties": {
-          "workspacePath": {
-            "type": "string",
-            "description": "Absolute path to the initialized workspace."
-          },
-          "provider": {
-            "type": "string",
-            "enum": ["claude", "opencode", "copilot"],
-            "description": "Provider initialized for the trusted workspace."
-          }
-        },
-        "additionalProperties": false
-      }
-    },
     "providers": {
       "type": "object",
       "description": "Per-provider overrides for chatFlags and envVars. chatFlags replaces built-in defaults entirely when set; envVars are merged on top of defaults (user values win on conflict). Local .atomic/settings.json takes precedence over global ~/.atomic/settings.json.",

--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -183,7 +183,7 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
 
   await ensureAtomicGlobalAgentConfigs(configRoot);
 
-  // ── Preflight: project setup (onboarding files, skills, trusted workspace) ──
+  // ── Preflight: project setup (onboarding files, skills) ──
   await ensureProjectSetup(agentType, projectRoot);
 
   // ── Build argv ──

--- a/src/commands/cli/init/index.ts
+++ b/src/commands/cli/init/index.ts
@@ -1,15 +1,13 @@
 /**
  * Automatic project setup — replaces the interactive `atomic init` command.
  *
- * Applies onboarding files (MCP configs, settings) and registers the
- * workspace as trusted. Called transparently during `atomic chat` preflight
- * so users never need to think about initialization.
+ * Applies onboarding files (MCP configs, settings). Called transparently
+ * during `atomic chat` preflight so users never need to think about
+ * initialization.
  */
 
-import { resolve } from "node:path";
 import type { AgentKey } from "../../../services/config/index.ts";
 import { getConfigRoot } from "../../../services/config/config-path.ts";
-import { upsertTrustedWorkspacePath } from "../../../services/config/settings.ts";
 import { applyManagedOnboardingFiles } from "./onboarding.ts";
 
 /**
@@ -22,5 +20,4 @@ export async function ensureProjectSetup(
 ): Promise<void> {
   const configRoot = getConfigRoot();
   await applyManagedOnboardingFiles(agentKey, projectRoot, configRoot);
-  await upsertTrustedWorkspacePath(resolve(projectRoot), agentKey);
 }

--- a/src/services/config/settings.ts
+++ b/src/services/config/settings.ts
@@ -9,23 +9,17 @@
  * The --model CLI flag takes precedence over both (handled at call site).
  */
 
-import { join, dirname, resolve } from "node:path";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { SETTINGS_SCHEMA_URL } from "./settings-schema.ts";
 import { ensureDir } from "../system/copy.ts";
 import { errorMessage } from "../../sdk/errors.ts";
 import type { AgentKey, ProviderOverrides } from "./definitions.ts";
 
-export interface TrustedPathEntry {
-  workspacePath: string;
-  provider: AgentKey;
-}
-
 interface AtomicSettings {
   $schema?: string;
   version?: number;
   lastUpdated?: string;
-  trustedPaths?: TrustedPathEntry[];
   telemetryEnabled?: boolean;
   providers?: Partial<Record<AgentKey, ProviderOverrides>>;
 }
@@ -56,62 +50,6 @@ async function writeGlobalSettings(settings: AtomicSettings): Promise<void> {
   const path = globalSettingsPath();
   await ensureDir(dirname(path));
   await Bun.write(path, JSON.stringify(settings, null, 2));
-}
-
-function normalizeTrustedPathEntry(entry: TrustedPathEntry): TrustedPathEntry {
-  return {
-    workspacePath: resolve(entry.workspacePath),
-    provider: entry.provider,
-  };
-}
-
-function normalizeTrustedPaths(entries: TrustedPathEntry[] | undefined): TrustedPathEntry[] {
-  const deduped = new Map<string, TrustedPathEntry>();
-
-  for (const entry of entries ?? []) {
-    if (
-      typeof entry.workspacePath !== "string" ||
-      typeof entry.provider !== "string"
-    ) {
-      continue;
-    }
-
-    const normalizedEntry = normalizeTrustedPathEntry(entry);
-    deduped.set(
-      `${normalizedEntry.provider}:${normalizedEntry.workspacePath}`,
-      normalizedEntry,
-    );
-  }
-
-  return Array.from(deduped.values());
-}
-
-export async function isTrustedWorkspacePath(
-  workspacePath: string,
-  provider: AgentKey,
-): Promise<boolean> {
-  const settings = await loadSettingsFile(globalSettingsPath());
-  const normalizedWorkspacePath = resolve(workspacePath);
-
-  return normalizeTrustedPaths(settings.trustedPaths).some((entry) =>
-    entry.provider === provider && entry.workspacePath === normalizedWorkspacePath
-  );
-}
-
-export async function upsertTrustedWorkspacePath(
-  workspacePath: string,
-  provider: AgentKey,
-): Promise<void> {
-  try {
-    const settings = await loadSettingsFile(globalSettingsPath());
-    settings.trustedPaths = normalizeTrustedPaths([
-      ...(settings.trustedPaths ?? []),
-      { workspacePath, provider },
-    ]);
-    await writeGlobalSettings(settings);
-  } catch (e) {
-    console.warn(`[settings] failed to upsert trusted path: ${errorMessage(e)}`);
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes the `trustedPaths` registry from global settings entirely. Since onboarding runs transparently during `atomic chat` preflight, the workspace trust gate has no user-facing purpose and adds unnecessary complexity.

## Key Changes

- **`src/services/config/settings.ts`**: Removed `TrustedPathEntry` interface, `trustedPaths` field from `AtomicSettings`, and all related helpers (`normalizeTrustedPaths`, `normalizeTrustedPathEntry`, `isTrustedWorkspacePath`, `upsertTrustedWorkspacePath`)
- **`src/commands/cli/init/index.ts`**: Removed `upsertTrustedWorkspacePath` call from `ensureProjectSetup`; updated module doc comment
- **`src/commands/cli/chat/index.ts`**: Updated preflight comment to reflect removal of trusted workspace step
- **`assets/settings.schema.json`**: Removed `trustedPaths` schema definition
- **`README.md`**: Removed `trustedPaths` from settings documentation table and example

## Breaking Changes

The `trustedPaths` field is removed from `~/.atomic/settings.json`. Existing entries in that field will be silently ignored on next load (they are no longer read). No migration is needed — the field served only as a re-prompt gate that is now bypassed entirely.