### PR TITLE
chore(release): bump version to v0.6.4-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.3",
+  "version": "0.6.4-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.6.3` to `0.6.4-0` to prepare the prerelease for the in-flight subagent gating hotfix landed in #762.

## Key Changes

- `package.json`: version `0.6.3` → `0.6.4-0`

## Context

This prerelease follows the hotfix in #762 which fixed a race condition where the Claude Stop hook would tear down the tmux pane while background subagents (`Agent` with `run_in_background: true`) and `TaskCreate` jobs were still running, causing intermittent `tmux respawn-pane: fork failed: Device not configured` errors on the next stage spawn.