### PR TITLE
refactor(claude): replace tmux-polling idle detection with event-driven Stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,5 +21,17 @@
     "kotlin-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
     "lua-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "atomic _claude-stop-hook"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -283,6 +283,16 @@ Examples:
             process.exit(exitCode);
         });
 
+    // ── Internal: Claude Stop hook handler ────────────────────────────────
+    program
+        .command("_claude-stop-hook", { hidden: true })
+        .description("Internal: Claude Code Stop hook handler — writes a marker file for idle detection")
+        .action(async () => {
+            const { claudeStopHookCommand } = await import("./commands/cli/claude-stop-hook.ts");
+            const exitCode = await claudeStopHookCommand();
+            process.exit(exitCode);
+        });
+
     // ── Completions command ────────────────────────────────────────────────
     program
         .command("completions")
@@ -333,7 +343,8 @@ async function main(): Promise<void> {
             argv.includes("--help") ||
             argv.includes("-h") ||
             argv[0] === "completions" ||
-            argv[0] === "_footer";
+            argv[0] === "_footer" ||
+            argv[0] === "_claude-stop-hook";
 
         if (!isInfoCommand) {
             const { autoSyncIfStale } = await import("./services/system/auto-sync.ts");

--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -190,7 +190,15 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
   const args = await buildAgentArgs(agentType, passthroughArgs, projectRoot);
   const cmd = [config.cmd, ...args];
   const overrides = await getProviderOverrides(agentType, projectRoot);
-  const envVars = { ...config.env_vars, ...overrides.envVars };
+  // ATOMIC_AGENT must be baked into the launcher env so the agent CLI
+  // (and anything it spawns) can read it. `setSessionEnv` below only
+  // affects processes spawned *after* the initial command, so it cannot
+  // populate the env of the agent CLI that `new-session` kicks off.
+  const envVars = {
+    ...config.env_vars,
+    ...overrides.envVars,
+    ATOMIC_AGENT: agentType,
+  };
 
   // ── No TTY: tmux attach requires a real terminal ──
   if (!process.stdin.isTTY) {

--- a/src/commands/cli/claude-stop-hook.test.ts
+++ b/src/commands/cli/claude-stop-hook.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for claudeStopHookCommand.
+ *
+ * Strategy: monkey-patch `Bun.stdin.text` to return preset strings so we can
+ * call the function directly without spawning subprocesses.  This is
+ * consistent with how other CLI-command tests in this directory work.
+ *
+ * Filesystem isolation: we use `crypto.randomUUID()` for unique session IDs
+ * and clean up in `afterEach` so test runs never collide with each other
+ * or with real marker files.
+ */
+
+import { describe, test, expect, afterEach, mock, spyOn } from "bun:test";
+import { access, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { claudeStopHookCommand } from "./claude-stop-hook.ts";
+
+// Paths we'll need in every test.
+const markerDir = join(homedir(), ".atomic", "claude-stop");
+
+/** Returns true when a file exists at `filePath`. */
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Patch `Bun.stdin.text` for the duration of one test. */
+function mockStdin(text: string): void {
+  // Bun.stdin is a readonly property on the global `Bun` object.
+  // We reach it through the prototype chain the same way other tests
+  // in this repo patch globals (e.g. process.stdout.write).
+  (Bun.stdin as { text: () => Promise<string> }).text = () =>
+    Promise.resolve(text);
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+const sessionIdsToClean: string[] = [];
+
+afterEach(async () => {
+  // Remove any marker files created during the test.
+  for (const id of sessionIdsToClean) {
+    await rm(join(markerDir, id), { force: true });
+    await rm(join(markerDir, `${id}.tmp`), { force: true });
+  }
+  sessionIdsToClean.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("claudeStopHookCommand", () => {
+  // 1. Valid payload → writes marker file
+  test("valid payload writes marker file and returns 0", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionIdsToClean.push(sessionId);
+
+    mockStdin(JSON.stringify({ session_id: sessionId }));
+
+    const code = await claudeStopHookCommand();
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(markerDir, sessionId))).toBe(true);
+    expect(await fileExists(join(markerDir, `${sessionId}.tmp`))).toBe(false);
+  });
+
+  // 2. stop_hook_active: true → no-op
+  test("stop_hook_active:true is a no-op and returns 0", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionIdsToClean.push(sessionId);
+
+    mockStdin(
+      JSON.stringify({ session_id: sessionId, stop_hook_active: true }),
+    );
+
+    const code = await claudeStopHookCommand();
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(markerDir, sessionId))).toBe(false);
+    expect(await fileExists(join(markerDir, `${sessionId}.tmp`))).toBe(false);
+  });
+
+  // 3. Malformed JSON → returns 0, logs to console.error
+  test("malformed JSON returns 0 and logs an error", async () => {
+    mockStdin("not json {{{");
+
+    // Spy on console.error so the error doesn't bleed into test output.
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await claudeStopHookCommand();
+
+    expect(code).toBe(0);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  // 4. Missing session_id → returns 0, logs to console.error
+  test("missing session_id returns 0 and logs an error", async () => {
+    mockStdin(JSON.stringify({}));
+
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await claudeStopHookCommand();
+
+    expect(code).toBe(0);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  // 5. Extra payload fields are tolerated
+  test("valid payload with optional fields writes marker and returns 0", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionIdsToClean.push(sessionId);
+
+    mockStdin(
+      JSON.stringify({
+        session_id: sessionId,
+        transcript_path: "/tmp/transcript.json",
+        cwd: "/home/user/project",
+        stop_hook_active: false,
+      }),
+    );
+
+    const code = await claudeStopHookCommand();
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(markerDir, sessionId))).toBe(true);
+    expect(await fileExists(join(markerDir, `${sessionId}.tmp`))).toBe(false);
+  });
+});

--- a/src/commands/cli/claude-stop-hook.ts
+++ b/src/commands/cli/claude-stop-hook.ts
@@ -1,0 +1,90 @@
+/**
+ * Claude Stop Hook command — internal handler for Claude Code's Stop hook.
+ *
+ * Claude invokes `atomic _claude-stop-hook` at the end of every turn,
+ * piping a JSON payload via stdin. This handler writes a marker file that
+ * another part of the system watches via `fs.watch`, replacing tmux-pane-
+ * scraping idle detection with a clean event-driven approach.
+ *
+ * Usage (configured in Claude's Stop hook):
+ *   atomic _claude-stop-hook
+ *
+ * Payload (JSON via stdin):
+ *   {
+ *     "session_id": "abc123",
+ *     "transcript_path": "/path/to/transcript",
+ *     "cwd": "/path/to/cwd",
+ *     "stop_hook_active": false
+ *   }
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+/** Shape of the JSON payload Claude pipes to the Stop hook via stdin. */
+export interface ClaudeStopHookPayload {
+  session_id: string;
+  transcript_path?: string;
+  cwd?: string;
+  stop_hook_active?: boolean;
+}
+
+/**
+ * Type guard to verify that a parsed value conforms to ClaudeStopHookPayload.
+ */
+function isClaudeStopHookPayload(value: unknown): value is ClaudeStopHookPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj["session_id"] !== "string") return false;
+  if (obj["transcript_path"] !== undefined && typeof obj["transcript_path"] !== "string") return false;
+  if (obj["cwd"] !== undefined && typeof obj["cwd"] !== "string") return false;
+  if (obj["stop_hook_active"] !== undefined && typeof obj["stop_hook_active"] !== "boolean") return false;
+  return true;
+}
+
+/**
+ * Handler for the hidden `_claude-stop-hook` subcommand.
+ *
+ * Returns an exit code (0 on success or benign failure).  The caller
+ * in src/cli.ts does `process.exit(exitCode)`, so we just return the code.
+ *
+ * We always return 0 — a non-zero exit would surface as a hook error in
+ * Claude's transcript, which is not what we want.
+ */
+export async function claudeStopHookCommand(): Promise<number> {
+  // 1. Read stdin
+  const raw = await Bun.stdin.text();
+
+  // 2. Parse JSON
+  let payload: ClaudeStopHookPayload;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isClaudeStopHookPayload(parsed)) {
+      console.error("[claude-stop-hook] Invalid payload: missing or malformed 'session_id'");
+      return 0;
+    }
+    payload = parsed;
+  } catch {
+    console.error("[claude-stop-hook] Failed to parse stdin as JSON");
+    return 0;
+  }
+
+  // 3. Guard against infinite Stop-hook loops
+  if (payload.stop_hook_active === true) {
+    return 0;
+  }
+
+  // 4. Write the marker file atomically
+  const markerDir = path.join(os.homedir(), ".atomic", "claude-stop");
+  await fs.mkdir(markerDir, { recursive: true });
+
+  const tmpPath = path.join(markerDir, `${payload.session_id}.tmp`);
+  const finalPath = path.join(markerDir, payload.session_id);
+
+  // Write contents — the watcher only cares that the file appears.
+  await Bun.write(tmpPath, raw);
+  await fs.rename(tmpPath, finalPath);
+
+  return 0;
+}

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -37,10 +37,11 @@ import {
   waitForPaneReady,
   attemptSubmitRounds,
 } from "../runtime/tmux.ts";
