### PR TITLE
feat(ci,devcontainer): musl parity in validate matrix + bootstrap install paths

### DIFF
--- a/.devcontainer/claude/devcontainer.json
+++ b/.devcontainer/claude/devcontainer.json
@@ -4,15 +4,30 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils": {},
     "ghcr.io/flora131/atomic/claude:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
   "remoteEnv": {
     "GH_TOKEN": "${localEnv:GH_TOKEN}",
     "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
   },
+  "postCreateCommand": "bun install",
+  "mounts": [
+    {
+      "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.ssh",
+      "target": "/home/vscode/.ssh",
+      "type": "bind"
+    },
+    {
+      "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig",
+      "target": "/home/vscode/.gitconfig",
+      "type": "bind"
+    }
+  ],
   "customizations": {
     "vscode": {
       "extensions": [
+        "oven.bun-vscode",
         "shd101wyy.markdown-preview-enhanced",
         "Anthropic.claude-code"
       ]

--- a/.devcontainer/copilot/devcontainer.json
+++ b/.devcontainer/copilot/devcontainer.json
@@ -4,15 +4,32 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils": {},
     "ghcr.io/flora131/atomic/copilot:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
   "remoteEnv": {
     "COPILOT_GITHUB_TOKEN": "${localEnv:COPILOT_GITHUB_TOKEN}",
     "GH_TOKEN": "${localEnv:GH_TOKEN}"
   },
+  "postCreateCommand": "bun install",
+  "mounts": [
+    {
+      "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.ssh",
+      "target": "/home/vscode/.ssh",
+      "type": "bind"
+    },
+    {
+      "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig",
+      "target": "/home/vscode/.gitconfig",
+      "type": "bind"
+    }
+  ],
   "customizations": {
     "vscode": {
-      "extensions": ["shd101wyy.markdown-preview-enhanced"]
+      "extensions": [
+        "oven.bun-vscode",
+        "shd101wyy.markdown-preview-enhanced"
+      ]
     }
   }
 }

--- a/.devcontainer/features/claude/devcontainer-feature.json
+++ b/.devcontainer/features/claude/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "claude",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "name": "Atomic + Claude Code",
   "description": "Installs Atomic CLI with Claude Code agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/.devcontainer/features/claude/install.sh
+++ b/.devcontainer/features/claude/install.sh
@@ -132,27 +132,34 @@ echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 # Agent CLIs (e.g. Copilot) emit Unicode box-drawing / figlet characters.
 # Without a UTF-8 locale the output is garbled when spawned as a Bun
 # subprocess inside the devcontainer.
+#
+# Branches by host package manager:
+#   apt-get → install `locales`, run `locale-gen en_US.UTF-8`, `update-locale`
+#   apk     → install `musl-locales` (Alpine; no locale-gen needed)
+#   neither → skip silently — the rc-file env exports below still set
+#             LANG/LC_ALL so most agent CLIs render correctly even without
+#             a generated locale archive.
 
-# Step 1: install locales package if locale-gen is not present
-if ! command -v locale-gen >/dev/null 2>&1; then
-    apt-get update -y
-    apt-get install -y --no-install-recommends locales
-fi
-
-# Step 2: ensure en_US.UTF-8 UTF-8 is uncommented in /etc/locale.gen
-if [ -f /etc/locale.gen ]; then
-    sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
-fi
-if ! grep -q '^en_US\.UTF-8 UTF-8' /etc/locale.gen 2>/dev/null; then
-    echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
-fi
-
-# Step 3: generate the locale
-locale-gen en_US.UTF-8
-
-# Step 4: set system default locale when update-locale is available
-if command -v update-locale >/dev/null 2>&1; then
-    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
+if command -v apt-get >/dev/null 2>&1; then
+    if ! command -v locale-gen >/dev/null 2>&1; then
+        apt-get update -y
+        apt-get install -y --no-install-recommends locales
+    fi
+    if [ -f /etc/locale.gen ]; then
+        sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+    fi
+    if ! grep -q '^en_US\.UTF-8 UTF-8' /etc/locale.gen 2>/dev/null; then
+        echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
+    fi
+    locale-gen en_US.UTF-8
+    if command -v update-locale >/dev/null 2>&1; then
+        update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
+    fi
+elif command -v apk >/dev/null 2>&1; then
+    # Alpine ships a stripped-down musl libc with no locale data. The
+    # `musl-locales` community package installs the en_US.UTF-8 archive,
+    # which the env exports below then activate.
+    apk add --no-cache musl-locales musl-locales-lang 2>/dev/null || true
 fi
 
 cat > /etc/profile.d/atomic-locale.sh <<'LOCALE_EOF'

--- a/.devcontainer/features/copilot/devcontainer-feature.json
+++ b/.devcontainer/features/copilot/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "name": "Atomic + Copilot CLI",
   "description": "Installs Atomic CLI with GitHub Copilot agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/.devcontainer/features/copilot/install.sh
+++ b/.devcontainer/features/copilot/install.sh
@@ -132,27 +132,34 @@ echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 # Agent CLIs (e.g. Copilot) emit Unicode box-drawing / figlet characters.
 # Without a UTF-8 locale the output is garbled when spawned as a Bun
 # subprocess inside the devcontainer.
+#
+# Branches by host package manager:
+#   apt-get → install `locales`, run `locale-gen en_US.UTF-8`, `update-locale`
+#   apk     → install `musl-locales` (Alpine; no locale-gen needed)
+#   neither → skip silently — the rc-file env exports below still set
+#             LANG/LC_ALL so most agent CLIs render correctly even without
+#             a generated locale archive.
 
-# Step 1: install locales package if locale-gen is not present
-if ! command -v locale-gen >/dev/null 2>&1; then
-    apt-get update -y
-    apt-get install -y --no-install-recommends locales
-fi
-
-# Step 2: ensure en_US.UTF-8 UTF-8 is uncommented in /etc/locale.gen
-if [ -f /etc/locale.gen ]; then
-    sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
-fi
-if ! grep -q '^en_US\.UTF-8 UTF-8' /etc/locale.gen 2>/dev/null; then
-    echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
-fi
-
-# Step 3: generate the locale
-locale-gen en_US.UTF-8
-
-# Step 4: set system default locale when update-locale is available
-if command -v update-locale >/dev/null 2>&1; then
-    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
+if command -v apt-get >/dev/null 2>&1; then
+    if ! command -v locale-gen >/dev/null 2>&1; then
+        apt-get update -y
+        apt-get install -y --no-install-recommends locales
+    fi
+    if [ -f /etc/locale.gen ]; then
+        sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+    fi
+    if ! grep -q '^en_US\.UTF-8 UTF-8' /etc/locale.gen 2>/dev/null; then
+        echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
+    fi
+    locale-gen en_US.UTF-8
+    if command -v update-locale >/dev/null 2>&1; then
+        update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
+    fi
+elif command -v apk >/dev/null 2>&1; then
+    # Alpine ships a stripped-down musl libc with no locale data. The
+    # `musl-locales` community package installs the en_US.UTF-8 archive,
+    # which the env exports below then activate.
+    apk add --no-cache musl-locales musl-locales-lang 2>/dev/null || true
 fi
 
 cat > /etc/profile.d/atomic-locale.sh <<'LOCALE_EOF'

--- a/.devcontainer/features/opencode/devcontainer-feature.json
+++ b/.devcontainer/features/opencode/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "opencode",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "name": "Atomic + OpenCode",
   "description": "Installs Atomic CLI with OpenCode agent, skills, and shared tooling (playwright, liteparse)",
   "documentationURL": "https://github.com/flora131/atomic",

--- a/.devcontainer/features/opencode/install.sh
+++ b/.devcontainer/features/opencode/install.sh
@@ -132,27 +132,34 @@ echo "✓ Atomic CLI installed (${ATOMIC_SPEC})"
 # Agent CLIs (e.g. Copilot) emit Unicode box-drawing / figlet characters.
 # Without a UTF-8 locale the output is garbled when spawned as a Bun
 # subprocess inside the devcontainer.
+#
+# Branches by host package manager:
+#   apt-get → install `locales`, run `locale-gen en_US.UTF-8`, `update-locale`
+#   apk     → install `musl-locales` (Alpine; no locale-gen needed)
+#   neither → skip silently — the rc-file env exports below still set
+#             LANG/LC_ALL so most agent CLIs render correctly even without
+#             a generated locale archive.
 
-# Step 1: install locales package if locale-gen is not present
-if ! command -v locale-gen >/dev/null 2>&1; then
-    apt-get update -y
-    apt-get install -y --no-install-recommends locales
-fi
-
-# Step 2: ensure en_US.UTF-8 UTF-8 is uncommented in /etc/locale.gen
-if [ -f /etc/locale.gen ]; then
-    sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
-fi
-if ! grep -q '^en_US\.UTF-8 UTF-8' /etc/locale.gen 2>/dev/null; then
-    echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
-fi
-
-# Step 3: generate the locale
-locale-gen en_US.UTF-8
-
-# Step 4: set system default locale when update-locale is available
-if command -v update-locale >/dev/null 2>&1; then
-    update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
+if command -v apt-get >/dev/null 2>&1; then
+    if ! command -v locale-gen >/dev/null 2>&1; then
+        apt-get update -y
+        apt-get install -y --no-install-recommends locales
+    fi
+    if [ -f /etc/locale.gen ]; then
+        sed -i 's/^# *en_US\.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+    fi
+    if ! grep -q '^en_US\.UTF-8 UTF-8' /etc/locale.gen 2>/dev/null; then
+        echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
+    fi
+    locale-gen en_US.UTF-8
+    if command -v update-locale >/dev/null 2>&1; then
+        update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
+    fi
+elif command -v apk >/dev/null 2>&1; then
+    # Alpine ships a stripped-down musl libc with no locale data. The
+    # `musl-locales` community package installs the en_US.UTF-8 archive,
+    # which the env exports below then activate.
+    apk add --no-cache musl-locales musl-locales-lang 2>/dev/null || true
 fi
 
 cat > /etc/profile.d/atomic-locale.sh <<'LOCALE_EOF'

--- a/.devcontainer/opencode/devcontainer.json
+++ b/.devcontainer/opencode/devcontainer.json
@@ -4,14 +4,32 @@
   "features": {
     "ghcr.io/devcontainers/features/common-utils": {},
     "ghcr.io/flora131/atomic/opencode:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
   "remoteEnv": {
     "GH_TOKEN": "${localEnv:GH_TOKEN}"
   },
+  "postCreateCommand": "bun install",
+  "mounts": [
+    {
+      "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.ssh",
+      "target": "/home/vscode/.ssh",
+      "type": "bind"
+    },
+    {
+      "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig",
+      "target": "/home/vscode/.gitconfig",
+      "type": "bind"
+    }
+  ],
   "customizations": {
     "vscode": {
-      "extensions": ["shd101wyy.markdown-preview-enhanced", "sst-dev.opencode"]
+      "extensions": [
+        "oven.bun-vscode",
+        "shd101wyy.markdown-preview-enhanced",
+        "sst-dev.opencode"
+      ]
     }
   }
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,27 +79,45 @@ jobs:
   # Catches regressions BEFORE we touch the public npm registry, so a
   # bad publish never reaches users.
   validate:
-    name: Validate ${{ matrix.os }} ${{ matrix.arch }}
+    name: Validate ${{ matrix.os }} ${{ matrix.arch }}${{ matrix.libc == 'musl' && ' (musl)' || '' }}
     needs: [build]
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest,    arch: x64,   mux: true,  preflight: true  }
-          - { os: ubuntu-24.04-arm, arch: arm64, mux: false, preflight: false }
-          - { os: macos-26-intel,   arch: x64,   mux: false, preflight: false }
-          - { os: macos-latest,     arch: arm64, mux: true,  preflight: false }
-          - { os: windows-latest,   arch: x64,   mux: true,  preflight: false }
-          - { os: windows-11-arm,   arch: arm64, mux: false, preflight: false }
+          - { os: ubuntu-latest,    arch: x64,   mux: true,  preflight: true,  libc: glibc }
+          - { os: ubuntu-24.04-arm, arch: arm64, mux: false, preflight: false, libc: glibc }
+          - { os: macos-26-intel,   arch: x64,   mux: false, preflight: false, libc: glibc }
+          - { os: macos-latest,     arch: arm64, mux: true,  preflight: false, libc: glibc }
+          - { os: windows-latest,   arch: x64,   mux: true,  preflight: false, libc: glibc }
+          - { os: windows-11-arm,   arch: arm64, mux: false, preflight: false, libc: glibc }
+          # musl rows mirror the linux glibc rows' mux/preflight choices so
+          # auto-install + chat-preflight paths get exercised against musl too.
+          - { os: ubuntu-latest,    arch: x64,   mux: true,  preflight: true,  libc: musl,
+              container: 'node:lts-alpine' }
+          - { os: ubuntu-24.04-arm, arch: arm64, mux: false, preflight: false, libc: musl,
+              container: 'node:lts-alpine' }
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container || '' }}
     steps:
