### PR TITLE
chore(release): bump version to v0.7.4-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.4-0",
+  "version": "0.7.4-1",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.4-0",
+  "version": "0.7.4-1",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.4-0",
+  "version": "0.7.4-1",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
Bumps the prerelease version from `v0.7.4-0` to `v0.7.4-1` across all monorepo packages.

## Changes

- `package.json` (monorepo root): `0.7.4-0` → `0.7.4-1`
- `packages/atomic/package.json`: `0.7.4-0` → `0.7.4-1`
- `packages/atomic-sdk/package.json`: `0.7.4-0` → `0.7.4-1`

## Notes

- This is a prerelease increment; no breaking changes or new features are included.
- Version was bumped using `bun run src/scripts/bump-version.ts --from-branch`.