### PR TITLE
fix(workflow-picker): handle bracketed-paste events via onPaste handler

### DIFF
--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -589,11 +589,7 @@ function TextAreaContent({
 
   const refCallback = useCallback((instance: TextareaRenderable | null) => {
     instanceRef.current = instance;
-    // Bracketed-paste events don't fire keydown, so subscribing to
-    // onPaste ensures pasted content propagates without requiring a
-    // follow-up keystroke to trigger the keydown-polling path below.
-    if (instance) instance.onPaste = flushPending;
-  }, [flushPending]);
+  }, []);
 
   // Sync external value → textarea when it diverges (e.g. initial value
   // or reset after phase transition).
@@ -604,11 +600,12 @@ function TextAreaContent({
     }
   }, [value]);
 
-  // Detect text changes after each keypress. The native Zig edit buffer's
-  // "content-changed" event is unreliable for propagating to the JS
-  // _contentChangeListener in certain installed environments. Instead,
-  // we hook into useKeyboard (which fires before the textarea processes
-  // the key) and defer the read with queueMicrotask so the textarea has
+  // flushPending fires on each keystroke via useKeyboard; onPaste handles
+  // bracketed pastes (which don't fire keydown). The native Zig edit
+  // buffer's "content-changed" event is unreliable for propagating to the
+  // JS _contentChangeListener in certain installed environments, so we
+  // hook into useKeyboard (which fires before the textarea processes the
+  // key) and defer the read with queueMicrotask so the textarea has
   // processed the keystroke by the time we read plainText.
   useKeyboard(flushPending);
 
@@ -625,6 +622,7 @@ function TextAreaContent({
       placeholderColor={theme.textDim}
       wrapMode="word"
       flexGrow={1}
+      onPaste={flushPending}
     />
   );
 }

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -572,9 +572,28 @@ function TextAreaContent({
   const onInputRef = useLatest(onInput);
   const lastTextRef = useRef(value);
 
+  // Read plainText on the next microtask so the textarea has applied the
+  // keystroke/paste before we observe its content, then fire onInput if
+  // it changed.
+  const flushPending = useCallback(() => {
+    queueMicrotask(() => {
+      const inst = instanceRef.current;
+      if (!inst) return;
+      const current = inst.plainText;
+      if (current !== lastTextRef.current) {
+        lastTextRef.current = current;
+        onInputRef.current(current);
+      }
+    });
+  }, []);
+
   const refCallback = useCallback((instance: TextareaRenderable | null) => {
     instanceRef.current = instance;
-  }, []);
+    // Bracketed-paste events don't fire keydown, so subscribing to
+    // onPaste ensures pasted content propagates without requiring a
+    // follow-up keystroke to trigger the keydown-polling path below.
+    if (instance) instance.onPaste = flushPending;
+  }, [flushPending]);
 
   // Sync external value → textarea when it diverges (e.g. initial value
   // or reset after phase transition).
@@ -591,17 +610,7 @@ function TextAreaContent({
   // we hook into useKeyboard (which fires before the textarea processes
   // the key) and defer the read with queueMicrotask so the textarea has
   // processed the keystroke by the time we read plainText.
-  useKeyboard(useCallback(() => {
-    queueMicrotask(() => {
-      const inst = instanceRef.current;
-      if (!inst) return;
-      const current = inst.plainText;
-      if (current !== lastTextRef.current) {
-        lastTextRef.current = current;
-        onInputRef.current(current);
-      }
-    });
-  }, []));
+  useKeyboard(flushPending);
 
   return (
     <textarea

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -646,6 +646,23 @@ describe("WorkflowPicker PROMPT keyboard", () => {
     expect(frame).toContain("hello");
   });
 
+  test("bracketed paste in a text field propagates to onSubmit without further keystrokes", async () => {
+    // Bracketed pastes bypass useKeyboard, so this regression-pins the
+    // textarea's onPaste handler — without it, pasted content never
+    // reaches onFieldInput and the submitted payload would be empty.
+    let result: WorkflowPickerResult | null = null;
+    const setup = await renderAndEnterPrompt({
+      onSubmit: (r) => {
+        result = r;
+      },
+    });
+    await press(setup, (i) => i.pasteBracketedText("pasted task body"));
+    await press(setup, (i) => i.pressKey("d", { ctrl: true }));
+    await press(setup, (i) => i.pressKey("y"));
+    expect(result).not.toBeNull();
+    expect(result!.inputs.task).toContain("pasted task body");
+  });
+
   test("return in a text field inserts a newline", async () => {
     const setup = await renderAndEnterPrompt();
     await press(setup, (i) => i.typeText("line1"));


### PR DESCRIPTION
Bracketed-paste events don't fire `keydown`, so the existing keyboard-polling path missed pasted content until a follow-up keystroke. This fix wires paste events directly into the same flush logic used for keystrokes, ensuring state updates immediately on paste.

## Summary

- Extracts the deferred `plainText` read into a shared `flushPending` callback, then assigns it to both `useKeyboard` and the textarea's `onPaste` prop
- Adds a regression test that pastes text and submits without any follow-up keystroke, confirming the submitted payload contains the pasted content

## Key Changes

- **Extracted `flushPending` callback**: `queueMicrotask`-deferred read of `plainText` is now a named `useCallback` instead of an inline closure inside `useKeyboard`, eliminating duplication
- **`onPaste={flushPending}` on `<textarea>`**: Bracketed pastes (which bypass `keydown` entirely) now trigger the same flush logic as keystrokes, closing the observation gap
- **Regression test**: `"bracketed paste in a text field propagates to onSubmit without further keystrokes"` pins the `onPaste` handler path so future refactors can't silently drop it

## Root Cause

The native Zig edit buffer's `content-changed` event is unreliable in certain installed environments, so `plainText` is polled via `useKeyboard`. However, bracketed pastes bypass `keydown` entirely, leaving pasted content unobserved until the next keystroke. Adding `onPaste={flushPending}` closes this gap.