### PR TITLE
chore(examples): make each example a standalone workspace with package.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,26 +493,10 @@ The [`examples/`](./examples) directory contains small, complete user apps you c
 | `commander-embed`               | Mount an atomic workflow under a parent Commander CLI by calling `runWorkflow({ workflow, inputs })` inside a Commander action, alongside a plain Commander sibling command. No re-entry boilerplate — the SDK ships its own orchestrator entry script.                                                                |
 | `pane-navigation`               | Driver CLI for the SDK pane-navigation primitives (`nextWindow`, `previousWindow`, `gotoOrchestrator`, `attachSession`, `detachSession`). Spawns a 3-stage workflow detached and exposes `start / list / status / next / prev / home / attach / stop` subcommands. Catches `SessionNotFoundError` for friendly errors. |
 
-Run any of them with:
+Each example directory ships its own `package.json` and `README.md` with the run command, inputs, and a one-paragraph explanation — head to [`examples/`](./examples) and pick one. The general shape is:
 
-```bash
-# Single-workflow workers — agent is pinned by which file you run, so no `-a` flag.
-# Inputs map to `--<input>=<value>` flags; if the workflow declares no inputs,
-# trailing positional tokens become the prompt.
-bun run examples/hello-world/claude-worker.ts --greeting="Hello" --style=casual
-bun run examples/sequential-describe-summarize/claude-worker.ts --topic="Bun"
-bun run examples/review-fix-loop/claude-worker.ts --topic="adopting Bun" --max_iterations=3
-bun run examples/headless-test/copilot-worker.ts --prompt="TypeScript"
-
-# Multi-workflow CLI — one cli.ts, one Commander subcommand per registered workflow.
-bun run examples/multi-workflow/cli.ts hello   --who=Alex
-bun run examples/multi-workflow/cli.ts goodbye --tone=melodramatic
-
-# Commander embedding — atomic workflow mounted as `greet` alongside plain Commander commands.
-bun run examples/commander-embed/cli.ts greet --who=Alex
-bun run examples/commander-embed/cli.ts status                # sibling Commander command
-bun run examples/commander-embed/cli.ts --help                # all commands
-```
+- **Worker-style examples** — `bun install && bun run <agent>-worker.ts --<input>=<value>`. Agent is pinned by which worker file you run (no `-a` flag). Inputs map to `--<input>=<value>` flags; if the workflow declares no inputs, trailing positional tokens become the prompt.
+- **CLI-style examples** (`multi-workflow`, `commander-embed`, `pane-navigation`) — `bun install && bun run cli.ts <subcommand>`. See each folder's README for subcommands.
 
 Copy an example directory into your project as a starting point — swap the workflow import in each `<agent>-worker.ts` (or in `cli.ts` for the multi-workflow / commander-embed shapes) for your own definition and you're done.
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,118 @@
         "yaml": "^2.8.4",
       },
     },
