### PR TITLE
fix(sdk): surface Claude SDK failures and lazy-resolve headless session id

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -21,7 +21,7 @@ Load references on demand. **Only `getting-started.md` is always-load.** Everyth
 | File | Load when |
 |---|---|
 | `getting-started.md` | **Always** — quick-start examples for all 3 SDKs, SDK exports, `SessionContext` field reference |
-| `failure-modes.md` | Before shipping **any** multi-session workflow. 16 catalogued failures (silent + loud) with wrong-vs-right patterns and a pre-ship design checklist |
+| `failure-modes.md` | Before shipping any multi-session workflow. 16 catalogued failures (silent + loud) with wrong-vs-right patterns and a pre-ship design checklist |
 | `workflow-inputs.md` | When declaring structured inputs or documenting how a workflow is invoked — `WorkflowInput` schema, field-type selection, picker + CLI flag semantics, builtin-protection rules |
 | `agent-sessions.md` | When writing SDK calls — `s.session.query()` (Claude), `s.session.send()` (Copilot), `s.client.session.prompt()` (OpenCode); includes session-lifecycle pitfalls and when to use `sendAndWait` with explicit timeouts |
 | `control-flow.md` | When using loops, conditionals, parallel execution (`Promise.all`), headless fan-out, or review/fix patterns |
@@ -35,65 +35,23 @@ Load references on demand. **Only `getting-started.md` is always-load.** Everyth
 ## Information Flow Is a First-Class Design Concern
 
 **A workflow is an information flow problem, not a sequence of prompts.**
-Before you write a single `ctx.stage()` call, answer these three questions
-for every session boundary in your workflow:
+Before writing any `ctx.stage()` call, answer for every session boundary:
 
-1. **What context does this session need to succeed?** The original user
-   spec? Prior stage output? File paths? Git state? A summary?
-2. **How will that context reach the session?** Built into the prompt?
-   Read from a file? Retrieved via a tool? Kept inside one continued
-   multi-turn stage instead of crossing a stage boundary?
-3. **What happens if the context window fills up?** Compact? Clear? Spawn
-   a sub-session? Offload to files?
+- What context does this session need, how will it reach the session
+  (prompt handoff, file, single multi-turn stage), and what happens if the
+  context window fills up?
 
-If you can't answer all three crisply, you don't have a workflow — you have
-a sequence of hopeful prompts that will fail in non-deterministic ways at
-scale.
+For Copilot and OpenCode, every `ctx.stage()` is a fresh conversation;
+Claude reuses a tmux pane per stage. Read these before shipping any
+multi-session workflow:
 
-### Session lifecycle controls information flow
-
-| Lifecycle state | Context visible to the model | When it happens |
-|---|---|---|
-| **Fresh** | **Nothing** — empty conversation | Each new `ctx.stage()` call — the runtime creates a new session |
-| **Continued** | Everything sent so far in this session | Additional turns within the same stage callback |
-| **Closed** | Gone from the live client; persisted only through what you explicitly saved | Runtime auto-cleanup after the stage callback returns |
-
-**Closing a session and creating a new one wipes all in-session context.**
-The new session knows *only* what you put in its first prompt.
-
-Claude is different in one respect: the runtime reuses a single persistent
-tmux pane per stage, so every turn within a stage accumulates in the same
-conversation. But for Copilot and OpenCode, **every `ctx.stage()` is a fresh
-conversation** — you must explicitly forward context across the boundary.
-
-(An advanced `Resumed` state exists at the provider level for same-role
-continuation — see `agent-sessions.md` for when it applies.)
-
-### Avoiding context loss
-
-Three reliable patterns (they compose — using 1+2 together is common):
-
-1. **Explicit prompt handoff** — capture the prior session's output via
-   `s.transcript()` and inject it into the next session's first prompt.
-   Simple, always works.
-2. **External shared state** — write to files, git, or a database; the next
-   session reads from there. Best when data is already structured.
-3. **Keep related turns in one stage callback** — if the next step needs
-   full conversation history, send another turn to `s.session` instead of
-   spawning a new stage. The idiomatic way to preserve context.
-
-**Context is finite.** Even within one session, context can overflow.
-Symptoms: lost-in-middle, repeated questions, forgotten decisions. Compact
-(summarize prior turns) or clear (drop non-essential turns) before this
-happens. Consult `context-compression` and `context-optimization`.
-
-**Load-bearing references:**
-- `references/failure-modes.md` — read before shipping any multi-session
-  workflow. Silent + loud failures with wrong-vs-right patterns and a
-  pre-ship design checklist.
 - `references/agent-sessions.md` §"Critical pitfall: session lifecycle
-  controls what context is available" — full explanation with code examples
-  and the context engineering skill-map.
+  controls what context is available" — lifecycle table, context-loss
+  patterns, and per-SDK details.
+- `references/failure-modes.md` — silent + loud failures with wrong-vs-right
+  patterns and the pre-ship design checklist.
+- `references/state-and-data-flow.md` — `s.save()`, `s.transcript()`, and
+  file-based handoff patterns.
 
 ## Design Advisory Skills
 
@@ -153,98 +111,35 @@ completion; throws mark errors. `.compile()` produces a branded
 
 ### Background (headless) stages
 
-Stages can run in **headless mode** by passing `{ headless: true }` in
-`stageOpts` (the first argument to `ctx.stage()`). Headless stages execute
-the provider SDK **in-process** instead of spawning a tmux window — they are
-invisible in the workflow graph but tracked via a background task counter in
-the statusline.
-
-```ts
-// Headless stage — runs in-process, no tmux window, invisible in graph
-await ctx.stage(
-  { name: "background-analysis", headless: true },
-  {}, {},
-  async (s) => {
-    const result = await s.session.query("Analyze the codebase structure.");
-    s.save(s.sessionId);
-    return extractAssistantText(result, 0);
-  },
-);
-```
-
-**When to use headless stages:**
-- Parallel data-gathering tasks that don't need a visible TUI (codebase
-  research, infrastructure discovery)
-- Support tasks that should run alongside visible stages without cluttering
-  the graph
-- Any stage where only the result matters, not the live TUI interaction
-
-**How they work per provider:**
-- **Claude**: Uses the Agent SDK `query()` API directly in-process (no tmux pane)
-- **Copilot**: SDK spawns its own CLI subprocess internally (no tmux pane needed)
-- **OpenCode**: Uses `createOpencode()` to start both server and client in-process
-
-**Key behaviors:**
-- The callback interface is **identical** to interactive stages — `s.client`,
-  `s.session`, `s.save()`, `s.transcript()` all work the same way.
-- Headless stages are **transparent to graph topology** — they don't consume
-  or update the execution frontier, so `visible → [3 headless] → visible`
-  renders as `visible → visible` in the graph.
-- Errors in headless stages still fail the workflow — they are tracked and
-  recorded identically to interactive stages.
-- The `paneId` for headless stages is a virtual identifier: `headless-<name>-<sessionId>`.
-
-For the canonical fan-out pattern (visible seed → parallel headless → visible
-merge), see `references/control-flow.md` §"Headless stages: transparent to
-graph topology". Per-SDK headless session behavior is in
-`references/agent-sessions.md`.
+Pass `{ headless: true }` in `stageOpts` to run a stage in-process with no
+tmux window or graph node. The callback interface is identical
+(`s.client`, `s.session`, `s.save()`, `s.transcript()` all work). For
+mechanics, fan-out patterns, and graph topology see
+`references/control-flow.md` §"Headless stages" and
+`references/agent-sessions.md` per-SDK "Headless mode" sections.
 
 ### Installing the workflow SDK
 
-Workflows are SDK-specific. User-created workflows live in a project with
-`@bastani/atomic` installed as a dependency, along with the native agent
-SDK(s) for the provider(s) you target. Install only the SDK(s) you need:
-
-```bash
-bun add @bastani/atomic                    # Workflow SDK
-bun add @anthropic-ai/claude-agent-sdk    # For Claude workflows
-bun add @github/copilot-sdk               # For Copilot workflows
-bun add @opencode-ai/sdk                  # For OpenCode workflows
-```
-
-Workflow files live at `.atomic/workflows/<name>/<agent>/index.ts`. Discovery
-sources: **Local** (`.atomic/workflows/`), **Global** (`~/.atomic/workflows/`),
-and **Built-in** (SDK-shipped). Built-in names (`ralph`,
-`deep-research-codebase`) are **reserved** — any local/global workflow with
-the same name is dropped before resolution. Among non-reserved names, local
-takes precedence over global. See `references/discovery-and-verification.md`
-for full discovery paths and validation.
+Install `@bastani/atomic` plus the native SDK(s) you target
+(`@anthropic-ai/claude-agent-sdk`, `@github/copilot-sdk`,
+`@opencode-ai/sdk`). Workflow files live at
+`.atomic/workflows/<name>/<agent>/index.ts`. Full paths, precedence, and
+reserved built-in names live in `references/discovery-and-verification.md`.
 
 ### Two context levels
 
-| Context | Available in | SDK handles (`client`, `session`, `save`) | Purpose |
-|---|---|---|---|
-| `WorkflowContext` (`ctx`) | `.run(async (ctx) => ...)` | No | Orchestration: `ctx.stage()` to spawn sessions, `ctx.transcript()` to read completed transcripts, `ctx.inputs` for declared inputs |
-| `SessionContext` (`s`) | `ctx.stage(opts, clientOpts, sessionOpts, async (s) => ...)` | Yes | Agent work: use `s.client` and `s.session` for SDK calls, `s.save()` output, `s.stage()` for nested sub-sessions |
+`WorkflowContext` (`ctx`) drives orchestration in `.run()`; `SessionContext`
+(`s`) drives agent work inside each stage callback. Full field reference in
+`references/getting-started.md` §"`SessionContext` reference".
 
-Both contexts expose typed `inputs` (keys restricted to declared input
-names), `stage()`, `transcript()`, and `getMessages()`. See
-`references/getting-started.md` for the full `SessionContext` field reference.
+### Declared inputs
 
-### Declared inputs: one API, three invocation surfaces
-
-Workflows receive user data exclusively through `ctx.inputs` (and `s.inputs`
-inside stage callbacks). Declare `inputs: WorkflowInput[]` inline on
-`defineWorkflow()`. TypeScript infers literal field names from the array and
-restricts `ctx.inputs` to only those keys — accessing an undeclared field is
-a **compile-time error**. The CLI materializes one `--<field>=<value>` flag
-per entry, validates required fields + enum membership before launching, and
-the picker renders a form. Three field types: `string` (single-line), `text`
-(multi-line), `enum` (fixed set).
-
-**Load `references/workflow-inputs.md`** for the full schema shape,
-validation rules, picker semantics, invocation cheat sheet, and the "declare
-your prompt input explicitly" pattern.
+Workflows receive user data exclusively through `ctx.inputs` / `s.inputs`,
+declared inline as `inputs: WorkflowInput[]` on `defineWorkflow()`.
+TypeScript restricts `ctx.inputs` to declared keys (undeclared access is a
+compile-time error). Load `references/workflow-inputs.md` for schema shape,
+field types (`string` / `text` / `enum`), validation rules, picker
+semantics, and the "declare your prompt input explicitly" pattern.
 
 ### Invocation surfaces
 
@@ -263,9 +158,6 @@ Any of the named shapes above (positional or structured) accepts
 `-d` / `--detach` to run without attaching. Use it when you're automating
 from a script and want the CLI to return as soon as the session is spawned.
 
-**Builtin workflows are reserved** — local/global workflows cannot shadow
-them. Pick distinct names.
-
 ### Declaring SDK compatibility (`minSDKVersion`)
 
 Opt-in version gate for workflows that depend on a specific SDK release.
