### PR TITLE
chore(examples): bump @bastani/atomic-sdk to ^0.7.5

### DIFF
--- a/examples/claude-background-subagents/package.json
+++ b/examples/claude-background-subagents/package.json
@@ -8,7 +8,7 @@
     "claude": "bun run claude-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/commander-embed/package.json
+++ b/examples/commander-embed/package.json
@@ -10,7 +10,7 @@
     "status": "bun run cli.ts status"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/headless-test/package.json
+++ b/examples/headless-test/package.json
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0"
   }

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/hil-favorite-color-headless/package.json
+++ b/examples/hil-favorite-color-headless/package.json
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/hil-favorite-color/package.json
+++ b/examples/hil-favorite-color/package.json
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/multi-workflow/package.json
+++ b/examples/multi-workflow/package.json
@@ -10,7 +10,7 @@
     "goodbye": "bun run cli.ts goodbye"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/pane-navigation/package.json
+++ b/examples/pane-navigation/package.json
@@ -8,7 +8,7 @@
     "start": "bun run cli.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/parallel-hello-world/package.json
+++ b/examples/parallel-hello-world/package.json
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/review-fix-loop/package.json
+++ b/examples/review-fix-loop/package.json
@@ -8,7 +8,7 @@
     "claude": "bun run claude-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/reviewer-tool-test/package.json
+++ b/examples/reviewer-tool-test/package.json
@@ -8,7 +8,7 @@
     "copilot": "bun run copilot-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",
     "zod": "^4.4.3"

--- a/examples/sequential-describe-summarize/package.json
+++ b/examples/sequential-describe-summarize/package.json
@@ -8,7 +8,7 @@
     "claude": "bun run claude-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/structured-output-demo/package.json
+++ b/examples/structured-output-demo/package.json
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.4",
+    "@bastani/atomic-sdk": "^0.7.5",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Summary

Bumps `@bastani/atomic-sdk` from `^0.7.4` to `^0.7.5` across all 13 example projects to track the latest published SDK release.

## Changes

- Updated `@bastani/atomic-sdk` version constraint in `package.json` for all examples:
  - `claude-background-subagents`
  - `commander-embed`
  - `headless-test`
  - `hello-world`
  - `hil-favorite-color`
  - `hil-favorite-color-headless`
  - `multi-workflow`
  - `pane-navigation`
  - `parallel-hello-world`
  - `review-fix-loop`
  - `reviewer-tool-test`
  - `sequential-describe-summarize`
  - `structured-output-demo`

## Test plan

- [ ] `bun install` resolves cleanly in each example
- [ ] Examples continue to run against the new SDK version