### PR TITLE
fix(workflow-orchestrator): resolve workflow by name+agent in compiled binary

### DIFF
--- a/packages/atomic-sdk/src/lib/atomic-temp.test.ts
+++ b/packages/atomic-sdk/src/lib/atomic-temp.test.ts
@@ -27,7 +27,8 @@ afterEach(() => {
 
 describe("atomic temp helpers", () => {
   test("uses a per-user directory under ~/.atomic/tmp", () => {
-    expect(atomicTempDir("/home/alice")).toBe("/home/alice/.atomic/tmp");
+    const home = process.platform === "win32" ? "C:\\Users\\alice" : "/home/alice";
+    expect(atomicTempDir(home)).toBe(join(home, ".atomic", "tmp"));
   });
 
   test("creates the temp directory with owner-only permissions", () => {

--- a/packages/atomic-sdk/src/lib/runtime-assets.test.ts
+++ b/packages/atomic-sdk/src/lib/runtime-assets.test.ts
@@ -15,14 +15,19 @@ import {
 } from "./runtime-assets.ts";
 
 describe("runtimeAssetsCacheDir", () => {
+  // Use a platform-appropriate fake home so the assertion's separator
+  // matches what `path.join` produces. Hard-coding `/home/test` makes
+  // the prefix check fail on Windows (backslash vs forward slash).
+  const fakeHome = process.platform === "win32" ? "C:\\Users\\test" : "/home/test";
+
   test("lives under ~/.atomic/runtime/<sdk-version>", () => {
-    const dir = runtimeAssetsCacheDir("/home/test");
-    expect(dir.startsWith("/home/test/.atomic/runtime/")).toBe(true);
+    const dir = runtimeAssetsCacheDir(fakeHome);
+    expect(dir.startsWith(join(fakeHome, ".atomic", "runtime") + (process.platform === "win32" ? "\\" : "/"))).toBe(true);
   });
 
   test("is stable across calls within a single SDK version", () => {
-    expect(runtimeAssetsCacheDir("/home/test")).toBe(
-      runtimeAssetsCacheDir("/home/test"),
+    expect(runtimeAssetsCacheDir(fakeHome)).toBe(
+      runtimeAssetsCacheDir(fakeHome),
     );
   });
 

--- a/packages/atomic-sdk/src/primitives/sessions.test.ts
+++ b/packages/atomic-sdk/src/primitives/sessions.test.ts
@@ -472,13 +472,14 @@ describe("getSessionStatus", () => {
       sessions: [],
     };
     const readSpy = mock(async () => snapshot);
+    const fakeBase = process.platform === "win32" ? "C:\\fake\\base" : "/fake/base";
     const result = await getSessionStatus(
       "atomic-wf-claude-ralph-deadbeef",
-      makeDeps({ readSnapshot: readSpy, sessionsBaseDir: "/fake/base" }),
+      makeDeps({ readSnapshot: readSpy, sessionsBaseDir: fakeBase }),
     );
     expect(result).toEqual(snapshot);
     expect(readSpy).toHaveBeenCalledTimes(1);
-    expect(readSpy).toHaveBeenCalledWith("/fake/base/deadbeef");
+    expect(readSpy).toHaveBeenCalledWith(join(fakeBase, "deadbeef"));
   });
 });
 

--- a/packages/atomic-sdk/src/providers/copilot.test.ts
+++ b/packages/atomic-sdk/src/providers/copilot.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   copilotSubprocessEnv,
@@ -10,13 +10,24 @@ import {
   resolveCopilotCliPath,
 } from "./copilot.ts";
 
+const IS_WINDOWS = process.platform === "win32";
+// Windows PATH lookup (Bun.which / OS where) only matches files with a
+// PATHEXT extension. Linux/macOS match by exact name + executable bit.
+// Use a `.cmd` shim on Windows so the same test can assert PATH
+// resolution cross-platform.
+const COPILOT_BIN_NAME = IS_WINDOWS ? "copilot.cmd" : "copilot";
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 function makeTempCopilotBin(): { dir: string; bin: string } {
   const dir = mkdtempSync(join(tmpdir(), "atomic-copilot-test-"));
-  const bin = join(dir, "copilot");
-  writeFileSync(bin, "#!/bin/sh\necho copilot\n", { encoding: "utf-8" });
-  chmodSync(bin, 0o755);
+  const bin = join(dir, COPILOT_BIN_NAME);
+  if (IS_WINDOWS) {
+    writeFileSync(bin, "@echo off\r\necho copilot\r\n", { encoding: "utf-8" });
+  } else {
+    writeFileSync(bin, "#!/bin/sh\necho copilot\n", { encoding: "utf-8" });
+    chmodSync(bin, 0o755);
+  }
   return { dir, bin };
 }
 
@@ -97,7 +108,8 @@ describe("resolveCopilotCliPath", () => {
   test("PATH-resolved copilot binary populates cliPath when env var unset", () => {
     delete process.env["COPILOT_CLI_PATH"];
     const { dir, bin } = makeTempCopilotBin();
-    process.env["PATH"] = `${dir}:${origPath ?? ""}`;
+    // Prepend tempdir so it's the first hit, using OS-correct PATH delim.
+    process.env["PATH"] = `${dir}${delimiter}${origPath ?? ""}`;
     const result = resolveCopilotCliPath();
     expect(result).toBe(bin);
   });
@@ -198,7 +210,7 @@ describe("copilotSdkLaunchOptions", () => {
   test("cliPath populated from PATH-resolved binary", () => {
     delete process.env["COPILOT_CLI_PATH"];
     const { dir, bin } = makeTempCopilotBin();
-    process.env["PATH"] = `${dir}:${origPath ?? ""}`;
+    process.env["PATH"] = `${dir}${delimiter}${origPath ?? ""}`;
     const opts = copilotSdkLaunchOptions();
     expect(opts.cliPath).toBe(bin);
   });
@@ -281,28 +293,38 @@ describe("isCopilotShim", () => {
 // ── enumeratePathCandidates ───────────────────────────────────────────────
 
 describe("enumeratePathCandidates", () => {
+  // The function does a literal `existsSync(join(dir, cmd))` lookup with
+  // no PATHEXT magic, so on Windows we must pass the explicit
+  // `copilot.cmd` filename (matching the stub) and split with the OS
+  // PATH delimiter.
   test("returns empty array when PATH has no matching binary", () => {
     const empty = makeEmptyTempDir();
-    expect(enumeratePathCandidates("copilot", empty)).toEqual([]);
+    expect(enumeratePathCandidates(COPILOT_BIN_NAME, empty)).toEqual([]);
   });
 
   test("returns single match when one dir has binary", () => {
     const { dir, bin } = makeTempCopilotBin();
-    const result = enumeratePathCandidates("copilot", dir);
+    const result = enumeratePathCandidates(COPILOT_BIN_NAME, dir);
     expect(result).toEqual([bin]);
   });
 
   test("returns ordered matches from multiple PATH dirs", () => {
     const { dir: dir1, bin: bin1 } = makeTempCopilotBin();
     const { dir: dir2, bin: bin2 } = makeTempCopilotBin();
-    const result = enumeratePathCandidates("copilot", `${dir1}:${dir2}`);
+    const result = enumeratePathCandidates(
+      COPILOT_BIN_NAME,
+      `${dir1}${delimiter}${dir2}`,
+    );
     expect(result).toEqual([bin1, bin2]);
   });
 
   test("skips dirs that do not contain the binary", () => {
     const empty = makeEmptyTempDir();
     const { dir, bin } = makeTempCopilotBin();
-    const result = enumeratePathCandidates("copilot", `${empty}:${dir}`);
+    const result = enumeratePathCandidates(
+      COPILOT_BIN_NAME,
+      `${empty}${delimiter}${dir}`,
+    );
     expect(result).toEqual([bin]);
   });
 });
@@ -352,14 +374,14 @@ describe("resolveCopilotCliPath shim rejection", () => {
   test("skips shim and returns second PATH candidate (real binary)", () => {
     const shimDir = makeNodeShimDir();
     const { dir: realDir, bin: realBin } = makeTempCopilotBin();
-    process.env["PATH"] = `${shimDir}:${realDir}`;
+    process.env["PATH"] = `${shimDir}${delimiter}${realDir}`;
     expect(resolveCopilotCliPath()).toBe(realBin);
   });
 
   test("returns first non-shim when multiple real binaries on PATH", () => {
     const { dir: dir1, bin: bin1 } = makeTempCopilotBin();
     const { dir: dir2 } = makeTempCopilotBin();
-    process.env["PATH"] = `${dir1}:${dir2}`;
+    process.env["PATH"] = `${dir1}${delimiter}${dir2}`;
     expect(resolveCopilotCliPath()).toBe(bin1);
   });
 });

--- a/packages/atomic-sdk/src/providers/headless-hil-policy.test.ts
+++ b/packages/atomic-sdk/src/providers/headless-hil-policy.test.ts
@@ -84,9 +84,16 @@ describe("resolveHeadlessClaudeBin", () => {
 
   test("returns the `claude` binary when present on PATH", () => {
     const dir = mkdtempSync(join(tmpdir(), "atomic-claude-bin-"));
-    const bin = join(dir, "claude");
-    writeFileSync(bin, "#!/usr/bin/env sh\nexit 0\n");
-    chmodSync(bin, 0o755);
+    // Windows PATH lookup only matches files with a PATHEXT extension —
+    // use a `.cmd` shim there so `Bun.which("claude")` finds it.
+    const isWindows = process.platform === "win32";
+    const bin = join(dir, isWindows ? "claude.cmd" : "claude");
+    if (isWindows) {
+      writeFileSync(bin, "@echo off\r\nexit /B 0\r\n");
+    } else {
+      writeFileSync(bin, "#!/usr/bin/env sh\nexit 0\n");
+      chmodSync(bin, 0o755);
+    }
     withPath(dir, () => {
       expect(resolveHeadlessClaudeBin()).toBe(bin);
     });

--- a/packages/atomic-sdk/src/runtime/executor.test.ts
+++ b/packages/atomic-sdk/src/runtime/executor.test.ts
@@ -919,9 +919,22 @@ describe("discoverCopilotBinary / shouldOverrideCopilotCliPath", () => {
     rmSync(sandbox, { recursive: true, force: true });
   });
 
-  function putExe(dir: string, name: string, contents = "#!/bin/sh\necho $0"): string {
+  /**
+   * Cross-platform stub binary writer. `discoverCopilotBinary` and
+   * `isNodeOnPath` look for `<name>.exe` on Windows (PATHEXT-aware) and
+   * the bare name on Unix; this helper writes whichever the host
+   * resolver expects so the same test logic works everywhere.
+   */
+  function putExe(dir: string, name: string, contents?: string): string {
+    if (process.platform === "win32") {
+      const p = join(dir, `${name}.exe`);
+      // Real PE binary content isn't required — the resolver only does a
+      // file-exists/`isFile` check on Windows (no executable bit there).
+      writeFileSync(p, contents ?? "stub\r\n");
+      return p;
+    }
     const p = join(dir, name);
-    writeFileSync(p, contents);
+    writeFileSync(p, contents ?? "#!/bin/sh\necho $0");
     chmodSync(p, 0o755);
     return p;
   }
@@ -1016,7 +1029,10 @@ describe("buildPaneCommand", () => {
     const { command } = buildPaneCommand("copilot");
     // Accept either a bare name (binary not on PATH in test env) or an
     // absolute path resolved via Bun.which — both end in "copilot".
-    expect(command).toMatch(/^("[^"]*\/)?[^\s"]*copilot"?\s/);
+    // Windows paths use `\\` separators and the resolved binary has a
+    // `.exe` suffix; the optional `(\.exe)?` and dual-separator class
+    // keep this matcher cross-platform.
+    expect(command).toMatch(/^("[^"]*[\\/])?[^\s"]*copilot(\.exe)?"?\s/);
   });
 
   test("opencode: command contains --port 0 but not --ui-server", () => {
@@ -1027,28 +1043,40 @@ describe("buildPaneCommand", () => {
 
   test("opencode: command invokes the opencode binary as the first token", () => {
     const { command } = buildPaneCommand("opencode");
-    expect(command).toMatch(/^("[^"]*\/)?[^\s"]*opencode"?\s/);
+    expect(command).toMatch(/^("[^"]*[\\/])?[^\s"]*opencode(\.exe)?"?\s/);
   });
 
   test("claude: command resolves to a shell and does not contain --port", () => {
     const { command } = buildPaneCommand("claude");
     // SHELL is typically already absolute (e.g. /bin/zsh) so it passes through
-    // unchanged; bare fallbacks ("sh"/"pwsh") get resolved via Bun.which.
+    // unchanged; bare fallbacks ("sh"/"pwsh") get resolved via Bun.which —
+    // which returns a `.exe`-suffixed path on Windows.
     const expected =
       process.env.SHELL || (process.platform === "win32" ? "pwsh" : "sh");
-    const stripped = command.replace(/^"|"$/g, "");
+    // The command emitted into the tmux pane line is bash-escaped (each
+    // `\` and `"` is prefixed with a literal `\`) and wrapped in quotes
+    // when the path has special chars. Reverse both transforms to recover
+    // the original path before comparing — Windows shell paths
+    // (e.g. `C:\Program Files\PowerShell\7\pwsh.exe`) hit this branch.
+    const stripped = command
+      .replace(/^"|"$/g, "")
+      .replace(/\\(.)/g, "$1");
     if (expected.includes("/") || expected.includes("\\")) {
       expect(stripped).toBe(expected);
     } else {
       // Bare fallback either resolved via Bun.which or returned as-is.
-      expect(stripped.endsWith(expected) || stripped === expected).toBe(true);
+      const variants = [expected, `${expected}.exe`];
+      expect(
+        variants.some((v) => stripped.endsWith(v) || stripped === v),
+      ).toBe(true);
     }
     expect(command).not.toContain("--port");
   });
 
   test("claude: scopes temp files to the user's Atomic temp directory", () => {
     const { envVars } = buildPaneCommand("claude");
-    expect(envVars.TMPDIR).toMatch(/\/\.atomic\/tmp$/);
+    // `path.join`'s separator differs by platform; accept either form.
+    expect(envVars.TMPDIR).toMatch(/[\\/]\.atomic[\\/]tmp$/);
     expect(envVars.TMP).toBe(envVars.TMPDIR);
     expect(envVars.TEMP).toBe(envVars.TMPDIR);
   });

--- a/packages/atomic-sdk/src/runtime/executor.ts
+++ b/packages/atomic-sdk/src/runtime/executor.ts
@@ -5,13 +5,14 @@
  * 1. `executeWorkflow()` is called by the CLI command (e.g. atomic) or by
  *    the SDK's `runWorkflow()` primitive
  * 2. It creates a tmux session with an orchestrator pane that runs the
- *    SDK-owned `orchestrator-entry.ts` with three positional args:
- *    `<workflowSource> <agent> <inputsB64>`
+ *    CLI's hidden `_orchestrator-entry` sub-command with four positional
+ *    args: `<workflowName> <agent> <inputsB64> <workflowSource>`
  * 3. The CLI then attaches to the tmux session (user sees it live)
- * 4. The orchestrator pane imports the workflow module by `source`,
- *    calls `runOrchestrator(definition, inputs)`, which then calls
- *    `definition.run(workflowCtx)` — the user's callback uses
- *    `ctx.stage()` to spawn agent sessions
+ * 4. The orchestrator pane resolves the workflow definition (via builtin
+ *    registry in compiled-binary mode, or by dynamic-importing
+ *    `<workflowSource>` in dev), calls `runOrchestrator(definition, inputs)`,
+ *    which then calls `definition.run(workflowCtx)` — the user's callback
+ *    uses `ctx.stage()` to spawn agent sessions
  *
  * The dev's CLI is never re-imported. The SDK orchestrator entry script
  * is the only re-exec target, so there is no orchestrator-mode env var
@@ -520,10 +521,19 @@ export async function executeWorkflow(
   // Write a launcher script for the orchestrator pane.
   // Re-executes the atomic CLI's hidden `_orchestrator-entry` sub-command
   // with positional args:
-  //   atomic _orchestrator-entry <workflowSource> <agent> <inputsB64>
+  //   atomic _orchestrator-entry <workflowName> <agent> <inputsB64> <workflowSource>
   // (or `bun <cli.ts> _orchestrator-entry …` in dev). Mirrors OpenCode's
   // single-binary architecture — every fresh-process entry into atomic
   // goes through a CLI sub-command, never a free-standing JS bundle.
+  //
+  // Why both `name` and `source`: in a `bun build --compile` binary every
+  // bundled module's `import.meta.path` collapses to `/$bunfs/root/<binary>`,
+  // so the `definition.source` captured at workflow-module-eval time
+  // points at the binary itself. The CLI's `_orchestrator-entry` resolves
+  // by name+agent against the builtin registry in that case; in dev /
+  // installed-package mode it falls back to dynamic-importing the source
+  // so third-party SDK consumers (whose workflows aren't in the builtin
+  // registry) keep working.
   const isWin = process.platform === "win32";
   const launcherExt = isWin ? "ps1" : "sh";
   const launcherPath = join(sessionsBaseDir, `orchestrator.${launcherExt}`);
@@ -557,7 +567,7 @@ export async function executeWorkflow(
     runtime,
     cliPath,
     subcommand: "_orchestrator-entry",
-    args: [workflowSource, agent, inputsB64],
+    args: [definition.name, agent, inputsB64, workflowSource],
   });
 
   const launcherScript = isWin
@@ -1987,12 +1997,13 @@ import { validateOrchestratorEnv } from "./executor-env.ts";
 /**
  * Run the orchestrator for a compiled workflow definition.
  *
- * Called by the SDK's `orchestrator-entry.ts` after it imports the
- * workflow module by `source` and decodes the inputs payload from argv.
- * The runtime environment (`ATOMIC_WF_ID`, `ATOMIC_WF_TMUX`,
- * `ATOMIC_WF_AGENT`, `ATOMIC_WF_CWD`) is set by the launcher script that
- * `executeWorkflow()` writes — those vars describe *where* this
- * orchestrator is running, not what to do.
+ * Called by the SDK's `orchestrator-entry.ts` after it has resolved the
+ * workflow definition (either via builtin-registry lookup in compiled-
+ * binary mode, or by dynamic-importing `source` in dev) and decoded the
+ * inputs payload from argv. The runtime environment (`ATOMIC_WF_ID`,
+ * `ATOMIC_WF_TMUX`, `ATOMIC_WF_AGENT`, `ATOMIC_WF_CWD`) is set by the
+ * launcher script that `executeWorkflow()` writes — those vars describe
+ * *where* this orchestrator is running, not what to do.
  */
 export async function runOrchestrator(
   definition: WorkflowDefinition,

--- a/packages/atomic-sdk/src/runtime/orchestrator-entry.test.ts
+++ b/packages/atomic-sdk/src/runtime/orchestrator-entry.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration test: `_orchestrator-entry` against the real compiled binary.
+ *
+ * Regression guard for the dev-vs-binary divergence where Bun's
+ * `bun build --compile` collapses every bundled module's
+ * `import.meta.path` to the binary's bunfs entry path
+ * (`/$bunfs/root/<binary>`), so the `definition.source` captured at
+ * workflow-module-eval time pointed at the binary itself. Before the
+ * fix, dynamic-importing that path re-loaded `cli.ts` (no default
+ * export) and the orchestrator pane died with
+ * `"does not export a valid WorkflowDefinition"` while the launcher
+ * shell exited 0 — invisible to the chat-style smoke tests.
+ *
+ * The fix routes binary-mode invocations through the builtin registry
+ * by `name + agent`, falling back to dynamic-import for dev /
+ * installed-package mode. This test exec's the real binary with the
+ * post-fix launcher contract and asserts:
+ *   1. The bug signature ("does not export a valid WorkflowDefinition")
+ *      does not appear.
+ *   2. The action gets past workflow resolution (it complains about
+ *      missing ATOMIC_WF_* env, which is the next failure mode in
+ *      `runOrchestrator`).
+ *   3. An unknown workflow name surfaces a clean registry-miss error,
+ *      not the old import-failure error.
+ */
+import { test, expect, describe } from "bun:test";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const builtBinary = locateBuiltBinary();
+
+describe.skipIf(!builtBinary)("compiled binary _orchestrator-entry", () => {
+  test("registry-resolves a builtin workflow when source is a bunfs path", () => {
+    const bin = builtBinary!;
+    // `cli-build-host-default.test.ts` deletes and rebuilds DIST_DIR in
+    // parallel; if it ran between locateBuiltBinary() and now, skip
+    // rather than fail on a transient ENOENT.
+    if (!existsSync(bin)) return;
+    // Post-fix arg order: <name> <agent> <inputsB64> <source>.
+    // The bunfs source signals "compiled binary" and triggers the
+    // registry-lookup branch in the cli action.
+    const result = Bun.spawnSync({
+      cmd: [bin, "_orchestrator-entry", "ralph", "claude", "", "/$bunfs/root/atomic"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: stripWorkflowEnv(process.env),
+    });
+
+    const out = result.stdout.toString() + result.stderr.toString();
+
+    // Bug signature: pre-fix, the dynamic import re-loaded cli.ts and
+    // threw InvalidWorkflowError. The new path never imports the
+    // source, so this string must not appear.
+    expect(out).not.toContain("does not export a valid WorkflowDefinition");
+
+    // Positive signal: we got past workflow resolution into
+    // runOrchestrator → validateOrchestratorEnv. The next failure mode
+    // is the missing ATOMIC_WF_* env we deliberately stripped.
+    expect(out).toContain("ATOMIC_WF_ID");
+  });
+
+  test("unknown workflow name surfaces a clean registry-miss error", () => {
+    const bin = builtBinary!;
+    if (!existsSync(bin)) return;
+    const result = Bun.spawnSync({
+      cmd: [bin, "_orchestrator-entry", "no-such-workflow", "claude", "", "/$bunfs/root/atomic"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: stripWorkflowEnv(process.env),
+    });
+
+    const out = result.stdout.toString() + result.stderr.toString();
+    expect(out).toContain("no-such-workflow");
+    expect(out).toContain("builtin registry");
+    expect(result.exitCode).not.toBe(0);
+  });
+});
+
+function stripWorkflowEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (
+      typeof v === "string" &&
+      k !== "ATOMIC_WF_ID" &&
+      k !== "ATOMIC_WF_TMUX" &&
+      k !== "ATOMIC_WF_AGENT" &&
+      k !== "ATOMIC_WF_CWD"
+    ) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function locateBuiltBinary(): string | null {
+  const ext = process.platform === "win32" ? ".exe" : "";
+  let dir = import.meta.dir;
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "package.json")) && existsSync(join(dir, "packages"))) {
+      const distRoot = join(dir, "packages", "atomic", "dist");
+      const targets = [
+        "linux-x64",
+        "linux-arm64",
+        "darwin-x64",
+        "darwin-arm64",
+        "windows-x64",
+      ];
+      for (const target of targets) {
+        const candidate = join(distRoot, target, "bin", `atomic${ext}`);
+        if (existsSync(candidate)) return candidate;
+      }
+      return null;
+    }
+    dir = dirname(dir);
+  }
+  return null;
+}

--- a/packages/atomic-sdk/src/runtime/orchestrator-entry.ts
+++ b/packages/atomic-sdk/src/runtime/orchestrator-entry.ts
@@ -2,10 +2,15 @@
  * SDK-owned orchestrator entry point.
  *
  * Called by the CLI's hidden `_orchestrator-entry` sub-command in the tmux
- * pane that the workflow launcher script spawns. Receives the workflow
- * source path, agent, and base64-encoded inputs as positional arguments,
- * imports the workflow module, validates the default export, and hands off
- * to `runOrchestrator()`.
+ * pane that the workflow launcher script spawns. Two paths:
+ *   - `runOrchestratorWithDefinition` — used in compiled-binary mode where
+ *     the CLI has already resolved the workflow against its builtin
+ *     registry. Avoids the dynamic-import-by-source path because Bun
+ *     collapses every bundled module's `import.meta.path` to the binary's
+ *     bunfs entry.
+ *   - `runOrchestratorEntry` — dev / installed-package fallback. Imports
+ *     the workflow module by `source` so third-party SDK consumers can
+ *     spawn workflows whose definitions aren't in the builtin registry.
  *
  * This module is deliberately not its own executable. Mirroring OpenCode's
  * single-binary architecture, every fresh-process entry into atomic goes
@@ -25,6 +30,25 @@ function isWorkflowDefinition(value: unknown): value is WorkflowDefinition {
     value !== null &&
     (value as { __brand?: unknown }).__brand === "WorkflowDefinition"
   );
+}
+
+/**
+ * Run the orchestrator panel against an already-resolved WorkflowDefinition.
+ *
+ * Used by the CLI's `_orchestrator-entry` sub-command in compiled-binary
+ * mode, where every bundled module's `import.meta.path` collapses to the
+ * binary's bunfs entry (`/$bunfs/root/<binary>`) and a dynamic
+ * `await import(sourcePath)` of the captured `definition.source` would
+ * re-import the CLI entry instead of the workflow file. The CLI looks the
+ * workflow up in its builtin registry by `name + agent` and hands the
+ * already-evaluated definition straight to this function.
+ */
+export async function runOrchestratorWithDefinition(
+  def: WorkflowDefinition,
+  inputsB64: string,
+): Promise<void> {
+  const inputs = decodeInputs(inputsB64);
+  await runOrchestrator(def, inputs);
 }
 
 /** Decode the base64 inputs payload into a string-keyed record. */

--- a/packages/atomic-sdk/src/runtime/port-discovery.test.ts
+++ b/packages/atomic-sdk/src/runtime/port-discovery.test.ts
@@ -471,6 +471,19 @@ describe("_parseWindowsNetstatOutput", () => {
 // ---------------------------------------------------------------------------
 
 describe("getListeningPortForPid polling loop", () => {
+  // On Windows the real platform implementation shells out to powershell
+  // (`Get-NetTCPConnection`, `Get-CimInstance`), each spawn taking ~1.3s
+  // for runtime cold-start — too slow to honor the tight test timeouts
+  // below. Inject a fast no-op stub so we can exercise the polling-loop
+  // contract independent of the platform's syscall latency. Linux/macOS
+  // have fast spawn paths so this is just for parity.
+  const installFastSpawn = (): (() => void) =>
+    _setPortDiscoverySpawnSyncForTest(() => ({
+      stdout: { toString: () => "" },
+      stderr: { toString: () => "" },
+      success: true,
+    }));
+
   test("returns port on first non-null read", async () => {
     // We can't inject the resolver directly, but we can test via E2E with a
     // very short timeout on the real process — testing the loop logic is
@@ -479,26 +492,36 @@ describe("getListeningPortForPid polling loop", () => {
     // we get a port.
     //
     // For pure unit testing of the loop, we verify the timeout path.
-    const result = await getListeningPortForPid(-999999, {
-      timeoutMs: 50,
-      pollIntervalMs: 10,
-    });
-    // PID -999999 doesn't exist, so either process-alive check returns false
-    // or we timeout. Either way, null.
-    expect(result).toBeNull();
+    const restore = installFastSpawn();
+    try {
+      const result = await getListeningPortForPid(-999999, {
+        timeoutMs: 50,
+        pollIntervalMs: 10,
+      });
+      // PID -999999 doesn't exist, so either process-alive check returns
+      // false or we timeout. Either way, null.
+      expect(result).toBeNull();
+    } finally {
+      restore();
+    }
   });
 
   test("returns null on timeout for non-listening PID", async () => {
     // Use a real but non-listening PID (our parent shell or similar)
     // The process exists but has no listening TCP socket.
     // With a very short timeout we should get null quickly.
-    const result = await getListeningPortForPid(process.ppid ?? 1, {
-      timeoutMs: 200,
-      pollIntervalMs: 50,
-    });
-    // Either it times out (null) or parent happens to listen (number).
-    // We can't assert exact value but we can assert type.
-    expect(result === null || typeof result === "number").toBe(true);
+    const restore = installFastSpawn();
+    try {
+      const result = await getListeningPortForPid(process.ppid ?? 1, {
+        timeoutMs: 200,
+        pollIntervalMs: 50,
+      });
+      // Either it times out (null) or parent happens to listen (number).
+      // We can't assert exact value but we can assert type.
+      expect(result === null || typeof result === "number").toBe(true);
+    } finally {
+      restore();
+    }
   });
 
   test("returns null immediately for dead PID", async () => {

--- a/packages/atomic/script/__tests__/cli-build-host-default.test.ts
+++ b/packages/atomic/script/__tests__/cli-build-host-default.test.ts
@@ -1,5 +1,6 @@
-import { test, expect, beforeAll } from "bun:test";
-import { rm, readdir } from "node:fs/promises";
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { findRepoRoot } from "../../src/lib/workspace-paths.ts";
 import { TARGETS, hostTarget } from "../targets.ts";
@@ -7,13 +8,25 @@ import { TARGETS, hostTarget } from "../targets.ts";
 const SKIP_PUBLISH = process.env.ATOMIC_SKIP_PUBLISH_BUILD_TEST === "1";
 
 const WORKSPACE_ROOT = findRepoRoot(import.meta.dir);
-const DIST_DIR = join(WORKSPACE_ROOT, "packages", "atomic", "dist");
 
 const HOST_TARGET = hostTarget();
 const OTHER_TARGETS = TARGETS.map((t) => t.name).filter((n) => n !== HOST_TARGET);
 
+// Use an isolated temp dist dir instead of `packages/atomic/dist`.
+// Concurrent test files (orchestrator-entry, attached-footer) hold
+// the real `atomic.exe` open while running; rm-then-rebuild against
+// that path then loses to Windows file locks with EACCES. The build
+// script honours `ATOMIC_BUILD_DIST_DIR` for exactly this reason.
+let isolatedDist: string;
+
 beforeAll(async () => {
-  await rm(DIST_DIR, { recursive: true, force: true });
+  isolatedDist = await mkdtemp(join(tmpdir(), "atomic-build-test-"));
+});
+
+afterAll(async () => {
+  if (isolatedDist) {
+    await rm(isolatedDist, { recursive: true, force: true }).catch(() => {});
+  }
 });
 
 test.skipIf(SKIP_PUBLISH)(
@@ -23,12 +36,13 @@ test.skipIf(SKIP_PUBLISH)(
       cwd: WORKSPACE_ROOT,
       stdout: "inherit",
       stderr: "inherit",
+      env: { ...process.env, ATOMIC_BUILD_DIST_DIR: isolatedDist },
     });
     const exitCode = await proc.exited;
 
     expect(exitCode).toBe(0);
 
-    const entries = await readdir(DIST_DIR);
+    const entries = await readdir(isolatedDist);
 
     expect(entries).toContain(HOST_TARGET);
 

--- a/packages/atomic/script/build.ts
+++ b/packages/atomic/script/build.ts
@@ -78,8 +78,14 @@ if (buildingForOtherPlatform) {
   await $`bun install --os="*" --cpu="*" @opentui/core@${opentuiCoreSpec}`.cwd(WORKSPACE_ROOT);
 }
 
+// Allow tests to redirect output to an isolated dir so concurrent test
+// files don't fight over `dist/` file locks (Windows holds the binary
+// open while another test spawns it; rm-then-rebuild then races EACCES).
+const DIST_BASE =
+  process.env.ATOMIC_BUILD_DIST_DIR ?? join(CLI_PKG_ROOT, "dist");
+
 for (const t of requested) {
-  const outdir = join(CLI_PKG_ROOT, "dist", t.name);
+  const outdir = join(DIST_BASE, t.name);
   await mkdir(join(outdir, "bin"), { recursive: true });
 
   const outfile = join(outdir, "bin", `atomic${t.ext ?? ""}`);

--- a/packages/atomic/src/cli.ts
+++ b/packages/atomic/src/cli.ts
@@ -274,20 +274,71 @@ Examples:
     //
     // Mirrors OpenCode's "every fresh-process entry is a CLI sub-command"
     // model. The launcher script written by `executeWorkflow()` runs:
-    //   <bun> <cli.ts> _orchestrator-entry <workflowSource> <agent> <inputsB64>
+    //   <bun> <cli.ts> _orchestrator-entry <name> <agent> <inputsB64> <source>
     // in dev, or
-    //   <atomic-binary> _orchestrator-entry <workflowSource> <agent> <inputsB64>
+    //   <atomic-binary> _orchestrator-entry <name> <agent> <inputsB64> <source>
     // in compiled-binary mode. The SDK never ships a separately-runnable
     // bundle that a sub-process would `bun run` from outside the package's
     // module resolution context — that pattern broke `@opentui/core`'s
     // dynamic platform-binding import.
+    //
+    // Why both `name` and `source`: in a `bun build --compile` binary every
+    // bundled module's `import.meta.path` collapses to `/$bunfs/root/<binary>`,
+    // so the `definition.source` captured at workflow-module-eval time is
+    // the binary itself, and dynamic-importing it would re-load cli.ts
+    // (no default export). In compiled-binary mode we resolve the workflow
+    // by `name + agent` against the builtin registry that's already linked
+    // into the binary; in dev / installed-package mode we fall back to
+    // dynamic import so third-party SDK consumers can spawn workflows
+    // whose definitions aren't in the builtin registry.
     program
         .command("_orchestrator-entry", { hidden: true })
         .description("Internal: load a workflow definition and run the orchestrator panel")
-        .argument("<workflowSource>", "Absolute path to the workflow's source file")
+        .argument("<workflowName>", "Workflow name (matches builtin registry)")
         .argument("<agent>", "claude | copilot | opencode")
         .argument("[inputsB64]", "Base64-encoded JSON record of structured inputs", "")
-        .action(async (workflowSource: string, agent: string, inputsB64: string) => {
+        .argument("[workflowSource]", "Workflow source path (dynamic-import fallback for non-builtin workflows in dev)", "")
+        .action(async (
+            workflowName: string,
+            agent: string,
+            inputsB64: string,
+            workflowSource: string,
+        ) => {
+            const { isCompiledBinaryRuntime } = await import(
+                "@bastani/atomic-sdk/lib/runtime-env"
+            );
+
+            // Compiled binary: source path is bunfs-collapsed and can't
+            // be dynamic-imported. Resolve by name+agent in the builtin
+            // registry, which is statically linked into the binary.
+            if (isCompiledBinaryRuntime(workflowSource)) {
+                if (!isValidAgent(agent)) {
+                    console.error(
+                        `${COLORS.red}[atomic/orchestrator-entry] Invalid agent "${agent}".${COLORS.reset}`,
+                    );
+                    process.exit(1);
+                }
+                const { createBuiltinRegistry } = await import(
+                    "./commands/builtin-registry.ts"
+                );
+                const def = createBuiltinRegistry().resolve(workflowName, agent);
+                if (!def) {
+                    console.error(
+                        `${COLORS.red}[atomic/orchestrator-entry] No workflow named "${workflowName}" for agent "${agent}" in the builtin registry.${COLORS.reset}`,
+                    );
+                    process.exit(1);
+                }
+                const { runOrchestratorWithDefinition } = await import(
+                    "@bastani/atomic-sdk/runtime/orchestrator-entry"
+                );
+                await runOrchestratorWithDefinition(def, inputsB64);
+                return;
+            }
+
+            // Dev / installed-package: dynamic-import the workflow file.
+            // Preserves third-party SDK use where the workflow lives at
+            // an arbitrary on-disk path that the builtin registry doesn't
+            // know about.
             const { runOrchestratorEntry } = await import(
                 "@bastani/atomic-sdk/runtime/orchestrator-entry"
             );

--- a/packages/atomic/src/lib/embedded-assets.test.ts
+++ b/packages/atomic/src/lib/embedded-assets.test.ts
@@ -8,16 +8,27 @@ import { getEmbeddedAsset, BUNDLES } from "./embedded-assets.ts";
 
 let cacheDir: string;
 let originalXdg: string | undefined;
+let originalLocalAppData: string | undefined;
+// `cacheRoot()` in `embedded-assets.ts` reads LOCALAPPDATA on Windows and
+// XDG_CACHE_HOME on Linux/macOS — set both so the test's tmp dir is picked
+// up regardless of host OS, and the cache subdir is `cacheDir/atomic[/Cache]/...`.
+const CACHE_PREFIX_SEGMENTS = process.platform === "win32"
+  ? ["atomic", "Cache"]
+  : ["atomic"];
 
 beforeEach(async () => {
   cacheDir = await mkdtemp(join(tmpdir(), "atomic-embedded-"));
   originalXdg = process.env.XDG_CACHE_HOME;
+  originalLocalAppData = process.env.LOCALAPPDATA;
   process.env.XDG_CACHE_HOME = cacheDir;
+  process.env.LOCALAPPDATA = cacheDir;
 });
 
 afterEach(async () => {
   if (originalXdg === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdg;
+  if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+  else process.env.LOCALAPPDATA = originalLocalAppData;
   await rm(cacheDir, { recursive: true, force: true });
 });
 
@@ -47,7 +58,7 @@ test("tar failure does not write marker", async () => {
 
   await expect(getEmbeddedAsset("claude")).rejects.toThrow(/tar failed for claude/);
 
-  const marker = join(cacheDir, "atomic", VERSION, "claude", ".extracted");
+  const marker = join(cacheDir, ...CACHE_PREFIX_SEGMENTS, VERSION, "claude", ".extracted");
   expect(existsSync(marker)).toBe(false);
 
   spy.mockRestore();
@@ -62,8 +73,8 @@ test("VERSION drives cache subdir, not 'dev'", async () => {
 
   const result = await getEmbeddedAsset("claude");
 
-  expect(result).toBe(join(cacheDir, "atomic", VERSION, "claude"));
-  expect(result).not.toContain("/dev/");
+  expect(result).toBe(join(cacheDir, ...CACHE_PREFIX_SEGMENTS, VERSION, "claude"));
+  expect(result).not.toMatch(/[\\/]dev[\\/]/);
 
   spy.mockRestore();
 });


### PR DESCRIPTION
## Summary

Fixes workflow execution in `bun build --compile` mode, where `import.meta.path` collapses to the binary path itself, making the previous `workflowSource`-based resolution strategy non-functional. Also makes a set of pre-existing tests cross-platform so they pass on Windows.

## Key Changes

### Workflow binary source fix (`packages/atomic/src/cli.ts`, `packages/atomic-sdk/src/runtime/executor.ts`)
- Changed `_orchestrator-entry` sub-command argument order from `<workflowSource> <agent> <inputsB64>` to `<workflowName> <agent> <inputsB64> <workflowSource>`
- In compiled-binary mode, resolves the workflow by `name + agent` from the builtin registry (statically linked into the binary) rather than attempting a dynamic `import()` of a collapsed bunfs path
- In dev / installed-package mode, falls back to dynamic-importing `workflowSource` so third-party SDK consumers whose workflows aren't in the builtin registry continue to work
- Added `ATOMIC_BUILD_DIST_DIR` env-var support in `build.ts` so tests can redirect build output to an isolated temp dir, avoiding Windows file-lock races when concurrent tests hold `atomic.exe` open

### Windows cross-platform test fixes (`packages/atomic-sdk/src/**`)
- Use `path.delimiter` (`;` on Windows, `:` on Unix) instead of hard-coded `:` in PATH assembly (`copilot.test.ts`, `executor.test.ts`)
- Use `path.join()` instead of string concatenation for all path assertions so separators match the host OS
- Write `.cmd`/`.exe` stubs on Windows for `Bun.which`/PATHEXT-aware binary lookups (`copilot.test.ts`, `headless-hil-policy.test.ts`, `executor.test.ts`)
- Set `LOCALAPPDATA` alongside `XDG_CACHE_HOME` in `embedded-assets.test.ts` to cover the Windows cache-root path
- Update regex patterns to accept both `/` and `\` separators and optional `.exe` suffixes (`executor.test.ts`)