### PR TITLE
feat(auth): fail fast in chat/workflow when CLI isn't logged in

### DIFF
--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -22,6 +22,7 @@ import { getCopilotScmDisableFlags } from "../../../services/config/scm-sync.ts"
 import { ensureProjectSetup } from "../init/index.ts";
 import { COLORS } from "../../../theme/colors.ts";
 import { isCommandInstalled } from "../../../services/system/detect.ts";
+import { checkAgentAuth, printAuthError } from "../../../services/system/auth.ts";
 import {
   ensureAtomicGlobalAgentConfigs,
 } from "../../../services/config/atomic-global-config.ts";
@@ -182,6 +183,16 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
       `${COLORS.red}Error: '${config.cmd}' is not installed or not in PATH.${COLORS.reset}`
     );
     console.error(`Install it from: ${config.install_url}`);
+    return 1;
+  }
+
+  // ── Preflight: authentication ──
+  // Copilot and Claude expose SDK-level login checks; run them now so
+  // users get a short actionable error instead of being dropped into a
+  // native CLI that immediately redirects them to /login.
+  const auth = await checkAgentAuth(agentType);
+  if (!auth.loggedIn) {
+    printAuthError(agentType, auth);
     return 1;
   }
 

--- a/src/commands/cli/workflow-command.test.ts
+++ b/src/commands/cli/workflow-command.test.ts
@@ -34,6 +34,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import * as realWorkflows from "../../sdk/workflows/index.ts";
 import * as realDetect from "../../services/system/detect.ts";
