### PR TITLE
chore: drop GITHUB_PERSONAL_ACCESS_TOKEN from .mcp.json + install.ps1, bump features

### DIFF
--- a/.devcontainer/claude/devcontainer.json
+++ b/.devcontainer/claude/devcontainer.json
@@ -19,8 +19,7 @@
     }
   ],
   "remoteEnv": {
-    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/copilot/devcontainer.json
+++ b/.devcontainer/copilot/devcontainer.json
@@ -19,8 +19,7 @@
     }
   ],
   "remoteEnv": {
-    "GH_TOKEN": "${localEnv:GH_TOKEN}",
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
   },
   "remoteEnv": {
     "GH_TOKEN": "${localEnv:GH_TOKEN}",
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}",
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
   },
   "postCreateCommand": "bun install && curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | bash",

--- a/.devcontainer/opencode/devcontainer.json
+++ b/.devcontainer/opencode/devcontainer.json
@@ -18,9 +18,6 @@
       "type": "bind"
     }
   ],
-  "remoteEnv": {
-    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
-  },
   "customizations": {
     "vscode": {
       "extensions": ["shd101wyy.markdown-preview-enhanced", "sst-dev.opencode"]

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "github": {
       "type": "http",
-      "url": "https://api.githubcopilot.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      }
+      "url": "https://api.githubcopilot.com/mcp"
     },
     "azure-devops": {
       "type": "stdio",

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -5,9 +5,6 @@
     "github": {
       "type": "remote",
       "url": "https://api.githubcopilot.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
-      },
       "enabled": true
     },
     "azure-devops": {

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -24,14 +24,14 @@ Add them to your shell profile (e.g. `~/.zshrc`, `~/.bashrc`) or export them in 
 **macOS / Linux:**
 
 ```bash
-export GH_TOKEN="ghp_..." # requires Copilot Requests scope
+export GH_TOKEN="ghp_..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-$env:GH_TOKEN = "ghp_..." # requires Copilot Requests scope
+$env:GH_TOKEN = "ghp_..."
 $env:ANTHROPIC_API_KEY = "sk-ant-..."
 ```
 

--- a/devcontainer-features/src/claude/devcontainer-feature.json
+++ b/devcontainer-features/src/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "claude",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "name": "Atomic + Claude Code",
   "description": "Installs Atomic CLI with Claude Code agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/devcontainer-features/src/copilot/devcontainer-feature.json
+++ b/devcontainer-features/src/copilot/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "name": "Atomic + Copilot CLI",
   "description": "Installs Atomic CLI with GitHub Copilot agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/devcontainer-features/src/opencode/devcontainer-feature.json
+++ b/devcontainer-features/src/opencode/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "name": "Atomic + OpenCode",
   "description": "Installs Atomic CLI with OpenCode agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/install.ps1
+++ b/install.ps1
@@ -393,60 +393,10 @@ function Install-Completions {
     Add-Content -Path $PROFILE -Value "`n$marker`nif (Test-Path `"$scriptPath`") { . `"$scriptPath`" }"
 }
 
-# Cache the GitHub MCP token once per day so `gh auth token` isn't
-# forked on every shell spawn. Mirrors the bash/zsh helper installed
-# by install.sh.
-function Install-GhTokenCache {
-    $cacheDir = Join-Path $HOME ".atomic"
-    if (-not (Test-Path $cacheDir)) {
-        New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
-    }
-    $scriptPath = Join-Path $cacheDir "gh-token-cache.ps1"
-
-    $helperBody = @'
-# Atomic: cache `gh auth token` for 24h to avoid shelling out on every
-# shell spawn. Refreshes the cache lazily when it's missing or stale.
-function Set-GitHubToken {
-    if ($env:GITHUB_PERSONAL_ACCESS_TOKEN) { return }
-    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return }
-
-    $cache = Join-Path $HOME '.atomic\gh-auth-token'
-    if ((Test-Path $cache) -and
-        ((Get-Date) - (Get-Item $cache).LastWriteTime).TotalMinutes -lt 1440) {
-        $env:GITHUB_PERSONAL_ACCESS_TOKEN = [System.IO.File]::ReadAllText($cache).Trim()
-        return
-    }
-
-    $tok = & gh auth token 2>$null
-    if ($LASTEXITCODE -eq 0 -and $tok) {
-        New-Item -ItemType Directory -Force -Path (Split-Path $cache) | Out-Null
-        [System.IO.File]::WriteAllText($cache, $tok.Trim())
-        $env:GITHUB_PERSONAL_ACCESS_TOKEN = $tok.Trim()
-    }
-}
-
-Set-GitHubToken
-'@
-
-    Set-Content -Path $scriptPath -Value $helperBody -Encoding utf8
-
-    $profileDir = Split-Path $PROFILE -Parent
-    if (-not (Test-Path $profileDir)) {
-        New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
-    }
-
-    $marker = '# Atomic CLI gh auth token cache'
-    if ((Test-Path $PROFILE) -and
-        (Select-String -Path $PROFILE -Pattern ([regex]::Escape($marker)) -Quiet)) {
-        return
-    }
-    Add-Content -Path $PROFILE -Value "`n$marker`nif (Test-Path `"$scriptPath`") { . `"$scriptPath`" }"
-}
-
 # ── Main ────────────────────────────────────────────────────────────────────
 
 # Count upcoming steps so the progress bar is honest.
