### PR TITLE
chore(release): bump version to v0.6.3-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.2",
+  "version": "0.6.3-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.6.2` to `0.6.3-0` as a prerelease ahead of the `v0.6.3` stable release.

## Changes

- `package.json`: version `0.6.2` → `0.6.3-0`

## Test plan

- [ ] CI passes
- [ ] GitHub Release created automatically on merge