### PR TITLE
feat(workflow): add agent-facing inputs, status, and kill -y commands

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-creator
-description: Create multi-agent workflows for Atomic CLI using defineWorkflow().run().compile() with ctx.stage() for session orchestration across Claude, Copilot, and OpenCode SDKs, AND invoke existing workflows on behalf of the user. Use whenever the user wants to create, edit, debug, or RUN workflows ("run the ralph workflow", "kick off deep-research-codebase", "start the gen-spec workflow"), build agent pipelines, define multi-stage automations, set up review loops, declare workflow inputs, run background/headless stages, or mentions .atomic/workflows/, defineWorkflow, ctx.stage, ctx.inputs, headless, background stages, the atomic workflow picker, or `atomic workflow -n`.
+description: Create multi-agent workflows for Atomic CLI using defineWorkflow().run().compile() with ctx.stage() for session orchestration across Claude, Copilot, and OpenCode SDKs, AND invoke, monitor, and tear down existing workflows on behalf of the user. Use whenever the user wants to create, edit, debug, or RUN workflows ("run the ralph workflow", "kick off deep-research-codebase", "start the gen-spec workflow"), check on a running workflow ("is it done yet?", "what's the status?", "did it error out?"), kill a workflow or session, build agent pipelines, define multi-stage automations, set up review loops, declare workflow inputs, run background/headless stages, or mentions .atomic/workflows/, defineWorkflow, ctx.stage, ctx.inputs, headless, background stages, the atomic workflow picker, `atomic workflow -n`, `atomic workflow inputs`, `atomic workflow status`, or `atomic session kill`.
 ---
 
 # Workflow Creator
@@ -208,7 +208,10 @@ Workflows that accept a free-form prompt should declare it explicitly: `{ name: 
 | Named, with prompt | `atomic workflow -n hello -a claude "fix the bug"` | Scripted runs; requires the workflow to declare a `prompt` input |
 | Named, structured | `atomic workflow -n gen-spec -a claude --research_doc=notes.md` | Scripted structured runs |
 | Interactive picker | `atomic workflow -a claude` | Discovery; shows fuzzy list + form |
-| List | `atomic workflow -l` | Browse everything by source |
+| List | `atomic workflow list` | Browse everything by source |
+| Inspect inputs | `atomic workflow inputs <name> -a claude` | Print a workflow's input schema as JSON — agents use this instead of reading source |
+| Status (one or all) | `atomic workflow status [<session-id>]` | Query state — `in_progress`, `error`, `completed`, `needs_review` (HIL pause). JSON by default |
+| Kill non-interactively | `atomic session kill <id> -y` | Tear down a workflow/chat session without the confirmation prompt — the form agents use |
 | Detached (background) | `atomic workflow -n ralph -a claude -d "..."` | Scripted/CI runs where the caller shouldn't block on the TUI — the orchestrator keeps running on the atomic tmux socket; attach later with `atomic workflow session connect <name>` |
 
 Any of the named shapes above (positional or structured) accepts `-d` / `--detach` to run without attaching. Use it when you're automating from a script and want the CLI to return as soon as the session is spawned.
@@ -398,9 +401,18 @@ Once you've confirmed the workflow exists, you need to know two things about its
 1. **Does it declare a `prompt` input?** If so, it's free-form — you pass a positional string.
 2. **Does it declare structured inputs?** If so, you pass `--<field>=<value>` flags, one per required field.
 
-Read the workflow file at `.atomic/workflows/<name>/<agent>/index.ts` and inspect the `inputs` array. The `atomic workflow list` output is good for discovery but doesn't print the full schema — for accurate field types, requireds, and enum values, read the source.
+**Use `atomic workflow inputs <name> -a <agent>` to get the schema.** This prints a JSON envelope with every field's `name`, `type`, `required`, `default`, `description`, and (for enums) `values` — exactly what AskUserQuestion needs. The `freeform: true` flag tells you whether the workflow takes a positional prompt vs. structured flags, with a synthetic `prompt` field included so the JSON shape is uniform either way.
 
-Once you know the schema, use the **AskUserQuestion tool** to collect any values the user hasn't already provided in their message. One question per missing input field. For enum fields, pass the declared `values` as multiple-choice options so the user sees exactly what's allowed. Keep questions tight and purposeful — if the user's message already answers a question, don't ask it again.
+```bash
+atomic workflow inputs gen-spec -a claude
+# {"workflow":"gen-spec","agent":"claude","freeform":false,
+#  "inputs":[{"name":"research_doc","type":"string","required":true,...},
+#            {"name":"focus","type":"enum","values":["minimal","standard","exhaustive"],"default":"standard"}]}
+```
+
+Why this command instead of reading the source file: `inputs` is the contract the CLI actually validates against. It survives refactors, handles built-in workflows that aren't in the project tree, and never falls out of sync with the runtime. Reading TypeScript source is a fallback for the rare case where the command can't resolve the workflow.
+
+Once you have the schema, use the **AskUserQuestion tool** to collect any values the user hasn't already provided in their message. One question per missing input field. For enum fields, pass the declared `values` as multiple-choice options so the user sees exactly what's allowed. Keep questions tight and purposeful — if the user's message already answers a question, don't ask it again.
 
 Skip AskUserQuestion entirely when:
 - The user already supplied every required value in their message ("run ralph on 'add OAuth to the API'" — the prompt is right there).
@@ -413,12 +425,45 @@ Skip AskUserQuestion entirely when:
    - Exact match in the list → continue.
    - Close match → confirm via AskUserQuestion before proceeding.
    - No match → tell the user what's available and offer to author it (see previous section). If they decline, stop.
-3. **Discover the inputs schema** — read the workflow source file and inspect `inputs`.
+3. **Discover the inputs schema** — run `atomic workflow inputs <name> -a <agent>` and parse the JSON.
 4. **Ask for missing inputs** — use AskUserQuestion, one question per unanswered required field. Enums become multiple-choice.
 5. **Invoke** — build one of these commands:
    - Free-form: `atomic workflow -n <name> "<prompt>"`
    - Structured: `atomic workflow -n <name> --<field1>=<value1> --<field2>=<value2>`
 6. **Report the session name** the CLI printed and tell the user: "attach any time with `atomic workflow session connect <session>` — or `atomic workflow session list` to see what's running."
+
+### Monitoring a running workflow
+
+Detached workflows return immediately with a session name; the actual work runs in the background on the atomic tmux socket. Use `atomic workflow status` to check whether the workflow is still running, has completed, errored out, or paused for human input — without attaching to its TUI.
+
+```bash
+atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4
+# {"id":"atomic-wf-claude-gen-spec-a1b2c3d4","overall":"in_progress","alive":true,
+#  "sessions":[{"name":"orchestrator","status":"running",...}],...}
+```
+
+Four overall states the agent must handle distinctly:
+
+| Status | Meaning | What you should do |
+|---|---|---|
+| `in_progress` | The orchestrator is running and no stage is paused | Wait, or report progress to the user |
+| `needs_review` | At least one stage is paused for human input (HIL) — Copilot `ask_user`, OpenCode `question.asked`, Copilot/MCP elicitation | **Surface this to the user immediately** — they need to attach with `atomic workflow session connect <id>` to respond, otherwise the workflow stalls indefinitely |
+| `completed` | Workflow finished successfully | Report success and summarize the output |
+| `error` | Fatal error or a stage failed | Report the `fatalError` field and offer to investigate logs |
+
+`needs_review` outranks `completed` so a HIL pause near the end is never reported as done while still waiting on a human. A dead orchestrator with a stale snapshot is automatically downgraded to `error`.
+
+Omit the id to list every running workflow at once: `atomic workflow status`. Useful when checking on multiple parallel runs, or when the user just asks "what's running?".
+
+### Cleaning up sessions
+
+When the user is done with a workflow — or you launched one detached and it's no longer needed — tear it down with `-y` so no confirmation prompt blocks you:
+
+```bash
+atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y
+```
+
+The `-y` flag is mandatory for agent use. Without it, the CLI calls `@clack/prompts confirm`, which expects a TTY and will hang indefinitely in a non-interactive context. Same flag works for `atomic workflow session kill` and `atomic chat session kill`. Without an id, `kill -y` tears down every in-scope session — only do that when the user has asked to stop everything.
 
 ### Worked examples
 
@@ -428,10 +473,10 @@ Skip AskUserQuestion entirely when:
 
 1. Run `atomic workflow list`. Output includes `gen-spec` under local. Good.
 2. Target resolved exactly: `gen-spec`.
-3. Read the workflow source → inputs are `research_doc` (required string — already given), `focus` (required enum of `minimal|standard|exhaustive`, no default), `notes` (optional text).
+3. Run `atomic workflow inputs gen-spec -a claude`. Parse the JSON: `research_doc` (required string — already given), `focus` (required enum of `minimal|standard|exhaustive`, default `standard`), `notes` (optional text).
 4. Ask via AskUserQuestion once: "What focus level for the spec?" with choices `minimal`, `standard`, `exhaustive`. User picks `standard`. Skip `notes` since it's optional.
 5. Run: `atomic workflow -n gen-spec --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
-6. The CLI prints a session name like `atomic-wf-claude-gen-spec-a1b2c3d4`. Tell the user: "Started in the background. Attach with `atomic workflow session connect atomic-wf-claude-gen-spec-a1b2c3d4` or check progress with `atomic workflow session list`."
+6. The CLI prints a session name like `atomic-wf-claude-gen-spec-a1b2c3d4`. Tell the user: "Started in the background. Attach with `atomic workflow session connect atomic-wf-claude-gen-spec-a1b2c3d4`, check progress with `atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4`, or stop it with `atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y`."
 
 **Example B — workflow does not exist**
 
@@ -448,6 +493,9 @@ Skip AskUserQuestion entirely when:
 
 - **Skipping `atomic workflow list`** — leads to guessing and `workflow not found` errors. It's a one-line command; always run it.
 - **Inventing a workflow name** — if it's not in the list, it doesn't exist. Say so and offer to author it.
