### PR TITLE
fix(chat): render attached footer in compiled binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,109 +218,25 @@ jobs:
             # PATH and asserts the agent ended up running INSIDE tmux/psmux
             # (i.e. `$TMUX` / `$PSMUX` is populated when the stub runs).
             #
-            # This catches regressions that the asset-only smoke can't, e.g.:
-            #  - tmux `attach-session` failing because $TERM is unset/dumb
-            #    on the host (silent fallback to spawnDirect).
-            #  - any future regression that breaks the full launch chain
-            #    (createSession -> spawnAttachedFooter -> spawnMuxAttach).
+            # The chat code's first guard is `process.stdin.isTTY`; GitHub
+            # Actions steps run with piped stdio, so we have to manufacture
+            # a real PTY. `chat-smoke.ts` uses `bun-pty` (forkpty on Unix,
+            # ConPTY on Windows) so the same invocation works on every
+            # runner — replacing the prior `script -qfc` / `Start-Process`
+            # split that was non-portable (GNU `timeout` missing on macOS,
+            # `Start-Process -RedirectStandardOutput` allocates pipes not
+            # a PTY on Windows).
             #
             # `--no-login` skips the SDK auth probe so we can pair this with
             # a stub `opencode` binary (opencode's auth check is a no-op
             # anyway, but the flag keeps the test agent-agnostic).
-            - name: Stage stub agent + run chat smoke (Unix)
-              if: runner.os != 'Windows'
+            - name: Run chat-launch smoke
               shell: bash
               run: |
                   set -e
-                  STUB_DIR="$RUNNER_TEMP/atomic-stub-bin"
-                  mkdir -p "$STUB_DIR"
-                  # Stub opencode prints diagnostic line, then sleeps. The
-                  # sleep is load-bearing: atomic.chatCommand runs ~7 follow-up
-                  # tmux commands (set-options, split-window, set-hooks,
-                  # attach-session) within ~60ms of `new-session`. If the
-                  # stub exits in <60ms the pane closure triggers
-                  # killSessionOnPaneExit → server dies → every later tmux
-                  # call fails with "no server running" and chat falls
-                  # back to spawnDirect. Real agents take >100ms to
-                  # initialise so they don't hit this race; the stub has to
-                  # stick around long enough to mimic that.
-                  cat > "$STUB_DIR/opencode" <<'STUB'
-                  #!/bin/bash
-                  echo "ATOMIC_CHAT_SMOKE TMUX=${TMUX:-} PSMUX=${PSMUX:-}"
-                  exec sleep 5
-                  STUB
-                  chmod +x "$STUB_DIR/opencode"
-                  export PATH="$STUB_DIR:$PATH"
-
-                  ATOMIC=$(find packages/atomic/dist -type f -name 'atomic*' | head -n 1)
-                  echo "Chat-smoke binary: $ATOMIC"
-
-                  # `script -qfc` allocates a real PTY; the chat code path's
-                  # `process.stdin.isTTY` check would otherwise force the
-                  # spawnDirect fallback regardless of tmux state.
-                  OUT="$RUNNER_TEMP/chat-smoke.log"
-                  if [ "$RUNNER_OS" = "macOS" ]; then
-                      # BSD `script` syntax: `script -q logfile cmd args...`
-                      timeout --kill-after=2 8 script -q "$OUT" "$ATOMIC" chat -a opencode --no-login || true
-                  else
-                      # GNU `script` syntax
-                      timeout --kill-after=2 8 script -qfc "$ATOMIC chat -a opencode --no-login" "$OUT" || true
-                  fi
-
-                  echo "--- captured chat output ---"
-                  cat "$OUT" || true
-                  echo "--- assertion ---"
-                  if grep -E 'ATOMIC_CHAT_SMOKE TMUX=[^ ]+/atomic' "$OUT" >/dev/null; then
-                      echo "PASS: stub agent ran inside tmux session"
-                  else
-                      echo "FAIL: stub agent did not see \$TMUX populated — chat fell back to spawnDirect"
+                  ATOMIC=$(find packages/atomic/dist -type f \( -name 'atomic' -o -name 'atomic.exe' \) | head -n 1)
+                  if [ -z "$ATOMIC" ]; then
+                      echo "Could not locate built binary under packages/atomic/dist"
                       exit 1
                   fi
