### PR TITLE
chore(release): bump version to v0.5.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.29-0",
+  "version": "0.5.29",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.29-0` to the stable release `0.5.29` by updating `package.json`.

## Changes

- `package.json`: version `0.5.29-0` → `0.5.29`

## Test plan

- [x] `bun run src/scripts/bump-version.ts --from-branch`
- [x] Pre-commit hooks (typecheck, lint, test, test-coverage) pass