### PR TITLE
fix(claude): remove waitForIdle safety timeout so Stop hook can complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.27",
+  "version": "0.5.28-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/src/commands/cli/claude-stop-hook.ts
+++ b/src/commands/cli/claude-stop-hook.ts
@@ -121,9 +121,9 @@ export async function claudeStopHookCommand(
   // `src/query.ts` → `transition: { reason: 'stop_hook_blocking' }`). In a
   // multi-turn workflow, every follow-up turn after the first is therefore
   // invoked with `stop_hook_active=true`. Returning early here would skip the
-  // marker write, leaving `waitForIdle` hanging until its 15-minute safety
-  // timeout, and would skip the queue poll so the workflow's next
-  // `s.session.query(...)` would never reach Claude.
+  // marker write, leaving `waitForIdle` hanging forever, and would skip the
+  // queue poll so the workflow's next `s.session.query(...)` would never
+  // reach Claude.
   //
   // Our design doesn't need the generic loop guard: the hook only emits a
   // `block` decision when the workflow runtime has written a prompt to the

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -641,11 +641,6 @@ export async function releaseClaudeSession(claudeSessionId: string): Promise<voi
  * @param claudeSessionId       - Claude's session UUID (used to identify marker file)
  * @param transcriptBeforeCount - number of messages in transcript before this turn
  */
-/** Safety timeout so the workflow's next stage still fires if the Stop hook
- * never runs (misconfigured settings, killed Claude process, etc.). 15 min
- * covers any reasonable single-turn run without hanging forever. */
-const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
-
 /**
  * @internal Exported for unit tests.
  */
@@ -658,7 +653,6 @@ export async function waitForIdle(
   const sessionId = claudeSessionId;
   const target = markerPath(sessionId);
   const ac = new AbortController();
-  const timeout = setTimeout(() => ac.abort(), IDLE_TIMEOUT_MS);
 
   // Process a marker that has appeared on disk. Returns a tuple:
   //   [resolved, result] — when resolved=true, waitForIdle should return.
@@ -743,13 +737,10 @@ export async function waitForIdle(
       }
     }
   } catch (e: unknown) {
-    // AbortError is expected when we call ac.abort() to stop watching, or
-    // when the safety timeout fires.
+    // AbortError is expected when we call ac.abort() to stop watching.
     if (!(e instanceof Error && e.name === "AbortError")) {
       throw e;
     }
-  } finally {
-    clearTimeout(timeout);
   }
 
   return [];


### PR DESCRIPTION
## Summary

Removes the 15-minute `IDLE_TIMEOUT_MS` safety timeout from `waitForIdle()` that was prematurely aborting the marker watcher before Claude Code finished its Stop hook phases. This is the prerelease for v0.5.28-0.

## Key Changes

- **`src/sdk/providers/claude.ts`**: Removed `IDLE_TIMEOUT_MS` constant (15-minute timeout) and the `setTimeout`/`clearTimeout` calls in `waitForIdle()`. The function now waits indefinitely until the Stop hook fires or the user aborts.
- **`src/commands/cli/claude-stop-hook.ts`**: Updated inline comment to reflect that `waitForIdle` now hangs forever (not for 15 min) if the marker is never written.
- **`package.json`**: Bumped version to `v0.5.28-0`.

## Root Cause

The Stop hook lifecycle progresses through phases: `Initial → TaskCompleted → TeammateIdle`. When the `TaskList` tool is active, the `TaskCompleted` phase can run longer than 15 minutes before atomic's phase-1 hook writes the marker file. The old safety timeout fired during this window, leaving the workflow stuck with the next `s.session.query(...)` never reaching Claude.

## Migration Notes

None. The safety timeout is replaced by relying on the Stop hook firing normally or an explicit user abort. There is no longer a maximum wait time in `waitForIdle`.