### PR TITLE
chore(release): bump version to v0.5.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.19-0",
+  "version": "0.5.19",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the package version from prerelease `0.5.19-0` to stable `0.5.19`, cutting the official release.

## Changes

- `package.json`: version `0.5.19-0` → `0.5.19`

## Test plan

- [ ] CI passes on the PR.
- [ ] Merging triggers the GitHub Release and npm publish for `v0.5.19`.