### PR TITLE
chore(release): bump version to v0.5.20-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.19",
+  "version": "0.5.20-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump package version from `0.5.19` to `0.5.20-0` in preparation for the next prerelease cycle.

## Changes

- `package.json`: version `0.5.19` → `0.5.20-0`

## Test plan

- [ ] CI passes
- [ ] Prerelease is published to npm on merge