### PR TITLE
fix(claude): use SessionStart hook for spawn readiness

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -350,6 +350,16 @@ Examples:
             process.exit(exitCode);
         });
 
+    // ── Internal: Claude SessionStart hook handler ────────────────────────
+    program
+        .command("_claude-session-start-hook", { hidden: true })
+        .description("Internal: Claude Code SessionStart hook handler — writes a ready-marker file")
+        .action(async () => {
+            const { claudeSessionStartHookCommand } = await import("./commands/cli/claude-session-start-hook.ts");
+            const exitCode = await claudeSessionStartHookCommand();
+            process.exit(exitCode);
+        });
+
     // ── Internal: Claude AskUserQuestion hook handler ─────────────────────
     program
         .command("_claude-ask-hook", { hidden: true })
@@ -423,7 +433,8 @@ async function main(): Promise<void> {
             argv[0] === "completions" ||
             argv[0] === "_footer" ||
             argv[0] === "_claude-stop-hook" ||
-            argv[0] === "_claude-ask-hook";
+            argv[0] === "_claude-ask-hook" ||
+            argv[0] === "_claude-session-start-hook";
 
         if (!isInfoCommand) {
             const { autoSyncIfStale } = await import("./services/system/auto-sync.ts");

--- a/src/commands/cli/claude-session-start-hook.ts
+++ b/src/commands/cli/claude-session-start-hook.ts
@@ -1,0 +1,61 @@
+/**
+ * Claude SessionStart Hook command — internal handler for the `startup` matcher.
+ *
+ * Invoked as:
+ *   atomic _claude-session-start-hook
+ *
+ * Writes `~/.atomic/claude-ready/<session_id>` as a positive readiness signal.
+ * The workflow runtime (`src/sdk/providers/claude.ts`) `fs.watch`es that dir so
+ * it can resolve the spawn wait the instant Claude dispatches SessionStart —
+ * which fires before the JSONL transcript is created, making it a stricter and
+ * more reliable readiness signal than polling for the transcript file.
+ *
+ * Always exits 0 so a hook failure never shows up as a red "hook error" in
+ * Claude's transcript. The runtime's spawn timeout still protects against a
+ * truly broken startup (bad binary, exec failure).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { claudeHookDirs } from "./claude-stop-hook.ts";
+
+/** Shape of the JSON payload Claude pipes to the SessionStart hook via stdin. */
+export interface ClaudeSessionStartHookPayload {
+  session_id: string;
+  source?: string;
+  transcript_path?: string;
+  cwd?: string;
+}
+
+function isClaudeSessionStartHookPayload(
+  value: unknown,
+): value is ClaudeSessionStartHookPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj["session_id"] === "string";
+}
+
+export async function claudeSessionStartHookCommand(): Promise<number> {
+  const raw = await Bun.stdin.text();
+
+  let payload: ClaudeSessionStartHookPayload;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isClaudeSessionStartHookPayload(parsed)) {
+      console.error(
+        "[claude-session-start-hook] Invalid payload: missing or malformed 'session_id'",
+      );
+      return 0;
+    }
+    payload = parsed;
+  } catch {
+    console.error("[claude-session-start-hook] Failed to parse stdin as JSON");
+    return 0;
+  }
+
+  const { ready } = claudeHookDirs();
+  await fs.mkdir(ready, { recursive: true });
+  await Bun.write(path.join(ready, payload.session_id), raw);
+
+  return 0;
+}

--- a/src/commands/cli/claude-stop-hook.ts
+++ b/src/commands/cli/claude-stop-hook.ts
@@ -67,6 +67,7 @@ export function claudeHookDirs(): {
   release: string;
   hil: string;
   pid: string;
+  ready: string;
 } {
   const base = path.join(os.homedir(), ".atomic");
   return {
@@ -80,6 +81,10 @@ export function claudeHookDirs(): {
     // can detect the orphaned session and self-exit instead of sitting in
     // its wait loop for ~24 days.
     pid: path.join(base, "claude-pid"),
+    // Written by the SessionStart hook on fresh spawns. The workflow runtime
+    // watches this directory to detect readiness — positive signal, unlike
+    // racing the JSONL writer.
+    ready: path.join(base, "claude-ready"),
   };
 }
 

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -49,8 +49,6 @@ interface PaneState {
   claudeStarted: boolean;
   /** CLI flags to pass to `claude` when it is spawned on the first query. */
   chatFlags: string[];
-  /** Timeout in ms waiting for Claude TUI / JSONL file on first spawn. */
-  readyTimeoutMs: number;
 }
 
 const initializedPanes = new Map<string, PaneState>();
@@ -76,6 +74,13 @@ export async function clearClaudeSession(paneId: string): Promise<void> {
     } catch {
       // Best-effort — stale pid file is inert; the next session writes a
       // fresh one under its own UUID.
+    }
+    try {
+      await clearStaleReadyMarker(state.claudeSessionId);
+    } catch {
+      // Best-effort — stale ready marker is inert; the next session writes
+      // a fresh one under its own UUID and clears any prior leftover in
+      // `claudeQuery` before respawn.
     }
   }
   initializedPanes.delete(paneId);
