### PR TITLE
chore(config): remove stale lastUpdated field from .atomic/settings.json

### DIFF
--- a/.atomic/settings.json
+++ b/.atomic/settings.json
@@ -1,6 +1,5 @@
 {
   "scm": "github",
   "version": 1,
-  "lastUpdated": "2026-04-03T21:30:24.690Z",
   "$schema": "https://raw.githubusercontent.com/flora131/atomic/main/assets/settings.schema.json"
 }


### PR DESCRIPTION
## Summary

Removes the leftover `lastUpdated` timestamp from the committed `.atomic/settings.json` file. PR #723 already dropped `lastUpdated` from the config schema, types, and all read/write helpers — this cleans up the only remaining reference in the tracked settings file.

## Key Changes

- Removed `lastUpdated` field from `.atomic/settings.json`

## Context

The `lastUpdated` field was written on every config save, causing unnecessary git churn whenever a project's local `.atomic/settings.json` was committed. PR #723 removed it from the codebase (`AtomicConfig`/`AtomicSettings` interfaces, `pickAtomicConfig`, `mergeConfigs`, `saveAtomicConfig`, and the JSON schema). This PR removes the stale value from the settings file itself.