### PR TITLE
fix(ci): install musl bun via bun.sh/install in validate matrix bootstrap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,14 +105,25 @@ jobs:
       # later steps have bash/jq/tmux/libstdc++ available. node + npm are
       # pre-installed in `node:lts-alpine`; we skip `setup-node` below since
       # its prebuilt binaries are glibc-linked and would crash on Alpine.
+      # `oven-sh/setup-bun@v2` is also skipped on musl: it unconditionally
+      # fetches the glibc bun zip, which can't load Alpine's musl linker.
+      # The upstream `bun.sh/install` script reads /etc/os-release and
+      # selects the musl variant, so we run it here and prepend ~/.bun/bin
+      # to PATH for subsequent steps.
       - name: Bootstrap Alpine toolchain (musl rows)
         if: matrix.libc == 'musl'
         shell: sh
-        run: apk add --no-cache git bash curl jq tmux libstdc++ libgcc
+        run: |
+          set -e
+          apk add --no-cache git bash curl jq tmux libstdc++ libgcc unzip
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+          "$HOME/.bun/bin/bun" --version
 
       - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      - if: matrix.libc != 'musl'
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
## Summary

`oven-sh/setup-bun@v2` unconditionally downloads the glibc bun zip, which fails with `ENOENT` inside Alpine-based (`node:lts-alpine`) musl containers because no `ld-linux-*.so.2` linker is present. This fix installs bun via the official `bun.sh/install` script for musl rows — which reads `/etc/os-release` and selects the correct musl variant — and gates `setup-bun@v2` to glibc rows only.

Fixes the `Validate ubuntu-latest x64 (musl)` and `Validate ubuntu-24.04-arm arm64 (musl)` failures introduced by #849.

## Key Changes

- **`publish.yml` — Bootstrap Alpine toolchain step**: Added `unzip` to `apk` packages (required by the bun installer), run `curl -fsSL https://bun.sh/install | bash`, and append `~/.bun/bin` to `$GITHUB_PATH` so all subsequent steps see the musl bun binary.
- **`publish.yml` — `setup-bun` step**: Gated with `if: matrix.libc != 'musl'` so glibc rows continue using the action unchanged.

## Test Plan

- [ ] `Validate * (musl)` jobs reach `bun install` and proceed past the bootstrap step
- [ ] glibc validate rows continue to use `setup-bun@v2` unchanged
- [ ] After merge, trigger Publish via `workflow_dispatch` with tag `v0.7.9` to re-run the release publish