### PR TITLE
feat: add additional-instructions service and overhaul deep-research-codebase

### DIFF
--- a/.agents/skills/ast-grep/SKILL.md
+++ b/.agents/skills/ast-grep/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: ast-grep
+description: Guide for writing ast-grep rules to perform structural code search and analysis. Use when users need to search codebases using Abstract Syntax Tree (AST) patterns, find specific code structures, or perform complex code queries that go beyond simple text search. This skill should be used when users ask to search for code patterns, find specific language constructs, or locate code with particular structural characteristics.
+---
+
+# ast-grep Code Search
+
+## Overview
+
+This skill helps translate natural language queries into ast-grep rules for structural code search. ast-grep uses Abstract Syntax Tree (AST) patterns to match code based on its structure rather than just text, enabling powerful and precise code search across large codebases.
+
+## When to Use This Skill
+
+Use this skill when users:
+- Need to search for code patterns using structural matching (e.g., "find all async functions that don't have error handling")
+- Want to locate specific language constructs (e.g., "find all function calls with specific parameters")
+- Request searches that require understanding code structure rather than just text
+- Ask to search for code with particular AST characteristics
+- Need to perform complex code queries that traditional text search cannot handle
+
+## General Workflow
+
+Follow this process to help users write effective ast-grep rules:
+
+### Step 1: Understand the Query
+
+Clearly understand what the user wants to find. Ask clarifying questions if needed:
+- What specific code pattern or structure are they looking for?
+- Which programming language?
+- Are there specific edge cases or variations to consider?
+- What should be included or excluded from matches?
+
+### Step 2: Create Example Code
+
+Write a simple code snippet that represents what the user wants to match. Save this to a temporary file for testing.
+
+**Example:**
+If searching for "async functions that use await", create a test file:
+
+```javascript
+// test_example.js
+async function example() {
+  const result = await fetchData();
+  return result;
+}
+```
+
+### Step 3: Write the ast-grep Rule
+
+Translate the pattern into an ast-grep rule. Start simple and add complexity as needed.
+
+**Key principles:**
+- Always use `stopBy: end` for relational rules (`inside`, `has`) to ensure search goes to the end of the direction
+- Use `pattern` for simple structures
+- Use `kind` with `has`/`inside` for complex structures
+- Break complex queries into smaller sub-rules using `all`, `any`, or `not`
+
+**Example rule file (test_rule.yml):**
+```yaml
+id: async-with-await
+language: javascript
+rule:
+  kind: function_declaration
+  has:
+    pattern: await $EXPR
+    stopBy: end
+```
+
+See `references/rule_reference.md` for comprehensive rule documentation.
+
+### Step 4: Test the Rule
+
+Use ast-grep CLI to verify the rule matches the example code. There are two main approaches:
+
+**Option A: Test with inline rules (for quick iterations)**
+```bash
+echo "async function test() { await fetch(); }" | ast-grep scan --inline-rules "id: test
+language: javascript
+rule:
+  kind: function_declaration
+  has:
+    pattern: await \$EXPR
+    stopBy: end" --stdin
+```
+
+**Option B: Test with rule files (recommended for complex rules)**
+```bash
+ast-grep scan --rule test_rule.yml test_example.js
+```
+
+**Debugging if no matches:**
+1. Simplify the rule (remove sub-rules)
+2. Add `stopBy: end` to relational rules if not present
+3. Use `--debug-query` to understand the AST structure (see below)
+4. Check if `kind` values are correct for the language
+
+### Step 5: Search the Codebase
+
+Once the rule matches the example code correctly, search the actual codebase:
+
+**For simple pattern searches:**
+```bash
+ast-grep run --pattern 'console.log($ARG)' --lang javascript /path/to/project
+```
+
+**For complex rule-based searches:**
+```bash
+ast-grep scan --rule my_rule.yml /path/to/project
+```
+
+**For inline rules (without creating files):**
+```bash
+ast-grep scan --inline-rules "id: my-rule
+language: javascript
+rule:
+  pattern: \$PATTERN" /path/to/project
+```
+
+## ast-grep CLI Commands
+
+### Inspect Code Structure (--debug-query)
+
+Dump the AST structure to understand how code is parsed:
+
+```bash
+ast-grep run --pattern 'async function example() { await fetch(); }' \
+  --lang javascript \
+  --debug-query=cst
+```
+
+**Available formats:**
+- `cst`: Concrete Syntax Tree (shows all nodes including punctuation)
+- `ast`: Abstract Syntax Tree (shows only named nodes)
+- `pattern`: Shows how ast-grep interprets your pattern
+
+**Use this to:**
+- Find the correct `kind` values for nodes
+- Understand the structure of code you want to match
+- Debug why patterns aren't matching
+
+**Example:**
+```bash
+# See the structure of your target code
+ast-grep run --pattern 'class User { constructor() {} }' \
+  --lang javascript \
+  --debug-query=cst
+
+# See how ast-grep interprets your pattern
+ast-grep run --pattern 'class $NAME { $$$BODY }' \
+  --lang javascript \
+  --debug-query=pattern
+```
+
+### Test Rules (scan with --stdin)
+
+Test a rule against code snippet without creating files:
+
+```bash
+echo "const x = await fetch();" | ast-grep scan --inline-rules "id: test
+language: javascript
+rule:
+  pattern: await \$EXPR" --stdin
+```
+
+**Add --json for structured output:**
+```bash
+echo "const x = await fetch();" | ast-grep scan --inline-rules "..." --stdin --json
+```
+
+### Search with Patterns (run)
+
+Simple pattern-based search for single AST node matches:
+
+```bash
+# Basic pattern search
+ast-grep run --pattern 'console.log($ARG)' --lang javascript .
+
+# Search specific files
+ast-grep run --pattern 'class $NAME' --lang python /path/to/project
+
+# JSON output for programmatic use
+ast-grep run --pattern 'function $NAME($$$)' --lang javascript --json .
+```
+
+**When to use:**
+- Simple, single-node matches
+- Quick searches without complex logic
+- When you don't need relational rules (inside/has)
+
+### Search with Rules (scan)
+
+YAML rule-based search for complex structural queries:
+
+```bash
+# With rule file
+ast-grep scan --rule my_rule.yml /path/to/project
+
+# With inline rules
+ast-grep scan --inline-rules "id: find-async
+language: javascript
+rule:
+  kind: function_declaration
+  has:
+    pattern: await \$EXPR
+    stopBy: end" /path/to/project
+
+# JSON output
+ast-grep scan --rule my_rule.yml --json /path/to/project
+```
+
+**When to use:**
+- Complex structural searches
+- Relational rules (inside, has, precedes, follows)
+- Composite logic (all, any, not)
+- When you need the power of full YAML rules
+
+**Tip:** For relational rules (inside/has), always add `stopBy: end` to ensure complete traversal.
+
+## Tips for Writing Effective Rules
+
+### Always Use stopBy: end
+
+For relational rules, always use `stopBy: end` unless there's a specific reason not to:
+
+```yaml
+has:
+  pattern: await $EXPR
+  stopBy: end
+```
+
+This ensures the search traverses the entire subtree rather than stopping at the first non-matching node.
+
+### Start Simple, Then Add Complexity
+
+Begin with the simplest rule that could work:
+1. Try a `pattern` first
+2. If that doesn't work, try `kind` to match the node type
+3. Add relational rules (`has`, `inside`) as needed
+4. Combine with composite rules (`all`, `any`, `not`) for complex logic
+
+### Use the Right Rule Type
+
+- **Pattern**: For simple, direct code matching (e.g., `console.log($ARG)`)
+- **Kind + Relational**: For complex structures (e.g., "function containing await")
+- **Composite**: For logical combinations (e.g., "function with await but not in try-catch")
+
+### Debug with AST Inspection
+
+When rules don't match:
+1. Use `--debug-query=cst` to see the actual AST structure
+2. Check if metavariables are being detected correctly
+3. Verify the node `kind` matches what you expect
+4. Ensure relational rules are searching in the right direction
+
+### Escaping in Inline Rules
+
+When using `--inline-rules`, escape metavariables in shell commands:
+- Use `\$VAR` instead of `$VAR` (shell interprets `$` as variable)
+- Or use single quotes: `'$VAR'` works in most shells
+
+**Example:**
+```bash
+# Correct: escaped $
+ast-grep scan --inline-rules "rule: {pattern: 'console.log(\$ARG)'}" .
+
+# Or use single quotes
+ast-grep scan --inline-rules 'rule: {pattern: "console.log($ARG)"}' .
+```
+
+## Common Use Cases
+
+### Find Functions with Specific Content
+
+Find async functions that use await:
+```bash
+ast-grep scan --inline-rules "id: async-await
+language: javascript
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        pattern: await \$EXPR
+        stopBy: end" /path/to/project
+```
+
+### Find Code Inside Specific Contexts
+
+Find console.log inside class methods:
+```bash
+ast-grep scan --inline-rules "id: console-in-class
+language: javascript
+rule:
+  pattern: console.log(\$\$\$)
+  inside:
+    kind: method_definition
+    stopBy: end" /path/to/project
+```
+
+### Find Code Missing Expected Patterns
+
+Find async functions without try-catch:
+```bash
+ast-grep scan --inline-rules "id: async-no-trycatch
+language: javascript
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        pattern: await \$EXPR
+        stopBy: end
+    - not:
+        has:
+          pattern: try { \$\$\$ } catch (\$E) { \$\$\$ }
+          stopBy: end" /path/to/project
+```
+
+## Resources
+
+### references/
+Contains detailed documentation for ast-grep rule syntax:
+- `rule_reference.md`: Comprehensive ast-grep rule documentation covering atomic rules, relational rules, composite rules, and metavariables
+
+Load these references when detailed rule syntax information is needed.

--- a/.agents/skills/ast-grep/references/rule_reference.md
+++ b/.agents/skills/ast-grep/references/rule_reference.md
@@ -1,0 +1,297 @@
+# ast-grep Rule Reference
+
+This document provides comprehensive documentation for ast-grep rule syntax, covering all rule types and metavariables.
+
+## Introduction to ast-grep Rules
+
+ast-grep rules are declarative specifications for matching and filtering Abstract Syntax Tree (AST) nodes. They enable structural code search and analysis by defining conditions an AST node must meet to be matched.
+
+### Rule Categories
+
+ast-grep rules are categorized into three types:
+
+* **Atomic Rules**: Match individual AST nodes based on intrinsic properties like code patterns (`pattern`), node type (`kind`), or text content (`regex`).
+* **Relational Rules**: Define conditions based on a target node's position or relationship to other nodes (e.g., `inside`, `has`, `precedes`, `follows`).
+* **Composite Rules**: Combine other rules using logical operations (AND, OR, NOT) to form complex matching criteria (e.g., `all`, `any`, `not`, `matches`).
+
+## Anatomy of an ast-grep Rule Object
+
+The ast-grep rule object is the core configuration unit defining how ast-grep identifies and filters AST nodes. It's typically written in YAML format.
+
+### General Structure
+
+Every field within an ast-grep Rule Object is optional, but at least one "positive" key (e.g., `kind`, `pattern`) must be present.
+
+A node matches a rule if it satisfies all fields defined within that rule object, implying an implicit logical AND operation.
+
+For rules using metavariables that depend on prior matching, explicit `all` composite rules are recommended to guarantee execution order.
+
+### Rule Object Properties
+
+| Property | Type | Category | Purpose | Example |
+| :--- | :--- | :--- | :--- | :--- |
+| `pattern` | String or Object | Atomic | Matches AST node by code pattern. | `pattern: console.log($ARG)` |
+| `kind` | String | Atomic | Matches AST node by its kind name. | `kind: call_expression` |
+| `regex` | String | Atomic | Matches node's text by Rust regex. | `regex: ^[a-z]+$` |
+| `nthChild` | number, string, Object | Atomic | Matches nodes by their index within parent's children. | `nthChild: 1` |
+| `range` | RangeObject | Atomic | Matches node by character-based start/end positions. | `range: { start: { line: 0, column: 0 }, end: { line: 0, column: 10 } }` |
+| `inside` | Object | Relational | Target node must be inside node matching sub-rule. | `inside: { pattern: class $C { $$$ }, stopBy: end }` |
+| `has` | Object | Relational | Target node must have descendant matching sub-rule. | `has: { pattern: await $EXPR, stopBy: end }` |
+| `precedes` | Object | Relational | Target node must appear before node matching sub-rule. | `precedes: { pattern: return $VAL }` |
+| `follows` | Object | Relational | Target node must appear after node matching sub-rule. | `follows: { pattern: import $M from '$P' }` |
+| `all` | Array<Rule> | Composite | Matches if all sub-rules match. | `all: [ { kind: call_expression }, { pattern: foo($A) } ]` |
+| `any` | Array<Rule> | Composite | Matches if any sub-rules match. | `any: [ { pattern: foo() }, { pattern: bar() } ]` |
+| `not` | Object | Composite | Matches if sub-rule does not match. | `not: { pattern: console.log($ARG) }` |
+| `matches` | String | Composite | Matches if predefined utility rule matches. | `matches: my-utility-rule-id` |
+
+## Atomic Rules
+
+Atomic rules match individual AST nodes based on their intrinsic properties.
+
+### pattern: String and Object Forms
+
+The `pattern` rule matches a single AST node based on a code pattern.
+
+**String Pattern**: Directly matches using ast-grep's pattern syntax with metavariables.
+
+```yaml
+pattern: console.log($ARG)
+```
+
+**Object Pattern**: Offers granular control for ambiguous patterns or specific contexts.
+
+* `selector`: Pinpoints a specific part of the parsed pattern to match.
+  ```yaml
+  pattern:
+    selector: field_definition
+    context: class { $F }
+  ```
+
+* `context`: Provides surrounding code context for correct parsing.
+
+* `strictness`: Modifies the pattern's matching algorithm (`cst`, `smart`, `ast`, `relaxed`, `signature`).
+  ```yaml
+  pattern:
+    context: foo($BAR)
+    strictness: relaxed
+  ```
+
+### kind: Matching by Node Type
+
+The `kind` rule matches an AST node by its `tree_sitter_node_kind` name, derived from the language's Tree-sitter grammar. Useful for targeting constructs like `call_expression` or `function_declaration`.
+
+```yaml
+kind: call_expression
+```
+
+### regex: Text-Based Node Matching
+
+The `regex` rule matches the entire text content of an AST node using a Rust regular expression. It's not a "positive" rule, meaning it matches any node whose text satisfies the regex, regardless of its structural kind.
+
+### nthChild: Positional Node Matching
+
+The `nthChild` rule finds nodes by their 1-based index within their parent's children list, counting only named nodes by default.
+
+* `number`: Matches the exact nth child. Example: `nthChild: 1`
+* `string`: Matches positions using An+B formula. Example: `2n+1`
+* `Object`: Provides granular control:
+  * `position`: `number` or An+B string.
+  * `reverse`: `true` to count from the end.
+  * `ofRule`: An ast-grep rule to filter the sibling list before counting.
+
+### range: Position-Based Node Matching
+
+The `range` rule matches an AST node based on its character-based start and end positions. A `RangeObject` defines `start` and `end` fields, each with 0-based `line` and `column`. `start` is inclusive, `end` is exclusive.
+
+## Relational Rules
+
+Relational rules filter targets based on their position relative to other AST nodes. They can include `stopBy` and `field` options.
+
+### inside: Matching Within a Parent Node
+
+Requires the target node to be inside another node matching the `inside` sub-rule.
+
+```yaml
+inside:
+  pattern: class $C { $$$ }
+  stopBy: end
+```
+
+### has: Matching with a Descendant Node
+
+Requires the target node to have a descendant node matching the `has` sub-rule.
+
+```yaml
+has:
+  pattern: await $EXPR
+  stopBy: end
+```
+
+### precedes and follows: Sequential Node Matching
+
+* `precedes`: Target node must appear before a node matching the `precedes` sub-rule.
+* `follows`: Target node must appear after a node matching the `follows` sub-rule.
+
+Both include `stopBy` but not `field`.
+
+### stopBy and field: Refining Relational Searches
+
+**stopBy**: Controls search termination for relational rules.
+
+* `"neighbor"` (default): Stops when immediate surrounding node doesn't match.
+* `"end"`: Searches to the end of the direction (root for `inside`, leaf for `has`).
+* `Rule object`: Stops when a surrounding node matches the provided rule (inclusive).
+
+**field**: Specifies a sub-node within the target node that should match the relational rule. Only for `inside` and `has`.
+
+**Best Practice**: When unsure, always use `stopBy: end` to ensure the search goes to the end of the direction.
+
+## Composite Rules
+
+Composite rules combine atomic and relational rules using logical operations.
+
+### all: Conjunction (AND) of Rules
+
+Matches a node only if all sub-rules in the list match. Guarantees order of rule matching, important for metavariables.
+
+```yaml
+all:
+  - kind: call_expression
+  - pattern: console.log($ARG)
+```
+
+### any: Disjunction (OR) of Rules
+
+Matches a node if any sub-rules in the list match.
+
+```yaml
+any:
+  - pattern: console.log($ARG)
+  - pattern: console.warn($ARG)
+  - pattern: console.error($ARG)
+```
+
+### not: Negation (NOT) of a Rule
+
+Matches a node if the single sub-rule does not match.
+
+```yaml
+not:
+  pattern: console.log($ARG)
+```
+
+### matches: Rule Reuse and Utility Rules
+
+Takes a rule-id string, matching if the referenced utility rule matches. Enables rule reuse and recursive rules.
+
+## Metavariables
+
+Metavariables are placeholders in patterns to match dynamic content in the AST.
+
+### $VAR: Single Named Node Capture
+
+Captures a single named node in the AST.
+
+* **Valid**: `$META`, `$META_VAR`, `$_`
+* **Invalid**: `$invalid`, `$123`, `$KEBAB-CASE`
+* **Example**: `console.log($GREETING)` matches `console.log('Hello World')`.
+* **Reuse**: `$A == $A` matches `a == a` but not `a == b`.
+
+### $$VAR: Single Unnamed Node Capture
+
+Captures a single unnamed node (e.g., operators, punctuation).
+
+**Example**: To match the operator in `a + b`, use `$$OP`.
+
+```yaml
+rule:
+  kind: binary_expression
+  has:
+    field: operator
+    pattern: $$OP
+```
+
+### $$$MULTI_META_VARIABLE: Multi-Node Capture
+
+Matches zero or more AST nodes (non-greedy). Useful for variable numbers of arguments or statements.
+
+* **Example**: `console.log($$$)` matches `console.log()`, `console.log('hello')`, and `console.log('debug:', key, value)`.
+* **Example**: `function $FUNC($$$ARGS) { $$$ }` matches functions with varying parameters/statements.
+
+### Non-Capturing Metavariables (_VAR)
+
+Metavariables starting with an underscore (`_`) are not captured. They can match different content even if named identically, optimizing performance.
+
+* **Example**: `$_FUNC($_FUNC)` matches `test(a)` and `testFunc(1 + 1)`.
+
+### Important Considerations for Metavariable Detection
+
+* **Syntax Matching**: Only exact metavariable syntax (e.g., `$A`, `$$B`, `$$$C`) is recognized.
+* **Exclusive Content**: Metavariable text must be the only text within an AST node.
+* **Non-working**: `obj.on$EVENT`, `"Hello $WORLD"`, `a $OP b`, `$jq`.
+
+The ast-grep playground is useful for debugging patterns and visualizing metavariables.
+
+## Common Patterns and Examples
+
+### Finding Functions with Specific Content
+
+Find functions that contain await expressions:
+
+```yaml
+rule:
+  kind: function_declaration
+  has:
+    pattern: await $EXPR
+    stopBy: end
+```
+
+### Finding Code Inside Specific Contexts
+
+Find console.log calls inside class methods:
+
+```yaml
+rule:
+  pattern: console.log($$$)
+  inside:
+    kind: method_definition
+    stopBy: end
+```
+
+### Combining Multiple Conditions
+
+Find async functions that use await but don't have try-catch:
+
+```yaml
+rule:
+  all:
+    - kind: function_declaration
+    - has:
+        pattern: await $EXPR
+        stopBy: end
+    - not:
+        has:
+          pattern: try { $$$ } catch ($E) { $$$ }
+          stopBy: end
+```
+
+### Matching Multiple Alternatives
+
+Find any type of console method call:
+
+```yaml
+rule:
+  any:
+    - pattern: console.log($$$)
+    - pattern: console.warn($$$)
+    - pattern: console.error($$$)
+    - pattern: console.debug($$$)
+```
+
+## Troubleshooting Tips
+
+1. **Rule doesn't match**: Use `dump_syntax_tree` to see the actual AST structure
+2. **Relational rule issues**: Ensure `stopBy: end` is set for deep searches
+3. **Wrong node kind**: Check the language's Tree-sitter grammar for correct kind names
+4. **Metavariable not working**: Ensure it's the only content in its AST node
+5. **Pattern too complex**: Break it down into simpler sub-rules using `all`

