### PR TITLE
feat(ralph): enforce reviewer schema via SDK-native structured output

### DIFF
--- a/.atomic/workflows/structured-output-demo/claude/index.ts
+++ b/.atomic/workflows/structured-output-demo/claude/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Structured-output demo for Claude.
+ *
+ * Runs a single headless stage that asks for structured facts about a
+ * programming language and enforces the schema via the Claude Agent SDK's
+ * `outputFormat`. The validated object is read from
+ * `s.session.lastStructuredOutput` — no text parsing.
+ *
+ * Run: atomic workflow -n structured-output-demo -a claude "Python"
+ */
+
+import { defineWorkflow, extractAssistantText } from "@bastani/atomic/workflows";
+
+import {
+  LanguageFactsSchema,
+  LANGUAGE_FACTS_JSON_SCHEMA,
+  buildPrompt,
+  logFacts,
+  type LanguageFacts,
+} from "../helpers/schema.ts";
+
+export default defineWorkflow({
+  name: "structured-output-demo",
+  description:
+    "Ask for structured facts about a language and prove each SDK's native structured-output path works",
+  inputs: [
+    {
+      name: "prompt",
+      type: "string",
+      required: true,
+      description: "programming language to describe",
+      default: "Python",
+    },
+  ],
+})
+  .for<"claude">()
+  .run(async (ctx) => {
+    const topic = ctx.inputs.prompt ?? "Python";
+
+    await ctx.stage(
+      { name: "describe", headless: true },
+      {},
+      {},
+      async (s) => {
+        const result = await s.session.query(buildPrompt(topic), {
+          permissionMode: "bypassPermissions",
+          allowDangerouslySkipPermissions: true,
+          outputFormat: {
+            type: "json_schema",
+            schema: LANGUAGE_FACTS_JSON_SCHEMA,
+          },
+        });
+        s.save(s.sessionId);
+
+        // safeParse catches drift between the JSON Schema the SDK
+        // validated against and the Zod shape the workflow consumes —
+        // if the two fall out of sync we want a loud failure, not a
+        // silent mis-typed object.
+        const parsed = LanguageFactsSchema.safeParse(
+          s.session.lastStructuredOutput,
+        );
+        const facts: LanguageFacts | null = parsed.success
+          ? parsed.data
+          : null;
+
+        logFacts("claude", facts);
+        if (!facts) {
+          const raw = extractAssistantText(result, 0);
+          console.log(
+            `[claude] validation failed — raw assistant text:\n${raw}`,
+          );
+          throw new Error(
+            "Claude structured output was missing or failed schema validation",
+          );
+        }
+      },
+    );
+  })
+  .compile();

--- a/.atomic/workflows/structured-output-demo/copilot/index.ts
+++ b/.atomic/workflows/structured-output-demo/copilot/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Structured-output demo for Copilot.
+ *
+ * Copilot SDK doesn't expose a `json_schema`-style response format — its
+ * native path for schema-enforced output is a custom tool built with
+ * `defineTool`. The Copilot SDK validates the tool-call arguments
+ * against the Zod schema before the handler fires, so by the time
+ * `handler(data)` runs, `data` is already a typed, validated object.
+ *
+ * Run: atomic workflow -n structured-output-demo -a copilot "Python"
+ */
+
+import { defineWorkflow } from "@bastani/atomic/workflows";
+import { defineTool } from "@github/copilot-sdk";
+
+import {
+  LanguageFactsSchema,
+  buildPrompt,
+  logFacts,
+  type LanguageFacts,
+} from "../helpers/schema.ts";
+
+const SUBMIT_TOOL_DESCRIPTION =
+  "Submit the structured language facts. You MUST call this tool exactly " +
+  "once with your complete answer. Do not output the facts as plain text.";
+
+export default defineWorkflow({
+  name: "structured-output-demo",
+  description:
+    "Ask for structured facts about a language and prove each SDK's native structured-output path works",
+  inputs: [
+    {
+      name: "prompt",
+      type: "string",
+      required: true,
+      description: "programming language to describe",
+      default: "Python",
+    },
+  ],
+})
+  .for<"copilot">()
+  .run(async (ctx) => {
+    const topic = ctx.inputs.prompt ?? "Python";
+
+    let captured: LanguageFacts | null = null;
+    const submitFacts = defineTool("submit_facts", {
+      description: SUBMIT_TOOL_DESCRIPTION,
+      parameters: LanguageFactsSchema,
+      skipPermission: true,
+      handler: async (data: LanguageFacts) => {
+        captured = data;
+        return "Facts submitted.";
+      },
+    });
+
+    await ctx.stage(
+      { name: "describe" },
+      {},
+      { tools: [submitFacts] },
+      async (s) => {
+        await s.session.send({
+          prompt:
+            buildPrompt(topic) +
+            "\n\nCall the `submit_facts` tool with your answer.",
+        });
+        s.save(await s.session.getMessages());
+
+        logFacts("copilot", captured);
+        if (!captured) {
+          throw new Error(
+            "Copilot did not call submit_facts — structured output unavailable",
+          );
+        }
+      },
+    );
+  })
+  .compile();

