### PR TITLE
chore(release): bump version to v0.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.5-0",
+  "version": "0.7.5",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.5-0",
+  "version": "0.7.5",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.5-0",
+  "version": "0.7.5",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Promotes the prerelease `0.7.5-0` to the stable `0.7.5` release by bumping the version across all package manifests in the monorepo.

## Changes

- `package.json` — root monorepo version `0.7.5-0` → `0.7.5`
- `packages/atomic/package.json` — `@bastani/atomic` version `0.7.5-0` → `0.7.5`
- `packages/atomic-sdk/package.json` — `@bastani/atomic-sdk` version `0.7.5-0` → `0.7.5`

## Test plan

- [ ] CI passes (typecheck, lint, tests)
- [ ] Release workflow triggers and publishes `v0.7.5` to npm upon merge