### PR TITLE
chore(release): bump version to v0.7.0-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.0-3",
+  "version": "0.7.0-4",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.0-3",
+  "version": "0.7.0-4",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.0-3",
+  "version": "0.7.0-4",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Bumps the prerelease version from `v0.7.0-3` to `v0.7.0-4` across all packages in the monorepo.

## Changes

- Bumped version to `0.7.0-4` in `package.json`, `packages/atomic/package.json`, and `packages/atomic-sdk/package.json`

## Included Fixes

This prerelease packages the following fix over `v0.7.0-3`:

- **fix(chat)**: Keep tmux attach alive when the client `TERM` variable is unset or set to `dumb` (PR #797)