### PR TITLE
chore: remove GITHUB_PERSONAL_ACCESS_TOKEN plumbing

### DIFF
--- a/.devcontainer/claude/devcontainer.json
+++ b/.devcontainer/claude/devcontainer.json
@@ -19,8 +19,7 @@
     }
   ],
   "remoteEnv": {
-    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/copilot/devcontainer.json
+++ b/.devcontainer/copilot/devcontainer.json
@@ -19,8 +19,7 @@
     }
   ],
   "remoteEnv": {
-    "GH_TOKEN": "${localEnv:GH_TOKEN}",
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
   },
   "remoteEnv": {
     "GH_TOKEN": "${localEnv:GH_TOKEN}",
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}",
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
   },
   "postCreateCommand": "bun install && curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash",

--- a/.devcontainer/opencode/devcontainer.json
+++ b/.devcontainer/opencode/devcontainer.json
@@ -18,9 +18,6 @@
       "type": "bind"
     }
   ],
-  "remoteEnv": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
-  },
   "customizations": {
     "vscode": {
       "extensions": ["shd101wyy.markdown-preview-enhanced", "sst-dev.opencode"]

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -5,9 +5,6 @@
     "github": {
       "type": "remote",
       "url": "https://api.githubcopilot.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
-      },
       "enabled": true
     },
     "azure-devops": {

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -24,14 +24,14 @@ Add them to your shell profile (e.g. `~/.zshrc`, `~/.bashrc`) or export them in 
 **macOS / Linux:**
 
 ```bash
-export GH_TOKEN="ghp_..." # requires Copilot Requests scope
+export GH_TOKEN="ghp_..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-$env:GH_TOKEN = "ghp_..." # requires Copilot Requests scope
+$env:GH_TOKEN = "ghp_..."
 $env:ANTHROPIC_API_KEY = "sk-ant-..."
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -339,57 +339,11 @@ install_completions() {
     esac
 }
 
-# Cache the GitHub MCP token once per day so `gh auth token` isn't
-# forked on every shell spawn. Uses bash/zsh-specific syntax, so we
-# only install it for those shells.
-install_gh_token_cache() {
-    local shell_name
-    shell_name=$(basename "${SHELL:-}")
-
-    local rc
-    case "$shell_name" in
-        bash) rc="$HOME/.bashrc" ;;
-        zsh)  rc="$HOME/.zshrc"  ;;
-        *)    return 0           ;;  # silently skip other shells
-    esac
-
-    mkdir -p "$HOME/.atomic"
-    cat > "$HOME/.atomic/gh-token-cache.sh" <<'EOF'
-# Atomic: cache `gh auth token` for 24h to avoid shelling out on every
-# shell spawn. Refreshes the cache lazily when it's missing or stale.
-load_github_token() {
-  [[ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]] && return 0
-  command -v gh >/dev/null 2>&1 || return 0
-
-  local cache="${XDG_CACHE_HOME:-$HOME/.cache}/gh-auth-token"
-  local tok
-
-  if [[ -s "$cache" && -n "$(find "$cache" -mmin -1440 2>/dev/null)" ]]; then
-    export GITHUB_PERSONAL_ACCESS_TOKEN="$(<"$cache")"
-  elif tok=$(gh auth token 2>/dev/null); then
-    mkdir -p "${cache%/*}"
-    (umask 077; printf '%s' "$tok" > "$cache")
-    export GITHUB_PERSONAL_ACCESS_TOKEN="$tok"
-  fi
-}
-
-load_github_token
-EOF
-
-    local marker='# Atomic CLI gh auth token cache'
-    if ! grep -qF "$marker" "$rc" 2>/dev/null; then
-        {
-            printf '\n%s\n' "$marker"
-            printf '[ -f "$HOME/.atomic/gh-token-cache.sh" ] && source "$HOME/.atomic/gh-token-cache.sh"\n'
-        } >> "$rc"
-    fi
-}
-
 # ── Main ────────────────────────────────────────────────────────────────────
 
 main() {
     # Count upcoming steps so the progress bar is honest.
-    STEP_TOTAL=3  # atomic install + completions + gh token cache
+    STEP_TOTAL=2  # atomic install + completions
     if ! command -v bun >/dev/null 2>&1; then
         STEP_TOTAL=$((STEP_TOTAL + 1))  # bun install
     fi
@@ -416,11 +370,6 @@ main() {
     # Best-effort: don't fail the install if completions can't be set up
     if ! run_step "Installing shell completions" install_completions; then
         warn "Could not detect shell — install completions manually: atomic completions --help"
-    fi
-
-    # Best-effort: gh token caching speeds up shell startup for MCP users
-    if ! run_step "Installing gh auth token cache" install_gh_token_cache; then
-        warn "Could not install gh auth token cache"
     fi
 
     printf '\n  %s✓%s %sAtomic installed successfully%s\n\n' \


### PR DESCRIPTION
## Summary

Removes all `GITHUB_PERSONAL_ACCESS_TOKEN` plumbing from devcontainer configs, the OpenCode GitHub MCP configuration, and the installer — since the GitHub MCP server no longer requires an explicit PAT when `GH_TOKEN` / `gh auth token` is already in scope.

## Changes

**Devcontainer configs** (all four variants):
- Drop `GITHUB_PERSONAL_ACCESS_TOKEN` from `remoteEnv` in base, claude, copilot, and opencode devcontainers
- The opencode devcontainer's `remoteEnv` block is removed entirely since it only held this one entry

**OpenCode MCP config** (`.opencode/opencode.json`):
- Remove the `Authorization: Bearer ${env:GITHUB_PERSONAL_ACCESS_TOKEN}` header from the GitHub MCP server entry; the server connects without it

**Installer** (`install.sh`):
- Delete the `install_gh_token_cache` function — it existed solely to populate `GITHUB_PERSONAL_ACCESS_TOKEN` via `gh auth token` and write a shell-init snippet
- Remove the corresponding `run_step` call and adjust `STEP_TOTAL` from 3 → 2

**Docs** (`DEV_SETUP.md`):
- Strip the "requires Copilot Requests scope" annotation from `GH_TOKEN` examples since that scope was only needed for the PAT-based MCP auth

## Test plan

- [ ] `bun typecheck`
- [ ] Manually verify devcontainer builds for base/claude/copilot/opencode still launch and connect to GitHub MCP
- [ ] Re-run `install.sh` end-to-end and confirm completions still install and the script reports the correct step count (2, or 3 when bun is absent)
- [ ] Confirm OpenCode's GitHub MCP server connects without the explicit `Authorization` header