### PR TITLE
chore(release): bump version to v0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.6-1",
+  "version": "0.6.6",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes the prerelease `v0.6.6-1` to a stable release by bumping `package.json` from `0.6.6-1` to `0.6.6`. This release includes CI reliability fixes and test isolation improvements shipped in the prerelease.

## Key Changes

- **Version bump**: `package.json` version updated from `0.6.6-1` → `0.6.6`

### Included since v0.6.5 (via prerelease v0.6.6-1)

- **fix(ci)**: Add `set -o pipefail` to `ci.yml` and `publish.yml` so piped `bun test` commands correctly propagate non-zero exit codes on test failures
- **refactor(copilot/chat)**: Introduce `CommandPathResolver` type and inject it as a parameter into `resolveCopilotCliPath`, `copilotSdkLaunchOptions`, and `resolveChatCommand` — eliminates module-level `mock.module()` calls that leaked state across Bun's parallel test runner
- **test**: Update copilot and chat integration tests to pass mock resolvers directly rather than using module-level mocks, fixing flaky test isolation in CI