### PR TITLE
feat(claude): replace tmux send-keys with Stop hook follow-up delivery

### DIFF
--- a/.atomic/workflows/hello-world/claude/index.ts
+++ b/.atomic/workflows/hello-world/claude/index.ts
@@ -15,7 +15,7 @@ function buildHelloPrompt(inputs: Record<string, string>): string {
 
 export default defineWorkflow({
     name: "hello-world",
-    description: "A simple single-session hello world workflow",
+    description: "A simple single-session hello world workflow (two turns)",
     inputs: [
       {
         name: "greeting",
@@ -48,7 +48,18 @@ export default defineWorkflow({
       {},
       {},
       async (s) => {
+        // First query — spawns the Claude CLI with the prompt baked into
+        // argv as `'Read the prompt in <path>'`.
         await s.session.query(prompt);
+
+        // Follow-up query — exercises the Stop-hook-driven idle detection
+        // and the argv-style prompt delivery (a short "Read the prompt in
+        // <path>" instruction into the already-running Claude TUI). If the
+        // Stop hook wiring is correct, this second turn completes without
+        // any pane-polling or paste-buffer retry dance.
+        await s.session.query(
+          "Now translate your previous greeting into pig latin. One line only.",
+        );
         s.save(s.sessionId);
       },
     );

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,17 +21,5 @@
     "kotlin-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
     "lua-lsp@claude-plugins-official": true
-  },
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "atomic _claude-stop-hook"
-          }
-        ]
-      }
-    ]
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -50,6 +50,7 @@ coveragePathIgnorePatterns = [
   "src/services/telemetry/**",
   # Config I/O
   "src/services/config/atomic-config.ts",
+  "src/services/config/atomic-global-config.ts",
   "src/services/config/config-path.ts",
   "src/services/config/definitions.ts",
   "src/services/config/mcp-config.ts",

--- a/src/commands/cli/claude-stop-hook.test.ts
+++ b/src/commands/cli/claude-stop-hook.test.ts
@@ -2,22 +2,27 @@
  * Tests for claudeStopHookCommand.
  *
  * Strategy: monkey-patch `Bun.stdin.text` to return preset strings so we can
- * call the function directly without spawning subprocesses.  This is
+ * call the function directly without spawning subprocesses. This is
  * consistent with how other CLI-command tests in this directory work.
  *
  * Filesystem isolation: we use `crypto.randomUUID()` for unique session IDs
  * and clean up in `afterEach` so test runs never collide with each other
- * or with real marker files.
+ * or with real marker/queue/release files.
+ *
+ * The hook's default wait for a queued follow-up prompt is 15 minutes.
+ * Every test here passes a short `waitTimeoutMs` so the hook exits quickly
+ * when no queue entry is present — we are testing the branching logic,
+ * not the real-world wait budget.
  */
 
-import { describe, test, expect, afterEach, mock, spyOn } from "bun:test";
-import { access, rm } from "node:fs/promises";
+import { describe, test, expect, afterEach, spyOn } from "bun:test";
+import { access, rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir } from "node:os";
-import { claudeStopHookCommand } from "./claude-stop-hook.ts";
+import { claudeStopHookCommand, claudeHookDirs } from "./claude-stop-hook.ts";
 
-// Paths we'll need in every test.
-const markerDir = join(homedir(), ".atomic", "claude-stop");
+const { marker: markerDir, queue: queueDir, release: releaseDir } = claudeHookDirs();
+
+const SHORT_TIMEOUT_MS = 300;
 
 /** Returns true when a file exists at `filePath`. */
 async function fileExists(filePath: string): Promise<boolean> {
@@ -31,9 +36,6 @@ async function fileExists(filePath: string): Promise<boolean> {
 
 /** Patch `Bun.stdin.text` for the duration of one test. */
 function mockStdin(text: string): void {
-  // Bun.stdin is a readonly property on the global `Bun` object.
-  // We reach it through the prototype chain the same way other tests
-  // in this repo patch globals (e.g. process.stdout.write).
   (Bun.stdin as { text: () => Promise<string> }).text = () =>
     Promise.resolve(text);
 }
@@ -45,10 +47,12 @@ function mockStdin(text: string): void {
 const sessionIdsToClean: string[] = [];
 
 afterEach(async () => {
-  // Remove any marker files created during the test.
   for (const id of sessionIdsToClean) {
-    await rm(join(markerDir, id), { force: true });
-    await rm(join(markerDir, `${id}.tmp`), { force: true });
+    await Promise.all([
+      rm(join(markerDir, id), { force: true }),
+      rm(join(queueDir, id), { force: true }),
+      rm(join(releaseDir, id), { force: true }),
+    ]);
   }
   sessionIdsToClean.length = 0;
 });
@@ -65,37 +69,63 @@ describe("claudeStopHookCommand", () => {
 
     mockStdin(JSON.stringify({ session_id: sessionId }));
 
-    const code = await claudeStopHookCommand();
+    const code = await claudeStopHookCommand({ waitTimeoutMs: SHORT_TIMEOUT_MS });
 
     expect(code).toBe(0);
     expect(await fileExists(join(markerDir, sessionId))).toBe(true);
+    // No .tmp file should ever be created — we write directly to final path.
     expect(await fileExists(join(markerDir, `${sessionId}.tmp`))).toBe(false);
   });
 
-  // 2. stop_hook_active: true → no-op
-  test("stop_hook_active:true is a no-op and returns 0", async () => {
+  // 2. stop_hook_active: true still writes marker and polls the queue
+  //
+  // Claude Code sets `stopHookActive: true` on every Stop hook invocation
+  // after a prior `{decision:"block"}` response (see `src/query.ts` →
+  // `transition: { reason: 'stop_hook_blocking' }`). Multi-turn workflows
+  // therefore see `stop_hook_active=true` on every turn past the first. The
+  // hook must still write the marker so `waitForIdle` unblocks, and must
+  // still poll for queued follow-ups so the next `s.session.query(...)` can
+  // reach Claude.
+  test("stop_hook_active:true still writes marker and polls the queue", async () => {
     const sessionId = crypto.randomUUID();
     sessionIdsToClean.push(sessionId);
+
+    const queuedPrompt = "Third turn follow-up";
+    await mkdir(queueDir, { recursive: true });
+    await writeFile(join(queueDir, sessionId), queuedPrompt, "utf-8");
 
     mockStdin(
       JSON.stringify({ session_id: sessionId, stop_hook_active: true }),
     );
 
-    const code = await claudeStopHookCommand();
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      (chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      },
+    );
+
+    const code = await claudeStopHookCommand({ waitTimeoutMs: SHORT_TIMEOUT_MS });
+
+    stdoutSpy.mockRestore();
 
     expect(code).toBe(0);
-    expect(await fileExists(join(markerDir, sessionId))).toBe(false);
-    expect(await fileExists(join(markerDir, `${sessionId}.tmp`))).toBe(false);
+    // Marker must be written so waitForIdle unblocks on every turn.
+    expect(await fileExists(join(markerDir, sessionId))).toBe(true);
+    // Queue entry consumed and emitted as a block decision.
+    expect(await fileExists(join(queueDir, sessionId))).toBe(false);
+    const parsed: unknown = JSON.parse(stdoutChunks.join(""));
+    expect(parsed).toEqual({ decision: "block", reason: queuedPrompt });
   });
 
   // 3. Malformed JSON → returns 0, logs to console.error
   test("malformed JSON returns 0 and logs an error", async () => {
     mockStdin("not json {{{");
 
-    // Spy on console.error so the error doesn't bleed into test output.
     const errorSpy = spyOn(console, "error").mockImplementation(() => {});
 
-    const code = await claudeStopHookCommand();
+    const code = await claudeStopHookCommand({ waitTimeoutMs: SHORT_TIMEOUT_MS });
 
     expect(code).toBe(0);
     expect(errorSpy).toHaveBeenCalled();
@@ -109,7 +139,7 @@ describe("claudeStopHookCommand", () => {
 
     const errorSpy = spyOn(console, "error").mockImplementation(() => {});
 
-    const code = await claudeStopHookCommand();
+    const code = await claudeStopHookCommand({ waitTimeoutMs: SHORT_TIMEOUT_MS });
 
     expect(code).toBe(0);
     expect(errorSpy).toHaveBeenCalled();
@@ -131,10 +161,111 @@ describe("claudeStopHookCommand", () => {
       }),
     );
 
-    const code = await claudeStopHookCommand();
+    const code = await claudeStopHookCommand({ waitTimeoutMs: SHORT_TIMEOUT_MS });
 
     expect(code).toBe(0);
     expect(await fileExists(join(markerDir, sessionId))).toBe(true);
     expect(await fileExists(join(markerDir, `${sessionId}.tmp`))).toBe(false);
+  });
+
+  // 6. Queue file present at entry → emit block+reason, consume queue
+  test("queued prompt is emitted as a block decision and the queue file is consumed", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionIdsToClean.push(sessionId);
+
+    const queuedPrompt = "Now translate your previous greeting into pig latin.";
+    await mkdir(queueDir, { recursive: true });
+    await writeFile(join(queueDir, sessionId), queuedPrompt, "utf-8");
+
+    mockStdin(JSON.stringify({ session_id: sessionId }));
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      (chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      },
+    );
+
+    const code = await claudeStopHookCommand({ waitTimeoutMs: SHORT_TIMEOUT_MS });
+
+    stdoutSpy.mockRestore();
+
+    expect(code).toBe(0);
+    // Marker still written, since the workflow's waitForIdle depends on it.
+    expect(await fileExists(join(markerDir, sessionId))).toBe(true);
+    // Queue entry consumed.
+    expect(await fileExists(join(queueDir, sessionId))).toBe(false);
+    // Block decision emitted with the queued prompt as `reason`.
+    const emitted = stdoutChunks.join("");
+    const parsed: unknown = JSON.parse(emitted);
+    expect(parsed).toEqual({ decision: "block", reason: queuedPrompt });
+  });
+
+  // 7. Queue file appears during wait → still consumed and emitted
+  test("queue file written during the wait is consumed and emitted", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionIdsToClean.push(sessionId);
+
+    const queuedPrompt = "Follow-up written mid-wait";
+
+    mockStdin(JSON.stringify({ session_id: sessionId }));
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      (chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      },
+    );
+
+    // Kick the hook off, then write the queue file partway through its wait.
+    const hookPromise = claudeStopHookCommand({
+      waitTimeoutMs: 2_000,
+      pollIntervalMs: 25,
+    });
+
+    await Bun.sleep(120);
+    await mkdir(queueDir, { recursive: true });
+    await writeFile(join(queueDir, sessionId), queuedPrompt, "utf-8");
+
+    const code = await hookPromise;
+    stdoutSpy.mockRestore();
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(queueDir, sessionId))).toBe(false);
+    const parsed: unknown = JSON.parse(stdoutChunks.join(""));
+    expect(parsed).toEqual({ decision: "block", reason: queuedPrompt });
+  });
+
+  // 8. Release file present → exit 0, no stdout, consume release
+  test("release file lets the hook exit promptly without a decision", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionIdsToClean.push(sessionId);
+
+    await mkdir(releaseDir, { recursive: true });
+    await writeFile(join(releaseDir, sessionId), "", "utf-8");
+
+    mockStdin(JSON.stringify({ session_id: sessionId }));
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      (chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      },
+    );
+
+    const code = await claudeStopHookCommand({ waitTimeoutMs: SHORT_TIMEOUT_MS });
+
+    stdoutSpy.mockRestore();
+
+    expect(code).toBe(0);
+    // Release consumed so it doesn't carry over.
+    expect(await fileExists(join(releaseDir, sessionId))).toBe(false);
+    // Marker still written.
+    expect(await fileExists(join(markerDir, sessionId))).toBe(true);
+    // No block decision emitted.
+    expect(stdoutChunks.join("")).toBe("");
   });
 });

--- a/src/commands/cli/claude-stop-hook.ts
+++ b/src/commands/cli/claude-stop-hook.ts
@@ -2,9 +2,19 @@
  * Claude Stop Hook command — internal handler for Claude Code's Stop hook.
  *
  * Claude invokes `atomic _claude-stop-hook` at the end of every turn,
- * piping a JSON payload via stdin. This handler writes a marker file that
- * another part of the system watches via `fs.watch`, replacing tmux-pane-
- * scraping idle detection with a clean event-driven approach.
+ * piping a JSON payload via stdin. This handler has two jobs:
+ *
+ *   1. Write a per-session marker file that the workflow runtime watches via
+ *      `fs.watch` to detect turn completion (replacing tmux-pane scraping).
+ *
+ *   2. Deliver follow-up prompts without tmux send-keys. After the marker is
+ *      written, this process block-polls `~/.atomic/claude-queue/<session_id>`.
+ *      If the workflow enqueues a prompt there, we read it, delete the queue
+ *      entry, and emit `{"decision":"block","reason":<prompt>}` on stdout.
+ *      Claude Code treats `reason` as the next user message and keeps the
+ *      agent loop running on the same session — no TUI keystrokes required.
+ *      If the workflow instead signals session end via
+ *      `~/.atomic/claude-release/<session_id>`, we exit 0 and let Claude stop.
  *
  * Usage (configured in Claude's Stop hook):
  *   atomic _claude-stop-hook
@@ -19,6 +29,7 @@
  */
 
 import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -44,6 +55,32 @@ function isClaudeStopHookPayload(value: unknown): value is ClaudeStopHookPayload
 }
 
 /**
+ * Directory paths used by the Stop hook and the workflow runtime to exchange
+ * per-session signals.
+ *
+ * Exported so tests and `src/sdk/providers/claude.ts` share one source of truth.
+ */
+export function claudeHookDirs(): { marker: string; queue: string; release: string } {
+  const base = path.join(os.homedir(), ".atomic");
+  return {
+    marker: path.join(base, "claude-stop"),
+    queue: path.join(base, "claude-queue"),
+    release: path.join(base, "claude-release"),
+  };
+}
+
+/** Options for {@link claudeStopHookCommand}. Primarily used by tests to shrink the wait budget. */
+export interface ClaudeStopHookOptions {
+  /** Maximum time the hook waits for a queued follow-up prompt before letting Claude stop. */
+  waitTimeoutMs?: number;
+  /** Polling interval for queue/release detection. */
+  pollIntervalMs?: number;
+}
+
+const DEFAULT_WAIT_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+
+/**
  * Handler for the hidden `_claude-stop-hook` subcommand.
  *
  * Returns an exit code (0 on success or benign failure).  The caller
@@ -52,7 +89,12 @@ function isClaudeStopHookPayload(value: unknown): value is ClaudeStopHookPayload
  * We always return 0 — a non-zero exit would surface as a hook error in
  * Claude's transcript, which is not what we want.
  */
