### PR TITLE
fix(claude): pin headless SDK queries to the PATH `claude` CLI

### DIFF
--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -1090,6 +1090,40 @@ export class HeadlessClaudeClientWrapper {
 }
 
 /**
+ * Resolve the `claude` CLI binary for headless SDK queries.
+ *
+ * Pins the SDK to the same binary interactive stages already spawn via tmux
+ * (`AGENT_CONFIG.claude.cmd` on PATH), bypassing
+ * `@anthropic-ai/claude-agent-sdk`'s built-in resolver. That resolver probes
+ * optional native packages in a fixed order — on Linux it tries
+ * `linux-${arch}-musl` before `linux-${arch}` and returns whichever
+ * `require.resolve` finds first — so on a glibc host where both optional
+ * packages got installed (Bun installs every optionalDependency by default)
+ * it picks the musl binary, which can't exec because its dynamic linker
+ * (`/lib/ld-musl-*.so.1`) is absent. The SDK surfaces the resulting ENOENT
+ * as a misleading "Claude Code native binary not found" error.
+ *
+ * `chatCommand` and `workflowCommand` already fail fast when `claude` isn't
+ * on PATH (see `isCommandInstalled` in each), so in practice this lookup
+ * always succeeds. The throw here is a belt-and-suspenders guard that
+ * prefers a clear failure over silently falling back to the SDK's resolver.
+ */
+export function resolveHeadlessClaudeBin(): string {
+  // Pass PATH explicitly — the 1-arg form of Bun.which caches the value
+  // captured at process start, which makes the lookup insensitive to later
+  // env mutations (and un-exercisable from tests that tweak `process.env.PATH`).
+  const onPath = Bun.which("claude", { PATH: process.env.PATH ?? "" });
+  if (!onPath) {
+    throw new Error(
+      "`claude` CLI not found on PATH. Install Claude Code via the native " +
+        "installer (https://docs.claude.com/en/docs/claude-code/overview) " +
+        "and retry.",
+    );
+  }
+  return onPath;
+}
+
+/**
  * Headless session wrapper for Claude stages. Uses the Agent SDK's `query()`
  * directly instead of tmux pane operations. Implements the same `query()`
  * interface as {@link ClaudeSessionWrapper} so workflow callbacks work
@@ -1124,6 +1158,8 @@ export class HeadlessClaudeSessionWrapper {
     const sdkOpts = options ?? {};
     const headlessSdkOpts: Partial<SDKOptions> = {
       ...sdkOpts,
+      pathToClaudeCodeExecutable:
+        sdkOpts.pathToClaudeCodeExecutable ?? resolveHeadlessClaudeBin(),
       disallowedTools: mergeDisallowedTools(sdkOpts.disallowedTools, [
         "AskUserQuestion",
       ]),

--- a/src/sdk/providers/headless-hil-policy.test.ts
+++ b/src/sdk/providers/headless-hil-policy.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { test, expect, describe } from "bun:test";
-import { mergeDisallowedTools } from "./claude.ts";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mergeDisallowedTools, resolveHeadlessClaudeBin } from "./claude.ts";
 import {
   HEADLESS_OPENCODE_CLIENT_ID,
   withHeadlessOpencodeEnv,
@@ -60,6 +63,43 @@ describe("mergeExcludedTools (Copilot)", () => {
       "ask_user",
       "bash",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claude — headless binary resolution pins to the PATH `claude` CLI
+// ---------------------------------------------------------------------------
+
+describe("resolveHeadlessClaudeBin", () => {
+  const withPath = (path: string, fn: () => void) => {
+    const before = process.env.PATH;
+    process.env.PATH = path;
+    try {
+      fn();
+    } finally {
+      if (before === undefined) delete process.env.PATH;
+      else process.env.PATH = before;
+    }
+  };
+
+  test("returns the `claude` binary when present on PATH", () => {
+    const dir = mkdtempSync(join(tmpdir(), "atomic-claude-bin-"));
+    const bin = join(dir, "claude");
+    writeFileSync(bin, "#!/usr/bin/env sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+    withPath(dir, () => {
+      expect(resolveHeadlessClaudeBin()).toBe(bin);
+    });
+  });
+
+  test("throws with installer URL when PATH has no `claude`", () => {
+    const empty = mkdtempSync(join(tmpdir(), "atomic-empty-path-"));
+    withPath(empty, () => {
+      expect(() => resolveHeadlessClaudeBin()).toThrow(/CLI not found on PATH/);
+      expect(() => resolveHeadlessClaudeBin()).toThrow(
+        /docs\.claude\.com.*claude-code/,
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a Linux-specific crash where headless Claude stages (`headless: true`) consistently fail with a misleading "Claude Code native binary not found" error while interactive stages succeed. The root cause is the SDK's built-in native binary resolver picking a musl binary on glibc hosts.

## Root Cause

`@anthropic-ai/claude-agent-sdk`'s resolver probes `linux-${arch}-musl` before `linux-${arch}`. Bun installs every `optionalDependencies` entry by default, so on a glibc host **both** native packages land on disk. The resolver picks the musl binary, whose dynamic linker (`/lib/ld-musl-*.so.1`) is absent on glibc distros — spawn returns `ENOENT`, and the SDK surfaces it as a misleading "Claude Code native binary not found" error.

Observed across four consecutive `ralph/claude` runs: every `infra-*` stage (`headless: true`) failed while interactive `planner`/`orchestrator` stages succeeded via the on-PATH CLI.

## Key Changes

- **`src/sdk/providers/claude.ts`** — adds `resolveHeadlessClaudeBin()`, which resolves the `claude` binary via `Bun.which("claude", { PATH: process.env.PATH })` and throws a clear error with an installer link if not found; sets `pathToClaudeCodeExecutable` in `HeadlessClaudeSessionWrapper.query` to bypass the SDK's native resolver
- **`src/sdk/providers/headless-hil-policy.test.ts`** — adds unit tests for `resolveHeadlessClaudeBin()` covering the success path (binary on PATH) and failure path (throws with installer URL)

## Why This Fix Works

Pinning to `Bun.which("claude")` uses the same binary that tmux-driven interactive stages already spawn — one source of truth, unaffected by which optional native packages the package manager materialized. Passing `PATH` explicitly to `Bun.which` avoids the 1-arg form's process-start snapshot, keeping the resolver testable in environments that mutate `process.env.PATH`.