### PR TITLE
chore(release): bump version to v0.7.0-6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.0-5",
+  "version": "0.7.0-6",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.0-5",
+  "version": "0.7.0-6",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.0-5",
+  "version": "0.7.0-6",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Bumps the prerelease version from `v0.7.0-5` to `v0.7.0-6` across all packages in the monorepo.

## Changes

- `package.json` (monorepo root): `0.7.0-5` → `0.7.0-6`
- `packages/atomic/package.json`: `0.7.0-5` → `0.7.0-6`
- `packages/atomic-sdk/package.json`: `0.7.0-5` → `0.7.0-6`

## Test plan

- [ ] CI passes
- [ ] Release workflow publishes prerelease on merge to `main`