### PR TITLE
fix(wrapper): append -musl suffix when host is Alpine/musl

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,11 +91,15 @@ jobs:
           - { os: macos-latest,     arch: arm64, mux: true,  preflight: false, libc: glibc }
           - { os: windows-latest,   arch: x64,   mux: true,  preflight: false, libc: glibc }
           - { os: windows-11-arm,   arch: arm64, mux: false, preflight: false, libc: glibc }
-          # musl rows mirror the linux glibc rows' mux/preflight choices so
-          # auto-install + chat-preflight paths get exercised against musl too.
+          # musl row mirrors the linux x64 glibc row's mux/preflight choices
+          # so auto-install + chat-preflight paths get exercised against musl
+          # too. arm64 musl is intentionally absent: GitHub Actions blocks
+          # JavaScript actions inside Alpine containers on ARM64 runners
+          # (https://github.com/actions/runner/issues/801) — the runner ships
+          # no node externals for that combo, so `actions/checkout` aborts
+          # before any of our steps can run. x64 coverage is sufficient to
+          # catch musl-vs-glibc regressions in the install + launcher paths.
           - { os: ubuntu-latest,    arch: x64,   mux: true,  preflight: true,  libc: musl,
-              container: 'node:lts-alpine' }
-          - { os: ubuntu-24.04-arm, arch: arm64, mux: false, preflight: false, libc: musl,
               container: 'node:lts-alpine' }
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container || '' }}

--- a/packages/atomic/bin/atomic
+++ b/packages/atomic/bin/atomic
@@ -3,6 +3,7 @@
 "use strict"
 
 const childProcess = require("child_process")
+const fs = require("fs")
 const path = require("path")
 const os = require("os")
 
@@ -32,7 +33,23 @@ if (!platform || !arch) {
   process.exit(1)
 }
 
-const packageName = "@bastani/atomic-" + platform + "-" + arch
+// Linux ships separate glibc/musl binaries (`@bastani/atomic-linux-<arch>` vs
+// `@bastani/atomic-linux-<arch>-musl`). Without a libc suffix we'd resolve the
+// glibc variant on Alpine, then `spawnSync` fails with ENOENT when the kernel
+// can't find `ld-linux-*.so.2`. Detect via the musl runtime linker on disk —
+// it's the same heuristic the install.sh launcher uses, and it works without
+// pulling in `detect-libc`.
+function libcSuffix() {
+  if (platform !== "linux") return ""
+  const muslLinker =
+    "/lib/ld-musl-" + (arch === "arm64" ? "aarch64" : "x86_64") + ".so.1"
+  try {
+    if (fs.existsSync(muslLinker)) return "-musl"
+  } catch (_) {}
+  return ""
+}
+
+const packageName = "@bastani/atomic-" + platform + "-" + arch + libcSuffix()
 const binaryName = "atomic" + (platform === "windows" ? ".exe" : "")
 
 let packageJsonPath


### PR DESCRIPTION
## Summary

Fixes `atomic --version` failing with `ENOENT` on Alpine/musl hosts by detecting the musl runtime linker on disk and appending \`-musl\` to the resolved platform package name. Also drops the arm64 musl CI row that was blocked by a GitHub Actions runner limitation.

## Root Cause

The \`packages/atomic/bin/atomic\` wrapper resolved the platform binary package as \`@bastani/atomic-\${platform}-\${arch}\`, which always pointed to the glibc variant. On Alpine Linux (musl), the kernel can't find \`ld-linux-x86_64.so.2\` for that glibc-linked binary, causing \`spawnSync\` to throw \`ENOENT\`.

PR #849 added \`libc: ["glibc"|"musl"]\` to per-platform \`package.json\` so npm/bun's optionalDeps resolver would install the correct binary — but the wrapper script itself never used the \`-musl\` suffix, so it still tried to resolve the wrong package at runtime.

## Key Changes

- **`packages/atomic/bin/atomic`**: Added \`libcSuffix()\` which checks for the musl runtime linker at \`/lib/ld-musl-{x86_64,aarch64}.so.1\`. When found, returns \`"-musl"\` so the wrapper resolves \`@bastani/atomic-linux-<arch>-musl\` instead of the glibc variant. Mirrors the heuristic already used in \`install.sh\`, with no new runtime dependencies.

- **`.github/workflows/publish.yml`**: Removed the \`ubuntu-24.04-arm\` (arm64 musl) CI row. GitHub Actions blocks JavaScript actions inside Alpine containers on ARM64 runners ([actions/runner#801](https://github.com/actions/runner/issues/801)) — \`actions/checkout\` aborts before any project steps run. x64 musl coverage is sufficient to catch musl-vs-glibc regressions. Expanded the inline comment to document this limitation.

## Test Plan

- [x] \`Validate ubuntu-latest x64 (musl)\` passes the Smoke (Unix) step
- [x] glibc and macOS/Windows rows resolve their own packages unchanged
- [x] arm64 musl row removed (blocked by runner limitation, documented in comment)