### PR TITLE
fix(build-assets): exclude .claude/skills symlink from .claude.tar bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.7-0",
+  "version": "0.7.7",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.7-0",
+  "version": "0.7.7",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.7-0",
+  "version": "0.7.7",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Fixes `getEmbeddedAsset: tar failed for claude (exit 1)` on Windows by excluding the `.claude/skills` symlink entry from `.claude.tar`. On standard Windows accounts (without Developer Mode or admin rights), bsdtar's `CreateSymbolicLinkW` fails with "Invalid argument" when recreating symlinks, breaking first-time extraction for all non-elevated users.

## Changes

- **`packages/atomic/script/build-assets.ts`** — adds `excludes: ["skills"]` to the `.claude.tar` archive spec, filtering out the `.claude/skills → ../.agents/skills` symlink entry before it reaches bsdtar
- **`package.json` / `packages/atomic/package.json` / `packages/atomic-sdk/package.json`** — version bump to v0.7.7

## Why this is safe

Skills already ship in their own `skills.tar` bundle and are copied (not symlinked) into `~/.claude/skills` at install time via `copyDir`. The excluded symlink entry was purely redundant — removing it has no runtime effect on any platform.

## Test plan
- [x] Rebuilt all four bundles; verified `tar -tf .claude.tar | grep skill` is empty
- [x] Audited `.opencode` and `.github` for symlinks — only `.claude/skills` is one
- [ ] Validate matrix in `publish.yml` runs the full Windows install lifecycle against a verdaccio-published copy