-$script:StepTotal = 3  # atomic install + completions + gh token cache
+$script:StepTotal = 2  # atomic install + completions
 if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
     $script:StepTotal++
 }
@@ -474,12 +424,6 @@ if (-not (Get-Command atomic -ErrorAction SilentlyContinue)) {
 $ok = Invoke-Step -Label "Installing shell completions" -Action { Install-Completions }
 if (-not $ok) {
     Write-Warn "Could not install PowerShell completions — run: atomic completions powershell | Invoke-Expression"
-}
-
-# Best-effort: gh token caching speeds up shell startup for MCP users
-$ok = Invoke-Step -Label "Installing gh auth token cache" -Action { Install-GhTokenCache }
-if (-not $ok) {
-    Write-Warn "Could not install gh auth token cache"
 }
 
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -339,57 +339,11 @@ install_completions() {
     esac
 }
 
-# Cache the GitHub MCP token once per day so `gh auth token` isn't
-# forked on every shell spawn. Uses bash/zsh-specific syntax, so we
-# only install it for those shells.
-install_gh_token_cache() {
-    local shell_name
-    shell_name=$(basename "${SHELL:-}")
-
-    local rc
-    case "$shell_name" in
-        bash) rc="$HOME/.bashrc" ;;
-        zsh)  rc="$HOME/.zshrc"  ;;
-        *)    return 0           ;;  # silently skip other shells
-    esac
-
-    mkdir -p "$HOME/.atomic"
-    cat > "$HOME/.atomic/gh-token-cache.sh" <<'EOF'
-# Atomic: cache `gh auth token` for 24h to avoid shelling out on every
-# shell spawn. Refreshes the cache lazily when it's missing or stale.
-load_github_token() {
-  [[ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]] && return 0
-  command -v gh >/dev/null 2>&1 || return 0
-
-  local cache="${XDG_CACHE_HOME:-$HOME/.cache}/gh-auth-token"
-  local tok
-
-  if [[ -s "$cache" && -n "$(find "$cache" -mmin -1440 2>/dev/null)" ]]; then
-    export GITHUB_PERSONAL_ACCESS_TOKEN="$(<"$cache")"
-  elif tok=$(gh auth token 2>/dev/null); then
-    mkdir -p "${cache%/*}"
-    (umask 077; printf '%s' "$tok" > "$cache")
-    export GITHUB_PERSONAL_ACCESS_TOKEN="$tok"
-  fi
-}
-
-load_github_token
-EOF
-
-    local marker='# Atomic CLI gh auth token cache'
-    if ! grep -qF "$marker" "$rc" 2>/dev/null; then
-        {
-            printf '\n%s\n' "$marker"
-            printf '[ -f "$HOME/.atomic/gh-token-cache.sh" ] && source "$HOME/.atomic/gh-token-cache.sh"\n'
-        } >> "$rc"
-    fi
-}
-
 # ── Main ────────────────────────────────────────────────────────────────────
 
 main() {
     # Count upcoming steps so the progress bar is honest.
-    STEP_TOTAL=3  # atomic install + completions + gh token cache
+    STEP_TOTAL=2  # atomic install + completions
     if ! command -v bun >/dev/null 2>&1; then
         STEP_TOTAL=$((STEP_TOTAL + 1))  # bun install
     fi
@@ -416,11 +370,6 @@ main() {
     # Best-effort: don't fail the install if completions can't be set up
     if ! run_step "Installing shell completions" install_completions; then
         warn "Could not detect shell — install completions manually: atomic completions --help"
-    fi
-
-    # Best-effort: gh token caching speeds up shell startup for MCP users
-    if ! run_step "Installing gh auth token cache" install_gh_token_cache; then
-        warn "Could not install gh auth token cache"
     fi
 
     printf '\n  %s✓%s %sAtomic installed successfully%s\n\n' \


### PR DESCRIPTION
## Summary
- Remove the `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}` header from the `github` MCP entry in `.mcp.json` (kept the server config itself).
- Remove the `Install-GhTokenCache` helper, its call site, and the `gh token cache` step from `install.ps1` to mirror what was done in `install.sh` in #757.
- Bump the `claude`, `copilot`, and `opencode` devcontainer feature manifests from `1.0.13` → `1.0.14` so the publish-features workflow republishes to GHCR.

Follow-up to #757, which missed `.mcp.json` and `install.ps1`.

## Test plan
- [ ] `bun typecheck` and `bun lint` pass
- [ ] `pwsh -File install.ps1` runs cleanly without referencing the gh token cache
- [ ] `.mcp.json` parses and the `github` MCP server connects via OAuth without the bearer header
- [ ] `publish-features.yml` republishes `ghcr.io/flora131/atomic/{claude,copilot,opencode}:1.0.14` on merge