### PR TITLE
fix(chat): materialize bunfs runtime assets for tmux subprocess access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,103 @@ jobs:
                   for agent in claude copilot opencode; do
                       atomic chat -a "$agent" --preflight-only
                   done
+                  # Catches the `/$bunfs/...` runtime-asset regression that
+                  # caused `atomic chat` to silently fall back to a non-tmux
+                  # spawn on every published binary. Mirrors the per-platform
+                  # check below, but exercised here against the freshly
+                  # `bun install -g`'d wrapper to cover the end-to-end
+                  # publish layout.
+                  atomic _runtime-assets-smoke
+
+    # Per-platform regression test for the bunfs-materialization bug:
+    # `with { type: "file" }` imports resolve to `/$bunfs/...` paths inside
+    # a compiled binary, which Bun APIs can read but spawned OS processes
+    # (tmux, bun run, ...) cannot. `runtime-assets.ts` copies each asset
+    # to `~/.atomic/runtime/<sdk-version>/` on first use; the smoke command
+    # asserts the materialized paths are subprocess-readable AND that
+    # tmux/psmux can actually load the conf and create a session.
+    #
+    # We run on Linux / macOS / Windows because the bug is platform-specific
+    # in two ways: the bunfs path shape differs (`/$bunfs/...` vs
+    # `<DRIVE>:\~BUN\...`), and the multiplexer (tmux vs psmux) reads the
+    # conf via different syscall paths. A regression on any one of them
+    # would re-introduce the silent-fallback behavior on that platform.
+    runtime-assets-smoke:
+        name: Runtime assets smoke (${{ matrix.os }})
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install
+
+            - name: Install tmux (Linux)
+              if: runner.os == 'Linux'
+              run: sudo apt-get update -qq && sudo apt-get install -y tmux
+
+            - name: Install tmux (macOS)
+              if: runner.os == 'macOS'
+              run: brew install tmux || true
+
+            # psmux isn't on the official chocolatey/winget feeds with a
+            # stable id we can rely on, so download the pinned GitHub
+            # release directly — same path as `installPsmuxFromGitHubRelease`
+            # in spawn.ts, but inline so the test doesn't depend on the
+            # binary it's about to test.
+            - name: Install psmux (Windows)
+              if: runner.os == 'Windows'
+              shell: pwsh
+              run: |
+                  $latest = Invoke-RestMethod -Headers @{ Accept = 'application/vnd.github+json' } `
+                      -Uri 'https://api.github.com/repos/psmux/psmux/releases/latest'
+                  $asset = $latest.assets | Where-Object { $_.name -like '*windows-x64.zip' } | Select-Object -First 1
+                  if (-not $asset) { throw 'No psmux windows-x64 release asset found' }
+                  $tmp = New-Item -ItemType Directory -Force -Path (Join-Path $env:RUNNER_TEMP 'psmux')
+                  $zip = Join-Path $tmp 'psmux.zip'
+                  Invoke-WebRequest -UseBasicParsing -Uri $asset.browser_download_url -OutFile $zip
+                  Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
+                  $bin = Join-Path $env:LOCALAPPDATA 'Programs\psmux'
+                  New-Item -ItemType Directory -Force -Path $bin | Out-Null
+                  Get-ChildItem $tmp -Filter 'psmux.exe' -Recurse | ForEach-Object {
+                      Copy-Item $_.FullName -Destination (Join-Path $bin 'psmux.exe') -Force
+                  }
+                  echo $bin >> $env:GITHUB_PATH
+
+            - name: Build host-target binary
+              run: bun packages/atomic/script/build.ts
+
+            # Wipe any cache the build step might have warmed via dev-mode
+            # imports so the smoke step exercises the real first-run
+            # materialize-from-bunfs code path, not a hot cache.
+            - name: Clear runtime-assets cache (Unix)
+              if: runner.os != 'Windows'
+              shell: bash
+              run: rm -rf "$HOME/.atomic/runtime"
+
+            - name: Clear runtime-assets cache (Windows)
+              if: runner.os == 'Windows'
+              shell: pwsh
+              run: |
+                  $cache = Join-Path $env:USERPROFILE '.atomic\runtime'
+                  if (Test-Path $cache) { Remove-Item -Recurse -Force $cache }
+
+            - name: Run runtime-assets smoke
+              shell: bash
+              run: |
+                  set -e
+                  ATOMIC=$(find packages/atomic/dist -type f -name 'atomic*' | head -n 1)
+                  if [ -z "$ATOMIC" ]; then
+                      echo "Could not locate built binary under packages/atomic/dist"
+                      exit 1
+                  fi
+                  echo "Smoke-testing: $ATOMIC"
+                  "$ATOMIC" _runtime-assets-smoke

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -32,6 +32,7 @@
     "./lib/common-ignore": "./src/lib/common-ignore.ts",
     "./lib/path-root-guard": "./src/lib/path-root-guard.ts",
     "./lib/runtime-env": "./src/lib/runtime-env.ts",
+    "./lib/runtime-assets": "./src/lib/runtime-assets.ts",
     "./services/config/definitions": "./src/services/config/definitions.ts",
     "./services/config/atomic-config": "./src/services/config/atomic-config.ts",
     "./services/config/scm-sync": "./src/services/config/scm-sync.ts",

--- a/packages/atomic-sdk/src/lib/runtime-assets.test.ts
+++ b/packages/atomic-sdk/src/lib/runtime-assets.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import {
+  materializeRuntimeAsset,
+  runtimeAssetsCacheDir,
+} from "./runtime-assets.ts";
+
+describe("runtimeAssetsCacheDir", () => {
+  test("lives under ~/.atomic/runtime/<sdk-version>", () => {
+    const dir = runtimeAssetsCacheDir("/home/test");
+    expect(dir.startsWith("/home/test/.atomic/runtime/")).toBe(true);
+  });
+
+  test("is stable across calls within a single SDK version", () => {
+    expect(runtimeAssetsCacheDir("/home/test")).toBe(
+      runtimeAssetsCacheDir("/home/test"),
+    );
+  });
+
+  test("does not pick up XDG_CACHE_HOME / LOCALAPPDATA", () => {
+    // The cache lives under ~/.atomic, NOT the platform cache dir, so a
+    // user nuking ~/.cache or its Windows/macOS equivalents leaves the
+    // materialized assets intact.
+    const previousXdg = process.env.XDG_CACHE_HOME;
+    const previousLocal = process.env.LOCALAPPDATA;
+    process.env.XDG_CACHE_HOME = "/should/not/be/used";
+    process.env.LOCALAPPDATA = "C:\\Should\\Not\\Be\\Used";
+    try {
+      const dir = runtimeAssetsCacheDir("/home/test");
+      expect(dir).not.toContain("/should/not/be/used");
+      expect(dir).not.toContain("Should\\Not\\Be\\Used");
+    } finally {
+      if (previousXdg === undefined) delete process.env.XDG_CACHE_HOME;
+      else process.env.XDG_CACHE_HOME = previousXdg;
+      if (previousLocal === undefined) delete process.env.LOCALAPPDATA;
+      else process.env.LOCALAPPDATA = previousLocal;
+    }
+  });
+});
+
+describe("materializeRuntimeAsset", () => {
+  let tmp: string;
+  let cacheDir: string;
+  let realAsset: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "atomic-runtime-assets-"));
+    cacheDir = join(tmp, "cache");
+    realAsset = join(tmp, "tmux.conf");
+    writeFileSync(realAsset, "set -g status off\n");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("returns a real on-disk path unchanged (dev / installed-package)", async () => {
+    expect(await materializeRuntimeAsset(realAsset, cacheDir)).toBe(realAsset);
+    expect(existsSync(cacheDir)).toBe(false);
+  });
+
+  test("copies a /$bunfs/… asset to the cache directory", async () => {
+    // We can't construct a real /$bunfs/ asset in unit tests — those only
+    // exist inside compiled binaries. Instead, place a fake file at a
+    // path `isCompiledBinaryRuntime` recognizes as bunfs. The Windows
+    // `~BUN` variant lets us stage a real on-disk file under a temp dir
+    // whose path contains `~BUN` between separators, so `Bun.file()` can
+    // still read it during the test.
+    const fakeBunfsDir = join(tmp, "~BUN", "root");
+    mkdirSync(fakeBunfsDir, { recursive: true });
+    const fakeBundled = join(fakeBunfsDir, "tmux.conf");
+    writeFileSync(fakeBundled, "set -g status off\n# bundled\n");
+
+    const out = await materializeRuntimeAsset(fakeBundled, cacheDir);
+
+    expect(out).toBe(join(cacheDir, "tmux.conf"));
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out, "utf-8")).toBe("set -g status off\n# bundled\n");
+  });
+
+  test("is idempotent — does not re-copy when destination already exists", async () => {
+    const fakeBunfsDir = join(tmp, "~BUN", "root");
+    mkdirSync(fakeBunfsDir, { recursive: true });
+    const fakeBundled = join(fakeBunfsDir, "tmux.conf");
+    writeFileSync(fakeBundled, "first\n");
+
+    const first = await materializeRuntimeAsset(fakeBundled, cacheDir);
+    // Mutate the source to prove the helper does NOT re-copy on the second
+    // call. (In a real binary the bundled asset is read-only, but the
+    // contract is "first call wins per (cache-dir, basename) tuple".)
+    writeFileSync(fakeBundled, "second\n");
+    const second = await materializeRuntimeAsset(fakeBundled, cacheDir);
+
+    expect(second).toBe(first);
+    expect(readFileSync(second, "utf-8")).toBe("first\n");
+  });
+
+  test("returns a path that is NOT under /$bunfs/ for bunfs inputs", async () => {
+    // The whole point of the helper: spawned OS subprocesses must be able
+    // to read the returned path. If it still points into /$bunfs/, the
+    // bug is unfixed.
+    const fakeBunfsDir = join(tmp, "~BUN", "root");
+    mkdirSync(fakeBunfsDir, { recursive: true });
+    const fakeBundled = join(fakeBunfsDir, "tmux.conf");
+    writeFileSync(fakeBundled, "x\n");
+
+    const out = await materializeRuntimeAsset(fakeBundled, cacheDir);
+
+    expect(out).not.toMatch(/[\\/]~BUN[\\/]/);
+    expect(out).not.toContain("$bunfs");
+  });
+
+  test("creates the cache directory on demand", async () => {
+    const fakeBundled = join(tmp, "~BUN", "root", basename("conf"));
+    mkdirSync(join(tmp, "~BUN", "root"), { recursive: true });
+    writeFileSync(fakeBundled, "x\n");
+    expect(existsSync(cacheDir)).toBe(false);
+
+    await materializeRuntimeAsset(fakeBundled, cacheDir);
+
+    expect(existsSync(cacheDir)).toBe(true);
+  });
+});

--- a/packages/atomic-sdk/src/lib/runtime-assets.ts
+++ b/packages/atomic-sdk/src/lib/runtime-assets.ts
@@ -13,7 +13,28 @@
  * `emitRuntimeScriptBundles` (RFC §5.3) so a runtime asset import never
  * collides with a module import of the canonical `cc-debounce.ts` /
  * `orchestrator-entry.ts` source (RFC §5.6).
+ *
+ * ### Bunfs materialization
+ *
+ * In a compiled binary, `with { type: "file" }` returns a `/$bunfs/…` path
+ * that is accessible to Bun APIs but NOT to spawned OS processes — `tmux`
+ * cannot read `/$bunfs/.../tmux.conf`, and a re-exec'd `bun` cannot resolve
+ * `/$bunfs/.../orchestrator-entry.script.js` from a different binary
+ * instance. Mirrors the tarball treatment in
+ * `packages/atomic/src/lib/embedded-assets.ts`.
+ *
+ * To bridge that gap we copy each asset to a stable on-disk cache the
+ * first time this module loads in a compiled binary. Subsequent loads see
+ * an existing destination and skip the write. In dev / installed-package
+ * runtime the import already resolves to a real on-disk path, so the
+ * helper is a no-op.
  */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import sdkPackageJson from "../../package.json";
+import { isCompiledBinaryRuntime } from "./runtime-env.ts";
 
 import tmuxConfAsset          from "../runtime/tmux.conf"                           with { type: "file" };
 // `with { type: "file" }` makes Bun return a path string at runtime, but TypeScript
@@ -24,11 +45,66 @@ import ccDebounceAsset         from "./runtime-scripts/cc-debounce.script.js"   
 // @ts-expect-error see comment above
 import orchestratorEntryAsset  from "./runtime-scripts/orchestrator-entry.script.js" with { type: "file" };
 
+const SDK_VERSION = sdkPackageJson.version;
+
+/**
+ * Cache root for materialized runtime assets.
+ *
+ * Lives under `~/.atomic/runtime/<sdk-version>/` rather than the platform
+ * cache dir (`~/.cache`, `~/Library/Caches`, `%LOCALAPPDATA%\…\Cache`):
+ *
+ *  - `~/.cache` and friends are routinely wiped by users / cleanup tools.
+ *    A wipe between atomic runs would force a re-extract on next launch
+ *    — recoverable, but a needless cost.
+ *  - All other atomic state already lives under `~/.atomic` (sessions/,
+ *    tmp/, bin/, .synced-version), so keeping runtime assets there gives
+ *    operators a single directory to inspect when debugging.
+ *
+ * Versioning the path lets two atomic versions share the same machine
+ * without their assets stomping each other; a stale version directory
+ * is a few KB and harmless.
+ */
+export function runtimeAssetsCacheDir(home: string = homedir()): string {
+  return join(home, ".atomic", "runtime", SDK_VERSION);
+}
+
+/**
+ * Copy a `/$bunfs/…` asset to a real on-disk path so spawned OS
+ * subprocesses can read it. Returns `bundledPath` unchanged in dev /
+ * installed-package runtime.
+ *
+ * Async because `/$bunfs/` paths are NOT readable via OS-level syscalls
+ * (`copyfile(2)`, `open(2)`, …) — they only work through Bun's
+ * `Bun.file()` API, which is async-only. Module-level evaluation uses
+ * top-level await to keep the public API a plain `string` constant.
+ *
+ * Idempotent: when the destination already exists we skip the write.
+ * The cache key includes the SDK version so an upgrade transparently
+ * invalidates the cache without us having to hash file contents on
+ * every startup.
+ */
+export async function materializeRuntimeAsset(
+  bundledPath: string,
+  cacheDir: string = runtimeAssetsCacheDir(),
+): Promise<string> {
+  if (!isCompiledBinaryRuntime(bundledPath)) return bundledPath;
+
+  const dest = join(cacheDir, basename(bundledPath));
+  if (existsSync(dest)) return dest;
+
+  mkdirSync(dirname(dest), { recursive: true });
+  // `copyFileSync` and friends fail with ENOENT against `/$bunfs/` source
+  // paths — Bun's virtual FS is only exposed through `Bun.file()` /
+  // `Bun.write()`. Mirrors `packages/atomic/src/lib/embedded-assets.ts`.
+  await Bun.write(dest, await Bun.file(bundledPath).bytes());
+  return dest;
+}
+
 /** Resolved path to the tmux.conf runtime asset. */
-export const tmuxConfPath: string = tmuxConfAsset;
+export const tmuxConfPath: string = await materializeRuntimeAsset(tmuxConfAsset);
 
 /** Resolved path to the cc-debounce runtime script. */
-export const ccDebounceScriptPath: string = ccDebounceAsset;
+export const ccDebounceScriptPath: string = await materializeRuntimeAsset(ccDebounceAsset);
 
 /** Resolved path to the orchestrator-entry runtime script. */
-export const orchestratorEntryPath: string = orchestratorEntryAsset;
+export const orchestratorEntryPath: string = await materializeRuntimeAsset(orchestratorEntryAsset);

--- a/packages/atomic/src/cli.ts
+++ b/packages/atomic/src/cli.ts
@@ -21,7 +21,7 @@
  *   atomic --help                             Show help
  */
 
-import { Command } from "@commander-js/extra-typings";
+import { Command, Option } from "@commander-js/extra-typings";
 import { VERSION } from "./version.ts";
 import { COLORS } from "@bastani/atomic-sdk/theme/colors";
 import { AGENT_CONFIG, isValidAgent } from "./services/config/index.ts";
@@ -71,9 +71,13 @@ export function createProgram() {
         .command("chat", { isDefault: true })
         .description("Start an interactive chat session with a coding agent")
         .option("-a, --agent <name>", `Agent to chat with (${agentChoices})`)
-        .option(
-            "--preflight-only",
-            "Run onboarding preflight (global-config sync + project setup) and exit 0 without spawning the agent. Skips executable and auth checks.",
+        // Internal flag — exercised by the verdaccio smoke test and the
+        // cross-platform runtime-assets matrix in CI to run onboarding
+        // preflight (global-config sync + project setup) without spawning
+        // the agent or checking executables/auth. Hidden from `--help` so
+        // end users aren't tempted to use it.
+        .addOption(
+            new Option("--preflight-only").hideHelp(),
         )
         .allowUnknownOption()
         .allowExcessArguments(true)
@@ -288,6 +292,23 @@ Examples:
             }
             const { claudeAskHookCommand } = await import("./commands/cli/claude-ask-hook.ts");
             const exitCode = await claudeAskHookCommand(mode);
+            process.exit(exitCode);
+        });
+
+    // ── Internal: runtime-assets smoke check (CI cross-platform harness) ─
+    //
+    // Verifies that bundled runtime assets (tmux.conf, debounce script,
+    // orchestrator entry) materialize out of `/$bunfs/` to a real on-disk
+    // path and that tmux can actually load the conf. Headless — no TTY,
+    // no agent CLI, no auth.
+    program
+        .command("_runtime-assets-smoke", { hidden: true })
+        .description("Internal: verify bundled runtime assets are subprocess-readable")
+        .action(async () => {
+            const { runtimeAssetsSmokeCommand } = await import(
+                "./commands/cli/runtime-assets-smoke.ts"
+            );
+            const exitCode = await runtimeAssetsSmokeCommand();
             process.exit(exitCode);
         });
 

--- a/packages/atomic/src/commands/cli/runtime-assets-smoke.ts
+++ b/packages/atomic/src/commands/cli/runtime-assets-smoke.ts
@@ -1,0 +1,111 @@
+/**
+ * Internal smoke command: verifies that runtime sibling assets (tmux.conf,
+ * cc-debounce script, orchestrator-entry script) are accessible to spawned
+ * OS subprocesses.
+ *
+ * Why this exists: in a compiled binary, `with { type: "file" }` imports
+ * resolve to `/$bunfs/…` paths inside Bun's virtual filesystem. Those
+ * paths are readable by Bun APIs but NOT by external processes — so a
+ * `tmux -f /$bunfs/.../tmux.conf` invocation fails with "no such file"
+ * and `chatCommand` falls back to a plain spawn (no tmux). The
+ * `materializeRuntimeAsset` helper in `runtime-assets.ts` copies each
+ * asset to `~/.atomic/runtime/<sdk-version>/` on first use to bridge the
+ * gap.
+ *
+ * This command exercises that materialization end-to-end so a CI matrix
+ * job (Linux / macOS / Windows) can catch regressions before they ship.
+ * Output is human-readable; CI just checks the exit code.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import {
+  ccDebounceScriptPath,
+  orchestratorEntryPath,
+  tmuxConfPath,
+} from "@bastani/atomic-sdk/lib/runtime-assets";
+import { isCompiledBinaryRuntime } from "@bastani/atomic-sdk/lib/runtime-env";
+import {
+  createSession,
+  isTmuxInstalled,
+  killSession,
+} from "@bastani/atomic-sdk/runtime/tmux";
+
+interface CheckResult {
+  readonly ok: boolean;
+  readonly detail: string;
+}
+
+/**
+ * Verify the resolved asset path is on a real on-disk filesystem
+ * (not `/$bunfs/`) and points at a non-empty file.
+ */
+function checkAssetReadable(label: string, path: string): CheckResult {
+  if (isCompiledBinaryRuntime(path)) {
+    return {
+      ok: false,
+      detail: `${label}: still under /$bunfs/ — bunfs materialization did not run: ${path}`,
+    };
+  }
+  if (!existsSync(path)) {
+    return { ok: false, detail: `${label}: not found on disk: ${path}` };
+  }
+  const stat = statSync(path);
+  if (!stat.isFile() || stat.size === 0) {
+    return {
+      ok: false,
+      detail: `${label}: empty or not a regular file: ${path} (size=${stat.size})`,
+    };
+  }
+  return { ok: true, detail: `${label}: ${stat.size} bytes at ${path}` };
+}
+
+/**
+ * The end-to-end check: does `tmux` (a regular OS process) successfully
+ * load the materialized conf and spin up a session on the atomic socket?
+ *
+ * `createSession` invokes `tmux -f <conf> -L atomic new-session -d …`.
+ * If the conf path is unreadable to tmux, this throws.
+ */
+function checkTmuxLoadsConf(): CheckResult {
+  if (!isTmuxInstalled()) {
+    return {
+      ok: false,
+      detail: "tmux/psmux is not installed — cannot verify conf load",
+    };
+  }
+  const sessionName = `atomic-smoke-${process.pid}`;
+  try {
+    // `:` is a POSIX no-op shell builtin; on Windows psmux invokes via
+    // pwsh where `:` is also a valid no-op (label statement). Either way
+    // the session stays alive until we kill it.
+    createSession(sessionName, ":");
+    killSession(sessionName);
+    return { ok: true, detail: `tmux loaded conf and created/destroyed a session on socket "atomic"` };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      killSession(sessionName);
+    } catch {
+      // best-effort cleanup
+    }
+    return { ok: false, detail: `tmux failed: ${message}` };
+  }
+}
+
+export async function runtimeAssetsSmokeCommand(): Promise<number> {
+  const checks: ReadonlyArray<readonly [string, CheckResult]> = [
+    ["tmux.conf", checkAssetReadable("tmux.conf", tmuxConfPath)],
+    ["cc-debounce.script.js", checkAssetReadable("cc-debounce.script.js", ccDebounceScriptPath)],
+    ["orchestrator-entry.script.js", checkAssetReadable("orchestrator-entry.script.js", orchestratorEntryPath)],
+    ["tmux load conf", checkTmuxLoadsConf()],
+  ];
+
+  let allOk = true;
+  for (const [name, result] of checks) {
+    const symbol = result.ok ? "PASS" : "FAIL";
+    console.log(`${symbol} ${name}: ${result.detail}`);
+    if (!result.ok) allOk = false;
+  }
+
+  return allOk ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

In a compiled binary, `with { type: "file" }` imports for `tmux.conf`, `cc-debounce.script.js`, and `orchestrator-entry.script.js` resolve to `/$bunfs/…` virtual paths. Bun APIs can read these paths, but spawned OS processes cannot — so `tmux -f /$bunfs/.../tmux.conf` fails with ENOENT, `createSession` throws, and `chatCommand` silently falls back to a non-tmux direct spawn. This is the same class of defect that `embedded-assets.ts` already documents and works around for tarballs.

## Key Changes

### Core fix — `packages/atomic-sdk/src/lib/runtime-assets.ts`
- Added `runtimeAssetsCacheDir()`: resolves to `~/.atomic/runtime/<sdk-version>/` — versioned to avoid cross-version stomping, placed under `~/.atomic/` (not `~/.cache`) so a cache wipe doesn't strand the binary.
- Added `materializeRuntimeAsset(bundledPath)`: on compiled-binary startup, copies each `/$bunfs/…` asset to the cache dir using `Bun.file().bytes()` + `Bun.write()` (the only Bun API that works against bunfs sources — `copyFileSync` ENOENT's). Idempotent via `existsSync`; no-op in dev/installed-package runtime.
- Applied via top-level `await` to all three exported path constants (`tmuxConfPath`, `ccDebounceScriptPath`, `orchestratorEntryPath`).

### Hidden smoke command — `packages/atomic/src/commands/cli/runtime-assets-smoke.ts` + `cli.ts`
- New hidden `_runtime-assets-smoke` command that asserts each materialized path lives on real disk (not under `/$bunfs/`), then calls `createSession`/`killSession` to prove tmux/psmux can actually load the conf from a subprocess.
- `--preflight-only` is now hidden from `atomic chat --help` — it's an internal CI hook, not a user-facing flag.

### Tests — `packages/atomic-sdk/src/lib/runtime-assets.test.ts`
- Unit tests for `runtimeAssetsCacheDir()` and `materializeRuntimeAsset()`, covering: bunfs detection, idempotency, cache-dir versioning, and no-op behavior in dev runtime.

### CI — `.github/workflows/ci.yml`
- **`validate-publish`** (verdaccio): now invokes `atomic _runtime-assets-smoke` on the `bun install -g`'d wrapper, covering the end-to-end publish layout.
- **New `runtime-assets-smoke` matrix** (ubuntu / macos / windows): builds the host binary, wipes `~/.atomic/runtime`, and runs the smoke command. The bug is platform-specific in two ways — bunfs path shape (`/$bunfs/…` vs `<DRIVE>:\~BUN\…`) and multiplexer syscall path (tmux vs psmux) — so a regression on any one platform would otherwise ship silently.

## Root Cause

`/$bunfs/` paths are part of Bun's virtual in-process filesystem. They are not mounted at the OS level, so any subprocess (tmux, a re-exec'd bun, etc.) receives ENOENT when trying to open them. The fix mirrors the existing `embedded-assets.ts` workaround used for tarball assets.