### PR TITLE
chore(release): bump version to v0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.4-0",
+  "version": "0.6.4",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the `v0.6.4-0` prerelease to a stable `v0.6.4` release, finalizing the version bump in `package.json`.

## What's included in v0.6.4

- **fix(claude): gate stage teardown on in-flight subagent drain** — Background subagents (`Agent` tool with `run_in_background: true`) and `TaskCreate` jobs could cause `tmux respawn-pane: fork failed: Device not configured` errors when the Stop hook tore down the pane while children still held FDs/PTYs. In-flight subagents/tasks are now tracked via `SubagentStart/SubagentStop` and `TaskCreated/TaskCompleted` hooks under `~/.atomic/claude-inflight/<root_session_id>/<id>`, and teardown is deferred until that directory drains.
- **docs(claude-code): refresh hooks reference** — Synced `docs/claude-code/cli/hooks.md` with upstream, adding schemas for `SubagentStart/SubagentStop`, `TaskCreated/TaskCompleted`, and `TeammateIdle` events.
- Includes a new end-to-end example (`examples/claude-background-subagents/`) that deterministically reproduces the background subagent bug.

## Changes

- `package.json`: `0.6.4-0` → `0.6.4`