### PR TITLE
fix(ci,test): propagate bun test failures and fix parallel test isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
               run: bun run lint
 
             - name: Run tests with coverage
-              run: bun run test:coverage 2>&1 | cat
+              run: |
+                  set -o pipefail
+                  bun run test:coverage 2>&1 | cat
 
             - name: Validate SDK build
               run: bun run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,9 @@ jobs:
         run: bun run typecheck
 
       - name: Run tests
-        run: bun test 2>&1 | cat
+        run: |
+          set -o pipefail
+          bun test 2>&1 | cat
 
       - name: Determine npm publish tag
         id: npm-tag

--- a/src/commands/cli/chat/index.ts
+++ b/src/commands/cli/chat/index.ts
@@ -49,7 +49,10 @@ import {
   buildTmuxEnv,
 } from "../../../lib/terminal-env.ts";
 import { atomicTempEnv } from "../../../lib/atomic-temp.ts";
-import { resolveCopilotCliPath } from "../../../sdk/providers/copilot.ts";
+import {
+  type CommandPathResolver,
+  resolveCopilotCliPath,
+} from "../../../sdk/providers/copilot.ts";
 
 export {
   buildLauncherEnv,
@@ -134,13 +137,16 @@ export function getAdditionalInstructionsDir(
   return path ? dirname(path) : undefined;
 }
 
-export function resolveChatCommand(agentType: AgentType): string | undefined {
+export function resolveChatCommand(
+  agentType: AgentType,
+  resolveCommandPath: CommandPathResolver = getCommandPath,
+): string | undefined {
   if (agentType === "copilot") {
-    return resolveCopilotCliPath();
+    return resolveCopilotCliPath(resolveCommandPath);
   }
 
   const config = AGENT_CONFIG[agentType];
-  return getCommandPath(config.cmd) ?? undefined;
+  return resolveCommandPath(config.cmd) ?? undefined;
 }
 
 function generateChatId(): string {

--- a/src/sdk/providers/copilot.ts
+++ b/src/sdk/providers/copilot.ts
@@ -94,11 +94,15 @@ export function enumeratePathCandidates(cmd: string, pathEnv: string): string[] 
   return results;
 }
 
-export function resolveCopilotCliPath(): string | undefined {
+export type CommandPathResolver = (cmd: string) => string | null;
+
+export function resolveCopilotCliPath(
+  resolveCommandPath: CommandPathResolver = getCommandPath,
+): string | undefined {
   const envPath = process.env["COPILOT_CLI_PATH"];
   if (envPath) return envPath;
 
-  const primary = getCommandPath("copilot");
+  const primary = resolveCommandPath("copilot");
   if (primary === null) return undefined;
   if (!isCopilotShim(primary)) return primary;
 
@@ -119,11 +123,13 @@ export function resolveCopilotCliPath(): string | undefined {
  * - `cliPath` from {@link resolveCopilotCliPath} when resolvable; omitted
  *   otherwise so the SDK falls back to its bundled CLI.
  */
-export function copilotSdkLaunchOptions(): CopilotClientOptions {
+export function copilotSdkLaunchOptions(
+  resolveCommandPath: CommandPathResolver = getCommandPath,
+): CopilotClientOptions {
   const options: CopilotClientOptions = {
     env: copilotSubprocessEnv(),
   };
-  const cliPath = resolveCopilotCliPath();
+  const cliPath = resolveCopilotCliPath(resolveCommandPath);
   if (cliPath !== undefined) {
     options.cliPath = cliPath;
   }

--- a/tests/commands/cli/chat/chat-integration.test.ts
+++ b/tests/commands/cli/chat/chat-integration.test.ts
@@ -13,18 +13,7 @@
  *    launcher env.
  */
 
-import { mock, test, expect, describe, beforeEach, afterEach } from "bun:test";
-
-// ---------------------------------------------------------------------------
-// Module-level mock for detect.ts — must precede imports.
-// ---------------------------------------------------------------------------
-
-let mockGetCommandPath: (cmd: string) => string | null = () => null;
-
-await mock.module("../../../../src/services/system/detect.ts", () => ({
-  getCommandPath: (cmd: string) => mockGetCommandPath(cmd),
-  getCommandVersion: () => null,
-}));
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 
 import {
   resolveChatCommand,
@@ -33,12 +22,14 @@ import {
   buildTmuxEnv,
   TERMINAL_ENV_KEYS,
 } from "../../../../src/commands/cli/chat/index.ts";
+import type { CommandPathResolver } from "../../../../src/sdk/providers/copilot.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 let savedEnv: NodeJS.ProcessEnv;
+let mockGetCommandPath: CommandPathResolver = () => null;
 
 function saveEnv() {
   savedEnv = { ...process.env };
@@ -70,25 +61,25 @@ describe("resolveChatCommand – copilot", () => {
   test("returns COPILOT_CLI_PATH when set, even if PATH lookup returns null", () => {
     process.env["COPILOT_CLI_PATH"] = "/custom/bin/copilot";
     mockGetCommandPath = () => null;
-    expect(resolveChatCommand("copilot")).toBe("/custom/bin/copilot");
+    expect(resolveChatCommand("copilot", mockGetCommandPath)).toBe("/custom/bin/copilot");
   });
 
   test("returns PATH-resolved path when COPILOT_CLI_PATH absent", () => {
     delete process.env["COPILOT_CLI_PATH"];
     mockGetCommandPath = (cmd) => (cmd === "copilot" ? "/usr/local/bin/copilot" : null);
-    expect(resolveChatCommand("copilot")).toBe("/usr/local/bin/copilot");
+    expect(resolveChatCommand("copilot", mockGetCommandPath)).toBe("/usr/local/bin/copilot");
   });
 
   test("returns undefined when COPILOT_CLI_PATH unset and copilot not in PATH", () => {
     delete process.env["COPILOT_CLI_PATH"];
     mockGetCommandPath = () => null;
-    expect(resolveChatCommand("copilot")).toBeUndefined();
+    expect(resolveChatCommand("copilot", mockGetCommandPath)).toBeUndefined();
   });
 
   test("COPILOT_CLI_PATH takes precedence over PATH-resolved path", () => {
     process.env["COPILOT_CLI_PATH"] = "/explicit/copilot";
     mockGetCommandPath = () => "/usr/local/bin/copilot";
-    expect(resolveChatCommand("copilot")).toBe("/explicit/copilot");
+    expect(resolveChatCommand("copilot", mockGetCommandPath)).toBe("/explicit/copilot");
   });
 });
 
@@ -108,23 +99,23 @@ describe("resolveChatCommand – claude / opencode", () => {
 
   test("claude: returns path from getCommandPath('claude')", () => {
     mockGetCommandPath = (cmd) => (cmd === "claude" ? "/usr/bin/claude" : null);
-    expect(resolveChatCommand("claude")).toBe("/usr/bin/claude");
+    expect(resolveChatCommand("claude", mockGetCommandPath)).toBe("/usr/bin/claude");
   });
 
   test("claude: returns undefined when not in PATH", () => {
     mockGetCommandPath = () => null;
-    expect(resolveChatCommand("claude")).toBeUndefined();
+    expect(resolveChatCommand("claude", mockGetCommandPath)).toBeUndefined();
   });
 
   test("opencode: returns path from getCommandPath('opencode')", () => {
     mockGetCommandPath = (cmd) => (cmd === "opencode" ? "/usr/local/bin/opencode" : null);
-    expect(resolveChatCommand("opencode")).toBe("/usr/local/bin/opencode");
+    expect(resolveChatCommand("opencode", mockGetCommandPath)).toBe("/usr/local/bin/opencode");
   });
 
   test("copilot COPILOT_CLI_PATH does not affect claude resolution", () => {
     process.env["COPILOT_CLI_PATH"] = "/custom/copilot";
     mockGetCommandPath = (cmd) => (cmd === "claude" ? "/usr/bin/claude" : null);
-    expect(resolveChatCommand("claude")).toBe("/usr/bin/claude");
+    expect(resolveChatCommand("claude", mockGetCommandPath)).toBe("/usr/bin/claude");
   });
 });
 

--- a/tests/sdk/providers/copilot.test.ts
+++ b/tests/sdk/providers/copilot.test.ts
@@ -5,25 +5,15 @@
  *   - copilotSdkLaunchOptions()
  *
  * Strategy:
- * - Mock `../../src/services/system/detect.ts` to control `getCommandPath`.
+ * - Inject a command-path resolver to control PATH lookups.
  * - Mutate `process.env` within each test; restore in afterEach.
- * - Never leak PATH mutations; use mock instead of real Bun.which.
+ * - Never leak PATH mutations or module mocks into parallel test files.
  */
 
-import { mock, test, expect, describe, beforeEach, afterEach } from "bun:test";
-
-// ---------------------------------------------------------------------------
-// Module-level mock — must precede the import under test.
-// ---------------------------------------------------------------------------
-
-let mockGetCommandPath: (cmd: string) => string | null = () => null;
-
-await mock.module("../../../src/services/system/detect.ts", () => ({
-  getCommandPath: (cmd: string) => mockGetCommandPath(cmd),
-  getCommandVersion: () => null,
-}));
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 
 import {
+  type CommandPathResolver,
   resolveCopilotCliPath,
   copilotSubprocessEnv,
   copilotSdkLaunchOptions,
@@ -32,6 +22,8 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+let mockGetCommandPath: CommandPathResolver = () => null;
 
 function makeBaseEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
   return {
@@ -72,14 +64,14 @@ describe("resolveCopilotCliPath()", () => {
     process.env["COPILOT_CLI_PATH"] = "/custom/path/copilot";
     mockGetCommandPath = () => "/usr/local/bin/copilot";
 
-    expect(resolveCopilotCliPath()).toBe("/custom/path/copilot");
+    expect(resolveCopilotCliPath(mockGetCommandPath)).toBe("/custom/path/copilot");
   });
 
   test("COPILOT_CLI_PATH non-empty string returned verbatim", () => {
     process.env["COPILOT_CLI_PATH"] = "/opt/copilot/bin/copilot";
     mockGetCommandPath = () => null;
 
-    expect(resolveCopilotCliPath()).toBe("/opt/copilot/bin/copilot");
+    expect(resolveCopilotCliPath(mockGetCommandPath)).toBe("/opt/copilot/bin/copilot");
   });
 
   test("PATH-resolved copilot binary returned when COPILOT_CLI_PATH not set", () => {
@@ -87,14 +79,14 @@ describe("resolveCopilotCliPath()", () => {
     mockGetCommandPath = (cmd: string) =>
       cmd === "copilot" ? "/usr/local/bin/copilot" : null;
 
-    expect(resolveCopilotCliPath()).toBe("/usr/local/bin/copilot");
+    expect(resolveCopilotCliPath(mockGetCommandPath)).toBe("/usr/local/bin/copilot");
   });
 
   test("returns undefined when COPILOT_CLI_PATH unset and command not on PATH", () => {
     delete process.env["COPILOT_CLI_PATH"];
     mockGetCommandPath = () => null;
 
-    expect(resolveCopilotCliPath()).toBeUndefined();
+    expect(resolveCopilotCliPath(mockGetCommandPath)).toBeUndefined();
   });
 
   test("empty COPILOT_CLI_PATH falls through to PATH resolution", () => {
@@ -102,7 +94,7 @@ describe("resolveCopilotCliPath()", () => {
     mockGetCommandPath = (cmd: string) =>
       cmd === "copilot" ? "/usr/bin/copilot" : null;
 
-    expect(resolveCopilotCliPath()).toBe("/usr/bin/copilot");
+    expect(resolveCopilotCliPath(mockGetCommandPath)).toBe("/usr/bin/copilot");
   });
 });
 
@@ -182,21 +174,21 @@ describe("copilotSdkLaunchOptions()", () => {
   test("env field always present in returned options", () => {
     mockGetCommandPath = () => null;
     delete process.env["COPILOT_CLI_PATH"];
-    const opts = copilotSdkLaunchOptions();
+    const opts = copilotSdkLaunchOptions(mockGetCommandPath);
     expect(opts.env).toBeDefined();
   });
 
   test("env includes NODE_NO_WARNINGS=1", () => {
     mockGetCommandPath = () => null;
     delete process.env["COPILOT_CLI_PATH"];
-    const opts = copilotSdkLaunchOptions();
+    const opts = copilotSdkLaunchOptions(mockGetCommandPath);
     expect(opts.env?.["NODE_NO_WARNINGS"]).toBe("1");
   });
 
   test("cliPath set when COPILOT_CLI_PATH provided", () => {
     process.env["COPILOT_CLI_PATH"] = "/custom/copilot";
     mockGetCommandPath = () => null;
-    const opts = copilotSdkLaunchOptions();
+    const opts = copilotSdkLaunchOptions(mockGetCommandPath);
     expect(opts.cliPath).toBe("/custom/copilot");
   });
 
@@ -204,14 +196,14 @@ describe("copilotSdkLaunchOptions()", () => {
     delete process.env["COPILOT_CLI_PATH"];
     mockGetCommandPath = (cmd: string) =>
       cmd === "copilot" ? "/usr/local/bin/copilot" : null;
-    const opts = copilotSdkLaunchOptions();
+    const opts = copilotSdkLaunchOptions(mockGetCommandPath);
     expect(opts.cliPath).toBe("/usr/local/bin/copilot");
   });
 
   test("cliPath absent when command not resolvable", () => {
     delete process.env["COPILOT_CLI_PATH"];
     mockGetCommandPath = () => null;
-    const opts = copilotSdkLaunchOptions();
+    const opts = copilotSdkLaunchOptions(mockGetCommandPath);
     expect(Object.prototype.hasOwnProperty.call(opts, "cliPath")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Ensures test failures are properly detected in CI pipelines and eliminates module-level mock leakage across Bun's parallel test runner by switching to dependency injection.

## Key Changes

### CI Reliability (`ci.yml`, `publish.yml`)
- Add `set -o pipefail` to `bun test | cat` pipeline steps so that a non-zero exit from `bun test` fails the workflow step instead of being swallowed by `cat`

### Dependency Injection for Testability (`src/sdk/providers/copilot.ts`, `src/commands/cli/chat/index.ts`)
- Export `CommandPathResolver` type from `copilot.ts`
- Add optional `resolveCommandPath: CommandPathResolver` parameter (defaulting to `getCommandPath`) to `resolveCopilotCliPath()`, `copilotSdkLaunchOptions()`, and `resolveChatCommand()`
- Remove all `mock.module()` calls on `detect.ts` from test files — module-level mocks were leaking state into sibling test workers under Bun's parallel runner
- Tests now inject a local `mockGetCommandPath` function directly into the functions under test

## Why This Matters

Bun's parallel test runner executes test files in separate worker threads that share module state when `mock.module()` is used at the module level. Injecting the resolver as a parameter eliminates the shared-state dependency entirely, making tests hermetic and order-independent.