### PR TITLE
chore(release): bump version to v0.5.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.28-2",
+  "version": "0.5.28",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `0.5.28-2` to the stable `0.5.28` release by updating the version in `package.json`.

## Changes

- `package.json`: `0.5.28-2` → `0.5.28`

## Test plan

- [ ] CI passes
- [ ] On merge, GitHub Release is created and version is published to npm