### PR TITLE
fix(install,runtime): harden Windows psmux setup and session lifecycle

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.4.6"
+    "@opencode-ai/plugin": "1.14.22"
   }
 }

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ bun install -g @bastani/atomic
 ```
 
 This skips the Bun install step but doesn't set up shell completions — run `atomic completions <shell>` separately if you want them (see [Commands Reference](#atomic-completions--shell-completions)).
+If your shell cannot find `atomic` after the install, add the directory from `bun pm bin -g` to your PATH or use the bootstrap installer above to do it automatically.
 
 **Prerelease builds:** `bun install -g @bastani/atomic@next` (may contain breaking changes).
 

--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,8 @@
 # silently syncs tooling deps and bundled skills on first launch — see
 # src/services/system/auto-sync.ts.
 #
-# If you already have bun, you can skip this script entirely:
+# If you already have bun and `bun pm bin -g` is on PATH, you can skip this
+# script entirely:
 #   bun install -g @bastani/atomic@latest
 #
 # Usage:
@@ -193,6 +194,134 @@ function Refresh-Path {
                 [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
 }
 
+# These environment helpers follow Bun's Windows installer. They write the
+# user environment registry value directly so existing %VAR% entries are not
+# accidentally expanded, then notify running shells/editors that it changed.
+function Publish-Env {
+    if (-not ("Win32.NativeMethods" -as [Type])) {
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+    IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+    uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [IntPtr]0xffff
+    $WM_SETTINGCHANGE = 0x1a
+    $result = [UIntPtr]::Zero
+    [Win32.NativeMethods]::SendMessageTimeout(
+        $HWND_BROADCAST,
+        $WM_SETTINGCHANGE,
+        [UIntPtr]::Zero,
+        "Environment",
+        2,
+        5000,
+        [ref]$result
+    ) | Out-Null
+}
+
+function Write-Env {
+    param(
+        [string]$Key,
+        [AllowNull()][string]$Value
+    )
+
+    $registerKey = Get-Item -Path 'HKCU:'
+    $envRegisterKey = $registerKey.OpenSubKey('Environment', $true)
+
+    if ($null -eq $Value) {
+        $envRegisterKey.DeleteValue($Key)
+    } else {
+        $registryValueKind = if ($Value.Contains('%')) {
+            [Microsoft.Win32.RegistryValueKind]::ExpandString
+        } elseif ($envRegisterKey.GetValue($Key)) {
+            $envRegisterKey.GetValueKind($Key)
+        } else {
+            [Microsoft.Win32.RegistryValueKind]::String
+        }
+        $envRegisterKey.SetValue($Key, $Value, $registryValueKind)
+    }
+
+    Publish-Env
+}
+
+function Get-Env {
+    param([string]$Key)
+
+    $registerKey = Get-Item -Path 'HKCU:'
+    $envRegisterKey = $registerKey.OpenSubKey('Environment')
+    $envRegisterKey.GetValue($Key, $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+}
+
+function Get-BunGlobalBinDir {
+    $binDir = & bun pm bin -g 2>$null | Select-Object -First 1
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($binDir)) {
+        return $binDir.Trim()
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:BUN_INSTALL_BIN)) {
+        return $env:BUN_INSTALL_BIN
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:BUN_INSTALL)) {
+        return (Join-Path $env:BUN_INSTALL "bin")
+    }
+    return (Join-Path $HOME ".bun\bin")
+}
+
+function Normalize-PathEntry {
+    param([string]$PathEntry)
+
+    if ([string]::IsNullOrWhiteSpace($PathEntry)) { return "" }
+    $value = [System.Environment]::ExpandEnvironmentVariables($PathEntry.Trim().Trim('"'))
+    while ($value.EndsWith("\") -or $value.EndsWith("/")) {
+        $value = $value.Substring(0, $value.Length - 1)
+    }
+    return $value
+}
+
+function Test-PathContains {
+    param(
+        [string]$PathValue,
+        [string]$Entry
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) { return $false }
+    $target = Normalize-PathEntry $Entry
+    foreach ($item in ($PathValue -split ';')) {
+        if ((Normalize-PathEntry $item) -ieq $target) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Ensure-BunGlobalBinOnPath {
+    $binDir = Get-BunGlobalBinDir
+    if (-not (Test-Path $binDir)) {
+        New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+    }
+
+    if (-not (Test-PathContains $env:Path $binDir)) {
+        $env:Path = if ([string]::IsNullOrWhiteSpace($env:Path)) { $binDir } else { "$env:Path;$binDir" }
+    }
+
+    $userPathValue = Get-Env -Key "Path"
+    $userPath = if ([string]::IsNullOrWhiteSpace($userPathValue)) { @() } else { $userPathValue -split ';' }
+    if (-not (Test-PathContains $userPathValue $binDir)) {
+        $newUserPathEntries = @($userPath) + @($binDir)
+        $newUserPath = ($newUserPathEntries | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ';'
+        Write-Env -Key 'Path' -Value $newUserPath
+        $env:Path = @($env:Path -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ';'
+        if (-not (Test-PathContains $env:Path $binDir)) {
+            $env:Path = "$env:Path;$binDir"
+        }
+        Write-Info "added bun global bin to user PATH ($binDir)"
+    } else {
+        Write-Info "bun global bin already on user PATH ($binDir)"
+    }
+}
+
 # ── Installers ──────────────────────────────────────────────────────────────
 
 function Install-Bun {
@@ -326,11 +455,18 @@ Write-Host ""
 
 if (-not (Install-Bun)) { exit 1 }
 
+Ensure-BunGlobalBinOnPath
+
 # Embed the package name as a literal so the scriptblock needs no closure.
 $atomicAction = [ScriptBlock]::Create("bun install -g '$PACKAGE'")
 $ok = Invoke-Step -Label "Installing @bastani/atomic" -Action $atomicAction
 if (-not $ok) {
     Write-Err2 "Failed to install atomic"
+    exit 1
+}
+
+if (-not (Get-Command atomic -ErrorAction SilentlyContinue)) {
+    Write-Err2 "atomic installed but is not on PATH — add $(Get-BunGlobalBinDir) to PATH"
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,8 @@
 # silently syncs tooling deps and bundled skills on first launch — see
 # src/services/system/auto-sync.ts.
 #
-# If you already have bun, you can skip this script entirely:
+# If you already have bun and `bun pm bin -g` is on PATH, you can skip this
+# script entirely:
 #   bun install -g @bastani/atomic@latest
 #
 # Usage:
@@ -177,6 +178,80 @@ run_step() {
     fi
 }
 
+# `bun install -g` links CLIs into Bun's global bin directory. Use Bun's
+# own package-manager helper so custom BUN_INSTALL/BUN_INSTALL_BIN settings
+# are respected, then persist that directory for future shells.
+bun_global_bin_dir() {
+    local bin_dir=""
+    if bin_dir=$(bun pm bin -g 2>/dev/null) && [[ -n "$bin_dir" ]]; then
+        printf '%s\n' "$bin_dir"
+        return 0
+    fi
+
+    if [[ -n "${BUN_INSTALL_BIN:-}" ]]; then
+        printf '%s\n' "$BUN_INSTALL_BIN"
+    elif [[ -n "${BUN_INSTALL:-}" ]]; then
+        printf '%s\n' "$BUN_INSTALL/bin"
+    elif [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+        printf '%s\n' "$XDG_CACHE_HOME/.bun/bin"
+    else
+        printf '%s\n' "$HOME/.bun/bin"
+    fi
+}
+
+path_contains() {
+    local dir=$1
+    case ":$PATH:" in
+        *":$dir:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+install_path_rc_snippet() {
+    local rc=$1 shell_name=$2 bin_dir=$3
+    local marker='# Atomic CLI bun global bin PATH'
+
+    mkdir -p "$(dirname "$rc")"
+    touch "$rc"
+
+    if grep -qF "$marker" "$rc" 2>/dev/null || grep -qF "$bin_dir" "$rc" 2>/dev/null; then
+        return 0
+    fi
+
+    {
+        printf '\n%s\n' "$marker"
+        if [[ "$shell_name" == "fish" ]]; then
+            printf 'fish_add_path "%s"\n' "$bin_dir"
+        else
+            printf 'case ":$PATH:" in\n'
+            printf '    *":%s:"*) ;;\n' "$bin_dir"
+            printf '    *) export PATH="%s:$PATH" ;;\n' "$bin_dir"
+            printf 'esac\n'
+        fi
+    } >> "$rc"
+}
+
+ensure_bun_global_bin_on_path() {
+    local bin_dir shell_name rc
+    bin_dir=$(bun_global_bin_dir)
+    mkdir -p "$bin_dir"
+
+    if ! path_contains "$bin_dir"; then
+        export PATH="$bin_dir:$PATH"
+    fi
+
+    shell_name=$(basename "${SHELL:-}")
+    case "$shell_name" in
+        bash) rc="$HOME/.bashrc" ;;
+        zsh)  rc="$HOME/.zshrc" ;;
+        fish) rc="$HOME/.config/fish/config.fish" ;;
+        *)    rc="$HOME/.profile" ;;
+    esac
+
+    install_path_rc_snippet "$rc" "$shell_name" "$bin_dir"
+    info "bun global bin on PATH ($bin_dir)"
+}
+
 # ── Installers ──────────────────────────────────────────────────────────────
 
 install_bun() {
@@ -326,8 +401,15 @@ main() {
         exit 1
     fi
 
+    ensure_bun_global_bin_on_path
+
     if ! install_atomic; then
         error "atomic installation failed"
+        exit 1
+    fi
+
+    if ! command -v atomic >/dev/null 2>&1; then
+        error "atomic installed but is not on PATH — add $(bun_global_bin_dir) to PATH"
         exit 1
     fi
 

--- a/src/commands/cli/chat/index.test.ts
+++ b/src/commands/cli/chat/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { buildLauncherScript } from "./index.ts";
+
+function withMockPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+  }
+}
+
+describe("buildLauncherScript", () => {
+  test("adds PowerShell session cleanup after the agent exits", () => {
+    const { script, ext } = withMockPlatform("win32", () =>
+      buildLauncherScript(
+        "copilot",
+        ["--debug"],
+        "C:\\repo",
+        { ATOMIC_AGENT: "copilot" },
+        "atomic-chat-copilot-abc12345",
+      )
+    );
+
+    expect(ext).toBe("ps1");
+    expect(script).toContain("try {");
+    expect(script).toContain("} finally {");
+    expect(script).toContain("Invoke-AtomicSessionCleanup");
+    expect(script).toContain('-L "atomic" kill-session -t "atomic-chat-copilot-abc12345"');
+    expect(script).toContain("exit $atomicExitCode");
+  });
+
+  test("adds bash session cleanup without execing away the launcher", () => {
+    const { script, ext } = withMockPlatform("linux", () =>
+      buildLauncherScript(
+        "claude",
+        ["--dangerously-skip-permissions"],
+        "/repo",
+        { ATOMIC_AGENT: "claude" },
+        "atomic-chat-claude-abc12345",
+      )
+    );
+
+    expect(ext).toBe("sh");
+    expect(script).toContain("trap atomic_cleanup EXIT");
+    expect(script).toContain('tmux -L "atomic" kill-session -t "atomic-chat-claude-abc12345"');
+    expect(script).toContain("atomic_exit_code=$?");
+    expect(script).not.toContain("exec ");
+  });
+});

--- a/src/commands/cli/chat/index.test.ts
+++ b/src/commands/cli/chat/index.test.ts
@@ -18,40 +18,43 @@ function withMockPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
 }
 
 describe("buildLauncherScript", () => {
-  test("adds PowerShell session cleanup after the agent exits", () => {
+  test("builds a PowerShell launcher with cwd, env, args, and exit code", () => {
     const { script, ext } = withMockPlatform("win32", () =>
       buildLauncherScript(
         "copilot",
         ["--debug"],
         "C:\\repo",
         { ATOMIC_AGENT: "copilot" },
-        "atomic-chat-copilot-abc12345",
       )
     );
 
     expect(ext).toBe("ps1");
-    expect(script).toContain("try {");
-    expect(script).toContain("} finally {");
-    expect(script).toContain("Invoke-AtomicSessionCleanup");
-    expect(script).toContain('-L "atomic" kill-session -t "atomic-chat-copilot-abc12345"');
+    expect(script).toContain('Set-Location "C:\\repo"');
+    expect(script).toContain('$env:ATOMIC_AGENT = "copilot"');
+    expect(script).toContain('& "copilot" @("--debug")');
+    expect(script).toContain('if ($LASTEXITCODE -is [int]) { $atomicExitCode = $LASTEXITCODE }');
     expect(script).toContain("exit $atomicExitCode");
+    expect(script).not.toContain("Invoke-AtomicSessionCleanup");
   });
 
-  test("adds bash session cleanup without execing away the launcher", () => {
+  test("builds a bash launcher without tmux input suppression", () => {
     const { script, ext } = withMockPlatform("linux", () =>
       buildLauncherScript(
         "claude",
         ["--dangerously-skip-permissions"],
         "/repo",
         { ATOMIC_AGENT: "claude" },
-        "atomic-chat-claude-abc12345",
       )
     );
 
     expect(ext).toBe("sh");
-    expect(script).toContain("trap atomic_cleanup EXIT");
-    expect(script).toContain('tmux -L "atomic" kill-session -t "atomic-chat-claude-abc12345"');
+    expect(script).toContain('cd "/repo"');
+    expect(script).toContain('export ATOMIC_AGENT="claude"');
+    expect(script).toContain('"claude" "--dangerously-skip-permissions"');
     expect(script).toContain("atomic_exit_code=$?");
     expect(script).not.toContain("exec ");
+    expect(script).not.toContain("stty -echo -icanon");
+    expect(script).not.toContain("atomic_original_tty_state");
+    expect(script).not.toContain("trap atomic_cleanup");
   });
 });

--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -39,6 +39,7 @@ import {
   killSession,
   killSessionOnPaneExit,
   setSessionEnv,
+  SOCKET_NAME,
   spawnMuxAttach,
   switchClient,
 } from "../../../sdk/workflows/index.ts";
@@ -113,11 +114,12 @@ function escPwsh(s: string): string {
  * Build a launcher script that preserves cwd and properly quotes args.
  * This avoids shell-injection risks from passthrough args.
  */
-function buildLauncherScript(
+export function buildLauncherScript(
   cmd: string,
   args: string[],
   projectRoot: string,
   envVars: Record<string, string> = {},
+  cleanupSessionName?: string,
 ): { script: string; ext: string } {
   const isWin = process.platform === "win32";
   const envEntries = Object.entries(envVars);
@@ -128,12 +130,35 @@ function buildLauncherScript(
     const envLines = envEntries.map(
       ([key, value]) => `$env:${key} = "${escPwsh(value)}"`,
     );
+    const cleanupLines = cleanupSessionName
+      ? [
+          "function Invoke-AtomicSessionCleanup {",
+          "  $mux = Get-Command psmux -ErrorAction SilentlyContinue",
+          "  if (-not $mux) { $mux = Get-Command pmux -ErrorAction SilentlyContinue }",
+          "  if (-not $mux) { $mux = Get-Command tmux -ErrorAction SilentlyContinue }",
+          `  if ($mux) { & $mux.Source -L "${escPwsh(SOCKET_NAME)}" kill-session -t "${escPwsh(cleanupSessionName)}" *> $null }`,
+          "}",
+          "$atomicExitCode = 0",
+          "try {",
+        ]
+      : [];
+    const cleanupFinallyLines = cleanupSessionName
+      ? [
+          "  if ($LASTEXITCODE -is [int]) { $atomicExitCode = $LASTEXITCODE }",
+          "} finally {",
+          "  Invoke-AtomicSessionCleanup",
+          "}",
+          "exit $atomicExitCode",
+        ]
+      : [];
     const script = [
+      ...cleanupLines,
       `Set-Location "${escPwsh(projectRoot)}"`,
       ...envLines,
       argList.length > 0
         ? `& "${escPwsh(cmd)}" @(${argList})`
         : `& "${escPwsh(cmd)}"`,
+      ...cleanupFinallyLines,
     ].join("\n");
     return { script, ext: "ps1" };
   }
@@ -145,6 +170,14 @@ function buildLauncherScript(
   const envLines = envEntries.map(
     ([key, value]) => `export ${key}="${escBash(value)}"`,
   );
+  const cleanupLines = cleanupSessionName
+    ? [
+        "atomic_cleanup() {",
+        `  tmux -L "${escBash(SOCKET_NAME)}" kill-session -t "${escBash(cleanupSessionName)}" >/dev/null 2>&1 || true`,
+        "}",
+        "trap atomic_cleanup EXIT",
+      ]
+    : [];
   // Pre-silence the tty before exec'ing the agent. copilot and opencode
   // write terminal-capability probes (CSI ?Pn $p, OSC 4;0;?, CSI c) to
   // stdout at startup; under tmux the DECRPM / OSC 4 / DA1 replies arrive
@@ -156,10 +189,13 @@ function buildLauncherScript(
   // (no tty) harmlessly no-ops the stty call.
   const script = [
     "#!/bin/bash",
+    ...cleanupLines,
     `cd "${escBash(projectRoot)}"`,
     ...envLines,
     "stty -echo -icanon 2>/dev/null || true",
-    `exec "${escBash(cmd)}" ${quotedArgs}`,
+    `"${escBash(cmd)}" ${quotedArgs}`,
+    "atomic_exit_code=$?",
+    'exit "$atomic_exit_code"',
   ].join("\n");
   return { script, ext: "sh" };
 }
@@ -261,6 +297,7 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
     args,
     projectRoot,
     envVars,
+    windowName,
   );
   const launcherPath = join(sessionsDir, `${windowName}.${ext}`);
   await writeFile(launcherPath, script, { mode: 0o755 });

--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -2,10 +2,7 @@
 /**
  * Chat CLI command for atomic
  *
- * Spawns the native agent CLI as an interactive subprocess.
- * When already inside a tmux/psmux session, the agent spawns inline
- * in the current pane. When outside tmux, it creates a new tmux
- * session and attaches to it.
+ * Spawns the native agent CLI in tmux/psmux with an OpenTUI footer pane.
  *
  * All extra arguments after `-a <agent>` are forwarded to the native CLI.
  *
@@ -36,10 +33,8 @@ import {
 import {
   createSession,
   detachAndAttachAtomic,
-  killSession,
   killSessionOnPaneExit,
-  setSessionEnv,
-  SOCKET_NAME,
+  killSession,
   spawnMuxAttach,
   switchClient,
 } from "../../../sdk/workflows/index.ts";
@@ -119,7 +114,6 @@ export function buildLauncherScript(
   args: string[],
   projectRoot: string,
   envVars: Record<string, string> = {},
-  cleanupSessionName?: string,
 ): { script: string; ext: string } {
   const isWin = process.platform === "win32";
   const envEntries = Object.entries(envVars);
@@ -130,35 +124,15 @@ export function buildLauncherScript(
     const envLines = envEntries.map(
       ([key, value]) => `$env:${key} = "${escPwsh(value)}"`,
     );
-    const cleanupLines = cleanupSessionName
-      ? [
-          "function Invoke-AtomicSessionCleanup {",
-          "  $mux = Get-Command psmux -ErrorAction SilentlyContinue",
-          "  if (-not $mux) { $mux = Get-Command pmux -ErrorAction SilentlyContinue }",
-          "  if (-not $mux) { $mux = Get-Command tmux -ErrorAction SilentlyContinue }",
-          `  if ($mux) { & $mux.Source -L "${escPwsh(SOCKET_NAME)}" kill-session -t "${escPwsh(cleanupSessionName)}" *> $null }`,
-          "}",
-          "$atomicExitCode = 0",
-          "try {",
-        ]
-      : [];
-    const cleanupFinallyLines = cleanupSessionName
-      ? [
-          "  if ($LASTEXITCODE -is [int]) { $atomicExitCode = $LASTEXITCODE }",
-          "} finally {",
-          "  Invoke-AtomicSessionCleanup",
-          "}",
-          "exit $atomicExitCode",
-        ]
-      : [];
     const script = [
-      ...cleanupLines,
       `Set-Location "${escPwsh(projectRoot)}"`,
       ...envLines,
       argList.length > 0
         ? `& "${escPwsh(cmd)}" @(${argList})`
         : `& "${escPwsh(cmd)}"`,
-      ...cleanupFinallyLines,
+      "$atomicExitCode = 0",
+      "if ($LASTEXITCODE -is [int]) { $atomicExitCode = $LASTEXITCODE }",
+      "exit $atomicExitCode",
     ].join("\n");
     return { script, ext: "ps1" };
   }
@@ -170,29 +144,10 @@ export function buildLauncherScript(
   const envLines = envEntries.map(
     ([key, value]) => `export ${key}="${escBash(value)}"`,
   );
-  const cleanupLines = cleanupSessionName
-    ? [
-        "atomic_cleanup() {",
-        `  tmux -L "${escBash(SOCKET_NAME)}" kill-session -t "${escBash(cleanupSessionName)}" >/dev/null 2>&1 || true`,
-        "}",
-        "trap atomic_cleanup EXIT",
-      ]
-    : [];
-  // Pre-silence the tty before exec'ing the agent. copilot and opencode
-  // write terminal-capability probes (CSI ?Pn $p, OSC 4;0;?, CSI c) to
-  // stdout at startup; under tmux the DECRPM / OSC 4 / DA1 replies arrive
-  // on stdin a few ms later. If the agent hasn't enabled raw mode yet,
-  // the tty driver echoes those replies back to the screen as garbage
-  // (e.g. `^[[?1016;2$y^[[?2004;1$y^[]4;0;rgb:...`). Disabling echo and
-  // canonical mode here means the driver drops them silently; the agent's
-  // own termios setup then takes over once it's ready. Redirected stdin
-  // (no tty) harmlessly no-ops the stty call.
   const script = [
     "#!/bin/bash",
-    ...cleanupLines,
     `cd "${escBash(projectRoot)}"`,
     ...envLines,
-    "stty -echo -icanon 2>/dev/null || true",
     `"${escBash(cmd)}" ${quotedArgs}`,
     "atomic_exit_code=$?",
     'exit "$atomic_exit_code"',
@@ -257,9 +212,7 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
   const cmd = [config.cmd, ...args];
   const overrides = await getProviderOverrides(agentType, projectRoot);
   // ATOMIC_AGENT must be baked into the launcher env so the agent CLI
-  // (and anything it spawns) can read it. `setSessionEnv` below only
-  // affects processes spawned *after* the initial command, so it cannot
-  // populate the env of the agent CLI that `new-session` kicks off.
+  // and anything it spawns can read it from process start.
   const envVars = {
     ...config.env_vars,
     ...overrides.envVars,
@@ -297,7 +250,6 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
     args,
     projectRoot,
     envVars,
-    windowName,
   );
   const launcherPath = join(sessionsDir, `${windowName}.${ext}`);
   await writeFile(launcherPath, script, { mode: 0o755 });
@@ -309,19 +261,8 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
   // ── Create session on the atomic socket and attach ──
   try {
     const paneId = createSession(windowName, shellCmd, undefined, projectRoot);
-    setSessionEnv(windowName, "ATOMIC_AGENT", agentType);
-
-    // When the agent CLI exits (via `/exit`, double Ctrl+C, or crash),
-    // tear down the whole session so the footer pane doesn't keep it
-    // alive in the background. Pane-scoped so the footer's own exit
-    // (which cascades from the kill-session) doesn't re-trigger.
-    killSessionOnPaneExit(windowName, paneId);
-
-    // Split the pane so the agent CLI runs on top and the React footer
-    // (provider pill + window name) runs in a 5% bottom pane. Matches
-    // the workflow-window layout, minus the keyboard hints (chat sessions
-    // only host a single agent, so ctrl+g / ctrl+\ navigation is moot).
     spawnAttachedFooter(windowName, paneId, agentType);
+    killSessionOnPaneExit(windowName, paneId);
 
     if (isInsideAtomicSocket()) {
       // Already on the atomic server — just switch to the new session.

--- a/src/commands/cli/footer.tsx
+++ b/src/commands/cli/footer.tsx
@@ -13,7 +13,7 @@
 
 import { useEffect } from "react";
 import { createCliRenderer } from "@opentui/core";
-import { createRoot, useRenderer } from "@opentui/react";
+import { createRoot, flushSync, useRenderer } from "@opentui/react";
 import { resolveTheme } from "../../sdk/runtime/theme.ts";
 import {
   deriveGraphTheme,
@@ -23,6 +23,13 @@ import { AttachedStatusline } from "../../sdk/components/attached-statusline.tsx
 import type { AgentType } from "../../sdk/types.ts";
 
 const PARENT_WATCHDOG_MS = 2000;
+const FOOTER_RENDER_ROWS = 1;
+
+type FooterStdoutSource = {
+  readonly columns?: number;
+  readonly rows?: number;
+  write: NodeJS.WriteStream["write"];
+};
 
 /**
  * Snapshot the parent PID at module load. `process.ppid` is cached in both
@@ -58,6 +65,31 @@ const EXIT_SIGNALS: NodeJS.Signals[] =
   process.platform === "win32"
     ? ["SIGTERM", "SIGINT", "SIGBREAK", "SIGHUP"]
     : ["SIGHUP", "SIGTERM", "SIGINT", "SIGPIPE"];
+
+/**
+ * The footer runs in a tmux/psmux pane that is intentionally one row tall.
+ * On Windows, psmux child processes can expose no TTY row count to Bun, which
+ * makes OpenTUI fall back to 24 rows and paint the one-line footer off-screen.
+ */
+export function createFooterStdout(
+  stdout: FooterStdoutSource = process.stdout,
+): NodeJS.WriteStream {
+  const footerStdout = Object.create(stdout) as NodeJS.WriteStream;
+  Object.defineProperties(footerStdout, {
+    columns: {
+      configurable: true,
+      enumerable: true,
+      get: () => Math.max(stdout.columns ?? 80, 1),
+    },
+    rows: {
+      configurable: true,
+      enumerable: true,
+      get: () => FOOTER_RENDER_ROWS,
+    },
+  });
+  footerStdout.write = stdout.write.bind(stdout) as NodeJS.WriteStream["write"];
+  return footerStdout;
+}
 
 function FooterShell({
   name,
@@ -121,11 +153,16 @@ export async function footerCommand(
 ): Promise<number> {
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
+    stdout: createFooterStdout(),
   });
   const theme = deriveGraphTheme(resolveTheme(renderer.themeMode));
-  createRoot(renderer).render(
-    <FooterShell name={name} theme={theme} agentType={agentType} />,
-  );
+  const root = createRoot(renderer);
+  flushSync(() => {
+    root.render(
+      <FooterShell name={name} theme={theme} agentType={agentType} />,
+    );
+  });
+  renderer.requestRender();
 
   await new Promise<void>(() => {});
   return 0;

--- a/src/commands/cli/footer.tsx
+++ b/src/commands/cli/footer.tsx
@@ -30,6 +30,11 @@ const FOOTER_RENDER_INTERVAL_MS = 250;
 const FOOTER_RENDER_ROWS = 1;
 const CLEAR_LINE = "\r\x1b[2K";
 
+type FooterOutput = {
+  columns?: number;
+  write(chunk: string): unknown;
+};
+
 /**
  * Snapshot the parent PID at module load. `process.ppid` is cached in both
  * Node and Bun, so we can't re-read it to detect reparenting — instead we
@@ -159,7 +164,7 @@ export async function runFooterRenderer({
 }: {
   name: string;
   agentType?: AgentType;
-  stdout?: NodeJS.WriteStream;
+  stdout?: FooterOutput;
 }): Promise<void> {
   const testSetup = await createFooterTestRenderer({
     name,

--- a/src/commands/cli/footer.tsx
+++ b/src/commands/cli/footer.tsx
@@ -35,6 +35,13 @@ type FooterOutput = {
   write(chunk: string): unknown;
 };
 
+type FooterRendererOptions = {
+  name: string;
+  agentType?: AgentType;
+  stdout?: FooterOutput;
+  onReady?: () => void;
+};
+
 /**
  * Snapshot the parent PID at module load. `process.ppid` is cached in both
  * Node and Bun, so we can't re-read it to detect reparenting — instead we
@@ -161,11 +168,8 @@ export async function runFooterRenderer({
   name,
   agentType,
   stdout = process.stdout,
-}: {
-  name: string;
-  agentType?: AgentType;
-  stdout?: FooterOutput;
-}): Promise<void> {
+  onReady,
+}: FooterRendererOptions): Promise<void> {
   const testSetup = await createFooterTestRenderer({
     name,
     agentType,
@@ -230,13 +234,15 @@ export async function runFooterRenderer({
     const watchdog = setInterval(() => {
       if (!originalParentAlive()) teardown();
     }, PARENT_WATCHDOG_MS);
+    onReady?.();
   });
 }
 
 export async function footerCommand(
   name: string,
   agentType?: AgentType,
+  options: Omit<FooterRendererOptions, "name" | "agentType"> = {},
 ): Promise<number> {
-  await runFooterRenderer({ name, agentType });
+  await runFooterRenderer({ name, agentType, ...options });
   return 0;
 }

--- a/src/commands/cli/footer.tsx
+++ b/src/commands/cli/footer.tsx
@@ -4,32 +4,31 @@
  * tmux window. The executor splits each agent window after creation and
  * runs `atomic _footer --name <window-name>` in the bottom pane.
  *
- * Setting `exitOnCtrlC: false` suppresses OpenTUI's built-in signal
- * handling, so we install our own teardown path. In the tmux case the
- * closed pty raises SIGPIPE on the next render, which hits our handler.
- * The parent-liveness watchdog is a portable fallback for the orphan case
- * where no signal arrives (process gets reparented to init/unknown).
+ * The footer is rendered through OpenTUI's headless renderer and repainted
+ * into the footer pane. A normal CLI renderer must not be used here:
+ * terminal capability probes from a footer pane can be answered by the
+ * attached client and routed by tmux into the active agent pane as input.
  */
 
-import { useEffect } from "react";
-import { createCliRenderer } from "@opentui/core";
-import { createRoot, flushSync, useRenderer } from "@opentui/react";
+import {
+  getBaseAttributes,
+  TextAttributes,
+  type CapturedFrame,
+  type CapturedSpan,
+} from "@opentui/core";
+import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
 import { resolveTheme } from "../../sdk/runtime/theme.ts";
 import {
   deriveGraphTheme,
-  type GraphTheme,
 } from "../../sdk/components/graph-theme.ts";
 import { AttachedStatusline } from "../../sdk/components/attached-statusline.tsx";
 import type { AgentType } from "../../sdk/types.ts";
 
 const PARENT_WATCHDOG_MS = 2000;
+const FOOTER_RENDER_INTERVAL_MS = 250;
 const FOOTER_RENDER_ROWS = 1;
-
-type FooterStdoutSource = {
-  readonly columns?: number;
-  readonly rows?: number;
-  write: NodeJS.WriteStream["write"];
-};
+const CLEAR_LINE = "\r\x1b[2K";
 
 /**
  * Snapshot the parent PID at module load. `process.ppid` is cached in both
@@ -66,104 +65,173 @@ const EXIT_SIGNALS: NodeJS.Signals[] =
     ? ["SIGTERM", "SIGINT", "SIGBREAK", "SIGHUP"]
     : ["SIGHUP", "SIGTERM", "SIGINT", "SIGPIPE"];
 
-/**
- * The footer runs in a tmux/psmux pane that is intentionally one row tall.
- * On Windows, psmux child processes can expose no TTY row count to Bun, which
- * makes OpenTUI fall back to 24 rows and paint the one-line footer off-screen.
- */
-export function createFooterStdout(
-  stdout: FooterStdoutSource = process.stdout,
-): NodeJS.WriteStream {
-  const footerStdout = Object.create(stdout) as NodeJS.WriteStream;
-  Object.defineProperties(footerStdout, {
-    columns: {
-      configurable: true,
-      enumerable: true,
-      get: () => Math.max(stdout.columns ?? 80, 1),
-    },
-    rows: {
-      configurable: true,
-      enumerable: true,
-      get: () => FOOTER_RENDER_ROWS,
-    },
-  });
-  footerStdout.write = stdout.write.bind(stdout) as NodeJS.WriteStream["write"];
-  return footerStdout;
+const ANSI_RESET = "\x1b[0m";
+
+function ansiColor(kind: 38 | 48, spanColor: CapturedSpan["fg"]): string {
+  const [r, g, b] = spanColor.toInts();
+  return `${kind};2;${r};${g};${b}`;
 }
 
-function FooterShell({
+function sanitizeText(text: string): string {
+  return text.replace(/[\x00-\x1f\x7f]/g, " ");
+}
+
+function spanToAnsi(span: CapturedSpan): string {
+  const attrs = getBaseAttributes(span.attributes);
+  const codes = [
+    ansiColor(38, span.fg),
+    ansiColor(48, span.bg),
+  ];
+
+  if ((attrs & TextAttributes.BOLD) !== 0) codes.unshift("1");
+  if ((attrs & TextAttributes.DIM) !== 0) codes.unshift("2");
+  if ((attrs & TextAttributes.ITALIC) !== 0) codes.unshift("3");
+  if ((attrs & TextAttributes.UNDERLINE) !== 0) codes.unshift("4");
+  if ((attrs & TextAttributes.INVERSE) !== 0) codes.unshift("7");
+
+  return `\x1b[${codes.join(";")}m${sanitizeText(span.text)}`;
+}
+
+function frameToAnsi(frame: CapturedFrame): string {
+  const lines = frame.lines.map((line) =>
+    line.spans.map(spanToAnsi).join("")
+  );
+  return `${lines.join("\n")}${ANSI_RESET}`;
+}
+
+async function createFooterTestRenderer({
   name,
-  theme,
   agentType,
+  width = process.stdout.columns ?? 80,
 }: {
   name: string;
-  theme: GraphTheme;
   agentType?: AgentType;
+  width?: number;
 }) {
-  const renderer = useRenderer();
+  const theme = deriveGraphTheme(resolveTheme(null));
+  return await testRender(
+    <AttachedStatusline name={name} theme={theme} agentType={agentType} />,
+    {
+      width: Math.max(width, 1),
+      height: FOOTER_RENDER_ROWS,
+      exitOnCtrlC: false,
+      exitSignals: [],
+      clearOnShutdown: false,
+      useMouse: false,
+      useKittyKeyboard: null,
+      openConsoleOnError: false,
+    },
+  );
+}
 
-  useEffect(() => {
-    let tornDown = false;
-    const teardown = () => {
+async function renderFooterSetupFrame(
+  testSetup: Awaited<ReturnType<typeof createFooterTestRenderer>>,
+): Promise<string> {
+  await act(async () => {
+    await testSetup.renderOnce();
+  });
+  return frameToAnsi(testSetup.captureSpans());
+}
+
+export async function renderFooterFrame({
+  name,
+  agentType,
+  width = process.stdout.columns ?? 80,
+}: {
+  name: string;
+  agentType?: AgentType;
+  width?: number;
+}): Promise<string> {
+  const testSetup = await createFooterTestRenderer({ name, agentType, width });
+  try {
+    return await renderFooterSetupFrame(testSetup);
+  } finally {
+    act(() => {
+      testSetup.renderer.destroy();
+    });
+  }
+}
+
+export async function runFooterRenderer({
+  name,
+  agentType,
+  stdout = process.stdout,
+}: {
+  name: string;
+  agentType?: AgentType;
+  stdout?: NodeJS.WriteStream;
+}): Promise<void> {
+  const testSetup = await createFooterTestRenderer({
+    name,
+    agentType,
+    width: stdout.columns,
+  });
+  let currentWidth = Math.max(stdout.columns ?? 80, 1);
+  let lastFrame = "";
+  let renderInFlight = false;
+  let tornDown = false;
+  let teardown!: () => void;
+
+  const render = async () => {
+    if (tornDown || renderInFlight) return;
+    renderInFlight = true;
+    try {
+      const nextWidth = Math.max(stdout.columns ?? 80, 1);
+      if (nextWidth !== currentWidth) {
+        currentWidth = nextWidth;
+        testSetup.resize(currentWidth, FOOTER_RENDER_ROWS);
+      }
+
+      const frame = await renderFooterSetupFrame(testSetup);
+      if (!tornDown && frame !== lastFrame) {
+        stdout.write(`${CLEAR_LINE}${frame}`);
+        lastFrame = frame;
+      }
+    } finally {
+      renderInFlight = false;
+    }
+  };
+
+  await render();
+
+  await new Promise<void>((resolve) => {
+    teardown = () => {
       if (tornDown) return;
       tornDown = true;
-      try {
-        renderer.destroy();
-      } catch {
-        // renderer may already be mid-destroy; the pty is likely gone
-      }
-      // Pane pty is already closed by the time we reach here, so there is
-      // no terminal state left to preserve. Exit explicitly in case
-      // destroy() doesn't (e.g. when stdout writes fail silently).
-      process.exit(0);
-    };
-    for (const sig of EXIT_SIGNALS) {
-      process.on(sig, teardown);
-    }
-
-    const watchdog = setInterval(() => {
-      if (!originalParentAlive()) teardown();
-    }, PARENT_WATCHDOG_MS);
-    watchdog.unref?.();
-
-    return () => {
       for (const sig of EXIT_SIGNALS) {
         process.off(sig, teardown);
       }
+      process.off("SIGWINCH", requestRender);
+      clearInterval(renderTick);
       clearInterval(watchdog);
+      act(() => {
+        testSetup.renderer.destroy();
+      });
+      resolve();
     };
-  }, [renderer]);
 
-  return (
-    <box
-      width="100%"
-      height="100%"
-      flexDirection="column"
-      justifyContent="flex-end"
-      backgroundColor={theme.background}
-    >
-      <AttachedStatusline name={name} theme={theme} agentType={agentType} />
-    </box>
-  );
+    const requestRender = () => {
+      void render();
+    };
+
+    for (const sig of EXIT_SIGNALS) {
+      process.on(sig, teardown);
+    }
+    process.on("SIGWINCH", requestRender);
+
+    const renderTick = setInterval(() => {
+      void render();
+    }, FOOTER_RENDER_INTERVAL_MS);
+    const watchdog = setInterval(() => {
+      if (!originalParentAlive()) teardown();
+    }, PARENT_WATCHDOG_MS);
+  });
 }
 
 export async function footerCommand(
   name: string,
   agentType?: AgentType,
 ): Promise<number> {
-  const renderer = await createCliRenderer({
-    exitOnCtrlC: false,
-    stdout: createFooterStdout(),
-  });
-  const theme = deriveGraphTheme(resolveTheme(renderer.themeMode));
-  const root = createRoot(renderer);
-  flushSync(() => {
-    root.render(
-      <FooterShell name={name} theme={theme} agentType={agentType} />,
-    );
-  });
-  renderer.requestRender();
-
-  await new Promise<void>(() => {});
+  await runFooterRenderer({ name, agentType });
   return 0;
 }

--- a/src/lib/spawn.test.ts
+++ b/src/lib/spawn.test.ts
@@ -3,6 +3,8 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  hasRequiredMuxBinary,
+  isMuxBinaryRequiredForPlatform,
   prependPath,
   resolveCommandFromCurrentPath,
 } from "./spawn.ts";
@@ -35,6 +37,29 @@ describe("spawn PATH helpers", () => {
     prependPath(tempDir);
 
     expect(resolveCommandFromCurrentPath("atomic-spawn-test")).toBe(commandPath);
+  });
+
+  test("requires native psmux binaries on Windows", () => {
+    expect(isMuxBinaryRequiredForPlatform("psmux", "win32")).toBe(true);
+    expect(isMuxBinaryRequiredForPlatform("pmux", "win32")).toBe(true);
+    expect(isMuxBinaryRequiredForPlatform("tmux", "win32")).toBe(false);
+  });
+
+  test("requires tmux on Unix-like platforms", () => {
+    expect(isMuxBinaryRequiredForPlatform("tmux", "linux")).toBe(true);
+    expect(isMuxBinaryRequiredForPlatform("psmux", "linux")).toBe(false);
+    expect(isMuxBinaryRequiredForPlatform("pmux", "darwin")).toBe(false);
+  });
+
+  test("uses platform requirement when checking PATH", () => {
+    const commandPath = join(tempDir, "tmux");
+
+    writeFileSync(commandPath, "#!/bin/sh\n");
+    chmodSync(commandPath, 0o755);
+
+    process.env.PATH = tempDir;
+
+    expect(hasRequiredMuxBinary()).toBe(process.platform !== "win32");
   });
 
   test("does not add duplicate PATH entries", () => {

--- a/src/lib/spawn.test.ts
+++ b/src/lib/spawn.test.ts
@@ -6,7 +6,10 @@ import {
   hasRequiredMuxBinary,
   isMuxBinaryRequiredForPlatform,
   prependPath,
+  psmuxReleaseAssetSuffix,
+  requiredMuxBinaryCandidatesForPlatform,
   resolveCommandFromCurrentPath,
+  runCommand,
 } from "./spawn.ts";
 
 describe("spawn PATH helpers", () => {
@@ -40,15 +43,28 @@ describe("spawn PATH helpers", () => {
   });
 
   test("requires native psmux binaries on Windows", () => {
+    expect(requiredMuxBinaryCandidatesForPlatform("win32")).toEqual([
+      "psmux",
+      "pmux",
+    ]);
     expect(isMuxBinaryRequiredForPlatform("psmux", "win32")).toBe(true);
     expect(isMuxBinaryRequiredForPlatform("pmux", "win32")).toBe(true);
     expect(isMuxBinaryRequiredForPlatform("tmux", "win32")).toBe(false);
   });
 
   test("requires tmux on Unix-like platforms", () => {
+    expect(requiredMuxBinaryCandidatesForPlatform("linux")).toEqual(["tmux"]);
+    expect(requiredMuxBinaryCandidatesForPlatform("darwin")).toEqual(["tmux"]);
     expect(isMuxBinaryRequiredForPlatform("tmux", "linux")).toBe(true);
     expect(isMuxBinaryRequiredForPlatform("psmux", "linux")).toBe(false);
     expect(isMuxBinaryRequiredForPlatform("pmux", "darwin")).toBe(false);
+  });
+
+  test("maps supported Windows architectures to psmux release assets", () => {
+    expect(psmuxReleaseAssetSuffix("x64")).toBe("windows-x64.zip");
+    expect(psmuxReleaseAssetSuffix("ia32")).toBe("windows-x86.zip");
+    expect(psmuxReleaseAssetSuffix("arm64")).toBe("windows-arm64.zip");
+    expect(psmuxReleaseAssetSuffix("arm")).toBeNull();
   });
 
   test("uses platform requirement when checking PATH", () => {
@@ -71,5 +87,23 @@ describe("spawn PATH helpers", () => {
     const delimiter = process.platform === "win32" ? ";" : ":";
     const entries = (process.env.PATH ?? "").split(delimiter);
     expect(entries.filter((entry) => entry === tempDir)).toHaveLength(1);
+  });
+
+  test("runCommand keeps stdout and stderr separate", async () => {
+    const scriptPath = join(tempDir, "streams.ts");
+    writeFileSync(
+      scriptPath,
+      "await Bun.write(Bun.stderr, 'warning\\n'); await Bun.write(Bun.stdout, 'value\\n');\n",
+    );
+
+    const result = await runCommand([
+      process.execPath,
+      scriptPath,
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.details).toBe("warning");
+    expect(result.stderr).toBe("warning");
+    expect(result.stdout).toBe("value");
   });
 });

--- a/src/lib/spawn.test.ts
+++ b/src/lib/spawn.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  prependPath,
+  resolveCommandFromCurrentPath,
+} from "./spawn.ts";
+
+describe("spawn PATH helpers", () => {
+  let originalPath: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+    tempDir = mkdtempSync(join(tmpdir(), "atomic-spawn-"));
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  test("resolves commands added to PATH during the current process", () => {
+    const commandName = process.platform === "win32"
+      ? "atomic-spawn-test.cmd"
+      : "atomic-spawn-test";
+    const commandPath = join(tempDir, commandName);
+    const body = process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\n";
+
+    writeFileSync(commandPath, body);
+    chmodSync(commandPath, 0o755);
+
+    process.env.PATH = originalPath ?? "";
+    prependPath(tempDir);
+
+    expect(resolveCommandFromCurrentPath("atomic-spawn-test")).toBe(commandPath);
+  });
+
+  test("does not add duplicate PATH entries", () => {
+    process.env.PATH = originalPath ?? "";
+
+    prependPath(tempDir);
+    prependPath(tempDir);
+
+    const delimiter = process.platform === "win32" ? ";" : ":";
+    const entries = (process.env.PATH ?? "").split(delimiter);
+    expect(entries.filter((entry) => entry === tempDir)).toHaveLength(1);
+  });
+});

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -5,13 +5,21 @@
  * eliminating duplication across postinstall-playwright, postinstall-liteparse, etc.
  */
 
-import { existsSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 
 export interface SpawnResult {
   success: boolean;
   details: string;
+  stdout?: string;
+  stderr?: string;
 }
 
 export interface RunCommandOptions {
@@ -50,14 +58,19 @@ export async function runCommand(cmd: string[], options?: RunCommandOptions): Pr
       new Response(proc.stdout).text(),
       proc.exited,
     ]);
+    const trimmedStdout = stdout.trim();
+    const trimmedStderr = stderr.trim();
     return {
       success: exitCode === 0,
-      details: stderr.trim().length > 0 ? stderr.trim() : stdout.trim(),
+      details: trimmedStderr.length > 0 ? trimmedStderr : trimmedStdout,
+      stdout: trimmedStdout,
+      stderr: trimmedStderr,
     };
   } catch (error) {
     return {
       success: false,
       details: error instanceof Error ? error.message : String(error),
+      stderr: error instanceof Error ? error.message : String(error),
     };
   }
 }
@@ -77,27 +90,32 @@ export function prependPath(directory: string): void {
   }
 }
 
+function windowsAtomicBinDir(): string {
+  return join(getHomeDir(), ".atomic", "bin");
+}
+
 export function resolveCommandFromCurrentPath(cmd: string): string | null {
   return Bun.which(cmd, { PATH: process.env.PATH ?? "" });
 }
 
-type MuxBinaryName = "tmux" | "psmux" | "pmux";
+export type MuxBinaryName = "tmux" | "psmux" | "pmux";
+
+export function requiredMuxBinaryCandidatesForPlatform(
+  platform: NodeJS.Platform = process.platform,
+): MuxBinaryName[] {
+  return platform === "win32" ? ["psmux", "pmux"] : ["tmux"];
+}
 
 export function isMuxBinaryRequiredForPlatform(
   binary: MuxBinaryName,
   platform: NodeJS.Platform = process.platform,
 ): boolean {
-  if (platform === "win32") {
-    return binary === "psmux" || binary === "pmux";
-  }
-  return binary === "tmux";
+  return requiredMuxBinaryCandidatesForPlatform(platform).includes(binary);
 }
 
 export function hasRequiredMuxBinary(): boolean {
-  const candidates: MuxBinaryName[] = ["psmux", "pmux", "tmux"];
-  return candidates.some((candidate) =>
-    isMuxBinaryRequiredForPlatform(candidate) &&
-    resolveCommandFromCurrentPath(candidate)
+  return requiredMuxBinaryCandidatesForPlatform().some(
+    (candidate) => resolveCommandFromCurrentPath(candidate),
   );
 }
 
@@ -131,6 +149,7 @@ function prependWindowsMuxInstallPaths(): void {
   );
   prependPathIfDirectory("C:\\ProgramData\\chocolatey\\bin");
   prependPathIfDirectory(home ? join(home, ".cargo", "bin") : undefined);
+  prependPathIfDirectory(windowsAtomicBinDir());
 }
 
 function mergePath(pathValue: string): void {
@@ -160,8 +179,8 @@ async function refreshWindowsPathFromRegistry(): Promise<void> {
     "-Command",
     readRegistryPath,
   ]);
-  if (result.success && result.details) {
-    mergePath(result.details);
+  if (result.success && result.stdout) {
+    mergePath(result.stdout);
   }
 }
 
@@ -169,6 +188,150 @@ async function refreshWindowsMuxPath(): Promise<void> {
   prependWindowsMuxInstallPaths();
   await refreshWindowsPathFromRegistry();
   prependWindowsMuxInstallPaths();
+}
+
+interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GitHubRelease {
+  assets: GitHubReleaseAsset[];
+}
+
+export function psmuxReleaseAssetSuffix(
+  arch: NodeJS.Architecture = process.arch,
+): string | null {
+  switch (arch) {
+    case "x64":
+      return "windows-x64.zip";
+    case "ia32":
+      return "windows-x86.zip";
+    case "arm64":
+      return "windows-arm64.zip";
+    default:
+      return null;
+  }
+}
+
+function powershellLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+async function persistWindowsUserPath(directory: string): Promise<SpawnResult> {
+  const shell = resolveCommandFromCurrentPath("powershell") ??
+    resolveCommandFromCurrentPath("pwsh");
+  if (!shell) return { success: true, details: "" };
+
+  const script =
+    `$dir = ${powershellLiteral(directory)}; ` +
+    "$current = [Environment]::GetEnvironmentVariable('Path','User'); " +
+    "$entries = if ([string]::IsNullOrWhiteSpace($current)) { @() } else { $current -split ';' }; " +
+    "$expandedDir = [Environment]::ExpandEnvironmentVariables($dir) -replace '[\\\\/]+$',''; " +
+    "$hasDir = $false; " +
+    "foreach ($entry in $entries) { " +
+    "  $expandedEntry = [Environment]::ExpandEnvironmentVariables($entry).Trim().Trim('\"') -replace '[\\\\/]+$',''; " +
+    "  if ($expandedEntry -ieq $expandedDir) { $hasDir = $true; break } " +
+    "} " +
+    "if (-not $hasDir) { " +
+    "  $next = (@($entries) + @($dir) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ';'; " +
+    "  [Environment]::SetEnvironmentVariable('Path', $next, 'User'); " +
+    "}";
+
+  return runCommand([shell, "-NoProfile", "-Command", script]);
+}
+
+async function installPsmuxFromGitHubRelease(): Promise<SpawnResult> {
+  try {
+    const suffix = psmuxReleaseAssetSuffix();
+    if (!suffix) {
+      return {
+        success: false,
+        details: `No psmux release asset is available for ${process.arch}.`,
+      };
+    }
+
+    const response = await fetch(
+      "https://api.github.com/repos/psmux/psmux/releases/latest",
+      { headers: { "Accept": "application/vnd.github+json" } },
+    );
+    if (!response.ok) {
+      return {
+        success: false,
+        details: `Could not fetch latest psmux release: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const release = await response.json() as GitHubRelease;
+    const asset = release.assets.find((item) => item.name.endsWith(suffix));
+    if (!asset) {
+      return {
+        success: false,
+        details: `Latest psmux release does not include a ${suffix} asset.`,
+      };
+    }
+
+    const archiveResponse = await fetch(asset.browser_download_url);
+    if (!archiveResponse.ok) {
+      return {
+        success: false,
+        details: `Could not download ${asset.name}: ${archiveResponse.status} ${archiveResponse.statusText}`,
+      };
+    }
+
+    const tempDir = mkdtempSync(join(tmpdir(), "atomic-psmux-"));
+    const zipPath = join(tempDir, asset.name);
+    const extractDir = join(tempDir, "extract");
+    const installDir = windowsAtomicBinDir();
+
+    try {
+      await Bun.write(zipPath, await archiveResponse.arrayBuffer());
+      mkdirSync(extractDir, { recursive: true });
+      mkdirSync(installDir, { recursive: true });
+
+      const shell = resolveCommandFromCurrentPath("powershell") ??
+        resolveCommandFromCurrentPath("pwsh");
+      if (!shell) {
+        return {
+          success: false,
+          details: "PowerShell is required to expand the psmux release archive.",
+        };
+      }
+
+      const expand = await runCommand([
+        shell,
+        "-NoProfile",
+        "-Command",
+        `Expand-Archive -LiteralPath ${powershellLiteral(zipPath)} -DestinationPath ${powershellLiteral(extractDir)} -Force`,
+      ]);
+      if (!expand.success) return expand;
+
+      for (const binary of ["psmux.exe", "pmux.exe", "tmux.exe"]) {
+        const source = join(extractDir, binary);
+        if (existsSync(source)) {
+          copyFileSync(source, join(installDir, binary));
+        }
+      }
+
+      prependPath(installDir);
+      const persistResult = await persistWindowsUserPath(installDir);
+      if (!persistResult.success) return persistResult;
+
+      return hasRequiredMuxBinary()
+        ? { success: true, details: "" }
+        : {
+            success: false,
+            details: `Downloaded psmux but no psmux binary was found in ${installDir}.`,
+          };
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  } catch (error) {
+    return {
+      success: false,
+      details: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 /**
@@ -241,7 +404,7 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
 
   let capturedDetails = "";
   const record = (result: SpawnResult) => {
-    if (quiet && !result.success && result.details) {
+    if (!result.success && result.details) {
       capturedDetails = result.details;
     }
   };
@@ -298,8 +461,13 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
         if (hasRequiredMuxBinary()) return;
       }
     }
+
+    const directResult = await installPsmuxFromGitHubRelease();
+    record(directResult);
+    if (directResult.success) return;
+
     throw new Error(
-      capturedDetails || "Could not install psmux — no supported Windows package manager succeeded.",
+      capturedDetails || "Could not install psmux automatically.",
     );
   }
 

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -81,11 +81,23 @@ export function resolveCommandFromCurrentPath(cmd: string): string | null {
   return Bun.which(cmd, { PATH: process.env.PATH ?? "" });
 }
 
-function hasMuxBinary(): boolean {
-  return Boolean(
-    resolveCommandFromCurrentPath("tmux") ||
-    resolveCommandFromCurrentPath("psmux") ||
-    resolveCommandFromCurrentPath("pmux"),
+type MuxBinaryName = "tmux" | "psmux" | "pmux";
+
+export function isMuxBinaryRequiredForPlatform(
+  binary: MuxBinaryName,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform === "win32") {
+    return binary === "psmux" || binary === "pmux";
+  }
+  return binary === "tmux";
+}
+
+export function hasRequiredMuxBinary(): boolean {
+  const candidates: MuxBinaryName[] = ["psmux", "pmux", "tmux"];
+  return candidates.some((candidate) =>
+    isMuxBinaryRequiredForPlatform(candidate) &&
+    resolveCommandFromCurrentPath(candidate)
   );
 }
 
@@ -224,8 +236,8 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
   const quiet = options.quiet ?? false;
   const inherit = !quiet;
 
-  // Check for any multiplexer binary
-  if (hasMuxBinary()) return;
+  // Check for the platform-native multiplexer binary.
+  if (hasRequiredMuxBinary()) return;
 
   let capturedDetails = "";
   const record = (result: SpawnResult) => {
@@ -250,7 +262,7 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
       record(result);
       if (result.success) {
         await refreshWindowsMuxPath();
-        if (hasMuxBinary()) return;
+        if (hasRequiredMuxBinary()) return;
       }
     }
 
@@ -261,7 +273,7 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
       record(result);
       if (result.success) {
         await refreshWindowsMuxPath();
-        if (hasMuxBinary()) return;
+        if (hasRequiredMuxBinary()) return;
       }
     }
 
@@ -271,7 +283,7 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
       record(result);
       if (result.success) {
         await refreshWindowsMuxPath();
-        if (hasMuxBinary()) return;
+        if (hasRequiredMuxBinary()) return;
       }
     }
 
@@ -283,7 +295,7 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
         const home = getHomeDir();
         if (home) prependPath(join(home, ".cargo", "bin"));
         await refreshWindowsMuxPath();
-        if (hasMuxBinary()) return;
+        if (hasRequiredMuxBinary()) return;
       }
     }
     throw new Error(

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -5,6 +5,7 @@
  * eliminating duplication across postinstall-playwright, postinstall-liteparse, etc.
  */
 
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -68,9 +69,94 @@ export function prependPath(directory: string): void {
   const pathDelimiter = process.platform === "win32" ? ";" : ":";
   const currentPath = process.env.PATH ?? "";
   const entries = currentPath.split(pathDelimiter);
-  if (!entries.includes(directory)) {
+  const alreadyPresent = process.platform === "win32"
+    ? entries.some((entry) => entry.toLowerCase() === directory.toLowerCase())
+    : entries.includes(directory);
+  if (!alreadyPresent) {
     process.env.PATH = directory + pathDelimiter + currentPath;
   }
+}
+
+export function resolveCommandFromCurrentPath(cmd: string): string | null {
+  return Bun.which(cmd, { PATH: process.env.PATH ?? "" });
+}
+
+function hasMuxBinary(): boolean {
+  return Boolean(
+    resolveCommandFromCurrentPath("tmux") ||
+    resolveCommandFromCurrentPath("psmux") ||
+    resolveCommandFromCurrentPath("pmux"),
+  );
+}
+
+function prependPathIfDirectory(directory: string | undefined): void {
+  if (!directory || !existsSync(directory)) return;
+  prependPath(directory);
+}
+
+function prependWindowsMuxInstallPaths(): void {
+  if (process.platform !== "win32") return;
+
+  const home = getHomeDir();
+  prependPathIfDirectory(
+    process.env.SCOOP ? join(process.env.SCOOP, "shims") : undefined,
+  );
+  prependPathIfDirectory(home ? join(home, "scoop", "shims") : undefined);
+  prependPathIfDirectory(
+    process.env.LOCALAPPDATA
+      ? join(process.env.LOCALAPPDATA, "Microsoft", "WinGet", "Links")
+      : undefined,
+  );
+  prependPathIfDirectory(
+    process.env.LOCALAPPDATA
+      ? join(process.env.LOCALAPPDATA, "Microsoft", "WindowsApps")
+      : undefined,
+  );
+  prependPathIfDirectory(
+    process.env.ChocolateyInstall
+      ? join(process.env.ChocolateyInstall, "bin")
+      : undefined,
+  );
+  prependPathIfDirectory("C:\\ProgramData\\chocolatey\\bin");
+  prependPathIfDirectory(home ? join(home, ".cargo", "bin") : undefined);
+}
+
+function mergePath(pathValue: string): void {
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  for (const entry of pathValue.split(delimiter)) {
+    const trimmed = entry.trim();
+    if (trimmed) prependPath(trimmed);
+  }
+}
+
+async function refreshWindowsPathFromRegistry(): Promise<void> {
+  if (process.platform !== "win32") return;
+
+  const shell = resolveCommandFromCurrentPath("powershell") ??
+    resolveCommandFromCurrentPath("pwsh");
+  if (!shell) return;
+
+  const readRegistryPath =
+    "$paths = @([Environment]::GetEnvironmentVariable('Path','Process'), " +
+    "[Environment]::GetEnvironmentVariable('Path','User'), " +
+    "[Environment]::GetEnvironmentVariable('Path','Machine')) | " +
+    "Where-Object { $_ }; $paths -join ';'";
+
+  const result = await runCommand([
+    shell,
+    "-NoProfile",
+    "-Command",
+    readRegistryPath,
+  ]);
+  if (result.success && result.details) {
+    mergePath(result.details);
+  }
+}
+
+async function refreshWindowsMuxPath(): Promise<void> {
+  prependWindowsMuxInstallPaths();
+  await refreshWindowsPathFromRegistry();
+  prependWindowsMuxInstallPaths();
 }
 
 /**
@@ -139,7 +225,7 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
   const inherit = !quiet;
 
   // Check for any multiplexer binary
-  if (Bun.which("tmux") || Bun.which("psmux") || Bun.which("pmux")) return;
+  if (hasMuxBinary()) return;
 
   let capturedDetails = "";
   const record = (result: SpawnResult) => {
@@ -150,36 +236,54 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
 
   if (process.platform === "win32") {
     // Windows: install psmux
-    const winget = Bun.which("winget");
+    const winget = resolveCommandFromCurrentPath("winget");
     if (winget) {
-      const result = await runCommand([winget, "install", "psmux", "--accept-source-agreements", "--accept-package-agreements"], { inherit });
+      const result = await runCommand([
+        winget,
+        "install",
+        "--id",
+        "marlocarlo.psmux",
+        "--exact",
+        "--accept-source-agreements",
+        "--accept-package-agreements",
+      ], { inherit });
       record(result);
-      if (result.success && (Bun.which("psmux") || Bun.which("tmux"))) return;
+      if (result.success) {
+        await refreshWindowsMuxPath();
+        if (hasMuxBinary()) return;
+      }
     }
 
-    const scoop = Bun.which("scoop");
+    const scoop = resolveCommandFromCurrentPath("scoop");
     if (scoop) {
       await runCommand([scoop, "bucket", "add", "psmux", "https://github.com/psmux/scoop-psmux"], { inherit });
       const result = await runCommand([scoop, "install", "psmux"], { inherit });
       record(result);
-      if (result.success && (Bun.which("psmux") || Bun.which("tmux"))) return;
+      if (result.success) {
+        await refreshWindowsMuxPath();
+        if (hasMuxBinary()) return;
+      }
     }
 
-    const choco = Bun.which("choco");
+    const choco = resolveCommandFromCurrentPath("choco");
     if (choco) {
       const result = await runCommand([choco, "install", "psmux", "-y", "--no-progress"], { inherit });
       record(result);
-      if (result.success && (Bun.which("psmux") || Bun.which("tmux"))) return;
+      if (result.success) {
+        await refreshWindowsMuxPath();
+        if (hasMuxBinary()) return;
+      }
     }
 
-    const cargo = Bun.which("cargo");
+    const cargo = resolveCommandFromCurrentPath("cargo");
     if (cargo) {
       const result = await runCommand([cargo, "install", "psmux"], { inherit });
       record(result);
       if (result.success) {
         const home = getHomeDir();
         if (home) prependPath(join(home, ".cargo", "bin"));
-        if (Bun.which("psmux") || Bun.which("tmux")) return;
+        await refreshWindowsMuxPath();
+        if (hasMuxBinary()) return;
       }
     }
     throw new Error(
@@ -189,11 +293,11 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
 
   // Unix / macOS
   if (process.platform === "darwin") {
-    const brew = Bun.which("brew");
+    const brew = resolveCommandFromCurrentPath("brew");
     if (brew) {
       const result = await runCommand([brew, "install", "tmux"], { inherit });
       record(result);
-      if (result.success && Bun.which("tmux")) return;
+      if (result.success && resolveCommandFromCurrentPath("tmux")) return;
     }
   }
 
@@ -214,7 +318,7 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
 
   for (const script of managers) {
     record(await runCommand([shell, "-lc", script], { inherit }));
-    if (Bun.which("tmux")) return;
+    if (resolveCommandFromCurrentPath("tmux")) return;
   }
 
   throw new Error(

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -152,6 +152,32 @@ function prependWindowsMuxInstallPaths(): void {
   prependPathIfDirectory(windowsAtomicBinDir());
 }
 
+function prependBunInstallPaths(): void {
+  const home = getHomeDir();
+  prependPathIfDirectory(process.env.BUN_INSTALL_BIN);
+  prependPathIfDirectory(
+    process.env.BUN_INSTALL ? join(process.env.BUN_INSTALL, "bin") : undefined,
+  );
+  prependPathIfDirectory(home ? join(home, ".bun", "bin") : undefined);
+
+  if (process.platform !== "win32") return;
+
+  prependPathIfDirectory(
+    process.env.SCOOP ? join(process.env.SCOOP, "shims") : undefined,
+  );
+  prependPathIfDirectory(home ? join(home, "scoop", "shims") : undefined);
+  prependPathIfDirectory(
+    process.env.LOCALAPPDATA
+      ? join(process.env.LOCALAPPDATA, "Microsoft", "WinGet", "Links")
+      : undefined,
+  );
+  prependPathIfDirectory(
+    process.env.LOCALAPPDATA
+      ? join(process.env.LOCALAPPDATA, "Microsoft", "WindowsApps")
+      : undefined,
+  );
+}
+
 function mergePath(pathValue: string): void {
   const delimiter = process.platform === "win32" ? ";" : ":";
   for (const entry of pathValue.split(delimiter)) {
@@ -188,6 +214,12 @@ async function refreshWindowsMuxPath(): Promise<void> {
   prependWindowsMuxInstallPaths();
   await refreshWindowsPathFromRegistry();
   prependWindowsMuxInstallPaths();
+}
+
+async function refreshWindowsBunPath(): Promise<void> {
+  prependBunInstallPaths();
+  await refreshWindowsPathFromRegistry();
+  prependBunInstallPaths();
 }
 
 interface GitHubReleaseAsset {
@@ -511,51 +543,73 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
  * No-op when already present.
  */
 export async function ensureBunInstalled(): Promise<void> {
-  if (Bun.which("bun")) return;
-
-  const home = getHomeDir();
+  if (resolveCommandFromCurrentPath("bun")) return;
 
   if (process.platform === "win32") {
     // Windows
-    const winget = Bun.which("winget");
+    const winget = resolveCommandFromCurrentPath("winget");
     if (winget) {
       const result = await runCommand([winget, "install", "Oven-sh.Bun", "--accept-source-agreements", "--accept-package-agreements"], { inherit: true });
       if (result.success) {
-        if (home) prependPath(join(home, ".bun", "bin"));
-        if (Bun.which("bun")) return;
+        await refreshWindowsBunPath();
+        if (resolveCommandFromCurrentPath("bun")) return;
       }
     }
 
-    const scoop = Bun.which("scoop");
+    const scoop = resolveCommandFromCurrentPath("scoop");
     if (scoop) {
       const result = await runCommand([scoop, "install", "bun"], { inherit: true });
-      if (result.success && Bun.which("bun")) return;
+      if (result.success) {
+        await refreshWindowsBunPath();
+        if (resolveCommandFromCurrentPath("bun")) return;
+      }
     }
 
-    return;
+    const shell = resolveCommandFromCurrentPath("powershell") ??
+      resolveCommandFromCurrentPath("pwsh");
+    if (shell) {
+      const result = await runCommand([
+        shell,
+        "-NoProfile",
+        "-Command",
+        "irm bun.sh/install.ps1 | iex",
+      ], { inherit: true });
+      if (result.success) {
+        await refreshWindowsBunPath();
+        if (resolveCommandFromCurrentPath("bun")) return;
+      }
+    }
+
+    throw new Error("Could not install bun automatically.");
   }
 
   // Unix / macOS
-  const shell = Bun.which("bash") ?? Bun.which("sh");
+  const shell = resolveCommandFromCurrentPath("bash") ??
+    resolveCommandFromCurrentPath("sh");
   if (shell) {
     const result = await runCommand(
       [shell, "-lc", "curl -fsSL https://bun.sh/install | bash"],
       { inherit: true },
     );
     if (result.success) {
-      if (home) prependPath(join(home, ".bun", "bin"));
-      if (Bun.which("bun")) return;
+      prependBunInstallPaths();
+      if (resolveCommandFromCurrentPath("bun")) return;
     }
   }
 
   // macOS Homebrew fallback
   if (process.platform === "darwin") {
-    const brew = Bun.which("brew");
+    const brew = resolveCommandFromCurrentPath("brew");
     if (brew) {
       const result = await runCommand([brew, "install", "oven-sh/bun/bun"], { inherit: true });
-      if (result.success && Bun.which("bun")) return;
+      if (result.success) {
+        prependBunInstallPaths();
+        if (resolveCommandFromCurrentPath("bun")) return;
+      }
     }
   }
+
+  throw new Error("Could not install bun automatically.");
 }
 
 /**

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -112,12 +112,29 @@ function buildWorkflowHookCommand(subcommand: string, extraArgs: readonly string
   }
   const runtime = process.execPath;
   const cliPath = join(import.meta.dir, "..", "..", "cli.ts");
+  if (process.platform === "win32") {
+    const script = [
+      quotePwshLiteral(runtime),
+      quotePwshLiteral(cliPath),
+      quotePwshLiteral(subcommand),
+      ...extraArgs.map(quotePwshLiteral),
+    ].join(" ");
+    const encoded = Buffer.from(`& ${script}`, "utf16le").toString("base64");
+    return `pwsh -NoProfile -EncodedCommand ${encoded}`;
+  }
   return [
     `"${escBash(runtime)}"`,
     `"${escBash(cliPath)}"`,
     subcommand,
     ...extraArgs,
   ].join(" ");
+}
+
+function quotePwshLiteral(s: string): string {
+  return `'${s
+    .replace(/\x00/g, "")
+    .replace(/[\n\r]+/g, " ")
+    .replace(/'/g, "''")}'`;
 }
 
 /**

--- a/src/sdk/runtime/attached-footer.ts
+++ b/src/sdk/runtime/attached-footer.ts
@@ -13,7 +13,7 @@
  * so it can't be used here.
  */
 
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 import type { AgentType } from "../types.ts";
 import { tmuxRun } from "./tmux.ts";
 
@@ -31,6 +31,61 @@ function escBash(s: string): string {
     .replace(/[\\"$`!]/g, "\\$&");
 }
 
+/** Escape a string as a PowerShell single-quoted literal. */
+function quotePwshLiteral(s: string): string {
+  return `'${s
+    .replace(/\x00/g, "")
+    .replace(/[\n\r]+/g, " ")
+    .replace(/'/g, "''")}'`;
+}
+
+function encodePwshCommand(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+export function resolveAttachedFooterCliPath(
+  runtimeDir = import.meta.dir,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return platform === "win32"
+    ? win32.join(runtimeDir, "..", "..", "cli.ts")
+    : join(runtimeDir, "..", "..", "cli.ts");
+}
+
+export function buildAttachedFooterCommand({
+  runtime,
+  cliPath,
+  windowName,
+  agentType,
+  platform = process.platform,
+}: {
+  runtime: string;
+  cliPath: string;
+  windowName: string;
+  agentType?: AgentType;
+  platform?: NodeJS.Platform;
+}): string {
+  if (platform === "win32") {
+    const script = [
+      quotePwshLiteral(runtime),
+      quotePwshLiteral(cliPath),
+      quotePwshLiteral("_footer"),
+      quotePwshLiteral("--name"),
+      quotePwshLiteral(windowName),
+      ...(agentType
+        ? [quotePwshLiteral("--agent"), quotePwshLiteral(agentType)]
+        : []),
+    ].join(" ");
+    return `pwsh -NoProfile -EncodedCommand ${encodePwshCommand(`& ${script}`)}`;
+  }
+
+  const agentFlag = agentType ? ` --agent "${escBash(agentType)}"` : "";
+  return (
+    `"${escBash(runtime)}" "${escBash(cliPath)}" _footer ` +
+    `--name "${escBash(windowName)}"${agentFlag}`
+  );
+}
+
 export function spawnAttachedFooter(
   windowName: string,
   paneId: string,
@@ -38,11 +93,13 @@ export function spawnAttachedFooter(
 ): void {
   const runtime = process.execPath;
   if (!runtime) return;
-  const cliPath = join(import.meta.dir, "..", "..", "cli.ts");
-  const agentFlag = agentType ? ` --agent "${escBash(agentType)}"` : "";
-  const cmd =
-    `"${escBash(runtime)}" "${escBash(cliPath)}" _footer ` +
-    `--name "${escBash(windowName)}"${agentFlag}`;
+  const cliPath = resolveAttachedFooterCliPath();
+  const cmd = buildAttachedFooterCommand({
+    runtime,
+    cliPath,
+    windowName,
+    agentType,
+  });
   const split = tmuxRun([
     "split-window",
     "-t", paneId,

--- a/src/sdk/runtime/attached-footer.ts
+++ b/src/sdk/runtime/attached-footer.ts
@@ -15,7 +15,7 @@
 
 import { posix, win32 } from "node:path";
 import type { AgentType } from "../types.ts";
-import { tmuxRun } from "./tmux.ts";
+import { getMuxBinary, tmuxRun } from "./tmux.ts";
 
 /**
  * Rows reserved for the footer pane. Matches the single-row height of
@@ -86,6 +86,27 @@ export function buildAttachedFooterCommand({
   );
 }
 
+export function buildAttachedFooterCloseHooks(
+  agentPaneId: string,
+  footerPaneId: string,
+  options: { guardAgentPane?: boolean } = {},
+): Array<{ event: string; command: string }> {
+  const killFooter = `kill-pane -t ${footerPaneId}`;
+  const paneExitedCommand = options.guardAgentPane === false
+    ? killFooter
+    : `if -F '#{==:#{hook_pane},${agentPaneId}}' '${killFooter}'`;
+
+  return [
+    { event: "pane-exited", command: paneExitedCommand },
+    { event: "after-kill-pane", command: killFooter },
+  ];
+}
+
+function muxSupportsHookPaneFormat(): boolean {
+  const binary = getMuxBinary();
+  return binary !== "psmux" && binary !== "pmux";
+}
+
 export function spawnAttachedFooter(
   windowName: string,
   paneId: string,
@@ -110,6 +131,17 @@ export function spawnAttachedFooter(
   if (!split.ok) return;
   const footerPaneId = split.stdout.trim();
   if (!footerPaneId) return;
+  tmuxRun(["select-pane", "-t", paneId]);
+  for (const hook of buildAttachedFooterCloseHooks(paneId, footerPaneId, {
+    guardAgentPane: muxSupportsHookPaneFormat(),
+  })) {
+    tmuxRun([
+      "set-hook",
+      "-w", "-t", footerPaneId,
+      hook.event,
+      hook.command,
+    ]);
+  }
   // Pin the footer to FOOTER_PANE_LINES on every resize so the agent pane
   // absorbs all new space. Tmux's default proportional redistribution
   // would otherwise grow the footer on larger windows. Window-scoped

--- a/src/sdk/runtime/attached-footer.ts
+++ b/src/sdk/runtime/attached-footer.ts
@@ -13,7 +13,7 @@
  * so it can't be used here.
  */
 
-import { join, win32 } from "node:path";
+import { posix, win32 } from "node:path";
 import type { AgentType } from "../types.ts";
 import { tmuxRun } from "./tmux.ts";
 
@@ -49,7 +49,7 @@ export function resolveAttachedFooterCliPath(
 ): string {
   return platform === "win32"
     ? win32.join(runtimeDir, "..", "..", "cli.ts")
-    : join(runtimeDir, "..", "..", "cli.ts");
+    : posix.join(runtimeDir, "..", "..", "cli.ts");
 }
 
 export function buildAttachedFooterCommand({

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -218,26 +218,50 @@ export function createSession(
   return paneId || tmux(["list-panes", "-t", sessionName, "-F", "#{pane_id}"]).split("\n")[0]!;
 }
 
+export function buildKillSessionOnPaneExitHooks(
+  sessionName: string,
+  paneId: string,
+  options: { guardPaneExited?: boolean } = {},
+): Array<{ event: string; command: string }> {
+  const killCommand = `kill-session -t ${sessionName}`;
+  const paneExitedCommand = options.guardPaneExited === false
+    ? killCommand
+    : `if -F '#{==:#{hook_pane},${paneId}}' '${killCommand}'`;
+  return [
+    { event: "pane-exited", command: paneExitedCommand },
+    { event: "after-kill-pane", command: killCommand },
+  ];
+}
+
+function supportsHookPaneFormat(binary = getMuxBinary()): boolean {
+  return binary !== "psmux" && binary !== "pmux";
+}
+
 /**
- * Install a hook that kills the entire session when the given pane's
- * process exits. Used by chat sessions so the session is torn down
- * when the agent CLI exits — whether via `/exit`, a deliberate double
- * Ctrl+C, or a crash — without leaving the footer pane keeping the
- * session alive.
+ * Install hooks that kill the entire session when the agent pane goes away.
+ * Used by chat sessions so the session is torn down when the agent CLI exits
+ * — whether via `/exit`, a deliberate double Ctrl+C, a crash, or a direct
+ * pane close — without leaving the footer pane keeping the session alive.
  *
- * The hook is session-scoped (pane-scoped hooks don't fire because the
- * pane is already gone when `pane-exited` would run) and guarded with
- * `#{hook_pane}` so the footer pane's eventual exit cascade doesn't
- * re-trigger it. `kill-session` is idempotent in any case.
+ * tmux fires `pane-exited` when a pane process exits; psmux also supports
+ * that event, but does not currently populate tmux's `#{hook_pane}` format,
+ * so the psmux hook is session-scoped. A direct pane close/kill fires
+ * `after-kill-pane` instead. These session-scoped hooks are safe for chat
+ * sessions: they only have the agent pane plus its footer, and closing either
+ * should close the entire chat window.
  */
 export function killSessionOnPaneExit(sessionName: string, paneId: string): void {
-  const guard = `if -F '#{==:#{hook_pane},${paneId}}' 'kill-session -t ${sessionName}'`;
-  tmuxRun([
-    "set-hook",
-    "-t", sessionName,
-    "pane-exited",
-    guard,
-  ]);
+  const hooks = buildKillSessionOnPaneExitHooks(sessionName, paneId, {
+    guardPaneExited: supportsHookPaneFormat(),
+  });
+  for (const hook of hooks) {
+    tmuxRun([
+      "set-hook",
+      "-t", sessionName,
+      hook.event,
+      hook.command,
+    ]);
+  }
 }
 
 /**

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -439,6 +439,14 @@ export function setSessionEnv(sessionName: string, key: string, value: string): 
   tmuxRun(["set-environment", "-t", sessionName, key, value]);
 }
 
+export function parseSessionEnvValue(stdout: string, key: string): string | null {
+  const prefix = `${key}=`;
+  const line = stdout
+    .split(/\r?\n/)
+    .find((entry) => entry.startsWith(prefix));
+  return line ? line.slice(prefix.length) : null;
+}
+
 /**
  * Read a session-level environment variable.
  * Returns `null` when the session doesn't exist or the variable isn't set.
@@ -446,9 +454,10 @@ export function setSessionEnv(sessionName: string, key: string, value: string): 
 export function getSessionEnv(sessionName: string, key: string): string | null {
   const result = tmuxRun(["show-environment", "-t", sessionName, key]);
   if (!result.ok) return null;
-  // Output format: "KEY=VALUE"
-  const eq = result.stdout.indexOf("=");
-  return eq >= 0 ? result.stdout.slice(eq + 1) : null;
+  // tmux returns "KEY=VALUE" for a requested key. psmux can append its own
+  // PSMUX_* metadata or return all environment lines, so only accept an exact
+  // key match and ignore every unrelated line.
+  return parseSessionEnvValue(result.stdout, key);
 }
 
 /** Session type derived from the session name prefix. */
@@ -510,6 +519,38 @@ export interface TmuxSession {
 
 const SESSION_LIST_DELIMITER = "__ATOMIC_SESSION_FIELD__";
 
+function isAtomicManagedSessionName(name: string): boolean {
+  return name.startsWith("atomic-");
+}
+
+export function parseListSessionsOutput(
+  stdout: string,
+  getEnv: (sessionName: string, key: string) => string | null = getSessionEnv,
+): TmuxSession[] {
+  return stdout
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .filter((line) => line.includes(SESSION_LIST_DELIMITER))
+    .flatMap((line) => {
+      const [name, windowsStr, createdStr, attachedStr] = line.split(SESSION_LIST_DELIMITER);
+      if (!name || !windowsStr || !createdStr || attachedStr === undefined) return [];
+      if (!isAtomicManagedSessionName(name)) return [];
+
+      const epochSec = Number(createdStr);
+      const parsed = parseSessionName(name);
+      return [{
+        name,
+        windows: Number(windowsStr) || 1,
+        created: Number.isFinite(epochSec) && epochSec > 0
+          ? new Date(epochSec * 1000).toISOString()
+          : createdStr,
+        attached: attachedStr === "1",
+        type: parsed.type,
+        agent: parsed.agent ?? getEnv(name, "ATOMIC_AGENT") ?? undefined,
+      }];
+    });
+}
+
 /**
  * List all sessions on the atomic tmux socket.
  *
@@ -527,27 +568,7 @@ export function listSessions(): TmuxSession[] {
   const result = tmuxRun(["list-sessions", "-F", fmt]);
   if (!result.ok) return [];
 
-  const sessions = result.stdout
-    .split("\n")
-    .filter((line) => line.trim() !== "")
-    .filter((line) => line.includes(SESSION_LIST_DELIMITER))
-    .map((line) => {
-      const [name, windowsStr, createdStr, attachedStr] = line.split(SESSION_LIST_DELIMITER);
-      const epochSec = Number(createdStr);
-      const parsed = parseSessionName(name!);
-      return {
-        name: name!,
-        windows: Number(windowsStr) || 1,
-        created: Number.isFinite(epochSec) && epochSec > 0
-          ? new Date(epochSec * 1000).toISOString()
-          : createdStr!,
-        attached: attachedStr === "1",
-        type: parsed.type,
-        agent: parsed.agent ?? getSessionEnv(name!, "ATOMIC_AGENT") ?? undefined,
-      };
-    });
-
-  return sessions;
+  return parseListSessionsOutput(result.stdout);
 }
 
 /** Build the full argument list for an attach-session command. */

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -7,6 +7,7 @@
  */
 
 import { join } from "node:path";
+import { requiredMuxBinaryCandidatesForPlatform } from "../../lib/spawn.ts";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import type { Subprocess } from "bun";
@@ -45,7 +46,9 @@ let resolvedMuxBinary: string | null | undefined; // undefined = not yet resolve
 /**
  * Resolve the terminal multiplexer binary for the current platform.
  *
- * On Windows, tries psmux → pmux → tmux (psmux ships all three as aliases).
+ * On Windows, tries psmux → pmux. Do not accept arbitrary `tmux.exe` because
+ * that can be a non-native shim and would prevent the psmux installer from
+ * running.
  * On Unix/macOS, uses tmux directly.
  *
  * Returns the binary name (not the full path) or null if none is found.
@@ -59,19 +62,14 @@ export function getMuxBinary(): string | null {
   // so that callers who modify PATH (e.g. tests) get correct results.
   const pathOpt = { PATH: process.env.PATH ?? "" };
 
-  if (process.platform === "win32") {
-    for (const candidate of ["psmux", "pmux", "tmux"]) {
-      if (Bun.which(candidate, pathOpt)) {
-        resolvedMuxBinary = candidate;
-        return resolvedMuxBinary;
-      }
+  for (const candidate of requiredMuxBinaryCandidatesForPlatform()) {
+    if (Bun.which(candidate, pathOpt)) {
+      resolvedMuxBinary = candidate;
+      return resolvedMuxBinary;
     }
-    resolvedMuxBinary = null;
-    return null;
   }
 
-  // Unix / macOS
-  resolvedMuxBinary = Bun.which("tmux", pathOpt) ? "tmux" : null;
+  resolvedMuxBinary = null;
   return resolvedMuxBinary;
 }
 
@@ -510,6 +508,8 @@ export interface TmuxSession {
   agent?: string;
 }
 
+const SESSION_LIST_DELIMITER = "__ATOMIC_SESSION_FIELD__";
+
 /**
  * List all sessions on the atomic tmux socket.
  *
@@ -518,15 +518,21 @@ export interface TmuxSession {
  * sessions (tmux exits non-zero in both cases).
  */
 export function listSessions(): TmuxSession[] {
-  const fmt = "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}";
+  const fmt = [
+    "#{session_name}",
+    "#{session_windows}",
+    "#{session_created}",
+    "#{session_attached}",
+  ].join(SESSION_LIST_DELIMITER);
   const result = tmuxRun(["list-sessions", "-F", fmt]);
   if (!result.ok) return [];
 
   const sessions = result.stdout
     .split("\n")
     .filter((line) => line.trim() !== "")
+    .filter((line) => line.includes(SESSION_LIST_DELIMITER))
     .map((line) => {
-      const [name, windowsStr, createdStr, attachedStr] = line.split("\t");
+      const [name, windowsStr, createdStr, attachedStr] = line.split(SESSION_LIST_DELIMITER);
       const epochSec = Number(createdStr);
       const parsed = parseSessionName(name!);
       return {
@@ -679,4 +685,3 @@ export function normalizeTmuxLines(text: string): string {
     .join("\n")
     .trim();
 }
-

--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -29,6 +29,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { VERSION } from "../../version.ts";
 import {
+  hasRequiredMuxBinary,
   ensureTmuxInstalled,
   upgradeGlobalToolPackages,
 } from "../../lib/spawn.ts";
@@ -77,7 +78,8 @@ async function silentStep(fn: () => Promise<unknown>): Promise<boolean> {
 /**
  * Sync tooling deps, bundled agents, and global skills if the marker
  * doesn't match the bundled VERSION. No-op in dev checkouts and when the
- * marker already matches the current version.
+ * marker already matches the current version and the platform-native
+ * multiplexer is present.
  *
  * Runs entirely silently — no spinner, no progress bar, no banner. The
  * only loading UI lives in the bootstrap installers (install.sh / install.ps1).
@@ -91,17 +93,21 @@ export async function autoSyncIfStale(): Promise<void> {
     stored = (await marker.text()).trim();
   }
 
-  if (stored === VERSION) return;
+  if (stored === VERSION && hasRequiredMuxBinary()) return;
+
+  const steps = stored === VERSION
+    ? [silentStep(() => ensureTmuxInstalled({ quiet: true }))]
+    : [
+        silentStep(() => ensureTmuxInstalled({ quiet: true })),
+        silentStep(installGlobalAgents),
+        silentStep(upgradeGlobalToolPackages),
+        silentStep(installGlobalSkills),
+      ];
 
   // All steps run in parallel and silently. Failures are swallowed so the
   // CLI can proceed. The marker is only written when every step succeeds;
   // on partial failure the next launch retries (all steps are idempotent).
-  const results = await Promise.all([
-    silentStep(() => ensureTmuxInstalled({ quiet: true })),
-    silentStep(installGlobalAgents),
-    silentStep(upgradeGlobalToolPackages),
-    silentStep(installGlobalSkills),
-  ]);
+  const results = await Promise.all(steps);
 
   const allOk = results.every(Boolean);
 

--- a/tests/commands/cli/footer.test.ts
+++ b/tests/commands/cli/footer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   footerCommand,
   renderFooterFrame,
@@ -123,15 +123,10 @@ describe("headless footer frame", () => {
 
   test.serial("footer command exits successfully after renderer teardown", async () => {
     const previousSigtermListeners = process.listeners("SIGTERM");
-    const stdoutChunks: string[] = [];
+    const stdout = createFooterTestStream(80);
     let rendererReady = false;
-    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
-      (chunk: unknown) => {
-        stdoutChunks.push(String(chunk));
-        return true;
-      },
-    );
     const command = footerCommand("atomic-chat-opencode-abcd1234", "opencode", {
+      stdout,
       onReady: () => {
         rendererReady = true;
       },
@@ -146,11 +141,10 @@ describe("headless footer frame", () => {
       invokeNewListeners("SIGTERM", previousSigtermListeners);
       await expect(command).resolves.toBe(0);
     } finally {
-      stdoutSpy.mockRestore();
       invokeNewListeners("SIGTERM", previousSigtermListeners);
     }
 
-    expect(stdoutChunks.join("")).toContain("OPENCODE");
-    expect(stdoutChunks.join("")).toContain("atomic-chat-opencode-abcd1234");
+    expect(stdout.writes.join("")).toContain("OPENCODE");
+    expect(stdout.writes.join("")).toContain("atomic-chat-opencode-abcd1234");
   });
 });

--- a/tests/commands/cli/footer.test.ts
+++ b/tests/commands/cli/footer.test.ts
@@ -1,5 +1,53 @@
-import { describe, expect, test } from "bun:test";
-import { renderFooterFrame } from "../../../src/commands/cli/footer.tsx";
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  footerCommand,
+  renderFooterFrame,
+  runFooterRenderer,
+} from "../../../src/commands/cli/footer.tsx";
+
+type FooterTestStream = {
+  columns: number;
+  writes: string[];
+  write(chunk: string | Uint8Array): boolean;
+};
+
+function createFooterTestStream(columns: number): FooterTestStream {
+  return {
+    columns,
+    writes: [],
+    write(chunk: string | Uint8Array): boolean {
+      this.writes.push(String(chunk));
+      return true;
+    },
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await delay(10);
+  }
+  throw new Error(message);
+}
+
+function newListeners(eventName: string, previous: Function[]): Function[] {
+  return process.listeners(eventName).filter((listener) => !previous.includes(listener));
+}
+
+function invokeNewListeners(eventName: string, previous: Function[]): void {
+  for (const listener of newListeners(eventName, previous)) {
+    listener();
+  }
+}
 
 describe("headless footer frame", () => {
   test("renders the OpenTUI footer without terminal capability probes", async () => {
@@ -28,5 +76,73 @@ describe("headless footer frame", () => {
     expect(frame).toContain("o");
     expect(frame).not.toContain("\x1b]x");
     expect(frame).not.toContain("\x07");
+  });
+
+  test.serial("repaints on resize and tears down on a process signal", async () => {
+    const stdout = createFooterTestStream(36);
+    const previousSigtermListeners = process.listeners("SIGTERM");
+    const previousSigwinchListeners = process.listeners("SIGWINCH");
+    const renderer = runFooterRenderer({
+      name: "atomic-chat-claude-long-session-name",
+      agentType: "claude",
+      stdout,
+    });
+
+    try {
+      await waitFor(
+        () =>
+          stdout.writes.length > 0 &&
+          newListeners("SIGTERM", previousSigtermListeners).length > 0 &&
+          newListeners("SIGWINCH", previousSigwinchListeners).length > 0,
+        "footer renderer did not start",
+      );
+
+      const writeCountBeforeResize = stdout.writes.length;
+      stdout.columns = 120;
+      invokeNewListeners("SIGWINCH", previousSigwinchListeners);
+
+      await waitFor(
+        () => stdout.writes.length > writeCountBeforeResize,
+        "footer renderer did not repaint after resize",
+      );
+
+      invokeNewListeners("SIGTERM", previousSigtermListeners);
+      await renderer;
+    } finally {
+      invokeNewListeners("SIGTERM", previousSigtermListeners);
+    }
+
+    expect(newListeners("SIGTERM", previousSigtermListeners)).toHaveLength(0);
+    expect(newListeners("SIGWINCH", previousSigwinchListeners)).toHaveLength(0);
+    expect(stdout.writes.join("")).toContain("CLAUDE");
+    expect(stdout.writes.join("")).toContain("atomic-chat-claude-long-session-name");
+  });
+
+  test.serial("footer command exits successfully after renderer teardown", async () => {
+    const previousSigtermListeners = process.listeners("SIGTERM");
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
+      (chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      },
+    );
+    const command = footerCommand("atomic-chat-opencode-abcd1234", "opencode");
+
+    try {
+      await waitFor(
+        () => newListeners("SIGTERM", previousSigtermListeners).length > 0,
+        "footer command did not start renderer",
+      );
+
+      invokeNewListeners("SIGTERM", previousSigtermListeners);
+      await expect(command).resolves.toBe(0);
+    } finally {
+      stdoutSpy.mockRestore();
+      invokeNewListeners("SIGTERM", previousSigtermListeners);
+    }
+
+    expect(stdoutChunks.join("")).toContain("OPENCODE");
+    expect(stdoutChunks.join("")).toContain("atomic-chat-opencode-abcd1234");
   });
 });

--- a/tests/commands/cli/footer.test.ts
+++ b/tests/commands/cli/footer.test.ts
@@ -1,57 +1,32 @@
 import { describe, expect, test } from "bun:test";
-import { createFooterStdout } from "../../../src/commands/cli/footer.tsx";
+import { renderFooterFrame } from "../../../src/commands/cli/footer.tsx";
 
-function createFakeStdout({
-  columns,
-  rows,
-  chunks = [],
-}: {
-  columns?: number;
-  rows?: number;
-  chunks?: string[];
-}): {
-  readonly columns?: number;
-  readonly rows?: number;
-  write: NodeJS.WriteStream["write"];
-} {
-  return {
-    get columns() {
-      return columns;
-    },
-    get rows() {
-      return rows;
-    },
-    write: ((chunk: string | Uint8Array) => {
-      chunks.push(chunk.toString());
-      return true;
-    }) as NodeJS.WriteStream["write"],
-  };
-}
+describe("headless footer frame", () => {
+  test("renders the OpenTUI footer without terminal capability probes", async () => {
+    const frame = await renderFooterFrame({
+      name: "atomic-chat-copilot-abcd1234",
+      agentType: "copilot",
+      width: 120,
+    });
 
-describe("footer renderer stdout", () => {
-  test("pins OpenTUI geometry to the one-row footer pane", () => {
-    const stdout = createFakeStdout({ columns: 132, rows: 24 });
-    const footerStdout = createFooterStdout(stdout);
-
-    expect(footerStdout.rows).toBe(1);
-    expect(footerStdout.columns).toBe(132);
+    expect(frame).toContain("COPILOT");
+    expect(frame).toContain("atomic-chat-copilot-abcd1234");
+    expect(frame).toContain("ctrl+b d");
+    expect(frame).toContain("detach");
+    expect(frame).not.toContain("\x1b[?");
+    expect(frame).not.toContain("\x1b]");
+    expect(frame).not.toContain("\x1b_");
   });
 
-  test("falls back to a safe width when the pane width is unavailable", () => {
-    const stdout = createFakeStdout({});
-    const footerStdout = createFooterStdout(stdout);
+  test("sanitizes control characters from rendered footer text", async () => {
+    const frame = await renderFooterFrame({
+      name: "b\x1b]x\x07o",
+      width: 80,
+    });
 
-    expect(footerStdout.rows).toBe(1);
-    expect(footerStdout.columns).toBe(80);
-  });
-
-  test("delegates writes to the original stdout stream", () => {
-    const chunks: string[] = [];
-    const stdout = createFakeStdout({ columns: 80, rows: 24, chunks });
-    const footerStdout = createFooterStdout(stdout);
-
-    footerStdout.write("visible footer");
-
-    expect(chunks.join("")).toBe("visible footer");
+    expect(frame).toContain("b");
+    expect(frame).toContain("o");
+    expect(frame).not.toContain("\x1b]x");
+    expect(frame).not.toContain("\x07");
   });
 });

--- a/tests/commands/cli/footer.test.ts
+++ b/tests/commands/cli/footer.test.ts
@@ -82,18 +82,21 @@ describe("headless footer frame", () => {
     const stdout = createFooterTestStream(36);
     const previousSigtermListeners = process.listeners("SIGTERM");
     const previousSigwinchListeners = process.listeners("SIGWINCH");
+    let rendererReady = false;
     const renderer = runFooterRenderer({
       name: "atomic-chat-claude-long-session-name",
       agentType: "claude",
       stdout,
+      onReady: () => {
+        rendererReady = true;
+      },
     });
 
     try {
       await waitFor(
         () =>
           stdout.writes.length > 0 &&
-          newListeners("SIGTERM", previousSigtermListeners).length > 0 &&
-          newListeners("SIGWINCH", previousSigwinchListeners).length > 0,
+          rendererReady,
         "footer renderer did not start",
       );
 
@@ -121,17 +124,22 @@ describe("headless footer frame", () => {
   test.serial("footer command exits successfully after renderer teardown", async () => {
     const previousSigtermListeners = process.listeners("SIGTERM");
     const stdoutChunks: string[] = [];
+    let rendererReady = false;
     const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(
       (chunk: unknown) => {
         stdoutChunks.push(String(chunk));
         return true;
       },
     );
-    const command = footerCommand("atomic-chat-opencode-abcd1234", "opencode");
+    const command = footerCommand("atomic-chat-opencode-abcd1234", "opencode", {
+      onReady: () => {
+        rendererReady = true;
+      },
+    });
 
     try {
       await waitFor(
-        () => newListeners("SIGTERM", previousSigtermListeners).length > 0,
+        () => rendererReady,
         "footer command did not start renderer",
       );
 

--- a/tests/commands/cli/footer.test.ts
+++ b/tests/commands/cli/footer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { createFooterStdout } from "../../../src/commands/cli/footer.tsx";
+
+function createFakeStdout({
+  columns,
+  rows,
+  chunks = [],
+}: {
+  columns?: number;
+  rows?: number;
+  chunks?: string[];
+}): {
+  readonly columns?: number;
+  readonly rows?: number;
+  write: NodeJS.WriteStream["write"];
+} {
+  return {
+    get columns() {
+      return columns;
+    },
+    get rows() {
+      return rows;
+    },
+    write: ((chunk: string | Uint8Array) => {
+      chunks.push(chunk.toString());
+      return true;
+    }) as NodeJS.WriteStream["write"],
+  };
+}
+
+describe("footer renderer stdout", () => {
+  test("pins OpenTUI geometry to the one-row footer pane", () => {
+    const stdout = createFakeStdout({ columns: 132, rows: 24 });
+    const footerStdout = createFooterStdout(stdout);
+
+    expect(footerStdout.rows).toBe(1);
+    expect(footerStdout.columns).toBe(132);
+  });
+
+  test("falls back to a safe width when the pane width is unavailable", () => {
+    const stdout = createFakeStdout({});
+    const footerStdout = createFooterStdout(stdout);
+
+    expect(footerStdout.rows).toBe(1);
+    expect(footerStdout.columns).toBe(80);
+  });
+
+  test("delegates writes to the original stdout stream", () => {
+    const chunks: string[] = [];
+    const stdout = createFakeStdout({ columns: 80, rows: 24, chunks });
+    const footerStdout = createFooterStdout(stdout);
+
+    footerStdout.write("visible footer");
+
+    expect(chunks.join("")).toBe("visible footer");
+  });
+});

--- a/tests/sdk/components/attached-statusline.test.tsx
+++ b/tests/sdk/components/attached-statusline.test.tsx
@@ -1,11 +1,10 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { AttachedStatusline } from "../../../src/sdk/components/attached-statusline.tsx";
-import { TEST_THEME } from "./test-helpers.tsx";
+import { renderReact, TEST_THEME, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -14,7 +13,7 @@ afterEach(() => {
 
 describe("AttachedStatusline", () => {
   test("renders window name badge and navigation hints (workflow variant)", async () => {
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <AttachedStatusline name="worker-1" theme={TEST_THEME} />,
       { width: 120, height: 3 },
     );
@@ -33,7 +32,7 @@ describe("AttachedStatusline", () => {
   });
 
   test("renders uppercase agent pill, pane name, and detach hint (chat variant)", async () => {
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <AttachedStatusline
         name="atomic-chat-copilot-abcd1234"
         theme={TEST_THEME}

--- a/tests/sdk/components/edge.test.tsx
+++ b/tests/sdk/components/edge.test.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { Edge } from "../../../src/sdk/components/edge.tsx";
+import { renderReact, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe("Edge", () => {
   test("renders straight vertical connector text", async () => {
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <Edge text="│" col={5} row={2} width={1} height={1} color="#6c7086" />,
       { width: 40, height: 10 },
     );
@@ -24,7 +24,7 @@ describe("Edge", () => {
 
   test("renders branching connector with horizontal bar", async () => {
     const branchText = "╭──┬──╮";
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <Edge text={branchText} col={0} row={0} width={7} height={1} color="#6c7086" />,
       { width: 40, height: 10 },
     );
@@ -35,7 +35,7 @@ describe("Edge", () => {
 
   test("renders multiline connector text", async () => {
     const text = "│\n╰──╮";
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <Edge text={text} col={0} row={0} width={4} height={2} color="#ffffff" />,
       { width: 40, height: 10 },
     );

--- a/tests/sdk/components/error-boundary.test.tsx
+++ b/tests/sdk/components/error-boundary.test.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach, mock } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { ErrorBoundary } from "../../../src/sdk/components/error-boundary.tsx";
+import { renderReact, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -17,7 +17,7 @@ function ThrowingChild({ message }: { message: string }): never {
 
 describe("ErrorBoundary", () => {
   test("renders children when no error is thrown", async () => {
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <ErrorBoundary fallback={() => <text>fallback</text>}>
         <text>safe content</text>
       </ErrorBoundary>,
@@ -34,7 +34,7 @@ describe("ErrorBoundary", () => {
     const originalError = console.error;
     console.error = mock(() => {});
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <ErrorBoundary
         fallback={(err) => <text>{`caught: ${err.message}`}</text>}
       >
@@ -54,7 +54,7 @@ describe("ErrorBoundary", () => {
     const originalError = console.error;
     console.error = (...args: unknown[]) => { calls.push(args); };
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <ErrorBoundary fallback={() => <text>fallback</text>}>
         <ThrowingChild message="log test" />
       </ErrorBoundary>,
@@ -74,7 +74,7 @@ describe("ErrorBoundary", () => {
     const originalError = console.error;
     console.error = mock(() => {});
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <ErrorBoundary
         fallback={(err) => <text>{err.constructor.name}</text>}
       >

--- a/tests/sdk/components/header.test.tsx
+++ b/tests/sdk/components/header.test.tsx
@@ -1,12 +1,11 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import { Header } from "../../../src/sdk/components/header.tsx";
-import { TestProviders } from "./test-helpers.tsx";
+import { renderReact, TestProviders, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -18,7 +17,7 @@ describe("Header", () => {
     const store = new PanelStore();
     store.setWorkflowInfo("my-wf", "claude", [{ name: "s1", parents: [] }], "prompt");
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Header />
       </TestProviders>,
@@ -36,7 +35,7 @@ describe("Header", () => {
     store.completeSession("s1");
     store.setCompletion("my-wf", "/tmp/transcripts");
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Header />
       </TestProviders>,
@@ -53,7 +52,7 @@ describe("Header", () => {
     store.setWorkflowInfo("my-wf", "claude", [], "p");
     store.setFatalError("something broke");
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Header />
       </TestProviders>,
@@ -75,7 +74,7 @@ describe("Header", () => {
     store.completeSession("s1");
     // Now: orchestrator=running(1), s1=complete(1), s2=pending(1)
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Header />
       </TestProviders>,
@@ -91,7 +90,7 @@ describe("Header", () => {
     const store = new PanelStore();
     store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store} tmuxSession="atomic-abc123">
         <Header />
       </TestProviders>,
@@ -108,7 +107,7 @@ describe("Header", () => {
     store.startSession("s1");
     store.failSession("s1", "oops");
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Header />
       </TestProviders>,

--- a/tests/sdk/components/node-card.test.tsx
+++ b/tests/sdk/components/node-card.test.tsx
@@ -1,14 +1,13 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import { NodeCard } from "../../../src/sdk/components/node-card.tsx";
 import type { LayoutNode } from "../../../src/sdk/components/layout.ts";
 import { NODE_H } from "../../../src/sdk/components/layout.ts";
-import { TestProviders } from "./test-helpers.tsx";
+import { renderReact, TestProviders, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -35,7 +34,7 @@ describe("NodeCard", () => {
     const store = new PanelStore();
     const node = makeLayoutNode({ name: "my-session", status: "pending" });
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={NODE_H} />
       </TestProviders>,
@@ -56,7 +55,7 @@ describe("NodeCard", () => {
       startedAt: now - 65000, // 1m 05s ago
     });
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={NODE_H} />
       </TestProviders>,
@@ -77,7 +76,7 @@ describe("NodeCard", () => {
       endedAt: 6000, // 5 seconds
     });
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={NODE_H} />
       </TestProviders>,
@@ -99,7 +98,7 @@ describe("NodeCard", () => {
       endedAt: 3000,
     });
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={NODE_H} />
       </TestProviders>,
@@ -114,7 +113,7 @@ describe("NodeCard", () => {
     const store = new PanelStore();
     const node = makeLayoutNode({ name: "focused-node", status: "pending" });
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={true} pulsePhase={0} displayH={NODE_H} />
       </TestProviders>,
@@ -133,7 +132,7 @@ describe("NodeCard", () => {
       startedAt: Date.now() - 5000,
     });
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={6} />
       </TestProviders>,
@@ -153,7 +152,7 @@ describe("NodeCard", () => {
       startedAt: Date.now() - 5000,
     });
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={6} />
       </TestProviders>,
@@ -173,7 +172,7 @@ describe("NodeCard", () => {
     });
 
     // Phase 0
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={6} />
       </TestProviders>,
@@ -184,7 +183,7 @@ describe("NodeCard", () => {
     testSetup.renderer.destroy();
 
     // Phase 16 (half cycle)
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={true} pulsePhase={16} displayH={6} />
       </TestProviders>,
@@ -199,7 +198,7 @@ describe("NodeCard", () => {
     const node = makeLayoutNode({ name: "pulse-test", status: "running", startedAt: Date.now() });
 
     // Test at phase 0
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={false} pulsePhase={0} displayH={NODE_H} />
       </TestProviders>,
@@ -210,7 +209,7 @@ describe("NodeCard", () => {
     testSetup.renderer.destroy();
 
     // Test at phase 16 (half cycle)
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <NodeCard node={node} focused={true} pulsePhase={16} displayH={NODE_H} />
       </TestProviders>,

--- a/tests/sdk/components/orchestrator-panel-contexts.test.tsx
+++ b/tests/sdk/components/orchestrator-panel-contexts.test.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import {
   StoreContext,
@@ -10,9 +9,9 @@ import {
   useGraphTheme,
   useStoreVersion,
 } from "../../../src/sdk/components/orchestrator-panel-contexts.ts";
-import { TEST_THEME } from "./test-helpers.tsx";
+import { renderReact, TEST_THEME, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -39,7 +38,7 @@ describe("useStore", () => {
     const store = new PanelStore();
     store.setWorkflowInfo("test-wf", "claude", [], "p");
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <StoreContext.Provider value={store}>
         <StoreConsumer />
       </StoreContext.Provider>,
@@ -62,7 +61,7 @@ describe("useStore", () => {
 
 describe("useGraphTheme", () => {
   test("returns theme from context", async () => {
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <ThemeContext.Provider value={TEST_THEME}>
         <ThemeConsumer />
       </ThemeContext.Provider>,
@@ -85,7 +84,7 @@ describe("useStoreVersion", () => {
   test("returns current version from store", async () => {
     const store = new PanelStore();
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <StoreContext.Provider value={store}>
         <VersionConsumer store={store} />
       </StoreContext.Provider>,
@@ -102,7 +101,7 @@ describe("useStoreVersion", () => {
     // Mutate before render — useSyncExternalStore reads the latest snapshot
     store.setWorkflowInfo("wf", "claude", [], "p");
 
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <StoreContext.Provider value={store}>
         <VersionConsumer store={store} />
       </StoreContext.Provider>,

--- a/tests/sdk/components/orchestrator-panel.test.tsx
+++ b/tests/sdk/components/orchestrator-panel.test.tsx
@@ -2,10 +2,9 @@
 
 import { test, expect, describe, afterEach } from "bun:test";
 import { createTestRenderer } from "@opentui/core/testing";
-import { testRender } from "@opentui/react/test-utils";
 import { OrchestratorPanel } from "../../../src/sdk/components/orchestrator-panel.tsx";
 import { ErrorBoundary } from "../../../src/sdk/components/error-boundary.tsx";
-import { TEST_THEME } from "./test-helpers.tsx";
+import { renderReact, TEST_THEME } from "./test-helpers.tsx";
 
 let panel: OrchestratorPanel | null = null;
 let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | null = null;
@@ -142,7 +141,7 @@ describe("OrchestratorPanel", () => {
       const originalError = console.error;
       console.error = () => {};
 
-      const setup = await testRender(
+      const setup = await renderReact(
         <ErrorBoundary
           fallback={(err) => (
             <box

--- a/tests/sdk/components/session-graph-panel.test.tsx
+++ b/tests/sdk/components/session-graph-panel.test.tsx
@@ -1,12 +1,11 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import { SessionGraphPanel } from "../../../src/sdk/components/session-graph-panel.tsx";
-import { TestProviders } from "./test-helpers.tsx";
+import { renderReact, TestProviders, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -24,7 +23,7 @@ function createPopulatedStore(): PanelStore {
 }
 
 async function renderPanel(store: PanelStore) {
-  testSetup = await testRender(
+  testSetup = await renderReact(
     <TestProviders store={store}>
       <SessionGraphPanel />
     </TestProviders>,
@@ -271,7 +270,7 @@ describe("SessionGraphPanel", () => {
 
     async function renderNarrow(store: PanelStore) {
       // Use a very small viewport so the graph overflows in both axes
-      testSetup = await testRender(
+      testSetup = await renderReact(
         <TestProviders store={store}>
           <SessionGraphPanel />
         </TestProviders>,

--- a/tests/sdk/components/statusline.test.tsx
+++ b/tests/sdk/components/statusline.test.tsx
@@ -1,12 +1,11 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import { Statusline } from "../../../src/sdk/components/statusline.tsx";
-import { TestProviders } from "./test-helpers.tsx";
+import { renderReact, TestProviders, type ReactTestSetup } from "./test-helpers.tsx";
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -16,7 +15,7 @@ afterEach(() => {
 describe("Statusline", () => {
   test("renders GRAPH badge", async () => {
     const store = new PanelStore();
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Statusline attachMsg="" />
       </TestProviders>,
@@ -29,7 +28,7 @@ describe("Statusline", () => {
 
   test("shows navigation hints when no attach message", async () => {
     const store = new PanelStore();
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Statusline attachMsg="" />
       </TestProviders>,
@@ -43,7 +42,7 @@ describe("Statusline", () => {
 
   test("shows attach message when provided", async () => {
     const store = new PanelStore();
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Statusline attachMsg={"\u2192 worker-1"} />
       </TestProviders>,
@@ -59,7 +58,7 @@ describe("Statusline", () => {
     store.workflowName = "my-workflow";
     store.setWorkflowInfo("my-workflow", "claude", [{ name: "worker-1", parents: [] }], "p");
     store.startSession("worker-1");
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Statusline attachMsg="" />
       </TestProviders>,
@@ -75,7 +74,7 @@ describe("Statusline", () => {
     const store = new PanelStore();
     store.incrementBackgroundTasks();
     store.incrementBackgroundTasks();
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Statusline attachMsg="" />
       </TestProviders>,
@@ -88,7 +87,7 @@ describe("Statusline", () => {
 
   test("shows quit option", async () => {
     const store = new PanelStore();
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Statusline attachMsg="" />
       </TestProviders>,
@@ -101,7 +100,7 @@ describe("Statusline", () => {
 
   test("shows ctrl+b d detach hint", async () => {
     const store = new PanelStore();
-    testSetup = await testRender(
+    testSetup = await renderReact(
       <TestProviders store={store}>
         <Statusline attachMsg="" />
       </TestProviders>,

--- a/tests/sdk/components/test-helpers.tsx
+++ b/tests/sdk/components/test-helpers.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @opentui/react */
 
-import type { ReactNode } from "react";
+import { createTestRenderer, type TestRendererOptions } from "@opentui/core/testing";
+import { createRoot } from "@opentui/react";
+import { act, type ReactNode } from "react";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import {
   StoreContext,
@@ -8,6 +10,14 @@ import {
   TmuxSessionContext,
 } from "../../../src/sdk/components/orchestrator-panel-contexts.ts";
 import type { GraphTheme } from "../../../src/sdk/components/graph-theme.ts";
+
+export type ReactTestSetup = Awaited<ReturnType<typeof createTestRenderer>>;
+
+type ActGlobal = typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const actGlobal = globalThis as ActGlobal;
 
 export const TEST_THEME: GraphTheme = {
   background: "#1e1e2e",
@@ -24,6 +34,161 @@ export const TEST_THEME: GraphTheme = {
   border: "#585b70",
   borderActive: "#6c7086",
 };
+
+function restoreActEnvironment(previousValue: boolean | undefined) {
+  if (previousValue === undefined) {
+    delete actGlobal.IS_REACT_ACT_ENVIRONMENT;
+    return;
+  }
+
+  actGlobal.IS_REACT_ACT_ENVIRONMENT = previousValue;
+}
+
+export function setReactActEnvironment(value: boolean | undefined) {
+  restoreActEnvironment(value);
+}
+
+function wrapInputInAct(testSetup: ReactTestSetup) {
+  const { mockInput } = testSetup;
+
+  const pressKey = mockInput.pressKey;
+  mockInput.pressKey = (key, modifiers) => {
+    act(() => {
+      pressKey(key, modifiers);
+    });
+  };
+
+  const pressEnter = mockInput.pressEnter;
+  mockInput.pressEnter = (modifiers) => {
+    act(() => {
+      pressEnter(modifiers);
+    });
+  };
+
+  const pressEscape = mockInput.pressEscape;
+  mockInput.pressEscape = (modifiers) => {
+    act(() => {
+      pressEscape(modifiers);
+    });
+  };
+
+  const pressTab = mockInput.pressTab;
+  mockInput.pressTab = (modifiers) => {
+    act(() => {
+      pressTab(modifiers);
+    });
+  };
+
+  const pressBackspace = mockInput.pressBackspace;
+  mockInput.pressBackspace = (modifiers) => {
+    act(() => {
+      pressBackspace(modifiers);
+    });
+  };
+
+  const pressArrow = mockInput.pressArrow;
+  mockInput.pressArrow = (direction, modifiers) => {
+    act(() => {
+      pressArrow(direction, modifiers);
+    });
+  };
+
+  const pressCtrlC = mockInput.pressCtrlC;
+  mockInput.pressCtrlC = () => {
+    act(() => {
+      pressCtrlC();
+    });
+  };
+
+  const pressKeys = mockInput.pressKeys;
+  mockInput.pressKeys = async (keys, delayMs) => {
+    await act(async () => {
+      await pressKeys(keys, delayMs);
+    });
+  };
+
+  const typeText = mockInput.typeText;
+  mockInput.typeText = async (text, delayMs) => {
+    await act(async () => {
+      await typeText(text, delayMs);
+    });
+  };
+
+  const pasteBracketedText = mockInput.pasteBracketedText;
+  mockInput.pasteBracketedText = async (text) => {
+    await act(async () => {
+      await pasteBracketedText(text);
+    });
+  };
+}
+
+export async function renderReact(
+  node: ReactNode,
+  options: TestRendererOptions,
+): Promise<ReactTestSetup> {
+  const previousActEnvironment = actGlobal.IS_REACT_ACT_ENVIRONMENT;
+  actGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+  let testSetup: ReactTestSetup;
+  try {
+    testSetup = await createTestRenderer({
+      ...options,
+      screenMode: options.screenMode ?? "main-screen",
+      footerHeight: options.footerHeight ?? 12,
+      consoleMode: options.consoleMode ?? "disabled",
+      externalOutputMode: options.externalOutputMode ?? "passthrough",
+    });
+  } catch (error) {
+    restoreActEnvironment(previousActEnvironment);
+    throw error;
+  }
+
+  const root = createRoot(testSetup.renderer);
+  const renderOnce = testSetup.renderOnce;
+  testSetup.renderOnce = async () => {
+    await act(async () => {
+      await renderOnce();
+    });
+  };
+
+  const resize = testSetup.resize;
+  testSetup.resize = (width, height) => {
+    act(() => {
+      resize(width, height);
+    });
+  };
+
+  wrapInputInAct(testSetup);
+
+  const destroy = testSetup.renderer.destroy.bind(testSetup.renderer);
+  let destroyed = false;
+  testSetup.renderer.destroy = () => {
+    if (destroyed) {
+      return;
+    }
+
+    destroyed = true;
+    try {
+      act(() => {
+        root.unmount();
+        destroy();
+      });
+    } finally {
+      restoreActEnvironment(previousActEnvironment);
+    }
+  };
+
+  try {
+    await act(async () => {
+      root.render(node);
+    });
+  } catch (error) {
+    testSetup.renderer.destroy();
+    throw error;
+  }
+
+  return testSetup;
+}
 
 export function TestProviders({
   store,

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { testRender } from "@opentui/react/test-utils";
 import { createTestRenderer } from "@opentui/core/testing";
 import { act } from "react";
 import {
@@ -17,6 +16,11 @@ import {
 } from "../../../src/sdk/components/workflow-picker-panel.tsx";
 import type { WorkflowDefinition, WorkflowInput } from "../../../src/sdk/types.ts";
 import { createRegistry } from "../../../src/sdk/registry.ts";
+import {
+  renderReact,
+  setReactActEnvironment,
+  type ReactTestSetup,
+} from "./test-helpers.tsx";
 
 // ─── Keyboard input helpers ───────────────────────
 //
@@ -24,11 +28,10 @@ import { createRegistry } from "../../../src/sdk/registry.ts";
 // either a follow-up byte or a timeout to disambiguate a bare escape
 // key from the start of an escape sequence. In tests that never
 // advance the clock, we need to force-flush the parser explicitly.
-// We also wrap every input action in React's `act()` so the resulting
-// state updates are committed before the next `renderOnce()` captures
-// a frame.
+// The shared React renderer helper wraps input and render cycles in
+// React's `act()` so state updates commit before frame capture.
 
-type TestSetup = Awaited<ReturnType<typeof testRender>>;
+type TestSetup = ReactTestSetup;
 
 function flushPendingInput(setup: TestSetup) {
   // stdinParser is public on CliRenderer (no underscore).
@@ -45,10 +48,9 @@ async function press(
   await act(async () => {
     await action(setup.mockInput);
     flushPendingInput(setup);
+    await Promise.resolve();
   });
-  await act(async () => {
-    await setup.renderOnce();
-  });
+  await setup.renderOnce();
 }
 
 // ─── Fixtures ─────────────────────────────────────
@@ -142,7 +144,7 @@ const WORKFLOWS: WorkflowDefinition[] = [
 
 // ─── Lifecycle ────────────────────────────────────
 
-let testSetup: Awaited<ReturnType<typeof testRender>> | null = null;
+let testSetup: ReactTestSetup | null = null;
 
 afterEach(() => {
   testSetup?.renderer.destroy();
@@ -161,7 +163,7 @@ async function renderPicker(
 ) {
   const onSubmit = opts.onSubmit ?? (() => {});
   const onCancel = opts.onCancel ?? (() => {});
-  testSetup = await testRender(
+  testSetup = await renderReact(
     <WorkflowPicker
       theme={TEST_THEME}
       agent="claude"
@@ -178,9 +180,7 @@ async function renderPicker(
       kittyKeyboard: opts.kittyKeyboard ?? false,
     },
   );
-  await act(async () => {
-    await testSetup!.renderOnce();
-  });
+  await testSetup.renderOnce();
   return testSetup;
 }
 
@@ -867,22 +867,24 @@ describe("WorkflowPickerPanel class", () => {
   let coreSetup: Awaited<ReturnType<typeof createTestRenderer>> | null = null;
 
   afterEach(() => {
-    panel?.destroy();
+    act(() => {
+      panel?.destroy();
+    });
     panel = null;
-    coreSetup?.renderer.destroy();
+    act(() => {
+      coreSetup?.renderer.destroy();
+    });
     coreSetup = null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = false;
+    setReactActEnvironment(false);
   });
 
   async function createPanel() {
     coreSetup = await createTestRenderer({ width: 120, height: 40 });
-    // Match what `testRender` does so useEffect-backed subscriptions (like
+    // Match what the React renderer helper does so useEffect-backed subscriptions (like
     // `useKeyboard`) flush synchronously during construction — without
     // this, the keyboard listener isn't attached in time for subsequent
     // mockInput events.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    setReactActEnvironment(true);
     const registry = WORKFLOWS.reduce(
       (r, wf) => r.register(wf),
       createRegistry(),
@@ -924,7 +926,9 @@ describe("WorkflowPickerPanel class", () => {
   test("destroy resolves a pending selection with null", async () => {
     const p = await createPanel();
     const promise = p.waitForSelection();
-    p.destroy();
+    act(() => {
+      p.destroy();
+    });
     panel = null;
     const result = await promise;
     expect(result).toBeNull();
@@ -932,16 +936,25 @@ describe("WorkflowPickerPanel class", () => {
 
   test("destroy is idempotent", async () => {
     const p = await createPanel();
-    p.destroy();
-    expect(() => p.destroy()).not.toThrow();
+    act(() => {
+      p.destroy();
+    });
+    expect(() => {
+      act(() => {
+        p.destroy();
+      });
+    }).not.toThrow();
     panel = null;
   });
 
   test("createWithRenderer with empty registry still mounts", async () => {
     coreSetup = await createTestRenderer({ width: 120, height: 40 });
-    panel = WorkflowPickerPanel.createWithRenderer(coreSetup.renderer, {
-      agent: "opencode",
-      registry: createRegistry(),
+    setReactActEnvironment(true);
+    act(() => {
+      panel = WorkflowPickerPanel.createWithRenderer(coreSetup!.renderer, {
+        agent: "opencode",
+        registry: createRegistry(),
+      });
     });
     expect(panel).toBeInstanceOf(WorkflowPickerPanel);
   });
@@ -953,6 +966,7 @@ describe("WorkflowPickerPanel class", () => {
       const r = coreSetup!.renderer as any;
       r.stdinParser?.flushTimeout?.(Number.POSITIVE_INFINITY);
       r.drainStdinParser?.();
+      await Promise.resolve();
     });
     await act(async () => {
       await coreSetup!.renderOnce();
@@ -967,7 +981,9 @@ describe("WorkflowPickerPanel class", () => {
     expect(result).toBeNull();
     // Prevent afterEach from double-destroying after handleCancel.
     panel = null;
-    p.destroy();
+    act(() => {
+      p.destroy();
+    });
   });
 
   test("handleSubmit: driving the full pick→prompt→confirm→y flow resolves with payload", async () => {
@@ -990,6 +1006,8 @@ describe("WorkflowPickerPanel class", () => {
     expect(result!.workflow.name).toBe("ralph");
     expect(result!.inputs.task).toContain("via class");
     panel = null;
-    p.destroy();
+    act(() => {
+      p.destroy();
+    });
   });
 });

--- a/tests/sdk/runtime/attached-footer.test.ts
+++ b/tests/sdk/runtime/attached-footer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildAttachedFooterCommand,
+  buildAttachedFooterCloseHooks,
   resolveAttachedFooterCliPath,
 } from "../../../src/sdk/runtime/attached-footer.ts";
 
@@ -63,5 +64,27 @@ describe("attached footer command harness", () => {
     expect(
       resolveAttachedFooterCliPath("/repo/src/sdk/runtime", "linux"),
     ).toBe("/repo/src/cli.ts");
+  });
+
+  test("builds guarded footer close hooks for tmux", () => {
+    expect(buildAttachedFooterCloseHooks("%1", "%2")).toEqual([
+      {
+        event: "pane-exited",
+        command: "if -F '#{==:#{hook_pane},%1}' 'kill-pane -t %2'",
+      },
+      {
+        event: "after-kill-pane",
+        command: "kill-pane -t %2",
+      },
+    ]);
+  });
+
+  test("builds unguarded footer close hooks for psmux", () => {
+    expect(
+      buildAttachedFooterCloseHooks("%1", "%2", { guardAgentPane: false }),
+    ).toEqual([
+      { event: "pane-exited", command: "kill-pane -t %2" },
+      { event: "after-kill-pane", command: "kill-pane -t %2" },
+    ]);
   });
 });

--- a/tests/sdk/runtime/attached-footer.test.ts
+++ b/tests/sdk/runtime/attached-footer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAttachedFooterCommand,
+  resolveAttachedFooterCliPath,
+} from "../../../src/sdk/runtime/attached-footer.ts";
+
+function decodeEncodedCommand(cmd: string): string {
+  const prefix = "pwsh -NoProfile -EncodedCommand ";
+  expect(cmd.startsWith(prefix)).toBe(true);
+  return Buffer.from(cmd.slice(prefix.length), "base64").toString("utf16le");
+}
+
+describe("attached footer command harness", () => {
+  test("builds the POSIX footer command with bash-safe quoting", () => {
+    const cmd = buildAttachedFooterCommand({
+      runtime: "/opt/bun/bin/bun",
+      cliPath: "/repo/src/cli.ts",
+      windowName: "atomic-wf-claude-ralph-a$b`c!",
+      agentType: "claude",
+      platform: "linux",
+    });
+
+    expect(cmd).toBe(
+      '"/opt/bun/bin/bun" "/repo/src/cli.ts" _footer --name "atomic-wf-claude-ralph-a\\$b\\`c\\!" --agent "claude"',
+    );
+  });
+
+  test("builds a Windows footer command that invokes paths through PowerShell", () => {
+    const cmd = buildAttachedFooterCommand({
+      runtime: "C:\\Program Files\\Bun\\bun.exe",
+      cliPath: "C:\\Users\\alexlavaee\\atomic repo\\src\\cli.ts",
+      windowName: "atomic-wf-copilot-ralph-abcd1234",
+      agentType: "copilot",
+      platform: "win32",
+    });
+
+    expect(decodeEncodedCommand(cmd)).toBe(
+      "& 'C:\\Program Files\\Bun\\bun.exe' 'C:\\Users\\alexlavaee\\atomic repo\\src\\cli.ts' '_footer' '--name' 'atomic-wf-copilot-ralph-abcd1234' '--agent' 'copilot'",
+    );
+  });
+
+  test("Windows command literals preserve metacharacters without bash escaping", () => {
+    const cmd = buildAttachedFooterCommand({
+      runtime: "C:\\Users\\alexlavaee\\.bun\\bin\\bun.exe",
+      cliPath: "C:\\repo\\src\\cli.ts",
+      windowName: "wf's $HOME `tick` bang!",
+      platform: "win32",
+    });
+
+    const script = decodeEncodedCommand(cmd);
+    expect(script).toContain("'wf''s $HOME `tick` bang!'");
+    expect(script).not.toContain("\\!");
+    expect(script).not.toContain("\\$HOME");
+  });
+
+  test("resolves the CLI path with Windows separators when simulating win32", () => {
+    expect(
+      resolveAttachedFooterCliPath("C:\\repo\\src\\sdk\\runtime", "win32"),
+    ).toBe("C:\\repo\\src\\cli.ts");
+  });
+
+  test("resolves the CLI path with POSIX separators on Unix-like platforms", () => {
+    expect(
+      resolveAttachedFooterCliPath("/repo/src/sdk/runtime", "linux"),
+    ).toBe("/repo/src/cli.ts");
+  });
+});

--- a/tests/sdk/runtime/tmux.test.ts
+++ b/tests/sdk/runtime/tmux.test.ts
@@ -19,6 +19,7 @@ import {
   killSession,
   sessionExists,
   listSessions,
+  parseListSessionsOutput,
   normalizeTmuxCapture,
   normalizeTmuxLines,
   attachSession,
@@ -34,6 +35,7 @@ import {
   spawnMuxAttach,
   detachAndAttachAtomic,
   parseSessionName,
+  parseSessionEnvValue,
   sendViaPasteBuffer,
 } from "../../../src/sdk/runtime/tmux.ts";
 
@@ -385,6 +387,120 @@ describe("parseSessionName", () => {
   test("returns empty object for empty string", () => {
     const result = parseSessionName("");
     expect(result).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSessionEnvValue — pure function
+// ---------------------------------------------------------------------------
+
+describe("parseSessionEnvValue", () => {
+  test("returns only the exact requested key from psmux-noisy output", () => {
+    const value = parseSessionEnvValue(
+      [
+        "ATOMIC_AGENT=claude",
+        "PSMUX_CONFIG_FILE=C:\\dev\\atomic\\src\\sdk\\runtime\\tmux.conf",
+        "PSMUX_TARGET_SESSION=atomic__atomic-senv-abc12345",
+      ].join("\n"),
+      "ATOMIC_AGENT",
+    );
+
+    expect(value).toBe("claude");
+  });
+
+  test("returns null when psmux returns other environment keys", () => {
+    const value = parseSessionEnvValue(
+      [
+        "ATOMIC_AGENT=claude",
+        "PSMUX_CONFIG_FILE=C:\\dev\\atomic\\src\\sdk\\runtime\\tmux.conf",
+      ].join("\n"),
+      "NONEXISTENT_KEY",
+    );
+
+    expect(value).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseListSessionsOutput — pure function
+// ---------------------------------------------------------------------------
+
+describe("parseListSessionsOutput", () => {
+  const delimiter = "__ATOMIC_SESSION_FIELD__";
+
+  test("filters psmux internal target sessions and metadata leakage", () => {
+    const output = [
+      [
+        "pwsh -NoProfile -Command Start-Sleep -Seconds 1",
+        "1",
+        "50.175.4.2 59740 10.1.0.4 22",
+        "0",
+      ].join(delimiter),
+      "PSMUX_CONFIG_FILE=C:\\dev\\atomic\\src\\sdk\\runtime\\tmux.conf",
+      "PSMUX_TARGET_SESSION=atomic__pwsh -NoProfile -Command Start-Sleep -Seconds 1]",
+      [
+        "atomic-chat-copilot-abc12345",
+        "1",
+        "1700000000",
+        "0",
+      ].join(delimiter),
+    ].join("\n");
+
+    const sessions = parseListSessionsOutput(output, () => null);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.name).toBe("atomic-chat-copilot-abc12345");
+    expect(sessions[0]!.type).toBe("chat");
+    expect(sessions[0]!.agent).toBe("copilot");
+    expect(JSON.stringify(sessions)).not.toContain("PSMUX");
+    expect(JSON.stringify(sessions)).not.toContain("Start-Sleep");
+  });
+
+  test("keeps Atomic-managed sessions that rely on session env for agent", () => {
+    const output = [
+      "atomic-senv-abc12345",
+      "1",
+      "1700000000",
+      "1",
+    ].join(delimiter);
+
+    const sessions = parseListSessionsOutput(output, (name, key) =>
+      name === "atomic-senv-abc12345" && key === "ATOMIC_AGENT" ? "claude" : null
+    );
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]!.name).toBe("atomic-senv-abc12345");
+    expect(sessions[0]!.attached).toBe(true);
+    expect(sessions[0]!.agent).toBe("claude");
+  });
+
+  test("ignores malformed formatter rows", () => {
+    const sessions = parseListSessionsOutput(
+      [
+        "atomic-chat-claude-missing-fields",
+        ["atomic-chat-claude-good1234", "1", "1700000000", "0"].join(delimiter),
+      ].join("\n"),
+      () => null,
+    );
+
+    expect(sessions.map((s) => s.name)).toEqual(["atomic-chat-claude-good1234"]);
+  });
+
+  test("uses only the exact requested environment key for agent fallback", () => {
+    const output = [
+      "atomic-senv-abc12345",
+      "1",
+      "1700000000",
+      "0",
+    ].join(delimiter);
+
+    const sessions = parseListSessionsOutput(output, (_name, key) =>
+      key === "ATOMIC_AGENT"
+        ? "claude"
+        : "PSMUX_CONFIG_FILE=C:\\dev\\atomic\\tmux.conf"
+    );
+
+    expect(sessions[0]!.agent).toBe("claude");
   });
 });
 

--- a/tests/sdk/runtime/tmux.test.ts
+++ b/tests/sdk/runtime/tmux.test.ts
@@ -1,4 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   getMuxBinary,
   resetMuxBinaryCache,
@@ -57,6 +60,30 @@ function withEnvRestore(vars: string[]) {
   });
 }
 
+function writeFakeCommand(directory: string, name: string): void {
+  const extension = process.platform === "win32" ? ".cmd" : "";
+  const commandPath = join(directory, `${name}${extension}`);
+  const body = process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\n";
+  writeFileSync(commandPath, body);
+  chmodSync(commandPath, 0o755);
+}
+
+function withMockPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // getMuxBinary
 // ---------------------------------------------------------------------------
@@ -95,6 +122,46 @@ describe("getMuxBinary", () => {
     // After reset, the next call re-resolves (doesn't throw, returns consistent result)
     const result = getMuxBinary();
     expect(typeof result === "string" || result === null).toBe(true);
+  });
+
+  test.serial("ignores tmux-only shims on Windows", () => {
+    const originalPath = process.env.PATH;
+    const tempDir = mkdtempSync(join(tmpdir(), "atomic-mux-"));
+    try {
+      writeFakeCommand(tempDir, "tmux");
+      process.env.PATH = tempDir;
+      resetMuxBinaryCache();
+
+      withMockPlatform("win32", () => {
+        expect(getMuxBinary()).toBeNull();
+        expect(isTmuxInstalled()).toBe(false);
+      });
+    } finally {
+      process.env.PATH = originalPath;
+      resetMuxBinaryCache();
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  test.serial("prefers native psmux on Windows", () => {
+    const originalPath = process.env.PATH;
+    const tempDir = mkdtempSync(join(tmpdir(), "atomic-mux-"));
+    try {
+      writeFakeCommand(tempDir, "psmux");
+      writeFakeCommand(tempDir, "pmux");
+      writeFakeCommand(tempDir, "tmux");
+      process.env.PATH = tempDir;
+      resetMuxBinaryCache();
+
+      withMockPlatform("win32", () => {
+        expect(getMuxBinary()).toBe("psmux");
+        expect(isTmuxInstalled()).toBe(true);
+      });
+    } finally {
+      process.env.PATH = originalPath;
+      resetMuxBinaryCache();
+      rmSync(tempDir, { force: true, recursive: true });
+    }
   });
 });
 
@@ -661,7 +728,7 @@ describe("tmuxRun — no binary on PATH", () => {
     resetMuxBinaryCache();
   });
 
-  test("returns ok:false when no mux binary found", () => {
+  test.serial("returns ok:false when no mux binary found", () => {
     const result = tmuxRun(["list-sessions"]);
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -688,15 +755,15 @@ describe("no-binary error paths", () => {
     resetMuxBinaryCache();
   });
 
-  test("spawnMuxAttach throws when no binary found", () => {
+  test.serial("spawnMuxAttach throws when no binary found", () => {
     expect(() => spawnMuxAttach("any-session")).toThrow(/No terminal multiplexer/);
   });
 
-  test("detachAndAttachAtomic throws when no binary found", () => {
+  test.serial("detachAndAttachAtomic throws when no binary found", () => {
     expect(() => detachAndAttachAtomic("any-session")).toThrow(/No terminal multiplexer/);
   });
 
-  test("attachSession throws when no binary found", () => {
+  test.serial("attachSession throws when no binary found", () => {
     expect(() => attachSession("any-session")).toThrow(/No terminal multiplexer/);
   });
 });
@@ -841,15 +908,15 @@ describe.if(tmuxAvailable)("listSessions", () => {
     killSession(LIST_SESSION);
   });
 
-  test("returns an empty array when no sessions exist on a clean server", () => {
+  test.serial("returns an empty array when no sessions exist on a clean server", () => {
     // If there are no sessions specifically named our test session,
     // listSessions should at least return an array.
     const sessions = listSessions();
     expect(Array.isArray(sessions)).toBe(true);
   });
 
-  test("includes a session after creation with parsed type and agent", () => {
-    createSession(LIST_SESSION, "bash");
+  test.serial("includes a session after creation with parsed type and agent", () => {
+    createSession(LIST_SESSION, "sleep 60");
     const sessions = listSessions();
     const found = sessions.find((s) => s.name === LIST_SESSION);
     expect(found).toBeDefined();
@@ -858,17 +925,12 @@ describe.if(tmuxAvailable)("listSessions", () => {
     expect(typeof found!.attached).toBe("boolean");
     expect(found!.type).toBe("chat");
     expect(found!.agent).toBe("claude");
-  });
 
-  test("session has a parseable ISO date", () => {
-    const sessions = listSessions();
-    const found = sessions.find((s) => s.name === LIST_SESSION);
-    expect(found).toBeDefined();
     const d = new Date(found!.created);
     expect(Number.isNaN(d.getTime())).toBe(false);
   });
 
-  test("session is gone after kill", () => {
+  test.serial("session is gone after kill", () => {
     killSession(LIST_SESSION);
     const sessions = listSessions();
     const found = sessions.find((s) => s.name === LIST_SESSION);
@@ -887,25 +949,23 @@ describe.if(tmuxAvailable)("setSessionEnv / getSessionEnv", () => {
     killSession(ENV_VAR_SESSION);
   });
 
-  test("setSessionEnv stores and getSessionEnv retrieves a value", () => {
-    createSession(ENV_VAR_SESSION, "bash");
+  test.serial("setSessionEnv stores and getSessionEnv retrieves a value", () => {
+    createSession(ENV_VAR_SESSION, "sleep 60");
     setSessionEnv(ENV_VAR_SESSION, "ATOMIC_AGENT", "claude");
     expect(getSessionEnv(ENV_VAR_SESSION, "ATOMIC_AGENT")).toBe("claude");
-  });
 
-  test("getSessionEnv returns null for unset key", () => {
-    expect(getSessionEnv(ENV_VAR_SESSION, "NONEXISTENT_KEY")).toBeNull();
-  });
-
-  test("getSessionEnv returns null for non-existent session", () => {
-    expect(getSessionEnv("nonexistent-session-xyz-99999", "ATOMIC_AGENT")).toBeNull();
-  });
-
-  test("listSessions includes agent from ATOMIC_AGENT env var", () => {
     const sessions = listSessions();
     const found = sessions.find((s) => s.name === ENV_VAR_SESSION);
     expect(found).toBeDefined();
     expect(found!.agent).toBe("claude");
   });
-});
 
+  test.serial("getSessionEnv returns null for unset key", () => {
+    expect(getSessionEnv(ENV_VAR_SESSION, "NONEXISTENT_KEY")).toBeNull();
+  });
+
+  test.serial("getSessionEnv returns null for non-existent session", () => {
+    expect(getSessionEnv("nonexistent-session-xyz-99999", "ATOMIC_AGENT")).toBeNull();
+  });
+
+});

--- a/tests/sdk/runtime/tmux.test.ts
+++ b/tests/sdk/runtime/tmux.test.ts
@@ -34,6 +34,7 @@ import {
   selectWindow,
   spawnMuxAttach,
   detachAndAttachAtomic,
+  buildKillSessionOnPaneExitHooks,
   parseSessionName,
   parseSessionEnvValue,
   sendViaPasteBuffer,
@@ -501,6 +502,40 @@ describe("parseListSessionsOutput", () => {
     );
 
     expect(sessions[0]!.agent).toBe("claude");
+  });
+});
+
+describe("buildKillSessionOnPaneExitHooks", () => {
+  test("installs a direct pane-kill hook alongside the tmux pane-exited hook", () => {
+    const hooks = buildKillSessionOnPaneExitHooks("atomic-chat-copilot-abc12345", "%1");
+
+    expect(hooks).toEqual([
+      {
+        event: "pane-exited",
+        command: "if -F '#{==:#{hook_pane},%1}' 'kill-session -t atomic-chat-copilot-abc12345'",
+      },
+      {
+        event: "after-kill-pane",
+        command: "kill-session -t atomic-chat-copilot-abc12345",
+      },
+    ]);
+  });
+
+  test("uses a session-scoped pane-exited hook for psmux", () => {
+    const hooks = buildKillSessionOnPaneExitHooks("atomic-chat-copilot-abc12345", "%1", {
+      guardPaneExited: false,
+    });
+
+    expect(hooks).toEqual([
+      {
+        event: "pane-exited",
+        command: "kill-session -t atomic-chat-copilot-abc12345",
+      },
+      {
+        event: "after-kill-pane",
+        command: "kill-session -t atomic-chat-copilot-abc12345",
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Hardens Windows installation reliability and mux session management by improving PATH detection, enforcing native psmux/pmux requirements, and fixing footer rendering in the psmux pane.

## Key Changes

### Installation
- **PATH detection**: Refresh common install paths at Atomic startup so psmux installed by Windows package managers is found immediately (`e7f0111a`)
- **psmux retry**: Require `psmux` or `pmux` as the Windows multiplexer (not arbitrary tmux shims); retry only the mux install step when the sync marker is current but the binary is still missing (`f81295d2`)
- **Bun path refresh**: Resolve `bun` and installer commands from the refreshed `PATH` after installation so installs can be verified in the current process (`7dbfcb93`)

### Runtime
- **Mux startup hardening**: Require native psmux/pmux on Windows, add a direct psmux release fallback, and use a printable session-list delimiter for robust session parsing (`8e9ee273`)
- **PowerShell encoding**: Use base64-encoded PowerShell commands when re-invoking Bun entrypoints on Windows to preserve paths with spaces and shell metacharacters (`bb7daee3`)
- **Footer rendering**: Pin the OpenTUI footer renderer to the one-row psmux pane and switch to headless `testRender` + frame capture to prevent terminal capability probes (CSI/OSC/DA1) from leaking into the agent pane (`e7dded36`, `27c24106`)
- **Session cleanup**: Filter mux session listings to Atomic-managed names and install `pane-exited`/`after-kill-pane` hooks so sessions are torn down cleanly when an agent exits or the pane is closed (`0fd2622e`, `38a1187d`)

### Tests & Dependencies
- Added footer renderer lifecycle tests (resize, signal teardown, `footerCommand` completion) (`58b45bbf`, `2972e102`, `c93e91fb`)
- Added React-aware `renderComponent` test helper for OpenTUI components (`e8a261ea`)
- Bumped `@opencode-ai/plugin` to `1.14.22` (`e14d2d70`)