### PR TITLE
chore(release): bump version to v0.5.29-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.28",
+  "version": "0.5.29-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.28` to `0.5.29-0` as a prerelease ahead of the `v0.5.29` release.

## Changes

- `package.json`: version `0.5.28` → `0.5.29-0`

## Test plan

- [x] Version bumped via `bun run src/scripts/bump-version.ts --from-branch`
- [ ] CI passes
- [ ] GitHub Release auto-created on merge