### PR TITLE
fix(onboarding): repair MCP setup across providers

### DIFF
--- a/.claude/.mcp.json
+++ b/.claude/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "github-mcp-server": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GH_TOKEN}"
+      }
+    },
+    "azure-devops": {
+      "type": "stdio",
+      "command": "bunx",
+      "args": [
+        "-y",
+        "@azure-devops/mcp",
+        "<your-org>"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,3 +258,46 @@ jobs:
                       bun packages/atomic/script/chat-smoke.ts "$ATOMIC" "$agent"
                       echo "::endgroup::"
                   done
+
+    # Cross-platform onboarding contract test. Reuses the host-target
+    # binary built per runner and asserts every agent's declared
+    # `onboarding_files` (claude/copilot/opencode) materialises in a
+    # fresh project root after `atomic chat -a <agent> --preflight-only`.
+    #
+    # Why this needs a dedicated job:
+    #   - `validate-publish` runs preflight but doesn't assert files
+    #     landed on disk (a silent no-op would slip through).
+    #   - The original test was Linux-only; the bug fixed by this PR
+    #     (copilot's empty `onboarding_files` → no `.mcp.json`) was a
+    #     config-data regression with no platform-specific aspect, but
+    #     the resolver code path (embedded-asset extraction, `~/...`
+    #     destination expansion) does differ across Linux/macOS/Windows.
+    #     A cross-platform contract test catches both classes of bug.
+    #
+    # The job sets `RUN_CI_E2E=1` to opt the gated test in.
+    onboarding-matrix:
+        name: Onboarding preflight (${{ matrix.os }})
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              run: bun install
+
+            - name: Build host-target binary
+              run: bun packages/atomic/script/build.ts
+
+            - name: Run onboarding preflight test
+              shell: bash
+              env:
+                  RUN_CI_E2E: "1"
+              run: bun test tests/ci/onboarding.test.ts

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -4,7 +4,10 @@
     "github-mcp-server": {
       "type": "remote",
       "url": "https://api.githubcopilot.com/mcp",
-      "enabled": true
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer {env:GH_TOKEN}"
+      }
     },
     "azure-devops": {
       "type": "local",
@@ -17,5 +20,8 @@
       "enabled": false
     }
   },
-  "permission": "allow"
+  "permission": "allow",
+  "instructions": [
+    "~/.atomic/AGENTS.md"
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
       "name": "@bastani/example-claude-background-subagents",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -31,7 +31,7 @@
       "name": "@bastani/example-commander-embed",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -39,7 +39,7 @@
       "name": "@bastani/example-headless-test",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.3.0",
       },
@@ -48,7 +48,7 @@
       "name": "@bastani/example-hello-world",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -56,7 +56,7 @@
       "name": "@bastani/example-hil-favorite-color",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -64,7 +64,7 @@
       "name": "@bastani/example-hil-favorite-color-headless",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -72,7 +72,7 @@
       "name": "@bastani/example-multi-workflow",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -80,7 +80,7 @@
       "name": "@bastani/example-pane-navigation",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -88,7 +88,7 @@
       "name": "@bastani/example-parallel-hello-world",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -96,7 +96,7 @@
       "name": "@bastani/example-review-fix-loop",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -104,7 +104,7 @@
       "name": "@bastani/example-reviewer-tool-test",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.3.0",
         "zod": "^4.4.3",
@@ -114,7 +114,7 @@
       "name": "@bastani/example-sequential-describe-summarize",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
       },
     },
@@ -122,7 +122,7 @@
       "name": "@bastani/example-structured-output-demo",
       "version": "0.7.4",
       "dependencies": {
-        "@bastani/atomic-sdk": "^0.7.4",
+        "@bastani/atomic-sdk": "^0.7.5",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.3.0",
         "zod": "^4.4.3",
@@ -130,7 +130,7 @@
     },
     "packages/atomic": {
       "name": "@bastani/atomic",
-      "version": "0.7.5-0",
+      "version": "0.7.5",
       "bin": {
         "atomic": "src/cli.ts",
       },
@@ -153,7 +153,7 @@
     },
     "packages/atomic-sdk": {
       "name": "@bastani/atomic-sdk",
-      "version": "0.7.5-0",
+      "version": "0.7.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.128",
         "@catppuccin/palette": "^1.8.0",
@@ -604,32 +604,6 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
-
-    "@bastani/example-claude-background-subagents/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-commander-embed/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-headless-test/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-hello-world/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-hil-favorite-color/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-hil-favorite-color-headless/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-multi-workflow/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-pane-navigation/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-parallel-hello-world/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-review-fix-loop/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-reviewer-tool-test/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-sequential-describe-summarize/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
-
-    "@bastani/example-structured-output-demo/@bastani/atomic-sdk": ["@bastani/atomic-sdk@0.7.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.128", "@catppuccin/palette": "^1.8.0", "@clack/prompts": "^1.3.0", "@commander-js/extra-typings": "^14.0.0", "@github/copilot-sdk": "^0.3.0", "@opencode-ai/sdk": "^1.14.33", "@opentui/core": "^0.2.2", "@opentui/react": "^0.2.2", "commander": "^14.0.3", "ignore": "^7.0.5", "ignore-by-default": "^2.1.0", "linguist-languages": "^9.3.2", "yaml": "^2.8.4", "zod": "^4.4.3" }, "peerDependencies": { "react": "^19.2.5" }, "optionalPeers": ["react"] }, "sha512-zLHuIo52YowFpdCLfO7aCnhzSBm3xyiiCxMhP/YXlaBiC83pRlj6GEeqltmHpB1A4vJvDtNZTfJlz1Q2w08XVw=="],
 
     "@github/copilot-sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/packages/atomic-sdk/src/services/config/additional-instructions.ts
