### PR TITLE
feat(workflows/ralph): add code-simplifier stage and expand CI audit in infra discovery

### DIFF
--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -28,6 +28,7 @@ import { defineWorkflow, extractAssistantText } from "../../../index.ts";
 import {
   buildPlannerPrompt,
   buildOrchestratorPrompt,
+  buildCodeSimplifierPrompt,
   buildInfraDiscoveryPrompts,
   buildReviewPrompt,
   filterActionable,
@@ -130,6 +131,22 @@ export default defineWorkflow({
         {},
         async (s) => {
           await s.session.query(buildOrchestratorPrompt(prompt));
+          s.save(s.sessionId);
+        },
+      );
+
+      // ── Code Simplifier ─────────────────────────────────────────────────
+      await ctx.stage(
+        { name: `code-simplifier-${iteration}` },
+        {
+          chatFlags: [
+            "--allow-dangerously-skip-permissions",
+            "--dangerously-skip-permissions",
+          ],
+        },
+        {},
+        async (s) => {
+          await s.session.query(buildCodeSimplifierPrompt(prompt));
           s.save(s.sessionId);
         },
       );

--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -140,6 +140,8 @@ export default defineWorkflow({
         { name: `code-simplifier-${iteration}` },
         {
           chatFlags: [
+            "--agent",
+            "code-simplifier",
             "--allow-dangerously-skip-permissions",
             "--dangerously-skip-permissions",
           ],

--- a/src/sdk/workflows/builtin/ralph/claude/index.ts
+++ b/src/sdk/workflows/builtin/ralph/claude/index.ts
@@ -95,7 +95,7 @@ export default defineWorkflow({
 
     for (let iteration = 1; iteration <= maxLoops; iteration++) {
       // ── Plan ────────────────────────────────────────────────────────────
-      await ctx.stage(
+      const planner = await ctx.stage(
         { name: `planner-${iteration}` },
         {
           chatFlags: [
@@ -107,13 +107,14 @@ export default defineWorkflow({
         },
         {},
         async (s) => {
-          await s.session.query(
+          const result = await s.session.query(
             buildPlannerPrompt(prompt, {
               iteration,
               reviewReport: reviewReport || undefined,
             }),
           );
           s.save(s.sessionId);
+          return extractAssistantText(result, 0);
         },
       );
 
@@ -130,7 +131,11 @@ export default defineWorkflow({
         },
         {},
         async (s) => {
-          await s.session.query(buildOrchestratorPrompt(prompt));
+          await s.session.query(
+            buildOrchestratorPrompt(prompt, {
+              plannerNotes: planner.result,
+            }),
+          );
           s.save(s.sessionId);
         },
       );
@@ -148,7 +153,11 @@ export default defineWorkflow({
         },
         {},
         async (s) => {
-          await s.session.query(buildCodeSimplifierPrompt(prompt));
+          await s.session.query(
+            buildCodeSimplifierPrompt(prompt, {
+              plannerNotes: planner.result,
+            }),
+          );
           s.save(s.sessionId);
         },
       );

--- a/src/sdk/workflows/builtin/ralph/copilot/index.ts
+++ b/src/sdk/workflows/builtin/ralph/copilot/index.ts
@@ -27,6 +27,7 @@ import type { SessionEvent } from "@github/copilot-sdk";
 import {
   buildPlannerPrompt,
   buildOrchestratorPrompt,
+  buildCodeSimplifierPrompt,
   buildInfraDiscoveryPrompts,
   buildReviewPrompt,
   filterActionable,
@@ -133,6 +134,21 @@ export default defineWorkflow({
         async (s) => {
           await s.session.send({
             prompt: buildOrchestratorPrompt(userPromptText, {
+              plannerNotes: planner.result,
+            }),
+          });
+          s.save(await s.session.getMessages());
+        },
+      );
+
+      // ── Code Simplifier ───────────────────────────────────────────────
+      await ctx.stage(
+        { name: `code-simplifier-${iteration}` },
+        {},
+        {},
+        async (s) => {
+          await s.session.send({
+            prompt: buildCodeSimplifierPrompt(userPromptText, {
               plannerNotes: planner.result,
             }),
           });

--- a/src/sdk/workflows/builtin/ralph/copilot/index.ts
+++ b/src/sdk/workflows/builtin/ralph/copilot/index.ts
@@ -145,7 +145,7 @@ export default defineWorkflow({
       await ctx.stage(
         { name: `code-simplifier-${iteration}` },
         {},
-        {},
+        { agent: "code-simplifier" },
         async (s) => {
           await s.session.send({
             prompt: buildCodeSimplifierPrompt(userPromptText, {

--- a/src/sdk/workflows/builtin/ralph/helpers/prompts.ts
+++ b/src/sdk/workflows/builtin/ralph/helpers/prompts.ts
@@ -555,6 +555,60 @@ records — those must remain self-contained and unambiguous.`);
 }
 
 // ============================================================================
+// CODE SIMPLIFIER
+// ============================================================================
+
+export interface CodeSimplifierContext {
+  /** Optional planner output (RFC markdown or absolute path to spec). */
+  plannerNotes?: string;
+}
+
+/**
+ * Build the code-simplifier prompt. Invokes the `/code-simplifier` skill to
+ * inspect only the orchestrator's changes on the current branch and refine
+ * them for clarity, consistency, and maintainability — without altering
+ * functionality or test behaviour.
+ *
+ * @param spec - The user's original specification, used as context/fallback
+ *   when planner output is missing or ambiguous.
+ * @param context - Optional planner handoff (spec path or inline RFC markdown).
+ */
+export function buildCodeSimplifierPrompt(
+  spec: string,
+  context: CodeSimplifierContext = {},
+): string {
+  const plannerNotes = context.plannerNotes?.trim() ?? "";
+  const plannerSection =
+    plannerNotes.length > 0
+      ? `<planner_output>
+${plannerNotes}
+</planner_output>`
+      : `<planner_output>
+(empty — fall back to the Original User Specification below)
+</planner_output>`;
+
+  return withCaveman(`/code-simplifier Inspect the orchestrator's changes on the current branch and simplify the implementation for clarity, consistency, and maintainability.
+
+## Design Input (authoritative)
+
+${plannerSection}
+
+## Original User Specification (context / fallback)
+
+<specification>
+${spec}
+</specification>
+
+## Instructions
+
+1. **Scope to branch changes only.** Run \`git diff\` and \`git status\` to identify every file the orchestrator touched. Do NOT modify files outside that set.
+2. **Simplify and refine.** Within the changed files, improve clarity, consistency, naming, and structure. Remove dead code, unnecessary comments, and redundant abstractions. Prefer simple, direct implementations.
+3. **Preserve all functionality and test behaviour.** No feature regressions, no removed tests, no altered public interfaces unless the change is strictly cosmetic (e.g. rename of an internal variable).
+4. **Keep changes minimal and focused.** No scope creep. Do not rewrite working code that is already clear. Touch only what genuinely benefits from simplification.
+5. **Verify after edits.** Run \`bun typecheck\` and \`bun lint\` from the repository root after all edits are complete. Fix any errors they surface before finishing.`);
+}
+
+// ============================================================================
 // INFRASTRUCTURE DISCOVERY
 // ============================================================================
 
@@ -592,7 +646,7 @@ one-line description of each.
 - **Build config**: tsconfig.json, webpack.config.*, vite.config.*, esbuild.*, rollup.config.*, Makefile, etc.
 - **Test config**: jest.config.*, vitest.config.*, playwright.config.*, .mocharc.*, pytest.ini, etc.
 - **Lint / format config**: .eslintrc.*, eslint.config.*, biome.json, .prettierrc.*, oxlint.json, etc.
-- **CI/CD workflows**: .github/workflows/*.yml, .gitlab-ci.yml, Jenkinsfile, .circleci/config.yml, etc.
+- **CI/CD workflows (REQUIRED)**: .github/workflows/*.yml, .gitlab-ci.yml, Jenkinsfile, .circleci/config.yml, azure-pipelines.yml, etc. List every workflow file separately — reviewers need full coverage.
 - **Agent config files**: CLAUDE.md, AGENTS.md, .claude/*, .github/copilot-instructions.md (these often document project commands)
 
 ## Output format
@@ -625,7 +679,12 @@ which commands to run to verify an implementation.
    executes" list.
 4. Read CLAUDE.md / AGENTS.md if present — they often document the
    canonical commands for contributors.
-5. Identify the test framework(s) in use and how to invoke them.
+5. **Audit CI workflows.** When the \`gh\` CLI is available (check via \`command -v gh\`), run:
+   - \`gh workflow list\` to enumerate active workflows.
+   - \`gh run list --limit 5\` to see the most recent runs and their statuses.
+   - \`gh workflow view <name>\` for any workflow whose name suggests it gates merges.
+   When \`gh\` is unavailable or unauthenticated, fall back to reading the workflow YAML files directly. Capture: workflow names, triggers (push / pull_request / schedule / workflow_dispatch), job names, the exact \`run:\` commands per job, and recent run statuses.
+6. Identify the test framework(s) in use and how to invoke them.
 
 ## Output format
 
@@ -644,6 +703,10 @@ which commands to run to verify an implementation.
 
 ## CI Commands (from workflow files)
 - \`<command>\` — <source file and context>
+
+## CI / GitHub Actions
+- Workflow: \`<name>\` — triggers: \`<push|pr|schedule|...>\` — jobs: \`<job names>\`
+- Recent runs (when \`gh\` available): \`<conclusion>\` on \`<branch>\` (\`<run id>\`)
 \`\`\`
 
 Be specific — include the exact invocation string (e.g. \`bun test\`, not
@@ -670,6 +733,10 @@ but HOW they are used in practice.
    order CI runs them.
 5. **Dependency install pattern**: How are dependencies installed before
    build/test (e.g. \`bun install\`, \`npm ci\`)?
+6. **CI audit patterns**: Map out the CI structure so reviewers can audit it. Identify matrix builds, job dependencies (\`needs:\`), conditional runs (\`if:\`), required checks, and which jobs gate merges. When \`gh\` is available, surface example commands a reviewer could use:
+   - \`gh run view <id> --log-failed\` — inspect a failed run.
+   - \`gh pr checks\` — see check status on the current PR.
+   - \`gh workflow view <name> --yaml\` — view the canonical workflow definition.
 
 ## Output format
 
@@ -679,7 +746,7 @@ For each pattern found, report:
 - A brief explanation of when/how it's used
 
 End with a brief trailing summary of the overall build/test workflow order
-(e.g. "install → typecheck → lint → test → build").`),
+(e.g. "install → typecheck → lint → test → build"). Also summarise CI workflow order: which workflows fire on what triggers, in what order jobs run within each.`),
   };
 }
 

--- a/src/sdk/workflows/builtin/ralph/helpers/prompts.ts
+++ b/src/sdk/workflows/builtin/ralph/helpers/prompts.ts
@@ -564,10 +564,10 @@ export interface CodeSimplifierContext {
 }
 
 /**
- * Build the code-simplifier prompt. Invokes the `/code-simplifier` skill to
- * inspect only the orchestrator's changes on the current branch and refine
- * them for clarity, consistency, and maintainability — without altering
- * functionality or test behaviour.
+ * Build the code-simplifier prompt. Run by the `code-simplifier` sub-agent
+ * to inspect only the orchestrator's changes on the current branch and
+ * refine them for clarity, consistency, and maintainability — without
+ * altering functionality or test behaviour.
  *
  * @param spec - The user's original specification, used as context/fallback
  *   when planner output is missing or ambiguous.
@@ -587,7 +587,7 @@ ${plannerNotes}
 (empty — fall back to the Original User Specification below)
 </planner_output>`;
 
-  return withCaveman(`/code-simplifier Inspect the orchestrator's changes on the current branch and simplify the implementation for clarity, consistency, and maintainability.
+  return withCaveman(`Inspect the orchestrator's changes on the current branch and simplify the implementation for clarity, consistency, and maintainability.
 
 ## Design Input (authoritative)
 

--- a/src/sdk/workflows/builtin/ralph/opencode/index.ts
+++ b/src/sdk/workflows/builtin/ralph/opencode/index.ts
@@ -24,6 +24,7 @@ import { defineWorkflow } from "../../../index.ts";
 import {
   buildPlannerPrompt,
   buildOrchestratorPrompt,
+  buildCodeSimplifierPrompt,
   buildInfraDiscoveryPrompts,
   buildReviewPrompt,
   filterActionable,
@@ -135,6 +136,27 @@ export default defineWorkflow({
               },
             ],
             agent: "orchestrator",
+          });
+          s.save(result.data!);
+        },
+      );
+
+      // ── Code Simplifier ───────────────────────────────────────────────
+      await ctx.stage(
+        { name: `code-simplifier-${iteration}` },
+        {},
+        { title: `code-simplifier-${iteration}` },
+        async (s) => {
+          const result = await s.client.session.prompt({
+            sessionID: s.session.id,
+            parts: [
+              {
+                type: "text",
+                text: buildCodeSimplifierPrompt(prompt, {
+                  plannerNotes: planner.result,
+                }),
+              },
+            ],
           });
           s.save(result.data!);
         },

--- a/src/sdk/workflows/builtin/ralph/opencode/index.ts
+++ b/src/sdk/workflows/builtin/ralph/opencode/index.ts
@@ -157,6 +157,7 @@ export default defineWorkflow({
                 }),
               },
             ],
+            agent: "code-simplifier",
           });
           s.save(result.data!);
         },


### PR DESCRIPTION
## Summary

Adds a `code-simplifier` stage to the Ralph workflow (all three SDK variants: claude, copilot, opencode) that runs after the orchestrator in each iteration, and expands the infrastructure-discovery prompts to require full CI workflow coverage via the `gh` CLI.

## Key Changes

### Code Simplifier Stage (`claude`, `copilot`, `opencode`)
- Inserts a `code-simplifier-<n>` stage immediately after the orchestrator stage in each Ralph iteration across all three SDK variants.
- The stage invokes the `code-simplifier` sub-agent scoped to files the orchestrator touched (`git diff` / `git status`) and runs `bun typecheck` + `bun lint` to verify the result.
- Planner output (`plannerNotes`) is forwarded to the simplifier for context; falls back to the original user specification when absent.

### `buildCodeSimplifierPrompt` helper (`helpers/prompts.ts`)
- New exported function that constructs the code-simplifier prompt.
- Accepts an optional `CodeSimplifierContext` with `plannerNotes` for context handoff from the planner stage.
- Instructs the agent to simplify only within the orchestrator's branch diff and preserve all functionality, public interfaces, and test behaviour.

### Expanded CI audit in infra-discovery prompts
- Marks CI/CD workflow discovery as **REQUIRED** and lists every workflow file separately.
- Adds a mandatory CI audit step using the `gh` CLI (`gh workflow list`, `gh run list --limit 5`, `gh workflow view <name>`), with a fallback to reading YAML directly when `gh` is unavailable.
- Extends the output format to include per-workflow details: names, triggers, job names, and recent run statuses.
- Adds CI audit patterns guidance: matrix builds, `needs:` dependencies, `if:` conditionals, required checks, and example reviewer commands (`gh run view`, `gh pr checks`, `gh workflow view --yaml`).

## Test Plan

- [ ] Run a Ralph workflow end-to-end with each SDK (`claude`, `copilot`, `opencode`) and confirm `code-simplifier-<n>` executes after the orchestrator.
- [ ] Confirm the simplifier only modifies files present in the orchestrator's branch diff.
- [ ] Confirm `bun typecheck` and `bun lint` are run and pass inside the simplifier stage.
- [ ] Confirm infra-discovery output includes per-workflow CI details (triggers, jobs, recent runs) when `gh` is available.
- [ ] `bun typecheck`
- [ ] `bun lint`