### PR TITLE
feat(workflow): add detach mode and ATOMIC_AGENT inference

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-creator
-description: Create multi-agent workflows for Atomic CLI using defineWorkflow().run().compile() with ctx.stage() for session orchestration across Claude, Copilot, and OpenCode SDKs. Use whenever the user wants to create, edit, or debug workflows, build agent pipelines, define multi-stage automations, set up review loops, declare workflow inputs, run background/headless stages, or mentions .atomic/workflows/, defineWorkflow, ctx.stage, ctx.inputs, headless, background stages, or the atomic workflow picker.
+description: Create multi-agent workflows for Atomic CLI using defineWorkflow().run().compile() with ctx.stage() for session orchestration across Claude, Copilot, and OpenCode SDKs, AND invoke existing workflows on behalf of the user. Use whenever the user wants to create, edit, debug, or RUN workflows ("run the ralph workflow", "kick off deep-research-codebase", "start the gen-spec workflow"), build agent pipelines, define multi-stage automations, set up review loops, declare workflow inputs, run background/headless stages, or mentions .atomic/workflows/, defineWorkflow, ctx.stage, ctx.inputs, headless, background stages, the atomic workflow picker, or `atomic workflow -n`.
 ---
 
 # Workflow Creator
@@ -209,6 +209,9 @@ Workflows that accept a free-form prompt should declare it explicitly: `{ name: 
 | Named, structured | `atomic workflow -n gen-spec -a claude --research_doc=notes.md` | Scripted structured runs |
 | Interactive picker | `atomic workflow -a claude` | Discovery; shows fuzzy list + form |
 | List | `atomic workflow -l` | Browse everything by source |
+| Detached (background) | `atomic workflow -n ralph -a claude -d "..."` | Scripted/CI runs where the caller shouldn't block on the TUI — the orchestrator keeps running on the atomic tmux socket; attach later with `atomic workflow session connect <name>` |
+
+Any of the named shapes above (positional or structured) accepts `-d` / `--detach` to run without attaching. Use it when you're automating from a script and want the CLI to return as soon as the session is spawned.
 
 **Builtin workflows are reserved** — local/global workflows cannot shadow them. Pick distinct names.
 
@@ -341,4 +344,110 @@ atomic workflow -n <workflow-name> -a <agent> --research_doc=notes.md --focus=st
 
 # Interactive picker (discovery)
 atomic workflow -a <agent>
+
+# Detached — run in the background without attaching. Useful when testing
+# from scripts or CI, or when the workflow will run long enough that you
+# want your terminal back. Reattach later with:
+#   atomic workflow session connect <printed-session-name>
+atomic workflow -n <workflow-name> -a <agent> -d "<your prompt>"
 ```