+++ b/packages/atomic-sdk/src/services/config/additional-instructions.ts
@@ -111,6 +111,29 @@ export function getLocalAdditionalInstructionsPath(
 }
 
 /**
+ * Portable form of a resolved AGENTS.md path for OpenCode's `instructions`
+ * array. OpenCode expands a leading `~/` to the user's home dir and resolves
+ * relative paths from the project root, so we can write a machine-independent
+ * entry that's safe to commit to source control:
+ *   - global seed → `~/.atomic/AGENTS.md`
+ *   - project-local override → `.atomic/AGENTS.md` (relative to project root)
+ *
+ * Returns the input unchanged if it doesn't match either of those (defensive
+ * fallback; in practice the resolver only ever returns one of the two).
+ *
+ * Source: opencode `packages/opencode/src/session/instruction.ts` —
+ *   `raw.startsWith("~/") ? path.join(global.home, raw.slice(2)) : raw`,
+ *   then `path.isAbsolute(raw) ? raw : globUp(raw, cwd)`.
+ */
+function toOpencodePortable(absPath: string, projectRoot: string): string {
+  const globalAbs = getGlobalAdditionalInstructionsPath();
+  if (absPath === globalAbs) return "~/.atomic/AGENTS.md";
+  const localAbs = getLocalAdditionalInstructionsPath(projectRoot);
+  if (absPath === localAbs) return ".atomic/AGENTS.md";
+  return absPath;
+}
+
+/**
  * Resolve the effective additional-instructions file for a project.
  *
  * Returns the project-local override if it exists, otherwise the global
@@ -163,11 +186,17 @@ export async function seedGlobalAdditionalInstructions(): Promise<void> {
 
 /**
  * Build a predicate that identifies OpenCode `instructions` entries atomic
- * owns. Matches exact equality against the two paths we ever inject — the
- * global seed (`~/.atomic/AGENTS.md`) and the project-local override
- * (`<projectRoot>/.atomic/AGENTS.md`). A tighter scope than a tail-match
- * ensures legal-but-unusual user entries like `vendor/.atomic/AGENTS.md`
- * are preserved across reconciliation passes.
+ * owns. Matches exact equality against the four forms we may have written:
+ *   - global absolute (legacy) — `<home>/.atomic/AGENTS.md`
+ *   - global portable          — `~/.atomic/AGENTS.md`
+ *   - local absolute (legacy)  — `<projectRoot>/.atomic/AGENTS.md`
+ *   - local portable           — `.atomic/AGENTS.md`
+ *
+ * The legacy absolute forms are matched so existing configs migrate to the
+ * portable form on the next reconcile pass without leaving duplicate entries.
+ *
+ * A tighter scope than a tail-match ensures legal-but-unusual user entries
+ * like `vendor/.atomic/AGENTS.md` are preserved across reconciliation passes.
  */
 function buildAtomicOwnedMatcher(
   projectRoot: string,
@@ -175,6 +204,8 @@ function buildAtomicOwnedMatcher(
   const owned = new Set<string>([
     getGlobalAdditionalInstructionsPath(),
     getLocalAdditionalInstructionsPath(projectRoot),
+    "~/.atomic/AGENTS.md",
+    ".atomic/AGENTS.md",
   ]);
   return (entry: unknown): entry is string =>
     typeof entry === "string" && owned.has(entry);
@@ -207,9 +238,10 @@ function sameInstructionMultiset(
  * file. Strategy:
  *   - Resolve the effective path via {@link resolveAdditionalInstructionsPath}.
  *   - Strip any prior atomic-managed entries (matches `.atomic/AGENTS.md`).
- *   - Append the absolute resolved path. Absolute is fine because OpenCode
- *     happily takes them; we don't expect the user to commit this entry
- *     across machines (and even if they do, the next run reconciles it).
+ *   - Append a portable form via {@link toOpencodePortable} — `~/...` for the
+ *     global seed, a project-relative path for the local override. OpenCode
+ *     expands both at load time, so the resulting `opencode.json` is safe to
+ *     commit and shared across machines without rewriting per-checkout.
  *   - When nothing resolves (file truly missing on this machine), we still
  *     run the cleanup pass so a previously-seeded entry doesn't leak.
  *
@@ -251,7 +283,10 @@ export async function reconcileOpencodeInstructions(
   const preserved = existing.filter((e) => !isAtomicOwned(e));
 
   const resolved = resolveAdditionalInstructionsPath(projectRoot);
-  const next = resolved ? [...preserved, resolved] : preserved;
+  const portable = resolved
+    ? toOpencodePortable(resolved, projectRoot)
+    : undefined;
+  const next = portable ? [...preserved, portable] : preserved;
 
   // Skip the write when the entry set is unchanged — avoids touching mtime
   // on every spawn, keeps the file out of `git status` noise, and preserves

--- a/packages/atomic-sdk/src/services/config/definitions.ts
+++ b/packages/atomic-sdk/src/services/config/definitions.ts
@@ -45,6 +45,15 @@ export interface AgentConfig {
      * destination like `~/.claude/settings.json`.
      */
     excludeConfigKeys?: readonly string[];
+    /**
+     * Top-level keys for which Atomic's source forcibly overwrites the
+     * destination's existing value, opting out of the default
+     * user-precedence merge. Use sparingly — only for keys whose
+     * canonical state is owned by Atomic (e.g. forced security
+     * defaults). Anything else should follow the golden rule and let
+     * the user's value win.
+     */
+    overwriteConfigKeys?: readonly string[];
   }>;
 }
 
@@ -115,7 +124,17 @@ export const AGENT_CONFIG: Record<AgentKey, AgentConfig> = {
     install_url:
       "https://github.com/github/copilot-cli?tab=readme-ov-file#installation",
     exclude: ["workflows", "dependabot.yml"],
-    onboarding_files: [],
+    onboarding_files: [
+      // Workspace `.mcp.json` is shared with Claude — Copilot reads the
+      // same file at the project root. We source it from the `claude`
+      // bundle so a single canonical template ships in both providers.
+      {
+        kind: "claude",
+        source: ".mcp.json",
+        destination: ".mcp.json",
+        merge: true,
+      },
+    ],
   },
 };
 

--- a/packages/atomic/src/commands/cli/init/onboarding.ts
+++ b/packages/atomic/src/commands/cli/init/onboarding.ts
@@ -43,6 +43,7 @@ export async function applyManagedOnboardingFiles(
       destinationPath,
       managedFile.merge,
       managedFile.excludeConfigKeys ?? [],
+      managedFile.overwriteConfigKeys ?? [],
     );
   }
 }

