### PR TITLE
chore(release): bump version to v0.5.21-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.21-0",
+  "version": "0.5.21-1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.5.21-0` to `v0.5.21-1` (prerelease increment).

## Changes

- `package.json`: version `0.5.21-0` → `0.5.21-1`

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes the prerelease to npm after merge