### PR TITLE
feat(workflow): gate workflows on minSDKVersion and surface broken entries

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -218,6 +218,28 @@ Any of the named shapes above (positional or structured) accepts `-d` / `--detac
 
 **Builtin workflows are reserved** — local/global workflows cannot shadow them. Pick distinct names.
 
+### Declaring SDK compatibility (`minSDKVersion`)
+
+Opt-in version gate for workflows that depend on a specific SDK release. **Default is unset — do not add it to new workflows unless you have a concrete reason.**
+
+```ts
+defineWorkflow({
+  name: "uses-new-api",
+  minSDKVersion: "0.6.0", // refuse to load on older CLI
+})
+```
+
+| Behaviour | Unset (default) | Set to a version newer than the installed CLI |
+|---|---|---|
+| Loader | Always loads | Refuses to load, returns `IncompatibleSDKError` |
+| `atomic workflow -l` | Normal row | `⚠ needs v<X> (installed v<Y>)` — dim name, visible |
+| Picker | Normal row | `⚠ update required` glyph + preview explains the gap; Enter is disabled |
+| `atomic workflow -n <name>` | Runs | Errors with an upgrade hint, non-zero exit |
+
+When to set it: the workflow calls into a newly-added SDK surface (new `stage()` option, new helper export, new provider method) that older installs don't ship. Omit it for workflows that use only stable APIs — most workflows qualify.
+
+The point of the field is to convert a silent "workflow vanished after upgrade" failure into a visible, actionable row the user can fix. See `references/discovery-and-verification.md` for semver semantics and the visible-diagnostic contract.
+
 ### Structural Rules
 
 Hard constraints enforced by the builder, loader, and runtime:

--- a/.agents/skills/workflow-creator/references/discovery-and-verification.md
+++ b/.agents/skills/workflow-creator/references/discovery-and-verification.md
@@ -108,6 +108,81 @@ At load time, the runtime verifies:
 - The export has `__brand === "WorkflowDefinition"`
 - The definition has a `name` and a `run` callback
 
+## SDK version compatibility
+
+Workflows may opt in to a minimum Atomic CLI version by declaring
+`minSDKVersion` on `defineWorkflow()`. The field is **optional and
+unset by default** — workflows that don't declare it are treated as
+compatible with every CLI release.
+
+```ts
+export default defineWorkflow({
+    name: "uses-new-stage-option",
+    description: "...",
+    minSDKVersion: "0.6.0",
+  })
+  .for<"claude">()
+  .run(async (ctx) => { /* ... */ })
+  .compile();
+```
+
+### When to set it
+
+Set `minSDKVersion` when the workflow uses an SDK surface that older
+CLIs don't ship — for example a new `ctx.stage()` option, a newly
+exported helper, or a new provider method. The version you declare is
+the **earliest release you tested against**, not a future wish list.
+
+Skip it when the workflow only touches stable APIs. Most workflows
+qualify. A needlessly high `minSDKVersion` is worse than no gate —
+it'll lock users out for no reason.
+
+### Accepted format
+
+`MAJOR.MINOR.PATCH` with an optional numeric prerelease, matching the
+shape of Atomic's own releases:
+
+| Example | Parses | Notes |
+|---|---|---|
+| `"0.6.0"` | ✅ | Standard release |
+| `"1.2.3"` | ✅ | Standard release |
+| `"0.6.0-0"` | ✅ | Prerelease; ranks below the equivalent stable release (semver-compliant) |
+| `"0.6"` | ❌ | Missing patch; treated as unparseable and ignored |
+| `"latest"` | ❌ | Unparseable; ignored |
+
+Unparseable strings are silently accepted (the workflow loads as if
+`minSDKVersion` were unset) so a typo never blocks a workflow —
+the visible load error path is friendlier than a hard refusal with no
+context.
+
+### What happens when the gate trips
+
+A workflow whose `minSDKVersion` exceeds the installed CLI is kept in
+discovery but marked **incompatible** — it never silently vanishes:
+
+| Surface | Behaviour |
+|---|---|
+| `WorkflowLoader.loadWorkflow()` | Returns `{ ok: false, stage: "load", error: IncompatibleSDKError }` carrying `requiredVersion` + `currentVersion` |
+| `loadWorkflowsMetadata()` | Yields an entry with `status: { kind: "incompatible", requiredVersion, currentVersion, message }` |
+| `atomic workflow -l` | Row is dimmed, with an inline `⚠ needs v<X> (installed v<Y>)` badge after the name |
+| `atomic workflow -a <agent>` picker | Row shows a `⚠` gutter glyph; preview pane explains the version gap and remediation; Enter does not advance to the prompt phase; bottom hint dims `↵ select` to `↵ unavailable` |
+| `atomic workflow -n <name> -a <agent>` | Exits non-zero, prints the `IncompatibleSDKError` message (`requires Atomic SDK v<X>, but v<Y> is installed. Update Atomic, or re-save the workflow against the current SDK.`) |
+
+Load failures that aren't version-related (syntax error, missing
+`.compile()`, invalid default export) follow the same visible-entry
+contract but surface as `status: { kind: "error", stage, message }`
+with a `✗ broken` badge.
+
+### Why this exists
+
+The previous default was to silently drop any workflow that failed to
+load. That turned the "I bumped `@bastani/atomic` and a user/global
+workflow quietly stopped showing up" scenario into a ghost bug — the
+user had no breadcrumb to follow. The `minSDKVersion` field lets
+workflow authors opt in to a clear upgrade path, and the visible
+diagnostic rows make the failure discoverable even for workflows that
+never declared the field.
+
 ## TypeScript configuration
 
 Standard module resolution handles all imports. The project's `tsconfig.json` should use `"moduleResolution": "bundler"` (Bun's default).

--- a/src/commands/cli/workflow-command.test.ts
+++ b/src/commands/cli/workflow-command.test.ts
@@ -300,7 +300,11 @@ describe("workflowCommand --list", () => {
     expect(cap.stdout).not.toContain("copilot-only");
   });
 
-  test("excludes workflows missing .compile() from the list", async () => {
+  test("shows workflows missing .compile() with a broken marker", async () => {
+    // Broken workflows used to vanish from the list silently. Surfacing
+    // them with a visible "✗ broken" badge is the remediation for the
+    // "my workflow disappeared after upgrading" class of bug reports —
+    // the user can now see the file still exists and needs a fix.
     await writeCompiledWorkflow({ name: "good", agent: "copilot" });
     await writeCompiledWorkflow({
       name: "not-compiled",
@@ -324,10 +328,11 @@ export default defineWorkflow({ name: "not-compiled" })
 
     expect(code).toBe(0);
     expect(cap.stdout).toContain("good");
-    expect(cap.stdout).not.toContain("not-compiled");
+    expect(cap.stdout).toContain("not-compiled");
+    expect(cap.stdout).toContain("✗ broken");
   });
 
-  test("excludes workflows with type errors from the list", async () => {
+  test("shows workflows with type errors with a broken marker", async () => {
     await writeCompiledWorkflow({ name: "valid", agent: "copilot" });
     await writeCompiledWorkflow({
       name: "broken-syntax",
@@ -345,7 +350,8 @@ export default defineWorkflow({ name: "not-compiled" })
 
     expect(code).toBe(0);
     expect(cap.stdout).toContain("valid");
-    expect(cap.stdout).not.toContain("broken-syntax");
+    expect(cap.stdout).toContain("broken-syntax");
+    expect(cap.stdout).toContain("✗ broken");
   });
 
   test("renders the empty state when no workflows exist and no agent filter is set", async () => {

--- a/src/commands/cli/workflow-inputs.test.ts
+++ b/src/commands/cli/workflow-inputs.test.ts
@@ -172,6 +172,7 @@ function fakeDefinition(
     name,
     description,
     inputs,
+    minSDKVersion: null,
     run: async () => {},
   } as WorkflowDefinition;
 }

--- a/src/commands/cli/workflow.test.ts
+++ b/src/commands/cli/workflow.test.ts
@@ -6,7 +6,10 @@ import {
   renderWorkflowList,
 } from "./workflow.ts";
 import type { WorkflowInput } from "../../sdk/workflows/index.ts";
-import type { DiscoveredWorkflow } from "../../sdk/workflows/index.ts";
+import type {
+  DiscoveredWorkflow,
+  WorkflowWithMetadata,
+} from "../../sdk/workflows/index.ts";
 
 // ─── Colour handling ────────────────────────────────────────────────────────
 // The renderer emits ANSI sequences when the host terminal claims truecolor
@@ -190,12 +193,16 @@ function wf(
   name: string,
   agent: DiscoveredWorkflow["agent"],
   source: DiscoveredWorkflow["source"],
-): DiscoveredWorkflow {
+  status: WorkflowWithMetadata["status"] = { kind: "ok" },
+): WorkflowWithMetadata {
   return {
     name,
     agent,
     source,
     path: `/tmp/fake/${source}/${name}/${agent}/index.ts`,
+    description: "",
+    inputs: [],
+    status,
   };
 }
 
@@ -216,7 +223,7 @@ describe("renderWorkflowList", () => {
   });
 
   test("groups entries by source → provider and sorts names", () => {
-    const workflows: DiscoveredWorkflow[] = [
+    const workflows: WorkflowWithMetadata[] = [
       wf("zebra", "claude", "local"),
       wf("apple", "claude", "local"),
       wf("middle", "opencode", "local"),

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -27,6 +27,7 @@ import type {
   AgentType,
   DiscoveredWorkflow,
   WorkflowInput,
+  WorkflowMetadataStatus,
   WorkflowWithMetadata,
 } from "../../sdk/workflows/index.ts";
 import { WorkflowPickerPanel } from "../../sdk/components/workflow-picker-panel.tsx";
@@ -227,8 +228,11 @@ export async function workflowCommand(options: {
       options.agent as AgentType | undefined,
       { merge: false },
     );
-    // Filter out workflows that fail to load (type errors, missing
-    // .compile(), etc.) so the list only shows workflows ready to run.
+    // Keep workflows that failed to load in the list — their status is
+    // surfaced inline as a "needs update" or "broken" tag so the user
+    // can see that a workflow still exists on disk even after an SDK
+    // bump invalidated it. Silent filtering was the original cause of
+    // the "workflow vanished after upgrade" report.
     const workflows = await loadWorkflowsMetadata(discovered);
     process.stdout.write(renderWorkflowList(workflows));
     return 0;
@@ -477,9 +481,13 @@ async function runNamedMode(
       `  ~/.atomic/workflows/${name}/${agent}/index.ts ${COLORS.dim}(global)${COLORS.reset}`,
     );
 
-    const available = await loadWorkflowsMetadata(
-      await discoverWorkflows(cwd, agent),
-    );
+    // Only suggest runnable alternatives — broken/incompatible workflows
+    // are visible via `atomic workflow -l` where their status is surfaced;
+    // listing them here would mask the real problem (the name the user
+    // typed does not exist) behind a dead-end suggestion.
+    const available = (
+      await loadWorkflowsMetadata(await discoverWorkflows(cwd, agent))
+    ).filter((w) => w.status.kind === "ok");
     if (available.length > 0) {
       console.error(`\nAvailable ${agent} workflows:`);
       for (const wf of available) {
@@ -609,6 +617,29 @@ const SOURCE_COLORS: Record<DiscoveredWorkflow["source"], PaletteKey> = {
 };
 
 /**
+ * Per-row status badge shown in `atomic workflow -l` output. `ok` rows
+ * render with no badge (the list is already dense; flagging only
+ * non-ok rows keeps the happy path untouched). Incompatible rows
+ * include the required version so the user can compare at a glance;
+ * error rows stay terse and defer detail to `atomic workflow -n
+ * <name>` which surfaces the structured loader message.
+ */
+function renderStatusBadge(
+  paint: ReturnType<typeof createPainter>,
+  status: WorkflowMetadataStatus,
+): string {
+  if (status.kind === "ok") return "";
+  if (status.kind === "incompatible") {
+    return (
+      "  " +
+      paint("warning", "⚠ needs v" + status.requiredVersion) +
+      paint("dim", `  (installed v${status.currentVersion})`)
+    );
+  }
+  return "  " + paint("error", "✗ broken");
+}
+
+/**
  * Render `atomic workflow --list` output as a printable string.
  *
  * Three-level hierarchy: source → provider → workflow name.
@@ -635,7 +666,7 @@ const SOURCE_COLORS: Record<DiscoveredWorkflow["source"], PaletteKey> = {
  * Exported for testing — the pure-function shape makes coverage for the
  * renderer trivial without spinning up a full CLI invocation.
  */
-export function renderWorkflowList(workflows: DiscoveredWorkflow[]): string {
+export function renderWorkflowList(workflows: WorkflowWithMetadata[]): string {
   const paint = createPainter();
   const lines: string[] = [];
 
@@ -653,9 +684,11 @@ export function renderWorkflowList(workflows: DiscoveredWorkflow[]): string {
     return lines.join("\n") + "\n";
   }
 
-  // Group by source → agent → sorted names. This gives the renderer O(1)
-  // lookups at both nesting levels and keeps the output deterministic.
-  type ByAgent = Map<AgentType, string[]>;
+  // Group by source → agent → sorted entries. Entries carry the full
+  // metadata (name + status) so the row renderer can append a status
+  // badge to non-ok rows without another lookup.
+  type EntrySummary = { name: string; status: WorkflowMetadataStatus };
+  type ByAgent = Map<AgentType, EntrySummary[]>;
   const bySource = new Map<DiscoveredWorkflow["source"], ByAgent>();
   for (const wf of workflows) {
     let byAgent = bySource.get(wf.source);
@@ -663,13 +696,13 @@ export function renderWorkflowList(workflows: DiscoveredWorkflow[]): string {
       byAgent = new Map();
       bySource.set(wf.source, byAgent);
     }
-    const names = byAgent.get(wf.agent) ?? [];
-    names.push(wf.name);
-    byAgent.set(wf.agent, names);
+    const entries = byAgent.get(wf.agent) ?? [];
+    entries.push({ name: wf.name, status: wf.status });
+    byAgent.set(wf.agent, entries);
   }
   for (const byAgent of bySource.values()) {
-    for (const names of byAgent.values()) {
-      names.sort((a, b) => a.localeCompare(b));
+    for (const entries of byAgent.values()) {
+      entries.sort((a, b) => a.name.localeCompare(b.name));
     }
   }
 
@@ -702,8 +735,8 @@ export function renderWorkflowList(workflows: DiscoveredWorkflow[]): string {
     );
 
     for (const agent of AGENT_ORDER) {
-      const names = byAgent.get(agent);
-      if (!names || names.length === 0) continue;
+      const entries = byAgent.get(agent);
+      if (!entries || entries.length === 0) continue;
 
       // Provider heading: bold accent blue — a clearly different layer from
       // both the semantic source heading above and the neutral entries below.
@@ -712,8 +745,14 @@ export function renderWorkflowList(workflows: DiscoveredWorkflow[]): string {
         "    " + paint("accent", AGENT_DISPLAY_NAMES[agent], { bold: true }),
       );
 
-      for (const name of names) {
-        lines.push("      " + paint("text", name));
+      for (const entry of entries) {
+        // Dim the name on non-ok rows so the eye lands on the status
+        // badge rather than the workflow name — the badge is where the
+        // actionable info lives, and the name is already unrunnable.
+        const nameCol: PaletteKey = entry.status.kind === "ok" ? "text" : "dim";
+        lines.push(
+          "      " + paint(nameCol, entry.name) + renderStatusBadge(paint, entry.status),
+        );
       }
     }
   }

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -42,7 +42,10 @@ import { useState, useEffect, useMemo, useRef, useCallback, useContext, createCo
 import { useLatest } from "./hooks.ts";
 import { resolveTheme, type TerminalTheme } from "../runtime/theme.ts";
 import type { AgentType, WorkflowInput } from "../types.ts";
-import type { WorkflowWithMetadata } from "../runtime/discovery.ts";
+import type {
+  WorkflowWithMetadata,
+  WorkflowMetadataStatus,
+} from "../runtime/discovery.ts";
 import { ErrorBoundary } from "./error-boundary.tsx";
 
 // ─── Theme ──────────────────────────────────────
@@ -258,6 +261,38 @@ export function buildRows(entries: ListEntry[], query: string): ListRow[] {
   return rows;
 }
 
+// ─── Status helpers ─────────────────────────────
+// Non-ok entries stay visible in the picker so the user sees that a
+// workflow from an older SDK release (or one with a load error) still
+// exists on disk — the previous behaviour silently dropped them, which
+// made user/global workflows appear to vanish after an atomic upgrade.
+
+/** Unicode glyph that prefixes a non-ok entry and heads its preview. */
+const STATUS_ICON: Record<WorkflowMetadataStatus["kind"], string> = {
+  ok: " ",
+  incompatible: "⚠",
+  error: "✗",
+};
+
+/** Compact single-word label used in list rows and the bottom hint. */
+const STATUS_LABEL: Record<WorkflowMetadataStatus["kind"], string> = {
+  ok: "",
+  incompatible: "update",
+  error: "broken",
+};
+
+/** Map each status kind to its semantic palette slot. */
+const STATUS_COLOR: Record<WorkflowMetadataStatus["kind"], keyof PickerTheme> = {
+  ok: "success",
+  incompatible: "warning",
+  error: "error",
+};
+
+/** Non-ok rows are inert — Enter / run commands must not transition the picker. */
+function isRunnable(wf: WorkflowWithMetadata): boolean {
+  return wf.status.kind === "ok";
+}
+
 // ─── Validation ─────────────────────────────────
 
 export function isFieldValid(field: WorkflowInput, value: string): boolean {
@@ -385,6 +420,24 @@ const WorkflowList = memo(function WorkflowList({
         const entryIdx = entryIndexByRow.get(i) ?? -1;
         const isFocused = entryIdx === focusedEntryIdx;
         const wf = row.entry.workflow;
+        const statusKind = wf.status.kind;
+        const runnable = statusKind === "ok";
+        // Status indicator sits between the focus marker and the name so
+        // every row shares a 4-character gutter — ok rows render a blank
+        // gutter, so the list stays visually flush while non-ok rows
+        // always occupy a fixed slot (no layout jitter when filtering).
+        const statusIcon = STATUS_ICON[statusKind];
+        const statusCol = theme[STATUS_COLOR[statusKind]];
+        // Non-ok rows fade the name so the "diagnostic, not selectable"
+        // read is immediate even when the user hasn't reached the row
+        // yet — the eye catches the warning glyph + dim text together.
+        const nameCol = runnable
+          ? isFocused
+            ? theme.text
+            : theme.textMuted
+          : isFocused
+            ? theme.textMuted
+            : theme.textDim;
 
         return (
           <box
@@ -399,7 +452,10 @@ const WorkflowList = memo(function WorkflowList({
               <span fg={isFocused ? theme.primary : theme.textDim}>
                 {isFocused ? "▸ " : "  "}
               </span>
-              <span fg={isFocused ? theme.text : theme.textMuted}>
+              <span fg={statusCol}>
+                {statusIcon + " "}
+              </span>
+              <span fg={nameCol}>
                 {wf.name}
               </span>
             </text>
@@ -459,6 +515,59 @@ const ArgumentRow = memo(function ArgumentRow({
   );
 });
 
+/**
+ * Diagnostic block for non-ok workflows. Replaces the description +
+ * arguments sections in the preview pane so the user sees *why* a row
+ * is inert and what to do about it, instead of an empty-looking panel.
+ */
+const StatusDiagnostic = memo(function StatusDiagnostic({
+  status,
+}: {
+  status: Exclude<WorkflowMetadataStatus, { kind: "ok" }>;
+}) {
+  const theme = usePickerTheme();
+  const color = theme[STATUS_COLOR[status.kind]];
+  const icon = STATUS_ICON[status.kind];
+
+  // Headline + sub-copy split: the headline is terse (three words) so
+  // it reads at a glance even on a narrow right pane; the sub-copy
+  // explains *why* and the third paragraph tells the user what to do.
+  const headline =
+    status.kind === "incompatible"
+      ? "update required"
+      : "failed to load";
+  const detail =
+    status.kind === "incompatible"
+      ? `Needs Atomic v${status.requiredVersion}. Installed: v${status.currentVersion}.`
+      : status.message;
+  const remediation =
+    status.kind === "incompatible"
+      ? "Update Atomic, or re-save the workflow against the current SDK."
+      : "Open the workflow file and fix the error above.";
+
+  return (
+    <box flexDirection="column">
+      <text>
+        <span fg={color}>
+          <strong>{icon + " " + headline}</strong>
+        </span>
+      </text>
+
+      <box height={1} />
+
+      <text>
+        <span fg={theme.textMuted}>{detail}</span>
+      </text>
+
+      <box height={1} />
+
+      <text>
+        <span fg={theme.textDim}>{remediation}</span>
+      </text>
+    </box>
+  );
+});
+
 const Preview = memo(function Preview({
   wf,
 }: {
@@ -466,6 +575,7 @@ const Preview = memo(function Preview({
 }) {
   const theme = usePickerTheme();
   const args = wf.inputs;
+  const status = wf.status;
 
   return (
     <box
@@ -493,21 +603,27 @@ const Preview = memo(function Preview({
 
       <box height={2} />
 
-      <text>
-        <span fg={theme.textMuted}>
-          {wf.description || "(no description)"}
-        </span>
-      </text>
-
-      {args.length > 0 && (
+      {status.kind === "ok" ? (
         <>
-          <box height={2} />
-          <SectionLabel label="ARGUMENTS" />
-          <box height={1} />
-          {args.map((f) => (
-            <ArgumentRow key={f.name} field={f} />
-          ))}
+          <text>
+            <span fg={theme.textMuted}>
+              {wf.description || "(no description)"}
+            </span>
+          </text>
+
+          {args.length > 0 && (
+            <>
+              <box height={2} />
+              <SectionLabel label="ARGUMENTS" />
+              <box height={1} />
+              {args.map((f) => (
+                <ArgumentRow key={f.name} field={f} />
+              ))}
+            </>
+          )}
         </>
+      ) : (
+        <StatusDiagnostic status={status} />
       )}
     </box>
   );
@@ -1022,6 +1138,14 @@ const PICK_HINTS: Hint[] = [
   { key: "↵", label: "select" },
   { key: "esc", label: "quit" },
 ];
+// Shown instead of PICK_HINTS when the focused row is non-ok — the dim
+// `↵ unavailable` reads immediately as "this row is navigable but not
+// runnable", which matches the muted row colour and preview diagnostic.
+const PICK_HINTS_UNAVAILABLE: Hint[] = [
+  { key: "↑↓", label: "navigate" },
+  { key: "↵", label: "unavailable", dim: true },
+  { key: "esc", label: "quit" },
+];
 const CONFIRM_HINTS: Hint[] = [
   { key: "y", label: "submit" },
   { key: "n", label: "cancel" },
@@ -1134,7 +1258,26 @@ const Statusline = memo(function Statusline({
       {focusedWf ? (
         <box paddingLeft={1} paddingRight={1} alignItems="center">
           <text>
-            <span fg={theme.text}>{focusedWf.name}</span>
+            {focusedWf.status.kind !== "ok" ? (
+              <span fg={theme[STATUS_COLOR[focusedWf.status.kind]]}>
+                {STATUS_ICON[focusedWf.status.kind] + " "}
+              </span>
+            ) : null}
+            <span
+              fg={
+                focusedWf.status.kind === "ok" ? theme.text : theme.textMuted
+              }
+            >
+              {focusedWf.name}
+            </span>
+            {focusedWf.status.kind !== "ok" ? (
+              <>
+                <span fg={theme.textDim}>{"  ·  "}</span>
+                <span fg={theme[STATUS_COLOR[focusedWf.status.kind]]}>
+                  {STATUS_LABEL[focusedWf.status.kind]}
+                </span>
+              </>
+            ) : null}
           </text>
         </box>
       ) : null}
@@ -1247,7 +1390,10 @@ function usePickerKeyboard(state: PickerKeyboardState): void {
     if (key.name === "return") {
       key.stopPropagation();
       const wf = focusedWfRef.current;
-      if (wf) {
+      // Silently swallow Enter on incompatible / broken entries — the
+      // preview pane already explains the failure; advancing into the
+      // prompt phase would be misleading since the workflow can't run.
+      if (wf && isRunnable(wf)) {
         const initial: Record<string, string> = {};
         for (const f of wf.inputs) {
           initial[f.name] =
@@ -1408,10 +1554,13 @@ export function WorkflowPicker({
     setConfirmOpen,
   });
 
+  const focusedIsRunnable = focusedWf ? isRunnable(focusedWf) : true;
   const hints = confirmOpen
     ? CONFIRM_HINTS
     : phase === "pick"
-      ? PICK_HINTS
+      ? focusedIsRunnable
+        ? PICK_HINTS
+        : PICK_HINTS_UNAVAILABLE
       : isFormValid
         ? PROMPT_HINTS_VALID
         : PROMPT_HINTS_INVALID;

--- a/src/sdk/define-workflow.ts
+++ b/src/sdk/define-workflow.ts
@@ -152,6 +152,7 @@ export class WorkflowBuilder<A extends AgentType = AgentType, N extends string =
       name: this.options.name,
       description: this.options.description ?? "",
       inputs,
+      minSDKVersion: this.options.minSDKVersion ?? null,
       run: runFn,
     };
   }

--- a/src/sdk/errors.ts
+++ b/src/sdk/errors.ts
@@ -38,6 +38,26 @@ export class InvalidWorkflowError extends Error {
   }
 }
 
+/**
+ * Thrown when a workflow declares a `minSDKVersion` newer than the
+ * bundled CLI. Carries both versions so the CLI can render an
+ * actionable "update atomic or re-save the workflow" hint rather than
+ * a generic load error.
+ */
+export class IncompatibleSDKError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly requiredVersion: string,
+    public readonly currentVersion: string,
+  ) {
+    super(
+      `${path} requires Atomic SDK v${requiredVersion}, but v${currentVersion} is installed.\n` +
+      `  Update Atomic, or re-save the workflow against the current SDK.`,
+    );
+    this.name = "IncompatibleSDKError";
+  }
+}
+
 /** Extract a human-readable message from an unknown thrown value. */
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/src/sdk/runtime/discovery.ts
+++ b/src/sdk/runtime/discovery.ts
@@ -17,6 +17,7 @@ import { homedir } from "node:os";
 import ignore from "ignore";
 import type { AgentType, WorkflowInput } from "../types.ts";
 import { WorkflowLoader } from "./loader.ts";
+import { IncompatibleSDKError } from "../errors.ts";
 
 export interface DiscoveredWorkflow {
   name: string;
@@ -249,46 +250,119 @@ export async function findWorkflow(
 }
 
 /**
+ * Load status for a {@link WorkflowWithMetadata} entry.
+ *
+ * - `ok`            — the workflow compiled cleanly and is ready to run.
+ * - `incompatible`  — the workflow declared a `minSDKVersion` newer
+ *                     than the bundled CLI. The CLI renders it with an
+ *                     "update required" badge so users see the mismatch
+ *                     rather than a silent disappearance.
+ * - `error`         — any other load failure (syntax error, missing
+ *                     `.compile()`, invalid default export, etc.).
+ *                     Rendered with a "failed to load" badge plus the
+ *                     underlying message.
+ */
+export type WorkflowMetadataStatus =
+  | { kind: "ok" }
+  | {
+      kind: "incompatible";
+      requiredVersion: string;
+      currentVersion: string;
+      message: string;
+    }
+  | {
+      kind: "error";
+      stage: "resolve" | "validate" | "load";
+      message: string;
+    };
+
+/**
  * A discovered workflow enriched with the metadata the picker needs to
- * render it: the human description and the declared input schema.
+ * render it: the human description, the declared input schema, and the
+ * load status.
  *
  * Populated by {@link loadWorkflowsMetadata}, which runs each discovered
- * workflow through {@link WorkflowLoader.loadWorkflow} and extracts just
- * the display-relevant fields — the full compiled definition is
- * discarded after extraction so re-imports during execution are cheap.
+ * workflow through {@link WorkflowLoader.loadWorkflow} and extracts the
+ * display-relevant fields — the full compiled definition is discarded
+ * after extraction so re-imports during execution are cheap.
+ *
+ * Broken entries still materialise with empty `description` / `inputs`
+ * and a non-`ok` {@link status}, so the picker can render them as
+ * visible "update required" / "failed to load" rows instead of
+ * silently omitting them (the previous behaviour, which made user and
+ * global workflows vanish whenever the base SDK shape drifted between
+ * releases).
  */
 export interface WorkflowWithMetadata extends DiscoveredWorkflow {
-  /** Workflow description, empty string when none was declared. */
+  /** Workflow description, empty string when none was declared or the workflow failed to load. */
   description: string;
-  /** Picker-ready input schema; free-form workflows materialize a prompt field. */
+  /** Picker-ready input schema; empty for free-form or failed-to-load workflows. */
   inputs: readonly WorkflowInput[];
+  /** Load outcome — non-`ok` entries are rendered as visible diagnostics in the picker/list. */
+  status: WorkflowMetadataStatus;
 }
 
 /**
- * Load metadata (description + picker-ready inputs) for a batch of discovered workflows.
+ * Load metadata (description + picker-ready inputs + status) for a batch
+ * of discovered workflows.
  *
- * Workflows that fail to import are **skipped silently** so one broken
- * entry can never prevent the picker from rendering. Callers that need
- * to surface load errors (e.g. `atomic workflow -n broken`) should use
- * {@link WorkflowLoader.loadWorkflow} directly — that path produces
- * structured error reports.
+ * **Failed workflows are kept in the returned list**, not dropped. Each
+ * broken entry carries a {@link WorkflowMetadataStatus} explaining the
+ * failure so the picker and `atomic workflow -l` can surface it as an
+ * actionable diagnostic. This is the only way end users discover that a
+ * workflow from an older SDK release has gone incompatible after an
+ * `atomic` upgrade — silent filtering would leave them with a missing
+ * entry and no breadcrumb.
+ *
+ * Callers that want to execute a workflow should still route through
+ * {@link WorkflowLoader.loadWorkflow} — this function throws away the
+ * compiled definition so re-running the loader on a confirmed pick is
+ * unavoidable.
  */
 export async function loadWorkflowsMetadata(
   discovered: DiscoveredWorkflow[],
 ): Promise<WorkflowWithMetadata[]> {
-  const results = await Promise.all(
-    discovered.map(async (wf): Promise<WorkflowWithMetadata | null> => {
+  return Promise.all(
+    discovered.map(async (wf): Promise<WorkflowWithMetadata> => {
       const loaded = await WorkflowLoader.loadWorkflow(wf);
-      if (!loaded.ok) return null;
+      if (loaded.ok) {
+        return {
+          ...wf,
+          description: loaded.value.definition.description,
+          inputs: loaded.value.definition.inputs,
+          status: { kind: "ok" },
+        };
+      }
+
+      // Incompatible SDK version is a first-class status so the UI can
+      // show a dedicated "update required" hint. Every other failure
+      // maps to a generic `error` variant — the picker renders the
+      // message but doesn't try to interpret it further.
+      if (loaded.error instanceof IncompatibleSDKError) {
+        return {
+          ...wf,
+          description: "",
+          inputs: [],
+          status: {
+            kind: "incompatible",
+            requiredVersion: loaded.error.requiredVersion,
+            currentVersion: loaded.error.currentVersion,
+            message: loaded.message,
+          },
+        };
+      }
+
       return {
         ...wf,
-        description: loaded.value.definition.description,
-        inputs: loaded.value.definition.inputs,
+        description: "",
+        inputs: [],
+        status: {
+          kind: "error",
+          stage: loaded.stage,
+          message: loaded.message,
+        },
       };
     }),
-  );
-  return results.filter(
-    (r): r is WorkflowWithMetadata => r !== null,
   );
 }
 

--- a/src/sdk/runtime/loader.ts
+++ b/src/sdk/runtime/loader.ts
@@ -12,10 +12,17 @@
 
 import type { WorkflowDefinition, AgentType } from "../types.ts";
 import type { DiscoveredWorkflow } from "./discovery.ts";
-import { errorMessage, WorkflowNotCompiledError, InvalidWorkflowError } from "../errors.ts";
+import {
+  errorMessage,
+  WorkflowNotCompiledError,
+  InvalidWorkflowError,
+  IncompatibleSDKError,
+} from "../errors.ts";
 import { validateCopilotWorkflow } from "../providers/copilot.ts";
 import { validateOpenCodeWorkflow } from "../providers/opencode.ts";
 import { validateClaudeWorkflow } from "../providers/claude.ts";
+import { satisfiesMinVersion } from "./version-compat.ts";
+import { VERSION } from "../../version.ts";
 
 export namespace WorkflowLoader {
   // ---------------------------------------------------------------------------
@@ -180,9 +187,29 @@ export namespace WorkflowLoader {
         };
       }
 
+      const def = definition as WorkflowDefinition;
+
+      // Refuse workflows whose declared minSDKVersion is newer than the
+      // bundled CLI — the workflow author opted in to a version gate
+      // exactly so the loader could surface a clear upgrade hint
+      // instead of letting a shape-drift error bubble up at run time.
+      if (!satisfiesMinVersion(VERSION, def.minSDKVersion)) {
+        const err = new IncompatibleSDKError(
+          validated.path,
+          def.minSDKVersion ?? "",
+          VERSION,
+        );
+        return {
+          ok: false,
+          stage: "load",
+          error: err,
+          message: err.message,
+        };
+      }
+
       return {
         ok: true,
-        value: { ...validated, definition: definition as WorkflowDefinition },
+        value: { ...validated, definition: def },
       };
     } catch (error) {
       return {

--- a/src/sdk/runtime/version-compat.ts
+++ b/src/sdk/runtime/version-compat.ts
@@ -1,0 +1,68 @@
+/**
+ * Tiny semver comparator used to check a workflow's declared
+ * `minSDKVersion` against the bundled CLI {@link VERSION}.
+ *
+ * Accepts the subset of semver we actually ship: `MAJOR.MINOR.PATCH`
+ * with an optional numeric prerelease (e.g. `0.5.21`, `0.5.21-0`).
+ * Anything more exotic (build metadata, alpha tags) is treated as a
+ * plain string and compared lexicographically on the prerelease tail,
+ * which is good enough for "is the installed CLI new enough?".
+ *
+ * Isolated from the `semver` npm package so the workflow loader stays
+ * dependency-free — this check runs for every discovered workflow on
+ * every CLI launch.
+ */
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string;
+}
+
+function parseVersion(v: string): ParsedVersion | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(v.trim());
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? "",
+  };
+}
+
+/**
+ * Return a negative number if `a < b`, positive if `a > b`, 0 if equal.
+ * Unparseable inputs compare as equal so we never block a workflow over
+ * a typo in its `minSDKVersion` — the visible load error is friendlier
+ * than a hard refusal.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return 0;
+
+  if (pa.major !== pb.major) return pa.major - pb.major;
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
+  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
+
+  // Per semver, a version without a prerelease outranks one with a
+  // prerelease at the same MAJOR.MINOR.PATCH (1.0.0 > 1.0.0-0).
+  if (pa.prerelease === "" && pb.prerelease !== "") return 1;
+  if (pa.prerelease !== "" && pb.prerelease === "") return -1;
+  if (pa.prerelease === pb.prerelease) return 0;
+  return pa.prerelease < pb.prerelease ? -1 : 1;
+}
+
+/**
+ * True when the current CLI is new enough to run a workflow that
+ * declared `minRequired`. A null/undefined requirement always
+ * satisfies — workflows that don't opt in are treated as compatible.
+ */
+export function satisfiesMinVersion(
+  current: string,
+  minRequired: string | null | undefined,
+): boolean {
+  if (!minRequired) return true;
+  return compareVersions(current, minRequired) >= 0;
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -366,6 +366,22 @@ export interface WorkflowOptions<
    * and enforce them on `ctx.inputs`.
    */
   inputs?: I;
+  /**
+   * Minimum Atomic CLI version this workflow is known to work with.
+   *
+   * When set, the CLI refuses to load the workflow on an older install
+   * and surfaces an actionable "update required" entry in the picker
+   * and `atomic workflow -l` output instead of silently dropping it.
+   *
+   * Leave unset (the default) to opt out entirely — the workflow will
+   * be treated as compatible with every CLI version. Use this when you
+   * consume a new SDK feature (new provider API, a new field on the
+   * stage options, etc.) that older installs can't honour.
+   *
+   * Accepts `MAJOR.MINOR.PATCH` with an optional numeric prerelease
+   * (`0.6.0`, `0.6.0-0`). Invalid strings are ignored.
+   */
+  minSDKVersion?: string;
 }
 
 /**
@@ -377,6 +393,11 @@ export interface WorkflowDefinition<A extends AgentType = AgentType, N extends s
   readonly description: string;
   /** Declared input schema — empty array for free-form workflows. */
   readonly inputs: readonly WorkflowInput[];
+  /**
+   * Minimum Atomic SDK version required. `null` when the workflow
+   * declared no requirement — treated as compatible with every CLI.
+   */
+  readonly minSDKVersion: string | null;
   /** The workflow's entry point. Called by the executor with a WorkflowContext. */
   readonly run: (ctx: WorkflowContext<A, N>) => Promise<void>;
 }

--- a/src/sdk/workflows/index.ts
+++ b/src/sdk/workflows/index.ts
@@ -105,6 +105,7 @@ export {
 export type {
   DiscoveredWorkflow,
   WorkflowWithMetadata,
+  WorkflowMetadataStatus,
 } from "../runtime/discovery.ts";
 
 // Runtime — workflow loader pipeline

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -64,6 +64,7 @@ function makeWorkflow(
     source: "local",
     description: "",
     inputs: [],
+    status: { kind: "ok" },
     ...overrides,
   };
 }
@@ -576,6 +577,116 @@ describe("WorkflowPicker PICK keyboard", () => {
     // Still in PICK phase.
     const frame = setup.captureCharFrame();
     expect(frame).toContain("PICK");
+  });
+
+  test("enter on an incompatible workflow does not transition", async () => {
+    // Non-ok entries stay visible so the user can *see* the failure —
+    // but the picker must refuse to advance into the prompt phase,
+    // because there's no runnable definition on the other side.
+    const workflows = [
+      makeWorkflow({
+        name: "needs-update",
+        source: "local",
+        status: {
+          kind: "incompatible",
+          requiredVersion: "99.0.0",
+          currentVersion: "0.5.0",
+          message: "needs newer SDK",
+        },
+      }),
+    ];
+    let submitted = false;
+    const setup = await renderPicker({
+      workflows,
+      onSubmit: () => {
+        submitted = true;
+      },
+    });
+    await press(setup, (i) => i.pressEnter());
+    const frame = setup.captureCharFrame();
+    // Still on the picker — no PROMPT transition, no submission.
+    expect(frame).toContain("PICK");
+    expect(frame).not.toContain("PROMPT");
+    expect(submitted).toBe(false);
+  });
+
+  test("enter on a broken workflow does not transition", async () => {
+    const workflows = [
+      makeWorkflow({
+        name: "broken-wf",
+        source: "local",
+        status: { kind: "error", stage: "load", message: "syntax error" },
+      }),
+    ];
+    let submitted = false;
+    const setup = await renderPicker({
+      workflows,
+      onSubmit: () => {
+        submitted = true;
+      },
+    });
+    await press(setup, (i) => i.pressEnter());
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("PICK");
+    expect(submitted).toBe(false);
+  });
+});
+
+describe("WorkflowPicker status rendering", () => {
+  test("incompatible entry shows a warning glyph and 'update required' preview", async () => {
+    const workflows = [
+      makeWorkflow({
+        name: "future-wf",
+        source: "local",
+        status: {
+          kind: "incompatible",
+          requiredVersion: "99.0.0",
+          currentVersion: "0.5.21-0",
+          message: "requires 99.0.0",
+        },
+      }),
+    ];
+    const setup = await renderPicker({ workflows });
+    const frame = setup.captureCharFrame();
+    // Warning glyph gutter + actionable preview copy.
+    expect(frame).toContain("⚠");
+    expect(frame).toContain("update required");
+    expect(frame).toContain("99.0.0");
+  });
+
+  test("broken entry shows an error glyph and 'failed to load' preview", async () => {
+    const workflows = [
+      makeWorkflow({
+        name: "broken-wf",
+        source: "local",
+        status: {
+          kind: "error",
+          stage: "load",
+          message: "unique-diagnostic-marker",
+        },
+      }),
+    ];
+    const setup = await renderPicker({ workflows });
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("✗");
+    expect(frame).toContain("failed to load");
+    // The underlying loader message is surfaced in the preview so
+    // users don't have to guess what went wrong.
+    expect(frame).toContain("unique-diagnostic-marker");
+  });
+
+  test("status hint dims the select label to 'unavailable' on non-ok rows", async () => {
+    const workflows = [
+      makeWorkflow({
+        name: "broken-only",
+        source: "local",
+        status: { kind: "error", stage: "load", message: "oops" },
+      }),
+    ];
+    const setup = await renderPicker({ workflows });
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("unavailable");
+    expect(frame).not.toContain("↵ select");
   });
 });
 

--- a/tests/sdk/runtime/discovery.test.ts
+++ b/tests/sdk/runtime/discovery.test.ts
@@ -416,5 +416,116 @@ export default defineWorkflow({ name: "picker-freeform" })
 
     expect(metadata).toHaveLength(1);
     expect(metadata[0]!.inputs).toEqual([]);
+    expect(metadata[0]!.status.kind).toBe("ok");
+  });
+
+  test("returns incompatible status when minSDKVersion exceeds current", async () => {
+    // The core promise of minSDKVersion: a workflow that opts in to a
+    // future SDK release surfaces in the picker/list as a visible
+    // "update required" row instead of silently disappearing.
+    const workflowDir = join(
+      tempDir,
+      ".atomic",
+      "workflows",
+      "future-wf",
+      "copilot",
+    );
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, "index.ts"),
+      `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({
+  name: "future-wf",
+  minSDKVersion: "99.0.0",
+})
+  .run(async () => {})
+  .compile();
+`,
+    );
+
+    const discovered = await discoverWorkflows(tempDir, "copilot");
+    const metadata = await loadWorkflowsMetadata(
+      discovered.filter((wf) => wf.name === "future-wf"),
+    );
+
+    expect(metadata).toHaveLength(1);
+    const status = metadata[0]!.status;
+    expect(status.kind).toBe("incompatible");
+    if (status.kind === "incompatible") {
+      expect(status.requiredVersion).toBe("99.0.0");
+      expect(status.currentVersion).toMatch(/^\d+\.\d+\.\d+/);
+    }
+  });
+
+  test("returns error status instead of dropping workflows that fail to load", async () => {
+    // Broken workflows used to vanish silently from discovery — this
+    // test guards the new surface-failure contract so the picker can
+    // render a "✗ broken" row with the loader message attached.
+    const workflowDir = join(
+      tempDir,
+      ".atomic",
+      "workflows",
+      "uncompiled-wf",
+      "copilot",
+    );
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, "index.ts"),
+      `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({ name: "uncompiled-wf" })
+  .run(async () => {});
+// intentionally missing .compile()
+`,
+    );
+
+    const discovered = await discoverWorkflows(tempDir, "copilot");
+    const metadata = await loadWorkflowsMetadata(
+      discovered.filter((wf) => wf.name === "uncompiled-wf"),
+    );
+
+    expect(metadata).toHaveLength(1);
+    const status = metadata[0]!.status;
+    expect(status.kind).toBe("error");
+    if (status.kind === "error") {
+      expect(status.message).toMatch(/not compiled/);
+    }
+  });
+
+  test("keeps ok status for workflows with a satisfied minSDKVersion", async () => {
+    // 0.0.0 is below any real release — the loader should accept it
+    // without routing through the incompatible branch.
+    const workflowDir = join(
+      tempDir,
+      ".atomic",
+      "workflows",
+      "satisfied-wf",
+      "copilot",
+    );
+    await mkdir(workflowDir, { recursive: true });
+    await writeFile(
+      join(workflowDir, "index.ts"),
+      `
+import { defineWorkflow } from "${join(process.cwd(), "src/sdk/workflows/index.ts")}";
+
+export default defineWorkflow({
+  name: "satisfied-wf",
+  minSDKVersion: "0.0.0",
+})
+  .run(async () => {})
+  .compile();
+`,
+    );
+
+    const discovered = await discoverWorkflows(tempDir, "copilot");
+    const metadata = await loadWorkflowsMetadata(
+      discovered.filter((wf) => wf.name === "satisfied-wf"),
+    );
+
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]!.status.kind).toBe("ok");
   });
 });

--- a/tests/sdk/runtime/version-compat.test.ts
+++ b/tests/sdk/runtime/version-compat.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "bun:test";
+import {
+  compareVersions,
+  satisfiesMinVersion,
+} from "../../../src/sdk/runtime/version-compat.ts";
+
+describe("compareVersions", () => {
+  test("compares major versions", () => {
+    expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("2.0.0", "1.0.0")).toBeGreaterThan(0);
+  });
+
+  test("compares minor versions when major matches", () => {
+    expect(compareVersions("1.1.0", "1.2.0")).toBeLessThan(0);
+    expect(compareVersions("1.2.0", "1.1.0")).toBeGreaterThan(0);
+  });
+
+  test("compares patch versions when major and minor match", () => {
+    expect(compareVersions("1.0.1", "1.0.2")).toBeLessThan(0);
+    expect(compareVersions("1.0.2", "1.0.1")).toBeGreaterThan(0);
+  });
+
+  test("returns 0 for identical versions", () => {
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+    expect(compareVersions("0.5.21-0", "0.5.21-0")).toBe(0);
+  });
+
+  test("prerelease ranks below the equivalent stable release", () => {
+    // Per semver, 1.0.0 > 1.0.0-0 — a declared minSDKVersion of 1.0.0
+    // should NOT be satisfied by a prerelease of the same triple.
+    expect(compareVersions("1.0.0", "1.0.0-0")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0-0", "1.0.0")).toBeLessThan(0);
+  });
+
+  test("prerelease strings compare lexicographically", () => {
+    expect(compareVersions("1.0.0-alpha", "1.0.0-beta")).toBeLessThan(0);
+    expect(compareVersions("1.0.0-2", "1.0.0-10")).toBeGreaterThan(0);
+  });
+
+  test("treats unparseable versions as equal (graceful fallback)", () => {
+    // A typo in minSDKVersion must not block the workflow — the visible
+    // load error path is friendlier than a hard refusal with no context.
+    expect(compareVersions("not-a-version", "1.0.0")).toBe(0);
+    expect(compareVersions("1.0.0", "garbage")).toBe(0);
+  });
+});
+
+describe("satisfiesMinVersion", () => {
+  test("null / undefined requirement always satisfies", () => {
+    // The "opt-in" contract: workflows that omit minSDKVersion are
+    // treated as compatible with every CLI release.
+    expect(satisfiesMinVersion("0.1.0", null)).toBe(true);
+    expect(satisfiesMinVersion("0.1.0", undefined)).toBe(true);
+  });
+
+  test("satisfies when current >= required", () => {
+    expect(satisfiesMinVersion("1.0.0", "1.0.0")).toBe(true);
+    expect(satisfiesMinVersion("2.0.0", "1.5.0")).toBe(true);
+    expect(satisfiesMinVersion("0.6.0", "0.5.0")).toBe(true);
+  });
+
+  test("does not satisfy when current < required", () => {
+    expect(satisfiesMinVersion("0.5.21-0", "0.6.0")).toBe(false);
+    expect(satisfiesMinVersion("1.0.0-0", "1.0.0")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces version-gating for workflows: a new `minSDKVersion` field on `defineWorkflow()` lets authors declare minimum CLI requirements. Incompatible and broken workflows are now surfaced with actionable badges in the picker and `atomic workflow -l` instead of silently disappearing.

## Key Changes

- **`minSDKVersion` field** — optional field on `WorkflowOptions` and `WorkflowDefinition` lets workflow authors declare the minimum Atomic CLI version required
- **`IncompatibleSDKError`** — new error class thrown by the loader when a workflow's declared version exceeds the bundled CLI; carries both versions for actionable upgrade hints
- **`WorkflowMetadataStatus`** — new discriminated union (`ok` | `incompatible` | `error`) attached to every `WorkflowWithMetadata` entry so the UI knows how to render it
- **Non-silent failures** — `loadWorkflowsMetadata` now returns broken/incompatible entries rather than filtering them out; the picker and `atomic workflow -l` render them with dedicated badges
- **`runtime/version-compat.ts`** — dependency-free semver comparator (`compareVersions`, `satisfiesMinVersion`) to avoid pulling in the `semver` package on every CLI launch
- **Tests** — unit coverage for `version-compat.ts`, `discovery.ts`, `workflow-picker-panel`, and `workflow-command`
- **Skill docs** — updated `workflow-creator` skill and added `discovery-and-verification.md` reference doc

## Breaking Changes

None. `minSDKVersion` is optional; omitting it preserves the existing behavior (workflow is treated as compatible with all CLI versions).