### PR TITLE
chore(release): bump version to v0.5.27-0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,10 @@
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
-  "disabledMcpjsonServers": ["github", "azure-devops"],
+  "disabledMcpjsonServers": [
+    "github",
+    "azure-devops"
+  ],
   "enabledPlugins": {
     "pyright-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,11 @@
     "azure-devops": {
       "type": "stdio",
       "command": "bunx",
-      "args": ["-y", "@azure-devops/mcp", "<your-org>"]
+      "args": [
+        "-y",
+        "@azure-devops/mcp",
+        "<your-org>"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.26",
+  "version": "0.5.27-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.5.26` to `v0.5.27-0` (prerelease) and applies minor JSON formatting normalization to config files.

## Changes

- **`package.json`**: Version bumped from `0.5.26` → `0.5.27-0`
- **`.claude/settings.json`**: Reformatted `disabledMcpjsonServers` array from inline to multi-line style
- **`.mcp.json`**: Reformatted `azure-devops` args array from inline to multi-line style

## Test plan

- [ ] CI passes
- [ ] On merge, GitHub Release workflow creates the prerelease and publishes to npm