+
+## Running a Workflow on Behalf of the User
+
+When the user asks you to **run** (or "kick off" / "start" / "execute") a workflow — *not* author one — your job is to translate their request into a single `atomic workflow` invocation and run it. This section is the playbook for that flow. It is different from the authoring playbook above: the workflow already exists on disk; you just need to invoke it correctly.
+
+### You don't need to pass `-a` or `-d`
+
+When you (the agent) are running inside an atomic chat or workflow pane, the CLI reads `$ATOMIC_AGENT` from your environment and:
+
+- Fills in `-a <agent>` automatically if you don't pass it.
+- Forces detached mode on, so launching a workflow never takes over your pane.
+
+The practical result: your command is just `atomic workflow -n <name> <inputs>`. No provider flag, no detach flag, no chance of the orchestrator hijacking your terminal. The CLI prints the session name and returns immediately; you relay that name to the user.
+
+Override only when the user explicitly asks for a different provider (e.g. "run it on Copilot") — pass `-a copilot` and the CLI will honor it over the env var.
+
+### Always list first
+
+**Before anything else, run `atomic workflow list`.** (Optionally filter with `-a <agent>` if the user's pinned to one — usually unnecessary.) This is a cheap, read-only call that tells you three things in one shot:
+
+- Whether the workflow the user named actually exists.
+- What other workflows are available (so you can suggest close matches on a typo).
+- Source + metadata for every discoverable workflow (local vs. global vs. builtin).
+
+Skipping this step is how you end up guessing a name, typing it into `atomic workflow -n <name>`, and getting a `workflow not found` error you could have predicted. List first, decide second, run third.
+
+If the user's request is ambiguous ("run the research one"), the list output is also how you show them the candidates so they can pick — present the matching names and ask with AskUserQuestion.
+
+### If the workflow doesn't exist: offer to create it
+
+When the listed workflows don't include what the user asked for:
+
+1. **Tell the user explicitly** — "I don't see a `<name>` workflow in `.atomic/workflows/` or `~/.atomic/workflows/`. Available: \<short list from `atomic workflow list`>."
+2. **Check for typos first** — if one of the listed names is a close match, surface it via AskUserQuestion ("Did you mean `<close-match>`?") before offering to author anything.
+3. **Offer to create it** — ask with AskUserQuestion: "Want me to create a `<name>` workflow first?" with choices `Yes, create it` / `No, pick from the list` / `No, cancel`.
+4. **If yes → switch modes** — hand off to the authoring flow in the [Authoring Process](#authoring-process) section above (Steps 1-5). Interview the user for intent, write the file at `.atomic/workflows/<name>/<agent>/index.ts`, typecheck it, *then* come back to this runner section and invoke it. Do not skip the typecheck — an uncompiled workflow won't run.
+5. **If no → stop** — don't fabricate a command that will fail. Let the user redirect you.
+
+Never invent a workflow name or silently fall back to a different workflow. If the thing the user asked for doesn't exist, the correct answer is to say so and offer concrete next steps.
+
+### Collecting inputs with AskUserQuestion
+
+Once you've confirmed the workflow exists, you need to know two things about its invocation shape:
+
+1. **Does it declare a `prompt` input?** If so, it's free-form — you pass a positional string.
+2. **Does it declare structured inputs?** If so, you pass `--<field>=<value>` flags, one per required field.
+
+Read the workflow file at `.atomic/workflows/<name>/<agent>/index.ts` and inspect the `inputs` array. The `atomic workflow list` output is good for discovery but doesn't print the full schema — for accurate field types, requireds, and enum values, read the source.
+
+Once you know the schema, use the **AskUserQuestion tool** to collect any values the user hasn't already provided in their message. One question per missing input field. For enum fields, pass the declared `values` as multiple-choice options so the user sees exactly what's allowed. Keep questions tight and purposeful — if the user's message already answers a question, don't ask it again.
+
+Skip AskUserQuestion entirely when:
+- The user already supplied every required value in their message ("run ralph on 'add OAuth to the API'" — the prompt is right there).
+- The workflow declares no required inputs and needs no prompt.
+
+### End-to-end recipe
+
+1. **List available workflows** — run `atomic workflow list`. Always. This is your ground truth.
+2. **Resolve the target**:
+   - Exact match in the list → continue.
+   - Close match → confirm via AskUserQuestion before proceeding.
+   - No match → tell the user what's available and offer to author it (see previous section). If they decline, stop.
+3. **Discover the inputs schema** — read the workflow source file and inspect `inputs`.
+4. **Ask for missing inputs** — use AskUserQuestion, one question per unanswered required field. Enums become multiple-choice.
+5. **Invoke** — build one of these commands:
+   - Free-form: `atomic workflow -n <name> "<prompt>"`
+   - Structured: `atomic workflow -n <name> --<field1>=<value1> --<field2>=<value2>`
+6. **Report the session name** the CLI printed and tell the user: "attach any time with `atomic workflow session connect <session>` — or `atomic workflow session list` to see what's running."
+
+### Worked examples
+
+**Example A — workflow exists, structured inputs**
+
+> **User:** "run gen-spec on research/docs/2026-04-11-auth.md"
+
+1. Run `atomic workflow list`. Output includes `gen-spec` under local. Good.
+2. Target resolved exactly: `gen-spec`.
+3. Read the workflow source → inputs are `research_doc` (required string — already given), `focus` (required enum of `minimal|standard|exhaustive`, no default), `notes` (optional text).
+4. Ask via AskUserQuestion once: "What focus level for the spec?" with choices `minimal`, `standard`, `exhaustive`. User picks `standard`. Skip `notes` since it's optional.
+5. Run: `atomic workflow -n gen-spec --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
+6. The CLI prints a session name like `atomic-wf-claude-gen-spec-a1b2c3d4`. Tell the user: "Started in the background. Attach with `atomic workflow session connect atomic-wf-claude-gen-spec-a1b2c3d4` or check progress with `atomic workflow session list`."
+
+**Example B — workflow does not exist**
+
+> **User:** "run the security-audit workflow on src/auth"
+
+1. Run `atomic workflow list`. Available: `ralph`, `deep-research-codebase`, `gen-spec`, `review-to-merge`. No `security-audit`.
+2. Tell the user: "I don't see a `security-audit` workflow. Available: ralph, deep-research-codebase, gen-spec, review-to-merge."
+3. Ask via AskUserQuestion: "Want me to create a `security-audit` workflow first?" with choices `Yes, create it`, `No, use one of the existing workflows`, `No, cancel`.
+4. If **Yes**: switch to the Authoring Process — interview the user for what the workflow should do, draft it, typecheck, *then* return here and invoke it.
+5. If **No, use existing**: ask which one via AskUserQuestion over the listed options, then continue from step 3 of the recipe.
+6. If **Cancel**: stop, no command runs.
+
+### Common mistakes to avoid
+
+- **Skipping `atomic workflow list`** — leads to guessing and `workflow not found` errors. It's a one-line command; always run it.
+- **Inventing a workflow name** — if it's not in the list, it doesn't exist. Say so and offer to author it.
+- **Asking everything at once** — let AskUserQuestion drive one question per field. Enum fields are multiple-choice, not free text.
+- **Re-asking what the user already said** — read their message first.
+- **Forgetting to report the session name** — the user needs it to reattach.

--- a/.agents/skills/workflow-creator/references/workflow-inputs.md
+++ b/.agents/skills/workflow-creator/references/workflow-inputs.md
@@ -241,11 +241,21 @@ atomic workflow -n gen-spec -a claude \
 
 # Structured, long-form flag value (= form)
 atomic workflow -n gen-spec -a claude --focus standard --research_doc notes.md
+
+# Detached (background) — starts the orchestrator on the atomic tmux
+# socket and returns immediately. The command prints the session name
+# and hints for attaching later. Use this for scripted / CI runs where
+# the caller shouldn't block on the TUI.
+atomic workflow -n hello -a claude -d "hello world"
+atomic workflow session connect atomic-wf-claude-hello-<id>   # attach later
 ```
 
 Both `--flag=value` and `--flag value` forms are accepted. Short flags
 (`-x value`) are NOT parsed as structured inputs — only long-form
 `--<name>` flags resolve against the schema.
+
+The `-d` / `--detach` flag composes with any named shape (positional
+prompt, structured flags) and is independent of the inputs schema.
 
 ## Pitfalls
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ atomic session kill <name>       # kill one (or all, with confirmation)
 
 Session names follow `atomic-chat-<id>` or `atomic-wf-<workflow>-<id>`. Scope with `atomic chat session …` or `atomic workflow session …`.
 
+Need a workflow to run in the background while you do something else? Pass `-d` / `--detach`:
+
+```bash
+atomic workflow -n ralph -a claude -d "build the auth module"   # returns immediately
+atomic workflow session connect atomic-wf-claude-ralph-<id>      # attach later
+```
+
+Detached mode is what you want for scripted / CI automation and long-running tasks — the orchestrator keeps running on the atomic tmux socket regardless of your terminal.
+
 ---
 
 ## Why Atomic
@@ -973,10 +982,11 @@ atomic chat -a claude --verbose              # forward --verbose to claude
 | -------------------- | ------------------------------------------------------------------------------------------------- |
 | `-n, --name <name>`  | Workflow name (matches directory under `.atomic/workflows/<name>/`)                               |
 | `-a, --agent <name>` | Agent: `claude`, `opencode`, `copilot`                                                            |
+| `-d, --detach`       | Start the workflow in the background without attaching — ideal for scripted / CI runs; attach later with `atomic workflow session connect <name>` |
 | `--<field>=<value>`  | Structured input for workflows that declare an `inputs` schema (also accepts `--<field> <value>`) |
 | `[prompt...]`        | Positional prompt — requires the workflow to declare a `prompt` input                             |
 
-Four invocation shapes:
+Five invocation shapes:
 
 ```bash
 # 1. List every workflow available, grouped by source
@@ -993,6 +1003,10 @@ atomic workflow -n ralph -a claude "build a REST API for user management"
 atomic workflow -n gen-spec -a claude \
   --research_doc=research/docs/2026-04-11-auth.md \
   --focus=standard
+
+# 5. Run detached — orchestrator runs in the background; prints the session name
+#    and returns immediately. Attach any time with `atomic workflow session connect`.
+atomic workflow -n ralph -a claude -d "build a REST API for user management"
 ```
 
 Workflows that declare `inputs: WorkflowInput[]` get CLI flag validation for free. **Builtin workflows (e.g. `ralph`) are reserved** — a local/global workflow with the same name will not shadow a builtin.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -204,6 +204,7 @@ Examples:
         .description("Run a multi-session agent workflow")
         .option("-n, --name <name>", "Workflow name (matches directory under .atomic/workflows/<name>/)")
         .option("-a, --agent <name>", `Agent to use (${agentChoices})`)
+        .option("-d, --detach", "Start the workflow in the background without attaching (auto-enabled when launched from inside an atomic chat/workflow session to avoid hijacking it). Attach later with 'atomic workflow session connect <id>'.")
         .allowUnknownOption()
         .allowExcessArguments(true)
         .enablePositionalOptions()
@@ -218,6 +219,7 @@ Examples:
   $ atomic workflow -n ralph -a claude "fix bug"    Run a free-form workflow
   $ atomic workflow -n gen-spec -a claude --research_doc=notes.md --focus=standard
                                                     Run a structured-input workflow
+  $ atomic workflow -n ralph -a claude -d "fix bug" Run detached in the background
   $ atomic workflow session list                    List running sessions
   $ atomic workflow session connect <id>            Attach to a session
   $ atomic workflow session kill [id]               Kill a workflow session (or all)`,
@@ -227,6 +229,7 @@ Examples:
             const exitCode = await workflowCommand({
                 name: localOpts.name,
                 agent: localOpts.agent,
+                detach: localOpts.detach,
                 passthroughArgs: cmd.args,
             });
             process.exit(exitCode);

--- a/src/commands/cli/workflow-command.test.ts
+++ b/src/commands/cli/workflow-command.test.ts
@@ -174,13 +174,19 @@ function captureOutput(): CapturedOutput {
 // so the env var must already be set by the time workflow.ts gets imported.
 
 let originalNoColor: string | undefined;
+let originalAtomicAgent: string | undefined;
 beforeAll(() => {
   originalNoColor = process.env.NO_COLOR;
   process.env.NO_COLOR = "1";
+  // Snapshot once so tests can freely set/unset ATOMIC_AGENT without
+  // leaking into unrelated suites in the same bun-test process.
+  originalAtomicAgent = process.env.ATOMIC_AGENT;
 });
 afterAll(() => {
   if (originalNoColor === undefined) delete process.env.NO_COLOR;
   else process.env.NO_COLOR = originalNoColor;
+  if (originalAtomicAgent === undefined) delete process.env.ATOMIC_AGENT;
+  else process.env.ATOMIC_AGENT = originalAtomicAgent;
 });
 
 // ─── Temp workspace plumbing ────────────────────────────────────────────────
@@ -192,6 +198,12 @@ let tempDir: string;
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "atomic-workflow-cmd-test-"));
+  // Clear ATOMIC_AGENT by default — `workflowCommand` falls back to this
+  // env var when `-a` is omitted, and we don't want the ambient env (e.g.
+  // a developer running tests from inside an atomic chat pane) to silently
+  // change the agent any given test sees. Tests that need it explicitly
+  // set it themselves.
+  delete process.env.ATOMIC_AGENT;
   // Reset every mock to its default pass-through / no-op so tests are
   // independent — no leftover state from prior overrides. `mockClear` wipes
   // call history; `mockImplementation` replaces the queued implementation
@@ -634,6 +646,41 @@ describe("workflowCommand named-mode success paths", () => {
     expect(executeWorkflowMock.mock.calls[0]![0].inputs).toEqual({});
   });
 
+  test("detach flag is threaded through to the executor", async () => {
+    await writeCompiledWorkflow({ name: "detached", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "detached",
+      agent: "copilot",
+      detach: true,
+      passthroughArgs: ["run", "in", "bg"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock).toHaveBeenCalledTimes(1);
+    expect(executeWorkflowMock.mock.calls[0]![0].detach).toBe(true);
+  });
+
+  test("detach defaults to false when not provided", async () => {
+    await writeCompiledWorkflow({ name: "default-attach", agent: "copilot" });
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "default-attach",
+      agent: "copilot",
+      passthroughArgs: [],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock).toHaveBeenCalledTimes(1);
+    expect(executeWorkflowMock.mock.calls[0]![0].detach).toBe(false);
+  });
+
   test("structured workflow resolves flags and calls executor with merged inputs", async () => {
     await writeCompiledWorkflow({
       name: "struct-run",
@@ -711,6 +758,105 @@ export default defineWorkflow({
 
     expect(code).toBe(1);
     expect(cap.stderr).toContain("raw string failure");
+  });
+});
+
+// ─── ATOMIC_AGENT env var inference ────────────────────────────────────────
+
+describe("workflowCommand ATOMIC_AGENT inference", () => {
+  // Top-level beforeEach already clears ATOMIC_AGENT; tests that need it
+  // set it explicitly and rely on the next test's clear to reset.
+
+  test("infers -a from ATOMIC_AGENT when omitted", async () => {
+    // Agents spawned inside an atomic chat/workflow pane inherit
+    // ATOMIC_AGENT. Re-passing their own provider back through `-a` is
+    // boilerplate we can eliminate.
+    await writeCompiledWorkflow({ name: "inferred", agent: "claude" });
+    process.env.ATOMIC_AGENT = "claude";
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "inferred",
+      // no agent passed
+      passthroughArgs: ["go"],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock).toHaveBeenCalledTimes(1);
+    expect(executeWorkflowMock.mock.calls[0]![0].agent).toBe("claude");
+  });
+
+  test("forces detach=true when ATOMIC_AGENT is set", async () => {
+    // Attaching from inside the atomic socket would switch-client the
+    // caller's own terminal onto the new workflow session — hijacking the
+    // very pane the agent is running in. Force detach so the command
+    // returns immediately and the caller can attach on their own terms.
+    await writeCompiledWorkflow({ name: "auto-detach", agent: "copilot" });
+    process.env.ATOMIC_AGENT = "copilot";
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "auto-detach",
+      agent: "copilot",
+      // detach intentionally omitted
+      passthroughArgs: [],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock.mock.calls[0]![0].detach).toBe(true);
+  });
+
+  test("explicit -a wins over ATOMIC_AGENT", async () => {
+    // Users running on Claude who want to invoke a Copilot workflow must
+    // be able to override — the env var is a fallback, not a pin.
+    await writeCompiledWorkflow({ name: "override", agent: "copilot" });
+    process.env.ATOMIC_AGENT = "claude";
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "override",
+      agent: "copilot",
+      passthroughArgs: [],
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(0);
+    expect(executeWorkflowMock.mock.calls[0]![0].agent).toBe("copilot");
+  });
+
+  test("no ATOMIC_AGENT + no -a still errors", async () => {
+    // Baseline: outside an atomic session, `-a` is still required.
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "anything",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("Missing agent");
+  });
+
+  test("empty ATOMIC_AGENT is treated as unset", async () => {
+    // Shells sometimes export empty strings; don't let that poison the
+    // agent fallback with an empty value that fails validation with a
+    // misleading "unknown agent ''" message.
+    process.env.ATOMIC_AGENT = "";
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "anything",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("Missing agent");
   });
 });
 

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -6,6 +6,7 @@
  *   atomic workflow -n <name> -a <agent> <prompt>  free-form workflow
  *   atomic workflow -n <name> -a <agent> --<field>=<value> ...
  *                                                  structured-input workflow
+ *   atomic workflow -n <name> -a <agent> -d <args> run detached (background)
  *   atomic workflow list [-a <agent>]              list discoverable workflows
  */
 
@@ -175,6 +176,12 @@ export async function workflowCommand(options: {
   agent?: string;
   list?: boolean;
   /**
+   * When true, create the tmux session and return immediately without
+   * attaching. Callers can use `atomic workflow session connect <id>`
+   * to attach later. Useful for scripting / background automation.
+   */
+  detach?: boolean;
+  /**
    * Everything commander parked in `cmd.args` — a mix of positional
    * prompt tokens and unknown `--<name>` flags that the
    * {@link parsePassthroughArgs} helper splits apart.
@@ -190,6 +197,23 @@ export async function workflowCommand(options: {
 }): Promise<number> {
   const passthroughArgs = options.passthroughArgs ?? [];
   const cwd = options.cwd;
+
+  // `ATOMIC_AGENT` is set by `atomic chat` and `atomic workflow` on the tmux
+  // session they create, so every pane in that session inherits it. Its
+  // presence is a reliable signal that this command is being invoked from
+  // inside an atomic-managed session (i.e., the caller is an agent running
+  // in a chat or a workflow pane rather than a plain shell). We use that in
+  // two places:
+  //   1. If `-a` was omitted, fall back to ATOMIC_AGENT so agents don't have
+  //      to pass their own provider back to themselves.
+  //   2. Force `detach = true`, because attaching from inside the atomic
+  //      socket would `switch-client` the caller's own terminal onto the new
+  //      session — i.e., the agent would hijack the user's view. Detach is
+  //      always the safe choice here; the CLI prints attach hints so the
+  //      user can switch to the workflow whenever they want.
+  const atomicAgentEnv = process.env.ATOMIC_AGENT;
+  const insideAtomicSession = atomicAgentEnv !== undefined && atomicAgentEnv !== "";
+  const detach = insideAtomicSession ? true : (options.detach ?? false);
 
   // ── List mode ──
   // `merge: false` keeps local and global entries independent so the
@@ -211,7 +235,11 @@ export async function workflowCommand(options: {
   }
 
   // ── Agent validation (required for every non-list branch) ──
-  if (!options.agent) {
+  // Explicit `-a` wins; otherwise fall back to the ATOMIC_AGENT env var so
+  // workflows launched from inside an atomic chat/workflow session don't
+  // need to re-specify the provider they're already running under.
+  const agentInput = options.agent ?? atomicAgentEnv;
+  if (!agentInput) {
     console.error(
       `${COLORS.red}Error: Missing agent. Use -a <agent>.${COLORS.reset}`,
     );
@@ -219,14 +247,14 @@ export async function workflowCommand(options: {
   }
 
   const validAgents = Object.keys(AGENT_CONFIG);
-  if (!validAgents.includes(options.agent)) {
+  if (!validAgents.includes(agentInput)) {
     console.error(
-      `${COLORS.red}Error: Unknown agent '${options.agent}'.${COLORS.reset}`,
+      `${COLORS.red}Error: Unknown agent '${agentInput}'.${COLORS.reset}`,
     );
     console.error(`Valid agents: ${validAgents.join(", ")}`);
     return 1;
   }
-  const agent = options.agent as AgentKey;
+  const agent = agentInput as AgentKey;
 
   // ── Preflight checks (shared between picker and named modes) ──
   const preflightCode = await runPrereqChecks(agent);
@@ -234,11 +262,11 @@ export async function workflowCommand(options: {
 
   // ── Picker mode: -a <agent>, no -n ──
   if (!options.name) {
-    return runPickerMode(agent, passthroughArgs, cwd);
+    return runPickerMode(agent, passthroughArgs, cwd, detach);
   }
 
   // ── Named mode: -n <name> -a <agent> [args...] ──
-  return runNamedMode(options.name, agent, passthroughArgs, cwd);
+  return runNamedMode(options.name, agent, passthroughArgs, cwd, detach);
 }
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────
@@ -313,6 +341,7 @@ async function runLoadedWorkflow(args: {
   agent: AgentKey;
   inputs: Record<string, string>;
   workflowFile: string;
+  detach: boolean;
 }): Promise<number> {
   try {
     await executeWorkflow({
@@ -320,6 +349,7 @@ async function runLoadedWorkflow(args: {
       agent: args.agent,
       inputs: args.inputs,
       workflowFile: args.workflowFile,
+      detach: args.detach,
     });
     return 0;
   } catch (error) {
@@ -341,6 +371,7 @@ async function runPickerMode(
   agent: AgentKey,
   passthroughArgs: string[],
   cwd: string | undefined,
+  detach: boolean,
 ): Promise<number> {
   if (passthroughArgs.length > 0) {
     console.error(
@@ -386,7 +417,7 @@ async function runPickerMode(
     return 0;
   }
 
-  return runResolvedSelection(result.workflow, agent, result.inputs);
+  return runResolvedSelection(result.workflow, agent, result.inputs, detach);
 }
 
 /**
@@ -399,6 +430,7 @@ async function runResolvedSelection(
   workflow: WorkflowWithMetadata,
   agent: AgentKey,
   inputs: Record<string, string>,
+  detach: boolean,
 ): Promise<number> {
   const loaded = await WorkflowLoader.loadWorkflow(workflow, {
     warn(warnings) {
@@ -417,6 +449,7 @@ async function runResolvedSelection(
     agent,
     inputs,
     workflowFile: workflow.path,
+    detach,
   });
 }
 
@@ -427,6 +460,7 @@ async function runNamedMode(
   agent: AgentKey,
   passthroughArgs: string[],
   cwd: string | undefined,
+  detach: boolean,
 ): Promise<number> {
   // Find the workflow
   const discovered = await findWorkflow(name, agent, cwd);
@@ -517,6 +551,7 @@ async function runNamedMode(
       agent,
       inputs: resolvedInputs,
       workflowFile: discovered.path,
+      detach,
     });
   }
 
@@ -543,6 +578,7 @@ async function runNamedMode(
     agent,
     inputs,
     workflowFile: discovered.path,
+    detach,
   });
 }
 

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -56,6 +56,7 @@ import {
 import { OrchestratorPanel } from "./panel.tsx";
 import { GraphFrontierTracker } from "./graph-inference.ts";
 import { errorMessage } from "../errors.ts";
+import { createPainter } from "../../theme/colors.ts";
 
 /** Maximum time (ms) to wait for an agent's server to become reachable. */
 const SERVER_WAIT_TIMEOUT_MS = 60_000;
@@ -131,6 +132,13 @@ export interface WorkflowRunOptions {
   workflowFile: string;
   /** Project root (defaults to cwd) */
   projectRoot?: string;
+  /**
+   * When true, create the tmux session and return immediately instead
+   * of attaching. The orchestrator keeps running in the background on
+   * the atomic tmux socket; users can attach later with
+   * `atomic workflow session connect <name>`.
+   */
+  detach?: boolean;
 }
 
 interface SessionResult {
@@ -452,6 +460,7 @@ export async function executeWorkflow(
     inputs = {},
     workflowFile,
     projectRoot = process.cwd(),
+    detach = false,
   } = options;
 
   const workflowRunId = generateId();
@@ -507,6 +516,14 @@ export async function executeWorkflow(
   tmux.createSession(tmuxSessionName, shellCmd, "orchestrator");
   tmux.setSessionEnv(tmuxSessionName, "ATOMIC_AGENT", agent);
 
+  if (detach) {
+    // Session is already running detached on the atomic socket (tmux
+    // new-session -d). Print connection hints and return so the caller
+    // can exit cleanly without blocking on the orchestrator.
+    printDetachedBanner(tmuxSessionName);
+    return;
+  }
+
   if (tmux.isInsideAtomicSocket()) {
     // Already on the atomic server — just switch to the new session.
     tmux.switchClient(tmuxSessionName);
@@ -518,6 +535,25 @@ export async function executeWorkflow(
     const attachProc = spawnMuxAttach(tmuxSessionName);
     await attachProc.exited;
   }
+}
+
+/**
+ * Print a short banner telling the user the workflow is running in the
+ * background and how to attach to it. Written to stdout so scripts can
+ * capture the session name with a simple redirect.
+ */
+function printDetachedBanner(tmuxSessionName: string): void {
+  const paint = createPainter();
+  process.stdout.write(
+    "\n" +
+      "  " + paint("success", "✓") + " " + paint("text", "workflow started in background", { bold: true }) + "\n" +
+      "  " + paint("dim", "session: ") + paint("accent", tmuxSessionName) + "\n" +
+      "\n" +
+      "  " + paint("dim", "attach: ") + paint("accent", `atomic workflow session connect ${tmuxSessionName}`) + "\n" +
+      "  " + paint("dim", "list:   ") + paint("accent", "atomic workflow session list") + "\n" +
+      "  " + paint("dim", "kill:   ") + paint("accent", `atomic workflow session kill ${tmuxSessionName}`) + "\n" +
+      "\n",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `-d`/`--detach` so workflows start in the background and return immediately, printing tmux attach hints instead of blocking the terminal. When invoked from inside an atomic-managed session (`ATOMIC_AGENT` env var present), detach is forced on automatically and `-a` falls back to the env var — so nested agents can invoke workflows without re-passing their own provider.

## Key Changes

- **`-d` / `--detach` flag** (`src/cli.ts`, `src/commands/cli/workflow.ts`): New CLI option that creates the tmux session and returns immediately. Works with all named invocation shapes (positional prompt, structured `--flag=value` inputs).
- **`ATOMIC_AGENT` inference** (`src/commands/cli/workflow.ts`): When `$ATOMIC_AGENT` is set (i.e., command runs from inside an atomic chat/workflow pane), `-a` falls back to the env var and `detach` is forced `true` to prevent the new session from hijacking the caller's terminal view.
- **`executeWorkflow` detach support** (`src/sdk/runtime/executor.ts`): Added `detach?: boolean` to `WorkflowRunOptions`. When true, the function returns right after `tmux new-session`, printing a colored banner with the session name and attach/list/kill hints.
- **Tests** (`src/commands/cli/workflow-command.test.ts`): New tests for detach flag threading, `ATOMIC_AGENT` agent inference, auto-detach inside atomic sessions, explicit `-a` override priority, and proper env var isolation across the test suite.
- **Docs** (`README.md`, `SKILL.md`, `workflow-inputs.md`): Documents the new 5th invocation shape and the agent-invocation playbook in the workflow-creator skill.

## New Invocation Shape

```bash
# 5. Run detached — returns immediately; attach later
atomic workflow -n ralph -a claude -d "build a REST API for user management"
atomic workflow session connect atomic-wf-claude-ralph-<id>
```

## Behavior Inside Atomic Sessions

Agents running inside an atomic chat or workflow pane inherit `$ATOMIC_AGENT`. The CLI now detects this and:
1. Uses `$ATOMIC_AGENT` as the provider if `-a` is not passed.
2. Forces `--detach` on to prevent `switch-client` from hijacking the agent's own pane.

No breaking changes — existing invocations without `-d` are unaffected.