### PR TITLE
fix(build-assets): exclude .claude/skills symlink from bundle to fix Windows install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.7.7-0",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.6",
+  "version": "0.7.7-0",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.7.7-0",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",

--- a/packages/atomic/script/build-assets.ts
+++ b/packages/atomic/script/build-assets.ts
@@ -37,7 +37,13 @@ export async function bundleEmbeddedAssets(rootDir: string): Promise<void> {
   await mkdir(join(rootDir, ".agents"), { recursive: true });
 
   const archives: ArchiveSpec[] = [
-    { outPath: join(rootDir, ".claude.tar"),           leafDir: join(rootDir, ".claude") },
+    { outPath: join(rootDir, ".claude.tar"),           leafDir: join(rootDir, ".claude"),
+      // `.claude/skills` is a symlink to `.agents/skills`. Skills ship in
+      // their own bundle (`skills.tar`) and are copied into `~/.claude/skills`
+      // at install time, so the symlink entry is redundant. Excluding it also
+      // avoids extraction failures on Windows accounts without Developer Mode
+      // or admin rights, where bsdtar can't recreate symlinks.
+      excludes: ["skills"] },
     { outPath: join(rootDir, ".opencode.tar"),         leafDir: join(rootDir, ".opencode") },
     { outPath: join(rootDir, ".github.tar"),           leafDir: join(rootDir, ".github"),
       excludes: ["workflows", "dependabot.yml"] },


### PR DESCRIPTION
## Summary

Excludes the `.claude/skills` symlink from `.claude.tar` to fix extraction failures on Windows accounts that lack Developer Mode or admin rights. This is a prerelease bump to v0.7.7-0.

## Key Changes

- **`packages/atomic/script/build-assets.ts`**: Adds `excludes: ["skills"]` to the `.claude.tar` archive spec so the `.claude/skills → ../.agents/skills` symlink is never packed into the bundle
- **Version bump**: All packages updated from `0.7.6` → `0.7.7-0`

## Root Cause

`bsdtar`'s `CreateSymbolicLinkW` fails with "Invalid argument" on Windows unless the user has Developer Mode enabled or runs as administrator. The `.claude/skills` entry was being archived as a symlink, so any standard Windows user hit `getEmbeddedAsset: tar failed for claude (exit 1)` on first install.

## Why It's Safe to Exclude

Skills already ship via the dedicated `skills.tar` bundle. At install time, `copyDir` copies them into `~/.claude/skills` directly — the symlink was purely redundant. Removing it has no runtime effect on any platform.

## Test Plan

- [x] Rebuilt all four bundles; verified `tar -tf .claude.tar | grep skill` is empty
- [x] Audited `.opencode` and `.github` for symlinks — only `.claude/skills` is one
- [ ] Validate matrix in `publish.yml` runs the full Windows install lifecycle against a verdaccio-published copy