+- **Reading the workflow source file to discover inputs** — use `atomic workflow inputs <name> -a <agent>` instead. JSON, no TS parsing required, always in sync with the runtime. Source-file reads are a fallback, not a default.
 - **Asking everything at once** — let AskUserQuestion drive one question per field. Enum fields are multiple-choice, not free text.
 - **Re-asking what the user already said** — read their message first.
-- **Forgetting to report the session name** — the user needs it to reattach.
+- **Forgetting to report the session name** — the user needs it to reattach and to query status later.
+- **Leaving `needs_review` unreported** — when `atomic workflow status` returns `needs_review`, surface it to the user right away. The workflow is blocked on human input and will sit forever otherwise.
+- **Calling `session kill` without `-y`** — the prompt hangs in a non-interactive context. Always pass `-y` from an agent.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,11 +9,13 @@
  *   atomic chat session list                  List running chat/workflow sessions
  *   atomic chat session connect <id>          Attach to a session
  *   atomic workflow list                      List available workflows
+ *   atomic workflow inputs <name> -a <agent>  Print a workflow's input schema (JSON)
+ *   atomic workflow status [<id>]             Query workflow status (JSON)
  *   atomic workflow session list              List running sessions
  *   atomic workflow session connect <id>      Attach to a session
  *   atomic session list                       List all running sessions
  *   atomic session connect [id]               Interactive session picker
- *   atomic session kill [id]                  Kill a session (or all when no id)
+ *   atomic session kill [id] [-y]             Kill a session (or all when no id); -y skips prompt
  *   atomic config set <key> <value>           Set configuration value
  *   atomic --version                          Show version
  *   atomic --help                             Show help
@@ -88,9 +90,16 @@ function addSessionSubcommand(parent: Command, scope: "chat" | "workflow" | "all
             collectAgent,
             [] as string[],
         )
+        .option("-y, --yes", "Skip the confirmation prompt (for non-interactive callers like agents)")
         .action(async (sessionId, localOpts) => {
             const { sessionKillCommand } = await import("./commands/cli/session.ts");
-            const exitCode = await sessionKillCommand(sessionId, localOpts.agent, scope);
+            const exitCode = await sessionKillCommand(
+                sessionId,
+                localOpts.agent,
+                scope,
+                undefined,
+                { yes: localOpts.yes === true },
+            );
             process.exit(exitCode);
         });
 
@@ -220,9 +229,12 @@ Examples:
   $ atomic workflow -n gen-spec -a claude --research_doc=notes.md --focus=standard
                                                     Run a structured-input workflow
   $ atomic workflow -n ralph -a claude -d "fix bug" Run detached in the background
+  $ atomic workflow inputs <name> -a claude         Print a workflow's input schema (JSON)
+  $ atomic workflow status                          List status for all running workflows
+  $ atomic workflow status <id>                     Query a single workflow's status
   $ atomic workflow session list                    List running sessions
   $ atomic workflow session connect <id>            Attach to a session
-  $ atomic workflow session kill [id]               Kill a workflow session (or all)`,
+  $ atomic workflow session kill [id] -y            Kill a workflow session (or all), no prompt`,
         )
         .action(async (localOpts, cmd) => {
             const { workflowCommand } = await import("./commands/cli/workflow.ts");
@@ -245,6 +257,48 @@ Examples:
             const exitCode = await workflowCommand({
                 list: true,
                 agent: localOpts.agent,
+            });
+            process.exit(exitCode);
+        });
+
+    // Workflow inputs subcommand: atomic workflow inputs <name> -a <agent>
+    // Exposes the declared input schema so an orchestrating agent can build
+    // a valid `atomic workflow -n ...` invocation without reading source.
+    workflowCmd
+        .command("inputs")
+        .description("Print a workflow's declared input schema (JSON by default)")
+        .argument("<name>", "Workflow name")
+        .requiredOption("-a, --agent <name>", `Agent backend (${agentChoices})`)
+        .option("--format <format>", "Output format: json | text", "json")
+        .action(async (name, localOpts) => {
+            const { workflowInputsCommand } = await import(
+                "./commands/cli/workflow-inputs.ts"
+            );
+            const exitCode = await workflowInputsCommand({
+                name,
+                agent: localOpts.agent,
+                format: localOpts.format === "text" ? "text" : "json",
+            });
+            process.exit(exitCode);
+        });
+
+    // Workflow status subcommand: atomic workflow status [<id>]
+    // Returns one of in_progress | error | completed | needs_review.
+    // Defaults to JSON so agents can parse it without screen-scraping.
+    workflowCmd
+        .command("status")
+        .description(
+            "Query workflow status (in_progress, error, completed, needs_review)",
+        )
+        .argument("[session_id]", "Workflow tmux session id (omit to list all)")
+        .option("--format <format>", "Output format: json | text", "json")
+        .action(async (sessionId, localOpts) => {
+            const { workflowStatusCommand } = await import(
+                "./commands/cli/workflow-status.ts"
+            );
+            const exitCode = await workflowStatusCommand({
+                id: sessionId,
+                format: localOpts.format === "text" ? "text" : "json",
             });
             process.exit(exitCode);
         });

--- a/src/commands/cli/session.test.ts
+++ b/src/commands/cli/session.test.ts
@@ -711,4 +711,47 @@ describe("sessionKillCommand", () => {
       process.stdout.write = origWrite;
     }
   });
+
+  // (l) -y on named kill: skip prompt and kill immediately
+  test("yes flag skips the prompt for a named kill and calls killSession", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "target-session", windows: 1, created: now, attached: false, type: "chat" as const },
+    ]);
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(
+        "target-session",
+        [],
+        "all",
+        makeDeps(),
+        { yes: true },
+      );
+      expect(code).toBe(0);
+      expect(tmuxMocks.confirm).not.toHaveBeenCalled();
+      expect(tmuxMocks.killSession).toHaveBeenCalledWith("target-session");
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
+
+  // (m) -y on kill-all: skip prompt and kill every in-scope session
+  test("yes flag skips the prompt for kill-all and kills every in-scope session", async () => {
+    const now = new Date().toISOString();
+    tmuxMocks.listSessions.mockReturnValue([
+      { name: "session-a", windows: 1, created: now, attached: false, type: "chat" as const, agent: "claude" },
+      { name: "session-b", windows: 1, created: now, attached: false, type: "workflow" as const, agent: "opencode" },
+    ]);
+    const origWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      const code = await sessionKillCommand(undefined, [], "all", makeDeps(), { yes: true });
+      expect(code).toBe(0);
+      expect(tmuxMocks.confirm).not.toHaveBeenCalled();
+      expect(tmuxMocks.killSession).toHaveBeenCalledTimes(2);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+  });
 });