--- a/.atomic/workflows/structured-output-demo/helpers/schema.ts
+++ b/.atomic/workflows/structured-output-demo/helpers/schema.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared schema and prompt for the structured-output demo workflow.
+ *
+ * Each provider (Claude, Copilot, OpenCode) adapts this schema to its
+ * native structured-output mechanism:
+ *   - Claude: `outputFormat: { type: "json_schema", schema }` in
+ *     `s.session.query()` options (headless); validated output is read
+ *     from `s.session.lastStructuredOutput`.
+ *   - OpenCode: `format: { type: "json_schema", schema }` in
+ *     `s.client.session.prompt()`; validated output is read from
+ *     `result.data.info.structured`.
+ *   - Copilot: `defineTool` with `parameters: LanguageFactsSchema`; the
+ *     handler receives already-validated args.
+ *
+ * The goal is NOT to test the model's knowledge — it's to prove the SDK
+ * returns an object that matches the schema shape.
+ */
+
+import { z } from "zod";
+
+export const LanguageFactsSchema = z.object({
+  name: z.string().describe("Canonical language name, e.g. 'Python'"),
+  year_created: z
+    .number()
+    .int()
+    .describe("Year the language was first released"),
+  paradigms: z
+    .array(z.string())
+    .describe("Programming paradigms it supports, e.g. ['object-oriented', 'functional']"),
+  statically_typed: z
+    .boolean()
+    .describe("True if the language is statically typed by default"),
+  summary: z
+    .string()
+    .describe("One-sentence summary of what the language is"),
+});
+
+export type LanguageFacts = z.infer<typeof LanguageFactsSchema>;
+
+/**
+ * JSON Schema derived from the Zod shape — used by Claude and OpenCode.
+ *
+ * `target: "openapi-3.0"` drops the `$schema` draft URL that Zod stamps
+ * by default. The Claude Agent SDK's validator silently drops
+ * `structured_output` when that metadata field is present, so we emit
+ * the OpenAPI-flavoured variant which matches the hand-written shape in
+ * the SDK docs' Quick Start example.
+ */
+export const LANGUAGE_FACTS_JSON_SCHEMA = z.toJSONSchema(LanguageFactsSchema, {
+  target: "openapi-3.0",
+});
+
+export function buildPrompt(topic: string): string {
+  return `Return structured facts about the programming language "${topic}".
+
+Fill every field based on widely-known facts. Your final response must
+validate against the schema enforced by the SDK.`;
+}
+
+/**
+ * Log the validated object in a way that's easy to eyeball in the
+ * orchestrator log. Using `console.log` (not a workflow-scoped logger)
+ * because the demo is about visible proof, not production observability.
+ */
+export function logFacts(agent: string, facts: LanguageFacts | null): void {
+  if (!facts) {
+    console.log(`[${agent}] structured output: <missing or invalid>`);
+    return;
+  }
+  console.log(`[${agent}] structured output:\n${JSON.stringify(facts, null, 2)}`);
+}