+    "examples/claude-background-subagents": {
+      "name": "@bastani/example-claude-background-subagents",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/commander-embed": {
+      "name": "@bastani/example-commander-embed",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/headless-test": {
+      "name": "@bastani/example-headless-test",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+        "@github/copilot-sdk": "^0.3.0",
+      },
+    },
+    "examples/hello-world": {
+      "name": "@bastani/example-hello-world",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/hil-favorite-color": {
+      "name": "@bastani/example-hil-favorite-color",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/hil-favorite-color-headless": {
+      "name": "@bastani/example-hil-favorite-color-headless",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/multi-workflow": {
+      "name": "@bastani/example-multi-workflow",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/pane-navigation": {
+      "name": "@bastani/example-pane-navigation",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/parallel-hello-world": {
+      "name": "@bastani/example-parallel-hello-world",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/review-fix-loop": {
+      "name": "@bastani/example-review-fix-loop",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/reviewer-tool-test": {
+      "name": "@bastani/example-reviewer-tool-test",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+        "@github/copilot-sdk": "^0.3.0",
+        "zod": "^4.4.3",
+      },
+    },
+    "examples/sequential-describe-summarize": {
+      "name": "@bastani/example-sequential-describe-summarize",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+      },
+    },
+    "examples/structured-output-demo": {
+      "name": "@bastani/example-structured-output-demo",
+      "version": "0.7.3",
+      "dependencies": {
+        "@bastani/atomic-sdk": "workspace:*",
+        "@commander-js/extra-typings": "^14.0.0",
+        "@github/copilot-sdk": "^0.3.0",
+        "zod": "^4.4.3",
+      },
+    },
     "packages/atomic": {
       "name": "@bastani/atomic",
-      "version": "0.7.0-4",
+      "version": "0.7.3",
       "bin": {
         "atomic": "src/cli.ts",
       },
@@ -44,7 +153,7 @@
     },
     "packages/atomic-sdk": {
       "name": "@bastani/atomic-sdk",
-      "version": "0.7.0-4",
+      "version": "0.7.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.128",
         "@catppuccin/palette": "^1.8.0",
@@ -95,6 +204,32 @@
     "@bastani/atomic": ["@bastani/atomic@workspace:packages/atomic"],
 
     "@bastani/atomic-sdk": ["@bastani/atomic-sdk@workspace:packages/atomic-sdk"],
+
+    "@bastani/example-claude-background-subagents": ["@bastani/example-claude-background-subagents@workspace:examples/claude-background-subagents"],
+
+    "@bastani/example-commander-embed": ["@bastani/example-commander-embed@workspace:examples/commander-embed"],
+
+    "@bastani/example-headless-test": ["@bastani/example-headless-test@workspace:examples/headless-test"],
+
+    "@bastani/example-hello-world": ["@bastani/example-hello-world@workspace:examples/hello-world"],
+
+    "@bastani/example-hil-favorite-color": ["@bastani/example-hil-favorite-color@workspace:examples/hil-favorite-color"],
+
+    "@bastani/example-hil-favorite-color-headless": ["@bastani/example-hil-favorite-color-headless@workspace:examples/hil-favorite-color-headless"],
+
+    "@bastani/example-multi-workflow": ["@bastani/example-multi-workflow@workspace:examples/multi-workflow"],
+
+    "@bastani/example-pane-navigation": ["@bastani/example-pane-navigation@workspace:examples/pane-navigation"],
+
+    "@bastani/example-parallel-hello-world": ["@bastani/example-parallel-hello-world@workspace:examples/parallel-hello-world"],
+
+    "@bastani/example-review-fix-loop": ["@bastani/example-review-fix-loop@workspace:examples/review-fix-loop"],
+
+    "@bastani/example-reviewer-tool-test": ["@bastani/example-reviewer-tool-test@workspace:examples/reviewer-tool-test"],
+
+    "@bastani/example-sequential-describe-summarize": ["@bastani/example-sequential-describe-summarize@workspace:examples/sequential-describe-summarize"],
+
+    "@bastani/example-structured-output-demo": ["@bastani/example-structured-output-demo@workspace:examples/structured-output-demo"],
 
     "@catppuccin/palette": ["@catppuccin/palette@1.8.0", "", {}, "sha512-qXhwKiLzQomUygUJYB36YAFgs+dET5bIocfkiaFIatQF5Pwc7L112TlF9P8J5Oqs3x3XTjYSucG0ncHXSCuk7Q=="],
 

--- a/examples/claude-background-subagents/README.md
+++ b/examples/claude-background-subagents/README.md
@@ -1,0 +1,17 @@
+# claude-background-subagents
+
+Two-stage Claude workflow that exercises the SDK's in-flight subagent gating. Stage 1 spawns three **background** subagents (`run_in_background: true`) and ends its turn immediately; stage 2 verifies all three finished before it started.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts
+```
+
+Each subagent writes a marker file under `/tmp/atomic-bg-<n>.txt` after a deterministic delay. Without the in-flight gating, stage 2 would race past the unfinished subagents and either find missing files or hit FD pressure on the tmux server.
+
+## What's here
+
+- `claude/` — the two-stage workflow definition
+- `claude-worker.ts` — Commander entrypoint

--- a/examples/claude-background-subagents/package.json
+++ b/examples/claude-background-subagents/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bastani/example-claude-background-subagents",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Stage 1 spawns 3 background subagents and ends its turn immediately; stage 2 verifies they all finished before it started.",
+  "scripts": {
+    "claude": "bun run claude-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/commander-embed/README.md
+++ b/examples/commander-embed/README.md
@@ -1,0 +1,17 @@
+# commander-embed
+
+Mount an atomic workflow under a parent Commander CLI by calling `runWorkflow({ workflow, inputs })` inside a Commander action — alongside a plain Commander sibling command. No re-entry boilerplate: the SDK ships its own orchestrator entry script.
+
+## Run
+
+```bash
+bun install
+bun run cli.ts greet --who=Alex
+bun run cli.ts status                # plain Commander sibling
+bun run cli.ts --help                # all commands
+```
+
+## What's here
+
+- `claude/` — the embedded workflow
+- `cli.ts` — parent Commander tree with `greet` (workflow) and `status` (plain command)

--- a/examples/commander-embed/package.json
+++ b/examples/commander-embed/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bastani/example-commander-embed",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Mount an atomic workflow under a parent Commander CLI alongside plain Commander commands",
+  "scripts": {
+    "start": "bun run cli.ts",
+    "greet": "bun run cli.ts greet",
+    "status": "bun run cli.ts status"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/headless-test/README.md
+++ b/examples/headless-test/README.md
@@ -1,0 +1,19 @@
+# headless-test
+
+Visible seed → 3 parallel headless stages → visible merge → headless verdict. Demonstrates mixing visible (tmux pane) and headless (no pane) stages in one workflow.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts   --prompt="TypeScript"
+bun run copilot-worker.ts  --prompt="TypeScript"
+bun run opencode-worker.ts --prompt="TypeScript"
+```
+
+## What's here
+
+- `claude/`, `copilot/`, `opencode/` — workflow definitions per agent
+- `<agent>-worker.ts` — Commander entrypoint
+
+Headless stages still appear as graph nodes in the orchestrator panel — they just don't grab a tmux window.

--- a/examples/headless-test/package.json
+++ b/examples/headless-test/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bastani/example-headless-test",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Visible seed -> 3 parallel headless stages -> visible merge -> headless verdict",
+  "scripts": {
+    "claude": "bun run claude-worker.ts",
+    "copilot": "bun run copilot-worker.ts",
+    "opencode": "bun run opencode-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0",
+    "@github/copilot-sdk": "^0.3.0"
+  }
+}

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,27 @@
+# hello-world
+
+Minimal single-session workflow with structured inputs (`greeting`, `style`, optional `notes`). The simplest possible shape for a workflow worker.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts   --greeting="Hello" --style=casual
+bun run copilot-worker.ts  --greeting="Hello" --style=casual
+bun run opencode-worker.ts --greeting="Hello" --style=casual
+```
+
+Or via the package scripts:
+
+```bash
+bun run claude   -- --greeting="Hello" --style=casual
+bun run copilot  -- --greeting="Hello" --style=casual
+bun run opencode -- --greeting="Hello" --style=casual
+```
+
+## What's here
+
+- `claude/`, `copilot/`, `opencode/` — one workflow definition per agent
+- `<agent>-worker.ts` — Commander entrypoint that wires the workflow inputs to `--<flag>` options and calls `runWorkflow`
+
+Copy this directory as a starting point — swap the workflow import for your own and you're done.

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bastani/example-hello-world",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Minimal single-session workflow with structured inputs (greeting, style, optional notes)",
+  "scripts": {
+    "claude": "bun run claude-worker.ts",
+    "copilot": "bun run copilot-worker.ts",
+    "opencode": "bun run opencode-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/hil-favorite-color-headless/README.md
+++ b/examples/hil-favorite-color-headless/README.md
@@ -1,0 +1,19 @@
+# hil-favorite-color-headless
+
+HIL pause inside a **headless** stage — the agent escalates from no-pane mode into an interactive prompt only when it needs human input.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts
+bun run copilot-worker.ts
+bun run opencode-worker.ts
+```
+
+## What's here
+
+- `claude/`, `copilot/`, `opencode/` — workflow definitions per agent
+- `<agent>-worker.ts` — Commander entrypoint
+
+Compare with `hil-favorite-color/` — same flow, but the question is asked from a stage that ran headless until the prompt arrived.

