### PR TITLE
chore(release): bump version to v0.5.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.27-0",
+  "version": "0.5.27",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the `0.5.27-0` prerelease to the stable `0.5.27` release by bumping the version in `package.json`.

## Changes

- `package.json`: `0.5.27-0` → `0.5.27`

## Test plan

- [ ] CI passes on the release branch
- [ ] Merging triggers the release workflow and publishes `v0.5.27` to npm