--- a/.atomic/workflows/structured-output-demo/opencode/index.ts
+++ b/.atomic/workflows/structured-output-demo/opencode/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Structured-output demo for OpenCode.
+ *
+ * Runs a single stage that asks for structured facts about a programming
+ * language and enforces the schema via `format: { type: "json_schema" }`.
+ * The validated object is read from the AssistantMessage's `structured`
+ * field (see `@opencode-ai/sdk` v2 types — AssistantMessage.structured).
+ *
+ * Run: atomic workflow -n structured-output-demo -a opencode "Python"
+ */
+
+import { defineWorkflow } from "@bastani/atomic/workflows";
+
+import {
+  LanguageFactsSchema,
+  LANGUAGE_FACTS_JSON_SCHEMA,
+  buildPrompt,
+  logFacts,
+  type LanguageFacts,
+} from "../helpers/schema.ts";
+
+export default defineWorkflow({
+  name: "structured-output-demo",
+  description:
+    "Ask for structured facts about a language and prove each SDK's native structured-output path works",
+  inputs: [
+    {
+      name: "prompt",
+      type: "string",
+      required: true,
+      description: "programming language to describe",
+      default: "Python",
+    },
+  ],
+})
+  .for<"opencode">()
+  .run(async (ctx) => {
+    const topic = ctx.inputs.prompt ?? "Python";
+
+    await ctx.stage(
+      { name: "describe" },
+      {},
+      { title: "describe" },
+      async (s) => {
+        const result = await s.client.session.prompt({
+          sessionID: s.session.id,
+          parts: [{ type: "text", text: buildPrompt(topic) }],
+          format: {
+            type: "json_schema" as const,
+            schema: LANGUAGE_FACTS_JSON_SCHEMA,
+          },
+        });
+        s.save(result.data!);
+
+        const structured = (result.data!.info as { structured?: unknown })
+          ?.structured;
+        const parsed = LanguageFactsSchema.safeParse(structured);
+        const facts: LanguageFacts | null = parsed.success
+          ? parsed.data
+          : null;
+
+        logFacts("opencode", facts);
+        if (!facts) {
+          console.log(
+            `[opencode] validation failed — raw structured value: ${JSON.stringify(structured)}`,
+          );
+          throw new Error(
+            "OpenCode structured output was missing or failed schema validation",
+          );
+        }
+      },
+    );
+  })
+  .compile();

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -1064,6 +1064,16 @@ export class ClaudeSessionWrapper {
     });
   }
 
+  /**
+   * Structured output is only produced by the Agent SDK's `result` message,
+   * which interactive stages don't consume (they drive the `claude` CLI via
+   * tmux, not the SDK). Always `undefined` here — pair `outputFormat` with a
+   * headless stage to read {@link HeadlessClaudeSessionWrapper#lastStructuredOutput}.
+   */
+  get lastStructuredOutput(): unknown {
+    return undefined;
+  }
+
   /** Noop — for API symmetry with CopilotSession.disconnect(). */
   async disconnect(): Promise<void> {}
 }
