### PR TITLE
fix(chat): keep tmux attach alive when client TERM is unset/dumb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,3 +212,115 @@ jobs:
                   fi
                   echo "Smoke-testing: $ATOMIC"
                   "$ATOMIC" _runtime-assets-smoke
+
+            # End-to-end chat-launch smoke: invokes the *full* chat command
+            # (`atomic chat -a opencode --no-login`) against a stub agent on
+            # PATH and asserts the agent ended up running INSIDE tmux/psmux
+            # (i.e. `$TMUX` / `$PSMUX` is populated when the stub runs).
+            #
+            # This catches regressions that the asset-only smoke can't, e.g.:
+            #  - tmux `attach-session` failing because $TERM is unset/dumb
+            #    on the host (silent fallback to spawnDirect).
+            #  - any future regression that breaks the full launch chain
+            #    (createSession -> spawnAttachedFooter -> spawnMuxAttach).
+            #
+            # `--no-login` skips the SDK auth probe so we can pair this with
+            # a stub `opencode` binary (opencode's auth check is a no-op
+            # anyway, but the flag keeps the test agent-agnostic).
+            - name: Stage stub agent + run chat smoke (Unix)
+              if: runner.os != 'Windows'
+              shell: bash
+              run: |
+                  set -e
+                  STUB_DIR="$RUNNER_TEMP/atomic-stub-bin"
+                  mkdir -p "$STUB_DIR"
+                  # Stub opencode prints diagnostic line, then sleeps. The
+                  # sleep is load-bearing: atomic.chatCommand runs ~7 follow-up
+                  # tmux commands (set-options, split-window, set-hooks,
+                  # attach-session) within ~60ms of `new-session`. If the
+                  # stub exits in <60ms the pane closure triggers
+                  # killSessionOnPaneExit → server dies → every later tmux
+                  # call fails with "no server running" and chat falls
+                  # back to spawnDirect. Real agents take >100ms to
+                  # initialise so they don't hit this race; the stub has to
+                  # stick around long enough to mimic that.
+                  cat > "$STUB_DIR/opencode" <<'STUB'
+                  #!/bin/bash
+                  echo "ATOMIC_CHAT_SMOKE TMUX=${TMUX:-} PSMUX=${PSMUX:-}"
+                  exec sleep 5
+                  STUB
+                  chmod +x "$STUB_DIR/opencode"
+                  export PATH="$STUB_DIR:$PATH"
+
+                  ATOMIC=$(find packages/atomic/dist -type f -name 'atomic*' | head -n 1)
+                  echo "Chat-smoke binary: $ATOMIC"
+
+                  # `script -qfc` allocates a real PTY; the chat code path's
+                  # `process.stdin.isTTY` check would otherwise force the
+                  # spawnDirect fallback regardless of tmux state.
+                  OUT="$RUNNER_TEMP/chat-smoke.log"
+                  if [ "$RUNNER_OS" = "macOS" ]; then
+                      # BSD `script` syntax: `script -q logfile cmd args...`
+                      timeout --kill-after=2 8 script -q "$OUT" "$ATOMIC" chat -a opencode --no-login || true
+                  else
+                      # GNU `script` syntax
+                      timeout --kill-after=2 8 script -qfc "$ATOMIC chat -a opencode --no-login" "$OUT" || true
+                  fi
+
+                  echo "--- captured chat output ---"
+                  cat "$OUT" || true
+                  echo "--- assertion ---"
+                  if grep -E 'ATOMIC_CHAT_SMOKE TMUX=[^ ]+/atomic' "$OUT" >/dev/null; then
+                      echo "PASS: stub agent ran inside tmux session"
+                  else
+                      echo "FAIL: stub agent did not see \$TMUX populated — chat fell back to spawnDirect"
+                      exit 1
+                  fi
+
+            - name: Stage stub agent + run chat smoke (Windows)
+              if: runner.os == 'Windows'
+              shell: pwsh
+              run: |
+                  $stubDir = Join-Path $env:RUNNER_TEMP 'atomic-stub-bin'
+                  New-Item -ItemType Directory -Force -Path $stubDir | Out-Null
+                  # psmux invokes pane commands via `pwsh -NoProfile -File <ps1>`,
+                  # so a stub PowerShell script is what gets exec'd as the agent.
+                  # Sleep is load-bearing — see the Unix sibling step for the
+                  # race condition this avoids.
+                  @'
+                  Write-Host "ATOMIC_CHAT_SMOKE TMUX=$($env:TMUX) PSMUX=$($env:PSMUX)"
+                  Start-Sleep -Seconds 5
+                  '@ | Set-Content -Path (Join-Path $stubDir 'opencode.ps1') -Encoding ASCII
+
+                  # The CLI looks up the agent via Bun.which("opencode"); on
+                  # Windows that resolves a `.cmd` shim. Provide one.
+                  @'
+                  @echo off
+                  pwsh -NoProfile -File "%~dp0opencode.ps1" %*
+                  '@ | Set-Content -Path (Join-Path $stubDir 'opencode.cmd') -Encoding ASCII
+
+                  $env:Path = "$stubDir;$env:Path"
+
+                  $atomic = Get-ChildItem -Path packages/atomic/dist -Recurse -Filter 'atomic.exe' | Select-Object -First 1
+                  if (-not $atomic) { throw 'atomic.exe not found under packages/atomic/dist' }
+                  Write-Host "Chat-smoke binary: $($atomic.FullName)"
+
+                  $out = Join-Path $env:RUNNER_TEMP 'chat-smoke.log'
+                  $proc = Start-Process -FilePath $atomic.FullName `
+                      -ArgumentList 'chat','-a','opencode','--no-login' `
+                      -RedirectStandardOutput $out -RedirectStandardError "$out.err" `
+                      -PassThru -NoNewWindow
+                  if (-not $proc.WaitForExit(8000)) { $proc.Kill() }
+
+                  Write-Host '--- captured chat output ---'
+                  if (Test-Path $out)     { Get-Content $out }
+                  if (Test-Path "$out.err") { Get-Content "$out.err" }
+                  Write-Host '--- assertion ---'
+                  $captured = ''
+                  if (Test-Path $out) { $captured = Get-Content $out -Raw }
+                  if ($captured -match 'ATOMIC_CHAT_SMOKE\s+TMUX=\S*atomic|ATOMIC_CHAT_SMOKE\s+\S*PSMUX=\S*atomic') {
+                      Write-Host 'PASS: stub agent ran inside psmux session'
+                  } else {
+                      Write-Host 'FAIL: stub agent did not see $TMUX/$PSMUX populated — chat fell back to spawnDirect'
+                      exit 1
+                  }

--- a/packages/atomic-sdk/src/runtime/tmux.ts
+++ b/packages/atomic-sdk/src/runtime/tmux.ts
@@ -11,6 +11,7 @@ import { tmuxConfPath, ccDebounceScriptPath } from "../lib/runtime-assets.ts";
 import { writeFileSync, unlinkSync } from "node:fs";
 import type { Subprocess } from "bun";
 import { atomicTempPath } from "../lib/atomic-temp.ts";
+import { normalizedTerminalEnv } from "../lib/terminal-env.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -625,6 +626,24 @@ function buildAttachArgs(sessionName: string): string[] {
 }
 
 /**
+ * Build the env for an attach-session client process.
+ *
+ * tmux probes the client's $TERM at attach time and aborts with
+ * "open terminal failed: terminal does not support clear" when the
+ * value is unset, "dumb", or has no terminfo entry on the host. That
+ * branches the chat command into a silent `spawnDirect` fallback even
+ * though the session was created successfully — exactly the failure
+ * mode that CI / Docker / `script(1)`-wrapped invocations hit.
+ *
+ * Reusing `normalizedTerminalEnv` keeps the override aligned with what
+ * we already inject into tmux *new-session* via `-e TERM=…`, so the
+ * client and the in-pane processes always agree on the terminal type.
+ */
+function attachClientEnv(): Record<string, string> {
+  return normalizedTerminalEnv(process.env);
+}
+
+/**
  * Attach to an existing tmux session (takes over the current terminal).
  */
 export function attachSession(sessionName: string): void {
@@ -634,6 +653,7 @@ export function attachSession(sessionName: string): void {
     stdin: "inherit",
     stdout: "inherit",
     stderr: "pipe",
+    env: attachClientEnv(),
   });
   if (!proc.success) {
     const stderr = proc.stderr.toString().trim();
@@ -649,6 +669,7 @@ export function attachSession(sessionName: string): void {
 export function spawnMuxAttach(sessionName: string): Subprocess {
   return Bun.spawn(buildAttachArgs(sessionName), {
     stdio: ["inherit", "inherit", "inherit"],
+    env: attachClientEnv(),
   });
 }
 

--- a/packages/atomic/src/cli.ts
+++ b/packages/atomic/src/cli.ts
@@ -79,6 +79,13 @@ export function createProgram() {
         .addOption(
             new Option("--preflight-only").hideHelp(),
         )
+        // Internal flag — bypasses `checkAgentAuth` for claude/copilot.
+        // Paired with a stub agent on PATH it lets the CI matrix exercise
+        // the real `chatCommand` tmux-launch path on every platform
+        // without holding live credentials. Hidden from `--help`.
+        .addOption(
+            new Option("--no-login").hideHelp(),
+        )
         .allowUnknownOption()
         .allowExcessArguments(true)
         .enablePositionalOptions()
@@ -123,6 +130,9 @@ Examples:
                 agentType,
                 passthroughArgs: cmd.args,
                 preflightOnly: localOpts.preflightOnly,
+                // Commander turns `--no-login` into `login: false`. Treat
+                // either explicit form as "skip the auth probe".
+                noLogin: localOpts.login === false,
             });
 
             process.exit(exitCode);

--- a/packages/atomic/src/commands/cli/chat/index.ts
+++ b/packages/atomic/src/commands/cli/chat/index.ts
@@ -83,6 +83,15 @@ export interface ChatCommandOptions {
    * and auth checks so it works even when the agent CLI is not installed.
    */
   preflightOnly?: boolean;
+  /**
+   * When true, skip the SDK-level auth probe in `checkAgentAuth`.
+   * Internal — exists so the cross-platform CI smoke matrix can exercise
+   * the *real* tmux launch path against a stub agent on PATH without
+   * needing live Claude / Copilot credentials. The chat flow continues
+   * normally past the auth gate; it does NOT alter what the agent CLI
+   * itself does once spawned.
+   */
+  noLogin?: boolean;
 }
 
 // ============================================================================
@@ -259,7 +268,7 @@ export function buildLauncherScript(
  * @returns Exit code from the agent process
  */
 export async function chatCommand(options: ChatCommandOptions = {}): Promise<number> {
-  const { agentType, passthroughArgs, preflightOnly } = options;
+  const { agentType, passthroughArgs, preflightOnly, noLogin } = options;
 
   if (!agentType) {
     throw new Error("agentType is required. Start chat with `atomic chat -a <agent>`.");
@@ -293,11 +302,15 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
   // ── Preflight: authentication ──
   // Copilot and Claude expose SDK-level login checks; run them now so
   // users get a short actionable error instead of being dropped into a
-  // native CLI that immediately redirects them to /login.
-  const auth = await checkAgentAuth(agentType);
-  if (!auth.loggedIn) {
-    printAuthError(agentType, auth);
-    return 1;
+  // native CLI that immediately redirects them to /login. The
+  // `--no-login` escape hatch skips this for CI smoke-tests that pair
+  // a stub agent on PATH with the real chat-launch code path.
+  if (!noLogin) {
+    const auth = await checkAgentAuth(agentType);
+    if (!auth.loggedIn) {
+      printAuthError(agentType, auth);
+      return 1;
+    }
   }
 
   // ── Preflight: global config sync ──
@@ -411,8 +424,17 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
 
     await removeLauncher(launcherPath);
 
-    // If tmux attach itself failed (e.g. lost TTY), clean up and fall back
+    // If tmux attach itself failed (e.g. unsuitable TERM, lost TTY) we
+    // surface that explicitly before falling back to a plain spawn —
+    // otherwise the user lands in the agent CLI without realising tmux
+    // never opened, and the multi-pane footer / Ctrl-C debounce / chat
+    // session manager are all silently disabled.
     if (exitCode !== 0) {
+      console.error(
+        `${COLORS.yellow}Warning: tmux attach-session exited ${exitCode}. ` +
+        `Common cause: $TERM is unset or has no terminfo entry on this host. ` +
+        `Falling back to direct spawn — chat session features will be disabled.${COLORS.reset}`,
+      );
       try { killSession(windowName); } catch {}
       return spawnDirect(cmd, projectRoot, spawnEnv);
     }


### PR DESCRIPTION
Reproduced in a fresh Docker container against the v0.7.0-3 binary: `atomic chat -a opencode` silently falls back to spawnDirect (no tmux) whenever the calling shell's $TERM is missing or has no terminfo entry on the host. tmux's attach-session probes the client's TERM and aborts with "open terminal failed: terminal does not support clear" — exit 1 — and chatCommand's `if (exitCode !== 0)` branch turns that into a quiet `spawnDirect` with no diagnostic.

The previous bunfs-materialization fix (commit 1de6fac3) is correct but only covers the asset-loading half of the launch path; the attach-side TERM gap is what actually surfaces as "doesn't open in tmux" for users on hosts where TERM has been stripped by `script(1)`, nohup, headless devcontainers, etc.

Three changes:

  - tmux.ts: spawnMuxAttach + attachSession now pass an env built via `normalizedTerminalEnv(process.env)`, so TERM gets coerced to xterm-256color when missing/dumb, COLORTERM defaults to truecolor, and the locale keys stay UTF-8. Mirrors the per-process env we already inject into tmux new-session via `-e KEY=VAL`, so the client and the in-pane processes always agree on the terminal type.

  - chat/index.ts: when attach-session exits non-zero we now print a yellow warning naming the most common cause ($TERM) before falling back. The silent fallback is the worst part of this bug — users land in the agent CLI without realising the multi-pane footer / Ctrl-C debounce / chat session manager are all disabled.

  - chat command: new `--no-login` hidden flag bypasses `checkAgentAuth` for claude/copilot. Pairs with a stub agent on PATH so the cross-platform CI smoke matrix can drive the *real* chat-launch code path without holding live credentials.

CI:
  - Extends the runtime-assets-smoke matrix (Linux/macOS/Windows) with a second step that stages a stub `opencode` on PATH, runs `atomic chat -a opencode --no-login` under a real PTY (`script -qfc` on Unix; `Start-Process` on Windows), and asserts the stub saw $TMUX / $PSMUX populated. Catches both this regression and the earlier bunfs one — either failure mode lands the agent outside tmux with the env var unset.
  - Stub sleeps 5s after its diagnostic line (load-bearing): atomic runs ~7 follow-up tmux commands within ~60ms of `new-session`, and if the stub exits inside that window the killSessionOnPaneExit hook tears the server down before attach-session ever connects.

Verified end-to-end in Docker: TERM=<unset>, TERM=dumb, and TERM=xterm-256color all now produce a session whose pane env contains TMUX=/tmp/tmux-0/atomic,…