### PR TITLE
chore(examples): bump examples to v0.7.8 and atomic-sdk ^0.7.8

### DIFF
--- a/examples/claude-background-subagents/package.json
+++ b/examples/claude-background-subagents/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@bastani/example-claude-background-subagents",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Stage 1 spawns 3 background subagents and ends its turn immediately; stage 2 verifies they all finished before it started.",
   "scripts": {
     "claude": "bun run claude-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/commander-embed/package.json
+++ b/examples/commander-embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-commander-embed",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Mount an atomic workflow under a parent Commander CLI alongside plain Commander commands",
   "scripts": {
@@ -10,7 +10,7 @@
     "status": "bun run cli.ts status"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/headless-test/package.json
+++ b/examples/headless-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-headless-test",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Visible seed -> 3 parallel headless stages -> visible merge -> headless verdict",
   "scripts": {
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0"
   }

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-hello-world",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Minimal single-session workflow with structured inputs (greeting, style, optional notes)",
   "scripts": {
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/hil-favorite-color-headless/package.json
+++ b/examples/hil-favorite-color-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-hil-favorite-color-headless",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "HIL pause inside a headless stage",
   "scripts": {
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/hil-favorite-color/package.json
+++ b/examples/hil-favorite-color/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-hil-favorite-color",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Human-in-the-loop prompt mid-workflow",
   "scripts": {
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/multi-workflow/package.json
+++ b/examples/multi-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-multi-workflow",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Two Claude workflows (hello, goodbye) under one cli.ts — Commander subcommand per registered workflow",
   "scripts": {
@@ -10,7 +10,7 @@
     "goodbye": "bun run cli.ts goodbye"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/pane-navigation/package.json
+++ b/examples/pane-navigation/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@bastani/example-pane-navigation",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Driver CLI for the SDK pane-navigation primitives (start / list / status / next / prev / home / attach / stop)",
   "scripts": {
     "start": "bun run cli.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/parallel-hello-world/package.json
+++ b/examples/parallel-hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-parallel-hello-world",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Promise.all() fan-out and transcript merge across parallel stages",
   "scripts": {
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/review-fix-loop/package.json
+++ b/examples/review-fix-loop/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@bastani/example-review-fix-loop",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Draft -> loop(review -> fix) with bounded iterations and early exit on a CLEAN verdict",
   "scripts": {
     "claude": "bun run claude-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/reviewer-tool-test/package.json
+++ b/examples/reviewer-tool-test/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@bastani/example-reviewer-tool-test",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Custom reviewer tool wiring (Copilot)",
   "scripts": {
     "copilot": "bun run copilot-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",
     "zod": "^4.4.3"

--- a/examples/sequential-describe-summarize/package.json
+++ b/examples/sequential-describe-summarize/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@bastani/example-sequential-describe-summarize",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Two stages passing data via s.save() -> s.transcript(handle) — the canonical handoff pattern",
   "scripts": {
     "claude": "bun run claude-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0"
   }
 }

--- a/examples/structured-output-demo/package.json
+++ b/examples/structured-output-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-structured-output-demo",
   "private": true,
-  "version": "0.7.4",
+  "version": "0.7.8",
   "type": "module",
   "description": "Per-SDK structured output (JSON-schema validation, Zod)",
   "scripts": {
@@ -10,7 +10,7 @@
     "opencode": "bun run opencode-worker.ts"
   },
   "dependencies": {
-    "@bastani/atomic-sdk": "^0.7.5",
+    "@bastani/atomic-sdk": "^0.7.8",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Summary

Sync all 13 example packages with the latest SDK release (v0.7.8).

## Changes

- Bump `version` field from `0.7.4` → `0.7.8` in all 13 example `package.json` files
- Bump `@bastani/atomic-sdk` dependency from `^0.7.5` → `^0.7.8` across all examples

**Affected examples:** `claude-background-subagents`, `commander-embed`, `headless-test`, `hello-world`, `hil-favorite-color-headless`, `hil-favorite-color`, `multi-workflow`, `pane-navigation`, `parallel-hello-world`, `review-fix-loop`, `reviewer-tool-test`, `sequential-describe-summarize`, `structured-output-demo`

## Test plan

- [ ] `bun install` resolves cleanly in each example
- [ ] CI passes