### PR TITLE
chore(release): bump version to v0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.3-0",
+  "version": "0.7.3",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.3-0",
+  "version": "0.7.3",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.3-0",
+  "version": "0.7.3",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Promotes the v0.7.3-0 prerelease to the v0.7.3 stable release by bumping the version field across all packages in the monorepo.

## Changes

- `package.json` (monorepo root): `0.7.3-0` → `0.7.3`
- `packages/atomic/package.json`: `0.7.3-0` → `0.7.3`
- `packages/atomic-sdk/package.json`: `0.7.3-0` → `0.7.3`

## What's in v0.7.3

- Hotfix for Copilot skills (PR #819): enforces skill description length validation.

## Test plan

- [ ] CI passes (typecheck, lint, tests).
- [ ] On merge, the release workflow tags `v0.7.3` and publishes `@bastani/atomic-sdk` to npm.