### PR TITLE
feat(config): add excludeConfigKeys to scope project-local keys during sync

### DIFF
--- a/.atomic/settings.json
+++ b/.atomic/settings.json
@@ -1,4 +1,5 @@
 {
+  "scm": "github",
   "version": 1,
   "lastUpdated": "2026-04-03T21:30:24.690Z",
   "$schema": "https://raw.githubusercontent.com/flora131/atomic/main/assets/settings.schema.json"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,6 @@
     "defaultMode": "bypassPermissions"
   },
   "disabledMcpjsonServers": [
-    "github",
     "azure-devops"
   ],
   "enabledPlugins": {

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -8,11 +8,16 @@
       "headers": {
         "Authorization": "Bearer ${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
       },
-      "enabled": false
+      "enabled": true
     },
     "azure-devops": {
       "type": "local",
-      "command": ["bunx", "-y", "@azure-devops/mcp", "<your-org>"],
+      "command": [
+        "bunx",
+        "-y",
+        "@azure-devops/mcp",
+        "<your-org>"
+      ],
       "enabled": false
     }
   }

--- a/bun.lock
+++ b/bun.lock
@@ -34,23 +34,23 @@
     "lefthook",
   ],
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.116", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.116", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.116", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.116", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.116", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.116", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.116", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.116", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.116" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-5NKpgaOZkzNCGCvLxJZUVGimf5IcYmpQ2x2XrR9ilK+2UkWrnnwcUfIWo8bBz9e7lSYcUf9XleGigq2eOOF7aw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.117", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.117", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.117", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.117", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.117" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pVBss1Vu0w87nKCBhWtjMggSgCh6GVUtdRmuE58ZvXv0E2q0JcnUCQHehmn92BAW0+VCwPY8q/k7uKWkgwz/gA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.116", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mG19ovtXCpETmd5KmTU1JO2iIHZBG09IP8DmgZjLA3wLmTzpgn9Au9veRaeJeXb1EqiHiFZU+z+mNB79+w5v9g=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.117", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZeC/Lz8XMKQ5w+GmjTziPR8bSSarBtNCJMkMAYRT9ekNmyXSWXEwGLENe5TDDmtpzNNzAB1mQNuIYoqTsqgV3w=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.116", "", { "os": "darwin", "cpu": "x64" }, "sha512-qC25N0HRM8IXbM4Qi4svH9f51Y6DciDvjLV+oNYnxkdPgDG8p/+b7vQirN7qPxytIQb2TPdoFgUeCsSe7lrQyw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.117", "", { "os": "darwin", "cpu": "x64" }, "sha512-DKyggGzzpDcr9S435xlpbpwkEYKZNbePSekug75tJclK8l4ddD9+M9BFgMiSUq9F1Zt53kUaRDihDu/cBKvkdQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.116", "", { "os": "linux", "cpu": "arm64" }, "sha512-MQIcJhhPM+RPJ7kMQdOQarkJ2FlJqOiu953c08YyJOoWdHykd3DIiHws3mf1Mwl/dfFeIyshOVpNND3hyIy5Dg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.117", "", { "os": "linux", "cpu": "arm64" }, "sha512-jyHmyZQavpPOe3zxBRX3KbdOAJ8JwZ8m/wMr5bhHhhcstugm/vJx6IIs7D44VvFjk+8sqdvR2ZrliL8PUcJL0g=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.116", "", { "os": "linux", "cpu": "arm64" }, "sha512-Dg/T3NkSp35ODiwdhj0KquvC6Xu+DMbyWFNkfepA3bz4oF2SVSgyOPYwVmfoJerzEUnYDldP4YhOxRrhbt0vXA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.117", "", { "os": "linux", "cpu": "arm64" }, "sha512-bJU5gEOmM4VCOn4h8vipOKgdhPATePQ23mMpvyVqtVyipWppHfOUfVkqXb+SrF/hfkNSMYxDuoKxbJ+MmKtGjg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.116", "", { "os": "linux", "cpu": "x64" }, "sha512-Bww1fzQB+vcF0tRhmCAlwSsN4wR2HgX7pBT9AWuwzJj6DKsVC23N54Ea80lsnM7dTUtUTrGYMTwVUHTWqfYnfQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.117", "", { "os": "linux", "cpu": "x64" }, "sha512-Zb5PXKrDNbQ1dyNYwxZMNL+F2Dhgjh9f9B21wZUJqkhJL69hRJwJyxO42HiNmB2zGCaTxQTyjPhLdB/eQJo74Q=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.116", "", { "os": "linux", "cpu": "x64" }, "sha512-LMYxUMa1nK4N9BPRJdcGBAvl9rjTI4ZHo+kfAKrJ3MlfB6VFF1tRIubwsWOaOtkuNazMdAYovsZJg4bdzOBBTQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.117", "", { "os": "linux", "cpu": "x64" }, "sha512-LIkKTAYZGugEVssAuWCPqlDWSqhVZAveNPNsfKLbuG1naIMCR04fUqil6i3d3mAAfk7FaS5D4IdHp45psi+GDw=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.116", "", { "os": "win32", "cpu": "arm64" }, "sha512-h0YO1vkTIeUtffQhONrYbNC1pXmk1yjb1xxMEw7bAwucqtFoFpLDWe+q4+RhxaQr8ZOj6LtRE/U3dzPWHOlshA=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.117", "", { "os": "win32", "cpu": "arm64" }, "sha512-uetggH3B83PiH0a9D/5MVXB5Hqnlr2DVajehwAP2x0Mt4DBd632ICnHpu6pnSP+vVkWgq3FgQlkHe91RfP+peA=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.116", "", { "os": "win32", "cpu": "x64" }, "sha512-3lllmtDFHgpW0ZM3iNvxsEjblrgRzF9Qm1lxTOtunP3hIn+pA/IkWMtKlN1ixxWiaBguLVQkJ90V6JHsvJJIvw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.117", "", { "os": "win32", "cpu": "x64" }, "sha512-TT4KngAokDTJSvQ2mrAP6ZRkXj50OLj7Tb1zZA4CnkmrrEidgs4KrMx7er1ZwoivngIvCekV9+TbtC9giknr5w=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
@@ -140,7 +140,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.19", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-9sTGsi8/HlBBeaWfsUjdJ2yi/SqpRvqSld0IFXc3ldaPb1w1uIPvgCGzhlHYQtqatXxSaX5lTN7zpudMaE21aw=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.20", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-kPZP1An1ZdWOfLfDYhNjh665HX4RcI8au6Lzjn0FktoQ3RpWHq1WXRLHrJO8rJqwWvQDOzS48cXt9jbr+uwQiA=="],
 
     "@opentui/core": ["@opentui/core@0.1.102", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.102", "@opentui/core-darwin-x64": "0.1.102", "@opentui/core-linux-arm64": "0.1.102", "@opentui/core-linux-x64": "0.1.102", "@opentui/core-win32-arm64": "0.1.102", "@opentui/core-win32-x64": "0.1.102", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-gNbU4XnSifo429nZ6T4jcxSmp5pFDrh0AsGJ73Vmlpc4YVWnLJ25RGsZXRsJhvxUK9OtAWJj2wq/kmiFcPLBCw=="],
 

