### PR TITLE
chore(release): bump version to v0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.2-0",
+  "version": "0.6.2",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the `v0.6.2-0` prerelease to a stable `v0.6.2` release. Carries forward the `@opentui/{core,react}` pin to `0.1.102` from #755, which fixes the infinite OSC 10/11 query loop in orchestrator/picker panes running under tmux on macOS ([anomalyco/opentui#975](https://github.com/anomalyco/opentui/issues/975)).

## Changes

- `package.json`: bump version `0.6.2-0` → `0.6.2`

## Test plan

- [x] `bun typecheck` clean
- [x] `bun test tests/sdk/components` — 271/271 pass on `v0.6.2-0`
- [x] Interactive confirmation on `v0.6.2-0`: orchestrator pane accepts keys without infinite OSC loop
- [ ] Smoke test the published `v0.6.2` artifact end-to-end after release workflow runs