### PR TITLE
chore(release): bump version to v0.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.7-0",
+  "version": "0.6.7",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Promotes the `v0.6.7-0` prerelease to a stable release by bumping `package.json` from `0.6.7-0` to `0.6.7`.

## Changes since v0.6.6

- **feat(session):** add selective session kill — users can now target individual sessions instead of killing all at once
- **fix(tui):** improve workflow UI rendering — corrects visual issues in the OpenTUI workflow component
- **test(tui):** add renderer diagnostics helper coverage
- **docs:** update session kill command documentation