### PR TITLE
fix(ci): symlink bunx after bun install on musl bootstrap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,8 +117,12 @@ jobs:
           set -e
           apk add --no-cache git bash curl jq tmux libstdc++ libgcc unzip
           curl -fsSL https://bun.sh/install | bash
+          # `bun.sh/install` only drops `bun`; `setup-bun@v2` also creates a
+          # `bunx` symlink, which scripts using `bun $ \`bunx ...\`` rely on.
+          ln -sf bun "$HOME/.bun/bin/bunx"
           echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
           "$HOME/.bun/bin/bun" --version
+          "$HOME/.bun/bin/bunx" --version
 
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

`bun.sh/install` only writes `~/.bun/bin/bun`; unlike `oven-sh/setup-bun@v2`, it does not create a `bunx` shim. SDK build scripts invoke `bun $\`bunx tsc …\``, causing a `bun: command not found: bunx` failure on the Alpine (musl) validate rows at the `Publish SDK to verdaccio` step. This PR drops a `bunx → bun` symlink into the Alpine bootstrap and verifies both binaries resolve before later steps run.

## Key Changes

- **`.github/workflows/publish.yml`**: add `ln -sf bun "$HOME/.bun/bin/bunx"` immediately after `curl -fsSL https://bun.sh/install | bash` in the musl bootstrap `run` block
- Add `"$HOME/.bun/bin/bunx" --version` verification so the step fails fast if the symlink is ever missing
- Inline comment explains the `setup-bun@v2` vs `bun.sh/install` shim discrepancy for future readers

## Context

Follow-up to #852, which wired musl rows into the validate matrix. The rows now reach further in the pipeline and expose the missing `bunx` shim for the first time.

## Test Plan

- [ ] `Validate * (musl)` jobs pass through `Publish SDK to verdaccio`
- [ ] glibc validate rows continue to pass (unchanged — they use `setup-bun@v2`)