@@ -279,22 +171,13 @@ defineWorkflow({
 })
 ```
 
-| Behaviour | Unset (default) | Set to a version newer than the installed CLI |
-|---|---|---|
-| Loader | Always loads | Refuses to load, returns `IncompatibleSDKError` |
-| `atomic workflow list` | Normal row | `⚠ needs v<X> (installed v<Y>)` — dim name, visible |
-| Picker | Normal row | `⚠ update required` glyph + preview explains the gap; Enter is disabled |
-| `atomic workflow -n <name>` | Runs | Errors with an upgrade hint, non-zero exit |
-
-When to set it: the workflow calls into a newly-added SDK surface (new
-`stage()` option, new helper export, new provider method) that older installs
-don't ship. Omit it for workflows that use only stable APIs — most workflows
-qualify.
-
-The field converts a silent "workflow vanished after upgrade" failure into a
-visible, actionable row the user can fix. See
-`references/discovery-and-verification.md` for semver semantics and the
-visible-diagnostic contract.
+When set to a version newer than the installed CLI, the workflow refuses to
+load and surfaces a visible row in `atomic workflow list` and the picker
+(rather than silently vanishing). Set it only when the workflow calls a
+newly-added SDK surface (new `stage()` option, new helper export, new
+provider method); omit it for workflows on stable APIs. Full semver
+semantics and the visible-diagnostic contract live in
+`references/discovery-and-verification.md`.
 
 ## Structural Rules (hard constraints)
 
@@ -352,21 +235,11 @@ Map the user's intent to sessions and patterns:
 | Does the workflow need user input? | SDK-specific user input APIs (see `references/user-input.md`) |
 | Do any steps need a specific model? | SDK-specific session config (see `references/session-config.md`) |
 
-Then apply **design advisory checks** — these catch architectural and prompt
-quality issues before you write code:
-
-| Design Question | If Yes → Consult |
-|-----------------|------------------|
-| Do session prompts need to be clear, structured, or include examples? | `prompt-engineer` — use XML tags, chain-of-thought, few-shot examples, explicit output format |
-| Is this task actually viable for agent automation? | `project-development` — validate task-model fit before building |
-| Could any single session exceed context limits? | `context-fundamentals` — budget tokens; split into sub-sessions if needed |
-| Do loops accumulate state that degrades over iterations? | `context-degradation` — add compaction triggers; detect lost-in-middle risk |
-| Are large transcripts passed between sessions? | `context-compression` — summarize at boundaries; preserve key decisions and file paths |
-| Should this be one session or many? | `multi-agent-patterns` — choose coordination topology based on task decomposability |
-| Do sessions coordinate via shared files? | `filesystem-context` — use scratch pads, dynamic loading, file-based handoffs |
-| Does the workflow need automated quality checks? | `evaluation` + `advanced-evaluation` — design rubrics; mitigate judge bias |
-| Does the workflow expose custom tools to agents? | `tool-design` — consolidate tools; write unambiguous descriptions |
-| Does the workflow need cross-run knowledge retention? | `memory-systems` — choose persistence layer based on retrieval needs |
+Then walk the **Design Advisory Skills** table above (§"Design Advisory
+Skills") — for each row whose trigger applies to your workflow, pull that
+skill in *before* writing code. Catching architectural and prompt-quality
+issues at design time is far cheaper than catching them in the first failed
+end-to-end run.
 
 ### 2. Choose the Target Agent
 
@@ -400,26 +273,19 @@ SDK-agnostic logic in a sibling `helpers/` directory:
 
 ### 3. Write the Workflow File
 
-**Load `references/getting-started.md`** for complete quick-start examples
-for all three SDKs with correct save patterns, response extraction, and
-timeout handling.
+Write the workflow file using the SDK-specific patterns. See
+`references/getting-started.md` for full quick-start examples for all 3
+SDKs (send/save/extract patterns, idle handling), and
+`references/agent-sessions.md` for per-SDK API details and lifecycle
+caveats.
 
-Per-SDK cheat sheet:
+The SDK ships two builtin workflows in `src/sdk/workflows/builtin/` as
+production reference implementations across all 3 SDKs:
+- **`ralph`** — iterative plan → orchestrate → review → debug loop.
+- **`deep-research-codebase`** — deterministic scout → parallel explorers →
+  aggregator.
 
-| Concern | Claude | Copilot | OpenCode |
-|---------|--------|---------|----------|
-| Send prompt | `s.session.query(prompt)` | `s.session.send({ prompt })` | `s.client.session.prompt({ sessionID: s.session.id, parts: [{ type: "text", text: prompt }] })` |
-| Save output | `s.save(s.sessionId)` | `s.save(await s.session.getMessages())` | `s.save(result.data!)` |
-| Timeout | Per-query defaults via sessionOpts | N/A (`send` has no timeout; `sendAndWait` accepts optional timeout, default 60s) | N/A |
-| Context model | Tmux pane (accumulates across turns) | Fresh per `ctx.stage()` | Fresh per `ctx.stage()` |
-| Extract text | `extractAssistantText(result, 0)` (uses `SessionMessage[]`) | `getAssistantText(messages)` (see `failure-modes.md` F1) | `extractResponseText(result.data!.parts)` (see `failure-modes.md` F3) |
-
-The SDK ships two builtin workflows as production reference implementations:
-- **`ralph`** — iterative plan → orchestrate → review → debug loop (all 3 SDKs)
-- **`deep-research-codebase`** — deterministic scout → parallel explorers → aggregator (all 3 SDKs)
-
-Both live in `src/sdk/workflows/builtin/` and demonstrate real patterns
-including shared helpers, context-aware prompt building, deterministic
+They demonstrate shared helpers, context-aware prompt building, deterministic
 heuristics, and cross-SDK adaptation.
 
 ### 4. Type-Check the Workflow

--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -1,30 +1,36 @@
 ---
 name: workflow-creator
-description: Create multi-agent workflows for Atomic CLI using defineWorkflow().run().compile() with ctx.stage() for session orchestration across Claude, Copilot, and OpenCode SDKs, AND invoke, monitor, and tear down existing workflows on behalf of the user. Use whenever the user wants to create, edit, debug, or RUN workflows ("run the ralph workflow", "kick off deep-research-codebase", "start the gen-spec workflow"), check on a running workflow ("is it done yet?", "what's the status?", "did it error out?"), kill a workflow or session, build agent pipelines, define multi-stage automations, set up review loops, declare workflow inputs, run background/headless stages, or mentions .atomic/workflows/, defineWorkflow, ctx.stage, ctx.inputs, headless, background stages, the atomic workflow picker, `atomic workflow -n`, `atomic workflow inputs`, `atomic workflow status`, or `atomic session kill`.
+description: Create AND run Atomic CLI workflows (`defineWorkflow().run().compile()` with `ctx.stage()`) across Claude, Copilot, and OpenCode SDKs. Use for **authoring** when the user wants to build, edit, debug, or design agent pipelines — multi-stage automations, review/fix loops, parallel fan-out, headless/background stages, `.atomic/workflows/` files, `defineWorkflow`, `ctx.stage`, `ctx.inputs`, or declared `WorkflowInput` schemas. Use for **running** when the user wants to kick off, execute, monitor, or tear down an existing workflow — "run the ralph workflow", "start gen-spec", "is it done yet?", "what's the status?", "kill the session", or any mention of `atomic workflow -n`, `atomic workflow inputs`, `atomic workflow status`, the picker, or `atomic session kill`.
 ---
 
 # Workflow Creator
 
-You are a workflow architect specializing in the Atomic CLI `defineWorkflow().run().compile()` API. Your role is to translate user intent into well-structured workflow files that orchestrate multiple coding agent sessions using **programmatic SDK code** — Claude Agent SDK, Copilot SDK, and OpenCode SDK. Sessions are spawned dynamically via `ctx.stage(opts, clientOpts, sessionOpts, callback)` inside the `.run()` callback, using native TypeScript control flow (loops, conditionals, `Promise.all()`) for orchestration. The runtime auto-creates the SDK client and session, injects them as `s.client` and `s.session`, runs the callback, then auto-cleans up.
+You are a workflow architect specializing in the Atomic CLI `defineWorkflow().run().compile()` API. You translate user intent into well-structured workflow files that orchestrate multiple coding agent sessions using **programmatic SDK code** — Claude Agent SDK, Copilot SDK, and OpenCode SDK. Sessions are spawned dynamically via `ctx.stage(stageOpts, clientOpts, sessionOpts, callback)` inside the `.run()` callback, using native TypeScript control flow (loops, conditionals, `Promise.all()`) for orchestration. The runtime auto-creates the SDK client and session, injects them as `s.client` and `s.session`, runs the callback, then auto-cleans up.
 
-You also serve as a **context engineering advisor**, applying principles from a suite of design skills to make informed architectural decisions about session structure, data flow, prompt composition, and quality assurance. Use these skills to elevate workflows beyond simple pipelines into robust, context-aware systems that respect token budgets, prevent degradation, and produce verifiable results.
+You also serve as a **context engineering advisor** — use the design skills listed under "Design Advisory Skills" to make informed architectural decisions about session structure, data flow, prompt composition, and quality assurance.
+
+Two user journeys live in this skill:
+
+- **Authoring** a new workflow (or editing/debugging an existing one) → read on below.
+- **Running** a workflow on the user's behalf ("run ralph on this spec", "is it done yet?", "kill it") → go to `references/running-workflows.md`.
 
 ## Reference Files
 
-Load the topic-specific reference files from `references/` based on priority. **Always load Tier 1 files.** Load Tier 2-3 files when the task requires that topic.
+Load references on demand. **Only `getting-started.md` is always-load.** Everything else is conditional — pull it in when the task matches the trigger column.
 
-| Tier | File | When to load |
-|---|---|---|
-| **1** | `getting-started.md` | **Always** — quick-start examples for all 3 SDKs, SDK exports, `SessionContext` reference |
-| **1** | `failure-modes.md` | **Always for multi-session workflows** — 15 catalogued failures (silent + loud) with wrong-vs-right patterns and a pre-ship design checklist |
-| **1** | `workflow-inputs.md` | **Always when declaring structured inputs or documenting how a workflow is invoked** — `WorkflowInput` schema, field-type selection, picker + CLI flag semantics, builtin-protection rules, invocation cheat sheet |
-| **2** | `agent-sessions.md` | When writing SDK calls — `s.session.query()` (Claude), `s.session.send()` (Copilot), `s.client.session.prompt()` (OpenCode); includes critical pitfalls on session lifecycle and when to use `sendAndWait` with explicit timeouts |
-| **2** | `control-flow.md` | When using loops, conditionals, parallel execution, or review/fix patterns |
-| **2** | `state-and-data-flow.md` | When passing data between sessions — `s.save()`, `s.transcript()`, `s.getMessages()`, file persistence, transcript compression |
-| **3** | `computation-and-validation.md` | When adding deterministic computation, response parsing, validation, quality gates, or file I/O |
-| **3** | `session-config.md` | When configuring model, tools, permissions, hooks, or structured output per SDK |
-| **3** | `user-input.md` | When collecting user input **mid-workflow** (not at invocation time) — Claude `canUseTool`, Copilot `onElicitationRequest`, OpenCode TUI control. For invocation-time inputs, see `workflow-inputs.md`. |
-| **3** | `discovery-and-verification.md` | When setting up workflow file structure, validation, or TypeScript config |
+| File | Load when |
+|---|---|
+| `getting-started.md` | **Always** — quick-start examples for all 3 SDKs, SDK exports, `SessionContext` field reference |
+| `failure-modes.md` | Before shipping **any** multi-session workflow. 16 catalogued failures (silent + loud) with wrong-vs-right patterns and a pre-ship design checklist |
+| `workflow-inputs.md` | When declaring structured inputs or documenting how a workflow is invoked — `WorkflowInput` schema, field-type selection, picker + CLI flag semantics, builtin-protection rules |
+| `agent-sessions.md` | When writing SDK calls — `s.session.query()` (Claude), `s.session.send()` (Copilot), `s.client.session.prompt()` (OpenCode); includes session-lifecycle pitfalls and when to use `sendAndWait` with explicit timeouts |
+| `control-flow.md` | When using loops, conditionals, parallel execution (`Promise.all`), headless fan-out, or review/fix patterns |
+| `state-and-data-flow.md` | When passing data between sessions — `s.save()`, `s.transcript()`, `s.getMessages()`, file persistence, transcript compression |
+| `running-workflows.md` | When the user asks you to **run** an existing workflow rather than author one |
+| `computation-and-validation.md` | When adding deterministic computation, response parsing, validation, quality gates, or file I/O |
+| `session-config.md` | When configuring model, tools, permissions, hooks, or structured output per SDK |
+| `user-input.md` | When collecting user input **mid-workflow** (not at invocation time — use `workflow-inputs.md` for that) |
+| `discovery-and-verification.md` | When setting up workflow file structure, validation, or TypeScript config |
 
 ## Information Flow Is a First-Class Design Concern
 
@@ -40,9 +46,9 @@ for every session boundary in your workflow:
 3. **What happens if the context window fills up?** Compact? Clear? Spawn
    a sub-session? Offload to files?
 
-If you can't answer all three crisply, you don't have a workflow — you
-have a sequence of hopeful prompts that will fail in non-deterministic
-ways at scale.
+If you can't answer all three crisply, you don't have a workflow — you have
+a sequence of hopeful prompts that will fail in non-deterministic ways at
+scale.
 
 ### Session lifecycle controls information flow
 
@@ -55,25 +61,48 @@ ways at scale.
 **Closing a session and creating a new one wipes all in-session context.**
 The new session knows *only* what you put in its first prompt.
 
-Claude is different: the runtime reuses a single persistent tmux pane, so every turn within a stage accumulates in the same conversation. But for Copilot and OpenCode, **every `ctx.stage()` is a fresh conversation** — you must explicitly forward context across the boundary.
+Claude is different in one respect: the runtime reuses a single persistent
+tmux pane per stage, so every turn within a stage accumulates in the same
+conversation. But for Copilot and OpenCode, **every `ctx.stage()` is a fresh
+conversation** — you must explicitly forward context across the boundary.
+
+(An advanced `Resumed` state exists at the provider level for same-role
+continuation — see `agent-sessions.md` for when it applies.)
 
 ### Avoiding context loss
 
-Three reliable patterns (they compose — using 1+2 together is common). See `references/agent-sessions.md` for detailed examples and wrong-vs-right code patterns.
+Three reliable patterns (they compose — using 1+2 together is common):
 
-1. **Explicit prompt handoff** — capture the prior session's output via `s.transcript()` and inject it into the next session's first prompt. Simple, always works.
-2. **External shared state** — write to files, git, or a database; the next session reads from there. Best when data is already structured.
-3. **Keep related turns in one stage callback** — if the next step needs full conversation history, send another turn to `s.session` instead of spawning a new stage. This is the idiomatic way to preserve context.
+1. **Explicit prompt handoff** — capture the prior session's output via
+   `s.transcript()` and inject it into the next session's first prompt.
+   Simple, always works.
+2. **External shared state** — write to files, git, or a database; the next
+   session reads from there. Best when data is already structured.
+3. **Keep related turns in one stage callback** — if the next step needs
+   full conversation history, send another turn to `s.session` instead of
+   spawning a new stage. The idiomatic way to preserve context.
 
-**Context is finite.** Even within one session, context can overflow. Symptoms: lost-in-middle, repeated questions, forgotten decisions. Compact (summarize prior turns) or clear (drop non-essential turns) before this happens. Consult `context-compression` and `context-optimization` for trade-offs.
+**Context is finite.** Even within one session, context can overflow.
+Symptoms: lost-in-middle, repeated questions, forgotten decisions. Compact
+(summarize prior turns) or clear (drop non-essential turns) before this
+happens. Consult `context-compression` and `context-optimization`.
 
-**Load-bearing references for these pitfalls:**
-- `references/failure-modes.md` — **read before shipping any multi-session workflow**. Catalogue of 15 silent + loud failures with wrong-vs-right patterns and a pre-ship design checklist.
-- `references/agent-sessions.md` §"Critical pitfall: session lifecycle controls what context is available" — full explanation with code examples and the context engineering skill-map.
+**Load-bearing references:**
+- `references/failure-modes.md` — read before shipping any multi-session
+  workflow. Silent + loud failures with wrong-vs-right patterns and a
+  pre-ship design checklist.
+- `references/agent-sessions.md` §"Critical pitfall: session lifecycle
+  controls what context is available" — full explanation with code examples
+  and the context engineering skill-map.
 
 ## Design Advisory Skills
 
-Workflow quality depends on two disciplines: **prompt engineering** (crafting clear, structured prompts that each session receives) and **context engineering** (ensuring the right information reaches each session at the right time without exceeding token budgets). Use `prompt-engineer` to improve individual session prompts — clarity, XML structure, few-shot examples, chain-of-thought — and the context engineering skills below to design the information flow between sessions.
+Workflow quality depends on two disciplines: **prompt engineering** (crafting
+clear, structured prompts each session receives) and **context engineering**
+(ensuring the right information reaches each session without exceeding token
+budgets). Use `prompt-engineer` to improve individual session prompts —
+clarity, XML structure, few-shot examples, chain-of-thought — and the
+context engineering skills below to design information flow between sessions.
 
 | Design Concern | Skill | Trigger |
 |---|---|---|
@@ -94,7 +123,11 @@ Workflow quality depends on two disciplines: **prompt engineering** (crafting cl
 
 ## How Workflows Work
 
-A workflow is a TypeScript file with a single `.run()` callback that orchestrates agent sessions dynamically. Inside the callback, `ctx.stage()` spawns sessions — each gets its own tmux window and graph node (unless running in headless mode). Native TypeScript handles all control flow: loops, conditionals, `Promise.all()`, `try`/`catch`.
+A workflow is a TypeScript file with a single `.run()` callback that
+orchestrates agent sessions dynamically. Inside the callback, `ctx.stage()`
+spawns sessions — each gets its own tmux window and graph node (unless
+running in headless mode). Native TypeScript handles all control flow:
+loops, conditionals, `Promise.all()`, `try`/`catch`.
 
 ```ts
 import { defineWorkflow, extractAssistantText } from "@bastani/atomic/workflows";
