### PR TITLE
chore(release): bump version to v0.5.31-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.30",
+  "version": "0.5.31-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.30` to `0.5.31-0` as a prerelease ahead of the `v0.5.31` stable release.

## Changes

- `package.json`: version `0.5.30` → `0.5.31-0`

## Notes

- This is a prerelease version (`-0` suffix); no functional code changes are included.
- A GitHub Release and npm publish will be triggered automatically upon merge to `main`.

## Test plan

- [ ] CI passes
- [ ] GitHub Release created automatically on merge