### PR TITLE
chore(release): bump version to v0.5.24-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.23",
+  "version": "0.5.24-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.23` to `0.5.24-0` (prerelease) in `package.json` ahead of the next release cycle.

## Changes

- **`package.json`**: `version` `0.5.23` → `0.5.24-0`

## Test plan

- [ ] CI passes
- [ ] Merging triggers the automated GitHub Release + npm publish for `v0.5.24-0`