### PR TITLE
chore(release): bump v0.7.0-5 with Windows path fixes and expanded smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,4 +239,8 @@ jobs:
                       echo "Could not locate built binary under packages/atomic/dist"
                       exit 1
                   fi
-                  bun packages/atomic/script/chat-smoke.ts "$ATOMIC" opencode
+                  for agent in opencode claude copilot; do
+                      echo "::group::chat-smoke ${agent}"
+                      bun packages/atomic/script/chat-smoke.ts "$ATOMIC" "$agent"
+                      echo "::endgroup::"
+                  done

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.0-4",
+  "version": "0.7.0-5",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.0-4",
+  "version": "0.7.0-5",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.0-4",
+  "version": "0.7.0-5",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",

--- a/packages/atomic/script/chat-smoke.ts
+++ b/packages/atomic/script/chat-smoke.ts
@@ -92,6 +92,14 @@ console.log("--- captured chat output ---");
 console.log(captured);
 console.log("--- assertion ---");
 
+// psmux paints pane content with `\x1B[<n>C` cursor-forward escapes between
+// fields instead of literal whitespace, so a regex anchored on `\s+` between
+// the marker and the env-var dump never matches on Windows. Strip ANSI/CSI
+// escapes once and run all assertions against the clean stream.
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const cleaned = captured.replace(ANSI_RE, "");
+
 // Two independent invariants of a healthy chat launch:
 //
 //   1. agent ran INSIDE the multiplexer — the stub prints `$TMUX` / `$PSMUX`
@@ -109,8 +117,8 @@ console.log("--- assertion ---");
 const muxRe = /ATOMIC_CHAT_SMOKE\s+(?:TMUX=\S*atomic|\S*PSMUX=\S*atomic)/;
 const footerRe = new RegExp(agent.toUpperCase());
 
