### PR TITLE
chore(release): bump version to v0.5.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.34-0",
+  "version": "0.5.34",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.5.34-0` to the stable release `0.5.34` in `package.json`.

## Changes

- `package.json`: version `0.5.34-0` → `0.5.34`

## Test plan

- [x] Version bumped via `bun run src/scripts/bump-version.ts --from-branch`
- [ ] CI passes
- [ ] Merge will trigger GitHub Release and npm publish