### PR TITLE
chore(release): bump version to v0.6.1-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.0",
+  "version": "0.6.1-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version to `0.6.1-0` to prepare the next prerelease cycle following the `0.6.0` stable release.

## Changes

- Updates `version` in `package.json` from `0.6.0` to `0.6.1-0`

## Notes

- This is a prerelease version (`-0` suffix) intended for the `prerelease/v0.6.1-0` branch workflow
- No functional code changes; version metadata only