### PR TITLE
fix(tui): fix workflow UI background rendering and add TUI diagnostics

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -83,6 +83,27 @@ Run these inside the container:
 | `bun run lint:fix`  | Auto-fix linting issues                 |
 | `bun run dev`       | Run CLI in development mode             |
 
+## Workflow UI Diagnostics
+
+Set `ATOMIC_TUI_DIAGNOSTICS=1` when reproducing workflow graph rendering
+issues. The orchestrator writes JSON frame-buffer snapshots that include
+terminal capabilities, workflow state, and background-color counts.
+
+```bash
+ATOMIC_TUI_DIAGNOSTICS=1 \
+ATOMIC_TUI_DIAGNOSTICS_DIR=/tmp/atomic-tui-diagnostics \
+bun run examples/hello-world/claude-worker.ts --greeting="Hello" --style=casual
+```
+
+Optional tuning:
+
+| Variable | Purpose |
+| --- | --- |
+| `ATOMIC_TUI_DIAGNOSTICS_DIR` | Output directory; defaults to a temp directory |
+| `ATOMIC_TUI_DIAGNOSTICS_INTERVAL_MS` | Snapshot interval in milliseconds |
+| `ATOMIC_TUI_DIAGNOSTICS_MAX` | Maximum number of snapshots |
+| `ATOMIC_TUI_DIAGNOSTICS_OPENTUI_DUMP=1` | Also call OpenTUI's native buffer/stdout dump hooks |
+
 ## Quick Reference
 
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@bastani/atomic",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.126",
+        "@catppuccin/palette": "^1.8.0",
         "@clack/prompts": "^1.3.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.3.0",
@@ -54,6 +55,8 @@
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@catppuccin/palette": ["@catppuccin/palette@1.8.0", "", {}, "sha512-qXhwKiLzQomUygUJYB36YAFgs+dET5bIocfkiaFIatQF5Pwc7L112TlF9P8J5Oqs3x3XTjYSucG0ncHXSCuk7Q=="],
 
     "@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.126",
+    "@catppuccin/palette": "^1.8.0",
     "@clack/prompts": "^1.3.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",

--- a/src/sdk/components/compact-switcher.tsx
+++ b/src/sdk/components/compact-switcher.tsx
@@ -44,6 +44,9 @@ export function CompactSwitcher({ selectedIndex }: CompactSwitcherProps) {
         const isSelected = i === selectedIndex;
         const icon = statusIcon(agent.status);
         const iconColor = statusColor(agent.status, theme);
+        const rowBackground = isSelected
+          ? lerpColor(theme.backgroundElement, theme.primary, 0.12)
+          : theme.backgroundElement;
         const duration =
           agent.startedAt !== null
             ? fmtDuration((agent.endedAt ?? Date.now()) - agent.startedAt)
@@ -56,15 +59,17 @@ export function CompactSwitcher({ selectedIndex }: CompactSwitcherProps) {
             flexDirection="row"
             paddingLeft={1}
             paddingRight={1}
-            backgroundColor={isSelected ? lerpColor(theme.backgroundElement, theme.primary, 0.12) : theme.backgroundElement}
+            backgroundColor={rowBackground}
           >
             <text>
-              <span fg={theme.textDim}>{String(i + 1).padStart(2)} </span>
-              <span fg={iconColor}>{icon} </span>
-              <span fg={isSelected ? theme.text : theme.textMuted}>{agent.name}</span>
+              <span fg={theme.textDim} bg={rowBackground}>{String(i + 1).padStart(2)} </span>
+              <span fg={iconColor} bg={rowBackground}>{icon} </span>
+              <span fg={isSelected ? theme.text : theme.textMuted} bg={rowBackground}>{agent.name}</span>
             </text>
             <box flexGrow={1} />
-            <text fg={theme.textDim}>{duration}</text>
+            <text>
+              <span fg={theme.textDim} bg={rowBackground}>{duration}</span>
+            </text>
           </box>
         );
       })}

--- a/src/sdk/components/connectors.ts
+++ b/src/sdk/components/connectors.ts
@@ -10,6 +10,7 @@ export interface ConnectorResult {
   width: number;
   height: number;
   color: string;
+  backgroundColor: string;
 }
 
 /** Fan-out connector: one parent branching down to one or more tree children. */
@@ -39,6 +40,7 @@ export function buildConnector(
       width: 1,
       height: numRows,
       color: theme.borderActive,
+      backgroundColor: theme.background,
     };
   }
 
@@ -85,6 +87,7 @@ export function buildConnector(
     width,
     height: numRows,
     color: theme.borderActive,
+    backgroundColor: theme.background,
   };
 }
 
@@ -152,5 +155,6 @@ export function buildMergeConnector(
     width,
     height: numRows,
     color: theme.borderActive,
+    backgroundColor: theme.background,
   };
 }

--- a/src/sdk/components/edge.tsx
+++ b/src/sdk/components/edge.tsx
@@ -2,10 +2,12 @@
 
 import type { ConnectorResult } from "./connectors.ts";
 
