### PR TITLE
fix(claude): extend Stop hook timeout and apply headless opts in SDK query

### DIFF
--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -110,6 +110,25 @@ function buildWorkflowHookCommand(subcommand: string, extraArgs: readonly string
 }
 
 /**
+ * Effectively-unbounded timeout (in seconds) for the Stop hook command.
+ *
+ * Claude Code's Stop hook process runs three phases sequentially — the
+ * initial Stop hooks, then TaskCompleted hooks (per in-progress task owned
+ * by the teammate), then TeammateIdle hooks — and the per-hook `timeout`
+ * applies to the entire lifecycle. Under Claude Code's default (10 min),
+ * a turn that leaves tasks in-progress (e.g. via the TaskList/TodoWrite
+ * tool) can blow the budget and get killed, which also severs our
+ * `_claude-stop-hook`'s queue/release poll and strands the workflow.
+ *
+ * ~24 days — the max safe `setTimeout` value (2^31 - 1 ms) expressed in
+ * seconds — removes the timeout in practical terms. `waitForIdle`'s
+ * marker-file watch still fires as soon as our initial hook writes the
+ * marker, so the workflow proceeds on real hook completion, not on timer
+ * expiry.
+ */
+const STOP_HOOK_TIMEOUT_SECONDS = 2_147_483;
+
+/**
  * Inline settings injected via `claude --settings <json>` on every workflow
  * spawn. Registers the workflow-owned hooks without relying on
  * `.claude/settings.json` — so the hooks fire only for workflow-spawned
@@ -117,7 +136,9 @@ function buildWorkflowHookCommand(subcommand: string, extraArgs: readonly string
  *
  * Registered hooks:
  *   - `Stop`: deliver queued follow-up prompts via `{decision:"block"}` and
- *     write an idle-marker file that `waitForIdle` watches.
+ *     write an idle-marker file that `waitForIdle` watches. `timeout` is
+ *     set to {@link STOP_HOOK_TIMEOUT_SECONDS} so the hook survives long
+ *     TaskCompleted/TeammateIdle phases — see the constant's docstring.
  *   - `PreToolUse` matched on `AskUserQuestion`: write
  *     `~/.atomic/claude-hil/<session_id>` so `watchHILMarker` can fire
  *     `onHIL(true)` — the node card flips to the blue "awaiting_input" pulse.
@@ -140,6 +161,7 @@ const WORKFLOW_HOOK_SETTINGS = JSON.stringify({
           {
             type: "command",
             command: buildWorkflowHookCommand("_claude-stop-hook"),
+            timeout: STOP_HOOK_TIMEOUT_SECONDS,
           },
         ],
       },
@@ -1074,7 +1096,7 @@ export class HeadlessClaudeSessionWrapper {
 
     let sdkSessionId = "";
     try {
-      for await (const msg of sdkQuery({ prompt, options: options ?? {} })) {
+      for await (const msg of sdkQuery({ prompt, options: headlessSdkOpts })) {
         if (msg.type === "result") {
           sdkSessionId = String(
             (msg as Record<string, unknown>).session_id ?? "",


### PR DESCRIPTION
## Summary

Fixes two related issues in the Claude SDK provider: the Stop hook being killed during long `TaskCompleted`/`TeammateIdle` phases, and headless SDK queries incorrectly ignoring the auto-deny options for `AskUserQuestion`.

## Key Changes

- **Stop hook timeout** (`WORKFLOW_HOOK_SETTINGS`): Introduces `STOP_HOOK_TIMEOUT_SECONDS = 2_147_483` (~24 days, the max-safe `setTimeout` value in seconds) and passes it as `timeout` on the Stop hook entry. Claude Code's Stop hook process runs three phases sequentially — Stop hooks, then `TaskCompleted` hooks per in-progress task, then `TeammateIdle` hooks — and the per-hook `timeout` applies to the whole lifecycle. The prior default (10 min) could kill the hook mid-run, severing the `_claude-stop-hook` queue/release poll and stranding the workflow. `waitForIdle` still resolves on the marker-file write, not on timer expiry, so real hook completion is unaffected.

- **Headless SDK query options** (`HeadlessClaudeSessionWrapper.query`): The `sdkQuery` call was passing `options ?? {}` instead of the constructed `headlessSdkOpts`, so the `AskUserQuestion` auto-deny (`disallowedTools` merge) was silently dropped on every headless run. Now passes `headlessSdkOpts` so the tool is correctly blocked and headless queries cannot stall waiting for a human response.