### PR TITLE
feat(settings): globally seed CLAUDE_CODE_TMUX_TRUECOLOR for claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,7 @@
   "env": {
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "ENABLE_LSP_TOOL": "1",
-    "CLAUDE_CODE_NO_FLICKER": "1",
-    "CLAUDE_CODE_TMUX_TRUECOLOR": "1"
+    "CLAUDE_CODE_NO_FLICKER": "1"
   },
   "includeCoAuthoredBy": false,
   "skipDangerousModePermissionPrompt": true,

--- a/src/services/config/settings.ts
+++ b/src/services/config/settings.ts
@@ -104,7 +104,9 @@ export async function setScmProvider(scm: ScmProvider): Promise<void> {
 
 /**
  * Seed `COLORTERM=truecolor` into each agent's `providers.<agent>.envVars`
- * in `~/.atomic/settings.json` on install / version bump.
+ * in `~/.atomic/settings.json` on install / version bump. Also seeds
+ * `CLAUDE_CODE_TMUX_TRUECOLOR=1` for the `claude` provider so Claude Code
+ * emits truecolor escapes when running under tmux.
  *
  * The runtime default in `lib/terminal-env.ts` already injects
  * `COLORTERM=truecolor` for every spawned agent — this seed surfaces that
@@ -125,8 +127,20 @@ export async function seedGlobalProviderEnvVars(): Promise<void> {
     for (const agentKey of getAgentKeys()) {
       const provider: ProviderOverrides = providers[agentKey] ?? {};
       const envVars: Record<string, string> = provider.envVars ?? {};
-      if ("COLORTERM" in envVars) continue;
-      envVars.COLORTERM = "truecolor";
+      let providerChanged = false;
+
+      if (!("COLORTERM" in envVars)) {
+        envVars.COLORTERM = "truecolor";
+        providerChanged = true;
+      }
+
+      if (agentKey === "claude" && !("CLAUDE_CODE_TMUX_TRUECOLOR" in envVars)) {
+        envVars.CLAUDE_CODE_TMUX_TRUECOLOR = "1";
+        providerChanged = true;
+      }
+
+      if (!providerChanged) continue;
+
       provider.envVars = envVars;
       providers[agentKey] = provider;
       changed = true;

--- a/tests/services/config/settings-seed-envvars.test.ts
+++ b/tests/services/config/settings-seed-envvars.test.ts
@@ -143,4 +143,41 @@ describe("seedGlobalProviderEnvVars", () => {
     expect(claude?.envVars?.ANTHROPIC_API_KEY).toBe("sk-test");
     expect(claude?.envVars?.COLORTERM).toBe("truecolor");
   });
+
+  test("seeds CLAUDE_CODE_TMUX_TRUECOLOR=1 only on the claude provider", async () => {
+    await seedGlobalProviderEnvVars();
+
+    const settings = await readGlobalSettings();
+    const providers = settings.providers as Record<
+      string,
+      { envVars?: Record<string, string> }
+    >;
+    expect(providers.claude?.envVars?.CLAUDE_CODE_TMUX_TRUECOLOR).toBe("1");
+    expect(providers.opencode?.envVars).not.toHaveProperty(
+      "CLAUDE_CODE_TMUX_TRUECOLOR",
+    );
+    expect(providers.copilot?.envVars).not.toHaveProperty(
+      "CLAUDE_CODE_TMUX_TRUECOLOR",
+    );
+  });
+
+  test("preserves a user-set CLAUDE_CODE_TMUX_TRUECOLOR override", async () => {
+    await writeGlobalSettings({
+      version: 1,
+      providers: {
+        claude: { envVars: { CLAUDE_CODE_TMUX_TRUECOLOR: "" } },
+      },
+    });
+
+    await seedGlobalProviderEnvVars();
+
+    const settings = await readGlobalSettings();
+    const providers = settings.providers as Record<
+      string,
+      { envVars?: Record<string, string> }
+    >;
+    expect(providers.claude?.envVars?.CLAUDE_CODE_TMUX_TRUECOLOR).toBe("");
+    // COLORTERM should still be seeded alongside it
+    expect(providers.claude?.envVars?.COLORTERM).toBe("truecolor");
+  });
 });


### PR DESCRIPTION
## Summary

Moves `CLAUDE_CODE_TMUX_TRUECOLOR=1` from the project-local `.claude/settings.json` into `seedGlobalProviderEnvVars()`, ensuring the setting is applied for every Atomic user automatically on install or version bump rather than only in this checkout.

## Key Changes

- **`src/services/config/settings.ts`**: Extends `seedGlobalProviderEnvVars()` to seed `CLAUDE_CODE_TMUX_TRUECOLOR=1` exclusively for the `claude` provider alongside the existing `COLORTERM=truecolor` seed. Refactors the per-provider loop to use a `providerChanged` flag so multiple env vars can be set in a single pass without short-circuiting.
- **`.claude/settings.json`**: Removes `CLAUDE_CODE_TMUX_TRUECOLOR=1` from the project-level env config since it is now managed globally by the seeder.
- **`tests/services/config/settings-seed-envvars.test.ts`**: Adds two new tests — one asserting the var is seeded only on the `claude` provider (not `opencode` or `copilot`), and one asserting a pre-existing user override is preserved.

## Notes

No breaking changes. Users who already have `CLAUDE_CODE_TMUX_TRUECOLOR` set in their global `~/.atomic/settings.json` will not have their value overwritten.