@@ -114,11 +147,17 @@ export default defineWorkflow({
   .compile();
 ```
 
-The runtime manages the full session lifecycle — callback return marks completion; throws mark errors. `.compile()` produces a branded `WorkflowDefinition` consumed by the CLI.
+The runtime manages the full session lifecycle — callback return marks
+completion; throws mark errors. `.compile()` produces a branded
+`WorkflowDefinition` consumed by the CLI.
 
 ### Background (headless) stages
 
-Stages can run in **headless mode** by passing `{ headless: true }` in `SessionRunOptions`. Headless stages execute the provider SDK **in-process** instead of spawning a tmux window — they are invisible in the workflow graph but tracked via a background task counter in the statusline.
+Stages can run in **headless mode** by passing `{ headless: true }` in
+`stageOpts` (the first argument to `ctx.stage()`). Headless stages execute
+the provider SDK **in-process** instead of spawning a tmux window — they are
+invisible in the workflow graph but tracked via a background task counter in
+the statusline.
 
 ```ts
 // Headless stage — runs in-process, no tmux window, invisible in graph
@@ -134,8 +173,10 @@ await ctx.stage(
 ```
 
 **When to use headless stages:**
-- Parallel data-gathering tasks that don't need a visible TUI (e.g., codebase research, infrastructure discovery)
-- Support tasks that should run alongside visible stages without cluttering the graph
+- Parallel data-gathering tasks that don't need a visible TUI (codebase
+  research, infrastructure discovery)
+- Support tasks that should run alongside visible stages without cluttering
+  the graph
 - Any stage where only the result matters, not the live TUI interaction
 
 **How they work per provider:**
@@ -144,34 +185,25 @@ await ctx.stage(
 - **OpenCode**: Uses `createOpencode()` to start both server and client in-process
 
 **Key behaviors:**
-- The callback interface is **identical** to interactive stages — `s.client`, `s.session`, `s.save()`, `s.transcript()` all work the same way
-- Headless stages are **transparent to graph topology** — they don't consume or update the execution frontier, so `visible → [3 headless] → visible` renders as `visible → visible` in the graph
-- Errors in headless stages still fail the workflow — they are tracked and recorded identically to interactive stages
-- The `paneId` for headless stages is a virtual identifier: `headless-<name>-<sessionId>`
+- The callback interface is **identical** to interactive stages — `s.client`,
+  `s.session`, `s.save()`, `s.transcript()` all work the same way.
+- Headless stages are **transparent to graph topology** — they don't consume
+  or update the execution frontier, so `visible → [3 headless] → visible`
+  renders as `visible → visible` in the graph.
+- Errors in headless stages still fail the workflow — they are tracked and
+  recorded identically to interactive stages.
+- The `paneId` for headless stages is a virtual identifier: `headless-<name>-<sessionId>`.
 
-**Common pattern — fan-out with headless background stages:**
+For the canonical fan-out pattern (visible seed → parallel headless → visible
+merge), see `references/control-flow.md` §"Headless stages: transparent to
+graph topology". Per-SDK headless session behavior is in
+`references/agent-sessions.md`.
 
-```ts
-// Visible stage seeds context
-const seed = await ctx.stage({ name: "seed" }, {}, {}, async (s) => { /* ... */ });
+### Installing the workflow SDK
 
-// Three parallel headless stages gather data in the background
-const [a, b, c] = await Promise.all([
-  ctx.stage({ name: "gather-a", headless: true }, {}, {}, async (s) => { /* ... */ }),
-  ctx.stage({ name: "gather-b", headless: true }, {}, {}, async (s) => { /* ... */ }),
-  ctx.stage({ name: "gather-c", headless: true }, {}, {}, async (s) => { /* ... */ }),
-]);
-
-// Visible stage merges background results
-await ctx.stage({ name: "merge" }, {}, {}, async (s) => {
-  await s.session.query(`Merge:\n${a.result}\n${b.result}\n${c.result}`);
-  s.save(s.sessionId);
-});
-```
-
-See `references/control-flow.md` for full headless pattern details and `references/agent-sessions.md` for per-SDK headless session behavior.
-
-Workflows are SDK-specific. User-created workflows live in a project with `@bastani/atomic` installed as a dependency, along with the native agent SDK(s) for the provider(s) you target. Install only the SDK(s) you need:
+Workflows are SDK-specific. User-created workflows live in a project with
+`@bastani/atomic` installed as a dependency, along with the native agent
+SDK(s) for the provider(s) you target. Install only the SDK(s) you need:
 
 ```bash
 bun add @bastani/atomic                    # Workflow SDK
@@ -180,26 +212,39 @@ bun add @github/copilot-sdk               # For Copilot workflows
 bun add @opencode-ai/sdk                  # For OpenCode workflows
 ```
 
-Workflow files live at `.atomic/workflows/<name>/<agent>/index.ts`. Discovery sources: **Local** (`.atomic/workflows/`), **Global** (`~/.atomic/workflows/`), and **Built-in** (SDK-shipped). Built-in names (`ralph`, `deep-research-codebase`) are **reserved** — any local/global workflow with the same name is dropped before resolution. Among non-reserved names, local takes precedence over global. See `references/discovery-and-verification.md` for full discovery paths and validation.
+Workflow files live at `.atomic/workflows/<name>/<agent>/index.ts`. Discovery
+sources: **Local** (`.atomic/workflows/`), **Global** (`~/.atomic/workflows/`),
+and **Built-in** (SDK-shipped). Built-in names (`ralph`,
+`deep-research-codebase`) are **reserved** — any local/global workflow with
+the same name is dropped before resolution. Among non-reserved names, local
+takes precedence over global. See `references/discovery-and-verification.md`
+for full discovery paths and validation.
 
 ### Two context levels
 
-| Context | Available in | Has `client`/`session`/`save`? | Purpose |
-|---------|-------------|-------------------------------|---------|
-| `WorkflowContext` (`ctx`) | `.run(async (ctx) => ...)` | No | Orchestration: spawn sessions, read transcripts, read `ctx.inputs` |
-| `SessionContext` (`s`) | `ctx.stage(opts, clientOpts, sessionOpts, async (s) => ...)` | Yes | Agent work: use `s.client` and `s.session` for SDK calls, save output |
+| Context | Available in | SDK handles (`client`, `session`, `save`) | Purpose |
+|---|---|---|---|
+| `WorkflowContext` (`ctx`) | `.run(async (ctx) => ...)` | No | Orchestration: `ctx.stage()` to spawn sessions, `ctx.transcript()` to read completed transcripts, `ctx.inputs` for declared inputs |
+| `SessionContext` (`s`) | `ctx.stage(opts, clientOpts, sessionOpts, async (s) => ...)` | Yes | Agent work: use `s.client` and `s.session` for SDK calls, `s.save()` output, `s.stage()` for nested sub-sessions |
 
-Both contexts expose typed `inputs` (keys restricted to declared input names), `stage()`, `transcript()`, and `getMessages()`. See `references/getting-started.md` for the full `SessionContext` field reference.
+Both contexts expose typed `inputs` (keys restricted to declared input
+names), `stage()`, `transcript()`, and `getMessages()`. See
+`references/getting-started.md` for the full `SessionContext` field reference.
 
 ### Declared inputs: one API, three invocation surfaces
 
-Workflows receive user data exclusively through `ctx.inputs` (and `s.inputs` inside stage callbacks).
+Workflows receive user data exclusively through `ctx.inputs` (and `s.inputs`
+inside stage callbacks). Declare `inputs: WorkflowInput[]` inline on
+`defineWorkflow()`. TypeScript infers literal field names from the array and
+restricts `ctx.inputs` to only those keys — accessing an undeclared field is
+a **compile-time error**. The CLI materializes one `--<field>=<value>` flag
+per entry, validates required fields + enum membership before launching, and
+the picker renders a form. Three field types: `string` (single-line), `text`
+(multi-line), `enum` (fixed set).
 
-Declare `inputs: WorkflowInput[]` inline on `defineWorkflow()`. TypeScript infers literal field names from the array and restricts `ctx.inputs` to only those keys — accessing an undeclared field is a **compile-time error**. The CLI materializes one `--<field>=<value>` flag per entry, validates required fields + enum membership before launching, and the picker renders a form. Three field types: `string` (single-line), `text` (multi-line), `enum` (fixed set).
-
-Workflows that accept a free-form prompt should declare it explicitly: `{ name: "prompt", type: "text", required: true }`.
-
-**Load `references/workflow-inputs.md`** for the full schema shape, validation rules, picker semantics, and invocation cheat sheet.
+**Load `references/workflow-inputs.md`** for the full schema shape,
+validation rules, picker semantics, invocation cheat sheet, and the "declare
+your prompt input explicitly" pattern.
 
 ### Invocation surfaces
 
@@ -214,13 +259,18 @@ Workflows that accept a free-form prompt should declare it explicitly: `{ name: 
 | Kill non-interactively | `atomic session kill <id> -y` | Tear down a workflow/chat session without the confirmation prompt — the form agents use |
 | Detached (background) | `atomic workflow -n ralph -a claude -d "..."` | Scripted/CI runs where the caller shouldn't block on the TUI — the orchestrator keeps running on the atomic tmux socket; attach later with `atomic workflow session connect <name>` |
 
-Any of the named shapes above (positional or structured) accepts `-d` / `--detach` to run without attaching. Use it when you're automating from a script and want the CLI to return as soon as the session is spawned.
+Any of the named shapes above (positional or structured) accepts
+`-d` / `--detach` to run without attaching. Use it when you're automating
+from a script and want the CLI to return as soon as the session is spawned.
 
-**Builtin workflows are reserved** — local/global workflows cannot shadow them. Pick distinct names.
+**Builtin workflows are reserved** — local/global workflows cannot shadow
+them. Pick distinct names.
 
 ### Declaring SDK compatibility (`minSDKVersion`)
 
-Opt-in version gate for workflows that depend on a specific SDK release. **Default is unset — do not add it to new workflows unless you have a concrete reason.**
+Opt-in version gate for workflows that depend on a specific SDK release.
+**Default is unset — do not add it to new workflows unless you have a
+concrete reason.**
 
 ```ts
 defineWorkflow({
@@ -236,13 +286,19 @@ defineWorkflow({
 | Picker | Normal row | `⚠ update required` glyph + preview explains the gap; Enter is disabled |
 | `atomic workflow -n <name>` | Runs | Errors with an upgrade hint, non-zero exit |
 
-When to set it: the workflow calls into a newly-added SDK surface (new `stage()` option, new helper export, new provider method) that older installs don't ship. Omit it for workflows that use only stable APIs — most workflows qualify.
+When to set it: the workflow calls into a newly-added SDK surface (new
+`stage()` option, new helper export, new provider method) that older installs
+don't ship. Omit it for workflows that use only stable APIs — most workflows
+qualify.
 
-The point of the field is to convert a silent "workflow vanished after upgrade" failure into a visible, actionable row the user can fix. See `references/discovery-and-verification.md` for semver semantics and the visible-diagnostic contract.
+The field converts a silent "workflow vanished after upgrade" failure into a
+visible, actionable row the user can fix. See
+`references/discovery-and-verification.md` for semver semantics and the
+visible-diagnostic contract.
 
-### Structural Rules
+## Structural Rules (hard constraints)
 
-Hard constraints enforced by the builder, loader, and runtime:
+Enforced by the builder, loader, and runtime:
 
 1. **`.run()` required** — the builder must have a `.run(async (ctx) => { ... })` call.
 2. **`.compile()` required** — the chain must end with `.compile()`.
@@ -269,10 +325,14 @@ Every workflow pattern maps directly to TypeScript code:
 | Return data from session | `const h = await ctx.stage(opts, {}, {}, async (s) => { return value; }); h.result` |
 | Data flow between sessions | `s.save()` to persist → `s.transcript(handle)` or `s.transcript("name")` to retrieve |
 | Deterministic computation (no LLM) | Plain TypeScript inside `.run()` or inside a session callback |
-| Subagent orchestration | Claude: `@"agent (agent)"` prefix in prompt; Copilot: `{ agent: "name" }` in sessionOpts; OpenCode: `agent` param in `s.client.session.prompt()` |
+| Subagent orchestration | Claude: `--agent` via `chatFlags` (interactive) or `agent` SDK option (headless); Copilot: `{ agent: "name" }` in sessionOpts; OpenCode: `agent` param in `s.client.session.prompt()` |
 | Per-session configuration | Pass `clientOpts` (2nd arg) and `sessionOpts` (3rd arg) to `ctx.stage()` |
 
-For full pattern examples with code, see `references/control-flow.md` (loops, conditionals, review/fix, graph topology), `references/state-and-data-flow.md` (data passing, file coordination, transcript compression), and `references/computation-and-validation.md` (parsing, validation, quality gates).
+For full pattern examples with code, see `references/control-flow.md`
+(loops, conditionals, review/fix, graph topology, headless fan-out),
+`references/state-and-data-flow.md` (data passing, file coordination,
+transcript compression), and `references/computation-and-validation.md`
+(parsing, validation, quality gates).
 
 ## Authoring Process
 
@@ -292,7 +352,8 @@ Map the user's intent to sessions and patterns:
 | Does the workflow need user input? | SDK-specific user input APIs (see `references/user-input.md`) |
 | Do any steps need a specific model? | SDK-specific session config (see `references/session-config.md`) |
 
-Then apply **design advisory checks** — these catch architectural and prompt quality issues before you write code:
+Then apply **design advisory checks** — these catch architectural and prompt
+quality issues before you write code:
 
 | Design Question | If Yes → Consult |
 |-----------------|------------------|
@@ -309,7 +370,8 @@ Then apply **design advisory checks** — these catch architectural and prompt q
 
 ### 2. Choose the Target Agent
 
-Use `.for<"agent">()` on the builder to narrow all context types and get correct `s.client`/`s.session` types. Call `.for()` **before** `.run()`:
+Use `.for<"agent">()` on the builder to narrow all context types and get
+correct `s.client`/`s.session` types. Call `.for()` **before** `.run()`:
 
 | Agent | Builder Chain | Primary Session API |
 |-------|---------------|---------------------|
@@ -317,9 +379,13 @@ Use `.for<"agent">()` on the builder to narrow all context types and get correct
 | Copilot | `defineWorkflow({...}).for<"copilot">()` | `s.session.send({ prompt })` — the runtime wraps `send` to block until `session.idle` with no timeout (see `failure-modes.md` §F10); do not use `sendAndWait` in Atomic workflows |
 | OpenCode | `defineWorkflow({...}).for<"opencode">()` | `s.client.session.prompt({ sessionID: s.session.id, parts: [...] })` |
 
-The runtime manages client/session lifecycle automatically. For native SDK types and advanced APIs, import directly from the provider packages (`@github/copilot-sdk`, `@anthropic-ai/claude-agent-sdk`, `@opencode-ai/sdk/v2`).
+The runtime manages client/session lifecycle automatically. For native SDK
+types and advanced APIs, import directly from the provider packages
+(`@github/copilot-sdk`, `@anthropic-ai/claude-agent-sdk`, `@opencode-ai/sdk/v2`).
 
-For cross-agent support, create one workflow file per agent under `.atomic/workflows/<name>/<agent>/index.ts`. Use shared helper modules for SDK-agnostic logic in a sibling `helpers/` directory:
+For cross-agent support, create one workflow file per agent under
+`.atomic/workflows/<name>/<agent>/index.ts`. Use shared helper modules for
+SDK-agnostic logic in a sibling `helpers/` directory:
 
 ```
 .atomic/workflows/<name>/
@@ -334,7 +400,9 @@ For cross-agent support, create one workflow file per agent under `.atomic/workf
 
 ### 3. Write the Workflow File
 
-**Load `references/getting-started.md`** for complete quick-start examples for all three SDKs with correct save patterns, response extraction, and timeout handling.
+**Load `references/getting-started.md`** for complete quick-start examples
+for all three SDKs with correct save patterns, response extraction, and
+timeout handling.
 
 Per-SDK cheat sheet:
 
@@ -350,7 +418,9 @@ The SDK ships two builtin workflows as production reference implementations:
 - **`ralph`** — iterative plan → orchestrate → review → debug loop (all 3 SDKs)
 - **`deep-research-codebase`** — deterministic scout → parallel explorers → aggregator (all 3 SDKs)
 
-Both live in `src/sdk/workflows/builtin/` and demonstrate real patterns including shared helpers, context-aware prompt building, deterministic heuristics, and cross-SDK adaptation.
+Both live in `src/sdk/workflows/builtin/` and demonstrate real patterns
+including shared helpers, context-aware prompt building, deterministic
+heuristics, and cross-SDK adaptation.
 
 ### 4. Type-Check the Workflow
 
@@ -377,147 +447,22 @@ atomic workflow -a <agent>
 atomic workflow -n <workflow-name> -a <agent> -d "<your prompt>"
 ```
 
-## Running a Workflow on Behalf of the User
+## Running an Existing Workflow
 
-When the user asks you to **run** (or "kick off" / "start" / "execute") a workflow — *not* author one — your job is to translate their request into a single `atomic workflow` invocation and run it. This section is the playbook for that flow. It is different from the authoring playbook above: the workflow already exists on disk; you just need to invoke it correctly.
+If the user asks you to **run** (or "kick off" / "start" / "execute") a
+workflow — not author one — the workflow already exists on disk and you
+just need to invoke it correctly. That's a different playbook from
+authoring.
 
-### You don't need to pass `-a` or `-d`
+**Read `references/running-workflows.md`.** It covers:
 
-When you (the agent) are running inside an atomic chat or workflow pane, the CLI reads `$ATOMIC_AGENT` from your environment and:
-
-- Fills in `-a <agent>` automatically if you don't pass it.
-- Forces detached mode on, so launching a workflow never takes over your pane.
-
-The practical result: your command is just `atomic workflow -n <name> <inputs>`. No provider flag, no detach flag, no chance of the orchestrator hijacking your terminal. The CLI prints the session name and returns immediately; you relay that name to the user.
-
-Override only when the user explicitly asks for a different provider (e.g. "run it on Copilot") — pass `-a copilot` and the CLI will honor it over the env var.
-
-### Always list first
-
-**Before anything else, run `atomic workflow list`.** (Optionally filter with `-a <agent>` if the user's pinned to one — usually unnecessary.) This is a cheap, read-only call that tells you three things in one shot:
-
-- Whether the workflow the user named actually exists.
-- What other workflows are available (so you can suggest close matches on a typo).
-- Source + metadata for every discoverable workflow (local vs. global vs. builtin).
-
-Skipping this step is how you end up guessing a name, typing it into `atomic workflow -n <name>`, and getting a `workflow not found` error you could have predicted. List first, decide second, run third.
-
-If the user's request is ambiguous ("run the research one"), the list output is also how you show them the candidates so they can pick — present the matching names and ask with AskUserQuestion.
-
-### If the workflow doesn't exist: offer to create it
-
-When the listed workflows don't include what the user asked for:
-
-1. **Tell the user explicitly** — "I don't see a `<name>` workflow in `.atomic/workflows/` or `~/.atomic/workflows/`. Available: \<short list from `atomic workflow list`>."
-2. **Check for typos first** — if one of the listed names is a close match, surface it via AskUserQuestion ("Did you mean `<close-match>`?") before offering to author anything.
-3. **Offer to create it** — ask with AskUserQuestion: "Want me to create a `<name>` workflow first?" with choices `Yes, create it` / `No, pick from the list` / `No, cancel`.
-4. **If yes → switch modes** — hand off to the authoring flow in the [Authoring Process](#authoring-process) section above (Steps 1-5). Interview the user for intent, write the file at `.atomic/workflows/<name>/<agent>/index.ts`, typecheck it, *then* come back to this runner section and invoke it. Do not skip the typecheck — an uncompiled workflow won't run.
-5. **If no → stop** — don't fabricate a command that will fail. Let the user redirect you.
-
-Never invent a workflow name or silently fall back to a different workflow. If the thing the user asked for doesn't exist, the correct answer is to say so and offer concrete next steps.
-
-### Collecting inputs with AskUserQuestion
-
-Once you've confirmed the workflow exists, you need to know two things about its invocation shape:
-
-1. **Does it declare a `prompt` input?** If so, it's free-form — you pass a positional string.
-2. **Does it declare structured inputs?** If so, you pass `--<field>=<value>` flags, one per required field.
-
-**Use `atomic workflow inputs <name> -a <agent>` to get the schema.** This prints a JSON envelope with every field's `name`, `type`, `required`, `default`, `description`, and (for enums) `values` — exactly what AskUserQuestion needs. The `freeform: true` flag tells you whether the workflow takes a positional prompt vs. structured flags, with a synthetic `prompt` field included so the JSON shape is uniform either way.
-
-```bash
-atomic workflow inputs gen-spec -a claude
-# {"workflow":"gen-spec","agent":"claude","freeform":false,
-#  "inputs":[{"name":"research_doc","type":"string","required":true,...},
-#            {"name":"focus","type":"enum","values":["minimal","standard","exhaustive"],"default":"standard"}]}
-```
-
-Why this command instead of reading the source file: `inputs` is the contract the CLI actually validates against. It survives refactors, handles built-in workflows that aren't in the project tree, and never falls out of sync with the runtime. Reading TypeScript source is a fallback for the rare case where the command can't resolve the workflow.
-
-Once you have the schema, use the **AskUserQuestion tool** to collect any values the user hasn't already provided in their message. One question per missing input field. For enum fields, pass the declared `values` as multiple-choice options so the user sees exactly what's allowed. Keep questions tight and purposeful — if the user's message already answers a question, don't ask it again.
-
-Skip AskUserQuestion entirely when:
-- The user already supplied every required value in their message ("run ralph on 'add OAuth to the API'" — the prompt is right there).
-- The workflow declares no required inputs and needs no prompt.
-
-### End-to-end recipe
-
-1. **List available workflows** — run `atomic workflow list`. Always. This is your ground truth.
-2. **Resolve the target**:
-   - Exact match in the list → continue.
-   - Close match → confirm via AskUserQuestion before proceeding.
-   - No match → tell the user what's available and offer to author it (see previous section). If they decline, stop.
-3. **Discover the inputs schema** — run `atomic workflow inputs <name> -a <agent>` and parse the JSON.
-4. **Ask for missing inputs** — use AskUserQuestion, one question per unanswered required field. Enums become multiple-choice.
-5. **Invoke** — build one of these commands:
-   - Free-form: `atomic workflow -n <name> "<prompt>"`
-   - Structured: `atomic workflow -n <name> --<field1>=<value1> --<field2>=<value2>`
-6. **Report the session name** the CLI printed and tell the user: "attach any time with `atomic workflow session connect <session>` — or `atomic workflow session list` to see what's running."
-
-### Monitoring a running workflow
-
-Detached workflows return immediately with a session name; the actual work runs in the background on the atomic tmux socket. Use `atomic workflow status` to check whether the workflow is still running, has completed, errored out, or paused for human input — without attaching to its TUI.
-
-```bash
-atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4
-# {"id":"atomic-wf-claude-gen-spec-a1b2c3d4","overall":"in_progress","alive":true,
-#  "sessions":[{"name":"orchestrator","status":"running",...}],...}
-```
-
-Four overall states the agent must handle distinctly:
-
-| Status | Meaning | What you should do |
-|---|---|---|
-| `in_progress` | The orchestrator is running and no stage is paused | Wait, or report progress to the user |
-| `needs_review` | At least one stage is paused for human input (HIL) — Copilot `ask_user`, OpenCode `question.asked`, Copilot/MCP elicitation | **Surface this to the user immediately** — they need to attach with `atomic workflow session connect <id>` to respond, otherwise the workflow stalls indefinitely |
-| `completed` | Workflow finished successfully | Report success and summarize the output |
-| `error` | Fatal error or a stage failed | Report the `fatalError` field and offer to investigate logs |
-
-`needs_review` outranks `completed` so a HIL pause near the end is never reported as done while still waiting on a human. A dead orchestrator with a stale snapshot is automatically downgraded to `error`.
-
-Omit the id to list every running workflow at once: `atomic workflow status`. Useful when checking on multiple parallel runs, or when the user just asks "what's running?".
-
-### Cleaning up sessions
-
-When the user is done with a workflow — or you launched one detached and it's no longer needed — tear it down with `-y` so no confirmation prompt blocks you:
-
-```bash
-atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y
-```
-
-The `-y` flag is mandatory for agent use. Without it, the CLI calls `@clack/prompts confirm`, which expects a TTY and will hang indefinitely in a non-interactive context. Same flag works for `atomic workflow session kill` and `atomic chat session kill`. Without an id, `kill -y` tears down every in-scope session — only do that when the user has asked to stop everything.
-
-### Worked examples
-
-**Example A — workflow exists, structured inputs**
-
-> **User:** "run gen-spec on research/docs/2026-04-11-auth.md"
-
-1. Run `atomic workflow list`. Output includes `gen-spec` under local. Good.
-2. Target resolved exactly: `gen-spec`.
-3. Run `atomic workflow inputs gen-spec -a claude`. Parse the JSON: `research_doc` (required string — already given), `focus` (required enum of `minimal|standard|exhaustive`, default `standard`), `notes` (optional text).
-4. Ask via AskUserQuestion once: "What focus level for the spec?" with choices `minimal`, `standard`, `exhaustive`. User picks `standard`. Skip `notes` since it's optional.
-5. Run: `atomic workflow -n gen-spec --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
-6. The CLI prints a session name like `atomic-wf-claude-gen-spec-a1b2c3d4`. Tell the user: "Started in the background. Attach with `atomic workflow session connect atomic-wf-claude-gen-spec-a1b2c3d4`, check progress with `atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4`, or stop it with `atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y`."
-
-**Example B — workflow does not exist**
-
-> **User:** "run the security-audit workflow on src/auth"
-
-1. Run `atomic workflow list`. Available: `ralph`, `deep-research-codebase`, `gen-spec`, `review-to-merge`. No `security-audit`.
-2. Tell the user: "I don't see a `security-audit` workflow. Available: ralph, deep-research-codebase, gen-spec, review-to-merge."
-3. Ask via AskUserQuestion: "Want me to create a `security-audit` workflow first?" with choices `Yes, create it`, `No, use one of the existing workflows`, `No, cancel`.
-4. If **Yes**: switch to the Authoring Process — interview the user for what the workflow should do, draft it, typecheck, *then* return here and invoke it.
-5. If **No, use existing**: ask which one via AskUserQuestion over the listed options, then continue from step 3 of the recipe.
-6. If **Cancel**: stop, no command runs.
-
-### Common mistakes to avoid
-
-- **Skipping `atomic workflow list`** — leads to guessing and `workflow not found` errors. It's a one-line command; always run it.
-- **Inventing a workflow name** — if it's not in the list, it doesn't exist. Say so and offer to author it.
-- **Reading the workflow source file to discover inputs** — use `atomic workflow inputs <name> -a <agent>` instead. JSON, no TS parsing required, always in sync with the runtime. Source-file reads are a fallback, not a default.
-- **Asking everything at once** — let AskUserQuestion drive one question per field. Enum fields are multiple-choice, not free text.
-- **Re-asking what the user already said** — read their message first.
-- **Forgetting to report the session name** — the user needs it to reattach and to query status later.
-- **Leaving `needs_review` unreported** — when `atomic workflow status` returns `needs_review`, surface it to the user right away. The workflow is blocked on human input and will sit forever otherwise.
-- **Calling `session kill` without `-y`** — the prompt hangs in a non-interactive context. Always pass `-y` from an agent.
+- Why you don't usually need `-a` or `-d` (env-driven auto-detach).
+- Why you must run `atomic workflow list` first.
+- How to handle missing workflows (offer to author, not fabricate).
+- Using `atomic workflow inputs <name> -a <agent>` to discover the schema
+  and drive AskUserQuestion.
+- The six-step invocation recipe.
+- Monitoring with `atomic workflow status` — and why `needs_review` must be
+  surfaced immediately.
+- Tearing down with `atomic session kill -y` (the `-y` is mandatory).
+- Worked examples for "workflow exists" and "workflow doesn't exist".

--- a/.agents/skills/workflow-creator/references/agent-sessions.md
+++ b/.agents/skills/workflow-creator/references/agent-sessions.md
@@ -97,43 +97,16 @@ Claude maintains conversation context across calls within the same pane. Call `s
 
 ### Advanced: Claude Agent SDK `query()` option surface (reference only)
 
-**Do not import `query` from `@anthropic-ai/claude-agent-sdk` inside a `ctx.stage()` callback.** In a non-headless stage it double-spawns Claude (idle TUI pane + in-process SDK call) — see `failure-modes.md` §F17. In a headless stage it bypasses the runtime's wiring. Always go through `s.session.query()`; the runtime forwards options to the SDK for headless stages and routes the interactive TUI for non-headless stages.
+**Do not import `query` from `@anthropic-ai/claude-agent-sdk` inside a `ctx.stage()` callback.** In a non-headless stage it double-spawns Claude (idle TUI pane + in-process SDK call) — see `failure-modes.md` §F16. In a headless stage it bypasses the runtime's wiring. Always go through `s.session.query()`; the runtime forwards options to the SDK for headless stages and routes the interactive TUI for non-headless stages.
 
 Two correct routes:
 
 1. **Headless + SDK options** — `s.session.query(prompt, sdkOptions)` inside `{ headless: true }`.
 2. **Interactive TUI + `--agent`** — `chatFlags: ["--agent", "<name>", ...]` in `clientOpts`.
 
-The snippet below is a **reference cheatsheet for the SDK option shape only** — it is *not* valid workflow code. Use it to learn what `sdkOptions` accepts when passed as the second argument to `s.session.query()` in a headless stage:
+For the full SDK option surface, see `session-config.md` §"`query()` options".
 
-```ts
-// ❌ Do not call query() like this from a workflow. Reference-only to show
-//    which options are available when you pass them to s.session.query().
-import { query } from "@anthropic-ai/claude-agent-sdk";
-
-query({
-  prompt: "...",
-  options: {
-    model: "claude-opus-4-6",
-    effort: "high",
-    maxTurns: 50,
-    maxBudgetUsd: 5.0,
-    permissionMode: "acceptEdits",
-    allowedTools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
-    disallowedTools: ["AskUserQuestion"],
-    systemPrompt: "You are a senior engineer...",
-    outputFormat: {
-      type: "json_schema",
-      schema: { type: "object", properties: { tasks: { type: "array", items: { type: "string" } } } },
-    },
-    agents: {
-      reviewer: { description: "Review code changes", prompt: "You are a code reviewer..." },
-    },
-  },
-});
-```
-
-The ✅ equivalent in a real workflow:
+Example workflow usage in a headless stage:
 
 ```ts
 await ctx.stage({ name: "implement", headless: true }, {}, {}, async (s) => {
@@ -153,7 +126,7 @@ await ctx.stage({ name: "implement", headless: true }, {}, {}, async (s) => {
 
 Key `query()` options:
 - `model` — model ID (`"claude-opus-4-6"`, `"claude-sonnet-4-6"`) or alias (`"opus"`, `"sonnet"`, `"haiku"`)
-- `effort` — reasoning effort (`"low"`, `"medium"`, `"high"`, `"max"` — `"max"` is Opus 4.6 only)
+- `effort` — reasoning effort (`"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` — `"max"` is Opus 4.6/4.7 only)
 - `thinking` — thinking/reasoning config: `{ type: "adaptive" }` (default for supported models), `{ type: "enabled", budgetTokens: N }`, or `{ type: "disabled" }`
 - `maxTurns` — maximum conversation turns
 - `maxBudgetUsd` — spending cap in USD
@@ -176,7 +149,7 @@ Key `query()` options:
 Claude supports parallel subagents via the `agents` option (a
 `Record<string, AgentDefinition>` keyed by agent name). In a workflow,
 pass the option through `s.session.query(prompt, sdkOptions)` in a
-**headless** stage — see §F17 for why the raw SDK `query()` import is
+**headless** stage — see §F16 for why the raw SDK `query()` import is
 an anti-pattern:
 
 ```ts
@@ -231,9 +204,9 @@ await ctx.stage({ name: "fork", headless: true }, {}, {}, async (s) => {
 });
 ```
 
-### Sub-agent delegation
+### Subagent delegation
 
-For stages that call a single sub-agent, use `--agent` (interactive) or the SDK `agent` option (headless) to route all prompts through that agent. The agent must be defined in `.claude/agents/` or `.agents/skills/`.
+For stages that call a single subagent, use `--agent` (interactive) or the SDK `agent` option (headless) to route all prompts through that agent. The agent must be defined in `.claude/agents/` or `.agents/skills/`.
 
 **Interactive stages** — pass `--agent` via `chatFlags` in client opts (2nd arg):
 
@@ -360,7 +333,7 @@ A workflow is not just a sequence of agent calls — it is an **information
 flow problem**. The single most common failure mode in Copilot workflows is
 assuming context carries across session boundaries when it doesn't.
 Designing a workflow without thinking about information flow produces
-sub-agents that hallucinate, repeat work, or drop requirements silently.
+subagents that hallucinate, repeat work, or drop requirements silently.
 
 **Treat this section as load-bearing**, not decorative. If you skip it, your
 workflow will ship broken in subtle, non-deterministic ways.
@@ -374,12 +347,12 @@ you need full history, prefer another turn inside the same stage callback.
 Copilot also exposes an advanced `Resumed` state at the provider level. Each
 state determines what context the model sees on its next turn:
 
-| State | How you get there | Context available | Action needed |
-|---|---|---|---|
-| **Fresh** | `client.createSession(...)` (what `ctx.stage()` does) | **None** — empty conversation | You MUST inject everything the agent needs in the first prompt |
-| **Continued** | Same session, additional `send` calls | All prior turns in this session | Nothing — but watch total token usage |
-| **Resumed** *(advanced)* | `client.resumeSession(sessionId)` | All persisted turns from the prior session of the SAME agent | Nothing — full history is reattached. Use only for same-role continuation |
-| **Closed** | `session.disconnect()` or `client.stop()` (auto-handled by runtime after the stage callback returns) | **Gone** from the live client; persisted on disk if the host enables it | Either resume by ID (same agent) or start fresh and re-inject context |
+| State                    | How you get there                                                                                    | Context available                                                       | Action needed                                                             |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Fresh**                | `client.createSession(...)` (what `ctx.stage()` does)                                                | **None** — empty conversation                                           | You MUST inject everything the agent needs in the first prompt            |
+| **Continued**            | Same session, additional `send` calls                                                                | All prior turns in this session                                         | Nothing — but watch total token usage                                     |
+| **Resumed** *(advanced)* | `client.resumeSession(sessionId)`                                                                    | All persisted turns from the prior session of the SAME agent            | Nothing — full history is reattached. Use only for same-role continuation |
+| **Closed**               | `session.disconnect()` or `client.stop()` (auto-handled by runtime after the stage callback returns) | **Gone** from the live client; persisted on disk if the host enables it | Either resume by ID (same agent) or start fresh and re-inject context     |
 
 The failure mode: you close a session, create a new one, and assume the new
 one "remembers" the previous conversation. It doesn't. `client` is just the
@@ -392,7 +365,7 @@ handoff path.
 // the planner just produced, because each ctx.stage() starts a brand-new
 // conversation for Copilot.
 await ctx.stage({ name: "planner" }, {}, { agent: "planner" }, async (s) => {
-  await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+  await s.session.send({ prompt: buildPlannerPrompt((s.inputs.prompt ?? "")) });
   s.save(await s.session.getMessages());
 });
 await ctx.stage({ name: "orchestrator" }, {}, { agent: "orchestrator" }, async (s) => {
@@ -421,7 +394,7 @@ const plannerHandle = await ctx.stage(
   {},
   { agent: "planner" },
   async (s) => {
-    await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+    await s.session.send({ prompt: buildPlannerPrompt((s.inputs.prompt ?? "")) });
     const messages = await s.session.getMessages();
     s.save(messages);
     return getAssistantText(messages); // see failure-modes.md §F1 for getAssistantText
@@ -435,7 +408,7 @@ await ctx.stage(
   async (s) => {
     await s.session.send({
       prompt: buildOrchestratorPrompt(
-        (ctx.inputs.prompt ?? ""),
+        (s.inputs.prompt ?? ""),
         { plannerNotes: plannerHandle.result },
       ),
     });
@@ -491,15 +464,15 @@ trade-offs in depth.
 Information flow is a design problem, not an implementation detail. Before
 committing to a session layout, pull in the relevant skills:
 
-| When you're deciding... | Consult |
-|---|---|
-| What context each session actually needs (anatomy + token budget) | `context-fundamentals` |
+| When you're deciding...                                                  | Consult                |
+| ------------------------------------------------------------------------ | ---------------------- |
+| What context each session actually needs (anatomy + token budget)        | `context-fundamentals` |
 | How many sessions and how they hand off (orchestrator vs peers vs swarm) | `multi-agent-patterns` |
-| How to compress large planner/reviewer output before re-injecting | `context-compression` |
-| How to detect and prevent lost-in-middle, poisoning, and distraction | `context-degradation` |
-| How to use files as coordination medium across sessions | `filesystem-context` |
-| How to persist knowledge across whole workflow runs | `memory-systems` |
-| Which turns to drop, which to cache, when to compact | `context-optimization` |
+| How to compress large planner/reviewer output before re-injecting        | `context-compression`  |
+| How to detect and prevent lost-in-middle, poisoning, and distraction     | `context-degradation`  |
+| How to use files as coordination medium across sessions                  | `filesystem-context`   |
+| How to persist knowledge across whole workflow runs                      | `memory-systems`       |
+| Which turns to drop, which to cache, when to compact                     | `context-optimization` |
 
 These aren't optional reading — they're the difference between a workflow
 that works on day one and a workflow that silently degrades as inputs grow.
@@ -582,27 +555,17 @@ await ctx.stage(
 
 Do **not** just grab `.at(-1).data.content` — a Copilot turn's final
 `assistant.message` often has empty `content` (tool-calls-only) and
-sub-agent messages can pollute the stream via `parentToolCallId`. Concatenate
-every top-level turn's non-empty content instead. See
-`references/failure-modes.md` §"Copilot: `getLastAssistantText` returns
-empty string" for the full explanation and wrong-vs-right examples.
+subagent messages can pollute the stream via `parentToolCallId`. Concatenate
+every top-level turn's non-empty content instead.
+
+The canonical `getAssistantText` helper lives in `failure-modes.md` §F1 —
+copy it into a sibling `helpers/parsers.ts` and import it. Usage:
 
 ```ts
-import type { SessionEvent } from "@github/copilot-sdk";
+import { getAssistantText } from "../helpers/parsers.ts";
 
-/** Concatenate every top-level assistant turn's non-empty content.
- *  Canonical definition — also referenced in failure-modes.md §F1
- *  and computation-and-validation.md. */
-function getAssistantText(messages: SessionEvent[]): string {
-  return messages
-    .filter(
-      (m): m is Extract<SessionEvent, { type: "assistant.message" }> =>
-        m.type === "assistant.message" && !m.data.parentToolCallId,
-    )
-    .map((m) => m.data.content)
-    .filter((c) => c.length > 0)
-    .join("\n\n");
-}
+const messages = await s.session.getMessages();
+const text = getAssistantText(messages);
 ```
 
 ### Streaming events
@@ -618,9 +581,9 @@ s.session.on("assistant.reasoning_delta", (event) => {
 });
 ```
 
-### Sub-agent delegation
+### Subagent delegation
 
-Pass the `agent` parameter in `sessionOpts` (3rd arg to `ctx.stage()`) to bind the session to a named sub-agent:
+Pass the `agent` parameter in `sessionOpts` (3rd arg to `ctx.stage()`) to bind the session to a named subagent:
 
 ```ts
 .run(async (ctx) => {
@@ -693,11 +656,11 @@ export default defineWorkflow({
 
 OpenCode sessions have **exactly the same isolation semantics as Copilot
 sessions**. Every call to `client.session.create(...)` returns a fresh,
-empty conversation. Creating a new session for the next sub-agent wipes
+empty conversation. Creating a new session for the next subagent wipes
 everything the prior session knew — conversation history, tool-call
 results, intermediate reasoning — unless you forward it explicitly.
 
-The full explanation, the three lifecycle states (Fresh / Continued /
+The full explanation, the four lifecycle states (Fresh / Continued /
 Resumed / Closed), the three valid ways to carry context across a session
 boundary, compaction & clearing guidance, and the context engineering
 skill-map live in the **Copilot** section above under
@@ -706,13 +669,13 @@ available"](#critical-pitfall-session-lifecycle-controls-what-context-is-availab
 Every principle there applies to OpenCode without modification — just
 substitute the OpenCode API equivalents:
 
-| Concept | Copilot API | OpenCode API |
-|---|---|---|
-| Fresh session (auto-created) | `s.session` (runtime creates via `createSession`) | `s.session` (runtime creates via `session.create`) |
-| Send a turn | `s.session.send({ prompt })` | `s.client.session.prompt({ sessionID: s.session.id, parts })` |
-| Close / disconnect | Auto-handled by runtime | session lifecycle managed via server; no explicit disconnect in typical flow |
-| Continue prior conversation | `s.client.resumeSession(sessionId)` (provider API; advanced) | Reuse the same `sessionID` with `s.client.session.prompt()` inside the same logical conversation. `ctx.stage()` itself still creates a fresh session every time |
-| Extract final text | `getAssistantText(messages)` (see `failure-modes.md` §F1) | `extractResponseText(result.data!.parts)` |
+| Concept                      | Copilot API                                                  | OpenCode API                                                                                                                                                    |
+| ---------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fresh session (auto-created) | `s.session` (runtime creates via `createSession`)            | `s.session` (runtime creates via `session.create`)                                                                                                              |
+| Send a turn                  | `s.session.send({ prompt })`                                 | `s.client.session.prompt({ sessionID: s.session.id, parts })`                                                                                                   |
+| Close / disconnect           | Auto-handled by runtime                                      | session lifecycle managed via server; no explicit disconnect in typical flow                                                                                    |
+| Continue prior conversation  | `s.client.resumeSession(sessionId)` (provider API; advanced) | Reuse the same `sessionID` with `s.client.session.prompt()` inside the same logical conversation. `ctx.stage()` itself still creates a fresh session every time |
+| Extract final text           | `getAssistantText(messages)` (see `failure-modes.md` §F1)    | `extractResponseText(result.data!.parts)`                                                                                                                       |
 
 **Multi-agent handoff example (applies the same pattern as Copilot):**
 
@@ -722,7 +685,7 @@ substitute the OpenCode API equivalents:
 await ctx.stage({ name: "planner" }, {}, { title: "planner" }, async (s) => {
   const result = await s.client.session.prompt({
     sessionID: s.session.id,
-    parts: [{ type: "text", text: buildPlannerPrompt((ctx.inputs.prompt ?? "")) }],
+    parts: [{ type: "text", text: buildPlannerPrompt((s.inputs.prompt ?? "")) }],
     agent: "planner",
   });
   s.save(result.data!);
@@ -744,7 +707,7 @@ const plannerHandle = await ctx.stage(
   async (s) => {
     const result = await s.client.session.prompt({
       sessionID: s.session.id,
-      parts: [{ type: "text", text: buildPlannerPrompt((ctx.inputs.prompt ?? "")) }],
+      parts: [{ type: "text", text: buildPlannerPrompt((s.inputs.prompt ?? "")) }],
       agent: "planner",
     });
     s.save(result.data!);
@@ -762,7 +725,7 @@ await ctx.stage(
       parts: [{
         type: "text",
         text: buildOrchestratorPrompt(
-          (ctx.inputs.prompt ?? ""),
+          (s.inputs.prompt ?? ""),
           { plannerNotes: plannerHandle.result },
         ),
       }],
@@ -853,20 +816,14 @@ const result = await s.client.session.prompt({
 
 ### Extracting response text
 
-```ts
-/** Filter for text parts only — non-text parts produce [object Object].
- *  Canonical definition — also referenced in failure-modes.md §F3
- *  and computation-and-validation.md. */
-function extractResponseText(
-  parts: Array<{ type: string; [key: string]: unknown }>,
-): string {
-  return parts
-    .filter((p) => p.type === "text")
-    .map((p) => (p as { type: string; text: string }).text)
-    .join("\n");
-}
+Non-text parts (`tool`, `file`, `reasoning`, …) coexist with `text` parts in
+`result.data!.parts`; naive `.map(p => p.text)` emits `undefined` for them.
+The canonical `extractResponseText` helper lives in `failure-modes.md` §F3 —
+copy it into a sibling `helpers/parsers.ts` and import it. Usage:
 
-// Usage inside a ctx.stage callback:
+```ts
+import { extractResponseText } from "../helpers/parsers.ts";
+
 const result = await s.client.session.prompt({
   sessionID: s.session.id,
   parts: [{ type: "text", text: (s.inputs.prompt ?? "") }],
@@ -885,9 +842,9 @@ const unsubscribe = await s.client.event.subscribe((event) => {
 });
 ```
 
-### Sub-agent delegation
+### Subagent delegation
 
-Pass the `agent` parameter to `s.client.session.prompt()` to route a prompt to a named sub-agent:
+Pass the `agent` parameter to `s.client.session.prompt()` to route a prompt to a named subagent:
 
 ```ts
 .run(async (ctx) => {

--- a/.agents/skills/workflow-creator/references/agent-sessions.md
+++ b/.agents/skills/workflow-creator/references/agent-sessions.md
@@ -95,42 +95,60 @@ Claude maintains conversation context across calls within the same pane. Call `s
 })
 ```
 
-### Advanced: Claude Agent SDK `query()` API
+### Advanced: Claude Agent SDK `query()` option surface (reference only)
 
-For programmatic control beyond tmux automation, the Claude Agent SDK provides `query()`. **Do not call it from inside a non-headless `ctx.stage()`** — that spawns a TUI in a tmux pane that goes unused while the SDK runs in-process (see `failure-modes.md` §F17). Either set `headless: true` on the stage and pass SDK options through `s.session.query(prompt, options)` (the headless wrapper forwards them to `query()`), or use the interactive TUI route below with `chatFlags: ["--agent", "<name>", ...]` plus `s.session.query(prompt)`.
+**Do not import `query` from `@anthropic-ai/claude-agent-sdk` inside a `ctx.stage()` callback.** In a non-headless stage it double-spawns Claude (idle TUI pane + in-process SDK call) — see `failure-modes.md` §F17. In a headless stage it bypasses the runtime's wiring. Always go through `s.session.query()`; the runtime forwards options to the SDK for headless stages and routes the interactive TUI for non-headless stages.
 
-The example below is reference for the SDK option surface — in real workflow code, prefer `s.session.query()` so the runtime, not your callback, decides which transport to use:
+Two correct routes:
+
+1. **Headless + SDK options** — `s.session.query(prompt, sdkOptions)` inside `{ headless: true }`.
+2. **Interactive TUI + `--agent`** — `chatFlags: ["--agent", "<name>", ...]` in `clientOpts`.
+
+The snippet below is a **reference cheatsheet for the SDK option shape only** — it is *not* valid workflow code. Use it to learn what `sdkOptions` accepts when passed as the second argument to `s.session.query()` in a headless stage:
 
 ```ts
+// ❌ Do not call query() like this from a workflow. Reference-only to show
+//    which options are available when you pass them to s.session.query().
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
-.run(async (ctx) => {
-  await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
-    const result = query({
-      prompt: (s.inputs.prompt ?? ""),
-      options: {
-        model: "claude-opus-4-6",
-        effort: "high",
-        maxTurns: 50,
-        maxBudgetUsd: 5.0,
-        permissionMode: "acceptEdits",
-        allowedTools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
-        disallowedTools: ["AskUserQuestion"],
-        systemPrompt: "You are a senior engineer...",
-        outputFormat: {
-          type: "json_schema",
-          schema: { type: "object", properties: { tasks: { type: "array", items: { type: "string" } } } },
-        },
-        agents: {
-          reviewer: { description: "Review code changes", prompt: "You are a code reviewer..." },
-        },
-      },
-    });
-    for await (const message of result) {
-      // Process streaming messages
-    }
+query({
+  prompt: "...",
+  options: {
+    model: "claude-opus-4-6",
+    effort: "high",
+    maxTurns: 50,
+    maxBudgetUsd: 5.0,
+    permissionMode: "acceptEdits",
+    allowedTools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
+    disallowedTools: ["AskUserQuestion"],
+    systemPrompt: "You are a senior engineer...",
+    outputFormat: {
+      type: "json_schema",
+      schema: { type: "object", properties: { tasks: { type: "array", items: { type: "string" } } } },
+    },
+    agents: {
+      reviewer: { description: "Review code changes", prompt: "You are a code reviewer..." },
+    },
+  },
+});
+```
+
+The ✅ equivalent in a real workflow:
+
+```ts
+await ctx.stage({ name: "implement", headless: true }, {}, {}, async (s) => {
+  const messages = await s.session.query(s.inputs.prompt ?? "", {
+    model: "claude-opus-4-6",
+    permissionMode: "acceptEdits",
+    allowedTools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
+    outputFormat: {
+      type: "json_schema",
+      schema: { type: "object", properties: { tasks: { type: "array", items: { type: "string" } } } },
+    },
   });
-})
+  s.save(s.sessionId);
+  return extractAssistantText(messages, 0);
+});
 ```
 
 Key `query()` options:
@@ -155,38 +173,62 @@ Key `query()` options:
 
 ### Subagents
 
-Claude supports parallel subagents via the `agents` option (a `Record<string, AgentDefinition>` keyed by agent name):
+Claude supports parallel subagents via the `agents` option (a
+`Record<string, AgentDefinition>` keyed by agent name). In a workflow,
+pass the option through `s.session.query(prompt, sdkOptions)` in a
+**headless** stage — see §F17 for why the raw SDK `query()` import is
+an anti-pattern:
 
 ```ts
-const agents = {
-  worker: {
-    description: "Implement a single task",
-    prompt: "You are a task implementer...",
-    tools: ["Read", "Write", "Edit", "Bash"],
+await ctx.stage(
+  { name: "implement-and-review", headless: true },
+  {}, {},
+  async (s) => {
+    const messages = await s.session.query(
+      "Implement and review the feature",
+      {
+        agents: {
+          worker: {
+            description: "Implement a single task",
+            prompt: "You are a task implementer...",
+            tools: ["Read", "Write", "Edit", "Bash"],
+          },
+          reviewer: {
+            description: "Review code changes",
+            prompt: "You are a code reviewer...",
+            tools: ["Read", "Grep", "Glob"],
+          },
+        },
+      },
+    );
+    s.save(s.sessionId);
+    return extractAssistantText(messages, 0);
   },
-  reviewer: {
-    description: "Review code changes",
-    prompt: "You are a code reviewer...",
-    tools: ["Read", "Grep", "Glob"],
-  },
-};
-
-const result = query({
-  prompt: "Implement and review the feature",
-  options: { agents },
-});
+);
 ```
 
 ### Session continuity
 
-Resume or fork prior sessions:
+Resume or fork prior sessions through `s.session.query()` in a headless
+stage (same reasoning as Subagents above — never import `query` directly):
 
 ```ts
 // Resume a session (continues the same conversation)
-const result = query({ prompt: "Continue...", options: { resume: sessionId } });
+await ctx.stage({ name: "continue", headless: true }, {}, {}, async (s) => {
+  const messages = await s.session.query("Continue...", { resume: sessionId });
+  s.save(s.sessionId);
+  return extractAssistantText(messages, 0);
+});
 
 // Fork a session (creates a new branch from the session's history)
-const result = query({ prompt: "Try a different approach", options: { resume: sessionId, forkSession: true } });
+await ctx.stage({ name: "fork", headless: true }, {}, {}, async (s) => {
+  const messages = await s.session.query(
+    "Try a different approach",
+    { resume: sessionId, forkSession: true },
+  );
+  s.save(s.sessionId);
+  return extractAssistantText(messages, 0);
+});
 ```
 
 ### Sub-agent delegation
@@ -323,33 +365,40 @@ sub-agents that hallucinate, repeat work, or drop requirements silently.
 **Treat this section as load-bearing**, not decorative. If you skip it, your
 workflow will ship broken in subtle, non-deterministic ways.
 
-#### The three session lifecycle states
+#### Session lifecycle states
 
-Every Copilot session is always in exactly one of these states, and the
+For normal workflow authoring, use the **3-state rubric** from SKILL.md:
+`Fresh` / `Continued` / `Closed`. Every new `ctx.stage()` call is fresh; if
+you need full history, prefer another turn inside the same stage callback.
+
+Copilot also exposes an advanced `Resumed` state at the provider level. Each
 state determines what context the model sees on its next turn:
 
 | State | How you get there | Context available | Action needed |
 |---|---|---|---|
-| **Fresh** | `client.createSession(...)` | **None** — empty conversation | You MUST inject everything the agent needs in the first prompt |
+| **Fresh** | `client.createSession(...)` (what `ctx.stage()` does) | **None** — empty conversation | You MUST inject everything the agent needs in the first prompt |
 | **Continued** | Same session, additional `send` calls | All prior turns in this session | Nothing — but watch total token usage |
-| **Resumed** | `client.resumeSession(sessionId)` | All persisted turns from the prior session of the SAME agent | Nothing — full history is reattached |
-| **Closed** | `session.disconnect()` or `client.stop()` | **Gone** from the live client; persisted on disk if the host enables it | Either resume by ID (same agent) or start fresh and re-inject context |
+| **Resumed** *(advanced)* | `client.resumeSession(sessionId)` | All persisted turns from the prior session of the SAME agent | Nothing — full history is reattached. Use only for same-role continuation |
+| **Closed** | `session.disconnect()` or `client.stop()` (auto-handled by runtime after the stage callback returns) | **Gone** from the live client; persisted on disk if the host enables it | Either resume by ID (same agent) or start fresh and re-inject context |
 
 The failure mode: you close a session, create a new one, and assume the new
 one "remembers" the previous conversation. It doesn't. `client` is just the
-transport — each session is a fully independent conversation.
-
-For normal workflow authoring, the key rule is simpler than the full lifecycle
-table: **every new `ctx.stage()` call is fresh**. If you need full history,
-prefer another turn inside the same stage callback. Resume/fork APIs are
-provider-specific escape hatches, not the default stage-to-stage handoff path.
+transport — each session is a fully independent conversation. Resume/fork
+APIs are provider-specific escape hatches, not the default stage-to-stage
+handoff path.
 
 ```ts
-// Buggy — the orchestrator session is fresh and knows NOTHING about
-// what the planner just produced, because createSession() started a
-// brand-new conversation.
-await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
-await runAgent("orchestrator", buildOrchestratorPrompt());
+// Buggy — the orchestrator stage is fresh and knows NOTHING about what
+// the planner just produced, because each ctx.stage() starts a brand-new
+// conversation for Copilot.
+await ctx.stage({ name: "planner" }, {}, { agent: "planner" }, async (s) => {
+  await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+  s.save(await s.session.getMessages());
+});
+await ctx.stage({ name: "orchestrator" }, {}, { agent: "orchestrator" }, async (s) => {
+  await s.session.send({ prompt: buildOrchestratorPrompt() });
+  s.save(await s.session.getMessages());
+});
 // ↑ orchestrator only sees buildOrchestratorPrompt() — no planner output,
 //   no original user spec, no context.
 ```
@@ -361,22 +410,37 @@ mutually exclusive — ralph uses (1) + (2) together as belt-and-braces.
 
 **1. Explicit prompt handoff** — capture the prior session's last assistant
 message and inject it (or a summary) into the next session's first prompt.
-Simplest and most common fix:
+Simplest and most common fix. Use `ctx.stage()` — the runtime auto-creates
+and cleans up each session, so never call `client.createSession()` directly
+(see Structural Rule 7 in SKILL.md):
 
 ```ts
-async function runAgent(agent: string, prompt: string): Promise<string> {
-  const session = await client.createSession({ agent, onPermissionRequest: approveAll });
-  await session.send({ prompt });
-  const messages = await session.getMessages();
-  await session.disconnect();
-  return getAssistantText(messages); // concatenate every top-level turn — see failure-modes.md §F1
-}
-
 // Correct — forward the planner's output into the orchestrator prompt
-const plannerNotes = await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
-await runAgent(
-  "orchestrator",
-  buildOrchestratorPrompt((ctx.inputs.prompt ?? ""), { plannerNotes }),
+const plannerHandle = await ctx.stage(
+  { name: "planner" },
+  {},
+  { agent: "planner" },
+  async (s) => {
+    await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+    const messages = await s.session.getMessages();
+    s.save(messages);
+    return getAssistantText(messages); // see failure-modes.md §F1 for getAssistantText
+  },
+);
+
+await ctx.stage(
+  { name: "orchestrator" },
+  {},
+  { agent: "orchestrator" },
+  async (s) => {
+    await s.session.send({
+      prompt: buildOrchestratorPrompt(
+        (ctx.inputs.prompt ?? ""),
+        { plannerNotes: plannerHandle.result },
+      ),
+    });
+    s.save(await s.session.getMessages());
+  },
 );
 ```
 
@@ -653,21 +717,59 @@ substitute the OpenCode API equivalents:
 **Multi-agent handoff example (applies the same pattern as Copilot):**
 
 ```ts
-// Buggy — orchestrator session is fresh; it has no idea what the planner
-// produced because we created a brand-new session for it.
-await runAgent("planner-1", "planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
-await runAgent("orchestrator-1", "orchestrator", buildOrchestratorPrompt());
+// Buggy — orchestrator stage is fresh; it has no idea what the planner
+// produced because each ctx.stage() starts a brand-new session.
+await ctx.stage({ name: "planner" }, {}, { title: "planner" }, async (s) => {
+  const result = await s.client.session.prompt({
+    sessionID: s.session.id,
+    parts: [{ type: "text", text: buildPlannerPrompt((ctx.inputs.prompt ?? "")) }],
+    agent: "planner",
+  });
+  s.save(result.data!);
+});
+await ctx.stage({ name: "orchestrator" }, {}, { title: "orchestrator" }, async (s) => {
+  await s.client.session.prompt({
+    sessionID: s.session.id,
+    parts: [{ type: "text", text: buildOrchestratorPrompt() }],
+    agent: "orchestrator",
+  });
+  s.save(/* ... */);
+});
 
 // Correct — capture planner output and forward it into orchestrator prompt
-const plannerNotes = await runAgent(
-  "planner-1",
-  "planner",
-  buildPlannerPrompt((ctx.inputs.prompt ?? "")),
+const plannerHandle = await ctx.stage(
+  { name: "planner" },
+  {},
+  { title: "planner" },
+  async (s) => {
+    const result = await s.client.session.prompt({
+      sessionID: s.session.id,
+      parts: [{ type: "text", text: buildPlannerPrompt((ctx.inputs.prompt ?? "")) }],
+      agent: "planner",
+    });
+    s.save(result.data!);
+    return extractResponseText(result.data!.parts); // see failure-modes.md §F3
+  },
 );
-await runAgent(
-  "orchestrator-1",
-  "orchestrator",
-  buildOrchestratorPrompt((ctx.inputs.prompt ?? ""), { plannerNotes }),
+
+await ctx.stage(
+  { name: "orchestrator" },
+  {},
+  { title: "orchestrator" },
+  async (s) => {
+    const result = await s.client.session.prompt({
+      sessionID: s.session.id,
+      parts: [{
+        type: "text",
+        text: buildOrchestratorPrompt(
+          (ctx.inputs.prompt ?? ""),
+          { plannerNotes: plannerHandle.result },
+        ),
+      }],
+      agent: "orchestrator",
+    });
+    s.save(result.data!);
+  },
 );
 ```
 

--- a/.agents/skills/workflow-creator/references/computation-and-validation.md
+++ b/.agents/skills/workflow-creator/references/computation-and-validation.md
@@ -4,12 +4,14 @@ Deterministic computation — validation, data transforms, file I/O, API calls �
 
 ## Inline computation
 
-Any TypeScript code inside a session callback that doesn't call an SDK prompt function is deterministic computation:
+Any TypeScript code inside a session callback that doesn't call an SDK prompt function is deterministic computation. Prefer handle-based lookups (`s.getMessages(plannerHandle)`) over string names when a handle is in scope — it preserves type information and survives stage renames:
 
 ```ts
+const plannerHandle = await ctx.stage({ name: "planner" }, {}, {}, async (s) => { /* ... */ });
+
 await ctx.stage({ name: "validate-and-fix", description: "Validate, then fix if needed" }, {}, {}, async (s) => {
-  // Step 1: Deterministic — parse prior session's output
-  const messages = await s.getMessages("planner");
+  // Step 1: Deterministic — parse prior session's output (handle-based lookup)
+  const messages = await s.getMessages(plannerHandle);
   const planText = extractText(messages);
   const plan = JSON.parse(planText);
 

--- a/.agents/skills/workflow-creator/references/computation-and-validation.md
+++ b/.agents/skills/workflow-creator/references/computation-and-validation.md
@@ -74,39 +74,12 @@ const text = extractResponseText(result.data!.parts);
 
 ### JSON parsing with fallback
 
-Use a layered fallback: direct parse, then the **last** fenced block (not
-the first — see `failure-modes.md` §F4 / §F8 for why), then last balanced
-object:
-
-```ts
-function parseJsonResponse(text: string): Record<string, unknown> | null {
-  // 1. Direct parse
-  try { return JSON.parse(text); } catch {}
-
-  // 2. LAST fenced code block (prose often quotes examples before the real output)
-  const blockRe = /```(?:json)?\s*\n([\s\S]*?)\n```/g;
-  let lastBlock: string | null = null;
-  let m: RegExpExecArray | null;
-  while ((m = blockRe.exec(text)) !== null) {
-    if (m[1]) lastBlock = m[1];
-  }
-  if (lastBlock) {
-    try { return JSON.parse(lastBlock); } catch {}
-  }
-
-  // 3. Last balanced JSON object
-  const objRe = /\{[\s\S]*\}/g;
-  let lastObj: string | null = null;
-  while ((m = objRe.exec(text)) !== null) {
-    if (m[0]) lastObj = m[0];
-  }
-  if (lastObj) {
-    try { return JSON.parse(lastObj); } catch {}
-  }
-
-  return null;
-}
-```
+Use a layered fallback: direct parse → **last** fenced block (not the
+first — prose often quotes examples earlier; see `failure-modes.md` §F8) →
+last balanced object. Canonical helper lives in `state-and-data-flow.md`
+§"Response parsers"; copy it into a sibling `helpers/parsers.ts` and
+import. The full three-layer implementation, including the balanced-object
+fallback, is in `src/sdk/workflows/builtin/ralph/helpers/prompts.ts`.
 
 ### Zod validation
 
@@ -173,7 +146,7 @@ Transform data between sessions:
 ```ts
 // Inside a ctx.stage() callback:
 async (s) => {
-  const raw = await s.getMessages("planner");
+  const raw = await s.getMessages("planner"); // or s.getMessages(handle) if a handle is in scope (preferred)
 
   // Transform: extract only task IDs and descriptions
   const tasks = extractTasks(raw).map(t => ({

--- a/.agents/skills/workflow-creator/references/control-flow.md
+++ b/.agents/skills/workflow-creator/references/control-flow.md
@@ -22,7 +22,7 @@ import { extractAssistantText } from "@bastani/atomic/workflows";
   // Step 1: Classify the request
   const triage = await ctx.stage({ name: "triage" }, {}, {}, async (s) => {
     const result = await s.session.query(
-      `Classify this as "bug", "feature", or "question": ${(ctx.inputs.prompt ?? "")}`,
+      `Classify this as "bug", "feature", or "question": ${(s.inputs.prompt ?? "")}`,
     );
     s.save(s.sessionId);
     return extractAssistantText(result, 0).toLowerCase();
@@ -60,7 +60,7 @@ import { extractAssistantText } from "@bastani/atomic/workflows";
 .run(async (ctx) => {
   await ctx.stage({ name: "triage-and-act" }, {}, {}, async (s) => {
     const triageResult = await s.session.query(
-      `Classify this as "bug", "feature", or "question": ${(ctx.inputs.prompt ?? "")}`,
+      `Classify this as "bug", "feature", or "question": ${(s.inputs.prompt ?? "")}`,
     );
 
     const classification = extractAssistantText(triageResult, 0).toLowerCase();
@@ -143,7 +143,7 @@ import { extractAssistantText } from "@bastani/atomic/workflows";
   for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
     // Each review is a visible graph node
     const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
-      const result = await s.session.query(buildReviewPrompt((ctx.inputs.prompt ?? "")));
+      const result = await s.session.query(buildReviewPrompt((s.inputs.prompt ?? "")));
       s.save(s.sessionId);
       return extractAssistantText(result, 0);
     });
@@ -162,8 +162,8 @@ import { extractAssistantText } from "@bastani/atomic/workflows";
     consecutiveClean = 0;
 
     const fixPrompt = parsed
-      ? buildFixSpecFromReview(parsed, (ctx.inputs.prompt ?? ""))
-      : buildFixSpecFromRawReview(reviewRaw, (ctx.inputs.prompt ?? ""));
+      ? buildFixSpecFromReview(parsed, (s.inputs.prompt ?? ""))
+      : buildFixSpecFromRawReview(reviewRaw, (s.inputs.prompt ?? ""));
 
     // Each fix is also a visible graph node
     await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
@@ -190,7 +190,7 @@ import { getAssistantText } from "../helpers/parsers.ts"; // see failure-modes.m
   for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
     const review = await ctx.stage({ name: `review-${cycle}` }, {}, {}, async (s) => {
       await s.session.send({
-        prompt: buildReviewPrompt((ctx.inputs.prompt ?? "")),
+        prompt: buildReviewPrompt((s.inputs.prompt ?? "")),
       });
       const reviewRaw = getAssistantText(await s.session.getMessages());
 
@@ -209,8 +209,8 @@ import { getAssistantText } from "../helpers/parsers.ts"; // see failure-modes.m
     consecutiveClean = 0;
 
     const fixPrompt = parsed
-      ? buildFixSpecFromReview(parsed, (ctx.inputs.prompt ?? ""))
-      : buildFixSpecFromRawReview(reviewRaw, (ctx.inputs.prompt ?? ""));
+      ? buildFixSpecFromReview(parsed, (s.inputs.prompt ?? ""))
+      : buildFixSpecFromRawReview(reviewRaw, (s.inputs.prompt ?? ""));
 
     await ctx.stage({ name: `fix-${cycle}` }, {}, {}, async (s) => {
       await s.session.send({
@@ -391,11 +391,11 @@ Within a single session callback, each SDK call adds to the conversation context
 .run(async (ctx) => {
   await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
     try {
-      await s.session.query((ctx.inputs.prompt ?? ""));
+      await s.session.query((s.inputs.prompt ?? ""));
     } catch (error) {
       // Retry with simpler prompt
       await s.session.query(
-        `The previous attempt failed. Please try a simpler approach: ${(ctx.inputs.prompt ?? "")}`,
+        `The previous attempt failed. Please try a simpler approach: ${(s.inputs.prompt ?? "")}`,
       );
     }
     s.save(s.sessionId);
@@ -424,7 +424,7 @@ async function retryWithBackoff<T>(
 
 .run(async (ctx) => {
   await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
-    await retryWithBackoff(() => s.session.query((ctx.inputs.prompt ?? "")));
+    await retryWithBackoff(() => s.session.query((s.inputs.prompt ?? "")));
     s.save(s.sessionId);
   });
 })
@@ -440,7 +440,7 @@ import { extractAssistantText } from "@bastani/atomic/workflows";
 .run(async (ctx) => {
   // Step 1: Analyse — result is available as a typed handle
   const analysisHandle = await ctx.stage({ name: "analyze" }, {}, {}, async (s) => {
-    const result = await s.session.query(`Analyse the task: ${(ctx.inputs.prompt ?? "")}`);
+    const result = await s.session.query(`Analyse the task: ${(s.inputs.prompt ?? "")}`);
     s.save(s.sessionId);
     return extractAssistantText(result, 0);
   });

--- a/.agents/skills/workflow-creator/references/control-flow.md
+++ b/.agents/skills/workflow-creator/references/control-flow.md
@@ -176,7 +176,13 @@ import { extractAssistantText } from "@bastani/atomic/workflows";
 
 ### Same pattern with Copilot
 
+Copilot lacks a built-in text extractor — define `getAssistantText` as a
+helper in your workflow (canonical definition in `failure-modes.md` §F1)
+and import it from a sibling file:
+
 ```ts
+import { getAssistantText } from "../helpers/parsers.ts"; // see failure-modes.md §F1
+
 .run(async (ctx) => {
   const MAX_CYCLES = 10;
   let consecutiveClean = 0;
@@ -186,7 +192,7 @@ import { extractAssistantText } from "@bastani/atomic/workflows";
       await s.session.send({
         prompt: buildReviewPrompt((ctx.inputs.prompt ?? "")),
       });
-      const reviewRaw = getAssistantText(await s.session.getMessages()); // see failure-modes.md §F1
+      const reviewRaw = getAssistantText(await s.session.getMessages());
 
       s.save(await s.session.getMessages());
       return reviewRaw;
@@ -252,7 +258,7 @@ Sessions passed to `Promise.all([...])` branch from the same parent and run conc
 A stage awaited after a `Promise.all` resolves automatically receives all parallel stages as parents — the graph draws a merge node:
 
 ```ts
-// ✅ Graph infers: orchestrator → A → [B, C] → D (fan-in merge)
+// ✅ Graph infers: A → [B, C] → D (fan-in merge)
 .run(async (ctx) => {
   await ctx.stage({ name: "A" }, {}, {}, async (s) => { /* ... */ });
 

--- a/.agents/skills/workflow-creator/references/discovery-and-verification.md
+++ b/.agents/skills/workflow-creator/references/discovery-and-verification.md
@@ -5,8 +5,8 @@
 ```bash
 bun init                                   # Create a new project
 bun add @bastani/atomic                    # Install the workflow SDK
-bun add @github/copilot-sdk               # For Copilot workflows
 bun add @anthropic-ai/claude-agent-sdk    # For Claude workflows
+bun add @github/copilot-sdk               # For Copilot workflows
 bun add @opencode-ai/sdk                  # For OpenCode workflows
 ```
 

--- a/.agents/skills/workflow-creator/references/failure-modes.md
+++ b/.agents/skills/workflow-creator/references/failure-modes.md
@@ -104,8 +104,8 @@ function getAssistantText(messages: SessionEvent[]): string {
 }
 ```
 
-**Detection.** Log the returned text length after every `runAgent` call
-during development. An empty or surprisingly short string for a stage
+**Detection.** Log the returned text length after every `getAssistantText`
+call during development. An empty or surprisingly short string for a stage
 that clearly ran is the signature.
 
 ---
@@ -239,18 +239,45 @@ mode does NOT apply to `s.session.query()`.)
 ### ❌ Wrong
 
 ```ts
-await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
+await ctx.stage({ name: "planner" }, {}, { agent: "planner" }, async (s) => {
+  await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+  s.save(await s.session.getMessages());
+});
 // orchestrator is a fresh session — it has no idea what the planner produced
-await runAgent("orchestrator", buildOrchestratorPrompt());
+await ctx.stage({ name: "orchestrator" }, {}, { agent: "orchestrator" }, async (s) => {
+  await s.session.send({ prompt: buildOrchestratorPrompt() });
+  s.save(await s.session.getMessages());
+});
 ```
 
 ### ✅ Right — explicit handoff
 
 ```ts
-const plannerNotes = await runAgent("planner", buildPlannerPrompt((ctx.inputs.prompt ?? "")));
-await runAgent(
-  "orchestrator",
-  buildOrchestratorPrompt((ctx.inputs.prompt ?? ""), { plannerNotes }),
+const plannerHandle = await ctx.stage(
+  { name: "planner" },
+  {},
+  { agent: "planner" },
+  async (s) => {
+    await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+    const messages = await s.session.getMessages();
+    s.save(messages);
+    return getAssistantText(messages); // see F1 for getAssistantText
+  },
+);
+
+await ctx.stage(
+  { name: "orchestrator" },
+  {},
+  { agent: "orchestrator" },
+  async (s) => {
+    await s.session.send({
+      prompt: buildOrchestratorPrompt(
+        (ctx.inputs.prompt ?? ""),
+        { plannerNotes: plannerHandle.result },
+      ),
+    });
+    s.save(await s.session.getMessages());
+  },
 );
 ```
 
@@ -508,9 +535,7 @@ to "be safe", you want `send`.
 
 ---
 
-## F11. ~~Manual Claude session initialization~~ (resolved by runtime)
-
-No longer a failure mode. The runtime now auto-initializes `s.client` and `s.session` before the callback runs — just use `s.session.query()` directly.
+## F11. ~~Manual Claude session initialization~~ — resolved, no longer applies.
 
 ---
 

--- a/.agents/skills/workflow-creator/references/failure-modes.md
+++ b/.agents/skills/workflow-creator/references/failure-modes.md
@@ -31,7 +31,7 @@ Silent failures are catalogued first below. Loud failures are grouped at the end
 | # | Failure | Affected | Silent? |
 |---|---|---|---|
 | [F1](#f1-copilot-getlastassistanttext-returns-empty-string) | Copilot: `getLastAssistantText` returns empty string | Copilot | silent |
-| [F2](#f2-copilot-sub-agent-messages-pollute-getmessages-stream) | Copilot: sub-agent messages pollute `getMessages()` stream | Copilot | silent |
+| [F2](#f2-copilot-subagent-messages-pollute-getmessages-stream) | Copilot: subagent messages pollute `getMessages()` stream | Copilot | silent |
 | [F3](#f3-opencode-result-parts-contain-non-text-parts) | OpenCode: `result.data.parts` contains non-text parts | OpenCode | silent |
 | [F4](#f4-claude-ssessionquery-returns-sessionmessage-extract-text-with-extractassistanttext) | Claude: `s.session.query()` returns `SessionMessage[]` — extract text with `extractAssistantText(result, 0)` | Claude | silent |
 | [F5](#f5-fresh-session-wipes-prior-stage-context) | Fresh session wipes prior stage context | Copilot, OpenCode | silent |
@@ -40,17 +40,18 @@ Silent failures are catalogued first below. Loud failures are grouped at the end
 | [F8](#f8-fenced-block-parsers-break-when-the-model-adds-prose) | Fenced-block parsers break when the model adds prose before/after | all | silent |
 | [F9](#f9-ssave-receives-the-wrong-shape) | `s.save()` receives the wrong shape for the SDK | all | silent |
 | [F10](#f10-copilot-sendandwait-default-60s-timeout-throws) | Copilot: `sendAndWait` default 60s timeout throws (use `send` by default) | Copilot | loud |
-| [F11](#f11-manual-claude-session-initialization-resolved-by-runtime) | ~~Manual Claude session initialization~~ (resolved by runtime) | Claude | N/A |
-| [F12](#f12-resume-session-tries-to-swap-agents) | Resume session tries to swap agents | Copilot, OpenCode | loud |
-| [F13](#f13-parallel-siblings-read-each-others-transcripts) | Parallel siblings read each other's transcripts | all | loud |
-| [F14](#f14-forgetting-to-await-ctxstage) | Forgetting to `await` `ctx.stage()` | all | silent |
-| [F15](#f15-using-a-pending-sessionhandle-before-completion) | Using a pending `SessionHandle` before completion | all | silent |
-| [F16](#f16-headless-stage-errors-are-invisible-in-the-graph) | Headless stage errors are invisible in the graph | all | silent |
-| [F17](#f17-claude-importing-sdk-query-inside-a-non-headless-stage) | Claude: importing the SDK `query()` inside a non-headless stage (anti-pattern) | Claude | silent |
+| [F11](#f11-provider-level-resume-tries-to-swap-agents) | Provider-level resume tries to swap agents | Copilot, OpenCode | loud |
+| [F12](#f12-parallel-siblings-read-each-others-transcripts) | Parallel siblings read each other's transcripts | all | loud |
+| [F13](#f13-forgetting-to-await-ctxstage) | Forgetting to `await` `ctx.stage()` | all | silent |
+| [F14](#f14-using-a-pending-sessionhandle-before-completion) | Using a pending `SessionHandle` before completion | all | silent |
+| [F15](#f15-headless-stage-errors-are-invisible-in-the-graph) | Headless stage errors are invisible in the graph | all | silent |
+| [F16](#f16-claude-importing-sdk-query-inside-a-non-headless-stage) | Claude: importing the SDK `query()` inside a non-headless stage (anti-pattern) | Claude | silent |
 
 ---
 
-## F1. Copilot: `getLastAssistantText` returns empty string
+## Silent failures
+
+### F1. Copilot: `getLastAssistantText` returns empty string
 
 **Symptom.** The orchestrator (or any downstream stage) receives an empty
 `plannerNotes` / `reviewerOutput` despite the prior agent running successfully
@@ -110,16 +111,16 @@ that clearly ran is the signature.
 
 ---
 
-## F2. Copilot: sub-agent messages pollute `getMessages()` stream
+### F2. Copilot: subagent messages pollute `getMessages()` stream
 
 **Symptom.** Downstream stages receive a snippet of text that doesn't match
-what the top-level agent said — it looks like a sub-agent's output.
+what the top-level agent said — it looks like a subagent's output.
 
 **Root cause.** `assistant.message` events carry a `parentToolCallId?: string`
 field, documented as *"Tool call ID of the parent tool invocation when this
-event originates from a sub-agent"*. When the top-level agent delegates,
-`getMessages()` returns **the complete history including sub-agent messages**.
-Filters that don't exclude `parentToolCallId` can pick a sub-agent's final
+event originates from a subagent"*. When the top-level agent delegates,
+`getMessages()` returns **the complete history including subagent messages**.
+Filters that don't exclude `parentToolCallId` can pick a subagent's final
 message via `.at(-1)`.
 
 **Affected SDKs.** Copilot.
@@ -143,7 +144,7 @@ scrollback for the top-level agent.
 
 ---
 
-## F3. OpenCode: `result.data.parts` contains non-text parts
+### F3. OpenCode: `result.data.parts` contains non-text parts
 
 **Symptom.** Concatenated response text contains `[object Object]`,
 truncated content, or swallows tool-call payloads into the prompt.
@@ -177,7 +178,7 @@ function extractResponseText(
 
 ---
 
-## F4. Claude: `s.session.query()` returns `SessionMessage[]` — extract text with `extractAssistantText`
+### F4. Claude: `s.session.query()` returns `SessionMessage[]` — extract text with `extractAssistantText`
 
 **Symptom.** Workflow code tries to access `.output` or `.text` on the
 result of `s.session.query()` and gets `undefined`, or passes the result
@@ -222,7 +223,7 @@ on an array returns `undefined`.
 
 ---
 
-## F5. Fresh session wipes prior stage context
+### F5. Fresh session wipes prior stage context
 
 **Symptom.** The orchestrator says "I don't see a task list" or "what
 specification are you referring to?" even though the planner clearly ran.
@@ -240,7 +241,7 @@ mode does NOT apply to `s.session.query()`.)
 
 ```ts
 await ctx.stage({ name: "planner" }, {}, { agent: "planner" }, async (s) => {
-  await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+  await s.session.send({ prompt: buildPlannerPrompt((s.inputs.prompt ?? "")) });
   s.save(await s.session.getMessages());
 });
 // orchestrator is a fresh session — it has no idea what the planner produced
@@ -258,7 +259,7 @@ const plannerHandle = await ctx.stage(
   {},
   { agent: "planner" },
   async (s) => {
-    await s.session.send({ prompt: buildPlannerPrompt((ctx.inputs.prompt ?? "")) });
+    await s.session.send({ prompt: buildPlannerPrompt((s.inputs.prompt ?? "")) });
     const messages = await s.session.getMessages();
     s.save(messages);
     return getAssistantText(messages); // see F1 for getAssistantText
@@ -272,7 +273,7 @@ await ctx.stage(
   async (s) => {
     await s.session.send({
       prompt: buildOrchestratorPrompt(
-        (ctx.inputs.prompt ?? ""),
+        (s.inputs.prompt ?? ""),
         { plannerNotes: plannerHandle.result },
       ),
     });
@@ -291,7 +292,7 @@ controls what context is available".
 
 ---
 
-## F6. Planner prompts that don't request trailing commentary produce empty handoffs
+### F6. Planner prompts that don't request trailing commentary produce empty handoffs
 
 **Symptom.** F1 / F5 are fixed, extraction is correct — and the orchestrator
 still receives empty `plannerNotes` because the planner's last turn legitimately
@@ -346,7 +347,7 @@ string + a correctly-fixed extraction helper = F6.
 
 ---
 
-## F7. Continued sessions accumulate state across loop iterations (lost-in-middle)
+### F7. Continued sessions accumulate state across loop iterations (lost-in-middle)
 
 **Symptom.** A review/fix loop works on iterations 1-3 then starts
 producing worse output — misidentifying files, hallucinating line numbers,
@@ -405,7 +406,7 @@ iteration N, N is your safe-turn budget before compaction.
 
 ---
 
-## F8. Fenced-block parsers break when the model adds prose
+### F8. Fenced-block parsers break when the model adds prose
 
 **Symptom.** `JSON.parse(content)` throws, or a "matches the first fenced
 block" regex picks up a code example inside prose instead of the actual
@@ -461,7 +462,7 @@ over several runs. If 1 in 20 runs fails to parse, you have F8.
 
 ---
 
-## F9. `s.save()` receives the wrong shape
+### F9. `s.save()` receives the wrong shape
 
 **Symptom.** `s.transcript("stage-name")` returns an empty or malformed
 `content` string in the next stage.
@@ -485,9 +486,11 @@ expects, and the runtime doesn't type-check the argument beyond "anything".
 // Claude — saves the wrong thing (result is SessionMessage[], not { output: string })
 s.save(result.output);  // TypeError: result.output is undefined; use s.save(s.sessionId)
 
-// Copilot — saves an empty array if called before send
-s.save(await s.session.getMessages());
-// Or saves one message object instead of the array
+// Copilot — calling getMessages() BEFORE send() returns an empty array
+const earlyMessages = await s.session.getMessages(); // [] — no turns yet
+s.save(earlyMessages);
+
+// Copilot — saving a single message instead of the full array
 s.save((await s.session.getMessages()).at(-1));
 
 // OpenCode — missing the data unwrap
@@ -506,7 +509,7 @@ log the length. A 0-length or JSON-that-isn't-prose signature = F9.
 
 ## Loud failures (throw, but still worth knowing)
 
-## F10. Copilot: `sendAndWait` default 60s timeout throws
+### F10. Copilot: `sendAndWait` default 60s timeout throws
 
 **Symptom.** `Timeout after 60000ms waiting for session.idle`. Every
 subsequent `ctx.stage()` call never executes — the throw propagates out of
@@ -535,11 +538,7 @@ to "be safe", you want `send`.
 
 ---
 
-## F11. ~~Manual Claude session initialization~~ — resolved, no longer applies.
-
----
-
-## F12. Provider-level resume tries to swap agents
+### F11. Provider-level resume tries to swap agents
 
 **Symptom.** Resumed Copilot / OpenCode session behaves as the original
 agent instead of the requested new one — or the SDK throws "agent mismatch"
@@ -555,7 +554,7 @@ over trying to reopen a prior stage.
 
 ---
 
-## F13. Parallel siblings read each other's transcripts
+### F12. Parallel siblings read each other's transcripts
 
 **Symptom.** `s.transcript("sibling-name")` inside a parallel session
 throws or returns empty.
@@ -571,27 +570,28 @@ shared state (files, DB) if siblings genuinely need to coordinate.
 
 ```ts
 // Fan-out → merge
-await ctx.stage({ name: "describe" }, {}, {}, async (s) => { /* ... */ });
+// Strings used here for brevity; prefer handles (s.transcript(handle)) when one is in scope.
+const describe = await ctx.stage({ name: "describe" }, {}, {}, async (s) => { /* ... */ });
 
-await Promise.all([
+const [summarizeA, summarizeB] = await Promise.all([
   ctx.stage({ name: "summarize-a" }, {}, {}, async (s) => {
-    const d = await s.transcript("describe"); // OK — prior completed session
+    const d = await s.transcript(describe); // OK — prior completed session (handle-based, preferred)
     // s.transcript("summarize-b") would fail here — sibling not yet complete
   }),
   ctx.stage({ name: "summarize-b" }, {}, {}, async (s) => {
-    const d = await s.transcript("describe"); // OK — prior completed session
+    const d = await s.transcript(describe); // OK — prior completed session
   }),
 ]);
 
 await ctx.stage({ name: "merge" }, {}, {}, async (s) => {
-  const a = await s.transcript("summarize-a"); // OK — prior completed session
-  const b = await s.transcript("summarize-b"); // OK — prior completed session
+  const a = await s.transcript(summarizeA); // OK — handle-based, preferred over "summarize-a"
+  const b = await s.transcript(summarizeB);
 });
 ```
 
 ---
 
-## F14. Forgetting to `await` `ctx.stage()`
+### F13. Forgetting to `await` `ctx.stage()`
 
 **Symptom.** A session runs (its tmux window opens, the agent does work)
 but the orchestrator doesn't wait for it. Subsequent sessions that depend
@@ -642,7 +642,7 @@ this at compile time.
 
 ---
 
-## F15. Using a pending `SessionHandle` before completion
+### F14. Using a pending `SessionHandle` before completion
 
 **Symptom.** `handle.result` is `undefined` or stale, or
 `s.transcript(handle)` throws / returns empty even though the session
@@ -695,7 +695,7 @@ accessing `.result` without awaiting, the type will be `Promise`, not `T`.
 
 ---
 
-## F16. Headless stage errors are invisible in the graph
+### F15. Headless stage errors are invisible in the graph
 
 **Symptom.** A workflow fails but the graph shows all visible stages as
 completed. The error message references a session name that doesn't appear
@@ -746,7 +746,7 @@ full error for each failed headless stage.
 
 ---
 
-## F17. Claude: importing the SDK `query()` inside a non-headless stage
+### F16. Claude: importing the SDK `query()` inside a non-headless stage
 
 **Symptom.** A reviewer / extractor / structured-output stage shows up in
 the workflow graph as a tmux pane, but the pane sits idle on the Claude
@@ -785,7 +785,7 @@ The runtime exposes exactly two routes for an SDK feature:
 | You want to use… | Stage shape | Code in callback |
 |---|---|---|
 | `outputFormat`, custom `agents`, `maxBudgetUsd`, etc. **without** a visible pane | `{ headless: true }` | `s.session.query(prompt, sdkOptions)` — wraps `HeadlessClaudeSessionWrapper.query()` which forwards `options` to the SDK |
-| The visible TUI with a sub-agent | omit `headless` and pass `chatFlags: ["--agent", "<name>", ...]` | `s.session.query(prompt)` — sends through tmux send-keys |
+| The visible TUI with a subagent | omit `headless` and pass `chatFlags: ["--agent", "<name>", ...]` | `s.session.query(prompt)` — sends through tmux send-keys |
 
 The one option that does **not** exist is "visible pane + in-process SDK call".
 That combination is always wrong — pick one route or the other.
@@ -812,9 +812,9 @@ await ctx.stage({ name: "review" }, {}, {}, async (s) => {
 });
 ```
 
-### ✅ Right (a) — visible TUI with sub-agent + chatFlags
+### ✅ Right (a) — visible TUI with subagent + chatFlags
 
-When you want the user to watch the review happen, run the sub-agent in
+When you want the user to watch the review happen, run the subagent in
 the pane via `--agent` and parse JSON out of the assistant text. The
 prompt should enumerate the schema fields so the model emits matching
 JSON; a tolerant parser (last-fenced-block + last-balanced-object
@@ -878,8 +878,8 @@ await ctx.stage(
    `s.client` and `s.session`.
 2. Watch the workflow run. If a visible pane shows the Claude welcome
    screen for the entire duration of a stage and never receives a prompt,
-   you have F17.
-3. Cost monitoring. F17 roughly doubles the Claude process count — if
+   you have F16.
+3. Cost monitoring. F16 roughly doubles the Claude process count — if
    stage spend looks 2× a single run, audit imports.
 
 ---
@@ -895,9 +895,9 @@ Before shipping a multi-session workflow, walk the list:
 - [ ] Structured-output parsers extract the LAST fenced block, not the first (F8)
 - [ ] `s.save()` receives the per-SDK correct shape — Copilot uses `s.session.getMessages()` (F9)
 - [ ] Loops over 10 iterations have a compaction / reset strategy (F7)
-- [ ] Parallel groups only read from prior completed sessions, never siblings (F13)
-- [ ] Every `ctx.stage()` call is `await`ed (F14)
-- [ ] `SessionHandle` values are only used after the promise resolves (F15)
-- [ ] If provider-level resume/fork is used at all, it stays within the same agent role (F12)
-- [ ] Headless stage callbacks include descriptive error context so failures can be diagnosed without a graph node (F16)
-- [ ] Claude stages never import `query` (or other entry points) from `@anthropic-ai/claude-agent-sdk` directly — go through `s.session.query()` so the runtime routes to the TUI (interactive) or the SDK (headless) consistently (F17)
+- [ ] Parallel groups only read from prior completed sessions, never siblings (F12)
+- [ ] Every `ctx.stage()` call is `await`ed (F13)
+- [ ] `SessionHandle` values are only used after the promise resolves (F14)
+- [ ] If provider-level resume/fork is used at all, it stays within the same agent role (F11)
+- [ ] Headless stage callbacks include descriptive error context so failures can be diagnosed without a graph node (F15)
+- [ ] Claude stages never import `query` (or other entry points) from `@anthropic-ai/claude-agent-sdk` directly — go through `s.session.query()` so the runtime routes to the TUI (interactive) or the SDK (headless) consistently (F16)

--- a/.agents/skills/workflow-creator/references/getting-started.md
+++ b/.agents/skills/workflow-creator/references/getting-started.md
@@ -171,33 +171,27 @@ if (needsReview) {
 
 ## Headless (background) stages
 
-Stages can run in headless mode by setting `headless: true` in the first argument to `ctx.stage()`. Headless stages execute the provider SDK in-process instead of spawning a tmux window — they are invisible in the workflow graph but tracked via a background task counter in the statusline.
+Set `headless: true` in the stage options to run the provider SDK
+in-process instead of spawning a tmux window — invisible in the graph,
+identical callback API.
 
 ```ts
-// Headless stage — identical callback API, no tmux window
 const result = await ctx.stage(
   { name: "background-task", headless: true },
   {}, {},
   async (s) => {
-    // s.client, s.session, s.save(), s.transcript() all work identically
     const result = await s.session.query("Analyze the codebase.");
     s.save(s.sessionId);
     return extractAssistantText(result, 0);
   },
 );
-// result.result contains the returned value
 ```
 
-The callback interface is identical to interactive stages. The only differences:
-- No tmux window is created
-- The stage does not appear as a node in the workflow graph
-- The `paneId` is a virtual identifier: `headless-<name>-<sessionId>`
-- Background stages are tracked by a counter in the orchestrator statusline
-
-**Common pattern — visible seed, parallel headless gather, visible merge:**
-see `control-flow.md` §"Headless stages: transparent to graph topology" for
-the canonical example. Headless stages are transparent to graph topology —
-`seed → [3 headless] → merge` renders as `seed → merge` in the graph.
+For per-provider mechanics, the canonical fan-out pattern (visible seed →
+parallel headless → visible merge), and topology semantics, see
+`control-flow.md` §"Headless stages: transparent to graph topology" and the
+per-SDK "Headless mode" sections in `agent-sessions.md`. Failure visibility
+caveats live in `failure-modes.md` §F15.
 
 ## SDK exports
 
@@ -261,18 +255,9 @@ The Atomic runtime provides `s.client` and `s.session` with types resolved from 
 
 ## Reference files
 
-| File | Topic |
-|---|---|
-| `failure-modes.md` | 16 catalogued silent + loud failures with wrong-vs-right patterns and a pre-ship design checklist — **read before shipping any multi-session workflow** |
-| `workflow-inputs.md` | Declaring the `inputs: WorkflowInput[]` schema, the free-form vs structured decision, CLI flag + picker invocation surfaces, builtin protection |
-| `agent-sessions.md` | Creating agent sessions with SDK calls per provider |
-| `computation-and-validation.md` | Deterministic computation, parsing, validation inside `run()` |
-| `user-input.md` | Collecting user input **mid-workflow** (for invocation-time inputs, see `workflow-inputs.md`) |
-| `control-flow.md` | Loops, conditionals, early termination in plain TypeScript |
-| `state-and-data-flow.md` | Data flow between sessions, transcripts, persistence |
-| `session-config.md` | Per-SDK session configuration: model, tools, permissions, hooks |
-| `running-workflows.md` | How to **run** (not author) an existing workflow on the user's behalf — invocation recipe, input discovery, status monitoring, teardown |
-| `discovery-and-verification.md` | Workflow file discovery, validation, TypeScript config |
+The full table of references with load triggers lives in SKILL.md
+§"Reference Files". Pull `failure-modes.md` before shipping any
+multi-session workflow, and `agent-sessions.md` whenever writing SDK calls.
 
 ## Builtin reference implementations
 
@@ -287,4 +272,4 @@ For a minimal headless example (not a builtin — it lives as a local workflow i
 
 ## Type safety
 
-The SDK is typed with **no `unknown` or `any`**. `SessionContext` fields are precisely typed, and native provider types may appear inside Atomic generic aliases and runtime values — if you need to name those types in your own code, import them from the provider SDK directly. Use `import type` for type-only imports. Use `.for<"agent">()` to narrow `s.client` and `s.session` to the correct provider types. Declare `inputs` inline so TypeScript enforces typed access on `ctx.inputs`.
+The SDK avoids `any` and uses `unknown` only at well-defined boundaries (e.g., `SessionRef = string | SessionHandle<unknown>` for handle-erased lookups). `SessionContext` fields are precisely typed, and native provider types may appear inside Atomic generic aliases and runtime values — if you need to name those types in your own code, import them from the provider SDK directly. Use `import type` for type-only imports. Use `.for<"agent">()` to narrow `s.client` and `s.session` to the correct provider types. Declare `inputs` inline so TypeScript enforces typed access on `ctx.inputs`.

--- a/.agents/skills/workflow-creator/references/getting-started.md
+++ b/.agents/skills/workflow-creator/references/getting-started.md
@@ -195,23 +195,9 @@ The callback interface is identical to interactive stages. The only differences:
 - Background stages are tracked by a counter in the orchestrator statusline
 
 **Common pattern — visible seed, parallel headless gather, visible merge:**
-
-```ts
-const seed = await ctx.stage({ name: "seed" }, {}, {}, async (s) => { /* ... */ });
-
-const [a, b, c] = await Promise.all([
-  ctx.stage({ name: "gather-a", headless: true }, {}, {}, async (s) => { /* ... */ }),
-  ctx.stage({ name: "gather-b", headless: true }, {}, {}, async (s) => { /* ... */ }),
-  ctx.stage({ name: "gather-c", headless: true }, {}, {}, async (s) => { /* ... */ }),
-]);
-
-await ctx.stage({ name: "merge" }, {}, {}, async (s) => {
-  await s.session.query(`Merge:\n${a.result}\n${b.result}\n${c.result}`);
-  s.save(s.sessionId);
-});
-```
-
-Headless stages are transparent to graph topology — `seed → [3 headless] → merge` renders as `seed → merge` in the graph.
+see `control-flow.md` §"Headless stages: transparent to graph topology" for
+the canonical example. Headless stages are transparent to graph topology —
+`seed → [3 headless] → merge` renders as `seed → merge` in the graph.
 
 ## SDK exports
 
@@ -277,6 +263,7 @@ The Atomic runtime provides `s.client` and `s.session` with types resolved from 
 
 | File | Topic |
 |---|---|
+| `failure-modes.md` | 16 catalogued silent + loud failures with wrong-vs-right patterns and a pre-ship design checklist — **read before shipping any multi-session workflow** |
 | `workflow-inputs.md` | Declaring the `inputs: WorkflowInput[]` schema, the free-form vs structured decision, CLI flag + picker invocation surfaces, builtin protection |
 | `agent-sessions.md` | Creating agent sessions with SDK calls per provider |
 | `computation-and-validation.md` | Deterministic computation, parsing, validation inside `run()` |
@@ -284,6 +271,7 @@ The Atomic runtime provides `s.client` and `s.session` with types resolved from 
 | `control-flow.md` | Loops, conditionals, early termination in plain TypeScript |
 | `state-and-data-flow.md` | Data flow between sessions, transcripts, persistence |
 | `session-config.md` | Per-SDK session configuration: model, tools, permissions, hooks |
+| `running-workflows.md` | How to **run** (not author) an existing workflow on the user's behalf — invocation recipe, input discovery, status monitoring, teardown |
 | `discovery-and-verification.md` | Workflow file discovery, validation, TypeScript config |
 
 ## Builtin reference implementations
@@ -292,9 +280,10 @@ The SDK ships two builtin workflows that demonstrate production patterns for all
 
 - **`ralph`** (`src/sdk/workflows/builtin/ralph/`) — iterative plan → orchestrate → review → debug loop with consecutive clean-pass detection, shared helpers for prompts/parsing/git, and cross-SDK adaptation
 - **`deep-research-codebase`** (`src/sdk/workflows/builtin/deep-research-codebase/`) — deterministic codebase scout → LOC-based heuristic explorer partitioning → parallel explorers → aggregator with file-based handoffs and context-aware prompt engineering
-- **`headless-test`** (`.atomic/workflows/headless-test/`) — demonstrates the visible → [parallel headless] → visible merge pattern (all 3 SDKs)
 
 Both include `helpers/` directories with SDK-agnostic logic (prompt builders, parsers, heuristics) and per-agent `index.ts` files showing how the same workflow topology adapts to Claude, Copilot, and OpenCode.
+
+For a minimal headless example (not a builtin — it lives as a local workflow in this repo), see `.atomic/workflows/headless-test/` — demonstrates the visible → [parallel headless] → visible merge pattern for all three SDKs.
 
 ## Type safety
 

--- a/.agents/skills/workflow-creator/references/running-workflows.md
+++ b/.agents/skills/workflow-creator/references/running-workflows.md
@@ -1,0 +1,235 @@
+# Running a Workflow on Behalf of the User
+
+When the user asks you to **run** (or "kick off" / "start" / "execute") a
+workflow — *not* author one — your job is to translate their request into a
+single `atomic workflow` invocation and run it. This is the playbook for that
+flow. It is different from the authoring playbook in `SKILL.md`: the workflow
+already exists on disk; you just need to invoke it correctly.
+
+## You don't need to pass `-a` or `-d`
+
+When you (the agent) are running inside an atomic chat or workflow pane, the
+CLI reads `$ATOMIC_AGENT` from your environment and:
+
+- Fills in `-a <agent>` automatically if you don't pass it.
+- Forces detached mode on, so launching a workflow never takes over your pane.
+
+The practical result: your command is just `atomic workflow -n <name> <inputs>`.
+No provider flag, no detach flag, no chance of the orchestrator hijacking your
+terminal. The CLI prints the session name and returns immediately; you relay
+that name to the user.
+
+Override only when the user explicitly asks for a different provider (e.g.
+"run it on Copilot") — pass `-a copilot` and the CLI will honor it over the
+env var.
+
+## Always list first
+
+**Before anything else, run `atomic workflow list`.** (Optionally filter with
+`-a <agent>` if the user's pinned to one — usually unnecessary.) This is a
+cheap, read-only call that tells you three things in one shot:
+
+- Whether the workflow the user named actually exists.
+- What other workflows are available (so you can suggest close matches on a typo).
+- Source + metadata for every discoverable workflow (local vs. global vs. builtin).
+
+Skipping this step is how you end up guessing a name, typing it into
+`atomic workflow -n <name>`, and getting a `workflow not found` error you
+could have predicted. List first, decide second, run third.
+
+If the user's request is ambiguous ("run the research one"), the list output
+is also how you show them the candidates so they can pick — present the
+matching names and ask with AskUserQuestion.
+
+## If the workflow doesn't exist: offer to create it
+
+When the listed workflows don't include what the user asked for:
+
+1. **Tell the user explicitly** — "I don't see a `<name>` workflow in
+   `.atomic/workflows/` or `~/.atomic/workflows/`. Available: \<short list from
+   `atomic workflow list`>."
+2. **Check for typos first** — if one of the listed names is a close match,
+   surface it via AskUserQuestion ("Did you mean `<close-match>`?") before
+   offering to author anything.
+3. **Offer to create it** — ask with AskUserQuestion: "Want me to create a
+   `<name>` workflow first?" with choices `Yes, create it` / `No, pick from
+   the list` / `No, cancel`.
+4. **If yes → switch modes** — hand off to the authoring flow in SKILL.md
+   (Steps 1-5). Interview the user for intent, write the file at
+   `.atomic/workflows/<name>/<agent>/index.ts`, typecheck it, *then* come back
+   here and invoke it. Do not skip the typecheck — an uncompiled workflow
+   won't run.
+5. **If no → stop** — don't fabricate a command that will fail. Let the user
+   redirect you.
+
+Never invent a workflow name or silently fall back to a different workflow.
+If the thing the user asked for doesn't exist, the correct answer is to say
+so and offer concrete next steps.
+
+## Collecting inputs with AskUserQuestion
+
+Once you've confirmed the workflow exists, you need to know two things about
+its invocation shape:
+
+1. **Does it declare a `prompt` input?** If so, it's free-form — you pass a
+   positional string.
+2. **Does it declare structured inputs?** If so, you pass `--<field>=<value>`
+   flags, one per required field.
+
+**Use `atomic workflow inputs <name> -a <agent>` to get the schema.** This
+prints a JSON envelope with every field's `name`, `type`, `required`,
+`default`, `description`, and (for enums) `values` — exactly what
+AskUserQuestion needs. The `freeform: true` flag tells you whether the
+workflow takes a positional prompt vs. structured flags, with a synthetic
+`prompt` field included so the JSON shape is uniform either way.
+
+```bash
+atomic workflow inputs gen-spec -a claude
+# {"workflow":"gen-spec","agent":"claude","freeform":false,
+#  "inputs":[{"name":"research_doc","type":"string","required":true,...},
+#            {"name":"focus","type":"enum","values":["minimal","standard","exhaustive"],"default":"standard"}]}
+```
+
+Why this command instead of reading the source file: `inputs` is the contract
+the CLI actually validates against. It survives refactors, handles built-in
+workflows that aren't in the project tree, and never falls out of sync with
+the runtime. Reading TypeScript source is a fallback for the rare case where
+the command can't resolve the workflow.
+
+Once you have the schema, use the **AskUserQuestion tool** to collect any
+values the user hasn't already provided in their message. One question per
+missing input field. For enum fields, pass the declared `values` as
+multiple-choice options so the user sees exactly what's allowed. Keep
+questions tight and purposeful — if the user's message already answers a
+question, don't ask it again.
+
+Skip AskUserQuestion entirely when:
+- The user already supplied every required value in their message
+  ("run ralph on 'add OAuth to the API'" — the prompt is right there).
+- The workflow declares no required inputs and needs no prompt.
+
+## End-to-end recipe
+
+1. **List available workflows** — run `atomic workflow list`. Always. This is
+   your ground truth.
+2. **Resolve the target**:
+   - Exact match in the list → continue.
+   - Close match → confirm via AskUserQuestion before proceeding.
+   - No match → tell the user what's available and offer to author it (see
+     previous section). If they decline, stop.
+3. **Discover the inputs schema** — run `atomic workflow inputs <name> -a <agent>`
+   and parse the JSON.
+4. **Ask for missing inputs** — use AskUserQuestion, one question per
+   unanswered required field. Enums become multiple-choice.
+5. **Invoke** — build one of these commands:
+   - Free-form: `atomic workflow -n <name> "<prompt>"`
+   - Structured: `atomic workflow -n <name> --<field1>=<value1> --<field2>=<value2>`
+6. **Report the session name** the CLI printed and tell the user: "attach any
+   time with `atomic workflow session connect <session>` — or
+   `atomic workflow session list` to see what's running."
+
+## Monitoring a running workflow
+
+Detached workflows return immediately with a session name; the actual work
+runs in the background on the atomic tmux socket. Use `atomic workflow status`
+to check whether the workflow is still running, has completed, errored out, or
+paused for human input — without attaching to its TUI.
+
+```bash
+atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4
+# {"id":"atomic-wf-claude-gen-spec-a1b2c3d4","overall":"in_progress","alive":true,
+#  "sessions":[{"name":"orchestrator","status":"running",...}],...}
+```
+
+Four overall states the agent must handle distinctly:
+
+| Status | Meaning | What you should do |
+|---|---|---|
+| `in_progress` | The orchestrator is running and no stage is paused | Wait, or report progress to the user |
+| `needs_review` | At least one stage is paused for human input (HIL) — Copilot `ask_user`, OpenCode `question.asked`, Copilot/MCP elicitation | **Surface this to the user immediately** — they need to attach with `atomic workflow session connect <id>` to respond, otherwise the workflow stalls indefinitely |
+| `completed` | Workflow finished successfully | Report success and summarize the output |
+| `error` | Fatal error or a stage failed | Report the `fatalError` field and offer to investigate logs |
+
+`needs_review` outranks `completed` so a HIL pause near the end is never
+reported as done while still waiting on a human. A dead orchestrator with a
+stale snapshot is automatically downgraded to `error`.
+
+Omit the id to list every running workflow at once: `atomic workflow status`.
+Useful when checking on multiple parallel runs, or when the user just asks
+"what's running?".
+
+## Cleaning up sessions
+
+When the user is done with a workflow — or you launched one detached and it's
+no longer needed — tear it down with `-y` so no confirmation prompt blocks you:
+
+```bash
+atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y
+```
+
+The `-y` flag is mandatory for agent use. Without it, the CLI calls
+`@clack/prompts confirm`, which expects a TTY and will hang indefinitely in a
+non-interactive context. Same flag works for `atomic workflow session kill`
+and `atomic chat session kill`. Without an id, `kill -y` tears down every
+in-scope session — only do that when the user has asked to stop everything.
+
+## Worked examples
+
+**Example A — workflow exists, structured inputs**
+
+> **User:** "run gen-spec on research/docs/2026-04-11-auth.md"
+
+1. Run `atomic workflow list`. Output includes `gen-spec` under local. Good.
+2. Target resolved exactly: `gen-spec`.
+3. Run `atomic workflow inputs gen-spec -a claude`. Parse the JSON:
+   `research_doc` (required string — already given), `focus` (required enum
+   of `minimal|standard|exhaustive`, default `standard`), `notes`
+   (optional text).
+4. Ask via AskUserQuestion once: "What focus level for the spec?" with
+   choices `minimal`, `standard`, `exhaustive`. User picks `standard`. Skip
+   `notes` since it's optional.
+5. Run: `atomic workflow -n gen-spec --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
+6. The CLI prints a session name like `atomic-wf-claude-gen-spec-a1b2c3d4`.
+   Tell the user: "Started in the background. Attach with
+   `atomic workflow session connect atomic-wf-claude-gen-spec-a1b2c3d4`,
+   check progress with `atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4`,
+   or stop it with `atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y`."
+
+**Example B — workflow does not exist**
+
+> **User:** "run the security-audit workflow on src/auth"
+
+1. Run `atomic workflow list`. Available: `ralph`, `deep-research-codebase`,
+   `gen-spec`, `review-to-merge`. No `security-audit`.
+2. Tell the user: "I don't see a `security-audit` workflow. Available:
+   ralph, deep-research-codebase, gen-spec, review-to-merge."
+3. Ask via AskUserQuestion: "Want me to create a `security-audit` workflow
+   first?" with choices `Yes, create it`, `No, use one of the existing
+   workflows`, `No, cancel`.
+4. If **Yes**: switch to SKILL.md's Authoring Process — interview the user
+   for what the workflow should do, draft it, typecheck, *then* return here
+   and invoke it.
+5. If **No, use existing**: ask which one via AskUserQuestion over the
+   listed options, then continue from step 3 of the recipe.
+6. If **Cancel**: stop, no command runs.
+
+## Common mistakes to avoid
+
+- **Skipping `atomic workflow list`** — leads to guessing and
+  `workflow not found` errors. It's a one-line command; always run it.
+- **Inventing a workflow name** — if it's not in the list, it doesn't exist.
+  Say so and offer to author it.
+- **Reading the workflow source file to discover inputs** — use
+  `atomic workflow inputs <name> -a <agent>` instead. JSON, no TS parsing
+  required, always in sync with the runtime. Source-file reads are a
+  fallback, not a default.
+- **Asking everything at once** — let AskUserQuestion drive one question per
+  field. Enum fields are multiple-choice, not free text.
+- **Re-asking what the user already said** — read their message first.
+- **Forgetting to report the session name** — the user needs it to reattach
+  and to query status later.
+- **Leaving `needs_review` unreported** — when `atomic workflow status`
+  returns `needs_review`, surface it to the user right away. The workflow is
+  blocked on human input and will sit forever otherwise.
+- **Calling `session kill` without `-y`** — the prompt hangs in a
+  non-interactive context. Always pass `-y` from an agent.

--- a/.agents/skills/workflow-creator/references/session-config.md
+++ b/.agents/skills/workflow-creator/references/session-config.md
@@ -25,7 +25,7 @@ If you want to configure agent/permission/tools behavior for a **headless** Clau
 
 ```ts
 await ctx.stage({ name: "..." }, {}, {}, async (s) => {
-  await s.session.query((ctx.inputs.prompt ?? ""));
+  await s.session.query((s.inputs.prompt ?? ""));
   s.save(s.sessionId);
 });
 ```
@@ -35,7 +35,7 @@ await ctx.stage({ name: "..." }, {}, {}, async (s) => {
 **This block is a reference cheatsheet for the SDK option shape — it is
 not valid workflow code.** Do not import `query` from
 `@anthropic-ai/claude-agent-sdk` inside a `ctx.stage()` callback (see
-`failure-modes.md` §F17). In a **headless** stage, pass these options as
+`failure-modes.md` §F16). In a **headless** stage, pass these options as
 the second argument to `s.session.query(prompt, sdkOptions)` — the runtime
 forwards them to the Agent SDK. In an **interactive** stage, the options
 are silently ignored; drive behaviour via `chatFlags` in `clientOpts`
@@ -50,7 +50,7 @@ const result = query({
   options: {
     // Model selection
     model: "claude-opus-4-6",         // Full model ID or alias ("opus", "sonnet", "haiku")
-    effort: "high",                   // "low", "medium", "high", "max" (max is Opus 4.6 only)
+    effort: "high",                   // "low", "medium", "high", "xhigh", "max" (max is Opus 4.6/4.7 only)
     thinking: { type: "adaptive" },   // Default for supported models; or { type: "enabled", budgetTokens: N }
     maxTurns: 50,                     // Maximum conversation turns
     maxBudgetUsd: 5.0,                // Spending cap in USD
@@ -236,7 +236,7 @@ await ctx.stage({ name: "plan" }, {}, {
     bufferExhaustionThreshold: 0.95,    // block at 95% until compaction completes
   },
 }, async (s) => {
-  await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
+  await s.session.send({ prompt: (s.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());
 });
 ```
@@ -246,7 +246,7 @@ await ctx.stage({ name: "plan" }, {}, {
 ```ts
 // Approve everything (autonomous) — this is the default
 await ctx.stage({ name: "plan" }, {}, { onPermissionRequest: approveAll }, async (s) => {
-  await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
+  await s.session.send({ prompt: (s.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());
 });
 
@@ -266,7 +266,7 @@ await ctx.stage({ name: "plan" }, {}, {
     }
   },
 }, async (s) => {
-  await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
+  await s.session.send({ prompt: (s.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());
 });
 ```
@@ -310,7 +310,7 @@ await ctx.stage({ name: "implement" }, {}, {}, async (s) => {
   // Basic prompt
   const result = await s.client.session.prompt({
     sessionID: s.session.id,
-    parts: [{ type: "text", text: (ctx.inputs.prompt ?? "") }],
+    parts: [{ type: "text", text: (s.inputs.prompt ?? "") }],
   });
 
   // Structured output

--- a/.agents/skills/workflow-creator/references/session-config.md
+++ b/.agents/skills/workflow-creator/references/session-config.md
@@ -30,9 +30,19 @@ await ctx.stage({ name: "..." }, {}, {}, async (s) => {
 });
 ```
 
-### `query()` options
+### `query()` options (reference for `s.session.query()` sdkOptions)
+
+**This block is a reference cheatsheet for the SDK option shape — it is
+not valid workflow code.** Do not import `query` from
+`@anthropic-ai/claude-agent-sdk` inside a `ctx.stage()` callback (see
+`failure-modes.md` §F17). In a **headless** stage, pass these options as
+the second argument to `s.session.query(prompt, sdkOptions)` — the runtime
+forwards them to the Agent SDK. In an **interactive** stage, the options
+are silently ignored; drive behaviour via `chatFlags` in `clientOpts`
+instead.
 
 ```ts
+// ❌ Reference only — do not call query() like this from a workflow.
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
 const result = query({
@@ -218,8 +228,13 @@ await ctx.stage({ name: "plan" }, {}, {
     onErrorOccurred: (event) => { /* error handling */ },
   },
 
-  // Advanced
-  infiniteSessions: true,             // Auto-manage context via compaction
+  // Advanced — auto-manage context via compaction. Pass an InfiniteSessionConfig,
+  // not a boolean. See docs/copilot-cli/sdk.md for the full threshold surface.
+  infiniteSessions: {
+    enabled: true,
+    backgroundCompactionThreshold: 0.8, // start compacting at 80% window usage
+    bufferExhaustionThreshold: 0.95,    // block at 95% until compaction completes
+  },
 }, async (s) => {
   await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());

--- a/.agents/skills/workflow-creator/references/state-and-data-flow.md
+++ b/.agents/skills/workflow-creator/references/state-and-data-flow.md
@@ -110,7 +110,7 @@ Use closures and variables for state within a single session:
 
     for (let cycle = 0; cycle < 10; cycle++) {
       const result = await s.session.query(
-        buildReviewPrompt((ctx.inputs.prompt ?? ""), priorOutput),
+        buildReviewPrompt((s.inputs.prompt ?? ""), priorOutput),
       );
 
       // Accumulate findings
@@ -128,7 +128,7 @@ Use closures and variables for state within a single session:
       consecutiveClean = 0;
 
       // Apply fix
-      const fixResult = await s.session.query(buildFixSpec(review, (ctx.inputs.prompt ?? "")));
+      const fixResult = await s.session.query(buildFixSpec(review, (s.inputs.prompt ?? "")));
       priorOutput = extractAssistantText(fixResult, 0);
     }
 
@@ -210,6 +210,11 @@ export function buildReviewPrompt(spec: string, priorOutput?: string): string {
 
 ### Response parsers
 
+For tolerant JSON parsing, see `failure-modes.md` §F8 — the canonical
+`parseReviewResult` helper uses a layered fallback (direct parse → last
+fenced block → last balanced object) that survives prose interleaving.
+Copy that implementation into `helpers/parsers.ts` and import.
+
 ```ts
 // .atomic/workflows/my-workflow/helpers/parsers.ts
 export interface ReviewResult {
@@ -217,27 +222,9 @@ export interface ReviewResult {
   overall_correctness: string;
 }
 
-/** Layered fallback: direct parse → last fenced block → last balanced object.
- *  Always extract the LAST block, not the first — see failure-modes.md §F4/§F8. */
+// See failure-modes.md §F8 for the full implementation.
 export function parseReviewResult(text: string): ReviewResult | null {
-  // 1. Direct parse
-  try {
-    const parsed = JSON.parse(text);
-    if (parsed?.findings) return parsed;
-  } catch {}
-
-  // 2. Last fenced block
-  const blockRe = /```(?:json)?\s*\n([\s\S]*?)\n```/g;
-  let lastBlock: string | null = null;
-  let m: RegExpExecArray | null;
-  while ((m = blockRe.exec(text)) !== null) {
-    if (m[1]) lastBlock = m[1];
-  }
-  if (lastBlock) {
-    try { return JSON.parse(lastBlock); } catch {}
-  }
-
-  return null;
+  // ... three-layer fallback per §F8
 }
 ```
 

--- a/.agents/skills/workflow-creator/references/state-and-data-flow.md
+++ b/.agents/skills/workflow-creator/references/state-and-data-flow.md
@@ -148,10 +148,6 @@ import { readFile, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 
 .run(async (ctx) => {
-  await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
-    // ... plan session ...
-  });
-
   const planHandle = await ctx.stage({ name: "plan" }, {}, {}, async (s) => {
     // Write artifacts to session directory
     const artifactDir = join(s.sessionDir, "artifacts");

--- a/.agents/skills/workflow-creator/references/user-input.md
+++ b/.agents/skills/workflow-creator/references/user-input.md
@@ -7,7 +7,7 @@ For **invocation-time** inputs (the values the user supplies when they launch th
 ## Claude
 
 Never import `query` from `@anthropic-ai/claude-agent-sdk` inside a stage
-callback — that's the F17 anti-pattern (see `failure-modes.md` §F17). All
+callback — that's the F16 anti-pattern (see `failure-modes.md` §F16). All
 options route through `s.session.query(prompt, sdkOptions)` in headless
 stages, or through `chatFlags` in interactive stages.
 
@@ -106,7 +106,7 @@ await ctx.stage({ name: "plan" }, {}, {
     return answer;
   },
 }, async (s) => {
-  await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
+  await s.session.send({ prompt: (s.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());
 });
 ```
@@ -126,7 +126,7 @@ await ctx.stage({ name: "plan" }, {}, {
     };
   },
 }, async (s) => {
-  await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
+  await s.session.send({ prompt: (s.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());
 });
 ```
@@ -141,7 +141,7 @@ import { approveAll } from "@github/copilot-sdk";
 
 // Explicit (same as the default):
 await ctx.stage({ name: "plan" }, {}, { onPermissionRequest: approveAll }, async (s) => {
-  await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
+  await s.session.send({ prompt: (s.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());
 });
 ```
@@ -160,7 +160,7 @@ await ctx.stage({ name: "plan" }, {}, {
     return { kind: "approved" };
   },
 }, async (s) => {
-  await s.session.send({ prompt: (ctx.inputs.prompt ?? "") });
+  await s.session.send({ prompt: (s.inputs.prompt ?? "") });
   s.save(await s.session.getMessages());
 });
 ```
@@ -215,11 +215,10 @@ Use user input results in conditional logic. This Claude example uses
 user directly, and you parse the response to branch:
 
 ```ts
-import { query } from "@anthropic-ai/claude-agent-sdk";
-
-// Inside a ctx.stage() callback (Claude example):
+// Inside a ctx.stage() callback (Claude example).
+// AskUserQuestion must be in allowedTools — see "Via AskUserQuestion tool" above.
 async (s) => {
-  const plan = await s.transcript("plan");
+  const plan = await s.transcript("plan"); // or s.transcript(handle) if a handle is in scope (preferred)
 
   // Let the agent ask the user for approval via AskUserQuestion
   const result = await s.session.query(

--- a/.agents/skills/workflow-creator/references/user-input.md
+++ b/.agents/skills/workflow-creator/references/user-input.md
@@ -6,57 +6,86 @@ For **invocation-time** inputs (the values the user supplies when they launch th
 
 ## Claude
 
-### Via `canUseTool` callback
+Never import `query` from `@anthropic-ai/claude-agent-sdk` inside a stage
+callback — that's the F17 anti-pattern (see `failure-modes.md` §F17). All
+options route through `s.session.query(prompt, sdkOptions)` in headless
+stages, or through `chatFlags` in interactive stages.
 
-The Claude Agent SDK provides a `canUseTool` callback for runtime approval and user interaction:
+### Via `canUseTool` callback (headless stages only)
+
+`canUseTool` is an SDK option — it only applies in a headless stage, where
+the second argument to `s.session.query()` is forwarded to the Agent SDK as
+`Partial<SDKOptions>`. In interactive stages the option is silently ignored
+because `s.session.query()` is driving the `claude` CLI binary, not the SDK.
 
 ```ts
-import { query } from "@anthropic-ai/claude-agent-sdk";
-
-// Inside a ctx.stage() callback:
-async (s) => {
-  const result = query({
-    prompt: "Implement the feature, but ask me before making any database changes.",
-    options: {
-      canUseTool: async (toolName, toolInput, options) => {
-        if (toolName === "Write" && toolInput.file_path?.includes("migration")) {
-          // Prompt the user for approval
-          const approved = await promptUser("Allow database migration?");
-          return approved
-            ? { behavior: "allow" }
-            : { behavior: "deny", message: "User declined migration" };
-        }
-        return { behavior: "allow" };
+await ctx.stage(
+  { name: "implement", headless: true },
+  {}, {},
+  async (s) => {
+    const messages = await s.session.query(
+      "Implement the feature, but ask me before making any database changes.",
+      {
+        canUseTool: async (toolName, toolInput) => {
+          if (toolName === "Write" && typeof toolInput.file_path === "string" && toolInput.file_path.includes("migration")) {
+            const approved = await promptUser("Allow database migration?");
+            return approved
+              ? { behavior: "allow", updatedInput: toolInput }
+              : { behavior: "deny", message: "User declined migration" };
+          }
+          return { behavior: "allow", updatedInput: toolInput };
+        },
       },
-    },
-  });
-  for await (const msg of result) { /* process */ }
-},
+    );
+    s.save(s.sessionId);
+    return extractAssistantText(messages, 0);
+  },
+);
 ```
 
 ### Via `AskUserQuestion` tool
 
-Allow the agent to ask the user questions by including `AskUserQuestion` in `allowedTools`:
+Allow the agent to ask the user questions by including `AskUserQuestion` in
+`allowedTools`. This works for both interactive stages (via `chatFlags`) and
+headless stages (via sdkOptions on `s.session.query()`).
+
+**Interactive stage** — pass the tool allowlist via `chatFlags`:
 
 ```ts
-const result = query({
-  prompt: (ctx.inputs.prompt ?? ""),
-  options: {
-    allowedTools: ["Read", "Write", "Edit", "Bash", "AskUserQuestion"],
+await ctx.stage(
+  { name: "implement" },
+  { chatFlags: ["--allowed-tools", "Read,Write,Edit,Bash,AskUserQuestion"] },
+  {},
+  async (s) => {
+    await s.session.query(s.inputs.prompt ?? "");
+    s.save(s.sessionId);
   },
-});
+);
 ```
 
-### Via streaming input
-
-For interactive sessions, use streaming mode to feed user input:
+**Headless stage** — pass `allowedTools` in the sdkOptions:
 
 ```ts
-const q = query({ prompt: (ctx.inputs.prompt ?? ""), options: { ... } });
-
-// Feed additional input while the agent is running
-q.streamInput("Here's the additional context you asked for...");
+await ctx.stage(
+  { name: "implement", headless: true },
+  {}, {},
+  async (s) => {
+    const messages = await s.session.query(s.inputs.prompt ?? "", {
+      allowedTools: ["Read", "Write", "Edit", "Bash", "AskUserQuestion"],
+    });
+    s.save(s.sessionId);
+    return extractAssistantText(messages, 0);
+  },
+);
 ```
+
+### Via streaming input (headless stages only)
+
+The Agent SDK's `streamInput()` feeds additional input while a query is
+running. It's only reachable from headless stages via an async iterable
+prompt — pass an `AsyncIterable<SDKUserMessage>` as the first argument to
+`s.session.query()` instead of a plain string. In interactive stages, send
+follow-up turns with another `s.session.query()` call to the same session.
 
 ## Copilot
 

--- a/.agents/skills/workflow-creator/references/workflow-inputs.md
+++ b/.agents/skills/workflow-creator/references/workflow-inputs.md
@@ -89,6 +89,18 @@ The nullish coalescing on `notes` handles the optional field case —
 declared-but-unset inputs resolve to `undefined` unless they have a
 `default`.
 
+**Style convention.** Inside a stage callback, both `s.inputs.<name>` and
+`ctx.inputs.<name>` resolve to the same value. Either of these patterns
+works:
+
+- **Destructure once at the top of `.run()`** so each stage closes over a
+  bare local. Best when many stages reference the same input.
+- **Inline access** with `(s.inputs.<name> ?? "")` at each call site. Best
+  for short workflows or when each stage uses a different field.
+
+Pick whichever reads cleaner for your workflow. Examples in other reference
+files use the inline form for brevity in focused snippets.
+
 ## Declaring an input schema
 
 Pass an `inputs` array to `defineWorkflow({ ... })`. Each entry is a
@@ -205,21 +217,9 @@ because the form teaches the schema as the user fills it in.
 
 ## Builtin protection
 
-Builtin workflows (the ones shipped inside the SDK — currently `ralph`
-and `deep-research-codebase`) are **reserved**. A local or global
-workflow with the same name will not shadow the builtin at resolution
-time — the runtime drops user-defined workflows with reserved names
-before any precedence merge. This prevents a user from accidentally
-redefining the canonical version of a workflow in a way that confuses
-teammates or breaks automation.
-
-You'll still see shadowed local/global workflows in
-`atomic workflow list` output so the collision is visible, but running
-`atomic workflow -n ralph -a claude` will always land on the builtin.
-
-The practical implication: **don't name a new workflow `ralph` or
-`deep-research-codebase`**. Pick a distinct name and you'll never hit
-this.
+Builtin names (`ralph`, `deep-research-codebase`) are reserved — pick
+distinct names for your workflows. Full precedence + shadowing rules
+live in `discovery-and-verification.md`.
 
 ## Invocation details
 

--- a/.agents/skills/workflow-creator/references/workflow-inputs.md
+++ b/.agents/skills/workflow-creator/references/workflow-inputs.md
@@ -221,34 +221,11 @@ The practical implication: **don't name a new workflow `ralph` or
 `deep-research-codebase`**. Pick a distinct name and you'll never hit
 this.
 
-## Invocation cheat sheet
+## Invocation details
 
-```bash
-# List everything, grouped by source
-atomic workflow list
-
-# Launch the picker for a pinned agent
-atomic workflow -a claude
-
-# Free-form, positional prompt
-atomic workflow -n hello -a claude "hello world"
-
-# Structured, one flag per field
-atomic workflow -n gen-spec -a claude \
-  --research_doc=research/docs/2026-04-11-auth.md \
-  --focus=standard \
-  --notes="pay special attention to session token storage"
-
-# Structured, long-form flag value (= form)
-atomic workflow -n gen-spec -a claude --focus standard --research_doc notes.md
-
-# Detached (background) — starts the orchestrator on the atomic tmux
-# socket and returns immediately. The command prints the session name
-# and hints for attaching later. Use this for scripted / CI runs where
-# the caller shouldn't block on the TUI.
-atomic workflow -n hello -a claude -d "hello world"
-atomic workflow session connect atomic-wf-claude-hello-<id>   # attach later
-```
+See SKILL.md §"Invocation surfaces" for the table of every top-level
+command. This section only covers the flag-parsing nuances specific to
+structured inputs.
 
 Both `--flag=value` and `--flag value` forms are accepted. Short flags
 (`-x value`) are NOT parsed as structured inputs — only long-form
@@ -256,6 +233,12 @@ Both `--flag=value` and `--flag value` forms are accepted. Short flags
 
 The `-d` / `--detach` flag composes with any named shape (positional
 prompt, structured flags) and is independent of the inputs schema.
+
+```bash
+# Structured, both flag forms work identically
+atomic workflow -n gen-spec -a claude --focus=standard --research_doc=notes.md
+atomic workflow -n gen-spec -a claude --focus standard --research_doc notes.md
+```
 
 ## Pitfalls
 

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -994,7 +994,7 @@ export class ClaudeSessionWrapper {
    * Send a prompt to Claude and wait for the response.
    *
    * The `_options` parameter exists for signature compatibility with
-   * {@link HeadlessClaudeSessionWrapper.query} (which forwards SDK options
+   * {@link HeadlessClaudeSessionWrapper#query} (which forwards SDK options
    * like `agent`, `permissionMode`, etc. to the Agent SDK). In the
    * interactive pane path these options don't apply — we're driving the
    * `claude` CLI binary, not the SDK — so they are silently ignored.
@@ -1027,7 +1027,7 @@ export class HeadlessClaudeClientWrapper {
    * Headless Claude stages don't pre-allocate a session — each `query()` call
    * to {@link HeadlessClaudeSessionWrapper} spawns a fresh Agent SDK run that
    * emits its own `session_id`. We still return an empty string here so the
-   * method signature matches {@link ClaudeClientWrapper.start}.
+   * method signature matches {@link ClaudeClientWrapper#start}.
    */
   async start(): Promise<string> {
     return "";

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -1077,7 +1077,7 @@ export class HeadlessClaudeSessionWrapper {
 
     let sdkSessionId = "";
     try {
-      for await (const msg of sdkQuery({ prompt, options: headlessSdkOpts })) {
+      for await (const msg of sdkQuery({ prompt, options: options ?? {} })) {
         if (msg.type === "result") {
           sdkSessionId = String(
             (msg as Record<string, unknown>).session_id ?? "",
@@ -1088,11 +1088,16 @@ export class HeadlessClaudeSessionWrapper {
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(`Claude SDK query failed: ${detail}`);
     }
-    if (sdkSessionId) {
-      this._lastSessionId = sdkSessionId;
-      return getSessionMessages(sdkSessionId, { dir: process.cwd() });
+    if (!sdkSessionId) {
+      throw new Error(
+        "Claude SDK query completed without a `result` message — " +
+          "likely a stream idle timeout, aborted request, or upstream API error. " +
+          "Set CLAUDE_ENABLE_STREAM_WATCHDOG=1 (and tune CLAUDE_STREAM_IDLE_TIMEOUT_MS / " +
+          "API_TIMEOUT_MS) so the CLI surfaces a concrete failure instead of exiting silently.",
+      );
     }
-    return [];
+    this._lastSessionId = sdkSessionId;
+    return getSessionMessages(sdkSessionId, { dir: process.cwd() });
   }
 
   async disconnect(): Promise<void> {}


### PR DESCRIPTION
## Summary

Fixes two silent failure modes in the Claude SDK headless provider and overhauls the `workflow-creator` skill documentation with a comprehensive new `running-workflows` reference guide.

## Key Changes

### Bug Fixes (`src/sdk/providers/claude.ts`)

- **Surface SDK errors**: Wrapped the `sdkQuery` loop in a `try/catch` that re-throws with a descriptive message. Previously, stream idle timeouts or upstream API errors caused the loop to exit silently, returning an empty transcript with no indication of failure.
- **Throw on missing session ID**: After the query loop, an empty `sdkSessionId` now throws a structured error with actionable guidance (e.g. `CLAUDE_ENABLE_STREAM_WATCHDOG=1`, `CLAUDE_STREAM_IDLE_TIMEOUT_MS`) instead of silently returning `[]`.
- **Fix `headlessSdkOpts` shadowing**: Passed `options ?? {}` directly to `sdkQuery` instead of the previously-undefined `headlessSdkOpts` local.
- **JSDoc `@link` separator fix**: Changed `{@link Foo.bar}` to `{@link Foo#bar}` for correct instance-method references in generated docs.

### Documentation (`workflow-creator` skill)

- **New reference**: Added `references/running-workflows.md` covering how to run, compile, and debug workflows end-to-end.
- **Overhauled** `SKILL.md`, `references/agent-sessions.md`, `references/user-input.md`, and `references/workflow-inputs.md` for clarity and accuracy.
- **Minor corrections** to `computation-and-validation.md`, `control-flow.md`, `failure-modes.md`, `getting-started.md`, `session-config.md`, and `state-and-data-flow.md`.