### PR TITLE
chore(release): bump version to v0.5.30-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.29",
+  "version": "0.5.30-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.29` to `0.5.30-0` as a prerelease ahead of the `v0.5.30` stable release.

## Changes

- `package.json`: version `0.5.29` → `0.5.30-0`

## Test plan

- [x] Version bumped correctly in `package.json`
- [ ] CI passes