@@ -1143,9 +1153,22 @@ export class HeadlessClaudeSessionWrapper {
    * Claude stages run in parallel (each call gets its own SDK-assigned UUID).
    */
   private _lastSessionId: string = "";
+  /**
+   * Validated structured output captured from the most recent `query()`'s
+   * `result` message. Populated only when callers pass
+   * `options.outputFormat = { type: "json_schema", schema }` and the SDK
+   * produced a `subtype: "success"` result with `structured_output` attached.
+   * Remains `undefined` on plain text runs or when the SDK fails validation
+   * (`error_max_structured_output_retries`).
+   */
+  private _lastStructuredOutput: unknown = undefined;
 
   get sessionId(): string {
     return this._lastSessionId;
+  }
+
+  get lastStructuredOutput(): unknown {
+    return this._lastStructuredOutput;
   }
 
   async query(
@@ -1166,12 +1189,15 @@ export class HeadlessClaudeSessionWrapper {
     };
 
     let sdkSessionId = "";
+    let structuredOutput: unknown = undefined;
     try {
       for await (const msg of sdkQuery({ prompt, options: headlessSdkOpts })) {
         if (msg.type === "result") {
-          sdkSessionId = String(
-            (msg as Record<string, unknown>).session_id ?? "",
-          );
+          const record = msg as Record<string, unknown>;
+          sdkSessionId = String(record.session_id ?? "");
+          if (record.subtype === "success" && "structured_output" in record) {
+            structuredOutput = record.structured_output;
+          }
         }
       }
     } catch (err) {
@@ -1187,6 +1213,7 @@ export class HeadlessClaudeSessionWrapper {
       );
     }
     this._lastSessionId = sdkSessionId;
+    this._lastStructuredOutput = structuredOutput;
     return getSessionMessages(sdkSessionId, { dir: process.cwd() });
   }
 

--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -7,13 +7,13 @@
  *   - `max_loops` iterations have completed (defaults to {@link DEFAULT_MAX_LOOPS}), OR
  *   - Two parallel reviewer passes both return zero findings.
  *
- * The reviewer stages run the `reviewer` sub-agent in a visible TUI via the
- * `--agent reviewer` chatFlag, then parse the JSON review out of the
- * assistant text with {@link parseReviewResult}. The prompt enumerates the
- * {@link ReviewResultSchema} fields so the model emits matching JSON. We
- * deliberately avoid invoking the Claude Agent SDK's `query()` from inside a
- * non-headless stage — that would spawn a TUI pane that goes unused while
- * the SDK runs in-process (see workflow-creator skill, failure-modes F17).
+ * The reviewer stages run **headless** via the Claude Agent SDK with
+ * `outputFormat: { type: "json_schema", schema: REVIEW_RESULT_JSON_SCHEMA }`,
+ * so the SDK validates {@link ReviewResultSchema} before returning. The
+ * validated object is read from `s.session.lastStructuredOutput` — no text
+ * parsing required. Running the reviewers headless (no tmux pane) keeps the
+ * graph focused on stages the user cares about and lets the SDK enforce the
+ * schema without TUI round-trips.
  *
  * Run: atomic workflow -n ralph -a claude "<your spec>"
  */
@@ -27,8 +27,10 @@ import {
   buildReviewPrompt,
   buildDebuggerReportPrompt,
   extractMarkdownBlock,
-  parseReviewResult,
+  filterActionable,
   mergeReviewResults,
+  REVIEW_RESULT_JSON_SCHEMA,
+  type ReviewResult,
   type StructuredReviewResult,
 } from "../helpers/prompts.ts";
 import { hasActionableFindings } from "../helpers/review.ts";
@@ -42,13 +44,23 @@ const DEFAULT_MAX_LOOPS = 10;
 // timeout is needed.
 
 /**
- * Extract a {@link StructuredReviewResult} from the reviewer TUI's assistant
- * text. {@link parseReviewResult} tolerates surrounding prose and fenced
- * code blocks; the prompt instructs the model to emit JSON matching
- * {@link ReviewResultSchema}.
+ * Turn the SDK's validated structured_output (plus raw transcript text) into a
+ * {@link StructuredReviewResult}. When the SDK failed to validate the schema
+ * (`error_max_structured_output_retries`) `structured_output` is absent and
+ * we propagate `null` so {@link mergeReviewResults} treats the pass as
+ * unknown/actionable.
  */
-function extractReview(rawText: string): StructuredReviewResult {
-  return { structured: parseReviewResult(rawText), raw: rawText };
+function extractReview(
+  structuredOutput: unknown,
+  rawText: string,
+): StructuredReviewResult {
+  if (structuredOutput && typeof structuredOutput === "object") {
+    return {
+      structured: filterActionable(structuredOutput as ReviewResult),
+      raw: rawText,
+    };
+  }
+  return { structured: null, raw: rawText };
 }
 
 export default defineWorkflow({
@@ -179,41 +191,39 @@ export default defineWorkflow({
           patternResult.result,
       ].join("\n\n---\n\n");
 
-      // ── Review (two parallel passes) ────────────────────────────────────
+      // ── Review (two parallel headless passes with schema enforcement) ──
       const reviewPrompt = buildReviewPrompt(prompt, {
         changeset,
         iteration,
         discoveryContext,
       });
 
-      const reviewerChatFlags = [
-        "--agent",
-        "reviewer",
-        "--allow-dangerously-skip-permissions",
-        "--dangerously-skip-permissions",
-      ];
+      const runReviewer = (name: string) =>
+        ctx.stage(
+          { name, headless: true },
+          {},
+          {},
+          async (s) => {
+            const result = await s.session.query(reviewPrompt, {
+              agent: "reviewer",
+              permissionMode: "bypassPermissions",
+              allowDangerouslySkipPermissions: true,
+              outputFormat: {
+                type: "json_schema",
+                schema: REVIEW_RESULT_JSON_SCHEMA,
+              },
+            });
+            s.save(s.sessionId);
+            return extractReview(
+              s.session.lastStructuredOutput,
+              extractAssistantText(result, 0),
+            );
+          },
+        );
 
       const [reviewA, reviewB] = await Promise.all([
-        ctx.stage(
-          { name: `reviewer-${iteration}-a` },
-          { chatFlags: reviewerChatFlags },
-          {},
-          async (s) => {
-            const result = await s.session.query(reviewPrompt);
-            s.save(s.sessionId);
-            return extractReview(extractAssistantText(result, 0));
-          },
-        ),
-        ctx.stage(
-          { name: `reviewer-${iteration}-b` },
-          { chatFlags: reviewerChatFlags },
-          {},
-          async (s) => {
-            const result = await s.session.query(reviewPrompt);
-            s.save(s.sessionId);
-            return extractReview(extractAssistantText(result, 0));
-          },
-        ),
+        runReviewer(`reviewer-${iteration}-a`),
+        runReviewer(`reviewer-${iteration}-b`),
       ]);
 
       const merged = mergeReviewResults(reviewA.result, reviewB.result);

--- a/src/sdk/workflows/builtin/ralph/helpers/prompts.ts
+++ b/src/sdk/workflows/builtin/ralph/helpers/prompts.ts
@@ -78,8 +78,18 @@ export const ReviewResultSchema = z.object({
     .describe("Overall confidence in the review (0.0–1.0)"),
 });
 
-/** JSON Schema derived from the Zod schema — used by Claude and OpenCode SDKs. */
-export const REVIEW_RESULT_JSON_SCHEMA = z.toJSONSchema(ReviewResultSchema);
+/**
+ * JSON Schema derived from the Zod schema — used by Claude and OpenCode SDKs.
+ *
+ * `target: "openapi-3.0"` drops the `$schema` draft URL that Zod stamps
+ * by default. The Claude Agent SDK's validator silently drops
+ * `structured_output` when that metadata field is present, so we emit
+ * the OpenAPI-flavoured variant which matches the hand-written shape in
+ * the SDK's structured-output guide.
+ */
+export const REVIEW_RESULT_JSON_SCHEMA = z.toJSONSchema(ReviewResultSchema, {
+  target: "openapi-3.0",
+});
 
 /** Result from a reviewer stage with structured output support. */
 export interface StructuredReviewResult {
@@ -92,10 +102,12 @@ export interface StructuredReviewResult {
 /**
  * Merge two parallel reviewer results into one.
  *
- * Two independent reviewers run the same prompt simultaneously. This function
- * unions their findings and picks the more conservative overall_correctness.
- * When either reviewer's structured output is unavailable, it falls back to
- * text parsing ({@link parseReviewResult}) before merging.
+ * Each SDK enforces {@link ReviewResultSchema} at the provider level (Claude
+ * `outputFormat`, OpenCode `format: json_schema`, Copilot `defineTool`), so a
+ * non-null `structured` is already a validated {@link ReviewResult}. When
+ * either reviewer failed to produce validated output we propagate `null` —
+ * {@link hasActionableFindings} then treats the raw response as actionable so
+ * the loop keeps iterating instead of silently exiting on a missing reviewer.
  */
 export function mergeReviewResults(
   a: StructuredReviewResult,
@@ -103,38 +115,30 @@ export function mergeReviewResults(
 ): StructuredReviewResult {
   const rawCombined = [a.raw, b.raw].filter(Boolean).join("\n\n---\n\n");
 
-  // Resolve: prefer structured output, fall back to text parsing
-  const parsedA =
-    a.structured ?? (a.raw.trim() ? parseReviewResult(a.raw) : null);
-  const parsedB =
-    b.structured ?? (b.raw.trim() ? parseReviewResult(b.raw) : null);
-
-  if (!parsedA && !parsedB) {
+  // Conservative: any missing structured output → propagate null. Fabricating
+  // a "patch is correct" default here is how the loop previously exited after
+  // a single iteration when one reviewer's output failed SDK validation.
+  if (!a.structured || !b.structured) {
     return { structured: null, raw: rawCombined };
   }
 
-  const findingsA = parsedA?.findings ?? [];
-  const findingsB = parsedB?.findings ?? [];
-
-  const correctnessA = parsedA?.overall_correctness ?? "patch is correct";
-  const correctnessB = parsedB?.overall_correctness ?? "patch is correct";
   const isIncorrect =
-    correctnessA === "patch is incorrect" ||
-    correctnessB === "patch is incorrect";
+    a.structured.overall_correctness === "patch is incorrect" ||
+    b.structured.overall_correctness === "patch is incorrect";
 
   const explanations = [
-    parsedA?.overall_explanation,
-    parsedB?.overall_explanation,
-  ].filter(Boolean) as string[];
+    a.structured.overall_explanation,
+    b.structured.overall_explanation,
+  ].filter((e): e is string => typeof e === "string" && e.length > 0);
 
   const confidences = [
-    parsedA?.overall_confidence_score,
-    parsedB?.overall_confidence_score,
+    a.structured.overall_confidence_score,
+    b.structured.overall_confidence_score,
   ].filter((c): c is number => c !== undefined);
 
   return {
     structured: {
-      findings: [...findingsA, ...findingsB],
+      findings: [...a.structured.findings, ...b.structured.findings],
       overall_correctness: isIncorrect
         ? "patch is incorrect"
         : "patch is correct",
@@ -980,65 +984,6 @@ the "Pitfalls" section entirely if there are none. Begin now.`;
 // ============================================================================
 // PARSING HELPERS
 // ============================================================================
-
-/**
- * Parse the reviewer's JSON output. Tries, in order:
- *   1. Direct JSON.parse on the entire content.
- *   2. The LAST fenced ```json (or unlabelled) code block.
- *   3. The LAST balanced object containing a "findings" key in surrounding prose.
- *
- * Filters out P3 (minor/style) findings — only P0/P1/P2 count as actionable.
- * Returns null when no parse strategy succeeds.
- */
-export function parseReviewResult(content: string): ReviewResult | null {
-  // Strategy 1: direct JSON
-  try {
-    const parsed = JSON.parse(content);
-    if (parsed && parsed.findings && parsed.overall_correctness) {
-      return filterActionable(parsed);
-    }
-  } catch {
-    /* fall through */
-  }
-
-  // Strategy 2: last fenced code block
-  const blockRe = /```(?:json)?\s*\n([\s\S]*?)\n```/g;
-  let lastBlock: string | null = null;
-  let blockMatch: RegExpExecArray | null;
-  while ((blockMatch = blockRe.exec(content)) !== null) {
-    if (blockMatch[1]) lastBlock = blockMatch[1];
-  }
-  if (lastBlock !== null) {
-    try {
-      const parsed = JSON.parse(lastBlock);
-      if (parsed && parsed.findings && parsed.overall_correctness) {
-        return filterActionable(parsed);
-      }
-    } catch {
-      /* fall through */
-    }
-  }
-
-  // Strategy 3: last "{...findings...}" object in surrounding prose
-  const objRe = /\{[\s\S]*?"findings"[\s\S]*?\}/g;
-  let lastObj: string | null = null;
-  let objMatch: RegExpExecArray | null;
-  while ((objMatch = objRe.exec(content)) !== null) {
-    lastObj = objMatch[0];
-  }
-  if (lastObj !== null) {
-    try {
-      const parsed = JSON.parse(lastObj);
-      if (parsed && parsed.findings && parsed.overall_correctness) {
-        return filterActionable(parsed);
-      }
-    } catch {
-      /* nothing more to try */
-    }
-  }
-
-  return null;
-}
 
 export function filterActionable(parsed: {
   findings: ReviewFinding[];

--- a/src/sdk/workflows/builtin/ralph/opencode/index.ts
+++ b/src/sdk/workflows/builtin/ralph/opencode/index.ts
@@ -46,15 +46,19 @@ function extractResponseText(
 
 /**
  * Extract a {@link StructuredReviewResult} from an OpenCode prompt response.
- * Prefers the SDK's structured_output field; falls back to text extraction.
+ *
+ * The OpenCode SDK places the SDK-validated structured output on the
+ * AssistantMessage as `structured` (see `@opencode-ai/sdk` v2 types.gen.d.ts
+ * — AssistantMessage.structured). Returns `structured: null` whenever the
+ * SDK did not produce a validated object so {@link mergeReviewResults}
+ * treats the pass as unknown/actionable.
  */
 function extractReview(
   data: { info?: Record<string, unknown>; parts: Array<{ type: string; [key: string]: unknown }> },
 ): StructuredReviewResult {
   const raw = extractResponseText(data.parts);
 
-  // The SDK places validated structured output at data.info.structured_output
-  const structuredOutput = data.info?.structured_output;
+  const structuredOutput = data.info?.structured;
   if (structuredOutput && typeof structuredOutput === "object") {
     return {
       structured: filterActionable(structuredOutput as ReviewResult),


### PR DESCRIPTION
## Summary

Replaces regex-based JSON parsing in Ralph's reviewer stages with SDK-native structured output enforcement across all three providers (Claude, OpenCode, Copilot), eliminating a class of silent loop-exit bugs caused by fabricated fallback defaults.

## Key Changes

**Claude reviewer (headless SDK path)**
- Reviewer stages now run headless with `outputFormat: { type: "json_schema", schema: REVIEW_RESULT_JSON_SCHEMA }`, delegating schema validation to the Agent SDK
- Structured output is read from `s.session.lastStructuredOutput` — no text parsing required
- `HeadlessClaudeSessionWrapper` gains a `_lastStructuredOutput` field; `ClaudeSessionWrapper` exposes a no-op `lastStructuredOutput` getter for API symmetry
- Drops the `parseReviewResult` regex helper and the `--agent reviewer` TUI chatFlag path

**OpenCode reviewer**
- Fixes latent field-name bug: `AssistantMessage` exposes the validated object as `structured`, not `structured_output`

**Merge logic (`mergeReviewResults`)**
- Removes fallback text-parsing and fabricated `"patch is correct"` defaults when a reviewer's structured output is null
- Null propagates through `mergeReviewResults` so `hasActionableFindings` keeps the loop iterating instead of silently exiting on a single flaky reviewer pass

**Schema helpers**
- `REVIEW_RESULT_JSON_SCHEMA` now uses `z.toJSONSchema(ReviewResultSchema, { target: "openapi-3.0" })` — omits the `$schema` draft URL that the Claude Agent SDK's validator silently rejects

**Demo workflow**
- Adds `.atomic/workflows/structured-output-demo/` with three implementations exercising the schema-enforcement path:
  - Claude: `outputFormat` with JSON schema
  - OpenCode: `format: json_schema`
  - Copilot: `defineTool` with Zod schema

## Breaking Changes / Migration Notes

None. All changes are internal to the Ralph workflow and its helpers.