### PR TITLE
chore(release): bump version to v0.6.6-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.6-0",
+  "version": "0.6.6-1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Bumps the prerelease version from `0.6.6-0` to `0.6.6-1` to publish the agent dependency updates landed in #779.

## Key changes

- `package.json`: version `0.6.6-0` → `0.6.6-1`

## Dependency updates included (from #779)

| Package | From | To |
|---|---|---|
| `@anthropic-ai/claude-agent-sdk` | `^0.2.119` | `^0.2.126` |
| `@opencode-ai/sdk` | `^1.14.24` | `^1.14.31` |
| `@opentui/react` | `0.1.105` | `^0.2.1` |
| `@clack/prompts` | `^1.2.0` | `^1.3.0` |
| `zod` | `^4.3.6` | `^4.4.1` |
| `oxlint` (dev) | `^1.61.0` | `^1.62.0` |
| `@j178/prek` (dev) | `^0.3.10` | `^0.3.11` |

No breaking changes. No migration steps required.