### PR TITLE
fix(ci): drop arm64 musl validate row (unsupported by runner)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,11 +91,15 @@ jobs:
           - { os: macos-latest,     arch: arm64, mux: true,  preflight: false, libc: glibc }
           - { os: windows-latest,   arch: x64,   mux: true,  preflight: false, libc: glibc }
           - { os: windows-11-arm,   arch: arm64, mux: false, preflight: false, libc: glibc }
-          # musl rows mirror the linux glibc rows' mux/preflight choices so
-          # auto-install + chat-preflight paths get exercised against musl too.
+          # musl row mirrors the linux x64 glibc row's mux/preflight choices
+          # so auto-install + chat-preflight paths get exercised against musl
+          # too. arm64 musl is intentionally absent: GitHub Actions blocks
+          # JavaScript actions inside Alpine containers on ARM64 runners
+          # (https://github.com/actions/runner/issues/801) — the runner ships
+          # no node externals for that combo, so `actions/checkout` aborts
+          # before any of our steps can run. x64 coverage is sufficient to
+          # catch musl-vs-glibc regressions in the install + launcher paths.
           - { os: ubuntu-latest,    arch: x64,   mux: true,  preflight: true,  libc: musl,
-              container: 'node:lts-alpine' }
-          - { os: ubuntu-24.04-arm, arch: arm64, mux: false, preflight: false, libc: musl,
               container: 'node:lts-alpine' }
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container || '' }}


### PR DESCRIPTION
## Summary

Removes the `ubuntu-24.04-arm` / arm64 / musl matrix row from the publish CI validate job, because GitHub Actions blocks JavaScript actions inside Alpine containers on ARM64 runners entirely — the `actions/checkout` step aborts before any project steps can run.

## Key changes

- **Removed** `{ os: ubuntu-24.04-arm, arch: arm64, libc: musl }` matrix row — this configuration is structurally unsupported by the runner ([actions/runner#801](https://github.com/actions/runner/issues/801): no Node externals bundled for alpine/arm64, so JS actions cannot execute)
- **Updated** inline comment to explain that arm64 musl is intentionally absent and why, so future contributors don't re-add it
- **Kept** the x64 musl row (`ubuntu-latest` + `node:lts-alpine`) — sufficient to catch musl-vs-glibc regressions in the auto-install and launcher paths

## Why not fix it differently?

There is no in-workflow workaround. The restriction is enforced by the GitHub Actions runner itself before any steps run, so self-hosted runners or container configuration changes cannot resolve it.

## Test plan

- [ ] Validate matrix has 7 rows (was 8); arm64 musl row is gone
- [ ] x64 musl row (`ubuntu-latest` / `node:lts-alpine`) still runs and passes end-to-end