### PR TITLE
feat(uninstall): detect install method; refuse pm-managed uninstalls

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -325,6 +325,98 @@ jobs:
             atomic chat -a "$agent" --preflight-only
           done
 
+      # ── Pm-managed install policy: while atomic still runs from the
+      #    bun-global install dir (~/.bun/install/global/.../@bastani/
+      #    atomic-<plat>-<arch>/bin/), `atomic uninstall` MUST refuse and
+      #    point the user at `bun remove -g @bastani/atomic` — running
+      #    cleanup on a pm-managed install would leave dangling links and
+      #    a broken `atomic` shim.
+      #
+      #    This step runs BEFORE `atomic install` migrates the launcher
+      #    to the canonical binary dir (which would flip detection to the
+      #    "binary" branch and re-enable cleanup).
+      - name: atomic uninstall refuses on bun install (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          export PATH="$HOME/.bun/bin:$PATH"
+          out=$(atomic uninstall 2>&1) && rc=0 || rc=$?
+          echo "$out"
+          if [ "$rc" -eq 0 ]; then
+            echo "expected non-zero exit on a bun-managed install"; exit 1
+          fi
+          echo "$out" | grep -q "atomic was installed via bun" \
+            || { echo "missing 'atomic was installed via bun' hint"; exit 1; }
+          echo "$out" | grep -q "bun remove -g @bastani/atomic" \
+            || { echo "missing 'bun remove -g' hint"; exit 1; }
+          command -v atomic >/dev/null 2>&1 \
+            || { echo "atomic disappeared after refusal — must touch nothing"; exit 1; }
+
+      - name: atomic uninstall refuses on bun install (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+          if ($userPath) { $env:Path = "$env:Path;$userPath" }
+          $out = atomic uninstall 2>&1 | Out-String
+          $rc = $LASTEXITCODE
+          Write-Output $out
+          if ($rc -eq 0) {
+            throw "expected non-zero exit on a bun-managed install"
+          }
+          if ($out -notmatch 'atomic was installed via bun') {
+            throw "missing 'atomic was installed via bun' hint"
+          }
+          if ($out -notmatch 'bun remove -g @bastani/atomic') {
+            throw "missing 'bun remove -g' hint"
+          }
+          if (-not (Get-Command atomic -ErrorAction SilentlyContinue)) {
+            throw "atomic disappeared after refusal — must touch nothing"
+          }
+
+      # ── Round-trip the documented pm uninstall path: `bun remove -g`
+      #    is what the refusal message above tells users to run, so we
+      #    smoke-test it actually evicts atomic from PATH.
+      - name: bun remove -g round-trip (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          export PATH="$HOME/.bun/bin:$PATH"
+          bun remove -g @bastani/atomic
+          if command -v atomic >/dev/null 2>&1; then
+            echo "atomic still on PATH after 'bun remove -g'"; exit 1
+          fi
+
+      - name: bun remove -g round-trip (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+          if ($userPath) { $env:Path = "$env:Path;$userPath" }
+          bun remove -g @bastani/atomic
+          if (Get-Command atomic -ErrorAction SilentlyContinue) {
+            throw "atomic still on PATH after 'bun remove -g'"
+          }
+
+      # ── Re-install via bun so the binary-branch lifecycle steps below
+      #    have a fresh atomic to migrate via `atomic install`.
+      - name: Re-install atomic from verdaccio (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: bun install -g "@bastani/atomic@${VERSION}" --registry http://localhost:4873
+
+      - name: Re-install atomic from verdaccio (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          bun install -g "@bastani/atomic@$env:VERSION" --registry http://localhost:4873
+          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+          if ($userPath) { $env:Path = "$env:Path;$userPath" }
+
       # ── `atomic install` lifecycle: drops launcher into the canonical
       #    install dir, writes rc snippets / profile wrapper, caches
       #    completions. Mirrors the install path users hit after running

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "examples/claude-background-subagents": {
       "name": "@bastani/example-claude-background-subagents",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -29,7 +29,7 @@
     },
     "examples/commander-embed": {
       "name": "@bastani/example-commander-embed",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -37,7 +37,7 @@
     },
     "examples/headless-test": {
       "name": "@bastani/example-headless-test",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -46,7 +46,7 @@
     },
     "examples/hello-world": {
       "name": "@bastani/example-hello-world",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -54,7 +54,7 @@
     },
     "examples/hil-favorite-color": {
       "name": "@bastani/example-hil-favorite-color",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -62,7 +62,7 @@
     },
     "examples/hil-favorite-color-headless": {
       "name": "@bastani/example-hil-favorite-color-headless",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -70,7 +70,7 @@
     },
     "examples/multi-workflow": {
       "name": "@bastani/example-multi-workflow",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -78,7 +78,7 @@
     },
     "examples/pane-navigation": {
       "name": "@bastani/example-pane-navigation",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -86,7 +86,7 @@
     },
     "examples/parallel-hello-world": {
       "name": "@bastani/example-parallel-hello-world",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -94,7 +94,7 @@
     },
     "examples/review-fix-loop": {
       "name": "@bastani/example-review-fix-loop",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -102,7 +102,7 @@
     },
     "examples/reviewer-tool-test": {
       "name": "@bastani/example-reviewer-tool-test",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -112,7 +112,7 @@
     },
     "examples/sequential-describe-summarize": {
       "name": "@bastani/example-sequential-describe-summarize",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -120,7 +120,7 @@
     },
     "examples/structured-output-demo": {
       "name": "@bastani/example-structured-output-demo",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -130,20 +130,20 @@
     },
     "packages/atomic": {
       "name": "@bastani/atomic",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "bin": {
         "atomic": "src/cli.ts",
       },
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.128",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.132",
         "@bastani/atomic-sdk": "workspace:*",
         "@catppuccin/palette": "^1.8.0",
         "@clack/prompts": "^1.3.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.3.0",
-        "@opentui/core": "^0.2.2",
-        "@opentui/react": "^0.2.2",
-        "react": "^19.2.5",
+        "@opentui/core": "^0.2.3",
+        "@opentui/react": "^0.2.3",
+        "react": "^19.2.6",
       },
       "devDependencies": {
         "@types/bun": "^1.3.13",
@@ -153,7 +153,7 @@
     },
     "packages/atomic-sdk": {
       "name": "@bastani/atomic-sdk",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.132",
         "@catppuccin/palette": "^1.8.0",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -19,15 +19,15 @@
     "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.128",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
     "@bastani/atomic-sdk": "workspace:*",
     "@catppuccin/palette": "^1.8.0",
     "@clack/prompts": "^1.3.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",
-    "@opentui/core": "^0.2.2",
-    "@opentui/react": "^0.2.2",
-    "react": "^19.2.5"
+    "@opentui/core": "^0.2.3",
+    "@opentui/react": "^0.2.3",
+    "react": "^19.2.6"
   },
   "devDependencies": {
     "@types/bun": "^1.3.13",

--- a/packages/atomic/src/commands/cli/install-method.test.ts
+++ b/packages/atomic/src/commands/cli/install-method.test.ts
@@ -1,0 +1,308 @@
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+    detectInstallMethod,
+    _resetInstallMethodCache,
+    type InstallMethod,
+} from "./install-method.ts";
+
+const home = homedir();
+
+// Probe that always fails — used for unknown fallthrough
+const noopProbe = (_cmd: string[]): { exitCode: number; stdout: string } => ({
+    exitCode: 1,
+    stdout: "",
+});
+
+describe("detectInstallMethod()", () => {
+    beforeEach(() => {
+        _resetInstallMethodCache();
+    });
+
+    // Case 1: Unix binary install path
+    test("~/.local/bin/atomic → binary", () => {
+        const execPath = join(home, ".local", "bin", "atomic");
+        expect(detectInstallMethod({ execPath })).toBe("binary" satisfies InstallMethod);
+    });
+
+    // Case 3: bun global node_modules — path heuristic, no probe needed
+    test("~/.bun/install/global/.../node_modules/@bastani/atomic/... → bun", () => {
+        const execPath = join(
+            home,
+            ".bun",
+            "install",
+            "global",
+            "node_modules",
+            "@bastani",
+            "atomic",
+            "bin",
+            "atomic",
+        );
+        let probeCallCount = 0;
+        const countingProbe = (_cmd: string[]): { exitCode: number; stdout: string } => {
+            probeCallCount++;
+            return { exitCode: 1, stdout: "" };
+        };
+        expect(detectInstallMethod({ execPath, probe: countingProbe })).toBe("bun" satisfies InstallMethod);
+        expect(probeCallCount).toBe(0);
+    });
+
+    // Case 4: pnpm global path heuristic
+    test(".../pnpm/global/.../node_modules/@bastani/atomic/... → pnpm", () => {
+        const execPath = join(
+            home,
+            ".local",
+            "share",
+            "pnpm",
+            "global",
+            "5",
+            "node_modules",
+            "@bastani",
+            "atomic",
+            "bin",
+            "atomic",
+        );
+        expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("pnpm" satisfies InstallMethod);
+    });
+
+    // Case 5: ambiguous node_modules path + npm probe succeeds
+    test("ambiguous node_modules + npm probe returns @bastani/atomic → npm", () => {
+        const execPath = join(
+            home,
+            ".nvm",
+            "versions",
+            "node",
+            "v20.0.0",
+            "lib",
+            "node_modules",
+            "@bastani",
+            "atomic",
+            "bin",
+            "atomic",
+        );
+        const probe = mock((cmd: string[]): { exitCode: number; stdout: string } => {
+            // Only respond to `npm list -g`
+            if (cmd[0] === "npm" && cmd.includes("list")) {
+                return { exitCode: 0, stdout: "/usr/local/lib\n├── @bastani/atomic@0.7.8\n" };
+            }
+            return { exitCode: 1, stdout: "" };
+        });
+        expect(detectInstallMethod({ execPath, probe })).toBe("npm" satisfies InstallMethod);
+    });
+
+    // Case 6: execPath is bun binary itself → source
+    test("/usr/bin/bun → source", () => {
+        expect(detectInstallMethod({ execPath: "/usr/bin/bun", probe: noopProbe })).toBe("source" satisfies InstallMethod);
+    });
+
+    // Case 7: random path, all probes fail → unknown
+    test("/tmp/random/atomic + all probes fail → unknown", () => {
+        expect(detectInstallMethod({ execPath: "/tmp/random/atomic", probe: noopProbe })).toBe("unknown" satisfies InstallMethod);
+    });
+
+    // RFC §8.3 — per-platform suffix regression tests
+    describe("per-platform suffix", () => {
+        test("@bastani/atomic-linux-x64 under bun global → bun", () => {
+            const execPath = join(
+                home,
+                ".bun",
+                "install",
+                "global",
+                "node_modules",
+                "@bastani",
+                "atomic-linux-x64",
+                "bin",
+                "atomic",
+            );
+            expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("bun" satisfies InstallMethod);
+        });
+
+        test("@bastani/atomic-darwin-arm64 under bun global → bun", () => {
+            const execPath = join(
+                home,
+                ".bun",
+                "install",
+                "global",
+                "node_modules",
+                "@bastani",
+                "atomic-darwin-arm64",
+                "bin",
+                "atomic",
+            );
+            expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("bun" satisfies InstallMethod);
+        });
+
+        test("@bastani/atomic-linux-x64 under pnpm global → pnpm", () => {
+            const execPath = join(
+                home,
+                ".local",
+                "share",
+                "pnpm",
+                "global",
+                "5",
+                "node_modules",
+                "@bastani",
+                "atomic-linux-x64",
+                "bin",
+                "atomic",
+            );
+            expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("pnpm" satisfies InstallMethod);
+        });
+
+        test("@bastani/atomic-darwin-x64 under yarn global → yarn", () => {
+            const execPath = join(
+                home,
+                ".config",
+                "yarn",
+                "global",
+                "node_modules",
+                "@bastani",
+                "atomic-darwin-x64",
+                "bin",
+                "atomic",
+            );
+            expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("yarn" satisfies InstallMethod);
+        });
+
+        test("@bastani/atomic-linux-x64 under nvm + npm probe success → npm", () => {
+            const execPath = join(
+                home,
+                ".nvm",
+                "versions",
+                "node",
+                "v20.0.0",
+                "lib",
+                "node_modules",
+                "@bastani",
+                "atomic-linux-x64",
+                "bin",
+                "atomic",
+            );
+            const probe = mock((cmd: string[]): { exitCode: number; stdout: string } => {
+                if (cmd[0] === "npm" && cmd.includes("list")) {
+                    return { exitCode: 0, stdout: "/usr/local/lib\n├── @bastani/atomic@0.7.8\n" };
+                }
+                return { exitCode: 1, stdout: "" };
+            });
+            expect(detectInstallMethod({ execPath, probe })).toBe("npm" satisfies InstallMethod);
+        });
+
+        test("@bastani-evil/atomic-linux-x64 must NOT match scope boundary → unknown", () => {
+            const execPath = join(
+                home,
+                ".bun",
+                "install",
+                "global",
+                "node_modules",
+                "@bastani-evil",
+                "atomic-linux-x64",
+                "bin",
+                "atomic",
+            );
+            expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("unknown" satisfies InstallMethod);
+        });
+    });
+
+    // defaultProbe branch tests — use spyOn so no probe injection required
+    describe("defaultProbe", () => {
+        let spawnSyncSpy: ReturnType<typeof spyOn<typeof Bun, "spawnSync">>;
+
+        afterEach(() => {
+            spawnSyncSpy.mockRestore();
+        });
+
+        // Ambiguous path: matches PKG_PATH_RE but none of the cheap heuristics
+        const ambiguousExecPath = "/some/other/global/node_modules/@bastani/atomic/bin/atomic";
+
+        test("happy path: first probe (bun pm ls -g) succeeds → bun", () => {
+            const fakeResult = {
+                exitCode: 0,
+                stdout: Buffer.from("@bastani/atomic@0.7.8\n"),
+                stderr: Buffer.from(""),
+                success: true,
+                pid: 0,
+                signalCode: null,
+                resourceUsage: undefined,
+            } as unknown as ReturnType<typeof Bun.spawnSync>;
+            spawnSyncSpy = spyOn(Bun, "spawnSync").mockReturnValue(fakeResult);
+            _resetInstallMethodCache();
+            const result = detectInstallMethod({ execPath: ambiguousExecPath });
+            expect(result).toBe("bun" satisfies InstallMethod);
+            // Verify spy was called with the bun probe options object
+            const firstCallArgs = spawnSyncSpy.mock.calls[0];
+            expect(firstCallArgs).toBeDefined();
+            const firstArg = firstCallArgs?.[0] as unknown as { cmd: string[] };
+            expect(firstArg.cmd).toEqual(["bun", "pm", "ls", "-g"]);
+        });
+
+        test("throw path: all Bun.spawnSync calls throw → npm fallback", () => {
+            spawnSyncSpy = spyOn(Bun, "spawnSync").mockImplementation((() => {
+                throw new Error("ENOENT");
+            }) as never);
+            _resetInstallMethodCache();
+            const result = detectInstallMethod({ execPath: ambiguousExecPath });
+            expect(result).toBe("npm" satisfies InstallMethod);
+        });
+    });
+
+    // npm fallback: injected probe always fails (non-zero exitCode)
+    test("npm fallback: all probes return exitCode 1 → npm", () => {
+        const execPath =
+            "/home/test/.nvm/versions/node/v20.0.0/lib/node_modules/@bastani/atomic/bin/atomic";
+        const result = detectInstallMethod({
+            execPath,
+            probe: () => ({ exitCode: 1, stdout: "" }),
+        });
+        expect(result).toBe("npm" satisfies InstallMethod);
+    });
+
+    // Iter 5 regression: separator-anchored binDir match
+    test("~/.local/bin-other/atomic → unknown (not binary)", () => {
+        const execPath = join(home, ".local", "bin-other", "atomic");
+        expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("unknown" satisfies InstallMethod);
+    });
+
+    test("~/.local/binx/atomic → unknown (not binary)", () => {
+        const execPath = join(home, ".local", "binx", "atomic");
+        expect(detectInstallMethod({ execPath, probe: noopProbe })).toBe("unknown" satisfies InstallMethod);
+    });
+
+    // Iter 5 regression: probe-only override must not poison cache for subsequent no-override reads
+    test("cache symmetry — probe-only override does not poison subsequent no-override read", () => {
+        // First call: probe-only override — returns bun via stdout match on ambiguous path.
+        const probeReturningBun = (_cmd: string[]): { exitCode: number; stdout: string } => ({
+            exitCode: 0,
+            stdout: "@bastani/atomic",
+        });
+        const ambiguousExecPath = "/some/other/global/node_modules/@bastani/atomic/bin/atomic";
+        const first = detectInstallMethod({ execPath: ambiguousExecPath, probe: probeReturningBun });
+        expect(first).toBe("bun" satisfies InstallMethod);
+
+        // Second call: no overrides — must resolve from real process.execPath (bun runtime → "source"),
+        // NOT from the bun result returned by the probe above.
+        const second = detectInstallMethod();
+        expect(second).toBe("source" satisfies InstallMethod);
+    });
+
+    test("cache poison guard: override call must not populate module cache", () => {
+        const bunFixture = join(
+            home,
+            ".bun",
+            "install",
+            "global",
+            "node_modules",
+            "@bastani",
+            "atomic-linux-x64",
+            "bin",
+            "atomic",
+        );
+        // First call WITH override — must not write cache
+        expect(detectInstallMethod({ execPath: bunFixture, probe: noopProbe })).toBe("bun" satisfies InstallMethod);
+        // Second call WITHOUT override — must resolve from real process.execPath, not cached "bun".
+        // In bun:test environment process.execPath is the bun host binary, so result is "source".
+        const second = detectInstallMethod();
+        expect(second).not.toBe("bun");
+        expect(second).toBe("source" satisfies InstallMethod);
+    });
+});

--- a/packages/atomic/src/commands/cli/install-method.ts
+++ b/packages/atomic/src/commands/cli/install-method.ts
@@ -1,0 +1,104 @@
+import { homedir, platform as osPlatform } from "node:os";
+import { join } from "node:path";
+
+export type InstallMethod =
+    | "binary"
+    | "bun"
+    | "npm"
+    | "pnpm"
+    | "yarn"
+    | "source"
+    | "unknown";
+
+export interface DetectOptions {
+    /** override for tests */
+    readonly execPath?: string;
+    /** override for tests; default `Bun.spawnSync` */
+    readonly probe?: (cmd: string[]) => { exitCode: number; stdout: string };
+    /** override for tests — platform string (e.g. "win32", "linux", "darwin") */
+    readonly platform?: string;
+}
+
+const PKG_PATH_RE = /\/node_modules\/@bastani\/atomic(?:-[a-z0-9-]+)?\//;
+
+const PM_PROBE_CMD: Record<"bun" | "pnpm" | "yarn" | "npm", string[]> = {
+    bun:  ["bun",  "pm",     "ls", "-g"],
+    pnpm: ["pnpm", "list",   "-g", "--depth=0"],
+    yarn: ["yarn", "global", "list"],
+    npm:  ["npm",  "list",   "-g", "--depth=0"],
+};
+
+let cached: InstallMethod | null = null;
+
+/** True when no test seams are injected — gates both cache read and write. */
+function hasNoOverrides(opts: DetectOptions): boolean {
+    return opts.execPath === undefined
+        && opts.platform === undefined
+        && opts.probe === undefined;
+}
+
+/** Lowercase + forward-slash so a single substring works on Unix and Windows. */
+function normalize(p: string): string {
+    return p.toLowerCase().replaceAll("\\", "/");
+}
+
+export function detectInstallMethod(opts: DetectOptions = {}): InstallMethod {
+    const pristine = hasNoOverrides(opts);
+    if (pristine && cached !== null) return cached;
+
+    const method = computeInstallMethod(opts);
+    if (pristine) cached = method;
+    return method;
+}
+
+function computeInstallMethod(opts: DetectOptions): InstallMethod {
+    const exec = normalize(opts.execPath ?? process.execPath);
+    const currentPlatform = opts.platform ?? osPlatform();
+
+    // 1. Binary install — canonical install dirs from `getInstallPaths()`.
+    const binDir = currentPlatform === "win32"
+        ? join(
+            process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local"),
+            "atomic",
+            "bin",
+        )
+        : join(homedir(), ".local", "bin");
+    // `normalize` collapses both `\` and `/` to `/`, so anchor on `/`
+    // regardless of platform — a platform-native `\` separator here would
+    // never match a post-normalize `exec` on a POSIX runtime.
+    const norm = normalize(binDir);
+    if (exec === norm || exec.startsWith(`${norm}/`)) return "binary";
+
+    // 2. Pkg-manager install — `node_modules/@bastani/atomic` or per-platform variant.
+    if (PKG_PATH_RE.test(exec)) {
+        // Cheap path heuristics first; fall back to `<pm> ls -g` probes.
+        if (exec.includes("/.bun/install/global/")) return "bun";
+        if (exec.includes("/pnpm/global/")) return "pnpm";
+        if (exec.includes("/.config/yarn/global/")) return "yarn";
+
+        const probe = opts.probe ?? defaultProbe;
+        for (const pm of ["bun", "pnpm", "yarn", "npm"] as const) {
+            const r = probe(PM_PROBE_CMD[pm]);
+            if (r.exitCode === 0 && r.stdout.includes("@bastani/atomic")) return pm;
+        }
+        // Default to npm — most common pkg manager and canonical npm-cli prefix.
+        return "npm";
+    }
+
+    // 3. Source checkout — repo `bun link` or local dev script.
+    if (exec.endsWith("/bun") || exec.endsWith("/bun.exe")) return "source";
+
+    return "unknown";
+}
+
+function defaultProbe(cmd: string[]): { exitCode: number; stdout: string } {
+    try {
+        const r = Bun.spawnSync({ cmd, stdout: "pipe", stderr: "pipe" });
+        return { exitCode: r.exitCode ?? 1, stdout: r.stdout.toString() };
+    } catch {
+        return { exitCode: 1, stdout: "" };
+    }
+}
+
+/** test-only — reset memoized result between cases */
+export function _resetInstallMethodCache(): void { cached = null; }

--- a/packages/atomic/src/commands/cli/install-method.win32.test.ts
+++ b/packages/atomic/src/commands/cli/install-method.win32.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Win32 branch coverage for detectInstallMethod().
+ *
+ * Uses the `platform` field of DetectOptions to inject "win32" without
+ * mocking node:os, so isolation is per-call and never leaks across files.
+ *
+ * LOCALAPPDATA is set/restored around each test so the win32 binDir path
+ * (`process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local")`)
+ * yields the known fixture value.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { detectInstallMethod, _resetInstallMethodCache } from "./install-method.ts";
+
+const FIX_LOCALAPPDATA = "C:\\Users\\test\\AppData\\Local";
+const ORIGINAL_LOCALAPPDATA = process.env.LOCALAPPDATA;
+
+describe("detectInstallMethod (win32 platform mock)", () => {
+    beforeEach(() => {
+        _resetInstallMethodCache();
+        process.env.LOCALAPPDATA = FIX_LOCALAPPDATA;
+    });
+
+    afterEach(() => {
+        if (ORIGINAL_LOCALAPPDATA === undefined) {
+            delete process.env.LOCALAPPDATA;
+        } else {
+            process.env.LOCALAPPDATA = ORIGINAL_LOCALAPPDATA;
+        }
+    });
+
+    test("LOCALAPPDATA/atomic/bin/atomic.exe (win32) → binary", () => {
+        const execPath = "C:\\Users\\test\\AppData\\Local\\atomic\\bin\\atomic.exe";
+        expect(detectInstallMethod({ execPath, platform: "win32" })).toBe("binary");
+    });
+
+    test("execPath outside binDir falls through to unknown", () => {
+        const execPath = "C:\\some\\random\\path\\atomic.exe";
+        expect(detectInstallMethod({ execPath, platform: "win32" })).toBe("unknown");
+    });
+
+    test("LOCALAPPDATA/atomic/bin-other/atomic.exe (win32) → unknown (separator-anchored match)", () => {
+        const execPath = "C:\\Users\\test\\AppData\\Local\\atomic\\bin-other\\atomic.exe";
+        expect(detectInstallMethod({ execPath, platform: "win32" })).toBe("unknown");
+    });
+});

--- a/packages/atomic/src/commands/cli/install.ts
+++ b/packages/atomic/src/commands/cli/install.ts
@@ -21,6 +21,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, renameSync, appendFileSync, chmodSync, unlinkSync, readdirSync, statSync, rmSync } from "node:fs";
 import { homedir, platform as osPlatform } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { detectInstallMethod, type InstallMethod } from "./install-method.ts";
 import {
     bashCompletionScript,
     zshCompletionScript,
@@ -607,13 +608,20 @@ function removeWindowsPath(dir: string): boolean {
 export interface UninstallOptions {
     /** Also remove ~/.atomic/ (config, completions cache, downloads). */
     readonly purge?: boolean;
+    /** Test seam — inject detector to avoid mock.module pollution. */
+    readonly detectInstall?: () => InstallMethod;
 }
 
-export async function uninstallCommand(opts: UninstallOptions = {}): Promise<number> {
-    const paths = getInstallPaths();
+const PACKAGE_NAME = "@bastani/atomic";
 
-    process.stdout.write("Uninstalling atomic...\n");
+const PM_REMOVE_CMD: Record<"bun" | "npm" | "pnpm" | "yarn", string[]> = {
+    bun:  ["bun",  "remove",    "-g",     PACKAGE_NAME],
+    npm:  ["npm",  "uninstall", "-g",     PACKAGE_NAME],
+    pnpm: ["pnpm", "remove",    "-g",     PACKAGE_NAME],
+    yarn: ["yarn", "global",    "remove", PACKAGE_NAME],
+};
 
+function uninstallBinary(paths: InstallPaths): void {
     // 1. Remove the launcher binary (and any leftover .old.*/.tmp.*).
     if (existsSync(paths.binPath)) {
         try {
@@ -675,26 +683,73 @@ export async function uninstallCommand(opts: UninstallOptions = {}): Promise<num
         try { unlinkSync(fishCompletion); } catch { /* ignore */ }
     }
 
-    // 5. Optional: nuke ~/.atomic/ entirely.
-    if (opts.purge) {
-        const atomicHome = join(homedir(), ".atomic");
-        try {
-            rmSync(atomicHome, { recursive: true, force: true });
-            process.stdout.write(`  ✓ purged ${atomicHome}\n`);
-        } catch (err) {
-            process.stderr.write(`  ! could not purge ${atomicHome}: ${(err as Error).message}\n`);
+    process.stdout.write("Restart your shell to drop the PATH entry from your env.\n");
+}
+
+function purgeAtomicHome(): void {
+    const atomicHome = join(homedir(), ".atomic");
+    try {
+        rmSync(atomicHome, { recursive: true, force: true });
+        process.stdout.write(`  ✓ purged ${atomicHome}\n`);
+    } catch (err) {
+        process.stderr.write(`  ! could not purge ${atomicHome}: ${(err as Error).message}\n`);
+    }
+}
+
+async function spawnPmRemove(cmd: string[]): Promise<number> {
+    const pm = cmd[0];
+    const manualHint = `    You may need to run manually: ${cmd.join(" ")}\n`;
+    try {
+        const proc = Bun.spawn({ cmd, stdout: "inherit", stderr: "inherit" });
+        const code = await proc.exited;
+        if (code !== 0) {
+            process.stderr.write(`  ! ${pm} exited with code ${code}.\n${manualHint}`);
         }
-    } else {
-        // Just the completions cache, leaving config/downloads alone.
-        rmSync(paths.completionsDir, { recursive: true, force: true });
+        return code;
+    } catch (err) {
+        process.stderr.write(`  ! ${pm} spawn failed: ${(err as Error).message}\n${manualHint}`);
+        return 1;
+    }
+}
+
+export async function uninstallCommand(opts: UninstallOptions = {}): Promise<number> {
+    const method = (opts.detectInstall ?? detectInstallMethod)();
+    const paths = getInstallPaths();
+    process.stdout.write(`Uninstalling atomic (install method: ${method})...\n`);
+
+    let pmExit = 0;
+    switch (method) {
+        case "binary":
+            uninstallBinary(paths);
+            break;
+        case "bun":
+        case "npm":
+        case "pnpm":
+        case "yarn":
+            pmExit = await spawnPmRemove(PM_REMOVE_CMD[method]);
+            break;
+        case "source":
+        case "unknown":
+            process.stdout.write(
+                `  · skipping package removal — atomic appears to run from ${process.execPath}\n` +
+                `    if you installed via a package manager, run its uninstall command manually.\n`,
+            );
+            break;
     }
 
-    process.stdout.write("\nAtomic uninstalled. Restart your shell to drop the PATH entry from your env.\n");
-    if (!opts.purge) {
+    if (opts.purge) {
+        purgeAtomicHome();
+    } else {
+        // Always reap the completions cache; --purge subsumes this by removing ~/.atomic.
+        try { rmSync(paths.completionsDir, { recursive: true, force: true }); }
+        catch { /* best-effort */ }
         process.stdout.write(`(Run with --purge to also remove ${join(homedir(), ".atomic")})\n`);
     }
-    process.stdout.write("\n");
-    return 0;
+
+    if (pmExit === 0) {
+        process.stdout.write("\nAtomic uninstalled.\n");
+    }
+    return pmExit;
 }
 
 // ── Public entry ───────────────────────────────────────────────────────────

--- a/packages/atomic/src/commands/cli/install.ts
+++ b/packages/atomic/src/commands/cli/install.ts
@@ -612,13 +612,11 @@ export interface UninstallOptions {
     readonly detectInstall?: () => InstallMethod;
 }
 
-const PACKAGE_NAME = "@bastani/atomic";
-
-const PM_REMOVE_CMD: Record<"bun" | "npm" | "pnpm" | "yarn", string[]> = {
-    bun:  ["bun",  "remove",    "-g",     PACKAGE_NAME],
-    npm:  ["npm",  "uninstall", "-g",     PACKAGE_NAME],
-    pnpm: ["pnpm", "remove",    "-g",     PACKAGE_NAME],
-    yarn: ["yarn", "global",    "remove", PACKAGE_NAME],
+const PM_REMOVE_HINT: Record<"bun" | "npm" | "pnpm" | "yarn", string> = {
+    bun:  "bun remove -g @bastani/atomic",
+    npm:  "npm uninstall -g @bastani/atomic",
+    pnpm: "pnpm remove -g @bastani/atomic",
+    yarn: "yarn global remove @bastani/atomic",
 };
 
 function uninstallBinary(paths: InstallPaths): void {
@@ -696,60 +694,43 @@ function purgeAtomicHome(): void {
     }
 }
 
-async function spawnPmRemove(cmd: string[]): Promise<number> {
-    const pm = cmd[0];
-    const manualHint = `    You may need to run manually: ${cmd.join(" ")}\n`;
-    try {
-        const proc = Bun.spawn({ cmd, stdout: "inherit", stderr: "inherit" });
-        const code = await proc.exited;
-        if (code !== 0) {
-            process.stderr.write(`  ! ${pm} exited with code ${code}.\n${manualHint}`);
-        }
-        return code;
-    } catch (err) {
-        process.stderr.write(`  ! ${pm} spawn failed: ${(err as Error).message}\n${manualHint}`);
-        return 1;
-    }
-}
-
 export async function uninstallCommand(opts: UninstallOptions = {}): Promise<number> {
     const method = (opts.detectInstall ?? detectInstallMethod)();
-    const paths = getInstallPaths();
-    process.stdout.write(`Uninstalling atomic (install method: ${method})...\n`);
 
-    let pmExit = 0;
     switch (method) {
-        case "binary":
-            uninstallBinary(paths);
-            break;
         case "bun":
         case "npm":
         case "pnpm":
         case "yarn":
-            pmExit = await spawnPmRemove(PM_REMOVE_CMD[method]);
-            break;
+            process.stderr.write(
+                `Error: atomic was installed via ${method}.\n` +
+                `Please run: ${PM_REMOVE_HINT[method]}\n`,
+            );
+            return 1;
         case "source":
         case "unknown":
-            process.stdout.write(
-                `  · skipping package removal — atomic appears to run from ${process.execPath}\n` +
-                `    if you installed via a package manager, run its uninstall command manually.\n`,
+            process.stderr.write(
+                `Error: atomic appears to run from ${process.execPath}.\n` +
+                `Cannot determine how to uninstall — remove manually or use your package manager.\n`,
             );
-            break;
+            return 1;
+        case "binary": {
+            const paths = getInstallPaths();
+            process.stdout.write("Uninstalling atomic (install method: binary)...\n");
+            uninstallBinary(paths);
+            if (opts.purge) {
+                purgeAtomicHome();
+            } else {
+                // ~/.atomic/completions is a derived cache — always reap.
+                // --purge subsumes this by removing ~/.atomic outright.
+                try { rmSync(paths.completionsDir, { recursive: true, force: true }); }
+                catch { /* best-effort */ }
+                process.stdout.write(`(Run with --purge to also remove ${join(homedir(), ".atomic")})\n`);
+            }
+            process.stdout.write("\nAtomic uninstalled.\n");
+            return 0;
+        }
     }
-
-    if (opts.purge) {
-        purgeAtomicHome();
-    } else {
-        // Always reap the completions cache; --purge subsumes this by removing ~/.atomic.
-        try { rmSync(paths.completionsDir, { recursive: true, force: true }); }
-        catch { /* best-effort */ }
-        process.stdout.write(`(Run with --purge to also remove ${join(homedir(), ".atomic")})\n`);
-    }
-
-    if (pmExit === 0) {
-        process.stdout.write("\nAtomic uninstalled.\n");
-    }
-    return pmExit;
 }
 
 // ── Public entry ───────────────────────────────────────────────────────────

--- a/packages/atomic/src/commands/cli/uninstall.test.ts
+++ b/packages/atomic/src/commands/cli/uninstall.test.ts
@@ -1,0 +1,417 @@
+/**
+ * RFC §8.3 branch tests for uninstallCommand().
+ *
+ * TEST ISOLATION CONTRACT (RFC §5.4):
+ * Any test in this file that imports `./install.ts` (directly or via
+ * loadUninstall) MUST run inside the env-redirect block established by
+ * the top-level beforeAll/afterAll. The redirect points HOME, USERPROFILE,
+ * and LOCALAPPDATA at a per-suite mkdtempSync(...) directory, so every
+ * homedir() callsite in install.ts and install-method.ts lands inside the
+ * tmp dir. The binary-branch describe additionally mocks fs.unlinkSync /
+ * appendFileSync / writeFileSync / renameSync / existsSync / rmSync so
+ * the run is deterministic regardless of stray sentinel files inside
+ * tmpHome.
+ *
+ * Each describe re-imports uninstallCommand via `loadUninstall(method)` so
+ * the mocked `detectInstallMethod` takes effect for that module load.
+ */
+
+import {
+    describe,
+    test,
+    expect,
+    afterAll,
+    beforeEach,
+    afterEach,
+    spyOn,
+    mock,
+} from "bun:test";
+import * as fs from "node:fs";
+import * as nodeOs from "node:os";
+import { join } from "node:path";
+import type { InstallMethod } from "./install-method.ts";
+
+// ─── tmp HOME isolation (RFC §5.4) ────────────────────────────────────────────
+// Bun's native homedir() caches the OS value at startup and ignores $HOME
+// mutations. We intercept it via mock.module("node:os") so every callsite
+// (install.ts, install-method.ts, and test bodies) sees the tmp dir.
+//
+// Bootstrapped at module evaluation time so mock.module takes effect before
+// the first dynamic import in loadUninstall — no beforeAll needed.
+
+const tmpHome = fs.mkdtempSync(join(nodeOs.tmpdir(), "atomic-uninstall-test-"));
+const origHome = process.env.HOME;
+const origUserProfile = process.env.USERPROFILE;
+const origLocalAppData = process.env.LOCALAPPDATA;
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+process.env.LOCALAPPDATA = join(tmpHome, "AppData", "Local");
+
+// Override homedir() for every module loaded in this test file.
+// The proxy forwards every other os export unchanged.
+await mock.module("node:os", () => ({
+    ...nodeOs,
+    homedir: () => tmpHome,
+}));
+
+afterAll(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    if (origUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = origUserProfile;
+    if (origLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+    else process.env.LOCALAPPDATA = origLocalAppData;
+});
+
+// ─── self-check (RFC §5.4): env-redirect must be active before any test ───────
+
+test("env-redirect: HOME and homedir() both point at tmpHome", () => {
+    // Fails loud if a future refactor short-circuits the redirect.
+    expect(process.env.HOME).toBe(tmpHome);
+    expect(nodeOs.homedir()).toBe(tmpHome);
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+interface CapturedIO {
+    readonly stdout: string[];
+    readonly stderr: string[];
+    readonly restore: () => void;
+}
+
+function captureIO(): CapturedIO {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const outSpy = spyOn(process.stdout, "write").mockImplementation(
+        (chunk: unknown) => { stdout.push(String(chunk)); return true; },
+    );
+    const errSpy = spyOn(process.stderr, "write").mockImplementation(
+        (chunk: unknown) => { stderr.push(String(chunk)); return true; },
+    );
+    return {
+        stdout,
+        stderr,
+        restore: () => { outSpy.mockRestore(); errSpy.mockRestore(); },
+    };
+}
+
+interface SpawnStub {
+    readonly spy: ReturnType<typeof spyOn<typeof Bun, "spawn">>;
+    readonly calls: { cmd: string[] }[];
+}
+
+function makeSpawnStub(exitCode: number): SpawnStub {
+    const calls: { cmd: string[] }[] = [];
+    const spy = spyOn(Bun, "spawn").mockImplementation(((opts: { cmd: string[] }) => {
+        calls.push(opts);
+        return { exited: Promise.resolve(exitCode) } as { exited: Promise<number> };
+    }) as unknown as typeof Bun.spawn);
+    return { spy, calls };
+}
+
+interface FsMocksOpts {
+    /** Exit code for the Bun.spawn stub. */
+    readonly exitCode: number;
+    /** When true, also spy on fs.unlinkSync / appendFileSync / writeFileSync / renameSync / existsSync. */
+    readonly binaryBranch?: boolean;
+    /** Custom impl for fs.rmSync; defaults to no-op. */
+    readonly rmImpl?: (path: fs.PathLike) => void;
+}
+
+interface FsMocksCtx {
+    io: CapturedIO;
+    spawn: SpawnStub;
+    rm: ReturnType<typeof spyOn<typeof fs, "rmSync">>;
+    /** Extra spies active when binaryBranch === true */
+    fsSpy?: {
+        unlink: ReturnType<typeof spyOn<typeof fs, "unlinkSync">>;
+        append: ReturnType<typeof spyOn<typeof fs, "appendFileSync">>;
+        write: ReturnType<typeof spyOn<typeof fs, "writeFileSync">>;
+        rename: ReturnType<typeof spyOn<typeof fs, "renameSync">>;
+        exists: ReturnType<typeof spyOn<typeof fs, "existsSync">>;
+    };
+}
+
+/**
+ * Unified fs-mocks lifecycle helper.
+ *
+ * Always mocks Bun.spawn (configurable exit code) and fs.rmSync (configurable
+ * impl, defaults to no-op). When binaryBranch is true, also mocks
+ * fs.unlinkSync / appendFileSync / writeFileSync / renameSync / existsSync so
+ * the binary branch runs deterministically without touching real HOME.
+ *
+ * All spies are restored in afterEach. Returns a live ctx object whose fields
+ * are populated in beforeEach and readable from test bodies.
+ */
+function withFsMocks(opts: FsMocksOpts): FsMocksCtx {
+    const rmImpl = opts.rmImpl ?? (() => {});
+    const ctx = {} as FsMocksCtx;
+
+    beforeEach(() => {
+        ctx.io = captureIO();
+        ctx.spawn = makeSpawnStub(opts.exitCode);
+        ctx.rm = spyOn(fs, "rmSync").mockImplementation(
+            ((path: fs.PathLike) => rmImpl(path)) as unknown as typeof fs.rmSync,
+        );
+
+        if (opts.binaryBranch) {
+            ctx.fsSpy = {
+                unlink: spyOn(fs, "unlinkSync").mockImplementation((() => {}) as unknown as typeof fs.unlinkSync),
+                append: spyOn(fs, "appendFileSync").mockImplementation((() => {}) as unknown as typeof fs.appendFileSync),
+                write: spyOn(fs, "writeFileSync").mockImplementation((() => {}) as unknown as typeof fs.writeFileSync),
+                rename: spyOn(fs, "renameSync").mockImplementation((() => {}) as unknown as typeof fs.renameSync),
+                exists: spyOn(fs, "existsSync").mockImplementation((() => false) as unknown as typeof fs.existsSync),
+            };
+        }
+    });
+
+    afterEach(() => {
+        ctx.io.restore();
+        ctx.spawn.spy.mockRestore();
+        ctx.rm.mockRestore();
+        if (ctx.fsSpy) {
+            for (const spy of Object.values(ctx.fsSpy)) spy.mockRestore();
+        }
+    });
+
+    return ctx;
+}
+
+/**
+ * Returns a bound uninstallCommand that injects the given install method via
+ * the `detectInstall` option — no global mock.module() needed.  This keeps
+ * install-method.ts uncontaminated so install-method.win32.test.ts (and any
+ * other file that imports the real module) sees the actual implementation.
+ */
+async function loadUninstall(method: InstallMethod): Promise<{
+    uninstallCommand: (opts?: { purge?: boolean }) => Promise<number>;
+}> {
+    const mod = await import("./install.ts");
+    const detectInstall = () => method;
+    return {
+        uninstallCommand: (opts = {}) => mod.uninstallCommand({ ...opts, detectInstall }),
+    };
+}
+
+// ─── binary branch ────────────────────────────────────────────────────────────
+
+describe("uninstallCommand — binary branch", () => {
+    // binaryBranch: also mock unlinkSync/writeFileSync/etc so real HOME is untouched
+    const ctx = withFsMocks({ exitCode: 0, binaryBranch: true });
+
+    test("binary: key step lines present in stdout", async () => {
+        const { uninstallCommand } = await loadUninstall("binary");
+        expect(await uninstallCommand({})).toBe(0);
+        const out = ctx.io.stdout.join("");
+        expect(out).toContain("Uninstalling atomic (install method: binary)");
+        expect(out).toContain("Atomic uninstalled");
+    });
+});
+
+// ─── pkg-manager branches (bun / npm / pnpm / yarn) ──────────────────────────
+
+const pmBranches: ReadonlyArray<{ method: InstallMethod; cmd: string[] }> = [
+    { method: "bun",  cmd: ["bun",  "remove",    "-g",     "@bastani/atomic"] },
+    { method: "npm",  cmd: ["npm",  "uninstall", "-g",     "@bastani/atomic"] },
+    { method: "pnpm", cmd: ["pnpm", "remove",    "-g",     "@bastani/atomic"] },
+    { method: "yarn", cmd: ["yarn", "global",    "remove", "@bastani/atomic"] },
+];
+
+for (const { method, cmd } of pmBranches) {
+    describe(`uninstallCommand — ${method} branch`, () => {
+        const ctx = withFsMocks({ exitCode: 0 });
+
+        test(`${method}: spawns ${cmd.join(" ")}`, async () => {
+            const { uninstallCommand } = await loadUninstall(method);
+            expect(await uninstallCommand({})).toBe(0);
+            expect(ctx.spawn.calls.length).toBeGreaterThanOrEqual(1);
+            expect(ctx.spawn.calls[0]?.cmd).toEqual(cmd);
+        });
+    });
+}
+
+// ─── pm non-zero exit ────────────────────────────────────────────────────────
+
+describe("uninstallCommand — pm non-zero exit", () => {
+    const ctx = withFsMocks({ exitCode: 1 });
+
+    test("pm exit 1: stderr has manual-run hint; uninstallCommand returns 1", async () => {
+        const { uninstallCommand } = await loadUninstall("npm");
+        expect(await uninstallCommand({})).toBe(1);
+        expect(ctx.io.stderr.join("")).toContain("You may need to run manually:");
+    });
+});
+
+// ─── source / unknown branches ───────────────────────────────────────────────
+
+for (const method of ["source", "unknown"] as const) {
+    describe(`uninstallCommand — ${method} branch`, () => {
+        const ctx = withFsMocks({ exitCode: 0 });
+
+        test(`${method}: no spawn; stdout contains skipping package removal; returns 0`, async () => {
+            const { uninstallCommand } = await loadUninstall(method);
+            expect(await uninstallCommand({})).toBe(0);
+            expect(ctx.spawn.calls.length).toBe(0);
+            expect(ctx.io.stdout.join("")).toContain("skipping package removal");
+        });
+    });
+}
+
+// ─── --purge flag ────────────────────────────────────────────────────────────
+
+describe("uninstallCommand — --purge flag", () => {
+    // join(nodeOs.homedir(), ".atomic") resolves to tmpHome/.atomic because beforeAll redirected HOME
+    const atomicHome = join(nodeOs.homedir(), ".atomic");
+    const ctx = withFsMocks({ exitCode: 0 });
+
+    test("purge: rmSync called with ~/.atomic when --purge set", async () => {
+        const { uninstallCommand } = await loadUninstall("bun");
+        expect(await uninstallCommand({ purge: true })).toBe(0);
+        const purgeCall = ctx.rm.mock.calls.find((args) => String(args[0]) === atomicHome);
+        expect(purgeCall).toBeDefined();
+        expect(purgeCall?.[1]).toMatchObject({ recursive: true, force: true });
+    });
+
+    test("no purge: rmSync NOT called with ~/.atomic when --purge absent", async () => {
+        const { uninstallCommand } = await loadUninstall("bun");
+        expect(await uninstallCommand({})).toBe(0);
+        const purgeCall = ctx.rm.mock.calls.find((args) => String(args[0]) === atomicHome);
+        expect(purgeCall).toBeUndefined();
+    });
+});
+
+// ─── --purge failure + pm non-zero exit ──────────────────────────────────────
+
+describe("uninstallCommand — --purge failure + pm non-zero", () => {
+    // join(nodeOs.homedir(), ".atomic") resolves to tmpHome/.atomic because beforeAll redirected HOME
+    const atomicHome = join(nodeOs.homedir(), ".atomic");
+    const ctx = withFsMocks({
+        exitCode: 1,
+        rmImpl: (path) => {
+            if (String(path) === atomicHome) {
+                throw new Error("EACCES: permission denied");
+            }
+        },
+    });
+
+    test("purge throws + pm exits 1: both errors surfaced; pm exit code wins", async () => {
+        const { uninstallCommand } = await loadUninstall("npm");
+        expect(await uninstallCommand({ purge: true })).toBe(1);
+        const errOut = ctx.io.stderr.join("");
+        expect(errOut).toContain("You may need to run manually:");
+        expect(errOut).toContain("could not purge");
+    });
+});
+
+// ─── Bun.spawn throws synchronously ──────────────────────────────────────────
+
+describe("uninstallCommand — Bun.spawn throws synchronously", () => {
+    let io: CapturedIO;
+    let spawnSpy: ReturnType<typeof spyOn<typeof Bun, "spawn">>;
+
+    beforeEach(() => {
+        io = captureIO();
+        spawnSpy = spyOn(Bun, "spawn").mockImplementation((() => {
+            throw new Error("Executable not found in $PATH: \"bun\"");
+        }) as unknown as typeof Bun.spawn);
+    });
+
+    afterEach(() => {
+        io.restore();
+        spawnSpy.mockRestore();
+    });
+
+    test("bun spawn throw: returns 1, stderr contains hint, does not unhandled-reject", async () => {
+        const { uninstallCommand } = await loadUninstall("bun");
+        expect(await uninstallCommand({})).toBe(1);
+        expect(io.stderr.join("")).toContain(
+            "You may need to run manually: bun remove -g @bastani/atomic",
+        );
+    });
+});
+
+// ─── completions cleanup hoist ───────────────────────────────────────────────
+
+describe("uninstallCommand — completions cleanup hoist", () => {
+    // join(nodeOs.homedir(), ".atomic", "completions") resolves to tmpHome/.atomic/completions
+    const completionsDir = join(nodeOs.homedir(), ".atomic", "completions");
+    const ctx = withFsMocks({ exitCode: 0 });
+
+    const methods: ReadonlyArray<InstallMethod> = [
+        "binary", "bun", "npm", "pnpm", "yarn", "source", "unknown",
+    ];
+    for (const method of methods) {
+        test(`${method}: rmSync called with completionsDir + {recursive,force}`, async () => {
+            const { uninstallCommand } = await loadUninstall(method);
+            expect(await uninstallCommand({})).toBe(0);
+            const completionsCall = ctx.rm.mock.calls.find(
+                (args) => String(args[0]) === completionsDir,
+            );
+            expect(completionsCall).toBeDefined();
+            expect(completionsCall?.[1]).toMatchObject({ recursive: true, force: true });
+        });
+    }
+});
+
+// ─── --purge subsumes completions cleanup ────────────────────────────────────
+
+describe("uninstallCommand --purge: completions cleanup subsumed by purge", () => {
+    // join(homedir(), ...) resolves to tmpHome/... because beforeAll redirected HOME
+    const completionsDir = join(nodeOs.homedir(), ".atomic", "completions");
+    const atomicHome = join(nodeOs.homedir(), ".atomic");
+    const ctx = withFsMocks({ exitCode: 0 });
+
+    test("bun + --purge: rmSync called with ~/.atomic; NOT called with completionsDir explicitly", async () => {
+        const { uninstallCommand } = await loadUninstall("bun");
+        expect(await uninstallCommand({ purge: true })).toBe(0);
+        expect(ctx.rm.mock.calls.find((args) => String(args[0]) === atomicHome)).toBeDefined();
+        expect(ctx.rm.mock.calls.find((args) => String(args[0]) === completionsDir)).toBeUndefined();
+    });
+});
+
+// ─── terminal success line: per-method ───────────────────────────────────────
+
+const successMethods: ReadonlyArray<InstallMethod> = [
+    "bun", "npm", "pnpm", "yarn", "source", "unknown",
+];
+
+for (const method of successMethods) {
+    describe(`uninstallCommand — terminal success line (${method})`, () => {
+        const ctx = withFsMocks({ exitCode: 0 });
+
+        test(`${method}: stdout ends with \\nAtomic uninstalled.\\n`, async () => {
+            const { uninstallCommand } = await loadUninstall(method);
+            expect(await uninstallCommand({})).toBe(0);
+            const out = ctx.io.stdout.join("");
+            expect(out).toContain("\nAtomic uninstalled.\n");
+        });
+    });
+}
+
+// ─── terminal success line: --purge variant ───────────────────────────────────
+
+describe("uninstallCommand — terminal success line with --purge (bun)", () => {
+    const ctx = withFsMocks({ exitCode: 0 });
+
+    test("purge=true + bun: stdout still contains \\nAtomic uninstalled.\\n", async () => {
+        const { uninstallCommand } = await loadUninstall("bun");
+        expect(await uninstallCommand({ purge: true })).toBe(0);
+        const out = ctx.io.stdout.join("");
+        expect(out).toContain("\nAtomic uninstalled.\n");
+    });
+});
+
+// ─── terminal success line suppressed on pm non-zero exit ────────────────────
+
+describe("uninstallCommand — terminal success line suppressed on pm exit 1 (npm)", () => {
+    const ctx = withFsMocks({ exitCode: 1 });
+
+    test("npm exit 1: stdout does NOT contain \\nAtomic uninstalled.\\n; returns 1", async () => {
+        const { uninstallCommand } = await loadUninstall("npm");
+        const code = await uninstallCommand({});
+        expect(code).toBe(1);
+        const out = ctx.io.stdout.join("");
+        expect(out).not.toContain("\nAtomic uninstalled.\n");
+    });
+});

--- a/packages/atomic/src/commands/cli/uninstall.test.ts
+++ b/packages/atomic/src/commands/cli/uninstall.test.ts
@@ -1,43 +1,38 @@
 /**
- * RFC §8.3 branch tests for uninstallCommand().
+ * Branch tests for uninstallCommand().
  *
- * TEST ISOLATION CONTRACT (RFC §5.4):
- * Any test in this file that imports `./install.ts` (directly or via
- * loadUninstall) MUST run inside the env-redirect block established by
- * the top-level beforeAll/afterAll. The redirect points HOME, USERPROFILE,
- * and LOCALAPPDATA at a per-suite mkdtempSync(...) directory, so every
- * homedir() callsite in install.ts and install-method.ts lands inside the
- * tmp dir. The binary-branch describe additionally mocks fs.unlinkSync /
- * appendFileSync / writeFileSync / renameSync / existsSync / rmSync so
- * the run is deterministic regardless of stray sentinel files inside
- * tmpHome.
+ * Policy:
+ *   - binary install         → full cleanup (launcher / rc / completions; --purge nukes ~/.atomic).
+ *   - bun/npm/pnpm/yarn      → refuse with hint pointing at the pm's own remove command, exit 1.
+ *   - source/unknown         → refuse with execPath hint, exit 1.
  *
- * Each describe re-imports uninstallCommand via `loadUninstall(method)` so
- * the mocked `detectInstallMethod` takes effect for that module load.
+ * Test isolation (RFC §5.4): a per-suite mkdtempSync HOME redirect plus
+ * a node:os.homedir() override (via mock.module) keeps every fs touch
+ * inside a tmp dir, so the binary branch can run without affecting the
+ * real HOME. The pm and source/unknown branches must never touch the
+ * filesystem at all — those tests assert `fs.rmSync` was never called.
  */
 
 import {
-    describe,
-    test,
-    expect,
     afterAll,
-    beforeEach,
     afterEach,
-    spyOn,
+    beforeEach,
+    describe,
+    expect,
     mock,
+    spyOn,
+    test,
 } from "bun:test";
 import * as fs from "node:fs";
 import * as nodeOs from "node:os";
 import { join } from "node:path";
 import type { InstallMethod } from "./install-method.ts";
 
-// ─── tmp HOME isolation (RFC §5.4) ────────────────────────────────────────────
+// ─── tmp HOME isolation ──────────────────────────────────────────────────────
 // Bun's native homedir() caches the OS value at startup and ignores $HOME
-// mutations. We intercept it via mock.module("node:os") so every callsite
-// (install.ts, install-method.ts, and test bodies) sees the tmp dir.
-//
-// Bootstrapped at module evaluation time so mock.module takes effect before
-// the first dynamic import in loadUninstall — no beforeAll needed.
+// mutations. Intercept via mock.module("node:os") so install.ts and any
+// test body see the tmp dir. Bootstrapped at module-eval time so the mock
+// takes effect before the first dynamic import in loadUninstall().
 
 const tmpHome = fs.mkdtempSync(join(nodeOs.tmpdir(), "atomic-uninstall-test-"));
 const origHome = process.env.HOME;
@@ -47,8 +42,6 @@ process.env.HOME = tmpHome;
 process.env.USERPROFILE = tmpHome;
 process.env.LOCALAPPDATA = join(tmpHome, "AppData", "Local");
 
-// Override homedir() for every module loaded in this test file.
-// The proxy forwards every other os export unchanged.
 await mock.module("node:os", () => ({
     ...nodeOs,
     homedir: () => tmpHome,
@@ -64,15 +57,12 @@ afterAll(() => {
     else process.env.LOCALAPPDATA = origLocalAppData;
 });
 
-// ─── self-check (RFC §5.4): env-redirect must be active before any test ───────
-
 test("env-redirect: HOME and homedir() both point at tmpHome", () => {
-    // Fails loud if a future refactor short-circuits the redirect.
     expect(process.env.HOME).toBe(tmpHome);
     expect(nodeOs.homedir()).toBe(tmpHome);
 });
 
-// ─── helpers ──────────────────────────────────────────────────────────────────
+// ─── helpers ─────────────────────────────────────────────────────────────────
 
 interface CapturedIO {
     readonly stdout: string[];
@@ -96,24 +86,8 @@ function captureIO(): CapturedIO {
     };
 }
 
-interface SpawnStub {
-    readonly spy: ReturnType<typeof spyOn<typeof Bun, "spawn">>;
-    readonly calls: { cmd: string[] }[];
-}
-
-function makeSpawnStub(exitCode: number): SpawnStub {
-    const calls: { cmd: string[] }[] = [];
-    const spy = spyOn(Bun, "spawn").mockImplementation(((opts: { cmd: string[] }) => {
-        calls.push(opts);
-        return { exited: Promise.resolve(exitCode) } as { exited: Promise<number> };
-    }) as unknown as typeof Bun.spawn);
-    return { spy, calls };
-}
-
 interface FsMocksOpts {
-    /** Exit code for the Bun.spawn stub. */
-    readonly exitCode: number;
-    /** When true, also spy on fs.unlinkSync / appendFileSync / writeFileSync / renameSync / existsSync. */
+    /** When true, also mock unlinkSync/append/write/rename/exists so the binary branch is deterministic. */
     readonly binaryBranch?: boolean;
     /** Custom impl for fs.rmSync; defaults to no-op. */
     readonly rmImpl?: (path: fs.PathLike) => void;
@@ -121,9 +95,7 @@ interface FsMocksOpts {
 
 interface FsMocksCtx {
     io: CapturedIO;
-    spawn: SpawnStub;
     rm: ReturnType<typeof spyOn<typeof fs, "rmSync">>;
-    /** Extra spies active when binaryBranch === true */
     fsSpy?: {
         unlink: ReturnType<typeof spyOn<typeof fs, "unlinkSync">>;
         append: ReturnType<typeof spyOn<typeof fs, "appendFileSync">>;
@@ -133,28 +105,15 @@ interface FsMocksCtx {
     };
 }
 
-/**
- * Unified fs-mocks lifecycle helper.
- *
- * Always mocks Bun.spawn (configurable exit code) and fs.rmSync (configurable
- * impl, defaults to no-op). When binaryBranch is true, also mocks
- * fs.unlinkSync / appendFileSync / writeFileSync / renameSync / existsSync so
- * the binary branch runs deterministically without touching real HOME.
- *
- * All spies are restored in afterEach. Returns a live ctx object whose fields
- * are populated in beforeEach and readable from test bodies.
- */
-function withFsMocks(opts: FsMocksOpts): FsMocksCtx {
+function withFsMocks(opts: FsMocksOpts = {}): FsMocksCtx {
     const rmImpl = opts.rmImpl ?? (() => {});
     const ctx = {} as FsMocksCtx;
 
     beforeEach(() => {
         ctx.io = captureIO();
-        ctx.spawn = makeSpawnStub(opts.exitCode);
         ctx.rm = spyOn(fs, "rmSync").mockImplementation(
             ((path: fs.PathLike) => rmImpl(path)) as unknown as typeof fs.rmSync,
         );
-
         if (opts.binaryBranch) {
             ctx.fsSpy = {
                 unlink: spyOn(fs, "unlinkSync").mockImplementation((() => {}) as unknown as typeof fs.unlinkSync),
@@ -168,7 +127,6 @@ function withFsMocks(opts: FsMocksOpts): FsMocksCtx {
 
     afterEach(() => {
         ctx.io.restore();
-        ctx.spawn.spy.mockRestore();
         ctx.rm.mockRestore();
         if (ctx.fsSpy) {
             for (const spy of Object.values(ctx.fsSpy)) spy.mockRestore();
@@ -179,10 +137,9 @@ function withFsMocks(opts: FsMocksOpts): FsMocksCtx {
 }
 
 /**
- * Returns a bound uninstallCommand that injects the given install method via
- * the `detectInstall` option — no global mock.module() needed.  This keeps
- * install-method.ts uncontaminated so install-method.win32.test.ts (and any
- * other file that imports the real module) sees the actual implementation.
+ * Binds uninstallCommand to a fixed install method via the `detectInstall`
+ * test seam. Avoids mock.module() pollution of install-method.ts so the
+ * detector tests in install-method.test.ts see the real implementation.
  */
 async function loadUninstall(method: InstallMethod): Promise<{
     uninstallCommand: (opts?: { purge?: boolean }) => Promise<number>;
@@ -194,224 +151,103 @@ async function loadUninstall(method: InstallMethod): Promise<{
     };
 }
 
-// ─── binary branch ────────────────────────────────────────────────────────────
+// ─── binary branch ───────────────────────────────────────────────────────────
 
 describe("uninstallCommand — binary branch", () => {
-    // binaryBranch: also mock unlinkSync/writeFileSync/etc so real HOME is untouched
-    const ctx = withFsMocks({ exitCode: 0, binaryBranch: true });
+    const ctx = withFsMocks({ binaryBranch: true });
 
-    test("binary: key step lines present in stdout", async () => {
+    test("binary: prints uninstall lines + exits 0", async () => {
         const { uninstallCommand } = await loadUninstall("binary");
         expect(await uninstallCommand({})).toBe(0);
         const out = ctx.io.stdout.join("");
         expect(out).toContain("Uninstalling atomic (install method: binary)");
         expect(out).toContain("Atomic uninstalled");
     });
-});
 
-// ─── pkg-manager branches (bun / npm / pnpm / yarn) ──────────────────────────
-
-const pmBranches: ReadonlyArray<{ method: InstallMethod; cmd: string[] }> = [
-    { method: "bun",  cmd: ["bun",  "remove",    "-g",     "@bastani/atomic"] },
-    { method: "npm",  cmd: ["npm",  "uninstall", "-g",     "@bastani/atomic"] },
-    { method: "pnpm", cmd: ["pnpm", "remove",    "-g",     "@bastani/atomic"] },
-    { method: "yarn", cmd: ["yarn", "global",    "remove", "@bastani/atomic"] },
-];
-
-for (const { method, cmd } of pmBranches) {
-    describe(`uninstallCommand — ${method} branch`, () => {
-        const ctx = withFsMocks({ exitCode: 0 });
-
-        test(`${method}: spawns ${cmd.join(" ")}`, async () => {
-            const { uninstallCommand } = await loadUninstall(method);
-            expect(await uninstallCommand({})).toBe(0);
-            expect(ctx.spawn.calls.length).toBeGreaterThanOrEqual(1);
-            expect(ctx.spawn.calls[0]?.cmd).toEqual(cmd);
-        });
-    });
-}
-
-// ─── pm non-zero exit ────────────────────────────────────────────────────────
-
-describe("uninstallCommand — pm non-zero exit", () => {
-    const ctx = withFsMocks({ exitCode: 1 });
-
-    test("pm exit 1: stderr has manual-run hint; uninstallCommand returns 1", async () => {
-        const { uninstallCommand } = await loadUninstall("npm");
-        expect(await uninstallCommand({})).toBe(1);
-        expect(ctx.io.stderr.join("")).toContain("You may need to run manually:");
-    });
-});
-
-// ─── source / unknown branches ───────────────────────────────────────────────
-
-for (const method of ["source", "unknown"] as const) {
-    describe(`uninstallCommand — ${method} branch`, () => {
-        const ctx = withFsMocks({ exitCode: 0 });
-
-        test(`${method}: no spawn; stdout contains skipping package removal; returns 0`, async () => {
-            const { uninstallCommand } = await loadUninstall(method);
-            expect(await uninstallCommand({})).toBe(0);
-            expect(ctx.spawn.calls.length).toBe(0);
-            expect(ctx.io.stdout.join("")).toContain("skipping package removal");
-        });
-    });
-}
-
-// ─── --purge flag ────────────────────────────────────────────────────────────
-
-describe("uninstallCommand — --purge flag", () => {
-    // join(nodeOs.homedir(), ".atomic") resolves to tmpHome/.atomic because beforeAll redirected HOME
-    const atomicHome = join(nodeOs.homedir(), ".atomic");
-    const ctx = withFsMocks({ exitCode: 0 });
-
-    test("purge: rmSync called with ~/.atomic when --purge set", async () => {
-        const { uninstallCommand } = await loadUninstall("bun");
-        expect(await uninstallCommand({ purge: true })).toBe(0);
-        const purgeCall = ctx.rm.mock.calls.find((args) => String(args[0]) === atomicHome);
-        expect(purgeCall).toBeDefined();
-        expect(purgeCall?.[1]).toMatchObject({ recursive: true, force: true });
-    });
-
-    test("no purge: rmSync NOT called with ~/.atomic when --purge absent", async () => {
-        const { uninstallCommand } = await loadUninstall("bun");
+    test("binary: completions cache reaped when --purge absent", async () => {
+        const completionsDir = join(nodeOs.homedir(), ".atomic", "completions");
+        const { uninstallCommand } = await loadUninstall("binary");
         expect(await uninstallCommand({})).toBe(0);
-        const purgeCall = ctx.rm.mock.calls.find((args) => String(args[0]) === atomicHome);
-        expect(purgeCall).toBeUndefined();
-    });
-});
-
-// ─── --purge failure + pm non-zero exit ──────────────────────────────────────
-
-describe("uninstallCommand — --purge failure + pm non-zero", () => {
-    // join(nodeOs.homedir(), ".atomic") resolves to tmpHome/.atomic because beforeAll redirected HOME
-    const atomicHome = join(nodeOs.homedir(), ".atomic");
-    const ctx = withFsMocks({
-        exitCode: 1,
-        rmImpl: (path) => {
-            if (String(path) === atomicHome) {
-                throw new Error("EACCES: permission denied");
-            }
-        },
-    });
-
-    test("purge throws + pm exits 1: both errors surfaced; pm exit code wins", async () => {
-        const { uninstallCommand } = await loadUninstall("npm");
-        expect(await uninstallCommand({ purge: true })).toBe(1);
-        const errOut = ctx.io.stderr.join("");
-        expect(errOut).toContain("You may need to run manually:");
-        expect(errOut).toContain("could not purge");
-    });
-});
-
-// ─── Bun.spawn throws synchronously ──────────────────────────────────────────
-
-describe("uninstallCommand — Bun.spawn throws synchronously", () => {
-    let io: CapturedIO;
-    let spawnSpy: ReturnType<typeof spyOn<typeof Bun, "spawn">>;
-
-    beforeEach(() => {
-        io = captureIO();
-        spawnSpy = spyOn(Bun, "spawn").mockImplementation((() => {
-            throw new Error("Executable not found in $PATH: \"bun\"");
-        }) as unknown as typeof Bun.spawn);
-    });
-
-    afterEach(() => {
-        io.restore();
-        spawnSpy.mockRestore();
-    });
-
-    test("bun spawn throw: returns 1, stderr contains hint, does not unhandled-reject", async () => {
-        const { uninstallCommand } = await loadUninstall("bun");
-        expect(await uninstallCommand({})).toBe(1);
-        expect(io.stderr.join("")).toContain(
-            "You may need to run manually: bun remove -g @bastani/atomic",
+        const completionsCall = ctx.rm.mock.calls.find(
+            (args) => String(args[0]) === completionsDir,
         );
+        expect(completionsCall).toBeDefined();
+        expect(completionsCall?.[1]).toMatchObject({ recursive: true, force: true });
     });
-});
 
-// ─── completions cleanup hoist ───────────────────────────────────────────────
-
-describe("uninstallCommand — completions cleanup hoist", () => {
-    // join(nodeOs.homedir(), ".atomic", "completions") resolves to tmpHome/.atomic/completions
-    const completionsDir = join(nodeOs.homedir(), ".atomic", "completions");
-    const ctx = withFsMocks({ exitCode: 0 });
-
-    const methods: ReadonlyArray<InstallMethod> = [
-        "binary", "bun", "npm", "pnpm", "yarn", "source", "unknown",
-    ];
-    for (const method of methods) {
-        test(`${method}: rmSync called with completionsDir + {recursive,force}`, async () => {
-            const { uninstallCommand } = await loadUninstall(method);
-            expect(await uninstallCommand({})).toBe(0);
-            const completionsCall = ctx.rm.mock.calls.find(
-                (args) => String(args[0]) === completionsDir,
-            );
-            expect(completionsCall).toBeDefined();
-            expect(completionsCall?.[1]).toMatchObject({ recursive: true, force: true });
-        });
-    }
-});
-
-// ─── --purge subsumes completions cleanup ────────────────────────────────────
-
-describe("uninstallCommand --purge: completions cleanup subsumed by purge", () => {
-    // join(homedir(), ...) resolves to tmpHome/... because beforeAll redirected HOME
-    const completionsDir = join(nodeOs.homedir(), ".atomic", "completions");
-    const atomicHome = join(nodeOs.homedir(), ".atomic");
-    const ctx = withFsMocks({ exitCode: 0 });
-
-    test("bun + --purge: rmSync called with ~/.atomic; NOT called with completionsDir explicitly", async () => {
-        const { uninstallCommand } = await loadUninstall("bun");
+    test("binary --purge: ~/.atomic wiped; completions not reaped explicitly (subsumed)", async () => {
+        const atomicHome = join(nodeOs.homedir(), ".atomic");
+        const completionsDir = join(atomicHome, "completions");
+        const { uninstallCommand } = await loadUninstall("binary");
         expect(await uninstallCommand({ purge: true })).toBe(0);
         expect(ctx.rm.mock.calls.find((args) => String(args[0]) === atomicHome)).toBeDefined();
         expect(ctx.rm.mock.calls.find((args) => String(args[0]) === completionsDir)).toBeUndefined();
     });
 });
 
-// ─── terminal success line: per-method ───────────────────────────────────────
+// ── purge throws — needs its own describe to register a different rmImpl ────
 
-const successMethods: ReadonlyArray<InstallMethod> = [
-    "bun", "npm", "pnpm", "yarn", "source", "unknown",
+describe("uninstallCommand — binary --purge: rmSync throws", () => {
+    const atomicHome = join(nodeOs.homedir(), ".atomic");
+    const ctx = withFsMocks({
+        binaryBranch: true,
+        rmImpl: (path) => {
+            if (String(path) === atomicHome) throw new Error("EACCES: permission denied");
+        },
+    });
+
+    test("rmSync(~/.atomic) throws → stderr has 'could not purge' hint, exit 0", async () => {
+        const { uninstallCommand } = await loadUninstall("binary");
+        expect(await uninstallCommand({ purge: true })).toBe(0);
+        expect(ctx.io.stderr.join("")).toContain("could not purge");
+    });
+});
+
+// ─── pm-managed installs: refuse with hint, exit 1 ───────────────────────────
+
+const pmHints: ReadonlyArray<{ method: InstallMethod; hint: string }> = [
+    { method: "bun",  hint: "bun remove -g @bastani/atomic" },
+    { method: "npm",  hint: "npm uninstall -g @bastani/atomic" },
+    { method: "pnpm", hint: "pnpm remove -g @bastani/atomic" },
+    { method: "yarn", hint: "yarn global remove @bastani/atomic" },
 ];
 
-for (const method of successMethods) {
-    describe(`uninstallCommand — terminal success line (${method})`, () => {
-        const ctx = withFsMocks({ exitCode: 0 });
+for (const { method, hint } of pmHints) {
+    describe(`uninstallCommand — ${method} branch (refuses)`, () => {
+        const ctx = withFsMocks();
 
-        test(`${method}: stdout ends with \\nAtomic uninstalled.\\n`, async () => {
+        test(`${method}: exit 1, stderr cites pm + hint, no fs.rmSync touches`, async () => {
             const { uninstallCommand } = await loadUninstall(method);
-            expect(await uninstallCommand({})).toBe(0);
-            const out = ctx.io.stdout.join("");
-            expect(out).toContain("\nAtomic uninstalled.\n");
+            expect(await uninstallCommand({})).toBe(1);
+            const err = ctx.io.stderr.join("");
+            expect(err).toContain(`atomic was installed via ${method}`);
+            expect(err).toContain(hint);
+            // Refusal must not touch ~/.atomic or completions cache.
+            expect(ctx.rm.mock.calls.length).toBe(0);
+        });
+
+        test(`${method} + --purge: still refuses; ~/.atomic untouched`, async () => {
+            const { uninstallCommand } = await loadUninstall(method);
+            expect(await uninstallCommand({ purge: true })).toBe(1);
+            expect(ctx.io.stderr.join("")).toContain(hint);
+            expect(ctx.rm.mock.calls.length).toBe(0);
         });
     });
 }
 
-// ─── terminal success line: --purge variant ───────────────────────────────────
+// ─── source / unknown: refuse with execPath hint, exit 1 ─────────────────────
 
-describe("uninstallCommand — terminal success line with --purge (bun)", () => {
-    const ctx = withFsMocks({ exitCode: 0 });
+for (const method of ["source", "unknown"] as const) {
+    describe(`uninstallCommand — ${method} branch (refuses)`, () => {
+        const ctx = withFsMocks();
 
-    test("purge=true + bun: stdout still contains \\nAtomic uninstalled.\\n", async () => {
-        const { uninstallCommand } = await loadUninstall("bun");
-        expect(await uninstallCommand({ purge: true })).toBe(0);
-        const out = ctx.io.stdout.join("");
-        expect(out).toContain("\nAtomic uninstalled.\n");
+        test(`${method}: exit 1, stderr cites execPath, no fs.rmSync touches`, async () => {
+            const { uninstallCommand } = await loadUninstall(method);
+            expect(await uninstallCommand({})).toBe(1);
+            const err = ctx.io.stderr.join("");
+            expect(err).toContain("atomic appears to run from");
+            expect(err).toContain(process.execPath);
+            expect(ctx.rm.mock.calls.length).toBe(0);
+        });
     });
-});
-
-// ─── terminal success line suppressed on pm non-zero exit ────────────────────
-
-describe("uninstallCommand — terminal success line suppressed on pm exit 1 (npm)", () => {
-    const ctx = withFsMocks({ exitCode: 1 });
-
-    test("npm exit 1: stdout does NOT contain \\nAtomic uninstalled.\\n; returns 1", async () => {
-        const { uninstallCommand } = await loadUninstall("npm");
-        const code = await uninstallCommand({});
-        expect(code).toBe(1);
-        const out = ctx.io.stdout.join("");
-        expect(out).not.toContain("\nAtomic uninstalled.\n");
-    });
-});
+}


### PR DESCRIPTION
## Summary

Gates \`atomic uninstall\` on how the binary was originally installed. Only binaries migrated by \`atomic install\` into \`~/.local/bin\` (Unix) or \`%LOCALAPPDATA%\atomic\bin\` (Windows) are permitted to self-uninstall; package-manager and source installs exit 1 with a targeted hint to the user.

## Key Changes

### \`install-method.ts\` (new)
- \`detectInstallMethod()\` classifies the running process as \`binary | bun | npm | pnpm | yarn | source | unknown\`
- Cheap \`execPath\` path heuristics first (\`~/.bun/install/global/\`, \`/pnpm/global/\`, \`/.config/yarn/global/\`), falling back to \`<pm> ls -g\` probes for ambiguous \`node_modules/@bastani/atomic-*/\` paths
- Memoized for production; overridable via \`execPath\` / \`platform\` / \`probe\` test seams to avoid \`mock.module\` pollution

### \`install.ts\` — \`uninstallCommand()\`
- **\`bun | npm | pnpm | yarn\`**: writes to stderr \`atomic was installed via <pm>\` and the exact remove command (e.g. \`bun remove -g @bastani/atomic\`), exits 1 — installation untouched
- **\`source | unknown\`**: writes \`execPath\` hint and exits 1
- **\`binary\`**: proceeds with full cleanup (binary removal, rc-snippet stripping, PATH update, fish completions, optional \`--purge\`)
- Refactored: extracted \`uninstallBinary()\` and \`purgeAtomicHome()\` helpers; \`uninstallCommand\` is now a pure dispatch switch

### \`publish.yml\` — CI validation harness
Added pre-\`atomic install\` steps (Unix + Windows) that assert the refusal behaviour on a fresh \`bun install -g\`:
- \`atomic uninstall\` exits non-zero
- Output contains \`atomic was installed via bun\` and \`bun remove -g @bastani/atomic\`
- \`atomic\` remains reachable on PATH after refusal (installation untouched)
- Smokes the \`bun remove -g @bastani/atomic\` round-trip, then re-installs for the existing binary lifecycle steps

## Test Coverage

| File | Tests |
|------|-------|
| \`install-method.test.ts\` | 308 lines |
| \`install-method.win32.test.ts\` | 46 lines |
| \`uninstall.test.ts\` | 253 lines |

- 250 tests pass / 0 fail (\`bun test packages/atomic/src/commands/cli/\`)
- \`bun typecheck\` — clean
- \`bun lint\` — clean

## Test Plan

- [x] \`bun test packages/atomic/src/commands/cli/\` — 250 pass / 0 fail
- [x] \`bun typecheck\` — clean for \`@bastani/atomic\`
- [x] \`bun lint\` — clean
- [ ] CI validate matrix passes on a release/prerelease PR (new harness lives in \`publish.yml\` validate, runs on release/prerelease merge)
- [ ] Manual: bun-install → \`atomic uninstall\` → assert refusal + hint, on Linux/macOS/Windows