### PR TITLE
chore(release): bump version to v0.5.26-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.25",
+  "version": "0.5.26-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.5.25` to `v0.5.26-0` in preparation for the next prerelease.

## Changes

- `package.json`: version `0.5.25` → `0.5.26-0`

## Test plan

- [ ] CI passes
- [ ] Prerelease published to npm on merge