### PR TITLE
chore(release): bump version to v0.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.6.8-0",
+  "version": "0.6.8",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Promotes `@bastani/atomic` from prerelease (`0.6.8-0`) to the stable release (`0.6.8`).

## Changes

- `package.json`: version bumped from `0.6.8-0` → `0.6.8`

## Notes

- No functional changes, no breaking changes.
- This is a standard release promotion following the project's release workflow.