+      # Alpine bootstrap: must run before any other step so `actions/checkout`
+      # can clone with native git (faster than the API tarball fallback) and
+      # later steps have bash/jq/tmux/libstdc++ available. node + npm are
+      # pre-installed in `node:lts-alpine`; we skip `setup-node` below since
+      # its prebuilt binaries are glibc-linked and would crash on Alpine.
+      - name: Bootstrap Alpine toolchain (musl rows)
+        if: matrix.libc == 'musl'
+        shell: sh
+        run: apk add --no-cache git bash curl jq tmux libstdc++ libgcc
+
       - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/setup-node@v6
+      - if: matrix.libc == 'glibc'
+        uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
 
@@ -172,12 +190,24 @@ jobs:
       #    triggered by `atomic workflow list` (ensureTmuxInstalled) is
       #    actually exercised end-to-end.
       - name: Strip tmux (Linux mux row)
-        if: matrix.mux && runner.os == 'Linux'
+        if: matrix.mux && runner.os == 'Linux' && matrix.libc == 'glibc'
         shell: bash
         run: |
           sudo apt-get remove -y tmux >/dev/null 2>&1 || true
           if command -v tmux >/dev/null 2>&1; then
             echo "tmux still on PATH after remove"; exit 1
+          fi
+
+      # Alpine has no apt-get / sudo; the bootstrap step above installed tmux,
+      # so `apk del` here mirrors the glibc strip and lets atomic's auto-install
+      # path run from a clean state.
+      - name: Strip tmux (Alpine mux row)
+        if: matrix.mux && matrix.libc == 'musl'
+        shell: sh
+        run: |
+          apk del tmux 2>/dev/null || true
+          if command -v tmux >/dev/null 2>&1; then
+            echo "tmux still on PATH after apk del"; exit 1
           fi
 
       - name: Strip tmux (macOS mux row)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ curl -fsSL https://raw.githubusercontent.com/flora131/atomic/main/install.sh | b
 
 # Windows (PowerShell 5.1+ or 7+)
 irm https://raw.githubusercontent.com/flora131/atomic/main/install.ps1 | iex