--- a/package.json
+++ b/package.json
@@ -75,11 +75,11 @@
     "typescript-language-server": "^5.1.3"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.116",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.117",
     "@clack/prompts": "^1.2.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.2.2",
-    "@opencode-ai/sdk": "^1.14.19",
+    "@opencode-ai/sdk": "^1.14.20",
     "@opentui/core": "^0.1.102",
     "@opentui/react": "^0.1.102",
     "commander": "^14.0.3",

--- a/src/commands/cli/init/onboarding.ts
+++ b/src/commands/cli/init/onboarding.ts
@@ -34,7 +34,12 @@ export async function applyManagedOnboardingFiles(
       managedFile.destination,
       projectRoot,
     );
-    await syncJsonFile(sourcePath, destinationPath, managedFile.merge);
+    await syncJsonFile(
+      sourcePath,
+      destinationPath,
+      managedFile.merge,
+      managedFile.excludeConfigKeys ?? [],
+    );
   }
 }
 

--- a/src/lib/merge.ts
+++ b/src/lib/merge.ts
@@ -10,27 +10,40 @@ type McpConfig = Record<string, unknown>;
 /** Keys that hold named-object maps (server registries). */
 const SERVER_MAP_KEYS = ["mcpServers", "servers", "lspServers"] as const;
 
