### PR TITLE
chore(release): bump version to v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.0-8",
+  "version": "0.7.0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.0-8",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.0-8",
+  "version": "0.7.0",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary
- Bumps version from `v0.7.0-8` (prerelease) to stable `v0.7.0` across `package.json`, `packages/atomic/package.json`, and `packages/atomic-sdk/package.json`.

## Test plan
- [ ] CI passes (typecheck, lint, tests)
- [ ] Release workflow publishes `v0.7.0` to npm on merge