### PR TITLE
chore(release): bump version to v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.1-0",
+  "version": "0.7.1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.1-0",
+  "version": "0.7.1",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.1-0",
+  "version": "0.7.1",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Promotes the `v0.7.1-0` prerelease to the stable `v0.7.1` release across the monorepo.

## Changes

- `package.json` (root): `0.7.1-0` → `0.7.1`
- `packages/atomic/package.json`: `0.7.1-0` → `0.7.1`
- `packages/atomic-sdk/package.json`: `0.7.1-0` → `0.7.1`

## Test plan
- [ ] CI passes (typecheck, lint, tests).
- [ ] Verify release workflow publishes `v0.7.1` to npm after merge.