### PR TITLE
chore(release): bump version to v0.5.23-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.22",
+  "version": "0.5.23-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.5.22` to `v0.5.23-0` as a prerelease ahead of the `v0.5.23` stable release.

## Changes

- `package.json`: version `0.5.22` → `0.5.23-0`

## Test plan

- [ ] CI passes
- [ ] Merge triggers prerelease publish to npm (`@bastani/atomic@0.5.23-0`)