### PR TITLE
chore(release): bump version to v0.6.6-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.5",
+  "version": "0.6.6-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.6.5` to `0.6.6-0` as a prerelease ahead of the `v0.6.6` stable release.

## Changes Since v0.6.5

- **feat(runtime):** Add cross-platform TCP port discovery module
- **fix(runtime):** Prevent workflow port conflicts
- **fix(runtime):** Follow child processes during port discovery
- **feat(workflows/ralph):** Add code-simplifier stage and expand CI audit in infra discovery
- **chore(skills):** Consolidate design skills into `impeccable` and refresh skill metadata

## Notes

- This is a prerelease (`-0` suffix) and will not be published as a stable release.
- No breaking changes or migration steps required.