### PR TITLE
fix(runtime): eliminate port conflicts with OS-assigned ports and PID-based discovery

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -364,6 +364,7 @@ Every workflow pattern maps directly to TypeScript code:
 | Deterministic work tied to an LLM call       | Inside the same stage callback, before/after the query. E.g. `s.session.query(...)` → parse → validate → `s.save(parsed)`.                                                            |
 | Subagent orchestration                       | Claude: `--agent` via `chatFlags` (interactive) or `agent` SDK option (headless); Copilot: `{ agent: "name" }` in sessionOpts; OpenCode: `agent` param in `s.client.session.prompt()` |
 | Per-session configuration                    | Pass `clientOpts` (2nd arg) and `sessionOpts` (3rd arg) to `ctx.stage()`                                                                                                              |
+| Per-session permission posture (autonomous)  | Claude: `chatFlags: ["--dangerously-skip-permissions"]` (interactive) or `permissionMode: "bypassPermissions"` on `s.session.query()` (headless). Copilot: `onPermissionRequest: approveAll` (default — auto-applied). OpenCode: pass `permission: [{ permission: "*", pattern: "*", action: "allow" }]` in `sessionOpts` on **every stage** so the posture is visible in the workflow source, not buried in runtime defaults. See `references/session-config.md` §"OpenCode session permission ruleset". |
 
 ### When to use a stage vs. plain TypeScript
 

--- a/.agents/skills/workflow-creator/references/session-config.md
+++ b/.agents/skills/workflow-creator/references/session-config.md
@@ -289,17 +289,64 @@ await ctx.stage({ name: "..." }, {
 ### Session options (`sessionOpts` — 3rd arg to `ctx.stage()`)
 
 These are forwarded to `client.session.create()`. Use them to set a title,
-parentID, or workspaceID for the session:
+parentID, workspaceID, or — most importantly — a `permission` ruleset for
+the session:
 
 ```ts
 await ctx.stage({ name: "..." }, {}, {
   title: "Feature implementation",
   parentID: "parent-session-id",
   workspaceID: "workspace-id",
+  // Recommended default — autonomous stages should approve every tool call.
+  // Mirrors Copilot's `approveAll` and Claude's `bypassPermissions`. Omit
+  // (or narrow) only when a stage must gate specific tools behind HIL.
+  permission: [{ permission: "*", pattern: "*", action: "allow" }],
 }, async (s) => {
   // s.session is the created OpencodeSession, s.session.id is the session ID
 });
 ```
+
+### OpenCode session permission ruleset (recommended default)
+
+Every opencode stage in the builtin and example workflows passes
+`permission: [{ permission: "*", pattern: "*", action: "allow" }]`
+explicitly. **Do the same for new opencode workflows.** This is OpenCode's
+equivalent of:
+
+| Agent    | Autonomous-default knob                                         |
+| -------- | --------------------------------------------------------------- |
+| Claude   | `chatFlags: ["--dangerously-skip-permissions"]` (interactive) / `permissionMode: "bypassPermissions"` (headless `s.session.query()` options) |
+| Copilot  | `onPermissionRequest: approveAll` (defaults on automatically)   |
+| OpenCode | `permission: [{ permission: "*", pattern: "*", action: "allow" }]` (default in the runtime; **set explicitly so workflow authors can see and override per stage**) |
+
+Why explicit:
+
+- The runtime applies the same allow-all ruleset as a fallback, but
+  **workflow authors should see the permission decision in the workflow
+  source** — not learn it by reading the executor.
+- A workflow author who needs a stricter ruleset (e.g. deny `bash` on a
+  production machine, ask before `edit` on a sensitive directory) can
+  override the field per stage. The runtime only applies the default when
+  `permission` is `undefined` in the session opts.
+- Mirroring the explicit pattern keeps the three SDK variants visually
+  symmetric — every stage in every agent shows its permission posture in
+  the same place (3rd arg to `ctx.stage()`).
+
+To narrow per stage, pass any other ruleset shape:
+
+```ts
+// Deny shell commands in this stage; ask for everything else.
+await ctx.stage({ name: "review" }, {}, {
+  title: "review",
+  permission: [
+    { permission: "bash", pattern: "*", action: "deny" },
+    { permission: "*", pattern: "*", action: "ask" },
+  ],
+}, async (s) => { /* ... */ });
+```
+
+The full type lives in `@opencode-ai/sdk/v2` as `PermissionRuleset`
+(`Array<{ permission: string; pattern?: string; action: "allow" | "deny" | "ask" }>`).
 
 ### Session prompting
 

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "permission": "allow",
   "mcp": {
     "github": {
       "type": "remote",
@@ -17,5 +16,8 @@
       ],
       "enabled": false
     }
-  }
+  },
+  "instructions": [
+    "/home/alilavaee/.atomic/AGENTS.md"
+  ]
 }

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.14.22"
+    "@opencode-ai/plugin": "1.14.29"
   }
 }