-
-            - name: Stage stub agent + run chat smoke (Windows)
-              if: runner.os == 'Windows'
-              shell: pwsh
-              run: |
-                  $stubDir = Join-Path $env:RUNNER_TEMP 'atomic-stub-bin'
-                  New-Item -ItemType Directory -Force -Path $stubDir | Out-Null
-                  # psmux invokes pane commands via `pwsh -NoProfile -File <ps1>`,
-                  # so a stub PowerShell script is what gets exec'd as the agent.
-                  # Sleep is load-bearing — see the Unix sibling step for the
-                  # race condition this avoids.
-                  @'
-                  Write-Host "ATOMIC_CHAT_SMOKE TMUX=$($env:TMUX) PSMUX=$($env:PSMUX)"
-                  Start-Sleep -Seconds 5
-                  '@ | Set-Content -Path (Join-Path $stubDir 'opencode.ps1') -Encoding ASCII
-
-                  # The CLI looks up the agent via Bun.which("opencode"); on
-                  # Windows that resolves a `.cmd` shim. Provide one.
-                  @'
-                  @echo off
-                  pwsh -NoProfile -File "%~dp0opencode.ps1" %*
-                  '@ | Set-Content -Path (Join-Path $stubDir 'opencode.cmd') -Encoding ASCII
-
-                  $env:Path = "$stubDir;$env:Path"
-
-                  $atomic = Get-ChildItem -Path packages/atomic/dist -Recurse -Filter 'atomic.exe' | Select-Object -First 1
-                  if (-not $atomic) { throw 'atomic.exe not found under packages/atomic/dist' }
-                  Write-Host "Chat-smoke binary: $($atomic.FullName)"
-
-                  $out = Join-Path $env:RUNNER_TEMP 'chat-smoke.log'
-                  $proc = Start-Process -FilePath $atomic.FullName `
-                      -ArgumentList 'chat','-a','opencode','--no-login' `
-                      -RedirectStandardOutput $out -RedirectStandardError "$out.err" `
-                      -PassThru -NoNewWindow
-                  if (-not $proc.WaitForExit(8000)) { $proc.Kill() }
-
-                  Write-Host '--- captured chat output ---'
-                  if (Test-Path $out)     { Get-Content $out }
-                  if (Test-Path "$out.err") { Get-Content "$out.err" }
-                  Write-Host '--- assertion ---'
-                  $captured = ''
-                  if (Test-Path $out) { $captured = Get-Content $out -Raw }
-                  if ($captured -match 'ATOMIC_CHAT_SMOKE\s+TMUX=\S*atomic|ATOMIC_CHAT_SMOKE\s+\S*PSMUX=\S*atomic') {
-                      Write-Host 'PASS: stub agent ran inside psmux session'
-                  } else {
-                      Write-Host 'FAIL: stub agent did not see $TMUX/$PSMUX populated — chat fell back to spawnDirect'
-                      exit 1
-                  }
+                  bun packages/atomic/script/chat-smoke.ts "$ATOMIC" opencode

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@opentui/react": "^0.2.2",
         "@types/bun": "^1.3.13",
         "@types/react": "^19.2.14",
+        "bun-pty": "0.4.8",
         "oxlint": "^1.62.0",
         "react": "^19.2.5",
         "typescript": "^6.0.3",
@@ -20,7 +21,7 @@
     },
     "packages/atomic": {
       "name": "@bastani/atomic",
-      "version": "0.7.0-1",
+      "version": "0.7.0-4",
       "bin": {
         "atomic": "src/cli.ts",
       },
@@ -43,7 +44,7 @@
     },
     "packages/atomic-sdk": {
       "name": "@bastani/atomic-sdk",
-      "version": "0.7.0-1",
+      "version": "0.7.0-4",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.126",
         "@catppuccin/palette": "^1.8.0",
@@ -232,6 +233,8 @@
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
+
+    "bun-pty": ["bun-pty@0.4.8", "", {}, "sha512-rO70Mrbr13+jxHHHu2YBkk2pNqrJE5cJn29WE++PUr+GFA0hq/VgtQPZANJ8dJo6d7XImvBk37Innt8GM7O28w=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@opentui/react": "^0.2.2",
     "@types/bun": "^1.3.13",
     "@types/react": "^19.2.14",
+    "bun-pty": "0.4.8",
     "oxlint": "^1.62.0",
     "react": "^19.2.5",
     "typescript": "^6.0.3",

--- a/packages/atomic-sdk/src/runtime/attached-footer.test.ts
+++ b/packages/atomic-sdk/src/runtime/attached-footer.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Regression coverage for the attached-footer command emitter.
+ *
+ * Two layers:
+ *   - Unit: assert the shell command shape for dev (runtime !== cliPath)
+ *     vs compiled (runtime === cliPath) on linux + win32. Catches naive
+ *     edits to `buildAttachedFooterCommand`.
+ *   - Integration (compiled binary only, skipped otherwise): exec the
+ *     emitted command against the real binary and assert it reaches the
+ *     `_footer` subcommand instead of the `chat` default. Catches the
+ *     specific Bun-compiled-binary argv regression where two copies of
+ *     the binary path in argv push the subcommand token past Commander's
+ *     default `slice(2)`, falling through to the default `chat` command
+ *     and printing "Missing agent".
+ */
+
+import { test, expect, describe } from "bun:test";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { buildAttachedFooterCommand } from "./attached-footer.ts";
+
+describe("buildAttachedFooterCommand", () => {
+  describe("dev mode (runtime !== cliPath)", () => {
+    test("linux: emits both runtime and cliPath", () => {
+      const cmd = buildAttachedFooterCommand({
+        runtime: "/usr/local/bin/bun",
+        cliPath: "/repo/packages/atomic/src/cli.ts",
+        windowName: "atomic-chat-opencode-abc",
+        agentType: "opencode",
+        platform: "linux",
+      });
+      expect(cmd).toBe(
+        `"/usr/local/bin/bun" "/repo/packages/atomic/src/cli.ts" _footer ` +
+          `--name "atomic-chat-opencode-abc" --agent "opencode"`,
+      );
+    });
+
+    test("win32: emits both runtime and cliPath inside the encoded pwsh script", () => {
+      const cmd = buildAttachedFooterCommand({
+        runtime: "C:\\bun\\bun.exe",
+        cliPath: "C:\\repo\\cli.ts",
+        windowName: "atomic-chat-opencode-abc",
+        agentType: "opencode",
+        platform: "win32",
+      });
+      const decoded = decodePwshEncodedCommand(cmd);
+      expect(decoded).toContain("'C:\\bun\\bun.exe'");
+      expect(decoded).toContain("'C:\\repo\\cli.ts'");
+      expect(decoded).toContain("'_footer'");
+      expect(decoded).toContain("'--agent' 'opencode'");
+    });
+  });
+
+  describe("compiled binary mode (runtime === cliPath)", () => {
+    // The compiled binary is its own runtime — Bun auto-injects argv[1] = binary
+    // so the emitted command must NOT duplicate the path, otherwise Commander's
+    // slice(2) drops the `_footer` token and falls through to the default `chat`.
+    const BIN = "/usr/local/bin/atomic";
+
+    test("linux: emits the binary path exactly once", () => {
+      const cmd = buildAttachedFooterCommand({
+        runtime: BIN,
+        cliPath: BIN,
+        windowName: "atomic-chat-opencode-abc",
+        agentType: "opencode",
+        platform: "linux",
+      });
+      expect(cmd).toBe(
+        `"${BIN}" _footer --name "atomic-chat-opencode-abc" --agent "opencode"`,
+      );
+      // Defensive: count occurrences of the binary path. Must be exactly one.
+      const occurrences = cmd.split(BIN).length - 1;
+      expect(occurrences).toBe(1);
+    });
+
+    test("win32: emits the binary path exactly once inside the encoded pwsh script", () => {
+      const winBin = "C:\\Program Files\\atomic\\atomic.exe";
+      const cmd = buildAttachedFooterCommand({
+        runtime: winBin,
+        cliPath: winBin,
+        windowName: "atomic-chat-opencode-abc",
+        agentType: "opencode",
+        platform: "win32",
+      });
+      const decoded = decodePwshEncodedCommand(cmd);
+      const occurrences = decoded.split(winBin).length - 1;
+      expect(occurrences).toBe(1);
+      expect(decoded).toContain("'_footer'");
+    });
+  });
+
+  test("agentType is optional (workflow path passes only window name)", () => {
+    const cmd = buildAttachedFooterCommand({
+      runtime: "/bin/atomic",
+      cliPath: "/bin/atomic",
+      windowName: "atomic-workflow-abc",
+      platform: "linux",
+    });
+    expect(cmd).toBe(`"/bin/atomic" _footer --name "atomic-workflow-abc"`);
+    expect(cmd).not.toContain("--agent");
+  });
+});
+
+// ── Integration: exec the emitted command against the real compiled binary ──
+// Skipped when no built binary is present (e.g. unit-test-only CI lanes that
+// run before the build). When the binary exists (locally or in CI's
+// runtime-assets-smoke job), this asserts the emitted command actually
+// dispatches to `_footer`, not to the default `chat` command.
+
+const builtBinary = locateBuiltBinary();
+
+describe.skipIf(!builtBinary)("compiled binary footer dispatch", () => {
+  test("emitted footer command reaches the _footer subcommand (not the chat default)", () => {
+    const bin = builtBinary!;
+    const cmd = buildAttachedFooterCommand({
+      runtime: bin,
+      cliPath: bin,
+      windowName: "atomic-chat-opencode-test",
+      agentType: "opencode",
+      platform: process.platform === "win32" ? "win32" : "linux",
+    });
+
+    // Run the emitted command verbatim through bash so we exercise the same
+    // argv tmux's split-window would produce. 1.5s is enough for the OpenTUI
+    // headless renderer to emit at least one frame containing the agent pill.
+    const result = Bun.spawnSync({
+      cmd: [
+        "bash",
+        "-c",
+        `${cmd} & PID=$!; sleep 1.5; kill -TERM $PID 2>/dev/null; wait $PID 2>/dev/null; exit 0`,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = result.stdout.toString();
+    const stderr = result.stderr.toString();
+
+    // Bug signature: when argv is malformed, Commander falls through to the
+    // default `chat` command which exits 1 with this message.
+    expect(stderr).not.toContain("Missing agent");
+    expect(stdout).not.toContain("Missing agent");
+
+    // Positive signal: the renderer painted the agent pill at least once.
+    // The pill text is uppercase agent name embedded in ANSI styling.
+    expect(stdout).toContain("OPENCODE");
+  });
+});
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function decodePwshEncodedCommand(cmd: string): string {
+  // Format: `pwsh -NoProfile -EncodedCommand <base64>`
+  const match = cmd.match(/-EncodedCommand\s+(\S+)/);
+  if (!match) throw new Error(`Not a pwsh -EncodedCommand string: ${cmd}`);
+  return Buffer.from(match[1]!, "base64").toString("utf16le");
+}
+
+function locateBuiltBinary(): string | null {
+  if (process.platform === "win32") return null; // bash test harness is unix-only
+  // Walk up from this test file (packages/atomic-sdk/src/runtime/) to the
+  // monorepo root, then look for a built atomic binary under
+  // packages/atomic/dist/<target>/bin/atomic. We can't use findRepoRoot from
+  // the atomic package here because atomic-sdk must not depend on atomic.
+  let dir = import.meta.dir;
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "package.json")) && existsSync(join(dir, "packages"))) {
+      const distRoot = join(dir, "packages", "atomic", "dist");
+      const targets = [
+        "linux-x64",
+        "linux-arm64",
+        "darwin-x64",
+        "darwin-arm64",
+      ];
+      for (const target of targets) {
+        const candidate = join(distRoot, target, "bin", "atomic");
+        if (existsSync(candidate)) return candidate;
+      }
+      return null;
+    }
+    dir = dirname(dir);
+  }
+  return null;
+}

--- a/packages/atomic-sdk/src/runtime/attached-footer.ts
+++ b/packages/atomic-sdk/src/runtime/attached-footer.ts
@@ -72,23 +72,35 @@ export function buildAttachedFooterCommand({
   agentType?: AgentType;
   platform?: NodeJS.Platform;
 }): string {
+  // In dev (`bun cli.ts _footer …`) the runtime (`bun`) and cli script
+  // (`cli.ts`) are distinct files and both must appear on the command line.
+  // In a compiled binary `process.execPath` is the binary itself, so runtime
+  // === cliPath; emitting both would put two copies of the binary path in
+  // argv. Bun's compiled binary already injects argv[1] = binary (Node-compat)
+  // so Commander's default `slice(2)` then sees the surplus `<binary>` token
+  // as the first user arg, fails to match the `_footer` subcommand, and
+  // falls through to the default `chat` command — which exits with
+  // "Missing agent" and leaves the footer pane blank.
+  const isSelfExec = runtime === cliPath;
   if (platform === "win32") {
-    const script = [
-      quotePwshLiteral(runtime),
-      quotePwshLiteral(cliPath),
+    const parts = [quotePwshLiteral(runtime)];
+    if (!isSelfExec) parts.push(quotePwshLiteral(cliPath));
+    parts.push(
       quotePwshLiteral("_footer"),
       quotePwshLiteral("--name"),
       quotePwshLiteral(windowName),
-      ...(agentType
-        ? [quotePwshLiteral("--agent"), quotePwshLiteral(agentType)]
-        : []),
-    ].join(" ");
+    );
+    if (agentType) {
+      parts.push(quotePwshLiteral("--agent"), quotePwshLiteral(agentType));
+    }
+    const script = parts.join(" ");
     return `pwsh -NoProfile -EncodedCommand ${encodePwshCommand(`& ${script}`)}`;
   }
 
   const agentFlag = agentType ? ` --agent "${escBash(agentType)}"` : "";
+  const cliPart = isSelfExec ? "" : `"${escBash(cliPath)}" `;
   return (
-    `"${escBash(runtime)}" "${escBash(cliPath)}" _footer ` +
+    `"${escBash(runtime)}" ${cliPart}_footer ` +
     `--name "${escBash(windowName)}"${agentFlag}`
   );
 }

--- a/packages/atomic/script/chat-smoke.ts
+++ b/packages/atomic/script/chat-smoke.ts
@@ -1,0 +1,132 @@
+/**
+ * Cross-platform chat-launch smoke for the published `atomic` binary.
+ *
+ * Spawns `<atomic-bin> chat -a <agent> --no-login` inside a real PTY
+ * (forkpty on Unix, ConPTY on Windows) so the chat command's
+ * `process.stdin.isTTY` guard sees a terminal and doesn't fall back to
+ * `spawnDirect`. Asserts that the stub agent ends up running INSIDE
+ * tmux/psmux by greping for the `$TMUX` / `$PSMUX` markers it prints.
+ *
+ * Replaces the prior shell-only invocation that was non-portable
+ * (GNU `timeout` missing on macOS, `Start-Process` allocates pipes not
+ * a PTY on Windows). Modeled on opencode's `bun-pty` usage.
+ */
+
+import { spawn as ptySpawn } from "bun-pty";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+const atomicBin = process.argv[2];
+const agent = process.argv[3] ?? "opencode";
+if (!atomicBin) {
+  console.error("usage: chat-smoke.ts <atomic-bin> [agent]");
+  process.exit(2);
+}
+
+const stubDir = mkdtempSync(join(tmpdir(), "atomic-chat-smoke-"));
+
+// The stub sleeps long enough to outlive atomic.chatCommand's ~7 follow-up
+// tmux calls; if it exits in <60ms the pane closure trips killSessionOnPaneExit
+// and every later tmux call sees "no server running".
+if (process.platform === "win32") {
+  // psmux invokes pane commands via `pwsh -NoProfile -File <ps1>`, so the
+  // stub must be a PowerShell script behind a `.cmd` shim Bun.which can find.
+  writeFileSync(
+    join(stubDir, `${agent}.ps1`),
+    `Write-Host "ATOMIC_CHAT_SMOKE TMUX=$($env:TMUX) PSMUX=$($env:PSMUX)"\r\nStart-Sleep -Seconds 5\r\n`,
+  );
+  writeFileSync(
+    join(stubDir, `${agent}.cmd`),
+    `@echo off\r\npwsh -NoProfile -File "%~dp0${agent}.ps1" %*\r\n`,
+  );
+} else {
+  const stubPath = join(stubDir, agent);
+  writeFileSync(
+    stubPath,
+    `#!/bin/bash\necho "ATOMIC_CHAT_SMOKE TMUX=\${TMUX:-} PSMUX=\${PSMUX:-}"\nexec sleep 5\n`,
+  );
+  chmodSync(stubPath, 0o755);
+}
+
+const env: Record<string, string> = {};
+for (const [key, value] of Object.entries(process.env)) {
+  if (value !== undefined) env[key] = value;
+}
+env.PATH = `${stubDir}${delimiter}${env.PATH ?? ""}`;
+
+console.log(`Chat-smoke binary: ${atomicBin}`);
+console.log(`Stub agent dir:    ${stubDir}`);
+
+const proc = ptySpawn(atomicBin, ["chat", "-a", agent, "--no-login"], {
+  name: "xterm-256color",
+  cols: 120,
+  rows: 40,
+  cwd: process.cwd(),
+  env,
+});
+
+const chunks: string[] = [];
+proc.onData((data) => {
+  chunks.push(data);
+});
+
+const TIMEOUT_MS = Number(process.env.ATOMIC_CHAT_SMOKE_TIMEOUT_MS ?? 8000);
+const killTimer = setTimeout(() => {
+  try {
+    proc.kill();
+  } catch {
+    // Already exited
+  }
+}, TIMEOUT_MS);
+
+await new Promise<void>((resolve) => {
+  proc.onExit(() => {
+    clearTimeout(killTimer);
+    resolve();
+  });
+});
+
+const captured = chunks.join("");
+console.log("--- captured chat output ---");
+console.log(captured);
+console.log("--- assertion ---");
+
+// Two independent invariants of a healthy chat launch:
+//
+//   1. agent ran INSIDE the multiplexer — the stub prints `$TMUX` / `$PSMUX`
+//      as set by tmux/psmux when it forks the pane process; an empty value
+//      means chatCommand fell back to spawnDirect (no tmux at all).
+//
+//   2. footer pane rendered — `spawnAttachedFooter` splits a second pane
+//      under the agent and runs `atomic _footer --agent <agent>`, which
+//      paints an uppercase agent pill ("OPENCODE") via the OpenTUI headless
+//      renderer. A blank footer pane means the spawn command was malformed
+//      (e.g. duplicated binary path on a compiled binary → Commander falls
+//      through to the default `chat` command → "Missing agent" → pane dies).
+//      The pill text appears verbatim inside the captured PTY stream
+//      because tmux paints both panes into the same client terminal.
+const muxRe = /ATOMIC_CHAT_SMOKE\s+(?:TMUX=\S*atomic|\S*PSMUX=\S*atomic)/;
+const footerRe = new RegExp(agent.toUpperCase());
+
+const muxOk = muxRe.test(captured);
+const footerOk = footerRe.test(captured);
+
+console.log(
+  `${muxOk ? "PASS" : "FAIL"}: stub agent ran inside tmux/psmux session`,
+);
+console.log(
+  `${footerOk ? "PASS" : "FAIL"}: footer pane rendered the ${agent.toUpperCase()} pill`,
+);
+
+if (muxOk && footerOk) process.exit(0);
+
+if (!muxOk) {
+  console.log("  → chat fell back to spawnDirect (no tmux/psmux pane)");
+}
+if (!footerOk) {
+  console.log(
+    `  → footer pane did not paint "${agent.toUpperCase()}" — likely a malformed split-window command`,
+  );
+}
+process.exit(1);


