### PR TITLE
fix(ralph/copilot): wire submit_review via customAgents and fix MCP disable flags

### DIFF
--- a/.atomic/workflows/reviewer-tool-test/copilot/index.ts
+++ b/.atomic/workflows/reviewer-tool-test/copilot/index.ts
@@ -1,0 +1,106 @@
+/**
+ * Dummy workflow to verify that a reviewer subagent can invoke a
+ * workflow-registered `submit_review` custom tool.
+ *
+ * Background: Copilot CLI treats a subagent's `tools:` frontmatter as a
+ * restrictive allowlist validated against its built-in tool-alias
+ * registry at parse time — custom SDK-registered tools are unknown then
+ * and get silently dropped. Defining the reviewer inline via
+ * `customAgents` at session creation runs the tool allowlist against the
+ * live tool registry, which DOES know about `submit_review`. This
+ * workflow proves that mechanic end-to-end.
+ *
+ * Pass criterion: the `submit_review` handler fires exactly once with a
+ * `{ verdict, explanation }` object. If it doesn't, the workflow throws.
+ *
+ * Run: atomic workflow -n reviewer-tool-test -a copilot
+ */
+
+import { defineWorkflow } from "@bastani/atomic/workflows";
+import { defineTool } from "@github/copilot-sdk";
+import type { CustomAgentConfig } from "@github/copilot-sdk";
+import { z } from "zod";
+
+const SubmitReviewSchema = z.object({
+  verdict: z
+    .enum(["patch is correct", "patch is incorrect"])
+    .describe("Exact literal verdict — no paraphrase."),
+  explanation: z.string().describe("One-sentence justification."),
+});
+
+type SubmitReviewArgs = z.infer<typeof SubmitReviewSchema>;
+
+const DUMMY_PATCH = `diff --git a/hello.ts b/hello.ts
+index 0000001..0000002 100644
+--- a/hello.ts
++++ b/hello.ts
+@@ -1 +1 @@
+-export const greeting = "hi";
++export const greeting = "hello";
+`;
+
+const REVIEW_PROMPT = `You are reviewing the following one-line patch.
+
+<patch>
+${DUMMY_PATCH}
+</patch>
+
+Call the \`submit_review\` tool exactly once with your verdict. Do NOT
+output the review as plain text — the tool enforces the required schema.`;
+
+export default defineWorkflow({
+  name: "reviewer-tool-test",
+  description:
+    "Verify the reviewer subagent can call a workflow-registered submit_review tool",
+  inputs: [],
+})
+  .for<"copilot">()
+  .run(async (ctx) => {
+    let captured: SubmitReviewArgs | null = null;
+
+    const submitReview = defineTool("submit_review", {
+      description:
+        "Submit the structured review verdict. Call this tool exactly once.",
+      parameters: SubmitReviewSchema,
+      skipPermission: true,
+      handler: async (data: SubmitReviewArgs) => {
+        captured = data;
+        return "Review submitted.";
+      },
+    });
+
+    const inlineReviewer: CustomAgentConfig = {
+      name: "reviewer",
+      displayName: "reviewer",
+      description: "Test reviewer subagent wired to submit_review.",
+      tools: ["execute", "read", "search", "submit_review"],
+      prompt:
+        "You are a code reviewer. Use the `submit_review` tool to return your verdict. Do not output the review as plain text.",
+    };
+
+    await ctx.stage(
+      { name: "review" },
+      {},
+      {
+        agent: "reviewer",
+        tools: [submitReview],
+        customAgents: [inlineReviewer],
+      },
+      async (s) => {
+        await s.session.send({ prompt: REVIEW_PROMPT });
+        s.save(await s.session.getMessages());
+
+        if (!captured) {
+          console.log("[reviewer-tool-test] submit_review was NOT called");
+          throw new Error(
+            "reviewer subagent did not call submit_review — tool allowlist likely filtered it out",
+          );
+        }
+
+        console.log(
+          `[reviewer-tool-test] submit_review fired:\n${JSON.stringify(captured, null, 2)}`,
+        );
+      },
+    );
+  })
+  .compile();

--- a/src/sdk/workflows/builtin/ralph/copilot/index.ts
+++ b/src/sdk/workflows/builtin/ralph/copilot/index.ts
@@ -38,6 +38,9 @@ import {
 } from "../helpers/prompts.ts";
 import { hasActionableFindings } from "../helpers/review.ts";
 import { captureBranchChangeset } from "../helpers/git.ts";
+import { buildRalphReviewerAgent } from "../helpers/copilot-reviewer.ts";
+
+const SUBMIT_REVIEW_TOOL_NAME = "submit_review";
 
 const DEFAULT_MAX_LOOPS = 10;
 
