### PR TITLE
chore(release): bump version to v0.7.4-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.3",
+  "version": "0.7.4-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.3",
+  "version": "0.7.4-0",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.3",
+  "version": "0.7.4-0",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Bumps the monorepo version from `0.7.3` to `0.7.4-0` across all packages as a prerelease ahead of the `v0.7.4` stable release.

## Key Changes

- `package.json` (monorepo root): `0.7.3` → `0.7.4-0`
- `packages/atomic/package.json`: `0.7.3` → `0.7.4-0`
- `packages/atomic-sdk/package.json`: `0.7.3` → `0.7.4-0`

## Included Since v0.7.3

- **feat(sdk):** Bundle internal CLI dispatcher to decouple the SDK from the user-facing CLI (#823)
- **chore(examples):** Add `package.json` and `README` to each example, with updated root README (#822)

## Notes

- This is a prerelease (`-0` suffix); the stable `v0.7.4` release will follow after validation.
- No breaking changes or migration steps required.