### PR TITLE
chore(release): bump version to v0.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.5-0",
+  "version": "0.6.5",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease version `0.6.5-0` to the stable release `0.6.5` by updating `package.json`.

## Changes

- `package.json`: version bumped from `0.6.5-0` → `0.6.5`

## Test plan

- [x] `bun run src/scripts/bump-version.ts --from-branch` updated `package.json` to `0.6.5`
- [x] `typecheck` passed via pre-commit hook
- [x] `test-coverage` passed via pre-push hook
- [ ] Once merged, CI publishes the GitHub Release and npm package (`@bastani/atomic@0.6.5`)