### PR TITLE
chore(release): bump version to v0.5.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.25-0",
+  "version": "0.5.25",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the package from prerelease `v0.5.25-0` to stable `v0.5.25`.

## Changes

- `package.json`: version `0.5.25-0` → `0.5.25`

## Test plan

- [ ] CI passes
- [ ] GitHub Release auto-created on merge
- [ ] Package published to npm as `v0.5.25`