-export function Edge({ text, col, row, width, height, color: edgeColor }: ConnectorResult) {
+export function Edge({ text, col, row, width, height, color: edgeColor, backgroundColor }: ConnectorResult) {
   return (
-    <box position="absolute" left={col} top={row} width={width} height={height}>
-      <text fg={edgeColor}>{text}</text>
+    <box position="absolute" left={col} top={row} width={width} height={height} backgroundColor={backgroundColor}>
+      <text>
+        <span fg={edgeColor} bg={backgroundColor}>{text}</span>
+      </text>
     </box>
   );
 }

--- a/src/sdk/components/graph-theme.ts
+++ b/src/sdk/components/graph-theme.ts
@@ -1,7 +1,6 @@
 // ─── Graph Theme ──────────────────────────────────
 
 import type { TerminalTheme } from "../runtime/theme.ts";
-import { lerpColor } from "./color-utils.ts";
 
 export interface GraphTheme {
   background: string;
@@ -24,13 +23,13 @@ export function deriveGraphTheme(t: TerminalTheme): GraphTheme {
     background: t.bg,
     backgroundElement: t.surface,
     text: t.text,
-    textMuted: lerpColor(t.text, t.bg, 0.3),
+    textMuted: t.textMuted,
     textDim: t.dim,
     primary: t.accent,
     success: t.success,
     error: t.error,
     warning: t.warning,
-    info: t.accent,
+    info: t.info,
     mauve: t.mauve,
     border: t.borderDim,
     borderActive: t.border,

--- a/src/sdk/components/header.tsx
+++ b/src/sdk/components/header.tsx
@@ -9,11 +9,21 @@ import {
   TmuxSessionContext,
 } from "./orchestrator-panel-contexts.ts";
 
-function CountBadge({ color, icon, count }: { color: string; icon: string; count: number }) {
+function CountBadge({
+  color,
+  icon,
+  count,
+  backgroundColor,
+}: {
+  color: string;
+  icon: string;
+  count: number;
+  backgroundColor: string;
+}) {
   if (count <= 0) return null;
   return (
     <text>
-      <span fg={color}>{icon} {count}</span>
+      <span fg={color} bg={backgroundColor}>{icon} {count}</span>
     </text>
   );
 }
@@ -55,18 +65,20 @@ export function Header() {
 
       {tmuxSession ? (
         <box paddingLeft={1} alignItems="center">
-          <text fg={theme.text}>
-            <strong>{tmuxSession}</strong>
+          <text>
+            <span fg={theme.text} bg={theme.backgroundElement}>
+              <strong>{tmuxSession}</strong>
+            </span>
           </text>
         </box>
       ) : null}
 
       <box flexGrow={1} justifyContent="flex-end" flexDirection="row" gap={2}>
-        <CountBadge color={theme.success} icon={"\u2713"} count={counts.complete} />
-        <CountBadge color={theme.warning} icon={"\u25CF"} count={counts.running} />
-        <CountBadge color={theme.info} icon={"?"} count={counts.awaiting_input} />
-        <CountBadge color={theme.textDim} icon={"\u25CB"} count={counts.pending} />
-        <CountBadge color={theme.error} icon={"\u2717"} count={counts.error} />
+        <CountBadge color={theme.success} backgroundColor={theme.backgroundElement} icon={"\u2713"} count={counts.complete} />
+        <CountBadge color={theme.warning} backgroundColor={theme.backgroundElement} icon={"\u25CF"} count={counts.running} />
+        <CountBadge color={theme.info} backgroundColor={theme.backgroundElement} icon={"?"} count={counts.awaiting_input} />
+        <CountBadge color={theme.textDim} backgroundColor={theme.backgroundElement} icon={"\u25CB"} count={counts.pending} />
+        <CountBadge color={theme.error} backgroundColor={theme.backgroundElement} icon={"\u2717"} count={counts.error} />
       </box>
     </box>
   );

--- a/src/sdk/components/node-card.tsx
+++ b/src/sdk/components/node-card.tsx
@@ -28,12 +28,12 @@ export const NodeCard = React.memo(function NodeCard({
   if (isRunning) {
     const t = (Math.sin((pulsePhase / 32) * Math.PI * 2 - Math.PI / 2) + 1) / 2;
     borderCol = focused
-      ? lerpColor(theme.warning, "#ffffff", 0.2)
+      ? lerpColor(theme.warning, theme.text, 0.2)
       : lerpColor(theme.border, theme.warning, t);
   } else if (isAwaitingInput) {
     const t = (Math.sin((pulsePhase / 32) * Math.PI * 2 - Math.PI / 2) + 1) / 2;
     borderCol = focused
-      ? lerpColor(theme.info, "#ffffff", 0.2)
+      ? lerpColor(theme.info, theme.text, 0.2)
       : lerpColor(theme.border, theme.info, t);
   } else if (isPending) {
     borderCol = focused ? sc : theme.borderActive;
@@ -41,8 +41,8 @@ export const NodeCard = React.memo(function NodeCard({
     borderCol = sc;
   }
 
-  // Background: focused nodes get a subtle status-colored tint
-  const bgCol = focused ? lerpColor(theme.background, sc, 0.12) : "transparent";
+  // Keep the card interior aligned with the graph canvas; status color belongs to the border/text.
+  const bgCol = theme.background;
 
   // Duration computed live from start/end timestamps
   const durCol = isPending ? theme.textDim : sc;
@@ -68,15 +68,21 @@ export const NodeCard = React.memo(function NodeCard({
       titleAlignment="center"
     >
       <box alignItems="center">
-        <text fg={durCol}>{duration}</text>
+        <text>
+          <span fg={durCol} bg={bgCol}>{duration}</span>
+        </text>
       </box>
       {isAwaitingInput && (
         <>
           <box alignItems="center">
-            <text fg={theme.info}>waiting for response</text>
+            <text>
+              <span fg={theme.info} bg={bgCol}>waiting for response</span>
+            </text>
           </box>
           <box alignItems="center">
-            <text fg={theme.textDim}>↵ enter to respond</text>
+            <text>
+              <span fg={theme.textDim} bg={bgCol}>↵ enter to respond</span>
+            </text>
           </box>
         </>
       )}

--- a/src/sdk/components/orchestrator-panel.tsx
+++ b/src/sdk/components/orchestrator-panel.tsx
@@ -14,20 +14,39 @@ import { StoreContext, ThemeContext, TmuxSessionContext } from "./orchestrator-p
 import type { PanelSession, PanelOptions, SessionData } from "./orchestrator-panel-types.ts";
 import { SessionGraphPanel } from "./session-graph-panel.tsx";
 import { ErrorBoundary } from "./error-boundary.tsx";
+import {
+  requestRendererBackgroundRepaint,
+  resetRendererTerminalBackground,
+  setRendererBackground,
+} from "./renderer-background.ts";
+import { createTuiDiagnostics, type TuiDiagnostics } from "./tui-diagnostics.ts";
 
 export class OrchestratorPanel {
   private store: PanelStore;
   private renderer: CliRenderer;
   private destroyed = false;
+  private terminalBackgroundSynced: boolean;
+  private diagnostics: TuiDiagnostics | null = null;
+  private unsubscribeDiagnostics: (() => void) | null = null;
 
   private constructor(
     renderer: CliRenderer,
     store: PanelStore,
     graphTheme: GraphTheme,
     tmuxSession: string,
+    terminalBackgroundSynced: boolean,
   ) {
     this.renderer = renderer;
     this.store = store;
+    this.terminalBackgroundSynced = terminalBackgroundSynced;
+    this.diagnostics = createTuiDiagnostics({
+      renderer,
+      graphTheme,
+      getSnapshot: () => this.getDiagnosticSnapshot(),
+    });
+    this.unsubscribeDiagnostics = this.diagnostics
+      ? store.subscribe(() => this.diagnostics?.capture("store-update"))
+      : null;
 
     createRoot(renderer).render(
       <StoreContext.Provider value={store}>
@@ -56,6 +75,8 @@ export class OrchestratorPanel {
         </ThemeContext.Provider>
       </StoreContext.Provider>,
     );
+    requestRendererBackgroundRepaint(this.renderer);
+    this.diagnostics?.capture("post-mount");
   }
 
   /**
@@ -69,18 +90,20 @@ export class OrchestratorPanel {
       exitOnCtrlC: false,
       exitSignals: ["SIGTERM", "SIGQUIT", "SIGABRT", "SIGHUP", "SIGPIPE", "SIGBUS", "SIGFPE"],
     });
-    return OrchestratorPanel.createWithRenderer(renderer, options);
+    return OrchestratorPanel.createWithRenderer(renderer, options, { syncTerminalBackground: true });
   }
 
   /** Create with an externally-provided renderer (e.g. a test renderer). */
   static createWithRenderer(
     renderer: CliRenderer,
     options: PanelOptions,
+    { syncTerminalBackground = false }: { syncTerminalBackground?: boolean } = {},
   ): OrchestratorPanel {
     const termTheme = resolveTheme(renderer.themeMode);
+    setRendererBackground(renderer, termTheme.bg, { syncTerminalDefault: syncTerminalBackground });
     const graphTheme = deriveGraphTheme(termTheme);
     const store = new PanelStore();
-    return new OrchestratorPanel(renderer, store, graphTheme, options.tmuxSession);
+    return new OrchestratorPanel(renderer, store, graphTheme, options.tmuxSession, syncTerminalBackground);
   }
 
   /**
@@ -175,7 +198,15 @@ export class OrchestratorPanel {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    this.unsubscribeDiagnostics?.();
+    this.unsubscribeDiagnostics = null;
+    this.diagnostics?.capture("destroy");
+    this.diagnostics?.dispose();
+    this.diagnostics = null;
     try {
+      if (this.terminalBackgroundSynced) {
+        resetRendererTerminalBackground(this.renderer);
+      }
       this.renderer.destroy();
     } catch {}
   }
@@ -212,6 +243,20 @@ export class OrchestratorPanel {
       fatalError: this.store.fatalError,
       completionReached: this.store.completionReached,
       sessions: this.store.sessions,
+    };
+  }
+
+  private getDiagnosticSnapshot() {
+    return {
+      workflowName: this.store.workflowName,
+      agent: this.store.agent,
+      prompt: this.store.prompt,
+      fatalError: this.store.fatalError,
+      completionReached: this.store.completionReached,
+      sessions: this.store.sessions,
+      backgroundTaskCount: this.store.backgroundTaskCount,
+      viewMode: this.store.viewMode,
+      activeAgentId: this.store.activeAgentId,
     };
   }
 }

--- a/src/sdk/components/renderer-background.ts
+++ b/src/sdk/components/renderer-background.ts
@@ -1,0 +1,49 @@
+import type { CliRenderer } from "@opentui/core";
+
+export function setRendererBackground(
+  renderer: CliRenderer,
+  color: string,
+  { syncTerminalDefault = false }: { syncTerminalDefault?: boolean } = {},
+): void {
+  renderer.setBackgroundColor(color);
+  if (syncTerminalDefault) {
+    process.stdout.write(wrapForTmuxIfNeeded(terminalBackgroundColorSequence(color)));
+  }
+}
+
+export function requestRendererBackgroundRepaint(renderer: CliRenderer): void {
+  // OpenTUI 0.1.103+ no longer syncs the renderer background to the terminal
+  // default via OSC 11. Force the next frame so blank cells with this background
+  // are emitted instead of being skipped as unchanged initial buffer contents.
+  Object.assign(renderer, { forceFullRepaintRequested: true });
+  renderer.requestRender();
+}
+
+export function resetRendererTerminalBackground(renderer: CliRenderer): void {
+  if (process.env.TMUX) {
+    process.stdout.write(wrapForTmuxIfNeeded("\x1b]111\x07"));
+    return;
+  }
+
+  renderer.resetTerminalBgColor();
+}
+
+export function terminalBackgroundColorSequence(color: string): string {
+  const match = /^#?([0-9a-f]{6})$/i.exec(color);
+  if (!match) {
+    throw new Error(`Cannot sync terminal background for non-hex color: ${color}`);
+  }
+
+  const hex = match[1]!;
+  return `\x1b]11;rgb:${hex.slice(0, 2)}/${hex.slice(2, 4)}/${hex.slice(4, 6)}\x07`;
+}
+
+export function wrapForTmuxIfNeeded(sequence: string): string {
+  if (!process.env.TMUX) return sequence;
+
+  let escaped = "";
+  for (const char of sequence) {
+    escaped += char === "\x1b" ? "\x1b\x1b" : char;
+  }
+  return `\x1bPtmux;${escaped}\x1b\\`;
+}

--- a/src/sdk/components/session-graph-panel.tsx
+++ b/src/sdk/components/session-graph-panel.tsx
@@ -433,9 +433,16 @@ export function SessionGraphPanel() {
           },
         }}
       >
-        <box width={canvasW} height={canvasH} position="relative">
+        <box width={canvasW} height={canvasH} position="relative" backgroundColor={theme.background}>
           {/* Offset all content by padding to center the graph */}
-          <box position="absolute" left={padX} top={padY} width={layout.width} height={layout.height}>
+          <box
+            position="absolute"
+            left={padX}
+            top={padY}
+            width={layout.width}
+            height={layout.height}
+            backgroundColor={theme.background}
+          >
             {/* Connectors (rendered behind nodes) */}
             {connectors.map((conn, i) => (
               <Edge key={`e${i}`} {...conn} />

--- a/src/sdk/components/statusline.tsx
+++ b/src/sdk/components/statusline.tsx
@@ -15,17 +15,19 @@ export function Statusline({
     <box height={1} flexDirection="row" backgroundColor={theme.backgroundElement}>
       {/* Mode badge — always GRAPH since this bar is only visible in the orchestrator window */}
       <box backgroundColor={theme.primary} paddingLeft={1} paddingRight={1} alignItems="center">
-        <text fg={theme.backgroundElement}>
-          <strong>GRAPH</strong>
+        <text>
+          <span fg={theme.backgroundElement} bg={theme.primary}>
+            <strong>GRAPH</strong>
+          </span>
         </text>
       </box>
 
       {store.backgroundTaskCount > 0 ? (
-        <box backgroundColor="transparent" paddingLeft={1} alignItems="center">
+        <box backgroundColor={theme.backgroundElement} paddingLeft={1} alignItems="center">
           <text>
-            <span fg={theme.textDim}>{"\u00B7"} </span>
-            <span fg={theme.warning}>{"\u25C6"} </span>
-            <span fg={theme.textMuted}>
+            <span fg={theme.textDim} bg={theme.backgroundElement}>{"\u00B7"} </span>
+            <span fg={theme.warning} bg={theme.backgroundElement}>{"\u25C6"} </span>
+            <span fg={theme.textMuted} bg={theme.backgroundElement}>
               {store.backgroundTaskCount} background
             </span>
           </text>
@@ -37,25 +39,27 @@ export function Statusline({
       {/* Navigation hints — always graph-mode (tmux status bar handles attached-mode hints) */}
       <box paddingRight={2} alignItems="center">
         {attachMsg ? (
-          <text fg={theme.text}>
-            <strong>{attachMsg}</strong>
+          <text>
+            <span fg={theme.text} bg={theme.backgroundElement}>
+              <strong>{attachMsg}</strong>
+            </span>
           </text>
         ) : (
           <text>
-            <span fg={theme.text}>{"\u2191\u2193\u2190\u2192"}</span>
-            <span fg={theme.textMuted}> navigate</span>
-            <span fg={theme.textDim}> {"\u00B7"} </span>
-            <span fg={theme.text}>{"\u21B5"}</span>
-            <span fg={theme.textMuted}> attach</span>
-            <span fg={theme.textDim}> {"\u00B7"} </span>
-            <span fg={theme.text}>/</span>
-            <span fg={theme.textMuted}> stages</span>
-            <span fg={theme.textDim}> {"\u00B7"} </span>
-            <span fg={theme.text}>ctrl+b d</span>
-            <span fg={theme.textMuted}> detach</span>
-            <span fg={theme.textDim}> {"\u00B7"} </span>
-            <span fg={theme.text}>q</span>
-            <span fg={theme.textMuted}> quit</span>
+            <span fg={theme.text} bg={theme.backgroundElement}>{"\u2191\u2193\u2190\u2192"}</span>
+            <span fg={theme.textMuted} bg={theme.backgroundElement}> navigate</span>
+            <span fg={theme.textDim} bg={theme.backgroundElement}> {"\u00B7"} </span>
+            <span fg={theme.text} bg={theme.backgroundElement}>{"\u21B5"}</span>
+            <span fg={theme.textMuted} bg={theme.backgroundElement}> attach</span>
+            <span fg={theme.textDim} bg={theme.backgroundElement}> {"\u00B7"} </span>
+            <span fg={theme.text} bg={theme.backgroundElement}>/</span>
+            <span fg={theme.textMuted} bg={theme.backgroundElement}> stages</span>
+            <span fg={theme.textDim} bg={theme.backgroundElement}> {"\u00B7"} </span>
+            <span fg={theme.text} bg={theme.backgroundElement}>ctrl+b d</span>
+            <span fg={theme.textMuted} bg={theme.backgroundElement}> detach</span>
+            <span fg={theme.textDim} bg={theme.backgroundElement}> {"\u00B7"} </span>
+            <span fg={theme.text} bg={theme.backgroundElement}>q</span>
+            <span fg={theme.textMuted} bg={theme.backgroundElement}> quit</span>
           </text>
         )}
       </box>

--- a/src/sdk/components/tui-diagnostics.ts
+++ b/src/sdk/components/tui-diagnostics.ts
@@ -1,0 +1,273 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { CliRenderer, OptimizedBuffer } from "@opentui/core";
+import type { GraphTheme } from "./graph-theme.ts";
+import type { SessionData } from "./orchestrator-panel-types.ts";
+
+type BackgroundRun = {
+  x: number;
+  width: number;
+  color: string;
+};
+
+type BufferRowDiagnostic = {
+  y: number;
+  text: string;
+  backgrounds: BackgroundRun[];
+};
+
+type ColorCount = {
+  color: string;
+  count: number;
+  percent: number;
+};
+
+export type BufferDiagnostic = {
+  width: number;
+  height: number;
+  topBackgrounds: ColorCount[];
+  yellowHueCells: number;
+  yellowHueSamples: Array<{ x: number; y: number; color: string; char: string }>;
+  rows: BufferRowDiagnostic[];
+};
+
+export type WorkflowDiagnosticSnapshot = {
+  workflowName: string;
+  agent: string;
+  prompt: string;
+  fatalError: string | null;
+  completionReached: boolean;
+  sessions: readonly SessionData[];
+  backgroundTaskCount: number;
+  viewMode: string;
+  activeAgentId: string;
+};
+
+export type TuiDiagnostics = {
+  capture: (reason: string) => void;
+  dispose: () => void;
+};
+
+type TuiDiagnosticsOptions = {
+  renderer: CliRenderer;
+  graphTheme: GraphTheme;
+  getSnapshot: () => WorkflowDiagnosticSnapshot;
+};
+
+const DEFAULT_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_CAPTURES = 45;
+
+export function isTuiDiagnosticsEnabled(): boolean {
+  const value = process.env.ATOMIC_TUI_DIAGNOSTICS;
+  return value === "1" || value === "true" || value === "yes";
+}
+
+export function createTuiDiagnostics({
+  renderer,
+  graphTheme,
+  getSnapshot,
+}: TuiDiagnosticsOptions): TuiDiagnostics | null {
+  if (!isTuiDiagnosticsEnabled()) return null;
+
+  const directory = resolveDiagnosticsDirectory();
+  mkdirSync(directory, { recursive: true });
+
+  let sequence = 0;
+  let disposed = false;
+  const maxCaptures = readPositiveInt(process.env.ATOMIC_TUI_DIAGNOSTICS_MAX, DEFAULT_MAX_CAPTURES);
+  const intervalMs = readPositiveInt(process.env.ATOMIC_TUI_DIAGNOSTICS_INTERVAL_MS, DEFAULT_INTERVAL_MS);
+
+  writeJson(join(directory, "metadata.json"), {
+    directory,
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    environment: diagnosticEnvironment(),
+    graphTheme,
+  });
+
+  const capture = (reason: string): void => {
+    if (disposed || sequence >= maxCaptures) return;
+    sequence++;
+    const timestamp = Date.now();
+    const payload = {
+      sequence,
+      reason,
+      capturedAt: new Date(timestamp).toISOString(),
+      environment: diagnosticEnvironment(),
+      renderer: {
+        width: renderer.width,
+        height: renderer.height,
+        terminalWidth: renderer.terminalWidth,
+        terminalHeight: renderer.terminalHeight,
+        themeMode: renderer.themeMode,
+        capabilities: cloneJson(renderer.capabilities),
+      },
+      graphTheme,
+      workflow: getSnapshot(),
+      currentRenderBuffer: summarizeBuffer(renderer.currentRenderBuffer),
+      nextRenderBuffer: summarizeBuffer(renderer.nextRenderBuffer),
+    };
+
+    writeJson(join(directory, `${String(sequence).padStart(4, "0")}-${sanitizeReason(reason)}.json`), payload);
+    writeJson(join(directory, "latest.json"), payload);
+
+    if (process.env.ATOMIC_TUI_DIAGNOSTICS_OPENTUI_DUMP === "1") {
+      renderer.dumpBuffers(timestamp);
+      renderer.dumpStdoutBuffer(timestamp);
+    }
+  };
+
+  const timer = setInterval(() => capture("interval"), intervalMs);
+  capture("created");
+
+  return {
+    capture,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      clearInterval(timer);
+      writeJson(join(directory, "disposed.json"), {
+        disposedAt: new Date().toISOString(),
+        captures: sequence,
+      });
+    },
+  };
+}
+
+export function summarizeBuffer(buffer: OptimizedBuffer): BufferDiagnostic {
+  const raw = buffer.buffers;
+  const width = buffer.width;
+  const height = buffer.height;
+  const counts = new Map<string, number>();
+  const rows: BufferRowDiagnostic[] = [];
+  const yellowHueSamples: Array<{ x: number; y: number; color: string; char: string }> = [];
+  let yellowHueCells = 0;
+
+  for (let y = 0; y < height; y++) {
+    const backgrounds: BackgroundRun[] = [];
+    let text = "";
+    let currentColor = "";
+    let runStart = 0;
+
+    for (let x = 0; x < width; x++) {
+      const index = y * width + x;
+      const color = readColor(raw.bg, index);
+      const char = readChar(raw.char[index] ?? 0);
+      text += char;
+
+      counts.set(color, (counts.get(color) ?? 0) + 1);
+      if (isYellowHue(color)) {
+        yellowHueCells++;
+        if (yellowHueSamples.length < 40) {
+          yellowHueSamples.push({ x, y, color, char });
+        }
+      }
+
+      if (x === 0) {
+        currentColor = color;
+        runStart = 0;
+      } else if (color !== currentColor) {
+        backgrounds.push({ x: runStart, width: x - runStart, color: currentColor });
+        currentColor = color;
+        runStart = x;
+      }
+    }
+
+    if (width > 0) {
+      backgrounds.push({ x: runStart, width: width - runStart, color: currentColor });
+    }
+    rows.push({ y, text: text.trimEnd(), backgrounds });
+  }
+
+  const total = Math.max(1, width * height);
+  const topBackgrounds = Array.from(counts.entries())
+    .map(([color, count]) => ({
+      color,
+      count,
+      percent: Math.round((count / total) * 10_000) / 100,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 16);
+
+  return {
+    width,
+    height,
+    topBackgrounds,
+    yellowHueCells,
+    yellowHueSamples,
+    rows,
+  };
+}
+
+function resolveDiagnosticsDirectory(): string {
+  const explicit = process.env.ATOMIC_TUI_DIAGNOSTICS_DIR;
+  if (explicit && explicit.trim() !== "") return explicit;
+  return join(tmpdir(), `atomic-tui-diagnostics-${process.pid}`);
+}
+
+function diagnosticEnvironment(): Record<string, string | null> {
+  return {
+    TERM: process.env.TERM ?? null,
+    TERM_PROGRAM: process.env.TERM_PROGRAM ?? null,
+    COLORTERM: process.env.COLORTERM ?? null,
+    TMUX: process.env.TMUX ?? null,
+    SSH_TTY: process.env.SSH_TTY ?? null,
+  };
+}
+
+function readPositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function writeJson(path: string, value: object): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function sanitizeReason(reason: string): string {
+  const sanitized = reason.replace(/[^a-z0-9_-]+/gi, "-").replace(/^-+|-+$/g, "");
+  return sanitized === "" ? "capture" : sanitized;
+}
+
+function readColor(buffer: Uint16Array, cellIndex: number): string {
+  const offset = cellIndex * 4;
+  return `#${toHex(buffer[offset] ?? 0)}${toHex(buffer[offset + 1] ?? 0)}${toHex(buffer[offset + 2] ?? 0)}`;
+}
+
+function toHex(value: number): string {
+  const clamped = Math.max(0, Math.min(255, value));
+  return clamped.toString(16).padStart(2, "0");
+}
+
+function readChar(codePoint: number): string {
+  if (codePoint <= 0 || codePoint > 0x10ffff) return " ";
+  return String.fromCodePoint(codePoint);
+}
+
+function isYellowHue(color: string): boolean {
+  const red = Number.parseInt(color.slice(1, 3), 16);
+  const green = Number.parseInt(color.slice(3, 5), 16);
+  const blue = Number.parseInt(color.slice(5, 7), 16);
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  if (max < 32 || max === min) return false;
+
+  const saturation = (max - min) / max;
+  if (saturation < 0.12) return false;
+
+  const hue =
+    max === red
+      ? ((green - blue) / (max - min)) * 60
+      : max === green
+        ? (2 + (blue - red) / (max - min)) * 60
+        : (4 + (red - green) / (max - min)) * 60;
+  const normalizedHue = hue < 0 ? hue + 360 : hue;
+  return normalizedHue >= 35 && normalizedHue <= 85;
+}
+
+function cloneJson(value: object | null): object | null {
+  if (value === null) return null;
+  return JSON.parse(JSON.stringify(value)) as object;
+}

--- a/src/sdk/components/workflow-picker-panel.tsx
+++ b/src/sdk/components/workflow-picker-panel.tsx
@@ -43,6 +43,11 @@ import { useLatest } from "./hooks.ts";
 import { resolveTheme, type TerminalTheme } from "../runtime/theme.ts";
 import type { AgentType, WorkflowInput, WorkflowDefinition, Registry } from "../types.ts";
 import { ErrorBoundary } from "./error-boundary.tsx";
+import {
+  requestRendererBackgroundRepaint,
+  resetRendererTerminalBackground,
+  setRendererBackground,
+} from "./renderer-background.ts";
 
 // ─── Theme ──────────────────────────────────────
 // The picker uses a slightly extended palette vs. the base terminal theme:
@@ -68,26 +73,21 @@ export interface PickerTheme {
   borderActive: string;
 }
 
-export function buildPickerTheme(base: TerminalTheme, isDark: boolean): PickerTheme {
-  // For dark mode the prototype values track Catppuccin Mocha. For light
-  // mode we derive muted variants from the base palette — the specific
-  // extras (`info`, `mauve`, the three-level background ladder) have no
-  // direct entries in `TerminalTheme`, so we pick close-enough Catppuccin
-  // values to keep the picker visually consistent with the orchestrator.
+export function buildPickerTheme(base: TerminalTheme): PickerTheme {
   return {
     background: base.bg,
-    backgroundPanel: isDark ? "#181825" : "#e6e9ef",
-    backgroundElement: isDark ? "#11111b" : "#dce0e8",
+    backgroundPanel: base.backgroundPanel,
+    backgroundElement: base.backgroundElement,
     surface: base.surface,
     text: base.text,
-    textMuted: isDark ? "#a6adc8" : "#5c5f77",
+    textMuted: base.textMuted,
     textDim: base.dim,
     primary: base.accent,
     success: base.success,
     error: base.error,
     warning: base.warning,
-    info: isDark ? "#89dceb" : "#04a5e5",
-    mauve: isDark ? "#cba6f7" : "#8839ef",
+    info: base.info,
+    mauve: base.mauve,
     border: base.borderDim,
     borderActive: base.border,
   };
@@ -324,7 +324,7 @@ const WorkflowList = memo(function WorkflowList({
 
   if (rows.length === 0) {
     return (
-      <box paddingLeft={2} paddingTop={2}>
+      <box paddingLeft={2} paddingTop={2} backgroundColor={theme.backgroundPanel}>
         <text>
           <span fg={theme.textDim}>no matches</span>
         </text>
@@ -333,7 +333,7 @@ const WorkflowList = memo(function WorkflowList({
   }
 
   return (
-    <box flexDirection="column">
+    <box flexDirection="column" backgroundColor={theme.backgroundPanel}>
       {rows.map((row, i) => {
         if (row.kind === "section") {
           const ag = row.agent;
@@ -343,6 +343,7 @@ const WorkflowList = memo(function WorkflowList({
               height={2}
               paddingTop={1}
               paddingLeft={2}
+              backgroundColor={theme.backgroundPanel}
             >
               <text>
                 <span fg={theme[AGENT_COLOR[ag]]}>
@@ -362,7 +363,7 @@ const WorkflowList = memo(function WorkflowList({
             key={`wf-${wf.agent}-${wf.name}`}
             height={1}
             flexDirection="row"
-            backgroundColor={isFocused ? theme.border : "transparent"}
+            backgroundColor={isFocused ? theme.border : theme.backgroundPanel}
             paddingLeft={1}
             paddingRight={2}
           >
@@ -545,6 +546,7 @@ function TextAreaContent({
   onInput: (value: string) => void;
 }) {
   const theme = usePickerTheme();
+  const backgroundColor = focused ? theme.backgroundPanel : theme.backgroundElement;
   const instanceRef = useRef<TextareaRenderable | null>(null);
   const onInputRef = useLatest(onInput);
   const lastTextRef = useRef(value);
@@ -593,8 +595,8 @@ function TextAreaContent({
       placeholder={placeholder}
       focused={focused}
       textColor={theme.text}
-      backgroundColor="transparent"
-      focusedBackgroundColor="transparent"
+      backgroundColor={backgroundColor}
+      focusedBackgroundColor={backgroundColor}
       focusedTextColor={theme.text}
       placeholderColor={theme.textDim}
       wrapMode="word"
@@ -616,6 +618,7 @@ function StringContent({
   onInput: (value: string) => void;
 }) {
   const theme = usePickerTheme();
+  const backgroundColor = focused ? theme.backgroundPanel : theme.backgroundElement;
   return (
     <input
       value={value}
@@ -623,8 +626,8 @@ function StringContent({
       focused={focused}
       onInput={onInput}
       textColor={theme.text}
-      backgroundColor="transparent"
-      focusedBackgroundColor="transparent"
+      backgroundColor={backgroundColor}
+      focusedBackgroundColor={backgroundColor}
       focusedTextColor={theme.text}
       flexGrow={1}
     />
@@ -883,7 +886,7 @@ function InputPhase({
         renderBefore={syncScrollFrame}
         style={{
           rootOptions: {
-            backgroundColor: "transparent",
+            backgroundColor: theme.background,
             border: false,
           },
           contentOptions: {
@@ -1481,6 +1484,7 @@ export class WorkflowPickerPanel {
   private renderer: CliRenderer;
   private root: Root;
   private destroyed = false;
+  private terminalBackgroundSynced: boolean;
   private resolveSelection: ((r: WorkflowPickerResult | null) => void) | null =
     null;
   private selectionPromise: Promise<WorkflowPickerResult | null>;
@@ -1488,14 +1492,17 @@ export class WorkflowPickerPanel {
   private constructor(
     renderer: CliRenderer,
     options: WorkflowPickerPanelOptions,
+    { syncTerminalBackground = false }: { syncTerminalBackground?: boolean } = {},
   ) {
     this.renderer = renderer;
+    this.terminalBackgroundSynced = syncTerminalBackground;
     this.selectionPromise = new Promise((resolve) => {
       this.resolveSelection = resolve;
     });
 
-    const isDark = renderer.themeMode !== "light";
-    const theme = buildPickerTheme(resolveTheme(renderer.themeMode), isDark);
+    const termTheme = resolveTheme(renderer.themeMode);
+    setRendererBackground(renderer, termTheme.bg, { syncTerminalDefault: syncTerminalBackground });
+    const theme = buildPickerTheme(termTheme);
     // Filter registry to only the workflows for the selected agent.
     const workflows = options.registry
       .list()
@@ -1528,6 +1535,7 @@ export class WorkflowPickerPanel {
         />
       </ErrorBoundary>,
     );
+    requestRendererBackgroundRepaint(this.renderer);
   }
 
   /**
@@ -1550,7 +1558,7 @@ export class WorkflowPickerPanel {
         "SIGFPE",
       ],
     });
-    return new WorkflowPickerPanel(renderer, options);
+    return new WorkflowPickerPanel(renderer, options, { syncTerminalBackground: true });
   }
 
   /** Create with an externally-provided renderer (e.g. a test renderer). */
@@ -1580,6 +1588,9 @@ export class WorkflowPickerPanel {
       this.resolveSelection = null;
     }
     try {
+      if (this.terminalBackgroundSynced) {
+        resetRendererTerminalBackground(this.renderer);
+      }
       this.renderer.destroy();
     } catch (err) {
       console.error("[WorkflowPickerPanel] destroy failed:", err);

--- a/src/sdk/runtime/executor.ts
+++ b/src/sdk/runtime/executor.ts
@@ -504,7 +504,11 @@ export async function executeWorkflow(
   const launcherExt = isWin ? "ps1" : "sh";
   const launcherPath = join(sessionsBaseDir, `orchestrator.${launcherExt}`);
   const logPath = join(sessionsBaseDir, "orchestrator.log");
-  const launcherEnvVars = agent === "claude" ? atomicTempEnv() : {};
+  const launcherEnvVars = {
+    ...(agent === "claude" ? atomicTempEnv() : {}),
+    ...terminalCapabilityEnv(),
+    ...workflowDiagnosticsEnv(),
+  };
 
   // Inputs are passed through as base64-encoded JSON so long multiline
   // text values survive shell quoting without any further escaping.
@@ -577,6 +581,29 @@ export async function executeWorkflow(
   }
 
   return { id: workflowRunId, tmuxSessionName };
+}
+
+function workflowDiagnosticsEnv(): Record<string, string> {
+  const keys = [
+    "ATOMIC_TUI_DIAGNOSTICS",
+    "ATOMIC_TUI_DIAGNOSTICS_DIR",
+    "ATOMIC_TUI_DIAGNOSTICS_INTERVAL_MS",
+    "ATOMIC_TUI_DIAGNOSTICS_MAX",
+    "ATOMIC_TUI_DIAGNOSTICS_OPENTUI_DUMP",
+  ];
+  const env: Record<string, string> = {};
+  for (const key of keys) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+function terminalCapabilityEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  const colorterm = process.env.COLORTERM;
+  if (colorterm !== undefined) env.COLORTERM = colorterm;
+  return env;
 }
 
 /**

--- a/src/sdk/runtime/theme.ts
+++ b/src/sdk/runtime/theme.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ThemeMode } from "@opentui/core";
+import { flavors, type CatppuccinFlavor } from "@catppuccin/palette";
 
 // ---------------------------------------------------------------------------
 // Theme type
@@ -15,56 +16,47 @@ import type { ThemeMode } from "@opentui/core";
 
 export interface TerminalTheme {
   bg: string;
+  backgroundPanel: string;
+  backgroundElement: string;
   surface: string;
   selection: string;
   border: string;
   borderDim: string;
   accent: string;
   text: string;
+  textMuted: string;
   dim: string;
+  info: string;
   success: string;
   error: string;
   warning: string;
   mauve: string;
 }
 
-// ---------------------------------------------------------------------------
-// Catppuccin Mocha (dark)
-// ---------------------------------------------------------------------------
+function buildTerminalTheme(flavor: CatppuccinFlavor): TerminalTheme {
+  const { colors } = flavor;
+  return {
+    bg: colors.base.hex,
+    backgroundPanel: colors.mantle.hex,
+    backgroundElement: colors.crust.hex,
+    surface: colors.surface0.hex,
+    selection: colors.surface1.hex,
+    border: colors.overlay0.hex,
+    borderDim: colors.surface2.hex,
+    accent: colors.blue.hex,
+    text: colors.text.hex,
+    textMuted: flavor.dark ? colors.subtext0.hex : colors.subtext1.hex,
+    dim: colors.overlay1.hex,
+    info: colors.sky.hex,
+    success: colors.green.hex,
+    error: colors.red.hex,
+    warning: colors.yellow.hex,
+    mauve: colors.mauve.hex,
+  };
+}
 
-const CATPPUCCIN_MOCHA: TerminalTheme = {
-  bg: "#1e1e2e",         // Base
-  surface: "#313244",    // Surface0
-  selection: "#45475a",  // Surface1
-  border: "#6c7086",     // Overlay0
-  borderDim: "#585b70",  // Surface2
-  accent: "#89b4fa",     // Blue
-  text: "#cdd6f4",       // Text
-  dim: "#7f849c",        // Overlay1
-  success: "#a6e3a1",    // Green
-  error: "#f38ba8",      // Red
-  warning: "#f9e2af",    // Yellow
-  mauve: "#cba6f7",      // Mauve
-};
-
-// ---------------------------------------------------------------------------
-// Catppuccin Latte (light)
-// ---------------------------------------------------------------------------
-
-const CATPPUCCIN_LATTE: TerminalTheme = {
-  bg: "#eff1f5",         // Base
-  surface: "#ccd0da",    // Surface0
-  selection: "#bcc0cc",  // Surface1
-  border: "#9ca0b0",     // Overlay0
-  borderDim: "#acb0be",  // Surface2
-  accent: "#1e66f5",     // Blue
-  text: "#4c4f69",       // Text
-  dim: "#8c8fa1",        // Overlay1
-  success: "#40a02b",    // Green
-  error: "#d20f39",      // Red
-  warning: "#df8e1d",    // Yellow
-  mauve: "#8839ef",      // Mauve
-};
+const CATPPUCCIN_MOCHA = buildTerminalTheme(flavors.mocha);
+const CATPPUCCIN_LATTE = buildTerminalTheme(flavors.latte);
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/src/services/system/install-ui.ts
+++ b/src/services/system/install-ui.ts
@@ -22,7 +22,7 @@
  * library, just what auto-sync needs to stop being visually noisy.
  */
 
-import { COLORS } from "../../theme/colors.ts";
+import { COLORS, PALETTE, paletteRgb, type PaletteKey } from "../../theme/colors.ts";
 import {
   supportsTrueColor,
   supports256Color,
@@ -34,9 +34,9 @@ const BAR_EMPTY = "･";
 
 /**
  * Semantic bar states mapped to Catppuccin Mocha colors:
- *   progress → Yellow #f9e2af (warm accent; "in flight")
- *   success  → Green  #a6e3a1 (universal "completed")
- *   error    → Red    #f38ba8 (universal "failed")
+ *   progress → Yellow (warm accent; "in flight")
+ *   success  → Green  (universal "completed")
+ *   error    → Red    (universal "failed")
  *
  * The empty track stays dim regardless — only the filled portion carries
  * the status signal, which keeps the bar legible while still telegraphing
@@ -44,17 +44,16 @@ const BAR_EMPTY = "･";
  */
 type BarState = "progress" | "success" | "error";
 
+const BAR_STATE_PALETTE: Record<BarState, PaletteKey> = {
+  progress: "warning",
+  success: "success",
+  error: "error",
+};
+
 function fillColor(state: BarState): string {
   if (supportsTrueColor()) {
-    switch (state) {
-      case "success":
-        return "\x1b[38;2;166;227;161m"; // Catppuccin Green  #a6e3a1
-      case "error":
-        return "\x1b[38;2;243;139;168m"; // Catppuccin Red    #f38ba8
-      case "progress":
-      default:
-        return "\x1b[38;2;249;226;175m"; // Catppuccin Yellow #f9e2af
-    }
+    const [r, g, b] = PALETTE[BAR_STATE_PALETTE[state]];
+    return `\x1b[38;2;${r};${g};${b}m`;
   }
   if (supports256Color()) {
     switch (state) {
@@ -78,7 +77,7 @@ function fillColor(state: BarState): string {
   }
 }
 
-type RGB = [number, number, number];
+type RGB = readonly [number, number, number];
 
 /**
  * Gradient endpoints for the filled bar segment. Each state interpolates
@@ -88,12 +87,12 @@ type RGB = [number, number, number];
 function gradientEndpoints(state: BarState): { start: RGB; end: RGB } {
   switch (state) {
     case "success":
-      return { start: [126, 201, 138], end: [166, 227, 161] };
+      return { start: paletteRgb("teal"), end: paletteRgb("green") };
     case "error":
-      return { start: [224, 108, 136], end: [243, 139, 168] };
+      return { start: paletteRgb("maroon"), end: paletteRgb("red") };
     case "progress":
     default:
-      return { start: [242, 196, 120], end: [249, 226, 175] };
+      return { start: paletteRgb("peach"), end: paletteRgb("yellow") };
   }
 }
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,4 +1,5 @@
 import { supportsColor, supportsTrueColor } from "../services/system/detect.ts";
+import { flavors, type ColorName } from "@catppuccin/palette";
 
 /**
  * ANSI color and formatting codes for CLI output
@@ -31,20 +32,24 @@ export const COLORS = supportsColor() ? ANSI_CODES : NO_COLORS;
 //
 // Truecolor terminals get the full palette via 24-bit ANSI SGR; legacy
 // terminals degrade to basic ANSI; NO_COLOR emits plain text.
-// Hex values mirror .impeccable.md and src/sdk/runtime/theme.ts.
 // ---------------------------------------------------------------------------
 
 export type PaletteKey = "text" | "dim" | "accent" | "success" | "error" | "warning" | "mauve" | "info";
 
+export function paletteRgb(name: ColorName): readonly [number, number, number] {
+  const { r, g, b } = flavors.mocha.colors[name].rgb;
+  return [r, g, b];
+}
+
 export const PALETTE: Record<PaletteKey, readonly [number, number, number]> = {
-  text:    [205, 214, 244], // #cdd6f4
-  dim:     [127, 132, 156], // #7f849c (Overlay1)
-  accent:  [137, 180, 250], // #89b4fa (Blue)
-  success: [166, 227, 161], // #a6e3a1 (Green)
-  error:   [243, 139, 168], // #f38ba8 (Red)
-  warning: [249, 226, 175], // #f9e2af (Yellow)
-  mauve:   [203, 166, 247], // #cba6f7 (Mauve)
-  info:    [137, 220, 235], // #89dceb (Sky)
+  text:    paletteRgb("text"),
+  dim:     paletteRgb("overlay1"),
+  accent:  paletteRgb("blue"),
+  success: paletteRgb("green"),
+  error:   paletteRgb("red"),
+  warning: paletteRgb("yellow"),
+  mauve:   paletteRgb("mauve"),
+  info:    paletteRgb("sky"),
 };
 
 export interface PaintOptions {

--- a/src/theme/logo.ts
+++ b/src/theme/logo.ts
@@ -9,6 +9,7 @@ import {
   supports256Color,
   supportsColor,
 } from "../services/system/detect.ts";
+import { flavors, type CatppuccinFlavor, type ColorName } from "@catppuccin/palette";
 
 export const ATOMIC_BLOCK_LOGO = [
   "█▀▀█ ▀▀█▀▀ █▀▀█ █▀▄▀█ ▀█▀ █▀▀",
@@ -16,17 +17,27 @@ export const ATOMIC_BLOCK_LOGO = [
   "▀  ▀   ▀   ▀▀▀▀ ▀   ▀ ▀▀▀ ▀▀▀",
 ];
 
-/** Catppuccin-inspired gradient (dark terminal). */
-export const GRADIENT_DARK = [
-  "#f5e0dc", "#f2cdcd", "#f5c2e7", "#cba6f7",
-  "#b4befe", "#89b4fa", "#74c7ec", "#89dceb", "#94e2d5",
-];
+const GRADIENT_COLOR_NAMES = [
+  "rosewater",
+  "flamingo",
+  "pink",
+  "mauve",
+  "lavender",
+  "blue",
+  "sapphire",
+  "sky",
+  "teal",
+] as const satisfies readonly ColorName[];
 
-/** Catppuccin-inspired gradient (light terminal). */
-export const GRADIENT_LIGHT = [
-  "#dc8a78", "#dd7878", "#ea76cb", "#8839ef",
-  "#7287fd", "#1e66f5", "#209fb5", "#04a5e5", "#179299",
-];
+function gradientFromFlavor(flavor: CatppuccinFlavor): string[] {
+  return GRADIENT_COLOR_NAMES.map((name) => flavor.colors[name].hex);
+}
+
+/** Catppuccin gradient (dark terminal). */
+export const GRADIENT_DARK = gradientFromFlavor(flavors.mocha);
+
+/** Catppuccin gradient (light terminal). */
+export const GRADIENT_LIGHT = gradientFromFlavor(flavors.latte);
 
 /** 256-color approximation of the gradient. */
 export const GRADIENT_256 = [224, 218, 219, 183, 147, 111, 117, 159, 115];
@@ -40,7 +51,7 @@ function hexToRgb(hex: string): [number, number, number] {
   ];
 }
 
-function interpolateHex(gradient: string[], t: number): [number, number, number] {
+function interpolateHex(gradient: readonly string[], t: number): [number, number, number] {
   const pos = Math.max(0, Math.min(1, t)) * (gradient.length - 1);
   const lo = Math.floor(pos);
   const hi = Math.min(lo + 1, gradient.length - 1);
@@ -60,7 +71,7 @@ function interpolate256(gradient: number[], t: number): number {
   return gradient[lo]!;
 }
 
-export function colorizeLineTrueColor(line: string, gradient: string[]): string {
+export function colorizeLineTrueColor(line: string, gradient: readonly string[]): string {
   let out = "";
   const len = line.length;
   for (let i = 0; i < len; i++) {

--- a/tests/sdk/components/edge.test.tsx
+++ b/tests/sdk/components/edge.test.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
+import type { CapturedSpan } from "@opentui/core";
 import { Edge } from "../../../src/sdk/components/edge.tsx";
-import { renderReact, type ReactTestSetup } from "./test-helpers.tsx";
+import { renderReact, TEST_THEME, type ReactTestSetup } from "./test-helpers.tsx";
 
 let testSetup: ReactTestSetup | null = null;
 
@@ -11,10 +12,30 @@ afterEach(() => {
   testSetup = null;
 });
 
+function spanHex(color: CapturedSpan["bg"]): string {
+  const [r, g, b] = color.toInts();
+  return "#" + [r, g, b].map((part) => part.toString(16).padStart(2, "0")).join("");
+}
+
+function findSpanContaining(setup: ReactTestSetup, text: string): CapturedSpan | undefined {
+  return setup
+    .captureSpans()
+    .lines.flatMap((line) => line.spans)
+    .find((span) => span.text.includes(text));
+}
+
 describe("Edge", () => {
   test("renders straight vertical connector text", async () => {
     testSetup = await renderReact(
-      <Edge text="│" col={5} row={2} width={1} height={1} color="#6c7086" />,
+      <Edge
+        text="│"
+        col={5}
+        row={2}
+        width={1}
+        height={1}
+        color={TEST_THEME.borderActive}
+        backgroundColor={TEST_THEME.background}
+      />,
       { width: 40, height: 10 },
     );
     await testSetup.renderOnce();
@@ -25,7 +46,15 @@ describe("Edge", () => {
   test("renders branching connector with horizontal bar", async () => {
     const branchText = "╭──┬──╮";
     testSetup = await renderReact(
-      <Edge text={branchText} col={0} row={0} width={7} height={1} color="#6c7086" />,
+      <Edge
+        text={branchText}
+        col={0}
+        row={0}
+        width={7}
+        height={1}
+        color={TEST_THEME.borderActive}
+        backgroundColor={TEST_THEME.background}
+      />,
       { width: 40, height: 10 },
     );
     await testSetup.renderOnce();
@@ -36,11 +65,40 @@ describe("Edge", () => {
   test("renders multiline connector text", async () => {
     const text = "│\n╰──╮";
     testSetup = await renderReact(
-      <Edge text={text} col={0} row={0} width={4} height={2} color="#ffffff" />,
+      <Edge
+        text={text}
+        col={0}
+        row={0}
+        width={4}
+        height={2}
+        color={TEST_THEME.text}
+        backgroundColor={TEST_THEME.background}
+      />,
       { width: 40, height: 10 },
     );
     await testSetup.renderOnce();
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("│");
+  });
+
+  test("paints connector text with graph background", async () => {
+    testSetup = await renderReact(
+      <Edge
+        text="│"
+        col={5}
+        row={2}
+        width={1}
+        height={1}
+        color={TEST_THEME.warning}
+        backgroundColor={TEST_THEME.background}
+      />,
+      { width: 40, height: 10 },
+    );
+    await testSetup.renderOnce();
+
+    const span = findSpanContaining(testSetup, "│");
+    expect(span).toBeDefined();
+    if (!span) throw new Error("Expected connector span");
+    expect(spanHex(span.bg)).toBe(TEST_THEME.background);
   });
 });

--- a/tests/sdk/components/graph-theme.test.ts
+++ b/tests/sdk/components/graph-theme.test.ts
@@ -1,21 +1,8 @@
 import { test, expect, describe } from "bun:test";
 import { deriveGraphTheme } from "../../../src/sdk/components/graph-theme.ts";
-import type { TerminalTheme } from "../../../src/sdk/runtime/theme.ts";
+import { resolveTheme } from "../../../src/sdk/runtime/theme.ts";
 
-const fakeTheme: TerminalTheme = {
-  bg: "#1e1e2e",
-  surface: "#313244",
-  selection: "#45475a",
-  border: "#6c7086",
-  borderDim: "#585b70",
-  accent: "#89b4fa",
-  text: "#cdd6f4",
-  dim: "#7f849c",
-  success: "#a6e3a1",
-  error: "#f38ba8",
-  warning: "#f9e2af",
-  mauve: "#cba6f7",
-};
+const fakeTheme = resolveTheme(null);
 
 describe("deriveGraphTheme", () => {
   test("maps background from theme bg", () => {
@@ -33,13 +20,9 @@ describe("deriveGraphTheme", () => {
     expect(gt.text).toBe(fakeTheme.text);
   });
 
-  test("computes textMuted as lerp between text and bg at 0.3", () => {
+  test("maps textMuted from theme textMuted", () => {
     const gt = deriveGraphTheme(fakeTheme);
-    // textMuted should be a valid hex color string
-    expect(gt.textMuted).toMatch(/^#[0-9a-f]{6}$/);
-    // Should not equal raw text or bg
-    expect(gt.textMuted).not.toBe(fakeTheme.text);
-    expect(gt.textMuted).not.toBe(fakeTheme.bg);
+    expect(gt.textMuted).toBe(fakeTheme.textMuted);
   });
 
   test("maps textDim from theme dim", () => {
@@ -67,9 +50,9 @@ describe("deriveGraphTheme", () => {
     expect(gt.warning).toBe(fakeTheme.warning);
   });
 
-  test("maps info from theme accent", () => {
+  test("maps info from theme info", () => {
     const gt = deriveGraphTheme(fakeTheme);
-    expect(gt.info).toBe(fakeTheme.accent);
+    expect(gt.info).toBe(fakeTheme.info);
   });
 
   test("maps border from theme borderDim", () => {

--- a/tests/sdk/components/node-card.test.tsx
+++ b/tests/sdk/components/node-card.test.tsx
@@ -1,11 +1,12 @@
 /** @jsxImportSource @opentui/react */
 
 import { test, expect, describe, afterEach } from "bun:test";
+import type { CapturedSpan } from "@opentui/core";
 import { PanelStore } from "../../../src/sdk/components/orchestrator-panel-store.ts";
 import { NodeCard } from "../../../src/sdk/components/node-card.tsx";
 import type { LayoutNode } from "../../../src/sdk/components/layout.ts";
 import { NODE_H } from "../../../src/sdk/components/layout.ts";
-import { renderReact, TestProviders, type ReactTestSetup } from "./test-helpers.tsx";
+import { renderReact, TestProviders, TEST_THEME, type ReactTestSetup } from "./test-helpers.tsx";
 
 let testSetup: ReactTestSetup | null = null;
 
@@ -27,6 +28,18 @@ function makeLayoutNode(overrides: Partial<LayoutNode> = {}): LayoutNode {
     y: 0,
     ...overrides,
   };
+}
+
+function spanHex(color: CapturedSpan["bg"]): string {
+  const [r, g, b] = color.toInts();
+  return "#" + [r, g, b].map((part) => part.toString(16).padStart(2, "0")).join("");
+}
+
+function findSpanContaining(setup: ReactTestSetup, text: string): CapturedSpan | undefined {
+  return setup
+    .captureSpans()
+    .lines.flatMap((line) => line.spans)
+    .find((span) => span.text.includes(text));
 }
 
 describe("NodeCard", () => {
@@ -217,5 +230,74 @@ describe("NodeCard", () => {
     );
     await testSetup.renderOnce();
     expect(testSetup.captureCharFrame()).toContain("pulse-test");
+  });
+
+  test("running node fills interior with graph background", async () => {
+    const store = new PanelStore();
+    const now = Date.now();
+    const node = makeLayoutNode({
+      name: "worker",
+      status: "running",
+      startedAt: now - 65000,
+    });
+
+    testSetup = await renderReact(
+      <TestProviders store={store}>
+        <NodeCard node={node} focused={false} pulsePhase={0} displayH={NODE_H} />
+      </TestProviders>,
+      { width: 60, height: 10 },
+    );
+    await testSetup.renderOnce();
+
+    const durationSpan = findSpanContaining(testSetup, "1m");
+    expect(durationSpan).toBeDefined();
+    if (!durationSpan) throw new Error("Expected running node duration span");
+    expect(spanHex(durationSpan.bg)).toBe(TEST_THEME.background);
+  });
+
+  test("focused running node does not tint interior with warning color", async () => {
+    const store = new PanelStore();
+    const now = Date.now();
+    const node = makeLayoutNode({
+      name: "focused-worker",
+      status: "running",
+      startedAt: now - 65000,
+    });
+
+    testSetup = await renderReact(
+      <TestProviders store={store}>
+        <NodeCard node={node} focused={true} pulsePhase={16} displayH={NODE_H} />
+      </TestProviders>,
+      { width: 60, height: 10 },
+    );
+    await testSetup.renderOnce();
+
+    const durationSpan = findSpanContaining(testSetup, "1m");
+    expect(durationSpan).toBeDefined();
+    if (!durationSpan) throw new Error("Expected focused running node duration span");
+    expect(spanHex(durationSpan.fg)).toBe(TEST_THEME.warning);
+    expect(spanHex(durationSpan.bg)).toBe(TEST_THEME.background);
+  });
+
+  test("running node border keeps explicit graph background", async () => {
+    const store = new PanelStore();
+    const node = makeLayoutNode({
+      name: "worker",
+      status: "running",
+      startedAt: Date.now() - 65000,
+    });
+
+    testSetup = await renderReact(
+      <TestProviders store={store}>
+        <NodeCard node={node} focused={true} pulsePhase={16} displayH={NODE_H} />
+      </TestProviders>,
+      { width: 60, height: 10 },
+    );
+    await testSetup.renderOnce();
+
+    const borderSpan = findSpanContaining(testSetup, "worker");
+    expect(borderSpan).toBeDefined();
+    if (!borderSpan) throw new Error("Expected running node border/title span");
+    expect(spanHex(borderSpan.bg)).toBe(TEST_THEME.background);
   });
 });

--- a/tests/sdk/components/orchestrator-panel.test.tsx
+++ b/tests/sdk/components/orchestrator-panel.test.tsx
@@ -30,6 +30,25 @@ describe("OrchestratorPanel", () => {
     expect(p).toBeInstanceOf(OrchestratorPanel);
   });
 
+  test("createWithRenderer applies the UI background to the renderer", async () => {
+    testSetup = await createTestRenderer({ width: 80, height: 24 });
+    const backgroundCapture: {
+      value: Parameters<typeof testSetup.renderer.setBackgroundColor>[0] | null;
+    } = { value: null };
+    const originalSetBackgroundColor = testSetup.renderer.setBackgroundColor.bind(testSetup.renderer);
+    testSetup.renderer.setBackgroundColor = (color) => {
+      backgroundCapture.value = color;
+      originalSetBackgroundColor(color);
+    };
+
+    panel = OrchestratorPanel.createWithRenderer(testSetup.renderer, {
+      tmuxSession: "test-session",
+    });
+
+    expect(backgroundCapture.value).toBe(TEST_THEME.background);
+    expect(Reflect.get(testSetup.renderer, "forceFullRepaintRequested")).toBe(true);
+  });
+
   test("showWorkflowInfo does not throw", async () => {
     const { panel: p } = await createPanel();
     expect(() =>

--- a/tests/sdk/components/renderer-background.test.ts
+++ b/tests/sdk/components/renderer-background.test.ts
@@ -1,8 +1,20 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, mock } from "bun:test";
+import type { CliRenderer } from "@opentui/core";
 import {
+  requestRendererBackgroundRepaint,
+  resetRendererTerminalBackground,
+  setRendererBackground,
   terminalBackgroundColorSequence,
   wrapForTmuxIfNeeded,
 } from "../../../src/sdk/components/renderer-background.ts";
+
+function createRendererStub(): CliRenderer {
+  return {
+    setBackgroundColor: mock(() => {}),
+    requestRender: mock(() => {}),
+    resetTerminalBgColor: mock(() => {}),
+  } as Partial<CliRenderer> as CliRenderer;
+}
 
 describe("terminalBackgroundColorSequence", () => {
   test("formats OSC 11 background sync for hex colors", () => {
@@ -35,6 +47,39 @@ describe("wrapForTmuxIfNeeded", () => {
     process.env.TMUX = "/tmp/tmux-test";
     try {
       expect(wrapForTmuxIfNeeded("\x1b]11;rgb:1e/1e/2e\x07")).toBe("\x1bPtmux;\x1b\x1b]11;rgb:1e/1e/2e\x07\x1b\\");
+    } finally {
+      if (previousTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = previousTmux;
+    }
+  });
+});
+
+describe("renderer background helpers", () => {
+  test("sets renderer background without syncing terminal by default", () => {
+    const renderer = createRendererStub();
+
+    setRendererBackground(renderer, "#1e1e2e");
+
+    expect(renderer.setBackgroundColor).toHaveBeenCalledWith("#1e1e2e");
+  });
+
+  test("requests a full repaint before rendering", () => {
+    const renderer = createRendererStub();
+
+    requestRendererBackgroundRepaint(renderer);
+
+    expect((renderer as unknown as { forceFullRepaintRequested: boolean }).forceFullRepaintRequested).toBe(true);
+    expect(renderer.requestRender).toHaveBeenCalled();
+  });
+
+  test("resets terminal background through renderer outside tmux", () => {
+    const previousTmux = process.env.TMUX;
+    delete process.env.TMUX;
+    const renderer = createRendererStub();
+    try {
+      resetRendererTerminalBackground(renderer);
+
+      expect(renderer.resetTerminalBgColor).toHaveBeenCalled();
     } finally {
       if (previousTmux === undefined) delete process.env.TMUX;
       else process.env.TMUX = previousTmux;

--- a/tests/sdk/components/renderer-background.test.ts
+++ b/tests/sdk/components/renderer-background.test.ts
@@ -1,0 +1,43 @@
+import { test, expect, describe } from "bun:test";
+import {
+  terminalBackgroundColorSequence,
+  wrapForTmuxIfNeeded,
+} from "../../../src/sdk/components/renderer-background.ts";
+
+describe("terminalBackgroundColorSequence", () => {
+  test("formats OSC 11 background sync for hex colors", () => {
+    expect(terminalBackgroundColorSequence("#1e1e2e")).toBe("\x1b]11;rgb:1e/1e/2e\x07");
+  });
+
+  test("accepts hex colors without a leading hash", () => {
+    expect(terminalBackgroundColorSequence("eff1f5")).toBe("\x1b]11;rgb:ef/f1/f5\x07");
+  });
+
+  test("rejects non-hex colors", () => {
+    expect(() => terminalBackgroundColorSequence("transparent")).toThrow("Cannot sync terminal background");
+  });
+});
+
+describe("wrapForTmuxIfNeeded", () => {
+  test("returns raw sequence outside tmux", () => {
+    const previousTmux = process.env.TMUX;
+    delete process.env.TMUX;
+    try {
+      expect(wrapForTmuxIfNeeded("\x1b]11;rgb:1e/1e/2e\x07")).toBe("\x1b]11;rgb:1e/1e/2e\x07");
+    } finally {
+      if (previousTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = previousTmux;
+    }
+  });
+
+  test("wraps OSC sequences for tmux passthrough", () => {
+    const previousTmux = process.env.TMUX;
+    process.env.TMUX = "/tmp/tmux-test";
+    try {
+      expect(wrapForTmuxIfNeeded("\x1b]11;rgb:1e/1e/2e\x07")).toBe("\x1bPtmux;\x1b\x1b]11;rgb:1e/1e/2e\x07\x1b\\");
+    } finally {
+      if (previousTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = previousTmux;
+    }
+  });
+});

--- a/tests/sdk/components/tui-diagnostics.test.ts
+++ b/tests/sdk/components/tui-diagnostics.test.ts
@@ -1,9 +1,77 @@
-import { describe, expect, test } from "bun:test";
-import { OptimizedBuffer, RGBA } from "@opentui/core";
+import { mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, mock, test } from "bun:test";
+import { OptimizedBuffer, RGBA, type CliRenderer } from "@opentui/core";
+import type { GraphTheme } from "../../../src/sdk/components/graph-theme.ts";
 import {
+  createTuiDiagnostics,
   isTuiDiagnosticsEnabled,
   summarizeBuffer,
 } from "../../../src/sdk/components/tui-diagnostics.ts";
+
+const graphTheme: GraphTheme = {
+  background: "#1e1e2e",
+  backgroundElement: "#313244",
+  text: "#cdd6f4",
+  textMuted: "#a6adc8",
+  textDim: "#6c7086",
+  primary: "#89b4fa",
+  success: "#a6e3a1",
+  error: "#f38ba8",
+  warning: "#f9e2af",
+  info: "#74c7ec",
+  mauve: "#cba6f7",
+  border: "#45475a",
+  borderActive: "#585b70",
+};
+
+function withEnv<T>(updates: Record<string, string | undefined>, run: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) {
+    previous.set(key, process.env[key]);
+    const value = updates[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function createRendererStub(width = 2, height = 1): { renderer: CliRenderer; destroy: () => void } {
+  const currentRenderBuffer = OptimizedBuffer.create(width, height, "unicode");
+  const nextRenderBuffer = OptimizedBuffer.create(width, height, "unicode");
+  const text = RGBA.fromInts(255, 255, 255, 255);
+  const background = RGBA.fromInts(30, 30, 46, 255);
+  currentRenderBuffer.setCell(0, 0, "a", text, background);
+  nextRenderBuffer.setCell(0, 0, "b", text, background);
+
+  return {
+    renderer: {
+      width,
+      height,
+      terminalWidth: width,
+      terminalHeight: height,
+      themeMode: "dark",
+      capabilities: { color: true },
+      currentRenderBuffer,
+      nextRenderBuffer,
+      dumpBuffers: mock(() => {}),
+      dumpStdoutBuffer: mock(() => {}),
+    } as Partial<CliRenderer> as CliRenderer,
+    destroy: () => {
+      currentRenderBuffer.destroy();
+      nextRenderBuffer.destroy();
+    },
+  };
+}
 
 describe("isTuiDiagnosticsEnabled", () => {
   test("requires an explicit opt-in value", () => {
@@ -54,6 +122,117 @@ describe("summarizeBuffer", () => {
       ]);
     } finally {
       buffer.destroy();
+    }
+  });
+
+  test("handles invalid code points", () => {
+    const buffer = OptimizedBuffer.create(1, 1, "unicode");
+    try {
+      buffer.buffers.char[0] = 0x11_0000;
+      const summary = summarizeBuffer(buffer);
+
+      expect(summary.width).toBe(1);
+      expect(summary.height).toBe(1);
+      expect(summary.topBackgrounds).toEqual([{ color: "#000000", count: 1, percent: 100 }]);
+      expect(summary.rows).toEqual([{ y: 0, text: "", backgrounds: [{ x: 0, width: 1, color: "#000000" }] }]);
+    } finally {
+      buffer.destroy();
+    }
+  });
+});
+
+describe("createTuiDiagnostics", () => {
+  test("returns null when diagnostics are disabled", () => {
+    const { renderer, destroy } = createRendererStub();
+    try {
+      withEnv({ ATOMIC_TUI_DIAGNOSTICS: undefined }, () => {
+        expect(
+          createTuiDiagnostics({
+            renderer,
+            graphTheme,
+            getSnapshot: () => ({
+              workflowName: "disabled",
+              agent: "copilot",
+              prompt: "",
+              fatalError: null,
+              completionReached: false,
+              sessions: [],
+              backgroundTaskCount: 0,
+              viewMode: "graph",
+              activeAgentId: "root",
+            }),
+          }),
+        ).toBeNull();
+      });
+    } finally {
+      destroy();
+    }
+  });
+
+  test("writes metadata, captures, and dispose files", () => {
+    const directory = join(tmpdir(), `atomic-tui-diagnostics-test-${process.pid}-${Date.now()}`);
+    const { renderer, destroy } = createRendererStub();
+    try {
+      withEnv(
+        {
+          ATOMIC_TUI_DIAGNOSTICS: "1",
+          ATOMIC_TUI_DIAGNOSTICS_DIR: directory,
+          ATOMIC_TUI_DIAGNOSTICS_MAX: "2",
+          ATOMIC_TUI_DIAGNOSTICS_INTERVAL_MS: "60000",
+          ATOMIC_TUI_DIAGNOSTICS_OPENTUI_DUMP: "1",
+          TERM: "xterm-256color",
+          TERM_PROGRAM: "test-terminal",
+          COLORTERM: "truecolor",
+          TMUX: "/tmp/tmux",
+          SSH_TTY: "/dev/pts/1",
+        },
+        () => {
+          mkdirSync(directory, { recursive: true });
+          const diagnostics = createTuiDiagnostics({
+            renderer,
+            graphTheme,
+            getSnapshot: () => ({
+              workflowName: "workflow",
+              agent: "copilot",
+              prompt: "prompt",
+              fatalError: null,
+              completionReached: true,
+              sessions: [{ name: "root", status: "complete", parents: [], startedAt: 1, endedAt: 2 }],
+              backgroundTaskCount: 1,
+              viewMode: "graph",
+              activeAgentId: "root",
+            }),
+          });
+
+          expect(diagnostics).not.toBeNull();
+          diagnostics?.capture("manual capture!");
+          diagnostics?.capture("over limit");
+          diagnostics?.dispose();
+          diagnostics?.dispose();
+
+          const files = readdirSync(directory).sort();
+          expect(files).toContain("metadata.json");
+          expect(files).toContain("latest.json");
+          expect(files).toContain("disposed.json");
+          expect(files.some((file) => file.endsWith("-created.json"))).toBe(true);
+          expect(files.some((file) => file.endsWith("-manual-capture.json"))).toBe(true);
+          expect(files.some((file) => file.endsWith("-over-limit.json"))).toBe(false);
+
+          const latest = JSON.parse(readFileSync(join(directory, "latest.json"), "utf8")) as {
+            reason: string;
+            environment: { TMUX: string | null };
+            workflow: { workflowName: string };
+          };
+          expect(latest.reason).toBe("manual capture!");
+          expect(latest.environment.TMUX).toBe("/tmp/tmux");
+          expect(latest.workflow.workflowName).toBe("workflow");
+          expect(renderer.dumpBuffers).toHaveBeenCalled();
+          expect(renderer.dumpStdoutBuffer).toHaveBeenCalled();
+        },
+      );
+    } finally {
+      destroy();
+      rmSync(directory, { recursive: true, force: true });
     }
   });
 });

--- a/tests/sdk/components/tui-diagnostics.test.ts
+++ b/tests/sdk/components/tui-diagnostics.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { OptimizedBuffer, RGBA } from "@opentui/core";
+import {
+  isTuiDiagnosticsEnabled,
+  summarizeBuffer,
+} from "../../../src/sdk/components/tui-diagnostics.ts";
+
+describe("isTuiDiagnosticsEnabled", () => {
+  test("requires an explicit opt-in value", () => {
+    const previous = process.env.ATOMIC_TUI_DIAGNOSTICS;
+    delete process.env.ATOMIC_TUI_DIAGNOSTICS;
+    try {
+      expect(isTuiDiagnosticsEnabled()).toBe(false);
+      process.env.ATOMIC_TUI_DIAGNOSTICS = "1";
+      expect(isTuiDiagnosticsEnabled()).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.ATOMIC_TUI_DIAGNOSTICS;
+      else process.env.ATOMIC_TUI_DIAGNOSTICS = previous;
+    }
+  });
+});
+
+describe("summarizeBuffer", () => {
+  test("groups background colors and flags yellow-hue cells", () => {
+    const buffer = OptimizedBuffer.create(4, 2, "unicode");
+    try {
+      const text = RGBA.fromInts(255, 255, 255, 255);
+      const dark = RGBA.fromInts(30, 30, 46, 255);
+      const yellow = RGBA.fromInts(249, 226, 175, 255);
+
+      for (let x = 0; x < 4; x++) {
+        buffer.setCell(x, 0, "a", text, x < 2 ? yellow : dark);
+        buffer.setCell(x, 1, "b", text, dark);
+      }
+
+      const summary = summarizeBuffer(buffer);
+
+      expect(summary.width).toBe(4);
+      expect(summary.height).toBe(2);
+      expect(summary.topBackgrounds[0]).toEqual({
+        color: "#1e1e2e",
+        count: 6,
+        percent: 75,
+      });
+      expect(summary.topBackgrounds[1]).toEqual({
+        color: "#f9e2af",
+        count: 2,
+        percent: 25,
+      });
+      expect(summary.yellowHueCells).toBe(2);
+      expect(summary.rows[0]?.backgrounds).toEqual([
+        { x: 0, width: 2, color: "#f9e2af" },
+        { x: 2, width: 2, color: "#1e1e2e" },
+      ]);
+    } finally {
+      buffer.destroy();
+    }
+  });
+});

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../../src/sdk/components/workflow-picker-panel.tsx";
 import type { WorkflowDefinition, WorkflowInput } from "../../../src/sdk/types.ts";
 import { createRegistry } from "../../../src/sdk/registry.ts";
+import { resolveTheme } from "../../../src/sdk/runtime/theme.ts";
 import {
   renderReact,
   setReactActEnvironment,
@@ -70,37 +71,10 @@ function makeWorkflow(
   } as WorkflowDefinition;
 }
 
-const TEST_DARK_BASE = {
-  bg: "#1e1e2e",
-  surface: "#313244",
-  selection: "#45475a",
-  border: "#6c7086",
-  borderDim: "#585b70",
-  accent: "#89b4fa",
-  text: "#cdd6f4",
-  dim: "#7f849c",
-  success: "#a6e3a1",
-  error: "#f38ba8",
-  warning: "#f9e2af",
-  mauve: "#cba6f7",
-};
+const TEST_DARK_BASE = resolveTheme(null);
+const TEST_LIGHT_BASE = resolveTheme("light");
 
-const TEST_LIGHT_BASE = {
-  bg: "#eff1f5",
-  surface: "#ccd0da",
-  selection: "#bcc0cc",
-  border: "#9ca0b0",
-  borderDim: "#acb0be",
-  accent: "#1e66f5",
-  text: "#4c4f69",
-  dim: "#8c8fa1",
-  success: "#40a02b",
-  error: "#d20f39",
-  warning: "#df8e1d",
-  mauve: "#8839ef",
-};
-
-const TEST_THEME: PickerTheme = buildPickerTheme(TEST_DARK_BASE, true);
+const TEST_THEME: PickerTheme = buildPickerTheme(TEST_DARK_BASE);
 
 // A catalog with workflows across agents.
 const WORKFLOWS: WorkflowDefinition[] = [
@@ -340,24 +314,24 @@ describe("buildRows", () => {
 });
 
 describe("buildPickerTheme", () => {
-  test("produces distinct dark-mode info/mauve for Mocha base", () => {
-    const theme = buildPickerTheme(TEST_DARK_BASE, true);
-    expect(theme.backgroundPanel).toBe("#181825");
-    expect(theme.backgroundElement).toBe("#11111b");
-    expect(theme.info).toBe("#89dceb");
-    expect(theme.mauve).toBe("#cba6f7");
+  test("maps extended picker roles from Mocha palette", () => {
+    const theme = buildPickerTheme(TEST_DARK_BASE);
+    expect(theme.backgroundPanel).toBe(TEST_DARK_BASE.backgroundPanel);
+    expect(theme.backgroundElement).toBe(TEST_DARK_BASE.backgroundElement);
+    expect(theme.info).toBe(TEST_DARK_BASE.info);
+    expect(theme.mauve).toBe(TEST_DARK_BASE.mauve);
   });
 
-  test("produces light-mode values when isDark is false", () => {
-    const theme = buildPickerTheme(TEST_LIGHT_BASE, false);
-    expect(theme.backgroundPanel).toBe("#e6e9ef");
-    expect(theme.backgroundElement).toBe("#dce0e8");
-    expect(theme.info).toBe("#04a5e5");
-    expect(theme.mauve).toBe("#8839ef");
+  test("maps extended picker roles from Latte palette", () => {
+    const theme = buildPickerTheme(TEST_LIGHT_BASE);
+    expect(theme.backgroundPanel).toBe(TEST_LIGHT_BASE.backgroundPanel);
+    expect(theme.backgroundElement).toBe(TEST_LIGHT_BASE.backgroundElement);
+    expect(theme.info).toBe(TEST_LIGHT_BASE.info);
+    expect(theme.mauve).toBe(TEST_LIGHT_BASE.mauve);
   });
 
   test("forwards base colors into matching theme slots", () => {
-    const theme = buildPickerTheme(TEST_DARK_BASE, true);
+    const theme = buildPickerTheme(TEST_DARK_BASE);
     expect(theme.background).toBe(TEST_DARK_BASE.bg);
     expect(theme.surface).toBe(TEST_DARK_BASE.surface);
     expect(theme.text).toBe(TEST_DARK_BASE.text);
@@ -901,6 +875,33 @@ describe("WorkflowPickerPanel class", () => {
   test("createWithRenderer returns an instance without throwing", async () => {
     const p = await createPanel();
     expect(p).toBeInstanceOf(WorkflowPickerPanel);
+  });
+
+  test("createWithRenderer applies the UI background to the renderer", async () => {
+    coreSetup = await createTestRenderer({ width: 120, height: 40 });
+    const backgroundCapture: {
+      value: Parameters<typeof coreSetup.renderer.setBackgroundColor>[0] | null;
+    } = { value: null };
+    const originalSetBackgroundColor = coreSetup.renderer.setBackgroundColor.bind(coreSetup.renderer);
+    coreSetup.renderer.setBackgroundColor = (color) => {
+      backgroundCapture.value = color;
+      originalSetBackgroundColor(color);
+    };
+
+    const registry = WORKFLOWS.reduce(
+      (r, wf) => r.register(wf),
+      createRegistry(),
+    );
+    setReactActEnvironment(true);
+    act(() => {
+      panel = WorkflowPickerPanel.createWithRenderer(coreSetup!.renderer, {
+        agent: "claude",
+        registry,
+      });
+    });
+
+    expect(backgroundCapture.value).toBe(TEST_DARK_BASE.bg);
+    expect(Reflect.get(coreSetup.renderer, "forceFullRepaintRequested")).toBe(true);
   });
 
   test("waitForSelection returns a pending promise", async () => {


### PR DESCRIPTION
## Summary

Fixes blank-cell and transparent-background rendering issues in the workflow UI by properly managing renderer and terminal background colors, consolidates the Catppuccin palette to a single authoritative source, and adds an opt-in diagnostics system for debugging rendering problems.

## Key Changes

### Background rendering fixes
- Add `renderer-background.ts` module with helpers: `setRendererBackground`, `requestRendererBackgroundRepaint`, `resetRendererTerminalBackground`, and tmux-passthrough `wrapForTmuxIfNeeded`
- Fix blank-cell rendering regression introduced in OpenTUI 0.1.103+ by forcing a full repaint on panel mount via `forceFullRepaintRequested`
- Sync terminal default background via OSC 11 escape sequences (with tmux DCS passthrough) on panel creation; restore on destroy
- Replace `"transparent"` backgrounds in `WorkflowPickerPanel` input fields and workflow list items with proper theme colors

### Theme consolidation
- Extend `TerminalTheme` interface with `backgroundPanel`, `backgroundElement`, `textMuted`, and `info` fields
- Replace hardcoded Catppuccin Mocha/Latte hex constants with `buildTerminalTheme()` that derives all values from `@catppuccin/palette`
- Remove the `isDark` parameter from `buildPickerTheme()` — all extra colors are now sourced from `TerminalTheme`
- Replace hardcoded RGB tuples in `theme/colors.ts` `PALETTE` with `paletteRgb()` helper backed by `@catppuccin/palette`

### TUI diagnostics system
- Add `tui-diagnostics.ts`: opt-in frame-buffer snapshot system enabled via `ATOMIC_TUI_DIAGNOSTICS=1`
- Captures renderer state, buffer contents, workflow snapshot, and background color histograms as JSON files
- Configurable via `ATOMIC_TUI_DIAGNOSTICS_DIR`, `ATOMIC_TUI_DIAGNOSTICS_INTERVAL_MS`, `ATOMIC_TUI_DIAGNOSTICS_MAX`, `ATOMIC_TUI_DIAGNOSTICS_OPENTUI_DUMP`
- Integrated into `OrchestratorPanel` (captures on mount, store update, and destroy)
- Executor now forwards `ATOMIC_TUI_DIAGNOSTICS_*` env vars and `COLORTERM` into the orchestrator subprocess

### Tests
- New `renderer-background.test.ts` and expanded `tui-diagnostics.test.ts` covering diagnostics capture lifecycle and buffer-summarization helpers
- Updated `edge`, `node-card`, `orchestrator-panel`, and `workflow-picker-panel` tests to match revised theme/background API

### Documentation
- Add `DEV_SETUP.md` section documenting the diagnostics env vars and usage example