### PR TITLE
chore(publish): stage filtered skills at publish time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,31 @@ jobs:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Stage filtered skills for npm package
+        env:
+          SKILLS_REPO: https://github.com/flora131/atomic.git
+        run: |
+          set -euo pipefail
+
+          # Replace the dev-laden checkout skills with the filtered set
+          # produced by `bunx skills add` (which excludes development-only
+          # skills). Install globally on the runner, then copy into the
+          # package root so npm pack picks them up.
+          rm -rf .agents/skills
+          bunx skills add "$SKILLS_REPO" \
+            --skill "*" \
+            -a opencode -a github-copilot \
+            -g -y
+
+          mkdir -p .agents/skills
+          cp -R "$HOME/.agents/skills/." .agents/skills/
+
+          # Whitelist the staged directory for `npm publish` without
+          # baking the entry into the committed package.json.
+          tmp=$(mktemp)
+          jq '.files += [".agents/skills"]' package.json > "$tmp"
+          mv "$tmp" package.json
+
       - name: Publish to npm
         run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "src",
     "dist",
     "assets/settings.schema.json",
-    ".agents/skills",
     ".claude/agents",
     ".claude/settings.json",
     ".opencode/agents",


### PR DESCRIPTION
## Summary

Replace the committed `.agents/skills` directory (which carries development-only skills useful in-repo) with the filtered, end-user skill set produced by `bunx skills add` during the publish job. This keeps dev-only skills out of the published npm package without having to scrub them from the working tree.

## Changes

- **`.github/workflows/publish.yml`**: New "Stage filtered skills for npm package" step runs before `npm publish` — clears `.agents/skills`, runs `bunx skills add "$SKILLS_REPO" --skill "*" -a opencode -a github-copilot -g -y`, copies the filtered skills into `.agents/skills/`, then patches `package.json` in-place via `jq` to whitelist the directory for `npm pack`.
- **`package.json`**: Removes the static `.agents/skills` entry from the `files` array — it's now added ad-hoc at publish time so the committed config doesn't pull in dev skills locally.

## Breaking Changes

None — CI-side packaging fix.