### PR TITLE
chore(hooks): streamline test hooks and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
             - name: Run linting
               run: bun run lint
 
-            - name: Run tests
-              run: bun test 2>&1 | cat
+            - name: Run tests with coverage
+              run: bun run test:coverage 2>&1 | cat
 
             - name: Validate SDK build
               run: bun run build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: local
     hooks:
@@ -12,12 +13,6 @@ repos:
         entry: bun run lint
         language: system
         files: \.(ts|tsx)$
-        pass_filenames: false
-        stages: [pre-commit]
-      - id: test
-        name: test
-        entry: bun test
-        language: system
         pass_filenames: false
         stages: [pre-commit]
       - id: test-coverage

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typecheck": "bunx tsc --noEmit && bunx tsc -p tests --noEmit",
     "lint": "oxlint --config=oxlint.json src",
     "lint:fix": "oxlint --config=oxlint.json --fix src",
-    "prepare": "prek install -t pre-commit -t pre-push || true"
+    "prepare": "prek install || true"
   },
   "devDependencies": {
     "@j178/prek": "^0.3.10",


### PR DESCRIPTION
Consolidates the test execution strategy across local git hooks and CI to eliminate redundancy and ensure coverage is always measured.

## Changes

- **`.pre-commit-config.yaml`**: Removes the redundant `test` hook from `pre-commit` stage; the `test-coverage` hook on `pre-push` already runs tests as part of coverage, making the separate pre-commit test run redundant. Adds `default_install_hook_types: [pre-commit, pre-push]` so a plain `prek install` (via `prepare` script) wires up both hook stages automatically.
- **`package.json`**: Simplifies the `prepare` script from `prek install -t pre-commit -t pre-push` to `prek install`, relying on the new `default_install_hook_types` config instead of explicit flags.
- **`.github/workflows/ci.yml`**: Replaces the bare `bun test` CI step with `bun run test:coverage` so CI always collects coverage in a single combined step rather than running tests twice.

## Result

- Pre-commit: typecheck + lint (fast feedback)
- Pre-push: tests + coverage (one combined step)
- CI: typecheck → lint → tests + coverage → build (no duplicate test runs)