### PR TITLE
chore(release): bump version to v0.7.0-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.0-7",
+  "version": "0.7.0-8",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.0-7",
+  "version": "0.7.0-8",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.0-7",
+  "version": "0.7.0-8",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Prerelease version bump from `v0.7.0-7` to `v0.7.0-8`, incorporating workflow orchestrator fixes and full Windows test-suite parity.

## What's included in this prerelease

### Bug Fixes

- **fix(workflow-orchestrator):** `atomic workflow -n <name>` failed in the compiled binary with *"does not export a valid WorkflowDefinition"* — the orchestrator pane died silently because `import.meta.path` collapses to the bunfs entry path inside a `bun build --compile` binary. Fixed by having the launcher emit `<workflowName> <agent> <inputsB64> <workflowSource>` and resolving workflows from the builtin registry (keyed by `name + agent`) when running inside a compiled binary, while falling back to the existing dynamic-import-by-source path in dev / installed-package mode.

### Tests

- **test(windows):** Resolved 21 pre-existing test failures on Windows host VMs — zero product-behavior regressions, all cross-platform parity gaps:
  - Path-separator parity (`/` vs `\`) in 3 tests
  - `LOCALAPPDATA` vs `XDG_CACHE_HOME` env var handling in 3 tests
  - `PATHEXT`-aware stub binaries (`.cmd` / `.exe`) in 10 tests
  - `buildPaneCommand` regex/string assertions accepting `[\\/]` separators and optional `.exe` suffix in 3 tests
  - Port-discovery polling timing on Windows (injected fast spawn stub) in 2 tests
  - `dist` EACCES race from parallel binary execs on Windows (isolated per-test dist dir via `ATOMIC_BUILD_DIST_DIR`) in 1 test

## Changed files

- `package.json` — `0.7.0-7` → `0.7.0-8`
- `packages/atomic/package.json` — `0.7.0-7` → `0.7.0-8`
- `packages/atomic-sdk/package.json` — `0.7.0-7` → `0.7.0-8`