+function stripKeys(config: McpConfig, keys: readonly string[]): McpConfig {
+  if (keys.length === 0) return config;
+  const next: McpConfig = { ...config };
+  for (const key of keys) delete next[key];
+  return next;
+}
+
 /**
  * Merge source JSON file into destination JSON file
  * - Preserves all existing keys in destination
  * - Adds/updates keys from source
  * - For MCP server maps: preserves user's servers, adds/updates CLI-managed servers
+ * - `excludeKeys` are stripped from the source before merging so they
+ *   never propagate to the destination (destination keeps its own value).
  *
  * @param srcPath Path to source JSON file
  * @param destPath Path to destination JSON file (will be modified in place)
+ * @param excludeKeys Top-level source keys to drop before merging
  */
 export async function mergeJsonFile(
   srcPath: string,
-  destPath: string
+  destPath: string,
+  excludeKeys: readonly string[] = [],
 ): Promise<void> {
   if (resolve(srcPath) === resolve(destPath)) {
     return;
   }
 
-  const [srcConfig, destConfig] = await Promise.all([
+  const [rawSrcConfig, destConfig] = await Promise.all([
     Bun.file(srcPath).json() as Promise<McpConfig>,
     Bun.file(destPath).json() as Promise<McpConfig>,
   ]);
+
+  const srcConfig = stripKeys(rawSrcConfig, excludeKeys);
 
   // Merge top-level config - preserve destination's other keys
   const mergedConfig: McpConfig = {
@@ -59,6 +72,9 @@ export async function mergeJsonFile(
  *   merges via {@link mergeJsonFile} (source keys win, server maps
  *   are merged individually)
  * - Otherwise copies the source as-is
+ * - `excludeKeys` drops top-level keys from the source before writing,
+ *   so they never land in the destination (applies to both the merge
+ *   and no-destination-yet code paths).
  *
  * This is the single entry-point for the merge-or-copy pattern used
  * by both project-level onboarding and global config sync.
@@ -67,12 +83,21 @@ export async function syncJsonFile(
   srcPath: string,
   destPath: string,
   merge: boolean = true,
+  excludeKeys: readonly string[] = [],
 ): Promise<void> {
   await ensureDir(dirname(destPath));
 
   if (merge && (await pathExists(destPath))) {
-    await mergeJsonFile(srcPath, destPath);
-  } else {
-    await copyFile(srcPath, destPath);
+    await mergeJsonFile(srcPath, destPath, excludeKeys);
+    return;
   }
+
+  if (excludeKeys.length === 0) {
+    await copyFile(srcPath, destPath);
+    return;
+  }
+
+  const srcConfig = (await Bun.file(srcPath).json()) as McpConfig;
+  const stripped = stripKeys(srcConfig, excludeKeys);
+  await Bun.write(destPath, JSON.stringify(stripped, null, 2) + "\n");
 }

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -1090,6 +1090,40 @@ export class HeadlessClaudeClientWrapper {
 }
 
 /**
+ * Resolve the `claude` CLI binary for headless SDK queries.
+ *
+ * Pins the SDK to the same binary interactive stages already spawn via tmux
+ * (`AGENT_CONFIG.claude.cmd` on PATH), bypassing
+ * `@anthropic-ai/claude-agent-sdk`'s built-in resolver. That resolver probes
+ * optional native packages in a fixed order — on Linux it tries
+ * `linux-${arch}-musl` before `linux-${arch}` and returns whichever
+ * `require.resolve` finds first — so on a glibc host where both optional
+ * packages got installed (Bun installs every optionalDependency by default)
+ * it picks the musl binary, which can't exec because its dynamic linker
+ * (`/lib/ld-musl-*.so.1`) is absent. The SDK surfaces the resulting ENOENT
+ * as a misleading "Claude Code native binary not found" error.
+ *
+ * `chatCommand` and `workflowCommand` already fail fast when `claude` isn't
+ * on PATH (see `isCommandInstalled` in each), so in practice this lookup
+ * always succeeds. The throw here is a belt-and-suspenders guard that
+ * prefers a clear failure over silently falling back to the SDK's resolver.
+ */
+export function resolveHeadlessClaudeBin(): string {
+  // Pass PATH explicitly — the 1-arg form of Bun.which caches the value
+  // captured at process start, which makes the lookup insensitive to later
+  // env mutations (and un-exercisable from tests that tweak `process.env.PATH`).
+  const onPath = Bun.which("claude", { PATH: process.env.PATH ?? "" });
+  if (!onPath) {
+    throw new Error(
+      "`claude` CLI not found on PATH. Install Claude Code via the native " +
+        "installer (https://docs.claude.com/en/docs/claude-code/overview) " +
+        "and retry.",
+    );
+  }
+  return onPath;
+}
+
+/**
  * Headless session wrapper for Claude stages. Uses the Agent SDK's `query()`
  * directly instead of tmux pane operations. Implements the same `query()`
  * interface as {@link ClaudeSessionWrapper} so workflow callbacks work
@@ -1124,6 +1158,8 @@ export class HeadlessClaudeSessionWrapper {
     const sdkOpts = options ?? {};
     const headlessSdkOpts: Partial<SDKOptions> = {
       ...sdkOpts,
+      pathToClaudeCodeExecutable:
+        sdkOpts.pathToClaudeCodeExecutable ?? resolveHeadlessClaudeBin(),
       disallowedTools: mergeDisallowedTools(sdkOpts.disallowedTools, [
         "AskUserQuestion",
       ]),

--- a/src/sdk/providers/headless-hil-policy.test.ts
+++ b/src/sdk/providers/headless-hil-policy.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { test, expect, describe } from "bun:test";
-import { mergeDisallowedTools } from "./claude.ts";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mergeDisallowedTools, resolveHeadlessClaudeBin } from "./claude.ts";
 import {
   HEADLESS_OPENCODE_CLIENT_ID,
   withHeadlessOpencodeEnv,
@@ -60,6 +63,43 @@ describe("mergeExcludedTools (Copilot)", () => {
       "ask_user",
       "bash",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Claude — headless binary resolution pins to the PATH `claude` CLI
+// ---------------------------------------------------------------------------
+
+describe("resolveHeadlessClaudeBin", () => {
+  const withPath = (path: string, fn: () => void) => {
+    const before = process.env.PATH;
+    process.env.PATH = path;
+    try {
+      fn();
+    } finally {
+      if (before === undefined) delete process.env.PATH;
+      else process.env.PATH = before;
+    }
+  };
+
+  test("returns the `claude` binary when present on PATH", () => {
+    const dir = mkdtempSync(join(tmpdir(), "atomic-claude-bin-"));
+    const bin = join(dir, "claude");
+    writeFileSync(bin, "#!/usr/bin/env sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+    withPath(dir, () => {
+      expect(resolveHeadlessClaudeBin()).toBe(bin);
+    });
+  });
+
+  test("throws with installer URL when PATH has no `claude`", () => {
+    const empty = mkdtempSync(join(tmpdir(), "atomic-empty-path-"));
+    withPath(empty, () => {
+      expect(() => resolveHeadlessClaudeBin()).toThrow(/CLI not found on PATH/);
+      expect(() => resolveHeadlessClaudeBin()).toThrow(
+        /docs\.claude\.com.*claude-code/,
+      );
+    });
   });
 });
 

--- a/src/services/config/definitions.ts
+++ b/src/services/config/definitions.ts
@@ -22,6 +22,13 @@ export interface AgentConfig {
     source: string;
     destination: string;
     merge: boolean;
+    /**
+     * Top-level keys to strip from the source before copying or merging.
+     * Useful when a key is project-local by design (e.g. Claude's
+     * `disabledMcpjsonServers`) and must not leak into a global
+     * destination like `~/.claude/settings.json`.
+     */
+    excludeConfigKeys?: readonly string[];
   }>;
 }
 
@@ -55,6 +62,9 @@ export const AGENT_CONFIG: Record<AgentKey, AgentConfig> = {
         source: ".claude/settings.json",
         destination: "~/.claude/settings.json",
         merge: true,
+        // `disabledMcpjsonServers` is reconciled per-project by scm-sync
+        // and must not leak into the user's global Claude settings.
+        excludeConfigKeys: ["disabledMcpjsonServers"],
       },
     ],
   },

--- a/tests/lib/merge.test.ts
+++ b/tests/lib/merge.test.ts
@@ -1,0 +1,82 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mergeJsonFile, syncJsonFile } from "../../src/lib/merge.ts";
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "atomic-merge-"));
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+async function writeJson(path: string, data: unknown): Promise<void> {
+  await Bun.write(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+async function readJson<T = unknown>(path: string): Promise<T> {
+  return (await Bun.file(path).json()) as T;
+}
+
+describe("mergeJsonFile excludeKeys", () => {
+  test("strips excluded keys from source before merging", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, {
+      env: { A: "1" },
+      disabledMcpjsonServers: ["azure-devops"],
+    });
+    await writeJson(dest, { existing: true });
+
+    await mergeJsonFile(src, dest, ["disabledMcpjsonServers"]);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.existing).toBe(true);
+    expect(result.env).toEqual({ A: "1" });
+    expect("disabledMcpjsonServers" in result).toBe(false);
+  });
+
+  test("preserves destination's value for excluded keys", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, { disabledMcpjsonServers: ["azure-devops"] });
+    await writeJson(dest, { disabledMcpjsonServers: ["user-choice"] });
+
+    await mergeJsonFile(src, dest, ["disabledMcpjsonServers"]);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.disabledMcpjsonServers).toEqual(["user-choice"]);
+  });
+});
+
+describe("syncJsonFile excludeKeys", () => {
+  test("strips excluded keys when destination does not exist", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "nested", "dest.json");
+    await writeJson(src, {
+      env: { A: "1" },
+      disabledMcpjsonServers: ["azure-devops"],
+    });
+
+    await syncJsonFile(src, dest, true, ["disabledMcpjsonServers"]);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.env).toEqual({ A: "1" });
+    expect("disabledMcpjsonServers" in result).toBe(false);
+  });
+
+  test("copies source as-is when excludeKeys is empty", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, { disabledMcpjsonServers: ["azure-devops"] });
+
+    await syncJsonFile(src, dest, true, []);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.disabledMcpjsonServers).toEqual(["azure-devops"]);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces an `excludeConfigKeys` option for managed config file entries, preventing specified top-level keys from propagating from project-local configs to global destinations during sync. Applied immediately to Claude's settings sync to prevent `disabledMcpjsonServers` — which is managed project-locally by `scm-sync` — from leaking into `~/.claude/settings.json`.

