### PR TITLE
chore(release): bump version to v0.7.3-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.2",
+  "version": "0.7.3-0",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3-0",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Bumps all monorepo packages from `v0.7.2` to `v0.7.3-0` as a prerelease in preparation for the next patch release.

## Changes

- `package.json` (monorepo root): `0.7.2` → `0.7.3-0`
- `packages/atomic/package.json`: `0.7.2` → `0.7.3-0`
- `packages/atomic-sdk/package.json`: `0.7.2` → `0.7.3-0`

## Test plan

- [ ] CI passes (typecheck, lint, tests)
- [ ] Verify GitHub Release is created automatically once merged