+
+# Already have Bun? Skip the bootstrap script entirely
+bun install -g @bastani/atomic
 ```
 
 Then kick off your first autonomous workflow:

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,20 @@ if [[ "$os" == "darwin" && "$arch" == "x64" ]]; then
     fi
 fi
 
-platform="${os}-${arch}"
+# Detect musl on Linux. Without this, Alpine hosts download the glibc
+# binary and fail at launch on `libc.so.6: not found`. busybox `ldd` on
+# Alpine prints "musl libc" to stderr; glibc's `ldd` prints "GLIBC". The
+# `/lib/ld-musl-*` fallback covers stripped images where `ldd` is absent.
+libc=""
+if [[ "$os" == "linux" ]]; then
+    if ldd --version 2>&1 | grep -qi musl \
+        || [ -f /lib/ld-musl-x86_64.so.1 ] \
+        || [ -f /lib/ld-musl-aarch64.so.1 ]; then
+        libc="-musl"
+    fi
+fi
+
+platform="${os}-${arch}${libc}"
 mkdir -p "$DOWNLOAD_DIR"
 
 # Resolve the manifest URL.

--- a/packages/atomic/script/build.ts
+++ b/packages/atomic/script/build.ts
@@ -112,6 +112,10 @@ for (const t of requested) {
     repository,
     os: [t.os],
     cpu: [t.cpu],
+    // `libc` discriminates Linux glibc/musl variants. Omitted on darwin/windows
+    // where it has no meaning. Without this, npm picks any matching os/cpu
+    // package on Alpine and crashes at runtime on `libc.so.6` lookup.
+    ...(t.libc ? { libc: [t.libc] } : {}),
     files: ["bin"],
     license: "MIT",
   }, null, 2) + "\n");

--- a/packages/atomic/script/targets.ts
+++ b/packages/atomic/script/targets.ts
@@ -13,15 +13,21 @@ export interface BuildTarget {
   readonly os: "linux" | "darwin" | "win32";
   /** Value for npm's `cpu` field. */
   readonly cpu: "x64" | "arm64";
+  /**
+   * Value for npm's `libc` field (Linux only). Without it, npm cannot
+   * distinguish glibc vs musl variants and may install the wrong binary on
+   * Alpine — crashing at launch on `libc.so.6` lookup.
+   */
+  readonly libc?: "glibc" | "musl";
   /** Binary file extension (Windows only). */
   readonly ext?: ".exe";
 }
 
 export const TARGETS: readonly BuildTarget[] = [
-  { name: "linux-x64",          bunTarget: "bun-linux-x64",            os: "linux",  cpu: "x64"   },
-  { name: "linux-arm64",        bunTarget: "bun-linux-arm64",          os: "linux",  cpu: "arm64" },
-  { name: "linux-x64-musl",     bunTarget: "bun-linux-x64-musl",       os: "linux",  cpu: "x64"   },
-  { name: "linux-arm64-musl",   bunTarget: "bun-linux-arm64-musl",     os: "linux",  cpu: "arm64" },
+  { name: "linux-x64",          bunTarget: "bun-linux-x64",            os: "linux",  cpu: "x64",   libc: "glibc" },
+  { name: "linux-arm64",        bunTarget: "bun-linux-arm64",          os: "linux",  cpu: "arm64", libc: "glibc" },
+  { name: "linux-x64-musl",     bunTarget: "bun-linux-x64-musl",       os: "linux",  cpu: "x64",   libc: "musl"  },
+  { name: "linux-arm64-musl",   bunTarget: "bun-linux-arm64-musl",     os: "linux",  cpu: "arm64", libc: "musl"  },
   { name: "darwin-x64",         bunTarget: "bun-darwin-x64",           os: "darwin", cpu: "x64"   },
   { name: "darwin-arm64",       bunTarget: "bun-darwin-arm64",         os: "darwin", cpu: "arm64" },
   { name: "windows-x64",        bunTarget: "bun-windows-x64",          os: "win32",  cpu: "x64",   ext: ".exe" },


### PR DESCRIPTION
## Summary

Surfaces and fixes gaps in musl / Alpine support across every install surface (npm wrapper, curl-bash, devcontainer features) and adds full musl coverage to the CI validate matrix.

### Binary distribution
- `packages/atomic/script/targets.ts` — `libc?: "glibc" | "musl"` field on `BuildTarget`; Linux entries tagged.
- `packages/atomic/script/build.ts` — emits `libc: [t.libc]` into per-platform `package.json`. **Bug fix:** without this, npm's optionalDependency picker on Alpine installs the glibc binary and crashes at launch on `libc.so.6`.
- `install.sh` — detects musl via `ldd --version | grep -i musl` with `/lib/ld-musl-*` fallback; appends `-musl` to the platform suffix.

### CI validate matrix (`.github/workflows/publish.yml`)
- Tagged existing 6 rows with `libc: glibc`; added **2 musl rows** running inside `node:lts-alpine`:
  - `ubuntu-latest x64 musl` — `mux: true, preflight: true` (mirrors glibc x64)
  - `ubuntu-24.04-arm arm64 musl` — plain (mirrors glibc arm64)
- `Bootstrap Alpine toolchain` step: pre-checkout `apk add git bash curl jq tmux libstdc++ libgcc`.
- Gated `actions/setup-node@v6` to `libc == 'glibc'` (its prebuilt binaries are glibc-linked).
- Narrowed `Strip tmux (Linux mux row)` to glibc; added `Strip tmux (Alpine mux row)` mirror using `apk del`.

### Devcontainer features (`claude` / `copilot` / `opencode`)
- `features/install.sh` — gated `apt-get` + `locale-gen` block on `command -v apt-get`; Alpine branch installs `musl-locales` via apk so the feature no longer hard-fails on non-Debian base images.
- Bumped `devcontainer-feature.json` version `1.0.14 → 1.0.15` on all three so `devcontainers/action` republishes the OCI artifact on merge.

### Devcontainer variants (`claude` / `copilot` / `opencode`)
- Restored drift vs the base `.devcontainer/devcontainer.json`:
  - `ghcr.io/devcontainers/features/docker-in-docker:2` feature
  - `postCreateCommand: bun install`
  - `~/.ssh` + `~/.gitconfig` bind-mounts (without these, variant users lost git/ssh identity inside the container)
  - `oven.bun-vscode` VS Code extension

### Quickstart
- `README.md` — surfaced `bun install -g @bastani/atomic` alongside `curl | bash` and `irm | iex` in the 60-second install section.

## Out of scope

- **Pinning hygiene** (S4 from the audit) — base image at floating `mcr.microsoft.com/devcontainers/base:ubuntu`, features at `:1`/`:2`. Worth a separate pass.
- **Variant features over OCI vs local path** (B1) — variants reference `ghcr.io/flora131/atomic/<agent>:1` which is published by `publish-features.yml`. Left as-is on the assumption the workflow has run; revisit if first-rebuild fails for variant users.

## Test plan

- [x] `bun typecheck` — all workspaces pass
- [x] `bun test` — 1814 pass / 5 skip / 0 fail (run on prerelease branch; same scripts here)
- [x] All `devcontainer.json` + `devcontainer-feature.json` files parse as valid JSON
- [x] `install.sh` + feature `install.sh` pass `bash -n`
- [x] `publish.yml` parses as valid YAML
- [x] Built `linux-x64`, `linux-x64-musl`, `darwin-arm64` locally and verified `libc: ["glibc"]` / `libc: ["musl"]` lands correctly (and is omitted on darwin)
- [x] Verified `install.sh` musl detection: glibc host correctly resolves to `linux-x64` (no false-positive `-musl` suffix)
- [ ] CI validate matrix passes both new musl rows
- [ ] Surface any gaps in `atomic`'s `ensureTmuxInstalled` for Alpine (apk support) — diagnostic the new mux row exists to expose