### PR TITLE
refactor(cli,sdk): rename github MCP server and drop chat auth probe

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "github": {
+    "github-mcp-server": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp",
       "headers": {

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "github": {
+    "github-mcp-server": {
       "type": "remote",
       "url": "https://api.githubcopilot.com/mcp",
       "enabled": true

--- a/packages/atomic-sdk/src/services/config/scm-sync.ts
+++ b/packages/atomic-sdk/src/services/config/scm-sync.ts
@@ -19,27 +19,29 @@ import { pathExists } from "../system/copy.ts";
 import type { ScmProvider } from "./atomic-config.ts";
 import { readAtomicConfig } from "./atomic-config.ts";
 
-const SCM_MCP_SERVERS = ["github", "azure-devops"] as const;
+const SCM_MCP_SERVERS = ["github-mcp-server", "azure-devops"] as const;
 type ScmMcpServer = (typeof SCM_MCP_SERVERS)[number];
 
 /** Which SCM MCP servers should be enabled for each scm value. */
 function enabledServersFor(scm: ScmProvider): Set<ScmMcpServer> {
-  if (scm === "github") return new Set(["github"]);
+  if (scm === "github") return new Set(["github-mcp-server"]);
   if (scm === "azure-devops") return new Set(["azure-devops"]);
   return new Set();
 }
 
 /**
  * Copilot CLI servers to disable per scm selection. Copilot ships with a
- * built-in `github-mcp-server`; when scm is `github` the user's own
- * `github` MCP is redundant with it, so we keep the built-in and disable
- * the user's. For `azure-devops` we keep the user's `azure-devops` and
- * disable both GitHub variants. Sapling disables everything.
+ * built-in `github-mcp-server`; our `.mcp.json` registers a server under
+ * the same name, so when scm is `github` we leave it alone — the
+ * workspace entry overrides the built-in transparently and we only
+ * disable `azure-devops`. For `azure-devops` we disable
+ * `github-mcp-server` (which knocks out both the workspace and built-in
+ * variants since they share a name). Sapling disables everything.
  */
 const COPILOT_DISABLE_BY_SCM: Record<ScmProvider, readonly string[]> = {
-  github: ["github", "azure-devops"],
-  "azure-devops": ["github", "github-mcp-server"],
-  sapling: ["github", "azure-devops", "github-mcp-server"],
+  github: ["azure-devops"],
+  "azure-devops": ["github-mcp-server"],
+  sapling: ["github-mcp-server", "azure-devops"],
 };
 
 /**

--- a/packages/atomic/script/chat-smoke.ts
+++ b/packages/atomic/script/chat-smoke.ts
@@ -1,7 +1,7 @@
 /**
  * Cross-platform chat-launch smoke for the published `atomic` binary.
  *
- * Spawns `<atomic-bin> chat -a <agent> --no-login` inside a real PTY
+ * Spawns `<atomic-bin> chat -a <agent>` inside a real PTY
  * (forkpty on Unix, ConPTY on Windows) so the chat command's
  * `process.stdin.isTTY` guard sees a terminal and doesn't fall back to
  * `spawnDirect`. Asserts that the stub agent ends up running INSIDE
@@ -67,7 +67,7 @@ env[pathKey] = `${stubDir}${delimiter}${process.env.PATH ?? ""}`;
 console.log(`Chat-smoke binary: ${atomicBin}`);
 console.log(`Stub agent dir:    ${stubDir}`);
 
-const proc = ptySpawn(atomicBin, ["chat", "-a", agent, "--no-login"], {
+const proc = ptySpawn(atomicBin, ["chat", "-a", agent], {
   name: "xterm-256color",
   cols: 120,
   rows: 40,

--- a/packages/atomic/src/cli.ts
+++ b/packages/atomic/src/cli.ts
@@ -74,17 +74,10 @@ export function createProgram() {
         // Internal flag — exercised by the verdaccio smoke test and the
         // cross-platform runtime-assets matrix in CI to run onboarding
         // preflight (global-config sync + project setup) without spawning
-        // the agent or checking executables/auth. Hidden from `--help` so
+        // the agent or checking executables. Hidden from `--help` so
         // end users aren't tempted to use it.
         .addOption(
             new Option("--preflight-only").hideHelp(),
-        )
-        // Internal flag — bypasses `checkAgentAuth` for claude/copilot.
-        // Paired with a stub agent on PATH it lets the CI matrix exercise
-        // the real `chatCommand` tmux-launch path on every platform
-        // without holding live credentials. Hidden from `--help`.
-        .addOption(
-            new Option("--no-login").hideHelp(),
         )
         .allowUnknownOption()
         .allowExcessArguments(true)
@@ -130,9 +123,6 @@ Examples:
                 agentType,
                 passthroughArgs: cmd.args,
                 preflightOnly: localOpts.preflightOnly,
-                // Commander turns `--no-login` into `login: false`. Treat
-                // either explicit form as "skip the auth probe".
-                noLogin: localOpts.login === false,
             });
 
             process.exit(exitCode);

--- a/packages/atomic/src/commands/cli/chat/index.ts
+++ b/packages/atomic/src/commands/cli/chat/index.ts
@@ -24,7 +24,6 @@ import { COLORS } from "@bastani/atomic-sdk/theme/colors";
 import {
   getCommandPath,
 } from "@bastani/atomic-sdk/services/system/detect";
-import { checkAgentAuth, printAuthError } from "../../../services/system/auth.ts";
 import {
   ensureAtomicGlobalAgentConfigs,
 } from "../../../services/config/atomic-global-config.ts";
@@ -80,18 +79,9 @@ export interface ChatCommandOptions {
    * When true, run only the preflight steps (global config sync + project
    * onboarding) and exit 0 without spawning the agent CLI. Intended for
    * integration tests and CI smoke-checks; skips the executable-existence
-   * and auth checks so it works even when the agent CLI is not installed.
+   * check so it works even when the agent CLI is not installed.
    */
   preflightOnly?: boolean;
-  /**
-   * When true, skip the SDK-level auth probe in `checkAgentAuth`.
-   * Internal — exists so the cross-platform CI smoke matrix can exercise
-   * the *real* tmux launch path against a stub agent on PATH without
-   * needing live Claude / Copilot credentials. The chat flow continues
-   * normally past the auth gate; it does NOT alter what the agent CLI
-   * itself does once spawned.
-   */
-  noLogin?: boolean;
 }
 
 // ============================================================================
@@ -268,7 +258,7 @@ export function buildLauncherScript(
  * @returns Exit code from the agent process
  */
 export async function chatCommand(options: ChatCommandOptions = {}): Promise<number> {
-  const { agentType, passthroughArgs, preflightOnly, noLogin } = options;
+  const { agentType, passthroughArgs, preflightOnly } = options;
 
   if (!agentType) {
     throw new Error("agentType is required. Start chat with `atomic chat -a <agent>`.");
@@ -297,20 +287,6 @@ export async function chatCommand(options: ChatCommandOptions = {}): Promise<num
     );
     console.error(`Install it from: ${config.install_url}`);
     return 1;
-  }
-
-  // ── Preflight: authentication ──
-  // Copilot and Claude expose SDK-level login checks; run them now so
-  // users get a short actionable error instead of being dropped into a
-  // native CLI that immediately redirects them to /login. The
-  // `--no-login` escape hatch skips this for CI smoke-tests that pair
-  // a stub agent on PATH with the real chat-launch code path.
-  if (!noLogin) {
-    const auth = await checkAgentAuth(agentType);
-    if (!auth.loggedIn) {
-      printAuthError(agentType, auth);
-      return 1;
-    }
   }
 
   // ── Preflight: global config sync ──

--- a/tests/services/config/scm-sync.test.ts
+++ b/tests/services/config/scm-sync.test.ts
@@ -57,32 +57,26 @@ describe("copilotScmDisableFlags", () => {
     expect(copilotScmDisableFlags(undefined)).toEqual([]);
   });
 
-  test("disables github and azure-devops when scm is github (keeps built-in github-mcp-server)", () => {
+  test("disables only azure-devops when scm is github (workspace github-mcp-server overrides the built-in)", () => {
     expect(copilotScmDisableFlags("github")).toEqual([
       "--disable-mcp-server",
-      "github",
-      "--disable-mcp-server",
       "azure-devops",
     ]);
   });
 
-  test("disables github and github-mcp-server when scm is azure-devops", () => {
+  test("disables github-mcp-server when scm is azure-devops", () => {
     expect(copilotScmDisableFlags("azure-devops")).toEqual([
       "--disable-mcp-server",
-      "github",
-      "--disable-mcp-server",
       "github-mcp-server",
     ]);
   });
 
-  test("disables github, azure-devops, and github-mcp-server when scm is sapling", () => {
+  test("disables github-mcp-server and azure-devops when scm is sapling", () => {
     expect(copilotScmDisableFlags("sapling")).toEqual([
       "--disable-mcp-server",
-      "github",
+      "github-mcp-server",
       "--disable-mcp-server",
       "azure-devops",
-      "--disable-mcp-server",
-      "github-mcp-server",
     ]);
   });
 });
@@ -104,8 +98,6 @@ describe("getCopilotScmDisableFlags", () => {
     await writeAtomicConfig(projectRoot, { scm: "github" });
 
     expect(await getCopilotScmDisableFlags(projectRoot)).toEqual([
-      "--disable-mcp-server",
-      "github",
       "--disable-mcp-server",
       "azure-devops",
     ]);
@@ -147,7 +139,7 @@ describe("syncScmMcpServers — Claude settings", () => {
     expect(settings.disabledMcpjsonServers).toEqual(["azure-devops"]);
   });
 
-  test("adds github to disabledMcpjsonServers when scm is azure-devops", async () => {
+  test("adds github-mcp-server to disabledMcpjsonServers when scm is azure-devops", async () => {
     const projectRoot = join(tmpDir, "claude-ado");
     await mkdir(projectRoot, { recursive: true });
     await writeAtomicConfig(projectRoot, { scm: "azure-devops" });
@@ -158,7 +150,7 @@ describe("syncScmMcpServers — Claude settings", () => {
     const settings = await readJsonFile(
       join(projectRoot, ".claude", "settings.json"),
     );
-    expect(settings.disabledMcpjsonServers).toEqual(["github"]);
+    expect(settings.disabledMcpjsonServers).toEqual(["github-mcp-server"]);
   });
 
   test("preserves unrelated entries in disabledMcpjsonServers", async () => {
@@ -195,7 +187,7 @@ describe("syncScmMcpServers — Claude settings", () => {
     const settings = await readJsonFile(
       join(projectRoot, ".claude", "settings.json"),
     );
-    expect(settings.disabledMcpjsonServers).toEqual(["github"]);
+    expect(settings.disabledMcpjsonServers).toEqual(["github-mcp-server"]);
   });
 
   test("no-ops when the resulting array matches existing", async () => {
@@ -228,7 +220,7 @@ describe("syncScmMcpServers — Claude settings", () => {
     const settings = await readJsonFile(
       join(projectRoot, ".claude", "settings.json"),
     );
-    expect(settings.disabledMcpjsonServers).toEqual(["keep", "github"]);
+    expect(settings.disabledMcpjsonServers).toEqual(["keep", "github-mcp-server"]);
   });
 
   test("skips when .claude/settings.json does not exist", async () => {
@@ -291,13 +283,13 @@ describe("syncScmMcpServers — OpenCode settings", () => {
     await writeFile(join(dir, "opencode.json"), JSON.stringify(config));
   }
 
-  test("enables github and disables azure-devops when scm is github", async () => {
+  test("enables github-mcp-server and disables azure-devops when scm is github", async () => {
     const projectRoot = join(tmpDir, "oc-gh");
     await mkdir(projectRoot, { recursive: true });
     await writeAtomicConfig(projectRoot, { scm: "github" });
     await writeOpencodeConfig(projectRoot, {
       mcp: {
-        github: { enabled: false, type: "local" },
+        "github-mcp-server": { enabled: false, type: "local" },
         "azure-devops": { enabled: true, type: "local" },
       },
     });
@@ -308,7 +300,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
       join(projectRoot, ".opencode", "opencode.json"),
     );
     const mcp = (config.mcp ?? {}) as Record<string, { enabled?: boolean }>;
-    expect(mcp.github?.enabled).toBe(true);
+    expect(mcp["github-mcp-server"]?.enabled).toBe(true);
     expect(mcp["azure-devops"]?.enabled).toBe(false);
   });
 
@@ -318,7 +310,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
     await writeAtomicConfig(projectRoot, { scm: "sapling" });
     await writeOpencodeConfig(projectRoot, {
       mcp: {
-        github: { enabled: true },
+        "github-mcp-server": { enabled: true },
         "azure-devops": { enabled: true },
       },
     });
@@ -329,7 +321,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
       join(projectRoot, ".opencode", "opencode.json"),
     );
     const mcp = (config.mcp ?? {}) as Record<string, { enabled?: boolean }>;
-    expect(mcp.github?.enabled).toBe(false);
+    expect(mcp["github-mcp-server"]?.enabled).toBe(false);
     expect(mcp["azure-devops"]?.enabled).toBe(false);
   });
 
@@ -339,7 +331,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
     await writeAtomicConfig(projectRoot, { scm: "github" });
     await writeOpencodeConfig(projectRoot, {
       mcp: {
-        github: { enabled: false },
+        "github-mcp-server": { enabled: false },
         "custom-server": { enabled: true, command: "x" },
       },
     });
@@ -350,7 +342,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
       join(projectRoot, ".opencode", "opencode.json"),
     );
     const mcp = config.mcp as Record<string, Record<string, unknown>>;
-    expect(mcp.github?.enabled).toBe(true);
+    expect(mcp["github-mcp-server"]?.enabled).toBe(true);
     expect(mcp["custom-server"]).toEqual({ enabled: true, command: "x" });
   });
 
@@ -374,7 +366,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
     await writeAtomicConfig(projectRoot, { scm: "github" });
     await writeOpencodeConfig(projectRoot, {
       mcp: {
-        github: { enabled: true },
+        "github-mcp-server": { enabled: true },
         "azure-devops": { enabled: false },
       },
     });
@@ -406,7 +398,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
     await writeAtomicConfig(projectRoot, { scm: "github" });
     await writeOpencodeConfig(projectRoot, {
       mcp: {
-        github: "not-an-object",
+        "github-mcp-server": "not-an-object",
         "azure-devops": { enabled: true },
       },
     });
@@ -417,7 +409,7 @@ describe("syncScmMcpServers — OpenCode settings", () => {
       join(projectRoot, ".opencode", "opencode.json"),
     );
     const mcp = config.mcp as Record<string, unknown>;
-    expect(mcp.github).toBe("not-an-object");
+    expect(mcp["github-mcp-server"]).toBe("not-an-object");
     expect((mcp["azure-devops"] as { enabled: boolean }).enabled).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Two focused refactors: aligns the workspace GitHub MCP server name so it transparently overrides Copilot's built-in, and removes the SDK-level auth pre-check from the chat command along with the internal `--no-login` bypass flag that was used to work around it in CI.

## Key Changes

### MCP Server Rename (`refactor(sdk)`)
- Renamed the `github` MCP entry to `github-mcp-server` in `.mcp.json` and `.opencode/opencode.json` so it matches Copilot's built-in server name
- The workspace registration now transparently overrides the built-in instead of co-existing with it as a separate entry
- Simplified the `COPILOT_DISABLE_BY_SCM` matrix in `scm-sync.ts`: since both the workspace and built-in share the same name, a single disable target covers both
  - `github` SCM: only `azure-devops` is disabled (workspace `github-mcp-server` overrides the built-in)
  - `azure-devops` SCM: only `github-mcp-server` is disabled
  - `sapling` SCM: both `github-mcp-server` and `azure-devops` are disabled
- Updated all tests in `scm-sync.test.ts` to reflect the new name and simplified disable-flag expectations

### Auth Probe Removal (`refactor(cli)`)
- Removed `checkAgentAuth` / `printAuthError` call from `chatCommand` — native agent CLIs already redirect unauthenticated users to their own login flows, making the SDK-level pre-check redundant
- Removed the internal `--no-login` Commander option from `cli.ts` and the corresponding `noLogin` field from `ChatCommandOptions`
- Updated the `chat-smoke.ts` CI script to drop the `--no-login` flag, letting the harness exercise the real launch path without a bypass