### PR TITLE
chore(release): bump version to v0.5.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.22-0",
+  "version": "0.5.22",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `0.5.22-0` to the stable `0.5.22` release by updating the version in `package.json`.

## Changes

- `package.json`: version `0.5.22-0` → `0.5.22`

## Release notes

This release includes all changes from the `0.5.22-0` prerelease:

- **feat**: Claude stop-hook follow-up delivery (#690) — improves reliability of stop-hook event delivery for Claude Code agents

## Test plan

- [ ] CI passes
- [ ] Merging to `main` triggers GitHub Release `v0.5.22` and npm publish