### PR TITLE
chore(release): bump version to v0.5.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.32-1",
+  "version": "0.5.32",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.32-1` to the stable release `0.5.32` by updating `package.json`.

## Changes

- `package.json`: version `0.5.32-1` → `0.5.32`

## Test plan

- [x] `bun typecheck` passes (pre-commit hook)
- [x] `bun test` passes (pre-commit hook)