### PR TITLE
chore(release): bump version to v0.7.6-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.5",
+  "version": "0.7.6-0",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6-0",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Bumps the monorepo version from `v0.7.5` to `v0.7.6-0` (prerelease) in preparation for the next minor release cycle.

## Changes

- `package.json` — root monorepo version: `0.7.5` → `0.7.6-0`
- `packages/atomic/package.json` — `@bastani/atomic` version: `0.7.5` → `0.7.6-0`
- `packages/atomic-sdk/package.json` — `@bastani/atomic-sdk` version: `0.7.5` → `0.7.6-0`

## Notes

This is a prerelease (`-0` suffix) branch. Once merged, the GitHub Release workflow will publish the prerelease to npm automatically.

## Test plan
- [x] CI passes