### PR TITLE
chore(release): bump version to v0.5.21-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.20",
+  "version": "0.5.21-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.20` to `0.5.21-0` as a prerelease increment in preparation for the next release.

## Changes

- `package.json`: version `0.5.20` → `0.5.21-0`

## Test plan

- [ ] CI passes
- [ ] GitHub Release is automatically created once merged