### PR TITLE
chore(release): bump version to v0.5.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.33-0",
+  "version": "0.5.33",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the pre-release `0.5.33-0` to the stable `0.5.33` release by updating the version in `package.json`.

## Changes

- **`package.json`**: version `0.5.33-0` → `0.5.33`

## Release Notes

This is a stable release cut from the `0.5.33-0` pre-release. No feature or bug-fix changes are included — this commit exists solely to publish the stable version to npm.

## Test plan

- [x] `bun typecheck` passes (ran via pre-commit hook)
- [ ] CI passes
- [ ] GitHub Release created automatically on merge
- [ ] npm package `@bastani/atomic@0.5.33` published successfully