### PR TITLE
chore(release): bump version to v0.5.25-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.24",
+  "version": "0.5.25-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.5.24` to `v0.5.25-0` (prerelease) in preparation for the next release.

## Changes

- `package.json`: version `0.5.24` → `0.5.25-0`

## Test plan

- [ ] CI passes
- [ ] GitHub Release auto-created on merge
- [ ] Prerelease published to npm