### PR TITLE
feat(workflows): add integer input type and max_loops to ralph

### DIFF
--- a/src/commands/cli/workflow-inputs.ts
+++ b/src/commands/cli/workflow-inputs.ts
@@ -114,7 +114,9 @@ export function renderInputsText(payload: WorkflowInputsResult): string {
     }
     if (field.default !== undefined) {
       lines.push(
-        "      " + paint("dim", "default: ") + paint("text", field.default),
+        "      " +
+          paint("dim", "default: ") +
+          paint("text", String(field.default)),
       );
     }
     if (field.placeholder) {

--- a/src/commands/cli/workflow.ts
+++ b/src/commands/cli/workflow.ts
@@ -110,9 +110,11 @@ export function validateInputsAgainstSchema(
 
   for (const field of schema) {
     const raw = inputs[field.name];
+    const defaultStr =
+      field.default !== undefined ? String(field.default) : undefined;
     const value =
       raw === undefined || raw === ""
-        ? field.default ?? (field.type === "enum" ? field.values?.[0] ?? "" : "")
+        ? defaultStr ?? (field.type === "enum" ? field.values?.[0] ?? "" : "")
         : raw;
 
     if (field.required) {
@@ -133,6 +135,19 @@ export function validateInputsAgainstSchema(
         errors.push(
           `Invalid value for --${field.name}: "${value}". ` +
             `Expected one of: ${allowed.join(", ")}.`,
+        );
+      }
+    }
+
+    if (field.type === "integer" && value !== "") {
+      const parsed = Number.parseInt(value, 10);
+      if (
+        !Number.isFinite(parsed) ||
+        !Number.isInteger(parsed) ||
+        String(parsed) !== value.trim()
+      ) {
+        errors.push(
+          `Invalid value for --${field.name}: "${value}". Expected an integer.`,
         );
       }
     }
@@ -166,7 +181,7 @@ export function resolveInputs(
     if (raw !== undefined && raw !== "") {
       out[field.name] = raw;
     } else if (field.default !== undefined) {
-      out[field.name] = field.default;
+      out[field.name] = String(field.default);
     } else if (field.type === "enum" && field.values && field.values.length > 0) {
       out[field.name] = field.values[0]!;
     }

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -296,6 +296,16 @@ function isRunnable(wf: WorkflowWithMetadata): boolean {
 // ─── Validation ─────────────────────────────────
 
 export function isFieldValid(field: WorkflowInput, value: string): boolean {
+  if (field.type === "integer") {
+    const trimmed = value.trim();
+    if (trimmed === "") return !field.required;
+    const parsed = Number.parseInt(trimmed, 10);
+    return (
+      Number.isFinite(parsed) &&
+      Number.isInteger(parsed) &&
+      String(parsed) === trimmed
+    );
+  }
   if (!field.required) return true;
   if (field.type === "enum") return value !== "";
   return value.trim() !== "";
@@ -864,7 +874,7 @@ const Field = memo(function Field({
             focused={focused}
             onInput={onInput}
           />
-        ) : field.type === "string" ? (
+        ) : field.type === "string" || field.type === "integer" ? (
           <StringContent
             value={value}
             placeholder={field.placeholder ?? ""}
@@ -1397,8 +1407,11 @@ function usePickerKeyboard(state: PickerKeyboardState): void {
         const initial: Record<string, string> = {};
         for (const f of wf.inputs) {
           initial[f.name] =
-            f.default ??
-            (f.type === "enum" ? (f.values?.[0] ?? "") : "");
+            f.default !== undefined
+              ? String(f.default)
+              : f.type === "enum"
+                ? (f.values?.[0] ?? "")
+                : "";
         }
         setFieldValues(initial);
         setFocusedFieldIdx(0);
@@ -1453,7 +1466,10 @@ function usePickerKeyboard(state: PickerKeyboardState): void {
       return;
     }
 
-    if (field.type === "string" && key.name === "return") {
+    if (
+      (field.type === "string" || field.type === "integer") &&
+      key.name === "return"
+    ) {
       key.stopPropagation();
       setFocusedFieldIdx((i: number) =>
         Math.min(currentFieldsRef.current.length - 1, i + 1),

--- a/src/sdk/define-workflow.ts
+++ b/src/sdk/define-workflow.ts
@@ -19,6 +19,8 @@ import type {
   WorkflowInput,
 } from "./types.ts";
 
+type AnyInputs = readonly WorkflowInput[];
+
 /**
  * Validate a single declared workflow input, throwing on authoring
  * mistakes that would otherwise surface as confusing runtime errors
@@ -45,11 +47,31 @@ function validateWorkflowInput(input: WorkflowInput, workflowName: string): void
           `declares no \`values\`.`,
       );
     }
-    if (input.default !== undefined && !input.values.includes(input.default)) {
+    if (input.default !== undefined) {
+      if (typeof input.default !== "string") {
+        throw new Error(
+          `Workflow "${workflowName}" input "${input.name}" (enum) has a ` +
+            `non-string default ${JSON.stringify(input.default)}.`,
+        );
+      }
+      if (!input.values.includes(input.default)) {
+        throw new Error(
+          `Workflow "${workflowName}" input "${input.name}" has a default ` +
+            `"${input.default}" that is not one of its declared values: ` +
+            `${input.values.join(", ")}.`,
+        );
+      }
+    }
+  }
+  if (input.type === "integer" && input.default !== undefined) {
+    const n =
+      typeof input.default === "number"
+        ? input.default
+        : Number.parseInt(input.default, 10);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
       throw new Error(
-        `Workflow "${workflowName}" input "${input.name}" has a default ` +
-          `"${input.default}" that is not one of its declared values: ` +
-          `${input.values.join(", ")}.`,
+        `Workflow "${workflowName}" input "${input.name}" (integer) has a ` +
+          `non-integer default ${JSON.stringify(input.default)}.`,
       );
     }
   }
@@ -59,13 +81,16 @@ function validateWorkflowInput(input: WorkflowInput, workflowName: string): void
  * Chainable workflow builder. Records the run callback,
  * then .compile() seals it into a WorkflowDefinition.
  */
-export class WorkflowBuilder<A extends AgentType = AgentType, N extends string = string> {
+export class WorkflowBuilder<
+  A extends AgentType = AgentType,
+  I extends AnyInputs = AnyInputs,
+> {
   /** @internal Brand for detection across package boundaries */
   readonly __brand = "WorkflowBuilder" as const;
-  private readonly options: WorkflowOptions;
-  private runFn: ((ctx: WorkflowContext<A, N>) => Promise<void>) | null = null;
+  private readonly options: WorkflowOptions<I>;
+  private runFn: ((ctx: WorkflowContext<A, I>) => Promise<void>) | null = null;
 
-  constructor(options: WorkflowOptions) {
+  constructor(options: WorkflowOptions<I>) {
     this.options = options;
   }
 
@@ -91,8 +116,8 @@ export class WorkflowBuilder<A extends AgentType = AgentType, N extends string =
    *   .compile();
    * ```
    */
-  for<B extends AgentType>(): WorkflowBuilder<B, N> {
-    return this as unknown as WorkflowBuilder<B, N>;
+  for<B extends AgentType>(): WorkflowBuilder<B, I> {
+    return this as unknown as WorkflowBuilder<B, I>;
   }
 
   /**
@@ -103,7 +128,7 @@ export class WorkflowBuilder<A extends AgentType = AgentType, N extends string =
    * reading completed session outputs. Use native TypeScript control flow
    * (loops, conditionals, `Promise.all()`) for orchestration.
    */
-  run(fn: (ctx: WorkflowContext<A, N>) => Promise<void>): this {
+  run(fn: (ctx: WorkflowContext<A, I>) => Promise<void>): this {
     if (this.runFn) {
       throw new Error("run() can only be called once per workflow.");
     }
@@ -120,7 +145,7 @@ export class WorkflowBuilder<A extends AgentType = AgentType, N extends string =
    * After calling compile(), the returned object is consumed by the
    * Atomic CLI runtime.
    */
-  compile(): WorkflowDefinition<A, N> {
+  compile(): WorkflowDefinition<A, I> {
     if (!this.runFn) {
       throw new Error(
         `Workflow "${this.options.name}" has no run callback. ` +
@@ -188,9 +213,9 @@ export function defineWorkflow<
   const I extends readonly WorkflowInput[] = readonly WorkflowInput[],
 >(
   options: WorkflowOptions<I>,
-): WorkflowBuilder<AgentType, I[number]["name"]> {
+): WorkflowBuilder<AgentType, I> {
   if (!options.name || options.name.trim() === "") {
     throw new Error("Workflow name is required.");
   }
-  return new WorkflowBuilder<AgentType, I[number]["name"]>(options);
+  return new WorkflowBuilder<AgentType, I>(options);
 }

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -21,6 +21,7 @@ import { statSync, accessSync, constants as fsConstants } from "node:fs";
 import type {
   WorkflowDefinition,
   WorkflowContext,
+  WorkflowInput,
   SessionContext,
   SessionRunOptions,
   SessionHandle,
@@ -416,6 +417,35 @@ export function parseInputsEnv(
   } catch {
     return {};
   }
+}
+
+/**
+ * Coerce raw string inputs to their declared runtime types. Integer inputs
+ * become `number`; every other declared type passes through as `string`.
+ * Unknown keys (not in the schema) are preserved as strings.
+ *
+ * Invalid integer strings fall back to the key being dropped — validation
+ * already runs upstream (in `validateInputsAgainstSchema`), so reaching
+ * this path with garbage means the executor was invoked out-of-band.
+ */
+export function coerceInputsBySchema(
+  inputs: Record<string, string>,
+  schema: readonly WorkflowInput[],
+): Record<string, string | number> {
+  const byName = new Map(schema.map((f) => [f.name, f]));
+  const out: Record<string, string | number> = {};
+  for (const [k, v] of Object.entries(inputs)) {
+    const field = byName.get(k);
+    if (field?.type === "integer") {
+      const parsed = Number.parseInt(v, 10);
+      if (Number.isFinite(parsed) && Number.isInteger(parsed)) {
+        out[k] = parsed;
+      }
+      continue;
+    }
+    out[k] = v;
+  }
+  return out;
 }
 
 // ============================================================================
@@ -1138,10 +1168,10 @@ interface SharedRunnerState {
   /**
    * Structured inputs for this workflow run. Free-form workflows use
    * `{ prompt: "..." }`; structured workflows use their declared field
-   * names. Workflow authors read both shapes via `ctx.inputs` — and
-   * specifically via `ctx.inputs.prompt` for the free-form case.
+   * names. Workflow authors read both shapes via `ctx.inputs` — integer
+   * inputs are parsed to `number`, everything else stays a `string`.
    */
-  inputs: Record<string, string>;
+  inputs: Record<string, string | number>;
   /** User-configured provider overrides (global + local merged). */
   providerOverrides: ProviderOverrides;
   /**
@@ -1662,7 +1692,7 @@ function createSessionRunner(
       const ctx: SessionContext = {
         client: providerClient,
         session: providerSession,
-        inputs: shared.inputs,
+        inputs: shared.inputs as SessionContext["inputs"],
         agent: shared.agent,
         sessionDir,
         paneId,
@@ -1904,6 +1934,11 @@ export async function runOrchestrator(): Promise<void> {
     }
     const definition = loaded.value.definition;
 
+    // Parse integer inputs to numbers so `ctx.inputs.<name>` matches the
+    // declared type. Do this after loading (when the schema is known) and
+    // mutate shared.inputs so per-stage SessionContexts see the same shape.
+    shared.inputs = coerceInputsBySchema(inputs, definition.inputs);
+
     await Bun.write(
       join(sessionsBaseDir, "metadata.json"),
       JSON.stringify(
@@ -1926,7 +1961,7 @@ export async function runOrchestrator(): Promise<void> {
     const sessionRunner = createSessionRunner(shared, "orchestrator");
 
     const workflowCtx: WorkflowContext = {
-      inputs,
+      inputs: shared.inputs as WorkflowContext["inputs"],
       agent,
       stage: sessionRunner as WorkflowContext["stage"],
       transcript: createTranscriptReader(shared.completedRegistry),

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -143,11 +143,12 @@ export function createProviderValidator(
 /**
  * Supported field types for a workflow's declared inputs.
  *
- * - `"string"` — single-line free-form input (short values, identifiers, paths)
- * - `"text"`   — multi-line free-form input (long prose, prompts, specs)
- * - `"enum"`   — one of a fixed list of allowed `values`
+ * - `"string"`  — single-line free-form input (short values, identifiers, paths)
+ * - `"text"`    — multi-line free-form input (long prose, prompts, specs)
+ * - `"enum"`    — one of a fixed list of allowed `values`
+ * - `"integer"` — whole number; parsed to `number` in `ctx.inputs`
  */
-export type WorkflowInputType = "string" | "text" | "enum";
+export type WorkflowInputType = "string" | "text" | "enum" | "integer";
 
 /**
  * A declared input for a workflow. When a workflow provides an `inputs`
@@ -170,11 +171,45 @@ export interface WorkflowInput {
   description?: string;
   /** Placeholder text shown when the field is empty. */
   placeholder?: string;
-  /** Default value pre-filled into the field. Enums use this to pick their initial value. */
-  default?: string;
+  /**
+   * Default value pre-filled into the field. Enums use this to pick
+   * their initial value. Integer inputs accept either a `number` or its
+   * decimal string representation.
+   */
+  default?: string | number;
   /** Allowed values — required when `type` is `"enum"`. */
   values?: readonly string[];
 }
+
+/**
+ * Map a {@link WorkflowInputType} to the runtime value type observed in
+ * `ctx.inputs`. Integer inputs are parsed to `number` at the executor
+ * boundary; everything else stays a `string`.
+ */
+export type WorkflowInputValue<T extends WorkflowInputType> =
+  T extends "integer" ? number : string;
+
+/**
+ * Compute the typed `ctx.inputs` shape from a workflow's declared input
+ * schema. Each declared field becomes an optional key whose value type
+ * is determined by {@link WorkflowInputValue}.
+ *
+ * Free-form workflows (no declared schema) fall back to a loose
+ * string-keyed record so authors can still read `ctx.inputs.prompt`.
+ */
+export type InputsOf<I extends readonly WorkflowInput[]> =
+  // Non-literal schema (default `I = readonly WorkflowInput[]`) or empty
+  // tuple — no type-level info about individual fields, so fall back to a
+  // loose string record that preserves the prior free-form behaviour.
+  WorkflowInput extends I[number]
+    ? Record<string, string | undefined>
+    : I[number] extends never
+      ? Record<string, string | undefined>
+      : {
+          [K in I[number]["name"]]?: WorkflowInputValue<
+            Extract<I[number], { name: K }>["type"]
+          >;
+        };
 
 // ─── Core types ─────────────────────────────────────────────────────────────
 
@@ -252,7 +287,10 @@ export interface SessionRunOptions {
  * Created by `ctx.stage(opts, clientOpts, sessionOpts, fn)` — the callback
  * receives this as its argument with pre-initialized `client` and `session`.
  */
-export interface SessionContext<A extends AgentType = AgentType, N extends string = string> {
+export interface SessionContext<
+  A extends AgentType = AgentType,
+  I extends readonly WorkflowInput[] = readonly WorkflowInput[],
+> {
   /** Provider-specific SDK client (auto-created by runtime) */
   client: ProviderClient<A>;
   /** Provider-specific session (auto-created by runtime) */
@@ -263,10 +301,11 @@ export interface SessionContext<A extends AgentType = AgentType, N extends strin
    *
    * When the workflow declares an `inputs` schema, only the declared
    * field names are valid keys — accessing undeclared fields is a
-   * compile-time error. Free-form workflows (no declared schema)
-   * allow any key, including the conventional `prompt` key.
+   * compile-time error. Each field's value type is determined by its
+   * declared `type` (integer inputs surface as `number`). Free-form
+   * workflows (no declared schema) allow any key.
    */
-  inputs: { [K in N]?: string };
+  inputs: InputsOf<I>;
   /** Which agent is running */
   agent: A;
   /**
@@ -299,7 +338,7 @@ export interface SessionContext<A extends AgentType = AgentType, N extends strin
     options: SessionRunOptions,
     clientOpts: StageClientOptions<A>,
     sessionOpts: StageSessionOptions<A>,
-    run: (ctx: SessionContext<A, N>) => Promise<T>,
+    run: (ctx: SessionContext<A, I>) => Promise<T>,
   ): Promise<SessionHandle<T>>;
 }
 
@@ -307,17 +346,21 @@ export interface SessionContext<A extends AgentType = AgentType, N extends strin
  * Top-level context provided to the workflow's `.run()` callback.
  * Does not have session-specific fields (paneId, save, etc.).
  */
-export interface WorkflowContext<A extends AgentType = AgentType, N extends string = string> {
+export interface WorkflowContext<
+  A extends AgentType = AgentType,
+  I extends readonly WorkflowInput[] = readonly WorkflowInput[],
+> {
   /**
    * Structured inputs for this workflow run. Populated from CLI flags
    * (`--<name>=<value>`) or the interactive picker.
    *
    * When the workflow declares an `inputs` schema, only the declared
    * field names are valid keys — accessing undeclared fields is a
-   * compile-time error. Free-form workflows (no declared schema)
-   * allow any key, including the conventional `prompt` key.
+   * compile-time error. Each field's value type is determined by its
+   * declared `type` (integer inputs surface as `number`). Free-form
+   * workflows (no declared schema) allow any key.
    */
-  inputs: { [K in N]?: string };
+  inputs: InputsOf<I>;
   /** Which agent is running */
   agent: A;
   /**
@@ -330,7 +373,7 @@ export interface WorkflowContext<A extends AgentType = AgentType, N extends stri
     options: SessionRunOptions,
     clientOpts: StageClientOptions<A>,
     sessionOpts: StageSessionOptions<A>,
-    run: (ctx: SessionContext<A, N>) => Promise<T>,
+    run: (ctx: SessionContext<A, I>) => Promise<T>,
   ): Promise<SessionHandle<T>>;
   /**
    * Get a completed session's transcript as rendered text.
@@ -385,7 +428,10 @@ export interface WorkflowOptions<
 /**
  * A compiled workflow definition — the sealed output of defineWorkflow().compile().
  */
-export interface WorkflowDefinition<A extends AgentType = AgentType, N extends string = string> {
+export interface WorkflowDefinition<
+  A extends AgentType = AgentType,
+  I extends readonly WorkflowInput[] = readonly WorkflowInput[],
+> {
   readonly __brand: "WorkflowDefinition";
   readonly name: string;
   readonly description: string;
@@ -397,5 +443,5 @@ export interface WorkflowDefinition<A extends AgentType = AgentType, N extends s
    */
   readonly minSDKVersion: string | null;
   /** The workflow's entry point. Called by the executor with a WorkflowContext. */
-  readonly run: (ctx: WorkflowContext<A, N>) => Promise<void>;
+  readonly run: (ctx: WorkflowContext<A, I>) => Promise<void>;
 }

--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -4,7 +4,7 @@
  * Each sub-agent invocation spawns its own visible session in the graph,
  * so users can see each iteration's progress in real time. The loop
  * terminates when:
- *   - {@link MAX_LOOPS} iterations have completed, OR
+ *   - `max_loops` iterations have completed (defaults to {@link DEFAULT_MAX_LOOPS}), OR
  *   - Two parallel reviewer passes both return zero findings.
  *
  * The reviewer stages run the `reviewer` sub-agent in a visible TUI via the
@@ -34,7 +34,7 @@ import {
 import { hasActionableFindings } from "../helpers/review.ts";
 import { captureBranchChangeset } from "../helpers/git.ts";
 
-const MAX_LOOPS = 10;
+const DEFAULT_MAX_LOOPS = 10;
 
 // The orchestrator stage implements the actual code changes and can run for
 // a very long time on large tasks. Completion is detected via session file
@@ -62,14 +62,21 @@ export default defineWorkflow({
       required: true,
       description: "task prompt",
     },
+    {
+      name: "max_loops",
+      type: "integer",
+      description: "maximum number of plan/orchestrate/review iterations",
+      default: DEFAULT_MAX_LOOPS,
+    },
   ],
 })
   .for<"claude">()
   .run(async (ctx) => {
     const prompt = ctx.inputs.prompt ?? "";
+    const maxLoops = ctx.inputs.max_loops ?? DEFAULT_MAX_LOOPS;
     let debuggerReport = "";
 
-    for (let iteration = 1; iteration <= MAX_LOOPS; iteration++) {
+    for (let iteration = 1; iteration <= maxLoops; iteration++) {
       // ── Plan ────────────────────────────────────────────────────────────
       await ctx.stage(
         { name: `planner-${iteration}` },
@@ -217,7 +224,7 @@ export default defineWorkflow({
       if (!hasActionableFindings(parsed, reviewRaw)) break;
 
       // ── Debug (only if another iteration is allowed) ────────────────────
-      if (iteration < MAX_LOOPS) {
+      if (iteration < maxLoops) {
         const debugger_ = await ctx.stage(
           { name: `debugger-${iteration}` },
           {

--- a/src/sdk/workflows/builtin/ralph/copilot/index.ts
+++ b/src/sdk/workflows/builtin/ralph/copilot/index.ts
@@ -4,7 +4,7 @@
  * Each sub-agent invocation spawns its own visible session in the graph,
  * so users can see each iteration's progress in real time. The loop
  * terminates when:
- *   - {@link MAX_LOOPS} iterations have completed, OR
+ *   - `max_loops` iterations have completed (defaults to {@link DEFAULT_MAX_LOOPS}), OR
  *   - Two parallel reviewer passes both return zero findings.
  *
  * The reviewer stages use a `submit_review` custom tool (defined via
@@ -35,7 +35,7 @@ import {
 import { hasActionableFindings } from "../helpers/review.ts";
 import { captureBranchChangeset } from "../helpers/git.ts";
 
-const MAX_LOOPS = 10;
+const DEFAULT_MAX_LOOPS = 10;
 
 const SUBMIT_REVIEW_DESCRIPTION =
   "Submit the structured code review result. You MUST call this tool " +
@@ -85,14 +85,21 @@ export default defineWorkflow({
       required: true,
       description: "task prompt",
     },
+    {
+      name: "max_loops",
+      type: "integer",
+      description: "maximum number of plan/orchestrate/review iterations",
+      default: DEFAULT_MAX_LOOPS,
+    },
   ],
 })
   .for<"copilot">()
   .run(async (ctx) => {
     const userPromptText = ctx.inputs.prompt ?? "";
+    const maxLoops = ctx.inputs.max_loops ?? DEFAULT_MAX_LOOPS;
     let debuggerReport = "";
 
-    for (let iteration = 1; iteration <= MAX_LOOPS; iteration++) {
+    for (let iteration = 1; iteration <= maxLoops; iteration++) {
       // ── Plan ──────────────────────────────────────────────────────────
       const planner = await ctx.stage(
         { name: `planner-${iteration}` },
@@ -247,7 +254,7 @@ export default defineWorkflow({
       if (!hasActionableFindings(parsed, reviewRaw)) break;
 
       // ── Debug (only if another iteration is allowed) ──────────────────
-      if (iteration < MAX_LOOPS) {
+      if (iteration < maxLoops) {
         const debugger_ = await ctx.stage(
           { name: `debugger-${iteration}` },
           {},

--- a/src/sdk/workflows/builtin/ralph/opencode/index.ts
+++ b/src/sdk/workflows/builtin/ralph/opencode/index.ts
@@ -4,7 +4,7 @@
  * Each sub-agent invocation spawns its own visible session in the graph,
  * so users can see each iteration's progress in real time. The loop
  * terminates when:
- *   - {@link MAX_LOOPS} iterations have completed, OR
+ *   - `max_loops` iterations have completed (defaults to {@link DEFAULT_MAX_LOOPS}), OR
  *   - Two parallel reviewer passes both return zero findings.
  *
  * The reviewer stages use the OpenCode SDK's structured output
@@ -32,7 +32,7 @@ import {
 import { hasActionableFindings } from "../helpers/review.ts";
 import { captureBranchChangeset } from "../helpers/git.ts";
 
-const MAX_LOOPS = 10;
+const DEFAULT_MAX_LOOPS = 10;
 
 /** Concatenate the text-typed parts of an OpenCode response. */
 function extractResponseText(
@@ -71,14 +71,21 @@ export default defineWorkflow({
     "Plan → orchestrate → review → debug loop with bounded iteration",
   inputs: [
     { name: "prompt", type: "text", required: true, description: "task prompt" },
+    {
+      name: "max_loops",
+      type: "integer",
+      description: "maximum number of plan/orchestrate/review iterations",
+      default: DEFAULT_MAX_LOOPS,
+    },
   ],
 })
   .for<"opencode">()
   .run(async (ctx) => {
     const prompt = ctx.inputs.prompt ?? "";
+    const maxLoops = ctx.inputs.max_loops ?? DEFAULT_MAX_LOOPS;
     let debuggerReport = "";
 
-    for (let iteration = 1; iteration <= MAX_LOOPS; iteration++) {
+    for (let iteration = 1; iteration <= maxLoops; iteration++) {
       // ── Plan ────────────────────────────────────────────────────────────
       const planner = await ctx.stage(
         { name: `planner-${iteration}` },
@@ -225,7 +232,7 @@ export default defineWorkflow({
       if (!hasActionableFindings(parsed, reviewRaw)) break;
 
       // ── Debug (only if another iteration is allowed) ────────────────────
-      if (iteration < MAX_LOOPS) {
+      if (iteration < maxLoops) {
         const debugger_ = await ctx.stage(
           { name: `debugger-${iteration}` },
           {},


### PR DESCRIPTION
## Summary

Extends `WorkflowInputType` with `"integer"` so workflows can declare numeric inputs that surface as `number` in `ctx.inputs` at runtime, eliminating the need for authors to hand-parse strings. All three Ralph workflow variants (claude, copilot, opencode) adopt this immediately by exposing a configurable `max_loops` input (default: 10).

## Key Changes

### Type System
- Added `"integer"` to `WorkflowInputType` union (`src/sdk/types.ts`)
- Added `WorkflowInputValue<T>` — maps an input type to its runtime value type (`number` for integer, `string` for everything else)
- Added `InputsOf<I>` — derives the fully typed `ctx.inputs` shape from the workflow's declared input tuple; free-form workflows retain the loose `Record<string, string | undefined>` fallback

### Generic Refactor
- `WorkflowBuilder`, `WorkflowContext`, `SessionContext`, and `WorkflowDefinition` generics were changed from carrying a name-union `N extends string` to carrying the full input tuple `I extends readonly WorkflowInput[]`, enabling per-field value-type inference at the callsite

### Runtime Coercion
- New `coerceInputsBySchema()` helper in `src/sdk/runtime/executor.ts` converts raw string inputs to their declared types (integers → `number`) before the workflow run callback receives them

### Validation
- Integer fields are validated in the CLI (`src/commands/cli/workflow.ts`) and in the interactive picker panel (`src/sdk/components/workflow-picker-panel.tsx`)
- Enum `validateWorkflowInput` now separately checks that the default is a `string` before checking membership

### Ralph Workflows
- All three Ralph variants (`claude/`, `copilot/`, `opencode/`) declare `max_loops` as an `integer` input with a default of 10, replacing the hard-coded `MAX_LOOPS` constant
- `max_loops` is optional — omitting it falls back to `DEFAULT_MAX_LOOPS` (10), so existing invocations are unaffected

### Display / CLI Fixes
- Non-string `default` values (e.g., numbers) are serialized via `String()` before being rendered in help text and used as fallback values in the CLI resolver

## Breaking Changes

None for existing workflow authors. Free-form workflows (no declared `inputs`) continue to type `ctx.inputs` as `Record<string, string | undefined>`. Structured workflows that only declare `string`, `text`, or `enum` fields are unaffected — `InputsOf<I>` still resolves those fields to `string`.