### PR TITLE
chore(release): bump version to v0.5.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.20-0",
+  "version": "0.5.20",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.20-0` to the stable release `0.5.20` in `package.json`.

## Changes

- `package.json`: version `0.5.20-0` → `0.5.20`

## Test plan

- [ ] CI passes on the release branch
- [ ] After merge, verify the GitHub Release is created automatically
- [ ] After merge, verify the package is published to npm as `@bastani/atomic@0.5.20`