-export async function claudeStopHookCommand(): Promise<number> {
+export async function claudeStopHookCommand(
+  options: ClaudeStopHookOptions = {},
+): Promise<number> {
+  const waitTimeoutMs = options.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
   // 1. Read stdin
   const raw = await Bun.stdin.text();
 
@@ -70,21 +112,85 @@ export async function claudeStopHookCommand(): Promise<number> {
     return 0;
   }
 
-  // 3. Guard against infinite Stop-hook loops
-  if (payload.stop_hook_active === true) {
-    return 0;
+  // NOTE: we intentionally do NOT early-exit on `stop_hook_active === true`.
+  //
+  // Claude Code sets `stopHookActive: true` in its query state after any Stop
+  // hook returns a `{decision:"block"}` response, and that flag stays true for
+  // every subsequent Stop hook invocation in the same session (see
+  // `src/query.ts` → `transition: { reason: 'stop_hook_blocking' }`). In a
+  // multi-turn workflow, every follow-up turn after the first is therefore
+  // invoked with `stop_hook_active=true`. Returning early here would skip the
+  // marker write, leaving `waitForIdle` hanging until its 15-minute safety
+  // timeout, and would skip the queue poll so the workflow's next
+  // `s.session.query(...)` would never reach Claude.
+  //
+  // Our design doesn't need the generic loop guard: the hook only emits a
+  // `block` decision when the workflow runtime has written a prompt to the
+  // queue file. Infinite loops are bounded by the workflow (which either
+  // enqueues a finite number of prompts or writes a release marker on
+  // teardown via `clearClaudeSession`).
+  const dirs = claudeHookDirs();
+  await Promise.all([
+    fs.mkdir(dirs.marker, { recursive: true }),
+    fs.mkdir(dirs.queue, { recursive: true }),
+    fs.mkdir(dirs.release, { recursive: true }),
+  ]);
+
+  // 4. Write the marker file directly.
+  //
+  // We intentionally do NOT use a tmp+rename dance here. On Linux, inotify
+  // emits the rename event with `filename=<session_id>.tmp` (the source),
+  // which made `waitForIdle`'s `event.filename === session_id` filter miss
+  // the event entirely and hang forever. A direct write on a tiny payload is
+  // effectively atomic at the page-cache level and generates a single event
+  // whose filename matches the session id — which is all `waitForIdle` needs.
+  const markerPath = path.join(dirs.marker, payload.session_id);
+  await Bun.write(markerPath, raw);
+
+  // 5. Block-poll for either a queued follow-up prompt or a release signal.
+  //
+  // The workflow's `waitForIdle` has already been unblocked by the marker
+  // write above and is now returning control to the user's stage callback.
+  // One of three things happens next:
+  //
+  //   a. The callback calls `s.session.query(next)`, which writes the next
+  //      prompt to `~/.atomic/claude-queue/<session_id>`. We read it, delete
+  //      the queue entry, and emit `{"decision":"block","reason":<prompt>}`
+  //      on stdout. Claude Code feeds `reason` back as the next user message
+  //      and keeps the turn loop running — no tmux keystrokes involved.
+  //
+  //   b. The callback returns and the runtime writes a release marker at
+  //      `~/.atomic/claude-release/<session_id>`. We exit 0 with no stdout
+  //      payload and Claude stops as usual.
+  //
+  //   c. Neither happens within `waitTimeoutMs`. We exit 0 on timeout as a
+  //      safety net — Claude stops rather than hanging its Stop hook forever.
+  const queuePath = path.join(dirs.queue, payload.session_id);
+  const releasePath = path.join(dirs.release, payload.session_id);
+
+  const deadline = Date.now() + waitTimeoutMs;
+  while (Date.now() <= deadline) {
+    if (existsSync(releasePath)) {
+      try { await fs.unlink(releasePath); } catch { /* ENOENT is fine */ }
+      return 0;
+    }
+    if (existsSync(queuePath)) {
+      let prompt: string;
+      try {
+        prompt = await fs.readFile(queuePath, "utf-8");
+      } catch {
+        return 0;
+      }
+      try { await fs.unlink(queuePath); } catch { /* ENOENT is fine */ }
+      process.stdout.write(JSON.stringify({
+        decision: "block",
+        reason: prompt,
+      }));
+      return 0;
+    }
+    await Bun.sleep(pollIntervalMs);
   }
 
-  // 4. Write the marker file atomically
-  const markerDir = path.join(os.homedir(), ".atomic", "claude-stop");
-  await fs.mkdir(markerDir, { recursive: true });
-
-  const tmpPath = path.join(markerDir, `${payload.session_id}.tmp`);
-  const finalPath = path.join(markerDir, payload.session_id);
-
-  // Write contents — the watcher only cares that the file appears.
-  await Bun.write(tmpPath, raw);
-  await fs.rename(tmpPath, finalPath);
-
+  // Timeout — no queued prompt arrived. Let Claude stop normally.
   return 0;
 }

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -14,6 +14,9 @@ import { AGENT_CONFIG, type AgentKey } from "../../services/config/index.ts";
 import { COLORS, createPainter, type PaletteKey } from "../../theme/colors.ts";
 import { isCommandInstalled } from "../../services/system/detect.ts";
 import { ensureTmuxInstalled, ensureBunInstalled } from "../../lib/spawn.ts";
+import { ensureProjectSetup } from "./init/index.ts";
+import { ensureAtomicGlobalAgentConfigs } from "../../services/config/atomic-global-config.ts";
+import { getConfigRoot } from "../../services/config/config-path.ts";
 import {
   isTmuxInstalled,
   discoverWorkflows,
@@ -263,6 +266,13 @@ export async function workflowCommand(options: {
   // ── Preflight checks (shared between picker and named modes) ──
   const preflightCode = await runPrereqChecks(agent);
   if (preflightCode !== 0) return preflightCode;
+
+  // ── Preflight: global config sync + project onboarding files ──
+  // Mirrors `atomic chat` so workflow runs see the same MCP configs,
+  // agent settings, and global agent folders the chat command auto-heals.
+  const projectRoot = cwd ?? process.cwd();
+  await ensureAtomicGlobalAgentConfigs(getConfigRoot());
+  await ensureProjectSetup(agent, projectRoot);
 
   // ── Picker mode: -a <agent>, no -n ──
   if (!options.name) {

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -369,6 +369,92 @@ export async function _runHILWatcher(
   }
 }
 
+/**
+ * Path helpers for the transcript JSONL written by Claude Code.
+ * @internal Exported for tests.
+ */
+export function transcriptDir(): string {
+  return resolveSessionDir(process.cwd());
+}
+
+/** @internal Exported for tests. */
+export function transcriptPath(claudeSessionId: string): string {
+  return join(transcriptDir(), `${claudeSessionId}.jsonl`);
+}
+
+/**
+ * Watch this session's transcript JSONL and call `onHIL` on every HIL-state
+ * transition — independently of the Stop hook.
+ *
+ * Why not piggyback on the Stop hook? `AskUserQuestion` is a deferred tool
+ * (`shouldDefer: true`, see Claude Code's
+ * `src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx`). While the question
+ * is pending, Claude's agent loop blocks on the tool with
+ * `needsFollowUp === true`, so `handleStopHooks` never runs
+ * (`src/query.ts`: `if (!needsFollowUp)`). A watcher tied to the Stop-hook
+ * marker would sleep through the entire HIL window and only wake up after
+ * the user has already answered.
+ *
+ * Watches the parent session directory rather than the file itself so the
+ * attach is safe before Claude has created the JSONL on first query. Events
+ * are filtered by `<sessionId>.jsonl`. Returns when `signal` is aborted.
+ *
+ * @internal Exported for tests.
+ */
+export async function watchTranscriptForHIL(
+  claudeSessionId: string,
+  onHIL: (waiting: boolean) => void,
+  signal: AbortSignal,
+): Promise<void> {
+  const dir = transcriptDir();
+
+  const readMessages = async (): Promise<SessionMessage[]> => {
+    try {
+      return await getSessionMessages(claudeSessionId, {
+        dir: process.cwd(),
+        includeSystemMessages: true,
+      });
+    } catch {
+      return [];
+    }
+  };
+
+  let wasHIL = false;
+  const check = async (): Promise<void> => {
+    const msgs = await readMessages();
+    const isHIL = _hasUnresolvedHILTool(msgs);
+    if (isHIL !== wasHIL) {
+      onHIL(isHIL);
+      wasHIL = isHIL;
+    }
+  };
+
+  await mkdir(dir, { recursive: true });
+
+  // Attach the watcher BEFORE the initial check so any events that arrive
+  // during the check are buffered by the iterator instead of being lost.
+  const watcher = watch(dir, { signal });
+
+  // Initial check: closes the race where the JSONL already contains an
+  // unresolved AskUserQuestion by the time this watcher attaches (resumed
+  // session, slow attach, etc.).
+  await check();
+
+  try {
+    for await (const _event of watcher) {
+      // We intentionally don't filter by `_event.filename`. On Linux, writes
+      // can deliver events with unrelated or `.tmp` basenames, and Bun's
+      // fs.watch behavior varies across OSes; `getSessionMessages` is keyed
+      // by `claudeSessionId` so a cheap re-read is authoritative.
+      await check();
+    }
+  } catch (e: unknown) {
+    if (!(e instanceof Error && e.name === "AbortError")) {
+      throw e;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -490,6 +576,11 @@ export async function releaseClaudeSession(claudeSessionId: string): Promise<voi
  * `fs.watch` event on the parent directory — far more reliable than polling
  * tmux pane glyphs, which vary between Claude Code versions.
  *
+ * This function is strictly about *idle detection*. HIL is detected separately
+ * by {@link watchTranscriptForHIL}; the Stop hook does not fire while
+ * `AskUserQuestion` is pending (the agent loop blocks on deferred tools), so
+ * mixing the two would silently miss the HIL window.
+ *
  * Algorithm:
  * 1. Attach the directory watcher, then check for the marker file on disk —
  *    this closes the race where the Stop hook fires between prompt submission
@@ -497,17 +588,12 @@ export async function releaseClaudeSession(claudeSessionId: string): Promise<voi
  * 2. On any event, re-check the marker file on disk (we intentionally do NOT
  *    filter by `event.filename`, because on Linux a write can deliver multiple
  *    events with varying filenames and editor tools may race us).
- * 3. Read the session transcript via `getSessionMessages` and test
- *    `_hasUnresolvedHILTool`:
- *    - If unresolved HIL: call `onHIL(true)`, unlink the marker (so the next
- *      turn's hook can fire again), and continue watching.
- *    - If no unresolved HIL after a prior HIL: call `onHIL(false)`.
- *    - If truly idle: slice messages from `transcriptBeforeCount` and return.
+ * 3. Read the session transcript via `getSessionMessages` and slice messages
+ *    from `transcriptBeforeCount`.
  * 4. Clean up the `fs.watch` watcher on any exit path via AbortController.
  *
  * @param claudeSessionId       - Claude's session UUID (used to identify marker file)
  * @param transcriptBeforeCount - number of messages in transcript before this turn
- * @param onHIL                 - optional callback for HIL state changes
  */
 /** Safety timeout so the workflow's next stage still fires if the Stop hook
  * never runs (misconfigured settings, killed Claude process, etc.). 15 min
@@ -520,7 +606,6 @@ const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 export async function waitForIdle(
   claudeSessionId: string,
   transcriptBeforeCount: number,
-  onHIL?: (waiting: boolean) => void,
 ): Promise<SessionMessage[]> {
 
   const dir = markerDir();
@@ -528,8 +613,6 @@ export async function waitForIdle(
   const target = markerPath(sessionId);
   const ac = new AbortController();
   const timeout = setTimeout(() => ac.abort(), IDLE_TIMEOUT_MS);
-
-  let hilActive = false;
 
   // Process a marker that has appeared on disk. Returns a tuple:
   //   [resolved, result] — when resolved=true, waitForIdle should return.
@@ -548,19 +631,6 @@ export async function waitForIdle(
     let msgs = await readMessages();
     if (msgs === null) {
       // Transcript read failed — keep watching; the next event will retry.
-      return [false, []];
-    }
-
-    if (_hasUnresolvedHILTool(msgs)) {
-      if (!hilActive) {
-        onHIL?.(true);
-        hilActive = true;
-      }
-      try {
-        await unlink(target);
-      } catch {
-        // ENOENT is fine.
-      }
       return [false, []];
     }
 
@@ -590,11 +660,6 @@ export async function waitForIdle(
       // Whether we recovered or ran out of budget, fall through — returning
       // what we have beats hanging forever if the writer really did drop a
       // message (e.g. max-tokens collapse, abort mid-stream).
-    }
-
-    if (hilActive) {
-      onHIL?.(false);
-      hilActive = false;
     }
 
     const sliced = msgs.length > transcriptBeforeCount
@@ -787,9 +852,31 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionM
       paneState.claudeStarted = true;
     }
 
-    // Wait for response completion via the Stop-hook marker file.
-    // HIL detection is integrated into waitForIdle.
-    return await waitForIdle(claudeSessionId, transcriptBeforeCount, onHIL);
+    // HIL detection runs in parallel with idle detection. The Stop hook
+    // (which drives waitForIdle) doesn't fire while `AskUserQuestion` is
+    // pending, so we watch the transcript JSONL directly for HIL transitions.
+    const hilAc = new AbortController();
+    if (onHIL) {
+      void watchTranscriptForHIL(claudeSessionId, onHIL, hilAc.signal).catch(
+        () => {
+          // Best-effort — never fail the query over HIL detection.
+        },
+      );
+    }
+
+    try {
+      return await waitForIdle(claudeSessionId, transcriptBeforeCount);
+    } finally {
+      hilAc.abort();
+      // Safety: waitForIdle only returns at true turn-idle (no unresolved
+      // AskUserQuestion by Claude's own `!needsFollowUp` gate). If the
+      // transcript watcher missed the final tool_result flush due to
+      // Claude's batched JSONL writes, the UI could be stuck on
+      // awaiting_input. `resumeSession` in the panel store is idempotent
+      // (no-op when the session isn't in awaiting_input), so this is
+      // always safe.
+      onHIL?.(false);
+    }
   } finally {
     if (spawnPromptFile) {
       try {

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -24,24 +24,13 @@ import {
   type SDKUserMessage,
   type Options as SDKOptions,
 } from "@anthropic-ai/claude-agent-sdk";
-import {
-  sendViaPasteBuffer,
-  sendSpecialKey,
-  sendKeysAndSubmit,
-  capturePaneVisible,
-  capturePaneScrollback,
-  normalizeTmuxCapture,
-  normalizeTmuxLines,
-  paneLooksReady,
-  paneHasActiveTask,
-  waitForPaneReady,
-  attemptSubmitRounds,
-} from "../runtime/tmux.ts";
-import { watch, unlink, mkdir } from "node:fs/promises";
+import { sendKeysAndSubmit } from "../runtime/tmux.ts";
+import { watch, unlink, mkdir, writeFile } from "node:fs/promises";
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import os from "node:os";
+import { claudeHookDirs } from "../../commands/cli/claude-stop-hook.ts";
 
 // ---------------------------------------------------------------------------
 // Session tracking — ensures createClaudeSession is called before claudeQuery
@@ -61,21 +50,27 @@ interface PaneState {
   chatFlags: string[];
   /** Timeout in ms waiting for Claude TUI / JSONL file on first spawn. */
   readyTimeoutMs: number;
-  /**
-   * Workflow session directory (`~/.atomic/sessions/<runId>/<name>-<sid>`).
-   * The first prompt is persisted here as `prompt.txt` so it appears in the
-   * session log alongside `messages.json`, `metadata.json`, etc.
-   */
-  sessionDir: string;
 }
 
 const initializedPanes = new Map<string, PaneState>();
 
 /**
- * Remove a pane from the initialized map, freeing memory.
- * Call when a Claude session is killed or no longer needed.
+ * Remove a pane from the initialized map and signal the currently-blocked
+ * Stop hook that the session is over, so Claude stops promptly instead of
+ * waiting out the hook's safety timeout.
+ *
+ * Called by the runtime when a Claude stage is being torn down. Idempotent.
  */
-export function clearClaudeSession(paneId: string): void {
+export async function clearClaudeSession(paneId: string): Promise<void> {
+  const state = initializedPanes.get(paneId);
+  if (state) {
+    try {
+      await releaseClaudeSession(state.claudeSessionId);
+    } catch {
+      // Best-effort — if release fails the hook will still exit on its
+      // own safety timeout.
+    }
+  }
   initializedPanes.delete(paneId);
 }
 
@@ -92,11 +87,6 @@ const DEFAULT_CHAT_FLAGS = [
 export interface ClaudeSessionOptions {
   /** tmux pane ID where Claude should be started */
   paneId: string;
-  /**
-   * Workflow session directory. The first prompt is written here as
-   * `prompt.txt` and Claude is told to read from that path.
-   */
-  sessionDir: string;
   /** CLI flags to pass to the `claude` command (default: ["--allow-dangerously-skip-permissions", "--dangerously-skip-permissions"]) */
   chatFlags?: string[];
   /** Timeout in ms waiting for Claude TUI to be ready (default: 30s) */
@@ -132,48 +122,54 @@ export interface ClaudeSessionOptions {
  * });
  * ```
  */
-export async function createClaudeSession(options: ClaudeSessionOptions): Promise<void> {
+export async function createClaudeSession(options: ClaudeSessionOptions): Promise<string> {
   const {
     paneId,
-    sessionDir,
     chatFlags = DEFAULT_CHAT_FLAGS,
     readyTimeoutMs = 30_000,
   } = options;
 
+  const claudeSessionId = randomUUID();
   initializedPanes.set(paneId, {
-    claudeSessionId: randomUUID(),
+    claudeSessionId,
     claudeStarted: false,
     chatFlags,
     readyTimeoutMs,
-    sessionDir,
   });
+  return claudeSessionId;
+}
+
+/**
+ * Build the short, single-line natural-language prompt we send to Claude
+ * (either as spawn argv or as a follow-up message). Claude's first action
+ * is then a Read tool call against `promptFile` — which sidesteps shell
+ * escaping, ARG_MAX, and tmux paste-buffer flakiness for large prompts.
+ *
+ * The session dir and filename are slug-based (`prompt-<N>.txt` under
+ * `~/.atomic/sessions/...`), so they never contain shell-special characters.
+ */
+function readPromptInstruction(promptFile: string): string {
+  return `Read ${promptFile} and follow the instructions inside.`;
 }
 
 /**
  * Spawn `claude` in the pane with the prompt baked in via the Read tool.
  *
- * The prompt is written to `${sessionDir}/prompt.txt` so it persists in the
- * workflow's session log alongside `messages.json`, `metadata.json`, etc.
- * The argv prompt is `Read the prompt in <path>`, so Claude's first action
- * is a Read tool call against that file. This sidesteps shell-escaping and
- * ARG_MAX entirely — the prompt bytes never traverse the shell parser or
- * the kernel argv cap.
+ * The prompt is already written to `promptFile` by the caller. The spawn
+ * argv is `'Read the prompt in <path>'`, so Claude's first action is a Read
+ * tool call against that file.
  */
 async function spawnClaudeWithPrompt(
   paneId: string,
-  prompt: string,
+  promptFile: string,
   chatFlags: string[],
   sessionId: string,
-  sessionDir: string,
   readyTimeoutMs: number,
 ): Promise<void> {
-  const promptFile = join(sessionDir, "prompt.txt");
-  writeFileSync(promptFile, prompt, "utf-8");
-
   // sessionDir is the workflow's `${name}-${sessionId}` directory under
   // ~/.atomic/sessions — slug-based, so single-quoting is sufficient on
   // POSIX and PowerShell alike.
-  const argvPrompt = `'Read the prompt in ${promptFile}'`;
+  const argvPrompt = `'${readPromptInstruction(promptFile)}'`;
   const cmd = [
     "claude",
     ...chatFlags,
@@ -309,6 +305,36 @@ export function _hasUnresolvedHILTool(messages: SessionMessage[]): boolean {
 }
 
 /**
+ * Returns true when the most recent assistant message in the transcript
+ * ended with `stop_reason: "tool_use"` — i.e. the agent stopped the current
+ * API response to call a tool but has not yet produced its post-tool answer.
+ *
+ * Claude Code's Stop hook fires each time Claude "finishes responding",
+ * which includes intermediate tool-use responses in a multi-step agent
+ * loop (not just the final `end_turn`). If we return from `waitForIdle`
+ * on the first Stop event, we capture the transcript mid-loop — the
+ * final assistant text block is still being generated and won't be on
+ * disk yet, so `inbox.md` drops the actual answer.
+ *
+ * We keep watching until we see an assistant message with a terminal
+ * stop_reason (`end_turn`, `max_tokens`, `stop_sequence`, `refusal`),
+ * which is the real end of the turn.
+ *
+ * Exported as `_isMidAgentLoop` for unit testing.
+ */
+export function _isMidAgentLoop(messages: SessionMessage[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.type !== "assistant") continue;
+    const inner = msg.message as { stop_reason?: unknown } | null;
+    const stopReason = inner?.stop_reason;
+    return stopReason === "tool_use";
+  }
+  // No assistant message yet — treat as mid-loop so we wait for one.
+  return true;
+}
+
+/**
  * Core HIL watcher loop — pure logic, dependency-injected for testability.
  *
  * Iterates an async iterable of "file change" events (each event triggers a
@@ -349,13 +375,13 @@ export async function _runHILWatcher(
 
 /**
  * Path of the directory where the claude-stop-hook writes marker files.
- * Each Claude turn creates `~/.atomic/claude-stop/<session_id>` atomically
- * via rename, which triggers the `fs.watch` event in `waitForIdle`.
+ * Each Claude turn creates `~/.atomic/claude-stop/<session_id>` which
+ * triggers the `fs.watch` event in `waitForIdle`.
  *
  * @internal Exported for unit tests.
  */
 export function markerDir(): string {
-  return join(os.homedir(), ".atomic", "claude-stop");
+  return claudeHookDirs().marker;
 }
 
 /**
@@ -365,6 +391,35 @@ export function markerDir(): string {
  */
 export function markerPath(claudeSessionId: string): string {
   return join(markerDir(), claudeSessionId);
+}
+
+/**
+ * Directory where the workflow runtime writes queued follow-up prompts that
+ * `atomic _claude-stop-hook` picks up and feeds back to Claude as
+ * `{decision:"block", reason:<prompt>}`. @internal Exported for unit tests.
+ */
+export function queueDir(): string {
+  return claudeHookDirs().queue;
+}
+
+/** Return the queue file path for a given Claude session ID. @internal */
+export function queuePath(claudeSessionId: string): string {
+  return join(queueDir(), claudeSessionId);
+}
+
+/**
+ * Directory where the runtime writes session-release signals. When the Stop
+ * hook sees `~/.atomic/claude-release/<session_id>` it exits 0 without
+ * emitting a block decision — the signal used by `clearClaudeSession` to
+ * tell Claude it's safe to actually stop. @internal Exported for unit tests.
+ */
+export function releaseDir(): string {
+  return claudeHookDirs().release;
+}
+
+/** Return the release file path for a given Claude session ID. @internal */
+export function releasePath(claudeSessionId: string): string {
+  return join(releaseDir(), claudeSessionId);
 }
 
 /**
@@ -386,6 +441,42 @@ async function clearStaleMarker(claudeSessionId: string): Promise<void> {
   }
 }
 
+/**
+ * Ensure the queue directory exists and remove any stale entry from a prior
+ * turn so the Stop hook doesn't race on it. Ignores ENOENT.
+ */
+async function clearStaleQueue(claudeSessionId: string): Promise<void> {
+  await mkdir(queueDir(), { recursive: true });
+  try {
+    await unlink(queuePath(claudeSessionId));
+  } catch (e: unknown) {
+    if (!(e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT")) {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Write the next prompt to the session queue file. The currently-running
+ * Stop hook process (blocked on poll from the previous turn) picks it up,
+ * emits `{decision:"block", reason:<prompt>}` on stdout, and Claude feeds
+ * it back as the next user message — no tmux keystrokes required.
+ */
+async function enqueuePrompt(claudeSessionId: string, prompt: string): Promise<void> {
+  await mkdir(queueDir(), { recursive: true });
+  await writeFile(queuePath(claudeSessionId), prompt, "utf-8");
+}
+
+/**
+ * Signal the Stop hook's blocking wait that this session is done. Called
+ * during session teardown so the final hook invocation exits 0 promptly.
+ * Safe to call more than once.
+ */
+export async function releaseClaudeSession(claudeSessionId: string): Promise<void> {
+  await mkdir(releaseDir(), { recursive: true });
+  await writeFile(releasePath(claudeSessionId), "");
+}
+
 // ---------------------------------------------------------------------------
 // Idle detection via marker file watch
 // ---------------------------------------------------------------------------
@@ -395,110 +486,159 @@ async function clearStaleMarker(claudeSessionId: string): Promise<void> {
  * `~/.atomic/claude-stop/` marker directory.
  *
  * When Claude finishes a turn, the `atomic _claude-stop-hook` Stop hook writes
- * `~/.atomic/claude-stop/<session_id>` atomically (tmp file + rename).  The
- * rename triggers an OS-native `fs.watch` event on the parent directory —
- * far more reliable than polling tmux pane glyphs, which vary between Claude
- * Code versions.
+ * `~/.atomic/claude-stop/<session_id>`. The write triggers an OS-native
+ * `fs.watch` event on the parent directory — far more reliable than polling
+ * tmux pane glyphs, which vary between Claude Code versions.
  *
  * Algorithm:
- * 1. Watch the marker directory for events whose `filename` matches
- *    `claudeSessionId`.
- * 2. On a matching event, read the session transcript via
- *    `getSessionMessages` and test `_hasUnresolvedHILTool`.
+ * 1. Attach the directory watcher, then check for the marker file on disk —
+ *    this closes the race where the Stop hook fires between prompt submission
+ *    and watcher attach.
+ * 2. On any event, re-check the marker file on disk (we intentionally do NOT
+ *    filter by `event.filename`, because on Linux a write can deliver multiple
+ *    events with varying filenames and editor tools may race us).
+ * 3. Read the session transcript via `getSessionMessages` and test
+ *    `_hasUnresolvedHILTool`:
  *    - If unresolved HIL: call `onHIL(true)`, unlink the marker (so the next
  *      turn's hook can fire again), and continue watching.
  *    - If no unresolved HIL after a prior HIL: call `onHIL(false)`.
  *    - If truly idle: slice messages from `transcriptBeforeCount` and return.
- * 3. Clean up the `fs.watch` watcher on any exit path via AbortController.
+ * 4. Clean up the `fs.watch` watcher on any exit path via AbortController.
  *
- * The function signature is intentionally identical to the previous polling
- * implementation so all callers remain unchanged.
- *
- * @param paneId           - tmux pane (kept in signature for caller compat; not used here)
- * @param claudeSessionId  - Claude's session UUID (used to identify marker file)
+ * @param claudeSessionId       - Claude's session UUID (used to identify marker file)
  * @param transcriptBeforeCount - number of messages in transcript before this turn
- * @param beforeContent    - (unused) pane content before send; kept for compat
- * @param pollIntervalMs   - (unused) kept for compat; watch is event-driven
- * @param onHIL            - optional callback for HIL state changes
+ * @param onHIL                 - optional callback for HIL state changes
  */
+/** Safety timeout so the workflow's next stage still fires if the Stop hook
+ * never runs (misconfigured settings, killed Claude process, etc.). 15 min
+ * covers any reasonable single-turn run without hanging forever. */
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+
 /**
  * @internal Exported for unit tests.
  */
 export async function waitForIdle(
-  _paneId: string,
-  claudeSessionId: string | undefined,
+  claudeSessionId: string,
   transcriptBeforeCount: number,
-  _beforeContent: string,
-  _pollIntervalMs: number,
   onHIL?: (waiting: boolean) => void,
 ): Promise<SessionMessage[]> {
-  // Without a session ID we cannot watch the marker directory — return empty.
-  if (!claudeSessionId) {
-    return [];
-  }
 
   const dir = markerDir();
   const sessionId = claudeSessionId;
+  const target = markerPath(sessionId);
   const ac = new AbortController();
+  const timeout = setTimeout(() => ac.abort(), IDLE_TIMEOUT_MS);
 
   let hilActive = false;
 
-  try {
-    for await (const event of watch(dir, { signal: ac.signal })) {
-      // Filter: only care about events for our session's marker file
-      if (event.filename !== sessionId) continue;
+  // Process a marker that has appeared on disk. Returns a tuple:
+  //   [resolved, result] — when resolved=true, waitForIdle should return.
+  const readMessages = async (): Promise<SessionMessage[] | null> => {
+    try {
+      return await getSessionMessages(sessionId, {
+        dir: process.cwd(),
+        includeSystemMessages: true,
+      });
+    } catch {
+      return null;
+    }
+  };
 
-      // Marker appeared — read transcript
-      let msgs: SessionMessage[];
+  const handleMarker = async (): Promise<[boolean, SessionMessage[]]> => {
+    let msgs = await readMessages();
+    if (msgs === null) {
+      // Transcript read failed — keep watching; the next event will retry.
+      return [false, []];
+    }
+
+    if (_hasUnresolvedHILTool(msgs)) {
+      if (!hilActive) {
+        onHIL?.(true);
+        hilActive = true;
+      }
       try {
-        msgs = await getSessionMessages(sessionId, {
-          dir: process.cwd(),
-          includeSystemMessages: true,
-        });
+        await unlink(target);
       } catch {
-        // Transcript read failed — wait for the next marker event
-        continue;
+        // ENOENT is fine.
       }
+      return [false, []];
+    }
 
-      if (_hasUnresolvedHILTool(msgs)) {
-        // Agent is blocked on user input (HIL).
-        if (!hilActive) {
-          onHIL?.(true);
-          hilActive = true;
-        }
-        // Remove the marker so the Stop hook can write a new one after the
-        // user responds and Claude finishes its next turn.
-        try {
-          await unlink(markerPath(sessionId));
-        } catch {
-          // ENOENT is fine — ignore
-        }
-        // Continue watching for the next marker event
-        continue;
+    // The Stop hook fires only once per agent loop completion (when there
+    // are no more tool_use blocks to resolve — see Claude Code's
+    // `src/query/stopHooks.ts` / `query.ts`: `if (!needsFollowUp)`). But
+    // Claude Code writes to the JSONL transcript asynchronously via
+    // `enqueueWrite()` with a batched ~100ms flush, so the final
+    // `assistant[text]` message can still be in the page-cache when our
+    // marker watcher fires. Reading the transcript at that moment races
+    // the writer and returns a prefix ending at `user[tool_result]`.
+    //
+    // Because no further marker events are coming, we can't just "keep
+    // watching the marker dir". Instead, poll the transcript file directly
+    // until it either settles on a terminal stop_reason or the poll budget
+    // expires. The budget covers Claude Code's flush interval plus headroom
+    // for slow disks and buffered `fs/promises` writes.
+    if (_isMidAgentLoop(msgs)) {
+      const pollIntervalMs = 50;
+      const pollBudgetMs = 3_000;
+      const start = Date.now();
+      while (_isMidAgentLoop(msgs) && Date.now() - start < pollBudgetMs) {
+        await Bun.sleep(pollIntervalMs);
+        const next = await readMessages();
+        if (next) msgs = next;
       }
+      // Whether we recovered or ran out of budget, fall through — returning
+      // what we have beats hanging forever if the writer really did drop a
+      // message (e.g. max-tokens collapse, abort mid-stream).
+    }
 
-      // No unresolved HIL — if we were in HIL state, signal resolution.
-      if (hilActive) {
-        onHIL?.(false);
-        hilActive = false;
+    if (hilActive) {
+      onHIL?.(false);
+      hilActive = false;
+    }
+
+    const sliced = msgs.length > transcriptBeforeCount
+      ? msgs.slice(transcriptBeforeCount)
+      : [];
+    return [true, sliced];
+  };
+
+  try {
+    // Attach the watcher FIRST; fs.watch returns an iterable whose underlying
+    // inotify/FSEvent subscription is live from this point on.
+    const watcher = watch(dir, { signal: ac.signal });
+
+    // Close the race: if the Stop hook fired between clearStaleMarker() and
+    // the watcher attach above, the marker is already on disk and no further
+    // events will be emitted. Handle it synchronously.
+    if (existsSync(target)) {
+      const [done, result] = await handleMarker();
+      if (done) {
+        ac.abort();
+        return result;
       }
+    }
 
-      // Truly idle — return transcript messages produced during this turn.
-      const result = msgs.length > transcriptBeforeCount
-        ? msgs.slice(transcriptBeforeCount)
-        : [];
+    for await (const _event of watcher) {
+      // We don't trust event.filename — on Linux, a tmp+rename write emits
+      // events with the `.tmp` basename, and other files in the marker dir
+      // can race us. The marker file's existence on disk is authoritative.
+      if (!existsSync(target)) continue;
 
-      ac.abort();
-      return result;
+      const [done, result] = await handleMarker();
+      if (done) {
+        ac.abort();
+        return result;
+      }
     }
   } catch (e: unknown) {
-    // AbortError is expected when we call ac.abort() to stop watching.
-    if (e instanceof Error && e.name === "AbortError") {
-      // Normal exit — return value was already set and returned above.
-      // If we somehow reach here without returning, fall through to [].
-    } else {
+    // AbortError is expected when we call ac.abort() to stop watching, or
+    // when the safety timeout fires.
+    if (!(e instanceof Error && e.name === "AbortError")) {
       throw e;
     }
+  } finally {
+    clearTimeout(timeout);
   }
 
   return [];
@@ -513,14 +653,6 @@ export interface ClaudeQueryOptions {
   paneId: string;
   /** The prompt to send */
   prompt: string;
-  /** Polling interval in ms (default: 2000) */
-  pollIntervalMs?: number;
-  /** Number of C-m presses per submit round (default: 1 for Claude) */
-  submitPresses?: number;
-  /** Max submit rounds if text isn't consumed (default: 6) */
-  maxSubmitRounds?: number;
-  /** Timeout in ms waiting for pane to be ready before sending (default: 30s) */
-  readyTimeoutMs?: number;
   /**
    * Called when the agent's human-in-the-loop state changes.
    * `waiting=true`  → AskUserQuestion is pending (agent blocked on user input).
@@ -567,14 +699,23 @@ export function extractAssistantText(
 /**
  * Send a prompt to a Claude Code interactive session running in a tmux pane.
  *
- * Flow (hardened from OMX's sendToWorker):
- * 1. Wait for pane readiness with exponential backoff
- * 2. Capture pane content before sending
- * 3. Send literal text via `send-keys -l --`
- * 4. Submit with C-m rounds and per-round capture verification
- * 5. Adaptive retry: clear line (C-u), re-type, re-submit
- * 6. Post-submit verification via active-task detection
- * 7. Wait for response by polling for output stabilization + prompt return
+ * First query and follow-up queries use different delivery channels:
+ *
+ *   - **First query**: stages the prompt in a tmp file and spawns
+ *     `claude --session-id <UUID> 'Read the prompt in <path>'` into the
+ *     empty pane. Claude's first action is a Read tool call, which
+ *     sidesteps ARG_MAX on the spawn argv.
+ *
+ *   - **Follow-up query**: writes the prompt to
+ *     `~/.atomic/claude-queue/<session_id>`. The Stop hook from the
+ *     previous turn is blocked in a poll loop there; it reads the queue
+ *     entry and emits `{"decision":"block","reason":<prompt>}` on stdout,
+ *     which Claude Code feeds back as the next user message. No tmux
+ *     keystrokes, no paste-buffer dance, no pane-state polling — the
+ *     whole delivery rides Claude's own continuation API.
+ *
+ * Both paths converge on `waitForIdle`, which watches the Stop-hook marker
+ * file for this session and returns the transcript slice for the turn.
  *
  * @example
  * ```typescript
@@ -588,15 +729,7 @@ export function extractAssistantText(
  * ```
  */
 export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionMessage[]> {
-  const {
-    paneId,
-    prompt,
-    pollIntervalMs = 2_000,
-    submitPresses = 1,
-    maxSubmitRounds = 6,
-    readyTimeoutMs = 30_000,
-    onHIL,
-  } = options;
+  const { paneId, prompt, onHIL } = options;
 
   const paneState = initializedPanes.get(paneId);
   if (!paneState) {
@@ -609,133 +742,68 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionM
   const dir = process.cwd();
   const claudeSessionId = paneState.claudeSessionId;
 
-  // ── Clear any stale marker left from a previous turn before submitting. ──
-  // This ensures `waitForIdle`'s watch loop doesn't fire on the marker written
-  // by the Stop hook at the end of the LAST turn instead of the current one.
+  // Clear stale marker AND stale queue entry before submitting so the
+  // Stop-hook for the previous turn (if any) cannot race this one.
   await clearStaleMarker(claudeSessionId);
+  await clearStaleQueue(claudeSessionId);
 
-  // ── First query: spawn `claude --session-id <UUID> 'Read the prompt in <path>'`.
-  // The prompt is delivered via Claude's Read tool on its first turn — no
-  // paste-buffer, no submit retries. Subsequent queries fall through to the
-  // existing paste-buffer flow against the now-running TUI.
-  if (!paneState.claudeStarted) {
-    await spawnClaudeWithPrompt(
-      paneId,
-      prompt,
-      paneState.chatFlags,
-      claudeSessionId,
-      paneState.sessionDir,
-      paneState.readyTimeoutMs,
-    );
-    paneState.claudeStarted = true;
-  } else {
-    // ── Transcript snapshot (before send) ──
-    // Taken BEFORE sending so we get an accurate baseline for slicing the
-    // returned messages to just this turn.
-    let transcriptBeforeCount = 0;
-    try {
-      const msgs = await getSessionMessages(claudeSessionId, {
-        dir,
-        includeSystemMessages: true,
-      });
-      transcriptBeforeCount = msgs.length;
-    } catch {
-      // Best-effort — 0 means we scan all messages (correct, slightly less efficient)
-    }
+  let transcriptBeforeCount = 0;
+  let spawnPromptFile: string | undefined;
 
-    const beforeContent = normalizeTmuxLines(capturePaneScrollback(paneId));
-    const normalizedPrompt = normalizeTmuxCapture(prompt).slice(0, 100);
-
-    // Step 1: Wait for pane readiness before sending
-    await waitForPaneReady(paneId, readyTimeoutMs);
-
-    // Step 2: Send text via paste buffer (atomic, handles large prompts)
-    sendViaPasteBuffer(paneId, prompt);
-    await Bun.sleep(150);
-
-    // Step 3: Submit with per-round capture verification
-    let delivered = await attemptSubmitRounds(paneId, normalizedPrompt, maxSubmitRounds, submitPresses);
-
-    // Step 4: Adaptive retry — clear line, re-type, re-submit
-    if (!delivered) {
-      const visibleCapture = capturePaneVisible(paneId);
-      const visibleNorm = normalizeTmuxCapture(visibleCapture);
-
-      // Only retry if text is still visible and pane is idle (not mid-task)
-      if (visibleNorm.includes(normalizedPrompt) && !paneHasActiveTask(visibleCapture) && paneLooksReady(visibleCapture)) {
-        sendSpecialKey(paneId, "C-u");
-        await Bun.sleep(80);
-        sendViaPasteBuffer(paneId, prompt);
-        await Bun.sleep(120);
-        delivered = await attemptSubmitRounds(paneId, normalizedPrompt, maxSubmitRounds, submitPresses);
-      }
-    }
-
-    // Step 5: Final fallback — double C-m nudge + post-submit verification
-    if (!delivered) {
-      sendSpecialKey(paneId, "C-m");
-      await Bun.sleep(120);
-      sendSpecialKey(paneId, "C-m");
-      await Bun.sleep(300);
-
-      const verifyCapture = capturePaneVisible(paneId);
-      if (paneHasActiveTask(verifyCapture)) {
-        delivered = true;
-      } else {
-        delivered = !normalizeTmuxCapture(verifyCapture).includes(normalizedPrompt);
+  try {
+    if (paneState.claudeStarted) {
+      // Follow-up query: snapshot the transcript length so waitForIdle can
+      // slice out the messages produced by THIS turn, then enqueue the
+      // prompt for the Stop hook to pick up.
+      try {
+        const msgs = await getSessionMessages(claudeSessionId, {
+          dir,
+          includeSystemMessages: true,
+        });
+        transcriptBeforeCount = msgs.length;
+      } catch {
+        // Best-effort — 0 means we scan all messages (correct, slightly less efficient)
       }
 
-      // One more attempt if text is still stuck
-      if (!delivered) {
-        sendSpecialKey(paneId, "C-m");
-        await Bun.sleep(150);
-        sendSpecialKey(paneId, "C-m");
-      }
+      await enqueuePrompt(claudeSessionId, prompt);
+    } else {
+      // First query: spawn claude with the prompt baked into argv via the
+      // Read-tool indirection. The tmp file only has to live long enough
+      // for Claude's first Read tool call, so we delete it once waitForIdle
+      // returns (the turn is complete by then).
+      spawnPromptFile = join(
+        os.tmpdir(),
+        `atomic-claude-prompt-${claudeSessionId}-${randomUUID()}.txt`,
+      );
+      writeFileSync(spawnPromptFile, prompt, "utf-8");
+
+      await spawnClaudeWithPrompt(
+        paneId,
+        spawnPromptFile,
+        paneState.chatFlags,
+        claudeSessionId,
+        paneState.readyTimeoutMs,
+      );
+      paneState.claudeStarted = true;
     }
 
-    // Wait for response completion via pane idle + transcript read.
+    // Wait for response completion via the Stop-hook marker file.
     // HIL detection is integrated into waitForIdle.
-    return await waitForIdle(
-      paneId,
-      claudeSessionId,
-      transcriptBeforeCount,
-      beforeContent,
-      pollIntervalMs,
-      onHIL,
-    );
+    return await waitForIdle(claudeSessionId, transcriptBeforeCount, onHIL);
+  } finally {
+    if (spawnPromptFile) {
+      try {
+        await unlink(spawnPromptFile);
+      } catch {
+        // ENOENT / already removed is fine.
+      }
+    }
   }
-
-  // First-query path: wait for Claude to finish the response. The prompt
-  // file lives in the workflow's session dir as `prompt.txt` and is kept
-  // as part of the session log — no cleanup needed.
-  return await waitForIdle(
-    paneId,
-    claudeSessionId,
-    0,
-    "",
-    pollIntervalMs,
-    onHIL,
-  );
 }
 
 // ---------------------------------------------------------------------------
 // Synthetic wrappers — uniform s.client / s.session API for Claude stages
 // ---------------------------------------------------------------------------
-
-/**
- * Default query options the user can set per-stage via the `sessionOpts` arg.
- * These become defaults for every `s.session.query()` call within that stage.
- */
-export interface ClaudeQueryDefaults {
-  /** Polling interval in ms (default: 2000) */
-  pollIntervalMs?: number;
-  /** Number of C-m presses per submit round (default: 1) */
-  submitPresses?: number;
-  /** Max submit rounds if text isn't consumed (default: 6) */
-  maxSubmitRounds?: number;
-  /** Timeout in ms waiting for pane to be ready before sending (default: 30s) */
-  readyTimeoutMs?: number;
-}
 
 /**
  * Synthetic client wrapper for Claude stages.
@@ -744,23 +812,26 @@ export interface ClaudeQueryDefaults {
 export class ClaudeClientWrapper {
   readonly paneId: string;
   private readonly opts: { chatFlags?: string[]; readyTimeoutMs?: number };
-  private readonly sessionDir: string;
 
   constructor(
     paneId: string,
     opts: { chatFlags?: string[]; readyTimeoutMs?: number } = {},
-    sessionDir: string,
   ) {
     this.paneId = paneId;
     this.opts = opts;
-    this.sessionDir = sessionDir;
   }
 
-  /** Start the Claude CLI in the tmux pane. Called by the runtime during init. */
-  async start(): Promise<void> {
-    await createClaudeSession({
+  /**
+   * Start the Claude CLI in the tmux pane. Returns the Claude session UUID
+   * so the caller can pass it to `ClaudeSessionWrapper` (and thus expose it
+   * as `s.sessionId` to workflows). This is the UUID used by Claude Code to
+   * name its JSONL transcript file and to key the Stop-hook marker — workflows
+   * pass it to `s.save(s.sessionId)` so the save path reads the correct
+   * transcript even when many Claude sessions run in parallel.
+   */
+  async start(): Promise<string> {
+    return await createClaudeSession({
       paneId: this.paneId,
-      sessionDir: this.sessionDir,
       chatFlags: this.opts.chatFlags,
       readyTimeoutMs: this.opts.readyTimeoutMs,
     });
@@ -777,31 +848,34 @@ export class ClaudeClientWrapper {
 export class ClaudeSessionWrapper {
   readonly paneId: string;
   readonly sessionId: string;
-  private readonly defaults: ClaudeQueryDefaults;
   private readonly onHIL: ((waiting: boolean) => void) | undefined;
 
   constructor(
     paneId: string,
     sessionId: string,
-    defaults: ClaudeQueryDefaults = {},
     onHIL?: (waiting: boolean) => void,
   ) {
     this.paneId = paneId;
     this.sessionId = sessionId;
-    this.defaults = defaults;
     this.onHIL = onHIL;
   }
 
-  /** Send a prompt to Claude and wait for the response. */
+  /**
+   * Send a prompt to Claude and wait for the response.
+   *
+   * The `_options` parameter exists for signature compatibility with
+   * {@link HeadlessClaudeSessionWrapper.query} (which forwards SDK options
+   * like `agent`, `permissionMode`, etc. to the Agent SDK). In the
+   * interactive pane path these options don't apply — we're driving the
+   * `claude` CLI binary, not the SDK — so they are silently ignored.
+   */
   async query(
     prompt: string,
-    opts?: Partial<ClaudeQueryDefaults & SDKOptions>,
+    _options?: Partial<SDKOptions>,
   ): Promise<SessionMessage[]> {
     return claudeQuery({
       paneId: this.paneId,
       prompt,
-      ...this.defaults,
-      ...opts,
       onHIL: this.onHIL,
     });
   }
@@ -819,7 +893,15 @@ export class ClaudeSessionWrapper {
  * Used when `options.headless` is true in `ctx.stage()`.
  */
 export class HeadlessClaudeClientWrapper {
-  async start(): Promise<void> {}
+  /**
+   * Headless Claude stages don't pre-allocate a session — each `query()` call
+   * to {@link HeadlessClaudeSessionWrapper} spawns a fresh Agent SDK run that
+   * emits its own `session_id`. We still return an empty string here so the
+   * method signature matches {@link ClaudeClientWrapper.start}.
+   */
+  async start(): Promise<string> {
+    return "";
+  }
   async stop(): Promise<void> {}
 }
 
@@ -836,33 +918,31 @@ export class HeadlessClaudeClientWrapper {
  */
 export class HeadlessClaudeSessionWrapper {
   readonly paneId = "";
-  readonly sessionId: string;
+  /**
+   * The Claude session UUID of the most recently completed `query()`. Exposed
+   * via `s.sessionId` so workflows can pass it to `s.save(s.sessionId)` and
+   * have the save path read the correct transcript, even when several headless
+   * Claude stages run in parallel (each call gets its own SDK-assigned UUID).
+   */
+  private _lastSessionId: string = "";
 
-  constructor(sessionId: string) {
-    this.sessionId = sessionId;
+  get sessionId(): string {
+    return this._lastSessionId;
   }
 
   async query(
     prompt: string | AsyncIterable<SDKUserMessage>,
-    options?: Partial<ClaudeQueryDefaults & SDKOptions>,
+    options?: Partial<SDKOptions>,
   ): Promise<SessionMessage[]> {
-    // Strip query-defaults fields; the rest are SDK options
-    const {
-      pollIntervalMs: _a,
-      submitPresses: _b,
-      maxSubmitRounds: _c,
-      readyTimeoutMs: _d,
-      ...sdkOpts
-    } = options ?? {};
-
     let sdkSessionId = "";
-    for await (const msg of sdkQuery({ prompt, options: sdkOpts })) {
+    for await (const msg of sdkQuery({ prompt, options: options ?? {} })) {
       if (msg.type === "result") {
         sdkSessionId = String((msg as Record<string, unknown>).session_id ?? "");
       }
     }
     // Read the transcript to return native SessionMessage[]
     if (sdkSessionId) {
+      this._lastSessionId = sdkSessionId;
       return getSessionMessages(sdkSessionId, { dir: process.cwd() });
     }
     return [];

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -25,6 +25,7 @@ import {
   type Options as SDKOptions,
 } from "@anthropic-ai/claude-agent-sdk";
 import { sendKeysAndSubmit } from "../runtime/tmux.ts";
+import { escBash } from "../runtime/executor.ts";
 import { watch, unlink, mkdir, writeFile } from "node:fs/promises";
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -79,6 +80,54 @@ const DEFAULT_CHAT_FLAGS = [
   "--allow-dangerously-skip-permissions",
   "--dangerously-skip-permissions",
 ];
+
+/**
+ * Build the shell command Claude Code runs from the injected Stop hook.
+ *
+ * - **Published install** (`import.meta.dir` under `node_modules`): resolve
+ *   `atomic` via the user's PATH. That's the binary they installed, and
+ *   relying on PATH is robust across shells and platforms.
+ * - **Dev** (source checkout): re-invoke THIS repo's `src/cli.ts` using the
+ *   same Bun runtime that's executing us, so edits to the hook logic are
+ *   picked up without rebuilding or re-linking. Mirrors the
+ *   `spawnAttachedFooter` pattern in `src/sdk/runtime/executor.ts:293-303`.
+ *
+ * The dev-detection heuristic (`node_modules` in `import.meta.dir`) is the
+ * same one used by `src/services/system/auto-sync.ts:50`.
+ */
+function buildWorkflowStopHookCommand(): string {
+  if (import.meta.dir.includes("node_modules")) {
+    return "atomic _claude-stop-hook";
+  }
+  const runtime = process.execPath;
+  const cliPath = join(import.meta.dir, "..", "..", "cli.ts");
+  return `"${escBash(runtime)}" "${escBash(cliPath)}" _claude-stop-hook`;
+}
+
+/**
+ * Inline settings injected via `claude --settings <json>` on every workflow
+ * spawn. Registers the workflow Stop hook that delivers follow-up prompts
+ * without relying on `.claude/settings.json` — so the hook fires only for
+ * workflow-spawned Claude sessions, not when a user runs `claude` manually.
+ *
+ * Built once at module load. Contains no single quotes (JSON syntax doesn't
+ * produce them and paths rarely do), so POSIX single-quoting at the spawn
+ * site is sufficient shell escaping.
+ */
+const WORKFLOW_STOP_HOOK_SETTINGS = JSON.stringify({
+  hooks: {
+    Stop: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: buildWorkflowStopHookCommand(),
+          },
+        ],
+      },
+    ],
+  },
+});
 
 // ---------------------------------------------------------------------------
 // createClaudeSession
@@ -173,6 +222,11 @@ async function spawnClaudeWithPrompt(
   const cmd = [
     "claude",
     ...chatFlags,
+    // Workflow-owned Stop hook. Placed AFTER chatFlags so commander's
+    // last-wins semantics shadow any user-provided --settings, making this
+    // non-overridable by `.atomic/settings.json` chatFlags overrides.
+    "--settings",
+    `'${WORKFLOW_STOP_HOOK_SETTINGS}'`,
     "--session-id",
     sessionId,
     argvPrompt,

--- a/src/sdk/runtime/executor.test.ts
+++ b/src/sdk/runtime/executor.test.ts
@@ -112,9 +112,13 @@ describe("renderMessagesToText", () => {
 
   // --- Copilot ---
 
-  test("extracts content from a copilot assistant.message event", () => {
-    const messages: SavedMessage[] = [makeCopilotAssistantEvent("Hello from Copilot")];
-    expect(renderMessagesToText(messages)).toBe("Hello from Copilot");
+  test("renders a copilot assistant.message under an Assistant header", () => {
+    const messages: SavedMessage[] = [
+      makeCopilotAssistantEvent("Hello from Copilot"),
+    ];
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nHello from Copilot",
+    );
   });
 
   test("skips copilot non-assistant events (session.start)", () => {
@@ -122,26 +126,30 @@ describe("renderMessagesToText", () => {
     expect(renderMessagesToText(messages)).toBe("");
   });
 
-  test("only includes copilot assistant.message events when mixed with other event types", () => {
+  test("only renders copilot assistant.message events when mixed with other event types", () => {
     const messages: SavedMessage[] = [
       makeCopilotSessionStartEvent(),
       makeCopilotAssistantEvent("First response"),
       makeCopilotSessionStartEvent(),
       makeCopilotAssistantEvent("Second response"),
     ];
-    expect(renderMessagesToText(messages)).toBe("First response\n\nSecond response");
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nFirst response\n\n### Assistant\n\nSecond response",
+    );
   });
 
   // --- OpenCode ---
 
-  test("joins opencode text parts with newlines", () => {
+  test("renders opencode text parts under an Assistant header", () => {
     const messages: SavedMessage[] = [
       makeOpenCodeMessage([
         { type: "text", text: "Line one" },
         { type: "text", text: "Line two" },
       ]),
     ];
-    expect(renderMessagesToText(messages)).toBe("Line one\nLine two");
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nLine one\n\nLine two",
+    );
   });
 
   test("filters out non-text parts from opencode messages", () => {
@@ -162,24 +170,32 @@ describe("renderMessagesToText", () => {
         { type: "subtask", text: "" },
       ]),
     ];
-    expect(renderMessagesToText(messages)).toBe("The answer is 42");
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nThe answer is 42",
+    );
   });
 
   // --- Claude ---
 
-  test("returns string message from claude assistant with plain string message", () => {
-    const messages: SavedMessage[] = [makeClaudeMessage("assistant", "Plain string output")];
-    expect(renderMessagesToText(messages)).toBe("Plain string output");
+  test("renders a claude assistant string message under an Assistant header", () => {
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("assistant", "Plain string output"),
+    ];
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nPlain string output",
+    );
   });
 
-  test("returns content when claude assistant message is an object with content string", () => {
+  test("renders claude assistant message with content as string under an Assistant header", () => {
     const messages: SavedMessage[] = [
       makeClaudeMessage("assistant", { content: "Content field string" }),
     ];
-    expect(renderMessagesToText(messages)).toBe("Content field string");
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nContent field string",
+    );
   });
 
-  test("joins text blocks when claude assistant message has content as text block array", () => {
+  test("joins claude text blocks with a double newline under a single Assistant header", () => {
     const messages: SavedMessage[] = [
       makeClaudeMessage("assistant", {
         content: [
@@ -188,48 +204,176 @@ describe("renderMessagesToText", () => {
         ],
       }),
     ];
-    expect(renderMessagesToText(messages)).toBe("Block one\nBlock two");
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nBlock one\n\nBlock two",
+    );
   });
 
-  test("skips claude user messages", () => {
-    const messages: SavedMessage[] = [makeClaudeMessage("user", "user prompt")];
-    expect(renderMessagesToText(messages)).toBe("");
+  test("renders a claude user string message under a User header", () => {
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("user", "user prompt"),
+    ];
+    expect(renderMessagesToText(messages)).toBe("### User\n\nuser prompt");
   });
 
   test("skips claude system messages", () => {
-    const messages: SavedMessage[] = [makeClaudeMessage("system", "system instructions")];
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("system", "system instructions"),
+    ];
     expect(renderMessagesToText(messages)).toBe("");
   });
 
-  test("returns empty string for claude assistant with unknown message shape", () => {
+  test("returns empty string for a claude assistant message with an unknown content shape", () => {
     const unknownMsg = { weird: "shape", count: 99 };
-    const messages: SavedMessage[] = [makeClaudeMessage("assistant", unknownMsg)];
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("assistant", unknownMsg),
+    ];
     expect(renderMessagesToText(messages)).toBe("");
   });
 
-  test("extracts text blocks from mixed claude content array (text + tool_use)", () => {
+  test("renders tool_use blocks inline with text under a single Assistant header", () => {
     const messages: SavedMessage[] = [
       makeClaudeMessage("assistant", {
         content: [
           { type: "text", text: "I'll read the file" },
-          { type: "tool_use", id: "tu-1", name: "Read", input: { path: "/tmp/foo" } },
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "Read",
+            input: { path: "/tmp/foo" },
+          },
           { type: "text", text: "Here's what I found" },
         ],
       }),
     ];
-    expect(renderMessagesToText(messages)).toBe("I'll read the file\nHere's what I found");
+    expect(renderMessagesToText(messages)).toBe(
+      [
+        "### Assistant",
+        "",
+        "I'll read the file",
+        "",
+        "**→ `Read`**",
+        "",
+        "```json",
+        "{\n  \"path\": \"/tmp/foo\"\n}",
+        "```",
+        "",
+        "Here's what I found",
+      ].join("\n"),
+    );
+  });
+
+  test("skips claude `thinking` blocks in the rendered transcript", () => {
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("assistant", {
+        content: [
+          { type: "thinking", thinking: "internal reasoning…", signature: "sig" },
+          { type: "text", text: "Public answer" },
+        ],
+      }),
+    ];
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nPublic answer",
+    );
+  });
+
+  test("omits `tool_result` payloads entirely — only the call and subsequent assistant turns survive", () => {
+    const big = "x".repeat(5_000);
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("assistant", {
+        content: [
+          {
+            type: "tool_use",
+            id: "tu-42",
+            name: "Read",
+            input: { file_path: "/tmp/note.md" },
+          },
+        ],
+      }),
+      makeClaudeMessage("user", {
+        content: [
+          { type: "tool_result", tool_use_id: "tu-42", content: big },
+        ],
+      }),
+      makeClaudeMessage("assistant", {
+        content: [{ type: "text", text: "Done." }],
+      }),
+    ];
+    const rendered = renderMessagesToText(messages);
+
+    // The tool call itself is present, with its input JSON.
+    expect(rendered).toContain("**→ `Read`**");
+    expect(rendered).toContain("/tmp/note.md");
+
+    // The follow-up assistant turn is present.
+    expect(rendered).toContain("### Assistant\n\nDone.");
+
+    // The tool_result payload is completely absent — not truncated, not
+    // labelled, not present in any form. This is the context-rot guard:
+    // even a 5_000-char result must not leak into the transcript.
+    expect(rendered).not.toContain("xxxxx");
+    expect(rendered).not.toContain("← `Read` result");
+    expect(rendered).not.toContain("← `Read`");
+  });
+
+  test("truncates very long tool_use `input` payloads with a `[+N chars]` suffix", () => {
+    const bigCommand = "echo " + "a".repeat(5_000);
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("assistant", {
+        content: [
+          {
+            type: "tool_use",
+            id: "tu-big",
+            name: "Bash",
+            input: { command: bigCommand },
+          },
+        ],
+      }),
+    ];
+    const rendered = renderMessagesToText(messages);
+    expect(rendered).toContain("**→ `Bash`**");
+    // Input budget is 800 chars of JSON — the long command must be truncated.
+    expect(rendered).toContain("chars]");
+    expect(rendered.length).toBeLessThan(bigCommand.length);
+  });
+
+  test("skips a user message whose only content is `tool_result` blocks", () => {
+    const messages: SavedMessage[] = [
+      makeClaudeMessage("user", {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu-a",
+            content: "would-be-noisy output",
+          },
+        ],
+      }),
+    ];
+    expect(renderMessagesToText(messages)).toBe("");
   });
 
   // --- Mixed providers ---
 
-  test("joins messages from mixed providers with double newlines", () => {
+  test("joins messages from mixed providers with double newlines and provider-appropriate headers", () => {
     const messages: SavedMessage[] = [
       makeCopilotAssistantEvent("Copilot says hello"),
       makeOpenCodeMessage([{ type: "text", text: "OpenCode says hello" }]),
       makeClaudeMessage("assistant", "Claude says hello"),
     ];
     expect(renderMessagesToText(messages)).toBe(
-      "Copilot says hello\n\nOpenCode says hello\n\nClaude says hello",
+      [
+        "### Assistant",
+        "",
+        "Copilot says hello",
+        "",
+        "### Assistant",
+        "",
+        "OpenCode says hello",
+        "",
+        "### Assistant",
+        "",
+        "Claude says hello",
+      ].join("\n"),
     );
   });
 
@@ -239,7 +383,9 @@ describe("renderMessagesToText", () => {
       makeCopilotAssistantEvent("Only one has content"),
       makeOpenCodeMessage([{ type: "reasoning", text: "ignored" }]),
     ];
-    expect(renderMessagesToText(messages)).toBe("Only one has content");
+    expect(renderMessagesToText(messages)).toBe(
+      "### Assistant\n\nOnly one has content",
+    );
   });
 });
 

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -557,17 +557,36 @@ function printDetachedBanner(tmuxSessionName: string): void {
   );
 }
 
