### PR TITLE
chore(release): bump version to v0.6.0-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.5.34",
+  "version": "0.6.0-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.5.34` to `0.6.0-0` as a prerelease for the `0.6.0` workflow SDK rewrite.

## Changes

- Updates `version` in `package.json` from `0.5.34` to `0.6.0-0`

## Breaking Changes

> **Note:** This is a prerelease (`0.6.0-0`) for the `0.6.0` line, which includes a **complete rewrite of the workflow SDK**. Consumers should review workflow SDK usage and migration requirements before upgrading to any `0.6.x` release.