### PR TITLE
chore(release)!: bump version to v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.0-0",
+  "version": "0.6.0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the `0.6.0-0` prerelease to the stable `0.6.0` release. This version contains a complete redesign of the workflow SDK with breaking API changes.

## Changes

- Bumps `package.json` version from `0.6.0-0` → `0.6.0`

## What's included in this release

**Workflow SDK redesign** (`#748`)
- Replaces directory-scanning (`WorkflowLoader`, `discoverWorkflows`, `findWorkflow`) with composable primitives: `createRegistry()`, `createWorkflowCli()`
- `createWorkflowCli` accepts a single workflow, array of workflows, or a registry — replaces both `createWorker` and `createDispatcher`
- `.for<A>()` replaced by `.for(agent)` runtime argument; compiled definitions now carry an `agent` field for registry keying
- Commander adapter extracted to `@bastani/atomic/workflows/commander` (`toCommand`, `runCli`) — SDK core is now framework-agnostic
- Shared `management-commands.ts` module auto-registers `session` and `status` subcommands for both root CLI and SDK-built CLIs
- Builtin workflows (`ralph`, `deep-research-codebase`, `open-claude-design`) moved to `src/sdk/workflows/builtin/` and assembled via `createBuiltinRegistry()`
- New examples added: `commander-embed`, `multi-workflow`, `review-fix-loop`, `sequential-describe-summarize`
- Added `rest-api/` workspace with HTTP server, typed store, and full test coverage

**Docs + Copilot SDK 0.3 fix** (`#749`)
- Documents required `-n/--name` flag for direct workflow runs
- Fixes Copilot SDK 0.3 external auth options (moves GitHub token auth to session options)

## Breaking Changes

> Consumers **must** migrate before upgrading to `v0.6.0`.

| Removed | Replacement |
|---|---|
| `WorkflowLoader`, `discoverWorkflows`, `findWorkflow` | `createRegistry()` |
| `createWorker(def)` | `createWorkflowCli(workflow).run()` |
| `createDispatcher(registry)` | `createWorkflowCli(registry).run()` |
| `.for<A>()` generic | `.for("claude")` / `.for("copilot")` / `.for("opencode")` |
| `.atomic/workflows/` directory scanning | TypeScript entrypoints with `createWorkflowCli` |

To embed a workflow under a parent Commander program, import `toCommand` from `@bastani/atomic/workflows/commander`.