### PR TITLE
chore(release): bump version to v0.7.2-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2-0",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2-0",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Prerelease version bump from `v0.7.1` to `v0.7.2-0` across all packages in the monorepo.

## Changes

- `package.json` (monorepo root): `0.7.1` → `0.7.2-0`
- `packages/atomic/package.json`: `0.7.1` → `0.7.2-0`
- `packages/atomic-sdk/package.json`: `0.7.1` → `0.7.2-0`

## Test plan

- [x] Version updated consistently across all three `package.json` files
- [ ] Once merged to `main`, the GitHub Release workflow auto-creates a prerelease and publishes to npm