### PR TITLE
feat(settings): seed COLORTERM=truecolor into provider envVars on install/update

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,16 +2,15 @@
   "env": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "ENABLE_LSP_TOOL": "1",
-    "CLAUDE_CODE_NO_FLICKER": "1"
+    "CLAUDE_CODE_NO_FLICKER": "1",
+    "CLAUDE_CODE_TMUX_TRUECOLOR": "1"
   },
   "includeCoAuthoredBy": false,
   "skipDangerousModePermissionPrompt": true,
   "permissions": {
     "defaultMode": "bypassPermissions"
   },
-  "disabledMcpjsonServers": [
-    "azure-devops"
-  ],
+  "disabledMcpjsonServers": ["azure-devops"],
   "enabledPlugins": {
     "pyright-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,

--- a/bun.lock
+++ b/bun.lock
@@ -10,15 +10,15 @@
         "@clack/prompts": "^1.3.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.3.0",
-        "@opencode-ai/sdk": "^1.14.31",
-        "@opentui/core": "0.2.1",
-        "@opentui/react": "^0.2.1",
+        "@opencode-ai/sdk": "^1.14.33",
+        "@opentui/core": "^0.2.2",
+        "@opentui/react": "^0.2.2",
         "commander": "^14.0.3",
         "ignore": "^7.0.5",
         "ignore-by-default": "^2.1.0",
         "linguist-languages": "^9.3.2",
-        "yaml": "^2.8.3",
-        "zod": "^4.4.1",
+        "yaml": "^2.8.4",
+        "zod": "^4.4.2",
       },
       "devDependencies": {
         "@j178/prek": "^0.3.11",
@@ -120,23 +120,23 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.31", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-QaV+ti3NYUITmgIDqtNMqGIYBXJOx2zheN1g+7w4HC8QQsbaW1c7glxXExQHRbdUzcQPP2vUQhnXOcEsTw5CcQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.33", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-LtP9oLMSxVw47AE562IagIOwxLfHLVjk/CTExkYCYtdjPXTQeU5mjyZDbahilAGeFUen9fFE/R9e933zvjF9sQ=="],
 
-    "@opentui/core": ["@opentui/core@0.2.1", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.2.1", "@opentui/core-darwin-x64": "0.2.1", "@opentui/core-linux-arm64": "0.2.1", "@opentui/core-linux-x64": "0.2.1", "@opentui/core-win32-arm64": "0.2.1", "@opentui/core-win32-x64": "0.2.1" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-tXFD2NeznXzZa02yOsQ/D0o/06GBqVrPR7VdmgqI+ZChcS7NY/QgNQGgAZUditW2vezFcxlgTqoCgQaZFqRfGQ=="],
+    "@opentui/core": ["@opentui/core@0.2.2", "", { "dependencies": { "bun-ffi-structs": "0.2.2", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.2.2", "@opentui/core-darwin-x64": "0.2.2", "@opentui/core-linux-arm64": "0.2.2", "@opentui/core-linux-x64": "0.2.2", "@opentui/core-win32-arm64": "0.2.2", "@opentui/core-win32-x64": "0.2.2" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-wxg1CD58SVrowu+WgbhZNi3UP/wWxPio2Kj2IeTjomoIE+6EXLxR8eCCxHYVuQUd9E4fknrKkY5HmiSsp6oPow=="],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vT8rgeNdkzD84wCcS5zmrSVFgR/SjeVr+2FNM/icTjwKh9Jq3cY6UY7/EFck3PRjrmanNu4zw7W5lFKSpMxnPQ=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tY5n3ZRQx+b0kyhQJJLsyJMeZ+0w4FV37YZc/Qqv3qvOqE9kZPw/7adR77FYwWDm/7fax94mLMrR8Y5bKUkDmw=="],
 
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-HAH1KeTejs0Z+RChNsNImI1eOlYJabKeAEvLtnn1aiHxvJFpzdAi6d/VrG5WFcxAem6TVRtnKN46gXff26lkig=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-W/R7OnqY30FXcTG0tiP2JkQFmgtYbIte5afQ5PC12TliRoee1RqG3iCG6kY1jxW+3Vg6jge88uiSjUEDpeV2gA=="],
 
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-447FI6xolsKbG1eH3hpNGQhQ/8M6FDJIgpiJhX9XXvZGO7vEyN6efyqqIzRF+quafqF69+rT3qK70S1svjwVKA=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-1pzTYFEZauYuw6AGycw2TYGtAlZVGjuUtSdxH1fP51kBPS3oVWduUY2j7GKREz3SU5NulvO2Wc6HWsm3feMqwQ=="],
 
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Xdds+HnAbFiylTdxyYhRxPFPnrHm75KTi7QCA1JHU3lb8Sfwrxv3nlYtFhEV798y4osafsghL20Nq5mqVPjizQ=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ucVwUtUYeOYGVFPBLbPoxzbrPdhD0PDyKNQ2X4n1AJ9jlQX4gqBZRcXMEF8hiXDjFxsikZwef7De0ciCcWvAMg=="],
 
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-VEuqX9OSFpw960mibe4OXVmnE43V/VYwB61zoxD5uw7L3jgCiOfrf+W2TuFbcRAgtTD35MypJ53fYxmUcVZc8g=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-MPhYdJNdxmC5Bqsq6sis/+VkjRgkEjm+bQ1Tl++NSKLuiTU32Re0ImcZlgHbe+LZtZoGMZHVSgZlkGd3oYXO2g=="],
 
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ywwRbyjPPEbNe3da+ez4NxIaJWQ79sA2gdepuHKUVdmdxsevdRpAxOHkEpJNtiVvphPc/On9EsP25Hmn5gjYxg=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-19BroLfn2h0RDYfJS5o96Fc8kYCDhRBcseIXtHIkoKIsKMxx62KiDLo/byVye6rp+yQRRB7Xkd2uWqsbdiWo9w=="],
 
-    "@opentui/react": ["@opentui/react@0.2.1", "", { "dependencies": { "@opentui/core": "0.2.1", "react-reconciler": "^0.32.0" }, "peerDependencies": { "react": ">=19.0.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-kHxNHqukauhf1StjuGV36DoR42dBPxU3YVj1wo/V2SOumC/enF6zxBnnsWC3EUWqxLKnMkufh38AvHL3EJ1Taw=="],
+    "@opentui/react": ["@opentui/react@0.2.2", "", { "dependencies": { "@opentui/core": "0.2.2", "react-reconciler": "^0.32.0" }, "peerDependencies": { "react": ">=19.0.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-29Lkyb6gZYccrGJG7swKe3VUXhPW1UpTiBBV0EZpRcbw1+rSaVGgWp4/xcF9V9zaYAxeB2LxQ1PN5QXAmUrfAw=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg=="],
 
@@ -192,7 +192,7 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -420,11 +420,11 @@
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
-    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+    "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 

--- a/package.json
+++ b/package.json
@@ -80,15 +80,15 @@
     "@clack/prompts": "^1.3.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",
-    "@opencode-ai/sdk": "^1.14.31",
-    "@opentui/core": "0.2.1",
-    "@opentui/react": "^0.2.1",
+    "@opencode-ai/sdk": "^1.14.33",
+    "@opentui/core": "^0.2.2",
+    "@opentui/react": "^0.2.2",
     "commander": "^14.0.3",
     "ignore": "^7.0.5",
     "ignore-by-default": "^2.1.0",
     "linguist-languages": "^9.3.2",
-    "yaml": "^2.8.3",
-    "zod": "^4.4.1"
+    "yaml": "^2.8.4",
+    "zod": "^4.4.2"
   },
   "peerDependencies": {
     "react": "^19.2.5"

--- a/src/services/config/settings.ts
+++ b/src/services/config/settings.ts
@@ -14,7 +14,7 @@ import { homedir } from "node:os";
 import { SETTINGS_SCHEMA_URL } from "./settings-schema.ts";
 import { ensureDir } from "../system/copy.ts";
 import { errorMessage } from "../../sdk/errors.ts";
-import type { AgentKey, ProviderOverrides } from "./definitions.ts";
+import { getAgentKeys, type AgentKey, type ProviderOverrides } from "./definitions.ts";
 import type { ScmProvider } from "./atomic-config.ts";
 
 interface AtomicSettings {
@@ -99,5 +99,46 @@ export async function setScmProvider(scm: ScmProvider): Promise<void> {
     await writeGlobalSettings(settings);
   } catch (e) {
     console.warn(`[settings] failed to set scm: ${errorMessage(e)}`);
+  }
+}
+
+/**
+ * Seed `COLORTERM=truecolor` into each agent's `providers.<agent>.envVars`
+ * in `~/.atomic/settings.json` on install / version bump.
+ *
+ * The runtime default in `lib/terminal-env.ts` already injects
+ * `COLORTERM=truecolor` for every spawned agent — this seed surfaces that
+ * default in the user-editable settings file so users with terminals that
+ * misbehave on truecolor have a discoverable place to override it (set
+ * to `""`, `256color`, etc.).
+ *
+ * Only writes a key when it isn't already present, so user edits — including
+ * an explicit empty-string override — are preserved across upgrades.
+ */
+export async function seedGlobalProviderEnvVars(): Promise<void> {
+  try {
+    const settings = await loadSettingsFile(globalSettingsPath());
+    const providers: Partial<Record<AgentKey, ProviderOverrides>> =
+      settings.providers ?? {};
+
+    let changed = false;
+    for (const agentKey of getAgentKeys()) {
+      const provider: ProviderOverrides = providers[agentKey] ?? {};
+      const envVars: Record<string, string> = provider.envVars ?? {};
+      if ("COLORTERM" in envVars) continue;
+      envVars.COLORTERM = "truecolor";
+      provider.envVars = envVars;
+      providers[agentKey] = provider;
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    settings.providers = providers;
+    await writeGlobalSettings(settings);
+  } catch (e) {
+    console.warn(
+      `[settings] failed to seed provider envVars: ${errorMessage(e)}`,
+    );
   }
 }

--- a/src/services/system/auto-sync.ts
+++ b/src/services/system/auto-sync.ts
@@ -37,6 +37,7 @@ import {
 import { installGlobalAgents } from "./agents.ts";
 import { installGlobalSkills } from "./skills.ts";
 import { seedGlobalAdditionalInstructions } from "../config/additional-instructions.ts";
+import { seedGlobalProviderEnvVars } from "../config/settings.ts";
 
 /** Path to the version marker. Honors ATOMIC_SETTINGS_HOME for tests. */
 function syncMarkerPath(): string {
@@ -111,6 +112,7 @@ export async function autoSyncIfStale(): Promise<void> {
         silentStep(installGlobalAgents),
         silentStep(upgradeGlobalToolPackages),
         silentStep(installGlobalSkills),
+        silentStep(seedGlobalProviderEnvVars),
       ];
 
   // All steps run in parallel and silently. Failures are swallowed so the

--- a/tests/services/config/settings-seed-envvars.test.ts
+++ b/tests/services/config/settings-seed-envvars.test.ts
@@ -1,0 +1,146 @@
+import {
+  test,
+  expect,
+  describe,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { seedGlobalProviderEnvVars } from "../../../src/services/config/settings.ts";
+
+let tmpDir: string;
+let previousSettingsHome: string | undefined;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "settings-seed-envvars-test-"));
+  previousSettingsHome = process.env.ATOMIC_SETTINGS_HOME;
+  process.env.ATOMIC_SETTINGS_HOME = tmpDir;
+});
+
+afterEach(async () => {
+  if (previousSettingsHome === undefined) {
+    delete process.env.ATOMIC_SETTINGS_HOME;
+  } else {
+    process.env.ATOMIC_SETTINGS_HOME = previousSettingsHome;
+  }
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+function settingsPath(): string {
+  return join(tmpDir, ".atomic", "settings.json");
+}
+
+async function writeGlobalSettings(value: Record<string, unknown>): Promise<void> {
+  const dir = join(tmpDir, ".atomic");
+  await mkdir(dir, { recursive: true });
+  await writeFile(settingsPath(), JSON.stringify(value));
+}
+
+async function readGlobalSettings(): Promise<Record<string, unknown>> {
+  const raw = await readFile(settingsPath(), "utf8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe("seedGlobalProviderEnvVars", () => {
+  test("seeds COLORTERM=truecolor into every provider when settings.json is missing", async () => {
+    await seedGlobalProviderEnvVars();
+
+    const settings = await readGlobalSettings();
+    const providers = settings.providers as Record<
+      string,
+      { envVars?: Record<string, string> }
+    >;
+    expect(providers.claude?.envVars?.COLORTERM).toBe("truecolor");
+    expect(providers.opencode?.envVars?.COLORTERM).toBe("truecolor");
+    expect(providers.copilot?.envVars?.COLORTERM).toBe("truecolor");
+  });
+
+  test("seeds COLORTERM into all providers when settings.json exists without providers", async () => {
+    await writeGlobalSettings({ version: 1, scm: "github" });
+
+    await seedGlobalProviderEnvVars();
+
+    const settings = await readGlobalSettings();
+    expect(settings.scm).toBe("github");
+    const providers = settings.providers as Record<
+      string,
+      { envVars?: Record<string, string> }
+    >;
+    expect(providers.claude?.envVars?.COLORTERM).toBe("truecolor");
+    expect(providers.opencode?.envVars?.COLORTERM).toBe("truecolor");
+    expect(providers.copilot?.envVars?.COLORTERM).toBe("truecolor");
+  });
+
+  test("is idempotent on a second run", async () => {
+    await seedGlobalProviderEnvVars();
+    const firstWrite = await readFile(settingsPath(), "utf8");
+
+    await seedGlobalProviderEnvVars();
+    const secondWrite = await readFile(settingsPath(), "utf8");
+
+    expect(secondWrite).toBe(firstWrite);
+  });
+
+  test("preserves a user-set COLORTERM value (e.g. '256color')", async () => {
+    await writeGlobalSettings({
+      version: 1,
+      providers: {
+        claude: { envVars: { COLORTERM: "256color" } },
+      },
+    });
+
+    await seedGlobalProviderEnvVars();
+
+    const settings = await readGlobalSettings();
+    const providers = settings.providers as Record<
+      string,
+      { envVars?: Record<string, string> }
+    >;
+    expect(providers.claude?.envVars?.COLORTERM).toBe("256color");
+    expect(providers.opencode?.envVars?.COLORTERM).toBe("truecolor");
+    expect(providers.copilot?.envVars?.COLORTERM).toBe("truecolor");
+  });
+
+  test("preserves an explicit empty-string COLORTERM override", async () => {
+    await writeGlobalSettings({
+      version: 1,
+      providers: {
+        opencode: { envVars: { COLORTERM: "" } },
+      },
+    });
+
+    await seedGlobalProviderEnvVars();
+
+    const settings = await readGlobalSettings();
+    const providers = settings.providers as Record<
+      string,
+      { envVars?: Record<string, string> }
+    >;
+    expect(providers.opencode?.envVars?.COLORTERM).toBe("");
+  });
+
+  test("preserves unrelated envVars and chatFlags on the same provider", async () => {
+    await writeGlobalSettings({
+      version: 1,
+      providers: {
+        claude: {
+          chatFlags: ["--print"],
+          envVars: { ANTHROPIC_API_KEY: "sk-test" },
+        },
+      },
+    });
+
+    await seedGlobalProviderEnvVars();
+
+    const settings = await readGlobalSettings();
+    const claude = (settings.providers as Record<string, {
+      chatFlags?: string[];
+      envVars?: Record<string, string>;
+    }>).claude;
+    expect(claude?.chatFlags).toEqual(["--print"]);
+    expect(claude?.envVars?.ANTHROPIC_API_KEY).toBe("sk-test");
+    expect(claude?.envVars?.COLORTERM).toBe("truecolor");
+  });
+});

--- a/tests/services/config/settings.test.ts
+++ b/tests/services/config/settings.test.ts
@@ -1,0 +1,160 @@
+import {
+  test,
+  expect,
+  describe,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  ensureGlobalAtomicSettings,
+  setTelemetryEnabled,
+  setScmProvider,
+} from "../../../src/services/config/settings.ts";
+import { SETTINGS_SCHEMA_URL } from "../../../src/services/config/settings-schema.ts";
+
+let tmpDir: string;
+let previousSettingsHome: string | undefined;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "settings-test-"));
+  previousSettingsHome = process.env.ATOMIC_SETTINGS_HOME;
+  process.env.ATOMIC_SETTINGS_HOME = tmpDir;
+});
+
+afterEach(async () => {
+  if (previousSettingsHome === undefined) {
+    delete process.env.ATOMIC_SETTINGS_HOME;
+  } else {
+    process.env.ATOMIC_SETTINGS_HOME = previousSettingsHome;
+  }
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+function settingsPath(): string {
+  return join(tmpDir, ".atomic", "settings.json");
+}
+
+async function writeGlobalSettings(value: Record<string, unknown>): Promise<void> {
+  const dir = join(tmpDir, ".atomic");
+  await mkdir(dir, { recursive: true });
+  await writeFile(settingsPath(), JSON.stringify(value));
+}
+
+async function readGlobalSettings(): Promise<Record<string, unknown>> {
+  const raw = await readFile(settingsPath(), "utf8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe("ensureGlobalAtomicSettings", () => {
+  test("creates settings.json with $schema and version when missing", async () => {
+    await ensureGlobalAtomicSettings();
+
+    const settings = await readGlobalSettings();
+    expect(settings.$schema).toBe(SETTINGS_SCHEMA_URL);
+    expect(settings.version).toBe(1);
+  });
+
+  test("is a no-op when settings.json already exists", async () => {
+    await writeGlobalSettings({ version: 99, telemetryEnabled: true });
+    const before = await readFile(settingsPath(), "utf8");
+
+    await ensureGlobalAtomicSettings();
+
+    const after = await readFile(settingsPath(), "utf8");
+    expect(after).toBe(before);
+  });
+
+  test("swallows filesystem errors instead of throwing", async () => {
+    // Point at a path that cannot be created (parent is a regular file).
+    const blockingFile = join(tmpDir, "blocker");
+    await writeFile(blockingFile, "not a directory");
+    process.env.ATOMIC_SETTINGS_HOME = blockingFile;
+
+    expect(await ensureGlobalAtomicSettings()).toBeUndefined();
+  });
+});
+
+describe("setTelemetryEnabled", () => {
+  test("writes telemetryEnabled: true into a fresh settings file", async () => {
+    await setTelemetryEnabled(true);
+
+    const settings = await readGlobalSettings();
+    expect(settings.telemetryEnabled).toBe(true);
+    expect(settings.$schema).toBe(SETTINGS_SCHEMA_URL);
+  });
+
+  test("writes telemetryEnabled: false", async () => {
+    await setTelemetryEnabled(false);
+
+    const settings = await readGlobalSettings();
+    expect(settings.telemetryEnabled).toBe(false);
+  });
+
+  test("preserves unrelated existing fields", async () => {
+    await writeGlobalSettings({
+      version: 1,
+      scm: "github",
+      providers: { claude: { envVars: { COLORTERM: "truecolor" } } },
+    });
+
+    await setTelemetryEnabled(true);
+
+    const settings = await readGlobalSettings();
+    expect(settings.telemetryEnabled).toBe(true);
+    expect(settings.scm).toBe("github");
+    expect((settings.providers as Record<string, { envVars?: Record<string, string> }>).claude?.envVars?.COLORTERM).toBe("truecolor");
+  });
+
+  test("swallows filesystem errors instead of throwing", async () => {
+    const blockingFile = join(tmpDir, "blocker");
+    await writeFile(blockingFile, "not a directory");
+    process.env.ATOMIC_SETTINGS_HOME = blockingFile;
+
+    expect(await setTelemetryEnabled(true)).toBeUndefined();
+  });
+});
+
+describe("setScmProvider", () => {
+  test("writes scm: 'github' into a fresh settings file", async () => {
+    await setScmProvider("github");
+
+    const settings = await readGlobalSettings();
+    expect(settings.scm).toBe("github");
+    expect(settings.$schema).toBe(SETTINGS_SCHEMA_URL);
+  });
+
+  test("overwrites a previously selected provider", async () => {
+    await writeGlobalSettings({ version: 1, scm: "github" });
+
+    await setScmProvider("azure-devops");
+
+    const settings = await readGlobalSettings();
+    expect(settings.scm).toBe("azure-devops");
+  });
+
+  test("preserves unrelated existing fields", async () => {
+    await writeGlobalSettings({
+      version: 1,
+      telemetryEnabled: false,
+      providers: { copilot: { chatFlags: ["--print"] } },
+    });
+
+    await setScmProvider("sapling");
+
+    const settings = await readGlobalSettings();
+    expect(settings.scm).toBe("sapling");
+    expect(settings.telemetryEnabled).toBe(false);
+    expect((settings.providers as Record<string, { chatFlags?: string[] }>).copilot?.chatFlags).toEqual(["--print"]);
+  });
+
+  test("swallows filesystem errors instead of throwing", async () => {
+    const blockingFile = join(tmpDir, "blocker");
+    await writeFile(blockingFile, "not a directory");
+    process.env.ATOMIC_SETTINGS_HOME = blockingFile;
+
+    expect(await setScmProvider("github")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Seeds `COLORTERM=truecolor` into each provider's (`claude`, `opencode`, `copilot`) `envVars` block in `~/.atomic/settings.json` on first install and every version bump, giving users a discoverable, overridable place to control truecolor behavior without touching their terminal config.

## Key Changes

- **`src/services/config/settings.ts`** — New `seedProviderColorterm()` helper writes `COLORTERM=truecolor` under each provider's `envVars` only when the key is absent, so explicit user overrides (including `""`) survive upgrades
- **`src/services/system/auto-sync.ts`** — Calls the new seed function during `autoSyncIfStale` so the value is backfilled on every version bump
- **`.claude/settings.json`** — Enables `CLAUDE_CODE_TMUX_TRUECOLOR=1` for Claude Code instances launched in this repo, pairing with the runtime seed
- **`package.json` / `bun.lock`** — Bumps `@opentui/{core,react}` to `^0.2.2` and minor bumps for `opencode-ai/sdk`, `yaml`, `zod` to resolve duplicate-package typecheck errors that were blocking pre-commit
- **`tests/services/config/settings.test.ts`** — 160-line test suite covering `ensureGlobalAtomicSettings`, `setTelemetryEnabled`, and `setScmProvider` (happy path, idempotency, field preservation, error-swallowing catch blocks)
- **`tests/services/config/settings-seed-envvars.test.ts`** — 146-line test suite covering the new colorterm seed logic