### PR TITLE
chore: remove stale `atomic init` command references

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,9 @@
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp",
-      "headers": { "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}" }
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
     }
   }
 }

--- a/devcontainer-features/src/claude/install.sh
+++ b/devcontainer-features/src/claude/install.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------------------
 # Installs the Atomic CLI globally via bun from the npm registry.
 # Config data, agent config syncing, tooling and SDK installation are all
-# handled on first `atomic init` / `atomic chat` run via auto-init.
+# handled on first `atomic chat` run via auto-init.
 #
 # NOTE: This script is duplicated across claude, copilot, and opencode features.
 #       Keep all three copies in sync when making changes.

--- a/devcontainer-features/src/copilot/install.sh
+++ b/devcontainer-features/src/copilot/install.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------------------
 # Installs the Atomic CLI globally via bun from the npm registry.
 # Config data, agent config syncing, tooling and SDK installation are all
-# handled on first `atomic init` / `atomic chat` run via auto-init.
+# handled on first `atomic chat` run via auto-init.
 #
 # NOTE: This script is duplicated across claude, copilot, and opencode features.
 #       Keep all three copies in sync when making changes.

--- a/devcontainer-features/src/opencode/install.sh
+++ b/devcontainer-features/src/opencode/install.sh
@@ -2,7 +2,7 @@
 #-------------------------------------------------------------------------------------------------------------
 # Installs the Atomic CLI globally via bun from the npm registry.
 # Config data, agent config syncing, tooling and SDK installation are all
-# handled on first `atomic init` / `atomic chat` run via auto-init.
+# handled on first `atomic chat` run via auto-init.
 #
 # NOTE: This script is duplicated across claude, copilot, and opencode features.
 #       Keep all three copies in sync when making changes.

--- a/install.ps1
+++ b/install.ps1
@@ -349,7 +349,7 @@ if (-not $ok) {
 Write-Host ""
 Write-Host "  ${C_GREEN}✓${C_RESET} ${C_BOLD}Atomic installed successfully${C_RESET}"
 Write-Host ""
-Write-Host "    Get started:  ${C_CYAN}atomic init${C_RESET}"
+Write-Host "    Get started:  ${C_CYAN}atomic chat -a <agent>${C_RESET}"
 Write-Host ""
 Write-Host "    ${C_DIM}Tooling deps and skills are synced silently on first launch.${C_RESET}"
 Write-Host "    ${C_DIM}To upgrade later: bun update -g @bastani/atomic${C_RESET}"

--- a/install.sh
+++ b/install.sh
@@ -343,7 +343,7 @@ main() {
 
     printf '\n  %s✓%s %sAtomic installed successfully%s\n\n' \
         "$C_GREEN" "$C_RESET" "$C_BOLD" "$C_RESET"
-    printf '    Get started:  %satomic init%s\n\n' "$C_CYAN" "$C_RESET"
+    printf '    Get started:  %satomic chat -a <agent>%s\n\n' "$C_CYAN" "$C_RESET"
     printf '    %sTooling deps and skills are synced silently on first launch.%s\n' \
         "$C_DIM" "$C_RESET"
     printf '    %sTo upgrade later: bun update -g @bastani/atomic%s\n\n' \

--- a/src/commands/cli/init/index.ts
+++ b/src/commands/cli/init/index.ts
@@ -1,5 +1,5 @@
 /**
- * Automatic project setup — replaces the interactive `atomic init` command.
+ * Automatic project setup.
  *
  * Applies onboarding files (MCP configs, settings). Called transparently
  * during `atomic chat` preflight so users never need to think about

--- a/src/services/config/atomic-global-config.ts
+++ b/src/services/config/atomic-global-config.ts
@@ -330,8 +330,8 @@ export async function hasAtomicGlobalAgentConfigs(
 }
 
 /**
- * Verify-and-repair entrypoint for user-facing commands (`atomic init`,
- * `atomic chat`). If every bundled agent file is present at its
+ * Verify-and-repair entrypoint for user-facing commands (`atomic chat`).
+ * If every bundled agent file is present at its
  * destination, returns immediately without touching disk. Otherwise
  * runs a merge re-sync, which fills the missing files from the local
  * config data dir while leaving user-added files alone.

--- a/src/services/config/definitions.ts
+++ b/src/services/config/definitions.ts
@@ -17,7 +17,7 @@ export interface AgentConfig {
   install_url: string;
   /** Paths to exclude when copying (relative to folder) */
   exclude: string[];
-  /** Project files managed by `atomic init` for provider onboarding */
+  /** Project files applied during `atomic chat` preflight for provider onboarding */
   onboarding_files: Array<{
     source: string;
     destination: string;


### PR DESCRIPTION
## Summary

Removes all remaining references to the deprecated `atomic init` command across install scripts, devcontainer features, and source code comments. The `atomic init` functionality was previously folded into the `atomic chat` preflight flow, making these references stale and misleading.

## Key Changes

- **Install scripts** (`install.sh`, `install.ps1`): Updated post-install "Get started" prompt from `atomic init` to `atomic chat -a <agent>`
- **Devcontainer features** (claude, copilot, opencode): Updated install comments to reflect that setup is handled on first `atomic chat` run, not `atomic init`
- **Source comments** (`atomic-global-config.ts`, `definitions.ts`, `init/index.ts`): Updated JSDoc and inline comments to remove `atomic init` references and clarify that onboarding is triggered via `atomic chat` preflight
- **Style** (`.mcp.json`): Formatted `headers` object across multiple lines for readability