### PR TITLE
chore(release): bump version to v0.5.33-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.32",
+  "version": "0.5.33-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.5.32` to `0.5.33-0` in preparation for the next release.

## Changes

- `package.json`: version `0.5.32` → `0.5.33-0`

## Test plan

- [ ] CI passes
- [ ] Release auto-publishes on merge