--- a/.agents/skills/ripgrep/SKILL.md
+++ b/.agents/skills/ripgrep/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: ripgrep
+description: Use when searching text in files, codebases, books, or documents. Use when finding files by pattern, searching large files that are too big to read fully, extracting specific content from many files, or when grep/find is too slow. Triggers on "search for", "find occurrences", "look for pattern", "search in files".
+---
+
+# Ripgrep (rg) - Fast Text Search Tool
+
+## Overview
+
+Ripgrep is a line-oriented search tool that recursively searches directories for regex patterns. It's **10-100x faster than grep** and respects `.gitignore` by default. Use it instead of grep, find, or manually reading large files.
+
+**Core principle:** When you need to find text in files, use ripgrep. Don't read entire files into context when you can search them.
+
+## When to Use
+
+**Use ripgrep when:**
+- Searching for text patterns across a codebase or directory
+- Finding all occurrences of a function, variable, or string
+- Searching through books, documentation, or large text files
+- Files are too large to read fully into context
+- Looking for specific content in many files at once
+- Finding files that contain (or don't contain) certain patterns
+- Extracting matching lines for analysis
+
+**Don't use when:**
+- You need the full file content (use Read tool)
+- Simple glob pattern matching for filenames only (use Glob tool)
+- You need structured data extraction (consider jq, awk)
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Basic search | `rg "pattern" [path]` |
+| Case insensitive | `rg -i "pattern"` |
+| Smart case (auto) | `rg -S "pattern"` |
+| Whole word only | `rg -w "word"` |
+| Fixed string (no regex) | `rg -F "literal.string"` |
+| Show context lines | `rg -C 3 "pattern"` (3 before & after) |
+| Show line numbers | `rg -n "pattern"` (default in tty) |
+| Only filenames | `rg -l "pattern"` |
+| Files without match | `rg --files-without-match "pattern"` |
+| Count matches | `rg -c "pattern"` |
+| Only matching part | `rg -o "pattern"` |
+| Invert match | `rg -v "pattern"` |
+| Multiline search | `rg -U "pattern.*\nmore"` |
+
+## File Filtering
+
+### By File Type
+
+Ripgrep has built-in file type definitions. Use `-t` to include, `-T` to exclude:
+
+```bash
+# Search only Python files
+rg -t py "def main"
+
+# Search only JavaScript and TypeScript
+rg -t js -t ts "import"
+
+# Exclude test files
+rg -T test "function"
+
+# List all known types
+rg --type-list
+```
+
+**Common types:** `py`, `js`, `ts`, `rust`, `go`, `java`, `c`, `cpp`, `rb`, `php`, `html`, `css`, `json`, `yaml`, `md`, `txt`, `sh`
+
+### By Glob Pattern
+
+```bash
+# Only .tsx files
+rg -g "*.tsx" "useState"
+
+# Exclude node_modules (in addition to gitignore)
+rg -g "!node_modules/**" "pattern"
+
+# Only files in src directory
+rg -g "src/**" "pattern"
+
+# Multiple globs
+rg -g "*.js" -g "*.ts" "pattern"
+
+# Case insensitive globs
+rg --iglob "*.JSON" "pattern"
+```
+
+### By File Size
+
+```bash
+# Skip files larger than 1MB
+rg --max-filesize 1M "pattern"
+```
+
+## Directory Control
+
+```bash
+# Limit depth
+rg --max-depth 2 "pattern"
+
+# Search hidden files (dotfiles)
+rg --hidden "pattern"
+
+# Follow symlinks
+rg -L "pattern"
+
+# Ignore all ignore files (.gitignore, etc.)
+rg --no-ignore "pattern"
+
+# Progressive unrestricted (-u can stack up to 3 times)
+rg -u "pattern"      # --no-ignore
+rg -uu "pattern"     # --no-ignore --hidden
+rg -uuu "pattern"    # --no-ignore --hidden --binary
+```
+
+## Context Options
+
+```bash
+# Lines after match
+rg -A 5 "pattern"
+
+# Lines before match
+rg -B 5 "pattern"
+
+# Lines before and after
+rg -C 5 "pattern"
+
+# Print entire file on match (passthrough mode)
+rg --passthru "pattern"
+```
+
+## Output Formats
+
+```bash
+# Just filenames with matches
+rg -l "pattern"
+
+# Files without matches
+rg --files-without-match "pattern"
+
+# Count matches per file
+rg -c "pattern"
+
+# Count total matches (not lines)
+rg --count-matches "pattern"
+
+# Only the matched text (not full line)
+rg -o "pattern"
+
+# JSON output (for parsing)
+rg --json "pattern"
+
+# Vim-compatible output (file:line:col:match)
+rg --vimgrep "pattern"
+
+# With statistics
+rg --stats "pattern"
+```
+
+## Regex Patterns
+
+Ripgrep uses Rust regex syntax by default:
+
+```bash
+# Alternation
+rg "foo|bar"
+
+# Character classes
+rg "[0-9]+"
+rg "[a-zA-Z_][a-zA-Z0-9_]*"
+
+# Word boundaries
+rg "\bword\b"
+
+# Quantifiers
+rg "colou?r"           # 0 or 1
+rg "go+gle"            # 1 or more
+rg "ha*"               # 0 or more
+rg "x{2,4}"            # 2 to 4 times
+
+# Groups
+rg "(foo|bar)baz"
+
+# Lookahead/lookbehind (requires -P for PCRE2)
+rg -P "(?<=prefix)content"
+rg -P "content(?=suffix)"
+```
+
+### Multiline Matching
+
+```bash
+# Enable multiline mode
+rg -U "start.*\nend"
+
+# Dot matches newline too
+rg -U --multiline-dotall "start.*end"
+
+# Match across lines
+rg -U "function\s+\w+\([^)]*\)\s*\{"
+```
+
+## Replacement (Preview Only)
+
+Ripgrep can show what replacements would look like (doesn't modify files):
+
+```bash
+# Simple replacement
+rg "old" -r "new"
+
+# Using capture groups
+rg "(\w+)@(\w+)" -r "$2::$1"
+
+# Remove matches (empty replacement)
+rg "pattern" -r ""
+```
+
+## Searching Special Files
+
+### Compressed Files
+
+```bash
+# Search in gzip, bzip2, xz, lz4, lzma, zstd files
+rg -z "pattern" file.gz
+rg -z "pattern" archive.tar.gz
+```
+
+### Binary Files
+
+```bash
+# Include binary files
+rg --binary "pattern"
+
+# Treat binary as text (may produce garbage)
+rg -a "pattern"
+```
+
+### Large Files
+
+For files too large to read into context:
+
+```bash
+# Search and show only matching lines
+rg "specific pattern" large_file.txt
+
+# Limit matches to first N per file
+rg -m 10 "pattern" huge_file.log
+
+# Show byte offset for large file navigation
+rg -b "pattern" large_file.txt
+
+# Use with head/tail for pagination
+rg "pattern" large_file.txt | head -100
+```
+
+## Performance Tips
+
+1. **Be specific with paths** - Don't search from root when you know the subdir
+2. **Use file types** - `-t py` is faster than `-g "*.py"`
+3. **Use fixed strings** - `-F` when you don't need regex
+4. **Limit depth** - `--max-depth` when you know structure
+5. **Let gitignore work** - Don't use `--no-ignore` unless needed
+6. **Use word boundaries** - `-w` is optimized
+
+## Common Patterns
+
+### Find function definitions
+```bash
+# Python
+rg "def \w+\(" -t py
+
+# JavaScript/TypeScript
+rg "(function|const|let|var)\s+\w+\s*=" -t js -t ts
+rg "^\s*(async\s+)?function" -t js
+
+# Go
+rg "^func\s+\w+" -t go
+```
+
+### Find imports/requires
+```bash
+# Python
+rg "^(import|from)\s+" -t py
+
+# JavaScript
+rg "^(import|require\()" -t js
+
+# Go
+rg "^import\s+" -t go
+```
+
+### Find TODO/FIXME comments
+```bash
+rg "(TODO|FIXME|HACK|XXX):"
+```
+
+### Find error handling
+```bash
+# Python
+rg "except\s+\w+:" -t py
+
+# JavaScript
+rg "\.catch\(|catch\s*\(" -t js
+```
+
+### Find class definitions
+```bash
+# Python
+rg "^class\s+\w+" -t py
+
+# JavaScript/TypeScript
+rg "^(export\s+)?(default\s+)?class\s+\w+" -t js -t ts
+```
+
+### Search in books/documents
+```bash
+# Find chapter headings
+rg "^(Chapter|CHAPTER)\s+\d+" book.txt
+
+# Find quoted text
+rg '"[^"]{20,}"' document.txt
+
+# Find paragraphs containing word
+rg -C 2 "keyword" book.txt
+```
+
+## Combining with Other Tools
+
+```bash
+# Find files, then search
+rg --files | xargs rg "pattern"
+
+# Search and count by file
+rg -c "pattern" | sort -t: -k2 -rn
+
+# Search and open in editor
+rg -l "pattern" | xargs code
+
+# Extract unique matches
+rg -o "\b[A-Z]{2,}\b" | sort -u
+
+# Search multiple patterns from file
+rg -f patterns.txt
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Matches found |
+| 1 | No matches found |
+| 2 | Error occurred |
+
+Useful for scripting:
+```bash
+if rg -q "pattern" file.txt; then
+    echo "Found"
+fi
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Pattern has special chars | Use `-F` for fixed strings or escape: `rg "foo\.bar"` |
+| Can't find hidden files | Add `--hidden` or `-uu` |
+| Missing node_modules | Add `--no-ignore` (but it's usually right to skip) |
+| Regex too complex | Try `-P` for PCRE2 with lookahead/lookbehind |
+| Output too long | Use `-m N` to limit, or `-l` for just filenames |
+| Binary file skipped | Add `--binary` or `-a` for text mode |
+| Need to see full line | Remove `-o` (only-matching) flag |
+
+## When to Prefer Other Tools
+
+| Task | Better Tool |
+|------|-------------|
+| Structured JSON queries | `jq` |
+| Column-based text processing | `awk` |
+| Stream editing/substitution | `sed` (actually modifies files) |
+| Find files by name only | `fd` or `find` |
+| Simple file listing | `ls` or `glob` |
+| Full file content needed | Read tool |

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,16 +2,15 @@
   "mcpServers": {
     "github": {
       "type": "http",
-      "url": "https://api.githubcopilot.com/mcp"
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GH_TOKEN}"
+      }
     },
     "azure-devops": {
       "type": "stdio",
       "command": "bunx",
-      "args": [
-        "-y",
-        "@azure-devops/mcp",
-        "<your-org>"
-      ]
+      "args": ["-y", "@azure-devops/mcp", "<your-org>"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Refer to `.impeccable.md`
 
 ## Testing
 
-Use `bun test` to run tests and make use of your testing-anti-patterns skill to write high quality tests. Here's an example of a simple test file:
+Use `bun test` to run tests and make use of your test-driven-development skill to write high quality tests. Here's an example of a simple test file:
 
 ```ts#index.test.ts
 import { test, expect } from "bun:test";

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,8 @@
         "@opentui/react": "0.1.102",
         "commander": "^14.0.3",
         "ignore": "^7.0.5",
+        "ignore-by-default": "^2.1.0",
+        "linguist-languages": "^9.3.2",
         "yaml": "^2.8.3",
         "zod": "^4.3.6",
       },
@@ -371,6 +373,8 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "ignore-by-default": ["ignore-by-default@2.1.0", "", {}, "sha512-yiWd4GVmJp0Q6ghmM2B/V3oZGRmjrKLXvHR3TE1nfoXsmoggllfZUQe74EN0fJdPFZu2NIvNdrMMLm3OsV7Ohw=="],
+
     "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -394,6 +398,8 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "linguist-languages": ["linguist-languages@9.3.2", "", {}, "sha512-AyYYwY2N7iG+tT+yAZmZbf+2PxVIbYfGtzDeT2qh4K/H8EvGbKCmeEdyzwTEGKK6PYcaaNqWv6aYYbCeN5LMTA=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -57,6 +57,7 @@ coveragePathIgnorePatterns = [
   "src/services/config/claude-config.ts",
   "src/services/config/agent-definition-loader.ts",
   "src/services/config/workflow-package.ts",
+  "src/services/config/additional-instructions.ts",
   # Agent/skill discovery (filesystem-dependent)
   "src/services/agent-discovery/discovery.ts",
   "src/services/agents/tools/discovery.ts",

--- a/docs/claude-code/agent-sdk/sdk-references/typescript.md
+++ b/docs/claude-code/agent-sdk/sdk-references/typescript.md
@@ -335,7 +335,7 @@ Configuration object for the `query()` function.
 | `disallowedTools`                 | `string[]`                                                                                               | `[]`                                        | Tools to always deny. Deny rules are checked first and override `allowedTools` and `permissionMode` (including `bypassPermissions`)                                                                                                                                                                                                                                                                                                                                                 |
 | `effort`                          | `'low' \| 'medium' \| 'high' \| 'xhigh' \| 'max'`                                                        | `'high'`                                    | Controls how much effort Claude puts into its response. Works with adaptive thinking to guide thinking depth                                                                                                                                                                                                                                                                                                                                                                        |
 | `enableFileCheckpointing`         | `boolean`                                                                                                | `false`                                     | Enable file change tracking for rewinding. See [File checkpointing](/en/agent-sdk/file-checkpointing)                                                                                                                                                                                                                                                                                                                                                                               |
-| `env`                             | `Record<string, string \| undefined>`                                                                    | `process.env`                               | Environment variables. Set `CLAUDE_AGENT_SDK_CLIENT_APP` to identify your app in the User-Agent header                                                                                                                                                                                                                                                                                                                                                                              |
+| `env`                             | `Record<string, string \| undefined>`                                                                    | `process.env`                               | Environment variables. See [Environment variables](/en/env-vars) for variables the underlying CLI reads. Set `CLAUDE_AGENT_SDK_CLIENT_APP` to identify your app in the User-Agent header                                                                                                                                                                                                                                                                                            |
 | `executable`                      | `'bun' \| 'deno' \| 'node'`                                                                              | Auto-detected                               | JavaScript runtime to use                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `executableArgs`                  | `string[]`                                                                                               | `[]`                                        | Arguments to pass to the executable                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `extraArgs`                       | `Record<string, string \| null>`                                                                         | `{}`                                        | Additional arguments                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -895,6 +895,7 @@ type SDKResultMessage =
       modelUsage: { [modelName: string]: ModelUsage };
       permission_denials: SDKPermissionDenial[];
       structured_output?: unknown;
+      deferred_tool_use?: { id: string; name: string; input: Record<string, unknown> };
     }
   | {
       type: "result";
@@ -917,6 +918,8 @@ type SDKResultMessage =
       errors: string[];
     };
 ```
+
+When a `PreToolUse` hook returns `permissionDecision: "defer"`, the result has `stop_reason: "tool_deferred"` and `deferred_tool_use` carries the pending tool's `id`, `name`, and `input`. Read this field to surface the request in your own UI, then resume with the same `session_id` to continue. See [Defer a tool call for later](/en/hooks#defer-a-tool-call-for-later) for the full round trip.
 
 ### `SDKSystemMessage`
 
@@ -1019,6 +1022,7 @@ type HookEvent =
   | "PreToolUse"
   | "PostToolUse"
   | "PostToolUseFailure"
+  | "PostToolBatch"
   | "Notification"
   | "UserPromptSubmit"
   | "SessionStart"
@@ -1069,6 +1073,7 @@ type HookInput =
   | PreToolUseHookInput
   | PostToolUseHookInput
   | PostToolUseFailureHookInput
+  | PostToolBatchHookInput
   | NotificationHookInput
   | UserPromptSubmitHookInput
   | SessionStartHookInput
@@ -1121,6 +1126,7 @@ type PostToolUseHookInput = BaseHookInput & {
   tool_input: unknown;
   tool_response: unknown;
   tool_use_id: string;
+  duration_ms?: number;
 };
 ```
 
@@ -1134,6 +1140,25 @@ type PostToolUseFailureHookInput = BaseHookInput & {
   tool_use_id: string;
   error: string;
   is_interrupt?: boolean;
+  duration_ms?: number;
+};
+```
+
+#### `PostToolBatchHookInput`
+
+Fires once after every tool call in a batch has resolved, before the next model request. `tool_response` carries the serialized `tool_result` content the model sees; the shape differs from `PostToolUseHookInput`'s structured `Output` object.
+
+```typescript theme={null}
+type PostToolBatchHookInput = BaseHookInput & {
+  hook_event_name: "PostToolBatch";
+  tool_calls: PostToolBatchToolCall[];
+};
+
+type PostToolBatchToolCall = {
+  tool_name: string;
+  tool_input: unknown;
+  tool_use_id: string;
+  tool_response?: unknown;
 };
 ```
 
@@ -1326,7 +1351,7 @@ type SyncHookJSONOutput = {
   hookSpecificOutput?:
     | {
         hookEventName: "PreToolUse";
-        permissionDecision?: "allow" | "deny" | "ask";
+        permissionDecision?: "allow" | "deny" | "ask" | "defer";
         permissionDecisionReason?: string;
         updatedInput?: Record<string, unknown>;
         additionalContext?: string;
@@ -1354,6 +1379,10 @@ type SyncHookJSONOutput = {
       }
     | {
         hookEventName: "PostToolUseFailure";
+        additionalContext?: string;
+      }
+    | {
+        hookEventName: "PostToolBatch";
         additionalContext?: string;
       }
     | {
@@ -1391,7 +1420,6 @@ type ToolInputSchemas =
   | AskUserQuestionInput
   | BashInput
   | TaskOutputInput
-  | ConfigInput
   | EnterWorktreeInput
   | ExitPlanModeInput
   | FileEditInput
@@ -1691,19 +1719,6 @@ type ReadMcpResourceInput = {
 
 Reads a specific MCP resource from a server.
 
-### Config
-
-**Tool name:** `Config`
-
-```typescript theme={null}
-type ConfigInput = {
-  setting: string;
-  value?: string | boolean | number;
-};
-```
-
-Gets or sets a configuration value.
-
 ### EnterWorktree
 
 **Tool name:** `EnterWorktree`
@@ -1730,7 +1745,6 @@ type ToolOutputSchemas =
   | AgentOutput
   | AskUserQuestionOutput
   | BashOutput
-  | ConfigOutput
   | EnterWorktreeOutput
   | ExitPlanModeOutput
   | FileEditOutput
@@ -2146,24 +2160,6 @@ type ReadMcpResourceOutput = {
 
 Returns the contents of the requested MCP resource.
 
-### Config
-
-**Tool name:** `Config`
-
-```typescript theme={null}
-type ConfigOutput = {
-  success: boolean;
-  operation?: "get" | "set";
-  setting?: string;
-  value?: unknown;
-  previousValue?: unknown;
-  newValue?: unknown;
-  error?: string;
-};
-```
-
-Returns the result of a configuration get or set operation.
-
 ### EnterWorktree
 
 **Tool name:** `EnterWorktree`
@@ -2276,6 +2272,7 @@ type SlashCommand = {
   name: string;
   description: string;
   argumentHint: string;
+  aliases?: string[];
 };
 ```
 
@@ -2745,7 +2742,7 @@ type SDKRateLimitEvent = {
 
 ### `SDKLocalCommandOutputMessage`
 
-Output from a local slash command (for example, `/voice` or `/cost`). Displayed as assistant-style text in the transcript.
+Output from a local slash command (for example, `/voice` or `/usage`). Displayed as assistant-style text in the transcript.
 
 ```typescript theme={null}
 type SDKLocalCommandOutputMessage = {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "@opentui/react": "0.1.102",
     "commander": "^14.0.3",
     "ignore": "^7.0.5",
+    "ignore-by-default": "^2.1.0",
+    "linguist-languages": "^9.3.2",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,6 +11,11 @@
       "sourceType": "github",
       "computedHash": "354414a934957f9d54a71468abe81888304d35b47a4fe8e27fff08f60b457d53"
     },
+    "ast-grep": {
+      "source": "ast-grep/agent-skill",
+      "sourceType": "github",
+      "computedHash": "3bca45167617f547e97454ae16d271ba3aeb2550d89e6ef1942057bd122c0061"
+    },
     "audit": {
       "source": "pbakaus/impeccable",
       "sourceType": "github",
@@ -120,6 +125,11 @@
       "source": "pbakaus/impeccable",
       "sourceType": "github",
       "computedHash": "2c20b12bb4ece445d45fc63bda020aecf78b3cdf6d593beb59c273f658293130"
+    },
+    "ripgrep": {
+      "source": "ratacat/claude-skills",
+      "sourceType": "github",
+      "computedHash": "bc5ed0a5b897b7e06db597c00d0e1554dc1db3671009cdeab7945addf0708808"
     },
     "shape": {
       "source": "pbakaus/impeccable",

--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -16,6 +16,10 @@ import { mkdir, writeFile, rm } from "node:fs/promises";
 import { AGENT_CONFIG, type AgentKey } from "../../../services/config/index.ts";
 import { getProviderOverrides } from "../../../services/config/atomic-config.ts";
 import { getCopilotScmDisableFlags } from "../../../services/config/scm-sync.ts";
+import {
+  resolveAdditionalInstructionsPath,
+} from "../../../services/config/additional-instructions.ts";
+import { dirname } from "node:path";
 import { ensureProjectSetup } from "../init/index.ts";
 import { COLORS } from "../../../theme/colors.ts";
 import { isCommandInstalled } from "../../../services/system/detect.ts";
@@ -88,7 +92,32 @@ export async function buildAgentArgs(
   const scmFlags =
     agentType === "copilot" ? await getCopilotScmDisableFlags(projectRoot) : [];
 
-  return [...flags, ...scmFlags, ...passthroughArgs];
+  // Claude Code is the only one with a flag that takes an instructions file.
+  // OpenCode and Copilot CLI consume the file via config (.opencode/opencode.json
+  // `instructions` array) and env var (`COPILOT_CUSTOM_INSTRUCTIONS_DIRS`)
+  // respectively — see `applyManagedOnboardingFiles` and `chatCommand`'s env
+  // build. Skipped silently when no file resolves so the CLI still spawns
+  // even on a fresh checkout that hasn't run `autoSyncIfStale` yet.
+  const instructionsFlags: string[] = [];
+  if (agentType === "claude") {
+    const path = resolveAdditionalInstructionsPath(projectRoot);
+    if (path) instructionsFlags.push("--append-system-prompt-file", path);
+  }
+
+  return [...flags, ...scmFlags, ...instructionsFlags, ...passthroughArgs];
+}
+
+/**
+ * Directory containing the resolved additional-instructions `AGENTS.md`,
+ * or `undefined` if no file resolves. Used to set
+ * `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` on Copilot spawns — Copilot loads
+ * `AGENTS.md` from each dir on that list.
+ */
+export function getAdditionalInstructionsDir(
+  projectRoot: string,
+): string | undefined {
+  const path = resolveAdditionalInstructionsPath(projectRoot);
+  return path ? dirname(path) : undefined;
 }
 
 function generateChatId(): string {
@@ -213,11 +242,25 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
   const overrides = await getProviderOverrides(agentType, projectRoot);
   // ATOMIC_AGENT must be baked into the launcher env so the agent CLI
   // and anything it spawns can read it from process start.
-  const envVars = {
+  const envVars: Record<string, string> = {
     ...config.env_vars,
     ...overrides.envVars,
     ATOMIC_AGENT: agentType,
   };
+
+  // Copilot CLI loads `AGENTS.md` from any directory listed in
+  // `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (comma-separated). Point it at the
+  // resolved AGENTS.md's parent dir so our additional instructions get
+  // appended to the persona without touching the project's `AGENTS.md`.
+  if (agentType === "copilot") {
+    const dir = getAdditionalInstructionsDir(projectRoot);
+    if (dir) {
+      const existing = envVars.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
+      envVars.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = existing
+        ? `${existing},${dir}`
+        : dir;
+    }
+  }
 
   // ── No TTY: tmux attach requires a real terminal ──
   if (!process.stdin.isTTY) {

--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -252,9 +252,16 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
   // `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (comma-separated). Point it at the
   // resolved AGENTS.md's parent dir so our additional instructions get
   // appended to the persona without touching the project's `AGENTS.md`.
+  // Skip dirs containing a comma — Copilot CLI has no documented escape
+  // syntax for the list separator, so a comma in the path (rare on POSIX,
+  // possible in Windows usernames) would be misparsed as a list boundary.
   if (agentType === "copilot") {
     const dir = getAdditionalInstructionsDir(projectRoot);
-    if (dir) {
+    if (dir && dir.includes(",")) {
+      console.error(
+        `${COLORS.yellow}Warning: skipping COPILOT_CUSTOM_INSTRUCTIONS_DIRS entry because the path contains a comma, which Copilot CLI cannot escape: ${dir}${COLORS.reset}`,
+      );
+    } else if (dir) {
       const existing = envVars.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
       envVars.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = existing
         ? `${existing},${dir}`

--- a/src/commands/cli/init/index.ts
+++ b/src/commands/cli/init/index.ts
@@ -9,6 +9,7 @@
 import type { AgentKey } from "../../../services/config/index.ts";
 import { getConfigRoot } from "../../../services/config/config-path.ts";
 import { syncScmMcpServers } from "../../../services/config/scm-sync.ts";
+import { reconcileOpencodeInstructions } from "../../../services/config/additional-instructions.ts";
 import { applyManagedOnboardingFiles } from "./onboarding.ts";
 
 /**
@@ -29,4 +30,12 @@ export async function ensureProjectSetup(
   const configRoot = getConfigRoot();
   await applyManagedOnboardingFiles(agentKey, projectRoot, configRoot);
   await syncScmMcpServers(projectRoot);
+
+  // OpenCode is the only provider whose CLI/SDK has no flag or env-var
+  // path for additional instructions — it consumes them via its project
+  // config. Reconcile only when targeting OpenCode so we don't touch
+  // `.opencode/opencode.json` from unrelated chat sessions.
+  if (agentKey === "opencode") {
+    await reconcileOpencodeInstructions(projectRoot);
+  }
 }

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -414,9 +414,13 @@ export async function upgradeGlobalPackages(pkgs: string[]): Promise<void> {
   }
 }
 
-/** Upgrade @playwright/cli and @llamaindex/liteparse globally in one pass. */
+/** Upgrade @playwright/cli, @llamaindex/liteparse, and @ast-grep/cli globally in one pass. */
 export async function upgradeGlobalToolPackages(): Promise<void> {
-  return upgradeGlobalPackages(["@playwright/cli", "@llamaindex/liteparse"]);
+  return upgradeGlobalPackages([
+    "@playwright/cli",
+    "@llamaindex/liteparse",
+    "@ast-grep/cli",
+  ]);
 }
 
 /**

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -1225,12 +1225,23 @@ export function resolveHeadlessClaudeBin(): string {
 export class HeadlessClaudeSessionWrapper {
   readonly paneId = "";
   /**
+   * Project root the workflow is operating against. Used to resolve
+   * project-scoped config (e.g. `additional-instructions`) against the
+   * workflow's actual root rather than `process.cwd()`, which can drift
+   * when workflows are invoked programmatically or from a subdirectory.
+   */
+  private readonly _projectRoot: string;
+  /**
    * The Claude session UUID of the most recently completed `query()`. Exposed
    * via `s.sessionId` so workflows can pass it to `s.save(s.sessionId)` and
    * have the save path read the correct transcript, even when several headless
    * Claude stages run in parallel (each call gets its own SDK-assigned UUID).
    */
   private _lastSessionId: string = "";
+
+  constructor(projectRoot: string) {
+    this._projectRoot = projectRoot;
+  }
   /**
    * Validated structured output captured from the most recent `query()`'s
    * `result` message. Populated only when callers pass
@@ -1257,7 +1268,7 @@ export class HeadlessClaudeSessionWrapper {
     // agent can call it and the SDK query will sit blocked forever since no
     // human is attached to answer.
     const sdkOpts = options ?? {};
-    const additional = await resolveAdditionalInstructionsContent(process.cwd());
+    const additional = await resolveAdditionalInstructionsContent(this._projectRoot);
     const headlessSdkOpts: Partial<SDKOptions> = {
       ...sdkOpts,
       pathToClaudeCodeExecutable:

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -32,6 +32,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import { claudeHookDirs } from "../../commands/cli/claude-stop-hook.ts";
+import { resolveAdditionalInstructionsContent } from "../../services/config/additional-instructions.ts";
 
 // ---------------------------------------------------------------------------
 // Session tracking — ensures createClaudeSession is called before claudeQuery
@@ -1038,6 +1039,36 @@ export function mergeDisallowedTools(
 }
 
 /**
+ * Fold the atomic-managed additional instructions into a caller's
+ * `systemPrompt` value. Behavior, in order of precedence:
+ *
+ *   - **No caller value** → return a `claude_code` preset with our content
+ *     in `append`. Preserves the SDK's full Claude Code persona.
+ *   - **Caller passed a preset object** → concatenate our content onto the
+ *     existing `append` (newline-separated when both are present).
+ *   - **Caller passed a custom string or array** → leave it alone. The
+ *     caller has explicitly opted into a custom prompt, and silently
+ *     prepending the persona-style preset text would break that contract.
+ *
+ * Exported for unit testing.
+ */
+export function mergeSystemPromptAppend(
+  existing: SDKOptions["systemPrompt"],
+  extra: string,
+): SDKOptions["systemPrompt"] {
+  if (!extra) return existing;
+  if (existing === undefined) {
+    return { type: "preset", preset: "claude_code", append: extra };
+  }
+  if (typeof existing === "object" && !Array.isArray(existing) && existing.type === "preset") {
+    const prevAppend = existing.append ?? "";
+    const merged = prevAppend ? `${prevAppend}\n\n${extra}` : extra;
+    return { ...existing, append: merged };
+  }
+  return existing;
+}
+
+/**
  * Synthetic client wrapper for Claude stages.
  * Auto-starts the Claude CLI in the tmux pane during `start()`.
  */
@@ -1226,6 +1257,7 @@ export class HeadlessClaudeSessionWrapper {
     // agent can call it and the SDK query will sit blocked forever since no
     // human is attached to answer.
     const sdkOpts = options ?? {};
+    const additional = await resolveAdditionalInstructionsContent(process.cwd());
     const headlessSdkOpts: Partial<SDKOptions> = {
       ...sdkOpts,
       pathToClaudeCodeExecutable:
@@ -1233,6 +1265,9 @@ export class HeadlessClaudeSessionWrapper {
       disallowedTools: mergeDisallowedTools(sdkOpts.disallowedTools, [
         "AskUserQuestion",
       ]),
+      ...(additional
+        ? { systemPrompt: mergeSystemPromptAppend(sdkOpts.systemPrompt, additional) }
+        : {}),
     };
 
     let sdkSessionId = "";

--- a/src/sdk/providers/copilot.ts
+++ b/src/sdk/providers/copilot.ts
@@ -1,10 +1,11 @@
 /**
- * Copilot workflow source validation.
+ * Copilot workflow source validation + helpers.
  *
  * Checks that Copilot workflow source files use the runtime-managed
  * `s.client` and `s.session` instead of manual SDK client creation.
  */
 
+import type { SessionConfig as CopilotSessionConfig } from "@github/copilot-sdk";
 import { createProviderValidator } from "../types.ts";
 
 /**
@@ -25,6 +26,34 @@ import { createProviderValidator } from "../types.ts";
  */
 export function copilotSubprocessEnv(): Record<string, string | undefined> {
   return { ...process.env, NODE_NO_WARNINGS: "1" };
+}
+
+/**
+ * Fold the atomic-managed additional instructions into a caller's
+ * `systemMessage` value on `client.createSession`. Behavior:
+ *
+ *   - **No caller value** → `{ mode: "append", content: extra }`. The
+ *     SDK's default mode is append and preserves the SDK persona.
+ *   - **Append/customize mode** → concatenate our content to the existing
+ *     `content` field (newline-separated when both are present).
+ *   - **Replace mode** → leave alone. The caller has explicitly opted out
+ *     of SDK-managed sections; silently re-adding the persona-style append
+ *     would violate that contract.
+ *
+ * Exported for unit testing.
+ */
+export function mergeCopilotSystemMessage(
+  existing: CopilotSessionConfig["systemMessage"],
+  extra: string,
+): CopilotSessionConfig["systemMessage"] {
+  if (!extra) return existing;
+  if (existing === undefined) {
+    return { mode: "append", content: extra };
+  }
+  if (existing.mode === "replace") return existing;
+  const prev = existing.content ?? "";
+  const merged = prev ? `${prev}\n\n${extra}` : extra;
+  return { ...existing, content: merged };
 }
 
 /**

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -40,6 +40,7 @@ import {
 } from "../../services/config/definitions.ts";
 import { getProviderOverrides } from "../../services/config/atomic-config.ts";
 import { getCopilotScmDisableFlags } from "../../services/config/scm-sync.ts";
+import { reconcileOpencodeInstructions } from "../../services/config/additional-instructions.ts";
 import { ensureDir } from "../../services/system/copy.ts";
 import type { SessionEvent } from "@github/copilot-sdk";
 import type { SessionPromptResponse } from "@opencode-ai/sdk/v2";
@@ -480,6 +481,19 @@ export async function executeWorkflow(
     projectRoot = process.cwd(),
     detach = false,
   } = options;
+
+  // OpenCode reads its `instructions` array from `.opencode/opencode.json`
+  // at server-start time — both for the interactive tmux-pane path and the
+  // headless `createOpencode({ port: 0 })` path. Reconcile here, before
+  // either spawn, so the resolved AGENTS.md is the source of truth on
+  // every workflow run. Best-effort: a malformed config shouldn't block.
+  if (agent === "opencode") {
+    try {
+      await reconcileOpencodeInstructions(projectRoot);
+    } catch {
+      /* swallow */
+    }
+  }
 
   const workflowRunId = generateId();
   const tmuxSessionName = `atomic-wf-${agent}-${definition.name}-${workflowRunId}`;
@@ -1289,7 +1303,12 @@ async function initProviderClientAndSession<A extends AgentType>(
   switch (agent) {
     case "copilot": {
       const { CopilotClient, approveAll } = await import("@github/copilot-sdk");
-      const { copilotSubprocessEnv } = await import("../providers/copilot.ts");
+      const { copilotSubprocessEnv, mergeCopilotSystemMessage } = await import(
+        "../providers/copilot.ts"
+      );
+      const { resolveAdditionalInstructionsContent } = await import(
+        "../../services/config/additional-instructions.ts"
+      );
       const copilotClientOpts = clientOpts as StageClientOptions<"copilot">;
       const copilotSessionOpts = sessionOpts as StageSessionOptions<"copilot">;
       // Headless: let the SDK spawn its own CLI process (no cliUrl).
@@ -1320,6 +1339,9 @@ async function initProviderClientAndSession<A extends AgentType>(
       // In headless stages, add `ask_user` to the session's excludedTools so
       // the agent cannot call the interactive question tool — there is no
       // human attached to answer and the SDK would otherwise sit blocked.
+      const additionalInstructions = await resolveAdditionalInstructionsContent(
+        process.cwd(),
+      );
       const sessionConfig = {
         onPermissionRequest: approveAll,
         ...copilotSessionOpts,
@@ -1331,6 +1353,14 @@ async function initProviderClientAndSession<A extends AgentType>(
               excludedTools: mergeExcludedTools(
                 copilotSessionOpts.excludedTools,
                 ["ask_user"],
+              ),
+            }
+          : {}),
+        ...(additionalInstructions
+          ? {
+              systemMessage: mergeCopilotSystemMessage(
+                copilotSessionOpts.systemMessage,
+                additionalInstructions,
               ),
             }
           : {}),

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -1188,6 +1188,14 @@ function createMessagesReader(
 interface SharedRunnerState {
   tmuxSessionName: string;
   sessionsBaseDir: string;
+  /**
+   * The project root the workflow is operating against. Threaded through to
+   * provider initialization so headless paths resolve project-scoped config
+   * (e.g. `additional-instructions`) from the workflow's actual root rather
+   * than `process.cwd()`, which can drift when workflows are invoked
+   * programmatically or from a subdirectory.
+   */
+  projectRoot: string;
   agent: AgentType;
   /**
    * Structured inputs for this workflow run. Free-form workflows use
@@ -1284,6 +1292,7 @@ async function initProviderClientAndSession<A extends AgentType>(
   agent: A,
   serverUrl: string,
   paneId: string,
+  projectRoot: string,
   clientOpts: StageClientOptions<A>,
   sessionOpts: StageSessionOptions<A>,
   headless = false,
@@ -1340,7 +1349,7 @@ async function initProviderClientAndSession<A extends AgentType>(
       // the agent cannot call the interactive question tool — there is no
       // human attached to answer and the SDK would otherwise sit blocked.
       const additionalInstructions = await resolveAdditionalInstructionsContent(
-        process.cwd(),
+        projectRoot,
       );
       const sessionConfig = {
         onPermissionRequest: approveAll,
@@ -1409,7 +1418,7 @@ async function initProviderClientAndSession<A extends AgentType>(
         // tracks the latest one and exposes it as `sessionId`.
         const client = new HeadlessClaudeClientWrapper();
         await client.start();
-        const session = new HeadlessClaudeSessionWrapper();
+        const session = new HeadlessClaudeSessionWrapper(projectRoot);
         // Cast through `unknown` — `HeadlessClaudeClientWrapper` intentionally
         // omits the interactive-only fields (`paneId`, `sessionDir`, etc.)
         // that `ClaudeClientWrapper` has; both satisfy the same runtime
@@ -1691,6 +1700,7 @@ function createSessionRunner(
         shared.agent,
         serverUrl,
         paneId,
+        shared.projectRoot,
         clientOpts,
         sessionOpts,
         isHeadless,
@@ -2032,6 +2042,7 @@ export async function runOrchestrator(
   const shared: SharedRunnerState = {
     tmuxSessionName,
     sessionsBaseDir,
+    projectRoot: cwd,
     agent,
     inputs,
     providerOverrides,

--- a/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
@@ -2,33 +2,44 @@
  * deep-research-codebase / claude
  *
  * A deterministically-orchestrated, distributed codebase researcher built on
- * the Claude Agent SDK's native sub-agent dispatch. Specialist sub-agents
- * (codebase-locator / codebase-pattern-finder / codebase-analyzer /
- * codebase-online-researcher / codebase-research-locator /
- * codebase-research-analyzer) are spawned as separate headless `ctx.stage()`
- * calls — each binds the SDK's `agent` option to the desired specialist
- * instead of relying on a coordinator agent that dispatches them via the
- * `@"name (agent)"` prompt syntax.
+ * the Claude Agent SDK with **batched** Task-tool fan-out. Specialist
+ * sub-agents (codebase-locator / codebase-pattern-finder / codebase-analyzer
+ * / codebase-online-researcher) run inside batch sessions: each batch is a
+ * single `ctx.stage()` whose orchestrator turn dispatches up to
+ * MAX_TASKS_PER_BATCH (≈10) specialists in parallel via the Task tool.
+ * Research-history specialists (codebase-research-locator /
+ * codebase-research-analyzer) remain as their own small pipeline since they
+ * have a strict sequential dependency and run only twice per workflow.
  *
- * Why SDK primitives instead of in-prompt orchestration:
+ * Why batched Task-tool dispatch instead of one ctx.stage per specialist:
  *
- *   • Each specialist runs in an ISOLATED conversation. The locator's giant
- *     file index doesn't pollute the analyzer's context window, and the
- *     online-researcher doesn't see the analyzer's reasoning at all. This is
- *     `multi-agent-patterns` swarm-style isolation, not orchestrator-style.
+ *   • SDK-level fan-out scales by codebase size — at 5K LOC per partition
+ *     and 4 specialists per partition, a 750K-LOC codebase would otherwise
+ *     spawn 600 `claude` subprocesses. Batches of 10 cap that at ~60 SDK
+ *     sessions, with each session internally fanning out via Task tool.
  *
- *   • There is no orchestrator turn whose context grows linearly with the
- *     number of specialists. Token cost per partition is bounded by the four
- *     specialists' independent prompts — adding more partitions scales
- *     cleanly because every fan-out is a fresh session.
+ *   • ~10 parallel Task tool sub-agents per single message is the practical
+ *     ceiling before rate limits, context contention, and degraded
+ *     coordination kick in (no documented hard cap; tunable in
+ *     helpers/batching.ts).
  *
- *   • Failure of one specialist does not abort the partition mid-thought —
- *     the runtime fails the stage, but its siblings' outputs are still on
- *     disk and the aggregator can continue with whatever completed.
+ *   • Sub-agents still run in ISOLATED contexts — Task tool gives every
+ *     sub-agent its own conversation window, so the locator's file index
+ *     doesn't pollute the analyzer the way it would inside a shared
+ *     conversation. (multi-agent-patterns swarm isolation.)
  *
- *   • The synthesis step that combines specialist outputs is plain TypeScript
- *     (`renderExplorerMarkdown` in helpers/scratch.ts) — no extra LLM call
- *     just to concatenate four markdown sections.
+ *   • The orchestrator's turn does NOT grow linearly with sub-agent count:
+ *     each Task sub-agent writes its verbatim findings to a per-task scratch
+ *     file and returns just "DONE", so the orchestrator collects N short
+ *     confirmations rather than N transcripts (filesystem-context skill).
+ *
+ *   • Failure isolation is preserved at two levels: (1) Promise.allSettled
+ *     around the batches means one failed batch doesn't abort siblings;
+ *     (2) inside a batch, the orchestrator is instructed not to retry
+ *     failed Task sub-agents — the synthesis step tolerates missing files.
+ *
+ *   • Synthesis remains plain TypeScript (`renderExplorerMarkdown` in
+ *     helpers/scratch.ts) — no extra LLM call just to concatenate sections.
  *
  * Topology:
  *
@@ -38,27 +49,31 @@
  *                                       │
  *                                       ▼
  *   ┌──────────────────────────────────────────────────────────────────────┐
- *   │  Per-partition (Promise.all over partitions, all stages headless):    │
- *   │                                                                       │
- *   │     locator-i      ∥   pattern-finder-i        (Layer 1, parallel)    │
- *   │            │                                                          │
- *   │            ▼                                                          │
- *   │     analyzer-i     ∥   online-researcher-i     (Layer 2, parallel)    │
- *   │            │                                                          │
- *   │            ▼                                                          │
- *   │     deterministic write to scratch file (TS helper, no LLM)           │
+ *   │  Wave 1 (locator + pattern-finder, no inter-deps):                    │
+ *   │     wave1-batch-1  ∥  wave1-batch-2  ∥  ...  (Promise.allSettled)     │
+ *   │       └── each batch session: orchestrator dispatches ≤10 Task        │
+ *   │           sub-agents in one assistant message; each writes to disk    │
+ *   │                                       │                                │
+ *   │                                       ▼                                │
+ *   │  TS reads locator-i.md files from disk for Layer 2 prompts            │
+ *   │                                       │                                │
+ *   │                                       ▼                                │
+ *   │  Wave 2 (analyzer + online-researcher, embed locator output):         │
+ *   │     wave2-batch-1  ∥  wave2-batch-2  ∥  ...  (Promise.allSettled)     │
+ *   │                                       │                                │
+ *   │                                       ▼                                │
+ *   │  Per partition i: TS reads 4 specialist files + writes explorer-i.md  │
  *   └──────────────────────────────────────────────────────────────────────┘
  *                                       │
  *                                       ▼
  *                                  aggregator (visible)
  *
- * Specialist stages run headless (in-process via the Agent SDK's `query()`),
- * so they are transparent to the workflow graph. The visible nodes are just:
- *   parent → [codebase-scout] → aggregator
+ * Batch sessions are headless (transparent to the workflow graph). Visible
+ * nodes: parent → [codebase-scout] → aggregator.
  */
 
 import { defineWorkflow, extractAssistantText } from "../../../index.ts";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -73,6 +88,7 @@ import {
 import {
   buildAggregatorPrompt,
   buildAnalyzerPrompt,
+  buildBatchOrchestratorPrompt,
   buildHistoryAnalyzerPrompt,
   buildHistoryLocatorPrompt,
   buildLocatorPrompt,
@@ -80,18 +96,50 @@ import {
   buildPatternFinderPrompt,
   buildScoutPrompt,
   slugifyPrompt,
+  wrapPromptForTaskDispatch,
 } from "../helpers/prompts.ts";
 import { writeExplorerScratchFile } from "../helpers/scratch.ts";
+import {
+  chunkBatches,
+  MAX_TASKS_PER_BATCH,
+  SUBAGENT_TYPE,
+  type Layer1Task,
+  type Layer2Task,
+} from "../helpers/batching.ts";
 
 /**
  * Shared SDK options for every sub-agent dispatch. `permissionMode` +
  * `allowDangerouslySkipPermissions` are required so the headless sub-agents
- * can use Read/Grep/Glob/Bash without prompting (we are running unattended).
+ * can use Read/Grep/Glob/Bash/Write/Task without prompting (we are running
+ * unattended).
  */
 const SUBAGENT_OPTS = {
   permissionMode: "bypassPermissions",
   allowDangerouslySkipPermissions: true,
 } as const;
+
+/**
+ * SDK options for batch sessions. Pin the dispatcher to the `orchestrator`
+ * agent (.claude/agents/orchestrator.md) — its system prompt is purpose-built
+ * to delegate everything to sub-agents via the Task tool, and its tool list
+ * (`Bash, Agent, Edit, Grep, Glob, Read, Task*`) excludes Write/etc., so the
+ * dispatcher cannot wander off and start doing the specialists' work itself.
+ * The orchestrator agent definition pins `model: opus`; override here to
+ * Sonnet if the per-batch dispatcher cost matters more than reliability.
+ */
+const BATCH_DISPATCHER_OPTS = {
+  ...SUBAGENT_OPTS,
+  agent: "orchestrator",
+} as const;
+
+/** Read a file as UTF-8, returning empty string if missing or unreadable. */
+async function safeReadFile(absPath: string): Promise<string> {
+  try {
+    return await readFile(absPath, "utf8");
+  } catch {
+    return "";
+  }
+}
 
 export default defineWorkflow({
   name: "deep-research-codebase",
@@ -135,7 +183,9 @@ export default defineWorkflow({
           if (data.units.length === 0) {
             throw new Error(
               `deep-research-codebase: scout found no source files under ${root}. ` +
-                `Run from inside a code repository or check the CODE_EXTENSIONS list.`,
+                `Run from inside a code repository, or verify your files use a ` +
+                `recognized programming-language extension (sourced from GitHub ` +
+                `Linguist + sql/graphql/proto).`,
             );
           }
 
@@ -231,136 +281,221 @@ export default defineWorkflow({
     // read is safe (failure-modes F13).
     const scoutOverview = (await ctx.transcript(scout)).content;
 
-    // ── Stage 2: per-partition specialist fan-out ─────────────────────────
+    // ── Stage 2: batched specialist fan-out ───────────────────────────────
     //
-    // Per partition i:
-    //   Layer 1 (parallel):  locator-i     ∥  pattern-finder-i
-    //   Layer 2 (parallel):  analyzer-i    ∥  online-researcher-i   ← depend on locator-i
-    //   Synthesis (deterministic TS):      renderExplorerMarkdown → scratch file
+    // Two waves, each chunked into batches of MAX_TASKS_PER_BATCH (≈10):
     //
-    // All N partitions run as parallel branches of the outer Promise.all.
-    // Sub-agent stages are headless: invisible in the graph and bounded only
-    // by SDK concurrency. Information flow is forward-only and all context
-    // each specialist needs (research question, scope, scout overview, and —
-    // for layer 2 — locator output) is injected into the first prompt.
+    //   Wave 1: locator + pattern-finder (no inter-task dependencies)
+    //   Wave 2: analyzer + online-researcher (read locator output from disk)
+    //
+    // Each batch is a single headless ctx.stage whose orchestrator turn
+    // dispatches all of its tasks via the Task tool in one assistant
+    // message. Specialists write their verbatim findings to per-task
+    // scratch files; the orchestrator only sees per-task "DONE" tokens, so
+    // batch session context stays bounded by O(tasks_per_batch). Synthesis
+    // reads the per-task files from disk.
+
+    /** Per-partition output paths. Specialists write these; synthesis reads them. */
+    const taskPaths = (i: number) => ({
+      locator: path.join(scratchDir, `locator-${i}.md`),
+      patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
+      analyzer: path.join(scratchDir, `analyzer-${i}.md`),
+      online: path.join(scratchDir, `online-${i}.md`),
+    });
+
+    // Wave 1 task list — flat across partitions and specialist kinds so the
+    // chunker can fill batches uniformly. Mixed-kind batches are fine: the
+    // Task tool's `subagent_type` is set per call inside the orchestrator.
+    const wave1Tasks: Layer1Task[] = partitions.flatMap((partition, idx) => {
+      const i = idx + 1;
+      const paths = taskPaths(i);
+      return [
+        {
+          kind: "locator" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.locator,
+        },
+        {
+          kind: "pattern-finder" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.patternFinder,
+        },
+      ];
+    });
+
+    const wave1Batches = chunkBatches(wave1Tasks, MAX_TASKS_PER_BATCH);
+
+    // Wave 1: dispatch all batches in parallel. allSettled so a single batch
+    // failure doesn't abort siblings — synthesis tolerates missing files.
+    await Promise.allSettled(
+      wave1Batches.map((batch, batchIdx) => {
+        const batchNumber = batchIdx + 1;
+        return ctx.stage(
+          {
+            name: `wave1-batch-${batchNumber}`,
+            headless: true,
+            description: `Layer 1 dispatch (${batch.length} tasks)`,
+          },
+          {},
+          {},
+          async (s) => {
+            const taskSpecs = batch.map((t) => {
+              const builder =
+                t.kind === "locator" ? buildLocatorPrompt : buildPatternFinderPrompt;
+              const specialistPrompt = builder({
+                question: prompt,
+                partition: t.partition,
+                scoutOverview,
+                index: t.partitionIndex,
+                total: explorerCount,
+              });
+              return {
+                subagentType: SUBAGENT_TYPE[t.kind],
+                outputPath: t.outputPath,
+                prompt: wrapPromptForTaskDispatch({
+                  specialistPrompt,
+                  outputPath: t.outputPath,
+                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                }),
+              };
+            });
+
+            await s.session.query(
+              buildBatchOrchestratorPrompt({
+                wave: 1,
+                batchIndex: batchNumber,
+                totalBatches: wave1Batches.length,
+                tasks: taskSpecs,
+              }),
+              BATCH_DISPATCHER_OPTS,
+            );
+            s.save(s.sessionId);
+          },
+        );
+      }),
+    );
+
+    // Read locator outputs from disk for Wave 2 prompts. Layer 2 specialists
+    // embed the locator's verbatim output rather than re-discovering it.
+    const locatorOutputs: Map<number, string> = new Map();
+    await Promise.all(
+      partitions.map(async (_p, idx) => {
+        const i = idx + 1;
+        locatorOutputs.set(i, await safeReadFile(taskPaths(i).locator));
+      }),
+    );
+
+    const wave2Tasks: Layer2Task[] = partitions.flatMap((partition, idx) => {
+      const i = idx + 1;
+      const paths = taskPaths(i);
+      const locatorOutput = locatorOutputs.get(i) ?? "";
+      return [
+        {
+          kind: "analyzer" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.analyzer,
+          locatorOutput,
+        },
+        {
+          kind: "online-researcher" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.online,
+          locatorOutput,
+        },
+      ];
+    });
+
+    const wave2Batches = chunkBatches(wave2Tasks, MAX_TASKS_PER_BATCH);
+
+    await Promise.allSettled(
+      wave2Batches.map((batch, batchIdx) => {
+        const batchNumber = batchIdx + 1;
+        return ctx.stage(
+          {
+            name: `wave2-batch-${batchNumber}`,
+            headless: true,
+            description: `Layer 2 dispatch (${batch.length} tasks)`,
+          },
+          {},
+          {},
+          async (s) => {
+            const taskSpecs = batch.map((t) => {
+              const specialistPrompt =
+                t.kind === "analyzer"
+                  ? buildAnalyzerPrompt({
+                      question: prompt,
+                      partition: t.partition,
+                      locatorOutput: t.locatorOutput,
+                      scoutOverview,
+                      index: t.partitionIndex,
+                      total: explorerCount,
+                    })
+                  : buildOnlineResearcherPrompt({
+                      question: prompt,
+                      partition: t.partition,
+                      locatorOutput: t.locatorOutput,
+                      index: t.partitionIndex,
+                      total: explorerCount,
+                    });
+              return {
+                subagentType: SUBAGENT_TYPE[t.kind],
+                outputPath: t.outputPath,
+                prompt: wrapPromptForTaskDispatch({
+                  specialistPrompt,
+                  outputPath: t.outputPath,
+                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                }),
+              };
+            });
+
+            await s.session.query(
+              buildBatchOrchestratorPrompt({
+                wave: 2,
+                batchIndex: batchNumber,
+                totalBatches: wave2Batches.length,
+                tasks: taskSpecs,
+              }),
+              BATCH_DISPATCHER_OPTS,
+            );
+            s.save(s.sessionId);
+          },
+        );
+      }),
+    );
+
+    // Synthesis: read all four specialist files per partition, then write
+    // the consolidated explorer scratch file the aggregator consumes.
+    // Missing files fall back to "" so the synthesis tolerates partial
+    // batch failures — the aggregator's prompt already handles empty
+    // sections via _(no … produced)_ placeholders in renderExplorerMarkdown.
     const explorerHandles = await Promise.all(
       partitions.map(async (partition, idx) => {
         const i = idx + 1;
+        const paths = taskPaths(i);
         const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
 
-        // Layer 1: locator + pattern-finder run independently.
-        const [locator, patternFinder] = await Promise.all([
-          ctx.stage(
-            {
-              name: `locator-${i}`,
-              headless: true,
-              description: `codebase-locator over partition ${i}`,
-            },
-            {},
-            {},
-            async (s) => {
-              const result = await s.session.query(
-                buildLocatorPrompt({
-                  question: prompt,
-                  partition,
-                  scoutOverview,
-                  index: i,
-                  total: explorerCount,
-                }),
-                { agent: "codebase-locator", ...SUBAGENT_OPTS },
-              );
-              s.save(s.sessionId);
-              return extractAssistantText(result, 0);
-            },
-          ),
-          ctx.stage(
-            {
-              name: `pattern-finder-${i}`,
-              headless: true,
-              description: `codebase-pattern-finder over partition ${i}`,
-            },
-            {},
-            {},
-            async (s) => {
-              const result = await s.session.query(
-                buildPatternFinderPrompt({
-                  question: prompt,
-                  partition,
-                  scoutOverview,
-                  index: i,
-                  total: explorerCount,
-                }),
-                { agent: "codebase-pattern-finder", ...SUBAGENT_OPTS },
-              );
-              s.save(s.sessionId);
-              return extractAssistantText(result, 0);
-            },
-          ),
-        ]);
+        const [locatorOutput, patternsOutput, analyzerOutput, onlineOutput] =
+          await Promise.all([
+            // Layer 1 locator was already read into locatorOutputs above —
+            // reuse it instead of re-reading from disk.
+            Promise.resolve(locatorOutputs.get(i) ?? ""),
+            safeReadFile(paths.patternFinder),
+            safeReadFile(paths.analyzer),
+            safeReadFile(paths.online),
+          ]);
 
-        const locatorOutput = locator.result;
-        const patternsOutput = patternFinder.result;
-
-        // Layer 2: analyzer + online-researcher both consume locator output.
-        const [analyzer, onlineResearcher] = await Promise.all([
-          ctx.stage(
-            {
-              name: `analyzer-${i}`,
-              headless: true,
-              description: `codebase-analyzer over partition ${i}`,
-            },
-            {},
-            {},
-            async (s) => {
-              const result = await s.session.query(
-                buildAnalyzerPrompt({
-                  question: prompt,
-                  partition,
-                  locatorOutput,
-                  scoutOverview,
-                  index: i,
-                  total: explorerCount,
-                }),
-                { agent: "codebase-analyzer", ...SUBAGENT_OPTS },
-              );
-              s.save(s.sessionId);
-              return extractAssistantText(result, 0);
-            },
-          ),
-          ctx.stage(
-            {
-              name: `online-researcher-${i}`,
-              headless: true,
-              description: `codebase-online-researcher over partition ${i}`,
-            },
-            {},
-            {},
-            async (s) => {
-              const result = await s.session.query(
-                buildOnlineResearcherPrompt({
-                  question: prompt,
-                  partition,
-                  locatorOutput,
-                  index: i,
-                  total: explorerCount,
-                }),
-                { agent: "codebase-online-researcher", ...SUBAGENT_OPTS },
-              );
-              s.save(s.sessionId);
-              return extractAssistantText(result, 0);
-            },
-          ),
-        ]);
-
-        // Deterministic synthesis — no fifth LLM call just to concatenate.
         await writeExplorerScratchFile(scratchPath, {
           index: i,
           total: explorerCount,
           partition,
           locatorOutput,
           patternsOutput,
-          analyzerOutput: analyzer.result,
-          onlineOutput: onlineResearcher.result,
+          analyzerOutput,
+          onlineOutput,
         });
 
         return { index: i, scratchPath, partition };

--- a/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/claude/index.ts
@@ -141,6 +141,22 @@ async function safeReadFile(absPath: string): Promise<string> {
   }
 }
 
+/**
+ * Log Promise.allSettled rejection reasons to stderr so an all-failed wave
+ * leaves a debugging trail instead of silently producing an empty report.
+ */
+function logBatchRejections(
+  label: string,
+  results: PromiseSettledResult<unknown>[],
+): void {
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r?.status === "rejected") {
+      console.error(`[deep-research-codebase] ${label} batch ${i + 1} failed:`, r.reason);
+    }
+  }
+}
+
 export default defineWorkflow({
   name: "deep-research-codebase",
   description:
@@ -295,12 +311,18 @@ export default defineWorkflow({
     // batch session context stays bounded by O(tasks_per_batch). Synthesis
     // reads the per-task files from disk.
 
-    /** Per-partition output paths. Specialists write these; synthesis reads them. */
-    const taskPaths = (i: number) => ({
-      locator: path.join(scratchDir, `locator-${i}.md`),
-      patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
-      analyzer: path.join(scratchDir, `analyzer-${i}.md`),
-      online: path.join(scratchDir, `online-${i}.md`),
+    // Per-partition output paths, computed once and reused across both wave
+    // task-list construction and synthesis. Specialists write these;
+    // synthesis reads them.
+    const partitionPaths = partitions.map((_, idx) => {
+      const i = idx + 1;
+      return {
+        locator: path.join(scratchDir, `locator-${i}.md`),
+        patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
+        analyzer: path.join(scratchDir, `analyzer-${i}.md`),
+        online: path.join(scratchDir, `online-${i}.md`),
+        explorer: path.join(scratchDir, `explorer-${i}.md`),
+      };
     });
 
     // Wave 1 task list — flat across partitions and specialist kinds so the
@@ -308,7 +330,7 @@ export default defineWorkflow({
     // Task tool's `subagent_type` is set per call inside the orchestrator.
     const wave1Tasks: Layer1Task[] = partitions.flatMap((partition, idx) => {
       const i = idx + 1;
-      const paths = taskPaths(i);
+      const paths = partitionPaths[idx]!;
       return [
         {
           kind: "locator" as const,
@@ -329,7 +351,9 @@ export default defineWorkflow({
 
     // Wave 1: dispatch all batches in parallel. allSettled so a single batch
     // failure doesn't abort siblings — synthesis tolerates missing files.
-    await Promise.allSettled(
+    // Rejection reasons are logged so an empty report is debuggable; without
+    // this, an all-failed wave would silently produce a confidently empty doc.
+    const wave1Results = await Promise.allSettled(
       wave1Batches.map((batch, batchIdx) => {
         const batchNumber = batchIdx + 1;
         return ctx.stage(
@@ -357,7 +381,7 @@ export default defineWorkflow({
                 prompt: wrapPromptForTaskDispatch({
                   specialistPrompt,
                   outputPath: t.outputPath,
-                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                  agentLabel: t.kind.toUpperCase().replaceAll("-", "_"),
                 }),
               };
             });
@@ -376,6 +400,7 @@ export default defineWorkflow({
         );
       }),
     );
+    logBatchRejections("wave1", wave1Results);
 
     // Read locator outputs from disk for Wave 2 prompts. Layer 2 specialists
     // embed the locator's verbatim output rather than re-discovering it.
@@ -383,13 +408,13 @@ export default defineWorkflow({
     await Promise.all(
       partitions.map(async (_p, idx) => {
         const i = idx + 1;
-        locatorOutputs.set(i, await safeReadFile(taskPaths(i).locator));
+        locatorOutputs.set(i, await safeReadFile(partitionPaths[idx]!.locator));
       }),
     );
 
     const wave2Tasks: Layer2Task[] = partitions.flatMap((partition, idx) => {
       const i = idx + 1;
-      const paths = taskPaths(i);
+      const paths = partitionPaths[idx]!;
       const locatorOutput = locatorOutputs.get(i) ?? "";
       return [
         {
@@ -411,7 +436,7 @@ export default defineWorkflow({
 
     const wave2Batches = chunkBatches(wave2Tasks, MAX_TASKS_PER_BATCH);
 
-    await Promise.allSettled(
+    const wave2Results = await Promise.allSettled(
       wave2Batches.map((batch, batchIdx) => {
         const batchNumber = batchIdx + 1;
         return ctx.stage(
@@ -447,7 +472,7 @@ export default defineWorkflow({
                 prompt: wrapPromptForTaskDispatch({
                   specialistPrompt,
                   outputPath: t.outputPath,
-                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                  agentLabel: t.kind.toUpperCase().replaceAll("-", "_"),
                 }),
               };
             });
@@ -466,6 +491,7 @@ export default defineWorkflow({
         );
       }),
     );
+    logBatchRejections("wave2", wave2Results);
 
     // Synthesis: read all four specialist files per partition, then write
     // the consolidated explorer scratch file the aggregator consumes.
@@ -475,8 +501,7 @@ export default defineWorkflow({
     const explorerHandles = await Promise.all(
       partitions.map(async (partition, idx) => {
         const i = idx + 1;
-        const paths = taskPaths(i);
-        const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
+        const paths = partitionPaths[idx]!;
 
         const [locatorOutput, patternsOutput, analyzerOutput, onlineOutput] =
           await Promise.all([
@@ -488,7 +513,7 @@ export default defineWorkflow({
             safeReadFile(paths.online),
           ]);
 
-        await writeExplorerScratchFile(scratchPath, {
+        await writeExplorerScratchFile(paths.explorer, {
           index: i,
           total: explorerCount,
           partition,
@@ -498,7 +523,7 @@ export default defineWorkflow({
           onlineOutput,
         });
 
-        return { index: i, scratchPath, partition };
+        return { index: i, scratchPath: paths.explorer, partition };
       }),
     );
 

--- a/src/sdk/workflows/builtin/deep-research-codebase/copilot/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/copilot/index.ts
@@ -91,6 +91,22 @@ async function safeReadFile(absPath: string): Promise<string> {
   }
 }
 
+/**
+ * Log Promise.allSettled rejection reasons to stderr so an all-failed wave
+ * leaves a debugging trail instead of silently producing an empty report.
+ */
+function logBatchRejections(
+  label: string,
+  results: PromiseSettledResult<unknown>[],
+): void {
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r?.status === "rejected") {
+      console.error(`[deep-research-codebase] ${label} batch ${i + 1} failed:`, r.reason);
+    }
+  }
+}
+
 export default defineWorkflow({
   name: "deep-research-codebase",
   description:
@@ -228,16 +244,22 @@ export default defineWorkflow({
     // everything via the `agent`/Task tool, so the dispatcher cannot wander
     // off and start doing the specialists' work itself.
 
-    const taskPaths = (i: number) => ({
-      locator: path.join(scratchDir, `locator-${i}.md`),
-      patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
-      analyzer: path.join(scratchDir, `analyzer-${i}.md`),
-      online: path.join(scratchDir, `online-${i}.md`),
+    // Per-partition output paths, computed once and reused across both wave
+    // task-list construction and synthesis.
+    const partitionPaths = partitions.map((_, idx) => {
+      const i = idx + 1;
+      return {
+        locator: path.join(scratchDir, `locator-${i}.md`),
+        patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
+        analyzer: path.join(scratchDir, `analyzer-${i}.md`),
+        online: path.join(scratchDir, `online-${i}.md`),
+        explorer: path.join(scratchDir, `explorer-${i}.md`),
+      };
     });
 
     const wave1Tasks: Layer1Task[] = partitions.flatMap((partition, idx) => {
       const i = idx + 1;
-      const paths = taskPaths(i);
+      const paths = partitionPaths[idx]!;
       return [
         {
           kind: "locator" as const,
@@ -256,7 +278,7 @@ export default defineWorkflow({
 
     const wave1Batches = chunkBatches(wave1Tasks, MAX_TASKS_PER_BATCH);
 
-    await Promise.allSettled(
+    const wave1Results = await Promise.allSettled(
       wave1Batches.map((batch, batchIdx) => {
         const batchNumber = batchIdx + 1;
         return ctx.stage(
@@ -284,7 +306,7 @@ export default defineWorkflow({
                 prompt: wrapPromptForTaskDispatch({
                   specialistPrompt,
                   outputPath: t.outputPath,
-                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                  agentLabel: t.kind.toUpperCase().replaceAll("-", "_"),
                 }),
               };
             });
@@ -302,18 +324,19 @@ export default defineWorkflow({
         );
       }),
     );
+    logBatchRejections("wave1", wave1Results);
 
     const locatorOutputs: Map<number, string> = new Map();
     await Promise.all(
       partitions.map(async (_p, idx) => {
         const i = idx + 1;
-        locatorOutputs.set(i, await safeReadFile(taskPaths(i).locator));
+        locatorOutputs.set(i, await safeReadFile(partitionPaths[idx]!.locator));
       }),
     );
 
     const wave2Tasks: Layer2Task[] = partitions.flatMap((partition, idx) => {
       const i = idx + 1;
-      const paths = taskPaths(i);
+      const paths = partitionPaths[idx]!;
       const locatorOutput = locatorOutputs.get(i) ?? "";
       return [
         {
@@ -335,7 +358,7 @@ export default defineWorkflow({
 
     const wave2Batches = chunkBatches(wave2Tasks, MAX_TASKS_PER_BATCH);
 
-    await Promise.allSettled(
+    const wave2Results = await Promise.allSettled(
       wave2Batches.map((batch, batchIdx) => {
         const batchNumber = batchIdx + 1;
         return ctx.stage(
@@ -371,7 +394,7 @@ export default defineWorkflow({
                 prompt: wrapPromptForTaskDispatch({
                   specialistPrompt,
                   outputPath: t.outputPath,
-                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                  agentLabel: t.kind.toUpperCase().replaceAll("-", "_"),
                 }),
               };
             });
@@ -389,6 +412,7 @@ export default defineWorkflow({
         );
       }),
     );
+    logBatchRejections("wave2", wave2Results);
 
     // Synthesis: read all four specialist files per partition and write the
     // consolidated explorer scratch file. Missing files fall back to "" so
@@ -396,8 +420,7 @@ export default defineWorkflow({
     const explorerHandles = await Promise.all(
       partitions.map(async (partition, idx) => {
         const i = idx + 1;
-        const paths = taskPaths(i);
-        const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
+        const paths = partitionPaths[idx]!;
 
         const [locatorOutput, patternsOutput, analyzerOutput, onlineOutput] =
           await Promise.all([
@@ -407,7 +430,7 @@ export default defineWorkflow({
             safeReadFile(paths.online),
           ]);
 
-        await writeExplorerScratchFile(scratchPath, {
+        await writeExplorerScratchFile(paths.explorer, {
           index: i,
           total: explorerCount,
           partition,
@@ -417,7 +440,7 @@ export default defineWorkflow({
           onlineOutput,
         });
 
-        return { index: i, scratchPath, partition };
+        return { index: i, scratchPath: paths.explorer, partition };
       }),
     );
 

--- a/src/sdk/workflows/builtin/deep-research-codebase/copilot/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/copilot/index.ts
@@ -1,34 +1,36 @@
 /**
  * deep-research-codebase / copilot
  *
- * Copilot replica of the Claude deep-research-codebase workflow. Specialist
- * sub-agents are dispatched as separate headless `ctx.stage()` calls — each
- * binds the SDK's session to a single named agent via `sessionOpts: { agent }`,
- * which is the SDK-native way to spawn a sub-agent on Copilot.
+ * Copilot replica of the Claude deep-research-codebase workflow with the
+ * same **batched** Task-tool fan-out. Specialist sub-agents run inside batch
+ * sessions: each batch is a single `ctx.stage()` whose orchestrator turn
+ * dispatches up to MAX_TASKS_PER_BATCH (≈10) specialists in parallel via
+ * Copilot's `agent` tool (alias `Task`, see Copilot subagents docs).
+ * Research-history specialists remain as their own sequential sub-pipeline.
+ *
+ * See claude/index.ts for the full design rationale and topology diagram.
  *
  * Copilot-specific concerns baked in (see references/failure-modes.md):
  *
- *   • F5 — every `ctx.stage()` is a FRESH session. Each specialist receives
- *     everything it needs (research question, scope, scout overview, and —
- *     for layer-2 specialists — verbatim locator output) in its first prompt.
- *
  *   • F1 — Copilot's last assistant turn is often empty when the agent ends
- *     on a tool call. We use `getAssistantText()` (canonical concatenation
- *     of every top-level non-empty assistant turn, ignoring sub-agent
- *     `parentToolCallId` traffic) instead of `.at(-1).data.content`.
+ *     on a tool call. Batch sessions don't read `getAssistantText` for the
+ *     orchestrator output (sub-agents write to disk; the orchestrator's text
+ *     reply is just a short tally), so this is no longer load-bearing for
+ *     Stage 2 — but the history pipeline still depends on it.
  *
- *   • F6 — every prompt explicitly requires trailing prose AFTER any tool
- *     call so `getAssistantText()` and downstream `transcript()` reads are
- *     never empty.
+ *   • F5 — every `ctx.stage()` is a FRESH session. Batch session prompts
+ *     embed everything the orchestrator needs (per-task subagent_type,
+ *     output path, and verbatim specialist prompt) in the first turn.
+ *
+ *   • F6 — orchestrator prompt requires a single-line tally as the trailing
+ *     turn so transcripts are never empty.
  *
  *   • F9 — `s.save()` receives `SessionEvent[]` from `s.session.getMessages()`.
- *
- * See claude/index.ts for the full design rationale and topology diagram.
  */
 
 import { defineWorkflow } from "../../../index.ts";
 import type { SessionEvent } from "@github/copilot-sdk";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -43,6 +45,7 @@ import {
 import {
   buildAggregatorPrompt,
   buildAnalyzerPrompt,
+  buildBatchOrchestratorPrompt,
   buildHistoryAnalyzerPrompt,
   buildHistoryLocatorPrompt,
   buildLocatorPrompt,
@@ -50,13 +53,23 @@ import {
   buildPatternFinderPrompt,
   buildScoutPrompt,
   slugifyPrompt,
+  wrapPromptForTaskDispatch,
 } from "../helpers/prompts.ts";
 import { writeExplorerScratchFile } from "../helpers/scratch.ts";
+import {
+  chunkBatches,
+  MAX_TASKS_PER_BATCH,
+  SUBAGENT_TYPE,
+  type Layer1Task,
+  type Layer2Task,
+} from "../helpers/batching.ts";
 
 /**
  * Concatenate every top-level assistant turn's non-empty content. The final
  * `assistant.message` of a Copilot turn is often empty when the agent ends
  * on a tool call (F1), and sub-agent traffic is signalled by `parentToolCallId`.
+ * Used for the history pipeline only — batch sessions don't need this since
+ * sub-agents write to disk.
  */
 function getAssistantText(messages: SessionEvent[]): string {
   return messages
@@ -67,6 +80,15 @@ function getAssistantText(messages: SessionEvent[]): string {
     .map((m) => m.data.content)
     .filter((c) => c.length > 0)
     .join("\n\n");
+}
+
+/** Read a file as UTF-8, returning empty string if missing or unreadable. */
+async function safeReadFile(absPath: string): Promise<string> {
+  try {
+    return await readFile(absPath, "utf8");
+  } catch {
+    return "";
+  }
 }
 
 export default defineWorkflow({
@@ -105,7 +127,9 @@ export default defineWorkflow({
           if (data.units.length === 0) {
             throw new Error(
               `deep-research-codebase: scout found no source files under ${root}. ` +
-                `Run from inside a code repository or check the CODE_EXTENSIONS list.`,
+                `Run from inside a code repository, or verify your files use a ` +
+                `recognized programming-language extension (sourced from GitHub ` +
+                `Linguist + sql/graphql/proto).`,
             );
           }
 
@@ -196,115 +220,192 @@ export default defineWorkflow({
 
     const scoutOverview = (await ctx.transcript(scout)).content;
 
-    // ── Stage 2: per-partition specialist fan-out ─────────────────────────
+    // ── Stage 2: batched specialist fan-out ───────────────────────────────
+    //
+    // Same two-wave batched design as claude/index.ts. Each batch session
+    // pins the dispatcher to the `orchestrator` agent (.github/agents/
+    // orchestrator.md) — its system prompt is purpose-built to delegate
+    // everything via the `agent`/Task tool, so the dispatcher cannot wander
+    // off and start doing the specialists' work itself.
+
+    const taskPaths = (i: number) => ({
+      locator: path.join(scratchDir, `locator-${i}.md`),
+      patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
+      analyzer: path.join(scratchDir, `analyzer-${i}.md`),
+      online: path.join(scratchDir, `online-${i}.md`),
+    });
+
+    const wave1Tasks: Layer1Task[] = partitions.flatMap((partition, idx) => {
+      const i = idx + 1;
+      const paths = taskPaths(i);
+      return [
+        {
+          kind: "locator" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.locator,
+        },
+        {
+          kind: "pattern-finder" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.patternFinder,
+        },
+      ];
+    });
+
+    const wave1Batches = chunkBatches(wave1Tasks, MAX_TASKS_PER_BATCH);
+
+    await Promise.allSettled(
+      wave1Batches.map((batch, batchIdx) => {
+        const batchNumber = batchIdx + 1;
+        return ctx.stage(
+          {
+            name: `wave1-batch-${batchNumber}`,
+            headless: true,
+            description: `Layer 1 dispatch (${batch.length} tasks)`,
+          },
+          {},
+          { agent: "orchestrator" },
+          async (s) => {
+            const taskSpecs = batch.map((t) => {
+              const builder =
+                t.kind === "locator" ? buildLocatorPrompt : buildPatternFinderPrompt;
+              const specialistPrompt = builder({
+                question: prompt,
+                partition: t.partition,
+                scoutOverview,
+                index: t.partitionIndex,
+                total: explorerCount,
+              });
+              return {
+                subagentType: SUBAGENT_TYPE[t.kind],
+                outputPath: t.outputPath,
+                prompt: wrapPromptForTaskDispatch({
+                  specialistPrompt,
+                  outputPath: t.outputPath,
+                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                }),
+              };
+            });
+
+            await s.session.send({
+              prompt: buildBatchOrchestratorPrompt({
+                wave: 1,
+                batchIndex: batchNumber,
+                totalBatches: wave1Batches.length,
+                tasks: taskSpecs,
+              }),
+            });
+            s.save(await s.session.getMessages());
+          },
+        );
+      }),
+    );
+
+    const locatorOutputs: Map<number, string> = new Map();
+    await Promise.all(
+      partitions.map(async (_p, idx) => {
+        const i = idx + 1;
+        locatorOutputs.set(i, await safeReadFile(taskPaths(i).locator));
+      }),
+    );
+
+    const wave2Tasks: Layer2Task[] = partitions.flatMap((partition, idx) => {
+      const i = idx + 1;
+      const paths = taskPaths(i);
+      const locatorOutput = locatorOutputs.get(i) ?? "";
+      return [
+        {
+          kind: "analyzer" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.analyzer,
+          locatorOutput,
+        },
+        {
+          kind: "online-researcher" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.online,
+          locatorOutput,
+        },
+      ];
+    });
+
+    const wave2Batches = chunkBatches(wave2Tasks, MAX_TASKS_PER_BATCH);
+
+    await Promise.allSettled(
+      wave2Batches.map((batch, batchIdx) => {
+        const batchNumber = batchIdx + 1;
+        return ctx.stage(
+          {
+            name: `wave2-batch-${batchNumber}`,
+            headless: true,
+            description: `Layer 2 dispatch (${batch.length} tasks)`,
+          },
+          {},
+          { agent: "orchestrator" },
+          async (s) => {
+            const taskSpecs = batch.map((t) => {
+              const specialistPrompt =
+                t.kind === "analyzer"
+                  ? buildAnalyzerPrompt({
+                      question: prompt,
+                      partition: t.partition,
+                      locatorOutput: t.locatorOutput,
+                      scoutOverview,
+                      index: t.partitionIndex,
+                      total: explorerCount,
+                    })
+                  : buildOnlineResearcherPrompt({
+                      question: prompt,
+                      partition: t.partition,
+                      locatorOutput: t.locatorOutput,
+                      index: t.partitionIndex,
+                      total: explorerCount,
+                    });
+              return {
+                subagentType: SUBAGENT_TYPE[t.kind],
+                outputPath: t.outputPath,
+                prompt: wrapPromptForTaskDispatch({
+                  specialistPrompt,
+                  outputPath: t.outputPath,
+                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                }),
+              };
+            });
+
+            await s.session.send({
+              prompt: buildBatchOrchestratorPrompt({
+                wave: 2,
+                batchIndex: batchNumber,
+                totalBatches: wave2Batches.length,
+                tasks: taskSpecs,
+              }),
+            });
+            s.save(await s.session.getMessages());
+          },
+        );
+      }),
+    );
+
+    // Synthesis: read all four specialist files per partition and write the
+    // consolidated explorer scratch file. Missing files fall back to "" so
+    // partial batch failures degrade gracefully.
     const explorerHandles = await Promise.all(
       partitions.map(async (partition, idx) => {
         const i = idx + 1;
+        const paths = taskPaths(i);
         const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
 
-        // Layer 1: locator + pattern-finder run independently.
-        const [locator, patternFinder] = await Promise.all([
-          ctx.stage(
-            {
-              name: `locator-${i}`,
-              headless: true,
-              description: `codebase-locator over partition ${i}`,
-            },
-            {},
-            { agent: "codebase-locator" },
-            async (s) => {
-              await s.session.send({
-                prompt: buildLocatorPrompt({
-                  question: prompt,
-                  partition,
-                  scoutOverview,
-                  index: i,
-                  total: explorerCount,
-                }),
-              });
-              const messages = await s.session.getMessages();
-              s.save(messages);
-              return getAssistantText(messages);
-            },
-          ),
-          ctx.stage(
-            {
-              name: `pattern-finder-${i}`,
-              headless: true,
-              description: `codebase-pattern-finder over partition ${i}`,
-            },
-            {},
-            { agent: "codebase-pattern-finder" },
-            async (s) => {
-              await s.session.send({
-                prompt: buildPatternFinderPrompt({
-                  question: prompt,
-                  partition,
-                  scoutOverview,
-                  index: i,
-                  total: explorerCount,
-                }),
-              });
-              const messages = await s.session.getMessages();
-              s.save(messages);
-              return getAssistantText(messages);
-            },
-          ),
-        ]);
-
-        const locatorOutput = locator.result;
-        const patternsOutput = patternFinder.result;
-
-        // Layer 2: analyzer + online-researcher consume locator output.
-        const [analyzer, onlineResearcher] = await Promise.all([
-          ctx.stage(
-            {
-              name: `analyzer-${i}`,
-              headless: true,
-              description: `codebase-analyzer over partition ${i}`,
-            },
-            {},
-            { agent: "codebase-analyzer" },
-            async (s) => {
-              await s.session.send({
-                prompt: buildAnalyzerPrompt({
-                  question: prompt,
-                  partition,
-                  locatorOutput,
-                  scoutOverview,
-                  index: i,
-                  total: explorerCount,
-                }),
-              });
-              const messages = await s.session.getMessages();
-              s.save(messages);
-              return getAssistantText(messages);
-            },
-          ),
-          ctx.stage(
-            {
-              name: `online-researcher-${i}`,
-              headless: true,
-              description: `codebase-online-researcher over partition ${i}`,
-            },
-            {},
-            { agent: "codebase-online-researcher" },
-            async (s) => {
-              await s.session.send({
-                prompt: buildOnlineResearcherPrompt({
-                  question: prompt,
-                  partition,
-                  locatorOutput,
-                  index: i,
-                  total: explorerCount,
-                }),
-              });
-              const messages = await s.session.getMessages();
-              s.save(messages);
-              return getAssistantText(messages);
-            },
-          ),
-        ]);
+        const [locatorOutput, patternsOutput, analyzerOutput, onlineOutput] =
+          await Promise.all([
+            Promise.resolve(locatorOutputs.get(i) ?? ""),
+            safeReadFile(paths.patternFinder),
+            safeReadFile(paths.analyzer),
+            safeReadFile(paths.online),
+          ]);
 
         await writeExplorerScratchFile(scratchPath, {
           index: i,
@@ -312,8 +413,8 @@ export default defineWorkflow({
           partition,
           locatorOutput,
           patternsOutput,
-          analyzerOutput: analyzer.result,
-          onlineOutput: onlineResearcher.result,
+          analyzerOutput,
+          onlineOutput,
         });
 
         return { index: i, scratchPath, partition };

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/batching.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/batching.ts
@@ -1,0 +1,65 @@
+/**
+ * Batching primitives for the deep-research-codebase workflow.
+ *
+ * The workflow caps SDK-level fan-out by grouping specialist invocations into
+ * "batch sessions" — one `ctx.stage()` per batch. Inside each batch session,
+ * the default Claude Code agent dispatches up to MAX_TASKS_PER_BATCH
+ * sub-agents in parallel via the Task tool. This keeps the parallel SDK
+ * subprocess count proportional to (specialists / 10) rather than to
+ * specialists itself, which scales linearly with codebase size.
+ *
+ * The per-message Task fan-out cap is empirical: there's no documented hard
+ * limit, but ~10 parallel sub-agents per single message is the reliable
+ * ceiling before rate limits, context contention, and degraded coordination
+ * kick in. Lower this if you see batch sessions stalling or returning
+ * partial completions; raise it only after measuring.
+ */
+
+import type { PartitionUnit } from "./scout.ts";
+
+/** Maximum Task-tool sub-agent dispatches per single batch session. */
+export const MAX_TASKS_PER_BATCH = 10;
+
+/** Specialist kinds that share Layer 1 (no inter-task dependencies). */
+export type Layer1Kind = "locator" | "pattern-finder";
+
+/** Specialist kinds that share Layer 2 (depend on Layer 1 locator output). */
+export type Layer2Kind = "analyzer" | "online-researcher";
+
+/** Maps a specialist kind to the Claude agent name it dispatches as. */
+export const SUBAGENT_TYPE: Record<Layer1Kind | Layer2Kind, string> = {
+  locator: "codebase-locator",
+  "pattern-finder": "codebase-pattern-finder",
+  analyzer: "codebase-analyzer",
+  "online-researcher": "codebase-online-researcher",
+};
+
+export type Layer1Task = {
+  kind: Layer1Kind;
+  partitionIndex: number;
+  partition: PartitionUnit[];
+  /** Absolute path the sub-agent must write its verbatim findings to. */
+  outputPath: string;
+};
+
+export type Layer2Task = {
+  kind: Layer2Kind;
+  partitionIndex: number;
+  partition: PartitionUnit[];
+  outputPath: string;
+  /** Verbatim locator text for this partition, embedded into the prompt. */
+  locatorOutput: string;
+};
+
+/** Split a flat task list into fixed-size chunks (last chunk may be smaller). */
+export function chunkBatches<T>(
+  items: T[],
+  size: number = MAX_TASKS_PER_BATCH,
+): T[][] {
+  if (size <= 0) throw new Error("chunkBatches: size must be > 0");
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/ignore-by-default.d.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/ignore-by-default.d.ts
@@ -1,0 +1,8 @@
+// `ignore-by-default` ships no .d.ts and `@types/ignore-by-default` is an
+// empty placeholder package. Declare the surface we use here so the import
+// in scout.ts type-checks. The runtime API is a single CJS export:
+// `module.exports.directories(): string[]`.
+declare module "ignore-by-default" {
+  const ibd: { directories(): string[] };
+  export default ibd;
+}

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/prompts.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/prompts.ts
@@ -49,6 +49,14 @@ const TRAILING_PROSE_REMINDER =
   "Do NOT end the turn on a tool call — downstream stages read your assistant " +
   "transcript and will see nothing if the final message is a tool invocation.";
 
+const AST_GREP_ENV_NOTICE =
+  "You are operating in an environment where ast-grep is installed. For any " +
+  "code search that requires understanding of syntax or code structure, you " +
+  "should default to using `ast-grep --lang [language] -p '<pattern>'`. Rely " +
+  "on your ast-grep skill for best practices. Adjust the --lang flag as " +
+  "needed for the specific programming language. Avoid using text-only " +
+  "search tools unless a plain-text search is explicitly requested.";
+
 /** Slugify the user's prompt for use in the final research filename. */
 export function slugifyPrompt(prompt: string): string {
   const slug = prompt
@@ -78,8 +86,15 @@ function renderPartitionDirs(partition: PartitionUnit[]): string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Stage 1a — codebase-scout (single LLM orientation call)
+// Stage 1a — codebase-scout + query planner (single LLM call)
 // ─────────────────────────────────────────────────────────────────────────────
+//
+// The scout produces both a ≤300-word architectural orientation AND a list of
+// per-partition ast-grep query seeds. The combined output is embedded verbatim
+// into each specialist sub-agent's prompt as a single <ARCHITECTURAL_ORIENTATION>
+// block — no JSON envelope, no deterministic parser. Specialists locate "their"
+// partition's seeds by searching for the matching section header inside the
+// block and treat them as starting points, not commands.
 
 export function buildScoutPrompt(opts: {
   question: string;
@@ -103,8 +118,9 @@ export function buildScoutPrompt(opts: {
     `</RESEARCH_QUESTION>`,
     ``,
     `<CONTEXT>`,
-    `You are the codebase scout for the deep-research-codebase workflow. The`,
-    `workflow has already computed the codebase layout deterministically:`,
+    `You are the codebase scout AND query planner for the deep-research-codebase`,
+    `workflow. The workflow has already computed the codebase layout`,
+    `deterministically:`,
     ``,
     `- Total source files: ${opts.totalFiles.toLocaleString()}`,
     `- Total LOC: ${opts.totalLoc.toLocaleString()}`,
@@ -119,25 +135,49 @@ export function buildScoutPrompt(opts: {
     "```",
     `</CONTEXT>`,
     ``,
-    `<TASK>`,
-    `Read the tree above and produce a brief architectural orientation that`,
-    `the downstream specialist sub-agents will use to anchor their searches.`,
+    `<TOOLING>`,
+    AST_GREP_ENV_NOTICE,
+    `Consult https://ast-grep.github.io/reference/languages.html for the`,
+    `canonical language list, and https://ast-grep.github.io/llms-full.txt for`,
+    `the full rule reference, when you need them.`,
+    `</TOOLING>`,
     ``,
-    `Cover, in ≤300 words:`,
+    `<TASK>`,
+    `Produce TWO sections — both will be embedded verbatim into the specialist`,
+    `sub-agents' prompts. Use the markdown headers shown so specialists can`,
+    `find their partition's seeds.`,
+    ``,
+    `## Orientation`,
+    `In ≤300 words, cover:`,
     `  1. The repo's overall shape (monorepo vs single package, polyglot or not)`,
     `  2. The 3-5 most important top-level directories and what each contains`,
-    `  3. Architectural boundaries / layering you can see from the tree`,
+    `  3. Architectural boundaries / layering visible from the tree`,
     `  4. Where entry points or main modules likely live`,
     ``,
-    `Do NOT attempt to answer the research question yet — your job is`,
-    `orientation for downstream specialists, not investigation. You may use`,
-    `Read/Glob/Grep sparingly to verify guesses about a few key files,`,
-    `but keep the output short.`,
+    `## Query Seeds`,
+    `For each of the ${opts.explorerCount} partitions, suggest 2-4 ast-grep`,
+    `query seeds the specialists could start from. Format each seed as:`,
+    ``,
+    `### Partition <n>`,
+    `- Query: \`ast-grep --lang <language> -p '<pattern>'\``,
+    `  Why: <one sentence>`,
+    ``,
+    `For structural rules (kind + has/inside), use a fenced YAML block instead`,
+    `of the \`-p\` form, with the same Why line.`,
+    ``,
+    `Seeds are starting points, not commands — specialists adapt as they find`,
+    `things. If a partition is clearly irrelevant to the question, write a`,
+    `single-line note explaining why and skip its seeds.`,
     `</TASK>`,
     ``,
     `<CONSTRAINTS>`,
     DOCUMENTARIAN_DISCLAIMER,
-    `Stay under 300 words. No bullet lists longer than 5 items.`,
+    `Do NOT investigate the codebase to answer the question yourself — your`,
+    `job is orientation + seeding, not investigation. You may use Read/Glob/`,
+    `Grep/ast-grep sparingly to verify guesses about a few key files or to`,
+    `confirm a pattern parses, but keep output focused.`,
+    `Stay under 300 words for the Orientation section. Plain markdown only —`,
+    `no JSON envelope, no structured output.`,
     TRAILING_PROSE_REMINDER,
     `</CONSTRAINTS>`,
     ``,
@@ -186,7 +226,16 @@ export function buildLocatorPrompt(opts: {
     `relates to the research question, and return a categorized index.`,
     `</MISSION>`,
     ``,
+    `<TOOLING>`,
+    AST_GREP_ENV_NOTICE,
+    `</TOOLING>`,
+    ``,
     `<ARCHITECTURAL_ORIENTATION>`,
+    `The briefing below contains both a high-level orientation AND per-partition`,
+    `ast-grep query seeds. Find the **Partition ${opts.index}** section for the`,
+    `seeds scoped to your investigation — treat them as starting points, not`,
+    `commands. Adapt or skip seeds that don't fit what you actually find.`,
+    ``,
     orientation,
     `</ARCHITECTURAL_ORIENTATION>`,
     ``,
@@ -267,7 +316,16 @@ export function buildPatternFinderPrompt(opts: {
     `Return runnable-looking snippets, not abstract descriptions.`,
     `</MISSION>`,
     ``,
+    `<TOOLING>`,
+    AST_GREP_ENV_NOTICE,
+    `</TOOLING>`,
+    ``,
     `<ARCHITECTURAL_ORIENTATION>`,
+    `The briefing below contains both a high-level orientation AND per-partition`,
+    `ast-grep query seeds. Find the **Partition ${opts.index}** section for the`,
+    `seeds scoped to your investigation — treat them as starting points, not`,
+    `commands. Adapt or skip seeds that don't fit what you actually find.`,
+    ``,
     orientation,
     `</ARCHITECTURAL_ORIENTATION>`,
     ``,
@@ -337,7 +395,16 @@ export function buildAnalyzerPrompt(opts: {
     `precise \`file.ts:line\` references throughout.`,
     `</MISSION>`,
     ``,
+    `<TOOLING>`,
+    AST_GREP_ENV_NOTICE,
+    `</TOOLING>`,
+    ``,
     `<ARCHITECTURAL_ORIENTATION>`,
+    `The briefing below contains both a high-level orientation AND per-partition`,
+    `ast-grep query seeds. Find the **Partition ${opts.index}** section for the`,
+    `seeds scoped to your investigation — treat them as starting points, not`,
+    `commands. Adapt or skip seeds that don't fit what you actually find.`,
+    ``,
     orientation,
     `</ARCHITECTURAL_ORIENTATION>`,
     ``,
@@ -763,5 +830,129 @@ export function buildAggregatorPrompt(opts: {
     `<RESEARCH_QUESTION_REMINDER>`,
     opts.question,
     `</RESEARCH_QUESTION_REMINDER>`,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stage 2 — batched specialist dispatch (Task-tool fan-out)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// To cap parallel SDK subprocesses, specialist invocations are grouped into
+// "batch sessions" (see helpers/batching.ts). Each batch session is a single
+// Claude Agent SDK call whose main thread dispatches up to N sub-agents via
+// the Task tool. The sub-agents write their verbatim findings to per-task
+// scratch files and reply with a single confirmation token, so the
+// orchestrator's context grows by N short lines rather than N transcripts
+// (filesystem-context skill).
+
+/**
+ * Wrap a specialist prompt with the "write to file, reply with token only"
+ * envelope. The envelope is what the orchestrator hands to the Task tool's
+ * `prompt` parameter — the inner specialist prompt is built by the existing
+ * `buildLocatorPrompt` / `buildPatternFinderPrompt` / etc. and embedded
+ * verbatim so prompt semantics stay identical to the unbatched workflow.
+ */
+export function wrapPromptForTaskDispatch(opts: {
+  specialistPrompt: string;
+  outputPath: string;
+  agentLabel: string;
+}): string {
+  return [
+    `<TASK_OUTPUT_CONTRACT>`,
+    `Write your COMPLETE response — the verbatim markdown findings exactly as`,
+    `the prompt below specifies — to this absolute path using the Write tool:`,
+    ``,
+    `  ${opts.outputPath}`,
+    ``,
+    `Then reply with exactly the single token "DONE" and nothing else. Your`,
+    `parent only needs confirmation; the file is the real output. Do NOT`,
+    `inline your findings into your reply, do NOT add commentary, do NOT`,
+    `summarise — just write the file, then reply "DONE".`,
+    ``,
+    `If you cannot produce useful findings (e.g. the partition has nothing`,
+    `relevant to the question), write a one-line sentinel to the file`,
+    `explaining why, then still reply "DONE". Reply with`,
+    `"FAILED: <one-line reason>" only if you could not even write the file.`,
+    `</TASK_OUTPUT_CONTRACT>`,
+    ``,
+    `<${opts.agentLabel}_TASK>`,
+    opts.specialistPrompt,
+    `</${opts.agentLabel}_TASK>`,
+  ].join("\n");
+}
+
+/**
+ * Build the orchestrator prompt for a batch session. The orchestrator's job
+ * is purely deterministic dispatch — fire one Task tool call per task in
+ * **a single assistant message** so they execute in parallel, then report a
+ * one-line tally. It must NOT inline sub-agent findings, paraphrase the
+ * embedded prompts, or retry failures — siblings still run and synthesis
+ * tolerates missing files.
+ */
+export function buildBatchOrchestratorPrompt(opts: {
+  wave: 1 | 2;
+  batchIndex: number;
+  totalBatches: number;
+  tasks: Array<{
+    subagentType: string;
+    prompt: string;
+    outputPath: string;
+  }>;
+}): string {
+  const taskBlocks = opts.tasks
+    .map((t, i) =>
+      [
+        `### Task ${i + 1} of ${opts.tasks.length} — \`${t.subagentType}\``,
+        `Output path the sub-agent will write to: \`${t.outputPath}\``,
+        ``,
+        `Verbatim prompt to pass as the Task tool's \`prompt\` parameter:`,
+        ``,
+        "````",
+        t.prompt,
+        "````",
+        ``,
+      ].join("\n"),
+    )
+    .join("\n");
+
+  return [
+    `<BATCH_DISPATCH_MISSION>`,
+    `You are the deterministic dispatcher for batch ${opts.batchIndex} of`,
+    `${opts.totalBatches} in wave ${opts.wave} of the deep-research-codebase`,
+    `workflow. Your sole job is to spawn the ${opts.tasks.length} sub-agent`,
+    `task${opts.tasks.length === 1 ? "" : "s"} listed below using the Task tool.`,
+    `</BATCH_DISPATCH_MISSION>`,
+    ``,
+    `<DISPATCH_RULES>`,
+    `1. Issue ALL ${opts.tasks.length} Task tool calls in a SINGLE assistant`,
+    `   message (parallel tool use), not sequentially across multiple turns.`,
+    `   Parallel dispatch is the only reason this batch exists — sequential`,
+    `   calls defeat its purpose.`,
+    `2. For each task: set \`subagent_type\` to the value shown, set \`prompt\``,
+    `   to the verbatim text inside the fenced block (no paraphrasing,`,
+    `   truncating, or added framing), and set \`description\` to a short`,
+    `   3–5 word label.`,
+    `3. Dispatch every task even if some look similar to others. Tasks here`,
+    `   cover DIFFERENT codebase partitions or DIFFERENT specialist roles —`,
+    `   apparent overlap is not real overlap. Do NOT merge, skip, or combine.`,
+    `4. Do NOT inline any sub-agent's findings into your reply. The sub-agents`,
+    `   write their output to disk; downstream stages read those files.`,
+    `5. Do NOT retry failed sub-agents. Siblings still run and the synthesis`,
+    `   step tolerates missing files.`,
+    `</DISPATCH_RULES>`,
+    ``,
+    `<FINAL_REPLY_FORMAT>`,
+    `After all sub-agents complete, your final assistant message must be`,
+    `exactly one line of the form:`,
+    ``,
+    `  BATCH ${opts.batchIndex} COMPLETE: <ok>/${opts.tasks.length} ok, <failed> failed`,
+    ``,
+    `where <ok> is the count that replied "DONE" and <failed> is the count`,
+    `that replied "FAILED" or otherwise did not produce a file.`,
+    `</FINAL_REPLY_FORMAT>`,
+    ``,
+    `---`,
+    ``,
+    taskBlocks,
   ].join("\n");
 }

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
@@ -3,7 +3,8 @@
  *
  * Responsibilities:
  *   1. Discover the codebase root (git toplevel, falling back to cwd).
- *   2. List all source files, respecting .gitignore when in a git repo.
+ *   2. List all source files, honoring `.gitignore` via git ls-files in repos
+ *      and via `rg --files` in non-repo directories that still have one.
  *   3. Count lines of code per file using batched `wc -l`.
  *   4. Render a compact directory tree (depth-bounded) for prompt context.
  *   5. Build "partition units" by aggregating LOC at depth-1, then drilling
@@ -15,32 +16,151 @@
 
 // Use Bun.spawnSync instead of node:child_process for consistency with the rest of the codebase.
 
-/** Source-file extensions we treat as "code" for LOC accounting. */
-const CODE_EXTENSIONS = new Set<string>([
-  // Web / TS / JS
-  "ts", "tsx", "js", "jsx", "mjs", "cjs",
-  "vue", "svelte", "astro",
-  // Systems
-  "c", "cc", "cpp", "cxx", "h", "hpp", "rs", "go", "zig",
-  // JVM / .NET
-  "java", "kt", "kts", "scala", "groovy", "cs", "fs",
-  // Scripting
-  "py", "rb", "php", "pl", "lua", "sh", "bash", "zsh", "fish",
-  // Mobile
-  "swift", "m", "mm",
-  // Functional / niche
-  "ex", "exs", "erl", "elm", "hs", "ml", "clj", "cljs", "edn",
-  "r", "jl", "dart", "nim",
-  // Schemas / DSLs that materially shape behavior
-  "sql", "graphql", "proto",
+import * as linguistLanguages from "linguist-languages";
+import ignore, { type Ignore } from "ignore";
+import ignoreByDefault from "ignore-by-default";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/**
+ * Source-file extensions we treat as "code" for LOC accounting.
+ *
+ * Derived from GitHub Linguist (`linguist-languages`), filtered to
+ * `type === "programming"`. Linguist tracks 500+ programming languages and
+ * keeps the canonical extension list per language up to date — using it
+ * removes a maintenance burden and picks up obscure-but-legitimate
+ * languages we'd never enumerate by hand.
+ *
+ * Three modifications layered on top of the raw linguist data:
+ *
+ *   1. **Multi-segment extensions are skipped.** Linguist lists entries like
+ *      `.coffee.md` (Literate CoffeeScript) and `.gradle.kts` (Gradle Kotlin
+ *      DSL). Our `isCodeFile()` only sees the tail after the final dot, so
+ *      collapsing `.coffee.md` to `md` would mis-classify Markdown as code.
+ *      Skipping them is safe because the base languages they extend always
+ *      list a single-segment extension as well (`.coffee`, `.kts`).
+ *   2. **EXCLUDE_EXTENSIONS denylist.** A handful of single-segment
+ *      extensions that programming-typed languages claim but which in
+ *      practice almost always mean a non-code file (`.md` is claimed by
+ *      GCC Machine Description but means Markdown 99.9% of the time).
+ *   3. **SCHEMA_EXTENSIONS allowlist.** Schemas/DSLs that linguist
+ *      categorises as `type: "data"` but which materially shape codebase
+ *      behaviour and belong in research scope.
+ */
+const SCHEMA_EXTENSIONS = ["sql", "graphql", "proto"] as const;
+
+/**
+ * Single-segment extensions that linguist's `programming`-typed languages
+ * claim but which in real-world codebases almost always mean a non-code
+ * file. Each entry needs a one-line justification.
+ */
+const EXCLUDE_EXTENSIONS = new Set<string>([
+  "md", // claimed by "GCC Machine Description"; almost always Markdown.
 ]);
 
-/** Directories we always exclude even when not using git ls-files. */
-const FIND_IGNORE_PATTERNS = [
-  "node_modules", ".git", "dist", "build", "out",
-  ".next", ".nuxt", ".turbo", ".vercel", ".cache",
-  "target", "vendor", "__pycache__", ".venv", "venv", "coverage",
-];
+const CODE_EXTENSIONS: Set<string> = (() => {
+  const out = new Set<string>();
+  const langs = linguistLanguages as unknown as Record<
+    string,
+    { type?: string; extensions?: readonly string[] }
+  >;
+  for (const lang of Object.values(langs)) {
+    if (lang?.type !== "programming") continue;
+    for (const ext of lang.extensions ?? []) {
+      const cleaned = ext.replace(/^\./, "").toLowerCase();
+      // Skip multi-segment extensions — see file-level comment.
+      if (cleaned.includes(".")) continue;
+      if (EXCLUDE_EXTENSIONS.has(cleaned)) continue;
+      out.add(cleaned);
+    }
+  }
+  for (const ext of SCHEMA_EXTENSIONS) out.add(ext);
+  return out;
+})();
+
+/**
+ * Recursively walk a directory tree, honoring nested `.gitignore` files at
+ * every level and seeding with `ignore-by-default`'s minimal universal set
+ * (`node_modules`, `.git`, `coverage`, etc.). Returns repo-relative paths.
+ *
+ * Used as the last-resort discovery fallback when neither `git ls-files` nor
+ * `rg --files` is available. The walker matches `.gitignore` semantics:
+ *   • Patterns from a `.gitignore` only apply to files at or below the
+ *     `.gitignore`'s directory.
+ *   • Inherited rules from ancestor directories continue to apply.
+ *   • Negations and the rest of gitignore syntax come from the `ignore`
+ *     package, which is the de facto JS implementation.
+ *
+ * Symlinks are intentionally not followed (avoids cycles).
+ */
+function walkWithIgnore(root: string): string[] {
+  const out: string[] = [];
+
+  const baseline: Ignore = ignore().add(ignoreByDefault.directories());
+  walk(root, [{ basePath: "", matcher: baseline }]);
+
+  function walk(
+    dir: string,
+    inheritedScopes: ReadonlyArray<{ basePath: string; matcher: Ignore }>,
+  ): void {
+    let scopes = inheritedScopes;
+    try {
+      const content = readFileSync(join(dir, ".gitignore"), "utf8");
+      const here = ignore().add(content);
+      scopes = [
+        ...inheritedScopes,
+        { basePath: relative(root, dir), matcher: here },
+      ];
+    } catch {
+      // No .gitignore at this level — keep inherited scopes.
+    }
+
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      // Skip everything that isn't a regular file or a regular directory —
+      // most importantly, skip symlinks so we don't follow cycles.
+      if (!entry.isFile() && !entry.isDirectory()) continue;
+
+      const full = join(dir, entry.name);
+      const rel = relative(root, full);
+      // The `ignore` package requires forward-slash paths.
+      const posix = sep === "/" ? rel : rel.split(sep).join("/");
+      // Trailing slash so directory-only patterns (`dist/`) match.
+      const probe = entry.isDirectory() ? `${posix}/` : posix;
+
+      let ignored = false;
+      for (const scope of scopes) {
+        const within =
+          scope.basePath === ""
+            ? probe
+            : relative(scope.basePath, posix).split(sep).join("/") +
+              (entry.isDirectory() ? "/" : "");
+        // If `within` escapes the scope (starts with `..`), the file isn't
+        // under this .gitignore's reach — skip the check.
+        if (within.startsWith("..")) continue;
+        if (scope.matcher.ignores(within)) {
+          ignored = true;
+          break;
+        }
+      }
+      if (ignored) continue;
+
+      if (entry.isDirectory()) {
+        walk(full, scopes);
+      } else {
+        out.push(rel);
+      }
+    }
+  }
+
+  return out;
+}
 
 /** Per-file LOC + path. */
 export type FileStats = { path: string; loc: number };
@@ -90,36 +210,53 @@ function isCodeFile(p: string): boolean {
   return CODE_EXTENSIONS.has(ext);
 }
 
-/** List all files in the repository. Prefers git ls-files (respects .gitignore). */
+/**
+ * List all files in the repository, honoring `.gitignore` whenever possible.
+ *
+ * Three discovery paths, tried in order — every path respects `.gitignore`:
+ *
+ *   1. **git ls-files** — for git repos. Combines `--cached` (tracked) with
+ *      `--others --exclude-standard` (untracked-but-not-ignored) so a freshly
+ *      created file the user hasn't `git add`-ed yet still appears, while
+ *      anything matching `.gitignore` / `.git/info/exclude` is excluded.
+ *   2. **ripgrep `rg --files --hidden`** — for non-git directories that still
+ *      have a `.gitignore` (or `.ignore`). `rg` honors both without needing
+ *      a repo, and always excludes `.git/`. `--hidden` keeps tracked dotfiles
+ *      like `.github/`, `.claude/` visible (matching git's behavior).
+ *   3. **In-process walker** — last-resort fallback when neither git nor rg
+ *      is available. Uses the `ignore` package to honor every `.gitignore`
+ *      it encounters (including nested ones), seeded with `ignore-by-default`
+ *      for the universal-ignore baseline (`node_modules`, `.git`, etc.).
+ */
 function listAllFiles(root: string): string[] {
-  const git = Bun.spawnSync({
-    cmd: ["git", "ls-files"],
-    cwd: root,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  if (git.success && git.stdout) {
-    return git.stdout.toString().split("\n").filter((l) => l.length > 0);
-  }
+  // Bun.spawnSync throws (rather than returning success:false) when the
+  // executable is missing from PATH, so each branch is wrapped in try/catch
+  // and falls through to the next discovery strategy on error.
+  try {
+    const git = Bun.spawnSync({
+      cmd: ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (git.success && git.stdout) {
+      return git.stdout.toString().split("\n").filter((l) => l.length > 0);
+    }
+  } catch { /* git not on PATH — fall through to rg */ }
 
-  // Fallback: shell out to find with the standard ignore patterns.
-  const args: string[] = ["find", ".", "-type", "f"];
-  for (const pattern of FIND_IGNORE_PATTERNS) {
-    args.push("-not", "-path", `*/${pattern}/*`);
-  }
-  const find = Bun.spawnSync({
-    cmd: args,
-    cwd: root,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  if (find.success && find.stdout) {
-    return find.stdout.toString()
-      .split("\n")
-      .map((p) => p.replace(/^\.\//, ""))
-      .filter((p) => p.length > 0);
-  }
-  return [];
+  try {
+    const rg = Bun.spawnSync({
+      cmd: ["rg", "--files", "--hidden"],
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (rg.success && rg.stdout) {
+      return rg.stdout.toString().split("\n").filter((l) => l.length > 0);
+    }
+  } catch { /* rg not on PATH — fall through to in-process walker */ }
+
+  return walkWithIgnore(root);
 }
 
 /**

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
@@ -17,6 +17,7 @@
 // Use Bun.spawnSync instead of node:child_process for consistency with the rest of the codebase.
 
 import * as linguistLanguages from "linguist-languages";
+import type { Language } from "linguist-languages";
 import ignore, { type Ignore } from "ignore";
 import ignoreByDefault from "ignore-by-default";
 import { readdirSync, readFileSync } from "node:fs";
@@ -60,12 +61,11 @@ const EXCLUDE_EXTENSIONS = new Set<string>([
 
 const CODE_EXTENSIONS: Set<string> = (() => {
   const out = new Set<string>();
-  const langs = linguistLanguages as unknown as Record<
-    string,
-    { type?: string; extensions?: readonly string[] }
-  >;
-  for (const lang of Object.values(langs)) {
-    if (lang?.type !== "programming") continue;
+  // Each named export of `linguist-languages` is a `Language`; the namespace
+  // import has no other shape, so casting `Object.values(...)` to `Language[]`
+  // is sound and removes the need for an `unknown` intermediary.
+  for (const lang of Object.values(linguistLanguages) as Language[]) {
+    if (lang.type !== "programming") continue;
     for (const ext of lang.extensions ?? []) {
       const cleaned = ext.replace(/^\./, "").toLowerCase();
       // Skip multi-segment extensions — see file-level comment.
@@ -198,14 +198,19 @@ export type CodebaseScout = {
 
 /** Resolve the project root. Prefers `git rev-parse --show-toplevel`. */
 export function getCodebaseRoot(): string {
-  const r = Bun.spawnSync({
-    cmd: ["git", "rev-parse", "--show-toplevel"],
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  if (r.success && r.stdout) {
-    return r.stdout.toString().trim();
-  }
+  // Bun.spawnSync throws (rather than returning success:false) when the
+  // executable is missing from PATH — wrap so the documented "falls back to
+  // cwd" contract holds even on machines without git installed.
+  try {
+    const r = Bun.spawnSync({
+      cmd: ["git", "rev-parse", "--show-toplevel"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (r.success && r.stdout) {
+      return r.stdout.toString().trim();
+    }
+  } catch { /* git not on PATH — fall back to cwd */ }
   return process.cwd();
 }
 
@@ -270,7 +275,11 @@ function listAllFiles(root: string): string[] {
  *   "  N filename"
  *   "  N total"   (when more than one file is passed)
  *
- * We batch to avoid command-line length limits.
+ * We batch to avoid command-line length limits. When `wc` is missing from
+ * PATH (typical on Windows) `Bun.spawnSync` throws ENOENT — each batch is
+ * wrapped so we can fall back to an in-process newline counter rather than
+ * aborting the workflow or silently zeroing every file's LOC (which would
+ * collapse the partition bin-packer).
  */
 function countLines(root: string, files: string[]): Map<string, number> {
   const result = new Map<string, number>();
@@ -279,22 +288,40 @@ function countLines(root: string, files: string[]): Map<string, number> {
   const BATCH = 200;
   for (let i = 0; i < files.length; i += BATCH) {
     const batch = files.slice(i, i + BATCH);
-    const r = Bun.spawnSync({
-      cmd: ["wc", "-l", "--", ...batch],
-      cwd: root,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    if (!r.stdout) continue;
-    for (const line of r.stdout.toString().split("\n")) {
-      const m = line.match(/^\s*(\d+)\s+(.+)$/);
-      // Regex groups are typed `string | undefined` under strict mode even
-      // when the whole match succeeded — guard explicitly.
-      const countStr = m?.[1];
-      const filename = m?.[2]?.trim();
-      if (countStr === undefined || filename === undefined) continue;
-      if (filename === "total") continue;
-      result.set(filename, parseInt(countStr, 10));
+    let wcOk = false;
+    try {
+      const r = Bun.spawnSync({
+        cmd: ["wc", "-l", "--", ...batch],
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (r.stdout) {
+        wcOk = true;
+        for (const line of r.stdout.toString().split("\n")) {
+          const m = line.match(/^\s*(\d+)\s+(.+)$/);
+          // Regex groups are typed `string | undefined` under strict mode even
+          // when the whole match succeeded — guard explicitly.
+          const countStr = m?.[1];
+          const filename = m?.[2]?.trim();
+          if (countStr === undefined || filename === undefined) continue;
+          if (filename === "total") continue;
+          result.set(filename, parseInt(countStr, 10));
+        }
+      }
+    } catch { /* wc not on PATH — fall through to in-process counter */ }
+    if (wcOk) continue;
+    // In-process fallback: count newline bytes. Matches `wc -l` semantics
+    // (a final line without a trailing `\n` is not counted).
+    for (const f of batch) {
+      try {
+        const content = readFileSync(join(root, f), "utf8");
+        let count = 0;
+        for (let j = 0; j < content.length; j++) {
+          if (content.charCodeAt(j) === 10) count++;
+        }
+        result.set(f, count);
+      } catch { /* unreadable — leave unset; consumer treats as 0 */ }
     }
   }
   return result;

--- a/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/helpers/scout.ts
@@ -20,7 +20,7 @@ import * as linguistLanguages from "linguist-languages";
 import ignore, { type Ignore } from "ignore";
 import ignoreByDefault from "ignore-by-default";
 import { readdirSync, readFileSync } from "node:fs";
-import { join, relative, sep } from "node:path";
+import { join, posix as posixPath, relative, sep } from "node:path";
 
 /**
  * Source-file extensions we treat as "code" for LOC accounting.
@@ -107,9 +107,15 @@ function walkWithIgnore(root: string): string[] {
     try {
       const content = readFileSync(join(dir, ".gitignore"), "utf8");
       const here = ignore().add(content);
+      // Normalize basePath to posix so it can be combined with `posix`
+      // (forward-slash) entry paths via `posix.relative` below — mixing
+      // separators in `path.relative` is undefined behaviour on Windows.
+      const basePathRel = relative(root, dir);
+      const basePath =
+        sep === "/" ? basePathRel : basePathRel.split(sep).join("/");
       scopes = [
         ...inheritedScopes,
-        { basePath: relative(root, dir), matcher: here },
+        { basePath, matcher: here },
       ];
     } catch {
       // No .gitignore at this level — keep inherited scopes.
@@ -139,7 +145,7 @@ function walkWithIgnore(root: string): string[] {
         const within =
           scope.basePath === ""
             ? probe
-            : relative(scope.basePath, posix).split(sep).join("/") +
+            : posixPath.relative(scope.basePath, posix) +
               (entry.isDirectory() ? "/" : "");
         // If `within` escapes the scope (starts with `..`), the file isn't
         // under this .gitignore's reach — skip the check.

--- a/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
@@ -82,6 +82,22 @@ async function safeReadFile(absPath: string): Promise<string> {
   }
 }
 
+/**
+ * Log Promise.allSettled rejection reasons to stderr so an all-failed wave
+ * leaves a debugging trail instead of silently producing an empty report.
+ */
+function logBatchRejections(
+  label: string,
+  results: PromiseSettledResult<unknown>[],
+): void {
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r?.status === "rejected") {
+      console.error(`[deep-research-codebase] ${label} batch ${i + 1} failed:`, r.reason);
+    }
+  }
+}
+
 export default defineWorkflow({
   name: "deep-research-codebase",
   description:
@@ -239,16 +255,22 @@ export default defineWorkflow({
     // everything via the `task` tool, so the dispatcher cannot wander off
     // and start doing the specialists' work itself.
 
-    const taskPaths = (i: number) => ({
-      locator: path.join(scratchDir, `locator-${i}.md`),
-      patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
-      analyzer: path.join(scratchDir, `analyzer-${i}.md`),
-      online: path.join(scratchDir, `online-${i}.md`),
+    // Per-partition output paths, computed once and reused across both wave
+    // task-list construction and synthesis.
+    const partitionPaths = partitions.map((_, idx) => {
+      const i = idx + 1;
+      return {
+        locator: path.join(scratchDir, `locator-${i}.md`),
+        patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
+        analyzer: path.join(scratchDir, `analyzer-${i}.md`),
+        online: path.join(scratchDir, `online-${i}.md`),
+        explorer: path.join(scratchDir, `explorer-${i}.md`),
+      };
     });
 
     const wave1Tasks: Layer1Task[] = partitions.flatMap((partition, idx) => {
       const i = idx + 1;
-      const paths = taskPaths(i);
+      const paths = partitionPaths[idx]!;
       return [
         {
           kind: "locator" as const,
@@ -267,7 +289,7 @@ export default defineWorkflow({
 
     const wave1Batches = chunkBatches(wave1Tasks, MAX_TASKS_PER_BATCH);
 
-    await Promise.allSettled(
+    const wave1Results = await Promise.allSettled(
       wave1Batches.map((batch, batchIdx) => {
         const batchNumber = batchIdx + 1;
         return ctx.stage(
@@ -295,7 +317,7 @@ export default defineWorkflow({
                 prompt: wrapPromptForTaskDispatch({
                   specialistPrompt,
                   outputPath: t.outputPath,
-                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                  agentLabel: t.kind.toUpperCase().replaceAll("-", "_"),
                 }),
               };
             });
@@ -320,18 +342,19 @@ export default defineWorkflow({
         );
       }),
     );
+    logBatchRejections("wave1", wave1Results);
 
     const locatorOutputs: Map<number, string> = new Map();
     await Promise.all(
       partitions.map(async (_p, idx) => {
         const i = idx + 1;
-        locatorOutputs.set(i, await safeReadFile(taskPaths(i).locator));
+        locatorOutputs.set(i, await safeReadFile(partitionPaths[idx]!.locator));
       }),
     );
 
     const wave2Tasks: Layer2Task[] = partitions.flatMap((partition, idx) => {
       const i = idx + 1;
-      const paths = taskPaths(i);
+      const paths = partitionPaths[idx]!;
       const locatorOutput = locatorOutputs.get(i) ?? "";
       return [
         {
@@ -353,7 +376,7 @@ export default defineWorkflow({
 
     const wave2Batches = chunkBatches(wave2Tasks, MAX_TASKS_PER_BATCH);
 
-    await Promise.allSettled(
+    const wave2Results = await Promise.allSettled(
       wave2Batches.map((batch, batchIdx) => {
         const batchNumber = batchIdx + 1;
         return ctx.stage(
@@ -389,7 +412,7 @@ export default defineWorkflow({
                 prompt: wrapPromptForTaskDispatch({
                   specialistPrompt,
                   outputPath: t.outputPath,
-                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                  agentLabel: t.kind.toUpperCase().replaceAll("-", "_"),
                 }),
               };
             });
@@ -414,6 +437,7 @@ export default defineWorkflow({
         );
       }),
     );
+    logBatchRejections("wave2", wave2Results);
 
     // Synthesis: read all four specialist files per partition and write the
     // consolidated explorer scratch file. Missing files fall back to "" so
@@ -421,8 +445,7 @@ export default defineWorkflow({
     const explorerHandles = await Promise.all(
       partitions.map(async (partition, idx) => {
         const i = idx + 1;
-        const paths = taskPaths(i);
-        const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
+        const paths = partitionPaths[idx]!;
 
         const [locatorOutput, patternsOutput, analyzerOutput, onlineOutput] =
           await Promise.all([
@@ -432,7 +455,7 @@ export default defineWorkflow({
             safeReadFile(paths.online),
           ]);
 
-        await writeExplorerScratchFile(scratchPath, {
+        await writeExplorerScratchFile(paths.explorer, {
           index: i,
           total: explorerCount,
           partition,
@@ -442,7 +465,7 @@ export default defineWorkflow({
           onlineOutput,
         });
 
-        return { index: i, scratchPath, partition };
+        return { index: i, scratchPath: paths.explorer, partition };
       }),
     );
 

--- a/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
@@ -1,33 +1,35 @@
 /**
  * deep-research-codebase / opencode
  *
- * OpenCode replica of the Claude deep-research-codebase workflow. Specialist
- * sub-agents are dispatched as separate headless `ctx.stage()` calls — each
- * call passes `agent: "<name>"` to `s.client.session.prompt()` directly,
- * which is OpenCode's SDK-native way to route a turn to a sub-agent.
+ * OpenCode replica of the Claude deep-research-codebase workflow with the
+ * same **batched** Task-tool fan-out. Specialist sub-agents run inside batch
+ * sessions: each batch is a single `ctx.stage()` whose orchestrator turn
+ * dispatches up to MAX_TASKS_PER_BATCH (≈10) specialists in parallel via
+ * OpenCode's `task` tool. The default agent must have `task: "allow"` in
+ * its permission ruleset (see `.opencode/agents/worker.md` for the
+ * canonical example).
+ *
+ * See claude/index.ts for the full design rationale and topology diagram.
  *
  * OpenCode-specific concerns baked in (see references/failure-modes.md):
  *
- *   • F5 — every `ctx.stage()` is a FRESH session. Each specialist receives
- *     everything it needs (research question, scope, scout overview, and —
- *     for layer-2 specialists — verbatim locator output) in its first prompt.
+ *   • F3 — `result.data!.parts` is heterogenous. Batch sessions don't read
+ *     `extractResponseText` for orchestrator output (sub-agents write to
+ *     disk; the orchestrator reply is just a short tally), but the history
+ *     pipeline still uses it.
  *
- *   • F3 — `result.data!.parts` is a heterogenous array (text/tool/reasoning/
- *     file parts). Use `extractResponseText()` to filter to text parts only;
- *     concatenating raw `parts` produces `[object Object]` strings.
+ *   • F5 — every `ctx.stage()` is a FRESH session. Batch session prompts
+ *     embed everything the orchestrator needs in the first turn.
  *
- *   • F6 — every prompt explicitly requires trailing prose so transcripts and
- *     `extractResponseText()` reads are never empty.
+ *   • F6 — orchestrator prompt requires a single-line tally as the trailing
+ *     turn so transcripts are never empty.
  *
  *   • F9 — `s.save()` receives the unwrapped `{ info, parts }` payload from
- *     `result.data!`; passing the full `result` or raw `result.data!.parts`
- *     breaks downstream `transcript()` reads.
- *
- * See claude/index.ts for the full design rationale and topology diagram.
+ *     `result.data!`.
  */
 
 import { defineWorkflow } from "../../../index.ts";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -42,6 +44,7 @@ import {
 import {
   buildAggregatorPrompt,
   buildAnalyzerPrompt,
+  buildBatchOrchestratorPrompt,
   buildHistoryAnalyzerPrompt,
   buildHistoryLocatorPrompt,
   buildLocatorPrompt,
@@ -49,8 +52,16 @@ import {
   buildPatternFinderPrompt,
   buildScoutPrompt,
   slugifyPrompt,
+  wrapPromptForTaskDispatch,
 } from "../helpers/prompts.ts";
 import { writeExplorerScratchFile } from "../helpers/scratch.ts";
+import {
+  chunkBatches,
+  MAX_TASKS_PER_BATCH,
+  SUBAGENT_TYPE,
+  type Layer1Task,
+  type Layer2Task,
+} from "../helpers/batching.ts";
 
 /** Filter for text parts only — non-text parts produce [object Object]. */
 function extractResponseText(
@@ -60,6 +71,15 @@ function extractResponseText(
     .filter((p) => p.type === "text")
     .map((p) => (p as { type: string; text: string }).text)
     .join("\n");
+}
+
+/** Read a file as UTF-8, returning empty string if missing or unreadable. */
+async function safeReadFile(absPath: string): Promise<string> {
+  try {
+    return await readFile(absPath, "utf8");
+  } catch {
+    return "";
+  }
 }
 
 export default defineWorkflow({
@@ -98,7 +118,9 @@ export default defineWorkflow({
           if (data.units.length === 0) {
             throw new Error(
               `deep-research-codebase: scout found no source files under ${root}. ` +
-                `Run from inside a code repository or check the CODE_EXTENSIONS list.`,
+                `Run from inside a code repository, or verify your files use a ` +
+                `recognized programming-language extension (sourced from GitHub ` +
+                `Linguist + sql/graphql/proto).`,
             );
           }
 
@@ -209,139 +231,206 @@ export default defineWorkflow({
 
     const scoutOverview = (await ctx.transcript(scout)).content;
 
-    // ── Stage 2: per-partition specialist fan-out ─────────────────────────
+    // ── Stage 2: batched specialist fan-out ───────────────────────────────
+    //
+    // Same two-wave batched design as claude/index.ts. Each batch session
+    // pins the dispatcher to the `orchestrator` agent (.opencode/agents/
+    // orchestrator.md) — its system prompt is purpose-built to delegate
+    // everything via the `task` tool, so the dispatcher cannot wander off
+    // and start doing the specialists' work itself.
+
+    const taskPaths = (i: number) => ({
+      locator: path.join(scratchDir, `locator-${i}.md`),
+      patternFinder: path.join(scratchDir, `pattern-finder-${i}.md`),
+      analyzer: path.join(scratchDir, `analyzer-${i}.md`),
+      online: path.join(scratchDir, `online-${i}.md`),
+    });
+
+    const wave1Tasks: Layer1Task[] = partitions.flatMap((partition, idx) => {
+      const i = idx + 1;
+      const paths = taskPaths(i);
+      return [
+        {
+          kind: "locator" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.locator,
+        },
+        {
+          kind: "pattern-finder" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.patternFinder,
+        },
+      ];
+    });
+
+    const wave1Batches = chunkBatches(wave1Tasks, MAX_TASKS_PER_BATCH);
+
+    await Promise.allSettled(
+      wave1Batches.map((batch, batchIdx) => {
+        const batchNumber = batchIdx + 1;
+        return ctx.stage(
+          {
+            name: `wave1-batch-${batchNumber}`,
+            headless: true,
+            description: `Layer 1 dispatch (${batch.length} tasks)`,
+          },
+          {},
+          { title: `wave1-batch-${batchNumber}` },
+          async (s) => {
+            const taskSpecs = batch.map((t) => {
+              const builder =
+                t.kind === "locator" ? buildLocatorPrompt : buildPatternFinderPrompt;
+              const specialistPrompt = builder({
+                question: prompt,
+                partition: t.partition,
+                scoutOverview,
+                index: t.partitionIndex,
+                total: explorerCount,
+              });
+              return {
+                subagentType: SUBAGENT_TYPE[t.kind],
+                outputPath: t.outputPath,
+                prompt: wrapPromptForTaskDispatch({
+                  specialistPrompt,
+                  outputPath: t.outputPath,
+                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                }),
+              };
+            });
+
+            const result = await s.client.session.prompt({
+              sessionID: s.session.id,
+              parts: [
+                {
+                  type: "text",
+                  text: buildBatchOrchestratorPrompt({
+                    wave: 1,
+                    batchIndex: batchNumber,
+                    totalBatches: wave1Batches.length,
+                    tasks: taskSpecs,
+                  }),
+                },
+              ],
+              agent: "orchestrator",
+            });
+            s.save(result.data!);
+          },
+        );
+      }),
+    );
+
+    const locatorOutputs: Map<number, string> = new Map();
+    await Promise.all(
+      partitions.map(async (_p, idx) => {
+        const i = idx + 1;
+        locatorOutputs.set(i, await safeReadFile(taskPaths(i).locator));
+      }),
+    );
+
+    const wave2Tasks: Layer2Task[] = partitions.flatMap((partition, idx) => {
+      const i = idx + 1;
+      const paths = taskPaths(i);
+      const locatorOutput = locatorOutputs.get(i) ?? "";
+      return [
+        {
+          kind: "analyzer" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.analyzer,
+          locatorOutput,
+        },
+        {
+          kind: "online-researcher" as const,
+          partitionIndex: i,
+          partition,
+          outputPath: paths.online,
+          locatorOutput,
+        },
+      ];
+    });
+
+    const wave2Batches = chunkBatches(wave2Tasks, MAX_TASKS_PER_BATCH);
+
+    await Promise.allSettled(
+      wave2Batches.map((batch, batchIdx) => {
+        const batchNumber = batchIdx + 1;
+        return ctx.stage(
+          {
+            name: `wave2-batch-${batchNumber}`,
+            headless: true,
+            description: `Layer 2 dispatch (${batch.length} tasks)`,
+          },
+          {},
+          { title: `wave2-batch-${batchNumber}` },
+          async (s) => {
+            const taskSpecs = batch.map((t) => {
+              const specialistPrompt =
+                t.kind === "analyzer"
+                  ? buildAnalyzerPrompt({
+                      question: prompt,
+                      partition: t.partition,
+                      locatorOutput: t.locatorOutput,
+                      scoutOverview,
+                      index: t.partitionIndex,
+                      total: explorerCount,
+                    })
+                  : buildOnlineResearcherPrompt({
+                      question: prompt,
+                      partition: t.partition,
+                      locatorOutput: t.locatorOutput,
+                      index: t.partitionIndex,
+                      total: explorerCount,
+                    });
+              return {
+                subagentType: SUBAGENT_TYPE[t.kind],
+                outputPath: t.outputPath,
+                prompt: wrapPromptForTaskDispatch({
+                  specialistPrompt,
+                  outputPath: t.outputPath,
+                  agentLabel: t.kind.toUpperCase().replace("-", "_"),
+                }),
+              };
+            });
+
+            const result = await s.client.session.prompt({
+              sessionID: s.session.id,
+              parts: [
+                {
+                  type: "text",
+                  text: buildBatchOrchestratorPrompt({
+                    wave: 2,
+                    batchIndex: batchNumber,
+                    totalBatches: wave2Batches.length,
+                    tasks: taskSpecs,
+                  }),
+                },
+              ],
+              agent: "orchestrator",
+            });
+            s.save(result.data!);
+          },
+        );
+      }),
+    );
+
+    // Synthesis: read all four specialist files per partition and write the
+    // consolidated explorer scratch file. Missing files fall back to "" so
+    // partial batch failures degrade gracefully.
     const explorerHandles = await Promise.all(
       partitions.map(async (partition, idx) => {
         const i = idx + 1;
+        const paths = taskPaths(i);
         const scratchPath = path.join(scratchDir, `explorer-${i}.md`);
 
-        // Layer 1: locator + pattern-finder run independently.
-        const [locator, patternFinder] = await Promise.all([
-          ctx.stage(
-            {
-              name: `locator-${i}`,
-              headless: true,
-              description: `codebase-locator over partition ${i}`,
-            },
-            {},
-            { title: `locator-${i}` },
-            async (s) => {
-              const result = await s.client.session.prompt({
-                sessionID: s.session.id,
-                parts: [
-                  {
-                    type: "text",
-                    text: buildLocatorPrompt({
-                      question: prompt,
-                      partition,
-                      scoutOverview,
-                      index: i,
-                      total: explorerCount,
-                    }),
-                  },
-                ],
-                agent: "codebase-locator",
-              });
-              s.save(result.data!);
-              return extractResponseText(result.data!.parts);
-            },
-          ),
-          ctx.stage(
-            {
-              name: `pattern-finder-${i}`,
-              headless: true,
-              description: `codebase-pattern-finder over partition ${i}`,
-            },
-            {},
-            { title: `pattern-finder-${i}` },
-            async (s) => {
-              const result = await s.client.session.prompt({
-                sessionID: s.session.id,
-                parts: [
-                  {
-                    type: "text",
-                    text: buildPatternFinderPrompt({
-                      question: prompt,
-                      partition,
-                      scoutOverview,
-                      index: i,
-                      total: explorerCount,
-                    }),
-                  },
-                ],
-                agent: "codebase-pattern-finder",
-              });
-              s.save(result.data!);
-              return extractResponseText(result.data!.parts);
-            },
-          ),
-        ]);
-
-        const locatorOutput = locator.result;
-        const patternsOutput = patternFinder.result;
-
-        // Layer 2: analyzer + online-researcher consume locator output.
-        const [analyzer, onlineResearcher] = await Promise.all([
-          ctx.stage(
-            {
-              name: `analyzer-${i}`,
-              headless: true,
-              description: `codebase-analyzer over partition ${i}`,
-            },
-            {},
-            { title: `analyzer-${i}` },
-            async (s) => {
-              const result = await s.client.session.prompt({
-                sessionID: s.session.id,
-                parts: [
-                  {
-                    type: "text",
-                    text: buildAnalyzerPrompt({
-                      question: prompt,
-                      partition,
-                      locatorOutput,
-                      scoutOverview,
-                      index: i,
-                      total: explorerCount,
-                    }),
-                  },
-                ],
-                agent: "codebase-analyzer",
-              });
-              s.save(result.data!);
-              return extractResponseText(result.data!.parts);
-            },
-          ),
-          ctx.stage(
-            {
-              name: `online-researcher-${i}`,
-              headless: true,
-              description: `codebase-online-researcher over partition ${i}`,
-            },
-            {},
-            { title: `online-researcher-${i}` },
-            async (s) => {
-              const result = await s.client.session.prompt({
-                sessionID: s.session.id,
-                parts: [
-                  {
-                    type: "text",
-                    text: buildOnlineResearcherPrompt({
-                      question: prompt,
-                      partition,
-                      locatorOutput,
-                      index: i,
-                      total: explorerCount,
-                    }),
-                  },
-                ],
-                agent: "codebase-online-researcher",
-              });
-              s.save(result.data!);
-              return extractResponseText(result.data!.parts);
-            },
-          ),
-        ]);
+        const [locatorOutput, patternsOutput, analyzerOutput, onlineOutput] =
+          await Promise.all([
+            Promise.resolve(locatorOutputs.get(i) ?? ""),
+            safeReadFile(paths.patternFinder),
+            safeReadFile(paths.analyzer),
+            safeReadFile(paths.online),
+          ]);
 
         await writeExplorerScratchFile(scratchPath, {
           index: i,
@@ -349,8 +438,8 @@ export default defineWorkflow({
           partition,
           locatorOutput,
           patternsOutput,
-          analyzerOutput: analyzer.result,
-          onlineOutput: onlineResearcher.result,
+          analyzerOutput,
+          onlineOutput,
         });
 
         return { index: i, scratchPath, partition };

--- a/src/services/config/additional-instructions.ts
+++ b/src/services/config/additional-instructions.ts
@@ -46,7 +46,7 @@ Use playwright-cli (refer to playwright-cli skill) for ALL browser automation ta
 
 You are operating in an environment where ast-grep is installed. For any code search that requires understanding of syntax or code structure, you should default to using \`ast-grep --lang [language] -p '<pattern>'\`. Rely on your ast-grep skill for best practices. Adjust the --lang flag as needed for the specific programming language. Avoid using text-only search tools unless a plain-text search is explicitly requested.
 
-3. **Testing**: ALWAYS invoke your testing-anti-patterns skill BEFORE creating or modifying any tests.
+3. **Testing**: ALWAYS invoke your test-driven-development skill BEFORE creating or modifying any tests.
 
 4. **Sub-agent Orchestration**: You have a large number of tools available to you. The most important one is the one that allows you to dispatch sub-agents: either \`Agent\` or \`Task\`.
 
@@ -61,7 +61,7 @@ IMPORTANT: sometimes sub-agents will take a long time. DO NOT attempt to do the 
 
 If you have not already been explicitly given a task, you should ask the user what task they would like for you to work on - do not assume or begin working on a ticket automatically.
 
-4. **Debugging**: When a user asks about debugging, ALWAYS spawn a debugger sub-agent first.
+5. **Debugging**: When a user asks about debugging, ALWAYS spawn a debugger sub-agent first.
    - Do not attempt to debug or analyze code yourself without first consulting the debugger sub-agent.
    - Explain the debugger's insights to the user clearly and concisely.
    - Once the user confirms, implement the necessary code changes based on those insights.

--- a/src/services/config/additional-instructions.ts
+++ b/src/services/config/additional-instructions.ts
@@ -162,18 +162,40 @@ export async function seedGlobalAdditionalInstructions(): Promise<void> {
 }
 
 /**
- * Identify entries in OpenCode's `instructions` array that atomic owns.
- *
- * We claim any entry whose path ends with `.atomic/AGENTS.md` (POSIX or
- * Windows separators), since both the global seed and the local override
- * land at that suffix. Reconciliation strips matches and re-adds the
- * currently-resolved path, so the on-disk config tracks the resolver
- * (e.g. flips when the user creates a local override) without piling up
- * stale entries across runs.
+ * Build a predicate that identifies OpenCode `instructions` entries atomic
+ * owns. Matches exact equality against the two paths we ever inject — the
+ * global seed (`~/.atomic/AGENTS.md`) and the project-local override
+ * (`<projectRoot>/.atomic/AGENTS.md`). A tighter scope than a tail-match
+ * ensures legal-but-unusual user entries like `vendor/.atomic/AGENTS.md`
+ * are preserved across reconciliation passes.
  */
-function isAtomicManagedInstruction(entry: unknown): entry is string {
-  if (typeof entry !== "string") return false;
-  return /(?:^|[\\/])\.atomic[\\/]AGENTS\.md$/.test(entry);
+function buildAtomicOwnedMatcher(
+  projectRoot: string,
+): (entry: unknown) => entry is string {
+  const owned = new Set<string>([
+    getGlobalAdditionalInstructionsPath(),
+    getLocalAdditionalInstructionsPath(projectRoot),
+  ]);
+  return (entry: unknown): entry is string =>
+    typeof entry === "string" && owned.has(entry);
+}
+
+/**
+ * Order-independent equality check for OpenCode's `instructions` array.
+ * OpenCode treats `instructions` as an unordered set of files to load, so
+ * a user reordering entries via their editor shouldn't trigger a rewrite
+ * (and the resulting "fight the user" mtime churn) on the next spawn.
+ * Uses `JSON.stringify` per-entry so non-string values (a malformed config
+ * we'd otherwise leave alone) are compared safely without spurious matches.
+ */
+function sameInstructionMultiset(
+  a: readonly unknown[],
+  b: readonly unknown[],
+): boolean {
+  if (a.length !== b.length) return false;
+  const aKeys = a.map((e) => JSON.stringify(e)).sort();
+  const bKeys = b.map((e) => JSON.stringify(e)).sort();
+  return aKeys.every((v, i) => v === bKeys[i]);
 }
 
 /**
@@ -194,6 +216,17 @@ function isAtomicManagedInstruction(entry: unknown): entry is string {
  * No-op on `.opencode/opencode.json` files we don't own (i.e. we never
  * create the file ourselves; `applyManagedOnboardingFiles` is responsible
  * for that). When the file is absent, this helper simply returns.
+ *
+ * Concurrency: this is a read-modify-write on `opencode.json` with no
+ * cross-process lock. Two concurrent `atomic` invocations (e.g. parallel
+ * `chat -a opencode` sessions, or a workflow racing the chat startup) can
+ * interleave reads and writes — A reads, B reads, A writes, B writes —
+ * and B's write loses any user-managed `instructions` entries A added in
+ * between. The window is tiny (a single `readFile` + `JSON.parse` +
+ * `writeFile`) and the damage is bounded: only concurrent edits to
+ * non-atomic entries are at risk, and the next reconcile pass restores
+ * the atomic entry. If this becomes a real problem in practice, wrap the
+ * read-modify-write in a file lock (`proper-lockfile` or similar).
  */
 export async function reconcileOpencodeInstructions(
   projectRoot: string,
@@ -214,22 +247,27 @@ export async function reconcileOpencodeInstructions(
   const existing = Array.isArray(config.instructions)
     ? (config.instructions as unknown[])
     : [];
-  const preserved = existing.filter((e) => !isAtomicManagedInstruction(e));
+  const isAtomicOwned = buildAtomicOwnedMatcher(projectRoot);
+  const preserved = existing.filter((e) => !isAtomicOwned(e));
 
   const resolved = resolveAdditionalInstructionsPath(projectRoot);
   const next = resolved ? [...preserved, resolved] : preserved;
 
-  // Skip the write when nothing actually changed — avoids touching mtime
-  // on every spawn and keeps the file out of `git status` noise.
-  const sameLength = next.length === existing.length;
-  const sameOrder =
-    sameLength && next.every((entry, i) => entry === existing[i]);
-  if (sameOrder) return;
+  // Skip the write when the entry set is unchanged — avoids touching mtime
+  // on every spawn, keeps the file out of `git status` noise, and preserves
+  // any reordering the user did in their editor (OpenCode is order-agnostic).
+  if (sameInstructionMultiset(next, existing)) return;
 
   if (next.length > 0) {
     config.instructions = next;
   } else {
     delete config.instructions;
   }
-  await writeFile(opencodeConfigPath, JSON.stringify(config, null, 2) + "\n");
+  // Preserve the file's existing line ending. JSON.stringify always emits
+  // LF; rewriting CRLF-edited config with LF would otherwise produce noisy
+  // diffs in workspaces with `eol=crlf` in `.gitattributes`.
+  const lineEnding = raw.includes("\r\n") ? "\r\n" : "\n";
+  const serialized =
+    JSON.stringify(config, null, 2).replace(/\n/g, lineEnding) + lineEnding;
+  await writeFile(opencodeConfigPath, serialized);
 }

--- a/src/services/config/additional-instructions.ts
+++ b/src/services/config/additional-instructions.ts
@@ -1,0 +1,235 @@
+/**
+ * Additional default instructions appended to every agent the CLI spawns.
+ *
+ * Lifecycle:
+ *   1. On first install / lazy auto-sync, the constant below is written to
+ *      `~/.atomic/AGENTS.md` if (and only if) that file is missing. Once it
+ *      exists, the user owns it — atomic never overwrites it on upgrade.
+ *   2. Each `atomic chat` / workflow run resolves an effective path via
+ *      {@link resolveAdditionalInstructionsPath}: a project-local
+ *      `.atomic/AGENTS.md` wins; otherwise the global file is used.
+ *   3. Each provider surface (CLI flags, env vars, SDK options) is wired to
+ *      reference the resolved path or read its contents.
+ *
+ * The constant ships as a seed only. Future `atomic` releases that change
+ * the prompt won't affect existing users — that's intentional, since the
+ * file becomes user-editable after install.
+ */
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { existsSync } from "node:fs";
+import { readFile, mkdir, writeFile } from "node:fs/promises";
+
+/**
+ * Default seed contents for `~/.atomic/AGENTS.md`. Markdown-format because
+ * Copilot CLI / OpenCode read instruction files as Markdown; Claude's
+ * `--append-system-prompt-file` accepts arbitrary text and is happy with
+ * Markdown too.
+ */
+export const ADDITIONAL_INSTRUCTIONS = `This section provides you with **CRITICAL** instructions that will help you to maintain coherency in long-horizon context-heavy tasks and better support users:
+
+<user_experience>
+- Always ask clarifying questions if the user's request is ambiguous or lacks necessary details. NEVER make assumptions about what the user wants.
+- If you find yourself circling in thought and asking what the user "really" wants, stop and ask the user for clarification. It's better to ask than to guess.
+</user_experience>
+
+<tool_policies>
+Follow these tool selection and usage rules in order of priority:
+
+1. **Browser search and automation**:
+
+Use playwright-cli (refer to playwright-cli skill) for ALL browser automation tasks, including web research, form filling, and UI interaction:
+   - ALWAYS load the playwright-cli skill before usage with the Skill tool.
+   - ALWAYS ASSUME playwright-cli is installed. If the \`playwright-cli\` command fails, fall back to \`bunx playwright-cli\`.
+
+2. **Structural code search**:
+
+You are operating in an environment where ast-grep is installed. For any code search that requires understanding of syntax or code structure, you should default to using \`ast-grep --lang [language] -p '<pattern>'\`. Rely on your ast-grep skill for best practices. Adjust the --lang flag as needed for the specific programming language. Avoid using text-only search tools unless a plain-text search is explicitly requested.
+
+3. **Testing**: ALWAYS invoke your testing-anti-patterns skill BEFORE creating or modifying any tests.
+
+4. **Sub-agent Orchestration**: You have a large number of tools available to you. The most important one is the one that allows you to dispatch sub-agents: either \`Agent\` or \`Task\`.
+
+All non-trivial operations should be delegated to sub-agents. You should delegate research and codebase understanding tasks to codebase-analyzer, codebase-locator and codebase-pattern-locator sub-agents.
+
+You should delegate running bash commands (particularly ones that are likely to produce lots of output) such as investigating with the \`aws\` CLI, using the \`gh\` CLI, digging through logs to \`Bash\` sub-agents.
+
+You should use separate sub-agents for separate tasks, and you may launch them in parallel - but do not delegate multiple tasks that are likely to have significant overlap to separate sub-agents.
+
+IMPORTANT: if the user has already given you a task, you should proceed with that task using this approach.
+IMPORTANT: sometimes sub-agents will take a long time. DO NOT attempt to do the job yourself while waiting for the sub-agent to respond. Instead, use the time to plan out your next steps, or ask the user follow-up questions to clarify the task requirements.
+
+If you have not already been explicitly given a task, you should ask the user what task they would like for you to work on - do not assume or begin working on a ticket automatically.
+
+4. **Debugging**: When a user asks about debugging, ALWAYS spawn a debugger sub-agent first.
+   - Do not attempt to debug or analyze code yourself without first consulting the debugger sub-agent.
+   - Explain the debugger's insights to the user clearly and concisely.
+   - Once the user confirms, implement the necessary code changes based on those insights.
+   - If the user has follow-up questions, spawn additional debugger and research sub-agents as needed.
+</tool_policies>
+
+<engineering_principles>
+Software engineering is fundamentally about **managing complexity** to prevent technical debt. When implementing features, prioritize maintainability and testability over cleverness.
+
+**Core Principles:**
+- **Single Responsibility (SRP):** Every class and module must have exactly one reason to change. If a unit does more than one job, split it.
+- **Dependency Inversion (DIP):** Depend on abstractions (interfaces), never on concrete implementations. Inject dependencies; do not instantiate them internally.
+- **KISS:** Keep solutions as simple as possible. Reject unnecessary abstraction layers.
+- **YAGNI:** Do not build generic frameworks or add configurability for hypothetical future requirements. Solve the problem at hand.
+
+**Design Patterns** — Use Gang of Four patterns as a shared vocabulary for recurring problems:
+- **Creational:** Use _Factory_ or _Builder_ to abstract complex object creation and isolate construction logic.
+- **Structural:** Use _Adapter_ or _Facade_ to decouple core logic from external APIs or legacy code.
+- **Behavioral:** Use _Strategy_ to make algorithms interchangeable. Use _Observer_ for event-driven communication between decoupled components.
+
+**Architectural Hygiene:**
+- **Separation of Concerns:** Isolate business logic (Domain) from infrastructure (Database, UI, networking). Never let infrastructure details leak into domain code.
+- **Anti-Pattern Detection:** Watch for **God Objects** (classes with too many responsibilities) and **Spaghetti Code** (tightly coupled, hard-to-follow control flow). Refactor them using polymorphism and clear interfaces.
+
+Create **seams** in your software using interfaces and abstractions. This ensures code remains flexible, testable, and capable of evolving independently.
+</engineering_principles>
+`;
+
+/**
+ * Honors `ATOMIC_SETTINGS_HOME` so tests can redirect the global file to a
+ * temp dir. Mirrors the convention used by `auto-sync.ts` and `agents.ts`.
+ */
+function homeRoot(): string {
+  return process.env.ATOMIC_SETTINGS_HOME ?? homedir();
+}
+
+/** Path to the global seed: `~/.atomic/AGENTS.md`. */
+export function getGlobalAdditionalInstructionsPath(): string {
+  return join(homeRoot(), ".atomic", "AGENTS.md");
+}
+
+/** Path to the per-project override: `<projectRoot>/.atomic/AGENTS.md`. */
+export function getLocalAdditionalInstructionsPath(
+  projectRoot: string,
+): string {
+  return join(projectRoot, ".atomic", "AGENTS.md");
+}
+
+/**
+ * Resolve the effective additional-instructions file for a project.
+ *
+ * Returns the project-local override if it exists, otherwise the global
+ * seed. Returns `undefined` only if neither exists — which can happen on a
+ * fresh dev checkout that hasn't yet run `autoSyncIfStale` (the seed write).
+ *
+ * Sync `existsSync` is intentional: this is called on every spawn and we
+ * want the cost to be a single `stat` per provider, not an `await`.
+ */
+export function resolveAdditionalInstructionsPath(
+  projectRoot: string,
+): string | undefined {
+  const local = getLocalAdditionalInstructionsPath(projectRoot);
+  if (existsSync(local)) return local;
+  const global = getGlobalAdditionalInstructionsPath();
+  if (existsSync(global)) return global;
+  return undefined;
+}
+
+/**
+ * Read the resolved file's contents, or `undefined` if no file exists.
+ * Used by SDK paths that need the raw string (Claude `systemPrompt.append`,
+ * Copilot `systemMessage.content`).
+ */
+export async function resolveAdditionalInstructionsContent(
+  projectRoot: string,
+): Promise<string | undefined> {
+  const path = resolveAdditionalInstructionsPath(projectRoot);
+  if (!path) return undefined;
+  try {
+    return await readFile(path, "utf-8");
+  } catch {
+    // Race: file disappeared between resolve and read. Treat as absent.
+    return undefined;
+  }
+}
+
+/**
+ * Write `~/.atomic/AGENTS.md` with {@link ADDITIONAL_INSTRUCTIONS} if (and
+ * only if) the file is missing. Idempotent and safe to call on every CLI
+ * start; the user is free to edit the file afterward without atomic
+ * clobbering their changes on upgrade.
+ */
+export async function seedGlobalAdditionalInstructions(): Promise<void> {
+  const path = getGlobalAdditionalInstructionsPath();
+  if (existsSync(path)) return;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, ADDITIONAL_INSTRUCTIONS, "utf-8");
+}
+
+/**
+ * Identify entries in OpenCode's `instructions` array that atomic owns.
+ *
+ * We claim any entry whose path ends with `.atomic/AGENTS.md` (POSIX or
+ * Windows separators), since both the global seed and the local override
+ * land at that suffix. Reconciliation strips matches and re-adds the
+ * currently-resolved path, so the on-disk config tracks the resolver
+ * (e.g. flips when the user creates a local override) without piling up
+ * stale entries across runs.
+ */
+function isAtomicManagedInstruction(entry: unknown): entry is string {
+  if (typeof entry !== "string") return false;
+  return /(?:^|[\\/])\.atomic[\\/]AGENTS\.md$/.test(entry);
+}
+
+/**
+ * Ensure the resolved `AGENTS.md` is wired into
+ * `<projectRoot>/.opencode/opencode.json`'s `instructions` array.
+ *
+ * OpenCode (CLI and SDK alike) consumes the `instructions` field from
+ * project config; there's no flag or env var that injects an instruction
+ * file. Strategy:
+ *   - Resolve the effective path via {@link resolveAdditionalInstructionsPath}.
+ *   - Strip any prior atomic-managed entries (matches `.atomic/AGENTS.md`).
+ *   - Append the absolute resolved path. Absolute is fine because OpenCode
+ *     happily takes them; we don't expect the user to commit this entry
+ *     across machines (and even if they do, the next run reconciles it).
+ *   - When nothing resolves (file truly missing on this machine), we still
+ *     run the cleanup pass so a previously-seeded entry doesn't leak.
+ *
+ * No-op on `.opencode/opencode.json` files we don't own (i.e. we never
+ * create the file ourselves; `applyManagedOnboardingFiles` is responsible
+ * for that). When the file is absent, this helper simply returns.
+ */
+export async function reconcileOpencodeInstructions(
+  projectRoot: string,
+): Promise<void> {
+  const opencodeConfigPath = join(projectRoot, ".opencode", "opencode.json");
+  if (!existsSync(opencodeConfigPath)) return;
+
+  const raw = await readFile(opencodeConfigPath, "utf-8");
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    // Malformed config — leave it alone; the user's editor will surface
+    // the error and our injection would only obscure it.
+    return;
+  }
+
+  const existing = Array.isArray(config.instructions)
+    ? (config.instructions as unknown[])
+    : [];
+  const preserved = existing.filter((e) => !isAtomicManagedInstruction(e));
+
+  const resolved = resolveAdditionalInstructionsPath(projectRoot);
+  const next = resolved ? [...preserved, resolved] : preserved;
+
+  // Skip the write when nothing actually changed — avoids touching mtime
+  // on every spawn and keeps the file out of `git status` noise.
+  const sameLength = next.length === existing.length;
+  const sameOrder =
+    sameLength && next.every((entry, i) => entry === existing[i]);
+  if (sameOrder) return;
+
+  if (next.length > 0) {
+    config.instructions = next;
+  } else {
+    delete config.instructions;
+  }
+  await writeFile(opencodeConfigPath, JSON.stringify(config, null, 2) + "\n");
+}

--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -17,7 +17,8 @@
  *     2. global agent configs    (file copies — no network)
  *     3. @playwright/cli         (bun install -g)
  *     4. @llamaindex/liteparse   (bun install -g)
- *     5. global skills           (file copies from bundled .agents/skills)
+ *     5. @ast-grep/cli           (bun install -g)
+ *     6. global skills           (file copies from bundled .agents/skills)
  *
  * All steps run silently. The only user-facing loading bar lives in the
  * bootstrap installers (install.sh / install.ps1). Failures are swallowed;
@@ -35,6 +36,7 @@ import {
 } from "../../lib/spawn.ts";
 import { installGlobalAgents } from "./agents.ts";
 import { installGlobalSkills } from "./skills.ts";
+import { seedGlobalAdditionalInstructions } from "../config/additional-instructions.ts";
 
 /** Path to the version marker. Honors ATOMIC_SETTINGS_HOME for tests. */
 function syncMarkerPath(): string {
@@ -85,6 +87,13 @@ async function silentStep(fn: () => Promise<unknown>): Promise<boolean> {
  * only loading UI lives in the bootstrap installers (install.sh / install.ps1).
  */
 export async function autoSyncIfStale(): Promise<void> {
+  // Seed the global additional-instructions AGENTS.md on every CLI start —
+  // a single `existsSync` when already present, so cheap enough to run
+  // outside the installed-package gate. This way dev checkouts also get
+  // the file and the resolver in `additional-instructions.ts` always finds
+  // a non-`undefined` path on machines that have ever run `atomic`.
+  await silentStep(seedGlobalAdditionalInstructions);
+
   if (!isInstalledPackage()) return;
 
   let stored = "";


### PR DESCRIPTION
## Summary

Introduces a new \`additional-instructions\` service that seeds and injects a user-editable \`AGENTS.md\` into every agent session across all three providers (Claude, Copilot, OpenCode), and rewrites the \`deep-research-codebase\` workflow with an improved scout/batching pipeline.

## Key Changes

### Additional instructions service (`src/services/config/additional-instructions.ts`)

- Seeds \`~/.atomic/AGENTS.md\` on CLI start via \`autoSyncIfStale\` (single \`existsSync\` check — effectively free when the file already exists); the file is user-owned after first write and **never overwritten on upgrade**
- Project-local \`.atomic/AGENTS.md\` takes precedence over the global file via \`resolveAdditionalInstructionsPath\`
- **Claude CLI**: passes \`--append-system-prompt-file <path>\` to the spawned agent
- **Claude SDK** (\`HeadlessClaudeSessionWrapper\`): merges content into \`systemPrompt\` via new \`mergeSystemPromptAppend\` helper, preserving the \`claude_code\` preset; adds \`_projectRoot\` tracking so the correct config dir is resolved regardless of \`process.cwd()\`
- **Copilot CLI**: sets \`COPILOT_CUSTOM_INSTRUCTIONS_DIRS\` env var pointing at the resolved file's parent directory; includes a comma-in-path guard since Copilot has no escape syntax for the list separator
- **Copilot SDK**: merges content via new \`mergeCopilotSystemMessage\` helper (respects \`replace\` mode opt-out)
- **OpenCode**: reconciles the resolved path into \`.opencode/opencode.json\`'s \`instructions\` array via \`reconcileOpencodeInstructions\`, called from both \`ensureProjectSetup\` and \`executeWorkflow\`

### \`deep-research-codebase\` workflow overhaul

- **Scout rewrite** (\`helpers/scout.ts\`): derives code file extensions from \`linguist-languages\`, honors \`.gitignore\` via ripgrep in non-repo directories, fixes partition unit aggregation
- **Batching helper** (\`helpers/batching.ts\`): new module for partitioning file lists into optimally-sized LLM context windows
- **Expanded prompts** (\`helpers/prompts.ts\`): richer stage prompts that consume the new scout output and batching pipeline
- **All three workflow backends** (Claude, Copilot, OpenCode) updated to use the new scout + batching pipeline

### Skills & tooling

- Bundle \`ast-grep\` and \`ripgrep\` skills into \`.agents/skills/\` and \`skills-lock.json\`
- Add \`@ast-grep/cli\` to the auto-sync global installs (step 5, shifting skills install to step 6)

### MCP / config

- Pass \`GH_TOKEN\` as \`Authorization: Bearer\` header in \`.mcp.json\` for the GitHub MCP server

## Test plan

- [ ] Fresh install: verify \`~/.atomic/AGENTS.md\` is seeded on first \`atomic chat\` / workflow run
- [ ] Subsequent runs: verify the file is **not** overwritten when it already exists
- [ ] Project-local \`.atomic/AGENTS.md\`: verify it takes precedence over the global file
- [ ] Claude CLI: confirm \`--append-system-prompt-file\` flag appears in the spawned command
- [ ] Copilot CLI: confirm \`COPILOT_CUSTOM_INSTRUCTIONS_DIRS\` is set correctly; test comma-in-path warning
- [ ] OpenCode: confirm \`.opencode/opencode.json\` \`instructions\` array is reconciled before each workflow run
- [ ] \`deep-research-codebase\`: run against a mid-size repo and verify scout/batching pipeline completes without errors for all three backends