### PR TITLE
chore(release): bump version to v0.5.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.24-0",
+  "version": "0.5.24",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `v0.5.24-0` to the stable `v0.5.24` release by updating the version in `package.json`.

## Changes

- `package.json`: version `0.5.24-0` → `0.5.24`

## Test plan

- [ ] CI passes
- [ ] GitHub Release is automatically created on merge
- [ ] Package is published to npm with provenance