--- a/examples/hil-favorite-color-headless/package.json
+++ b/examples/hil-favorite-color-headless/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bastani/example-hil-favorite-color-headless",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "HIL pause inside a headless stage",
+  "scripts": {
+    "claude": "bun run claude-worker.ts",
+    "copilot": "bun run copilot-worker.ts",
+    "opencode": "bun run opencode-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/hil-favorite-color/README.md
+++ b/examples/hil-favorite-color/README.md
@@ -1,0 +1,19 @@
+# hil-favorite-color
+
+Human-in-the-loop prompt mid-workflow — the agent pauses to ask the user a question, then continues.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts
+bun run copilot-worker.ts
+bun run opencode-worker.ts
+```
+
+The workflow asks for your favorite color in an interactive tmux pane, then prints a message that uses your answer. Attach to the session if it doesn't already have focus.
+
+## What's here
+
+- `claude/`, `copilot/`, `opencode/` — workflow definitions per agent
+- `<agent>-worker.ts` — Commander entrypoint

--- a/examples/hil-favorite-color/package.json
+++ b/examples/hil-favorite-color/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bastani/example-hil-favorite-color",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Human-in-the-loop prompt mid-workflow",
+  "scripts": {
+    "claude": "bun run claude-worker.ts",
+    "copilot": "bun run copilot-worker.ts",
+    "opencode": "bun run opencode-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/multi-workflow/README.md
+++ b/examples/multi-workflow/README.md
@@ -1,0 +1,19 @@
+# multi-workflow
+
+Two Claude workflows (`hello`, `goodbye`) under a single `cli.ts`. Uses `listWorkflows(registry)` to register one Commander subcommand per workflow, with each workflow's declared inputs mounted as `--<flag>` options.
+
+## Run
+
+```bash
+bun install
+bun run cli.ts hello   --who=Alex
+bun run cli.ts goodbye --tone=melodramatic
+bun run cli.ts --help
+```
+
+## What's here
+
+- `hello/`, `goodbye/` — two independent Claude workflows
+- `cli.ts` — single Commander entrypoint that dispatches by workflow name
+
+This is the shape to use when one CLI needs to expose multiple workflows. For the variant where the same dispatcher spans agents (claude/copilot/opencode), reach for the `-a/--agent` flag — see the atomic CLI's builtin registry for an example.

--- a/examples/multi-workflow/package.json
+++ b/examples/multi-workflow/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bastani/example-multi-workflow",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Two Claude workflows (hello, goodbye) under one cli.ts — Commander subcommand per registered workflow",
+  "scripts": {
+    "start": "bun run cli.ts",
+    "hello": "bun run cli.ts hello",
+    "goodbye": "bun run cli.ts goodbye"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/pane-navigation/README.md
+++ b/examples/pane-navigation/README.md
@@ -1,0 +1,31 @@
+# pane-navigation
+
+Driver CLI for the SDK pane-navigation primitives (`nextWindow`, `previousWindow`, `gotoOrchestrator`, `attachSession`, `detachSession`). Spawns a 3-stage workflow detached and exposes `start / list / status / next / prev / home / attach / stop` subcommands. Catches `SessionNotFoundError` for friendly errors.
+
+## Run
+
+```bash
+bun install
+
+# 1. Spawn the workflow detached and capture its session id
+bun run cli.ts start --agent claude
+
+# 2. In a second terminal, attach so you can watch window changes live
+tmux -L atomic attach -t <session-id>
+
+# 3. Back in the first terminal, drive the navigation primitives
+bun run cli.ts list
+bun run cli.ts status <session-id>
+bun run cli.ts next   <session-id>
+bun run cli.ts prev   <session-id>
+bun run cli.ts home   <session-id>
+bun run cli.ts attach <session-id>
+bun run cli.ts stop   <session-id>
+```
+
+`--agent` accepts `claude`, `copilot`, or `opencode`.
+
+## What's here
+
+- `claude/`, `copilot/`, `opencode/` — same 3-stage workflow per agent
+- `cli.ts` — Commander driver that wraps the SDK's session primitives

--- a/examples/pane-navigation/package.json
+++ b/examples/pane-navigation/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bastani/example-pane-navigation",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Driver CLI for the SDK pane-navigation primitives (start / list / status / next / prev / home / attach / stop)",
+  "scripts": {
+    "start": "bun run cli.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/parallel-hello-world/README.md
+++ b/examples/parallel-hello-world/README.md
@@ -1,0 +1,19 @@
+# parallel-hello-world
+
+`Promise.all()` fan-out and transcript merge — three stages run concurrently, then a final stage merges their transcripts.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts   --topic="Bun"
+bun run copilot-worker.ts  --topic="Bun"
+bun run opencode-worker.ts --topic="Bun"
+```
+
+## What's here
+
+- `claude/`, `copilot/`, `opencode/` — workflow definitions per agent
+- `<agent>-worker.ts` — Commander entrypoint that calls `runWorkflow`
+
+Demonstrates that JavaScript control flow (`Promise.all`, `for`, `if`) is the only orchestration primitive you need.

--- a/examples/parallel-hello-world/package.json
+++ b/examples/parallel-hello-world/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bastani/example-parallel-hello-world",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Promise.all() fan-out and transcript merge across parallel stages",
+  "scripts": {
+    "claude": "bun run claude-worker.ts",
+    "copilot": "bun run copilot-worker.ts",
+    "opencode": "bun run opencode-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/review-fix-loop/README.md
+++ b/examples/review-fix-loop/README.md
@@ -1,0 +1,17 @@
+# review-fix-loop
+
+Draft → loop(review → fix) with bounded iterations and early exit on a `CLEAN` verdict. A reliable review gate that shows how a stage's return value (`handle.result`) drives TypeScript control flow.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts --topic="adopting Bun" --max_iterations=3
+```
+
+## What's here
+
+- `claude/` — workflow with the bounded review loop
+- `claude-worker.ts` — Commander entrypoint
+
+The loop is a plain `for` with an `if (verdict === "CLEAN") break;` — no DSL, no state machine. That's the workflow SDK's whole pitch.

--- a/examples/review-fix-loop/package.json
+++ b/examples/review-fix-loop/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bastani/example-review-fix-loop",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Draft -> loop(review -> fix) with bounded iterations and early exit on a CLEAN verdict",
+  "scripts": {
+    "claude": "bun run claude-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/reviewer-tool-test/README.md
+++ b/examples/reviewer-tool-test/README.md
@@ -1,0 +1,17 @@
+# reviewer-tool-test
+
+Custom reviewer tool wiring on the Copilot SDK — defines a Zod-validated `defineTool` and exposes it inside a stage as the only allowed tool.
+
+> Copilot only — Claude and OpenCode have their own tool-definition shapes covered elsewhere.
+
+## Run
+
+```bash
+bun install
+bun run copilot-worker.ts
+```
+
+## What's here
+
+- `copilot/` — workflow that registers the reviewer tool
+- `copilot-worker.ts` — Commander entrypoint

--- a/examples/reviewer-tool-test/package.json
+++ b/examples/reviewer-tool-test/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bastani/example-reviewer-tool-test",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Custom reviewer tool wiring (Copilot)",
+  "scripts": {
+    "copilot": "bun run copilot-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0",
+    "@github/copilot-sdk": "^0.3.0",
+    "zod": "^4.4.3"
+  }
+}

--- a/examples/sequential-describe-summarize/README.md
+++ b/examples/sequential-describe-summarize/README.md
@@ -1,0 +1,17 @@
+# sequential-describe-summarize
+
+Two stages passing data via `s.save()` → `s.transcript(handle)` — the canonical handoff pattern between sessions.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts --topic="Bun"
+```
+
+## What's here
+
+- `claude/` — the two-stage workflow definition
+- `claude-worker.ts` — Commander entrypoint
+
+Stage 1 describes the topic and saves its session id; stage 2 reads stage 1's transcript path and summarizes it. The handle returned by `ctx.stage(...)` is how downstream stages address upstream output.

--- a/examples/sequential-describe-summarize/package.json
+++ b/examples/sequential-describe-summarize/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@bastani/example-sequential-describe-summarize",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Two stages passing data via s.save() -> s.transcript(handle) — the canonical handoff pattern",
+  "scripts": {
+    "claude": "bun run claude-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0"
+  }
+}

--- a/examples/structured-output-demo/README.md
+++ b/examples/structured-output-demo/README.md
@@ -1,0 +1,20 @@
+# structured-output-demo
+
+Per-SDK structured output — each agent's native schema-enforced response path (JSON schema for Claude / OpenCode, custom Zod-validated tool for Copilot) producing the same typed object.
+
+## Run
+
+```bash
+bun install
+bun run claude-worker.ts   --prompt=Python
+bun run copilot-worker.ts  --prompt=Python
+bun run opencode-worker.ts --prompt=Python
+```
+
+## What's here
+
+- `claude/`, `copilot/`, `opencode/` — per-agent structured-output workflow
+- `helpers/schema.ts` — shared Zod schema, prompt builder, and logger
+- `<agent>-worker.ts` — Commander entrypoint
+
+Read each `<agent>/index.ts` to see how the same Zod schema lands in three different SDK shapes.

--- a/examples/structured-output-demo/package.json
+++ b/examples/structured-output-demo/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@bastani/example-structured-output-demo",
+  "private": true,
+  "version": "0.7.3",
+  "type": "module",
+  "description": "Per-SDK structured output (JSON-schema validation, Zod)",
+  "scripts": {
+    "claude": "bun run claude-worker.ts",
+    "copilot": "bun run copilot-worker.ts",
+    "opencode": "bun run opencode-worker.ts"
+  },
+  "dependencies": {
+    "@bastani/atomic-sdk": "^0.7.3",
+    "@commander-js/extra-typings": "^14.0.0",
+    "@github/copilot-sdk": "^0.3.0",
+    "zod": "^4.4.3"
+  }
+}


### PR DESCRIPTION
## Summary

Each example directory is now a self-contained Bun workspace with its own `package.json` and `README.md`, so examples can be run in isolation (or copied out of the monorepo) with a simple `bun install && bun run <agent>-worker.ts`.

## Key Changes

- **`examples/*/package.json`** — Added a `package.json` to all 13 example folders, each scoped as `@bastani/example-<name>` with `@bastani/atomic-sdk` and Commander pinned as dependencies (plus `@github/copilot-sdk` / `zod` where used directly). Each package exposes `claude`, `copilot`, and `opencode` scripts.
- **`examples/*/README.md`** — Added a `README.md` to each example with a one-line description (lifted from the root runnable-examples table) and the exact `bun install` + run commands.
- **`README.md`** — Replaced the verbose bash block in the runnable-examples section with two bullet points describing the worker-style vs CLI-style shapes, pointing readers to each example's folder README.
- **`bun.lock`** — Updated lockfile to reflect the new workspace dependencies.