--- a/examples/headless-test/opencode/index.ts
+++ b/examples/headless-test/opencode/index.ts
@@ -32,7 +32,10 @@ export default defineWorkflow({
     const seed = await ctx.stage(
       { name: "seed", description: "Generate a topic overview" },
       {},
-      { title: "seed" },
+      {
+        title: "seed",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
@@ -53,7 +56,10 @@ export default defineWorkflow({
       ctx.stage(
         { name: "pros", headless: true },
         {},
-        { title: "pros" },
+        {
+          title: "pros",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -71,7 +77,10 @@ export default defineWorkflow({
       ctx.stage(
         { name: "cons", headless: true },
         {},
-        { title: "cons" },
+        {
+          title: "cons",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -89,7 +98,10 @@ export default defineWorkflow({
       ctx.stage(
         { name: "uses", headless: true },
         {},
-        { title: "uses" },
+        {
+          title: "uses",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -110,7 +122,10 @@ export default defineWorkflow({
     const mergeHandle = await ctx.stage(
       { name: "merge", description: "Combine background results" },
       {},
-      { title: "merge" },
+      {
+        title: "merge",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
@@ -135,7 +150,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "verdict", headless: true },
       {},
-      { title: "verdict" },
+      {
+        title: "verdict",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,

--- a/examples/hello-world/opencode/index.ts
+++ b/examples/hello-world/opencode/index.ts
@@ -47,7 +47,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "hello", description: "Say hello to the world" },
       {},
-      { title: "hello" },
+      {
+        title: "hello",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,

--- a/examples/hil-favorite-color-headless/opencode/index.ts
+++ b/examples/hil-favorite-color-headless/opencode/index.ts
@@ -28,7 +28,10 @@ export default defineWorkflow({
         description: "Headless: user-question should be disabled",
       },
       {},
-      { title: "ask-color-headless" },
+      {
+        title: "ask-color-headless",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,

--- a/examples/hil-favorite-color/opencode/index.ts
+++ b/examples/hil-favorite-color/opencode/index.ts
@@ -23,7 +23,10 @@ export default defineWorkflow({
         description: "Ask the user for their favorite color (HIL)",
       },
       {},
-      { title: "ask-color" },
+      {
+        title: "ask-color",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
@@ -50,7 +53,10 @@ export default defineWorkflow({
         description: "Write a short description of the chosen color",
       },
       {},
-      { title: "describe-color" },
+      {
+        title: "describe-color",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const prior = await s.transcript(askColor);
         const result = await s.client.session.prompt({

--- a/examples/pane-navigation/opencode/index.ts
+++ b/examples/pane-navigation/opencode/index.ts
@@ -18,7 +18,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "alpha", description: "Window 1 — say A" },
       {},
-      { title: "alpha" },
+      {
+        title: "alpha",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
@@ -31,7 +34,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "bravo", description: "Window 2 — say B" },
       {},
-      { title: "bravo" },
+      {
+        title: "bravo",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
@@ -44,7 +50,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "charlie", description: "Window 3 — say C" },
       {},
-      { title: "charlie" },
+      {
+        title: "charlie",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,

--- a/examples/parallel-hello-world/opencode/index.ts
+++ b/examples/parallel-hello-world/opencode/index.ts
@@ -35,7 +35,10 @@ export default defineWorkflow({
     const greet = await ctx.stage(
       { name: "greet", description: "Generate a greeting topic" },
       {},
-      { title: "greet" },
+      {
+        title: "greet",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
@@ -49,7 +52,10 @@ export default defineWorkflow({
       ctx.stage(
         { name: "formal", description: "Write a formal greeting" },
         {},
-        { title: "formal" },
+        {
+          title: "formal",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const prior = await s.transcript(greet);
           const result = await s.client.session.prompt({
@@ -67,7 +73,10 @@ export default defineWorkflow({
       ctx.stage(
         { name: "casual", description: "Write a casual greeting" },
         {},
-        { title: "casual" },
+        {
+          title: "casual",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const prior = await s.transcript(greet);
           const result = await s.client.session.prompt({
@@ -87,7 +96,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "merge", description: "Combine both greetings" },
       {},
-      { title: "merge" },
+      {
+        title: "merge",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const formalText = await s.transcript(formal);
         const casualText = await s.transcript(casual);

--- a/examples/structured-output-demo/opencode/index.ts
+++ b/examples/structured-output-demo/opencode/index.ts
@@ -41,7 +41,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "describe" },
       {},
-      { title: "describe" },
+      {
+        title: "describe",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,

--- a/specs/2026-04-30-tcp-port-race-fix-cross-uid.md
+++ b/specs/2026-04-30-tcp-port-race-fix-cross-uid.md
@@ -1,0 +1,485 @@
+# Cross-UID TCP Port Race Fix for OpenCode and Copilot Workflows — Technical Design Document
+
+| Document Metadata      | Details                                                        |
+| ---------------------- | -------------------------------------------------------------- |
+| Author(s)              | Norin Lavaee                                                   |
+| Status                 | Draft (WIP)                                                    |
+| Team / Owner           | Atomic CLI                                                     |
+| Created / Last Updated | 2026-04-30                                                     |
+
+## 1. Executive Summary
+
+Atomic workflows that use OpenCode or Copilot agents intermittently fail when **two different Linux users on the same VM run `atomic workflow` concurrently**. Symptom: the workflow gets stuck on its first stage with no error state, and attaching to the stage's tmux pane shows nothing — no agent visible. This is caused by two compounding bugs in `src/sdk/runtime/executor.ts`: (1) a TOCTOU race in `getRandomPort()` where the parent picks a port and the kernel can hand the same port to another atomic instance before the child binds, and (2) a silent fall-through in `waitForServer()` that returns a known-broken URL instead of throwing on probe timeout.
+
+This spec proposes a two-part fix: pass `--port 0` to OpenCode and Copilot (the OS atomically allocates a free port inside the child's `bind()` syscall, eliminating the race), and discover the bound port via **per-PID kernel introspection** — reading `/proc/<pid>/net/tcp` on Linux, `lsof` on macOS, and `Get-NetTCPConnection` on Windows — rather than parsing the agent's stdout banner. `waitForServer` is rewritten to discover the port and probe the SDK; on failure it throws a real `Error` so the workflow surfaces a `sessionError` instead of hanging silently. The fix is scoped to the workflow execution path and does not affect chat (which already runs the agent CLI raw with no port).
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+Atomic workflows spawn each stage's agent in a dedicated tmux window on the per-UID atomic socket (`/tmp/tmux-$UID/atomic`). For OpenCode and Copilot, the agent CLI is invoked with `--port <N>` (or `--ui-server --port <N>` for Copilot) so a TUI server listens on a TCP port. The parent atomic process then connects to `localhost:<N>` via the SDK's `cliUrl` / `baseUrl` option to inject prompts, read messages, etc.
+
+Port allocation lives in `src/sdk/runtime/executor.ts:173-189` (`getRandomPort`):
+
+```ts
+async function getRandomPort(): Promise<number> {
+  const net = await import("node:net");
+  const MAX_RETRIES = 3;
+  let lastPort = 0;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const port = await new Promise<number>((resolve, reject) => {
+      const server = net.createServer();
+      server.listen(0, () => {
+        const addr = server.address();
+        const p = typeof addr === "object" && addr ? addr.port : 0;
+        // ... resolve(p) and close()
+      });
+    });
+    // ... return port
+  }
+}
+```
+
+The flow:
+1. Parent calls `net.createServer().listen(0)` → kernel hands it free port P.
+2. Parent calls `server.close()` → P is returned to the global free pool.
+3. Parent spawns the agent CLI with `--port P` inside a tmux window.
+4. Agent CLI calls `bind(P)` — but between (2) and (4), any other process on the VM can grab P.
+
+`waitForServer` (lines 329-366) then probes the agent's port with the SDK and either succeeds, or — on timeout — falls through:
+
+```ts
+async function waitForServer(agent, port, paneId): Promise<string> {
+  // ... wait for tmux pane content to render ...
+  if (agent === "copilot") {
+    while (Date.now() < deadline) {
+      try { /* probe */; return serverUrl; } catch { await Bun.sleep(1_000); }
+    }
+    // No throw on timeout — falls through.
+  }
+  // For OpenCode, give it extra time after TUI renders
+  await Bun.sleep(3_000);
+  return serverUrl;  // ← always returns, even on probe failure
+}
+```
+
+**Why chat is unaffected**: `src/commands/cli/chat/index.ts` runs the agent CLI raw — no `--port`, no `--ui-server` — so chat never opens a TCP port and cannot race.
+
+**Why Claude is unaffected**: `buildPaneCommand` for Claude returns just a shell (`process.env.SHELL || "sh"`) — no port allocated. `waitForServer` returns `""` for claude immediately at line 334. The Claude Agent SDK uses UDS (Linux/macOS) and named pipes (Windows) per-user-home internally. Confirmed by the Claude Code maintainers: SDK uses `/tmp/claude-{uid}` and `~/.claude/`, no TCP fallback path.
+
+### 2.2 The Problem
+
+**Cross-UID conflict surface**: Different Linux users on the same VM have isolated tmux sockets at `/tmp/tmux-<UID>/atomic`, but **TCP ports are kernel-global**. When two atomic instances run concurrently as different UIDs:
+
+1. **Bind race (most common failure)**: User A's parent picks port P, closes the probe socket, spawns the agent. User B's parent simultaneously picks port P (the kernel's ephemeral allocator can re-hand it after the close). Whichever agent's `bind()` runs second gets `EADDRINUSE` and exits. Tmux's pane dies. The orchestrator's `waitForServer` polls a port that has no live server.
+2. **Cross-user probe (worse failure)**: User A's parent picks P; User B's agent is already listening on P. User A's `CopilotClient({cliUrl:"localhost:P"})` connects to User B's server, sees a healthy `listSessions()` response, returns success. User A then submits work to a session-handle that lives in User B's process.
+
+**Silent stick**: `waitForServer`'s fall-through means failures from (1) above don't error — `serverUrl` is returned, the SDK's JSON-RPC handshake hangs without a timeout, no `sessionError` is recorded, the session shows `running` in `state.json` indefinitely.
+
+**Observed symptom**: workflow stuck on first stage with no error; attaching to the stage shows no pane content (the agent process exited; tmux torn the window down).
+
+### 2.3 Why Now
+
+Multi-user shared dev VMs (e.g., remote pair-programming environments) are an increasingly common atomic deployment. The race is reproducible whenever two users run a workflow within the same ~10 second window. The fix unblocks reliable concurrent use.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] OpenCode and Copilot workflow stages must succeed when two different Linux users run atomic concurrently on the same VM.
+- [ ] Failures during agent startup (any cause) must surface as a real `sessionError` and not silently hang the workflow.
+- [ ] The fix must work on Linux, macOS, and Windows (atomic supports all three platforms; see `requiredMuxBinaryCandidatesForPlatform()` in `src/lib/spawn.ts`).
+- [ ] The fix must not require new runtime npm dependencies.
+- [ ] The fix must not break the existing chat path or the Claude workflow path.
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] We will NOT migrate Claude to a different transport. Claude already uses UDS / named pipes via the Claude Agent SDK and is cross-UID safe.
+- [ ] We will NOT add identity verification (auth tokens) to detect connections to another user's server. The `--port 0` fix removes the race entirely, so the cross-user probe scenario becomes statistically impossible. Token-based identity verification is deferred to a follow-up if observed cross-user incidents persist.
+- [ ] We will NOT investigate the separate "Claude visible-mode no pane" symptom. Reporter-conflated; needs its own debugger pass.
+- [ ] We will NOT change the SDK protocol or the way headless stages communicate (headless OpenCode already uses `port: 0` per `executor.ts:1358`).
+- [ ] We will NOT pre-bind in the parent and pass file descriptors to the child. OpenCode and Copilot CLIs do not implement systemd `LISTEN_FDS` socket activation, so this is impossible without upstream changes.
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 System Architecture Diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#f8f9fa','primaryTextColor':'#2c3e50','primaryBorderColor':'#4a5568','lineColor':'#4a90e2','secondaryColor':'#ffffff','tertiaryColor':'#e9ecef','background':'#f5f7fa','mainBkg':'#f8f9fa','nodeBorder':'#4a5568','clusterBkg':'#ffffff','clusterBorder':'#cbd5e0','edgeLabelBackground':'#ffffff'}}}%%
+
+flowchart TB
+    classDef parent fill:#5a67d8,stroke:#4c51bf,stroke-width:2.5px,color:#ffffff,font-weight:600
+    classDef child fill:#4a90e2,stroke:#357abd,stroke-width:2.5px,color:#ffffff,font-weight:600
+    classDef kernel fill:#48bb78,stroke:#38a169,stroke-width:2.5px,color:#ffffff,font-weight:600
+    classDef tmux fill:#667eea,stroke:#5a67d8,stroke-width:2.5px,color:#ffffff,font-weight:600
+
+    Parent["<b>Parent (atomic)</b><br>executor.ts<br><i>spawnStage()</i>"]:::parent
+
+    subgraph TmuxLayer["tmux server (per-UID socket)"]
+        TmuxWin["<b>tmux window</b><br><i>agent pane</i>"]:::tmux
+    end
+
+    subgraph KernelInfo["Kernel introspection"]
+        Proc["<b>/proc/PID/net/tcp</b><br><i>Linux</i>"]:::kernel
+        Lsof["<b>lsof -p PID</b><br><i>macOS</i>"]:::kernel
+        PSCmd["<b>Get-NetTCPConnection</b><br><i>Windows</i>"]:::kernel
+    end
+
+    subgraph AgentProc["Agent process (in tmux pane)"]
+        Agent["<b>opencode --port 0</b><br>or<br><b>copilot --ui-server --port 0</b><br><i>OS-allocated port P</i>"]:::child
+    end
+
+    Parent -->|"1. createWindow(--port 0)"| TmuxWin
+    TmuxWin -->|"2. spawn"| Agent
+    Agent -->|"3. bind(0) → P (atomic)"| Agent
+    Parent -->|"4. tmux display-message<br>get pane_pid"| TmuxWin
+    Parent -->|"5. poll PID's listening port"| Proc
+    Parent -->|"5. poll PID's listening port"| Lsof
+    Parent -->|"5. poll PID's listening port"| PSCmd
+    Proc -->|"6. P"| Parent
+    Lsof -->|"6. P"| Parent
+    PSCmd -->|"6. P"| Parent
+    Parent -->|"7. SDK probe localhost:P"| Agent
+
+    style TmuxLayer fill:#ffffff,stroke:#cbd5e0,stroke-width:2px,stroke-dasharray:6 4
+    style KernelInfo fill:#ffffff,stroke:#cbd5e0,stroke-width:2px,stroke-dasharray:6 4
+    style AgentProc fill:#ffffff,stroke:#cbd5e0,stroke-width:2px,stroke-dasharray:6 4
+```
+
+### 4.2 Architectural Pattern
+
+**Late port discovery via OS introspection.** Rather than the parent reserving a port and informing the child (which has an inherent TOCTOU race), the child does the allocation atomically inside its own `bind()`, and the parent discovers the result by querying the kernel about the child's listening sockets. This pattern is used by cloud-init, container runtimes that watch for service readiness, and tools like `ss --processes`. It mirrors how Chrome's DevTools port is discovered (Chrome writes a `DevToolsActivePort` file; we use the kernel's process socket table because OpenCode and Copilot don't write such a file).
+
+### 4.3 Key Components
+
+| Component                       | Responsibility                                    | Technology                            | Justification                                                                                  |
+| ------------------------------- | ------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `port-discovery.ts` (new)       | Resolve the listening TCP port for a given PID    | Bun.spawnSync + native `/proc` parsing | Cross-platform; no new dependency; survives banner format changes                              |
+| `waitForServer` (rewritten)     | Discover port from PID, probe SDK, throw on failure | Existing module                       | Eliminates silent fall-through; uses port-discovery helper                                     |
+| `buildPaneCommand` (modified)   | Emit `--port 0` instead of `--port <preallocated>` | Existing module                       | Lets OS allocate atomically inside child's bind() — no TOCTOU window                           |
+| `tmux.getPanePid` (new helper)  | Retrieve the PID of the agent process in a pane   | tmux `display-message #{pane_pid}`     | Already-known tmux primitive; centralizes the call                                             |
+
+## 5. Detailed Design
+
+### 5.1 Module API: `src/sdk/runtime/port-discovery.ts` (new file)
+
+Exposes a single function. No state. No singletons.
+
+```ts
+/**
+ * Discover the TCP port that a given process is listening on.
+ *
+ * Polls the kernel's per-process socket table at ~500ms intervals until
+ * a listening port is found or the timeout elapses. Returns null on
+ * timeout (caller is responsible for throwing if that's an error).
+ *
+ * Implementation per platform:
+ *   - Linux: parses /proc/<pid>/net/tcp (and /proc/<pid>/net/tcp6) directly,
+ *     filtering for state == 0x0A (LISTEN). No external binary required.
+ *   - macOS: shells out to `lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>` and
+ *     parses the output. lsof is preinstalled on all supported macOS versions.
+ *   - Windows: shells out to PowerShell `Get-NetTCPConnection -OwningProcess
+ *     <pid> -State Listen | Select-Object LocalPort | ConvertTo-Json` and
+ *     parses the JSON. Available on Windows 8+ / Server 2012+.
+ *
+ * If multiple listening ports exist for the PID, returns the first one
+ * bound to 127.0.0.1 / ::1 / 0.0.0.0 / ::. (Not relevant for OpenCode and
+ * Copilot — they bind exactly one TCP port — but the helper is generic.)
+ */
+export async function getListeningPortForPid(
+  pid: number,
+  options?: { timeoutMs?: number; pollIntervalMs?: number },
+): Promise<number | null>;
+```
+
+**Linux `/proc` parser specifics**: `/proc/<pid>/net/tcp` lines have the format `sl local_address rem_address st ... uid ... inode ...`. Local addresses are `HHHHHHHH:PPPP` (hex). State `0A` = LISTEN. The PID-to-inode mapping is in `/proc/<pid>/fd/*` (each fd has a `socket:[<inode>]` symlink target). We cross-reference: read all listening sockets in `/proc/net/tcp` and `/proc/net/tcp6`, then check which inode is owned by the target PID via `/proc/<pid>/fd/`. This avoids needing the `ss` or `netstat` binary.
+
+**Bun-specific note**: Bun's `Bun.spawnSync` is used for shell-outs (macOS/Windows) — already used elsewhere in the codebase (e.g., `tmux.ts:125`). For Linux `/proc` parsing, use Bun's built-in `Bun.file()` and standard string parsing.
+
+**Windows fallback**: The primary Windows path uses PowerShell `Get-NetTCPConnection` (Windows 8+/Server 2012+). On older Windows or when PowerShell is unavailable, the helper falls back to `netstat -ano | findstr <pid>` and parses the tabular output. Both parsers live in `port-discovery.ts`; the helper attempts PowerShell first and silently falls back on non-zero exit or "not recognized" stderr.
+
+**Pane PID resolution (open implementation detail)**: tmux's `#{pane_pid}` returns the PID of the foreground process in the pane. For `tmux new-window -d -t <session> -n <name> -- <command>`, tmux execs the command directly without a wrapper shell, so `pane_pid` should be the agent. **However**, this is a Phase 1 verification step before committing to the implementation — start a tmux pane with `copilot --ui-server --port 0` and confirm `pane_pid` matches the copilot process via `ps`. If a wrapper shell is involved on any platform, `getListeningPortForPid` walks the PID's children to find the listening process.
+
+### 5.2 Changes: `src/sdk/runtime/executor.ts`
+
+#### 5.2.1 Delete `getRandomPort` (lines 173-189)
+
+Unused after the change.
+
+#### 5.2.2 Modify `buildPaneCommand` (lines 283-327)
+
+Drop the `port: number` parameter — no longer needed. Emit `"--port", "0"` for both `copilot` and `opencode`. (Keeping `--port 0` explicit is clearer than omitting `--port` and depending on default behavior; user already confirmed both treat it identically.)
+
+```ts
+function buildPaneCommand(
+  agent: AgentType,
+  overrides: ProviderOverrides = {},
+  extraChatFlags: string[] = [],
+): { command: string; envVars: Record<string, string> } {
+  // ... same defaults extraction ...
+  switch (agent) {
+    case "copilot":
+      return {
+        command: [cmd, "--ui-server", "--port", "0", ...chatFlags, ...extraChatFlags].join(" "),
+        envVars,
+      };
+    case "opencode":
+      return {
+        command: [cmd, "--port", "0", ...chatFlags].join(" "),
+        envVars,
+      };
+    case "claude":
+      return {
+        command: process.env.SHELL || (process.platform === "win32" ? "pwsh" : "sh"),
+        envVars,
+      };
+    default:
+      return assertNever(agent);
+  }
+}
+```
+
+#### 5.2.3 Rewrite `waitForServer` (lines 329-366)
+
+New signature: takes `agent` and `paneId`, returns the server URL or **throws**.
+
+```ts
+async function waitForServer(
+  agent: AgentType,
+  paneId: string,
+): Promise<string> {
+  if (agent === "claude") return "";
+
+  const deadline = Date.now() + SERVER_WAIT_TIMEOUT_MS;
+
+  // 1. Wait for the agent process to start and the TUI to render.
+  while (Date.now() < deadline) {
+    const content = tmux.capturePane(paneId);
+    const lines = content.split("\n").filter((l) => l.trim().length > 0);
+    if (lines.length >= 3) break;
+    await Bun.sleep(1_000);
+  }
+
+  // 2. Discover the listening port via the agent's PID.
+  const panePid = tmux.getPanePid(paneId);
+  if (!panePid) {
+    throw new Error(`failed to resolve agent PID for pane ${paneId}`);
+  }
+  const remainingMs = Math.max(0, deadline - Date.now());
+  const port = await getListeningPortForPid(panePid, { timeoutMs: remainingMs });
+  if (port === null) {
+    throw new Error(
+      `agent (${agent}) did not bind a TCP port within ${SERVER_WAIT_TIMEOUT_MS}ms ` +
+      `(pane ${paneId}, pid ${panePid})`,
+    );
+  }
+  const serverUrl = `localhost:${port}`;
+
+  // 3. Verify the SDK can actually connect.
+  if (agent === "copilot") {
+    const { CopilotClient } = await import("@github/copilot-sdk");
+    while (Date.now() < deadline) {
+      try {
+        const probe = new CopilotClient({ cliUrl: serverUrl });
+        await probe.start();
+        await probe.listSessions();
+        await probe.stop();
+        return serverUrl;
+      } catch {
+        await Bun.sleep(1_000);
+      }
+    }
+    throw new Error(
+      `copilot SDK probe did not respond at ${serverUrl} within ${SERVER_WAIT_TIMEOUT_MS}ms`,
+    );
+  }
+
+  // OpenCode: short settle delay, then return.
+  await Bun.sleep(1_000);
+  return serverUrl;
+}
+```
+
+The key change: every failure path throws. The `if (agent === "copilot")` block no longer falls through silently. OpenCode no longer relies on a fixed 3-second sleep after the TUI renders — the port-discovery polling already proves the server is bound.
+
+#### 5.2.4 Modify the spawn site (line 1534+)
+
+Remove the `getRandomPort()` call and the `port` parameter from `buildPaneCommand` and `waitForServer`:
+
+```ts
+// Before (lines 1534-1567):
+const port = await getRandomPort();
+const { command: paneCmd, envVars: paneEnvVars } = buildPaneCommand(
+  shared.agent, port, shared.providerOverrides, shared.extraChatFlags,
+);
+// ... isHeadless branch ...
+paneId = tmux.createWindow(...);
+serverUrl = await waitForServer(shared.agent, port, paneId);
+
+// After:
+const { command: paneCmd, envVars: paneEnvVars } = buildPaneCommand(
+  shared.agent, shared.providerOverrides, shared.extraChatFlags,
+);
+// ... isHeadless branch ...
+paneId = tmux.createWindow(...);
+serverUrl = await waitForServer(shared.agent, paneId);
+```
+
+The `port` variable in the metadata write (referenced by the `tasks.jsonl` log) needs to be derived from `serverUrl` after `waitForServer` returns. Search for places where `port` is logged or persisted and adjust accordingly.
+
+### 5.3 Changes: `src/sdk/runtime/tmux.ts`
+
+Add a single helper:
+
+```ts
+/**
+ * Get the PID of the foreground process in a tmux pane.
+ * Returns null if the pane no longer exists or the query fails.
+ *
+ * Note: this is the pane's "current" process — typically the agent
+ * itself when the pane was created with the agent as the initial command.
+ * If tmux exec'd a wrapper shell that then exec'd the agent, the PID
+ * will refer to the same process (exec replaces in-place).
+ */
+export function getPanePid(paneId: string): number | null {
+  const result = tmuxRun(["display-message", "-t", paneId, "-p", "#{pane_pid}"]);
+  if (!result.ok) return null;
+  const pid = Number(result.stdout.trim());
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+```
+
+Place after `parseSessionEnvValue` and before `getCurrentSession`, near the other pane-introspection helpers.
+
+### 5.4 Algorithms and State Management
+
+#### 5.4.1 Polling loop
+
+Inside `getListeningPortForPid`:
+
+```
+deadline = Date.now() + timeoutMs
+while Date.now() < deadline:
+  port = readListeningPortForPid(pid)   // platform-specific
+  if port !== null: return port
+  if !isProcessAlive(pid): return null  // child exited; no point waiting
+  await sleep(pollIntervalMs)
+return null  // timeout
+```
+
+The `isProcessAlive(pid)` check fast-fails if the agent died before binding (e.g., crashed at startup, missing config, etc.). On Linux this is `existsSync(`/proc/${pid}`)`; on macOS/Windows we rely on the platform tool returning empty (and the timeout as backstop).
+
+#### 5.4.2 Concurrency safety
+
+The race we are eliminating happens *across* atomic processes (different users on the same VM). Within a single atomic process, port discovery is naturally serialized per stage by the existing executor logic (each stage's spawn is awaited). No new locking is introduced.
+
+## 6. Alternatives Considered
+
+| Option                                                | Pros                                                                | Cons                                                                                                    | Reason for Rejection                                                              |
+| ----------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| A. Retry on `EADDRINUSE`                              | Simple; pure cross-platform retry loop                              | Still has a race window per attempt; doesn't handle "connected to another user's server" case          | `--port 0` eliminates the race entirely without retries                           |
+| B. Banner regex parsing                               | Cross-platform with no shell-outs                                   | Fragile to upstream banner format changes; needs per-agent regex                                        | Kernel introspection is more durable; banner format is upstream-controlled        |
+| C. UDS / named pipes for OpenCode and Copilot         | Permanently eliminates port issues; cross-UID safe                  | OpenCode and Copilot CLIs are TCP-only; would require upstream SDK changes                              | Upstream changes are out of our control; deferred indefinitely                    |
+| D. Pre-bind in parent, pass listening fd to child     | True race-free: parent allocates atomically                         | Requires agent CLI to support inheriting a listening fd (systemd-style); OpenCode and Copilot don't     | Impossible without upstream changes                                               |
+| E. Identity tokens via env var (Claude SDK style)     | Defends against cross-user wrong-server connect even if race remains | Requires SDK support for arbitrary auth; OpenCode and Copilot SDKs don't expose this                    | `--port 0` removes the race so identity tokens become a low-priority safety net    |
+| F. Port range partitioning by UID                     | No code changes to agents                                           | Only shifts the problem; UIDs collide modulo, range exhaustion possible                                 | Not actually robust                                                               |
+| G. Lock file + atomic O_EXCL port reservation         | Mimics Claude's `computer-use-lock.json` pattern                    | Still has TOCTOU between unlock and bind; fundamentally doesn't solve the kernel-global port problem    | Doesn't solve the race                                                            |
+| **H. `--port 0` + kernel introspection (selected)**   | Robust, cross-platform, no agent changes, no banner parsing          | Per-platform code paths for `/proc` / lsof / PowerShell                                                  | **Selected** — best robustness/cost ratio                                          |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Security and Privacy
+
+- `lsof` and PowerShell `Get-NetTCPConnection` only need to introspect processes the user already owns. No elevated privileges required.
+- `/proc/<pid>/net/tcp` is readable by the owning UID without elevated privileges on standard Linux distros.
+- No new network surface is exposed. The agent CLI was already binding a TCP port; we now let the OS pick the number rather than the parent.
+- No new secrets are written to disk.
+
+### 7.2 Observability Strategy
+
+- `waitForServer` failures now produce specific error messages (`"agent ... did not bind a TCP port within Xms"` vs `"copilot SDK probe did not respond ..."`) — these flow to the existing `sessionError` path and `state.json`.
+- The discovered port should be logged in the existing `tasks.jsonl` entry for each stage (replacing the previously preallocated port). Field name `port` is preserved for compatibility with downstream tooling.
+- No new metrics needed for the initial implementation; if cross-user incidents persist, add a counter for `port_discovery_timeout` at that point.
+
+### 7.3 Scalability and Capacity Planning
+
+- Polling overhead is negligible: a single read of `/proc/<pid>/net/tcp` (Linux) or one `lsof` invocation (macOS) per ~500ms during the brief startup window. Bounded by `SERVER_WAIT_TIMEOUT_MS`.
+- The fix actually *reduces* startup latency in the common case: the existing OpenCode path always sleeps a fixed 3 seconds at line 364; the new path returns as soon as the port is detected (typically <500ms after the agent prints its first line of output).
+- No persistent resource leaks. The existing tmux window lifecycle is unchanged; the only new transient state is the polling loop, which terminates on success, timeout, or child-exited.
+
+## 8. Migration, Rollout, and Testing
+
+### 8.1 Deployment Strategy
+
+- Phase 1: **Verify pane PID assumption** — start a tmux pane with `copilot --ui-server --port 0` (also `opencode --port 0`) on Linux/macOS/Windows and confirm `tmux display-message -p '#{pane_pid}'` returns the agent's PID directly. Document the result in the implementation PR. If a wrapper shell is involved, switch `getListeningPortForPid` to walk children (one extra branch).
+- Phase 2: Land `port-discovery.ts` (with primary platform paths + Windows netstat fallback), `getPanePid`, and unit tests. No behavior change yet.
+- Phase 3: Land the `executor.ts` changes (`buildPaneCommand`, `waitForServer`, spawn site, delete `getRandomPort`). Single PR — these changes are interdependent.
+- Phase 4: Verify in pre-release on each platform (Linux, macOS, Windows) before bumping the released version. Concurrent-multi-user smoke test on Linux is required to confirm the original bug is fixed.
+
+There is no rollback feature flag — the change is structural and reversible only via revert. Acceptable because:
+- The fix is backward-compatible on the SDK side (servers still listen on `localhost:<port>` and respond to existing probes).
+- Failure modes are louder, not quieter (timeout throws instead of silent stick).
+
+### 8.2 Data Migration Plan
+
+None. No persisted schema or on-disk format changes. The `tasks.jsonl` and `state.json` schemas are unchanged; the `port` field continues to record the port the stage used (now discovered post-bind rather than preallocated).
+
+### 8.3 Test Plan
+
+#### Unit Tests (`src/sdk/runtime/port-discovery.test.ts`)
+
+- Linux `/proc` parser: synthetic `/proc/<pid>/net/tcp` content, verify hex-port decoding, LISTEN state filtering, and inode-to-PID mapping.
+- macOS lsof parser: synthetic `lsof` output, verify port extraction.
+- Windows PowerShell parser: synthetic JSON output, verify `LocalPort` extraction (single result and array).
+- Polling loop: mock platform-resolver, verify it returns on first non-null read, returns null on timeout, returns null when target PID exits.
+- `getListeningPortForPid` with a real `net.createServer()` bound to `127.0.0.1:0` and `process.pid` — end-to-end on the test runner's host platform.
+
+#### Unit Tests (`src/sdk/runtime/executor.test.ts` — extend existing)
+
+- `buildPaneCommand("copilot")` emits `... --ui-server --port 0 ...`.
+- `buildPaneCommand("opencode")` emits `... --port 0 ...`.
+- `buildPaneCommand("claude")` emits just the shell — unchanged.
+- `waitForServer("claude", paneId)` returns `""` immediately.
+- `waitForServer("copilot", paneId)` throws when port discovery times out (mock `tmux.getPanePid` and `getListeningPortForPid`).
+- `waitForServer("copilot", paneId)` throws when SDK probe fails (mock `CopilotClient`).
+- `waitForServer("copilot", paneId)` returns `localhost:<P>` on success.
+
+#### Integration Tests (manual for now; CI parity check optional)
+
+- On Linux: run two atomic workflows concurrently as the same user (simulates the cross-user race; same kernel port table). Verify both succeed.
+- On macOS: same as above.
+- On Windows: same as above using PowerShell + WSL or two terminal sessions.
+
+#### Regression Tests
+
+- Existing `chat` integration: chat sessions must continue to launch without modification (chat doesn't use the port path).
+- Existing Claude workflow stages: no behavior change.
+- Existing headless OpenCode stages: continue to work via `createOpencode({ port: 0 })` (`executor.ts:1358`) — unchanged.
+
+### 8.4 Verification Steps Before Marking Implemented
+
+1. `bun test` passes (existing + new tests).
+2. `bun lint` passes.
+3. `bun typecheck` passes.
+4. Manual: run a `deep-research-codebase` workflow on each platform; verify `tasks.jsonl` shows discovered ports and the workflow completes.
+5. Manual: launch two atomic workflows concurrently on Linux; verify both succeed.
+
+## 9. Open Questions / Unresolved Issues
+
+- [x] **Q1** *(resolved — investigate first)*: Pre-implementation, run a quick test: start a tmux pane with `sleep 100` (or directly with `copilot --ui-server --port 0`), check `pane_pid` vs the actual agent PID via `ps --ppid`. If tmux execs the command directly, `pane_pid` is the agent. If a wrapper shell is involved, `port-discovery.ts` walks the PID's children and uses the listening one. Decide and document the chosen approach during Phase 1 (port-discovery module landing).
+- [x] **Q2** *(resolved — split timeouts)*: Use **15s for port discovery** (the kernel sees the bind almost immediately; if it doesn't appear within 15s the agent is broken) and **60s for the SDK probe** (handshake can be slow on cold-start). Implementation: introduce two constants `PORT_DISCOVERY_TIMEOUT_MS = 15_000` and `SERVER_PROBE_TIMEOUT_MS = 60_000`. The combined deadline for `waitForServer` is the sum of both phases.
+- [x] **Q3** *(resolved — netstat fallback)*: Use `Get-NetTCPConnection` as the primary Windows path (Windows 8+/Server 2012+). Fall back to `netstat -ano | findstr <pid>` for older Windows. Implementation: try PowerShell first; on non-zero exit or "not recognized" error, fall back to netstat. Both parsers live in `port-discovery.ts`.
+- [x] **Q4** *(resolved — keep `port` unchanged)*: `tasks.jsonl` continues to record `port: <number>`. The discovered port is written to the same field after `waitForServer` returns. No schema change; downstream tooling unaffected.
+- [x] **Q5** *(resolved — defer telemetry)*: No metrics/logs for slow port discovery in the initial PR. Revisit only if cross-user incidents persist after the fix lands.
+
+## References
+
+- Existing research: [`research/docs/2026-01-31-github-copilot-sdk-research.md`](../research/docs/2026-01-31-github-copilot-sdk-research.md) — confirms `copilot --server --port 0` is supported and the SDK's `cliUrl` connection mode.
+- Existing research: [`research/docs/2026-03-01-opencode-tui-concurrency-bottlenecks.md`](../research/docs/2026-03-01-opencode-tui-concurrency-bottlenecks.md) — confirms OpenCode uses HTTP-on-TCP when `--port` is specified.
+- Claude Code maintainer response (in conversation history) — confirms Claude SDK is cross-UID safe via `/tmp/claude-{uid}` and `~/.claude/`, has no TCP fallback.
+- Source: `src/sdk/runtime/executor.ts:173-189` (`getRandomPort` — to be deleted).
+- Source: `src/sdk/runtime/executor.ts:283-327` (`buildPaneCommand` — to be modified).
+- Source: `src/sdk/runtime/executor.ts:329-366` (`waitForServer` — to be rewritten).
+- Source: `src/sdk/runtime/executor.ts:1534+` (spawn site — to be modified).
+- Source: `src/sdk/runtime/tmux.ts:185-219` (`createSession`) and `277-297` (`createWindow`) — pane creation primitives.
+- Source: `src/commands/cli/chat/index.ts` — chat path that bypasses the port logic.

--- a/src/sdk/runtime/executor.test.ts
+++ b/src/sdk/runtime/executor.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach, mock } from "bun:test";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -13,6 +13,8 @@ import {
   discoverCopilotBinary,
   applyContainerEnvDefaults,
   normalizeExternalCopilotOptions,
+  buildPaneCommand,
+  waitForServer,
   type CopilotHILSessionSurface,
 } from "./executor.ts";
 import type { SavedMessage } from "../types.ts";
@@ -996,5 +998,256 @@ describe("discoverCopilotBinary / shouldOverrideCopilotCliPath", () => {
     process.env.COPILOT_CLI_PATH = "/custom/copilot";
     applyContainerEnvDefaults();
     expect(process.env.COPILOT_CLI_PATH).toBe("/custom/copilot");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPaneCommand
+// ---------------------------------------------------------------------------
+
+describe("buildPaneCommand", () => {
+  test("copilot: command contains --ui-server and --port 0", () => {
+    const { command } = buildPaneCommand("copilot");
+    expect(command).toContain("--ui-server");
+    expect(command).toContain("--port 0");
+  });
+
+  test("copilot: command invokes the copilot binary as the first token", () => {
+    const { command } = buildPaneCommand("copilot");
+    // Accept either a bare name (binary not on PATH in test env) or an
+    // absolute path resolved via Bun.which — both end in "copilot".
+    expect(command).toMatch(/^("[^"]*\/)?[^\s"]*copilot"?\s/);
+  });
+
+  test("opencode: command contains --port 0 but not --ui-server", () => {
+    const { command } = buildPaneCommand("opencode");
+    expect(command).toContain("--port 0");
+    expect(command).not.toContain("--ui-server");
+  });
+
+  test("opencode: command invokes the opencode binary as the first token", () => {
+    const { command } = buildPaneCommand("opencode");
+    expect(command).toMatch(/^("[^"]*\/)?[^\s"]*opencode"?\s/);
+  });
+
+  test("claude: command resolves to a shell and does not contain --port", () => {
+    const { command } = buildPaneCommand("claude");
+    // SHELL is typically already absolute (e.g. /bin/zsh) so it passes through
+    // unchanged; bare fallbacks ("sh"/"pwsh") get resolved via Bun.which.
+    const expected =
+      process.env.SHELL || (process.platform === "win32" ? "pwsh" : "sh");
+    const stripped = command.replace(/^"|"$/g, "");
+    if (expected.includes("/") || expected.includes("\\")) {
+      expect(stripped).toBe(expected);
+    } else {
+      // Bare fallback either resolved via Bun.which or returned as-is.
+      expect(stripped.endsWith(expected) || stripped === expected).toBe(true);
+    }
+    expect(command).not.toContain("--port");
+  });
+
+  test("overrides.envVars merges with defaults for copilot", () => {
+    const { envVars } = buildPaneCommand("copilot", {
+      envVars: { MY_VAR: "hello" },
+    });
+    // Default copilot env var preserved
+    expect(envVars.COPILOT_ALLOW_ALL).toBe("true");
+    // Override merged in
+    expect(envVars.MY_VAR).toBe("hello");
+  });
+
+  test("overrides.chatFlags replaces defaults for copilot", () => {
+    const { command } = buildPaneCommand("copilot", {
+      chatFlags: ["--custom-flag"],
+    });
+    expect(command).toContain("--custom-flag");
+    // Default flags should be absent
+    expect(command).not.toContain("--add-dir");
+  });
+
+  test("extraChatFlags appended to copilot command", () => {
+    const { command } = buildPaneCommand("copilot", {}, ["--extra-flag"]);
+    expect(command).toContain("--extra-flag");
+  });
+
+  test("extraChatFlags not appended to opencode command", () => {
+    const { command } = buildPaneCommand("opencode", {}, ["--extra-flag"]);
+    expect(command).not.toContain("--extra-flag");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitForServer
+// ---------------------------------------------------------------------------
+
+// Three non-empty lines — enough to break the TUI-render loop.
+const PANE_CONTENT_READY = "line one\nline two\nline three\n";
+
+// ---------------------------------------------------------------------------
+// waitForServer — module-level captures for mock.module cleanup
+// ---------------------------------------------------------------------------
+
+// Snapshot the real function values BEFORE any mock.module call.
+// We can't hold the module namespace reference because mock.module mutates it
+// in-place, so we must copy the property values into a plain object snapshot.
+const _tmuxMod = await import("./tmux.ts");
+const realTmuxSnapshot = { ..._tmuxMod };
+const _portMod = await import("./port-discovery.ts");
+const realPortDiscoverySnapshot = { ..._portMod };
+let realCopilotSdkSnapshot: Record<string, unknown> | null = null;
+try {
+  const _copilotMod = await import("@github/copilot-sdk");
+  realCopilotSdkSnapshot = { ..._copilotMod };
+} catch {
+  // optional dependency — not installed in all environments
+}
+
+describe("waitForServer", () => {
+  // Save and restore Bun.sleep so we can make it instant in async tests.
+  let originalSleep: typeof Bun.sleep;
+
+  beforeEach(() => {
+    originalSleep = Bun.sleep;
+    // Make Bun.sleep a no-op so probe retry loops resolve immediately.
+    (globalThis as { Bun: { sleep: (ms: number) => Promise<void> } }).Bun.sleep =
+      () => Promise.resolve();
+  });
+
+  afterEach(() => {
+    (globalThis as { Bun: { sleep: typeof Bun.sleep } }).Bun.sleep =
+      originalSleep;
+    // Restore module mocks so they don't leak into subsequent test files.
+    // Use snapshot copies (not live references) because mock.module mutates
+    // the module namespace in-place.
+    mock.module("./tmux.ts", () => realTmuxSnapshot);
+    mock.module("./port-discovery.ts", () => realPortDiscoverySnapshot);
+    if (realCopilotSdkSnapshot !== null) {
+      mock.module("@github/copilot-sdk", () => realCopilotSdkSnapshot!);
+    }
+  });
+
+  test('returns "" immediately for agent "claude" without touching tmux', async () => {
+    // No mocks for tmux — any call would throw because real tmux isn't running.
+    const result = await waitForServer("claude", "%0");
+    expect(result).toBe("");
+  });
+
+  test("copilot: throws when getPanePid returns null", async () => {
+    mock.module("./tmux.ts", () => ({
+      capturePane: () => PANE_CONTENT_READY,
+      getPanePid: () => null,
+      // preserve other named exports as stubs
+      spawnMuxAttach: () => {},
+    }));
+
+    let err: Error | undefined;
+    try {
+      await waitForServer("copilot", "%0");
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err?.message).toContain("failed to resolve agent PID");
+  });
+
+  test("copilot: throws when port discovery times out (getListeningPortForPid returns null)", async () => {
+    mock.module("./tmux.ts", () => ({
+      capturePane: () => PANE_CONTENT_READY,
+      getPanePid: () => 12345,
+      spawnMuxAttach: () => {},
+    }));
+
+    mock.module("./port-discovery.ts", () => ({
+      getListeningPortForPid: async () => null,
+      PORT_DISCOVERY_TIMEOUT_MS: 100,
+    }));
+
+    let err: Error | undefined;
+    try {
+      await waitForServer("copilot", "%0");
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err?.message).toContain("did not bind a TCP port");
+  });
+
+  test("copilot: throws when SDK probe fails (CopilotClient.start rejects)", async () => {
+    mock.module("./tmux.ts", () => ({
+      capturePane: () => PANE_CONTENT_READY,
+      getPanePid: () => 12345,
+      spawnMuxAttach: () => {},
+    }));
+
+    mock.module("./port-discovery.ts", () => ({
+      getListeningPortForPid: async () => 50001,
+      PORT_DISCOVERY_TIMEOUT_MS: 100,
+    }));
+
+    mock.module("@github/copilot-sdk", () => ({
+      CopilotClient: class {
+        start() {
+          return Promise.reject(new Error("connection refused"));
+        }
+        listSessions() {
+          return Promise.resolve([]);
+        }
+        stop() {
+          return Promise.resolve();
+        }
+      },
+    }));
+
+    // SERVER_PROBE_TIMEOUT_MS is 60_000 but Bun.sleep is mocked to instant,
+    // so the loop burns through retries until Date.now() passes the deadline.
+    // To avoid a real 60s wall-clock wait we mock Date.now temporarily.
+    const realDateNow = Date.now;
+    let callCount = 0;
+    Date.now = () => {
+      callCount++;
+      // First few calls (port-deadline checks, probe-deadline setup): allow.
+      // After 10 calls assume probe deadline has passed.
+      return callCount > 10 ? realDateNow() + 999_999 : realDateNow();
+    };
+
+    let err: Error | undefined;
+    try {
+      try {
+        await waitForServer("copilot", "%0");
+      } catch (e) {
+        err = e as Error;
+      }
+    } finally {
+      Date.now = realDateNow;
+    }
+    expect(err?.message).toContain("copilot SDK probe did not respond");
+  });
+
+  test("copilot: returns localhost:<port> when SDK probe succeeds", async () => {
+    mock.module("./tmux.ts", () => ({
+      capturePane: () => PANE_CONTENT_READY,
+      getPanePid: () => 12345,
+      spawnMuxAttach: () => {},
+    }));
+
+    mock.module("./port-discovery.ts", () => ({
+      getListeningPortForPid: async () => 50001,
+      PORT_DISCOVERY_TIMEOUT_MS: 100,
+    }));
+
+    mock.module("@github/copilot-sdk", () => ({
+      CopilotClient: class {
+        start() {
+          return Promise.resolve();
+        }
+        listSessions() {
+          return Promise.resolve([]);
+        }
+        stop() {
+          return Promise.resolve();
+        }
+      },
+    }));
+
+    const result = await waitForServer("copilot", "%0");
+    expect(result).toBe("localhost:50001");
   });
 });

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -39,9 +39,7 @@ import type {
   ProviderClient,
   ProviderSession,
 } from "../types.ts";
-import {
-  type ProviderOverrides,
-} from "../../services/config/definitions.ts";
+import { type ProviderOverrides } from "../../services/config/definitions.ts";
 import { getProviderOverrides } from "../../services/config/atomic-config.ts";
 import { getCopilotScmDisableFlags } from "../../services/config/scm-sync.ts";
 import { reconcileOpencodeInstructions } from "../../services/config/additional-instructions.ts";
@@ -51,6 +49,10 @@ import type { SessionPromptResponse } from "@opencode-ai/sdk/v2";
 import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk";
 import * as tmux from "./tmux.ts";
 import { spawnMuxAttach } from "./tmux.ts";
+import {
+  getListeningPortForPid,
+  PORT_DISCOVERY_TIMEOUT_MS,
+} from "./port-discovery.ts";
 import { spawnAttachedFooter } from "./attached-footer.ts";
 import {
   clearClaudeSession,
@@ -66,8 +68,8 @@ import { buildSnapshot, writeSnapshot } from "./status-writer.ts";
 import { errorMessage } from "../errors.ts";
 import { createPainter } from "../../theme/colors.ts";
 
-/** Maximum time (ms) to wait for an agent's server to become reachable. */
-const SERVER_WAIT_TIMEOUT_MS = 60_000;
+/** Maximum time (ms) for the SDK probe to succeed after port is discovered. */
+export const SERVER_PROBE_TIMEOUT_MS = 60_000;
 
 /** Agent CLI configuration for spawning in tmux panes. */
 const AGENT_CLI: Record<
@@ -170,33 +172,6 @@ function getSessionsBaseDir(): string {
   return join(homedir(), ".atomic", "sessions");
 }
 
-async function getRandomPort(): Promise<number> {
-  const net = await import("node:net");
-
-  const MAX_RETRIES = 3;
-  let lastPort = 0;
-
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const port = await new Promise<number>((resolve, reject) => {
-      const server = net.createServer();
-      server.listen(0, () => {
-        const addr = server.address();
-        const p = typeof addr === "object" && addr ? addr.port : 0;
-        server.close(() => resolve(p));
-      });
-      server.on("error", reject);
-    });
-
-    if (port > 0) return port;
-    lastPort = port;
-    await Bun.sleep(50);
-  }
-
-  throw new Error(
-    `Failed to acquire a random port after ${MAX_RETRIES} attempts (last: ${lastPort})`,
-  );
-}
-
 /**
  * Resolve a non-JS Copilot CLI binary on PATH.
  *
@@ -280,9 +255,29 @@ export function applyContainerEnvDefaults(): void {
   if (bin) process.env.COPILOT_CLI_PATH = bin;
 }
 
-function buildPaneCommand(
+/**
+ * Resolve a CLI binary name to its absolute path using the parent atomic
+ * process's PATH. tmux's child shell can have a stripped or differently
+ * ordered PATH from the user's interactive shell — most visibly when atomic
+ * is launched from a globally-installed bin wrapper rather than `bun run dev`.
+ * Resolving here, where we still have the full interactive PATH, mirrors
+ * how `attached-footer.ts` injects `process.execPath` + an absolute cli.ts
+ * path so the footer always spawns regardless of the child shell's PATH.
+ *
+ * Falls back to the bare name when the binary isn't found on PATH so behavior
+ * stays unchanged for callers running entirely inside a normal interactive shell.
+ */
+function resolveCliBinary(cmd: string): string {
+  return Bun.which(cmd, { PATH: process.env.PATH ?? "" }) ?? cmd;
+}
+
+/** Wrap a path in bash double quotes only when it contains shell-significant characters. */
+function quotePathIfNeeded(path: string): string {
+  return /[\s'"$`!\\]/.test(path) ? `"${escBash(path)}"` : path;
+}
+
+export function buildPaneCommand(
   agent: AgentType,
-  port: number,
   overrides: ProviderOverrides = {},
   extraChatFlags: string[] = [],
 ): { command: string; envVars: Record<string, string> } {
@@ -296,14 +291,16 @@ function buildPaneCommand(
     ? { ...defaultEnvVars, ...overrides.envVars }
     : defaultEnvVars;
 
+  const resolvedCmd = quotePathIfNeeded(resolveCliBinary(cmd));
+
   switch (agent) {
     case "copilot":
       return {
         command: [
-          cmd,
+          resolvedCmd,
           "--ui-server",
           "--port",
-          String(port),
+          "0",
           ...chatFlags,
           ...extraChatFlags,
         ].join(" "),
@@ -311,43 +308,67 @@ function buildPaneCommand(
       };
     case "opencode":
       return {
-        command: [cmd, "--port", String(port), ...chatFlags].join(" "),
+        command: [resolvedCmd, "--port", "0", ...chatFlags].join(" "),
         envVars,
       };
-    case "claude":
-      // Claude is started via createClaudeSession() in the workflow's run()
+    case "claude": {
+      // Claude is started via createClaudeSession() in the workflow's run().
+      // Resolve $SHELL (or the platform default) to an absolute path for the
+      // same reason the agent CLIs are resolved above.
+      const fallback = process.platform === "win32" ? "pwsh" : "sh";
+      const shellCandidate = process.env.SHELL || fallback;
+      const resolvedShell =
+        shellCandidate.includes("/") || shellCandidate.includes("\\")
+          ? shellCandidate
+          : resolveCliBinary(shellCandidate);
       return {
-        command:
-          process.env.SHELL || (process.platform === "win32" ? "pwsh" : "sh"),
+        command: quotePathIfNeeded(resolvedShell),
         envVars,
       };
+    }
     default:
       return assertNever(agent);
   }
 }
 
-async function waitForServer(
+export async function waitForServer(
   agent: AgentType,
-  port: number,
   paneId: string,
 ): Promise<string> {
   if (agent === "claude") return "";
 
-  const serverUrl = `localhost:${port}`;
-  const deadline = Date.now() + SERVER_WAIT_TIMEOUT_MS;
+  const portDeadline = Date.now() + PORT_DISCOVERY_TIMEOUT_MS;
 
-  // Wait for the TUI to render first
-  while (Date.now() < deadline) {
+  // 1. Wait for the agent process to start and the TUI to render.
+  while (Date.now() < portDeadline) {
     const content = tmux.capturePane(paneId);
     const lines = content.split("\n").filter((l) => l.trim().length > 0);
     if (lines.length >= 3) break;
     await Bun.sleep(1_000);
   }
 
-  // Then verify the SDK can actually connect and list sessions
+  // 2. Discover the listening port via the agent's PID.
+  const panePid = tmux.getPanePid(paneId);
+  if (!panePid) {
+    throw new Error(`failed to resolve agent PID for pane ${paneId}`);
+  }
+  const remainingMs = Math.max(0, portDeadline - Date.now());
+  const port = await getListeningPortForPid(panePid, {
+    timeoutMs: remainingMs,
+  });
+  if (port === null) {
+    throw new Error(
+      `agent (${agent}) did not bind a TCP port within ${PORT_DISCOVERY_TIMEOUT_MS}ms ` +
+        `(pane ${paneId}, pid ${panePid})`,
+    );
+  }
+  const serverUrl = `localhost:${port}`;
+
+  // 3. Verify the SDK can actually connect.
   if (agent === "copilot") {
+    const probeDeadline = Date.now() + SERVER_PROBE_TIMEOUT_MS;
     const { CopilotClient } = await import("@github/copilot-sdk");
-    while (Date.now() < deadline) {
+    while (Date.now() < probeDeadline) {
       try {
         const probe = new CopilotClient({ cliUrl: serverUrl });
         await probe.start();
@@ -358,10 +379,13 @@ async function waitForServer(
         await Bun.sleep(1_000);
       }
     }
+    throw new Error(
+      `copilot SDK probe did not respond at ${serverUrl} within ${SERVER_PROBE_TIMEOUT_MS}ms`,
+    );
   }
 
-  // For OpenCode, give it extra time after TUI renders
-  await Bun.sleep(3_000);
+  // OpenCode: short settle delay, then return.
+  await Bun.sleep(1_000);
   return serverUrl;
 }
 
@@ -482,6 +506,12 @@ export async function executeWorkflow(
   const orchestratorEntry = join(import.meta.dir, "orchestrator-entry.ts");
   const workflowSource = definition.source;
 
+  // Resolve the bun binary to an absolute path here — `process.execPath` is
+  // the exact bun interpreter currently running atomic, so we don't depend on
+  // bare `bun` being on the tmux child shell's PATH (the same reason
+  // `attached-footer.ts` uses it).
+  const bunBinary = process.execPath;
+
   const launcherScript = isWin
     ? [
         `Set-Location "${escPwsh(projectRoot)}"`,
@@ -489,7 +519,7 @@ export async function executeWorkflow(
         `$env:ATOMIC_WF_TMUX = "${escPwsh(tmuxSessionName)}"`,
         `$env:ATOMIC_WF_AGENT = "${escPwsh(agent)}"`,
         `$env:ATOMIC_WF_CWD = "${escPwsh(projectRoot)}"`,
-        `bun run "${escPwsh(orchestratorEntry)}" "${escPwsh(workflowSource)}" "${escPwsh(agent)}" "${escPwsh(inputsB64)}" 2>"${escPwsh(logPath)}"`,
+        `& "${escPwsh(bunBinary)}" run "${escPwsh(orchestratorEntry)}" "${escPwsh(workflowSource)}" "${escPwsh(agent)}" "${escPwsh(inputsB64)}" 2>"${escPwsh(logPath)}"`,
       ].join("\n")
     : [
         "#!/bin/bash",
@@ -498,7 +528,7 @@ export async function executeWorkflow(
         `export ATOMIC_WF_TMUX="${escBash(tmuxSessionName)}"`,
         `export ATOMIC_WF_AGENT="${escBash(agent)}"`,
         `export ATOMIC_WF_CWD="${escBash(projectRoot)}"`,
-        `bun run "${escBash(orchestratorEntry)}" "${escBash(workflowSource)}" "${escBash(agent)}" "${escBash(inputsB64)}" 2>"${escBash(logPath)}"`,
+        `"${escBash(bunBinary)}" run "${escBash(orchestratorEntry)}" "${escBash(workflowSource)}" "${escBash(agent)}" "${escBash(inputsB64)}" 2>"${escBash(logPath)}"`,
       ].join("\n");
 
   await writeFile(launcherPath, launcherScript, { mode: 0o755 });
@@ -541,12 +571,28 @@ function printDetachedBanner(tmuxSessionName: string): void {
   const paint = createPainter();
   process.stdout.write(
     "\n" +
-      "  " + paint("success", "✓") + " " + paint("text", "workflow started in background", { bold: true }) + "\n" +
-      "  " + paint("dim", "session: ") + paint("accent", tmuxSessionName) + "\n" +
+      "  " +
+      paint("success", "✓") +
+      " " +
+      paint("text", "workflow started in background", { bold: true }) +
       "\n" +
-      "  " + paint("dim", "attach: ") + paint("accent", `atomic workflow session connect ${tmuxSessionName}`) + "\n" +
-      "  " + paint("dim", "list:   ") + paint("accent", "atomic workflow session list") + "\n" +
-      "  " + paint("dim", "kill:   ") + paint("accent", `atomic workflow session kill ${tmuxSessionName}`) + "\n" +
+      "  " +
+      paint("dim", "session: ") +
+      paint("accent", tmuxSessionName) +
+      "\n" +
+      "\n" +
+      "  " +
+      paint("dim", "attach: ") +
+      paint("accent", `atomic workflow session connect ${tmuxSessionName}`) +
+      "\n" +
+      "  " +
+      paint("dim", "list:   ") +
+      paint("accent", "atomic workflow session list") +
+      "\n" +
+      "  " +
+      paint("dim", "kill:   ") +
+      paint("accent", `atomic workflow session kill ${tmuxSessionName}`) +
+      "\n" +
       "\n",
   );
 }
@@ -579,7 +625,9 @@ function resolveProviderSessionId(
     return typeof obj["id"] === "string" ? (obj["id"] as string) : "";
   }
   // claude and copilot both expose `sessionId` as a string.
-  return typeof obj["sessionId"] === "string" ? (obj["sessionId"] as string) : "";
+  return typeof obj["sessionId"] === "string"
+    ? (obj["sessionId"] as string)
+    : "";
 }
 
 /** Type guard for objects with a string `content` property (Copilot assistant.message data). */
@@ -792,7 +840,9 @@ function renderCopilotTranscript(
  * invocations. `reasoning` and `subtask` parts are internal and omitted.
  */
 function renderOpencodeTranscript(response: {
-  parts?: ReadonlyArray<{ type?: unknown; text?: unknown } & Record<string, unknown>>;
+  parts?: ReadonlyArray<
+    { type?: unknown; text?: unknown } & Record<string, unknown>
+  >;
 }): string {
   if (!response.parts) return "";
   const parts: string[] = [];
@@ -811,8 +861,8 @@ function renderOpencodeTranscript(response: {
       const state = part["state"];
       const args =
         state && typeof state === "object"
-          ? (state as Record<string, unknown>)["input"] ??
-            (state as Record<string, unknown>)["args"]
+          ? ((state as Record<string, unknown>)["input"] ??
+            (state as Record<string, unknown>)["args"])
           : undefined;
       parts.push(
         `**→ \`${name}\`**\n\n\`\`\`json\n${renderToolInput(args)}\n\`\`\``,
@@ -842,9 +892,7 @@ export function renderMessagesToText(messages: SavedMessage[]): string {
 
   for (const m of messages) {
     if (m.provider === "claude") {
-      claudeBatch.push(
-        m.data as unknown as { type: string; message: unknown },
-      );
+      claudeBatch.push(m.data as unknown as { type: string; message: unknown });
       continue;
     }
     flushClaude();
@@ -880,7 +928,10 @@ function resolveRef(ref: SessionRef): string {
  * CopilotSession and lightweight test mocks.
  */
 export interface CopilotSendSessionSurface {
-  on(eventType: string, handler: (event: { data?: unknown }) => void): () => void;
+  on(
+    eventType: string,
+    handler: (event: { data?: unknown }) => void,
+  ): () => void;
 }
 
 /**
@@ -1078,11 +1129,7 @@ export function watchCopilotSessionForElicitation(
   });
   const unsubCompleted = session.on("elicitation.completed", (event) => {
     const data = event.data as { requestId?: string } | undefined;
-    if (
-      data?.requestId &&
-      active.delete(data.requestId) &&
-      active.size === 0
-    ) {
+    if (data?.requestId && active.delete(data.requestId) && active.size === 0) {
       onHIL(false);
     }
   });
@@ -1275,12 +1322,10 @@ async function initProviderClientAndSession<A extends AgentType>(
   switch (agent) {
     case "copilot": {
       const { CopilotClient, approveAll } = await import("@github/copilot-sdk");
-      const { copilotSubprocessEnv, mergeCopilotSystemMessage } = await import(
-        "../providers/copilot.ts"
-      );
-      const { resolveAdditionalInstructionsContent } = await import(
-        "../../services/config/additional-instructions.ts"
-      );
+      const { copilotSubprocessEnv, mergeCopilotSystemMessage } =
+        await import("../providers/copilot.ts");
+      const { resolveAdditionalInstructionsContent } =
+        await import("../../services/config/additional-instructions.ts");
       const copilotClientOpts = clientOpts as StageClientOptions<"copilot">;
       const copilotSessionOpts = sessionOpts as StageSessionOptions<"copilot">;
       // Headless: let the SDK spawn its own CLI process (no cliUrl).
@@ -1311,9 +1356,8 @@ async function initProviderClientAndSession<A extends AgentType>(
       // In headless stages, add `ask_user` to the session's excludedTools so
       // the agent cannot call the interactive question tool — there is no
       // human attached to answer and the SDK would otherwise sit blocked.
-      const additionalInstructions = await resolveAdditionalInstructionsContent(
-        projectRoot,
-      );
+      const additionalInstructions =
+        await resolveAdditionalInstructionsContent(projectRoot);
       const sessionConfig = {
         onPermissionRequest: approveAll,
         ...copilotSessionOpts,
@@ -1356,7 +1400,10 @@ async function initProviderClientAndSession<A extends AgentType>(
         // the session permission ruleset).
         return await withHeadlessOpencodeEnv(async () => {
           const oc = await createOpencode({ port: 0 });
-          const sessionResult = await oc.client.session.create(ocSessionOpts);
+          const sessionResult = await oc.client.session.create({
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+            ...ocSessionOpts,
+          });
           return {
             client: oc.client,
             session: sessionResult.data!,
@@ -1530,11 +1577,9 @@ function createSessionRunner(
     let panelSessionAdded = false;
 
     try {
-      // ── 6. Allocate port ──
-      const port = await getRandomPort();
+      // ── 6. Build pane command (OS allocates port via --port 0) ──
       const { command: paneCmd, envVars: paneEnvVars } = buildPaneCommand(
         shared.agent,
-        port,
         shared.providerOverrides,
         shared.extraChatFlags,
       );
@@ -1564,7 +1609,7 @@ function createSessionRunner(
 
         spawnAttachedFooter(name, paneId);
 
-        serverUrl = await waitForServer(shared.agent, port, paneId);
+        serverUrl = await waitForServer(shared.agent, paneId);
 
         shared.panel.addSession(name, graphParents);
         panelSessionAdded = true;
@@ -1592,8 +1637,8 @@ function createSessionRunner(
           if (!arg) {
             throw new Error(
               "wrapMessages: empty Claude session id. Call s.save(s.sessionId) " +
-              "only after a successful s.session.query() (headless wrappers " +
-              "only know their session_id once a query completes).",
+                "only after a successful s.session.query() (headless wrappers " +
+                "only know their session_id once a query completes).",
             );
           }
           const { getSessionMessages } =
@@ -1784,7 +1829,7 @@ function createSessionRunner(
             agent: shared.agent,
             paneId,
             serverUrl,
-            port,
+            port: serverUrl ? Number(serverUrl.split(":").pop()) : 0,
             startedAt: new Date().toISOString(),
           },
           null,
@@ -1886,7 +1931,8 @@ export async function runOrchestrator(
   definition: WorkflowDefinition,
   inputs: Record<string, string> = {},
 ): Promise<void> {
-  const { workflowRunId, tmuxSessionName, agent, cwd } = validateOrchestratorEnv();
+  const { workflowRunId, tmuxSessionName, agent, cwd } =
+    validateOrchestratorEnv();
   // A bare prompt string is still useful for the panel header and the
   // session-dir metadata.json — both just want something displayable.
   // Free-form workflows store their single positional prompt under the

--- a/src/sdk/runtime/port-discovery.test.ts
+++ b/src/sdk/runtime/port-discovery.test.ts
@@ -7,16 +7,60 @@
 
 import { test, expect, describe, mock, beforeAll, afterAll } from "bun:test";
 import {
+  _linuxGetListeningPort,
+  _macosGetChildren,
+  _macosReadListeningPort,
   _parseLinuxTcpLine,
   _parseLinuxTcpTable,
   _getLinuxPidSocketInodes,
   _parseMacosLsofOutput,
   _parseWindowsPowerShellOutput,
   _parseWindowsNetstatOutput,
+  _readListeningPortForPid,
+  _setPortDiscoverySpawnSyncForTest,
+  _windowsGetChildren,
+  _windowsReadListeningPort,
   getListeningPortForPid,
   PORT_DISCOVERY_TIMEOUT_MS,
 } from "./port-discovery.ts";
 import * as net from "node:net";
+import { Buffer } from "node:buffer";
+
+type Platform = typeof process.platform;
+type SpawnResult = {
+  stdout: Buffer;
+  stderr: Buffer;
+  success: boolean;
+};
+
+function withPlatform<T>(platform: Platform, fn: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  try {
+    return fn();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process, "platform", descriptor);
+    }
+  }
+}
+
+function spawnResult(stdout = "", stderr = "", success = true): SpawnResult {
+  return {
+    stdout: Buffer.from(stdout),
+    stderr: Buffer.from(stderr),
+    success,
+  };
+}
+
+function withSpawnSyncMock<T>(handler: (cmd: string[]) => SpawnResult, fn: () => T): T {
+  const restore = _setPortDiscoverySpawnSyncForTest(mock((options) => handler(options.cmd)));
+  try {
+    return fn();
+  } finally {
+    restore();
+  }
+}
 
 // ---------------------------------------------------------------------------
 // 1. Linux /proc parser
@@ -104,6 +148,27 @@ describe("_parseLinuxTcpTable", () => {
 
 // Note: _getLinuxPidSocketInodes relies on real /proc fs; tested in e2e section.
 
+describe("Linux discovery helpers", () => {
+  test("returns IPv4 port before IPv6 for matching socket inode", () => {
+    const tcp = "0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000 0 0 111 1";
+    const tcp6 = "0: 00000000000000000000000001000000:23FB 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000 0 0 111 1";
+
+    expect(_linuxGetListeningPort(tcp, tcp6, new Set([111]))).toBe(8080);
+  });
+
+  test("returns IPv6 port when no IPv4 table entry matches", () => {
+    const tcp6 = "0: 00000000000000000000000001000000:23FB 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000 0 0 222 1";
+
+    expect(_linuxGetListeningPort("", tcp6, new Set([222]))).toBe(9211);
+  });
+
+  test("platform dispatch uses Linux reader without subprocesses", () => {
+    const port = withPlatform("linux", () => _readListeningPortForPid(2_000_000_000));
+
+    expect(port).toBeNull();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 2. macOS lsof parser
 // ---------------------------------------------------------------------------
@@ -170,6 +235,61 @@ describe("_parseMacosLsofOutput", () => {
   });
 });
 
+describe("macOS discovery helpers", () => {
+  const lsofOutput = "COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nbun 123 user 10u IPv4 0 0t0 TCP 127.0.0.1:4567 (LISTEN)";
+
+  test("reads a port from lsof output", () => {
+    const port = withSpawnSyncMock(
+      () => spawnResult(lsofOutput),
+      () => _macosReadListeningPort(123, 0),
+    );
+
+    expect(port).toBe(4567);
+  });
+
+  test("walks child PIDs when parent has no listening port", () => {
+    const seenCommands: string[][] = [];
+    const port = withSpawnSyncMock(
+      (cmd) => {
+        seenCommands.push(cmd);
+        if (cmd[0] === "pgrep") return spawnResult("456\n");
+        if (cmd.includes("456")) return spawnResult(lsofOutput.replace("4567", "5678"));
+        return spawnResult("");
+      },
+      () => _macosReadListeningPort(123, 0),
+    );
+
+    expect(port).toBe(5678);
+    expect(seenCommands.some((cmd) => cmd[0] === "pgrep")).toBe(true);
+  });
+
+  test("returns null after macOS child traversal depth limit", () => {
+    const port = withSpawnSyncMock(
+      () => spawnResult(lsofOutput),
+      () => _macosReadListeningPort(123, 4),
+    );
+
+    expect(port).toBeNull();
+  });
+
+  test("parses pgrep child output and filters invalid values", () => {
+    const children = withSpawnSyncMock(
+      () => spawnResult("123\nnot-a-pid\n0\n456\n"),
+      () => _macosGetChildren(99),
+    );
+
+    expect(children).toEqual([123, 456]);
+  });
+
+  test("platform dispatch uses macOS reader", () => {
+    const port = withPlatform("darwin", () =>
+      withSpawnSyncMock(() => spawnResult(lsofOutput), () => _readListeningPortForPid(123)),
+    );
+
+    expect(port).toBe(4567);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 3. Windows PowerShell parser
 // ---------------------------------------------------------------------------
@@ -210,6 +330,92 @@ describe("_parseWindowsPowerShellOutput", () => {
 
   test("returns null for object without LocalPort", () => {
     expect(_parseWindowsPowerShellOutput('{"OtherField":1234}')).toBeNull();
+  });
+});
+
+describe("Windows discovery helpers", () => {
+  test("reads a port from PowerShell output", () => {
+    const port = withSpawnSyncMock(
+      () => spawnResult('{"LocalPort":7001}'),
+      () => _windowsReadListeningPort(321, 0),
+    );
+
+    expect(port).toBe(7001);
+  });
+
+  test("falls back to netstat when PowerShell is unavailable", () => {
+    const port = withSpawnSyncMock(
+      (cmd) => {
+        if (cmd[0] === "cmd") {
+          return spawnResult("TCP 0.0.0.0:7002 0.0.0.0:0 LISTENING 321");
+        }
+        return spawnResult("", "CommandNotFoundException", false);
+      },
+      () => _windowsReadListeningPort(321, 0),
+    );
+
+    expect(port).toBe(7002);
+  });
+
+  test("walks child PIDs when parent has no listening port", () => {
+    const port = withSpawnSyncMock(
+      (cmd) => {
+        const command = cmd.join(" ");
+        if (command.includes("Get-NetTCPConnection") && command.includes("654")) {
+          return spawnResult('{"LocalPort":7003}');
+        }
+        if (command.includes("Win32_Process")) {
+          return spawnResult('{"ProcessId":654}');
+        }
+        return spawnResult("null");
+      },
+      () => _windowsReadListeningPort(321, 0),
+    );
+
+    expect(port).toBe(7003);
+  });
+
+  test("returns null after Windows child traversal depth limit", () => {
+    const port = withSpawnSyncMock(
+      () => spawnResult('{"LocalPort":7004}'),
+      () => _windowsReadListeningPort(321, 4),
+    );
+
+    expect(port).toBeNull();
+  });
+
+  test("parses Windows child PID JSON arrays and objects", () => {
+    const arrayChildren = withSpawnSyncMock(
+      () => spawnResult('[{"ProcessId":111},{"ProcessId":"222"},{"Other":333},{"ProcessId":0}]'),
+      () => _windowsGetChildren(321),
+    );
+    const objectChildren = withSpawnSyncMock(
+      () => spawnResult('{"ProcessId":444}'),
+      () => _windowsGetChildren(321),
+    );
+
+    expect(arrayChildren).toEqual([111, 222]);
+    expect(objectChildren).toEqual([444]);
+  });
+
+  test("falls back to wmic when child PowerShell is unavailable", () => {
+    const children = withSpawnSyncMock(
+      (cmd) => {
+        if (cmd[0] === "wmic") return spawnResult("ProcessId\n111\nbad\n222\n");
+        return spawnResult("", "is not recognized", false);
+      },
+      () => _windowsGetChildren(321),
+    );
+
+    expect(children).toEqual([111, 222]);
+  });
+
+  test("platform dispatch uses Windows reader for non-Linux and non-macOS platforms", () => {
+    const port = withPlatform("win32", () =>
+      withSpawnSyncMock(() => spawnResult('{"LocalPort":7005}'), () => _readListeningPortForPid(321)),
+    );
+
+    expect(port).toBe(7005);
   });
 });
 

--- a/src/sdk/runtime/port-discovery.test.ts
+++ b/src/sdk/runtime/port-discovery.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for the cross-platform TCP port discovery module.
+ *
+ * Parser functions are tested with synthetic data to keep tests OS-independent.
+ * The end-to-end test uses a real server and only runs on Linux/macOS.
+ */
+
+import { test, expect, describe, mock, beforeAll, afterAll } from "bun:test";
+import {
+  _parseLinuxTcpLine,
+  _parseLinuxTcpTable,
+  _getLinuxPidSocketInodes,
+  _parseMacosLsofOutput,
+  _parseWindowsPowerShellOutput,
+  _parseWindowsNetstatOutput,
+  getListeningPortForPid,
+  PORT_DISCOVERY_TIMEOUT_MS,
+} from "./port-discovery.ts";
+import * as net from "node:net";
+
+// ---------------------------------------------------------------------------
+// 1. Linux /proc parser
+// ---------------------------------------------------------------------------
+
+describe("_parseLinuxTcpLine", () => {
+  test("returns null for header line", () => {
+    const line = "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+    expect(_parseLinuxTcpLine(line)).toBeNull();
+  });
+
+  test("returns null for non-LISTEN state (ESTABLISHED = 01)", () => {
+    const line = "   0: 0100007F:1F90 0200007F:C000 01 00000000:00000000 00:00000000 00000000  1000        0 12345 1 0000000000000000 20 4 24 10 -1";
+    expect(_parseLinuxTcpLine(line)).toBeNull();
+  });
+
+  test("parses LISTEN state (0A) and decodes port hex :1F90 → 8080", () => {
+    // 0x1F90 = 8080
+    const line = "   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 99001 1 0000000000000000 100 0 0 10 0";
+    const result = _parseLinuxTcpLine(line);
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(8080);
+    expect(result!.inode).toBe(99001);
+  });
+
+  test("parses port :50FF → 20735", () => {
+    // 0x50FF = 20735
+    const line = "   1: 00000000:50FF 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 55555 1 0000000000000000 100 0 0 10 0";
+    const result = _parseLinuxTcpLine(line);
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(0x50ff);
+  });
+
+  test("parses port :0050 → 80", () => {
+    // 0x0050 = 80
+    const line = "   2: 00000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000  0        0 1001 1 0000000000000000 100 0 0 10 0";
+    const result = _parseLinuxTcpLine(line);
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(80);
+  });
+
+  test("returns null for empty line", () => {
+    expect(_parseLinuxTcpLine("")).toBeNull();
+    expect(_parseLinuxTcpLine("   ")).toBeNull();
+  });
+
+  test("returns null for truncated line", () => {
+    expect(_parseLinuxTcpLine("   0: 0100007F:1F90 00000000:0000 0A")).toBeNull();
+  });
+
+  test("returns null when port hex is 0000", () => {
+    const line = "   0: 00000000:0000 00000000:0000 0A 00000000:00000000 00:00000000 00000000  0        0 1 1 0000000000000000 100 0 0 10 0";
+    expect(_parseLinuxTcpLine(line)).toBeNull();
+  });
+});
+
+describe("_parseLinuxTcpTable", () => {
+  const sampleTcp = [
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode",
+    "   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 99001 1 0000000000000000 100 0 0 10 0",
+    "   1: 0200007F:23FB 00000000:0000 01 00000000:00000000 00:00000000 00000000  1000        0 99002 1 0000000000000000 100 0 0 10 0",
+    "   2: 00000000:0050 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 99003 1 0000000000000000 100 0 0 10 0",
+  ].join("\n");
+
+  test("only includes LISTEN (0A) entries", () => {
+    const table = _parseLinuxTcpTable(sampleTcp);
+    // inode 99002 is ESTABLISHED (01) — must not appear
+    expect(table.has(99002)).toBe(false);
+  });
+
+  test("maps inode 99001 → port 8080", () => {
+    const table = _parseLinuxTcpTable(sampleTcp);
+    expect(table.get(99001)).toBe(8080);
+  });
+
+  test("maps inode 99003 → port 80", () => {
+    const table = _parseLinuxTcpTable(sampleTcp);
+    expect(table.get(99003)).toBe(80);
+  });
+
+  test("returns empty map for empty content", () => {
+    expect(_parseLinuxTcpTable("").size).toBe(0);
+  });
+});
+
+// Note: _getLinuxPidSocketInodes relies on real /proc fs; tested in e2e section.
+
+// ---------------------------------------------------------------------------
+// 2. macOS lsof parser
+// ---------------------------------------------------------------------------
+
+describe("_parseMacosLsofOutput", () => {
+  const sampleLsof = [
+    "COMMAND   PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME",
+    "node    12345 user   23u  IPv4 0x0000000000000000      0t0  TCP 127.0.0.1:8080 (LISTEN)",
+    "node    12345 user   24u  IPv4 0x0000000000000001      0t0  TCP 0.0.0.0:9090 (LISTEN)",
+  ].join("\n");
+
+  test("extracts port from 127.0.0.1:8080", () => {
+    expect(_parseMacosLsofOutput(sampleLsof)).toBe(8080);
+  });
+
+  test("prefers loopback over wildcard when loopback appears first", () => {
+    const output = [
+      "COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME",
+      "node    1 user 23u IPv4 0 0t0 TCP 127.0.0.1:8080 (LISTEN)",
+      "node    1 user 24u IPv4 0 0t0 TCP 0.0.0.0:9090 (LISTEN)",
+    ].join("\n");
+    expect(_parseMacosLsofOutput(output)).toBe(8080);
+  });
+
+  test("returns wildcard port when only 0.0.0.0 binding exists", () => {
+    const output = [
+      "COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME",
+      "node    1 user 23u IPv4 0 0t0 TCP 0.0.0.0:3000 (LISTEN)",
+    ].join("\n");
+    expect(_parseMacosLsofOutput(output)).toBe(3000);
+  });
+
+  test("returns null for empty output", () => {
+    expect(_parseMacosLsofOutput("")).toBeNull();
+  });
+
+  test("returns null for header-only output", () => {
+    expect(_parseMacosLsofOutput("COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME")).toBeNull();
+  });
+
+  test("handles ::1 IPv6 loopback", () => {
+    const output = [
+      "COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME",
+      "node 1 user 10u IPv6 0 0t0 TCP [::1]:4000 (LISTEN)",
+    ].join("\n");
+    // [::1]:4000 — lastIndexOf(':') points to the ':' before port
+    // After stripping brackets, host becomes "[::1]" which won't match our preferred list.
+    // The parser sees last colon, gets port 4000, host "[::1]" — falls to fallback candidates.
+    const port = _parseMacosLsofOutput(output);
+    expect(port).toBe(4000);
+  });
+
+  test("handles :: IPv6 wildcard", () => {
+    const output = [
+      "COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME",
+      "node 1 user 10u IPv6 0 0t0 TCP [::]:5000 (LISTEN)",
+    ].join("\n");
+    const port = _parseMacosLsofOutput(output);
+    expect(port).toBe(5000);
+  });
+
+  test("returns null when no valid port lines", () => {
+    expect(_parseMacosLsofOutput("COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\njunk line here")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Windows PowerShell parser
+// ---------------------------------------------------------------------------
+
+describe("_parseWindowsPowerShellOutput", () => {
+  test("returns null for empty string", () => {
+    expect(_parseWindowsPowerShellOutput("")).toBeNull();
+  });
+
+  test("returns null for literal null string", () => {
+    expect(_parseWindowsPowerShellOutput("null")).toBeNull();
+  });
+
+  test("returns null for whitespace-only string", () => {
+    expect(_parseWindowsPowerShellOutput("   ")).toBeNull();
+  });
+
+  test("parses single object {LocalPort: 12345}", () => {
+    expect(_parseWindowsPowerShellOutput('{"LocalPort":12345}')).toBe(12345);
+  });
+
+  test("parses array and returns first port", () => {
+    const json = '[{"LocalPort":8080},{"LocalPort":9090}]';
+    expect(_parseWindowsPowerShellOutput(json)).toBe(8080);
+  });
+
+  test("parses array with single element", () => {
+    expect(_parseWindowsPowerShellOutput('[{"LocalPort":3000}]')).toBe(3000);
+  });
+
+  test("returns null for invalid JSON", () => {
+    expect(_parseWindowsPowerShellOutput("not json")).toBeNull();
+  });
+
+  test("returns null for empty array", () => {
+    expect(_parseWindowsPowerShellOutput("[]")).toBeNull();
+  });
+
+  test("returns null for object without LocalPort", () => {
+    expect(_parseWindowsPowerShellOutput('{"OtherField":1234}')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Windows netstat parser
+// ---------------------------------------------------------------------------
+
+describe("_parseWindowsNetstatOutput", () => {
+  const sampleNetstat = [
+    "",
+    "Active Connections",
+    "",
+    "  Proto  Local Address          Foreign Address        State           PID",
+    "  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       884",
+    "  TCP    0.0.0.0:8080           0.0.0.0:0              LISTENING       1234",
+    "  TCP    0.0.0.0:9090           0.0.0.0:0              LISTENING       5678",
+    "  TCP    127.0.0.1:54321        127.0.0.1:12345        ESTABLISHED     1234",
+    "  UDP    0.0.0.0:3702           *:*                                    1234",
+  ].join("\n");
+
+  test("returns port 8080 for PID 1234", () => {
+    expect(_parseWindowsNetstatOutput(sampleNetstat, 1234)).toBe(8080);
+  });
+
+  test("returns port 9090 for PID 5678", () => {
+    expect(_parseWindowsNetstatOutput(sampleNetstat, 5678)).toBe(9090);
+  });
+
+  test("ignores ESTABLISHED connections", () => {
+    // PID 1234 has ESTABLISHED on 54321 too, but we should get the LISTENING one first
+    expect(_parseWindowsNetstatOutput(sampleNetstat, 1234)).toBe(8080);
+  });
+
+  test("returns null for unknown PID", () => {
+    expect(_parseWindowsNetstatOutput(sampleNetstat, 9999)).toBeNull();
+  });
+
+  test("returns null for empty output", () => {
+    expect(_parseWindowsNetstatOutput("", 1234)).toBeNull();
+  });
+
+  test("handles IPv6 addresses", () => {
+    const output = [
+      "  Proto  Local Address          Foreign Address        State           PID",
+      "  TCP6   [::]:8080              [::]:0                 LISTENING       4242",
+    ].join("\n");
+    expect(_parseWindowsNetstatOutput(output, 4242)).toBe(8080);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Polling loop (dependency-injection)
+// ---------------------------------------------------------------------------
+
+describe("getListeningPortForPid polling loop", () => {
+  test("returns port on first non-null read", async () => {
+    // We can't inject the resolver directly, but we can test via E2E with a
+    // very short timeout on the real process — testing the loop logic is
+    // validated through integration (see section 6). Here we test the contract:
+    // if the process is the current process and it has a listening socket,
+    // we get a port.
+    //
+    // For pure unit testing of the loop, we verify the timeout path.
+    const result = await getListeningPortForPid(-999999, {
+      timeoutMs: 50,
+      pollIntervalMs: 10,
+    });
+    // PID -999999 doesn't exist, so either process-alive check returns false
+    // or we timeout. Either way, null.
+    expect(result).toBeNull();
+  });
+
+  test("returns null on timeout for non-listening PID", async () => {
+    // Use a real but non-listening PID (our parent shell or similar)
+    // The process exists but has no listening TCP socket.
+    // With a very short timeout we should get null quickly.
+    const result = await getListeningPortForPid(process.ppid ?? 1, {
+      timeoutMs: 200,
+      pollIntervalMs: 50,
+    });
+    // Either it times out (null) or parent happens to listen (number).
+    // We can't assert exact value but we can assert type.
+    expect(result === null || typeof result === "number").toBe(true);
+  });
+
+  test("returns null immediately for dead PID", async () => {
+    // Use a very large PID unlikely to exist
+    const start = Date.now();
+    const result = await getListeningPortForPid(2_000_000_000, {
+      timeoutMs: 5_000,
+      pollIntervalMs: 100,
+    });
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    // Should exit well before the 5s timeout once it detects the process is dead
+    // (On Linux, /proc/2_000_000_000 won't exist; on macOS/Windows, kill(0) throws)
+    expect(elapsed).toBeLessThan(4_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. End-to-end (Linux/macOS only)
+// ---------------------------------------------------------------------------
+
+const isLinuxOrMac = process.platform === "linux" || process.platform === "darwin";
+
+describe("getListeningPortForPid end-to-end", () => {
+  let server: net.Server;
+  let serverPort: number;
+
+  beforeAll(async () => {
+    if (!isLinuxOrMac) return;
+    server = net.createServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address();
+    serverPort = typeof addr === "object" && addr !== null ? addr.port : 0;
+  });
+
+  afterAll(async () => {
+    if (!isLinuxOrMac) return;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test(
+    "discovers own listening port via getListeningPortForPid",
+    async () => {
+      if (!isLinuxOrMac) {
+        return; // Skip on Windows
+      }
+      expect(serverPort).toBeGreaterThan(0);
+
+      const discovered = await getListeningPortForPid(process.pid, {
+        timeoutMs: 5_000,
+        pollIntervalMs: 100,
+      });
+
+      // The discovered port should match what the server is listening on.
+      // Note: process may have multiple listening sockets (e.g., Bun test runner).
+      // We verify that discovered is a valid port number.
+      expect(discovered).not.toBeNull();
+      expect(typeof discovered).toBe("number");
+      expect(discovered!).toBeGreaterThan(0);
+    },
+    10_000,
+  );
+
+  test(
+    "PORT_DISCOVERY_TIMEOUT_MS is 15000",
+    () => {
+      expect(PORT_DISCOVERY_TIMEOUT_MS).toBe(15_000);
+    },
+  );
+});

--- a/src/sdk/runtime/port-discovery.ts
+++ b/src/sdk/runtime/port-discovery.ts
@@ -28,6 +28,30 @@ export interface GetListeningPortOptions {
   pollIntervalMs?: number;
 }
 
+type PortDiscoverySpawnOptions = {
+  cmd: string[];
+  stdout: "pipe";
+  stderr: "pipe";
+};
+
+type PortDiscoverySpawnResult = {
+  stdout: { toString(): string };
+  stderr: { toString(): string };
+  success: boolean;
+};
+
+type PortDiscoverySpawnSync = (options: PortDiscoverySpawnOptions) => PortDiscoverySpawnResult;
+
+let spawnSync: PortDiscoverySpawnSync = (options) => Bun.spawnSync(options);
+
+export function _setPortDiscoverySpawnSyncForTest(nextSpawnSync: PortDiscoverySpawnSync): () => void {
+  const previous = spawnSync;
+  spawnSync = nextSpawnSync;
+  return () => {
+    spawnSync = previous;
+  };
+}
+
 /**
  * Discover the TCP port that a given process is listening on.
  *
@@ -44,9 +68,9 @@ export async function getListeningPortForPid(
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    const port = readListeningPortForPid(pid);
+    const port = _readListeningPortForPid(pid);
     if (port !== null) return port;
-    if (!isProcessAlive(pid)) return null;
+    if (!_isProcessAlive(pid)) return null;
     await Bun.sleep(pollIntervalMs);
   }
   return null;
@@ -56,18 +80,18 @@ export async function getListeningPortForPid(
 // Platform dispatch
 // ---------------------------------------------------------------------------
 
-function readListeningPortForPid(pid: number): number | null {
+export function _readListeningPortForPid(pid: number): number | null {
   const platform = process.platform;
   if (platform === "linux") {
     return linuxReadListeningPort(pid, 0);
   } else if (platform === "darwin") {
-    return macosReadListeningPort(pid, 0);
+    return _macosReadListeningPort(pid, 0);
   } else {
-    return windowsReadListeningPort(pid, 0);
+    return _windowsReadListeningPort(pid, 0);
   }
 }
 
-function isProcessAlive(pid: number): boolean {
+export function _isProcessAlive(pid: number): boolean {
   if (process.platform === "linux") {
     return existsSync(`/proc/${pid}`);
   }
@@ -167,7 +191,7 @@ function readProcFile(path: string): string {
   }
 }
 
-function linuxGetListeningPort(
+export function _linuxGetListeningPort(
   tcpContent: string,
   tcp6Content: string,
   socketInodes: Set<number>,
@@ -191,11 +215,11 @@ function linuxReadListeningPort(pid: number, depth: number): number | null {
   const tcp6Content = readProcFile(`/proc/${pid}/net/tcp6`);
   const socketInodes = _getLinuxPidSocketInodes(pid);
 
-  const port = linuxGetListeningPort(tcpContent, tcp6Content, socketInodes);
+  const port = _linuxGetListeningPort(tcpContent, tcp6Content, socketInodes);
   if (port !== null) return port;
 
   // Walk children if no listening port found
-  const children = linuxGetChildren(pid);
+  const children = _linuxGetChildren(pid);
   for (const childPid of children) {
     const childPort = linuxReadListeningPort(childPid, depth + 1);
     if (childPort !== null) return childPort;
@@ -203,7 +227,7 @@ function linuxReadListeningPort(pid: number, depth: number): number | null {
   return null;
 }
 
-function linuxGetChildren(pid: number): number[] {
+export function _linuxGetChildren(pid: number): number[] {
   // /proc/<pid>/task/<pid>/children lists direct child PIDs (space-separated)
   const content = readProcFile(`/proc/${pid}/task/${pid}/children`).trim();
   if (!content) return [];
@@ -267,10 +291,10 @@ export function _parseMacosLsofOutput(output: string): number | null {
   return fallbackCandidates.length > 0 ? (fallbackCandidates[0] ?? null) : null;
 }
 
-function macosReadListeningPort(pid: number, depth: number): number | null {
+export function _macosReadListeningPort(pid: number, depth: number): number | null {
   if (depth > MACOS_MAX_CHILD_DEPTH) return null;
 
-  const result = Bun.spawnSync({
+  const result = spawnSync({
     cmd: ["lsof", "-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
     stdout: "pipe",
     stderr: "pipe",
@@ -281,16 +305,16 @@ function macosReadListeningPort(pid: number, depth: number): number | null {
   if (port !== null) return port;
 
   // Walk children via pgrep
-  const children = macosGetChildren(pid);
+  const children = _macosGetChildren(pid);
   for (const childPid of children) {
-    const childPort = macosReadListeningPort(childPid, depth + 1);
+    const childPort = _macosReadListeningPort(childPid, depth + 1);
     if (childPort !== null) return childPort;
   }
   return null;
 }
 
-function macosGetChildren(pid: number): number[] {
-  const result = Bun.spawnSync({
+export function _macosGetChildren(pid: number): number[] {
+  const result = spawnSync({
     cmd: ["pgrep", "-P", String(pid)],
     stdout: "pipe",
     stderr: "pipe",
@@ -371,10 +395,10 @@ export function _parseWindowsNetstatOutput(output: string, pid: number): number 
   return null;
 }
 
-function windowsReadListeningPort(pid: number, depth: number): number | null {
+export function _windowsReadListeningPort(pid: number, depth: number): number | null {
   if (depth > WINDOWS_MAX_CHILD_DEPTH) return null;
 
-  const psResult = Bun.spawnSync({
+  const psResult = spawnSync({
     cmd: [
       "powershell",
       "-NoProfile",
@@ -396,7 +420,7 @@ function windowsReadListeningPort(pid: number, depth: number): number | null {
     if (port !== null) return port;
   } else {
     // Fallback: netstat -ano | findstr <pid>
-    const nsResult = Bun.spawnSync({
+    const nsResult = spawnSync({
       cmd: ["cmd", "/c", `netstat -ano | findstr ${pid}`],
       stdout: "pipe",
       stderr: "pipe",
@@ -406,16 +430,16 @@ function windowsReadListeningPort(pid: number, depth: number): number | null {
   }
 
   // Walk children
-  const children = windowsGetChildren(pid);
+  const children = _windowsGetChildren(pid);
   for (const childPid of children) {
-    const childPort = windowsReadListeningPort(childPid, depth + 1);
+    const childPort = _windowsReadListeningPort(childPid, depth + 1);
     if (childPort !== null) return childPort;
   }
   return null;
 }
 
-function windowsGetChildren(pid: number): number[] {
-  const psResult = Bun.spawnSync({
+export function _windowsGetChildren(pid: number): number[] {
+  const psResult = spawnSync({
     cmd: [
       "powershell",
       "-NoProfile",
@@ -458,7 +482,7 @@ function windowsGetChildren(pid: number): number[] {
   }
 
   // Fallback: wmic
-  const wmicResult = Bun.spawnSync({
+  const wmicResult = spawnSync({
     cmd: ["wmic", "process", "where", `(ParentProcessId=${pid})`, "get", "ProcessId"],
     stdout: "pipe",
     stderr: "pipe",

--- a/src/sdk/runtime/port-discovery.ts
+++ b/src/sdk/runtime/port-discovery.ts
@@ -1,0 +1,472 @@
+/**
+ * Cross-platform TCP port discovery for child processes.
+ *
+ * Polls the kernel's per-process socket table until a listening TCP port
+ * is found for the given PID, or until the timeout elapses.
+ *
+ * Platform implementations:
+ *   - Linux: /proc/<pid>/net/tcp + /proc/<pid>/fd/* (no external binary)
+ *   - macOS: lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>
+ *   - Windows: Get-NetTCPConnection PowerShell; falls back to netstat -ano
+ */
+
+import {
+  existsSync,
+  readdirSync,
+  readlinkSync,
+  readFileSync,
+} from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const PORT_DISCOVERY_TIMEOUT_MS = 15_000;
+
+export interface GetListeningPortOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Discover the TCP port that a given process is listening on.
+ *
+ * Polls the kernel's per-process socket table at ~500ms intervals until
+ * a listening port is found or the timeout elapses. Returns null on
+ * timeout (caller is responsible for throwing if that's an error).
+ */
+export async function getListeningPortForPid(
+  pid: number,
+  options?: GetListeningPortOptions,
+): Promise<number | null> {
+  const timeoutMs = options?.timeoutMs ?? PORT_DISCOVERY_TIMEOUT_MS;
+  const pollIntervalMs = options?.pollIntervalMs ?? 500;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const port = readListeningPortForPid(pid);
+    if (port !== null) return port;
+    if (!isProcessAlive(pid)) return null;
+    await Bun.sleep(pollIntervalMs);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Platform dispatch
+// ---------------------------------------------------------------------------
+
+function readListeningPortForPid(pid: number): number | null {
+  const platform = process.platform;
+  if (platform === "linux") {
+    return linuxReadListeningPort(pid, 0);
+  } else if (platform === "darwin") {
+    return macosReadListeningPort(pid, 0);
+  } else {
+    return windowsReadListeningPort(pid, 0);
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (process.platform === "linux") {
+    return existsSync(`/proc/${pid}`);
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Linux implementation
+// ---------------------------------------------------------------------------
+
+const LINUX_MAX_CHILD_DEPTH = 3;
+
+/**
+ * Parse a single /proc/net/tcp or /proc/net/tcp6 line.
+ * Returns {inode, port} for LISTEN sockets (state 0A), or null otherwise.
+ */
+export function _parseLinuxTcpLine(line: string): { inode: number; port: number } | null {
+  // Format: sl  local_address  rem_address  st  tx:rx  tr:when  retrans  uid  timeout  inode
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("sl")) return null;
+
+  const cols = trimmed.split(/\s+/);
+  if (cols.length < 10) return null;
+
+  const localAddr: string = cols[1] ?? "";
+  const stateHex: string = cols[3] ?? "";
+  const inodeStr: string = cols[9] ?? "";
+
+  // Only LISTEN state (0x0A)
+  if (stateHex.toUpperCase() !== "0A") return null;
+  if (!localAddr) return null;
+
+  const colonIdx = localAddr.indexOf(":");
+  if (colonIdx === -1) return null;
+
+  // Port is big-endian hex after the colon
+  const portHex = localAddr.slice(colonIdx + 1);
+  const port = parseInt(portHex, 16);
+  if (isNaN(port) || port <= 0) return null;
+
+  const inode = parseInt(inodeStr, 10);
+  if (isNaN(inode)) return null;
+
+  return { inode, port };
+}
+
+/** Parse /proc/net/tcp or /proc/net/tcp6 content. Returns map of inode -> port for LISTEN sockets. */
+export function _parseLinuxTcpTable(content: string): Map<number, number> {
+  const result = new Map<number, number>();
+  for (const line of content.split("\n")) {
+    const entry = _parseLinuxTcpLine(line);
+    if (entry !== null) {
+      result.set(entry.inode, entry.port);
+    }
+  }
+  return result;
+}
+
+/** Get socket inodes owned by a PID via /proc/<pid>/fd/* symlinks. */
+export function _getLinuxPidSocketInodes(pid: number): Set<number> {
+  const inodes = new Set<number>();
+  const fdDir = `/proc/${pid}/fd`;
+  if (!existsSync(fdDir)) return inodes;
+
+  let fds: string[];
+  try {
+    fds = readdirSync(fdDir);
+  } catch {
+    return inodes;
+  }
+
+  for (const fd of fds) {
+    try {
+      const target = readlinkSync(`${fdDir}/${fd}`);
+      // Socket symlinks look like: socket:[<inode>]
+      const match = target.match(/^socket:\[(\d+)\]$/);
+      if (match && match[1]) {
+        inodes.add(parseInt(match[1], 10));
+      }
+    } catch {
+      // Permission denied or fd disappeared — skip
+    }
+  }
+  return inodes;
+}
+
+function readProcFile(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function linuxGetListeningPort(
+  tcpContent: string,
+  tcp6Content: string,
+  socketInodes: Set<number>,
+): number | null {
+  const table4 = _parseLinuxTcpTable(tcpContent);
+  const table6 = _parseLinuxTcpTable(tcp6Content);
+
+  for (const inode of socketInodes) {
+    const port4 = table4.get(inode);
+    if (port4 !== undefined) return port4;
+    const port6 = table6.get(inode);
+    if (port6 !== undefined) return port6;
+  }
+  return null;
+}
+
+function linuxReadListeningPort(pid: number, depth: number): number | null {
+  if (depth > LINUX_MAX_CHILD_DEPTH) return null;
+
+  const tcpContent = readProcFile(`/proc/${pid}/net/tcp`);
+  const tcp6Content = readProcFile(`/proc/${pid}/net/tcp6`);
+  const socketInodes = _getLinuxPidSocketInodes(pid);
+
+  const port = linuxGetListeningPort(tcpContent, tcp6Content, socketInodes);
+  if (port !== null) return port;
+
+  // Walk children if no listening port found
+  const children = linuxGetChildren(pid);
+  for (const childPid of children) {
+    const childPort = linuxReadListeningPort(childPid, depth + 1);
+    if (childPort !== null) return childPort;
+  }
+  return null;
+}
+
+function linuxGetChildren(pid: number): number[] {
+  // /proc/<pid>/task/<pid>/children lists direct child PIDs (space-separated)
+  const content = readProcFile(`/proc/${pid}/task/${pid}/children`).trim();
+  if (!content) return [];
+  return content
+    .split(/\s+/)
+    .map((s) => parseInt(s, 10))
+    .filter((n) => !isNaN(n) && n > 0);
+}
+
+// ---------------------------------------------------------------------------
+// macOS implementation
+// ---------------------------------------------------------------------------
+
+const MACOS_MAX_CHILD_DEPTH = 3;
+
+/**
+ * Parse lsof tabular output.
+ * Returns the first listening port, preferring loopback/any addresses.
+ */
+export function _parseMacosLsofOutput(output: string): number | null {
+  const lines = output.split("\n");
+  const fallbackCandidates: number[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("COMMAND")) continue;
+
+    const cols = trimmed.split(/\s+/);
+    // lsof NAME column: "host:port (LISTEN)" — may appear as two separate tokens
+    // when split by whitespace. Find the token that looks like "host:port".
+    // Strategy: reconstruct the trailing portion after NODE column (index 8),
+    // then strip "(LISTEN)".
+    // Simpler: join the last 1-2 cols and strip the LISTEN annotation.
+    const rawName = cols.slice(8).join(" ").replace(/\s*\(LISTEN\)\s*$/, "");
+    // rawName is now "NODE host:port" — take the last token which is "host:port"
+    const nameParts = rawName.trim().split(/\s+/);
+    const name: string = nameParts[nameParts.length - 1] ?? "";
+    if (!name) continue;
+    const nameWithoutListen = name;
+    const lastColon = nameWithoutListen.lastIndexOf(":");
+    if (lastColon === -1) continue;
+
+    const portStr = nameWithoutListen.slice(lastColon + 1);
+    const port = parseInt(portStr, 10);
+    if (isNaN(port) || port <= 0) continue;
+
+    const host = nameWithoutListen.slice(0, lastColon);
+    // Prefer loopback / wildcard
+    if (
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "*" ||
+      host === "0.0.0.0" ||
+      host === "::"
+    ) {
+      return port;
+    }
+    fallbackCandidates.push(port);
+  }
+
+  return fallbackCandidates.length > 0 ? (fallbackCandidates[0] ?? null) : null;
+}
+
+function macosReadListeningPort(pid: number, depth: number): number | null {
+  if (depth > MACOS_MAX_CHILD_DEPTH) return null;
+
+  const result = Bun.spawnSync({
+    cmd: ["lsof", "-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const output = result.stdout.toString();
+  const port = _parseMacosLsofOutput(output);
+  if (port !== null) return port;
+
+  // Walk children via pgrep
+  const children = macosGetChildren(pid);
+  for (const childPid of children) {
+    const childPort = macosReadListeningPort(childPid, depth + 1);
+    if (childPort !== null) return childPort;
+  }
+  return null;
+}
+
+function macosGetChildren(pid: number): number[] {
+  const result = Bun.spawnSync({
+    cmd: ["pgrep", "-P", String(pid)],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = result.stdout.toString().trim();
+  if (!output) return [];
+  return output
+    .split("\n")
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !isNaN(n) && n > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Windows implementation
+// ---------------------------------------------------------------------------
+
+const WINDOWS_MAX_CHILD_DEPTH = 3;
+
+/** Parse PowerShell Get-NetTCPConnection JSON output. */
+export function _parseWindowsPowerShellOutput(json: string): number | null {
+  const trimmed = json.trim();
+  if (!trimmed || trimmed === "null") return null;
+
+  type PortObject = { LocalPort: unknown };
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed === null || parsed === undefined) return null;
+
+    if (Array.isArray(parsed)) {
+      for (const item of parsed as unknown[]) {
+        if (item !== null && typeof item === "object" && "LocalPort" in (item as object)) {
+          const port = Number((item as PortObject).LocalPort);
+          if (!isNaN(port) && port > 0) return port;
+        }
+      }
+      return null;
+    }
+
+    if (typeof parsed === "object" && parsed !== null && "LocalPort" in parsed) {
+      const port = Number((parsed as PortObject).LocalPort);
+      return !isNaN(port) && port > 0 ? port : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse netstat -ano tabular output for a given PID. */
+export function _parseWindowsNetstatOutput(output: string, pid: number): number | null {
+  // Columns: Proto  LocalAddress  ForeignAddress  State  PID
+  // e.g.:    TCP    0.0.0.0:8080  0.0.0.0:0       LISTENING  1234
+  const pidStr = String(pid);
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const cols = trimmed.split(/\s+/);
+    if (cols.length < 5) continue;
+
+    const proto: string = (cols[0] ?? "").toUpperCase();
+    const localAddr: string = cols[1] ?? "";
+    const state: string = (cols[3] ?? "").toUpperCase();
+    const linePid: string = cols[4] ?? "";
+
+    if (proto !== "TCP" && proto !== "TCP6") continue;
+    if (state !== "LISTENING") continue;
+    if (linePid !== pidStr) continue;
+
+    const lastColon = localAddr.lastIndexOf(":");
+    if (lastColon === -1) continue;
+
+    const port = parseInt(localAddr.slice(lastColon + 1), 10);
+    if (!isNaN(port) && port > 0) return port;
+  }
+  return null;
+}
+
+function windowsReadListeningPort(pid: number, depth: number): number | null {
+  if (depth > WINDOWS_MAX_CHILD_DEPTH) return null;
+
+  const psResult = Bun.spawnSync({
+    cmd: [
+      "powershell",
+      "-NoProfile",
+      "-Command",
+      `Get-NetTCPConnection -OwningProcess ${pid} -State Listen -ErrorAction SilentlyContinue | Select-Object LocalPort | ConvertTo-Json`,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stderr = psResult.stderr.toString();
+  const useFallback =
+    !psResult.success ||
+    stderr.includes("is not recognized") ||
+    stderr.includes("CommandNotFoundException");
+
+  if (!useFallback) {
+    const port = _parseWindowsPowerShellOutput(psResult.stdout.toString());
+    if (port !== null) return port;
+  } else {
+    // Fallback: netstat -ano | findstr <pid>
+    const nsResult = Bun.spawnSync({
+      cmd: ["cmd", "/c", `netstat -ano | findstr ${pid}`],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const port = _parseWindowsNetstatOutput(nsResult.stdout.toString(), pid);
+    if (port !== null) return port;
+  }
+
+  // Walk children
+  const children = windowsGetChildren(pid);
+  for (const childPid of children) {
+    const childPort = windowsReadListeningPort(childPid, depth + 1);
+    if (childPort !== null) return childPort;
+  }
+  return null;
+}
+
+function windowsGetChildren(pid: number): number[] {
+  const psResult = Bun.spawnSync({
+    cmd: [
+      "powershell",
+      "-NoProfile",
+      "-Command",
+      `Get-CimInstance Win32_Process -Filter "ParentProcessId=${pid}" | Select-Object ProcessId | ConvertTo-Json`,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stderr = psResult.stderr.toString();
+  const useFallback =
+    !psResult.success ||
+    stderr.includes("is not recognized") ||
+    stderr.includes("CommandNotFoundException");
+
+  if (!useFallback) {
+    const output = psResult.stdout.toString().trim();
+    if (!output || output === "null") return [];
+    try {
+      const parsed: unknown = JSON.parse(output);
+      type PidObject = { ProcessId: unknown };
+      if (Array.isArray(parsed)) {
+        return (parsed as unknown[])
+          .filter(
+            (item): item is PidObject =>
+              item !== null && typeof item === "object" && "ProcessId" in (item as object),
+          )
+          .map((item) => Number(item.ProcessId))
+          .filter((n) => !isNaN(n) && n > 0);
+      }
+      if (typeof parsed === "object" && parsed !== null && "ProcessId" in parsed) {
+        const id = Number((parsed as PidObject).ProcessId);
+        return !isNaN(id) && id > 0 ? [id] : [];
+      }
+    } catch {
+      // ignore
+    }
+    return [];
+  }
+
+  // Fallback: wmic
+  const wmicResult = Bun.spawnSync({
+    cmd: ["wmic", "process", "where", `(ParentProcessId=${pid})`, "get", "ProcessId"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return wmicResult
+    .stdout.toString()
+    .split("\n")
+    .slice(1) // skip header
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !isNaN(n) && n > 0);
+}

--- a/src/sdk/runtime/tmux.ts
+++ b/src/sdk/runtime/tmux.ts
@@ -472,6 +472,22 @@ export function parseSessionEnvValue(stdout: string, key: string): string | null
 }
 
 /**
+ * Get the PID of the foreground process in a tmux pane.
+ * Returns null if the pane no longer exists or the query fails.
+ *
+ * Note: this is the pane's "current" process — typically the agent
+ * itself when the pane was created with the agent as the initial command.
+ * If tmux exec'd a wrapper shell that then exec'd the agent, the PID
+ * will refer to the same process (exec replaces in-place).
+ */
+export function getPanePid(paneId: string): number | null {
+  const result = tmuxRun(["display-message", "-t", paneId, "-p", "#{pane_pid}"]);
+  if (!result.ok) return null;
+  const pid = Number(result.stdout.trim());
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+/**
  * Read a session-level environment variable.
  * Returns `null` when the session doesn't exist or the variable isn't set.
  */

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -50,6 +50,7 @@ type SessionOptionsMap = {
     parentID?: string;
     title?: string;
     workspaceID?: string;
+    permission?: import("@opencode-ai/sdk/v2").PermissionRuleset;
   };
   copilot: Partial<CopilotSessionConfig>;
   claude: Record<string, never>;

--- a/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
+++ b/src/sdk/workflows/builtin/deep-research-codebase/opencode/index.ts
@@ -129,7 +129,10 @@ export default defineWorkflow({
             "Map codebase, count LOC, partition for parallel specialists",
         },
         {},
-        { title: "codebase-scout" },
+        {
+          title: "codebase-scout",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const data = scoutCodebase(root);
           if (data.units.length === 0) {
@@ -193,7 +196,10 @@ export default defineWorkflow({
             description: "Locate prior research docs (codebase-research-locator)",
           },
           {},
-          { title: "history-locator" },
+          {
+            title: "history-locator",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -219,7 +225,10 @@ export default defineWorkflow({
             description: "Synthesize prior research (codebase-research-analyzer)",
           },
           {},
-          { title: "history-analyzer" },
+          {
+            title: "history-analyzer",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -300,7 +309,10 @@ export default defineWorkflow({
             description: `Layer 1 dispatch (${batch.length} tasks)`,
           },
           {},
-          { title: `wave1-batch-${batchNumber}` },
+          {
+            title: `wave1-batch-${batchNumber}`,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const taskSpecs = batch.map((t) => {
               const builder =
@@ -387,7 +399,10 @@ export default defineWorkflow({
             description: `Layer 2 dispatch (${batch.length} tasks)`,
           },
           {},
-          { title: `wave2-batch-${batchNumber}` },
+          {
+            title: `wave2-batch-${batchNumber}`,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const taskSpecs = batch.map((t) => {
               const specialistPrompt =
@@ -485,7 +500,10 @@ export default defineWorkflow({
           "Synthesize partition findings + history into final research doc",
       },
       {},
-      { title: "aggregator" },
+      {
+        title: "aggregator",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,

--- a/src/sdk/workflows/builtin/open-claude-design/opencode/index.ts
+++ b/src/sdk/workflows/builtin/open-claude-design/opencode/index.ts
@@ -151,7 +151,10 @@ export default defineWorkflow({
             description: "Locate design files and tokens",
           },
           {},
-          { title: "ds-locator" },
+          {
+            title: "ds-locator",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -171,7 +174,10 @@ export default defineWorkflow({
             description: "Analyze design tokens and patterns",
           },
           {},
-          { title: "ds-analyzer" },
+          {
+            title: "ds-analyzer",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -191,7 +197,10 @@ export default defineWorkflow({
             description: "Find existing design patterns",
           },
           {},
-          { title: "ds-patterns" },
+          {
+            title: "ds-patterns",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -214,7 +223,10 @@ export default defineWorkflow({
           description: "Build design system with user approval (HIL)",
         },
         {},
-        { title: "design-system-builder" },
+        {
+          title: "design-system-builder",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -253,7 +265,10 @@ export default defineWorkflow({
               description: "Capture web reference via playwright",
             },
             {},
-            { title: "web-capture" },
+            {
+              title: "web-capture",
+              permission: [{ permission: "*", pattern: "*", action: "allow" }],
+            },
             async (s) => {
               const result = await s.client.session.prompt({
                 sessionID: s.session.id,
@@ -283,7 +298,10 @@ export default defineWorkflow({
               description: "Parse reference document",
             },
             {},
-            { title: "file-parser" },
+            {
+              title: "file-parser",
+              permission: [{ permission: "*", pattern: "*", action: "allow" }],
+            },
             async (s) => {
               const result = await s.client.session.prompt({
                 sessionID: s.session.id,
@@ -317,7 +335,10 @@ export default defineWorkflow({
     await ctx.stage(
       { name: "generator", description: "Generate first design version" },
       {},
-      { title: "generator" },
+      {
+        title: "generator",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,
@@ -351,7 +372,10 @@ export default defineWorkflow({
           description: `Collect refinement feedback (iteration ${iteration})`,
         },
         {},
-        { title: `user-feedback-${iteration}` },
+        {
+          title: `user-feedback-${iteration}`,
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -384,7 +408,10 @@ export default defineWorkflow({
             description: `Design critique (iteration ${iteration})`,
           },
           {},
-          { title: `critique-${iteration}` },
+          {
+            title: `critique-${iteration}`,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -411,7 +438,10 @@ export default defineWorkflow({
             description: `Visual validation (iteration ${iteration})`,
           },
           {},
-          { title: `screenshot-${iteration}` },
+          {
+            title: `screenshot-${iteration}`,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -450,7 +480,10 @@ export default defineWorkflow({
           description: `Apply refinements (iteration ${iteration})`,
         },
         {},
-        { title: `apply-changes-${iteration}` },
+        {
+          title: `apply-changes-${iteration}`,
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -495,7 +528,10 @@ export default defineWorkflow({
           description: "Remove banned anti-patterns before export",
         },
         {},
-        { title: "forced-fix" },
+        {
+          title: "forced-fix",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -539,7 +575,10 @@ export default defineWorkflow({
         description: "Export design and create handoff bundle",
       },
       {},
-      { title: "exporter" },
+      {
+        title: "exporter",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
       async (s) => {
         const result = await s.client.session.prompt({
           sessionID: s.session.id,

--- a/src/sdk/workflows/builtin/ralph/opencode/index.ts
+++ b/src/sdk/workflows/builtin/ralph/opencode/index.ts
@@ -99,7 +99,10 @@ export default defineWorkflow({
       const planner = await ctx.stage(
         { name: `planner-${iteration}` },
         {},
-        { title: `planner-${iteration}` },
+        {
+          title: `planner-${iteration}`,
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -123,7 +126,10 @@ export default defineWorkflow({
       await ctx.stage(
         { name: `orchestrator-${iteration}` },
         {},
-        { title: `orchestrator-${iteration}` },
+        {
+          title: `orchestrator-${iteration}`,
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -145,7 +151,10 @@ export default defineWorkflow({
       await ctx.stage(
         { name: `code-simplifier-${iteration}` },
         {},
-        { title: `code-simplifier-${iteration}` },
+        {
+          title: `code-simplifier-${iteration}`,
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        },
         async (s) => {
           const result = await s.client.session.prompt({
             sessionID: s.session.id,
@@ -171,7 +180,10 @@ export default defineWorkflow({
         ctx.stage(
           { name: `infra-locate-${iteration}`, headless: true },
           {},
-          { title: `infra-locate-${iteration}` },
+          {
+            title: `infra-locate-${iteration}`,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -185,7 +197,10 @@ export default defineWorkflow({
         ctx.stage(
           { name: `infra-analyze-${iteration}`, headless: true },
           {},
-          { title: `infra-analyze-${iteration}` },
+          {
+            title: `infra-analyze-${iteration}`,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -199,7 +214,10 @@ export default defineWorkflow({
         ctx.stage(
           { name: `infra-patterns-${iteration}`, headless: true },
           {},
-          { title: `infra-patterns-${iteration}` },
+          {
+            title: `infra-patterns-${iteration}`,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,
@@ -229,7 +247,10 @@ export default defineWorkflow({
         ctx.stage(
           { name },
           {},
-          { title: name },
+          {
+            title: name,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          },
           async (s) => {
             const result = await s.client.session.prompt({
               sessionID: s.session.id,

--- a/tests/sdk/runtime/tmux.test.ts
+++ b/tests/sdk/runtime/tmux.test.ts
@@ -38,6 +38,7 @@ import {
   parseSessionName,
   parseSessionEnvValue,
   sendViaPasteBuffer,
+  getPanePid,
 } from "../../../src/sdk/runtime/tmux.ts";
 
 // ---------------------------------------------------------------------------
@@ -1086,6 +1087,56 @@ describe.if(tmuxAvailable)("listSessions", () => {
     const sessions = listSessions();
     const found = sessions.find((s) => s.name === LIST_SESSION);
     expect(found).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPanePid
+// ---------------------------------------------------------------------------
+
+describe("getPanePid — no binary", () => {
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    resetMuxBinaryCache();
+    originalPath = process.env.PATH;
+    process.env.PATH = "/nonexistent-empty-dir";
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    resetMuxBinaryCache();
+  });
+
+  test.serial("returns null when no mux binary found", () => {
+    expect(getPanePid("%0")).toBeNull();
+  });
+});
+
+describe.if(tmuxAvailable)("getPanePid integration", () => {
+  const PID_SESSION = `atomic-pid-${crypto.randomUUID().slice(0, 8)}`;
+  let paneId: string;
+
+  beforeAll(async () => {
+    paneId = createSession(PID_SESSION, "sleep 60", "pid-test");
+    await Bun.sleep(300);
+  });
+
+  afterAll(() => {
+    killSession(PID_SESSION);
+  });
+
+  test("returns a positive integer PID for a live pane", () => {
+    const pid = getPanePid(paneId);
+    expect(pid).not.toBeNull();
+    expect(typeof pid).toBe("number");
+    expect(pid! > 0).toBe(true);
+    expect(Number.isFinite(pid!)).toBe(true);
+    expect(Number.isInteger(pid!)).toBe(true);
+  });
+
+  test("returns null for a non-existent pane ID", () => {
+    expect(getPanePid("%99999")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a TOCTOU race condition where workflow stages (OpenCode, Copilot) would fail to bind their pre-allocated ports, causing cascading server startup failures when multiple stages ran concurrently or shortly after each other.

## Key Changes

- **New `port-discovery` module** (`src/sdk/runtime/port-discovery.ts`): cross-platform `getListeningPortForPid()` that polls the kernel's per-process socket table until the child process binds a TCP port.
  - Linux: reads `/proc/<pid>/net/tcp` directly (no external binary)
  - macOS: uses `lsof -nP -iTCP -sTCP:LISTEN`
  - Windows: uses `Get-NetTCPConnection` (PowerShell) with `netstat -ano` fallback
  - Walks child processes to handle wrapper-shell cases where the direct PID is a shell, not the server

- **`executor.ts` — remove `getRandomPort()` race condition**: stages now start with port `0` (OS-assigned) instead of a pre-allocated random port. The actual bound port is discovered from the tmux pane PID via the new module. Startup probe failures are now surfaced instead of silently producing a broken server URL.

- **`resolveCliBinary()` helper**: resolves CLI binary paths at spawn time using the parent process's `PATH`, preventing PATH stripping issues in tmux child shells.

- **Examples & docs updated**: OpenCode permission posture is now explicit in all example workflows and `workflow-creator` skill docs, making autonomous defaults visible and overridable.

- **Test coverage**: 40+ unit tests for port-discovery (including an end-to-end test against a real server socket), expanded executor tests, and new tmux helper tests.

## Root Cause

The previous `getRandomPort()` approach bound an ephemeral port to discover a free port, then immediately released it before passing the number to the agent CLI. Between release and agent bind, another process (or a concurrent workflow stage) could claim that port — a classic TOCTOU race. The fix eliminates the pre-allocation entirely.