### PR TITLE
chore(release): bump version to v0.5.32-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.31",
+  "version": "0.5.32-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.31` to `0.5.32-0` in preparation for the next prerelease.

## Changes

- `package.json`: version `0.5.31` → `0.5.32-0`

## Test plan

- [ ] CI passes
- [ ] Release is automatically created on merge