@@ -198,7 +201,7 @@ export default defineWorkflow({
       let captureA: ReviewResult | null = null;
       let captureB: ReviewResult | null = null;
 
-      const toolA = defineTool("submit_review", {
+      const toolA = defineTool(SUBMIT_REVIEW_TOOL_NAME, {
         description: SUBMIT_REVIEW_DESCRIPTION,
         parameters: ReviewResultSchema,
         skipPermission: true,
@@ -208,7 +211,7 @@ export default defineWorkflow({
         },
       });
 
-      const toolB = defineTool("submit_review", {
+      const toolB = defineTool(SUBMIT_REVIEW_TOOL_NAME, {
         description: SUBMIT_REVIEW_DESCRIPTION,
         parameters: ReviewResultSchema,
         skipPermission: true,
@@ -218,11 +221,22 @@ export default defineWorkflow({
         },
       });
 
+      // Inline reviewer agent config overrides the disk-based
+      // `.github/agents/reviewer.md`. Defining it here lets the tool
+      // allowlist include `submit_review` — disk-loaded agents filter the
+      // frontmatter `tools:` list against Copilot's built-in alias
+      // registry at parse time, so session-level custom tools are dropped.
+      const ralphReviewer = buildRalphReviewerAgent(SUBMIT_REVIEW_TOOL_NAME);
+
       const [reviewA, reviewB] = await Promise.all([
         ctx.stage(
           { name: `reviewer-${iteration}-a` },
           {},
-          { agent: "reviewer", tools: [toolA] },
+          {
+            agent: "reviewer",
+            tools: [toolA],
+            customAgents: [ralphReviewer],
+          },
           async (s) => {
             await s.session.send({ prompt: reviewPrompt });
             const messages = await s.session.getMessages();
@@ -236,7 +250,11 @@ export default defineWorkflow({
         ctx.stage(
           { name: `reviewer-${iteration}-b` },
           {},
-          { agent: "reviewer", tools: [toolB] },
+          {
+            agent: "reviewer",
+            tools: [toolB],
+            customAgents: [ralphReviewer],
+          },
           async (s) => {
             await s.session.send({ prompt: reviewPrompt });
             const messages = await s.session.getMessages();

--- a/src/sdk/workflows/builtin/ralph/helpers/copilot-reviewer.ts
+++ b/src/sdk/workflows/builtin/ralph/helpers/copilot-reviewer.ts
@@ -1,0 +1,105 @@
+/**
+ * Inline reviewer `CustomAgentConfig` for the Copilot ralph workflow.
+ *
+ * Why this exists instead of reusing `.github/agents/reviewer.md`: Copilot
+ * CLI parses the disk agent's `tools:` frontmatter against its built-in
+ * alias registry at load time. Custom tool names (like `submit_review`
+ * registered via `defineTool` at session creation) are unknown at that
+ * moment and get silently dropped. Defining the agent inline in
+ * `customAgents` runs the tool-allowlist check against the session's live
+ * tool registry, so `submit_review` is actually exposed to the subagent.
+ *
+ * This is a ralph-specific fork — the disk reviewer stays general-purpose
+ * for non-ralph invocations.
+ */
+
+import type { CustomAgentConfig } from "@github/copilot-sdk";
+
+const REVIEWER_PROMPT = `# Review guidelines:
+
+You are acting as a reviewer for a proposed code change made by another engineer.
+
+Below are some default guidelines for determining whether the original author would appreciate the issue being flagged.
+
+These are not the final word in determining whether an issue is a bug. In many cases, you will encounter other, more specific guidelines. These may be present elsewhere in a developer message, a user message, a file, or even elsewhere in this system message.
+Those guidelines should be considered to override these general instructions.
+
+Here are the general guidelines for determining whether something is a bug and should be flagged.
+
+1. It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
+2. The bug is discrete and actionable (i.e. not a general issue with the codebase or a combination of multiple issues).
+3. Fixing the bug does not demand a level of rigor that is not present in the rest of the codebase (e.g. one doesn't need very detailed comments and input validation in a repository of one-off scripts in personal projects)
+4. The bug was introduced in the commit (pre-existing bugs should not be flagged).
+5. The author of the original PR would likely fix the issue if they were made aware of it.
+6. The bug does not rely on unstated assumptions about the codebase or author's intent.
+7. It is not enough to speculate that a change may disrupt another part of the codebase, to be considered a bug, one must identify the other parts of the code that are provably affected.
+8. The bug is clearly not just an intentional change by the original author.
+9. Use the repository's \`AGENTS.md\` and/or \`CLAUDE.md\` files (if present) for guidance on style, conventions, testing expectations, and architectural patterns. Your review should respect these project-level norms — flag deviations only when they conflict with correctness or security, not personal preference.
+
+When flagging a bug, you will also provide an accompanying comment. Once again, these guidelines are not the final word on how to construct a comment -- defer to any subsequent guidelines that you encounter.
+
+1. The comment should be clear about why the issue is a bug.
+2. The comment should appropriately communicate the severity of the issue. It should not claim that an issue is more severe than it actually is.
+3. The comment should be brief. The body should be at most 1 paragraph. It should not introduce line breaks within the natural language flow unless it is necessary for the code fragment.
+4. The comment should not include any chunks of code longer than 3 lines. Any code chunks should be wrapped in markdown inline code tags or a code block.
+5. The comment should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
+6. The comment's tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
+7. The comment should be written such that the original author can immediately grasp the idea without close reading.
+8. The comment should avoid excessive flattery and comments that are not helpful to the original author. The comment should avoid phrasing like "Great job ...", "Thanks for ...".
+
+Below are some more detailed guidelines that you should apply to this specific review.
+
+HOW MANY FINDINGS TO RETURN:
+
+Output all findings that the original author would fix if they knew about it. If there is no finding that a person would definitely love to see and fix, prefer outputting no findings. Do not stop at the first qualifying finding. Continue until you've listed every qualifying finding.
+
+GUIDELINES:
+
+- Ignore trivial style unless it obscures meaning or violates documented standards.
+- Use one comment per distinct issue (or a multi-line range if necessary).
+- Use \`\`\`suggestion blocks ONLY for concrete replacement code (minimal lines; no commentary inside the block).
+- In every \`\`\`suggestion block, preserve the exact leading whitespace of the replaced lines (spaces vs tabs, number of spaces).
+- Do NOT introduce or remove outer indentation levels unless that is the actual fix.
+
+The comments will be presented in the code review as inline comments. You should avoid providing unnecessary location details in the comment body. Always keep the line range as short as possible for interpreting the issue. Avoid ranges longer than 5–10 lines; instead, choose the most suitable subrange that pinpoints the problem.
+
+At the beginning of the finding title, tag the bug with priority level. For example "[P1] Un-padding slices along wrong tensor dimensions". [P0] – Drop everything to fix. Blocking release, operations, or major usage. Only use for universal issues that do not depend on any assumptions about the inputs. · [P1] – Urgent. Should be addressed in the next cycle · [P2] – Normal. To be fixed eventually · [P3] – Low. Nice to have.
+
+Additionally, include a numeric priority field in the JSON output for each finding: set "priority" to 0 for P0, 1 for P1, 2 for P2, or 3 for P3. If a priority cannot be determined, omit the field or use null.
+
+At the end of your findings, output an "overall correctness" verdict of whether or not the patch should be considered "correct".
+Correct implies that existing code and tests will not break, and the patch is free of bugs and other blocking issues.
+Ignore non-blocking issues such as style, formatting, typos, documentation, and other nits.
+
+FORMATTING GUIDELINES:
+The finding description should be one paragraph.
+
+OUTPUT: You MUST submit your review by calling the \`submit_review\` tool exactly once with the complete structured review. Do NOT output the review as plain text — the tool enforces the required schema.`;
+
+/**
+ * Build the ralph-specific reviewer `CustomAgentConfig`.
+ *
+ * Pass the session-level custom tool name(s) (e.g. `"submit_review"`) via
+ * `submitReviewToolName` so the reviewer subagent's tool allowlist
+ * includes it. Session-level tools named here are visible to the subagent;
+ * omitted names are filtered out.
+ */
+export function buildRalphReviewerAgent(
+  submitReviewToolName: string,
+): CustomAgentConfig {
+  return {
+    name: "reviewer",
+    displayName: "reviewer",
+    description: "Code reviewer for proposed code changes.",
+    tools: [
+      "execute",
+      "agent",
+      "search",
+      "read",
+      "web_fetch",
+      "sql",
+      submitReviewToolName,
+    ],
+    prompt: REVIEWER_PROMPT,
+  };
+}

--- a/src/services/config/scm-sync.ts
+++ b/src/services/config/scm-sync.ts
@@ -30,6 +30,19 @@ function enabledServersFor(scm: ScmProvider): Set<ScmMcpServer> {
 }
 
 /**
+ * Copilot CLI servers to disable per scm selection. Copilot ships with a
+ * built-in `github-mcp-server`; when scm is `github` the user's own
+ * `github` MCP is redundant with it, so we keep the built-in and disable
+ * the user's. For `azure-devops` we keep the user's `azure-devops` and
+ * disable both GitHub variants. Sapling disables everything.
+ */
+const COPILOT_DISABLE_BY_SCM: Record<ScmProvider, readonly string[]> = {
+  github: ["github", "azure-devops"],
+  "azure-devops": ["github", "github-mcp-server"],
+  sapling: ["github", "azure-devops", "github-mcp-server"],
+};
+
+/**
  * Pure helper: returns the `--disable-mcp-server <name>` flag sequence to
  * append when spawning Copilot CLI, given a selected scm provider.
  *
@@ -39,11 +52,9 @@ function enabledServersFor(scm: ScmProvider): Set<ScmMcpServer> {
  */
 export function copilotScmDisableFlags(scm: ScmProvider | undefined): string[] {
   if (!scm) return [];
-  const enabled = enabledServersFor(scm);
+  const names = COPILOT_DISABLE_BY_SCM[scm] ?? [];
   const flags: string[] = [];
-  for (const name of SCM_MCP_SERVERS) {
-    if (!enabled.has(name)) flags.push("--disable-mcp-server", name);
-  }
+  for (const name of names) flags.push("--disable-mcp-server", name);
   return flags;
 }
 

--- a/tests/services/config/scm-sync.test.ts
+++ b/tests/services/config/scm-sync.test.ts
@@ -57,26 +57,32 @@ describe("copilotScmDisableFlags", () => {
     expect(copilotScmDisableFlags(undefined)).toEqual([]);
   });
 
-  test("disables azure-devops when scm is github", () => {
+  test("disables github and azure-devops when scm is github (keeps built-in github-mcp-server)", () => {
     expect(copilotScmDisableFlags("github")).toEqual([
+      "--disable-mcp-server",
+      "github",
       "--disable-mcp-server",
       "azure-devops",
     ]);
   });
 
-  test("disables github when scm is azure-devops", () => {
+  test("disables github and github-mcp-server when scm is azure-devops", () => {
     expect(copilotScmDisableFlags("azure-devops")).toEqual([
       "--disable-mcp-server",
       "github",
+      "--disable-mcp-server",
+      "github-mcp-server",
     ]);
   });
 
-  test("disables all scm servers when scm is sapling (no matching mcp server)", () => {
+  test("disables github, azure-devops, and github-mcp-server when scm is sapling", () => {
     expect(copilotScmDisableFlags("sapling")).toEqual([
       "--disable-mcp-server",
       "github",
       "--disable-mcp-server",
       "azure-devops",
+      "--disable-mcp-server",
+      "github-mcp-server",
     ]);
   });
 });
@@ -98,6 +104,8 @@ describe("getCopilotScmDisableFlags", () => {
     await writeAtomicConfig(projectRoot, { scm: "github" });
 
     expect(await getCopilotScmDisableFlags(projectRoot)).toEqual([
+      "--disable-mcp-server",
+      "github",
       "--disable-mcp-server",
       "azure-devops",
     ]);


### PR DESCRIPTION
## Summary

Fixes two independent bugs in the Copilot integration: the `submit_review` custom tool being silently dropped by the reviewer subagent, and incorrect MCP server disable flags when selecting an SCM provider.

## Key Changes

### Fix: Reviewer subagent custom tool access (`ralph/copilot`)
- **Root cause**: Copilot CLI validates a disk-loaded agent's `tools:` frontmatter against its built-in alias registry at parse time. Session-level custom tools (e.g. `submit_review` registered via `defineTool`) are unknown at that point and get silently dropped.
- **Fix**: Define the reviewer inline via `customAgents` at session creation. This runs the tool allowlist against the live tool registry, which does know about `submit_review`.
- Extracted `buildRalphReviewerAgent(submitReviewToolName)` into `src/sdk/workflows/builtin/ralph/helpers/copilot-reviewer.ts` — a ralph-specific `CustomAgentConfig` that includes `submit_review` in its tool list alongside the standard built-in aliases.
- Both parallel reviewer stages now pass `customAgents: [ralphReviewer]` to ensure the tool is reachable.
- Added `.atomic/workflows/reviewer-tool-test/copilot/index.ts` — an end-to-end test workflow that verifies the mechanic (throws if `submit_review` is never called).

### Fix: Copilot MCP disable flags (`scm-sync`)
- Replaced the previous allowlist-subtraction logic with an explicit `COPILOT_DISABLE_BY_SCM` lookup table.
- **`github` SCM**: now also disables the user's `github` MCP, since Copilot ships a built-in `github-mcp-server` that is redundant with it. Previously only `azure-devops` was disabled.
- **`azure-devops` SCM**: disables both `github` and `github-mcp-server`.
- **`sapling` SCM**: disables all three (`github`, `azure-devops`, `github-mcp-server`).
- Updated unit tests to reflect the corrected disable flag sets.