### PR TITLE
fix(sdk): drop sudo from tmux auto-install on root containers

### DIFF
--- a/packages/atomic-sdk/src/lib/spawn.ts
+++ b/packages/atomic-sdk/src/lib/spawn.ts
@@ -523,13 +523,20 @@ export async function ensureTmuxInstalled(options: EnsureOptions = {}): Promise<
     throw new Error("Neither bash nor sh is available to install tmux.");
   }
 
+  // Drop `sudo` when we're already root or `sudo` isn't on PATH. Slim
+  // container images (`node:lts-alpine`, `node:slim`, distroless variants)
+  // run as uid 0 with no sudo installed, so `sudo apk add tmux` would fail
+  // with `sudo: command not found` before ever reaching the package manager.
+  const isRoot = process.getuid?.() === 0;
+  const sudo = isRoot || !resolveCommandFromCurrentPath("sudo") ? "" : "sudo ";
+
   const managers: string[] = [
-    "command -v apt-get >/dev/null 2>&1 && sudo apt-get update -qq && sudo apt-get install -y tmux",
-    "command -v dnf >/dev/null 2>&1 && sudo dnf install -y tmux",
-    "command -v yum >/dev/null 2>&1 && sudo yum install -y tmux",
-    "command -v pacman >/dev/null 2>&1 && sudo pacman -Sy --noconfirm tmux",
-    "command -v zypper >/dev/null 2>&1 && sudo zypper --non-interactive install tmux",
-    "command -v apk >/dev/null 2>&1 && sudo apk add --no-cache tmux",
+    `command -v apt-get >/dev/null 2>&1 && ${sudo}apt-get update -qq && ${sudo}apt-get install -y tmux`,
+    `command -v dnf >/dev/null 2>&1 && ${sudo}dnf install -y tmux`,
+    `command -v yum >/dev/null 2>&1 && ${sudo}yum install -y tmux`,
+    `command -v pacman >/dev/null 2>&1 && ${sudo}pacman -Sy --noconfirm tmux`,
+    `command -v zypper >/dev/null 2>&1 && ${sudo}zypper --non-interactive install tmux`,
+    `command -v apk >/dev/null 2>&1 && ${sudo}apk add --no-cache tmux`,
   ];
 
   for (const script of managers) {


### PR DESCRIPTION
## Summary

`ensureTmuxInstalled` prefixed every Linux package-manager invocation with `sudo`, causing failures in slim container images (e.g. `node:lts-alpine`, `node:slim`, distroless variants) that run as uid 0 with no `sudo` binary installed.

## Changes

- **`packages/atomic-sdk/src/lib/spawn.ts`** — detect whether the process is already root (`process.getuid() === 0`) or `sudo` is absent from `PATH`; if either is true, elide the `sudo ` prefix from all package-manager commands (`apt-get`, `dnf`, `yum`, `pacman`, `zypper`, `apk`)

## Root Cause

Slim container images run as uid 0 by default and ship without `sudo`. The previous code unconditionally prepended `sudo` to every install command, so the shell aborted with `sudo: command not found` before ever reaching the package manager.

## Verification

Built a `linux-x64-musl` binary and mounted it into `node:lts-alpine`:

```
=== before: atomic workflow list
tmux: not installed
=== after: atomic workflow list
/usr/bin/tmux
tmux 3.6
```

This is the same code path the CI step `Verify mux auto-install (Unix mux row)` exercises end-to-end.

## Test plan

- [x] Reproduced failure locally in `node:lts-alpine`
- [x] Patched and verified locally — `atomic workflow list` auto-installs tmux without sudo
- [x] `bun typecheck` passes
- [x] `bun test packages/atomic-sdk/src/lib` passes (101 tests)
- [ ] CI: `Validate ubuntu-latest x64 (musl)` reaches `Verify mux auto-install` and passes