### PR TITLE
chore(release): bump version to v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.1-0",
+  "version": "0.6.1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.6.1-0` to the stable release `0.6.1`.

## Changes

- Updates `package.json` version from `0.6.1-0` to `0.6.1`

## Notes

- Release branch: `release/v0.6.1`
- No functional changes — version bump only