### PR TITLE
chore(release): bump version to v0.6.8-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.7",
+  "version": "0.6.8-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.6.7` to `0.6.8-0` to initiate the prerelease cycle for the upcoming `v0.6.8` release.

## Key Changes

- Updated `version` field in `package.json` from `0.6.7` → `0.6.8-0`

## Notes

This is a prerelease (`-0` suffix) tracking the `prerelease/v0.6.8-0` branch. Once all changes for `v0.6.8` are validated, a final release PR will bump to `0.6.8`.