### PR TITLE
chore(release): bump version to v0.7.1-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1-0",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1-0",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Bumps the monorepo version from `0.7.0` to `0.7.1-0` (prerelease) in preparation for the next patch release.

## Changes

- `package.json` — root monorepo version: `0.7.0` → `0.7.1-0`
- `packages/atomic/package.json` — CLI package version: `0.7.0` → `0.7.1-0`
- `packages/atomic-sdk/package.json` — SDK package version: `0.7.0` → `0.7.1-0`

## Notes

- This is a prerelease (`-0` suffix) and will be published to npm under the `next` dist-tag on merge.
- On merge, a GitHub Release is automatically created from the `prerelease/v0.7.1-0` branch name.

## Test plan

- [ ] CI passes (typecheck, lint, tests)
- [ ] On merge, GitHub Release is automatically created and prerelease is published to npm