-/**
- * Small buffer (ms) subtracted from `Date.now()` when recording the Claude
- * session start timestamp.  Protects against fast sequential runs where
- * the system clock granularity could cause a just-created session's
- * `lastModified` to fall slightly before our recorded timestamp.
- */
-const CLAUDE_SESSION_TIMESTAMP_BUFFER_MS = 100;
-
 // ============================================================================
 // Session execution helpers
 // ============================================================================
+
+/**
+ * Resolve the provider-specific session identifier for use as
+ * `SessionContext.sessionId`:
+ *   - Claude interactive: `ClaudeSessionWrapper.sessionId` — the Claude UUID
+ *     set when `createClaudeSession` ran.
+ *   - Claude headless: `HeadlessClaudeSessionWrapper.sessionId` — the SDK
+ *     `session_id` from the most recently completed `query()` (empty string
+ *     until the first query returns).
+ *   - Copilot: `CopilotSession.sessionId`.
+ *   - OpenCode: `Session.id`.
+ *
+ * Returns an empty string for unknown shapes rather than throwing so
+ * early-init readers of `s.sessionId` (e.g. logging) don't crash.
+ */
+function resolveProviderSessionId(
+  agent: AgentType,
+  providerSession: unknown,
+): string {
+  if (!providerSession || typeof providerSession !== "object") return "";
+  const obj = providerSession as Record<string, unknown>;
+  if (agent === "opencode") {
+    return typeof obj["id"] === "string" ? (obj["id"] as string) : "";
+  }
+  // claude and copilot both expose `sessionId` as a string.
+  return typeof obj["sessionId"] === "string" ? (obj["sessionId"] as string) : "";
+}
 
 /** Type guard for objects with a string `content` property (Copilot assistant.message data). */
 export function hasContent(value: unknown): value is { content: string } {
@@ -579,56 +598,281 @@ export function hasContent(value: unknown): value is { content: string } {
   );
 }
 
