### PR TITLE
chore(release): bump version to v0.5.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.21-1",
+  "version": "0.5.21",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the pre-release version `0.5.21-1` to the stable release `0.5.21` by updating `package.json`.

## Changes

- `package.json`: version `0.5.21-1` → `0.5.21`

## Test plan

- [x] `bun run src/scripts/bump-version.ts --from-branch` updated `package.json`
- [ ] CI passes
- [ ] Merge triggers GitHub Release + npm publish