### PR TITLE
chore(release): bump version to v0.5.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.23-0",
+  "version": "0.5.23",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes prerelease `v0.5.23-0` to stable release `v0.5.23` by updating `package.json`.

## Changes

- `package.json`: version `0.5.23-0` → `0.5.23`

## Test plan

- [ ] CI passes
- [ ] GitHub Release is auto-created on merge
- [ ] npm publish succeeds with provenance