### PR TITLE
fix(claude): gate stage teardown on in-flight subagent drain

### DIFF
--- a/docs/claude-code/cli/hooks.md
+++ b/docs/claude-code/cli/hooks.md
@@ -2,618 +2,64 @@
 > Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
 > Use this file to discover all available pages before exploring further.
 
-# Automate workflows with hooks
+# Hooks reference
 
-> Run shell commands automatically when Claude Code edits files, finishes tasks, or needs input. Format code, send notifications, validate commands, and enforce project rules.
-
-Hooks are user-defined shell commands that execute at specific points in Claude Code's lifecycle. They provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM to choose to run them. Use hooks to enforce project rules, automate repetitive tasks, and integrate Claude Code with your existing tools.
-
-For decisions that require judgment rather than deterministic rules, you can also use [prompt-based hooks](#prompt-based-hooks) or [agent-based hooks](#agent-based-hooks) that use a Claude model to evaluate conditions.
-
-For other ways to extend Claude Code, see [skills](/en/skills) for giving Claude additional instructions and executable commands, [subagents](/en/sub-agents) for running tasks in isolated contexts, and [plugins](/en/plugins) for packaging extensions to share across projects.
+> Reference for Claude Code hook events, configuration schema, JSON input/output formats, exit codes, async hooks, HTTP hooks, prompt hooks, and MCP tool hooks.
 
 <Tip>
-  This guide covers common use cases and how to get started. For full event schemas, JSON input/output formats, and advanced features like async hooks and MCP tool hooks, see the [Hooks reference](/en/hooks).
+  For a quickstart guide with examples, see [Automate workflows with hooks](/en/hooks-guide).
 </Tip>
 
-## Set up your first hook
-
-To create a hook, add a `hooks` block to a [settings file](#configure-hook-location). This walkthrough creates a desktop notification hook, so you get alerted whenever Claude is waiting for your input instead of watching the terminal.
-
-<Steps>
-  <Step title="Add the hook to your settings">
-    Open `~/.claude/settings.json` and add a `Notification` hook. The example below uses `osascript` for macOS; see [Get notified when Claude needs input](#get-notified-when-claude-needs-input) for Linux and Windows commands.
-
-    ```json  theme={null}
-    {
-      "hooks": {
-        "Notification": [
-          {
-            "matcher": "",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "osascript -e 'display notification \"Claude Code needs your attention\" with title \"Claude Code\"'"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-
-    If your settings file already has a `hooks` key, merge the `Notification` entry into it rather than replacing the whole object. You can also ask Claude to write the hook for you by describing what you want in the CLI.
-  </Step>
-
-  <Step title="Verify the configuration">
-    Type `/hooks` to open the hooks browser. You'll see a list of all available hook events, with a count next to each event that has hooks configured. Select `Notification` to confirm your new hook appears in the list. Selecting the hook shows its details: the event, matcher, type, source file, and command.
-  </Step>
-
-  <Step title="Test the hook">
-    Press `Esc` to return to the CLI. Ask Claude to do something that requires permission, then switch away from the terminal. You should receive a desktop notification.
-  </Step>
-</Steps>
-
-<Tip>
-  The `/hooks` menu is read-only. To add, modify, or remove hooks, edit your settings JSON directly or ask Claude to make the change.
-</Tip>
-
-## What you can automate
-
-Hooks let you run code at key points in Claude Code's lifecycle: format files after edits, block commands before they execute, send notifications when Claude needs input, inject context at session start, and more. For the full list of hook events, see the [Hooks reference](/en/hooks#hook-lifecycle).
-
-Each example includes a ready-to-use configuration block that you add to a [settings file](#configure-hook-location). The most common patterns:
-
-* [Get notified when Claude needs input](#get-notified-when-claude-needs-input)
-* [Auto-format code after edits](#auto-format-code-after-edits)
-* [Block edits to protected files](#block-edits-to-protected-files)
-* [Re-inject context after compaction](#re-inject-context-after-compaction)
-* [Audit configuration changes](#audit-configuration-changes)
-* [Reload environment when directory or files change](#reload-environment-when-directory-or-files-change)
-* [Auto-approve specific permission prompts](#auto-approve-specific-permission-prompts)
-
-### Get notified when Claude needs input
-
-Get a desktop notification whenever Claude finishes working and needs your input, so you can switch to other tasks without checking the terminal.
-
-This hook uses the `Notification` event, which fires when Claude is waiting for input or permission. Each tab below uses the platform's native notification command. Add this to `~/.claude/settings.json`:
-
-<Tabs>
-  <Tab title="macOS">
-    ```json  theme={null}
-    {
-      "hooks": {
-        "Notification": [
-          {
-            "matcher": "",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "osascript -e 'display notification \"Claude Code needs your attention\" with title \"Claude Code\"'"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-
-  <Tab title="Linux">
-    ```json  theme={null}
-    {
-      "hooks": {
-        "Notification": [
-          {
-            "matcher": "",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "notify-send 'Claude Code' 'Claude Code needs your attention'"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-
-  <Tab title="Windows (PowerShell)">
-    ```json  theme={null}
-    {
-      "hooks": {
-        "Notification": [
-          {
-            "matcher": "",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "powershell.exe -Command \"[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms'); [System.Windows.Forms.MessageBox]::Show('Claude Code needs your attention', 'Claude Code')\""
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-</Tabs>
-
-### Auto-format code after edits
-
-Automatically run [Prettier](https://prettier.io/) on every file Claude edits, so formatting stays consistent without manual intervention.
-
-This hook uses the `PostToolUse` event with an `Edit|Write` matcher, so it runs only after file-editing tools. The command extracts the edited file path with [`jq`](https://jqlang.github.io/jq/) and passes it to Prettier. Add this to `.claude/settings.json` in your project root:
-
-```json  theme={null}
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path' | xargs npx prettier --write"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-<Note>
-  The Bash examples on this page use `jq` for JSON parsing. Install it with `brew install jq` (macOS), `apt-get install jq` (Debian/Ubuntu), or see [`jq` downloads](https://jqlang.github.io/jq/download/).
-</Note>
-
-### Block edits to protected files
-
-Prevent Claude from modifying sensitive files like `.env`, `package-lock.json`, or anything in `.git/`. Claude receives feedback explaining why the edit was blocked, so it can adjust its approach.
-
-This example uses a separate script file that the hook calls. The script checks the target file path against a list of protected patterns and exits with code 2 to block the edit.
-
-<Steps>
-  <Step title="Create the hook script">
-    Save this to `.claude/hooks/protect-files.sh`:
-
-    ```bash  theme={null}
-    #!/bin/bash
-    # protect-files.sh
-
-    INPUT=$(cat)
-    FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-    PROTECTED_PATTERNS=(".env" "package-lock.json" ".git/")
-
-    for pattern in "${PROTECTED_PATTERNS[@]}"; do
-      if [[ "$FILE_PATH" == *"$pattern"* ]]; then
-        echo "Blocked: $FILE_PATH matches protected pattern '$pattern'" >&2
-        exit 2
-      fi
-    done
-
-    exit 0
-    ```
-  </Step>
-
-  <Step title="Make the script executable (macOS/Linux)">
-    Hook scripts must be executable for Claude Code to run them:
-
-    ```bash  theme={null}
-    chmod +x .claude/hooks/protect-files.sh
-    ```
-  </Step>
-
-  <Step title="Register the hook">
-    Add a `PreToolUse` hook to `.claude/settings.json` that runs the script before any `Edit` or `Write` tool call:
-
-    ```json  theme={null}
-    {
-      "hooks": {
-        "PreToolUse": [
-          {
-            "matcher": "Edit|Write",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/protect-files.sh"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-  </Step>
-</Steps>
-
-### Re-inject context after compaction
-
-When Claude's context window fills up, compaction summarizes the conversation to free space. This can lose important details. Use a `SessionStart` hook with a `compact` matcher to re-inject critical context after every compaction.
-
-Any text your command writes to stdout is added to Claude's context. This example reminds Claude of project conventions and recent work. Add this to `.claude/settings.json` in your project root:
-
-```json  theme={null}
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "compact",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'Reminder: use Bun, not npm. Run bun test before committing. Current sprint: auth refactor.'"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-You can replace the `echo` with any command that produces dynamic output, like `git log --oneline -5` to show recent commits. For injecting context on every session start, consider using [CLAUDE.md](/en/memory) instead. For environment variables, see [`CLAUDE_ENV_FILE`](/en/hooks#persist-environment-variables) in the reference.
-
-### Audit configuration changes
-
-Track when settings or skills files change during a session. The `ConfigChange` event fires when an external process or editor modifies a configuration file, so you can log changes for compliance or block unauthorized modifications.
-
-This example appends each change to an audit log. Add this to `~/.claude/settings.json`:
-
-```json  theme={null}
-{
-  "hooks": {
-    "ConfigChange": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -c '{timestamp: now | todate, source: .source, file: .file_path}' >> ~/claude-config-audit.log"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-The matcher filters by configuration type: `user_settings`, `project_settings`, `local_settings`, `policy_settings`, or `skills`. To block a change from taking effect, exit with code 2 or return `{"decision": "block"}`. See the [ConfigChange reference](/en/hooks#configchange) for the full input schema.
-
-### Reload environment when directory or files change
-
-Some projects set different environment variables depending on which directory you are in. Tools like [direnv](https://direnv.net/) do this automatically in your shell, but Claude's Bash tool does not pick up those changes on its own.
-
-A `CwdChanged` hook fixes this: it runs each time Claude changes directory, so you can reload the correct variables for the new location. The hook writes the updated values to `CLAUDE_ENV_FILE`, which Claude Code applies before each Bash command. Add this to `~/.claude/settings.json`:
-
-```json  theme={null}
-{
-  "hooks": {
-    "CwdChanged": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "direnv export bash >> \"$CLAUDE_ENV_FILE\""
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-To react to specific files instead of every directory change, use `FileChanged` with a `matcher` listing the filenames to watch (pipe-separated). The `matcher` both configures which files to watch and filters which hooks run. This example watches `.envrc` and `.env` for changes in the current directory:
-
-```json  theme={null}
-{
-  "hooks": {
-    "FileChanged": [
-      {
-        "matcher": ".envrc|.env",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "direnv export bash >> \"$CLAUDE_ENV_FILE\""
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-See the [CwdChanged](/en/hooks#cwdchanged) and [FileChanged](/en/hooks#filechanged) reference entries for input schemas, `watchPaths` output, and `CLAUDE_ENV_FILE` details.
-
-### Auto-approve specific permission prompts
-
-Skip the approval dialog for tool calls you always allow. This example auto-approves `ExitPlanMode`, the tool Claude calls when it finishes presenting a plan and asks to proceed, so you aren't prompted every time a plan is ready.
-
-Unlike the exit-code examples above, auto-approval requires your hook to write a JSON decision to stdout. A `PermissionRequest` hook fires when Claude Code is about to show a permission dialog, and returning `"behavior": "allow"` answers it on your behalf.
-
-The matcher scopes the hook to `ExitPlanMode` only, so no other prompts are affected. Add this to `~/.claude/settings.json`:
-
-```json  theme={null}
-{
-  "hooks": {
-    "PermissionRequest": [
-      {
-        "matcher": "ExitPlanMode",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"PermissionRequest\", \"decision\": {\"behavior\": \"allow\"}}}'"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-When the hook approves, Claude Code exits plan mode and restores whatever permission mode was active before you entered plan mode. The transcript shows "Allowed by PermissionRequest hook" where the dialog would have appeared. The hook path always keeps the current conversation: it cannot clear context and start a fresh implementation session the way the dialog can.
-
-To set a specific permission mode instead, your hook's output can include an `updatedPermissions` array with a `setMode` entry. The `mode` value is any permission mode like `default`, `acceptEdits`, or `bypassPermissions`, and `destination: "session"` applies it for the current session only.
-
-To switch the session to `acceptEdits`, your hook writes this JSON to stdout:
-
-```json  theme={null}
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PermissionRequest",
-    "decision": {
-      "behavior": "allow",
-      "updatedPermissions": [
-        { "type": "setMode", "mode": "acceptEdits", "destination": "session" }
-      ]
-    }
-  }
-}
-```
-
-Keep the matcher as narrow as possible. Matching on `.*` or leaving the matcher empty would auto-approve every permission prompt, including file writes and shell commands. See the [PermissionRequest reference](/en/hooks#permissionrequest-decision-control) for the full set of decision fields.
-
-## How hooks work
-
-Hook events fire at specific lifecycle points in Claude Code. When an event fires, all matching hooks run in parallel, and identical hook commands are automatically deduplicated. The table below shows each event and when it triggers:
-
-| Event                | When it fires                                                                                                                                          |
-| :------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SessionStart`       | When a session begins or resumes                                                                                                                       |
-| `UserPromptSubmit`   | When you submit a prompt, before Claude processes it                                                                                                   |
-| `PreToolUse`         | Before a tool call executes. Can block it                                                                                                              |
-| `PermissionRequest`  | When a permission dialog appears                                                                                                                       |
-| `PostToolUse`        | After a tool call succeeds                                                                                                                             |
-| `PostToolUseFailure` | After a tool call fails                                                                                                                                |
-| `Notification`       | When Claude Code sends a notification                                                                                                                  |
-| `SubagentStart`      | When a subagent is spawned                                                                                                                             |
-| `SubagentStop`       | When a subagent finishes                                                                                                                               |
-| `TaskCreated`        | When a task is being created via `TaskCreate`                                                                                                          |
-| `TaskCompleted`      | When a task is being marked as completed                                                                                                               |
-| `Stop`               | When Claude finishes responding                                                                                                                        |
-| `StopFailure`        | When the turn ends due to an API error. Output and exit code are ignored                                                                               |
-| `TeammateIdle`       | When an [agent team](/en/agent-teams) teammate is about to go idle                                                                                     |
-| `InstructionsLoaded` | When a CLAUDE.md or `.claude/rules/*.md` file is loaded into context. Fires at session start and when files are lazily loaded during a session         |
-| `ConfigChange`       | When a configuration file changes during a session                                                                                                     |
-| `CwdChanged`         | When the working directory changes, for example when Claude executes a `cd` command. Useful for reactive environment management with tools like direnv |
-| `FileChanged`        | When a watched file changes on disk. The `matcher` field specifies which filenames to watch                                                            |
-| `WorktreeCreate`     | When a worktree is being created via `--worktree` or `isolation: "worktree"`. Replaces default git behavior                                            |
-| `WorktreeRemove`     | When a worktree is being removed, either at session exit or when a subagent finishes                                                                   |
-| `PreCompact`         | Before context compaction                                                                                                                              |
-| `PostCompact`        | After context compaction completes                                                                                                                     |
-| `Elicitation`        | When an MCP server requests user input during a tool call                                                                                              |
-| `ElicitationResult`  | After a user responds to an MCP elicitation, before the response is sent back to the server                                                            |
-| `SessionEnd`         | When a session terminates                                                                                                                              |
-
-Each hook has a `type` that determines how it runs. Most hooks use `"type": "command"`, which runs a shell command. Three other types are available:
-
-* `"type": "http"`: POST event data to a URL. See [HTTP hooks](#http-hooks).
-* `"type": "prompt"`: single-turn LLM evaluation. See [Prompt-based hooks](#prompt-based-hooks).
-* `"type": "agent"`: multi-turn verification with tool access. See [Agent-based hooks](#agent-based-hooks).
-
-### Read input and return output
-
-Hooks communicate with Claude Code through stdin, stdout, stderr, and exit codes. When an event fires, Claude Code passes event-specific data as JSON to your script's stdin. Your script reads that data, does its work, and tells Claude Code what to do next via the exit code.
-
-#### Hook input
-
-Every event includes common fields like `session_id` and `cwd`, but each event type adds different data. For example, when Claude runs a Bash command, a `PreToolUse` hook receives something like this on stdin:
-
-```json  theme={null}
-{
-  "session_id": "abc123",          // unique ID for this session
-  "cwd": "/Users/sarah/myproject", // working directory when the event fired
-  "hook_event_name": "PreToolUse", // which event triggered this hook
-  "tool_name": "Bash",             // the tool Claude is about to use
-  "tool_input": {                  // the arguments Claude passed to the tool
-    "command": "npm test"          // for Bash, this is the shell command
-  }
-}
-```
-
-Your script can parse that JSON and act on any of those fields. `UserPromptSubmit` hooks get the `prompt` text instead, `SessionStart` hooks get the `source` (startup, resume, clear, compact), and so on. See [Common input fields](/en/hooks#common-input-fields) in the reference for shared fields, and each event's section for event-specific schemas.
-
-#### Hook output
-
-Your script tells Claude Code what to do next by writing to stdout or stderr and exiting with a specific code. For example, a `PreToolUse` hook that wants to block a command:
-
-```bash  theme={null}
-#!/bin/bash
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
-
-if echo "$COMMAND" | grep -q "drop table"; then
-  echo "Blocked: dropping tables is not allowed" >&2  # stderr becomes Claude's feedback
-  exit 2                                               # exit 2 = block the action
-fi
-
-exit 0  # exit 0 = let it proceed
-```
-
-The exit code determines what happens next:
-
-* **Exit 0**: the action proceeds. For `UserPromptSubmit` and `SessionStart` hooks, anything you write to stdout is added to Claude's context.
-* **Exit 2**: the action is blocked. Write a reason to stderr, and Claude receives it as feedback so it can adjust.
-* **Any other exit code**: the action proceeds. Stderr is logged but not shown to Claude. Toggle verbose mode with `Ctrl+O` to see these messages in the transcript.
-
-#### Structured JSON output
-
-Exit codes give you two options: allow or block. For more control, exit 0 and print a JSON object to stdout instead.
-
-<Note>
-  Use exit 2 to block with a stderr message, or exit 0 with JSON for structured control. Don't mix them: Claude Code ignores JSON when you exit 2.
-</Note>
-
-For example, a `PreToolUse` hook can deny a tool call and tell Claude why, or escalate it to the user for approval:
-
-```json  theme={null}
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "deny",
-    "permissionDecisionReason": "Use rg instead of grep for better performance"
-  }
-}
-```
-
-Claude Code reads `permissionDecision` and cancels the tool call, then feeds `permissionDecisionReason` back to Claude as feedback. These three options are specific to `PreToolUse`:
-
-* `"allow"`: skip the interactive permission prompt. Deny and ask rules, including enterprise managed deny lists, still apply
-* `"deny"`: cancel the tool call and send the reason to Claude
-* `"ask"`: show the permission prompt to the user as normal
-
-Returning `"allow"` skips the interactive prompt but does not override [permission rules](/en/permissions#manage-permissions). If a deny rule matches the tool call, the call is blocked even when your hook returns `"allow"`. If an ask rule matches, the user is still prompted. This means deny rules from any settings scope, including [managed settings](/en/settings#settings-files), always take precedence over hook approvals.
-
-Other events use different decision patterns. For example, `PostToolUse` and `Stop` hooks use a top-level `decision: "block"` field, while `PermissionRequest` uses `hookSpecificOutput.decision.behavior`. See the [summary table](/en/hooks#decision-control) in the reference for a full breakdown by event.
-
-For `UserPromptSubmit` hooks, use `additionalContext` instead to inject text into Claude's context. Prompt-based hooks (`type: "prompt"`) handle output differently: see [Prompt-based hooks](#prompt-based-hooks).
-
-### Filter hooks with matchers
-
-Without a matcher, a hook fires on every occurrence of its event. Matchers let you narrow that down. For example, if you want to run a formatter only after file edits (not after every tool call), add a matcher to your `PostToolUse` hook:
-
-```json  theme={null}
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          { "type": "command", "command": "prettier --write ..." }
-        ]
-      }
-    ]
-  }
-}
-```
-
-The `"Edit|Write"` matcher is a regex pattern that matches the tool name. The hook only fires when Claude uses the `Edit` or `Write` tool, not when it uses `Bash`, `Read`, or any other tool.
-
-Each event type matches on a specific field. Matchers support exact strings and regex patterns:
-
-| Event                                                                                                                        | What the matcher filters                | Example matcher values                                                                                                    |
-| :--------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
-| `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`                                                       | tool name                               | `Bash`, `Edit\|Write`, `mcp__.*`                                                                                          |
-| `SessionStart`                                                                                                               | how the session started                 | `startup`, `resume`, `clear`, `compact`                                                                                   |
-| `SessionEnd`                                                                                                                 | why the session ended                   | `clear`, `resume`, `logout`, `prompt_input_exit`, `bypass_permissions_disabled`, `other`                                  |
-| `Notification`                                                                                                               | notification type                       | `permission_prompt`, `idle_prompt`, `auth_success`, `elicitation_dialog`                                                  |
-| `SubagentStart`                                                                                                              | agent type                              | `Bash`, `Explore`, `Plan`, or custom agent names                                                                          |
-| `PreCompact`, `PostCompact`                                                                                                  | what triggered compaction               | `manual`, `auto`                                                                                                          |
-| `SubagentStop`                                                                                                               | agent type                              | same values as `SubagentStart`                                                                                            |
-| `ConfigChange`                                                                                                               | configuration source                    | `user_settings`, `project_settings`, `local_settings`, `policy_settings`, `skills`                                        |
-| `StopFailure`                                                                                                                | error type                              | `rate_limit`, `authentication_failed`, `billing_error`, `invalid_request`, `server_error`, `max_output_tokens`, `unknown` |
-| `InstructionsLoaded`                                                                                                         | load reason                             | `session_start`, `nested_traversal`, `path_glob_match`, `include`, `compact`                                              |
-| `Elicitation`                                                                                                                | MCP server name                         | your configured MCP server names                                                                                          |
-| `ElicitationResult`                                                                                                          | MCP server name                         | same values as `Elicitation`                                                                                              |
-| `FileChanged`                                                                                                                | filename (basename of the changed file) | `.envrc`, `.env`, any filename you want to watch                                                                          |
-| `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCreated`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove`, `CwdChanged` | no matcher support                      | always fires on every occurrence                                                                                          |
-
-A few more examples showing matchers on different event types:
-
-<Tabs>
-  <Tab title="Log every Bash command">
-    Match only `Bash` tool calls and log each command to a file. The `PostToolUse` event fires after the command completes, so `tool_input.command` contains what ran. The hook receives the event data as JSON on stdin, and `jq -r '.tool_input.command'` extracts just the command string, which `>>` appends to the log file:
-
-    ```json  theme={null}
-    {
-      "hooks": {
-        "PostToolUse": [
-          {
-            "matcher": "Bash",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "jq -r '.tool_input.command' >> ~/.claude/command-log.txt"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-
-  <Tab title="Match MCP tools">
-    MCP tools use a different naming convention than built-in tools: `mcp__<server>__<tool>`, where `<server>` is the MCP server name and `<tool>` is the tool it provides. For example, `mcp__github__search_repositories` or `mcp__filesystem__read_file`. Use a regex matcher to target all tools from a specific server, or match across servers with a pattern like `mcp__.*__write.*`. See [Match MCP tools](/en/hooks#match-mcp-tools) in the reference for the full list of examples.
-
-    The command below extracts the tool name from the hook's JSON input with `jq` and writes it to stderr, where it shows up in verbose mode (`Ctrl+O`):
-
-    ```json  theme={null}
-    {
-      "hooks": {
-        "PreToolUse": [
-          {
-            "matcher": "mcp__github__.*",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "echo \"GitHub tool called: $(jq -r '.tool_name')\" >&2"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-
-  <Tab title="Clean up on session end">
-    The `SessionEnd` event supports matchers on the reason the session ended. This hook only fires on `clear` (when you run `/clear`), not on normal exits:
-
-    ```json  theme={null}
-    {
-      "hooks": {
-        "SessionEnd": [
-          {
-            "matcher": "clear",
-            "hooks": [
-              {
-                "type": "command",
-                "command": "rm -f /tmp/claude-scratch-*.txt"
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
-  </Tab>
-</Tabs>
-
-For full matcher syntax, see the [Hooks reference](/en/hooks#configuration).
-
-#### Filter by tool name and arguments with the `if` field
-
-<Note>
-  The `if` field requires Claude Code v2.1.85 or later. Earlier versions ignore it and run the hook on every matched call.
-</Note>
-
-The `if` field uses [permission rule syntax](/en/permissions) to filter hooks by tool name and arguments together, so the hook process only spawns when the tool call matches. This goes beyond `matcher`, which filters at the group level by tool name only.
-
-For example, to run a hook only when Claude uses `git` commands rather than all Bash commands:
-
-```json  theme={null}
+Hooks are user-defined shell commands, HTTP endpoints, or LLM prompts that execute automatically at specific points in Claude Code's lifecycle. Use this reference to look up event schemas, configuration options, JSON input/output formats, and advanced features like async hooks, HTTP hooks, and MCP tool hooks. If you're setting up hooks for the first time, start with the [guide](/en/hooks-guide) instead.
+
+## Hook lifecycle
+
+Hooks fire at specific points during a Claude Code session. When an event fires and a matcher matches, Claude Code passes JSON context about the event to your hook handler. For command hooks, input arrives on stdin. For HTTP hooks, it arrives as the POST request body. Your handler can then inspect the input, take action, and optionally return a decision. Events fall into three cadences: once per session (`SessionStart`, `SessionEnd`), once per turn (`UserPromptSubmit`, `Stop`, `StopFailure`), and on every tool call inside the agentic loop (`PreToolUse`, `PostToolUse`):
+
+<div style={{maxWidth: "500px", margin: "0 auto"}}>
+  <Frame>
+    <img src="https://mintcdn.com/claude-code/_SQ1BnFTP0QUrae-/images/hooks-lifecycle.svg?fit=max&auto=format&n=_SQ1BnFTP0QUrae-&q=85&s=75bd3d4bdefd4f08a7d736167243fd78" alt="Hook lifecycle diagram showing SessionStart, then a per-turn loop containing UserPromptSubmit, UserPromptExpansion for slash commands, the nested agentic loop (PreToolUse, PermissionRequest, PostToolUse, PostToolUseFailure, PostToolBatch, SubagentStart/Stop, TaskCreated, TaskCompleted), and Stop or StopFailure, followed by TeammateIdle, PreCompact, PostCompact, and SessionEnd, with Elicitation and ElicitationResult nested inside MCP tool execution, PermissionDenied as a side branch from PermissionRequest for auto-mode denials, and WorktreeCreate, WorktreeRemove, Notification, ConfigChange, InstructionsLoaded, CwdChanged, and FileChanged as standalone async events" width="520" height="1228" data-path="images/hooks-lifecycle.svg" />
+  </Frame>
+</div>
+
+The table below summarizes when each event fires. The [Hook events](#hook-events) section documents the full input schema and decision control options for each one.
+
+| Event                 | When it fires                                                                                                                                          |
+| :-------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SessionStart`        | When a session begins or resumes                                                                                                                       |
+| `UserPromptSubmit`    | When you submit a prompt, before Claude processes it                                                                                                   |
+| `UserPromptExpansion` | When a user-typed command expands into a prompt, before it reaches Claude. Can block the expansion                                                     |
+| `PreToolUse`          | Before a tool call executes. Can block it                                                                                                              |
+| `PermissionRequest`   | When a permission dialog appears                                                                                                                       |
+| `PermissionDenied`    | When a tool call is denied by the auto mode classifier. Return `{retry: true}` to tell the model it may retry the denied tool call                     |
+| `PostToolUse`         | After a tool call succeeds                                                                                                                             |
+| `PostToolUseFailure`  | After a tool call fails                                                                                                                                |
+| `PostToolBatch`       | After a full batch of parallel tool calls resolves, before the next model call                                                                         |
+| `Notification`        | When Claude Code sends a notification                                                                                                                  |
+| `SubagentStart`       | When a subagent is spawned                                                                                                                             |
+| `SubagentStop`        | When a subagent finishes                                                                                                                               |
+| `TaskCreated`         | When a task is being created via `TaskCreate`                                                                                                          |
+| `TaskCompleted`       | When a task is being marked as completed                                                                                                               |
+| `Stop`                | When Claude finishes responding                                                                                                                        |
+| `StopFailure`         | When the turn ends due to an API error. Output and exit code are ignored                                                                               |
+| `TeammateIdle`        | When an [agent team](/en/agent-teams) teammate is about to go idle                                                                                     |
+| `InstructionsLoaded`  | When a CLAUDE.md or `.claude/rules/*.md` file is loaded into context. Fires at session start and when files are lazily loaded during a session         |
+| `ConfigChange`        | When a configuration file changes during a session                                                                                                     |
+| `CwdChanged`          | When the working directory changes, for example when Claude executes a `cd` command. Useful for reactive environment management with tools like direnv |
+| `FileChanged`         | When a watched file changes on disk. The `matcher` field specifies which filenames to watch                                                            |
+| `WorktreeCreate`      | When a worktree is being created via `--worktree` or `isolation: "worktree"`. Replaces default git behavior                                            |
+| `WorktreeRemove`      | When a worktree is being removed, either at session exit or when a subagent finishes                                                                   |
+| `PreCompact`          | Before context compaction                                                                                                                              |
+| `PostCompact`         | After context compaction completes                                                                                                                     |
+| `Elicitation`         | When an MCP server requests user input during a tool call                                                                                              |
+| `ElicitationResult`   | After a user responds to an MCP elicitation, before the response is sent back to the server                                                            |
+| `SessionEnd`          | When a session terminates                                                                                                                              |
+
+### How a hook resolves
+
+To see how these pieces fit together, consider this `PreToolUse` hook that blocks destructive shell commands. The `matcher` narrows to Bash tool calls and the `if` condition narrows further to Bash subcommands matching `rm *`, so `block-rm.sh` only spawns when both filters match:
+
+```json theme={null}
 {
   "hooks": {
     "PreToolUse": [
@@ -622,8 +68,8 @@ For example, to run a hook only when Claude uses `git` commands rather than all 
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git *)",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-git-policy.sh"
+            "if": "Bash(rm *)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-rm.sh"
           }
         ]
       }
@@ -632,39 +78,2215 @@ For example, to run a hook only when Claude uses `git` commands rather than all 
 }
 ```
 
-The hook process only spawns when the Bash command starts with `git`. Other Bash commands skip this handler entirely. The `if` field accepts the same patterns as permission rules: `"Bash(git *)"`, `"Edit(*.ts)"`, and so on. To match multiple tool names, use separate handlers each with its own `if` value, or match at the `matcher` level where pipe alternation is supported.
+The script reads the JSON input from stdin, extracts the command, and returns a `permissionDecision` of `"deny"` if it contains `rm -rf`:
 
-`if` only works on tool events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, and `PermissionRequest`. Adding it to any other event prevents the hook from running.
+```bash theme={null}
+#!/bin/bash
+# .claude/hooks/block-rm.sh
+COMMAND=$(jq -r '.tool_input.command')
 
-### Configure hook location
+if echo "$COMMAND" | grep -q 'rm -rf'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Destructive command blocked by hook"
+    }
+  }'
+else
+  exit 0  # allow the command
+fi
+```
 
-Where you add a hook determines its scope:
+Now suppose Claude Code decides to run `Bash "rm -rf /tmp/build"`. Here's what happens:
 
-| Location                                                   | Scope                              | Shareable                          |
-| :--------------------------------------------------------- | :--------------------------------- | :--------------------------------- |
-| `~/.claude/settings.json`                                  | All your projects                  | No, local to your machine          |
-| `.claude/settings.json`                                    | Single project                     | Yes, can be committed to the repo  |
-| `.claude/settings.local.json`                              | Single project                     | No, gitignored                     |
-| Managed policy settings                                    | Organization-wide                  | Yes, admin-controlled              |
-| [Plugin](/en/plugins) `hooks/hooks.json`                   | When plugin is enabled             | Yes, bundled with the plugin       |
-| [Skill](/en/skills) or [agent](/en/sub-agents) frontmatter | While the skill or agent is active | Yes, defined in the component file |
+<Frame>
+  <img src="https://mintcdn.com/claude-code/-tYw1BD_DEqfyyOZ/images/hook-resolution.svg?fit=max&auto=format&n=-tYw1BD_DEqfyyOZ&q=85&s=c73ebc1eeda2037570427d7af1e0a891" alt="Hook resolution flow: PreToolUse event fires, matcher checks for Bash match, if condition checks for Bash(rm *) match, hook handler runs, result returns to Claude Code" width="930" height="290" data-path="images/hook-resolution.svg" />
+</Frame>
 
-Run [`/hooks`](/en/hooks#the-hooks-menu) in Claude Code to browse all configured hooks grouped by event. To disable all hooks at once, set `"disableAllHooks": true` in your settings file.
+<Steps>
+  <Step title="Event fires">
+    The `PreToolUse` event fires. Claude Code sends the tool input as JSON on stdin to the hook:
 
-If you edit settings files directly while Claude Code is running, the file watcher normally picks up hook changes automatically.
+    ```json theme={null}
+    { "tool_name": "Bash", "tool_input": { "command": "rm -rf /tmp/build" }, ... }
+    ```
+  </Step>
+
+  <Step title="Matcher checks">
+    The matcher `"Bash"` matches the tool name, so this hook group activates. If you omit the matcher or use `"*"`, the group activates on every occurrence of the event.
+  </Step>
+
+  <Step title="If condition checks">
+    The `if` condition `"Bash(rm *)"` matches because `rm -rf /tmp/build` is a subcommand matching `rm *`, so this handler spawns. If the command had been `npm test`, the `if` check would fail and `block-rm.sh` would never run, avoiding the process spawn overhead. The `if` field is optional; without it, every handler in the matched group runs.
+  </Step>
+
+  <Step title="Hook handler runs">
+    The script inspects the full command and finds `rm -rf`, so it prints a decision to stdout:
+
+    ```json theme={null}
+    {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "Destructive command blocked by hook"
+      }
+    }
+    ```
+
+    If the command had been a safer `rm` variant like `rm file.txt`, the script would hit `exit 0` instead, which tells Claude Code to allow the tool call with no further action.
+  </Step>
+
+  <Step title="Claude Code acts on the result">
+    Claude Code reads the JSON decision, blocks the tool call, and shows Claude the reason.
+  </Step>
+</Steps>
+
+The [Configuration](#configuration) section below documents the full schema, and each [hook event](#hook-events) section documents what input your command receives and what output it can return.
+
+## Configuration
+
+Hooks are defined in JSON settings files. The configuration has three levels of nesting:
+
+1. Choose a [hook event](#hook-events) to respond to, like `PreToolUse` or `Stop`
+2. Add a [matcher group](#matcher-patterns) to filter when it fires, like "only for the Bash tool"
+3. Define one or more [hook handlers](#hook-handler-fields) to run when matched
+
+See [How a hook resolves](#how-a-hook-resolves) above for a complete walkthrough with an annotated example.
+
+<Note>
+  This page uses specific terms for each level: **hook event** for the lifecycle point, **matcher group** for the filter, and **hook handler** for the shell command, HTTP endpoint, MCP tool, prompt, or agent that runs. "Hook" on its own refers to the general feature.
+</Note>
+
+### Hook locations
+
+Where you define a hook determines its scope:
+
+| Location                                                   | Scope                         | Shareable                          |
+| :--------------------------------------------------------- | :---------------------------- | :--------------------------------- |
+| `~/.claude/settings.json`                                  | All your projects             | No, local to your machine          |
+| `.claude/settings.json`                                    | Single project                | Yes, can be committed to the repo  |
+| `.claude/settings.local.json`                              | Single project                | No, gitignored                     |
+| Managed policy settings                                    | Organization-wide             | Yes, admin-controlled              |
+| [Plugin](/en/plugins) `hooks/hooks.json`                   | When plugin is enabled        | Yes, bundled with the plugin       |
+| [Skill](/en/skills) or [agent](/en/sub-agents) frontmatter | While the component is active | Yes, defined in the component file |
+
+For details on settings file resolution, see [settings](/en/settings). Enterprise administrators can use `allowManagedHooksOnly` to block user, project, and plugin hooks. Hooks from plugins force-enabled in managed settings `enabledPlugins` are exempt, so administrators can distribute vetted hooks through an organization marketplace. See [Hook configuration](/en/settings#hook-configuration).
+
+### Matcher patterns
+
+The `matcher` field filters when hooks fire. How a matcher is evaluated depends on the characters it contains:
+
+| Matcher value                       | Evaluated as                                          | Example                                                                                                            |
+| :---------------------------------- | :---------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- |
+| `"*"`, `""`, or omitted             | Match all                                             | fires on every occurrence of the event                                                                             |
+| Only letters, digits, `_`, and `\|` | Exact string, or `\|`-separated list of exact strings | `Bash` matches only the Bash tool; `Edit\|Write` matches either tool exactly                                       |
+| Contains any other character        | JavaScript regular expression                         | `^Notebook` matches any tool starting with Notebook; `mcp__memory__.*` matches every tool from the `memory` server |
+
+The `FileChanged` event does not follow these rules when building its watch list. See [FileChanged](#filechanged).
+
+Each event type matches on a different field:
+
+| Event                                                                                                                           | What the matcher filters                                     | Example matcher values                                                                                                    |
+| :------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`                                      | tool name                                                    | `Bash`, `Edit\|Write`, `mcp__.*`                                                                                          |
+| `SessionStart`                                                                                                                  | how the session started                                      | `startup`, `resume`, `clear`, `compact`                                                                                   |
+| `SessionEnd`                                                                                                                    | why the session ended                                        | `clear`, `resume`, `logout`, `prompt_input_exit`, `bypass_permissions_disabled`, `other`                                  |
+| `Notification`                                                                                                                  | notification type                                            | `permission_prompt`, `idle_prompt`, `auth_success`, `elicitation_dialog`                                                  |
+| `SubagentStart`                                                                                                                 | agent type                                                   | `Bash`, `Explore`, `Plan`, or custom agent names                                                                          |
+| `PreCompact`, `PostCompact`                                                                                                     | what triggered compaction                                    | `manual`, `auto`                                                                                                          |
+| `SubagentStop`                                                                                                                  | agent type                                                   | same values as `SubagentStart`                                                                                            |
+| `ConfigChange`                                                                                                                  | configuration source                                         | `user_settings`, `project_settings`, `local_settings`, `policy_settings`, `skills`                                        |
+| `CwdChanged`                                                                                                                    | no matcher support                                           | always fires on every directory change                                                                                    |
+| `FileChanged`                                                                                                                   | literal filenames to watch (see [FileChanged](#filechanged)) | `.envrc\|.env`                                                                                                            |
+| `StopFailure`                                                                                                                   | error type                                                   | `rate_limit`, `authentication_failed`, `billing_error`, `invalid_request`, `server_error`, `max_output_tokens`, `unknown` |
+| `InstructionsLoaded`                                                                                                            | load reason                                                  | `session_start`, `nested_traversal`, `path_glob_match`, `include`, `compact`                                              |
+| `UserPromptExpansion`                                                                                                           | command name                                                 | your skill or command names                                                                                               |
+| `Elicitation`                                                                                                                   | MCP server name                                              | your configured MCP server names                                                                                          |
+| `ElicitationResult`                                                                                                             | MCP server name                                              | same values as `Elicitation`                                                                                              |
+| `UserPromptSubmit`, `PostToolBatch`, `Stop`, `TeammateIdle`, `TaskCreated`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove` | no matcher support                                           | always fires on every occurrence                                                                                          |
+
+The matcher runs against a field from the [JSON input](#hook-input-and-output) that Claude Code sends to your hook on stdin. For tool events, that field is `tool_name`. Each [hook event](#hook-events) section lists the full set of matcher values and the input schema for that event.
+
+This example runs a linting script only when Claude writes or edits a file:
+
+```json theme={null}
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/lint-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`UserPromptSubmit`, `PostToolBatch`, `Stop`, `TeammateIdle`, `TaskCreated`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove`, and `CwdChanged` don't support matchers and always fire on every occurrence. If you add a `matcher` field to these events, it is silently ignored.
+
+For tool events, you can filter more narrowly by setting the [`if` field](#common-fields) on individual hook handlers. `if` uses [permission rule syntax](/en/permissions) to match against the tool name and arguments together, so `"Bash(git *)"` runs when any subcommand of the Bash input matches `git *` and `"Edit(*.ts)"` runs only for TypeScript files.
+
+#### Match MCP tools
+
+[MCP](/en/mcp) server tools appear as regular tools in tool events (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionDenied`), so you can match them the same way you match any other tool name.
+
+MCP tools follow the naming pattern `mcp__<server>__<tool>`, for example:
+
+* `mcp__memory__create_entities`: Memory server's create entities tool
+* `mcp__filesystem__read_file`: Filesystem server's read file tool
+* `mcp__github__search_repositories`: GitHub server's search tool
+
+To match every tool from a server, append `.*` to the server prefix. The `.*` is required: a matcher like `mcp__memory` contains only letters and underscores, so it is compared as an exact string and matches no tool.
+
+* `mcp__memory__.*` matches all tools from the `memory` server
+* `mcp__.*__write.*` matches any tool whose name starts with `write` from any server
+
+This example logs all memory server operations and validates write operations from any MCP server:
+
+```json theme={null}
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__memory__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Memory operation initiated' >> ~/mcp-operations.log"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*__write.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/user/scripts/validate-mcp-write.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Hook handler fields
+
+Each object in the inner `hooks` array is a hook handler: the shell command, HTTP endpoint, MCP tool, LLM prompt, or agent that runs when the matcher matches. There are five types:
+
+* **[Command hooks](#command-hook-fields)** (`type: "command"`): run a shell command. Your script receives the event's [JSON input](#hook-input-and-output) on stdin and communicates results back through exit codes and stdout.
+* **[HTTP hooks](#http-hook-fields)** (`type: "http"`): send the event's JSON input as an HTTP POST request to a URL. The endpoint communicates results back through the response body using the same [JSON output format](#json-output) as command hooks.
+* **[MCP tool hooks](#mcp-tool-hook-fields)** (`type: "mcp_tool"`): call a tool on an already-connected [MCP server](/en/mcp). The tool's text output is treated like command-hook stdout.
+* **[Prompt hooks](#prompt-and-agent-hook-fields)** (`type: "prompt"`): send a prompt to a Claude model for single-turn evaluation. The model returns a yes/no decision as JSON. See [Prompt-based hooks](#prompt-based-hooks).
+* **[Agent hooks](#prompt-and-agent-hook-fields)** (`type: "agent"`): spawn a subagent that can use tools like Read, Grep, and Glob to verify conditions before returning a decision. Agent hooks are experimental and may change. See [Agent-based hooks](#agent-based-hooks).
+
+#### Common fields
+
+These fields apply to all hook types:
+
+| Field           | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| :-------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`          | yes      | `"command"`, `"http"`, `"mcp_tool"`, `"prompt"`, or `"agent"`                                                                                                                                                                                                                                                                                                                                                                                          |
+| `if`            | no       | Permission rule syntax to filter when this hook runs, such as `"Bash(git *)"` or `"Edit(*.ts)"`. The hook only spawns if the tool call matches the pattern, or if a Bash command is too complex to parse. Only evaluated on tool events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, and `PermissionDenied`. On other events, a hook with `if` set never runs. Uses the same syntax as [permission rules](/en/permissions) |
+| `timeout`       | no       | Seconds before canceling. Defaults: 600 for command, 30 for prompt, 60 for agent                                                                                                                                                                                                                                                                                                                                                                       |
+| `statusMessage` | no       | Custom spinner message displayed while the hook runs                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `once`          | no       | If `true`, runs once per session then is removed. Only honored for hooks declared in [skill frontmatter](#hooks-in-skills-and-agents); ignored in settings files and agent frontmatter                                                                                                                                                                                                                                                                 |
+
+The `if` field holds exactly one permission rule. There is no `&&`, `||`, or list syntax for combining rules; to apply multiple conditions, define a separate hook handler for each. For Bash, the rule is matched against each subcommand of the tool input after leading `VAR=value` assignments are stripped, so `if: "Bash(git push *)"` matches both `FOO=bar git push` and `npm test && git push`. The hook runs if any subcommand matches, and always runs when the command is too complex to parse.
+
+#### Command hook fields
+
+In addition to the [common fields](#common-fields), command hooks accept these fields:
+
+| Field         | Required | Description                                                                                                                                                                                                                           |
+| :------------ | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `command`     | yes      | Shell command to execute                                                                                                                                                                                                              |
+| `async`       | no       | If `true`, runs in the background without blocking. See [Run hooks in the background](#run-hooks-in-the-background)                                                                                                                   |
+| `asyncRewake` | no       | If `true`, runs in the background and wakes Claude on exit code 2. Implies `async`. The hook's stderr, or stdout if stderr is empty, is shown to Claude as a system reminder so it can react to a long-running background failure     |
+| `shell`       | no       | Shell to use for this hook. Accepts `"bash"` (default) or `"powershell"`. Setting `"powershell"` runs the command via PowerShell on Windows. Does not require `CLAUDE_CODE_USE_POWERSHELL_TOOL` since hooks spawn PowerShell directly |
+
+#### HTTP hook fields
+
+In addition to the [common fields](#common-fields), HTTP hooks accept these fields:
+
+| Field            | Required | Description                                                                                                                                                                                      |
+| :--------------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`            | yes      | URL to send the POST request to                                                                                                                                                                  |
+| `headers`        | no       | Additional HTTP headers as key-value pairs. Values support environment variable interpolation using `$VAR_NAME` or `${VAR_NAME}` syntax. Only variables listed in `allowedEnvVars` are resolved  |
+| `allowedEnvVars` | no       | List of environment variable names that may be interpolated into header values. References to unlisted variables are replaced with empty strings. Required for any env var interpolation to work |
+
+Claude Code sends the hook's [JSON input](#hook-input-and-output) as the POST request body with `Content-Type: application/json`. The response body uses the same [JSON output format](#json-output) as command hooks.
+
+Error handling differs from command hooks: non-2xx responses, connection failures, and timeouts all produce non-blocking errors that allow execution to continue. To block a tool call or deny a permission, return a 2xx response with a JSON body containing `decision: "block"` or a `hookSpecificOutput` with `permissionDecision: "deny"`.
+
+This example sends `PreToolUse` events to a local validation service, authenticating with a token from the `MY_TOKEN` environment variable:
+
+```json theme={null}
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8080/hooks/pre-tool-use",
+            "timeout": 30,
+            "headers": {
+              "Authorization": "Bearer $MY_TOKEN"
+            },
+            "allowedEnvVars": ["MY_TOKEN"]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### MCP tool hook fields
+
+In addition to the [common fields](#common-fields), MCP tool hooks accept these fields:
+
+| Field    | Required | Description                                                                                                                                                          |
+| :------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server` | yes      | Name of a configured MCP server. The server must already be connected; the hook never triggers an OAuth or connection flow                                           |
+| `tool`   | yes      | Name of the tool to call on that server                                                                                                                              |
+| `input`  | no       | Arguments passed to the tool. String values support `${path}` substitution from the hook's [JSON input](#hook-input-and-output), such as `"${tool_input.file_path}"` |
+
+The tool's text content is treated like command-hook stdout: if it parses as valid [JSON output](#json-output) it is processed as a decision, otherwise it is shown as plain text. If the named server is not connected, or the tool returns `isError: true`, the hook produces a non-blocking error and execution continues.
+
+MCP tool hooks are available on every hook event once Claude Code has connected to your MCP servers. `SessionStart` and `Setup` typically fire before servers finish connecting, so hooks on those events should expect the "not connected" error on first run.
+
+This example calls the `security_scan` tool on the `my_server` MCP server after each `Write` or `Edit`, passing the edited file's path:
+
+```json theme={null}
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "mcp_tool",
+            "server": "my_server",
+            "tool": "security_scan",
+            "input": { "file_path": "${tool_input.file_path}" }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Prompt and agent hook fields
+
+In addition to the [common fields](#common-fields), prompt and agent hooks accept these fields:
+
+| Field    | Required | Description                                                                                 |
+| :------- | :------- | :------------------------------------------------------------------------------------------ |
+| `prompt` | yes      | Prompt text to send to the model. Use `$ARGUMENTS` as a placeholder for the hook input JSON |
+| `model`  | no       | Model to use for evaluation. Defaults to a fast model                                       |
+
+All matching hooks run in parallel, and identical handlers are deduplicated automatically. Command hooks are deduplicated by command string, and HTTP hooks are deduplicated by URL. Handlers run in the current directory with Claude Code's environment. The `$CLAUDE_CODE_REMOTE` environment variable is set to `"true"` in remote web environments and not set in the local CLI.
+
+### Reference scripts by path
+
+Use environment variables to reference hook scripts relative to the project or plugin root, regardless of the working directory when the hook runs:
+
+* `$CLAUDE_PROJECT_DIR`: the project root. Wrap in quotes to handle paths with spaces.
+* `${CLAUDE_PLUGIN_ROOT}`: the plugin's installation directory, for scripts bundled with a [plugin](/en/plugins). Changes on each plugin update.
+* `${CLAUDE_PLUGIN_DATA}`: the plugin's [persistent data directory](/en/plugins-reference#persistent-data-directory), for dependencies and state that should survive plugin updates.
+
+<Tabs>
+  <Tab title="Project scripts">
+    This example uses `$CLAUDE_PROJECT_DIR` to run a style checker from the project's `.claude/hooks/` directory after any `Write` or `Edit` tool call:
+
+    ```json theme={null}
+    {
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-style.sh"
+              }
+            ]
+          }
+        ]
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Plugin scripts">
+    Define plugin hooks in `hooks/hooks.json` with an optional top-level `description` field. When a plugin is enabled, its hooks merge with your user and project hooks.
+
+    This example runs a formatting script bundled with the plugin:
+
+    ```json theme={null}
+    {
+      "description": "Automatic code formatting",
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/format.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    }
+    ```
+
+    See the [plugin components reference](/en/plugins-reference#hooks) for details on creating plugin hooks.
+  </Tab>
+</Tabs>
+
+### Hooks in skills and agents
+
+In addition to settings files and plugins, hooks can be defined directly in [skills](/en/skills) and [subagents](/en/sub-agents) using frontmatter. These hooks are scoped to the component's lifecycle and only run when that component is active.
+
+All hook events are supported. For subagents, `Stop` hooks are automatically converted to `SubagentStop` since that is the event that fires when a subagent completes.
+
+Hooks use the same configuration format as settings-based hooks but are scoped to the component's lifetime and cleaned up when it finishes.
+
+This skill defines a `PreToolUse` hook that runs a security validation script before each `Bash` command:
+
+```yaml theme={null}
+---
+name: secure-operations
+description: Perform operations with security checks
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/security-check.sh"
+---
+```
+
+Agents use the same format in their YAML frontmatter.
+
+### The `/hooks` menu
+
+Type `/hooks` in Claude Code to open a read-only browser for your configured hooks. The menu shows every hook event with a count of configured hooks, lets you drill into matchers, and shows the full details of each hook handler. Use it to verify configuration, check which settings file a hook came from, or inspect a hook's command, prompt, or URL.
+
+The menu displays all five hook types: `command`, `prompt`, `agent`, `http`, and `mcp_tool`. Each hook is labeled with a `[type]` prefix and a source indicating where it was defined:
+
+* `User`: from `~/.claude/settings.json`
+* `Project`: from `.claude/settings.json`
+* `Local`: from `.claude/settings.local.json`
+* `Plugin`: from a plugin's `hooks/hooks.json`
+* `Session`: registered in memory for the current session
+* `Built-in`: registered internally by Claude Code
+
+Selecting a hook opens a detail view showing its event, matcher, type, source file, and the full command, prompt, or URL. The menu is read-only: to add, modify, or remove hooks, edit the settings JSON directly or ask Claude to make the change.
+
+### Disable or remove hooks
+
+To remove a hook, delete its entry from the settings JSON file.
+
+To temporarily disable all hooks without removing them, set `"disableAllHooks": true` in your settings file. There is no way to disable an individual hook while keeping it in the configuration.
+
+The `disableAllHooks` setting respects the managed settings hierarchy. If an administrator has configured hooks through managed policy settings, `disableAllHooks` set in user, project, or local settings cannot disable those managed hooks. Only `disableAllHooks` set at the managed settings level can disable managed hooks.
+
+Direct edits to hooks in settings files are normally picked up automatically by the file watcher.
+
+## Hook input and output
+
+Command hooks receive JSON data via stdin and communicate results through exit codes, stdout, and stderr. HTTP hooks receive the same JSON as the POST request body and communicate results through the HTTP response body. This section covers fields and behavior common to all events. Each event's section under [Hook events](#hook-events) includes its specific input schema and decision control options.
+
+### Common input fields
+
+Hook events receive these fields as JSON, in addition to event-specific fields documented in each [hook event](#hook-events) section. For command hooks, this JSON arrives via stdin. For HTTP hooks, it arrives as the POST request body.
+
+| Field             | Description                                                                                                                                                                                                                           |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `session_id`      | Current session identifier                                                                                                                                                                                                            |
+| `transcript_path` | Path to conversation JSON                                                                                                                                                                                                             |
+| `cwd`             | Current working directory when the hook is invoked                                                                                                                                                                                    |
+| `permission_mode` | Current [permission mode](/en/permissions#permission-modes): `"default"`, `"plan"`, `"acceptEdits"`, `"auto"`, `"dontAsk"`, or `"bypassPermissions"`. Not all events receive this field: see each event's JSON example below to check |
+| `hook_event_name` | Name of the event that fired                                                                                                                                                                                                          |
+
+When running with `--agent` or inside a subagent, two additional fields are included:
+
+| Field        | Description                                                                                                                                                                                                                          |
+| :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_id`   | Unique identifier for the subagent. Present only when the hook fires inside a subagent call. Use this to distinguish subagent hook calls from main-thread calls.                                                                     |
+| `agent_type` | Agent name (for example, `"Explore"` or `"security-reviewer"`). Present when the session uses `--agent` or the hook fires inside a subagent. For subagents, the subagent's type takes precedence over the session's `--agent` value. |
+
+For example, a `PreToolUse` hook for a Bash command receives this on stdin:
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/home/user/.claude/projects/.../transcript.jsonl",
+  "cwd": "/home/user/my-project",
+  "permission_mode": "default",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm test"
+  }
+}
+```
+
+The `tool_name` and `tool_input` fields are event-specific. Each [hook event](#hook-events) section documents the additional fields for that event.
+
+### Exit code output
+
+The exit code from your hook command tells Claude Code whether the action should proceed, be blocked, or be ignored.
+
+**Exit 0** means success. Claude Code parses stdout for [JSON output fields](#json-output). JSON output is only processed on exit 0. For most events, stdout is written to the debug log but not shown in the transcript. The exceptions are `UserPromptSubmit`, `UserPromptExpansion`, and `SessionStart`, where stdout is added as context that Claude can see and act on.
+
+**Exit 2** means a blocking error. Claude Code ignores stdout and any JSON in it. Instead, stderr text is fed back to Claude as an error message. The effect depends on the event: `PreToolUse` blocks the tool call, `UserPromptSubmit` rejects the prompt, and so on. See [exit code 2 behavior](#exit-code-2-behavior-per-event) for the full list.
+
+**Any other exit code** is a non-blocking error for most hook events. The transcript shows a `<hook name> hook error` notice followed by the first line of stderr, so you can identify the cause without `--debug`. Execution continues and the full stderr is written to the debug log.
+
+For example, a hook command script that blocks dangerous Bash commands:
+
+```bash theme={null}
+#!/bin/bash
+# Reads JSON input from stdin, checks the command
+command=$(jq -r '.tool_input.command' < /dev/stdin)
+
+if [[ "$command" == rm* ]]; then
+  echo "Blocked: rm commands are not allowed" >&2
+  exit 2  # Blocking error: tool call is prevented
+fi
+
+exit 0  # Success: tool call proceeds
+```
+
+<Warning>
+  For most hook events, only exit code 2 blocks the action. Claude Code treats exit code 1 as a non-blocking error and proceeds with the action, even though 1 is the conventional Unix failure code. If your hook is meant to enforce a policy, use `exit 2`. The exception is `WorktreeCreate`, where any non-zero exit code aborts worktree creation.
+</Warning>
+
+#### Exit code 2 behavior per event
+
+Exit code 2 is the way a hook signals "stop, don't do this." The effect depends on the event, because some events represent actions that can be blocked (like a tool call that hasn't happened yet) and others represent things that already happened or can't be prevented.
+
+| Hook event            | Can block? | What happens on exit 2                                                                                                               |
+| :-------------------- | :--------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `PreToolUse`          | Yes        | Blocks the tool call                                                                                                                 |
+| `PermissionRequest`   | Yes        | Denies the permission                                                                                                                |
+| `UserPromptSubmit`    | Yes        | Blocks prompt processing and erases the prompt                                                                                       |
+| `UserPromptExpansion` | Yes        | Blocks the expansion                                                                                                                 |
+| `Stop`                | Yes        | Prevents Claude from stopping, continues the conversation                                                                            |
+| `SubagentStop`        | Yes        | Prevents the subagent from stopping                                                                                                  |
+| `TeammateIdle`        | Yes        | Prevents the teammate from going idle (teammate continues working)                                                                   |
+| `TaskCreated`         | Yes        | Rolls back the task creation                                                                                                         |
+| `TaskCompleted`       | Yes        | Prevents the task from being marked as completed                                                                                     |
+| `ConfigChange`        | Yes        | Blocks the configuration change from taking effect (except `policy_settings`)                                                        |
+| `StopFailure`         | No         | Output and exit code are ignored                                                                                                     |
+| `PostToolUse`         | No         | Shows stderr to Claude (tool already ran)                                                                                            |
+| `PostToolUseFailure`  | No         | Shows stderr to Claude (tool already failed)                                                                                         |
+| `PostToolBatch`       | Yes        | Stops the agentic loop before the next model call                                                                                    |
+| `PermissionDenied`    | No         | Exit code and stderr are ignored (denial already occurred). Use JSON `hookSpecificOutput.retry: true` to tell the model it may retry |
+| `Notification`        | No         | Shows stderr to user only                                                                                                            |
+| `SubagentStart`       | No         | Shows stderr to user only                                                                                                            |
+| `SessionStart`        | No         | Shows stderr to user only                                                                                                            |
+| `SessionEnd`          | No         | Shows stderr to user only                                                                                                            |
+| `CwdChanged`          | No         | Shows stderr to user only                                                                                                            |
+| `FileChanged`         | No         | Shows stderr to user only                                                                                                            |
+| `PreCompact`          | Yes        | Blocks compaction                                                                                                                    |
+| `PostCompact`         | No         | Shows stderr to user only                                                                                                            |
+| `Elicitation`         | Yes        | Denies the elicitation                                                                                                               |
+| `ElicitationResult`   | Yes        | Blocks the response (action becomes decline)                                                                                         |
+| `WorktreeCreate`      | Yes        | Any non-zero exit code causes worktree creation to fail                                                                              |
+| `WorktreeRemove`      | No         | Failures are logged in debug mode only                                                                                               |
+| `InstructionsLoaded`  | No         | Exit code is ignored                                                                                                                 |
+
+### HTTP response handling
+
+HTTP hooks use HTTP status codes and response bodies instead of exit codes and stdout:
+
+* **2xx with an empty body**: success, equivalent to exit code 0 with no output
+* **2xx with a plain text body**: success, the text is added as context
+* **2xx with a JSON body**: success, parsed using the same [JSON output](#json-output) schema as command hooks
+* **Non-2xx status**: non-blocking error, execution continues
+* **Connection failure or timeout**: non-blocking error, execution continues
+
+Unlike command hooks, HTTP hooks cannot signal a blocking error through status codes alone. To block a tool call or deny a permission, return a 2xx response with a JSON body containing the appropriate decision fields.
+
+### JSON output
+
+Exit codes let you allow or block, but JSON output gives you finer-grained control. Instead of exiting with code 2 to block, exit 0 and print a JSON object to stdout. Claude Code reads specific fields from that JSON to control behavior, including [decision control](#decision-control) for blocking, allowing, or escalating to the user.
+
+<Note>
+  You must choose one approach per hook, not both: either use exit codes alone for signaling, or exit 0 and print JSON for structured control. Claude Code only processes JSON on exit 0. If you exit 2, any JSON is ignored.
+</Note>
+
+Your hook's stdout must contain only the JSON object. If your shell profile prints text on startup, it can interfere with JSON parsing. See [JSON validation failed](/en/hooks-guide#json-validation-failed) in the troubleshooting guide.
+
+Hook output injected into context (`additionalContext`, `systemMessage`, or plain stdout) is capped at 10,000 characters. Output that exceeds this limit is saved to a file and replaced with a preview and file path, the same way large tool results are handled.
+
+The JSON object supports three kinds of fields:
+
+* **Universal fields** like `continue` work across all events. These are listed in the table below.
+* **Top-level `decision` and `reason`** are used by some events to block or provide feedback.
+* **`hookSpecificOutput`** is a nested object for events that need richer control. It requires a `hookEventName` field set to the event name.
+
+| Field            | Default | Description                                                                                                                |
+| :--------------- | :------ | :------------------------------------------------------------------------------------------------------------------------- |
+| `continue`       | `true`  | If `false`, Claude stops processing entirely after the hook runs. Takes precedence over any event-specific decision fields |
+| `stopReason`     | none    | Message shown to the user when `continue` is `false`. Not shown to Claude                                                  |
+| `suppressOutput` | `false` | If `true`, omits stdout from the debug log                                                                                 |
+| `systemMessage`  | none    | Warning message shown to the user                                                                                          |
+
+To stop Claude entirely regardless of event type:
+
+```json theme={null}
+{ "continue": false, "stopReason": "Build failed, fix errors before continuing" }
+```
+
+#### Decision control
+
+Not every event supports blocking or controlling behavior through JSON. The events that do each use a different set of fields to express that decision. Use this table as a quick reference before writing a hook:
+
+| Events                                                                                                                              | Decision pattern               | Key fields                                                                                                                                                          |
+| :---------------------------------------------------------------------------------------------------------------------------------- | :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| UserPromptSubmit, UserPromptExpansion, PostToolUse, PostToolUseFailure, PostToolBatch, Stop, SubagentStop, ConfigChange, PreCompact | Top-level `decision`           | `decision: "block"`, `reason`                                                                                                                                       |
+| TeammateIdle, TaskCreated, TaskCompleted                                                                                            | Exit code or `continue: false` | Exit code 2 blocks the action with stderr feedback. JSON `{"continue": false, "stopReason": "..."}` also stops the teammate entirely, matching `Stop` hook behavior |
+| PreToolUse                                                                                                                          | `hookSpecificOutput`           | `permissionDecision` (allow/deny/ask/defer), `permissionDecisionReason`                                                                                             |
+| PermissionRequest                                                                                                                   | `hookSpecificOutput`           | `decision.behavior` (allow/deny)                                                                                                                                    |
+| PermissionDenied                                                                                                                    | `hookSpecificOutput`           | `retry: true` tells the model it may retry the denied tool call                                                                                                     |
+| WorktreeCreate                                                                                                                      | path return                    | Command hook prints path on stdout; HTTP hook returns `hookSpecificOutput.worktreePath`. Hook failure or missing path fails creation                                |
+| Elicitation                                                                                                                         | `hookSpecificOutput`           | `action` (accept/decline/cancel), `content` (form field values for accept)                                                                                          |
+| ElicitationResult                                                                                                                   | `hookSpecificOutput`           | `action` (accept/decline/cancel), `content` (form field values override)                                                                                            |
+| WorktreeRemove, Notification, SessionEnd, PostCompact, InstructionsLoaded, StopFailure, CwdChanged, FileChanged                     | None                           | No decision control. Used for side effects like logging or cleanup                                                                                                  |
+
+Here are examples of each pattern in action:
+
+<Tabs>
+  <Tab title="Top-level decision">
+    Used by `UserPromptSubmit`, `UserPromptExpansion`, `PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Stop`, `SubagentStop`, `ConfigChange`, and `PreCompact`. The only value is `"block"`. To allow the action to proceed, omit `decision` from your JSON, or exit 0 without any JSON at all:
+
+    ```json theme={null}
+    {
+      "decision": "block",
+      "reason": "Test suite must pass before proceeding"
+    }
+    ```
+  </Tab>
+
+  <Tab title="PreToolUse">
+    Uses `hookSpecificOutput` for richer control: allow, deny, or escalate to the user. You can also modify tool input before it runs or inject additional context for Claude. See [PreToolUse decision control](#pretooluse-decision-control) for the full set of options.
+
+    ```json theme={null}
+    {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "Database writes are not allowed"
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="PermissionRequest">
+    Uses `hookSpecificOutput` to allow or deny a permission request on behalf of the user. When allowing, you can also modify the tool's input or apply permission rules so the user isn't prompted again. See [PermissionRequest decision control](#permissionrequest-decision-control) for the full set of options.
+
+    ```json theme={null}
+    {
+      "hookSpecificOutput": {
+        "hookEventName": "PermissionRequest",
+        "decision": {
+          "behavior": "allow",
+          "updatedInput": {
+            "command": "npm run lint"
+          }
+        }
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+For extended examples including Bash command validation, prompt filtering, and auto-approval scripts, see [What you can automate](/en/hooks-guide#what-you-can-automate) in the guide and the [Bash command validator reference implementation](https://github.com/anthropics/claude-code/blob/main/examples/hooks/bash_command_validator_example.py).
+
+## Hook events
+
+Each event corresponds to a point in Claude Code's lifecycle where hooks can run. The sections below are ordered to match the lifecycle: from session setup through the agentic loop to session end. Each section describes when the event fires, what matchers it supports, the JSON input it receives, and how to control behavior through output.
+
+### SessionStart
+
+Runs when Claude Code starts a new session or resumes an existing session. Useful for loading development context like existing issues or recent changes to your codebase, or setting up environment variables. For static context that does not require a script, use [CLAUDE.md](/en/memory) instead.
+
+SessionStart runs on every session, so keep these hooks fast. Only `type: "command"` and `type: "mcp_tool"` hooks are supported.
+
+The matcher value corresponds to how the session was initiated:
+
+| Matcher   | When it fires                          |
+| :-------- | :------------------------------------- |
+| `startup` | New session                            |
+| `resume`  | `--resume`, `--continue`, or `/resume` |
+| `clear`   | `/clear`                               |
+| `compact` | Auto or manual compaction              |
+
+#### SessionStart input
+
+In addition to the [common input fields](#common-input-fields), SessionStart hooks receive `source`, `model`, and optionally `agent_type`. The `source` field indicates how the session started: `"startup"` for new sessions, `"resume"` for resumed sessions, `"clear"` after `/clear`, or `"compact"` after compaction. The `model` field contains the model identifier. If you start Claude Code with `claude --agent <name>`, an `agent_type` field contains the agent name.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "SessionStart",
+  "source": "startup",
+  "model": "claude-sonnet-4-6"
+}
+```
+
+#### SessionStart decision control
+
+Any text your hook script prints to stdout is added as context for Claude. In addition to the [JSON output fields](#json-output) available to all hooks, you can return these event-specific fields:
+
+| Field               | Description                                                               |
+| :------------------ | :------------------------------------------------------------------------ |
+| `additionalContext` | String added to Claude's context. Multiple hooks' values are concatenated |
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "My additional context here"
+  }
+}
+```
+
+#### Persist environment variables
+
+SessionStart hooks have access to the `CLAUDE_ENV_FILE` environment variable, which provides a file path where you can persist environment variables for subsequent Bash commands.
+
+To set individual environment variables, write `export` statements to `CLAUDE_ENV_FILE`. Use append (`>>`) to preserve variables set by other hooks:
+
+```bash theme={null}
+#!/bin/bash
+
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  echo 'export NODE_ENV=production' >> "$CLAUDE_ENV_FILE"
+  echo 'export DEBUG_LOG=true' >> "$CLAUDE_ENV_FILE"
+  echo 'export PATH="$PATH:./node_modules/.bin"' >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0
+```
+
+To capture all environment changes from setup commands, compare the exported variables before and after:
+
+```bash theme={null}
+#!/bin/bash
+
+ENV_BEFORE=$(export -p | sort)
+
+# Run your setup commands that modify the environment
+source ~/.nvm/nvm.sh
+nvm use 20
+
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  ENV_AFTER=$(export -p | sort)
+  comm -13 <(echo "$ENV_BEFORE") <(echo "$ENV_AFTER") >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0
+```
+
+Any variables written to this file will be available in all subsequent Bash commands that Claude Code executes during the session.
+
+<Note>
+  `CLAUDE_ENV_FILE` is available for SessionStart, [CwdChanged](#cwdchanged), and [FileChanged](#filechanged) hooks. Other hook types do not have access to this variable.
+</Note>
+
+### InstructionsLoaded
+
+Fires when a `CLAUDE.md` or `.claude/rules/*.md` file is loaded into context. This event fires at session start for eagerly-loaded files and again later when files are lazily loaded, for example when Claude accesses a subdirectory that contains a nested `CLAUDE.md` or when conditional rules with `paths:` frontmatter match. The hook does not support blocking or decision control. It runs asynchronously for observability purposes.
+
+The matcher runs against `load_reason`. For example, use `"matcher": "session_start"` to fire only for files loaded at session start, or `"matcher": "path_glob_match|nested_traversal"` to fire only for lazy loads.
+
+#### InstructionsLoaded input
+
+In addition to the [common input fields](#common-input-fields), InstructionsLoaded hooks receive these fields:
+
+| Field               | Description                                                                                                                                                                                                   |
+| :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `file_path`         | Absolute path to the instruction file that was loaded                                                                                                                                                         |
+| `memory_type`       | Scope of the file: `"User"`, `"Project"`, `"Local"`, or `"Managed"`                                                                                                                                           |
+| `load_reason`       | Why the file was loaded: `"session_start"`, `"nested_traversal"`, `"path_glob_match"`, `"include"`, or `"compact"`. The `"compact"` value fires when instruction files are re-loaded after a compaction event |
+| `globs`             | Path glob patterns from the file's `paths:` frontmatter, if any. Present only for `path_glob_match` loads                                                                                                     |
+| `trigger_file_path` | Path to the file whose access triggered this load, for lazy loads                                                                                                                                             |
+| `parent_file_path`  | Path to the parent instruction file that included this one, for `include` loads                                                                                                                               |
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../transcript.jsonl",
+  "cwd": "/Users/my-project",
+  "hook_event_name": "InstructionsLoaded",
+  "file_path": "/Users/my-project/CLAUDE.md",
+  "memory_type": "Project",
+  "load_reason": "session_start"
+}
+```
+
+#### InstructionsLoaded decision control
+
+InstructionsLoaded hooks have no decision control. They cannot block or modify instruction loading. Use this event for audit logging, compliance tracking, or observability.
+
+### UserPromptSubmit
+
+Runs when the user submits a prompt, before Claude processes it. This allows you
+to add additional context based on the prompt/conversation, validate prompts, or
+block certain types of prompts.
+
+#### UserPromptSubmit input
+
+In addition to the [common input fields](#common-input-fields), UserPromptSubmit hooks receive the `prompt` field containing the text the user submitted.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "UserPromptSubmit",
+  "prompt": "Write a function to calculate the factorial of a number"
+}
+```
+
+#### UserPromptSubmit decision control
+
+`UserPromptSubmit` hooks can control whether a user prompt is processed and add context. All [JSON output fields](#json-output) are available.
+
+There are two ways to add context to the conversation on exit code 0:
+
+* **Plain text stdout**: any non-JSON text written to stdout is added as context
+* **JSON with `additionalContext`**: use the JSON format below for more control. The `additionalContext` field is added as context
+
+Plain stdout is shown as hook output in the transcript. The `additionalContext` field is added more discretely.
+
+To block a prompt, return a JSON object with `decision` set to `"block"`:
+
+| Field               | Description                                                                                                        |
+| :------------------ | :----------------------------------------------------------------------------------------------------------------- |
+| `decision`          | `"block"` prevents the prompt from being processed and erases it from context. Omit to allow the prompt to proceed |
+| `reason`            | Shown to the user when `decision` is `"block"`. Not added to context                                               |
+| `additionalContext` | String added to Claude's context                                                                                   |
+| `sessionTitle`      | Sets the session title, same effect as `/rename`. Use to name sessions automatically based on the prompt content   |
+
+```json theme={null}
+{
+  "decision": "block",
+  "reason": "Explanation for decision",
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "My additional context here",
+    "sessionTitle": "My session title"
+  }
+}
+```
+
+<Note>
+  The JSON format isn't required for simple use cases. To add context, you can print plain text to stdout with exit code 0. Use JSON when you need to
+  block prompts or want more structured control.
+</Note>
+
+### UserPromptExpansion
+
+Runs when a user-typed slash command expands into a prompt before reaching Claude. Use this to block specific commands from direct invocation, inject context for a particular skill, or log which commands users invoke. For example, a hook matching `deploy` can block `/deploy` unless an approval file is present, or a hook matching a review skill can append the team's review checklist as `additionalContext`.
+
+This event covers the path `PreToolUse` does not: a `PreToolUse` hook matching the `Skill` tool fires only when Claude calls the tool, but typing `/skillname` directly bypasses `PreToolUse`. `UserPromptExpansion` fires on that direct path.
+
+Matches on `command_name`. Leave the matcher empty to fire on every prompt-type slash command.
+
+#### UserPromptExpansion input
+
+In addition to the [common input fields](#common-input-fields), UserPromptExpansion hooks receive `expansion_type`, `command_name`, `command_args`, `command_source`, and the original `prompt` string. The `expansion_type` field is `slash_command` for skill and custom commands, or `mcp_prompt` for MCP server prompts.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../00893aaf.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "UserPromptExpansion",
+  "expansion_type": "slash_command",
+  "command_name": "example-skill",
+  "command_args": "arg1 arg2",
+  "command_source": "plugin",
+  "prompt": "/example-skill arg1 arg2"
+}
+```
+
+#### UserPromptExpansion decision control
+
+`UserPromptExpansion` hooks can block the expansion or add context. All [JSON output fields](#json-output) are available.
+
+| Field               | Description                                                                      |
+| :------------------ | :------------------------------------------------------------------------------- |
+| `decision`          | `"block"` prevents the slash command from expanding. Omit to allow it to proceed |
+| `reason`            | Shown to the user when `decision` is `"block"`                                   |
+| `additionalContext` | String added to Claude's context alongside the expanded prompt                   |
+
+```json theme={null}
+{
+  "decision": "block",
+  "reason": "This slash command is not available",
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptExpansion",
+    "additionalContext": "Additional context for this expansion"
+  }
+}
+```
+
+### PreToolUse
+
+Runs after Claude creates tool parameters and before processing the tool call. Matches on tool name: `Bash`, `Edit`, `Write`, `Read`, `Glob`, `Grep`, `Agent`, `WebFetch`, `WebSearch`, `AskUserQuestion`, `ExitPlanMode`, and any [MCP tool names](#match-mcp-tools).
+
+Use [PreToolUse decision control](#pretooluse-decision-control) to allow, deny, ask, or defer the tool call.
+
+#### PreToolUse input
+
+In addition to the [common input fields](#common-input-fields), PreToolUse hooks receive `tool_name`, `tool_input`, and `tool_use_id`. The `tool_input` fields depend on the tool:
+
+##### Bash
+
+Executes shell commands.
+
+| Field               | Type    | Example            | Description                                   |
+| :------------------ | :------ | :----------------- | :-------------------------------------------- |
+| `command`           | string  | `"npm test"`       | The shell command to execute                  |
+| `description`       | string  | `"Run test suite"` | Optional description of what the command does |
+| `timeout`           | number  | `120000`           | Optional timeout in milliseconds              |
+| `run_in_background` | boolean | `false`            | Whether to run the command in background      |
+
+##### Write
+
+Creates or overwrites a file.
+
+| Field       | Type   | Example               | Description                        |
+| :---------- | :----- | :-------------------- | :--------------------------------- |
+| `file_path` | string | `"/path/to/file.txt"` | Absolute path to the file to write |
+| `content`   | string | `"file content"`      | Content to write to the file       |
+
+##### Edit
+
+Replaces a string in an existing file.
+
+| Field         | Type    | Example               | Description                        |
+| :------------ | :------ | :-------------------- | :--------------------------------- |
+| `file_path`   | string  | `"/path/to/file.txt"` | Absolute path to the file to edit  |
+| `old_string`  | string  | `"original text"`     | Text to find and replace           |
+| `new_string`  | string  | `"replacement text"`  | Replacement text                   |
+| `replace_all` | boolean | `false`               | Whether to replace all occurrences |
+
+##### Read
+
+Reads file contents.
+
+| Field       | Type   | Example               | Description                                |
+| :---------- | :----- | :-------------------- | :----------------------------------------- |
+| `file_path` | string | `"/path/to/file.txt"` | Absolute path to the file to read          |
+| `offset`    | number | `10`                  | Optional line number to start reading from |
+| `limit`     | number | `50`                  | Optional number of lines to read           |
+
+##### Glob
+
+Finds files matching a glob pattern.
+
+| Field     | Type   | Example          | Description                                                            |
+| :-------- | :----- | :--------------- | :--------------------------------------------------------------------- |
+| `pattern` | string | `"**/*.ts"`      | Glob pattern to match files against                                    |
+| `path`    | string | `"/path/to/dir"` | Optional directory to search in. Defaults to current working directory |
+
+##### Grep
+
+Searches file contents with regular expressions.
+
+| Field         | Type    | Example          | Description                                                                           |
+| :------------ | :------ | :--------------- | :------------------------------------------------------------------------------------ |
+| `pattern`     | string  | `"TODO.*fix"`    | Regular expression pattern to search for                                              |
+| `path`        | string  | `"/path/to/dir"` | Optional file or directory to search in                                               |
+| `glob`        | string  | `"*.ts"`         | Optional glob pattern to filter files                                                 |
+| `output_mode` | string  | `"content"`      | `"content"`, `"files_with_matches"`, or `"count"`. Defaults to `"files_with_matches"` |
+| `-i`          | boolean | `true`           | Case insensitive search                                                               |
+| `multiline`   | boolean | `false`          | Enable multiline matching                                                             |
+
+##### WebFetch
+
+Fetches and processes web content.
+
+| Field    | Type   | Example                       | Description                          |
+| :------- | :----- | :---------------------------- | :----------------------------------- |
+| `url`    | string | `"https://example.com/api"`   | URL to fetch content from            |
+| `prompt` | string | `"Extract the API endpoints"` | Prompt to run on the fetched content |
+
+##### WebSearch
+
+Searches the web.
+
+| Field             | Type   | Example                        | Description                                       |
+| :---------------- | :----- | :----------------------------- | :------------------------------------------------ |
+| `query`           | string | `"react hooks best practices"` | Search query                                      |
+| `allowed_domains` | array  | `["docs.example.com"]`         | Optional: only include results from these domains |
+| `blocked_domains` | array  | `["spam.example.com"]`         | Optional: exclude results from these domains      |
+
+##### Agent
+
+Spawns a [subagent](/en/sub-agents).
+
+| Field           | Type   | Example                    | Description                                  |
+| :-------------- | :----- | :------------------------- | :------------------------------------------- |
+| `prompt`        | string | `"Find all API endpoints"` | The task for the agent to perform            |
+| `description`   | string | `"Find API endpoints"`     | Short description of the task                |
+| `subagent_type` | string | `"Explore"`                | Type of specialized agent to use             |
+| `model`         | string | `"sonnet"`                 | Optional model alias to override the default |
+
+##### AskUserQuestion
+
+Asks the user one to four multiple-choice questions.
+
+| Field       | Type   | Example                                                                                                            | Description                                                                                                                                                                                      |
+| :---------- | :----- | :----------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `questions` | array  | `[{"question": "Which framework?", "header": "Framework", "options": [{"label": "React"}], "multiSelect": false}]` | Questions to present, each with a `question` string, short `header`, `options` array, and optional `multiSelect` flag                                                                            |
+| `answers`   | object | `{"Which framework?": "React"}`                                                                                    | Optional. Maps question text to the selected option label. Multi-select answers join labels with commas. Claude does not set this field; supply it via `updatedInput` to answer programmatically |
+
+#### PreToolUse decision control
+
+`PreToolUse` hooks can control whether a tool call proceeds. Unlike other hooks that use a top-level `decision` field, PreToolUse returns its decision inside a `hookSpecificOutput` object. This gives it richer control: four outcomes (allow, deny, ask, or defer) plus the ability to modify tool input before execution.
+
+| Field                      | Description                                                                                                                                                                                                                                                                                |
+| :------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `permissionDecision`       | `"allow"` skips the permission prompt. `"deny"` prevents the tool call. `"ask"` prompts the user to confirm. `"defer"` exits gracefully so the tool can be resumed later. [Deny and ask rules](/en/permissions#manage-permissions) are still evaluated regardless of what the hook returns |
+| `permissionDecisionReason` | For `"allow"` and `"ask"`, shown to the user but not Claude. For `"deny"`, shown to Claude. For `"defer"`, ignored                                                                                                                                                                         |
+| `updatedInput`             | Modifies the tool's input parameters before execution. Replaces the entire input object, so include unchanged fields alongside modified ones. Combine with `"allow"` to auto-approve, or `"ask"` to show the modified input to the user. For `"defer"`, ignored                            |
+| `additionalContext`        | String added to Claude's context before the tool executes. For `"defer"`, ignored                                                                                                                                                                                                          |
+
+When multiple PreToolUse hooks return different decisions, precedence is `deny` > `defer` > `ask` > `allow`.
+
+When a hook returns `"ask"`, the permission prompt displayed to the user includes a label identifying where the hook came from: for example, `[User]`, `[Project]`, `[Plugin]`, or `[Local]`. This helps users understand which configuration source is requesting confirmation.
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "permissionDecisionReason": "My reason here",
+    "updatedInput": {
+      "field_to_modify": "new value"
+    },
+    "additionalContext": "Current environment: production. Proceed with caution."
+  }
+}
+```
+
+`AskUserQuestion` and `ExitPlanMode` require user interaction and normally block in [non-interactive mode](/en/headless) with the `-p` flag. Returning `permissionDecision: "allow"` together with `updatedInput` satisfies that requirement: the hook reads the tool's input from stdin, collects the answer through your own UI, and returns it in `updatedInput` so the tool runs without prompting. Returning `"allow"` alone is not sufficient for these tools. For `AskUserQuestion`, echo back the original `questions` array and add an [`answers`](#askuserquestion) object mapping each question's text to the chosen answer.
+
+<Note>
+  PreToolUse previously used top-level `decision` and `reason` fields, but these are deprecated for this event. Use `hookSpecificOutput.permissionDecision` and `hookSpecificOutput.permissionDecisionReason` instead. The deprecated values `"approve"` and `"block"` map to `"allow"` and `"deny"` respectively. Other events like PostToolUse and Stop continue to use top-level `decision` and `reason` as their current format.
+</Note>
+
+#### Defer a tool call for later
+
+`"defer"` is for integrations that run `claude -p` as a subprocess and read its JSON output, such as an Agent SDK app or a custom UI built on top of Claude Code. It lets that calling process pause Claude at a tool call, collect input through its own interface, and resume where it left off. Claude Code honors this value only in [non-interactive mode](/en/headless) with the `-p` flag. In interactive sessions it logs a warning and ignores the hook result.
+
+<Note>
+  The `defer` value requires Claude Code v2.1.89 or later. Earlier versions do not recognize it and the tool proceeds through the normal permission flow.
+</Note>
+
+The `AskUserQuestion` tool is the typical case: Claude wants to ask the user something, but there is no terminal to answer in. The round trip works like this:
+
+1. Claude calls `AskUserQuestion`. The `PreToolUse` hook fires.
+2. The hook returns `permissionDecision: "defer"`. The tool does not execute. The process exits with `stop_reason: "tool_deferred"` and the pending tool call preserved in the transcript.
+3. The calling process reads `deferred_tool_use` from the SDK result, surfaces the question in its own UI, and waits for an answer.
+4. The calling process runs `claude -p --resume <session-id>`. The same tool call fires `PreToolUse` again.
+5. The hook returns `permissionDecision: "allow"` with the answer in `updatedInput`. The tool executes and Claude continues.
+
+The `deferred_tool_use` field carries the tool's `id`, `name`, and `input`. The `input` is the parameters Claude generated for the tool call, captured before execution:
+
+```json theme={null}
+{
+  "type": "result",
+  "subtype": "success",
+  "stop_reason": "tool_deferred",
+  "session_id": "abc123",
+  "deferred_tool_use": {
+    "id": "toolu_01abc",
+    "name": "AskUserQuestion",
+    "input": { "questions": [{ "question": "Which framework?", "header": "Framework", "options": [{"label": "React"}, {"label": "Vue"}], "multiSelect": false }] }
+  }
+}
+```
+
+There is no timeout or retry limit. The session remains on disk until you resume it, subject to the [`cleanupPeriodDays`](/en/settings#available-settings) retention sweep that deletes session files after 30 days by default. If the answer is not ready when you resume, the hook can return `"defer"` again and the process exits the same way. The calling process controls when to break the loop by eventually returning `"allow"` or `"deny"` from the hook.
+
+`"defer"` only works when Claude makes a single tool call in the turn. If Claude makes several tool calls at once, `"defer"` is ignored with a warning and the tool proceeds through the normal permission flow. The constraint exists because resume can only re-run one tool: there is no way to defer one call from a batch without leaving the others unresolved.
+
+If the deferred tool is no longer available when you resume, the process exits with `stop_reason: "tool_deferred_unavailable"` and `is_error: true` before the hook fires. This happens when an MCP server that provided the tool is not connected for the resumed session. The `deferred_tool_use` payload is still included so you can identify which tool went missing.
+
+<Warning>
+  `--resume` does not restore the permission mode from the prior session. Pass the same `--permission-mode` flag on resume that was active when the tool was deferred. Claude Code logs a warning if the modes differ.
+</Warning>
+
+### PermissionRequest
+
+Runs when the user is shown a permission dialog.
+Use [PermissionRequest decision control](#permissionrequest-decision-control) to allow or deny on behalf of the user.
+
+Matches on tool name, same values as PreToolUse.
+
+#### PermissionRequest input
+
+PermissionRequest hooks receive `tool_name` and `tool_input` fields like PreToolUse hooks, but without `tool_use_id`. An optional `permission_suggestions` array contains the "always allow" options the user would normally see in the permission dialog. The difference is when the hook fires: PermissionRequest hooks run when a permission dialog is about to be shown to the user, while PreToolUse hooks run before tool execution regardless of permission status.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "PermissionRequest",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "rm -rf node_modules",
+    "description": "Remove node_modules directory"
+  },
+  "permission_suggestions": [
+    {
+      "type": "addRules",
+      "rules": [{ "toolName": "Bash", "ruleContent": "rm -rf node_modules" }],
+      "behavior": "allow",
+      "destination": "localSettings"
+    }
+  ]
+}
+```
+
+#### PermissionRequest decision control
+
+`PermissionRequest` hooks can allow or deny permission requests. In addition to the [JSON output fields](#json-output) available to all hooks, your hook script can return a `decision` object with these event-specific fields:
+
+| Field                | Description                                                                                                                                                                                                                     |
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `behavior`           | `"allow"` grants the permission, `"deny"` denies it. [Deny and ask rules](/en/permissions#manage-permissions) are still evaluated, so a hook returning `"allow"` does not override a matching deny rule                         |
+| `updatedInput`       | For `"allow"` only: modifies the tool's input parameters before execution. Replaces the entire input object, so include unchanged fields alongside modified ones. The modified input is re-evaluated against deny and ask rules |
+| `updatedPermissions` | For `"allow"` only: array of [permission update entries](#permission-update-entries) to apply, such as adding an allow rule or changing the session permission mode                                                             |
+| `message`            | For `"deny"` only: tells Claude why the permission was denied                                                                                                                                                                   |
+| `interrupt`          | For `"deny"` only: if `true`, stops Claude                                                                                                                                                                                      |
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow",
+      "updatedInput": {
+        "command": "npm run lint"
+      }
+    }
+  }
+}
+```
+
+#### Permission update entries
+
+The `updatedPermissions` output field and the [`permission_suggestions` input field](#permissionrequest-input) both use the same array of entry objects. Each entry has a `type` that determines its other fields, and a `destination` that controls where the change is written.
+
+| `type`              | Fields                             | Effect                                                                                                                                                                      |
+| :------------------ | :--------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addRules`          | `rules`, `behavior`, `destination` | Adds permission rules. `rules` is an array of `{toolName, ruleContent?}` objects. Omit `ruleContent` to match the whole tool. `behavior` is `"allow"`, `"deny"`, or `"ask"` |
+| `replaceRules`      | `rules`, `behavior`, `destination` | Replaces all rules of the given `behavior` at the `destination` with the provided `rules`                                                                                   |
+| `removeRules`       | `rules`, `behavior`, `destination` | Removes matching rules of the given `behavior`                                                                                                                              |
+| `setMode`           | `mode`, `destination`              | Changes the permission mode. Valid modes are `default`, `acceptEdits`, `dontAsk`, `bypassPermissions`, and `plan`                                                           |
+| `addDirectories`    | `directories`, `destination`       | Adds working directories. `directories` is an array of path strings                                                                                                         |
+| `removeDirectories` | `directories`, `destination`       | Removes working directories                                                                                                                                                 |
+
+<Note>
+  `setMode` with `bypassPermissions` only takes effect if the session was launched with bypass mode already available: `--dangerously-skip-permissions`, `--permission-mode bypassPermissions`, `--allow-dangerously-skip-permissions`, or `permissions.defaultMode: "bypassPermissions"` in settings, and the mode is not disabled by [`permissions.disableBypassPermissionsMode`](/en/permissions#managed-settings). Otherwise the update is a no-op. `bypassPermissions` is never persisted as `defaultMode` regardless of `destination`.
+</Note>
+
+The `destination` field on every entry determines whether the change stays in memory or persists to a settings file.
+
+| `destination`     | Writes to                                       |
+| :---------------- | :---------------------------------------------- |
+| `session`         | in-memory only, discarded when the session ends |
+| `localSettings`   | `.claude/settings.local.json`                   |
+| `projectSettings` | `.claude/settings.json`                         |
+| `userSettings`    | `~/.claude/settings.json`                       |
+
+A hook can echo one of the `permission_suggestions` it received as its own `updatedPermissions` output, which is equivalent to the user selecting that "always allow" option in the dialog.
+
+### PostToolUse
+
+Runs immediately after a tool completes successfully.
+
+Matches on tool name, same values as PreToolUse.
+
+#### PostToolUse input
+
+`PostToolUse` hooks fire after a tool has already executed successfully. The input includes both `tool_input`, the arguments sent to the tool, and `tool_response`, the result it returned. The exact schema for both depends on the tool.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/path/to/file.txt",
+    "content": "file content"
+  },
+  "tool_response": {
+    "filePath": "/path/to/file.txt",
+    "success": true
+  },
+  "tool_use_id": "toolu_01ABC123...",
+  "duration_ms": 12
+}
+```
+
+| Field         | Description                                                                                                   |
+| :------------ | :------------------------------------------------------------------------------------------------------------ |
+| `duration_ms` | Optional. Tool execution time in milliseconds. Excludes time spent in permission prompts and PreToolUse hooks |
+
+#### PostToolUse decision control
+
+`PostToolUse` hooks can provide feedback to Claude after tool execution. In addition to the [JSON output fields](#json-output) available to all hooks, your hook script can return these event-specific fields:
+
+| Field                  | Description                                                                                |
+| :--------------------- | :----------------------------------------------------------------------------------------- |
+| `decision`             | `"block"` prompts Claude with the `reason`. Omit to allow the action to proceed            |
+| `reason`               | Explanation shown to Claude when `decision` is `"block"`                                   |
+| `additionalContext`    | Additional context for Claude to consider                                                  |
+| `updatedMCPToolOutput` | For [MCP tools](#match-mcp-tools) only: replaces the tool's output with the provided value |
+
+```json theme={null}
+{
+  "decision": "block",
+  "reason": "Explanation for decision",
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "Additional information for Claude"
+  }
+}
+```
+
+### PostToolUseFailure
+
+Runs when a tool execution fails. This event fires for tool calls that throw errors or return failure results. Use this to log failures, send alerts, or provide corrective feedback to Claude.
+
+Matches on tool name, same values as PreToolUse.
+
+#### PostToolUseFailure input
+
+PostToolUseFailure hooks receive the same `tool_name` and `tool_input` fields as PostToolUse, along with error information as top-level fields:
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUseFailure",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm test",
+    "description": "Run test suite"
+  },
+  "tool_use_id": "toolu_01ABC123...",
+  "error": "Command exited with non-zero status code 1",
+  "is_interrupt": false,
+  "duration_ms": 4187
+}
+```
+
+| Field          | Description                                                                                                   |
+| :------------- | :------------------------------------------------------------------------------------------------------------ |
+| `error`        | String describing what went wrong                                                                             |
+| `is_interrupt` | Optional boolean indicating whether the failure was caused by user interruption                               |
+| `duration_ms`  | Optional. Tool execution time in milliseconds. Excludes time spent in permission prompts and PreToolUse hooks |
+
+#### PostToolUseFailure decision control
+
+`PostToolUseFailure` hooks can provide context to Claude after a tool failure. In addition to the [JSON output fields](#json-output) available to all hooks, your hook script can return these event-specific fields:
+
+| Field               | Description                                                   |
+| :------------------ | :------------------------------------------------------------ |
+| `additionalContext` | Additional context for Claude to consider alongside the error |
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUseFailure",
+    "additionalContext": "Additional information about the failure for Claude"
+  }
+}
+```
+
+### PostToolBatch
+
+Runs once after every tool call in a batch has resolved, before Claude Code sends the next request to the model. `PostToolUse` fires once per tool, which means it fires concurrently when Claude makes parallel tool calls. `PostToolBatch` fires exactly once with the full batch, so it is the right place to inject context that depends on the set of tools that ran rather than on any single tool. There is no matcher for this event.
+
+#### PostToolBatch input
+
+In addition to the [common input fields](#common-input-fields), PostToolBatch hooks receive `tool_calls`, an array describing every tool call in the batch:
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolBatch",
+  "tool_calls": [
+    {
+      "tool_name": "Read",
+      "tool_input": {"file_path": "/.../ledger/accounts.py"},
+      "tool_use_id": "toolu_01...",
+      "tool_response": "     1\tfrom __future__ import annotations\n     2\t..."
+    },
+    {
+      "tool_name": "Read",
+      "tool_input": {"file_path": "/.../ledger/transactions.py"},
+      "tool_use_id": "toolu_02...",
+      "tool_response": "     1\tfrom __future__ import annotations\n     2\t..."
+    }
+  ]
+}
+```
+
+`tool_response` contains the same content the model receives in the corresponding `tool_result` block. The value is a serialized string or content-block array, exactly as the tool emitted it. For `Read`, that means line-number-prefixed text rather than raw file contents. Responses can be large, so parse only the fields you need.
+
+<Note>
+  The `tool_response` shape differs from `PostToolUse`'s. `PostToolUse` passes the tool's structured `Output` object, such as `{filePath: "...", success: true}` for `Write`; `PostToolBatch` passes the serialized `tool_result` content the model sees.
+</Note>
+
+#### PostToolBatch decision control
+
+`PostToolBatch` hooks can inject context for Claude. In addition to the [JSON output fields](#json-output) available to all hooks, your hook script can return these event-specific fields:
+
+| Field               | Description                                             |
+| :------------------ | :------------------------------------------------------ |
+| `additionalContext` | Context string injected once before the next model call |
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolBatch",
+    "additionalContext": "These files are part of the ledger module. Run pytest before marking the task complete."
+  }
+}
+```
+
+<Note>
+  Injected `additionalContext` is persisted to the session transcript. On `--continue` or `--resume`, the saved text is replayed from disk and the hook does not re-run for past turns. Prefer static context such as conventions or file-type guidance over dynamic values like timestamps or the current commit SHA, since those become stale on resume.
+
+  Frame the context as factual information rather than imperative system instructions. Text written as out-of-band system commands can trigger Claude's prompt-injection defenses, which surfaces the injection to the user instead of acting on it.
+</Note>
+
+Returning `decision: "block"` or `continue: false` stops the agentic loop before the next model call.
+
+### PermissionDenied
+
+Runs when the [auto mode](/en/permission-modes#eliminate-prompts-with-auto-mode) classifier denies a tool call. This hook only fires in auto mode: it does not run when you manually deny a permission dialog, when a `PreToolUse` hook blocks a call, or when a `deny` rule matches. Use it to log classifier denials, adjust configuration, or tell the model it may retry the tool call.
+
+Matches on tool name, same values as PreToolUse.
+
+#### PermissionDenied input
+
+In addition to the [common input fields](#common-input-fields), PermissionDenied hooks receive `tool_name`, `tool_input`, `tool_use_id`, and `reason`.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "auto",
+  "hook_event_name": "PermissionDenied",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "rm -rf /tmp/build",
+    "description": "Clean build directory"
+  },
+  "tool_use_id": "toolu_01ABC123...",
+  "reason": "Auto mode denied: command targets a path outside the project"
+}
+```
+
+| Field    | Description                                                   |
+| :------- | :------------------------------------------------------------ |
+| `reason` | The classifier's explanation for why the tool call was denied |
+
+#### PermissionDenied decision control
+
+PermissionDenied hooks can tell the model it may retry the denied tool call. Return a JSON object with `hookSpecificOutput.retry` set to `true`:
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionDenied",
+    "retry": true
+  }
+}
+```
+
+When `retry` is `true`, Claude Code adds a message to the conversation telling the model it may retry the tool call. The denial itself is not reversed. If your hook does not return JSON, or returns `retry: false`, the denial stands and the model receives the original rejection message.
+
+### Notification
+
+Runs when Claude Code sends notifications. Matches on notification type: `permission_prompt`, `idle_prompt`, `auth_success`, `elicitation_dialog`. Omit the matcher to run hooks for all notification types.
+
+Use separate matchers to run different handlers depending on the notification type. This configuration triggers a permission-specific alert script when Claude needs permission approval and a different notification when Claude has been idle:
+
+```json theme={null}
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/permission-alert.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/idle-notification.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Notification input
+
+In addition to the [common input fields](#common-input-fields), Notification hooks receive `message` with the notification text, an optional `title`, and `notification_type` indicating which type fired.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "Notification",
+  "message": "Claude needs your permission to use Bash",
+  "title": "Permission needed",
+  "notification_type": "permission_prompt"
+}
+```
+
+Notification hooks cannot block or modify notifications. In addition to the [JSON output fields](#json-output) available to all hooks, you can return `additionalContext` to add context to the conversation:
+
+| Field               | Description                      |
+| :------------------ | :------------------------------- |
+| `additionalContext` | String added to Claude's context |
+
+### SubagentStart
+
+Runs when a Claude Code subagent is spawned via the Agent tool. Supports matchers to filter by agent type name (built-in agents like `Bash`, `Explore`, `Plan`, or custom agent names from `.claude/agents/`).
+
+#### SubagentStart input
+
+In addition to the [common input fields](#common-input-fields), SubagentStart hooks receive `agent_id` with the unique identifier for the subagent and `agent_type` with the agent name (built-in agents like `"Bash"`, `"Explore"`, `"Plan"`, or custom agent names).
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "SubagentStart",
+  "agent_id": "agent-abc123",
+  "agent_type": "Explore"
+}
+```
+
+SubagentStart hooks cannot block subagent creation, but they can inject context into the subagent. In addition to the [JSON output fields](#json-output) available to all hooks, you can return:
+
+| Field               | Description                            |
+| :------------------ | :------------------------------------- |
+| `additionalContext` | String added to the subagent's context |
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SubagentStart",
+    "additionalContext": "Follow security guidelines for this task"
+  }
+}
+```
+
+### SubagentStop
+
+Runs when a Claude Code subagent has finished responding. Matches on agent type, same values as SubagentStart.
+
+#### SubagentStop input
+
+In addition to the [common input fields](#common-input-fields), SubagentStop hooks receive `stop_hook_active`, `agent_id`, `agent_type`, `agent_transcript_path`, and `last_assistant_message`. The `agent_type` field is the value used for matcher filtering. The `transcript_path` is the main session's transcript, while `agent_transcript_path` is the subagent's own transcript stored in a nested `subagents/` folder. The `last_assistant_message` field contains the text content of the subagent's final response, so hooks can access it without parsing the transcript file.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "~/.claude/projects/.../abc123.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "SubagentStop",
+  "stop_hook_active": false,
+  "agent_id": "def456",
+  "agent_type": "Explore",
+  "agent_transcript_path": "~/.claude/projects/.../abc123/subagents/agent-def456.jsonl",
+  "last_assistant_message": "Analysis complete. Found 3 potential issues..."
+}
+```
+
+SubagentStop hooks use the same decision control format as [Stop hooks](#stop-decision-control).
+
+### TaskCreated
+
+Runs when a task is being created via the `TaskCreate` tool. Use this to enforce naming conventions, require task descriptions, or prevent certain tasks from being created.
+
+When a `TaskCreated` hook exits with code 2, the task is not created and the stderr message is fed back to the model as feedback. To stop the teammate entirely instead of re-running it, return JSON with `{"continue": false, "stopReason": "..."}`. TaskCreated hooks do not support matchers and fire on every occurrence.
+
+#### TaskCreated input
+
+In addition to the [common input fields](#common-input-fields), TaskCreated hooks receive `task_id`, `task_subject`, and optionally `task_description`, `teammate_name`, and `team_name`.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "TaskCreated",
+  "task_id": "task-001",
+  "task_subject": "Implement user authentication",
+  "task_description": "Add login and signup endpoints",
+  "teammate_name": "implementer",
+  "team_name": "my-project"
+}
+```
+
+| Field              | Description                                           |
+| :----------------- | :---------------------------------------------------- |
+| `task_id`          | Identifier of the task being created                  |
+| `task_subject`     | Title of the task                                     |
+| `task_description` | Detailed description of the task. May be absent       |
+| `teammate_name`    | Name of the teammate creating the task. May be absent |
+| `team_name`        | Name of the team. May be absent                       |
+
+#### TaskCreated decision control
+
+TaskCreated hooks support two ways to control task creation:
+
+* **Exit code 2**: the task is not created and the stderr message is fed back to the model as feedback.
+* **JSON `{"continue": false, "stopReason": "..."}`**: stops the teammate entirely, matching `Stop` hook behavior. The `stopReason` is shown to the user.
+
+This example blocks tasks whose subjects don't follow the required format:
+
+```bash theme={null}
+#!/bin/bash
+INPUT=$(cat)
+TASK_SUBJECT=$(echo "$INPUT" | jq -r '.task_subject')
+
+if [[ ! "$TASK_SUBJECT" =~ ^\[TICKET-[0-9]+\] ]]; then
+  echo "Task subject must start with a ticket number, e.g. '[TICKET-123] Add feature'" >&2
+  exit 2
+fi
+
+exit 0
+```
+
+### TaskCompleted
+
+Runs when a task is being marked as completed. This fires in two situations: when any agent explicitly marks a task as completed through the TaskUpdate tool, or when an [agent team](/en/agent-teams) teammate finishes its turn with in-progress tasks. Use this to enforce completion criteria like passing tests or lint checks before a task can close.
+
+When a `TaskCompleted` hook exits with code 2, the task is not marked as completed and the stderr message is fed back to the model as feedback. To stop the teammate entirely instead of re-running it, return JSON with `{"continue": false, "stopReason": "..."}`. TaskCompleted hooks do not support matchers and fire on every occurrence.
+
+#### TaskCompleted input
+
+In addition to the [common input fields](#common-input-fields), TaskCompleted hooks receive `task_id`, `task_subject`, and optionally `task_description`, `teammate_name`, and `team_name`.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "TaskCompleted",
+  "task_id": "task-001",
+  "task_subject": "Implement user authentication",
+  "task_description": "Add login and signup endpoints",
+  "teammate_name": "implementer",
+  "team_name": "my-project"
+}
+```
+
+| Field              | Description                                             |
+| :----------------- | :------------------------------------------------------ |
+| `task_id`          | Identifier of the task being completed                  |
+| `task_subject`     | Title of the task                                       |
+| `task_description` | Detailed description of the task. May be absent         |
+| `teammate_name`    | Name of the teammate completing the task. May be absent |
+| `team_name`        | Name of the team. May be absent                         |
+
+#### TaskCompleted decision control
+
+TaskCompleted hooks support two ways to control task completion:
+
+* **Exit code 2**: the task is not marked as completed and the stderr message is fed back to the model as feedback.
+* **JSON `{"continue": false, "stopReason": "..."}`**: stops the teammate entirely, matching `Stop` hook behavior. The `stopReason` is shown to the user.
+
+This example runs tests and blocks task completion if they fail:
+
+```bash theme={null}
+#!/bin/bash
+INPUT=$(cat)
+TASK_SUBJECT=$(echo "$INPUT" | jq -r '.task_subject')
+
+# Run the test suite
+if ! npm test 2>&1; then
+  echo "Tests not passing. Fix failing tests before completing: $TASK_SUBJECT" >&2
+  exit 2
+fi
+
+exit 0
+```
+
+### Stop
+
+Runs when the main Claude Code agent has finished responding. Does not run if
+the stoppage occurred due to a user interrupt. API errors fire
+[StopFailure](#stopfailure) instead.
+
+#### Stop input
+
+In addition to the [common input fields](#common-input-fields), Stop hooks receive `stop_hook_active` and `last_assistant_message`. The `stop_hook_active` field is `true` when Claude Code is already continuing as a result of a stop hook. Check this value or process the transcript to prevent Claude Code from running indefinitely. The `last_assistant_message` field contains the text content of Claude's final response, so hooks can access it without parsing the transcript file.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "~/.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "Stop",
+  "stop_hook_active": true,
+  "last_assistant_message": "I've completed the refactoring. Here's a summary..."
+}
+```
+
+#### Stop decision control
+
+`Stop` and `SubagentStop` hooks can control whether Claude continues. In addition to the [JSON output fields](#json-output) available to all hooks, your hook script can return these event-specific fields:
+
+| Field      | Description                                                                |
+| :--------- | :------------------------------------------------------------------------- |
+| `decision` | `"block"` prevents Claude from stopping. Omit to allow Claude to stop      |
+| `reason`   | Required when `decision` is `"block"`. Tells Claude why it should continue |
+
+```json theme={null}
+{
+  "decision": "block",
+  "reason": "Must be provided when Claude is blocked from stopping"
+}
+```
+
+### StopFailure
+
+Runs instead of [Stop](#stop) when the turn ends due to an API error. Output and exit code are ignored. Use this to log failures, send alerts, or take recovery actions when Claude cannot complete a response due to rate limits, authentication problems, or other API errors.
+
+#### StopFailure input
+
+In addition to the [common input fields](#common-input-fields), StopFailure hooks receive `error`, optional `error_details`, and optional `last_assistant_message`. The `error` field identifies the error type and is used for matcher filtering.
+
+| Field                    | Description                                                                                                                                                                                                                                      |
+| :----------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `error`                  | Error type: `rate_limit`, `authentication_failed`, `billing_error`, `invalid_request`, `server_error`, `max_output_tokens`, or `unknown`                                                                                                         |
+| `error_details`          | Additional details about the error, when available                                                                                                                                                                                               |
+| `last_assistant_message` | The rendered error text shown in the conversation. Unlike `Stop` and `SubagentStop`, where this field holds Claude's conversational output, for `StopFailure` it contains the API error string itself, such as `"API Error: Rate limit reached"` |
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "StopFailure",
+  "error": "rate_limit",
+  "error_details": "429 Too Many Requests",
+  "last_assistant_message": "API Error: Rate limit reached"
+}
+```
+
+StopFailure hooks have no decision control. They run for notification and logging purposes only.
+
+### TeammateIdle
+
+Runs when an [agent team](/en/agent-teams) teammate is about to go idle after finishing its turn. Use this to enforce quality gates before a teammate stops working, such as requiring passing lint checks or verifying that output files exist.
+
+When a `TeammateIdle` hook exits with code 2, the teammate receives the stderr message as feedback and continues working instead of going idle. To stop the teammate entirely instead of re-running it, return JSON with `{"continue": false, "stopReason": "..."}`. TeammateIdle hooks do not support matchers and fire on every occurrence.
+
+#### TeammateIdle input
+
+In addition to the [common input fields](#common-input-fields), TeammateIdle hooks receive `teammate_name` and `team_name`.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "TeammateIdle",
+  "teammate_name": "researcher",
+  "team_name": "my-project"
+}
+```
+
+| Field           | Description                                   |
+| :-------------- | :-------------------------------------------- |
+| `teammate_name` | Name of the teammate that is about to go idle |
+| `team_name`     | Name of the team                              |
+
+#### TeammateIdle decision control
+
+TeammateIdle hooks support two ways to control teammate behavior:
+
+* **Exit code 2**: the teammate receives the stderr message as feedback and continues working instead of going idle.
+* **JSON `{"continue": false, "stopReason": "..."}`**: stops the teammate entirely, matching `Stop` hook behavior. The `stopReason` is shown to the user.
+
+This example checks that a build artifact exists before allowing a teammate to go idle:
+
+```bash theme={null}
+#!/bin/bash
+
+if [ ! -f "./dist/output.js" ]; then
+  echo "Build artifact missing. Run the build before stopping." >&2
+  exit 2
+fi
+
+exit 0
+```
+
+### ConfigChange
+
+Runs when a configuration file changes during a session. Use this to audit settings changes, enforce security policies, or block unauthorized modifications to configuration files.
+
+ConfigChange hooks fire for changes to settings files, managed policy settings, and skill files. The `source` field in the input tells you which type of configuration changed, and the optional `file_path` field provides the path to the changed file.
+
+The matcher filters on the configuration source:
+
+| Matcher            | When it fires                             |
+| :----------------- | :---------------------------------------- |
+| `user_settings`    | `~/.claude/settings.json` changes         |
+| `project_settings` | `.claude/settings.json` changes           |
+| `local_settings`   | `.claude/settings.local.json` changes     |
+| `policy_settings`  | Managed policy settings change            |
+| `skills`           | A skill file in `.claude/skills/` changes |
+
+This example logs all configuration changes for security auditing:
+
+```json theme={null}
+{
+  "hooks": {
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/audit-config-change.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### ConfigChange input
+
+In addition to the [common input fields](#common-input-fields), ConfigChange hooks receive `source` and optionally `file_path`. The `source` field indicates which configuration type changed, and `file_path` provides the path to the specific file that was modified.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "ConfigChange",
+  "source": "project_settings",
+  "file_path": "/Users/.../my-project/.claude/settings.json"
+}
+```
+
+#### ConfigChange decision control
+
+ConfigChange hooks can block configuration changes from taking effect. Use exit code 2 or a JSON `decision` to prevent the change. When blocked, the new settings are not applied to the running session.
+
+| Field      | Description                                                                              |
+| :--------- | :--------------------------------------------------------------------------------------- |
+| `decision` | `"block"` prevents the configuration change from being applied. Omit to allow the change |
+| `reason`   | Explanation shown to the user when `decision` is `"block"`                               |
+
+```json theme={null}
+{
+  "decision": "block",
+  "reason": "Configuration changes to project settings require admin approval"
+}
+```
+
+`policy_settings` changes cannot be blocked. Hooks still fire for `policy_settings` sources, so you can use them for audit logging, but any blocking decision is ignored. This ensures enterprise-managed settings always take effect.
+
+### CwdChanged
+
+Runs when the working directory changes during a session, for example when Claude executes a `cd` command. Use this to react to directory changes: reload environment variables, activate project-specific toolchains, or run setup scripts automatically. Pairs with [FileChanged](#filechanged) for tools like [direnv](https://direnv.net/) that manage per-directory environment.
+
+CwdChanged hooks have access to `CLAUDE_ENV_FILE`. Variables written to that file persist into subsequent Bash commands for the session, just as in [SessionStart hooks](#persist-environment-variables).
+
+CwdChanged does not support matchers and fires on every directory change.
+
+#### CwdChanged input
+
+In addition to the [common input fields](#common-input-fields), CwdChanged hooks receive `old_cwd` and `new_cwd`.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../transcript.jsonl",
+  "cwd": "/Users/my-project/src",
+  "hook_event_name": "CwdChanged",
+  "old_cwd": "/Users/my-project",
+  "new_cwd": "/Users/my-project/src"
+}
+```
+
+#### CwdChanged output
+
+In addition to the [JSON output fields](#json-output) available to all hooks, CwdChanged hooks can return `watchPaths` to dynamically set which file paths [FileChanged](#filechanged) watches:
+
+| Field        | Description                                                                                                                                                                                                                     |
+| :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `watchPaths` | Array of absolute paths. Replaces the current dynamic watch list (paths from your `matcher` configuration are always watched). Returning an empty array clears the dynamic list, which is typical when entering a new directory |
+
+CwdChanged hooks have no decision control. They cannot block the directory change.
+
+### FileChanged
+
+Runs when a watched file changes on disk. Useful for reloading environment variables when project configuration files are modified.
+
+The `matcher` for this event serves two roles:
+
+* **Build the watch list**: the value is split on `|` and each segment is registered as a literal filename in the working directory, so `".envrc|.env"` watches exactly those two files. Regex patterns are not useful here: a value like `^\.env` would watch a file literally named `^\.env`.
+* **Filter which hooks run**: when a watched file changes, the same value filters which hook groups run using the standard [matcher rules](#matcher-patterns) against the changed file's basename.
+
+FileChanged hooks have access to `CLAUDE_ENV_FILE`. Variables written to that file persist into subsequent Bash commands for the session, just as in [SessionStart hooks](#persist-environment-variables).
+
+#### FileChanged input
+
+In addition to the [common input fields](#common-input-fields), FileChanged hooks receive `file_path` and `event`.
+
+| Field       | Description                                                                                     |
+| :---------- | :---------------------------------------------------------------------------------------------- |
+| `file_path` | Absolute path to the file that changed                                                          |
+| `event`     | What happened: `"change"` (file modified), `"add"` (file created), or `"unlink"` (file deleted) |
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../transcript.jsonl",
+  "cwd": "/Users/my-project",
+  "hook_event_name": "FileChanged",
+  "file_path": "/Users/my-project/.envrc",
+  "event": "change"
+}
+```
+
+#### FileChanged output
+
+In addition to the [JSON output fields](#json-output) available to all hooks, FileChanged hooks can return `watchPaths` to dynamically update which file paths are watched:
+
+| Field        | Description                                                                                                                                                                                                                 |
+| :----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `watchPaths` | Array of absolute paths. Replaces the current dynamic watch list (paths from your `matcher` configuration are always watched). Use this when your hook script discovers additional files to watch based on the changed file |
+
+FileChanged hooks have no decision control. They cannot block the file change from occurring.
+
+### WorktreeCreate
+
+When you run `claude --worktree` or a [subagent uses `isolation: "worktree"`](/en/sub-agents#choose-the-subagent-scope), Claude Code creates an isolated working copy using `git worktree`. If you configure a WorktreeCreate hook, it replaces the default git behavior, letting you use a different version control system like SVN, Perforce, or Mercurial.
+
+Because the hook replaces the default behavior entirely, [`.worktreeinclude`](/en/common-workflows#copy-gitignored-files-to-worktrees) is not processed. If you need to copy local configuration files like `.env` into the new worktree, do it inside your hook script.
+
+The hook must return the absolute path to the created worktree directory. Claude Code uses this path as the working directory for the isolated session. Command hooks print it on stdout; HTTP hooks return it via `hookSpecificOutput.worktreePath`.
+
+This example creates an SVN working copy and prints the path for Claude Code to use. Replace the repository URL with your own:
+
+```json theme={null}
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'NAME=$(jq -r .name); DIR=\"$HOME/.claude/worktrees/$NAME\"; svn checkout https://svn.example.com/repo/trunk \"$DIR\" >&2 && echo \"$DIR\"'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook reads the worktree `name` from the JSON input on stdin, checks out a fresh copy into a new directory, and prints the directory path. The `echo` on the last line is what Claude Code reads as the worktree path. Redirect any other output to stderr so it doesn't interfere with the path.
+
+#### WorktreeCreate input
+
+In addition to the [common input fields](#common-input-fields), WorktreeCreate hooks receive the `name` field. This is a slug identifier for the new worktree, either specified by the user or auto-generated (for example, `bold-oak-a3f2`).
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "WorktreeCreate",
+  "name": "feature-auth"
+}
+```
+
+#### WorktreeCreate output
+
+WorktreeCreate hooks do not use the standard allow/block decision model. Instead, the hook's success or failure determines the outcome. The hook must return the absolute path to the created worktree directory:
+
+* **Command hooks** (`type: "command"`): print the path on stdout.
+* **HTTP hooks** (`type: "http"`): return `{ "hookSpecificOutput": { "hookEventName": "WorktreeCreate", "worktreePath": "/absolute/path" } }` in the response body.
+
+If the hook fails or produces no path, worktree creation fails with an error.
+
+### WorktreeRemove
+
+The cleanup counterpart to [WorktreeCreate](#worktreecreate). This hook fires when a worktree is being removed, either when you exit a `--worktree` session and choose to remove it, or when a subagent with `isolation: "worktree"` finishes. For git-based worktrees, Claude handles cleanup automatically with `git worktree remove`. If you configured a WorktreeCreate hook for a non-git version control system, pair it with a WorktreeRemove hook to handle cleanup. Without one, the worktree directory is left on disk.
+
+Claude Code passes the path returned by WorktreeCreate as `worktree_path` in the hook input. This example reads that path and removes the directory:
+
+```json theme={null}
+{
+  "hooks": {
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'jq -r .worktree_path | xargs rm -rf'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### WorktreeRemove input
+
+In addition to the [common input fields](#common-input-fields), WorktreeRemove hooks receive the `worktree_path` field, which is the absolute path to the worktree being removed.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "WorktreeRemove",
+  "worktree_path": "/Users/.../my-project/.claude/worktrees/feature-auth"
+}
+```
+
+WorktreeRemove hooks have no decision control. They cannot block worktree removal but can perform cleanup tasks like removing version control state or archiving changes. Hook failures are logged in debug mode only.
+
+### PreCompact
+
+Runs before Claude Code is about to run a compact operation.
+
+The matcher value indicates whether compaction was triggered manually or automatically:
+
+| Matcher  | When it fires                                |
+| :------- | :------------------------------------------- |
+| `manual` | `/compact`                                   |
+| `auto`   | Auto-compact when the context window is full |
+
+Exit with code 2 to block compaction. For a manual `/compact`, the stderr message is shown to the user. You can also block by returning JSON with `"decision": "block"`.
+
+Blocking automatic compaction has different effects depending on when it fires. If compaction was triggered proactively before the context limit, Claude Code skips it and the conversation continues uncompacted. If compaction was triggered to recover from a context-limit error already returned by the API, the underlying error surfaces and the current request fails.
+
+#### PreCompact input
+
+In addition to the [common input fields](#common-input-fields), PreCompact hooks receive `trigger` and `custom_instructions`. For `manual`, `custom_instructions` contains what the user passes into `/compact`. For `auto`, `custom_instructions` is empty.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "PreCompact",
+  "trigger": "manual",
+  "custom_instructions": ""
+}
+```
+
+### PostCompact
+
+Runs after Claude Code completes a compact operation. Use this event to react to the new compacted state, for example to log the generated summary or update external state.
+
+The same matcher values apply as for `PreCompact`:
+
+| Matcher  | When it fires                                      |
+| :------- | :------------------------------------------------- |
+| `manual` | After `/compact`                                   |
+| `auto`   | After auto-compact when the context window is full |
+
+#### PostCompact input
+
+In addition to the [common input fields](#common-input-fields), PostCompact hooks receive `trigger` and `compact_summary`. The `compact_summary` field contains the conversation summary generated by the compact operation.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "PostCompact",
+  "trigger": "manual",
+  "compact_summary": "Summary of the compacted conversation..."
+}
+```
+
+PostCompact hooks have no decision control. They cannot affect the compaction result but can perform follow-up tasks.
+
+### SessionEnd
+
+Runs when a Claude Code session ends. Useful for cleanup tasks, logging session
+statistics, or saving session state. Supports matchers to filter by exit reason.
+
+The `reason` field in the hook input indicates why the session ended:
+
+| Reason                        | Description                                |
+| :---------------------------- | :----------------------------------------- |
+| `clear`                       | Session cleared with `/clear` command      |
+| `resume`                      | Session switched via interactive `/resume` |
+| `logout`                      | User logged out                            |
+| `prompt_input_exit`           | User exited while prompt input was visible |
+| `bypass_permissions_disabled` | Bypass permissions mode was disabled       |
+| `other`                       | Other exit reasons                         |
+
+#### SessionEnd input
+
+In addition to the [common input fields](#common-input-fields), SessionEnd hooks receive a `reason` field indicating why the session ended. See the [reason table](#sessionend) above for all values.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "hook_event_name": "SessionEnd",
+  "reason": "other"
+}
+```
+
+SessionEnd hooks have no decision control. They cannot block session termination but can perform cleanup tasks.
+
+SessionEnd hooks have a default timeout of 1.5 seconds. This applies to session exit, `/clear`, and switching sessions via interactive `/resume`. If a hook needs more time, set a per-hook `timeout` in the hook configuration. The overall budget is automatically raised to the highest per-hook timeout configured in settings files, up to 60 seconds. Timeouts set on plugin-provided hooks do not raise the budget. To override the budget explicitly, set the `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` environment variable in milliseconds.
+
+```bash theme={null}
+CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS=5000 claude
+```
+
+### Elicitation
+
+Runs when an MCP server requests user input mid-task. By default, Claude Code shows an interactive dialog for the user to respond. Hooks can intercept this request and respond programmatically, skipping the dialog entirely.
+
+The matcher field matches against the MCP server name.
+
+#### Elicitation input
+
+In addition to the [common input fields](#common-input-fields), Elicitation hooks receive `mcp_server_name`, `message`, and optional `mode`, `url`, `elicitation_id`, and `requested_schema` fields.
+
+For form-mode elicitation (the most common case):
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "Elicitation",
+  "mcp_server_name": "my-mcp-server",
+  "message": "Please provide your credentials",
+  "mode": "form",
+  "requested_schema": {
+    "type": "object",
+    "properties": {
+      "username": { "type": "string", "title": "Username" }
+    }
+  }
+}
+```
+
+For URL-mode elicitation (browser-based authentication):
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "Elicitation",
+  "mcp_server_name": "my-mcp-server",
+  "message": "Please authenticate",
+  "mode": "url",
+  "url": "https://auth.example.com/login"
+}
+```
+
+#### Elicitation output
+
+To respond programmatically without showing the dialog, return a JSON object with `hookSpecificOutput`:
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Elicitation",
+    "action": "accept",
+    "content": {
+      "username": "alice"
+    }
+  }
+}
+```
+
+| Field     | Values                        | Description                                                      |
+| :-------- | :---------------------------- | :--------------------------------------------------------------- |
+| `action`  | `accept`, `decline`, `cancel` | Whether to accept, decline, or cancel the request                |
+| `content` | object                        | Form field values to submit. Only used when `action` is `accept` |
+
+Exit code 2 denies the elicitation and shows stderr to the user.
+
+### ElicitationResult
+
+Runs after a user responds to an MCP elicitation. Hooks can observe, modify, or block the response before it is sent back to the MCP server.
+
+The matcher field matches against the MCP server name.
+
+#### ElicitationResult input
+
+In addition to the [common input fields](#common-input-fields), ElicitationResult hooks receive `mcp_server_name`, `action`, and optional `mode`, `elicitation_id`, and `content` fields.
+
+```json theme={null}
+{
+  "session_id": "abc123",
+  "transcript_path": "/Users/.../.claude/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
+  "cwd": "/Users/...",
+  "permission_mode": "default",
+  "hook_event_name": "ElicitationResult",
+  "mcp_server_name": "my-mcp-server",
+  "action": "accept",
+  "content": { "username": "alice" },
+  "mode": "form",
+  "elicitation_id": "elicit-123"
+}
+```
+
+#### ElicitationResult output
+
+To override the user's response, return a JSON object with `hookSpecificOutput`:
+
+```json theme={null}
+{
+  "hookSpecificOutput": {
+    "hookEventName": "ElicitationResult",
+    "action": "decline",
+    "content": {}
+  }
+}
+```
+
+| Field     | Values                        | Description                                                            |
+| :-------- | :---------------------------- | :--------------------------------------------------------------------- |
+| `action`  | `accept`, `decline`, `cancel` | Overrides the user's action                                            |
+| `content` | object                        | Overrides form field values. Only meaningful when `action` is `accept` |
+
+Exit code 2 blocks the response, changing the effective action to `decline`.
 
 ## Prompt-based hooks
 
-For decisions that require judgment rather than deterministic rules, use `type: "prompt"` hooks. Instead of running a shell command, Claude Code sends your prompt and the hook's input data to a Claude model (Haiku by default) to make the decision. You can specify a different model with the `model` field if you need more capability.
+In addition to command, HTTP, and MCP tool hooks, Claude Code supports prompt-based hooks (`type: "prompt"`) that use an LLM to evaluate whether to allow or block an action, and agent hooks (`type: "agent"`) that spawn an agentic verifier with tool access. Not all events support every hook type.
 
-The model's only job is to return a yes/no decision as JSON:
+Events that support all five hook types (`command`, `http`, `mcp_tool`, `prompt`, and `agent`):
 
-* `"ok": true`: the action proceeds
-* `"ok": false`: the action is blocked. The model's `"reason"` is fed back to Claude so it can adjust.
+* `PermissionRequest`
+* `PostToolBatch`
+* `PostToolUse`
+* `PostToolUseFailure`
+* `PreToolUse`
+* `Stop`
+* `SubagentStop`
+* `TaskCompleted`
+* `TaskCreated`
+* `UserPromptExpansion`
+* `UserPromptSubmit`
 
-This example uses a `Stop` hook to ask the model whether all requested tasks are complete. If the model returns `"ok": false`, Claude keeps working and uses the `reason` as its next instruction:
+Events that support `command`, `http`, and `mcp_tool` hooks but not `prompt` or `agent`:
 
-```json  theme={null}
+* `ConfigChange`
+* `CwdChanged`
+* `Elicitation`
+* `ElicitationResult`
+* `FileChanged`
+* `InstructionsLoaded`
+* `Notification`
+* `PermissionDenied`
+* `PostCompact`
+* `PreCompact`
+* `SessionEnd`
+* `StopFailure`
+* `SubagentStart`
+* `TeammateIdle`
+* `WorktreeCreate`
+* `WorktreeRemove`
+
+`SessionStart` and `Setup` support `command` and `mcp_tool` hooks. They do not support `http`, `prompt`, or `agent` hooks.
+
+### How prompt-based hooks work
+
+Instead of executing a Bash command, prompt-based hooks:
+
+1. Send the hook input and your prompt to a Claude model, Haiku by default
+2. The LLM responds with structured JSON containing a decision
+3. Claude Code processes the decision automatically
+
+### Prompt hook configuration
+
+Set `type` to `"prompt"` and provide a `prompt` string instead of a `command`. Use the `$ARGUMENTS` placeholder to inject the hook's JSON input data into your prompt text. Claude Code sends the combined prompt and input to a fast Claude model, which returns a JSON decision.
+
+This `Stop` hook asks the LLM to evaluate whether all tasks are complete before allowing Claude to finish:
+
+```json theme={null}
 {
   "hooks": {
     "Stop": [
@@ -672,7 +2294,7 @@ This example uses a `Stop` hook to ask the model whether all requested tasks are
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check if all tasks are complete. If not, respond with {\"ok\": false, \"reason\": \"what remains to be done\"}."
+            "prompt": "Evaluate if Claude should stop: $ARGUMENTS. Check if all tasks are complete."
           }
         ]
       }
@@ -681,17 +2303,86 @@ This example uses a `Stop` hook to ask the model whether all requested tasks are
 }
 ```
 
-For full configuration options, see [Prompt-based hooks](/en/hooks#prompt-based-hooks) in the reference.
+| Field     | Required | Description                                                                                                                                                         |
+| :-------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `type`    | yes      | Must be `"prompt"`                                                                                                                                                  |
+| `prompt`  | yes      | The prompt text to send to the LLM. Use `$ARGUMENTS` as a placeholder for the hook input JSON. If `$ARGUMENTS` is not present, input JSON is appended to the prompt |
+| `model`   | no       | Model to use for evaluation. Defaults to a fast model                                                                                                               |
+| `timeout` | no       | Timeout in seconds. Default: 30                                                                                                                                     |
+
+### Response schema
+
+The LLM must respond with JSON containing:
+
+```json theme={null}
+{
+  "ok": true | false,
+  "reason": "Explanation for the decision"
+}
+```
+
+| Field    | Description                                                |
+| :------- | :--------------------------------------------------------- |
+| `ok`     | `true` allows the action, `false` prevents it              |
+| `reason` | Required when `ok` is `false`. Explanation shown to Claude |
+
+### Example: Multi-criteria Stop hook
+
+This `Stop` hook uses a detailed prompt to check three conditions before allowing Claude to stop. If `"ok"` is `false`, Claude continues working with the provided reason as its next instruction. `SubagentStop` hooks use the same format to evaluate whether a [subagent](/en/sub-agents) should stop:
+
+```json theme={null}
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "You are evaluating whether Claude should stop working. Context: $ARGUMENTS\n\nAnalyze the conversation and determine if:\n1. All user-requested tasks are complete\n2. Any errors need to be addressed\n3. Follow-up work is needed\n\nRespond with JSON: {\"ok\": true} to allow stopping, or {\"ok\": false, \"reason\": \"your explanation\"} to continue working.",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 ## Agent-based hooks
 
-When verification requires inspecting files or running commands, use `type: "agent"` hooks. Unlike prompt hooks which make a single LLM call, agent hooks spawn a subagent that can read files, search code, and use other tools to verify conditions before returning a decision.
+<Warning>
+  Agent hooks are experimental. Behavior and configuration may change in future releases. For production workflows, prefer [command hooks](#command-hook-fields).
+</Warning>
 
-Agent hooks use the same `"ok"` / `"reason"` response format as prompt hooks, but with a longer default timeout of 60 seconds and up to 50 tool-use turns.
+Agent-based hooks (`type: "agent"`) are like prompt-based hooks but with multi-turn tool access. Instead of a single LLM call, an agent hook spawns a subagent that can read files, search code, and inspect the codebase to verify conditions. Agent hooks support the same events as prompt-based hooks.
 
-This example verifies that tests pass before allowing Claude to stop:
+### How agent hooks work
 
-```json  theme={null}
+When an agent hook fires:
+
+1. Claude Code spawns a subagent with your prompt and the hook's JSON input
+2. The subagent can use tools like Read, Grep, and Glob to investigate
+3. After up to 50 turns, the subagent returns a structured `{ "ok": true/false }` decision
+4. Claude Code processes the decision the same way as a prompt hook
+
+Agent hooks are useful when verification requires inspecting actual files or test output, not just evaluating the hook input data alone.
+
+### Agent hook configuration
+
+Set `type` to `"agent"` and provide a `prompt` string. The configuration fields are the same as [prompt hooks](#prompt-hook-configuration), with a longer default timeout:
+
+| Field     | Required | Description                                                                                 |
+| :-------- | :------- | :------------------------------------------------------------------------------------------ |
+| `type`    | yes      | Must be `"agent"`                                                                           |
+| `prompt`  | yes      | Prompt describing what to verify. Use `$ARGUMENTS` as a placeholder for the hook input JSON |
+| `model`   | no       | Model to use. Defaults to a fast model                                                      |
+| `timeout` | no       | Timeout in seconds. Default: 60                                                             |
+
+The response schema is the same as prompt hooks: `{ "ok": true }` to allow or `{ "ok": false, "reason": "..." }` to block.
+
+This `Stop` hook verifies that all unit tests pass before allowing Claude to finish:
+
+```json theme={null}
 {
   "hooks": {
     "Stop": [
@@ -709,31 +2400,28 @@ This example verifies that tests pass before allowing Claude to stop:
 }
 ```
 
-Use prompt hooks when the hook input data alone is enough to make a decision. Use agent hooks when you need to verify something against the actual state of the codebase.
+## Run hooks in the background
 
-For full configuration options, see [Agent-based hooks](/en/hooks#agent-based-hooks) in the reference.
+By default, hooks block Claude's execution until they complete. For long-running tasks like deployments, test suites, or external API calls, set `"async": true` to run the hook in the background while Claude continues working. Async hooks cannot block or control Claude's behavior: response fields like `decision`, `permissionDecision`, and `continue` have no effect, because the action they would have controlled has already completed.
 
-## HTTP hooks
+### Configure an async hook
 
-Use `type: "http"` hooks to POST event data to an HTTP endpoint instead of running a shell command. The endpoint receives the same JSON that a command hook would receive on stdin, and returns results through the HTTP response body using the same JSON format.
+Add `"async": true` to a command hook's configuration to run it in the background without blocking Claude. This field is only available on `type: "command"` hooks.
 
-HTTP hooks are useful when you want a web server, cloud function, or external service to handle hook logic: for example, a shared audit service that logs tool use events across a team.
+This hook runs a test script after every `Write` tool call. Claude continues working immediately while `run-tests.sh` executes for up to 120 seconds. When the script finishes, its output is delivered on the next conversation turn:
 
-This example posts every tool use to a local logging service:
-
-```json  theme={null}
+```json theme={null}
 {
   "hooks": {
     "PostToolUse": [
       {
+        "matcher": "Write",
         "hooks": [
           {
-            "type": "http",
-            "url": "http://localhost:8080/hooks/tool-use",
-            "headers": {
-              "Authorization": "Bearer $MY_TOKEN"
-            },
-            "allowedEnvVars": ["MY_TOKEN"]
+            "type": "command",
+            "command": "/path/to/run-tests.sh",
+            "async": true,
+            "timeout": 120
           }
         ]
       }
@@ -742,95 +2430,129 @@ This example posts every tool use to a local logging service:
 }
 ```
 
-The endpoint should return a JSON response body using the same [output format](/en/hooks#json-output) as command hooks. To block a tool call, return a 2xx response with the appropriate `hookSpecificOutput` fields. HTTP status codes alone cannot block actions.
+The `timeout` field sets the maximum time in seconds for the background process. If not specified, async hooks use the same 10-minute default as sync hooks.
 
-Header values support environment variable interpolation using `$VAR_NAME` or `${VAR_NAME}` syntax. Only variables listed in the `allowedEnvVars` array are resolved; all other `$VAR` references remain empty.
+### How async hooks execute
 
-For full configuration options and response handling, see [HTTP hooks](/en/hooks#http-hook-fields) in the reference.
+When an async hook fires, Claude Code starts the hook process and immediately continues without waiting for it to finish. The hook receives the same JSON input via stdin as a synchronous hook.
 
-## Limitations and troubleshooting
+After the background process exits, if the hook produced a JSON response with a `systemMessage` or `additionalContext` field, that content is delivered to Claude as context on the next conversation turn.
+
+Async hook completion notifications are suppressed by default. To see them, enable verbose mode with `Ctrl+O` or start Claude Code with `--verbose`.
+
+### Example: run tests after file changes
+
+This hook starts a test suite in the background whenever Claude writes a file, then reports the results back to Claude when the tests finish. Save this script to `.claude/hooks/run-tests-async.sh` in your project and make it executable with `chmod +x`:
+
+```bash theme={null}
+#!/bin/bash
+# run-tests-async.sh
+
+# Read hook input from stdin
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only run tests for source files
+if [[ "$FILE_PATH" != *.ts && "$FILE_PATH" != *.js ]]; then
+  exit 0
+fi
+
+# Run tests and report results via systemMessage
+RESULT=$(npm test 2>&1)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "{\"systemMessage\": \"Tests passed after editing $FILE_PATH\"}"
+else
+  echo "{\"systemMessage\": \"Tests failed after editing $FILE_PATH: $RESULT\"}"
+fi
+```
+
+Then add this configuration to `.claude/settings.json` in your project root. The `async: true` flag lets Claude keep working while tests run:
+
+```json theme={null}
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/run-tests-async.sh",
+            "async": true,
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 ### Limitations
 
-* Command hooks communicate through stdout, stderr, and exit codes only. They cannot trigger commands or tool calls directly. HTTP hooks communicate through the response body instead.
-* Hook timeout is 10 minutes by default, configurable per hook with the `timeout` field (in seconds).
-* `PostToolUse` hooks cannot undo actions since the tool has already executed.
-* `PermissionRequest` hooks do not fire in [non-interactive mode](/en/headless) (`-p`). Use `PreToolUse` hooks for automated permission decisions.
-* `Stop` hooks fire whenever Claude finishes responding, not only at task completion. They do not fire on user interrupts. API errors fire [StopFailure](/en/hooks#stopfailure) instead.
+Async hooks have several constraints compared to synchronous hooks:
 
-### Hook not firing
+* Only `type: "command"` hooks support `async`. Prompt-based hooks cannot run asynchronously.
+* Async hooks cannot block tool calls or return decisions. By the time the hook completes, the triggering action has already proceeded.
+* Hook output is delivered on the next conversation turn. If the session is idle, the response waits until the next user interaction. Exception: an `asyncRewake` hook that exits with code 2 wakes Claude immediately even when the session is idle.
+* Each execution creates a separate background process. There is no deduplication across multiple firings of the same async hook.
 
-The hook is configured but never executes.
+## Security considerations
 
-* Run `/hooks` and confirm the hook appears under the correct event
-* Check that the matcher pattern matches the tool name exactly (matchers are case-sensitive)
-* Verify you're triggering the right event type (e.g., `PreToolUse` fires before tool execution, `PostToolUse` fires after)
-* If using `PermissionRequest` hooks in non-interactive mode (`-p`), switch to `PreToolUse` instead
+### Disclaimer
 
-### Hook error in output
+Command hooks run with your system user's full permissions.
 
-You see a message like "PreToolUse hook error: ..." in the transcript.
+<Warning>
+  Command hooks execute shell commands with your full user permissions. They can modify, delete, or access any files your user account can access. Review and test all hook commands before adding them to your configuration.
+</Warning>
 
-* Your script exited with a non-zero code unexpectedly. Test it manually by piping sample JSON:
-  ```bash  theme={null}
-  echo '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | ./my-hook.sh
-  echo $?  # Check the exit code
-  ```
-* If you see "command not found", use absolute paths or `$CLAUDE_PROJECT_DIR` to reference scripts
-* If you see "jq: command not found", install `jq` or use Python/Node.js for JSON parsing
-* If the script isn't running at all, make it executable: `chmod +x ./my-hook.sh`
+### Security best practices
 
-### `/hooks` shows no hooks configured
+Keep these practices in mind when writing hooks:
 
-You edited a settings file but the hooks don't appear in the menu.
+* **Validate and sanitize inputs**: never trust input data blindly
+* **Always quote shell variables**: use `"$VAR"` not `$VAR`
+* **Block path traversal**: check for `..` in file paths
+* **Use absolute paths**: specify full paths for scripts, using `"$CLAUDE_PROJECT_DIR"` for the project root
+* **Skip sensitive files**: avoid `.env`, `.git/`, keys, etc.
 
-* File edits are normally picked up automatically. If they haven't appeared after a few seconds, the file watcher may have missed the change: restart your session to force a reload.
-* Verify your JSON is valid (trailing commas and comments are not allowed)
-* Confirm the settings file is in the correct location: `.claude/settings.json` for project hooks, `~/.claude/settings.json` for global hooks
+## Windows PowerShell tool
 
-### Stop hook runs forever
+On Windows, you can run individual hooks in PowerShell by setting `"shell": "powershell"` on a command hook. Hooks spawn PowerShell directly, so this works regardless of whether `CLAUDE_CODE_USE_POWERSHELL_TOOL` is set. Claude Code auto-detects `pwsh.exe` (PowerShell 7+) with a fallback to `powershell.exe` (5.1).
 
-Claude keeps working in an infinite loop instead of stopping.
-
-Your Stop hook script needs to check whether it already triggered a continuation. Parse the `stop_hook_active` field from the JSON input and exit early if it's `true`:
-
-```bash  theme={null}
-#!/bin/bash
-INPUT=$(cat)
-if [ "$(echo "$INPUT" | jq -r '.stop_hook_active')" = "true" ]; then
-  exit 0  # Allow Claude to stop
-fi
-# ... rest of your hook logic
+```json theme={null}
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "powershell",
+            "command": "Write-Host 'File written'"
+          }
+        ]
+      }
+    ]
+  }
+}
 ```
 
-### JSON validation failed
+## Debug hooks
 
-Claude Code shows a JSON parsing error even though your hook script outputs valid JSON.
+Hook execution details, including which hooks matched, their exit codes, and full stdout and stderr, are written to the debug log file. Start Claude Code with `claude --debug-file <path>` to write the log to a known location, or run `claude --debug` and read the log at `~/.claude/debug/<session-id>.txt`. The `--debug` flag does not print to the terminal.
 
-When Claude Code runs a hook, it spawns a shell that sources your profile (`~/.zshrc` or `~/.bashrc`). If your profile contains unconditional `echo` statements, that output gets prepended to your hook's JSON:
-
-```text  theme={null}
-Shell ready on arm64
-{"decision": "block", "reason": "Not allowed"}
+```text theme={null}
+[DEBUG] Executing hooks for PostToolUse:Write
+[DEBUG] Found 1 hook commands to execute
+[DEBUG] Executing hook command: <Your command> with timeout 600000ms
+[DEBUG] Hook command completed with status 0: <Your stdout>
 ```
 
-Claude Code tries to parse this as JSON and fails. To fix this, wrap echo statements in your shell profile so they only run in interactive shells:
+For more granular hook matching details, set `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` to see additional log lines such as hook matcher counts and query matching.
 
-```bash  theme={null}
-# In ~/.zshrc or ~/.bashrc
-if [[ $- == *i* ]]; then
-  echo "Shell ready"
-fi
-```
-
-The `$-` variable contains shell flags, and `i` means interactive. Hooks run in non-interactive shells, so the echo is skipped.
-
-### Debug techniques
-
-Toggle verbose mode with `Ctrl+O` to see hook output in the transcript, or run `claude --debug` for full execution details including which hooks matched and their exit codes.
-
-## Learn more
-
-* [Hooks reference](/en/hooks): full event schemas, JSON output format, async hooks, and MCP tool hooks
-* [Security considerations](/en/hooks#security-considerations): review before deploying hooks in shared or production environments
-* [Bash command validator example](https://github.com/anthropics/claude-code/blob/main/examples/hooks/bash_command_validator_example.py): complete reference implementation
+For troubleshooting common issues like hooks not firing, infinite Stop hook loops, or configuration errors, see [Limitations and troubleshooting](/en/hooks-guide#limitations-and-troubleshooting) in the guide. For a broader diagnostic walkthrough covering `/context`, `/doctor`, and settings precedence, see [Debug your config](/en/debug-your-config).

--- a/examples/claude-background-subagents/claude-worker.ts
+++ b/examples/claude-background-subagents/claude-worker.ts
@@ -1,0 +1,4 @@
+import { createWorkflowCli } from "@bastani/atomic/workflows";
+import workflow from "./claude/index.ts";
+
+await createWorkflowCli(workflow).run();

--- a/examples/claude-background-subagents/claude/index.ts
+++ b/examples/claude-background-subagents/claude/index.ts
@@ -1,0 +1,120 @@
+/**
+ * Two-stage Claude workflow that exercises the in-flight subagent gating.
+ *
+ * Stage 1 ("dispatch") asks Claude to spawn three independent **background**
+ * subagents via the `Agent` tool with `run_in_background: true`. Each
+ * subagent waits a few seconds and writes a marker file under
+ * `/tmp/atomic-bg-<n>.txt`, then returns. Claude is told NOT to wait for
+ * them — its main turn ends right after dispatching.
+ *
+ * Stage 2 ("verify") reads the three marker files and confirms they all
+ * exist with non-empty content. If the harness advanced to stage 2 before
+ * the backgrounded subagents finished, the marker files would be missing
+ * and the assertion fails.
+ *
+ * Without the in-flight gating, this example surfaces the bug
+ * deterministically: stage 2 starts before the subagents finish and either
+ * (a) reads missing files, or (b) intermittently hits
+ * `tmux respawn-pane: fork failed: Device not configured` due to FD pressure
+ * on the atomic tmux server. With the gating, stage 1's Stop hook holds
+ * until all three SubagentStop events fire and the in-flight marker dir
+ * empties; only then does stage 2 spawn.
+ */
+
+import { defineWorkflow } from "@bastani/atomic/workflows";
+
+const MARKER_DIR = "/tmp";
+const MARKER_PREFIX = "atomic-bg-";
+const MARKER_PATHS = [1, 2, 3].map((n) => `${MARKER_DIR}/${MARKER_PREFIX}${n}.txt`);
+
+export default defineWorkflow({
+  name: "claude-background-subagents",
+  description:
+    "Stage 1 spawns 3 background subagents and ends its turn immediately; stage 2 verifies they all finished before it started.",
+  inputs: [],
+})
+  .for("claude")
+  .run(async (ctx) => {
+    // Stage 1: dispatch three background subagents and return immediately.
+    //
+    // The prompt is deliberately prescriptive — it names the tool, gives
+    // each subagent a deterministic 20 s sleep that is long enough to make
+    // the gating window unambiguous (if stage 2 starts mid-sleep, the
+    // marker files won't exist yet), and tells Claude to end its turn the
+    // moment all three are dispatched. The 20 s sleep is the test: if the
+    // executor advances to stage 2 in less than 20 s after stage 1 ends
+    // its turn, the gate is broken.
+    const dispatch = await ctx.stage(
+      {
+        name: "dispatch",
+        description: "Spawn three background subagents that each sleep 20s and write a marker file",
+      },
+      {},
+      {},
+      async (s) => {
+        // Wipe stale markers from prior runs so the verify step's check is
+        // unambiguous. A bare Bash call is fine — it's not what we're
+        // exercising in this stage.
+        await s.session.query(
+          [
+            "Step 1: clean any stale marker files from a previous run.",
+            `  Run: rm -f ${MARKER_PATHS.join(" ")}`,
+            "",
+            "Step 2: spawn three independent subagents using the Agent tool with run_in_background: true.",
+            "  Each subagent must:",
+            "    1. Run `sleep 20` via the Bash tool.",
+            `    2. Write a single line containing its own agent identifier into one of:`,
+            ...MARKER_PATHS.map((p, i) => `       - subagent #${i + 1} → ${p}`),
+            "    3. Return.",
+            "",
+            "Step 3: end your turn IMMEDIATELY after dispatching all three subagents.",
+            "  - Do NOT wait for them.",
+            "  - Do NOT poll or summarize their progress.",
+            "  - Do NOT call any further tools after the three Agent dispatches.",
+            "  - Your final assistant message in this turn should be a single short sentence acknowledging the three were dispatched, then stop.",
+            "",
+            "Use the Agent tool literally — three separate Agent tool calls in this same turn, each with run_in_background: true.",
+          ].join("\n"),
+        );
+        s.save(s.sessionId);
+      },
+    );
+
+    // Stage 2: assert all three marker files exist with content.
+    //
+    // The Stop-hook gate in stage 1 should hold until SubagentStop fires for
+    // all three subagents, so by the time this stage spawns, all three
+    // marker files are on disk. The prompt asks Claude to read them and
+    // report any missing/empty file.
+    //
+    // We don't need stage 1's transcript here — the assertion is on
+    // filesystem state, not on what Claude said in stage 1. Suppress the
+    // unused-handle warning by referencing it in a no-op type-position.
+    void dispatch;
+    await ctx.stage(
+      {
+        name: "verify",
+        description: "Confirm all three subagent marker files exist and are non-empty",
+      },
+      {},
+      {},
+      async (s) => {
+        await s.session.query(
+          [
+            "The previous stage spawned three background subagents. Each was instructed to write a marker file under /tmp.",
+            "",
+            "Read each of the following files in turn using your Read tool:",
+            ...MARKER_PATHS.map((p) => `  - ${p}`),
+            "",
+            "For each file, report:",
+            "  - whether it exists",
+            "  - the line of content it contains (the subagent's agent id)",
+            "",
+            "If any file is missing or empty, that means the harness advanced to this stage before the previous stage's background subagents finished — call this out explicitly as a FAILURE. Otherwise report SUCCESS with the three agent ids.",
+          ].join("\n"),
+        );
+        s.save(s.sessionId);
+      },
+    );
+  })
+  .compile();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -297,6 +297,22 @@ Examples:
             process.exit(exitCode);
         });
 
+    // ── Internal: Claude Subagent / TeammateIdle lifecycle hook handler ───
+    program
+        .command("_claude-inflight-hook", { hidden: true })
+        .description("Internal: Claude Code Subagent/TeammateIdle lifecycle hook handler — touches/removes inflight markers, or waits for them to drain")
+        .argument("<mode>", "start (SubagentStart), stop (SubagentStop), or wait (TeammateIdle)")
+        .action(async (mode: string) => {
+            if (mode !== "start" && mode !== "stop" && mode !== "wait") {
+                // Silent exit-0 to match the handler's contract — never red
+                // hook errors in transcripts.
+                process.exit(0);
+            }
+            const { claudeInflightHookCommand } = await import("./commands/cli/claude-inflight-hook.ts");
+            const exitCode = await claudeInflightHookCommand(mode);
+            process.exit(exitCode);
+        });
+
     // ── Completions command ────────────────────────────────────────────────
     program
         .command("completions")
@@ -373,7 +389,8 @@ async function main(): Promise<void> {
                 argv[0] === "_footer" ||
                 argv[0] === "_claude-stop-hook" ||
                 argv[0] === "_claude-ask-hook" ||
-                argv[0] === "_claude-session-start-hook";
+                argv[0] === "_claude-session-start-hook" ||
+                argv[0] === "_claude-inflight-hook";
 
             if (!isInfoCommand) {
                 const { autoSyncIfStale } = await import(

--- a/src/commands/cli/claude-inflight-hook.test.ts
+++ b/src/commands/cli/claude-inflight-hook.test.ts
@@ -1,0 +1,598 @@
+/**
+ * Tests for claudeInflightHookCommand and its helpers.
+ *
+ * Strategy: monkey-patch `Bun.stdin.text` to feed payloads to the handler
+ * directly, then assert against real filesystem state. No mocks of fs or of
+ * the hook internals — the contract is "marker files appear/disappear
+ * correctly under the per-root inflight dir," and we verify exactly that.
+ *
+ * Each test uses `crypto.randomUUID()` for unique session/agent ids and
+ * cleans up in `afterEach` so runs never collide with each other or with
+ * real workflow runs that share `~/.atomic/claude-inflight/`.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { access, mkdir, rm, stat, writeFile, utimes } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  claudeInflightHookCommand,
+  inflightDirIsEmpty,
+  sweepStaleInflight,
+  waitForInflightDrained,
+  clearInflightTracking,
+} from "./claude-inflight-hook.ts";
+import { claudeHookDirs, claudeStopHookCommand } from "./claude-stop-hook.ts";
+
+const dirs = claudeHookDirs();
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function mockStdin(text: string): void {
+  (Bun.stdin as { text: () => Promise<string> }).text = () =>
+    Promise.resolve(text);
+}
+
+const sessionsToClean: string[] = [];
+
+afterEach(async () => {
+  for (const id of sessionsToClean) {
+    await Promise.all([
+      rm(join(dirs.inflight, id), { recursive: true, force: true }),
+      rm(join(dirs.inflightRoots, id), { force: true }),
+      rm(join(dirs.marker, id), { force: true }),
+      rm(join(dirs.queue, id), { force: true }),
+      rm(join(dirs.release, id), { force: true }),
+      rm(join(dirs.pid, id), { force: true }),
+    ]);
+  }
+  sessionsToClean.length = 0;
+});
+
+describe("claudeInflightHookCommand — start mode", () => {
+  test("SubagentStart writes a marker file under <inflight>/<session>/<agent_id>", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    mockStdin(JSON.stringify({
+      session_id: sessionId,
+      hook_event_name: "SubagentStart",
+      agent_id: agentId,
+      agent_type: "general-purpose",
+    }));
+
+    const code = await claudeInflightHookCommand("start");
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(dirs.inflight, sessionId, agentId))).toBe(true);
+  });
+
+  test("marker payload captures parent_session_id, root, and a numeric ts", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    mockStdin(JSON.stringify({
+      session_id: sessionId,
+      hook_event_name: "SubagentStart",
+      agent_id: agentId,
+    }));
+
+    await claudeInflightHookCommand("start");
+
+    const body = await Bun.file(join(dirs.inflight, sessionId, agentId)).text();
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+
+    expect(parsed["parent_session_id"]).toBe(sessionId);
+    expect(parsed["root"]).toBe(sessionId);
+    expect(parsed["kind"]).toBe("SubagentStart");
+    expect(typeof parsed["ts"]).toBe("number");
+  });
+
+  test("nested SubagentStart resolves to the original root via .session-roots mapping", async () => {
+    const rootSession = crypto.randomUUID();
+    const childAgent = crypto.randomUUID();
+    const grandchildAgent = crypto.randomUUID();
+    sessionsToClean.push(rootSession, childAgent, grandchildAgent);
+
+    // Direct child: SubagentStart fires under root's session.
+    mockStdin(JSON.stringify({
+      session_id: rootSession,
+      hook_event_name: "SubagentStart",
+      agent_id: childAgent,
+    }));
+    await claudeInflightHookCommand("start");
+
+    // Grandchild: SubagentStart fires under the child's session_id (the
+    // child is itself a Claude session). The handler must resolve the root
+    // via the .session-roots mapping written for childAgent above.
+    mockStdin(JSON.stringify({
+      session_id: childAgent,
+      hook_event_name: "SubagentStart",
+      agent_id: grandchildAgent,
+    }));
+    await claudeInflightHookCommand("start");
+
+    // Both markers should land under <inflight>/<rootSession>/.
+    expect(await fileExists(join(dirs.inflight, rootSession, childAgent))).toBe(true);
+    expect(await fileExists(join(dirs.inflight, rootSession, grandchildAgent))).toBe(true);
+    // Grandchild must NOT also be under <inflight>/<childAgent>/ — that
+    // would mean the wait-for-drain on rootSession could empty out before
+    // the grandchild finishes.
+    expect(await fileExists(join(dirs.inflight, childAgent, grandchildAgent))).toBe(false);
+  });
+
+  test("payload missing agent_id is a no-op", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+
+    mockStdin(JSON.stringify({ session_id: sessionId, hook_event_name: "SubagentStart" }));
+
+    const code = await claudeInflightHookCommand("start");
+
+    expect(code).toBe(0);
+    // No marker dir should have been created.
+    expect(await fileExists(join(dirs.inflight, sessionId))).toBe(false);
+  });
+
+  test("malformed JSON is a no-op and returns 0", async () => {
+    mockStdin("not json {");
+    const code = await claudeInflightHookCommand("start");
+    expect(code).toBe(0);
+  });
+
+  test("missing session_id is a no-op and returns 0", async () => {
+    mockStdin(JSON.stringify({ agent_id: "orphan" }));
+    const code = await claudeInflightHookCommand("start");
+    expect(code).toBe(0);
+  });
+});
+
+describe("claudeInflightHookCommand — stop mode", () => {
+  test("SubagentStop removes the marker for the given agent_id", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    // Seed via start.
+    mockStdin(JSON.stringify({
+      session_id: sessionId,
+      hook_event_name: "SubagentStart",
+      agent_id: agentId,
+    }));
+    await claudeInflightHookCommand("start");
+    expect(await fileExists(join(dirs.inflight, sessionId, agentId))).toBe(true);
+
+    // Stop should remove it.
+    mockStdin(JSON.stringify({
+      session_id: sessionId,
+      hook_event_name: "SubagentStop",
+      agent_id: agentId,
+    }));
+    const code = await claudeInflightHookCommand("stop");
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(dirs.inflight, sessionId, agentId))).toBe(false);
+  });
+
+  test("stop on an unknown id is a no-op and returns 0", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+
+    mockStdin(JSON.stringify({
+      session_id: sessionId,
+      hook_event_name: "SubagentStop",
+      agent_id: agentId,
+    }));
+    const code = await claudeInflightHookCommand("stop");
+
+    expect(code).toBe(0);
+  });
+
+  test("stop resolves the same root as start for nested subagents", async () => {
+    const rootSession = crypto.randomUUID();
+    const childAgent = crypto.randomUUID();
+    const grandchildAgent = crypto.randomUUID();
+    sessionsToClean.push(rootSession, childAgent, grandchildAgent);
+
+    // Start child + grandchild.
+    mockStdin(JSON.stringify({ session_id: rootSession, agent_id: childAgent }));
+    await claudeInflightHookCommand("start");
+    mockStdin(JSON.stringify({ session_id: childAgent, agent_id: grandchildAgent }));
+    await claudeInflightHookCommand("start");
+
+    // Stop the grandchild — its `session_id` field is the child's session,
+    // but the marker lives under root. The handler must resolve correctly.
+    mockStdin(JSON.stringify({ session_id: childAgent, agent_id: grandchildAgent }));
+    await claudeInflightHookCommand("stop");
+
+    expect(await fileExists(join(dirs.inflight, rootSession, grandchildAgent))).toBe(false);
+    expect(await fileExists(join(dirs.inflight, rootSession, childAgent))).toBe(true);
+  });
+});
+
+describe("claudeInflightHookCommand — wait mode (TeammateIdle)", () => {
+  test("returns 0 immediately when the in-flight dir is empty", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+
+    mockStdin(JSON.stringify({ session_id: sessionId, hook_event_name: "TeammateIdle" }));
+
+    const start = Date.now();
+    const code = await claudeInflightHookCommand("wait");
+    const elapsed = Date.now() - start;
+
+    expect(code).toBe(0);
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  test("waits for the in-flight dir to drain before returning", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    // Seed an in-flight subagent on this root.
+    mockStdin(JSON.stringify({ session_id: sessionId, agent_id: agentId }));
+    await claudeInflightHookCommand("start");
+
+    // Drain after 80 ms.
+    setTimeout(() => {
+      void rm(join(dirs.inflight, sessionId, agentId), { force: true });
+    }, 80);
+
+    mockStdin(JSON.stringify({ session_id: sessionId, hook_event_name: "TeammateIdle" }));
+
+    const start = Date.now();
+    const code = await claudeInflightHookCommand("wait");
+    const elapsed = Date.now() - start;
+
+    expect(code).toBe(0);
+    expect(elapsed).toBeGreaterThanOrEqual(80);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  test("malformed JSON is a no-op and returns 0", async () => {
+    mockStdin("not json {");
+    const code = await claudeInflightHookCommand("wait");
+    expect(code).toBe(0);
+  });
+
+  test("resolves the root via .session-roots when the event fires under a teammate's session", async () => {
+    const rootSession = crypto.randomUUID();
+    const teammateSession = crypto.randomUUID();
+    const grandchildAgent = crypto.randomUUID();
+    sessionsToClean.push(rootSession, teammateSession, grandchildAgent);
+
+    // Set up: rootSession spawned teammateSession (which writes a roots-mapping
+    // entry pointing at rootSession), then teammateSession spawned grandchildAgent.
+    mockStdin(JSON.stringify({ session_id: rootSession, agent_id: teammateSession }));
+    await claudeInflightHookCommand("start");
+    mockStdin(JSON.stringify({ session_id: teammateSession, agent_id: grandchildAgent }));
+    await claudeInflightHookCommand("start");
+
+    // TeammateIdle fires under teammateSession's session_id. The wait must
+    // resolve the root and gate on rootSession's in-flight dir.
+    mockStdin(JSON.stringify({ session_id: teammateSession, hook_event_name: "TeammateIdle" }));
+
+    // Drain the root's markers after 80 ms.
+    setTimeout(() => {
+      void rm(join(dirs.inflight, rootSession), { recursive: true, force: true });
+    }, 80);
+
+    const start = Date.now();
+    const code = await claudeInflightHookCommand("wait");
+    const elapsed = Date.now() - start;
+
+    expect(code).toBe(0);
+    expect(elapsed).toBeGreaterThanOrEqual(80);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});
+
+describe("inflightDirIsEmpty", () => {
+  test("returns true when the dir is missing", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+    expect(await inflightDirIsEmpty(sessionId)).toBe(true);
+  });
+
+  test("returns false when the dir contains a marker", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+
+    mockStdin(JSON.stringify({
+      session_id: sessionId,
+      agent_id: crypto.randomUUID(),
+    }));
+    await claudeInflightHookCommand("start");
+
+    expect(await inflightDirIsEmpty(sessionId)).toBe(false);
+  });
+
+  test("returns true when the dir exists but is empty", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+    await mkdir(join(dirs.inflight, sessionId), { recursive: true });
+    expect(await inflightDirIsEmpty(sessionId)).toBe(true);
+  });
+});
+
+describe("sweepStaleInflight", () => {
+  test("removes markers older than threshold and leaves fresh ones alone", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+
+    const dir = join(dirs.inflight, sessionId);
+    await mkdir(dir, { recursive: true });
+    const stale = join(dir, "stale");
+    const fresh = join(dir, "fresh");
+    await writeFile(stale, "stale");
+    await writeFile(fresh, "fresh");
+    // Backdate the stale marker to 3 hours ago.
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000);
+    await utimes(stale, threeHoursAgo, threeHoursAgo);
+
+    const reaped = await sweepStaleInflight(sessionId);
+
+    expect(reaped).toBe(1);
+    expect(await fileExists(stale)).toBe(false);
+    expect(await fileExists(fresh)).toBe(true);
+  });
+
+  test("returns 0 when the dir is missing", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+    expect(await sweepStaleInflight(sessionId)).toBe(0);
+  });
+
+  test("custom threshold is honored", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+    const dir = join(dirs.inflight, sessionId);
+    await mkdir(dir, { recursive: true });
+    const marker = join(dir, "id");
+    await writeFile(marker, "x");
+    // Backdate 200 ms.
+    const past = new Date(Date.now() - 200);
+    await utimes(marker, past, past);
+
+    // Threshold of 50 ms → should sweep.
+    const reaped = await sweepStaleInflight(sessionId, 50);
+    expect(reaped).toBe(1);
+  });
+});
+
+describe("waitForInflightDrained", () => {
+  test("resolves immediately when the dir is empty/missing", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+
+    const start = Date.now();
+    await waitForInflightDrained(sessionId, { timeoutMs: 500, pollIntervalMs: 50 });
+    const elapsed = Date.now() - start;
+
+    // Should be effectively instant (well under one poll interval).
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  test("resolves once the marker is removed externally", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    mockStdin(JSON.stringify({ session_id: sessionId, agent_id: agentId }));
+    await claudeInflightHookCommand("start");
+
+    // Remove the marker after 80 ms — the wait should resolve shortly after.
+    setTimeout(() => {
+      void rm(join(dirs.inflight, sessionId, agentId), { force: true });
+    }, 80);
+
+    const start = Date.now();
+    await waitForInflightDrained(sessionId, {
+      timeoutMs: 2_000,
+      pollIntervalMs: 25,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(80);
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test("resolves on timeout even when the marker never drains", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    mockStdin(JSON.stringify({ session_id: sessionId, agent_id: agentId }));
+    await claudeInflightHookCommand("start");
+
+    const start = Date.now();
+    await waitForInflightDrained(sessionId, {
+      timeoutMs: 200,
+      pollIntervalMs: 25,
+      // Extremely high stale threshold so the sweep doesn't reap our marker.
+      staleMs: 24 * 60 * 60 * 1000,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(200);
+    expect(elapsed).toBeLessThan(800);
+    // Marker is still on disk — the wait gave up, didn't reap.
+    expect(await fileExists(join(dirs.inflight, sessionId, agentId))).toBe(true);
+  });
+
+  test("uses the in-loop stale sweep to recover from a wedged marker", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    // Seed a marker and immediately backdate it past the staleMs threshold.
+    mockStdin(JSON.stringify({ session_id: sessionId, agent_id: agentId }));
+    await claudeInflightHookCommand("start");
+    const path = join(dirs.inflight, sessionId, agentId);
+    const past = new Date(Date.now() - 60_000);
+    await utimes(path, past, past);
+
+    // staleMs = 30s → the marker is stale → first sweep tick reaps it.
+    const start = Date.now();
+    await waitForInflightDrained(sessionId, {
+      timeoutMs: 5_000,
+      pollIntervalMs: 25,
+      staleMs: 30_000,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+    expect(await fileExists(path)).toBe(false);
+  });
+});
+
+describe("clearInflightTracking", () => {
+  test("removes the marker dir and any roots-mapping entries pointing at it", async () => {
+    const rootSession = crypto.randomUUID();
+    const childAgent = crypto.randomUUID();
+    sessionsToClean.push(rootSession, childAgent);
+
+    mockStdin(JSON.stringify({ session_id: rootSession, agent_id: childAgent }));
+    await claudeInflightHookCommand("start");
+
+    expect(await fileExists(join(dirs.inflight, rootSession, childAgent))).toBe(true);
+    expect(await fileExists(join(dirs.inflightRoots, childAgent))).toBe(true);
+
+    await clearInflightTracking(rootSession);
+
+    expect(await fileExists(join(dirs.inflight, rootSession))).toBe(false);
+    expect(await fileExists(join(dirs.inflightRoots, childAgent))).toBe(false);
+  });
+
+  test("is idempotent / safe when nothing exists yet", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+    // Should not throw.
+    await clearInflightTracking(sessionId);
+  });
+});
+
+describe("Stop hook gates release on inflight drain", () => {
+  test("with markers present, the Stop hook does NOT consume the release marker", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    // Seed an in-flight subagent for this session.
+    mockStdin(JSON.stringify({ session_id: sessionId, agent_id: agentId }));
+    await claudeInflightHookCommand("start");
+
+    // Pre-write the release marker so the Stop hook would normally consume
+    // it on the first poll tick.
+    await mkdir(dirs.release, { recursive: true });
+    await writeFile(join(dirs.release, sessionId), "");
+
+    // Run the Stop hook with a short timeout so we don't actually wait 24 days.
+    mockStdin(JSON.stringify({ session_id: sessionId }));
+    const code = await claudeStopHookCommand({
+      waitTimeoutMs: 250,
+      pollIntervalMs: 25,
+    });
+
+    // Hook exits 0 (timeout path), but crucially the release marker was NOT
+    // consumed because inflight was non-empty.
+    expect(code).toBe(0);
+    expect(await fileExists(join(dirs.release, sessionId))).toBe(true);
+  });
+
+  test("with no markers, the Stop hook consumes the release marker promptly", async () => {
+    const sessionId = crypto.randomUUID();
+    sessionsToClean.push(sessionId);
+
+    await mkdir(dirs.release, { recursive: true });
+    await writeFile(join(dirs.release, sessionId), "");
+
+    mockStdin(JSON.stringify({ session_id: sessionId }));
+    const code = await claudeStopHookCommand({
+      waitTimeoutMs: 5_000,
+      pollIntervalMs: 25,
+    });
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(dirs.release, sessionId))).toBe(false);
+  });
+
+  test("release is consumed once markers drain mid-poll", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    mockStdin(JSON.stringify({ session_id: sessionId, agent_id: agentId }));
+    await claudeInflightHookCommand("start");
+
+    await mkdir(dirs.release, { recursive: true });
+    await writeFile(join(dirs.release, sessionId), "");
+
+    // Drain the marker after 100 ms.
+    setTimeout(() => {
+      void rm(join(dirs.inflight, sessionId, agentId), { force: true });
+    }, 100);
+
+    mockStdin(JSON.stringify({ session_id: sessionId }));
+    const code = await claudeStopHookCommand({
+      waitTimeoutMs: 5_000,
+      pollIntervalMs: 25,
+    });
+
+    expect(code).toBe(0);
+    expect(await fileExists(join(dirs.release, sessionId))).toBe(false);
+  });
+
+  test("queue marker still takes priority even with inflight markers present", async () => {
+    const sessionId = crypto.randomUUID();
+    const agentId = crypto.randomUUID();
+    sessionsToClean.push(sessionId, agentId);
+
+    mockStdin(JSON.stringify({ session_id: sessionId, agent_id: agentId }));
+    await claudeInflightHookCommand("start");
+
+    await mkdir(dirs.queue, { recursive: true });
+    await writeFile(join(dirs.queue, sessionId), "follow up", "utf-8");
+
+    const stdoutChunks: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    (process.stdout as unknown as { write: (s: unknown) => boolean }).write = (
+      s: unknown,
+    ) => {
+      stdoutChunks.push(String(s));
+      return true;
+    };
+
+    try {
+      mockStdin(JSON.stringify({ session_id: sessionId }));
+      const code = await claudeStopHookCommand({
+        waitTimeoutMs: 250,
+        pollIntervalMs: 25,
+      });
+      expect(code).toBe(0);
+    } finally {
+      (process.stdout as unknown as { write: typeof origWrite }).write = origWrite;
+    }
+
+    // Queue was consumed and a block decision was emitted with the prompt.
+    expect(await fileExists(join(dirs.queue, sessionId))).toBe(false);
+    const out = stdoutChunks.join("");
+    expect(out).toContain('"decision":"block"');
+    expect(out).toContain("follow up");
+
+    // Stat the marker via fs to confirm it stayed put. The queue path takes
+    // priority and doesn't touch inflight at all.
+    const markerStat = await stat(join(dirs.inflight, sessionId, agentId));
+    expect(markerStat.isFile()).toBe(true);
+  });
+});

--- a/src/commands/cli/claude-inflight-hook.ts
+++ b/src/commands/cli/claude-inflight-hook.ts
@@ -1,0 +1,359 @@
+/**
+ * Claude In-Flight Hook command — internal handler for the workflow's
+ * `SubagentStart` / `SubagentStop` / `TeammateIdle` hooks.
+ *
+ * Invoked as:
+ *   atomic _claude-inflight-hook start   (SubagentStart)
+ *   atomic _claude-inflight-hook stop    (SubagentStop)
+ *   atomic _claude-inflight-hook wait    (TeammateIdle)
+ *
+ * `start` / `stop` maintain a directory of one marker file per in-flight
+ * subagent under `~/.atomic/claude-inflight/<root_session_id>/<agent_id>`.
+ * `<root_session_id>` is the stage's top-level Claude session — for nested
+ * subagents (a subagent spawning its own subagent) we resolve the root by
+ * looking up the parent session's mapping, so all descendants of a stage
+ * funnel into the same marker dir.
+ *
+ * `wait` is the focused completion-signal handler used for `TeammateIdle`:
+ * read `session_id` from the payload, await `waitForInflightDrained`, exit
+ * 0. We don't reuse the Stop hook handler here because Stop also writes
+ * `~/.atomic/claude-stop/<session_id>` (which the runtime's `waitForIdle`
+ * watches) and polls queue/release — those are tied to the stage's root
+ * session, and TeammateIdle's `session_id` may be a teammate's session
+ * that the runtime never enqueues to or releases.
+ *
+ * Two consumers gate on the in-flight dir being empty:
+ *
+ *   1. `claudeStopHookCommand` — won't consume the `claude-release` marker
+ *      until in-flight is empty, so Claude itself doesn't exit while
+ *      backgrounded subagents are still running.
+ *
+ *   2. `clearClaudeSession` — calls `waitForInflightDrained` before tearing
+ *      down the pane, so the executor doesn't advance to the next stage
+ *      while the previous stage's subagents still hold FDs/PTYs on the
+ *      atomic tmux server.
+ *
+ * Always exits 0 — a non-zero exit would surface as a hook error in
+ * Claude's transcript, and silent miss + stale-sweep recovery is preferable
+ * to red noise on every workflow run.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { claudeHookDirs } from "./claude-stop-hook.ts";
+
+/**
+ * Shape of the JSON payload Claude pipes to the Subagent / TeammateIdle
+ * lifecycle hooks via stdin.
+ *
+ *   SubagentStart / SubagentStop  → `agent_id` (uuid), `agent_type`
+ *   TeammateIdle                  → `session_id` only (used by `wait` mode)
+ *
+ * `session_id` is the parent Claude session that triggered the event — for
+ * a top-level subagent, that's the stage's root; for a nested subagent,
+ * that's the spawning agent's session, and we look up its root via
+ * `inflightRoots`.
+ *
+ * Extra fields are ignored; missing ones cause a graceful exit-0 no-op.
+ */
+export interface ClaudeInflightHookPayload {
+  session_id: string;
+  hook_event_name?: string;
+  agent_id?: string;
+  agent_type?: string;
+  cwd?: string;
+}
+
+export type ClaudeInflightHookMode = "start" | "stop" | "wait";
+
+function isClaudeInflightHookPayload(
+  value: unknown,
+): value is ClaudeInflightHookPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj["session_id"] !== "string") return false;
+  return true;
+}
+
+/**
+ * Default TTL for stale-marker sweeps. A marker older than this is treated
+ * as orphaned (subagent crashed without firing SubagentStop) and removed.
+ *
+ * 2 hours is conservative: real subagents researching docs or running tests
+ * can exceed 30 minutes in ralph-style workflows, but no legitimate hook
+ * lifecycle should leave a marker on disk longer than ~2 h. Override at the
+ * environment via `ATOMIC_INFLIGHT_STALE_MS` for shorter runs in tests.
+ */
+const DEFAULT_INFLIGHT_STALE_MS = 2 * 60 * 60 * 1000;
+
+function staleMs(): number {
+  const raw = process.env["ATOMIC_INFLIGHT_STALE_MS"];
+  if (!raw) return DEFAULT_INFLIGHT_STALE_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INFLIGHT_STALE_MS;
+}
+
+/** Pick the unique id this event represents — `agent_id` for Subagent events. */
+function extractId(payload: ClaudeInflightHookPayload): string | null {
+  if (typeof payload.agent_id === "string" && payload.agent_id.length > 0) {
+    return payload.agent_id;
+  }
+  return null;
+}
+
+/** Path to the roots-mapping file for a given session. */
+function rootsMapPath(sessionId: string): string {
+  return path.join(claudeHookDirs().inflightRoots, sessionId);
+}
+
+/** Path to the marker dir for a given root session. */
+function markerDirFor(rootSessionId: string): string {
+  return path.join(claudeHookDirs().inflight, rootSessionId);
+}
+
+/** Path to a single marker file under a root session. */
+function markerPathFor(rootSessionId: string, id: string): string {
+  return path.join(markerDirFor(rootSessionId), id);
+}
+
+/**
+ * Resolve the stage root for an event's `session_id`. If the parent has a
+ * roots-mapping entry (it was itself spawned as a subagent), follow it.
+ * Otherwise the parent IS the root.
+ */
+async function resolveRoot(parentSessionId: string): Promise<string> {
+  try {
+    const mapped = await fs.readFile(rootsMapPath(parentSessionId), "utf-8");
+    const trimmed = mapped.trim();
+    if (trimmed.length > 0) return trimmed;
+  } catch {
+    // ENOENT (parent has no mapping → it is the root) or any read error
+    // falls through to the default.
+  }
+  return parentSessionId;
+}
+
+/**
+ * Best-effort marker payload — gives the stale sweep something to read for
+ * `ts`, and the Stop hook a way to log who got reaped.
+ */
+function markerBody(
+  payload: ClaudeInflightHookPayload,
+  rootSessionId: string,
+): string {
+  return JSON.stringify({
+    kind: payload.hook_event_name ?? null,
+    parent_session_id: payload.session_id,
+    root: rootSessionId,
+    agent_type: payload.agent_type ?? null,
+    ts: Date.now(),
+  });
+}
+
+/**
+ * Handler for the hidden `_claude-inflight-hook` subcommand.
+ *
+ * Always returns 0 — silently swallows all errors. A buggy tracker must
+ * never kill stages.
+ */
+export async function claudeInflightHookCommand(
+  mode: ClaudeInflightHookMode,
+): Promise<number> {
+  let raw: string;
+  try {
+    raw = await Bun.stdin.text();
+  } catch {
+    return 0;
+  }
+
+  let payload: ClaudeInflightHookPayload;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isClaudeInflightHookPayload(parsed)) {
+      return 0;
+    }
+    payload = parsed;
+  } catch {
+    return 0;
+  }
+
+  // `wait` is the TeammateIdle path — gate on the root session's in-flight
+  // dir draining and exit. No marker write, no queue/release polling: the
+  // event's `session_id` may be a teammate's session that the runtime never
+  // enqueues to or releases, so reusing the Stop hook would risk hanging
+  // for the whole 24-day timeout.
+  if (mode === "wait") {
+    try {
+      const root = await resolveRoot(payload.session_id);
+      await waitForInflightDrained(root);
+    } catch {
+      // Best-effort — the wait swallows internal errors and resolves on
+      // timeout. A throw here would only happen on a path bug.
+    }
+    return 0;
+  }
+
+  const id = extractId(payload);
+  if (!id) return 0;
+
+  try {
+    const dirs = claudeHookDirs();
+    await fs.mkdir(dirs.inflight, { recursive: true });
+    await fs.mkdir(dirs.inflightRoots, { recursive: true });
+
+    const root = await resolveRoot(payload.session_id);
+
+    if (mode === "start") {
+      // Record the new agent's mapping so its own future descendants can
+      // resolve the same root via `resolveRoot`.
+      try {
+        await Bun.write(rootsMapPath(id), root);
+      } catch {
+        // Best-effort: a missing mapping just means a nested subagent of
+        // this id would mark under its immediate parent instead of the
+        // ultimate root. Stale sweep cleans up either way.
+      }
+
+      await fs.mkdir(markerDirFor(root), { recursive: true });
+      await Bun.write(markerPathFor(root, id), markerBody(payload, root));
+    } else {
+      // mode === "stop"
+      try {
+        await fs.unlink(markerPathFor(root, id));
+      } catch (e: unknown) {
+        const code = (e as NodeJS.ErrnoException | null)?.code;
+        if (code !== "ENOENT") {
+          // Ignore other errors silently — exit 0 is the contract.
+        }
+      }
+    }
+  } catch {
+    // Catch-all: any FS or path failure → silent exit 0.
+  }
+
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers exported for the Stop hook and clearClaudeSession
+// ---------------------------------------------------------------------------
+
+/** True when the per-root marker dir is missing or contains no marker files. */
+export async function inflightDirIsEmpty(rootSessionId: string): Promise<boolean> {
+  try {
+    const entries = await fs.readdir(markerDirFor(rootSessionId));
+    return entries.length === 0;
+  } catch (e: unknown) {
+    const code = (e as NodeJS.ErrnoException | null)?.code;
+    if (code === "ENOENT") return true;
+    // On any other error, assume non-empty so we wait — wedging the wait is
+    // worse than letting it advance with leaked FDs only when the FS is
+    // genuinely broken.
+    return false;
+  }
+}
+
+/**
+ * Remove markers older than `thresholdMs` (default `ATOMIC_INFLIGHT_STALE_MS`
+ * or 2 h). Returns the number of markers reaped. Used by the Stop hook and
+ * `waitForInflightDrained` to recover from subagents that crashed without
+ * firing `SubagentStop`.
+ */
+export async function sweepStaleInflight(
+  rootSessionId: string,
+  thresholdMs?: number,
+): Promise<number> {
+  const dir = markerDirFor(rootSessionId);
+  const cutoff = Date.now() - (thresholdMs ?? staleMs());
+  let reaped = 0;
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const file = path.join(dir, entry);
+    try {
+      const stat = await fs.stat(file);
+      if (stat.mtimeMs < cutoff) {
+        await fs.unlink(file);
+        reaped += 1;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return reaped;
+}
+
+export interface WaitForInflightOptions {
+  /** How long to wait before giving up. Default 30 minutes. */
+  timeoutMs?: number;
+  /** Poll cadence. Default 100 ms. */
+  pollIntervalMs?: number;
+  /** Stale-marker TTL. Default `ATOMIC_INFLIGHT_STALE_MS` or 2 h. */
+  staleMs?: number;
+}
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_DRAIN_POLL_MS = 100;
+
+/**
+ * Resolve when the per-root marker dir is empty. Sweeps stale markers on
+ * every tick. Resolves silently on timeout — the caller can't usefully
+ * recover, so wedging vs. leaking is the only trade.
+ */
+export async function waitForInflightDrained(
+  rootSessionId: string,
+  options: WaitForInflightOptions = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_DRAIN_POLL_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    if (await inflightDirIsEmpty(rootSessionId)) return;
+    if (Date.now() >= deadline) return;
+    await sweepStaleInflight(rootSessionId, options.staleMs);
+    if (await inflightDirIsEmpty(rootSessionId)) return;
+    if (Date.now() >= deadline) return;
+    await new Promise<void>((r) => setTimeout(r, pollIntervalMs));
+  }
+}
+
+/**
+ * Remove the per-root marker dir and any roots-mapping entries that point
+ * at this root. Called by `clearClaudeSession` on stage teardown so
+ * leftovers cannot bleed into a future session that reuses the same id
+ * (UUID collision is astronomically unlikely, but stale-sweep + cleanup
+ * costs nothing).
+ */
+export async function clearInflightTracking(rootSessionId: string): Promise<void> {
+  try {
+    await fs.rm(markerDirFor(rootSessionId), { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+  // Sweep roots-mapping entries that point at this root.
+  const dirs = claudeHookDirs();
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dirs.inflightRoots);
+  } catch {
+    return;
+  }
+  await Promise.all(
+    entries.map(async (entry) => {
+      const file = path.join(dirs.inflightRoots, entry);
+      try {
+        const value = (await fs.readFile(file, "utf-8")).trim();
+        if (value === rootSessionId || entry === rootSessionId) {
+          await fs.unlink(file);
+        }
+      } catch {
+        // ignore
+      }
+    }),
+  );
+}

--- a/src/commands/cli/claude-stop-hook.ts
+++ b/src/commands/cli/claude-stop-hook.ts
@@ -33,6 +33,10 @@ import { watch as watchDir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import {
+  inflightDirIsEmpty,
+  sweepStaleInflight,
+} from "./claude-inflight-hook.ts";
 
 /** Shape of the JSON payload Claude pipes to the Stop hook via stdin. */
 export interface ClaudeStopHookPayload {
@@ -68,8 +72,11 @@ export function claudeHookDirs(): {
   hil: string;
   pid: string;
   ready: string;
+  inflight: string;
+  inflightRoots: string;
 } {
   const base = path.join(os.homedir(), ".atomic");
+  const inflightBase = path.join(base, "claude-inflight");
   return {
     marker: path.join(base, "claude-stop"),
     queue: path.join(base, "claude-queue"),
@@ -85,6 +92,19 @@ export function claudeHookDirs(): {
     // watches this directory to detect readiness — positive signal, unlike
     // racing the JSONL writer.
     ready: path.join(base, "claude-ready"),
+    // Per-root-session marker dirs (`<inflight>/<root_session_id>/<id>`)
+    // populated by the SubagentStart/SubagentStop and TaskCreated/
+    // TaskCompleted hooks. Both `clearClaudeSession` and the Stop hook gate
+    // on this dir being empty before letting the stage advance, so a stage
+    // never tears down while it still has live subagents/tasks holding FDs.
+    inflight: inflightBase,
+    // `<inflight>/.session-roots/<session_id>` → root_session_id mapping.
+    // SubagentStart writes a mapping for every spawned agent so that nested
+    // subagents (a subagent spawning its own subagent) can resolve which
+    // stage's root they belong to and write their marker under the right
+    // root. Lives alongside `inflight/` rather than under it so a `readdir`
+    // of `<inflight>/<root>/` only returns id markers.
+    inflightRoots: path.join(inflightBase, ".session-roots"),
   };
 }
 
@@ -292,10 +312,12 @@ export async function claudeStopHookCommand(
   type Hit = { kind: "release" } | { kind: "queue"; prompt: string };
 
   const check = async (): Promise<Hit | null> => {
-    if (existsSync(releasePath)) {
-      try { await fs.unlink(releasePath); } catch { /* ENOENT is fine */ }
-      return { kind: "release" };
-    }
+    // Queue takes priority over release: if the runtime enqueued a follow-up
+    // prompt, we want to deliver it and let Claude run another turn. The
+    // workflow only writes a release marker when it's actually torn down, so
+    // a queue + release race only happens at session end — and in that case
+    // the queue prompt was authored before teardown, so honoring it first is
+    // correct.
     if (existsSync(queuePath)) {
       let prompt: string;
       try {
@@ -306,6 +328,20 @@ export async function claudeStopHookCommand(
       }
       try { await fs.unlink(queuePath); } catch { /* ENOENT is fine */ }
       return { kind: "queue", prompt };
+    }
+    if (existsSync(releasePath)) {
+      // Don't consume the release marker until in-flight subagents/tasks
+      // have drained. Reaping the marker prematurely would let Claude exit
+      // while backgrounded children still hold FDs/PTYs on the atomic tmux
+      // server, which is the failure mode the inflight tracking exists to
+      // prevent. Stale-sweep first so a crashed subagent that never fired
+      // SubagentStop doesn't wedge the wait forever.
+      await sweepStaleInflight(payload.session_id);
+      if (!(await inflightDirIsEmpty(payload.session_id))) {
+        return null;
+      }
+      try { await fs.unlink(releasePath); } catch { /* ENOENT is fine */ }
+      return { kind: "release" };
     }
     return null;
   };

--- a/src/sdk/providers/claude.ts
+++ b/src/sdk/providers/claude.ts
@@ -32,6 +32,10 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import { claudeHookDirs } from "../../commands/cli/claude-stop-hook.ts";
+import {
+  clearInflightTracking,
+  waitForInflightDrained,
+} from "../../commands/cli/claude-inflight-hook.ts";
 import { resolveAdditionalInstructionsContent } from "../../services/config/additional-instructions.ts";
 
 // ---------------------------------------------------------------------------
@@ -60,6 +64,19 @@ const initializedPanes = new Map<string, PaneState>();
  * waiting out the hook's safety timeout.
  *
  * Called by the runtime when a Claude stage is being torn down. Idempotent.
+ *
+ * After writing the release marker, this waits for the per-session in-flight
+ * marker dir (`~/.atomic/claude-inflight/<session_id>/`) to drain. The
+ * marker dir is populated by the SubagentStart/Stop and TaskCreated/Completed
+ * hooks registered in {@link WORKFLOW_HOOK_SETTINGS}. This wait is the
+ * synchronization barrier that prevents the executor from advancing to the
+ * next stage while the previous stage's backgrounded subagents/tasks still
+ * hold FDs/PTYs on the atomic tmux server — the failure mode that surfaced
+ * intermittently as `tmux respawn-pane: fork failed: Device not configured`.
+ *
+ * The wait has its own bounded timeout (default 30 minutes) so a wedged
+ * subagent can't permanently block the workflow; the in-hook stale-sweep
+ * (~2 hours TTL) is the ultimate safety net.
  */
 export async function clearClaudeSession(paneId: string): Promise<void> {
   const state = initializedPanes.get(paneId);
@@ -69,6 +86,15 @@ export async function clearClaudeSession(paneId: string): Promise<void> {
     } catch {
       // Best-effort — if release fails the hook will still exit on its
       // own safety timeout.
+    }
+    // Wait for in-flight subagents/tasks to finish before letting the
+    // executor advance. Resolves immediately when the dir is empty/missing
+    // (the common case, including any stage that didn't spawn subagents).
+    try {
+      await waitForInflightDrained(state.claudeSessionId);
+    } catch {
+      // Best-effort — the wait swallows internal errors and resolves on
+      // timeout. A throw here would only happen on a path bug.
     }
     try {
       await unlinkAtomicPidFile(state.claudeSessionId);
@@ -82,6 +108,12 @@ export async function clearClaudeSession(paneId: string): Promise<void> {
       // Best-effort — stale ready marker is inert; the next session writes
       // a fresh one under its own UUID and clears any prior leftover in
       // `claudeQuery` before respawn.
+    }
+    try {
+      await clearInflightTracking(state.claudeSessionId);
+    } catch {
+      // Best-effort — leftover marker files are reaped by the next session's
+      // stale-sweep, and the .session-roots/ entries are tiny.
     }
   }
   initializedPanes.delete(paneId);
@@ -189,6 +221,20 @@ const READY_HOOK_TIMEOUT_MS = 2_147_483_000;
  *     catch path — see `src/services/tools/toolExecution.ts` in the CLI
  *     source), so registering the same command on both guarantees the
  *     marker clears regardless of which completion path the tool takes.
+ *   - `SubagentStart` / `SubagentStop`: maintain a per-root-session marker
+ *     dir under `~/.atomic/claude-inflight/<root>/` so the Stop hook and
+ *     `clearClaudeSession` can both gate on subagent completion before
+ *     letting the stage advance. Without this gate, a stage that spawned
+ *     `run_in_background: true` subagents would tear down its pane while
+ *     children still hold FDs/PTYs on the atomic tmux server, intermittently
+ *     surfacing as `tmux respawn-pane: fork failed: Device not configured`
+ *     when the next stage tried to spawn.
+ *   - `TeammateIdle`: same gating applied at agent-team teammate idle.
+ *     Unlike Stop, this fires when a teammate (potentially a different
+ *     `session_id` from the stage's root) goes idle, so we route it to a
+ *     focused `_claude-inflight-hook wait` mode that only awaits in-flight
+ *     drain — no claude-stop marker write (that would confuse `waitForIdle`)
+ *     and no queue/release polling (those are keyed on the stage's root).
  *
  * Built once at module load. Contains no single quotes (JSON syntax doesn't
  * produce them and paths rarely do), so POSIX single-quoting at the spawn
@@ -247,6 +293,45 @@ const WORKFLOW_HOOK_SETTINGS = JSON.stringify({
           {
             type: "command",
             command: buildWorkflowHookCommand("_claude-ask-hook", ["exit"]),
+          },
+        ],
+      },
+    ],
+    // SubagentStart/SubagentStop fire per Agent-tool dispatch (no matcher)
+    // and route to a single subcommand that touches/removes one marker file
+    // per `agent_id`. The handler is bulletproof — any error exits 0
+    // silently — so a hook failure can't kill the stage.
+    SubagentStart: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: buildWorkflowHookCommand("_claude-inflight-hook", ["start"]),
+          },
+        ],
+      },
+    ],
+    SubagentStop: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: buildWorkflowHookCommand("_claude-inflight-hook", ["stop"]),
+          },
+        ],
+      },
+    ],
+    // TeammateIdle gets a focused `wait` mode (gates on in-flight drain,
+    // nothing else) — see the WORKFLOW_HOOK_SETTINGS docstring for why this
+    // doesn't reuse the Stop hook handler. Timeout matches Stop's so the
+    // wait can run for as long as the workflow holds onto teammates.
+    TeammateIdle: [
+      {
+        hooks: [
+          {
+            type: "command",
+            command: buildWorkflowHookCommand("_claude-inflight-hook", ["wait"]),
+            timeout: STOP_HOOK_TIMEOUT_SECONDS,
           },
         ],
       },


### PR DESCRIPTION
## Summary

Fixes an intermittent `tmux respawn-pane: fork failed: Device not configured` error caused by background subagents (`Agent` tool with `run_in_background: true`) and `TaskCreate` jobs outliving their stage's pane teardown. The stop hook and `clearClaudeSession` now wait for all in-flight children to drain before letting the stage advance.

## Key Changes

- **New `claude-inflight-hook` command** (`src/commands/cli/claude-inflight-hook.ts`): Handles `SubagentStart`/`SubagentStop`/`TaskCreated`/`TaskCompleted`/`TeammateIdle` lifecycle hooks. Maintains per-root-session marker files under `~/.atomic/claude-inflight/<root_session_id>/<id>` to track in-flight children.
- **Stop hook gating** (`src/commands/cli/claude-stop-hook.ts`): Defers consuming the release marker until the in-flight dir is empty. Queue now takes priority over release so runtime-enqueued follow-up prompts deliver before teardown. Stale-marker sweep (2h TTL) recovers from crashed children that never fire their stop event.
- **`clearClaudeSession` gating** (`src/sdk/providers/claude.ts`): Calls `waitForInflightDrained` before tearing down the pane, with a 30-minute timeout to prevent permanent wedges. Registers `SubagentStart`/`SubagentStop` and `TeammateIdle` hooks in `WORKFLOW_HOOK_SETTINGS`.
- **Nested subagent support**: Nested subagents resolve their stage root via a `.session-roots/` mapping so all descendants funnel into the same marker dir.
- **`TeammateIdle` isolation**: Uses a focused `wait` mode rather than reusing the Stop handler, since the teammate's `session_id` may differ from the stage root.
- **Example** (`examples/claude-background-subagents/`): Reproduces the bug deterministically without the fix applied.
- **Tests** (`src/commands/cli/claude-inflight-hook.test.ts`): End-to-end coverage for the inflight tracking logic (598 lines).
- **Docs** (`docs/claude-code/cli/hooks.md`): Refreshed hooks reference with schemas for the new lifecycle events.