+import * as realAuth from "../../services/system/auth.ts";
 import * as realSpawn from "../../lib/spawn.ts";
 import { AGENT_CONFIG } from "../../services/config/index.ts";
 import type {
@@ -99,6 +100,14 @@ const ensureBunInstalledMock = mock<typeof realSpawn.ensureBunInstalled>(
   async () => {},
 );
 
+// Default: pretend auth succeeded. Real probes spawn the agent CLI via
+// its SDK to talk to an auth RPC — that's network/process-heavy and
+// non-deterministic on CI runners, so the auth branch is faked here and
+// exercised directly by `auth.test.ts`.
+const checkAgentAuthMock = mock<typeof realAuth.checkAgentAuth>(async () => ({
+  loggedIn: true,
+}));
+
 mock.module("../../sdk/workflows/index.ts", () => ({
   ...realWorkflows,
   executeWorkflow: executeWorkflowMock,
@@ -109,6 +118,10 @@ mock.module("../../sdk/workflows/index.ts", () => ({
 mock.module("../../services/system/detect.ts", () => ({
   ...realDetect,
   isCommandInstalled: isCommandInstalledMock,
+}));
+mock.module("../../services/system/auth.ts", () => ({
+  ...realAuth,
+  checkAgentAuth: checkAgentAuthMock,
 }));
 mock.module("../../lib/spawn.ts", () => ({
   ...realSpawn,
@@ -226,6 +239,8 @@ beforeEach(async () => {
   ensureTmuxInstalledMock.mockImplementation(async () => {});
   ensureBunInstalledMock.mockClear();
   ensureBunInstalledMock.mockImplementation(async () => {});
+  checkAgentAuthMock.mockClear();
+  checkAgentAuthMock.mockImplementation(async () => ({ loggedIn: true }));
 });
 
 afterEach(async () => {
@@ -906,6 +921,31 @@ describe("workflowCommand prereq checks", () => {
     expect(ensureTmuxInstalledMock).toHaveBeenCalledTimes(1);
     // Platform-specific message — both tmux and psmux acceptable.
     expect(cap.stderr).toMatch(/(tmux|psmux) is not installed/);
+  });
+
+  test("returns 1 with a login hint when the user isn't authenticated", async () => {
+    // Auth probe runs after `isCommandInstalled` and before tmux/bun
+    // installer checks — the workflow must bail before spawning a tmux
+    // session users would then have to kill manually.
+    checkAgentAuthMock.mockImplementationOnce(async () => ({
+      loggedIn: false,
+      detail: "oauth token missing",
+    }));
+
+    const cap = captureOutput();
+    const code = await workflowCommand({
+      name: "anything",
+      agent: "copilot",
+      cwd: tempDir,
+    });
+    cap.restore();
+
+    expect(code).toBe(1);
+    expect(cap.stderr).toContain("Not logged in to GitHub Copilot CLI");
+    expect(cap.stderr).toContain("oauth token missing");
+    expect(cap.stderr).toContain("copilot");
+    // Downstream installers never run — the auth gate short-circuits.
+    expect(ensureTmuxInstalledMock).not.toHaveBeenCalled();
   });
 
   test("best-effort tmux installer errors are swallowed", async () => {

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -13,6 +13,7 @@
 import { AGENT_CONFIG, type AgentKey } from "../../services/config/index.ts";
 import { COLORS, createPainter, type PaletteKey } from "../../theme/colors.ts";
 import { isCommandInstalled } from "../../services/system/detect.ts";
+import { checkAgentAuth, printAuthError } from "../../services/system/auth.ts";
 import { ensureTmuxInstalled, ensureBunInstalled } from "../../lib/spawn.ts";
 import { ensureProjectSetup } from "./init/index.ts";
 import { ensureAtomicGlobalAgentConfigs } from "../../services/config/atomic-global-config.ts";
@@ -296,6 +297,15 @@ async function runPrereqChecks(agent: AgentKey): Promise<number> {
       `${COLORS.red}Error: '${AGENT_CONFIG[agent].cmd}' is not installed.${COLORS.reset}`,
     );
     console.error(`Install it from: ${AGENT_CONFIG[agent].install_url}`);
+    return 1;
+  }
+
+  // Fail fast when the SDK reports the user isn't authenticated —
+  // otherwise the workflow spawns the agent CLI in a detached tmux pane
+  // and silently stalls on a login screen the user never sees.
+  const auth = await checkAgentAuth(agent);
+  if (!auth.loggedIn) {
+    printAuthError(agent, auth);
     return 1;
   }
 

--- a/src/sdk/providers/copilot.ts
+++ b/src/sdk/providers/copilot.ts
@@ -8,6 +8,26 @@
 import { createProviderValidator } from "../types.ts";
 
 /**
+ * Env inherited by the Copilot CLI subprocess the SDK spawns.
+ *
+ * `NODE_NO_WARNINGS=1` silences the
+ * `ExperimentalWarning: SQLite is an experimental feature` banner that
+ * Node prints via the CLI's bundled `require("node:sqlite")`. The SDK
+ * pipes the subprocess's stderr through `process.stderr` with a
+ * `[CLI subprocess]` prefix, so without this override the warning
+ * leaks into every `atomic chat -a copilot` and `atomic workflow -a
+ * copilot` invocation.
+ *
+ * The SDK uses `options.env ?? process.env` as-is (no merge) when
+ * spawning, so we must fold the existing env in ourselves. Returns a
+ * fresh object per call so callers can layer additional env without
+ * mutating shared state.
+ */
+export function copilotSubprocessEnv(): Record<string, string | undefined> {
+  return { ...process.env, NODE_NO_WARNINGS: "1" };
+}
+
+/**
  * Validate a Copilot workflow source file for common mistakes.
  */
 export const validateCopilotWorkflow = createProviderValidator([

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -1207,12 +1207,21 @@ async function initProviderClientAndSession<A extends AgentType>(
   switch (agent) {
     case "copilot": {
       const { CopilotClient, approveAll } = await import("@github/copilot-sdk");
+      const { copilotSubprocessEnv } = await import("../providers/copilot.ts");
       const copilotClientOpts = clientOpts as StageClientOptions<"copilot">;
       const copilotSessionOpts = sessionOpts as StageSessionOptions<"copilot">;
       // Headless: let the SDK spawn its own CLI process (no cliUrl).
       // Non-headless: connect to the CLI server running in a tmux pane.
+      // `env` is only meaningful in the headless path — the SDK ignores
+      // it when `cliUrl` is set — but layering in `copilotSubprocessEnv`
+      // when the caller didn't supply their own env keeps the
+      // SQLite `ExperimentalWarning` from leaking through the SDK's
+      // `[CLI subprocess]` stderr forwarder.
       const client = headless
-        ? new CopilotClient({ ...copilotClientOpts })
+        ? new CopilotClient({
+            env: copilotSubprocessEnv(),
+            ...copilotClientOpts,
+          })
         : new CopilotClient({ ...copilotClientOpts, cliUrl: serverUrl });
       await client.start();
       // In headless stages, add `ask_user` to the session's excludedTools so

--- a/src/services/system/auth.test.ts
+++ b/src/services/system/auth.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the SDK-level auth probes in `auth.ts`.
+ *
+ * Both the Copilot SDK and Claude Agent SDK spawn native agent binaries
+ * under the hood, which makes the probes unsuitable for unit tests on a
+ * CI runner that has neither binary installed. We `mock.module()` each
+ * SDK so the probes read from in-test fakes, then assert the wrapper's
+ * translation into `AuthCheckResult` shape.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  mock,
+} from "bun:test";
+
+// ─── Copilot SDK fake ──────────────────────────────────────────────────────
+// `CopilotClient` is a class; the constructor captures latest test state.
+// We swap `start` / `stop` / `getAuthStatus` per-test via mockable fns.
+
+interface CopilotAuthStatus {
+  isAuthenticated: boolean;
+  login?: string;
+  statusMessage?: string;
+}
+
+let copilotStart = mock(async () => {});
+let copilotStop = mock(async () => [] as unknown[]);
+let copilotGetAuthStatus = mock<() => Promise<CopilotAuthStatus>>(async () => ({
+  isAuthenticated: true,
+  login: "octocat",
+}));
+
+class FakeCopilotClient {
+  async start(): Promise<void> {
+    await copilotStart();
+  }
+  async stop(): Promise<unknown[]> {
+    return copilotStop();
+  }
+  async getAuthStatus(): Promise<CopilotAuthStatus> {
+    return copilotGetAuthStatus();
+  }
+}
+
+mock.module("@github/copilot-sdk", () => ({
+  CopilotClient: FakeCopilotClient,
+}));
+
+// ─── Claude Agent SDK fake ────────────────────────────────────────────────
+// `query()` returns something with `initializationResult()` and `close()`.
+// We ignore the `prompt` stream — the real SDK consumes it lazily, and the
+// probe only calls `initializationResult()` before closing.
+
+interface ClaudeAccount {
+  email?: string;
+  tokenSource?: string;
+  apiKeySource?: string;
+}
+
+let claudeInit = mock<() => Promise<{ account: ClaudeAccount }>>(async () => ({
+  account: { email: "user@example.com", tokenSource: "oauth" },
+}));
+let claudeClose = mock(() => {});
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => ({
+    initializationResult: () => claudeInit(),
+    close: () => claudeClose(),
+  }),
+}));
+
+// Stub the claude provider module so we don't probe PATH for `claude`.
+mock.module("../../sdk/providers/claude.ts", () => ({
+  resolveHeadlessClaudeBin: () => "/usr/local/bin/claude",
+}));
+
+const { checkAgentAuth } = await import("./auth.ts");
+
+beforeEach(() => {
+  copilotStart.mockClear();
+  copilotStart.mockImplementation(async () => {});
+  copilotStop.mockClear();
+  copilotStop.mockImplementation(async () => []);
+  copilotGetAuthStatus.mockClear();
+  copilotGetAuthStatus.mockImplementation(async () => ({
+    isAuthenticated: true,
+    login: "octocat",
+  }));
+  claudeInit.mockClear();
+  claudeInit.mockImplementation(async () => ({
+    account: { email: "user@example.com", tokenSource: "oauth" },
+  }));
+  claudeClose.mockClear();
+  claudeClose.mockImplementation(() => {});
+});
+
+describe("checkAgentAuth(copilot)", () => {
+  test("returns loggedIn=true when the SDK reports isAuthenticated", async () => {
+    const result = await checkAgentAuth("copilot");
+    expect(result.loggedIn).toBe(true);
+    expect(result.identity).toBe("octocat");
+    // Hygiene: client must be stopped even on the happy path so we
+    // don't leak a long-running CLI subprocess.
+    expect(copilotStop).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns loggedIn=false when the SDK reports isAuthenticated=false", async () => {
+    copilotGetAuthStatus.mockImplementationOnce(async () => ({
+      isAuthenticated: false,
+      statusMessage: "no credentials on disk",
+    }));
+    const result = await checkAgentAuth("copilot");
+    expect(result.loggedIn).toBe(false);
+    expect(result.detail).toBe("no credentials on disk");
+  });
+
+  test("returns loggedIn=false when the SDK throws on start", async () => {
+    copilotStart.mockImplementationOnce(async () => {
+      throw new Error("CLI not installed");
+    });
+    const result = await checkAgentAuth("copilot");
+    expect(result.loggedIn).toBe(false);
+    expect(result.detail).toContain("CLI not installed");
+  });
+
+  test("swallows errors from stop() on the failure path", async () => {
+    copilotGetAuthStatus.mockImplementationOnce(async () => {
+      throw new Error("auth probe failed");
+    });
+    copilotStop.mockImplementationOnce(async () => {
+      throw new Error("stop crashed");
+    });
+    const result = await checkAgentAuth("copilot");
+    expect(result.loggedIn).toBe(false);
+    expect(result.detail).toContain("auth probe failed");
+    // The stop failure must not shadow the probe result.
+    expect(result.detail).not.toContain("stop crashed");
+  });
+});
+
+describe("checkAgentAuth(claude)", () => {
+  test("returns loggedIn=true when initializationResult has account email", async () => {
+    const result = await checkAgentAuth("claude");
+    expect(result.loggedIn).toBe(true);
+    expect(result.identity).toBe("user@example.com");
+    expect(claudeClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns loggedIn=true when only tokenSource is populated", async () => {
+    claudeInit.mockImplementationOnce(async () => ({
+      account: { tokenSource: "oauth" },
+    }));
+    const result = await checkAgentAuth("claude");
+    expect(result.loggedIn).toBe(true);
+  });
+
+  test("returns loggedIn=true when only apiKeySource is populated", async () => {
+    claudeInit.mockImplementationOnce(async () => ({
+      account: { apiKeySource: "env" },
+    }));
+    const result = await checkAgentAuth("claude");
+    expect(result.loggedIn).toBe(true);
+  });
+
+  test("returns loggedIn=false when account is empty", async () => {
+    claudeInit.mockImplementationOnce(async () => ({ account: {} }));
+    const result = await checkAgentAuth("claude");
+    expect(result.loggedIn).toBe(false);
+  });
+
+  test("returns loggedIn=false when initializationResult throws", async () => {
+    claudeInit.mockImplementationOnce(async () => {
+      throw new Error("subprocess init failed — check authentication");
+    });
+    const result = await checkAgentAuth("claude");
+    expect(result.loggedIn).toBe(false);
+    expect(result.detail).toContain("subprocess init failed");
+  });
+});
+
+describe("checkAgentAuth(opencode)", () => {
+  test("is a no-op — returns loggedIn=true without probing the SDK", async () => {
+    // OpenCode handles auth interactively on first use; there's no
+    // equivalent RPC probe, so the wrapper short-circuits.
+    const result = await checkAgentAuth("opencode");
+    expect(result.loggedIn).toBe(true);
+    // Confirm neither SDK fake was touched.
+    expect(copilotStart).not.toHaveBeenCalled();
+    expect(claudeInit).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/system/auth.ts
+++ b/src/services/system/auth.ts
@@ -1,0 +1,137 @@
+/**
+ * Fail-fast login checks for the agent CLIs atomic drives.
+ *
+ * Copilot exposes `CopilotClient.getAuthStatus()` — a thin JSON-RPC call
+ * that returns `isAuthenticated: boolean`. Claude Agent SDK has no
+ * direct "is signed in" primitive, but `query().initializationResult()`
+ * returns an `account` record populated with `email`, `tokenSource`,
+ * and/or `apiKeySource` whenever the CLI has valid credentials — an
+ * empty record means the user never completed the OAuth flow and no
+ * API key is in the environment.
+ *
+ * We run these probes BEFORE spawning the native CLI from `atomic chat`
+ * or `atomic workflow` so the user sees a short actionable error
+ * instead of dropping into an interactive agent that immediately
+ * prompts for login (or, in the workflow case, silently stalls).
+ */
+
+import type { AgentKey } from "../config/index.ts";
+import { COLORS } from "../../theme/colors.ts";
+import { copilotSubprocessEnv } from "../../sdk/providers/copilot.ts";
+
+export interface AuthCheckResult {
+  /** True when the SDK reports the user is authenticated. */
+  loggedIn: boolean;
+  /** Optional human-readable detail — usually the SDK's status message. */
+  detail?: string;
+  /** Login identity if reported (GitHub login for Copilot, email for Claude). */
+  identity?: string;
+}
+
+/**
+ * Verify the user is authenticated for the given agent. For agents that
+ * do not expose an SDK-level auth probe (currently `opencode`), returns
+ * `{ loggedIn: true }` so the caller can skip the check.
+ */
+export async function checkAgentAuth(agent: AgentKey): Promise<AuthCheckResult> {
+  if (agent === "copilot") return checkCopilotAuth();
+  if (agent === "claude") return checkClaudeAuth();
+  return { loggedIn: true };
+}
+
+/**
+ * Print a consistent login-required banner to stderr. Exported so
+ * `chatCommand` and `workflowCommand` share the same wording.
+ */
+export function printAuthError(agent: AgentKey, result: AuthCheckResult): void {
+  const { name, loginHint } = AUTH_PROMPTS[agent];
+  console.error(
+    `${COLORS.red}Error: Not logged in to ${name}.${COLORS.reset}`,
+  );
+  if (result.detail) {
+    console.error(`${COLORS.dim}${result.detail}${COLORS.reset}`);
+  }
+  console.error(loginHint);
+}
+
+const AUTH_PROMPTS: Record<AgentKey, { name: string; loginHint: string }> = {
+  claude: {
+    name: "Claude Code",
+    loginHint:
+      "Run `claude` and complete the /login flow (or set ANTHROPIC_API_KEY), then retry.",
+  },
+  copilot: {
+    name: "GitHub Copilot CLI",
+    loginHint: "Run `copilot` and complete the `/login` flow, then retry.",
+  },
+  opencode: {
+    name: "OpenCode",
+    loginHint: "Run `opencode auth login`, then retry.",
+  },
+};
+
+async function checkCopilotAuth(): Promise<AuthCheckResult> {
+  const { CopilotClient } = await import("@github/copilot-sdk");
+  const client = new CopilotClient({ env: copilotSubprocessEnv() });
+  try {
+    await client.start();
+    const status = await client.getAuthStatus();
+    return {
+      loggedIn: status.isAuthenticated,
+      detail: status.statusMessage,
+      identity: status.login,
+    };
+  } catch (err) {
+    return {
+      loggedIn: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    try {
+      await client.stop();
+    } catch {
+      // Best effort — a failed stop shouldn't shadow the probe result.
+    }
+  }
+}
+
+async function checkClaudeAuth(): Promise<AuthCheckResult> {
+  const { query } = await import("@anthropic-ai/claude-agent-sdk");
+  const { resolveHeadlessClaudeBin } = await import("../../sdk/providers/claude.ts");
+
+  // A never-yielding iterable keeps the query idle while we probe the
+  // initialization result. The SDK starts the `claude` subprocess on
+  // query construction but only blocks on the stream once a prompt is
+  // actually delivered.
+  async function* emptyStream(): AsyncGenerator<never, void, void> {}
+
+  const q = query({
+    prompt: emptyStream(),
+    options: {
+      pathToClaudeCodeExecutable: resolveHeadlessClaudeBin(),
+    },
+  });
+
+  try {
+    const init = await q.initializationResult();
+    const account = init.account ?? {};
+    const loggedIn = Boolean(
+      account.email || account.tokenSource || account.apiKeySource,
+    );
+    return {
+      loggedIn,
+      identity: account.email,
+    };
+  } catch (err) {
+    return {
+      loggedIn: false,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    try {
+      q.close();
+    } catch {
+      // Best effort — the subprocess is torn down on process exit anyway.
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds preflight authentication checks to `atomic chat` and `atomic workflow` so users get an actionable error message instead of being dropped into a native CLI that immediately redirects to `/login` (or, for detached tmux workflows, silently stalls on a login screen they never see).

## Key Changes

- **New `src/services/system/auth.ts`** — `checkAgentAuth(agent)` probes:
  - **Copilot**: `CopilotClient.getAuthStatus()` — returns `isAuthenticated` + optional `login` identity
  - **Claude**: Agent SDK `query().initializationResult()` — inspects the `account` record for `email`, `tokenSource`, or `apiKeySource`; an empty record means no valid credentials
  - **OpenCode**: no SDK probe available, passes through as `loggedIn: true`
- **`printAuthError(agent, result)`** — shared stderr banner with agent-specific login hints (`claude /login`, `copilot /login`, `opencode auth login`)
- **`src/commands/cli/chat/index.ts`** — calls `checkAgentAuth` before the existing preflight checks; returns exit code `1` if not authenticated
- **`src/commands/cli/workflow.ts`** — same guard added to `runPrereqChecks()`, preventing silent workflow stalls in detached tmux panes
- **`src/sdk/providers/copilot.ts`** — new `copilotSubprocessEnv()` helper that merges `NODE_NO_WARNINGS=1` into `process.env` to suppress the `ExperimentalWarning: SQLite is an experimental feature` banner that was leaking through the SDK's `[CLI subprocess]` stderr forwarder on every Copilot spawn
- **`src/sdk/runtime/executor.ts`** — headless `CopilotClient` now uses `copilotSubprocessEnv()` so the SQLite warning is silenced in workflow runs too
- **Tests** — `src/services/system/auth.test.ts` and `src/commands/cli/workflow-command.test.ts` cover the auth probe logic and command-level gate