### PR DESCRIPTION
## Summary

\`atomic chat -a <agent>\` opened tmux with the agent in the top pane but the bottom statusline pane was always blank. The bug was silent — no tmux errors, exit code 0 — and invisible to the existing CI smoke.

## Root Cause

In \`buildAttachedFooterCommand\`, dev mode (\`bun cli.ts _footer …\`) needs both a runtime path and a CLI script path on the command line. In a compiled binary, \`process.execPath\` **is** the binary, so \`runtime === cliPath\`. The emitter was naively including both, producing a duplicated path.

Bun's compiled binary also auto-injects \`argv[1] = binary\` for Node-compat, so the resulting \`process.argv\` became \`[binary, binary, binary, _footer, …]\`. Commander's default \`slice(2)\` then saw the surplus \`<binary>\` token as the first user argument, failed to match the \`_footer\` subcommand, and fell through to the default \`chat\` command — which exits 1 with "Missing agent" and leaves the footer pane blank.

## Changes

- **\`packages/atomic-sdk/src/runtime/attached-footer.ts\`** — Fix: when \`runtime === cliPath\` (compiled binary), emit only the single binary path. Applies to both the Unix and win32 (\`pwsh -EncodedCommand\`) code paths. Restores the footer for both \`atomic chat -a <agent>\` and \`atomic workflow\`.

- **\`packages/atomic-sdk/src/runtime/attached-footer.test.ts\`** *(new)* — Unit tests for both branches (\`runtime !== cliPath\` → two paths, \`runtime === cliPath\` → one path) on linux and win32 (decoded \`pwsh -EncodedCommand\`). Plus an integration test (skipped when no built binary is present) that exec's the emitted command against the real compiled binary and asserts it reaches \`_footer\`, not the \`chat\` default.

- **\`packages/atomic/script/chat-smoke.ts\`** *(new)* — Replaces the prior shell-only smoke with a cross-platform Bun script using \`bun-pty\` (forkpty on Unix, ConPTY on Windows). Asserts **both** that the agent ran inside tmux/psmux **and** that the footer pane painted the agent pill — catches this exact regression end-to-end on every runner.

- **\`.github/workflows/ci.yml\`** — Rewires \`runtime-assets-smoke\` to use the new \`chat-smoke.ts\` helper, replacing the prior \`script -qfc\` / \`Start-Process\` split.

## Incidental CI Fixes

The chat-smoke replacement also fixes two pre-existing CI bugs that were masking the failure:

- **macOS**: \`runtime-assets-smoke\` was failing on \`timeout: command not found\` (BSD doesn't ship GNU \`timeout\`). The new helper uses a JS-level kill timer with no shell dependency.
- **Windows**: \`Start-Process -RedirectStandardOutput\` allocates anonymous pipes, not a PTY — \`chat\`'s \`process.stdin.isTTY\` guard tripped silently and the smoke couldn't validate anything past it. ConPTY via \`bun-pty\` replaces \`Start-Process\` and the same code now drives all three OSes.

## Verification

\`\`\`
# 6 pass with the fix; 4 fail without it (3 unit + 1 integration)
bun test packages/atomic-sdk/src/runtime/attached-footer.test.ts

# PASS/PASS with the fix; PASS (mux) / FAIL (footer) without it
bun packages/atomic/script/chat-smoke.ts <built-binary> opencode
\`\`\`