-const muxOk = muxRe.test(captured);
-const footerOk = footerRe.test(captured);
+const muxOk = muxRe.test(cleaned);
+const footerOk = footerRe.test(cleaned);
 
 console.log(
   `${muxOk ? "PASS" : "FAIL"}: stub agent ran inside tmux/psmux session`,

--- a/packages/atomic/script/chat-smoke.ts
+++ b/packages/atomic/script/chat-smoke.ts
@@ -114,7 +114,11 @@ const cleaned = captured.replace(ANSI_RE, "");
 //      through to the default `chat` command → "Missing agent" → pane dies).
 //      The pill text appears verbatim inside the captured PTY stream
 //      because tmux paints both panes into the same client terminal.
-const muxRe = /ATOMIC_CHAT_SMOKE\s+(?:TMUX=\S*atomic|\S*PSMUX=\S*atomic)/;
+// psmux separates the marker and `TMUX=…` field with a `\x1B[1C` cursor
+// advance rather than a literal space; once ANSI is stripped, the two
+// tokens are flush against each other (`ATOMIC_CHAT_SMOKETMUX=…`). Allow
+// zero-or-more whitespace between them.
+const muxRe = /ATOMIC_CHAT_SMOKE\s*(?:TMUX|PSMUX)=\S*atomic/;
 const footerRe = new RegExp(agent.toUpperCase());
 
 const muxOk = muxRe.test(cleaned);

--- a/packages/atomic/src/lib/embedded-assets.ts
+++ b/packages/atomic/src/lib/embedded-assets.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { homedir, platform, tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { VERSION } from "../version.ts";   // inlined by `bun build --compile`
 import type { EmbeddedAssetKind } from "@bastani/atomic-sdk/services/config/definitions";
 import { isCompiledBinaryRuntime } from "@bastani/atomic-sdk/lib/runtime-env";
@@ -56,7 +56,15 @@ export async function getEmbeddedAsset(kind: EmbeddedAssetKind): Promise<string>
     await Bun.write(tarPathForOs, await Bun.file(tarPath).bytes());
   }
 
-  const proc = Bun.spawn(["tar", "-xf", tarPathForOs, "-C", stagingDir], { stderr: "pipe" });
+  // GNU tar (shipped with Git Bash on the Windows runner) treats a colon
+  // before the first slash as an SCP-style `host:path` and tries to spawn
+  // rsh/ssh, which fails with "Cannot connect to C: resolve failed" on any
+  // absolute Windows path. Pass the archive as a basename via `cwd` so the
+  // `-f` argument never carries a drive letter.
+  const proc = Bun.spawn(["tar", "-xf", basename(tarPathForOs), "-C", stagingDir], {
+    cwd: dirname(tarPathForOs),
+    stderr: "pipe",
+  });
   const exitCode = await proc.exited;
   if (inBunfs) await rm(tarPathForOs, { force: true });
   if (exitCode !== 0) {

--- a/packages/atomic/src/lib/embedded-assets.ts
+++ b/packages/atomic/src/lib/embedded-assets.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { homedir, platform, tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { join } from "node:path";
 import { VERSION } from "../version.ts";   // inlined by `bun build --compile`
 import type { EmbeddedAssetKind } from "@bastani/atomic-sdk/services/config/definitions";
 import { isCompiledBinaryRuntime } from "@bastani/atomic-sdk/lib/runtime-env";
@@ -58,13 +58,14 @@ export async function getEmbeddedAsset(kind: EmbeddedAssetKind): Promise<string>
 
   // GNU tar (shipped with Git Bash on the Windows runner) treats a colon
   // before the first slash as an SCP-style `host:path` and tries to spawn
-  // rsh/ssh, which fails with "Cannot connect to C: resolve failed" on any
-  // absolute Windows path. Pass the archive as a basename via `cwd` so the
-  // `-f` argument never carries a drive letter.
-  const proc = Bun.spawn(["tar", "-xf", basename(tarPathForOs), "-C", stagingDir], {
-    cwd: dirname(tarPathForOs),
-    stderr: "pipe",
-  });
+  // rsh/ssh — `tar: Cannot connect to C: resolve failed` on any absolute
+  // Windows path. `--force-local` disables that interpretation; bsdtar
+  // doesn't recognize the flag, but bsdtar doesn't have the bug either,
+  // so we only pass it on win32 where GNU tar is what's resolved.
+  const args = ["tar"];
+  if (process.platform === "win32") args.push("--force-local");
+  args.push("-xf", tarPathForOs, "-C", stagingDir);
+  const proc = Bun.spawn(args, { stderr: "pipe" });
   const exitCode = await proc.exited;
   if (inBunfs) await rm(tarPathForOs, { force: true });
   if (exitCode !== 0) {

--- a/packages/atomic/src/lib/embedded-assets.ts
+++ b/packages/atomic/src/lib/embedded-assets.ts
@@ -56,16 +56,20 @@ export async function getEmbeddedAsset(kind: EmbeddedAssetKind): Promise<string>
     await Bun.write(tarPathForOs, await Bun.file(tarPath).bytes());
   }
 
-  // GNU tar (shipped with Git Bash on the Windows runner) treats a colon
-  // before the first slash as an SCP-style `host:path` and tries to spawn
-  // rsh/ssh — `tar: Cannot connect to C: resolve failed` on any absolute
-  // Windows path. `--force-local` disables that interpretation; bsdtar
-  // doesn't recognize the flag, but bsdtar doesn't have the bug either,
-  // so we only pass it on win32 where GNU tar is what's resolved.
-  const args = ["tar"];
-  if (process.platform === "win32") args.push("--force-local");
-  args.push("-xf", tarPathForOs, "-C", stagingDir);
-  const proc = Bun.spawn(args, { stderr: "pipe" });
+  // On Windows, prefer the bsdtar shipped in System32 over whatever `tar`
+  // resolves to on PATH. Git Bash provides a Cygwin-flavored GNU tar that
+  // mangles native Windows paths in two ways: the `-f` arg with a drive
+  // letter is read as SCP-style `host:path` (`Cannot connect to C:`), and
+  // the `-C` arg is silently truncated to its first path component. bsdtar
+  // (`%SystemRoot%\System32\tar.exe`, present on every supported Windows)
+  // handles native paths correctly and has shipped with Windows 10+ since
+  // 1803. Fall back to PATH lookup if it's somehow absent.
+  let tarBin = "tar";
+  if (process.platform === "win32") {
+    const sysTar = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "tar.exe");
+    if (existsSync(sysTar)) tarBin = sysTar;
+  }
+  const proc = Bun.spawn([tarBin, "-xf", tarPathForOs, "-C", stagingDir], { stderr: "pipe" });
   const exitCode = await proc.exited;
   if (inBunfs) await rm(tarPathForOs, { force: true });
   if (exitCode !== 0) {


### PR DESCRIPTION
## Summary

Prerelease version bump \`v0.7.0-4\` → \`v0.7.0-5\`, bundled with two Windows compatibility fixes (native tar path handling and ANSI escape stripping) and expanded CI smoke-test coverage across all three supported agents.

## Changes

### Version Bump
- \`package.json\` (monorepo root): \`0.7.0-4\` → \`0.7.0-5\`
- \`packages/atomic/package.json\`: \`0.7.0-4\` → \`0.7.0-5\`
- \`packages/atomic-sdk/package.json\`: \`0.7.0-4\` → \`0.7.0-5\`

### fix(embedded-assets): use Windows System32 bsdtar on win32

Git Bash ships a Cygwin-flavored GNU tar that mishandles native Windows paths in two ways:

- The \`-f\` argument with a drive letter (e.g. \`C:\...\`) is parsed as SCP-style \`host:path\`, triggering _"Cannot connect to C"_.
- The \`-C\` argument is silently truncated to its first path component.

On \`win32\`, \`embedded-assets.ts\` now prefers \`%SystemRoot%\System32\tar.exe\` (Windows bsdtar, present on every supported Windows since 10 v1803) over whatever \`tar\` resolves to on \`PATH\`. Falls back to the \`PATH\` lookup if \`System32\tar.exe\` is absent. macOS/Linux are unaffected.

### fix(chat-smoke): strip ANSI escapes before asserting tmux marker

psmux paints pane content with \`\x1B[<n>C\` cursor-forward escapes between fields instead of literal whitespace. Assertions anchored on \`\s+\` between the marker and the env-var dump never matched on Windows.

The captured output is now sanitized of all ANSI/CSI escape sequences before running \`muxRe\` and \`footerRe\` checks. The \`muxRe\` pattern is also relaxed to \`\s*\` (zero-or-more whitespace) so it matches whether or not a space is present after stripping.

### ci: expand chat-smoke coverage to all three agents

The \`chat-smoke\` CI step now iterates over all three supported agents (\`opencode\`, \`claude\`, \`copilot\`) instead of only \`opencode\`, with each run wrapped in a \`::group::\`/\`::endgroup::\` block for cleaner log folding in GitHub Actions.

## Test plan

- [ ] CI passes (typecheck, lint, tests)
- [ ] Pre-publish verdaccio matrix succeeds
- [ ] Chat-smoke passes for all three agents: \`opencode\`, \`claude\`, \`copilot\`
- [ ] On merge, GitHub Release is auto-created and prerelease published to npm