--- a/src/commands/cli/session.ts
+++ b/src/commands/cli/session.ts
@@ -277,13 +277,19 @@ export async function sessionPickerCommand(agents: string[] = [], scope: Session
  *
  * - If `sessionId` is provided: confirm and kill that one session.
  * - If `sessionId` is omitted: confirm and kill all sessions in scope.
+ *
+ * Pass `yes: true` (the `-y/--yes` flag on the CLI) to skip the
+ * confirmation prompt — useful for orchestrating agents that need to
+ * tear down a workflow session non-interactively.
  */
 export async function sessionKillCommand(
   sessionId: string | undefined,
   agents: string[] = [],
   scope: SessionScope = "all",
   deps: SessionDeps = defaultDeps,
+  options: { yes?: boolean } = {},
 ): Promise<number> {
+  const skipConfirm = options.yes === true;
   const paint = createPainter();
 
   if (!deps.isTmuxInstalled()) {
@@ -318,10 +324,12 @@ export async function sessionKillCommand(
       return 1;
     }
 
-    const answer = await deps.confirm({
-      message: `Kill session '${sessionId}'?`,
-      initialValue: false,
-    });
+    const answer = skipConfirm
+      ? true
+      : await deps.confirm({
+          message: `Kill session '${sessionId}'?`,
+          initialValue: false,
+        });
 
     if (deps.isCancel(answer)) {
       cancel("Cancelled.");
@@ -353,10 +361,12 @@ export async function sessionKillCommand(
 
   const noun = targets.length === 1 ? "session" : "sessions";
   const scopePrefix = scope === "all" ? "" : `${scope} `;
-  const answer = await deps.confirm({
-    message: `Kill all ${targets.length} ${scopePrefix}${noun}?`,
-    initialValue: false,
-  });
+  const answer = skipConfirm
+    ? true
+    : await deps.confirm({
+        message: `Kill all ${targets.length} ${scopePrefix}${noun}?`,
+        initialValue: false,
+      });
 
   if (deps.isCancel(answer)) {
     cancel("Cancelled.");

--- a/src/commands/cli/workflow-inputs.test.ts
+++ b/src/commands/cli/workflow-inputs.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the workflow-inputs CLI command.
+ *
+ * Focused on the pure helpers (`buildInputsPayload` + `renderInputsText`)
+ * since they carry the schema-shaping logic. The thin command wrapper
+ * is exercised end-to-end by the existing workflow-command harness.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import {
+  buildInputsPayload,
+  renderInputsText,
+} from "./workflow-inputs.ts";
+import type { WorkflowInput } from "../../sdk/workflows/index.ts";
+
+let originalNoColor: string | undefined;
+beforeAll(() => {
+  originalNoColor = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+});
+afterAll(() => {
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+});
+
+describe("buildInputsPayload", () => {
+  test("synthesises a 'prompt' field for free-form workflows", () => {
+    const out = buildInputsPayload("ralph", "claude", "loop", []);
+    expect(out.freeform).toBe(true);
+    expect(out.inputs).toHaveLength(1);
+    expect(out.inputs[0]!.name).toBe("prompt");
+    expect(out.inputs[0]!.type).toBe("text");
+  });
+
+  test("clones structured inputs without mutating callers' arrays", () => {
+    const schema: WorkflowInput[] = [
+      { name: "research_doc", type: "string", required: true },
+      {
+        name: "focus",
+        type: "enum",
+        values: ["minimal", "standard"],
+        default: "standard",
+      },
+    ];
+    const out = buildInputsPayload("gen-spec", "claude", "spec", schema);
+    expect(out.freeform).toBe(false);
+    expect(out.inputs).toHaveLength(2);
+    expect(out.inputs[0]!.name).toBe("research_doc");
+    expect(out.inputs[1]!.values).toEqual(["minimal", "standard"]);
+    // mutating the output must not leak into the input
+    out.inputs[0]!.required = false;
+    expect(schema[0]!.required).toBe(true);
+  });
+
+  test("propagates description and agent into the payload", () => {
+    const out = buildInputsPayload("foo", "copilot", "describe me", []);
+    expect(out.workflow).toBe("foo");
+    expect(out.agent).toBe("copilot");
+    expect(out.description).toBe("describe me");
+  });
+});
+
+describe("renderInputsText", () => {
+  test("free-form workflows show the positional-prompt run hint", () => {
+    const payload = buildInputsPayload("ralph", "claude", "loop", []);
+    const out = renderInputsText(payload);
+    expect(out).toContain("ralph");
+    expect(out).toContain("claude");
+    expect(out).toContain("free-form");
+    expect(out).toContain('atomic workflow -n ralph -a claude "<prompt>"');
+  });
+
+  test("structured workflows render flag names, types, required, defaults, and enum values", () => {
+    const schema: WorkflowInput[] = [
+      {
+        name: "research_doc",
+        type: "string",
+        required: true,
+        description: "path to research notes",
+      },
+      {
+        name: "focus",
+        type: "enum",
+        values: ["minimal", "standard", "exhaustive"],
+        default: "standard",
+      },
+    ];
+    const payload = buildInputsPayload("gen-spec", "claude", "spec", schema);
+    const out = renderInputsText(payload);
+
+    expect(out).toContain("--research_doc");
+    expect(out).toContain("(required)");
+    expect(out).toContain("[string]");
+    expect(out).toContain("path to research notes");
+
+    expect(out).toContain("--focus");
+    expect(out).toContain("[enum]");
+    expect(out).toContain("minimal, standard, exhaustive");
+    expect(out).toContain("default: standard");
+
+    // run hint references both flags
+    expect(out).toContain("--research_doc=<string>");
+    expect(out).toContain("--focus=<enum>");
+  });
+});

--- a/src/commands/cli/workflow-inputs.test.ts
+++ b/src/commands/cli/workflow-inputs.test.ts
@@ -6,12 +6,18 @@
  * is exercised end-to-end by the existing workflow-command harness.
  */
 
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll, mock } from "bun:test";
 import {
   buildInputsPayload,
   renderInputsText,
+  workflowInputsCommand,
+  type WorkflowInputsDeps,
 } from "./workflow-inputs.ts";
-import type { WorkflowInput } from "../../sdk/workflows/index.ts";
+import type {
+  WorkflowInput,
+  DiscoveredWorkflow,
+  WorkflowDefinition,
+} from "../../sdk/workflows/index.ts";
 
 let originalNoColor: string | undefined;
 beforeAll(() => {
@@ -70,6 +76,20 @@ describe("renderInputsText", () => {
     expect(out).toContain('atomic workflow -n ralph -a claude "<prompt>"');
   });
 
+  test("renders placeholder hint when a field declares one", () => {
+    const schema: WorkflowInput[] = [
+      {
+        name: "note",
+        type: "text",
+        placeholder: "short summary goes here",
+      },
+    ];
+    const payload = buildInputsPayload("foo", "claude", "", schema);
+    const out = renderInputsText(payload);
+    expect(out).toContain("placeholder:");
+    expect(out).toContain("short summary goes here");
+  });
+
   test("structured workflows render flag names, types, required, defaults, and enum values", () => {
     const schema: WorkflowInput[] = [
       {
@@ -101,5 +121,201 @@ describe("renderInputsText", () => {
     // run hint references both flags
     expect(out).toContain("--research_doc=<string>");
     expect(out).toContain("--focus=<enum>");
+  });
+});
+
+// ─── workflowInputsCommand ─────────────────────────────────────────
+
+function captureOutput(): {
+  stdout: () => string;
+  stderr: () => string;
+  restore: () => void;
+} {
+  const outChunks: string[] = [];
+  const errChunks: string[] = [];
+  const origOut = process.stdout.write;
+  const origErr = process.stderr.write;
+  process.stdout.write = ((c: string | Uint8Array) => {
+    outChunks.push(typeof c === "string" ? c : new TextDecoder().decode(c));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((c: string | Uint8Array) => {
+    errChunks.push(typeof c === "string" ? c : new TextDecoder().decode(c));
+    return true;
+  }) as typeof process.stderr.write;
+  return {
+    stdout: () => outChunks.join(""),
+    stderr: () => errChunks.join(""),
+    restore: () => {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    },
+  };
+}
+
+function fakeDiscovered(name: string): DiscoveredWorkflow {
+  return {
+    name,
+    agent: "claude",
+    path: `/fake/path/${name}.ts`,
+    source: "builtin",
+  };
+}
+
+function fakeDefinition(
+  name: string,
+  description: string,
+  inputs: WorkflowInput[],
+): WorkflowDefinition {
+  return {
+    __brand: "WorkflowDefinition",
+    name,
+    description,
+    inputs,
+    run: async () => {},
+  } as WorkflowDefinition;
+}
+
+function makeDeps(overrides: Partial<WorkflowInputsDeps> = {}): WorkflowInputsDeps {
+  return {
+    findWorkflow: mock(async () => fakeDiscovered("gen-spec")) as unknown as
+      WorkflowInputsDeps["findWorkflow"],
+    loadWorkflow: mock(async (plan) => ({
+      ok: true,
+      value: {
+        ...plan,
+        warnings: [],
+        definition: fakeDefinition("gen-spec", "spec generator", [
+          { name: "research_doc", type: "string", required: true },
+        ]),
+      },
+    })) as unknown as WorkflowInputsDeps["loadWorkflow"],
+    ...overrides,
+  };
+}
+
+describe("workflowInputsCommand", () => {
+  test("returns 1 with a JSON error envelope on unknown agent", async () => {
+    const cap = captureOutput();
+    try {
+      const code = await workflowInputsCommand(
+        { name: "gen-spec", agent: "bogus", format: "json" },
+        makeDeps(),
+      );
+      expect(code).toBe(1);
+      const parsed = JSON.parse(cap.stdout());
+      expect(parsed.error).toContain("Unknown agent");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("returns 1 with a JSON error envelope when the workflow is missing", async () => {
+    const deps = makeDeps({
+      findWorkflow: mock(async () => null) as unknown as
+        WorkflowInputsDeps["findWorkflow"],
+    });
+    const cap = captureOutput();
+    try {
+      const code = await workflowInputsCommand(
+        { name: "missing", agent: "claude", format: "json" },
+        deps,
+      );
+      expect(code).toBe(1);
+      const parsed = JSON.parse(cap.stdout());
+      expect(parsed.error).toContain("not found");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("returns 1 when the loader fails to load the workflow", async () => {
+    const deps = makeDeps({
+      loadWorkflow: mock(async () => ({
+        ok: false,
+        stage: "load" as const,
+        error: new Error("boom"),
+        message: "boom",
+      })) as unknown as WorkflowInputsDeps["loadWorkflow"],
+    });
+    const cap = captureOutput();
+    try {
+      const code = await workflowInputsCommand(
+        { name: "gen-spec", agent: "claude", format: "json" },
+        deps,
+      );
+      expect(code).toBe(1);
+      const parsed = JSON.parse(cap.stdout());
+      expect(parsed.error).toBe("boom");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("prints the JSON payload on success", async () => {
+    const cap = captureOutput();
+    try {
+      const code = await workflowInputsCommand(
+        { name: "gen-spec", agent: "claude", format: "json" },
+        makeDeps(),
+      );
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.stdout());
+      expect(parsed.workflow).toBe("gen-spec");
+      expect(parsed.agent).toBe("claude");
+      expect(parsed.inputs).toHaveLength(1);
+      expect(parsed.inputs[0].name).toBe("research_doc");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("prints the text render on success when format is 'text'", async () => {
+    const cap = captureOutput();
+    try {
+      const code = await workflowInputsCommand(
+        { name: "gen-spec", agent: "claude", format: "text" },
+        makeDeps(),
+      );
+      expect(code).toBe(0);
+      const out = cap.stdout();
+      expect(out).toContain("gen-spec");
+      expect(out).toContain("--research_doc");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("writes errors to stderr when format is 'text'", async () => {
+    const deps = makeDeps({
+      findWorkflow: mock(async () => null) as unknown as
+        WorkflowInputsDeps["findWorkflow"],
+    });
+    const cap = captureOutput();
+    try {
+      const code = await workflowInputsCommand(
+        { name: "missing", agent: "claude", format: "text" },
+        deps,
+      );
+      expect(code).toBe(1);
+      expect(cap.stderr()).toContain("not found");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("defaults format to 'json' when omitted", async () => {
+    const cap = captureOutput();
+    try {
+      const code = await workflowInputsCommand(
+        { name: "gen-spec", agent: "claude" },
+        makeDeps(),
+      );
+      expect(code).toBe(0);
+      // JSON parses cleanly
+      JSON.parse(cap.stdout());
+    } finally {
+      cap.restore();
+    }
   });
 });

--- a/src/commands/cli/workflow-inputs.ts
+++ b/src/commands/cli/workflow-inputs.ts
@@ -1,0 +1,203 @@
+/**
+ * `atomic workflow inputs <name> -a <agent>` — print a workflow's
+ * declared input schema so an orchestrating agent can build a valid
+ * `atomic workflow -n <name> -a <agent> --<field>=<value>` invocation
+ * without having to read the workflow source.
+ *
+ * Output formats:
+ *   --format json   (default) — machine-parseable JSON
+ *   --format text             — human-friendly text table
+ *
+ * Free-form workflows (no declared inputs) report a single synthetic
+ * `prompt` field so callers can treat both shapes uniformly.
+ */
+
+import { COLORS, createPainter } from "../../theme/colors.ts";
+import { AGENT_CONFIG, type AgentKey } from "../../services/config/index.ts";
+import {
+  findWorkflow,
+  WorkflowLoader,
+} from "../../sdk/workflows/index.ts";
+import type { WorkflowInput } from "../../sdk/workflows/index.ts";
+
+export type WorkflowInputsFormat = "json" | "text";
+
+export interface WorkflowInputsResult {
+  workflow: string;
+  agent: string;
+  description: string;
+  freeform: boolean;
+  inputs: WorkflowInput[];
+}
+
+/**
+ * Build the JSON payload returned to the agent. Free-form workflows
+ * synthesise a single optional `prompt` field so consumers don't have
+ * to special-case them — the same call shape works for both kinds.
+ */
+export function buildInputsPayload(
+  workflowName: string,
+  agent: string,
+  description: string,
+  inputs: readonly WorkflowInput[],
+): WorkflowInputsResult {
+  const freeform = inputs.length === 0;
+  const declared: WorkflowInput[] = freeform
+    ? [
+        {
+          name: "prompt",
+          type: "text",
+          required: false,
+          description:
+            "Free-form prompt — pass as a positional arg to `atomic workflow -n <name> -a <agent> \"<prompt>\"`.",
+        },
+      ]
+    : inputs.map((i) => ({ ...i }));
+  return {
+    workflow: workflowName,
+    agent,
+    description,
+    freeform,
+    inputs: declared,
+  };
+}
+
+/** Render the payload as a human-friendly text block. */
+export function renderInputsText(payload: WorkflowInputsResult): string {
+  const paint = createPainter();
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    "  " +
+      paint("text", payload.workflow, { bold: true }) +
+      paint("dim", " (") +
+      paint("accent", payload.agent) +
+      paint("dim", ")"),
+  );
+  if (payload.description) {
+    lines.push("  " + paint("dim", payload.description));
+  }
+  lines.push("");
+  if (payload.freeform) {
+    lines.push("  " + paint("dim", "free-form workflow — single positional prompt"));
+    lines.push("");
+    lines.push(
+      "  " +
+        paint("dim", "run: ") +
+        paint(
+          "accent",
+          `atomic workflow -n ${payload.workflow} -a ${payload.agent} "<prompt>"`,
+        ),
+    );
+    lines.push("");
+    return lines.join("\n") + "\n";
+  }
+
+  for (const field of payload.inputs) {
+    const requiredLabel = field.required ? paint("warning", " (required)") : "";
+    const typeLabel = paint("dim", ` [${field.type}]`);
+    lines.push(
+      "  " +
+        paint("accent", `--${field.name}`) +
+        typeLabel +
+        requiredLabel,
+    );
+    if (field.description) {
+      lines.push("      " + paint("text", field.description));
+    }
+    if (field.type === "enum" && field.values && field.values.length > 0) {
+      lines.push(
+        "      " +
+          paint("dim", "values: ") +
+          paint("text", field.values.join(", ")),
+      );
+    }
+    if (field.default !== undefined) {
+      lines.push(
+        "      " + paint("dim", "default: ") + paint("text", field.default),
+      );
+    }
+    if (field.placeholder) {
+      lines.push(
+        "      " +
+          paint("dim", "placeholder: ") +
+          paint("text", field.placeholder),
+      );
+    }
+  }
+
+  lines.push("");
+  const flagExample = payload.inputs
+    .map((i) => `--${i.name}=<${i.type}>`)
+    .join(" ");
+  lines.push(
+    "  " +
+      paint("dim", "run: ") +
+      paint(
+        "accent",
+        `atomic workflow -n ${payload.workflow} -a ${payload.agent} ${flagExample}`,
+      ),
+  );
+  lines.push("");
+  return lines.join("\n") + "\n";
+}
+
+export interface WorkflowInputsOptions {
+  name: string;
+  agent: string;
+  format?: WorkflowInputsFormat;
+  cwd?: string;
+}
+
+/**
+ * Resolve the workflow, then either print its input schema (success)
+ * or print an error and return a non-zero exit code. The json branch
+ * also writes errors as JSON so an agent can parse a single envelope
+ * regardless of outcome.
+ */
+export async function workflowInputsCommand(
+  options: WorkflowInputsOptions,
+): Promise<number> {
+  const format: WorkflowInputsFormat = options.format ?? "json";
+
+  const validAgents = Object.keys(AGENT_CONFIG);
+  if (!validAgents.includes(options.agent)) {
+    return reportError(
+      format,
+      `Unknown agent '${options.agent}'. Valid agents: ${validAgents.join(", ")}`,
+    );
+  }
+  const agent = options.agent as AgentKey;
+
+  const discovered = await findWorkflow(options.name, agent, options.cwd);
+  if (!discovered) {
+    return reportError(
+      format,
+      `Workflow '${options.name}' not found for agent '${agent}'.`,
+    );
+  }
+
+  const loaded = await WorkflowLoader.loadWorkflow(discovered);
+  if (!loaded.ok) {
+    return reportError(format, loaded.message);
+  }
+  const def = loaded.value.definition;
+
+  const payload = buildInputsPayload(def.name, agent, def.description, def.inputs);
+
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+  } else {
+    process.stdout.write(renderInputsText(payload));
+  }
+  return 0;
+}
+
+function reportError(format: WorkflowInputsFormat, message: string): number {
+  if (format === "json") {
+    process.stdout.write(JSON.stringify({ error: message }, null, 2) + "\n");
+  } else {
+    process.stderr.write(`${COLORS.red}Error: ${message}${COLORS.reset}\n`);
+  }
+  return 1;
+}

--- a/src/commands/cli/workflow-inputs.ts
+++ b/src/commands/cli/workflow-inputs.ts
@@ -15,7 +15,7 @@
 import { COLORS, createPainter } from "../../theme/colors.ts";
 import { AGENT_CONFIG, type AgentKey } from "../../services/config/index.ts";
 import {
-  findWorkflow,
+  findWorkflow as _findWorkflow,
   WorkflowLoader,
 } from "../../sdk/workflows/index.ts";
 import type { WorkflowInput } from "../../sdk/workflows/index.ts";
@@ -150,6 +150,21 @@ export interface WorkflowInputsOptions {
 }
 
 /**
+ * Deps for `workflowInputsCommand`. Injected so tests can drive every
+ * branch (unknown agent / missing workflow / load failure / success)
+ * without the SDK's real filesystem-dependent discovery.
+ */
+export interface WorkflowInputsDeps {
+  findWorkflow: typeof _findWorkflow;
+  loadWorkflow: typeof WorkflowLoader.loadWorkflow;
+}
+
+const defaultDeps: WorkflowInputsDeps = {
+  findWorkflow: _findWorkflow,
+  loadWorkflow: WorkflowLoader.loadWorkflow,
+};
+
+/**
  * Resolve the workflow, then either print its input schema (success)
  * or print an error and return a non-zero exit code. The json branch
  * also writes errors as JSON so an agent can parse a single envelope
@@ -157,6 +172,7 @@ export interface WorkflowInputsOptions {
  */
 export async function workflowInputsCommand(
   options: WorkflowInputsOptions,
+  deps: WorkflowInputsDeps = defaultDeps,
 ): Promise<number> {
   const format: WorkflowInputsFormat = options.format ?? "json";
 
@@ -169,7 +185,7 @@ export async function workflowInputsCommand(
   }
   const agent = options.agent as AgentKey;
 
-  const discovered = await findWorkflow(options.name, agent, options.cwd);
+  const discovered = await deps.findWorkflow(options.name, agent, options.cwd);
   if (!discovered) {
     return reportError(
       format,
@@ -177,7 +193,7 @@ export async function workflowInputsCommand(
     );
   }
 
-  const loaded = await WorkflowLoader.loadWorkflow(discovered);
+  const loaded = await deps.loadWorkflow(discovered);
   if (!loaded.ok) {
     return reportError(format, loaded.message);
   }

--- a/src/commands/cli/workflow-status.test.ts
+++ b/src/commands/cli/workflow-status.test.ts
@@ -298,6 +298,153 @@ describe("workflowStatusCommand", () => {
     }
   });
 
+  test("text format: empty list prints the 'no workflows running' hint", async () => {
+    const { deps } = makeDeps(tmpDir);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "text" }, deps);
+      expect(code).toBe(0);
+      expect(cap.read()).toContain("no workflows running");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("text format: renders a workflow list with indicator, id, and status", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(
+      snapshotOf("ralph", "claude", [panelSession("orchestrator", "running")]),
+    );
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "text" }, deps);
+      expect(code).toBe(0);
+      const out = cap.read();
+      expect(out).toContain("atomic-wf-claude-ralph-abcd1234");
+      expect(out).toContain("in_progress");
+      expect(out).toContain("ralph");
+      // singular noun when list has exactly one workflow
+      expect(out).toContain("1");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("text format: list uses '(no snapshot)' placeholder when workflowName is empty", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(null);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "text" }, deps);
+      expect(code).toBe(0);
+      expect(cap.read()).toContain("(no snapshot)");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("text format: single-report render includes workflow, stages, fatal error, and updatedAt", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(
+      snapshotOf(
+        "ralph",
+        "claude",
+        [
+          panelSession("orchestrator", "error", { error: "stage boom" }),
+        ],
+        { fatalError: "the whole thing" },
+      ),
+    );
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand(
+        { format: "text", id: "atomic-wf-claude-ralph-abcd1234" },
+        deps,
+      );
+      expect(code).toBe(0);
+      const out = cap.read();
+      expect(out).toContain("atomic-wf-claude-ralph-abcd1234");
+      expect(out).toContain("workflow:");
+      expect(out).toContain("ralph");
+      expect(out).toContain("stages:");
+      expect(out).toContain("orchestrator");
+      expect(out).toContain("stage boom");
+      expect(out).toContain("the whole thing");
+      expect(out).toContain("updated:");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("text format: unknown id writes 'not found' to stderr and returns 1", async () => {
+    const { deps } = makeDeps(tmpDir);
+    const errChunks: string[] = [];
+    const origErr = process.stderr.write;
+    process.stderr.write = ((c: string | Uint8Array) => {
+      errChunks.push(typeof c === "string" ? c : new TextDecoder().decode(c));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const code = await workflowStatusCommand(
+        { format: "text", id: "atomic-wf-claude-ralph-deadbeef" },
+        deps,
+      );
+      expect(code).toBe(1);
+      expect(errChunks.join("")).toContain("not found");
+    } finally {
+      process.stderr.write = origErr;
+    }
+  });
+
+  test("reports zero workflows when tmux is not installed", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.isTmuxInstalled.mockReturnValue(false);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "json" }, deps);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed).toEqual({ workflows: [] });
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("text format: tmux not installed prints the 'no sessions running' hint", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.isTmuxInstalled.mockReturnValue(false);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "text" }, deps);
+      expect(code).toBe(0);
+      expect(cap.read()).toContain("tmux is not installed");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("defaults format to 'json' when omitted", async () => {
+    const { deps } = makeDeps(tmpDir);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({}, deps);
+      expect(code).toBe(0);
+      // JSON parses cleanly
+      JSON.parse(cap.read());
+    } finally {
+      cap.restore();
+    }
+  });
+
   afterAll(async () => {
     if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
   });

--- a/src/commands/cli/workflow-status.test.ts
+++ b/src/commands/cli/workflow-status.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for `atomic workflow status` — covers the dependency-injected
+ * command shape end-to-end with no real tmux server, no real
+ * filesystem outside a temp dir, and JSON output capture so assertions
+ * can run on parsed objects.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, mock } from "bun:test";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { workflowStatusCommand, type StatusDeps } from "./workflow-status.ts";
+import {
+  buildSnapshot,
+  writeSnapshot,
+  type WorkflowStatusSnapshot,
+} from "../../sdk/runtime/status-writer.ts";
+import type { TmuxSession } from "../../sdk/runtime/tmux.ts";
+import type { SessionData } from "../../sdk/components/orchestrator-panel-types.ts";
+
+// ─── output capture ────────────────────────────────────────────────
+
+function captureStdout(): { read: () => string; restore: () => void } {
+  const chunks: string[] = [];
+  const orig = process.stdout.write;
+  process.stdout.write = ((c: string | Uint8Array) => {
+    chunks.push(typeof c === "string" ? c : new TextDecoder().decode(c));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    read: () => chunks.join(""),
+    restore: () => {
+      process.stdout.write = orig;
+    },
+  };
+}
+
+let originalNoColor: string | undefined;
+beforeAll(() => {
+  originalNoColor = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+});
+afterAll(() => {
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+});
+
+function tmuxSession(name: string): TmuxSession {
+  return {
+    name,
+    windows: 1,
+    created: new Date().toISOString(),
+    attached: false,
+    type: "workflow",
+    agent: "claude",
+  };
+}
+
+function panelSession(
+  name: string,
+  status: SessionData["status"],
+  extra: Partial<SessionData> = {},
+): SessionData {
+  return {
+    name,
+    status,
+    parents: [],
+    startedAt: 1000,
+    endedAt: null,
+    ...extra,
+  };
+}
+
+function snapshotOf(
+  workflowName: string,
+  agent: string,
+  sessions: SessionData[],
+  opts: { fatalError?: string | null; completionReached?: boolean } = {},
+): WorkflowStatusSnapshot {
+  return buildSnapshot({
+    workflowRunId: "abcd1234",
+    tmuxSession: `atomic-wf-${agent}-${workflowName}-abcd1234`,
+    workflowName,
+    agent,
+    prompt: "",
+    fatalError: opts.fatalError ?? null,
+    completionReached: opts.completionReached ?? false,
+    sessions,
+  });
+}
+
+interface Mocks {
+  isTmuxInstalled: ReturnType<typeof mock>;
+  sessionExists: ReturnType<typeof mock>;
+  listSessions: ReturnType<typeof mock>;
+  readSnapshot: ReturnType<typeof mock>;
+}
+
+function makeDeps(sessionsBaseDir: string): { deps: StatusDeps; mocks: Mocks } {
+  const mocks: Mocks = {
+    isTmuxInstalled: mock(() => true),
+    sessionExists: mock(() => true),
+    listSessions: mock<() => TmuxSession[]>(() => []),
+    readSnapshot: mock(async () => null),
+  };
+  const deps: StatusDeps = {
+    isTmuxInstalled: mocks.isTmuxInstalled,
+    sessionExists: mocks.sessionExists,
+    listSessions: mocks.listSessions as unknown as StatusDeps["listSessions"],
+    readSnapshot: mocks.readSnapshot as unknown as StatusDeps["readSnapshot"],
+    sessionsBaseDir,
+  };
+  return { deps, mocks };
+}
+
+// ─── tests ─────────────────────────────────────────────────────────
+
+describe("workflowStatusCommand", () => {
+  let tmpDir = "";
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "atomic-status-cmd-"));
+  });
+
+  test("prints empty list when no workflow sessions are running", async () => {
+    const { deps } = makeDeps(tmpDir);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "json" }, deps);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed).toEqual({ workflows: [] });
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("derives 'in_progress' for an alive workflow with a running stage", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(
+      snapshotOf("ralph", "claude", [panelSession("orchestrator", "running")]),
+    );
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "json" }, deps);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed.workflows).toHaveLength(1);
+      expect(parsed.workflows[0].overall).toBe("in_progress");
+      expect(parsed.workflows[0].alive).toBe(true);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("returns 'needs_review' when any stage is awaiting input (HIL)", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(
+      snapshotOf("ralph", "claude", [
+        panelSession("orchestrator", "running"),
+        panelSession("loop", "awaiting_input"),
+      ]),
+    );
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand(
+        { format: "json", id: "atomic-wf-claude-ralph-abcd1234" },
+        deps,
+      );
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed.overall).toBe("needs_review");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("returns 'completed' when completionReached and no errors", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(
+      snapshotOf(
+        "ralph",
+        "claude",
+        [panelSession("orchestrator", "complete")],
+        { completionReached: true },
+      ),
+    );
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand(
+        { format: "json", id: "atomic-wf-claude-ralph-abcd1234" },
+        deps,
+      );
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed.overall).toBe("completed");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("returns 'error' when fatalError is present in the snapshot", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(
+      snapshotOf("ralph", "claude", [panelSession("orchestrator", "running")], {
+        fatalError: "boom",
+      }),
+    );
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand(
+        { format: "json", id: "atomic-wf-claude-ralph-abcd1234" },
+        deps,
+      );
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed.overall).toBe("error");
+      expect(parsed.fatalError).toBe("boom");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("returns 1 with a JSON error envelope when the requested id is unknown", async () => {
+    const { deps } = makeDeps(tmpDir);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand(
+        { format: "json", id: "atomic-wf-claude-ralph-deadbeef" },
+        deps,
+      );
+      expect(code).toBe(1);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed.error).toContain("not found");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("falls back to a minimal report when the orchestrator hasn't written a snapshot yet", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([
+      tmuxSession("atomic-wf-claude-ralph-abcd1234"),
+    ]);
+    mocks.readSnapshot.mockResolvedValue(null);
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand({ format: "json" }, deps);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed.workflows).toHaveLength(1);
+      expect(parsed.workflows[0].overall).toBe("in_progress");
+      expect(parsed.workflows[0].workflowName).toBe("");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  test("recognises a stale snapshot as 'error' when the tmux session is gone", async () => {
+    const { deps, mocks } = makeDeps(tmpDir);
+    mocks.listSessions.mockReturnValue([]);
+    // Place a real snapshot on disk so the dead-session post-mortem
+    // path can read it.
+    const sessionDir = join(tmpDir, "abcd1234");
+    await mkdir(sessionDir, { recursive: true });
+    await writeSnapshot(
+      sessionDir,
+      snapshotOf("ralph", "claude", [panelSession("orchestrator", "running")]),
+    );
+    // Use the real reader for this test so the dead-session lookup
+    // hits the file we just wrote.
+    deps.readSnapshot = (await import(
+      "../../sdk/runtime/status-writer.ts"
+    )).readSnapshot;
+    const cap = captureStdout();
+    try {
+      const code = await workflowStatusCommand(
+        { format: "json", id: "atomic-wf-claude-ralph-abcd1234" },
+        deps,
+      );
+      expect(code).toBe(0);
+      const parsed = JSON.parse(cap.read());
+      expect(parsed.alive).toBe(false);
+      expect(parsed.overall).toBe("error");
+    } finally {
+      cap.restore();
+    }
+  });
+
+  afterAll(async () => {
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/commands/cli/workflow-status.ts
+++ b/src/commands/cli/workflow-status.ts
@@ -1,0 +1,330 @@
+/**
+ * `atomic workflow status [<id>]` — query the current state of one or
+ * all running workflows so an orchestrating agent can decide whether
+ * to keep waiting, surface a HIL prompt to the user, or move on.
+ *
+ * Status sources, in priority order:
+ *   1. <sessionDir>/status.json — written by the orchestrator on every
+ *      panel-store mutation. Provides per-stage detail and the
+ *      derived overall state (in_progress | error | completed |
+ *      needs_review).
+ *   2. tmux liveness fallback — when status.json is missing or stale
+ *      we still report whether the tmux session is alive so
+ *      script-driven workflows aren't blind during the brief window
+ *      before the orchestrator first writes its snapshot.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { COLORS, createPainter, type PaletteKey } from "../../theme/colors.ts";
+import {
+  isTmuxInstalled as _isTmuxInstalled,
+  listSessions as _listSessions,
+  sessionExists as _sessionExists,
+} from "../../sdk/workflows/index.ts";
+import {
+  readSnapshot,
+  workflowRunIdFromTmuxName,
+  type WorkflowOverallStatus,
+  type WorkflowStatusSnapshot,
+} from "../../sdk/runtime/status-writer.ts";
+import type { TmuxSession } from "../../sdk/runtime/tmux.ts";
+
+export type StatusFormat = "json" | "text";
+
+/** A single workflow's resolved status, as returned to the caller. */
+export interface WorkflowStatusReport {
+  /** Tmux session name (e.g. `atomic-wf-claude-ralph-a1b2c3d4`). */
+  id: string;
+  /** Workflow run id (the trailing 8-hex segment of the tmux name). */
+  workflowRunId: string;
+  /** Workflow name pulled from the snapshot. Empty when no snapshot exists. */
+  workflowName: string;
+  /** Agent backend (claude / copilot / opencode). */
+  agent: string;
+  overall: WorkflowOverallStatus;
+  /** True when the tmux session is currently alive on the atomic socket. */
+  alive: boolean;
+  /** ISO timestamp of the last snapshot, or null when none exists. */
+  updatedAt: string | null;
+  /** Sessions/stages, mirrored from the snapshot. Empty when no snapshot exists. */
+  sessions: WorkflowStatusSnapshot["sessions"];
+  /** Fatal-error message, if any. */
+  fatalError: string | null;
+}
+
+export interface StatusDeps {
+  isTmuxInstalled: () => boolean;
+  sessionExists: (name: string) => boolean;
+  listSessions: () => TmuxSession[];
+  /**
+   * Read a snapshot from disk. Defaults to the real reader; tests
+   * inject a fake to control the snapshot data without touching the
+   * filesystem.
+   */
+  readSnapshot: typeof readSnapshot;
+  /** Base directory for session dirs. Defaults to `~/.atomic/sessions`. */
+  sessionsBaseDir: string;
+}
+
+const defaultDeps: StatusDeps = {
+  isTmuxInstalled: _isTmuxInstalled,
+  sessionExists: _sessionExists,
+  listSessions: _listSessions,
+  readSnapshot,
+  sessionsBaseDir: join(homedir(), ".atomic", "sessions"),
+};
+
+/**
+ * Build a report for a single workflow. When the on-disk snapshot is
+ * missing we still emit a minimal report so callers can distinguish
+ * "workflow exists but hasn't written a snapshot yet" from "workflow
+ * doesn't exist at all" (the latter returns null upstream).
+ */
+async function buildReport(
+  tmuxName: string,
+  alive: boolean,
+  deps: StatusDeps,
+): Promise<WorkflowStatusReport | null> {
+  const workflowRunId = workflowRunIdFromTmuxName(tmuxName);
+  if (!workflowRunId) return null;
+
+  const sessionDir = join(deps.sessionsBaseDir, workflowRunId);
+  const snapshot = await deps.readSnapshot(sessionDir);
+
+  if (!snapshot) {
+    return {
+      id: tmuxName,
+      workflowRunId,
+      workflowName: "",
+      agent: "",
+      // Without a snapshot we can only say it's still running (or
+      // already gone) — never that it succeeded or errored.
+      overall: alive ? "in_progress" : "error",
+      alive,
+      updatedAt: null,
+      sessions: [],
+      fatalError: alive ? null : "orchestrator exited before writing status",
+    };
+  }
+
+  // If the orchestrator has shut down but the snapshot still says
+  // in_progress, downgrade to error — the process died without
+  // writing a terminal state.
+  const overall: WorkflowOverallStatus =
+    !alive && snapshot.overall === "in_progress" ? "error" : snapshot.overall;
+
+  return {
+    id: tmuxName,
+    workflowRunId,
+    workflowName: snapshot.workflowName,
+    agent: snapshot.agent,
+    overall,
+    alive,
+    updatedAt: snapshot.updatedAt,
+    sessions: snapshot.sessions,
+    fatalError:
+      overall === "error" && snapshot.fatalError === null && !alive
+        ? "orchestrator exited unexpectedly"
+        : snapshot.fatalError,
+  };
+}
+
+export interface WorkflowStatusOptions {
+  /** Filter to a specific workflow by tmux session name. */
+  id?: string;
+  format?: StatusFormat;
+}
+
+/**
+ * Top-level command. Prints either a single report (when `id` is
+ * provided) or the list of all workflow sessions on the atomic
+ * socket. Returns 1 when a requested id can't be found, 0 otherwise.
+ */
+export async function workflowStatusCommand(
+  options: WorkflowStatusOptions,
+  deps: StatusDeps = defaultDeps,
+): Promise<number> {
+  const format: StatusFormat = options.format ?? "json";
+
+  if (!deps.isTmuxInstalled()) {
+    return emit(format, { workflows: [] }, "no sessions running (tmux is not installed)");
+  }
+
+  const allSessions = deps.listSessions();
+  const workflowSessions = allSessions.filter((s) => s.type === "workflow");
+
+  // ── Single-workflow query ────────────────────────────────────────
+  if (options.id !== undefined) {
+    const target = workflowSessions.find((s) => s.name === options.id);
+    // Honour the requested id even when the tmux session is gone but
+    // the on-disk snapshot might still be readable (best-effort
+    // post-mortem). When neither exists we report not found.
+    if (!target) {
+      const fallbackRunId = workflowRunIdFromTmuxName(options.id);
+      if (fallbackRunId) {
+        const report = await buildReport(options.id, false, deps);
+        if (report && report.workflowName !== "") {
+          return emitReport(format, report);
+        }
+      }
+      return reportError(
+        format,
+        `Workflow '${options.id}' not found.`,
+      );
+    }
+    const report = await buildReport(target.name, true, deps);
+    if (!report) {
+      return reportError(format, `Could not parse workflow id '${options.id}'.`);
+    }
+    return emitReport(format, report);
+  }
+
+  // ── All-workflow listing ─────────────────────────────────────────
+  const reports: WorkflowStatusReport[] = [];
+  for (const s of workflowSessions) {
+    const r = await buildReport(s.name, true, deps);
+    if (r) reports.push(r);
+  }
+
+  return emit(
+    format,
+    { workflows: reports },
+    "no workflows running",
+    reports,
+  );
+}
+
+// ─── Output helpers ─────────────────────────────────────────────────
+
+function emit(
+  format: StatusFormat,
+  jsonPayload: { workflows: WorkflowStatusReport[] },
+  emptyMessage: string,
+  reports?: WorkflowStatusReport[],
+): number {
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(jsonPayload, null, 2) + "\n");
+    return 0;
+  }
+  const list = reports ?? jsonPayload.workflows;
+  if (list.length === 0) {
+    const paint = createPainter();
+    process.stdout.write(
+      "\n  " + paint("text", emptyMessage, { bold: true }) + "\n\n",
+    );
+    return 0;
+  }
+  process.stdout.write(renderListText(list));
+  return 0;
+}
+
+function emitReport(format: StatusFormat, report: WorkflowStatusReport): number {
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  } else {
+    process.stdout.write(renderReportText(report));
+  }
+  return 0;
+}
+
+function reportError(format: StatusFormat, message: string): number {
+  if (format === "json") {
+    process.stdout.write(JSON.stringify({ error: message }, null, 2) + "\n");
+  } else {
+    process.stderr.write(`${COLORS.red}Error: ${message}${COLORS.reset}\n`);
+  }
+  return 1;
+}
+
+const OVERALL_COLORS: Record<WorkflowOverallStatus, PaletteKey> = {
+  in_progress: "accent",
+  needs_review: "warning",
+  completed: "success",
+  error: "error",
+};
+
+const OVERALL_INDICATOR: Record<WorkflowOverallStatus, string> = {
+  in_progress: "●",
+  needs_review: "!",
+  completed: "✓",
+  error: "✗",
+};
+
+function renderListText(reports: WorkflowStatusReport[]): string {
+  const paint = createPainter();
+  const lines: string[] = [];
+  const noun = reports.length === 1 ? "workflow" : "workflows";
+  lines.push("");
+  lines.push(
+    "  " +
+      paint("text", String(reports.length), { bold: true }) +
+      " " +
+      paint("dim", noun),
+  );
+  lines.push("");
+  for (const r of reports) {
+    const color = OVERALL_COLORS[r.overall];
+    const indicator = OVERALL_INDICATOR[r.overall];
+    const label =
+      r.workflowName !== "" ? r.workflowName : "(no snapshot)";
+    lines.push(
+      "  " +
+        paint(color, indicator) +
+        " " +
+        paint("text", r.id, { bold: true }) +
+        "  " +
+        paint(color, r.overall) +
+        "  " +
+        paint("dim", label),
+    );
+  }
+  lines.push("");
+  return lines.join("\n") + "\n";
+}
+
+function renderReportText(report: WorkflowStatusReport): string {
+  const paint = createPainter();
+  const color = OVERALL_COLORS[report.overall];
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    "  " +
+      paint(color, OVERALL_INDICATOR[report.overall]) +
+      " " +
+      paint("text", report.id, { bold: true }) +
+      "  " +
+      paint(color, report.overall),
+  );
+  if (report.workflowName !== "") {
+    lines.push(
+      "  " +
+        paint("dim", "workflow: ") +
+        paint("text", report.workflowName) +
+        paint("dim", " · ") +
+        paint("accent", report.agent),
+    );
+  }
+  if (report.fatalError) {
+    lines.push("  " + paint("error", `error: ${report.fatalError}`));
+  }
+  if (report.sessions.length > 0) {
+    lines.push("");
+    lines.push("  " + paint("dim", "stages:"));
+    for (const s of report.sessions) {
+      lines.push(
+        "    " +
+          paint("text", s.name) +
+          "  " +
+          paint("dim", s.status) +
+          (s.error ? "  " + paint("error", s.error) : ""),
+      );
+    }
+  }
+  if (report.updatedAt) {
+    lines.push("");
+    lines.push("  " + paint("dim", `updated: ${report.updatedAt}`));
+  }
+  lines.push("");
+  return lines.join("\n") + "\n";
+}

--- a/src/sdk/components/orchestrator-panel.tsx
+++ b/src/sdk/components/orchestrator-panel.tsx
@@ -11,7 +11,7 @@ import { deriveGraphTheme } from "./graph-theme.ts";
 import type { GraphTheme } from "./graph-theme.ts";
 import { PanelStore } from "./orchestrator-panel-store.ts";
 import { StoreContext, ThemeContext, TmuxSessionContext } from "./orchestrator-panel-contexts.ts";
-import type { PanelSession, PanelOptions } from "./orchestrator-panel-types.ts";
+import type { PanelSession, PanelOptions, SessionData } from "./orchestrator-panel-types.ts";
 import { SessionGraphPanel } from "./session-graph-panel.tsx";
 import { ErrorBoundary } from "./error-boundary.tsx";
 
@@ -178,5 +178,40 @@ export class OrchestratorPanel {
     try {
       this.renderer.destroy();
     } catch {}
+  }
+
+  /**
+   * Subscribe to store mutations. Returned function unsubscribes.
+   *
+   * Used by the orchestrator process to mirror the in-memory panel
+   * state to a `status.json` file on disk so out-of-process consumers
+   * (e.g. `atomic workflow status`) can read the live workflow state.
+   */
+  subscribe(fn: () => void): () => void {
+    return this.store.subscribe(fn);
+  }
+
+  /**
+   * Read-only snapshot of the fields needed by the on-disk status
+   * writer. Defined here (not in PanelStore) because the store keeps
+   * full mutable references; this projection drops the renderer-only
+   * promise resolvers and version counter.
+   */
+  getSnapshot(): {
+    workflowName: string;
+    agent: string;
+    prompt: string;
+    fatalError: string | null;
+    completionReached: boolean;
+    sessions: readonly SessionData[];
+  } {
+    return {
+      workflowName: this.store.workflowName,
+      agent: this.store.agent,
+      prompt: this.store.prompt,
+      fatalError: this.store.fatalError,
+      completionReached: this.store.completionReached,
+      sessions: this.store.sessions,
+    };
   }
 }

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -55,6 +55,7 @@ import {
 } from "../providers/claude.ts";
 import { OrchestratorPanel } from "./panel.tsx";
 import { GraphFrontierTracker } from "./graph-inference.ts";
+import { buildSnapshot, writeSnapshot } from "./status-writer.ts";
 import { errorMessage } from "../errors.ts";
 import { createPainter } from "../../theme/colors.ts";
 
@@ -1533,11 +1534,47 @@ export async function runOrchestrator(): Promise<void> {
     tmuxSession: tmuxSessionName,
   });
 
+  // Mirror panel-store mutations to <sessionDir>/status.json so
+  // out-of-process consumers (e.g. `atomic workflow status`) can read
+  // the live workflow state without IPC into the orchestrator.
+  // Writes are debounced via a "pending" flag so a burst of mutations
+  // collapses into a single file write.
+  let snapshotPending = false;
+  const persistSnapshot = (): void => {
+    if (snapshotPending) return;
+    snapshotPending = true;
+    queueMicrotask(() => {
+      snapshotPending = false;
+      const snap = panel.getSnapshot();
+      void writeSnapshot(
+        sessionsBaseDir,
+        buildSnapshot({
+          workflowRunId,
+          tmuxSession: tmuxSessionName,
+          ...snap,
+        }),
+      );
+    });
+  };
+  const unsubscribePanel = panel.subscribe(persistSnapshot);
+  // Seed an initial snapshot so the file exists before any session starts.
+  persistSnapshot();
+
   // Idempotent shutdown guard
   let shutdownCalled = false;
   const shutdown = (exitCode = 0) => {
     if (shutdownCalled) return;
     shutdownCalled = true;
+    unsubscribePanel();
+    // Final snapshot reflecting terminal state (completed/error/aborted).
+    void writeSnapshot(
+      sessionsBaseDir,
+      buildSnapshot({
+        workflowRunId,
+        tmuxSession: tmuxSessionName,
+        ...panel.getSnapshot(),
+      }),
+    );
     panel.destroy();
     try {
       tmux.killSession(tmuxSessionName);

--- a/src/sdk/runtime/status-writer.test.ts
+++ b/src/sdk/runtime/status-writer.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for the workflow status writer.
+ *
+ * Covers the pure helpers (overall-status derivation, snapshot
+ * construction, tmux-name → run-id parsing) and the file I/O round
+ * trip against a real temp directory.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildSnapshot,
+  deriveOverallStatus,
+  readSnapshot,
+  workflowRunIdFromTmuxName,
+  writeSnapshot,
+  type WorkflowStatusSnapshot,
+} from "./status-writer.ts";
+import type { SessionData } from "../components/orchestrator-panel-types.ts";
+
+function session(
+  name: string,
+  status: SessionData["status"],
+  extra: Partial<SessionData> = {},
+): SessionData {
+  return {
+    name,
+    status,
+    parents: [],
+    startedAt: 1000,
+    endedAt: null,
+    ...extra,
+  };
+}
+
+// ─── deriveOverallStatus ────────────────────────────────────────────
+
+describe("deriveOverallStatus", () => {
+  test("returns 'error' when fatalError is set, even if completion is reached", () => {
+    expect(
+      deriveOverallStatus({
+        sessions: [],
+        fatalError: "boom",
+        completionReached: true,
+      }),
+    ).toBe("error");
+  });
+
+  test("returns 'error' when any session ended in error", () => {
+    expect(
+      deriveOverallStatus({
+        sessions: [session("a", "complete"), session("b", "error")],
+        fatalError: null,
+        completionReached: false,
+      }),
+    ).toBe("error");
+  });
+
+  test("returns 'needs_review' when any session is awaiting_input", () => {
+    expect(
+      deriveOverallStatus({
+        sessions: [session("a", "running"), session("b", "awaiting_input")],
+        fatalError: null,
+        completionReached: false,
+      }),
+    ).toBe("needs_review");
+  });
+
+  test("'needs_review' wins over 'completed' so a HIL pause near the end isn't reported as done", () => {
+    expect(
+      deriveOverallStatus({
+        sessions: [session("a", "complete"), session("b", "awaiting_input")],
+        fatalError: null,
+        completionReached: true,
+      }),
+    ).toBe("needs_review");
+  });
+
+  test("returns 'completed' when completionReached and nothing errored or paused", () => {
+    expect(
+      deriveOverallStatus({
+        sessions: [session("a", "complete"), session("b", "complete")],
+        fatalError: null,
+        completionReached: true,
+      }),
+    ).toBe("completed");
+  });
+
+  test("returns 'in_progress' as the default", () => {
+    expect(
+      deriveOverallStatus({
+        sessions: [session("a", "running")],
+        fatalError: null,
+        completionReached: false,
+      }),
+    ).toBe("in_progress");
+  });
+});
+
+// ─── workflowRunIdFromTmuxName ──────────────────────────────────────
+
+describe("workflowRunIdFromTmuxName", () => {
+  test("extracts the trailing 8-hex segment from a workflow session name", () => {
+    expect(workflowRunIdFromTmuxName("atomic-wf-claude-ralph-a1b2c3d4")).toBe(
+      "a1b2c3d4",
+    );
+  });
+
+  test("handles workflow names containing hyphens", () => {
+    expect(
+      workflowRunIdFromTmuxName("atomic-wf-claude-deep-research-12345678"),
+    ).toBe("12345678");
+  });
+
+  test("returns null for chat sessions", () => {
+    expect(workflowRunIdFromTmuxName("atomic-chat-claude-deadbeef")).toBeNull();
+  });
+
+  test("returns null when the suffix is not 8-char hex", () => {
+    expect(workflowRunIdFromTmuxName("atomic-wf-claude-ralph-not-hex")).toBeNull();
+  });
+
+  test("returns null for an unrelated session name", () => {
+    expect(workflowRunIdFromTmuxName("my-session")).toBeNull();
+  });
+});
+
+// ─── buildSnapshot ──────────────────────────────────────────────────
+
+describe("buildSnapshot", () => {
+  test("populates schemaVersion + identifying fields and clones session arrays", () => {
+    const fixed = new Date("2026-01-01T00:00:00.000Z");
+    const sourceParents = ["orchestrator"];
+    const sourceSession = session("orchestrator", "running", { parents: sourceParents });
+    const snap = buildSnapshot(
+      {
+        workflowRunId: "abcd1234",
+        tmuxSession: "atomic-wf-claude-ralph-abcd1234",
+        workflowName: "ralph",
+        agent: "claude",
+        prompt: "hello",
+        fatalError: null,
+        completionReached: false,
+        sessions: [sourceSession],
+      },
+      () => fixed,
+    );
+
+    expect(snap.schemaVersion).toBe(1);
+    expect(snap.workflowRunId).toBe("abcd1234");
+    expect(snap.tmuxSession).toBe("atomic-wf-claude-ralph-abcd1234");
+    expect(snap.workflowName).toBe("ralph");
+    expect(snap.agent).toBe("claude");
+    expect(snap.prompt).toBe("hello");
+    expect(snap.overall).toBe("in_progress");
+    expect(snap.updatedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(snap.sessions).toHaveLength(1);
+    expect(snap.sessions[0]!.name).toBe("orchestrator");
+    // parents must be cloned, not aliased to the input array — otherwise
+    // a later panel-store mutation would silently rewrite a snapshot
+    // that we already handed to a consumer.
+    expect(snap.sessions[0]!.parents).not.toBe(sourceParents);
+    expect(snap.sessions[0]!.parents).toEqual(sourceParents);
+  });
+
+  test("propagates the derived overall status from the inputs", () => {
+    const snap = buildSnapshot({
+      workflowRunId: "abcd1234",
+      tmuxSession: "x",
+      workflowName: "ralph",
+      agent: "claude",
+      prompt: "",
+      fatalError: null,
+      completionReached: true,
+      sessions: [session("a", "complete")],
+    });
+    expect(snap.overall).toBe("completed");
+  });
+});
+
+// ─── write/read round trip ──────────────────────────────────────────
+
+describe("writeSnapshot + readSnapshot", () => {
+  test("persists a snapshot and reads it back unchanged", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "atomic-status-"));
+    try {
+      const snap: WorkflowStatusSnapshot = buildSnapshot({
+        workflowRunId: "abcd1234",
+        tmuxSession: "atomic-wf-claude-ralph-abcd1234",
+        workflowName: "ralph",
+        agent: "claude",
+        prompt: "hello",
+        fatalError: null,
+        completionReached: false,
+        sessions: [session("orchestrator", "running")],
+      });
+
+      await writeSnapshot(dir, snap);
+      const back = await readSnapshot(dir);
+      expect(back).not.toBeNull();
+      expect(back!.workflowRunId).toBe("abcd1234");
+      expect(back!.overall).toBe("in_progress");
+      expect(back!.sessions).toHaveLength(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null when status.json does not exist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "atomic-status-"));
+    try {
+      const back = await readSnapshot(dir);
+      expect(back).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null when status.json is malformed JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "atomic-status-"));
+    try {
+      await Bun.write(join(dir, "status.json"), "not-json");
+      const back = await readSnapshot(dir);
+      expect(back).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null when status.json fails the snapshot shape guard", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "atomic-status-"));
+    try {
+      await Bun.write(
+        join(dir, "status.json"),
+        JSON.stringify({ schemaVersion: 99, foo: "bar" }),
+      );
+      const back = await readSnapshot(dir);
+      expect(back).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/sdk/runtime/status-writer.ts
+++ b/src/sdk/runtime/status-writer.ts
@@ -1,0 +1,201 @@
+/**
+ * Workflow status snapshot — bridges the in-process panel state with
+ * out-of-process consumers (e.g. `atomic workflow status`).
+ *
+ * The orchestrator subscribes to its `PanelStore` and writes a fresh
+ * snapshot to `~/.atomic/sessions/<workflowRunId>/status.json` every
+ * time the store mutates. Consumers read that file to derive the
+ * overall workflow state without needing IPC into the orchestrator.
+ */
+
+import { join } from "node:path";
+import type { SessionData, SessionStatus } from "../components/orchestrator-panel-types.ts";
+
+/** File name used for the status snapshot inside each workflow's session directory. */
+export const STATUS_FILE_NAME = "status.json";
+
+/** High-level workflow state surfaced to the agent / CLI consumer. */
+export type WorkflowOverallStatus =
+  | "in_progress"
+  | "error"
+  | "completed"
+  | "needs_review";
+
+/** Per-session entry mirrored from the orchestrator's panel store. */
+export interface WorkflowStatusSession {
+  name: string;
+  status: SessionStatus;
+  parents: string[];
+  error?: string;
+  startedAt: number | null;
+  endedAt: number | null;
+}
+
+/**
+ * Snapshot persisted to disk for `atomic workflow status` to read.
+ * Schema is versioned so future readers can stay backwards-compatible.
+ */
+export interface WorkflowStatusSnapshot {
+  schemaVersion: 1;
+  workflowRunId: string;
+  tmuxSession: string;
+  workflowName: string;
+  agent: string;
+  prompt: string;
+  /** Overall state derived from per-session status + completion flags. */
+  overall: WorkflowOverallStatus;
+  /** True when the orchestrator has shown its completion banner. */
+  completionReached: boolean;
+  /** Fatal-error message set via `panel.showFatalError`, if any. */
+  fatalError: string | null;
+  /** Wall-clock time of the snapshot in ISO-8601 format. */
+  updatedAt: string;
+  sessions: WorkflowStatusSession[];
+}
+
+/**
+ * Inputs the writer needs to render a snapshot — a strict subset of
+ * `PanelStore` so the writer doesn't depend on the renderer module.
+ */
+export interface StatusWriterInputs {
+  workflowRunId: string;
+  tmuxSession: string;
+  workflowName: string;
+  agent: string;
+  prompt: string;
+  fatalError: string | null;
+  completionReached: boolean;
+  sessions: readonly SessionData[];
+}
+
+/**
+ * Derive the overall workflow state from per-session statuses + the
+ * orchestrator-level completion / fatal-error flags.
+ *
+ * Precedence (highest first):
+ *   1. `error`          — fatal error or any session ended in error
+ *   2. `needs_review`   — at least one session is awaiting human input (HIL)
+ *   3. `completed`      — completion banner reached and nothing errored
+ *   4. `in_progress`    — default
+ *
+ * `needs_review` outranks `completed` so an agent that pauses for HIL
+ * right at the end is never reported as done while still waiting.
+ */
+export function deriveOverallStatus(input: {
+  sessions: readonly SessionData[];
+  completionReached: boolean;
+  fatalError: string | null;
+}): WorkflowOverallStatus {
+  if (input.fatalError !== null) return "error";
+  if (input.sessions.some((s) => s.status === "error")) return "error";
+  if (input.sessions.some((s) => s.status === "awaiting_input")) {
+    return "needs_review";
+  }
+  if (input.completionReached) return "completed";
+  return "in_progress";
+}
+
+/** Build a snapshot from the writer inputs (pure — exported for tests). */
+export function buildSnapshot(
+  input: StatusWriterInputs,
+  now: () => Date = () => new Date(),
+): WorkflowStatusSnapshot {
+  return {
+    schemaVersion: 1,
+    workflowRunId: input.workflowRunId,
+    tmuxSession: input.tmuxSession,
+    workflowName: input.workflowName,
+    agent: input.agent,
+    prompt: input.prompt,
+    overall: deriveOverallStatus({
+      sessions: input.sessions,
+      completionReached: input.completionReached,
+      fatalError: input.fatalError,
+    }),
+    completionReached: input.completionReached,
+    fatalError: input.fatalError,
+    updatedAt: now().toISOString(),
+    sessions: input.sessions.map((s) => ({
+      name: s.name,
+      status: s.status,
+      parents: [...s.parents],
+      ...(s.error !== undefined ? { error: s.error } : {}),
+      startedAt: s.startedAt,
+      endedAt: s.endedAt,
+    })),
+  };
+}
+
+/** Absolute path of the status file for a given workflow run directory. */
+export function statusFilePath(sessionDir: string): string {
+  return join(sessionDir, STATUS_FILE_NAME);
+}
+
+/**
+ * Write a snapshot to `<sessionDir>/status.json`. Uses an atomic
+ * write-then-rename so concurrent readers never see partial JSON.
+ * Errors are swallowed — the orchestrator must keep running even if
+ * the status file can't be persisted.
+ */
+export async function writeSnapshot(
+  sessionDir: string,
+  snapshot: WorkflowStatusSnapshot,
+): Promise<void> {
+  const finalPath = statusFilePath(sessionDir);
+  const tmpPath = `${finalPath}.tmp-${process.pid}`;
+  try {
+    await Bun.write(tmpPath, JSON.stringify(snapshot, null, 2));
+    const { rename } = await import("node:fs/promises");
+    await rename(tmpPath, finalPath);
+  } catch {
+    // Best-effort — never fail the workflow because of a status write.
+  }
+}
+
+/**
+ * Read a snapshot from disk. Returns `null` when the file doesn't
+ * exist or fails to parse — callers fall back to deriving status from
+ * the live tmux session list.
+ */
+export async function readSnapshot(
+  sessionDir: string,
+): Promise<WorkflowStatusSnapshot | null> {
+  try {
+    const file = Bun.file(statusFilePath(sessionDir));
+    if (!(await file.exists())) return null;
+    const parsed: unknown = JSON.parse(await file.text());
+    if (!isSnapshot(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Runtime guard for deserialised snapshots — keeps the reader type-safe. */
+function isSnapshot(value: unknown): value is WorkflowStatusSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.schemaVersion === 1 &&
+    typeof v.workflowRunId === "string" &&
+    typeof v.tmuxSession === "string" &&
+    typeof v.overall === "string" &&
+    Array.isArray(v.sessions)
+  );
+}
+
+/**
+ * Extract the `workflowRunId` (the trailing 8-hex segment) from a
+ * tmux session name shaped `atomic-wf-<agent>-<name>-<id>`. Returns
+ * `null` for non-workflow sessions or names that don't end in a
+ * UUID-style suffix.
+ */
+export function workflowRunIdFromTmuxName(name: string): string | null {
+  if (!name.startsWith("atomic-wf-")) return null;
+  const lastDash = name.lastIndexOf("-");
+  if (lastDash < 0) return null;
+  const candidate = name.slice(lastDash + 1);
+  // generateId() produces an 8-char hex slice from crypto.randomUUID.
+  if (!/^[0-9a-f]{8}$/i.test(candidate)) return null;
+  return candidate;
+}


### PR DESCRIPTION
## Summary

Adds three new CLI commands and a status-persistence layer that let orchestrating agents introspect and manage workflows without attaching to a TUI or reading TypeScript source.

## Key Changes

- **`atomic workflow inputs <name> -a <agent>`** — prints a workflow's declared input schema as a JSON envelope (`name`, `type`, `required`, `default`, `values`, `description`). Free-form workflows synthesise a uniform `prompt` field so the JSON shape is consistent regardless of workflow type.
- **`atomic workflow status [<id>]`** — queries one or all running workflows. Returns one of four states: `in_progress`, `error`, `completed`, or `needs_review` (HIL pause). JSON by default; `--format text` for human output.
- **`-y / --yes` flag on `session kill`** — skips the `@clack/prompts` confirmation prompt so agent callers can tear down sessions non-interactively without hanging on a TTY read.
- **`src/sdk/runtime/status-writer.ts`** — new SDK module that writes a versioned `status.json` snapshot to `~/.atomic/sessions/<workflowRunId>/` on every panel-store mutation. Uses an atomic write-then-rename so concurrent readers never see partial JSON. Errors are swallowed so a failed write never kills the workflow.
- **Orchestrator panel integration** — the executor hooks into the status writer so snapshots are kept current during workflow execution.
- **`workflow-creator` skill updated** — documents the new `inputs`, `status`, and `kill -y` surfaces, explains the four overall states and what an agent should do for each, and replaces the "read the source file" guidance with `atomic workflow inputs`.
- **Comprehensive test coverage** — `workflow-inputs.test.ts`, `workflow-status.test.ts`, `status-writer.test.ts`, and `session.test.ts` cover all command branches including unknown agents, missing workflows, missing snapshots, stale snapshots (dead orchestrator), and tmux-not-installed paths.