-export function renderMessagesToText(messages: SavedMessage[]): string {
-  return messages
-    .map((m) => {
-      switch (m.provider) {
-        case "copilot": {
-          if (m.data.type !== "assistant.message") return "";
-          // SessionEvent["data"] for assistant.message has a typed `content: string`
-          return hasContent(m.data.data) ? m.data.data.content : "";
+/**
+ * Character budget cap for tool-call `input` payloads embedded in the
+ * transcript. Tool call arguments can grow (diffs, large SQL strings, whole
+ * files passed inline), and the transcript's primary consumer is a
+ * downstream LLM that must `Read` this file as context for its own turn —
+ * so we cap the per-call JSON at a predictable size. The suffix
+ * `[+N chars]` preserves the dropped length for humans reviewing the file.
+ *
+ * Tool _results_ are intentionally NOT included in the transcript. File
+ * contents, shell output, and search results inflate the transcript
+ * dramatically and lead to context rot on the next stage. A reader (human
+ * or model) can still reconstruct what the tool returned by looking at
+ * the assistant's subsequent text — which is the whole point of the
+ * assistant summarising its own work.
+ */
+const TRANSCRIPT_TOOL_INPUT_BUDGET = 800;
+
+function truncateForTranscript(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + ` … [+${text.length - max} chars]`;
+}
+
+/** Render a tool_use `input` object as a JSON-ish block, capped to budget. */
+function renderToolInput(input: unknown): string {
+  let json: string;
+  try {
+    json = JSON.stringify(input, null, 2);
+  } catch {
+    json = String(input);
+  }
+  return truncateForTranscript(json, TRANSCRIPT_TOOL_INPUT_BUDGET);
+}
+
+/**
+ * Render a Claude transcript as readable Markdown.
+ *
+ * Captures the user/agent interaction chronologically:
+ *   - User messages (string content)                  → `### User`
+ *   - Assistant text blocks                           → `### Assistant`
+ *   - Assistant `tool_use` blocks                     → `**→ \`Name\`**` + JSON input
+ *
+ * Intentionally omitted:
+ *   - `tool_result` blocks — their payloads (file contents, shell output,
+ *     stringified diffs) dominate the transcript and lead to context rot on
+ *     the next stage. The assistant's subsequent text response already
+ *     summarises what the tool returned; re-including the raw output
+ *     duplicates that information at high token cost.
+ *   - `thinking` blocks — verbose internal reasoning rarely useful when the
+ *     transcript is re-ingested as context elsewhere.
+ *   - `system` / `summary` / other non-message types.
+ */
+function renderClaudeTranscript(
+  messages: ReadonlyArray<{ type: string; message: unknown }>,
+): string {
+  const sections: string[] = [];
+
+  for (const msg of messages) {
+    if (msg.type !== "user" && msg.type !== "assistant") continue;
+
+    // `message` shape is one of:
+    //   - a plain string (legacy path),
+    //   - `{ role, content: string }` (API-style plain text turn),
+    //   - `{ role, content: Block[] }` (tool-use / tool-result turns).
+    // Normalise the first two into a single string; handle the third below.
+    const rawMessage = msg.message;
+    let plainText: string | null = null;
+    let arrayContent: unknown[] | null = null;
+
+    if (typeof rawMessage === "string") {
+      plainText = rawMessage;
+    } else if (rawMessage && typeof rawMessage === "object") {
+      const content = (rawMessage as { content?: unknown }).content;
+      if (typeof content === "string") {
+        plainText = content;
+      } else if (Array.isArray(content)) {
+        arrayContent = content;
+      }
+    }
+
+    if (plainText !== null) {
+      const trimmed = plainText.trim();
+      if (trimmed) {
+        const header = msg.type === "user" ? "### User" : "### Assistant";
+        sections.push(`${header}\n\n${trimmed}`);
+      }
+      continue;
+    }
+
+    if (arrayContent === null) continue;
+    const content = arrayContent;
+
+    if (msg.type === "assistant") {
+      // Group all blocks from a single assistant message under one header
+      // so text and tool calls read as one coherent turn.
+      const parts: string[] = [];
+      for (const block of content) {
+        if (!block || typeof block !== "object") continue;
+        const b = block as Record<string, unknown>;
+        if (b["type"] === "text" && typeof b["text"] === "string") {
+          const txt = (b["text"] as string).trim();
+          if (txt) parts.push(txt);
+        } else if (b["type"] === "tool_use") {
+          const name =
+            typeof b["name"] === "string" ? (b["name"] as string) : "tool";
+          const input = renderToolInput(b["input"]);
+          parts.push(`**→ \`${name}\`**\n\n\`\`\`json\n${input}\n\`\`\``);
         }
-        case "opencode": {
-          // Part is a discriminated union; filter to TextPart which has { type: "text", text: string }
-          return m.data.parts
-            .filter(
-              (p): p is Extract<typeof p, { type: "text" }> =>
-                p.type === "text",
-            )
-            .map((p) => p.text)
-            .join("\n");
-        }
-        case "claude": {
-          if (m.data.type !== "assistant") return "";
-          const msg = m.data.message;
-          if (typeof msg === "string") return msg;
-          if (msg && typeof msg === "object" && "content" in msg) {
-            const { content } = msg as { content: unknown };
-            if (typeof content === "string") return content;
-            // Claude messages often have mixed content arrays (text +
-            // tool_use + thinking blocks). Filter for text blocks instead
-            // of requiring ALL blocks to be text — the old isTextBlockArray
-            // check caused a JSON.stringify fallback that embedded raw
-            // message objects into downstream prompts.
-            if (Array.isArray(content)) {
-              const textParts = content
-                .filter(
-                  (b): b is { type: "text"; text: string } =>
-                    typeof b === "object" &&
-                    b !== null &&
-                    b.type === "text" &&
-                    typeof b.text === "string",
-                )
-                .map((b) => b.text);
-              if (textParts.length > 0) return textParts.join("\n");
-            }
-          }
-          return "";
+        // Skip "thinking" blocks.
+      }
+      if (parts.length > 0) {
+        sections.push(`### Assistant\n\n${parts.join("\n\n")}`);
+      }
+      continue;
+    }
+
+    // msg.type === "user" with array content — usually a batch of tool_results
+    // responding to the previous assistant turn's tool_use blocks. We skip
+    // the tool_result payloads entirely (see function docstring for why) and
+    // only surface any inline `text` blocks, which is where a real follow-up
+    // user turn would land.
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+      if (b["type"] === "text" && typeof b["text"] === "string") {
+        const txt = (b["text"] as string).trim();
+        if (txt) sections.push(`### User\n\n${txt}`);
+      }
+    }
+  }
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Render a Copilot transcript as readable Markdown.
+ *
+ * Preserves the existing `assistant.message → content` extraction and adds
+ * `user.message` rendering plus any `toolCalls` attached to an assistant
+ * message. All other event types (`session.start`, `session.idle`, plain
+ * telemetry, etc.) are skipped.
+ */
+function renderCopilotTranscript(
+  events: ReadonlyArray<{ type?: unknown; data?: unknown }>,
+): string {
+  const sections: string[] = [];
+
+  for (const evt of events) {
+    if (evt.type === "assistant.message") {
+      const data = evt.data;
+      if (!hasContent(data)) continue;
+      const parts: string[] = [];
+      const text = data.content.trim();
+      if (text) parts.push(text);
+
+      // toolCalls is an array on `assistant.message` data when present.
+      const toolCalls = (data as Record<string, unknown>)["toolCalls"];
+      if (Array.isArray(toolCalls)) {
+        for (const call of toolCalls) {
+          if (!call || typeof call !== "object") continue;
+          const c = call as Record<string, unknown>;
+          const name =
+            typeof c["name"] === "string"
+              ? (c["name"] as string)
+              : typeof c["toolName"] === "string"
+                ? (c["toolName"] as string)
+                : "tool";
+          const args = c["arguments"] ?? c["input"] ?? c["parameters"];
+          parts.push(
+            `**→ \`${name}\`**\n\n\`\`\`json\n${renderToolInput(args)}\n\`\`\``,
+          );
         }
       }
-    })
-    .filter((txt): txt is string => typeof txt === "string" && txt.length > 0)
-    .join("\n\n");
+
+      if (parts.length > 0) {
+        sections.push(`### Assistant\n\n${parts.join("\n\n")}`);
+      }
+      continue;
+    }
+
+    if (evt.type === "user.message") {
+      const data = evt.data;
+      if (hasContent(data)) {
+        const text = data.content.trim();
+        if (text) sections.push(`### User\n\n${text}`);
+      }
+    }
+    // All other event types are intentionally skipped.
+  }
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Render an OpenCode prompt response as readable Markdown.
+ *
+ * OpenCode hands us `{ info, parts }`; `parts` is a discriminated union where
+ * `text` parts carry the assistant reply and `tool` parts carry tool
+ * invocations. `reasoning` and `subtask` parts are internal and omitted.
+ */
+function renderOpencodeTranscript(response: {
+  parts?: ReadonlyArray<{ type?: unknown; text?: unknown } & Record<string, unknown>>;
+}): string {
+  if (!response.parts) return "";
+  const parts: string[] = [];
+  for (const part of response.parts) {
+    if (!part || typeof part !== "object") continue;
+    if (part.type === "text" && typeof part.text === "string") {
+      const txt = part.text.trim();
+      if (txt) parts.push(txt);
+    } else if (part.type === "tool") {
+      const name =
+        typeof part["tool"] === "string"
+          ? (part["tool"] as string)
+          : typeof part["name"] === "string"
+            ? (part["name"] as string)
+            : "tool";
+      const state = part["state"];
+      const args =
+        state && typeof state === "object"
+          ? (state as Record<string, unknown>)["input"] ??
+            (state as Record<string, unknown>)["args"]
+          : undefined;
+      parts.push(
+        `**→ \`${name}\`**\n\n\`\`\`json\n${renderToolInput(args)}\n\`\`\``,
+      );
+      // Tool outputs are intentionally omitted — see the comment on
+      // `TRANSCRIPT_TOOL_INPUT_BUDGET` for the context-rot rationale.
+    }
+  }
+  if (parts.length === 0) return "";
+  return `### Assistant\n\n${parts.join("\n\n")}`;
+}
+
+export function renderMessagesToText(messages: SavedMessage[]): string {
+  // Claude messages already come in as a flat chronological list — render
+  // the whole slice at once so the helper can cross-reference tool_use_ids
+  // against tool_result blocks. Copilot and OpenCode keep their existing
+  // per-message rendering.
+  const sections: string[] = [];
+  const claudeBatch: Array<{ type: string; message: unknown }> = [];
+
+  const flushClaude = (): void => {
+    if (claudeBatch.length === 0) return;
+    const rendered = renderClaudeTranscript(claudeBatch);
+    if (rendered) sections.push(rendered);
+    claudeBatch.length = 0;
+  };
+
+  for (const m of messages) {
+    if (m.provider === "claude") {
+      claudeBatch.push(
+        m.data as unknown as { type: string; message: unknown },
+      );
+      continue;
+    }
+    flushClaude();
+    if (m.provider === "copilot") {
+      const rendered = renderCopilotTranscript([
+        m.data as unknown as { type?: unknown; data?: unknown },
+      ]);
+      if (rendered) sections.push(rendered);
+    } else if (m.provider === "opencode") {
+      const rendered = renderOpencodeTranscript(
+        m.data as unknown as {
+          parts?: ReadonlyArray<
+            { type?: unknown; text?: unknown } & Record<string, unknown>
+          >;
+        },
+      );
+      if (rendered) sections.push(rendered);
+    }
+  }
+  flushClaude();
+
+  return sections.join("\n\n");
 }
 
 /** Resolve a SessionRef (string or SessionHandle) to the session name. */
@@ -946,8 +1190,6 @@ async function initProviderClientAndSession<A extends AgentType>(
   agent: A,
   serverUrl: string,
   paneId: string,
-  sessionId: string,
-  sessionDir: string,
   clientOpts: StageClientOptions<A>,
   sessionOpts: StageSessionOptions<A>,
   headless = false,
@@ -1009,16 +1251,26 @@ async function initProviderClientAndSession<A extends AgentType>(
     case "claude": {
       if (headless) {
         // Headless Claude stages use the Agent SDK directly — no tmux pane.
+        // Each query gets its own SDK-assigned session_id; the wrapper
+        // tracks the latest one and exposes it as `sessionId`.
         const client = new HeadlessClaudeClientWrapper();
         await client.start();
-        const session = new HeadlessClaudeSessionWrapper(sessionId);
-        return { client, session } as Result;
+        const session = new HeadlessClaudeSessionWrapper();
+        // Cast through `unknown` — `HeadlessClaudeClientWrapper` intentionally
+        // omits the interactive-only fields (`paneId`, `sessionDir`, etc.)
+        // that `ClaudeClientWrapper` has; both satisfy the same runtime
+        // contract used by workflow code.
+        return { client, session } as unknown as Result;
       }
       const claudeClientOpts = clientOpts as StageClientOptions<"claude">;
-      const claudeSessionOpts = sessionOpts as StageSessionOptions<"claude">;
-      const client = new ClaudeClientWrapper(paneId, claudeClientOpts, sessionDir);
-      await client.start();
-      const session = new ClaudeSessionWrapper(paneId, sessionId, claudeSessionOpts, onHIL);
+      const client = new ClaudeClientWrapper(paneId, claudeClientOpts);
+      // `start()` now returns the Claude session UUID, which we pass through
+      // to the session wrapper so `s.sessionId` is the Claude UUID (not the
+      // atomic short ID). This fixes the parallel-workflow bug where save
+      // used to look up "the newest Claude session globally" and could
+      // attribute one branch's transcript to another.
+      const claudeSessionId = await client.start();
+      const session = new ClaudeSessionWrapper(paneId, claudeSessionId, onHIL);
       return { client, session } as Result;
     }
     default:
@@ -1066,7 +1318,13 @@ async function cleanupProvider<A extends AgentType>(
     case "claude":
       // Headless Claude stages have no tmux pane to clear.
       if (!paneId.startsWith("headless-")) {
-        clearClaudeSession(paneId);
+        try {
+          await clearClaudeSession(paneId);
+        } catch (e) {
+          console.warn(
+            `[cleanup] claude session clear failed: ${errorMessage(e)}`,
+          );
+        }
       }
       break;
     default:
@@ -1193,49 +1451,29 @@ function createSessionRunner(
       const messagesPath = join(sessionDir, "messages.json");
       const inboxPath = join(sessionDir, "inbox.md");
 
-      // ── 11. Claude session snapshot (for identifying new sessions later) ──
-      let knownClaudeSessionIds: Set<string> | undefined;
-      if (shared.agent === "claude") {
-        const { listSessions } = await import("@anthropic-ai/claude-agent-sdk");
-        const existing = await listSessions({ dir: process.cwd() });
-        knownClaudeSessionIds = new Set(existing.map((s) => s.sessionId));
-      }
-      const claudeSessionStartedAfter =
-        shared.agent === "claude"
-          ? Date.now() - CLAUDE_SESSION_TIMESTAMP_BUFFER_MS
-          : 0;
-
       // ── Message wrapping (Claude/Copilot/OpenCode) ──
       async function wrapMessages(
         arg: SessionEvent[] | SessionPromptResponse | string,
       ): Promise<SavedMessage[]> {
         if (typeof arg === "string") {
-          const { getSessionMessages, listSessions } =
-            await import("@anthropic-ai/claude-agent-sdk");
-          const dir = process.cwd();
-          const sessions = await listSessions({ dir });
-
-          const newSessions = knownClaudeSessionIds
-            ? sessions.filter((s) => !knownClaudeSessionIds!.has(s.sessionId))
-            : sessions.filter(
-                (s) => s.lastModified >= claudeSessionStartedAfter,
-              );
-
-          const candidates = newSessions.sort(
-            (a, b) => b.lastModified - a.lastModified,
-          );
-
-          const candidate = candidates[0];
-          if (!candidate) {
+          // `arg` is the Claude session UUID — either `s.sessionId` from an
+          // interactive `ClaudeSessionWrapper` (set at `createClaudeSession`
+          // time) or the SDK-emitted `session_id` tracked inside
+          // `HeadlessClaudeSessionWrapper.query`. Using it directly removes
+          // the "pick the globally newest Claude session" heuristic that
+          // misattributed transcripts across parallel branches.
+          if (!arg) {
             throw new Error(
-              `wrapMessages: no new Claude session found for ${dir}`,
+              "wrapMessages: empty Claude session id. Call s.save(s.sessionId) " +
+              "only after a successful s.session.query() (headless wrappers " +
+              "only know their session_id once a query completes).",
             );
           }
-
-          const msgs: SessionMessage[] = await getSessionMessages(
-            candidate.sessionId,
-            { dir },
-          );
+          const { getSessionMessages } =
+            await import("@anthropic-ai/claude-agent-sdk");
+          const msgs: SessionMessage[] = await getSessionMessages(arg, {
+            dir: process.cwd(),
+          });
           return msgs.map((m) => ({ provider: "claude" as const, data: m }));
         }
 
@@ -1298,8 +1536,6 @@ function createSessionRunner(
         shared.agent,
         serverUrl,
         paneId,
-        sessionId,
-        sessionDir,
         clientOpts,
         sessionOpts,
         isHeadless,
@@ -1380,6 +1616,16 @@ function createSessionRunner(
       // structured workflows read their declared fields the same way.
       // A single uniform access pattern means workflow code never has
       // to branch on "is this workflow structured or free-form".
+      //
+      // `s.sessionId` is the provider-specific session identifier — the
+      // Claude session UUID, the Copilot session id, or the OpenCode
+      // session id. This is what workflows pass to `s.save(s.sessionId)`
+      // to disambiguate their own transcript when several sessions run
+      // in parallel under the same workflow.
+      const providerSessionId = resolveProviderSessionId(
+        shared.agent,
+        providerSession,
+      );
       const ctx: SessionContext = {
         client: providerClient,
         session: providerSession,
@@ -1387,7 +1633,7 @@ function createSessionRunner(
         agent: shared.agent,
         sessionDir,
         paneId,
-        sessionId,
+        sessionId: providerSessionId,
         save,
         transcript: transcriptFn,
         getMessages: getMessagesFn,

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -22,7 +22,6 @@ import type {
 import type {
   ClaudeClientWrapper,
   ClaudeSessionWrapper,
-  ClaudeQueryDefaults,
 } from "./providers/claude.ts";
 
 /** Supported agent types */
@@ -44,7 +43,7 @@ type ClientOptionsMap = {
  * Maps each agent to the session create options the user passes to `ctx.stage()`.
  * - OpenCode: `client.session.create()` body params
  * - Copilot: `client.createSession()` config (onPermissionRequest defaults to approveAll)
- * - Claude: `claudeQuery()` defaults for subsequent queries
+ * - Claude: no per-session options — delivery is driven entirely by Stop hooks.
  */
 type SessionOptionsMap = {
   opencode: {
@@ -53,7 +52,7 @@ type SessionOptionsMap = {
     workspaceID?: string;
   };
   copilot: Partial<CopilotSessionConfig>;
-  claude: ClaudeQueryDefaults;
+  claude: Record<string, never>;
 };
 
 /** Maps each agent to the `s.client` type provided in the stage callback. */
@@ -92,7 +91,6 @@ export type {
   OpencodeSession,
   ClaudeClientWrapper,
   ClaudeSessionWrapper,
-  ClaudeQueryDefaults,
 };
 
 // ─── Validation ─────────────────────────────────────────────────────────────

--- a/src/sdk/workflows/index.ts
+++ b/src/sdk/workflows/index.ts
@@ -35,7 +35,6 @@ export type {
   OpencodeSession,
   ClaudeClientWrapper,
   ClaudeSessionWrapper,
-  ClaudeQueryDefaults,
 } from "../types.ts";
 
 // Re-export native SDK types for convenience

--- a/tests/lib/common-ignore.test.ts
+++ b/tests/lib/common-ignore.test.ts
@@ -1,0 +1,20 @@
+import { test, expect, describe } from "bun:test";
+import { createCommonIgnoreFilter } from "../../src/lib/common-ignore.ts";
+
+describe("createCommonIgnoreFilter", () => {
+  test("ignores common OS, dependency, and lockfile patterns", () => {
+    const filter = createCommonIgnoreFilter();
+    expect(filter.ignores(".DS_Store")).toBe(true);
+    expect(filter.ignores("Thumbs.db")).toBe(true);
+    expect(filter.ignores("node_modules/foo")).toBe(true);
+    expect(filter.ignores("bun.lock")).toBe(true);
+    expect(filter.ignores("build.log")).toBe(true);
+  });
+
+  test("does not match unrelated agent config files", () => {
+    const filter = createCommonIgnoreFilter();
+    expect(filter.ignores("CLAUDE.md")).toBe(false);
+    expect(filter.ignores("skills/my-skill/SKILL.md")).toBe(false);
+    expect(filter.ignores("settings.json")).toBe(false);
+  });
+});

--- a/tests/sdk/providers/claude-wait-for-idle.test.ts
+++ b/tests/sdk/providers/claude-wait-for-idle.test.ts
@@ -1,12 +1,13 @@
 /**
  * Tests for the `waitForIdle` marker-file flow in claude.ts.
  *
- * `waitForIdle` watches ~/.atomic/claude-stop/ via fs.watch and fires when a
+ * `waitForIdle` watches ~/.atomic/claude-stop/ via fs.watch and returns when a
  * marker file named `<claudeSessionId>` appears. On marker appearance it reads
- * the session transcript and checks `_hasUnresolvedHILTool`:
- *   - HIL unresolved → call onHIL(true), delete marker, keep watching
- *   - HIL resolved after prior HIL → call onHIL(false), return sliced messages
- *   - No HIL → return sliced messages
+ * the session transcript, optionally polls it for mid-loop flush races, and
+ * returns the sliced tail produced by the current turn.
+ *
+ * HIL detection is out of scope for this function — see
+ * `watchTranscriptForHIL` and its own test file.
  *
  * Strategy:
  * - mock.module "@anthropic-ai/claude-agent-sdk" to control getSessionMessages
@@ -150,7 +151,6 @@ describe("waitForIdle — marker-file flow", () => {
     const idlePromise = waitForIdle(
       sessionId,       // claudeSessionId
       2,               // transcriptBeforeCount (2 messages existed before)
-      undefined,       // onHIL
     );
 
     // Give the watcher a tick to set up, then write the marker
@@ -163,106 +163,6 @@ describe("waitForIdle — marker-file flow", () => {
     expect(result).toHaveLength(2);
     expect(result[0]?.uuid).toBe("u2");
     expect(result[1]?.uuid).toBe("a2");
-  });
-
-  // -------------------------------------------------------------------------
-  // 2. HIL gating — two markers required
-  // -------------------------------------------------------------------------
-
-  test("calls onHIL(true) on first marker with unresolved HIL, then onHIL(false) and returns on second marker", async () => {
-    const toolUseId = randomUUID();
-
-    // First transcript read: has an unresolved AskUserQuestion tool
-    const messagesWithHIL: SessionMessage[] = [
-      {
-        type: "assistant",
-        uuid: "a1",
-        session_id: sessionId,
-        message: {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_use",
-              id: toolUseId,
-              name: "AskUserQuestion",
-              input: { question: "What is your name?" },
-            },
-          ],
-        },
-        parent_tool_use_id: null,
-      },
-    ];
-
-    // Second transcript read: HIL resolved (user answered, assistant replied)
-    const messagesResolved: SessionMessage[] = [
-      ...messagesWithHIL,
-      {
-        type: "user",
-        uuid: "u2",
-        session_id: sessionId,
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: toolUseId,
-              content: "Alice",
-            },
-          ],
-        },
-        parent_tool_use_id: null,
-      },
-      {
-        type: "assistant",
-        uuid: "a2",
-        session_id: sessionId,
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "Hello Alice!" }],
-        },
-        parent_tool_use_id: null,
-      },
-    ];
-
-    sessionMessageQueue.push(messagesWithHIL);   // first marker read
-    sessionMessageQueue.push(messagesResolved);  // second marker read
-
-    const hilCalls: Array<boolean> = [];
-    const onHIL = (waiting: boolean): void => { hilCalls.push(waiting); };
-
-    await mkdir(markerDir(), { recursive: true });
-
-    const idlePromise = waitForIdle(
-      sessionId,
-      0,            // transcriptBeforeCount — all messages are "new"
-      onHIL,
-    );
-
-    // First marker — triggers HIL state
-    await Bun.sleep(80);
-    await writeMarker(sessionId);
-
-    // Wait for onHIL(true) to be called before writing the second marker
-    // Poll briefly (up to 1 s)
-    for (let i = 0; i < 100; i++) {
-      if (hilCalls.length >= 1) break;
-      await Bun.sleep(10);
-    }
-
-    expect(hilCalls).toEqual([true]);
-
-    // waitForIdle deletes the marker after the HIL event; write a second one
-    // to simulate the stop-hook firing after the user responds
-    await Bun.sleep(50);
-    await writeMarker(sessionId);
-
-    const result = await idlePromise;
-
-    // onHIL(false) should have been called to signal HIL resolution
-    expect(hilCalls).toEqual([true, false]);
-
-    // All 3 messages in resolved transcript are "new" (transcriptBeforeCount=0)
-    expect(result).toHaveLength(messagesResolved.length);
   });
 
   // -------------------------------------------------------------------------
@@ -351,7 +251,6 @@ describe("waitForIdle — marker-file flow", () => {
     const idlePromise = waitForIdle(
       sessionId,
       1,    // same count as transcript length → nothing new
-      undefined,
     );
 
     await Bun.sleep(80);
@@ -423,7 +322,7 @@ describe("waitForIdle — marker-file flow", () => {
 
     await mkdir(markerDir(), { recursive: true });
 
-    const idlePromise = waitForIdle(sessionId, 0, undefined);
+    const idlePromise = waitForIdle(sessionId, 0);
 
     // Fire the single Stop event. No second marker is ever written — the
     // mid-loop recovery must come from polling the transcript on disk.
@@ -464,7 +363,7 @@ describe("waitForIdle — marker-file flow", () => {
     // fire for this file because it's already there.
     await writeMarker(sessionId);
 
-    const result = await waitForIdle(sessionId, 0, undefined);
+    const result = await waitForIdle(sessionId, 0);
 
     expect(result).toHaveLength(1);
     expect(result[0]?.uuid).toBe("a1");
@@ -492,7 +391,7 @@ describe("waitForIdle — marker-file flow", () => {
 
     await mkdir(markerDir(), { recursive: true });
 
-    const idlePromise = waitForIdle(sessionId, 0, undefined);
+    const idlePromise = waitForIdle(sessionId, 0);
 
     await Bun.sleep(80);
     await writeMarker(sessionId);

--- a/tests/sdk/providers/claude-wait-for-idle.test.ts
+++ b/tests/sdk/providers/claude-wait-for-idle.test.ts
@@ -148,11 +148,8 @@ describe("waitForIdle — marker-file flow", () => {
     // Start waitForIdle watching; write the marker shortly after to simulate
     // the stop-hook firing.
     const idlePromise = waitForIdle(
-      "pane-0",        // _paneId (unused)
       sessionId,       // claudeSessionId
       2,               // transcriptBeforeCount (2 messages existed before)
-      "",              // _beforeContent (unused)
-      2000,            // _pollIntervalMs (unused)
       undefined,       // onHIL
     );
 
@@ -169,23 +166,7 @@ describe("waitForIdle — marker-file flow", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 2. No session ID → returns empty immediately
-  // -------------------------------------------------------------------------
-
-  test("returns empty array immediately when claudeSessionId is undefined", async () => {
-    const result = await waitForIdle(
-      "pane-0",
-      undefined,  // no session id
-      0,
-      "",
-      2000,
-      undefined,
-    );
-    expect(result).toEqual([]);
-  });
-
-  // -------------------------------------------------------------------------
-  // 3. HIL gating — two markers required
+  // 2. HIL gating — two markers required
   // -------------------------------------------------------------------------
 
   test("calls onHIL(true) on first marker with unresolved HIL, then onHIL(false) and returns on second marker", async () => {
@@ -252,11 +233,8 @@ describe("waitForIdle — marker-file flow", () => {
     await mkdir(markerDir(), { recursive: true });
 
     const idlePromise = waitForIdle(
-      "pane-0",
       sessionId,
       0,            // transcriptBeforeCount — all messages are "new"
-      "",
-      2000,
       onHIL,
     );
 
@@ -348,13 +326,20 @@ describe("waitForIdle — marker-file flow", () => {
   // -------------------------------------------------------------------------
 
   test("returns empty slice when transcript has no new messages beyond baseline", async () => {
-    // Transcript read returns exactly as many messages as before — no new ones
+    // Transcript read returns exactly as many messages as before — no new ones.
+    // Baseline is 1, transcript has 1 (an assistant message with end_turn),
+    // so the slice is empty. The assistant's stop_reason must be terminal
+    // (not "tool_use") or `_isMidAgentLoop` would keep watching.
     const messages: SessionMessage[] = [
       {
-        type: "user",
-        uuid: "u1",
+        type: "assistant",
+        uuid: "a1",
         session_id: sessionId,
-        message: { role: "user", content: "hi" },
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "hi" }],
+          stop_reason: "end_turn",
+        },
         parent_tool_use_id: null,
       },
     ];
@@ -364,11 +349,8 @@ describe("waitForIdle — marker-file flow", () => {
     await mkdir(markerDir(), { recursive: true });
 
     const idlePromise = waitForIdle(
-      "pane-0",
       sessionId,
       1,    // same count as transcript length → nothing new
-      "",
-      2000,
       undefined,
     );
 
@@ -381,7 +363,115 @@ describe("waitForIdle — marker-file flow", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 6. Cleanup — no unhandled rejection when watcher is aborted via return
+  // 5b. Async-flush race — Claude Code buffers the final assistant message
+  //     for ~100ms after firing the Stop hook. `waitForIdle` must poll the
+  //     transcript on a single marker event rather than wait for a second
+  //     one (Stop only fires once per agent loop).
+  // -------------------------------------------------------------------------
+
+  test("polls the transcript on one marker event when the final assistant message hasn't flushed yet", async () => {
+    // First transcript read: mid-loop (last assistant stopped on tool_use
+    // because the post-tool `assistant[text]` hasn't been flushed to disk).
+    const midLoopMessages: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a-mid",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tu-x", name: "Read", input: { path: "/x" } },
+          ],
+          stop_reason: "tool_use",
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    // Subsequent reads: the buffered `assistant[text]` has now hit disk.
+    const finalMessages: SessionMessage[] = [
+      ...midLoopMessages,
+      {
+        type: "user",
+        uuid: "u-result",
+        session_id: sessionId,
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tu-x", content: "file body" },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: "assistant",
+        uuid: "a-final",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Here's what I found" }],
+          stop_reason: "end_turn",
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    // First poll sees mid-loop; every subsequent poll returns the full
+    // transcript. `waitForIdle` should return the full one on retry.
+    sessionMessageQueue.push(midLoopMessages);
+    for (let i = 0; i < 20; i++) sessionMessageQueue.push(finalMessages);
+
+    await mkdir(markerDir(), { recursive: true });
+
+    const idlePromise = waitForIdle(sessionId, 0, undefined);
+
+    // Fire the single Stop event. No second marker is ever written — the
+    // mid-loop recovery must come from polling the transcript on disk.
+    await Bun.sleep(80);
+    await writeMarker(sessionId);
+
+    const result = await idlePromise;
+
+    expect(result.at(-1)?.uuid).toBe("a-final");
+    expect(result).toHaveLength(3);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Race fix — marker already on disk when waitForIdle is called.
+  // -------------------------------------------------------------------------
+
+  test("resolves immediately when the marker already exists at call time", async () => {
+    // Simulates the race where the Stop hook fires between clearStaleMarker()
+    // and waitForIdle()'s watcher attach: the marker is on disk but no
+    // further fs.watch events will be emitted.
+    const messages: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    sessionMessageQueue.push(messages);
+
+    await mkdir(markerDir(), { recursive: true });
+    // Write the marker BEFORE starting waitForIdle — no watch event will
+    // fire for this file because it's already there.
+    await writeMarker(sessionId);
+
+    const result = await waitForIdle(sessionId, 0, undefined);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.uuid).toBe("a1");
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Cleanup — no unhandled rejection when watcher is aborted via return
   // -------------------------------------------------------------------------
 
   test("resolves cleanly without throwing when marker appears (abort path exercised)", async () => {
@@ -402,14 +492,7 @@ describe("waitForIdle — marker-file flow", () => {
 
     await mkdir(markerDir(), { recursive: true });
 
-    const idlePromise = waitForIdle(
-      "pane-0",
-      sessionId,
-      0,
-      "",
-      2000,
-      undefined,
-    );
+    const idlePromise = waitForIdle(sessionId, 0, undefined);
 
     await Bun.sleep(80);
     await writeMarker(sessionId);

--- a/tests/sdk/providers/claude-watch-transcript-for-hil.test.ts
+++ b/tests/sdk/providers/claude-watch-transcript-for-hil.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for `watchTranscriptForHIL` in claude.ts.
+ *
+ * HIL detection is transcript-driven: whenever the JSONL is written, we
+ * re-read the session and check `_hasUnresolvedHILTool`. State transitions
+ * fire `onHIL(true|false)`; the watcher runs independently of the Stop hook
+ * so it can surface `AskUserQuestion` while the agent loop is still blocked
+ * on the deferred tool (needsFollowUp=true, Stop hook suppressed upstream).
+ *
+ * Strategy mirrors claude-wait-for-idle.test.ts:
+ * - mock.module the SDK so getSessionMessages returns a test-controlled queue
+ * - real fs.watch on the actual transcriptDir (unique UUID session ids avoid
+ *   cross-test contamination)
+ * - trigger transcript events by writing to the session's JSONL file
+ * - cleanup in afterEach
+ */
+
+import { mock, test, expect, describe, beforeEach, afterEach } from "bun:test";
+import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk";
+
+const sessionMessageQueue: SessionMessage[][] = [];
+
+await mock.module("@anthropic-ai/claude-agent-sdk", () => {
+  return {
+    getSessionMessages: async (_sessionId: string): Promise<SessionMessage[]> => {
+      const next = sessionMessageQueue.shift();
+      return next ?? [];
+    },
+    query: async function* () {},
+  };
+});
+
+import {
+  watchTranscriptForHIL,
+  transcriptDir,
+  transcriptPath,
+} from "../../../src/sdk/providers/claude.ts";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+/** Write a JSONL transcript file to trigger the filename-matching fs.watch event. */
+async function writeTranscript(sessionId: string, body = ""): Promise<void> {
+  await mkdir(transcriptDir(), { recursive: true });
+  await writeFile(transcriptPath(sessionId), body);
+}
+
+async function cleanupTranscript(sessionId: string): Promise<void> {
+  const target = transcriptPath(sessionId);
+  if (existsSync(target)) {
+    try {
+      await unlink(target);
+    } catch {
+      // ENOENT is fine
+    }
+  }
+}
+
+describe("watchTranscriptForHIL", () => {
+  let sessionId: string;
+
+  beforeEach(() => {
+    sessionId = randomUUID();
+    sessionMessageQueue.length = 0;
+  });
+
+  afterEach(async () => {
+    sessionMessageQueue.length = 0;
+    await cleanupTranscript(sessionId);
+  });
+
+  test("fires onHIL(true) when AskUserQuestion tool_use appears, then onHIL(false) when tool_result resolves it", async () => {
+    const toolUseId = randomUUID();
+
+    const pending: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: toolUseId,
+              name: "AskUserQuestion",
+              input: { questions: [{ question: "pick?", options: [] }] },
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    const resolved: SessionMessage[] = [
+      ...pending,
+      {
+        type: "user",
+        uuid: "u1",
+        session_id: sessionId,
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: toolUseId, content: "a" },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    // 1st call (initial check at attach): empty transcript, not HIL
+    sessionMessageQueue.push([]);
+    // 2nd call (after first transcript write): HIL pending
+    sessionMessageQueue.push(pending);
+    // 3rd call (after second write): HIL resolved
+    sessionMessageQueue.push(resolved);
+
+    const calls: boolean[] = [];
+    const ac = new AbortController();
+
+    const watchPromise = watchTranscriptForHIL(
+      sessionId,
+      (waiting) => calls.push(waiting),
+      ac.signal,
+    );
+
+    // Let the watcher attach and run its initial check.
+    await Bun.sleep(80);
+    expect(calls).toEqual([]);
+
+    // Simulate Claude writing the AskUserQuestion tool_use to the JSONL.
+    await writeTranscript(sessionId, "{}\n");
+    for (let i = 0; i < 100 && calls.length < 1; i++) await Bun.sleep(10);
+    expect(calls).toEqual([true]);
+
+    // Simulate user answering — tool_result appended, HIL resolved.
+    await writeTranscript(sessionId, "{}\n{}\n");
+    for (let i = 0; i < 100 && calls.length < 2; i++) await Bun.sleep(10);
+    expect(calls).toEqual([true, false]);
+
+    ac.abort();
+    await watchPromise;
+  });
+
+  test("fires onHIL(true) on attach when the transcript already has unresolved HIL (resumed-session race)", async () => {
+    const toolUseId = randomUUID();
+    const pending: SessionMessage[] = [
+      {
+        type: "assistant",
+        uuid: "a1",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: toolUseId,
+              name: "AskUserQuestion",
+              input: { questions: [] },
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+      },
+    ];
+
+    // Initial check sees HIL already present.
+    sessionMessageQueue.push(pending);
+
+    const calls: boolean[] = [];
+    const ac = new AbortController();
+
+    const watchPromise = watchTranscriptForHIL(
+      sessionId,
+      (waiting) => calls.push(waiting),
+      ac.signal,
+    );
+
+    for (let i = 0; i < 100 && calls.length < 1; i++) await Bun.sleep(10);
+    expect(calls).toEqual([true]);
+
+    ac.abort();
+    await watchPromise;
+  });
+
+  test("ignores transcript events from unrelated sessions (no spurious onHIL)", async () => {
+    const otherSessionId = randomUUID();
+
+    // getSessionMessages is keyed by OUR sessionId, so even though the
+    // watcher re-checks on every event in the dir, writes from unrelated
+    // sessions return an empty transcript → no HIL → no callback fires.
+    // Queue enough empty reads to cover initial check + any stray events.
+    for (let i = 0; i < 10; i++) sessionMessageQueue.push([]);
+
+    const calls: boolean[] = [];
+    const ac = new AbortController();
+
+    const watchPromise = watchTranscriptForHIL(
+      sessionId,
+      (waiting) => calls.push(waiting),
+      ac.signal,
+    );
+
+    await Bun.sleep(80);
+    await writeTranscript(otherSessionId, "{}\n");
+    await Bun.sleep(100);
+
+    expect(calls).toEqual([]);
+
+    ac.abort();
+    await watchPromise;
+    await cleanupTranscript(otherSessionId);
+  });
+
+  test("resolves cleanly when aborted before any events arrive", async () => {
+    sessionMessageQueue.push([]);
+
+    const calls: boolean[] = [];
+    const ac = new AbortController();
+
+    const watchPromise = watchTranscriptForHIL(
+      sessionId,
+      (waiting) => calls.push(waiting),
+      ac.signal,
+    );
+
+    await Bun.sleep(50);
+    ac.abort();
+
+    await expect(watchPromise).resolves.toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces tmux `send-keys` with Claude Code's Stop hook `decision: block` mechanism for delivering follow-up prompts between workflow stages, and switches HIL detection from the Stop hook to a transcript file watcher.

## Key Changes

- **Stop hook follow-up delivery** (`claude-stop-hook.ts`): After writing the turn-completion marker, the hook now block-polls `~/.atomic/claude-queue/<session_id>`. When the workflow enqueues a prompt there, the hook emits `{"decision":"block","reason":<prompt>}` — Claude Code treats `reason` as the next user message and continues the session without any TUI keystrokes.

- **Session release signaling** (`claude.ts`): `clearClaudeSession` is now `async` and writes a release marker to `~/.atomic/claude-release/<session_id>` so the blocked Stop hook exits promptly instead of waiting out its 15-minute safety timeout.

- **Stop hook scoped to workflows** (`claude.ts`, `workflow.ts`): The Stop hook is injected via `claude --settings <json>` at spawn time rather than written to `.claude/settings.json`, so it fires only during workflow runs and never pollutes the user's global Claude config.

- **HIL detection via transcript watcher** (`claude.ts`): Human-in-the-loop detection was moved from the Stop hook to a `fs.watch` listener on the JSONL transcript file, making it resilient to the `stop_hook_active=true` flag that Claude sets after any blocking hook response.

- **Workflow preflight sync** (`workflow.ts`): `workflowCommand` now calls `ensureAtomicGlobalAgentConfigs` and `ensureProjectSetup` before running, mirroring the `atomic chat` preflight so workflows see the same MCP configs and agent settings.

- **Improved transcript rendering** (`executor.ts`): Claude transcripts are now rendered as structured Markdown with tool-call input truncation; `tool_result` blocks are intentionally omitted to avoid context rot on downstream stages.

- **Test coverage**: New and expanded tests for the Stop hook (queue/release/timeout paths), executor transcript rendering, and the transcript-based HIL watcher.