### PR TITLE
fix(tests): raise onboarding preflight test timeout to 120s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.6-0",
+  "version": "0.7.6",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.6-0",
+  "version": "0.7.6",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.6-0",
+  "version": "0.7.6",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",

--- a/tests/ci/onboarding.test.ts
+++ b/tests/ci/onboarding.test.ts
@@ -199,6 +199,10 @@ describe.skipIf(!isE2EEnabled)("onboarding preflight (compiled binary)", () => {
           }
         }
       },
+      // Compiled-binary cold start + tar bundle extraction exceeds Bun's
+      // 5s default on macOS/Windows runners; mirror runPreflight's internal
+      // 120s subprocess timeout so the test wrapper isn't the limiting factor.
+      120_000,
     );
   }
 });


### PR DESCRIPTION
## Summary

Raise the Bun test-wrapper timeout for `onboarding preflight (compiled binary)` tests from the default 5 s to 120 s, matching `runPreflight`'s internal subprocess timeout.

## Key Changes

- **`tests/ci/onboarding.test.ts`**: Pass `120_000` ms as the timeout argument to the `test()` callback so the test wrapper is no longer the gating factor for slow cold-cache runs.

## Root Cause

Bun's 5 s default test timeout was killing `spawnSync` mid-flight on macOS and Windows CI runners. Compiled-binary cold start + embedded-asset tar bundle extraction routinely exceeds 5 s on cold caches, causing every preflight test to exit with code -1 and report `"this test timed out after 5000ms"` / `"killed 1 dangling process"`.

## Test Plan

- [x] CI green on `macos-latest` and `windows-latest` Onboarding preflight jobs