## Key Changes

### Core feature
- **`src/services/config/definitions.ts`**: Added `excludeConfigKeys?: readonly string[]` to the `AgentConfig.managedFiles` entry type
- **`src/lib/merge.ts`**: Added `stripKeys` helper and `excludeKeys` parameter to both `mergeJsonFile` and `syncJsonFile`; excluded keys are stripped from the source before merge or copy (both paths — destination-exists and destination-new — are handled)
- **`src/commands/cli/init/onboarding.ts`**: Passes `excludeConfigKeys` through to `syncJsonFile` during managed onboarding file application

### Configuration
- **`src/services/config/definitions.ts`**: Excludes `disabledMcpjsonServers` from Claude's `settings.json` sync so per-project server toggles never overwrite the user's global Claude settings
- **`.atomic/settings.json`**: Defaults `scm` to `"github"`
- **`.claude/settings.json`**: Re-enables the `github` MCP server (removes it from `disabledMcpjsonServers`)
- **`.opencode/opencode.json`**: Enables the GitHub MCP server by default

### Dependencies
- Bumps `@anthropic-ai/claude-agent-sdk` → `0.2.117`
- Bumps `@opencode-ai/sdk` → `1.14.20`

### Tests
- **`tests/lib/merge.test.ts`** *(new)*: Tests `mergeJsonFile` and `syncJsonFile` with `excludeKeys` — verifies that excluded keys are stripped from source, that the destination's own value is preserved, and that an empty `excludeKeys` list is a no-op passthrough