### PR TITLE
chore(release): promote v0.7.2 from prerelease to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.2-0",
+  "version": "0.7.2",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.2-0",
+  "version": "0.7.2",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.2-0",
+  "version": "0.7.2",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Promotes the `0.7.2-0` prerelease to a stable `0.7.2` release by bumping the version across all package manifests in the monorepo.

## Changes

- `package.json`: `0.7.2-0` → `0.7.2`
- `packages/atomic/package.json`: `0.7.2-0` → `0.7.2`
- `packages/atomic-sdk/package.json`: `0.7.2-0` → `0.7.2`

## Test plan

- [ ] Verify CI passes
- [ ] Confirm GitHub Release is auto-created on merge to `main`
- [ ] Confirm npm publish completes with provenance (no `NPM_TOKEN`/`NODE_AUTH_TOKEN` required)