@@ -135,6 +140,18 @@ function buildWorkflowHookCommand(subcommand: string, extraArgs: readonly string
 const STOP_HOOK_TIMEOUT_SECONDS = 2_147_483;
 
 /**
+ * Effectively-unbounded ms ceiling for `waitForReadyMarker`. Mirrors
+ * {@link STOP_HOOK_TIMEOUT_SECONDS} but expressed in ms for `setTimeout`.
+ *
+ * The SessionStart hook fires well under a second on a working spawn, so in
+ * practice this timer never expires. It only protects against failure modes
+ * where the hook will never fire at all (claude binary missing, hook
+ * command not resolvable, settings JSON rejected), where a clear error
+ * beats a hung pane.
+ */
+const READY_HOOK_TIMEOUT_MS = 2_147_483_000;
+
+/**
  * Inline settings injected via `claude --settings <json>` on every workflow
  * spawn. Registers the workflow-owned hooks without relying on
  * `.claude/settings.json` — so the hooks fire only for workflow-spawned
@@ -161,6 +178,17 @@ const STOP_HOOK_TIMEOUT_SECONDS = 2_147_483;
  */
 const WORKFLOW_HOOK_SETTINGS = JSON.stringify({
   hooks: {
+    SessionStart: [
+      {
+        matcher: "startup",
+        hooks: [
+          {
+            type: "command",
+            command: buildWorkflowHookCommand("_claude-session-start-hook"),
+          },
+        ],
+      },
+    ],
     Stop: [
       {
         hooks: [
@@ -217,8 +245,6 @@ export interface ClaudeSessionOptions {
   paneId: string;
   /** CLI flags to pass to the `claude` command (default: ["--allow-dangerously-skip-permissions", "--dangerously-skip-permissions"]) */
   chatFlags?: string[];
-  /** Timeout in ms waiting for Claude TUI to be ready (default: 30s) */
-  readyTimeoutMs?: number;
 }
 
 /**
@@ -251,18 +277,13 @@ export interface ClaudeSessionOptions {
  * ```
  */
 export async function createClaudeSession(options: ClaudeSessionOptions): Promise<string> {
-  const {
-    paneId,
-    chatFlags = DEFAULT_CHAT_FLAGS,
-    readyTimeoutMs = 30_000,
-  } = options;
+  const { paneId, chatFlags = DEFAULT_CHAT_FLAGS } = options;
 
   const claudeSessionId = randomUUID();
   initializedPanes.set(paneId, {
     claudeSessionId,
     claudeStarted: false,
     chatFlags,
-    readyTimeoutMs,
   });
 
   // Write our PID so the Stop hook can detect an orphaned session if we
@@ -298,7 +319,6 @@ async function spawnClaudeWithPrompt(
   promptFile: string,
   chatFlags: string[],
   sessionId: string,
-  readyTimeoutMs: number,
 ): Promise<void> {
   // sessionDir is the workflow's `${name}-${sessionId}` directory under
   // ~/.atomic/sessions — slug-based, so single-quoting is sufficient on
@@ -324,55 +344,58 @@ async function spawnClaudeWithPrompt(
   // the command typed at the prompt but never submitted.
   respawnPane(paneId, cmd);
 
-  // SDK-native readiness signal: wait for Claude to create its JSONL file
-  // at the known UUID path.
-  await waitForSessionFileAt(sessionId, readyTimeoutMs);
+  // Positive readiness signal: wait for Claude's SessionStart hook (matcher
+  // `startup`) to write `~/.atomic/claude-ready/<session_id>`. This fires
+  // before Claude writes the JSONL transcript, so it beats the old
+  // transcript-file race and is deterministic.
+  await waitForReadyMarker(sessionId);
 }
 
 /**
- * Wait for Claude's JSONL session file at a known UUID-named path to exist.
+ * Wait for the SessionStart hook's ready marker at
+ * `~/.atomic/claude-ready/<session_id>`.
  *
- * Because we pass `--session-id <UUID>` to the spawn, the file's exact path
- * is deterministic — we just need to wait for it to appear. Uses `fs.watch`
- * for instant OS-native notification (inotify/kqueue in Bun) racing against
- * a polling fallback that handles the case where the session directory
- * doesn't exist yet on first run.
+ * `atomic _claude-session-start-hook` is registered in
+ * {@link WORKFLOW_HOOK_SETTINGS} with matcher `startup`; the Claude CLI
+ * dispatches it during spawn, before the first API call and before the JSONL
+ * transcript is created. Waiting on the resulting marker file gives us a
+ * positive "Claude is alive" signal instead of racing the transcript writer.
+ *
+ * The timeout only fires on catastrophic startup failure (bad binary, exec
+ * error) — under load, Claude's own session bootstrap runs well under the
+ * limit because SessionStart is dispatched early in the startup sequence.
  */
-async function waitForSessionFileAt(
-  sessionId: string,
-  timeoutMs: number,
-): Promise<void> {
-  const sessionDir = resolveSessionDir(process.cwd());
-  const targetPath = `${sessionDir}/${sessionId}.jsonl`;
+async function waitForReadyMarker(sessionId: string): Promise<void> {
+  const { ready: readyDir } = claudeHookDirs();
+  await mkdir(readyDir, { recursive: true });
+  const target = join(readyDir, sessionId);
 
-  if (existsSync(targetPath)) return;
+  if (existsSync(target)) return;
 
   const ac = new AbortController();
-  const timeout = setTimeout(() => ac.abort(), timeoutMs);
+  const timeout = setTimeout(() => ac.abort(), READY_HOOK_TIMEOUT_MS);
 
   try {
     await Promise.race([
-      // fs.watch — instant OS-native notification when Claude writes the file
+      // fs.watch — instant OS-native notification when the hook writes the file
       (async (): Promise<void> => {
         try {
-          for await (const event of watch(sessionDir, { signal: ac.signal })) {
-            if (event.filename === `${sessionId}.jsonl` && existsSync(targetPath)) {
-              return;
-            }
+          for await (const _event of watch(readyDir, { signal: ac.signal })) {
+            // Trust disk state, not event.filename (Linux can deliver
+            // unexpected basenames under tmp+rename writes).
+            if (existsSync(target)) return;
           }
         } catch (e: unknown) {
           if (e instanceof Error && e.name === "AbortError") throw e;
-          // Directory doesn't exist yet — let polling handle it
         }
-        // Park this branch so polling can win the race
         return new Promise<void>(() => {});
       })(),
 
-      // Polling fallback — handles directory-not-yet-created case
+      // Polling fallback — catches dropped inotify/FSEvent notifications
       (async (): Promise<void> => {
         while (!ac.signal.aborted) {
-          if (existsSync(targetPath)) return;
-          await Bun.sleep(500);
+          if (existsSync(target)) return;
+          await Bun.sleep(250);
         }
         throw new DOMException("Aborted", "AbortError");
       })(),
@@ -380,8 +403,8 @@ async function waitForSessionFileAt(
   } catch (e: unknown) {
     if (e instanceof DOMException && e.name === "AbortError") {
       throw new Error(
-        `Timed out waiting for Claude session file at ${targetPath}. ` +
-        "Verify the `claude` command started successfully.",
+        `Timed out waiting for Claude SessionStart hook to signal readiness ` +
+        `at ${target}. Verify the \`claude\` command started successfully.`,
       );
     }
     throw e;
@@ -389,16 +412,6 @@ async function waitForSessionFileAt(
     clearTimeout(timeout);
     ac.abort();
   }
-}
-
-/**
- * Resolve the session directory for a given cwd.
- * Session files live at `~/.claude/projects/<encoded-cwd>/`.
- */
-function resolveSessionDir(cwd: string): string {
-  const encodedCwd = cwd.replace(/[^a-zA-Z0-9]/g, "-");
-  const home = process.env.HOME || process.env.USERPROFILE || "";
-  return `${home}/.claude/projects/${encodedCwd}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -593,6 +606,24 @@ async function clearStaleHILMarker(claudeSessionId: string): Promise<void> {
   await mkdir(hil, { recursive: true });
   try {
     await unlink(join(hil, claudeSessionId));
+  } catch (e: unknown) {
+    if (!(e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT")) {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Remove a stale ready marker from a prior session that reused this UUID (in
+ * practice impossible — UUIDs are fresh per session — but cheap insurance so
+ * `waitForReadyMarker`'s initial existsSync can't false-positive on anything
+ * we left behind). Ignores ENOENT.
+ */
+async function clearStaleReadyMarker(claudeSessionId: string): Promise<void> {
+  const { ready } = claudeHookDirs();
+  await mkdir(ready, { recursive: true });
+  try {
+    await unlink(join(ready, claudeSessionId));
   } catch (e: unknown) {
     if (!(e instanceof Error && "code" in e && (e as NodeJS.ErrnoException).code === "ENOENT")) {
       throw e;
@@ -895,6 +926,7 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionM
   await clearStaleMarker(claudeSessionId);
   await clearStaleQueue(claudeSessionId);
   await clearStaleHILMarker(claudeSessionId);
+  await clearStaleReadyMarker(claudeSessionId);
 
   let transcriptBeforeCount = 0;
   let spawnPromptFile: string | undefined;
@@ -931,7 +963,6 @@ export async function claudeQuery(options: ClaudeQueryOptions): Promise<SessionM
         spawnPromptFile,
         paneState.chatFlags,
         claudeSessionId,
-        paneState.readyTimeoutMs,
       );
       paneState.claudeStarted = true;
     }
@@ -995,11 +1026,11 @@ export function mergeDisallowedTools(
  */
 export class ClaudeClientWrapper {
   readonly paneId: string;
-  private readonly opts: { chatFlags?: string[]; readyTimeoutMs?: number };
+  private readonly opts: { chatFlags?: string[] };
 
   constructor(
     paneId: string,
-    opts: { chatFlags?: string[]; readyTimeoutMs?: number } = {},
+    opts: { chatFlags?: string[] } = {},
   ) {
     this.paneId = paneId;
     this.opts = opts;
@@ -1017,7 +1048,6 @@ export class ClaudeClientWrapper {
     return await createClaudeSession({
       paneId: this.paneId,
       chatFlags: this.opts.chatFlags,
-      readyTimeoutMs: this.opts.readyTimeoutMs,
     });
   }
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -36,7 +36,7 @@ export type AgentType = "copilot" | "opencode" | "claude";
 type ClientOptionsMap = {
   opencode: { directory?: string; experimental_workspaceID?: string };
   copilot: Omit<CopilotClientOptions, "cliUrl">;
-  claude: { chatFlags?: string[]; readyTimeoutMs?: number };
+  claude: { chatFlags?: string[] };
 };
 
 /**


### PR DESCRIPTION
## Summary

Replaces JSONL-transcript polling with a deterministic, positive readiness signal driven by Claude's `SessionStart` hook. This eliminates a race condition that caused flaky spawn timeouts during long `ralph` runs.

## Problem

`waitForSessionFileAt` raced Claude's transcript writer against a hard 30s timeout. As stale TUI processes accumulated across ralph iterations, cold-spawn latency on a fresh pane could exceed 30s — aborting the workflow even though `claude` was starting normally. The JSONL file is also written *after* the REPL is ready, making it a trailing signal.

## Changes

- **New `_claude-session-start-hook` subcommand** (`src/commands/cli/claude-session-start-hook.ts`): Internal hook handler registered under Claude's `SessionStart` event (matcher `startup`). Writes `~/.atomic/claude-ready/<session_id>` as a readiness marker. Always exits 0 so hook failures are silent and never surface as red errors in Claude's transcript.

- **`waitForReadyMarker` replaces `waitForSessionFileAt`** (`src/sdk/providers/claude.ts`): Watches `~/.atomic/claude-ready/` with the same `fs.watch` + polling fallback pattern used for the Stop-hook marker. The `SessionStart` hook fires before the REPL renders and before the JSONL is created — a stricter, earlier signal.

- **Timeout changed from 30s to ~24 days** (`READY_HOOK_TIMEOUT_MS`): The ceiling now mirrors `STOP_HOOK_TIMEOUT_SECONDS`. Since the signal is deterministic (Claude dispatches `SessionStart` early in its startup sequence), the timer only fires on catastrophic spawn failure (missing binary, unresolvable hook command). This is an internal constant, not a caller knob.

- **`readyTimeoutMs` option removed** from `ClaudeSessionOptions`, `ClaudeClientWrapper`, and the `claude` entry in `ClientOptionsMap` (`src/sdk/types.ts`). The timeout is no longer a meaningful caller concern.

- **`clearStaleReadyMarker`** added to session teardown in `clearClaudeSession` and pre-query cleanup in `claudeQuery`, guarding against false-positive `existsSync` hits on leftover files from prior sessions.

- **`ready` directory added to `claudeHookDirs()`** (`src/commands/cli/claude-stop-hook.ts`) so all hook directory paths are co-located.

## Breaking Changes

- `readyTimeoutMs` has been removed from `ClaudeSessionOptions` and `ClaudeClientWrapper` constructor options. Any callers passing this option will need to remove it.

## Testing Notes

- SessionStart fires before JSONL creation, so this signal can be validated by checking that `~/.atomic/claude-ready/<session_id>` is created during a `claude` spawn.
- The polling fallback interval tightened from 500ms → 250ms to reduce latency on systems where `fs.watch` drops events.