--- a/packages/atomic/src/lib/merge.ts
+++ b/packages/atomic/src/lib/merge.ts
@@ -5,63 +5,89 @@
 import { resolve, dirname } from "node:path";
 import { ensureDir, pathExists, copyFile } from "@bastani/atomic-sdk/services/system/copy";
 
-type McpConfig = Record<string, unknown>;
+type JsonObject = Record<string, unknown>;
 
-/** Keys that hold named-object maps (server registries). */
-const SERVER_MAP_KEYS = ["mcpServers", "servers", "lspServers"] as const;
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
-function stripKeys(config: McpConfig, keys: readonly string[]): McpConfig {
+function stripKeys(config: JsonObject, keys: readonly string[]): JsonObject {
   if (keys.length === 0) return config;
-  const next: McpConfig = { ...config };
+  const next: JsonObject = { ...config };
   for (const key of keys) delete next[key];
   return next;
 }
 
 /**
- * Merge source JSON file into destination JSON file
- * - Preserves all existing keys in destination
- * - Adds/updates keys from source
- * - For MCP server maps: preserves user's servers, adds/updates CLI-managed servers
- * - `excludeKeys` are stripped from the source before merging so they
- *   never propagate to the destination (destination keeps its own value).
+ * Deep-merge `src` into `dst` with user precedence: every conflict
+ * resolves to the destination's existing value. New keys from `src`
+ * are added; nested plain objects recurse so the user can customize
+ * a single field of a nested entry without losing Atomic's other
+ * defaults. Arrays and primitives are atomic — destination wins
+ * outright; we never concat or splice.
+ */
+function deepMergeUserPrecedence(
+  dst: JsonObject,
+  src: JsonObject,
+): JsonObject {
+  const merged: JsonObject = { ...src, ...dst };
+  for (const key of Object.keys(src)) {
+    const dstValue = dst[key];
+    const srcValue = src[key];
+    if (isPlainObject(dstValue) && isPlainObject(srcValue)) {
+      merged[key] = deepMergeUserPrecedence(dstValue, srcValue);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Merge `srcPath` into `destPath` following the project's golden rule:
+ * user (destination) values win on every conflict, except for keys
+ * listed in `overwriteKeys` which Atomic forcibly replaces.
+ *
+ * - `excludeKeys`: stripped from the source before merging — destination
+ *   keeps whatever value (if any) it already has.
+ * - `overwriteKeys`: top-level keys for which Atomic's value replaces
+ *   the destination's outright. Use sparingly — the default is
+ *   user precedence.
  *
  * @param srcPath Path to source JSON file
- * @param destPath Path to destination JSON file (will be modified in place)
+ * @param destPath Path to destination JSON file (modified in place)
  * @param excludeKeys Top-level source keys to drop before merging
+ * @param overwriteKeys Top-level source keys that overwrite destination
  */
 export async function mergeJsonFile(
   srcPath: string,
   destPath: string,
   excludeKeys: readonly string[] = [],
+  overwriteKeys: readonly string[] = [],
 ): Promise<void> {
   if (resolve(srcPath) === resolve(destPath)) {
     return;
   }
 
-  const [rawSrcConfig, destConfig] = await Promise.all([
-    Bun.file(srcPath).json() as Promise<McpConfig>,
-    Bun.file(destPath).json() as Promise<McpConfig>,
+  const [rawSrc, dest] = await Promise.all([
+    Bun.file(srcPath).json() as Promise<JsonObject>,
+    Bun.file(destPath).json() as Promise<JsonObject>,
   ]);
 
-  const srcConfig = stripKeys(rawSrcConfig, excludeKeys);
+  const src = stripKeys(rawSrc, excludeKeys);
 
-  // Merge top-level config - preserve destination's other keys
-  const mergedConfig: McpConfig = {
-    ...destConfig,
-    ...srcConfig,
-  };
-
-  // Server maps are merged individually so the destination's existing
-  // entries are preserved while source entries are added or updated.
-  for (const key of SERVER_MAP_KEYS) {
-    const dst = destConfig[key] as Record<string, unknown> | undefined;
-    const src = srcConfig[key] as Record<string, unknown> | undefined;
-    if (dst || src) {
-      mergedConfig[key] = { ...dst, ...src };
-    }
+  const overwrite = new Set(overwriteKeys);
+  const userMergeable: JsonObject = {};
+  const atomicOverrides: JsonObject = {};
+  for (const [key, value] of Object.entries(src)) {
+    if (overwrite.has(key)) atomicOverrides[key] = value;
+    else userMergeable[key] = value;
   }
 
-  await Bun.write(destPath, JSON.stringify(mergedConfig, null, 2) + "\n");
+  const merged = deepMergeUserPrecedence(dest, userMergeable);
+  for (const [key, value] of Object.entries(atomicOverrides)) {
+    merged[key] = value;
+  }
+
+  await Bun.write(destPath, JSON.stringify(merged, null, 2) + "\n");
 }
 
 /**
@@ -69,8 +95,8 @@ export async function mergeJsonFile(
  *
  * - Creates the destination's parent directory if needed
  * - When the destination exists and `merge` is true (the default),
- *   merges via {@link mergeJsonFile} (source keys win, server maps
- *   are merged individually)
+ *   merges via {@link mergeJsonFile} (user precedence by default;
+ *   `overwriteKeys` opts specific keys into Atomic-wins behavior)
  * - Otherwise copies the source as-is
  * - `excludeKeys` drops top-level keys from the source before writing,
  *   so they never land in the destination (applies to both the merge
@@ -84,11 +110,12 @@ export async function syncJsonFile(
   destPath: string,
   merge: boolean = true,
   excludeKeys: readonly string[] = [],
+  overwriteKeys: readonly string[] = [],
 ): Promise<void> {
   await ensureDir(dirname(destPath));
 
   if (merge && (await pathExists(destPath))) {
-    await mergeJsonFile(srcPath, destPath, excludeKeys);
+    await mergeJsonFile(srcPath, destPath, excludeKeys, overwriteKeys);
     return;
   }
 
@@ -97,7 +124,7 @@ export async function syncJsonFile(
     return;
   }
 
-  const srcConfig = (await Bun.file(srcPath).json()) as McpConfig;
+  const srcConfig = (await Bun.file(srcPath).json()) as JsonObject;
   const stripped = stripKeys(srcConfig, excludeKeys);
   await Bun.write(destPath, JSON.stringify(stripped, null, 2) + "\n");
 }

--- a/tests/ci/_helpers/binary.ts
+++ b/tests/ci/_helpers/binary.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared helpers for CI integration tests that exercise the compiled
+ * `atomic` binary. Centralised so multiple test files can re-use one
+ * build artifact instead of rebuilding per-suite (Windows in particular
+ * holds the .exe open after spawn, so a second build attempt while a
+ * previous test holds it racing-EACCESes).
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { TARGETS, hostTarget } from "../../../packages/atomic/script/targets.ts";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
+
+/**
+ * Resolve the host-platform compiled binary path. Mirrors `build.ts` —
+ * `dist/<target>/bin/atomic[.exe]` with the same target keys exposed
+ * by `targets.ts` so a target rename in one place propagates here.
+ */
+export function getBinaryPath(): string {
+  const target = hostTarget();
+  const meta = TARGETS.find((t) => t.name === target);
+  if (!meta) {
+    throw new Error(`Unknown host target "${target}". Update TARGETS.`);
+  }
+  return join(REPO_ROOT, "packages", "atomic", "dist", target, "bin", `atomic${meta.ext ?? ""}`);
+}
+
+let binaryReady = false;
+
+/**
+ * Build the host-platform binary if it doesn't already exist. Memoised
+ * so multiple tests sharing the same process pay the cost once.
+ *
+ * Build target is implicit (build.ts defaults to host) so this works on
+ * every CI runner without per-platform branching.
+ */
+export function ensureBinary(): void {
+  if (binaryReady) return;
+
+  const binaryPath = getBinaryPath();
+  if (existsSync(binaryPath)) {
+    binaryReady = true;
+    return;
+  }
+
+  const buildScript = join(REPO_ROOT, "packages", "atomic", "script", "build.ts");
+  const result = spawnSync("bun", [buildScript], {
+    stdio: "inherit",
+    cwd: REPO_ROOT,
+    timeout: 600_000,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`build.ts exited with status ${result.status ?? "null"}`);
+  }
+  binaryReady = true;
+}

--- a/tests/ci/mcp-bundle-source.test.ts
+++ b/tests/ci/mcp-bundle-source.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Drift guard: the bundled-template `.claude/.mcp.json` must match the
+ * project-root `.mcp.json`.
+ *
+ * Why this matters
+ * ────────────────
+ *   - `.mcp.json` at the repo root is what Atomic's own dogfood agents
+ *     (Claude Code, Copilot CLI) read when they run *inside this repo*.
+ *   - `.claude/.mcp.json` is what gets bundled into `.claude.tar` and
+ *     shipped to fresh user projects via `applyManagedOnboardingFiles`
+ *     (sourced as `kind: "claude", source: ".mcp.json"` in
+ *     `definitions.ts` for both claude and copilot).
+ *
+ * If those two drift, fresh user projects get a stale or wrong `.mcp.json`
+ * even though every dev locally sees Atomic working fine. The bug
+ * surfaces only on a `git clone` + `atomic chat -a copilot`.
+ *
+ * Failure mode caught by this test:
+ *   - The original mcp-setup hotfix added copilot to the onboarding
+ *     manifest but never created `.claude/.mcp.json` — `pathExists` on
+ *     the bundle-source returned false, `applyManagedOnboardingFiles`
+ *     silently skipped the copy, and `.mcp.json` was missing from
+ *     every fresh project on every platform. A cheap byte-equality
+ *     check at PR time would have caught it before the E2E matrix.
+ *
+ * Cheap to run, runs in the standard PR suite (no `RUN_CI_E2E` gate).
+ */
+
+import { test, expect } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const ROOT_MCP = join(REPO_ROOT, ".mcp.json");
+const BUNDLE_MCP = join(REPO_ROOT, ".claude", ".mcp.json");
+
+test("`.claude/.mcp.json` exists — the bundled template that ships in `.claude.tar`", () => {
+  expect(
+    existsSync(BUNDLE_MCP),
+    `Missing ${BUNDLE_MCP}. Without this file the build's tar bundle has no .mcp.json source, ` +
+      `and applyManagedOnboardingFiles will silently skip the copy for both claude and copilot.`,
+  ).toBe(true);
+});
+
+test("`.mcp.json` (repo root) and `.claude/.mcp.json` (bundle source) parse to the same JSON", async () => {
+  expect(existsSync(ROOT_MCP), `Missing ${ROOT_MCP}`).toBe(true);
+  expect(existsSync(BUNDLE_MCP), `Missing ${BUNDLE_MCP}`).toBe(true);
+
+  const [rootJson, bundleJson] = await Promise.all([
+    Bun.file(ROOT_MCP).json(),
+    Bun.file(BUNDLE_MCP).json(),
+  ]);
+
+  // Compare parsed JSON rather than raw bytes so trailing newline /
+  // whitespace differences don't trigger a false drift. The contract
+  // is "same logical config", not "same file contents".
+  expect(
+    bundleJson,
+    `Bundle template ${BUNDLE_MCP} has drifted from project-root ${ROOT_MCP}. ` +
+      `Re-sync them — fresh user projects will receive whatever's in the bundle copy.`,
+  ).toEqual(rootJson);
+});

--- a/tests/ci/onboarding.test.ts
+++ b/tests/ci/onboarding.test.ts
@@ -1,169 +1,214 @@
 /**
- * G3 Onboarding-on-compiled-binary integration test — RFC §8.3
+ * Onboarding-on-compiled-binary integration test — cross-platform.
  *
- * Guards against regressions where `applyManagedOnboardingFiles` and
- * `ensureAtomicGlobalAgentConfigs` silently no-op because the embedded-asset
- * resolver points to the wrong path after the package split.
+ * Guards against two classes of regression:
  *
- * Only runs when:
- *   - process.platform === "linux" && process.arch === "x64"
+ *   1. Provider-config initialisation in a fresh project. Every agent's
+ *      declared `onboarding_files` (see `AGENT_CONFIG`) must materialise
+ *      on disk after `atomic chat -a <agent> --preflight-only`. The
+ *      original mcp-setup bug was a silent omission in this list —
+ *      copilot shipped with `onboarding_files: []` so `.mcp.json` never
+ *      landed at the project root.
+ *
+ *   2. Embedded-asset resolver drift across the per-platform package
+ *      split (linux-x64, darwin-arm64, …). The compiled binary's tar
+ *      bundles must extract through the same code path on every OS;
+ *      a regression that points the resolver at a non-existent path
+ *      would no-op `applyManagedOnboardingFiles` and leave a fresh
+ *      project without any provider config.
+ *
+ * Runs only when:
  *   - RUN_CI_E2E=1 is set (slow build; never bloats the fast suite)
  *
- * Invocation strategy: `atomic chat -a claude --preflight-only`
- *   A `--preflight-only` flag was added to `atomic chat` specifically for this
- *   test. It runs `ensureAtomicGlobalAgentConfigs` + `ensureProjectSetup`
- *   (applyManagedOnboardingFiles) without checking that the agent CLI is
- *   installed or that the user is authenticated, then exits 0. This is the
- *   minimal change needed: no interactive UI, no agent binary required, fully
- *   exercising the post-split resolver code path.
+ * The build is host-target only — each CI runner builds for its own
+ * platform and exercises the binary it produced. That gives us real
+ * Linux × macOS × Windows coverage without cross-compile flakiness.
+ *
+ * Invocation: `atomic chat -a <agent> --preflight-only` runs the
+ * preflight steps (global config sync + project onboarding) then exits
+ * 0. The `--preflight-only` flag intentionally skips the agent-binary
+ * existence check and the auth probe so this works on a runner where
+ * none of claude/copilot/opencode is installed.
  */
 
-import { test, expect, afterAll } from "bun:test";
-import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { test, expect, afterAll, describe } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { tmpdir, homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { ensureBinary, getBinaryPath } from "./_helpers/binary.ts";
 
-// ─── Skip guards ────────────────────────────────────────────────────────────
+// ─── Skip guard ──────────────────────────────────────────────────────────────
 
-const isLinuxX64 = process.platform === "linux" && process.arch === "x64";
 const isE2EEnabled = process.env.RUN_CI_E2E === "1";
 
-// ─── Paths ───────────────────────────────────────────────────────────────────
+// ─── Sandbox ─────────────────────────────────────────────────────────────────
 
-interface SandboxPaths {
-  /** Temporary project root — onboarding files land here. */
+interface Sandbox {
+  /** Temporary project root — project-scoped onboarding files land here. */
   projectRoot: string;
-  /** Passed as ATOMIC_SETTINGS_HOME — installGlobalAgents writes here. */
+  /** HOME / ATOMIC_SETTINGS_HOME override — global onboarding files land here. */
   settingsHome: string;
 }
 
-// ─── Shared sandbox state ────────────────────────────────────────────────────
-
-let sandbox: SandboxPaths | null = null;
+const sandboxes: Sandbox[] = [];
 
 afterAll(async () => {
-  if (sandbox) {
-    await rm(sandbox.projectRoot, { recursive: true, force: true });
-    await rm(sandbox.settingsHome, { recursive: true, force: true });
-    sandbox = null;
-  }
+  await Promise.all(
+    sandboxes.map(async (s) => {
+      await rm(s.projectRoot, { recursive: true, force: true });
+      await rm(s.settingsHome, { recursive: true, force: true });
+    }),
+  );
+  sandboxes.length = 0;
 });
 
-// ─── Build helper ────────────────────────────────────────────────────────────
+async function createSandbox(label: string): Promise<Sandbox> {
+  const projectRoot = await mkdtemp(join(tmpdir(), `atomic-onboarding-${label}-proj-`));
+  const settingsHome = await mkdtemp(join(tmpdir(), `atomic-onboarding-${label}-home-`));
+  const sandbox = { projectRoot, settingsHome };
+  sandboxes.push(sandbox);
+  return sandbox;
+}
 
-const REPO_ROOT = join(import.meta.dir, "../..");
-const BINARY_PATH = join(REPO_ROOT, "packages/atomic/dist/linux-x64/bin/atomic");
-const BUILD_SCRIPT = join(REPO_ROOT, "packages/atomic/script/build.ts");
+interface PreflightResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
 
 /**
- * Build the linux-x64 binary if it doesn't exist. Accepts the target name as
- * the first argument to build.ts so only one target is compiled rather than
- * all six.
+ * Spawn the compiled binary in preflight mode against the given agent.
+ *
+ * Env isolation:
+ *   - `HOME` / `USERPROFILE` → consumed by `homedir()`, used by
+ *     `applyManagedOnboardingFiles`'s `~/...` destination resolver.
+ *   - `ATOMIC_SETTINGS_HOME` → consumed by `getSettingsHome`, used by
+ *     `installGlobalAgents`, skills sync, the auto-sync marker.
+ *   - `XDG_CACHE_HOME` (Linux) / `LOCALAPPDATA` (Windows) → consumed by
+ *     `cacheRoot()` in `embedded-assets.ts` to locate the bundle
+ *     extraction cache. Forcing them inside the sandbox prevents a
+ *     stale extraction from a previous version-matched run masking
+ *     a regression in the bundle contents.
+ *
+ * Setting all of them keeps every read AND write inside the sandbox so
+ * the test never pollutes the developer's real home and never picks up
+ * a cached bundle extracted by a prior test run.
  */
-function ensureBinary(): void {
-  if (existsSync(BINARY_PATH)) return;
-
+function runPreflight(agent: string, sandbox: Sandbox): PreflightResult {
   const result = spawnSync(
-    "bun",
-    [BUILD_SCRIPT, "linux-x64"],
+    getBinaryPath(),
+    ["chat", "-a", agent, "--preflight-only"],
     {
-      stdio: "inherit",
-      cwd: REPO_ROOT,
-      timeout: 300_000, // 5 min
+      cwd: sandbox.projectRoot,
+      env: {
+        ...process.env,
+        ATOMIC_SETTINGS_HOME: sandbox.settingsHome,
+        HOME: sandbox.settingsHome,
+        USERPROFILE: sandbox.settingsHome,
+        XDG_CACHE_HOME: join(sandbox.settingsHome, ".cache"),
+        LOCALAPPDATA: join(sandbox.settingsHome, "AppData", "Local"),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 120_000,
     },
   );
-
-  if (result.status !== 0) {
-    throw new Error(`build.ts exited with status ${result.status ?? "null"}`);
-  }
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout?.toString() ?? "",
+    stderr: result.stderr?.toString() ?? "",
+  };
 }
+
+/**
+ * Resolve a destination string from `AGENT_CONFIG` against the sandbox.
+ * Mirrors `resolveDestination` in `packages/atomic/src/commands/cli/init/onboarding.ts`,
+ * but redirects `~/` at the sandboxed settings home instead of the real
+ * homedir so we can assert paths without polluting `~`.
+ */
+function resolveSandboxPath(destination: string, sandbox: Sandbox): string {
+  if (destination === "~" || destination.startsWith("~/")) {
+    return join(sandbox.settingsHome, destination.slice(1));
+  }
+  return join(sandbox.projectRoot, destination);
+}
+
+// ─── Per-agent expected outputs ──────────────────────────────────────────────
+//
+// The contract is duplicated here intentionally — the test asserts against
+// hand-written invariants, NOT against AGENT_CONFIG. If a future change
+// silently empties an agent's `onboarding_files`, the test should fail.
+// Importing AGENT_CONFIG would mask exactly that regression.
+
+interface ExpectedFile {
+  /** Path string in the same shape as `AgentConfig.onboarding_files[].destination`. */
+  destination: string;
+  /**
+   * Optional shape check: assert the produced JSON has this top-level key.
+   * Use for keys that prove the file is the canonical template (e.g.
+   * `mcpServers` in `.mcp.json`) rather than an empty stub.
+   */
+  hasTopLevelKey?: string;
+}
+
+const EXPECTED: Record<string, readonly ExpectedFile[]> = {
+  claude: [
+    { destination: ".mcp.json", hasTopLevelKey: "mcpServers" },
+    { destination: ".claude/settings.json" },
+    { destination: "~/.claude/settings.json" },
+  ],
+  copilot: [
+    // Regression guard for the mcp-setup bug: copilot must produce
+    // `.mcp.json` at the project root. Keep `hasTopLevelKey` so a
+    // future "fix" that writes an empty `{}` stub still fails.
+    { destination: ".mcp.json", hasTopLevelKey: "mcpServers" },
+  ],
+  opencode: [{ destination: ".opencode/opencode.json" }],
+} as const;
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
-test.skipIf(!isLinuxX64 || !isE2EEnabled)(
-  "G3: binary produces project onboarding files and global agent configs",
-  async () => {
-    // Create sandbox dirs
-    const projectRoot = await mkdtemp(join(tmpdir(), "atomic-onboarding-proj-"));
-    const settingsHome = await mkdtemp(join(tmpdir(), "atomic-onboarding-home-"));
-    sandbox = { projectRoot, settingsHome };
+describe.skipIf(!isE2EEnabled)("onboarding preflight (compiled binary)", () => {
+  for (const [agent, expectedFiles] of Object.entries(EXPECTED)) {
+    test(
+      `${agent}: preflight materialises every declared onboarding file`,
+      async () => {
+        ensureBinary();
+        const sandbox = await createSandbox(agent);
 
-    // Build binary if missing
-    ensureBinary();
+        const result = runPreflight(agent, sandbox);
+        expect(
+          result.exitCode,
+          `binary exited ${result.exitCode}.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+        ).toBe(0);
 
-    // Spawn binary: preflight-only mode against the claude agent.
-    // stdin closed, stdout/stderr captured. The command runs
-    // ensureAtomicGlobalAgentConfigs + applyManagedOnboardingFiles then exits 0.
-    const result = spawnSync(
-      BINARY_PATH,
-      ["chat", "-a", "claude", "--preflight-only"],
-      {
-        cwd: projectRoot,
-        env: {
-          ...process.env,
-          ATOMIC_SETTINGS_HOME: settingsHome,
-          // XDG_CACHE_HOME: keep default so embedded-asset cache works in real home
-        },
-        stdio: ["pipe", "pipe", "pipe"],
-        timeout: 60_000,
+        for (const file of expectedFiles) {
+          const path = resolveSandboxPath(file.destination, sandbox);
+          expect(
+            existsSync(path),
+            `Expected ${agent} onboarding file at ${path} (declared as ${file.destination})`,
+          ).toBe(true);
+
+          if (file.hasTopLevelKey) {
+            const parsed = (await Bun.file(path).json()) as Record<string, unknown>;
+            expect(
+              parsed[file.hasTopLevelKey],
+              `${path} must contain top-level "${file.hasTopLevelKey}" — missing means the bundle template wasn't materialised`,
+            ).toBeDefined();
+          }
+        }
       },
     );
+  }
+});
 
-    const stdout = result.stdout?.toString() ?? "";
-    const stderr = result.stderr?.toString() ?? "";
-    const exitCode = result.status ?? -1;
-
-    // Should exit 0
-    expect(
-      exitCode,
-      `binary exited ${exitCode}. stdout: ${stdout} stderr: ${stderr}`,
-    ).toBe(0);
-
-    // ── Assert: project-level onboarding files ──────────────────────────────
-    // Claude's onboarding_files declares:
-    //   kind=claude  source=settings.json  destination=.claude/settings.json
-    const claudeProjectSettings = join(projectRoot, ".claude", "settings.json");
-    expect(
-      existsSync(claudeProjectSettings),
-      `Expected project onboarding file at ${claudeProjectSettings}`,
-    ).toBe(true);
-
-    // ── Assert: global agent configs (installGlobalAgents path) ─────────────
-    // installGlobalAgents respects ATOMIC_SETTINGS_HOME and writes
-    // $ATOMIC_SETTINGS_HOME/.claude/agents/  and siblings.
-    //
-    // autoSyncIfStale → installGlobalAgents runs on every non-info command
-    // invocation from a compiled binary. The marker path also honors
-    // ATOMIC_SETTINGS_HOME so the marker won't match and sync will run.
-    const globalAgentsDir = join(settingsHome, ".claude", "agents");
-    if (existsSync(globalAgentsDir)) {
-      const agentFiles = await readdir(globalAgentsDir);
-      expect(
-        agentFiles.length,
-        `Expected at least one agent file in ${globalAgentsDir}`,
-      ).toBeGreaterThan(0);
-    } else {
-      // installGlobalAgents may not have run if the marker already matched;
-      // fall back to asserting the real ~/.claude/agents exists (written by
-      // ensureAtomicGlobalAgentConfigs, which uses the real homedir).
-      const realGlobalAgentsDir = join(homedir(), ".claude", "agents");
-      expect(
-        existsSync(realGlobalAgentsDir),
-        `Neither sandboxed ${globalAgentsDir} nor real ${realGlobalAgentsDir} exists. ` +
-          "ensureAtomicGlobalAgentConfigs did not write any global agent files.",
-      ).toBe(true);
-    }
-  },
-);
-
-// ─── Placeholder for non-linux-x64 hosts ─────────────────────────────────────
-
-test.skipIf(isLinuxX64)(
-  "G3 [skip on non-linux-x64]: onboarding integration test not applicable to this platform",
+// Marker test so a CI runner with the gate off still produces a green
+// "tests ran" signal in this file (avoids zero-test ambiguity in
+// dashboards).
+test.skipIf(isE2EEnabled)(
+  "onboarding preflight [skip when RUN_CI_E2E unset]",
   () => {
-    // No-op: confirms the test file loads without errors on other platforms.
     expect(true).toBe(true);
   },
 );

--- a/tests/lib/merge.test.ts
+++ b/tests/lib/merge.test.ts
@@ -80,3 +80,114 @@ describe("syncJsonFile excludeKeys", () => {
     expect(result.disabledMcpjsonServers).toEqual(["azure-devops"]);
   });
 });
+
+describe("mergeJsonFile user precedence", () => {
+  test("destination value wins on conflicting top-level scalar", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, { permission: "deny" });
+    await writeJson(dest, { permission: "allow" });
+
+    await mergeJsonFile(src, dest);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.permission).toBe("allow");
+  });
+
+  test("adds missing top-level keys from source", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, { addedKey: 1, sharedKey: "src" });
+    await writeJson(dest, { sharedKey: "dst", existing: true });
+
+    await mergeJsonFile(src, dest);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.addedKey).toBe(1);
+    expect(result.sharedKey).toBe("dst");
+    expect(result.existing).toBe(true);
+  });
+
+  test("deep-merges nested objects with destination winning on conflict", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, {
+      mcpServers: {
+        "github-mcp-server": {
+          type: "http",
+          url: "https://api.githubcopilot.com/mcp",
+          headers: { Authorization: "Bearer ${GH_TOKEN}" },
+        },
+      },
+    });
+    await writeJson(dest, {
+      mcpServers: {
+        "github-mcp-server": {
+          headers: { Authorization: "Bearer user-token" },
+        },
+        "user-server": { command: "x" },
+      },
+    });
+
+    await mergeJsonFile(src, dest);
+
+    const result = await readJson<{
+      mcpServers: Record<string, Record<string, unknown>>;
+    }>(dest);
+    const gh = result.mcpServers["github-mcp-server"];
+    expect(gh?.type).toBe("http");
+    expect(gh?.url).toBe("https://api.githubcopilot.com/mcp");
+    expect(gh?.headers).toEqual({ Authorization: "Bearer user-token" });
+    expect(result.mcpServers["user-server"]).toEqual({ command: "x" });
+  });
+
+  test("treats arrays as atomic — destination array wins outright", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, { servers: ["a", "b"] });
+    await writeJson(dest, { servers: ["user-only"] });
+
+    await mergeJsonFile(src, dest);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.servers).toEqual(["user-only"]);
+  });
+});
+
+describe("mergeJsonFile overwriteKeys", () => {
+  test("source replaces destination for keys flagged as overwrite", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, {
+      atomicOwned: { canonical: true },
+      userOwned: { keep: "user" },
+    });
+    await writeJson(dest, {
+      atomicOwned: { canonical: false, leftover: 1 },
+      userOwned: { keep: "user-edit" },
+    });
+
+    await mergeJsonFile(src, dest, [], ["atomicOwned"]);
+
+    const result = await readJson<Record<string, Record<string, unknown>>>(
+      dest,
+    );
+    expect(result.atomicOwned).toEqual({ canonical: true });
+    expect(result.userOwned?.keep).toBe("user-edit");
+  });
+});
+
+describe("syncJsonFile overwriteKeys", () => {
+  test("forwards overwriteKeys to merge when destination exists", async () => {
+    const src = join(tmp, "src.json");
+    const dest = join(tmp, "dest.json");
+    await writeJson(src, { atomicOwned: ["a"], userOwned: ["src"] });
+    await writeJson(dest, { atomicOwned: ["dst"], userOwned: ["dst"] });
+
+    await syncJsonFile(src, dest, true, [], ["atomicOwned"]);
+
+    const result = await readJson<Record<string, unknown>>(dest);
+    expect(result.atomicOwned).toEqual(["a"]);
+    expect(result.userOwned).toEqual(["dst"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a silent regression where Copilot's \`onboarding_files\` was empty, causing fresh projects to never receive \`.mcp.json\`. The fix lands alongside a merge-engine rework (user-precedence deep merge), portable OpenCode instruction paths, a bundle drift guard, and a cross-platform CI matrix for the onboarding contract test.

## Key Changes

### Bug Fixes
- **Copilot \`onboarding_files\` was empty** — fresh \`atomic chat -a copilot\` never wrote \`.mcp.json\` to the project root. Copilot now sources the same canonical \`.mcp.json\` template as the claude bundle (\`kind: "claude", source: ".mcp.json"\`).
- **Portable OpenCode \`instructions\`** — reconciler now writes \`~/.atomic/AGENTS.md\` / \`.atomic/AGENTS.md\` instead of absolute paths. Configs are safe to commit across machines; legacy absolute entries auto-migrate on the next reconcile pass.

### Merge Engine Rework (\`packages/atomic/src/lib/merge.ts\`)
- \`mergeJsonFile\` now **deep-merges with user precedence**: destination wins on every conflict; nested plain objects recurse, arrays are atomic (destination wins outright).
- Adds an opt-in \`overwriteConfigKeys\` parameter for top-level keys Atomic forcibly owns (e.g. forced security defaults). Everything else follows the golden rule — user value wins.
- Drops the old hard-coded \`mcpServers\` / \`servers\` / \`lspServers\` special-case allowlist in favour of the general recursive strategy.

### Bundle Template & Drift Guard
- Adds \`.claude/.mcp.json\` as the bundled source template shipped in \`.claude.tar\`. Without this file \`applyManagedOnboardingFiles\` silently skips the copy for both claude and copilot.
- New \`tests/ci/mcp-bundle-source.test.ts\` asserts \`.claude/.mcp.json\` stays in sync with the repo-root \`.mcp.json\` (JSON-equality, no \`RUN_CI_E2E\` gate). Catches the exact class of drift that caused this bug.

### Cross-Platform CI (\`onboarding-matrix\`)
- New GitHub Actions job runs \`tests/ci/onboarding.test.ts\` on **ubuntu-latest / macos-latest / windows-latest**. The old test was Linux x64-only.
- Test now covers all three agents (claude, copilot, opencode), not just claude, with hand-written invariants rather than re-importing \`AGENT_CONFIG\` (so a silent empty-list regression still fails).
- Shared \`tests/ci/_helpers/binary.ts\` memoises the build step per-process — avoids a Windows EACCES race from building the same \`.exe\` twice.

## Test Plan

- [x] \`bun test tests/lib/merge.test.ts\` — user-precedence + overwriteKeys
- [x] \`bun test tests/ci/mcp-bundle-source.test.ts\` — bundle drift guard
- [ ] CI \`onboarding-matrix\` (ubuntu / macos / windows) — exercises the compiled binary's onboarding code path for all three agents
- [ ] Manually verify a fresh project root receives \`.mcp.json\` after \`atomic chat -a copilot --preflight-only\`
- [ ] Verify \`.opencode/opencode.json\` \`instructions\` round-trips as \`~/.atomic/AGENTS.md\` (no absolute path leak)