### PR TITLE
chore(release): bump version to v0.5.28-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.28-1",
+  "version": "0.5.28-2",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.28-1` to `0.5.28-2` as a prerelease patch.

## Changes

- `package.json`: version `0.5.28-1` → `0.5.28-2`

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes prerelease to npm