### PR TITLE
fix(chat): tear down tmux session on agent exit and forward Ctrl+C raw

### DIFF
--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -37,6 +37,7 @@ import {
   createSession,
   detachAndAttachAtomic,
   killSession,
+  killSessionOnPaneExit,
   setSessionEnv,
   spawnMuxAttach,
   switchClient,
@@ -262,6 +263,12 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
   try {
     const paneId = createSession(windowName, shellCmd, undefined, projectRoot);
     setSessionEnv(windowName, "ATOMIC_AGENT", agentType);
+
+    // When the agent CLI exits (via `/exit`, double Ctrl+C, or crash),
+    // tear down the whole session so the footer pane doesn't keep it
+    // alive in the background. Pane-scoped so the footer's own exit
+    // (which cascades from the kill-session) doesn't re-trigger.
+    killSessionOnPaneExit(windowName, paneId);
 
     // Split the pane so the agent CLI runs on top and the React footer
     // (provider pill + window name) runs in a 5% bottom pane. Matches

--- a/src/sdk/runtime/tmux.conf
+++ b/src/sdk/runtime/tmux.conf
@@ -53,14 +53,17 @@ bind -n C-g select-window -t :0
 # Ctrl+\: cycle to next agent window from anywhere
 bind -n C-\\ next-window
 
-# Ctrl+C debounce — forward the first press of a burst and swallow the
-# rest while the user is still pressing, preventing the "double-tap to
-# exit" behaviour of Claude Code / OpenCode / Copilot from firing on
-# accidental spam. Runs via bun so the same TypeScript helper works on
-# Linux, macOS, and Windows psmux. @atomic-bun and @atomic-cc-debounce
-# are set to absolute paths by tmux.ts on session creation — no PATH
-# lookup needed inside run-shell.
-bind -n C-c run-shell -b '"#{@atomic-bun}" "#{@atomic-cc-debounce}" "#{pane_id}"'
+# Ctrl+C handling — for workflow sessions, debounce bursts so the agent's
+# "double-tap to exit" doesn't trigger on accidental spam. For chat
+# sessions (atomic-chat-*) the user is in direct control of the single
+# agent CLI and a deliberate double-tap exit must reach the agent
+# verbatim, so we forward Ctrl+C unmodified.
+#
+# @atomic-bun and @atomic-cc-debounce are set to absolute paths by
+# tmux.ts on session creation — no PATH lookup needed inside run-shell.
+bind -n C-c if-shell -F '#{m:atomic-chat-*,#{session_name}}' \
+  'send-keys C-c' \
+  'run-shell -b "\"#{@atomic-bun}\" \"#{@atomic-cc-debounce}\" \"#{pane_id}\""'
 
 # Escape exits copy-mode (clear selection first if one exists, otherwise cancel)
 bind-key -T copy-mode-vi Escape if-shell -F "#{selection_present}" "send-keys -X clear-selection" "send-keys -X cancel"

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -221,6 +221,28 @@ export function createSession(
 }
 
 /**
+ * Install a hook that kills the entire session when the given pane's
+ * process exits. Used by chat sessions so the session is torn down
+ * when the agent CLI exits — whether via `/exit`, a deliberate double
+ * Ctrl+C, or a crash — without leaving the footer pane keeping the
+ * session alive.
+ *
+ * The hook is session-scoped (pane-scoped hooks don't fire because the
+ * pane is already gone when `pane-exited` would run) and guarded with
+ * `#{hook_pane}` so the footer pane's eventual exit cascade doesn't
+ * re-trigger it. `kill-session` is idempotent in any case.
+ */
+export function killSessionOnPaneExit(sessionName: string, paneId: string): void {
+  const guard = `if -F '#{==:#{hook_pane},${paneId}}' 'kill-session -t ${sessionName}'`;
+  tmuxRun([
+    "set-hook",
+    "-t", sessionName,
+    "pane-exited",
+    guard,
+  ]);
+}
+
+/**
  * Create a new window in an existing session without switching focus.
  *
  * @param sessionName - Target session name

--- a/src/sdk/workflows/index.ts
+++ b/src/sdk/workflows/index.ts
@@ -68,6 +68,7 @@ export {
   capturePaneVisible,
   capturePaneScrollback,
   killSession,
+  killSessionOnPaneExit,
   killWindow,
   sessionExists,
   listSessions,


### PR DESCRIPTION
Chat sessions now properly clean up when the agent CLI exits and receive unmodified Ctrl+C signals for direct agent control.

## Changes

- **Session teardown on agent exit**: Installs a session-scoped `pane-exited` tmux hook guarded by `#{hook_pane}` that kills the entire session when the agent CLI pane exits — via `/exit`, deliberate double Ctrl+C, or crash. Prevents the footer pane from keeping zombie sessions alive in the background.
- **Raw Ctrl+C for chat sessions**: Bypasses the workflow Ctrl+C debounce for `atomic-chat-*` sessions. Since the user is in direct control of a single agent CLI in chat mode, a deliberate double-tap exit must reach the agent verbatim rather than being debounced.
- **New export**: `killSessionOnPaneExit` is exported from `src/sdk/workflows/index.ts` for use by callers outside the runtime module.

## Files Changed

- `src/sdk/runtime/tmux.ts` — adds `killSessionOnPaneExit(sessionName, paneId)` which sets the `pane-exited` hook with a pane-ID guard so the footer's cascading exit doesn't re-trigger `kill-session`
- `src/sdk/runtime/tmux.conf` — updates the `C-c` binding to use `if-shell` to distinguish `atomic-chat-*` sessions (send raw) from workflow sessions (run debounce helper)
- `src/commands/cli/chat/index.ts` — calls `killSessionOnPaneExit` after creating the agent pane
- `src/sdk/workflows/index.ts` — re-exports `killSessionOnPaneExit`