### PR TITLE
chore(release): bump version to v0.5.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.31-0",
+  "version": "0.5.31",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `0.5.31-0` to the stable release `0.5.31` by updating the version in `package.json`.

## Changes

- `package.json`: version `0.5.31-0` → `0.5.31`

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes `v0.5.31` to npm upon merge