### PR TITLE
chore(release): bump version to v0.6.7-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.6",
+  "version": "0.6.7-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.6.6` to `0.6.7-0` in preparation for the next prerelease.

## Changes

- `package.json`: version `0.6.6` → `0.6.7-0`

## Notes

This is a prerelease bump (`-0` suffix). Once merged to `main`, the GitHub Release workflow will automatically publish `v0.6.7-0` to npm.