### PR TITLE
chore(release): bump version to v0.6.5-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.4",
+  "version": "0.6.5-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `v0.6.4` to `v0.6.5-0` (prerelease) in preparation for the next minor release cycle.

## Changes

- `package.json`: version `0.6.4` → `0.6.5-0`

## Test plan

- [x] Version bumped via `bun run src/scripts/bump-version.ts --from-branch`
- [x] Pre-commit hooks (typecheck, test-coverage) passed

## Notes

This is a prerelease (`-0`) bump. A full `v0.6.5` release PR will follow once the prerelease is validated.