-import { watch } from "node:fs/promises";
+import { watch, unlink, mkdir } from "node:fs/promises";
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import os from "node:os";
 
 // ---------------------------------------------------------------------------
 // Session tracking — ensures createClaudeSession is called before claudeQuery
@@ -346,95 +347,154 @@ export async function _runHILWatcher(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Path of the directory where the claude-stop-hook writes marker files.
+ * Each Claude turn creates `~/.atomic/claude-stop/<session_id>` atomically
+ * via rename, which triggers the `fs.watch` event in `waitForIdle`.
+ */
+function markerDir(): string {
+  return join(os.homedir(), ".atomic", "claude-stop");
+}
+
+/**
+ * Return the marker file path for a given Claude session ID.
+ */
+function markerPath(claudeSessionId: string): string {
+  return join(markerDir(), claudeSessionId);
+}
+
+/**
+ * Ensure the marker directory exists and remove any stale marker left from a
+ * previous turn of this session. Call this BEFORE submitting the prompt so
+ * the subsequent `waitForIdle` watch loop doesn't fire on a stale file.
+ *
+ * Ignores ENOENT on `unlink` — the file simply doesn't exist yet.
+ */
+async function clearStaleMarker(claudeSessionId: string): Promise<void> {
+  await mkdir(markerDir(), { recursive: true });
+  try {
+    await unlink(markerPath(claudeSessionId));
+  } catch (e: unknown) {
+    // ENOENT is expected — ignore it; rethrow anything else
+    if (!(e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT")) {
+      throw e;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Idle detection via pane capture
+// Idle detection via marker file watch
 // ---------------------------------------------------------------------------
 
 /**
- * Wait for the Claude session to become idle by polling the tmux pane.
+ * Wait for the Claude session to become idle using `fs.watch` on the
+ * `~/.atomic/claude-stop/` marker directory.
  *
- * Interactive Claude Code sessions don't write idle or result events to the
- * JSONL session file (those only flow through the SDK streaming output for
- * headless consumers). The pane prompt indicator is the only reliable idle
- * signal for interactive sessions.
+ * When Claude finishes a turn, the `atomic _claude-stop-hook` Stop hook writes
+ * `~/.atomic/claude-stop/<session_id>` atomically (tmp file + rename).  The
+ * rename triggers an OS-native `fs.watch` event on the parent directory —
+ * far more reliable than polling tmux pane glyphs, which vary between Claude
+ * Code versions.
  *
- * Once idle is detected, assistant output is extracted from the session
- * transcript via `getSessionMessages()` rather than scraping the pane —
- * the transcript has structured content blocks, not terminal escape codes.
+ * Algorithm:
+ * 1. Watch the marker directory for events whose `filename` matches
+ *    `claudeSessionId`.
+ * 2. On a matching event, read the session transcript via
+ *    `getSessionMessages` and test `_hasUnresolvedHILTool`.
+ *    - If unresolved HIL: call `onHIL(true)`, unlink the marker (so the next
+ *      turn's hook can fire again), and continue watching.
+ *    - If no unresolved HIL after a prior HIL: call `onHIL(false)`.
+ *    - If truly idle: slice messages from `transcriptBeforeCount` and return.
+ * 3. Clean up the `fs.watch` watcher on any exit path via AbortController.
  *
- * No timeout is imposed. The loop runs until the pane shows the idle prompt.
+ * The function signature is intentionally identical to the previous polling
+ * implementation so all callers remain unchanged.
+ *
+ * @param paneId           - tmux pane (kept in signature for caller compat; not used here)
+ * @param claudeSessionId  - Claude's session UUID (used to identify marker file)
+ * @param transcriptBeforeCount - number of messages in transcript before this turn
+ * @param beforeContent    - (unused) pane content before send; kept for compat
+ * @param pollIntervalMs   - (unused) kept for compat; watch is event-driven
+ * @param onHIL            - optional callback for HIL state changes
  */
 async function waitForIdle(
-  paneId: string,
+  _paneId: string,
   claudeSessionId: string | undefined,
   transcriptBeforeCount: number,
-  beforeContent: string,
-  pollIntervalMs: number,
+  _beforeContent: string,
+  _pollIntervalMs: number,
   onHIL?: (waiting: boolean) => void,
 ): Promise<SessionMessage[]> {
-  // Give Claude time to start processing before first poll
-  await Bun.sleep(3_000);
+  // Without a session ID we cannot watch the marker directory — return empty.
+  if (!claudeSessionId) {
+    return [];
+  }
+
+  const dir = markerDir();
+  const sessionId = claudeSessionId;
+  const ac = new AbortController();
 
   let hilActive = false;
 
-  while (true) {
-    const currentContent = normalizeTmuxLines(capturePaneScrollback(paneId));
+  try {
+    for await (const event of watch(dir, { signal: ac.signal })) {
+      // Filter: only care about events for our session's marker file
+      if (event.filename !== sessionId) continue;
 
-    // Must have new content compared to before we sent
-    if (currentContent !== beforeContent) {
-      const visible = capturePaneVisible(paneId);
-      if (paneLooksReady(visible) && !paneHasActiveTask(visible)) {
-        // Pane looks idle — but it might be waiting for user input (HIL).
-        // Check the transcript for an unresolved AskUserQuestion before
-        // treating this as a true completion.
-        if (claudeSessionId) {
-          try {
-            const msgs = await getSessionMessages(claudeSessionId, {
-              dir: process.cwd(),
-              includeSystemMessages: true,
-            });
-
-            if (_hasUnresolvedHILTool(msgs)) {
-              // Agent is blocked on user input — signal HIL and keep waiting
-              if (!hilActive && onHIL) {
-                onHIL(true);
-                hilActive = true;
-              }
-              await Bun.sleep(pollIntervalMs);
-              continue;
-            }
-
-            // HIL was active but is now resolved — signal resumption
-            if (hilActive && onHIL) {
-              onHIL(false);
-              hilActive = false;
-              // Agent may still be processing after HIL resolution — keep
-              // polling instead of returning immediately
-              await Bun.sleep(pollIntervalMs);
-              continue;
-            }
-
-            // Truly idle — return transcript messages from this turn
-            if (msgs.length > transcriptBeforeCount) {
-              return msgs.slice(transcriptBeforeCount);
-            }
-          } catch {
-            // Transcript read failed — return empty
-          }
-        }
-        return [];
-      } else if (hilActive) {
-        // Pane is active again (user responded, agent resumed processing).
-        // Clear HIL state.
-        if (onHIL) {
-          onHIL(false);
-          hilActive = false;
-        }
+      // Marker appeared — read transcript
+      let msgs: SessionMessage[];
+      try {
+        msgs = await getSessionMessages(sessionId, {
+          dir: process.cwd(),
+          includeSystemMessages: true,
+        });
+      } catch {
+        // Transcript read failed — wait for the next marker event
+        continue;
       }
-    }
 
-    await Bun.sleep(pollIntervalMs);
+      if (_hasUnresolvedHILTool(msgs)) {
+        // Agent is blocked on user input (HIL).
+        if (!hilActive) {
+          onHIL?.(true);
+          hilActive = true;
+        }
+        // Remove the marker so the Stop hook can write a new one after the
+        // user responds and Claude finishes its next turn.
+        try {
+          await unlink(markerPath(sessionId));
+        } catch {
+          // ENOENT is fine — ignore
+        }
+        // Continue watching for the next marker event
+        continue;
+      }
+
+      // No unresolved HIL — if we were in HIL state, signal resolution.
+      if (hilActive) {
+        onHIL?.(false);
+        hilActive = false;
+      }
+
+      // Truly idle — return transcript messages produced during this turn.
+      const result = msgs.length > transcriptBeforeCount
+        ? msgs.slice(transcriptBeforeCount)
+        : [];
+
+      ac.abort();
+      return result;
+    }
+  } catch (e: unknown) {
+    // AbortError is expected when we call ac.abort() to stop watching.
+    if (e instanceof Error && e.name === "AbortError") {
+      // Normal exit — return value was already set and returned above.
+      // If we somehow reach here without returning, fall through to [].
+    } else {
+      throw e;
+    }
   }
+
+  return [];
 }
 
 // ---------------------------------------------------------------------------
@@ -541,6 +601,11 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionM
 
   const dir = process.cwd();
   const claudeSessionId = paneState.claudeSessionId;
+
+  // ── Clear any stale marker left from a previous turn before submitting. ──
+  // This ensures `waitForIdle`'s watch loop doesn't fire on the marker written
+  // by the Stop hook at the end of the LAST turn instead of the current one.
+  await clearStaleMarker(claudeSessionId);
 
   // ── First query: spawn `claude --session-id <UUID> 'Read the prompt in <path>'`.
   // The prompt is delivered via Claude's Read tool on its first turn — no

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -351,15 +351,19 @@ export async function _runHILWatcher(
  * Path of the directory where the claude-stop-hook writes marker files.
  * Each Claude turn creates `~/.atomic/claude-stop/<session_id>` atomically
  * via rename, which triggers the `fs.watch` event in `waitForIdle`.
+ *
+ * @internal Exported for unit tests.
  */
-function markerDir(): string {
+export function markerDir(): string {
   return join(os.homedir(), ".atomic", "claude-stop");
 }
 
 /**
  * Return the marker file path for a given Claude session ID.
+ *
+ * @internal Exported for unit tests.
  */
-function markerPath(claudeSessionId: string): string {
+export function markerPath(claudeSessionId: string): string {
   return join(markerDir(), claudeSessionId);
 }
 
@@ -417,7 +421,10 @@ async function clearStaleMarker(claudeSessionId: string): Promise<void> {
  * @param pollIntervalMs   - (unused) kept for compat; watch is event-driven
  * @param onHIL            - optional callback for HIL state changes
  */
-async function waitForIdle(
+/**
+ * @internal Exported for unit tests.
+ */
+export async function waitForIdle(
   _paneId: string,
   claudeSessionId: string | undefined,
   transcriptBeforeCount: number,

--- a/tests/sdk/providers/claude-wait-for-idle.test.ts
+++ b/tests/sdk/providers/claude-wait-for-idle.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests for the `waitForIdle` marker-file flow in claude.ts.
+ *
+ * `waitForIdle` watches ~/.atomic/claude-stop/ via fs.watch and fires when a
+ * marker file named `<claudeSessionId>` appears. On marker appearance it reads
+ * the session transcript and checks `_hasUnresolvedHILTool`:
+ *   - HIL unresolved → call onHIL(true), delete marker, keep watching
+ *   - HIL resolved after prior HIL → call onHIL(false), return sliced messages
+ *   - No HIL → return sliced messages
+ *
+ * Strategy:
+ * - mock.module "@anthropic-ai/claude-agent-sdk" to control getSessionMessages
+ * - Use real fs.watch on the actual markerDir (unique UUID session ids prevent collision)
+ * - Write marker files directly with the sessionId filename (fs.watch generates
+ *   events with the exact filename, unlike atomic rename which generates the .tmp name)
+ * - Clean up marker files in afterEach
+ */
+
+import { mock, test, expect, describe, beforeEach, afterEach } from "bun:test";
+import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk";
+
+// ---------------------------------------------------------------------------
+// Module-level mock — must be declared before importing the module under test.
+// We use a shared array that individual tests push session-message arrays onto.
+// Each call to getSessionMessages pops from the front so tests can sequence
+// multiple transcript states.
+// ---------------------------------------------------------------------------
+
+const sessionMessageQueue: SessionMessage[][] = [];
+
+await mock.module("@anthropic-ai/claude-agent-sdk", () => {
+  return {
+    getSessionMessages: async (_sessionId: string): Promise<SessionMessage[]> => {
+      const next = sessionMessageQueue.shift();
+      return next ?? [];
+    },
+    // Provide stubs for other named exports used by claude.ts
+    query: async function* () {},
+  };
+});
+
+// Import AFTER mock.module is set up
+import {
+  waitForIdle,
+  markerDir,
+  markerPath,
+  _hasUnresolvedHILTool,
+} from "../../../src/sdk/providers/claude.ts";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a marker file directly, causing fs.watch to generate a "rename" event
+ * with `event.filename === sessionId`.
+ *
+ * Note: on Linux, atomic rename (tmp → sessionId) only generates an event with
+ * the .tmp filename (the source). Direct write generates the correct event name.
+ */
+async function writeMarker(sessionId: string): Promise<void> {
+  const dir = markerDir();
+  await mkdir(dir, { recursive: true });
+  const target = markerPath(sessionId);
+  await writeFile(target, "");
+}
+
+/** Remove marker file if it exists — used in afterEach cleanup. */
+async function cleanupMarker(sessionId: string): Promise<void> {
+  const target = markerPath(sessionId);
+  if (existsSync(target)) {
+    try {
+      await unlink(target);
+    } catch {
+      // ENOENT is fine
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("waitForIdle — marker-file flow", () => {
+  let sessionId: string;
+
+  beforeEach(() => {
+    sessionId = randomUUID();
+    // Clear any leftover queue entries
+    sessionMessageQueue.length = 0;
+  });
+
+  afterEach(async () => {
+    sessionMessageQueue.length = 0;
+    await cleanupMarker(sessionId);
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Resolves when marker appears, no HIL
+  // -------------------------------------------------------------------------
+
+  test("resolves and returns sliced messages when marker appears with no HIL", async () => {
+    // Transcript BEFORE this turn has 2 messages; AFTER has 4 — so the new
+    // turn produced messages at indices 2 and 3.
+    const baseMessages: SessionMessage[] = [
+      {
+        type: "user",
+        uuid: "u1",
+        session_id: sessionId,
+        message: { role: "user", content: "hello" },
+        parent_tool_use_id: null,
+      },
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: sessionId,
+        message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+        parent_tool_use_id: null,
+      },
+    ];
+    const newMessages: SessionMessage[] = [
+      ...baseMessages,
+      {
+        type: "user",
+        uuid: "u2",
+        session_id: sessionId,
+        message: { role: "user", content: "second" },
+        parent_tool_use_id: null,
+      },
+      {
+        type: "assistant",
+        uuid: "a2",
+        session_id: sessionId,
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    // getSessionMessages will return newMessages (4 items) on first call
+    sessionMessageQueue.push(newMessages);
+
+    // Ensure marker directory exists
+    await mkdir(markerDir(), { recursive: true });
+
+    // Start waitForIdle watching; write the marker shortly after to simulate
+    // the stop-hook firing.
+    const idlePromise = waitForIdle(
+      "pane-0",        // _paneId (unused)
+      sessionId,       // claudeSessionId
+      2,               // transcriptBeforeCount (2 messages existed before)
+      "",              // _beforeContent (unused)
+      2000,            // _pollIntervalMs (unused)
+      undefined,       // onHIL
+    );
+
+    // Give the watcher a tick to set up, then write the marker
+    await Bun.sleep(80);
+    await writeMarker(sessionId);
+
+    const result = await idlePromise;
+
+    // Should return only the messages produced during this turn (indices 2 & 3)
+    expect(result).toHaveLength(2);
+    expect(result[0]?.uuid).toBe("u2");
+    expect(result[1]?.uuid).toBe("a2");
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. No session ID → returns empty immediately
+  // -------------------------------------------------------------------------
+
+  test("returns empty array immediately when claudeSessionId is undefined", async () => {
+    const result = await waitForIdle(
+      "pane-0",
+      undefined,  // no session id
+      0,
+      "",
+      2000,
+      undefined,
+    );
+    expect(result).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. HIL gating — two markers required
+  // -------------------------------------------------------------------------
+
+  test("calls onHIL(true) on first marker with unresolved HIL, then onHIL(false) and returns on second marker", async () => {
+    const toolUseId = randomUUID();
+
+    // First transcript read: has an unresolved AskUserQuestion tool
+    const messagesWithHIL: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: toolUseId,
+              name: "AskUserQuestion",
+              input: { question: "What is your name?" },
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    // Second transcript read: HIL resolved (user answered, assistant replied)
+    const messagesResolved: SessionMessage[] = [
+      ...messagesWithHIL,
+      {
+        type: "user",
+        uuid: "u2",
+        session_id: sessionId,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolUseId,
+              content: "Alice",
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: "assistant",
+        uuid: "a2",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello Alice!" }],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    sessionMessageQueue.push(messagesWithHIL);   // first marker read
+    sessionMessageQueue.push(messagesResolved);  // second marker read
+
+    const hilCalls: Array<boolean> = [];
+    const onHIL = (waiting: boolean): void => { hilCalls.push(waiting); };
+
+    await mkdir(markerDir(), { recursive: true });
+
+    const idlePromise = waitForIdle(
+      "pane-0",
+      sessionId,
+      0,            // transcriptBeforeCount — all messages are "new"
+      "",
+      2000,
+      onHIL,
+    );
+
+    // First marker — triggers HIL state
+    await Bun.sleep(80);
+    await writeMarker(sessionId);
+
+    // Wait for onHIL(true) to be called before writing the second marker
+    // Poll briefly (up to 1 s)
+    for (let i = 0; i < 100; i++) {
+      if (hilCalls.length >= 1) break;
+      await Bun.sleep(10);
+    }
+
+    expect(hilCalls).toEqual([true]);
+
+    // waitForIdle deletes the marker after the HIL event; write a second one
+    // to simulate the stop-hook firing after the user responds
+    await Bun.sleep(50);
+    await writeMarker(sessionId);
+
+    const result = await idlePromise;
+
+    // onHIL(false) should have been called to signal HIL resolution
+    expect(hilCalls).toEqual([true, false]);
+
+    // All 3 messages in resolved transcript are "new" (transcriptBeforeCount=0)
+    expect(result).toHaveLength(messagesResolved.length);
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Verify _hasUnresolvedHILTool is used correctly (unit test of helper)
+  // -------------------------------------------------------------------------
+
+  test("_hasUnresolvedHILTool returns false for an empty transcript", () => {
+    expect(_hasUnresolvedHILTool([])).toBe(false);
+  });
+
+  test("_hasUnresolvedHILTool returns true when AskUserQuestion has no matching tool_result", () => {
+    const msgs: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: "s1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tool-1", name: "AskUserQuestion", input: {} },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+    expect(_hasUnresolvedHILTool(msgs)).toBe(true);
+  });
+
+  test("_hasUnresolvedHILTool returns false when AskUserQuestion has a matching tool_result", () => {
+    const msgs: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: "s1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tool-1", name: "AskUserQuestion", input: {} },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: "user",
+        uuid: "u1",
+        session_id: "s1",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tool-1", content: "answer" },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+    expect(_hasUnresolvedHILTool(msgs)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Transcript slicing — transcriptBeforeCount applied correctly
+  // -------------------------------------------------------------------------
+
+  test("returns empty slice when transcript has no new messages beyond baseline", async () => {
+    // Transcript read returns exactly as many messages as before — no new ones
+    const messages: SessionMessage[] = [
+      {
+        type: "user",
+        uuid: "u1",
+        session_id: sessionId,
+        message: { role: "user", content: "hi" },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    sessionMessageQueue.push(messages);
+
+    await mkdir(markerDir(), { recursive: true });
+
+    const idlePromise = waitForIdle(
+      "pane-0",
+      sessionId,
+      1,    // same count as transcript length → nothing new
+      "",
+      2000,
+      undefined,
+    );
+
+    await Bun.sleep(80);
+    await writeMarker(sessionId);
+
+    const result = await idlePromise;
+
+    expect(result).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Cleanup — no unhandled rejection when watcher is aborted via return
+  // -------------------------------------------------------------------------
+
+  test("resolves cleanly without throwing when marker appears (abort path exercised)", async () => {
+    const messages: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "response" }],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    sessionMessageQueue.push(messages);
+
+    await mkdir(markerDir(), { recursive: true });
+
+    const idlePromise = waitForIdle(
+      "pane-0",
+      sessionId,
+      0,
+      "",
+      2000,
+      undefined,
+    );
+
+    await Bun.sleep(80);
+    await writeMarker(sessionId);
+
+    // Should not throw
+    await expect(idlePromise).resolves.toBeDefined();
+  });
+});

--- a/tests/sdk/runtime/claude.test.ts
+++ b/tests/sdk/runtime/claude.test.ts
@@ -155,29 +155,9 @@ describe("paneHasActiveTask", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Combined idle detection logic
+// Note: the old "idle detection (paneLooksReady && !paneHasActiveTask)" section
+// has been removed. Idle detection in waitForIdle now uses fs.watch on the
+// ~/.atomic/claude-stop/ marker directory (see tests/sdk/providers/claude-wait-for-idle.test.ts).
+// paneLooksReady and paneHasActiveTask are still used for delivery verification
+// in the claudeQuery retry loop, so their individual tests above are retained.
 // ---------------------------------------------------------------------------
-
-describe("idle detection (paneLooksReady && !paneHasActiveTask)", () => {
-  test("idle when prompt visible and no active task", () => {
-    const capture = "❯ ";
-    expect(paneLooksReady(capture) && !paneHasActiveTask(capture)).toBe(true);
-  });
-
-  test("not idle when prompt visible but agent is working", () => {
-    // Claude shows prompt character even while streaming with "esc to interrupt"
-    const capture = [
-      "Reading src/index.ts",
-      "  esc to interrupt",
-      "❯ ",
-    ].join("\n");
-    expect(paneLooksReady(capture)).toBe(true);
-    expect(paneHasActiveTask(capture)).toBe(true);
-    expect(paneLooksReady(capture) && !paneHasActiveTask(capture)).toBe(false);
-  });
-
-  test("not idle when no prompt visible", () => {
-    const capture = "Processing something without a prompt";
-    expect(paneLooksReady(capture) && !paneHasActiveTask(capture)).toBe(false);
-  });
-});


### PR DESCRIPTION
## Summary

Replaces the brittle tmux pane-scraping approach to idle detection with a reliable, event-driven system using Claude Code's `Stop` hook and `fs.watch`. Also fixes `ATOMIC_AGENT` not being visible to the agent CLI at session start.

## Key Changes

- **`src/sdk/providers/claude.ts`**: Rewrites `waitForIdle` to watch `~/.atomic/claude-stop/<session_id>` via `fs.watch` + `AbortController` instead of polling tmux pane output with regex. Adds `markerDir()`, `markerPath()`, and `clearStaleMarker()` helpers.
- **`.claude/settings.json`**: Registers the `Stop` hook so Claude Code invokes `atomic _claude-stop-hook` at the end of every turn.
- **`src/commands/cli/claude-stop-hook.ts`**: New hidden subcommand (`atomic _claude-stop-hook`) that validates the Stop hook payload, guards against infinite loops via `stop_hook_active`, and atomically writes the marker file (tmp → final rename).
- **`src/cli.ts`**: Registers `_claude-stop-hook` as a hidden command and excludes it from auto-sync.
- **`src/commands/cli/chat/index.ts`**: Passes `ATOMIC_AGENT` through `config.env_vars` so the agent CLI launched by `new-session` inherits the correct value (fixes race with `setSessionEnv`).
- **Tests**: Adds `tests/sdk/providers/claude-wait-for-idle.test.ts` (marker-flow: idle resolve, HIL gating, transcript slicing, cleanup) and removes now-obsolete pane-scraping tests from `tests/sdk/runtime/claude.test.ts`.