### PR TITLE
chore(release): bump version to v0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.3-0",
+  "version": "0.6.3",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `0.6.3-0` to the stable `0.6.3` release by updating the version field in `package.json`.

## Changes

- `package.json`: `0.6.3-0` → `0.6.3`

## Test plan

- [ ] CI passes
- [ ] Merging triggers the release workflow and publishes `@bastani/atomic@0.6.3` to npm