### PR TITLE
feat(update): atomic update for binary installs, with per-platform CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -435,6 +435,224 @@ jobs:
           }
           Write-Output "wrapper OK: $($mux.Name) resolves to $($mux.Source)"
 
+      # ────────────────────────────────────────────────────────────────────
+      # ── `atomic update` lifecycle ──────────────────────────────────────
+      # ────────────────────────────────────────────────────────────────────
+      # Three checks run before uninstall:
+      #   1. PM `--check` smoke           — probes upstream version via
+      #                                     `bun pm view` etc., asserts
+      #                                     note rendering.
+      #   2. Binary download path         — points the CLI at a local
+      #                                     mock GitHub Releases server
+      #                                     (script/ci/mock-gh-releases.ts)
+      #                                     and runs the binary at its
+      #                                     install path so detection
+      #                                     returns "binary".
+      #   3. PM upgrade roundtrip         — bumps version to vN+1, re-
+      #                                     publishes to verdaccio, then
+      #                                     runs `atomic update -y` with
+      #                                     bun pinned at the local
+      #                                     registry.
+      #
+      # Caveat: the binaries themselves don't change between vN and vN+1
+      # (we re-tarball the same compiled output to keep the matrix cheap),
+      # so `atomic --version` reports vN throughout. The tests assert the
+      # update plumbing succeeds (download / verify / swap / spawn) but
+      # not that the version string advanced.
+      - name: Compute host target
+        id: host
+        shell: bash
+        run: |
+          case "${{ runner.os }}" in
+            Linux)   plat="linux"   ;;
+            macOS)   plat="darwin"  ;;
+            Windows) plat="windows" ;;
+            *) echo "unknown runner.os: ${{ runner.os }}"; exit 1 ;;
+          esac
+          arch="${{ matrix.arch }}"
+          libc_suffix=""
+          if [ "${{ matrix.libc }}" = "musl" ]; then libc_suffix="-musl"; fi
+          ext=""
+          if [ "${{ runner.os }}" = "Windows" ]; then ext=".exe"; fi
+          echo "host=${plat}-${arch}${libc_suffix}" >> $GITHUB_OUTPUT
+          echo "ext=${ext}" >> $GITHUB_OUTPUT
+
+      # Generates packages/atomic/release-assets/{atomic-<host>[.exe], manifest.json}
+      # from the matrix-built dist/ artifacts. Mock server reads from this
+      # directory; the manifest's sha256 must match the served binary.
+      - name: Generate release-assets manifest
+        shell: bash
+        run: bun packages/atomic/script/release-assets.ts
+
+      # ── 1. PM `--check` smoke ─────────────────────────────────────────
+      - name: atomic update --check (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          export PATH="$HOME/.bun/bin:$PATH"
+          out=$(atomic update --check 2>&1) || {
+            echo "$out"
+            echo "atomic update --check exited non-zero"
+            exit 1
+          }
+          echo "$out"
+          echo "$out" | grep -q "current=" || { echo "missing 'current=' in --check output"; exit 1; }
+          echo "$out" | grep -qE "method=(bun|npm|pnpm|yarn)" || { echo "missing 'method=<pm>' in --check output"; exit 1; }
+
+      - name: atomic update --check (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+          if ($userPath) { $env:Path = "$env:Path;$userPath" }
+          $out = atomic update --check 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output $out
+            throw "atomic update --check exited $LASTEXITCODE"
+          }
+          Write-Output $out
+          if ($out -notmatch 'current=')              { throw "missing 'current=' in --check output" }
+          if ($out -notmatch 'method=(bun|npm|pnpm|yarn)') { throw "missing 'method=<pm>' in --check output" }
+
+      # ── 2. Binary download path via mock GitHub Releases server ───────
+      # Uses port 4874 (verdaccio is on 4873). MOCK_VERSION=999.0.0 forces
+      # the `isNewer` check inside `runBinaryUpdate` to return true so the
+      # download/verify/swap path actually runs.
+      - name: atomic update -y via mock GitHub server (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          HOST: ${{ steps.host.outputs.host }}
+          EXT: ${{ steps.host.outputs.ext }}
+        run: |
+          set -euo pipefail
+          assets="$PWD/packages/atomic/release-assets"
+          test -f "$assets/atomic-${HOST}${EXT}" || { echo "host asset missing in $assets"; ls -la "$assets"; exit 1; }
+          test -f "$assets/manifest.json" || { echo "manifest.json missing in $assets"; exit 1; }
+
+          MOCK_PORT=4874 \
+          MOCK_VERSION="999.0.0" \
+          MOCK_ASSET_DIR="$assets" \
+          bun packages/atomic/script/ci/mock-gh-releases.ts \
+            > "$RUNNER_TEMP/mock-gh.log" 2>&1 &
+          mock_pid=$!
+          trap 'kill -TERM $mock_pid 2>/dev/null || true' EXIT
+
+          for i in $(seq 1 30); do
+            if grep -q "^READY " "$RUNNER_TEMP/mock-gh.log" 2>/dev/null; then break; fi
+            sleep 0.5
+          done
+          if ! grep -q "^READY " "$RUNNER_TEMP/mock-gh.log"; then
+            echo "mock-gh-releases failed to start"
+            cat "$RUNNER_TEMP/mock-gh.log" || true
+            exit 1
+          fi
+
+          export ATOMIC_GITHUB_API_BASE="http://127.0.0.1:4874/repos/flora131/atomic"
+          binary="$HOME/.local/bin/atomic"
+          test -x "$binary" || { echo "expected installed binary at $binary"; exit 1; }
+
+          # Run the update via the *installed* binary so detectInstallMethod
+          # returns "binary" (process.execPath == getInstallPaths().binPath).
+          "$binary" update -y --version 999.0.0
+          # Sanity: post-update binary still runs.
+          "$binary" --version
+
+      - name: atomic update -y via mock GitHub server (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          HOST: ${{ steps.host.outputs.host }}
+          EXT: ${{ steps.host.outputs.ext }}
+        run: |
+          $assets = Join-Path $PWD "packages\atomic\release-assets"
+          $hostAsset = Join-Path $assets "atomic-$env:HOST$env:EXT"
+          if (-not (Test-Path $hostAsset))                       { throw "host asset missing: $hostAsset" }
+          if (-not (Test-Path (Join-Path $assets 'manifest.json'))) { throw "manifest.json missing in $assets" }
+
+          $log = Join-Path $env:RUNNER_TEMP "mock-gh.log"
+          $mockEnv = @{
+            MOCK_PORT       = "4874"
+            MOCK_VERSION    = "999.0.0"
+            MOCK_ASSET_DIR  = $assets
+          }
+          foreach ($kv in $mockEnv.GetEnumerator()) { Set-Item -Path "Env:$($kv.Key)" -Value $kv.Value }
+
+          $mock = Start-Process -FilePath "bun" `
+            -ArgumentList "packages/atomic/script/ci/mock-gh-releases.ts" `
+            -NoNewWindow -PassThru `
+            -RedirectStandardOutput $log -RedirectStandardError "$log.err"
+          try {
+            for ($i = 0; $i -lt 30; $i++) {
+              if ((Test-Path $log) -and ((Get-Content $log -Raw -ErrorAction SilentlyContinue) -match '^READY ')) { break }
+              Start-Sleep -Milliseconds 500
+            }
+            if (-not ((Get-Content $log -Raw -ErrorAction SilentlyContinue) -match '^READY ')) {
+              if (Test-Path $log)       { Get-Content $log }
+              if (Test-Path "$log.err") { Get-Content "$log.err" }
+              throw "mock-gh-releases failed to start"
+            }
+
+            $env:ATOMIC_GITHUB_API_BASE = "http://127.0.0.1:4874/repos/flora131/atomic"
+            $binary = Join-Path $env:LOCALAPPDATA "atomic\bin\atomic.exe"
+            if (-not (Test-Path $binary)) { throw "expected installed binary at $binary" }
+
+            & $binary update -y --version 999.0.0
+            if ($LASTEXITCODE -ne 0) { throw "atomic update -y exited $LASTEXITCODE" }
+            & $binary --version
+            if ($LASTEXITCODE -ne 0) { throw "atomic --version exited $LASTEXITCODE post-update" }
+          } finally {
+            if (-not $mock.HasExited) { Stop-Process -Id $mock.Id -Force -ErrorAction SilentlyContinue }
+          }
+
+      # ── 3. PM upgrade roundtrip via verdaccio ────────────────────────
+      # Re-publishes the wrapper + platform packages at vN+1 (metadata-only
+      # bump; same binaries inside) so that `bun add -g @bastani/atomic@latest`
+      # — which `atomic update` shells out to — pulls a different version
+      # from the local registry.
+      - name: Bump version on verdaccio for update roundtrip
+        id: bump
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          NEXT="${VERSION}-update.1"
+          echo "next=${NEXT}" >> $GITHUB_OUTPUT
+          bun packages/atomic/script/bump-version.ts "$NEXT"
+          NPM_REGISTRY=http://localhost:4873 bun packages/atomic/script/publish.ts
+
+      - name: atomic update -y via verdaccio (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+          BUN_CONFIG_REGISTRY: http://localhost:4873
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.bun/bin:$PATH"
+          # `atomic update` for PM installs spawns `bun add -g @bastani/atomic@latest`,
+          # which inherits BUN_CONFIG_REGISTRY from this shell.
+          atomic update --check
+          atomic update -y
+          atomic --version
+
+      - name: atomic update -y via verdaccio (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+          BUN_CONFIG_REGISTRY: http://localhost:4873
+        run: |
+          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+          if ($userPath) { $env:Path = "$env:Path;$userPath" }
+          atomic update --check
+          if ($LASTEXITCODE -ne 0) { throw "atomic update --check exited $LASTEXITCODE" }
+          atomic update -y
+          if ($LASTEXITCODE -ne 0) { throw "atomic update -y exited $LASTEXITCODE" }
+          atomic --version
+          if ($LASTEXITCODE -ne 0) { throw "atomic --version exited $LASTEXITCODE post-update" }
+
       # ── `atomic uninstall`: removes launcher / rc snippets / completions
       #    cache but preserves ~/.atomic (no --purge flag).
       - name: atomic uninstall (Unix)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -438,27 +438,25 @@ jobs:
       # ────────────────────────────────────────────────────────────────────
       # ── `atomic update` lifecycle ──────────────────────────────────────
       # ────────────────────────────────────────────────────────────────────
-      # Three checks run before uninstall:
-      #   1. PM `--check` smoke           — probes upstream version via
-      #                                     `bun pm view` etc., asserts
-      #                                     note rendering.
-      #   2. Binary download path         — points the CLI at a local
-      #                                     mock GitHub Releases server
-      #                                     (script/ci/mock-gh-releases.ts)
-      #                                     and runs the binary at its
-      #                                     install path so detection
-      #                                     returns "binary".
-      #   3. PM upgrade roundtrip         — bumps version to vN+1, re-
-      #                                     publishes to verdaccio, then
-      #                                     runs `atomic update -y` with
-      #                                     bun pinned at the local
-      #                                     registry.
+      # `atomic update` is only a real upgrade path for the standalone
+      # binary install. PM-managed installs (bun/npm/pnpm/yarn) just print
+      # guidance pointing at the PM's own update command.
       #
-      # Caveat: the binaries themselves don't change between vN and vN+1
-      # (we re-tarball the same compiled output to keep the matrix cheap),
-      # so `atomic --version` reports vN throughout. The tests assert the
-      # update plumbing succeeds (download / verify / swap / spawn) but
-      # not that the version string advanced.
+      #   1. PM `--check` smoke   — runs against the bun-installed wrapper
+      #                             and asserts the rendered note tells
+      #                             the user to run `bun update -g`.
+      #   2. Binary download path — generates release-assets, points the
+      #                             CLI at a local mock GitHub Releases
+      #                             server (script/ci/mock-gh-releases.ts),
+      #                             and runs the installed binary so
+      #                             detection returns "binary". Exercises
+      #                             real download / verify / swap / spawn
+      #                             on every supported platform.
+      #
+      # Caveat (binary path): the same compiled binary is served as the
+      # vN+1 asset to keep the matrix cheap, so `atomic --version` still
+      # reports vN after the swap. The test asserts the plumbing
+      # succeeded, not that the version string advanced.
       - name: Compute host target
         id: host
         shell: bash
@@ -485,6 +483,9 @@ jobs:
         run: bun packages/atomic/script/release-assets.ts
 
       # ── 1. PM `--check` smoke ─────────────────────────────────────────
+      # `atomic` on PATH resolves to the bun-installed wrapper, so
+      # detectInstallMethod returns "bun" and `--check` should render
+      # a PM-update hint, not version metadata.
       - name: atomic update --check (Unix)
         if: runner.os != 'Windows'
         shell: bash
@@ -496,8 +497,8 @@ jobs:
             exit 1
           }
           echo "$out"
-          echo "$out" | grep -q "current=" || { echo "missing 'current=' in --check output"; exit 1; }
-          echo "$out" | grep -qE "method=(bun|npm|pnpm|yarn)" || { echo "missing 'method=<pm>' in --check output"; exit 1; }
+          echo "$out" | grep -q "installed via bun"           || { echo "missing 'installed via bun'"; exit 1; }
+          echo "$out" | grep -q "bun update -g @bastani/atomic" || { echo "missing PM update hint"; exit 1; }
 
       - name: atomic update --check (Windows)
         if: runner.os == 'Windows'
@@ -511,8 +512,8 @@ jobs:
             throw "atomic update --check exited $LASTEXITCODE"
           }
           Write-Output $out
-          if ($out -notmatch 'current=')              { throw "missing 'current=' in --check output" }
-          if ($out -notmatch 'method=(bun|npm|pnpm|yarn)') { throw "missing 'method=<pm>' in --check output" }
+          if ($out -notmatch 'installed via bun')             { throw "missing 'installed via bun'" }
+          if ($out -notmatch 'bun update -g @bastani/atomic') { throw "missing PM update hint" }
 
       # ── 2. Binary download path via mock GitHub Releases server ───────
       # Uses port 4874 (verdaccio is on 4873). MOCK_VERSION=999.0.0 forces
@@ -604,54 +605,6 @@ jobs:
           } finally {
             if (-not $mock.HasExited) { Stop-Process -Id $mock.Id -Force -ErrorAction SilentlyContinue }
           }
-
-      # ── 3. PM upgrade roundtrip via verdaccio ────────────────────────
-      # Re-publishes the wrapper + platform packages at vN+1 (metadata-only
-      # bump; same binaries inside) so that `bun add -g @bastani/atomic@latest`
-      # — which `atomic update` shells out to — pulls a different version
-      # from the local registry.
-      - name: Bump version on verdaccio for update roundtrip
-        id: bump
-        shell: bash
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          NEXT="${VERSION}-update.1"
-          echo "next=${NEXT}" >> $GITHUB_OUTPUT
-          bun packages/atomic/script/bump-version.ts "$NEXT"
-          NPM_REGISTRY=http://localhost:4873 bun packages/atomic/script/publish.ts
-
-      - name: atomic update -y via verdaccio (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        env:
-          NEXT: ${{ steps.bump.outputs.next }}
-          BUN_CONFIG_REGISTRY: http://localhost:4873
-        run: |
-          set -euo pipefail
-          export PATH="$HOME/.bun/bin:$PATH"
-          # `atomic update` for PM installs spawns `bun add -g @bastani/atomic@latest`,
-          # which inherits BUN_CONFIG_REGISTRY from this shell.
-          atomic update --check
-          atomic update -y
-          atomic --version
-
-      - name: atomic update -y via verdaccio (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        env:
-          NEXT: ${{ steps.bump.outputs.next }}
-          BUN_CONFIG_REGISTRY: http://localhost:4873
-        run: |
-          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
-          if ($userPath) { $env:Path = "$env:Path;$userPath" }
-          atomic update --check
-          if ($LASTEXITCODE -ne 0) { throw "atomic update --check exited $LASTEXITCODE" }
-          atomic update -y
-          if ($LASTEXITCODE -ne 0) { throw "atomic update -y exited $LASTEXITCODE" }
-          atomic --version
-          if ($LASTEXITCODE -ne 0) { throw "atomic --version exited $LASTEXITCODE post-update" }
 
       # ── `atomic uninstall`: removes launcher / rc snippets / completions
       #    cache but preserves ~/.atomic (no --purge flag).

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "examples/claude-background-subagents": {
       "name": "@bastani/example-claude-background-subagents",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -29,7 +29,7 @@
     },
     "examples/commander-embed": {
       "name": "@bastani/example-commander-embed",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -37,7 +37,7 @@
     },
     "examples/headless-test": {
       "name": "@bastani/example-headless-test",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -46,7 +46,7 @@
     },
     "examples/hello-world": {
       "name": "@bastani/example-hello-world",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -54,7 +54,7 @@
     },
     "examples/hil-favorite-color": {
       "name": "@bastani/example-hil-favorite-color",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -62,7 +62,7 @@
     },
     "examples/hil-favorite-color-headless": {
       "name": "@bastani/example-hil-favorite-color-headless",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -70,7 +70,7 @@
     },
     "examples/multi-workflow": {
       "name": "@bastani/example-multi-workflow",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -78,7 +78,7 @@
     },
     "examples/pane-navigation": {
       "name": "@bastani/example-pane-navigation",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -86,7 +86,7 @@
     },
     "examples/parallel-hello-world": {
       "name": "@bastani/example-parallel-hello-world",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -94,7 +94,7 @@
     },
     "examples/review-fix-loop": {
       "name": "@bastani/example-review-fix-loop",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -102,7 +102,7 @@
     },
     "examples/reviewer-tool-test": {
       "name": "@bastani/example-reviewer-tool-test",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -112,7 +112,7 @@
     },
     "examples/sequential-describe-summarize": {
       "name": "@bastani/example-sequential-describe-summarize",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -120,7 +120,7 @@
     },
     "examples/structured-output-demo": {
       "name": "@bastani/example-structured-output-demo",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@bastani/atomic-sdk": "workspace:*",
         "@commander-js/extra-typings": "^14.0.0",
@@ -130,7 +130,7 @@
     },
     "packages/atomic": {
       "name": "@bastani/atomic",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "bin": {
         "atomic": "src/cli.ts",
       },
@@ -153,14 +153,14 @@
     },
     "packages/atomic-sdk": {
       "name": "@bastani/atomic-sdk",
-      "version": "0.7.9-1",
+      "version": "0.7.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.132",
         "@catppuccin/palette": "^1.8.0",
         "@clack/prompts": "^1.3.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@github/copilot-sdk": "^0.3.0",
-        "@opencode-ai/sdk": "^1.14.39",
+        "@opencode-ai/sdk": "^1.14.40",
         "@opentui/core": "^0.2.3",
         "@opentui/react": "^0.2.3",
         "commander": "^14.0.3",
@@ -305,7 +305,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.39", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-hguOA5huhys7zwCR3ESbSHyQNuJBNtfrxUxYZF/s/6trRW+imqGmDtC/RsOSNuk7GE06ZnvOTwb4T2WhXYIBxw=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.40", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-e+Av0pNPhoPvQ02DK0Km6sHEXmTlFTuei6C8zV6E3/Iw8jQjTWsW/sssq0kKWnpeUqhdZVxPIqDc5Gvo+n/51A=="],
 
     "@opentui/core": ["@opentui/core@0.2.3", "", { "dependencies": { "bun-ffi-structs": "0.2.2", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.2.3", "@opentui/core-darwin-x64": "0.2.3", "@opentui/core-linux-arm64": "0.2.3", "@opentui/core-linux-x64": "0.2.3", "@opentui/core-win32-arm64": "0.2.3", "@opentui/core-win32-x64": "0.2.3" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-46YK/zF8NdpbaGzvo8zo+w8d6VFZTJpvVU+607SBgWE6yQDyDiyk0fk3TaJ6KwP9Fq0J1sALv0o2Q+AvXuXVcw=="],
 

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -71,7 +71,7 @@
     "@clack/prompts": "^1.3.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@github/copilot-sdk": "^0.3.0",
-    "@opencode-ai/sdk": "^1.14.39",
+    "@opencode-ai/sdk": "^1.14.40",
     "@opentui/core": "^0.2.3",
     "@opentui/react": "^0.2.3",
     "commander": "^14.0.3",

--- a/packages/atomic/script/ci/mock-gh-releases.ts
+++ b/packages/atomic/script/ci/mock-gh-releases.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+/**
+ * Mock GitHub Releases server for `atomic update` CI tests.
+ *
+ * Serves the two endpoints `release-fetch.ts` hits:
+ *   GET /releases/latest          → ReleaseInfo JSON
+ *   GET /releases/tags/<tag>      → ReleaseInfo JSON (same content)
+ *   GET /asset/<asset-name>       → raw binary bytes
+ *   GET /manifest.json            → manifest.json bytes
+ *
+ * Driven entirely by env vars so the publish.yml step doesn't need to
+ * pass shell-quoted JSON:
+ *
+ *   MOCK_PORT          (default 4874)
+ *   MOCK_VERSION       e.g. "0.7.9-update"  (renders as tag "v0.7.9-update")
+ *   MOCK_ASSET_DIR     directory containing the atomic-<host>[.exe] files
+ *                      (typically packages/atomic/release-assets/)
+ *   MOCK_MANIFEST_PATH path to manifest.json (typically MOCK_ASSET_DIR/manifest.json)
+ *
+ * On startup the server emits "READY <port>\n" to stdout — the calling
+ * shell can grep for it before exercising `atomic update`.
+ *
+ * Designed to run in the background (e.g. `bun … &`) and be killed via
+ * SIGTERM at the end of the matrix step.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+interface MockEnv {
+    readonly port: number;
+    readonly version: string;
+    readonly assetDir: string;
+    readonly manifestPath: string;
+}
+
+function readEnv(): MockEnv {
+    const port = Number(process.env.MOCK_PORT ?? "4874");
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+        throw new Error(`MOCK_PORT must be a valid TCP port; got "${process.env.MOCK_PORT}"`);
+    }
+    const version = process.env.MOCK_VERSION;
+    if (!version) throw new Error("MOCK_VERSION env var is required");
+    const assetDir = process.env.MOCK_ASSET_DIR;
+    if (!assetDir) throw new Error("MOCK_ASSET_DIR env var is required");
+    if (!existsSync(assetDir)) throw new Error(`MOCK_ASSET_DIR does not exist: ${assetDir}`);
+    const manifestPath = process.env.MOCK_MANIFEST_PATH ?? join(assetDir, "manifest.json");
+    if (!existsSync(manifestPath)) throw new Error(`manifest.json not found at: ${manifestPath}`);
+    return { port, version, assetDir, manifestPath };
+}
+
+function buildReleaseInfo(env: MockEnv, baseUrl: string): unknown {
+    // Enumerate every atomic-<target>[.exe] file in the asset dir plus the
+    // manifest. The CLI looks up an asset by name, so the set must include
+    // the host's binary; including all platforms keeps the mock honest.
+    const entries = readdirSync(env.assetDir).filter((name) => {
+        if (name === "manifest.json") return false;
+        const full = join(env.assetDir, name);
+        return statSync(full).isFile();
+    });
+
+    const assets = entries.map((name) => ({
+        name,
+        browser_download_url: `${baseUrl}/asset/${encodeURIComponent(name)}`,
+    }));
+    assets.push({
+        name: "manifest.json",
+        browser_download_url: `${baseUrl}/manifest.json`,
+    });
+
+    return {
+        tag_name: `v${env.version}`,
+        assets,
+    };
+}
+
+function main(): void {
+    const env = readEnv();
+
+    const server = Bun.serve({
+        port: env.port,
+        hostname: "127.0.0.1",
+        fetch(req: Request): Response {
+            const url = new URL(req.url);
+            const path = url.pathname;
+            const baseUrl = `http://${url.host}`;
+
+            // GitHub URL shapes — match both "/repos/<owner>/<repo>/releases/..."
+            // and bare "/releases/..." since callers can pass either base.
+            if (path.endsWith("/releases/latest") || path.includes("/releases/tags/")) {
+                return Response.json(buildReleaseInfo(env, baseUrl), {
+                    headers: { "Content-Type": "application/json" },
+                });
+            }
+
+            if (path === "/manifest.json") {
+                const bytes = readFileSync(env.manifestPath);
+                return new Response(bytes, {
+                    headers: { "Content-Type": "application/json" },
+                });
+            }
+
+            const assetMatch = path.match(/^\/asset\/(.+)$/);
+            if (assetMatch?.[1]) {
+                const assetName = decodeURIComponent(assetMatch[1]);
+                const filePath = join(env.assetDir, assetName);
+                if (!existsSync(filePath)) {
+                    return new Response(`asset not found: ${assetName}`, { status: 404 });
+                }
+                return new Response(Bun.file(filePath), {
+                    headers: { "Content-Type": "application/octet-stream" },
+                });
+            }
+
+            return new Response(`not found: ${path}`, { status: 404 });
+        },
+    });
+
+    process.stdout.write(`READY ${server.port}\n`);
+
+    const shutdown = (): void => {
+        server.stop(true);
+        process.exit(0);
+    };
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
+}
+
+main();

--- a/packages/atomic/src/cli.ts
+++ b/packages/atomic/src/cli.ts
@@ -430,6 +430,22 @@ Examples:
             process.exit(exitCode);
         });
 
+    program
+        .command("update")
+        .description("Update atomic to the latest release (or a pinned version)")
+        .option("--check", "Print current vs target without installing")
+        .option("--version <v>", "Pin a target version (default: latest)")
+        .option("-y, --yes", "Skip the confirmation prompt")
+        .action(async (localOpts: { check?: boolean; version?: string; yes?: boolean }) => {
+            const { updateCommand } = await import("./commands/cli/update.ts");
+            const exitCode = await updateCommand({
+                check: localOpts.check === true,
+                version: localOpts.version,
+                yes: localOpts.yes === true,
+            });
+            process.exit(exitCode);
+        });
+
     // ── Completions command ────────────────────────────────────────────────
     program
         .command("completions")
@@ -496,6 +512,7 @@ async function main(): Promise<void> {
             argv.includes("-h") ||
             argv[0] === "install" ||
             argv[0] === "uninstall" ||
+            argv[0] === "update" ||
             argv[0] === "completions" ||
             argv[0] === "_orchestrator-entry" ||
             argv[0] === "_cc-debounce" ||

--- a/packages/atomic/src/commands/cli/install.ts
+++ b/packages/atomic/src/commands/cli/install.ts
@@ -44,7 +44,7 @@ export interface InstallOptions {
     readonly noCompletions?: boolean;
 }
 
-interface InstallPaths {
+export interface InstallPaths {
     readonly binDir: string;
     readonly binPath: string;
     readonly completionsDir: string;
@@ -90,7 +90,40 @@ export function getInstallPaths(): InstallPaths {
  * before the new one rolls in. Stale `.old.*` files are reaped on
  * next install.
  */
-function copyBinary(paths: InstallPaths): void {
+export function copyBinary(paths: InstallPaths, sourcePath?: string): void {
+    // Allow override of source path for update (downloading a new binary)
+    if (sourcePath !== undefined) {
+        const sourceResolved = resolve(sourcePath);
+        const destResolved = resolve(paths.binPath);
+        if (sourceResolved.toLowerCase() === destResolved.toLowerCase()) return;
+        if (!existsSync(paths.binDir)) mkdirSync(paths.binDir, { recursive: true });
+        if (isWindows() && existsSync(paths.binPath)) {
+            const archivedPath = `${paths.binPath}.old.${Date.now()}`;
+            try {
+                renameSync(paths.binPath, archivedPath);
+            } catch (err) {
+                throw new Error(
+                    `Failed to archive existing atomic.exe at ${paths.binPath}: ${(err as Error).message}. ` +
+                    "If atomic is currently running, close it and retry.",
+                );
+            }
+        }
+        const tempPath = `${paths.binPath}.tmp.${process.pid}.${Date.now()}`;
+        try {
+            copyFileSync(sourcePath, tempPath);
+            if (!isWindows()) chmodSync(tempPath, 0o755);
+            renameSync(tempPath, paths.binPath);
+        } catch (err) {
+            try { unlinkSync(tempPath); } catch { /* ignore */ }
+            throw err;
+        }
+        return;
+    }
+    // Original: copy process.execPath
+    return _copyBinaryFromExecPath(paths);
+}
+
+function _copyBinaryFromExecPath(paths: InstallPaths): void {
     const source = process.execPath;
     const sourceResolved = resolve(source);
     const destResolved = resolve(paths.binPath);

--- a/packages/atomic/src/commands/cli/install.ts
+++ b/packages/atomic/src/commands/cli/install.ts
@@ -75,7 +75,9 @@ export function getInstallPaths(): InstallPaths {
 // ── Self-copy ──────────────────────────────────────────────────────────────
 
 /**
- * Copy the running binary (process.execPath) into the install dir.
+ * Copy a binary into the install dir. Defaults to the running binary
+ * (`process.execPath`) for `atomic install`; `atomic update` passes the
+ * freshly-downloaded artifact.
  *
  * Atomic move pattern (mirroring Claude Code's installer.ts
  * `atomicMoveToInstallPath`): copy to a per-process temp file next
@@ -90,45 +92,8 @@ export function getInstallPaths(): InstallPaths {
  * before the new one rolls in. Stale `.old.*` files are reaped on
  * next install.
  */
-export function copyBinary(paths: InstallPaths, sourcePath?: string): void {
-    // Allow override of source path for update (downloading a new binary)
-    if (sourcePath !== undefined) {
-        const sourceResolved = resolve(sourcePath);
-        const destResolved = resolve(paths.binPath);
-        if (sourceResolved.toLowerCase() === destResolved.toLowerCase()) return;
-        if (!existsSync(paths.binDir)) mkdirSync(paths.binDir, { recursive: true });
-        if (isWindows() && existsSync(paths.binPath)) {
-            const archivedPath = `${paths.binPath}.old.${Date.now()}`;
-            try {
-                renameSync(paths.binPath, archivedPath);
-            } catch (err) {
-                throw new Error(
-                    `Failed to archive existing atomic.exe at ${paths.binPath}: ${(err as Error).message}. ` +
-                    "If atomic is currently running, close it and retry.",
-                );
-            }
-        }
-        const tempPath = `${paths.binPath}.tmp.${process.pid}.${Date.now()}`;
-        try {
-            copyFileSync(sourcePath, tempPath);
-            if (!isWindows()) chmodSync(tempPath, 0o755);
-            renameSync(tempPath, paths.binPath);
-        } catch (err) {
-            try { unlinkSync(tempPath); } catch { /* ignore */ }
-            throw err;
-        }
-        return;
-    }
-    // Original: copy process.execPath
-    return _copyBinaryFromExecPath(paths);
-}
-
-function _copyBinaryFromExecPath(paths: InstallPaths): void {
-    const source = process.execPath;
-    const sourceResolved = resolve(source);
-    const destResolved = resolve(paths.binPath);
-
-    if (sourceResolved.toLowerCase() === destResolved.toLowerCase()) {
+export function copyBinary(paths: InstallPaths, sourcePath: string = process.execPath): void {
+    if (resolve(sourcePath).toLowerCase() === resolve(paths.binPath).toLowerCase()) {
         // Already running from the install location (e.g. user re-ran
         // `atomic install` after a previous install). Nothing to copy.
         return;
@@ -152,7 +117,7 @@ function _copyBinaryFromExecPath(paths: InstallPaths): void {
 
     const tempPath = `${paths.binPath}.tmp.${process.pid}.${Date.now()}`;
     try {
-        copyFileSync(source, tempPath);
+        copyFileSync(sourcePath, tempPath);
         if (!isWindows()) {
             chmodSync(tempPath, 0o755);
         }

--- a/packages/atomic/src/commands/cli/update.test.ts
+++ b/packages/atomic/src/commands/cli/update.test.ts
@@ -23,6 +23,7 @@ import {
     spyOn,
 } from "bun:test";
 import { writeFileSync } from "node:fs";
+import * as realClack from "@clack/prompts";
 import type { InstallMethod } from "../../services/system/install-method.ts";
 import type { ReleaseInfo, Manifest } from "../../services/system/release-fetch.ts";
 import type { InstallPaths } from "./install.ts";
@@ -54,8 +55,15 @@ const spinnerStartMock = mock((_msg: string) => {});
 const spinnerStopMock = mock((_msg: string) => {});
 const spinnerMock = mock(() => ({ start: spinnerStartMock, stop: spinnerStopMock }));
 
+// Spread the real module so every export (cancel, select, isCancel, log.warn,
+// etc.) stays available — `mock.module()` is process-global in Bun
+// (oven-sh/bun#12823) and a partial replacement breaks unrelated test files
+// that import the missing names from `@clack/prompts` later in the same
+// `bun test` run (e.g. session.test.ts → session.ts → import { cancel }).
 await mock.module("@clack/prompts", () => ({
+    ...realClack,
     log: {
+        ...realClack.log,
         info: logInfoMock,
         error: logErrorMock,
         success: logSuccessMock,

--- a/packages/atomic/src/commands/cli/update.test.ts
+++ b/packages/atomic/src/commands/cli/update.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Integration tests for `updateCommand` orchestrator.
+ *
+ * Mocking strategy:
+ *   - mock.module() at file level for ES module seams that don't leak into
+ *     other test files: @clack/prompts, install-method.ts, release-fetch.ts,
+ *     version.ts.
+ *   - spyOn(installModule, ...) for install.ts — `mock.module("./install.ts")`
+ *     leaks across test files (oven-sh/bun#12823) and breaks install.test.ts
+ *     when both files run in the same `bun test` invocation.
+ *   - mutable variables closed over by the factories so per-test return values work.
+ *   - spyOn(Bun, "spawn") / spyOn(Bun, "spawnSync") for process-dispatch tests.
+ *   - updateCommand is dynamically imported AFTER mocks are registered.
+ */
+
+import {
+    describe,
+    test,
+    expect,
+    beforeEach,
+    afterAll,
+    mock,
+    spyOn,
+} from "bun:test";
+import { writeFileSync } from "node:fs";
+import type { InstallMethod } from "../../services/system/install-method.ts";
+import type { ReleaseInfo, Manifest } from "../../services/system/release-fetch.ts";
+import type { InstallPaths } from "./install.ts";
+// Host-derived fixtures: mirror the production `hostTarget()` in update.ts:46-49.
+// We compute inline (rather than `import { hostTarget } from "../../../script/targets.ts"`)
+// because tsconfig sets `rootDir: "src"`, which forbids src files from importing
+// out-of-tree script/. Both production and tests still derive identically from
+// process.platform / process.arch — the single-source-of-truth property holds.
+const IS_WINDOWS_HOST = process.platform === "win32";
+const HOST = `${IS_WINDOWS_HOST ? "windows" : process.platform}-${process.arch}`;
+const HOST_ASSET = `atomic-${HOST}${IS_WINDOWS_HOST ? ".exe" : ""}`;
+
+// ── Fake install paths ────────────────────────────────────────────────────────
+
+const FAKE_PATHS: InstallPaths = {
+    binDir: "/tmp/atomic-test-bin",
+    binPath: "/tmp/atomic-test-bin/atomic",
+    completionsDir: "/tmp/atomic-test-completions",
+};
+
+// ── @clack/prompts stubs ──────────────────────────────────────────────────────
+
+const logInfoMock = mock((_msg: string) => {});
+const logErrorMock = mock((_msg: string) => {});
+const logSuccessMock = mock((_msg: string) => {});
+const noteMock = mock((_msg: string, _title?: string) => {});
+const confirmMock = mock(async (): Promise<boolean | symbol> => true);
+const spinnerStartMock = mock((_msg: string) => {});
+const spinnerStopMock = mock((_msg: string) => {});
+const spinnerMock = mock(() => ({ start: spinnerStartMock, stop: spinnerStopMock }));
+
+await mock.module("@clack/prompts", () => ({
+    log: {
+        info: logInfoMock,
+        error: logErrorMock,
+        success: logSuccessMock,
+    },
+    note: noteMock,
+    confirm: confirmMock,
+    spinner: spinnerMock,
+}));
+
+// ── install-method.ts stub ────────────────────────────────────────────────────
+
+let detectInstallMethodResult: InstallMethod = { kind: "unknown" };
+const detectInstallMethodMock = mock(async (): Promise<InstallMethod> => detectInstallMethodResult);
+
+await mock.module("../../services/system/install-method.ts", () => ({
+    detectInstallMethod: detectInstallMethodMock,
+}));
+
+// ── release-fetch.ts stub ─────────────────────────────────────────────────────
+
+const FAKE_RELEASE: ReleaseInfo = {
+    tag_name: "v0.9.0",
+    assets: [
+        {
+            name: HOST_ASSET,
+            browser_download_url: `https://example.com/${HOST_ASSET}`,
+        },
+        {
+            name: "manifest.json",
+            browser_download_url: "https://example.com/manifest.json",
+        },
+    ],
+};
+
+const getLatestReleaseMock = mock(async (): Promise<ReleaseInfo> => FAKE_RELEASE);
+const getReleaseByTagMock = mock(async (_tag: string): Promise<ReleaseInfo> => FAKE_RELEASE);
+const downloadAssetFromUrlMock = mock(async (_url: string, _dest: string): Promise<void> => {});
+const verifyChecksumMock = mock(async (_path: string, _checksum: string): Promise<void> => {});
+const isNewerMock = mock((_tag: string, _current: string): boolean => true);
+const normalizeVersionMock = mock((input: string): string => {
+    const t = input.trim();
+    if (t.toLowerCase() === "latest") return "latest";
+    return t.replace(/^v/, "");
+});
+
+await mock.module("../../services/system/release-fetch.ts", () => ({
+    getLatestRelease: getLatestReleaseMock,
+    getReleaseByTag: getReleaseByTagMock,
+    downloadAssetFromUrl: downloadAssetFromUrlMock,
+    verifyChecksum: verifyChecksumMock,
+    isNewer: isNewerMock,
+    normalizeVersion: normalizeVersionMock,
+}));
+
+// ── install.ts spies ──────────────────────────────────────────────────────────
+//
+// We deliberately do NOT use `mock.module("./install.ts", ...)` here:
+// Bun's `mock.module()` is process-global and leaks across test files when
+// `bun test` runs the entire suite in one process (oven-sh/bun#12823). That
+// breaks install.test.ts, which imports many real install.ts symbols.
+//
+// Instead, we `spyOn(installModule, "<name>")` to override the three functions
+// updateCommand depends on. spyOn returns Bun mock instances that support
+// `.mockImplementation(...)` / `.mockClear()` exactly like top-level mocks,
+// and `mock.restore()` (called from `afterAll`) reverts them so the real
+// module is intact for other test files.
+
+import * as installModule from "./install.ts";
+
+const getInstallPathsMock = spyOn(installModule, "getInstallPaths").mockImplementation(
+    (): InstallPaths => FAKE_PATHS,
+);
+const copyBinaryMock = spyOn(installModule, "copyBinary").mockImplementation(
+    (_paths: InstallPaths, _source?: string): void => {},
+);
+const cleanupOldArtifactsMock = spyOn(installModule, "cleanupOldArtifacts").mockImplementation(
+    (_binDir: string) => ({ oldBinariesRemoved: 0, tempFilesRemoved: 0 }),
+);
+
+// ── version.ts stub ───────────────────────────────────────────────────────────
+
+await mock.module("../../version.ts", () => ({
+    VERSION: "0.7.8",
+}));
+
+// ── Load updateCommand after all mocks are registered ─────────────────────────
+
+const { updateCommand } = await import("./update.ts");
+
+afterAll(() => {
+    // Restore install.ts spies so other test files in the same `bun test`
+    // process see the real module exports.
+    getInstallPathsMock.mockRestore();
+    copyBinaryMock.mockRestore();
+    cleanupOldArtifactsMock.mockRestore();
+});
+
+// ── Manifest JSON for binary tests ───────────────────────────────────────────
+
+function makeManifestContent(): string {
+    const manifest: Manifest = {
+        version: "0.9.0",
+        platforms: {
+            [HOST]: { checksum: "abc123" },
+        },
+    };
+    return JSON.stringify(manifest);
+}
+
+/**
+ * Run updateCommand with the given install method, capturing the argv that
+ * Bun.spawn would have been invoked with (the spawn itself is faked to exit 0).
+ */
+async function runDispatchAndCapture(
+    method: InstallMethod,
+): Promise<{ code: number; argv: string[] }> {
+    detectInstallMethodResult = method;
+    let argv: string[] = [];
+    const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((opts: { cmd: string[] }) => {
+        argv = opts.cmd;
+        return { exited: Promise.resolve(0) } as ReturnType<typeof Bun.spawn>;
+    }) as typeof Bun.spawn);
+    try {
+        const code = await updateCommand({ yes: true });
+        return { code, argv };
+    } finally {
+        spawnSpy.mockRestore();
+    }
+}
+
+/**
+ * Run updateCommand with a Bun.spawn that throws ENOENT, returning the exit code
+ * so callers can additionally assert the rendered error hint.
+ */
+async function runEnoentScenario(method: InstallMethod): Promise<number> {
+    detectInstallMethodResult = method;
+    const enoentErr = Object.assign(new Error("ENOENT: not found"), { code: "ENOENT" });
+    const spawnSpy = spyOn(Bun, "spawn").mockImplementation(
+        ((() => { throw enoentErr; }) as unknown) as typeof Bun.spawn,
+    );
+    try {
+        return await updateCommand({ yes: true });
+    } finally {
+        spawnSpy.mockRestore();
+    }
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    // Reset all call counts
+    logInfoMock.mockClear();
+    logErrorMock.mockClear();
+    logSuccessMock.mockClear();
+    noteMock.mockClear();
+    confirmMock.mockClear();
+    spinnerStartMock.mockClear();
+    spinnerStopMock.mockClear();
+    spinnerMock.mockClear();
+    detectInstallMethodMock.mockClear();
+    getLatestReleaseMock.mockClear();
+    getReleaseByTagMock.mockClear();
+    downloadAssetFromUrlMock.mockClear();
+    verifyChecksumMock.mockClear();
+    isNewerMock.mockClear();
+    normalizeVersionMock.mockClear();
+    getInstallPathsMock.mockClear();
+    copyBinaryMock.mockClear();
+    cleanupOldArtifactsMock.mockClear();
+
+    // Reset defaults
+    detectInstallMethodResult = { kind: "unknown" };
+    getLatestReleaseMock.mockImplementation(async () => FAKE_RELEASE);
+    getReleaseByTagMock.mockImplementation(async (_tag: string) => FAKE_RELEASE);
+    downloadAssetFromUrlMock.mockImplementation(async (_url: string, _dest: string) => {});
+    verifyChecksumMock.mockImplementation(async () => {});
+    isNewerMock.mockImplementation(() => true);
+    normalizeVersionMock.mockImplementation((input: string) => {
+        const t = input.trim();
+        if (t.toLowerCase() === "latest") return "latest";
+        return t.replace(/^v/, "");
+    });
+    getInstallPathsMock.mockImplementation(() => FAKE_PATHS);
+    copyBinaryMock.mockImplementation(() => {});
+    cleanupOldArtifactsMock.mockImplementation(() => ({ oldBinariesRemoved: 0, tempFilesRemoved: 0 }));
+    confirmMock.mockImplementation(async () => true);
+});
+
+// ── describe block ────────────────────────────────────────────────────────────
+
+describe("updateCommand", () => {
+    test("binary up-to-date short-circuit", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        isNewerMock.mockImplementation(() => false);
+
+        const spawnSpy = spyOn(Bun, "spawn");
+
+        try {
+            const code = await updateCommand({ yes: true });
+            expect(code).toBe(0);
+            expect(spawnSpy).not.toHaveBeenCalled();
+            const allInfoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
+            expect(allInfoCalls.some((m) => m.includes("Already up to date"))).toBe(true);
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
+
+    test("binary --check prints metadata note", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        isNewerMock.mockImplementation(() => true);
+
+        const code = await updateCommand({ check: true });
+        expect(code).toBe(0);
+        expect(noteMock).toHaveBeenCalledTimes(1);
+        // note text should contain version metadata
+        const noteArgs = noteMock.mock.calls[0] as [string, string?];
+        expect(noteArgs[0]).toContain("current=");
+        expect(downloadAssetFromUrlMock).not.toHaveBeenCalled();
+    });
+
+    test("binary happy path", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        isNewerMock.mockImplementation(() => true);
+
+        // downloadAssetFromUrl for manifest writes real JSON so readFileSync can parse it
+        downloadAssetFromUrlMock.mockImplementation(async (_url: string, dest: string) => {
+            if (dest.endsWith("manifest.json")) {
+                writeFileSync(dest, makeManifestContent());
+            }
+            // binary dest: leave as empty file (verifyChecksum is mocked)
+        });
+
+        const spawnSyncSpy = spyOn(Bun, "spawnSync").mockReturnValue({
+            exitCode: 0,
+            stdout: Buffer.from("atomic 0.9.0"),
+            stderr: Buffer.from(""),
+            success: true,
+        } as ReturnType<typeof Bun.spawnSync>);
+
+        try {
+            const code = await updateCommand({ yes: true });
+            expect(code).toBe(0);
+            expect(copyBinaryMock).toHaveBeenCalledTimes(1);
+            // copyBinary first arg is paths, second is assetDest
+            const [, assetDest] = copyBinaryMock.mock.calls[0] as [InstallPaths, string];
+            expect(assetDest).toContain(HOST_ASSET);
+        } finally {
+            spawnSyncSpy.mockRestore();
+        }
+    });
+
+    test("bun-global delegates to bun (P1 regression)", async () => {
+        const { code, argv } = await runDispatchAndCapture({
+            kind: "bun",
+            binPath: "/home/user/.bun/bin/atomic",
+        });
+        expect(code).toBe(0);
+        expect(argv).toEqual(["bun", "add", "-g", "@bastani/atomic@latest"]);
+    });
+
+    test("npm dispatch", async () => {
+        const { argv } = await runDispatchAndCapture({
+            kind: "npm",
+            binPath: "/usr/lib/node_modules/.bin/atomic",
+        });
+        expect(argv).toEqual(["npm", "install", "-g", "@bastani/atomic@latest"]);
+    });
+
+    test("pnpm dispatch", async () => {
+        const { argv } = await runDispatchAndCapture({
+            kind: "pnpm",
+            binPath: "/usr/lib/node_modules/.bin/atomic",
+        });
+        expect(argv).toEqual(["pnpm", "add", "-g", "@bastani/atomic@latest"]);
+    });
+
+    test("yarn dispatch", async () => {
+        const { argv } = await runDispatchAndCapture({
+            kind: "yarn",
+            binPath: "/usr/lib/node_modules/.bin/atomic",
+        });
+        expect(argv).toEqual(["yarn", "global", "add", "@bastani/atomic@latest"]);
+    });
+
+    test("source exits non-zero with guidance", async () => {
+        detectInstallMethodResult = { kind: "source" };
+
+        const spawnSpy = spyOn(Bun, "spawn");
+
+        try {
+            const code = await updateCommand({ yes: true });
+            expect(code).toBe(1);
+            expect(spawnSpy).not.toHaveBeenCalled();
+            const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+            const infoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
+            const allLogs = [...errorCalls, ...infoCalls].join("\n");
+            expect(allLogs).toContain("git pull && bun install");
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
+
+    test("unknown emits installer guidance, not git hint", async () => {
+        detectInstallMethodResult = { kind: "unknown" };
+
+        const spawnSpy = spyOn(Bun, "spawn");
+
+        try {
+            const code = await updateCommand({ yes: true });
+            expect(code).toBe(1);
+            expect(spawnSpy).not.toHaveBeenCalled();
+            const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+            const infoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
+            const allLogs = [...errorCalls, ...infoCalls].join("\n");
+            expect(allLogs).toMatch(/installer|package manager/i);
+            expect(allLogs).not.toContain("git pull");
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
+
+    test("--check on PM method prints metadata only", async () => {
+        detectInstallMethodResult = { kind: "bun", binPath: "/home/user/.bun/bin/atomic" };
+
+        const spawnSpy = spyOn(Bun, "spawn");
+
+        try {
+            const code = await updateCommand({ check: true });
+            expect(code).toBe(0);
+            expect(spawnSpy).not.toHaveBeenCalled();
+            // log.info called with current=... method=bun
+            const infoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
+            expect(infoCalls.some((m) => m.includes("current=") && m.includes("method=bun"))).toBe(true);
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
+
+    test("--version 0.7.5 pinned skips isNewer", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        // isNewer returns false (would short-circuit if pinned check is absent)
+        isNewerMock.mockImplementation(() => false);
+        normalizeVersionMock.mockImplementation((input: string) => {
+            const t = input.trim();
+            if (t.toLowerCase() === "latest") return "latest";
+            return t.replace(/^v/, "");
+        });
+
+        downloadAssetFromUrlMock.mockImplementation(async (_url: string, dest: string) => {
+            if (dest.endsWith("manifest.json")) {
+                writeFileSync(dest, makeManifestContent());
+            }
+        });
+
+        const spawnSyncSpy = spyOn(Bun, "spawnSync").mockReturnValue({
+            exitCode: 0,
+            stdout: Buffer.from("atomic 0.7.5"),
+            stderr: Buffer.from(""),
+            success: true,
+        } as ReturnType<typeof Bun.spawnSync>);
+
+        try {
+            const code = await updateCommand({ yes: true, version: "0.7.5" });
+            expect(code).toBe(0);
+            // copyBinary must have been called — pinned version skips isNewer
+            expect(copyBinaryMock).toHaveBeenCalledTimes(1);
+        } finally {
+            spawnSyncSpy.mockRestore();
+        }
+    });
+
+    test("sanity check failure surfaces error", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        isNewerMock.mockImplementation(() => true);
+
+        downloadAssetFromUrlMock.mockImplementation(async (_url: string, dest: string) => {
+            if (dest.endsWith("manifest.json")) {
+                writeFileSync(dest, makeManifestContent());
+            }
+        });
+
+        const spawnSyncSpy = spyOn(Bun, "spawnSync").mockReturnValue({
+            exitCode: 1,
+            stdout: Buffer.from(""),
+            stderr: Buffer.from("error"),
+            success: false,
+        } as ReturnType<typeof Bun.spawnSync>);
+
+        try {
+            const code = await updateCommand({ yes: true });
+            expect(code).toBe(1);
+            const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+            expect(errorCalls.some((m) => m.includes("Sanity check failed"))).toBe(true);
+        } finally {
+            spawnSyncSpy.mockRestore();
+        }
+    });
+
+    test("ENOENT on bun returns 1 with corrected hint", async () => {
+        const code = await runEnoentScenario({
+            kind: "bun",
+            binPath: "/home/user/.bun/bin/atomic",
+        });
+        expect(code).toBe(1);
+        const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+        expect(errorCalls.some((m) => m.includes("bun add -g @bastani/atomic"))).toBe(true);
+    });
+
+    test("ENOENT on yarn hints \"yarn global add\" (P3)", async () => {
+        const code = await runEnoentScenario({
+            kind: "yarn",
+            binPath: "/usr/lib/node_modules/.bin/atomic",
+        });
+        expect(code).toBe(1);
+        const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+        expect(errorCalls.some((m) => m.includes("yarn global add"))).toBe(true);
+    });
+});

--- a/packages/atomic/src/commands/cli/update.test.ts
+++ b/packages/atomic/src/commands/cli/update.test.ts
@@ -378,18 +378,28 @@ describe("updateCommand", () => {
         }
     });
 
-    test("--check on PM method prints metadata only", async () => {
+    test("--check on PM method probes upstream version and prints metadata", async () => {
         detectInstallMethodResult = { kind: "bun", binPath: "/home/user/.bun/bin/atomic" };
 
-        const spawnSpy = spyOn(Bun, "spawn");
+        // Stub `bun pm view @bastani/atomic version` → "0.7.9"
+        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((_opts: { cmd: string[] }) => ({
+            stdout: new Response("0.7.9\n").body,
+            stderr: new Response("").body,
+            exited: Promise.resolve(0),
+        })) as unknown as typeof Bun.spawn);
 
         try {
             const code = await updateCommand({ check: true });
             expect(code).toBe(0);
-            expect(spawnSpy).not.toHaveBeenCalled();
-            // log.info called with current=... method=bun
-            const infoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
-            expect(infoCalls.some((m) => m.includes("current=") && m.includes("method=bun"))).toBe(true);
+
+            // We spawned the version-probe subprocess.
+            expect(spawnSpy).toHaveBeenCalledTimes(1);
+            const spawnArgs = spawnSpy.mock.calls[0] as unknown as [{ cmd: string[] }];
+            expect(spawnArgs[0].cmd).toEqual(["bun", "pm", "view", "@bastani/atomic", "version"]);
+
+            // note() rendered with current/target/method.
+            const noteCalls = noteMock.mock.calls.map((c) => String(c[0]));
+            expect(noteCalls.some((m) => m.includes("current=") && m.includes("target=0.7.9") && m.includes("method=bun"))).toBe(true);
         } finally {
             spawnSpy.mockRestore();
         }

--- a/packages/atomic/src/commands/cli/update.test.ts
+++ b/packages/atomic/src/commands/cli/update.test.ts
@@ -405,6 +405,92 @@ describe("updateCommand", () => {
         }
     });
 
+    test("--check on yarn parses --json output", async () => {
+        detectInstallMethodResult = { kind: "yarn", binPath: "/usr/lib/node_modules/.bin/atomic" };
+
+        const yarnJson = JSON.stringify({ type: "inspect", data: "0.8.1" }) + "\n";
+        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((_opts: { cmd: string[] }) => ({
+            stdout: new Response(yarnJson).body,
+            stderr: new Response("").body,
+            exited: Promise.resolve(0),
+        })) as unknown as typeof Bun.spawn);
+
+        try {
+            const code = await updateCommand({ check: true });
+            expect(code).toBe(0);
+            const argv = (spawnSpy.mock.calls[0] as unknown as [{ cmd: string[] }])[0].cmd;
+            expect(argv).toEqual(["yarn", "info", "@bastani/atomic", "version", "--json"]);
+            const noteCalls = noteMock.mock.calls.map((c) => String(c[0]));
+            expect(noteCalls.some((m) => m.includes("target=0.8.1") && m.includes("method=yarn"))).toBe(true);
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
+
+    test("--check on PM method renders fallback note when probe fails", async () => {
+        detectInstallMethodResult = { kind: "npm", binPath: "/usr/lib/node_modules/.bin/atomic" };
+
+        // Probe fails: non-zero exit + stderr.
+        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((_opts: { cmd: string[] }) => ({
+            stdout: new Response("").body,
+            stderr: new Response("npm ERR! E404\n").body,
+            exited: Promise.resolve(1),
+        })) as unknown as typeof Bun.spawn);
+
+        try {
+            const code = await updateCommand({ check: true });
+            expect(code).toBe(0);
+            const argv = (spawnSpy.mock.calls[0] as unknown as [{ cmd: string[] }])[0].cmd;
+            expect(argv).toEqual(["npm", "view", "@bastani/atomic", "version"]);
+            const noteCalls = noteMock.mock.calls.map((c) => String(c[0]));
+            expect(noteCalls.some((m) => m.includes("target lookup failed"))).toBe(true);
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
+
+    test("binary path: confirm cancel returns 0 without downloading", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        isNewerMock.mockImplementation(() => true);
+        confirmMock.mockImplementation(async () => false);
+
+        const code = await updateCommand({});
+        expect(code).toBe(0);
+        expect(downloadAssetFromUrlMock).not.toHaveBeenCalled();
+        expect(copyBinaryMock).not.toHaveBeenCalled();
+        const infoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
+        expect(infoCalls.some((m) => m.includes("cancelled"))).toBe(true);
+    });
+
+    test("binary path: missing host asset returns 1 with error", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        isNewerMock.mockImplementation(() => true);
+        // Replace release with one that is missing the host asset.
+        getLatestReleaseMock.mockImplementation(async () => ({
+            tag_name: "v0.9.0",
+            assets: [{ name: "manifest.json", browser_download_url: "https://example.com/manifest.json" }],
+        }));
+
+        const code = await updateCommand({ yes: true });
+        expect(code).toBe(1);
+        const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+        expect(errorCalls.some((m) => m.includes(HOST_ASSET) && m.includes("not found"))).toBe(true);
+    });
+
+    test("binary path: missing manifest asset returns 1 with error", async () => {
+        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
+        isNewerMock.mockImplementation(() => true);
+        getLatestReleaseMock.mockImplementation(async () => ({
+            tag_name: "v0.9.0",
+            assets: [{ name: HOST_ASSET, browser_download_url: `https://example.com/${HOST_ASSET}` }],
+        }));
+
+        const code = await updateCommand({ yes: true });
+        expect(code).toBe(1);
+        const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+        expect(errorCalls.some((m) => m.includes("manifest.json") && m.includes("not found"))).toBe(true);
+    });
+
     test("--version 0.7.5 pinned skips isNewer", async () => {
         detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
         // isNewer returns false (would short-circuit if pinned check is absent)

--- a/packages/atomic/src/commands/cli/update.test.ts
+++ b/packages/atomic/src/commands/cli/update.test.ts
@@ -165,44 +165,6 @@ function makeManifestContent(): string {
     return JSON.stringify(manifest);
 }
 
-/**
- * Run updateCommand with the given install method, capturing the argv that
- * Bun.spawn would have been invoked with (the spawn itself is faked to exit 0).
- */
-async function runDispatchAndCapture(
-    method: InstallMethod,
-): Promise<{ code: number; argv: string[] }> {
-    detectInstallMethodResult = method;
-    let argv: string[] = [];
-    const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((opts: { cmd: string[] }) => {
-        argv = opts.cmd;
-        return { exited: Promise.resolve(0) } as ReturnType<typeof Bun.spawn>;
-    }) as typeof Bun.spawn);
-    try {
-        const code = await updateCommand({ yes: true });
-        return { code, argv };
-    } finally {
-        spawnSpy.mockRestore();
-    }
-}
-
-/**
- * Run updateCommand with a Bun.spawn that throws ENOENT, returning the exit code
- * so callers can additionally assert the rendered error hint.
- */
-async function runEnoentScenario(method: InstallMethod): Promise<number> {
-    detectInstallMethodResult = method;
-    const enoentErr = Object.assign(new Error("ENOENT: not found"), { code: "ENOENT" });
-    const spawnSpy = spyOn(Bun, "spawn").mockImplementation(
-        ((() => { throw enoentErr; }) as unknown) as typeof Bun.spawn,
-    );
-    try {
-        return await updateCommand({ yes: true });
-    } finally {
-        spawnSpy.mockRestore();
-    }
-}
-
 // ── Setup / teardown ──────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -308,38 +270,49 @@ describe("updateCommand", () => {
         }
     });
 
-    test("bun-global delegates to bun (P1 regression)", async () => {
-        const { code, argv } = await runDispatchAndCapture({
-            kind: "bun",
-            binPath: "/home/user/.bun/bin/atomic",
-        });
-        expect(code).toBe(0);
-        expect(argv).toEqual(["bun", "add", "-g", "@bastani/atomic@latest"]);
-    });
+    // ── PM-managed installs: atomic update is intentionally NOT dispatched
+    //    to the PM. Users are told to run `<pm> update -g` themselves so the
+    //    PM remains the single source of truth for global packages.
+    type PmCase = { kind: "bun" | "npm" | "pnpm" | "yarn"; hint: string };
+    const PM_CASES: readonly PmCase[] = [
+        { kind: "bun",  hint: "bun update -g @bastani/atomic" },
+        { kind: "npm",  hint: "npm update -g @bastani/atomic" },
+        { kind: "pnpm", hint: "pnpm update -g @bastani/atomic" },
+        { kind: "yarn", hint: "yarn global upgrade @bastani/atomic" },
+    ];
 
-    test("npm dispatch", async () => {
-        const { argv } = await runDispatchAndCapture({
-            kind: "npm",
-            binPath: "/usr/lib/node_modules/.bin/atomic",
+    for (const { kind, hint } of PM_CASES) {
+        test(`${kind} install: rejects update with PM hint, never spawns`, async () => {
+            detectInstallMethodResult = { kind, binPath: `/fake/${kind}/atomic` };
+            const spawnSpy = spyOn(Bun, "spawn");
+            try {
+                const code = await updateCommand({ yes: true });
+                expect(code).toBe(1);
+                expect(spawnSpy).not.toHaveBeenCalled();
+                const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
+                const infoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
+                const allLogs = [...errorCalls, ...infoCalls].join("\n");
+                expect(allLogs).toContain(`not available for ${kind}`);
+                expect(allLogs).toContain(hint);
+            } finally {
+                spawnSpy.mockRestore();
+            }
         });
-        expect(argv).toEqual(["npm", "install", "-g", "@bastani/atomic@latest"]);
-    });
 
-    test("pnpm dispatch", async () => {
-        const { argv } = await runDispatchAndCapture({
-            kind: "pnpm",
-            binPath: "/usr/lib/node_modules/.bin/atomic",
+        test(`${kind} install: --check renders PM hint, exits 0, never spawns`, async () => {
+            detectInstallMethodResult = { kind, binPath: `/fake/${kind}/atomic` };
+            const spawnSpy = spyOn(Bun, "spawn");
+            try {
+                const code = await updateCommand({ check: true });
+                expect(code).toBe(0);
+                expect(spawnSpy).not.toHaveBeenCalled();
+                const noteCalls = noteMock.mock.calls.map((c) => String(c[0]));
+                expect(noteCalls.some((m) => m.includes(`installed via ${kind}`) && m.includes(hint))).toBe(true);
+            } finally {
+                spawnSpy.mockRestore();
+            }
         });
-        expect(argv).toEqual(["pnpm", "add", "-g", "@bastani/atomic@latest"]);
-    });
-
-    test("yarn dispatch", async () => {
-        const { argv } = await runDispatchAndCapture({
-            kind: "yarn",
-            binPath: "/usr/lib/node_modules/.bin/atomic",
-        });
-        expect(argv).toEqual(["yarn", "global", "add", "@bastani/atomic@latest"]);
-    });
+    }
 
     test("source exits non-zero with guidance", async () => {
         detectInstallMethodResult = { kind: "source" };
@@ -373,77 +346,6 @@ describe("updateCommand", () => {
             const allLogs = [...errorCalls, ...infoCalls].join("\n");
             expect(allLogs).toMatch(/installer|package manager/i);
             expect(allLogs).not.toContain("git pull");
-        } finally {
-            spawnSpy.mockRestore();
-        }
-    });
-
-    test("--check on PM method probes upstream version and prints metadata", async () => {
-        detectInstallMethodResult = { kind: "bun", binPath: "/home/user/.bun/bin/atomic" };
-
-        // Stub `bun pm view @bastani/atomic version` → "0.7.9"
-        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((_opts: { cmd: string[] }) => ({
-            stdout: new Response("0.7.9\n").body,
-            stderr: new Response("").body,
-            exited: Promise.resolve(0),
-        })) as unknown as typeof Bun.spawn);
-
-        try {
-            const code = await updateCommand({ check: true });
-            expect(code).toBe(0);
-
-            // We spawned the version-probe subprocess.
-            expect(spawnSpy).toHaveBeenCalledTimes(1);
-            const spawnArgs = spawnSpy.mock.calls[0] as unknown as [{ cmd: string[] }];
-            expect(spawnArgs[0].cmd).toEqual(["bun", "pm", "view", "@bastani/atomic", "version"]);
-
-            // note() rendered with current/target/method.
-            const noteCalls = noteMock.mock.calls.map((c) => String(c[0]));
-            expect(noteCalls.some((m) => m.includes("current=") && m.includes("target=0.7.9") && m.includes("method=bun"))).toBe(true);
-        } finally {
-            spawnSpy.mockRestore();
-        }
-    });
-
-    test("--check on yarn parses --json output", async () => {
-        detectInstallMethodResult = { kind: "yarn", binPath: "/usr/lib/node_modules/.bin/atomic" };
-
-        const yarnJson = JSON.stringify({ type: "inspect", data: "0.8.1" }) + "\n";
-        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((_opts: { cmd: string[] }) => ({
-            stdout: new Response(yarnJson).body,
-            stderr: new Response("").body,
-            exited: Promise.resolve(0),
-        })) as unknown as typeof Bun.spawn);
-
-        try {
-            const code = await updateCommand({ check: true });
-            expect(code).toBe(0);
-            const argv = (spawnSpy.mock.calls[0] as unknown as [{ cmd: string[] }])[0].cmd;
-            expect(argv).toEqual(["yarn", "info", "@bastani/atomic", "version", "--json"]);
-            const noteCalls = noteMock.mock.calls.map((c) => String(c[0]));
-            expect(noteCalls.some((m) => m.includes("target=0.8.1") && m.includes("method=yarn"))).toBe(true);
-        } finally {
-            spawnSpy.mockRestore();
-        }
-    });
-
-    test("--check on PM method renders fallback note when probe fails", async () => {
-        detectInstallMethodResult = { kind: "npm", binPath: "/usr/lib/node_modules/.bin/atomic" };
-
-        // Probe fails: non-zero exit + stderr.
-        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((_opts: { cmd: string[] }) => ({
-            stdout: new Response("").body,
-            stderr: new Response("npm ERR! E404\n").body,
-            exited: Promise.resolve(1),
-        })) as unknown as typeof Bun.spawn);
-
-        try {
-            const code = await updateCommand({ check: true });
-            expect(code).toBe(0);
-            const argv = (spawnSpy.mock.calls[0] as unknown as [{ cmd: string[] }])[0].cmd;
-            expect(argv).toEqual(["npm", "view", "@bastani/atomic", "version"]);
-            const noteCalls = noteMock.mock.calls.map((c) => String(c[0]));
-            expect(noteCalls.some((m) => m.includes("target lookup failed"))).toBe(true);
         } finally {
             spawnSpy.mockRestore();
         }
@@ -551,23 +453,4 @@ describe("updateCommand", () => {
         }
     });
 
-    test("ENOENT on bun returns 1 with corrected hint", async () => {
-        const code = await runEnoentScenario({
-            kind: "bun",
-            binPath: "/home/user/.bun/bin/atomic",
-        });
-        expect(code).toBe(1);
-        const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
-        expect(errorCalls.some((m) => m.includes("bun add -g @bastani/atomic"))).toBe(true);
-    });
-
-    test("ENOENT on yarn hints \"yarn global add\" (P3)", async () => {
-        const code = await runEnoentScenario({
-            kind: "yarn",
-            binPath: "/usr/lib/node_modules/.bin/atomic",
-        });
-        expect(code).toBe(1);
-        const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
-        expect(errorCalls.some((m) => m.includes("yarn global add"))).toBe(true);
-    });
 });

--- a/packages/atomic/src/commands/cli/update.ts
+++ b/packages/atomic/src/commands/cli/update.ts
@@ -1,0 +1,236 @@
+/**
+ * `atomic update` — self-update entry point.
+ *
+ * Dispatches to the appropriate upgrade path based on how atomic was
+ * installed (binary download, bun, npm, pnpm, yarn, or source checkout).
+ */
+
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { confirm, spinner, log, note } from "@clack/prompts";
+
+import { VERSION } from "../../version.ts";
+import { detectInstallMethod } from "../../services/system/install-method.ts";
+import {
+    getLatestRelease,
+    getReleaseByTag,
+    downloadAsset,
+    verifyChecksum,
+    isNewer,
+    normalizeVersion,
+    type Manifest,
+} from "../../services/system/release-fetch.ts";
+import {
+    getInstallPaths,
+    copyBinary,
+    cleanupOldArtifacts,
+} from "./install.ts";
+/** Mirrors `hostTarget()` from `script/targets.ts` — inlined to stay within src/ rootDir. */
+function hostTarget(): string {
+    const plat = process.platform === "win32" ? "windows" : process.platform;
+    return `${plat}-${process.arch}`;
+}
+
+export interface UpdateOptions {
+    readonly yes?: boolean;
+    readonly check?: boolean;
+    readonly version?: string;
+}
+
+// ── PM-delegate helper ────────────────────────────────────────────────────────
+
+type PmKind = "bun" | "npm" | "pnpm" | "yarn";
+
+function buildArgv(pm: PmKind, packageSpec: string): string[] {
+    switch (pm) {
+        case "bun":  return ["bun",  "add",    "-g",        packageSpec];
+        case "npm":  return ["npm",  "install", "-g",        packageSpec];
+        case "pnpm": return ["pnpm", "add",    "-g",        packageSpec];
+        case "yarn": return ["yarn", "global",  "add",      packageSpec];
+    }
+}
+
+async function runPmUpgrade(pm: PmKind, target: string): Promise<number> {
+    const packageSpec = `@bastani/atomic@${target}`;
+    const argv = buildArgv(pm, packageSpec);
+    try {
+        const proc = Bun.spawn({ cmd: argv, stdio: ["inherit", "inherit", "inherit"] });
+        return await proc.exited;
+    } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+            log.error(`${pm} not found on PATH; reinstall it or run ${pm} add -g @bastani/atomic manually`);
+        } else {
+            log.error(`Failed to run ${pm}: ${(err as Error).message}`);
+        }
+        return 1;
+    }
+}
+
+// ── Main orchestrator ─────────────────────────────────────────────────────────
+
+export async function updateCommand(opts?: UpdateOptions): Promise<number> {
+    const target = normalizeVersion(opts?.version ?? "latest");
+    const method = await detectInstallMethod();
+
+    // ── --check for PM-delegate methods ──────────────────────────────────────
+    // RFC §5.4 simplification: for PM methods we just print current + method.
+    // A full `npm view @bastani/atomic version` lookup is non-trivial (network,
+    // cross-pm), so we skip it for v1 and document the gap here.
+    if (opts?.check) {
+        if (method.kind !== "binary") {
+            log.info(`current=${VERSION} method=${method.kind}`);
+            return 0;
+        }
+        // binary --check handled below after target resolution
+    }
+
+    // ── PM-delegate ───────────────────────────────────────────────────────────
+    const pmKinds: PmKind[] = ["bun", "npm", "pnpm", "yarn"];
+    if (pmKinds.includes(method.kind as PmKind)) {
+        const pm = method.kind as PmKind;
+        if (opts?.check) {
+            log.info(`current=${VERSION} method=${pm}`);
+            return 0;
+        }
+        log.info(`Updating via ${pm}...`);
+        return runPmUpgrade(pm, target);
+    }
+
+    // ── source | unknown ──────────────────────────────────────────────────────
+    if (method.kind === "source" || method.kind === "unknown") {
+        log.error("Cannot auto-update: atomic is running from a source checkout or unknown install method.");
+        log.info("To update: git pull && bun install");
+        log.info(`Detected execPath: ${process.execPath}`);
+        return 1;
+    }
+
+    // ── binary ────────────────────────────────────────────────────────────────
+    // method.kind === "binary"
+    const s = spinner();
+
+    // Resolve release
+    s.start("Checking for updates...");
+    let release: Awaited<ReturnType<typeof getLatestRelease>>;
+    try {
+        release = target === "latest"
+            ? await getLatestRelease()
+            : await getReleaseByTag("v" + target);
+    } catch (err) {
+        s.stop("Failed to fetch release info");
+        log.error((err as Error).message);
+        return 1;
+    }
+    s.stop(`Found release ${release.tag_name}`);
+
+    // Version comparison (skip when a specific version is pinned by the user)
+    const pinned = opts?.version !== undefined && opts.version !== "latest";
+    if (!pinned && !isNewer(release.tag_name, VERSION)) {
+        log.info(`Already up to date (${VERSION})`);
+        return 0;
+    }
+
+    // --check: print info and exit without downloading
+    if (opts?.check) {
+        note(
+            `current=${VERSION}  target=${release.tag_name}  method=binary`,
+            "atomic update --check",
+        );
+        return 0;
+    }
+
+    // Confirmation prompt (skipped when --yes)
+    if (!opts?.yes) {
+        const ok = await confirm({
+            message: `Update atomic from ${VERSION} to ${release.tag_name}?`,
+        });
+        if (!ok || typeof ok !== "boolean") {
+            log.info("Update cancelled.");
+            return 0;
+        }
+    }
+
+    // Download
+    const tmpDir = mkdtempSync(join(tmpdir(), "atomic-update-"));
+    const ext = process.platform === "win32" ? ".exe" : "";
+    const ht = hostTarget();
+    const assetName = `atomic-${ht}${ext}`;
+    const assetDest = join(tmpDir, assetName);
+    const manifestDest = join(tmpDir, "manifest.json");
+
+    s.start(`Downloading ${assetName}...`);
+    try {
+        await downloadAsset(release.tag_name, assetName, assetDest);
+    } catch (err) {
+        s.stop("Download failed");
+        log.error((err as Error).message);
+        return 1;
+    }
+    s.stop("Downloaded binary");
+
+    s.start("Downloading manifest...");
+    try {
+        await downloadAsset(release.tag_name, "manifest.json", manifestDest);
+    } catch (err) {
+        s.stop("Manifest download failed");
+        log.error((err as Error).message);
+        return 1;
+    }
+    s.stop("Downloaded manifest");
+
+    // Verify checksum
+    s.start("Verifying checksum...");
+    let manifest: Manifest;
+    try {
+        manifest = JSON.parse(readFileSync(manifestDest, "utf8")) as Manifest;
+    } catch (err) {
+        s.stop("Failed to parse manifest");
+        log.error((err as Error).message);
+        return 1;
+    }
+
+    const platformEntry = manifest.platforms[ht];
+    if (!platformEntry) {
+        s.stop("Checksum lookup failed");
+        log.error(`No manifest entry for platform "${ht}"`);
+        return 1;
+    }
+
+    try {
+        await verifyChecksum(assetDest, platformEntry.checksum);
+    } catch (err) {
+        s.stop("Checksum verification failed");
+        log.error((err as Error).message);
+        return 1;
+    }
+    s.stop("Checksum verified");
+
+    // Copy binary into install location
+    const paths = getInstallPaths();
+    const binDir = paths.binDir;
+    const binPath = paths.binPath;
+
+    s.start("Installing updated binary...");
+    try {
+        copyBinary(paths, assetDest);
+    } catch (err) {
+        s.stop("Installation failed");
+        log.error((err as Error).message);
+        return 1;
+    }
+    s.stop("Binary installed");
+
+    // Fire-and-forget reaper for prior artifacts
+    queueMicrotask(() => cleanupOldArtifacts(binDir));
+
+    // Sanity check: verify the new binary runs
+    const check = Bun.spawnSync({ cmd: [binPath, "--version"], stdout: "pipe", stderr: "pipe" });
+    if (check.exitCode !== 0) {
+        log.error(`Sanity check failed: ${binPath} --version returned exit code ${check.exitCode}`);
+        return 1;
+    }
+
+    log.success(`atomic updated to ${release.tag_name} (${check.stdout.toString().trim()})`);
+    return 0;
+}

--- a/packages/atomic/src/commands/cli/update.ts
+++ b/packages/atomic/src/commands/cli/update.ts
@@ -5,7 +5,7 @@
  * installed (binary download, bun, npm, pnpm, yarn, or source checkout).
  */
 
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { confirm, spinner, log, note } from "@clack/prompts";
@@ -15,22 +15,18 @@ import { detectInstallMethod } from "../../services/system/install-method.ts";
 import {
     getLatestRelease,
     getReleaseByTag,
-    downloadAsset,
+    downloadAssetFromUrl,
     verifyChecksum,
     isNewer,
     normalizeVersion,
     type Manifest,
+    type ReleaseInfo,
 } from "../../services/system/release-fetch.ts";
 import {
     getInstallPaths,
     copyBinary,
     cleanupOldArtifacts,
 } from "./install.ts";
-/** Mirrors `hostTarget()` from `script/targets.ts` — inlined to stay within src/ rootDir. */
-function hostTarget(): string {
-    const plat = process.platform === "win32" ? "windows" : process.platform;
-    return `${plat}-${process.arch}`;
-}
 
 export interface UpdateOptions {
     readonly yes?: boolean;
@@ -38,199 +34,281 @@ export interface UpdateOptions {
     readonly version?: string;
 }
 
+const PACKAGE_NAME = "@bastani/atomic";
+
+// ── Platform helpers ─────────────────────────────────────────────────────────
+
+const IS_WINDOWS = process.platform === "win32";
+
+/** Mirrors `hostTarget()` from `script/targets.ts` — inlined to stay within src/ rootDir. */
+function hostTarget(): string {
+    const plat = IS_WINDOWS ? "windows" : process.platform;
+    return `${plat}-${process.arch}`;
+}
+
 // ── PM-delegate helper ────────────────────────────────────────────────────────
 
 type PmKind = "bun" | "npm" | "pnpm" | "yarn";
 
-function buildArgv(pm: PmKind, packageSpec: string): string[] {
+function buildPmViewArgv(pm: PmKind): string[] {
     switch (pm) {
-        case "bun":  return ["bun",  "add",    "-g",        packageSpec];
-        case "npm":  return ["npm",  "install", "-g",        packageSpec];
-        case "pnpm": return ["pnpm", "add",    "-g",        packageSpec];
-        case "yarn": return ["yarn", "global",  "add",      packageSpec];
+        case "bun":  return ["bun", "pm", "view", PACKAGE_NAME, "version"];
+        case "npm":  return ["npm", "view", PACKAGE_NAME, "version"];
+        case "pnpm": return ["pnpm", "view", PACKAGE_NAME, "version"];
+        case "yarn": return ["yarn", "info", PACKAGE_NAME, "version", "--json"];
+    }
+}
+
+async function fetchPmUpstreamVersion(pm: PmKind): Promise<string> {
+    const argv = buildPmViewArgv(pm);
+    const proc = Bun.spawn({
+        cmd: argv,
+        stdout: "pipe",
+        stderr: "pipe",
+        signal: AbortSignal.timeout(5000),
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        throw new Error(stderr.trim() || `${pm} view exited with code ${exitCode}`);
+    }
+    const stdout = await new Response(proc.stdout).text();
+    if (pm === "yarn") {
+        // yarn --json outputs `{"type":"inspect","data":"<version>"}` per line
+        for (const line of stdout.split("\n")) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+                const parsed = JSON.parse(trimmed) as { data?: string };
+                if (parsed.data) return parsed.data.trim();
+            } catch {
+                // not JSON, skip
+            }
+        }
+        throw new Error("yarn info: could not parse version from JSON output");
+    }
+    return stdout.trim();
+}
+
+function buildPmArgv(pm: PmKind, packageSpec: string): string[] {
+    switch (pm) {
+        case "bun":  return ["bun", "add", "-g", packageSpec];
+        case "npm":  return ["npm", "install", "-g", packageSpec];
+        case "pnpm": return ["pnpm", "add", "-g", packageSpec];
+        case "yarn": return ["yarn", "global", "add", packageSpec];
     }
 }
 
 async function runPmUpgrade(pm: PmKind, target: string): Promise<number> {
-    const packageSpec = `@bastani/atomic@${target}`;
-    const argv = buildArgv(pm, packageSpec);
+    const argv = buildPmArgv(pm, `${PACKAGE_NAME}@${target}`);
     try {
         const proc = Bun.spawn({ cmd: argv, stdio: ["inherit", "inherit", "inherit"] });
         return await proc.exited;
     } catch (err) {
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code === "ENOENT") {
-            log.error(`${pm} not found on PATH; reinstall it or run ${pm} add -g @bastani/atomic manually`);
+        const e = err as NodeJS.ErrnoException;
+        if (e.code === "ENOENT") {
+            // Match the actual upgrade command per PM (yarn → "yarn global add").
+            const manualHint = buildPmArgv(pm, PACKAGE_NAME).join(" ");
+            log.error(`${pm} not found on PATH; reinstall it or run: ${manualHint}`);
         } else {
-            log.error(`Failed to run ${pm}: ${(err as Error).message}`);
+            log.error(`Failed to run ${pm}: ${e.message}`);
         }
         return 1;
     }
 }
 
-// ── Main orchestrator ─────────────────────────────────────────────────────────
+// ── Spinner step helper ───────────────────────────────────────────────────────
 
-export async function updateCommand(opts?: UpdateOptions): Promise<number> {
-    const target = normalizeVersion(opts?.version ?? "latest");
-    const method = await detectInstallMethod();
+type Spinner = ReturnType<typeof spinner>;
 
-    // ── --check for PM-delegate methods ──────────────────────────────────────
-    // RFC §5.4 simplification: for PM methods we just print current + method.
-    // A full `npm view @bastani/atomic version` lookup is non-trivial (network,
-    // cross-pm), so we skip it for v1 and document the gap here.
-    if (opts?.check) {
-        if (method.kind !== "binary") {
-            log.info(`current=${VERSION} method=${method.kind}`);
-            return 0;
-        }
-        // binary --check handled below after target resolution
+/**
+ * Run an async step under a spinner. Logs the underlying error and rethrows
+ * on failure so callers can fail-fast with a single try/catch around a
+ * sequence of steps.
+ */
+async function step<T>(
+    s: Spinner,
+    startMsg: string,
+    successMsg: string | ((result: T) => string),
+    failMsg: string,
+    fn: () => Promise<T> | T,
+): Promise<T> {
+    s.start(startMsg);
+    try {
+        const result = await fn();
+        s.stop(typeof successMsg === "function" ? successMsg(result) : successMsg);
+        return result;
+    } catch (err) {
+        s.stop(failMsg);
+        log.error((err as Error).message);
+        throw err;
     }
+}
 
-    // ── PM-delegate ───────────────────────────────────────────────────────────
-    const pmKinds: PmKind[] = ["bun", "npm", "pnpm", "yarn"];
-    if (pmKinds.includes(method.kind as PmKind)) {
-        const pm = method.kind as PmKind;
-        if (opts?.check) {
-            log.info(`current=${VERSION} method=${pm}`);
-            return 0;
-        }
-        log.info(`Updating via ${pm}...`);
-        return runPmUpgrade(pm, target);
-    }
+// ── Binary update path ────────────────────────────────────────────────────────
 
-    // ── source | unknown ──────────────────────────────────────────────────────
-    if (method.kind === "source" || method.kind === "unknown") {
-        log.error("Cannot auto-update: atomic is running from a source checkout or unknown install method.");
-        log.info("To update: git pull && bun install");
-        log.info(`Detected execPath: ${process.execPath}`);
-        return 1;
-    }
-
-    // ── binary ────────────────────────────────────────────────────────────────
-    // method.kind === "binary"
+async function runBinaryUpdate(opts: UpdateOptions, target: string): Promise<number> {
     const s = spinner();
 
-    // Resolve release
-    s.start("Checking for updates...");
-    let release: Awaited<ReturnType<typeof getLatestRelease>>;
+    let release: ReleaseInfo;
     try {
-        release = target === "latest"
-            ? await getLatestRelease()
-            : await getReleaseByTag("v" + target);
-    } catch (err) {
-        s.stop("Failed to fetch release info");
-        log.error((err as Error).message);
+        release = await step(
+            s,
+            "Checking for updates...",
+            (r) => `Found release ${r.tag_name}`,
+            "Failed to fetch release info",
+            () => target === "latest" ? getLatestRelease() : getReleaseByTag(`v${target}`),
+        );
+    } catch {
         return 1;
     }
-    s.stop(`Found release ${release.tag_name}`);
 
-    // Version comparison (skip when a specific version is pinned by the user)
-    const pinned = opts?.version !== undefined && opts.version !== "latest";
-    if (!pinned && !isNewer(release.tag_name, VERSION)) {
-        log.info(`Already up to date (${VERSION})`);
-        return 0;
-    }
-
-    // --check: print info and exit without downloading
-    if (opts?.check) {
+    if (opts.check) {
+        const upToDate = target === "latest" && !isNewer(release.tag_name, VERSION);
         note(
-            `current=${VERSION}  target=${release.tag_name}  method=binary`,
+            `current=${VERSION}  target=${release.tag_name}  method=binary${upToDate ? "  (up to date)" : ""}`,
             "atomic update --check",
         );
         return 0;
     }
 
-    // Confirmation prompt (skipped when --yes)
-    if (!opts?.yes) {
+    // Skip the up-to-date check when the user pinned a specific version.
+    if (target === "latest" && !isNewer(release.tag_name, VERSION)) {
+        log.info(`Already up to date (${VERSION})`);
+        return 0;
+    }
+
+    if (!opts.yes) {
         const ok = await confirm({
             message: `Update atomic from ${VERSION} to ${release.tag_name}?`,
         });
-        if (!ok || typeof ok !== "boolean") {
+        if (ok !== true) {
             log.info("Update cancelled.");
             return 0;
         }
     }
 
-    // Download
-    const tmpDir = mkdtempSync(join(tmpdir(), "atomic-update-"));
-    const ext = process.platform === "win32" ? ".exe" : "";
-    const ht = hostTarget();
-    const assetName = `atomic-${ht}${ext}`;
-    const assetDest = join(tmpDir, assetName);
-    const manifestDest = join(tmpDir, "manifest.json");
-
-    s.start(`Downloading ${assetName}...`);
-    try {
-        await downloadAsset(release.tag_name, assetName, assetDest);
-    } catch (err) {
-        s.stop("Download failed");
-        log.error((err as Error).message);
+    const host = hostTarget();
+    const assetName = `atomic-${host}${IS_WINDOWS ? ".exe" : ""}`;
+    const binaryAsset = release.assets.find((a) => a.name === assetName);
+    if (!binaryAsset) {
+        log.error(`Asset "${assetName}" not found in release ${release.tag_name}`);
         return 1;
     }
-    s.stop("Downloaded binary");
-
-    s.start("Downloading manifest...");
-    try {
-        await downloadAsset(release.tag_name, "manifest.json", manifestDest);
-    } catch (err) {
-        s.stop("Manifest download failed");
-        log.error((err as Error).message);
-        return 1;
-    }
-    s.stop("Downloaded manifest");
-
-    // Verify checksum
-    s.start("Verifying checksum...");
-    let manifest: Manifest;
-    try {
-        manifest = JSON.parse(readFileSync(manifestDest, "utf8")) as Manifest;
-    } catch (err) {
-        s.stop("Failed to parse manifest");
-        log.error((err as Error).message);
+    const manifestAsset = release.assets.find((a) => a.name === "manifest.json");
+    if (!manifestAsset) {
+        log.error(`Asset "manifest.json" not found in release ${release.tag_name}`);
         return 1;
     }
 
-    const platformEntry = manifest.platforms[ht];
-    if (!platformEntry) {
-        s.stop("Checksum lookup failed");
-        log.error(`No manifest entry for platform "${ht}"`);
-        return 1;
-    }
-
-    try {
-        await verifyChecksum(assetDest, platformEntry.checksum);
-    } catch (err) {
-        s.stop("Checksum verification failed");
-        log.error((err as Error).message);
-        return 1;
-    }
-    s.stop("Checksum verified");
-
-    // Copy binary into install location
     const paths = getInstallPaths();
-    const binDir = paths.binDir;
-    const binPath = paths.binPath;
-
-    s.start("Installing updated binary...");
+    const tmpDir = mkdtempSync(join(tmpdir(), "atomic-update-"));
     try {
-        copyBinary(paths, assetDest);
-    } catch (err) {
-        s.stop("Installation failed");
-        log.error((err as Error).message);
+        const assetDest = join(tmpDir, assetName);
+        const manifestDest = join(tmpDir, "manifest.json");
+
+        await step(
+            s,
+            `Downloading ${assetName}...`,
+            "Downloaded binary",
+            "Download failed",
+            () => downloadAssetFromUrl(binaryAsset.browser_download_url, assetDest),
+        );
+        await step(
+            s,
+            "Downloading manifest...",
+            "Downloaded manifest",
+            "Manifest download failed",
+            () => downloadAssetFromUrl(manifestAsset.browser_download_url, manifestDest),
+        );
+        await step(
+            s,
+            "Verifying checksum...",
+            "Checksum verified",
+            "Checksum verification failed",
+            async () => {
+                const manifest = JSON.parse(readFileSync(manifestDest, "utf8")) as Manifest;
+                const entry = manifest.platforms[host];
+                if (!entry) throw new Error(`No manifest entry for platform "${host}"`);
+                await verifyChecksum(assetDest, entry.checksum);
+            },
+        );
+        await step(
+            s,
+            "Installing updated binary...",
+            "Binary installed",
+            "Installation failed",
+            () => copyBinary(paths, assetDest),
+        );
+
+        queueMicrotask(() => cleanupOldArtifacts(paths.binDir));
+
+        // Sanity check: verify the new binary runs.
+        const check = Bun.spawnSync({ cmd: [paths.binPath, "--version"], stdout: "pipe", stderr: "pipe" });
+        if (check.exitCode !== 0) {
+            log.error(`Sanity check failed: ${paths.binPath} --version returned exit code ${check.exitCode}`);
+            return 1;
+        }
+
+        log.success(`atomic updated to ${release.tag_name} (${check.stdout.toString().trim()})`);
+        return 0;
+    } catch {
+        // step() already logged the underlying error; just propagate non-zero.
         return 1;
+    } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
     }
-    s.stop("Binary installed");
+}
 
-    // Fire-and-forget reaper for prior artifacts
-    queueMicrotask(() => cleanupOldArtifacts(binDir));
+// ── Main orchestrator ─────────────────────────────────────────────────────────
 
-    // Sanity check: verify the new binary runs
-    const check = Bun.spawnSync({ cmd: [binPath, "--version"], stdout: "pipe", stderr: "pipe" });
-    if (check.exitCode !== 0) {
-        log.error(`Sanity check failed: ${binPath} --version returned exit code ${check.exitCode}`);
-        return 1;
+export async function updateCommand(opts: UpdateOptions = {}): Promise<number> {
+    const target = normalizeVersion(opts.version ?? "latest");
+    const method = await detectInstallMethod();
+
+    switch (method.kind) {
+        case "binary":
+            return runBinaryUpdate(opts, target);
+
+        case "bun":
+        case "npm":
+        case "pnpm":
+        case "yarn":
+            if (opts.check) {
+                let pmTarget: string | undefined;
+                let reason: string | undefined;
+                try {
+                    pmTarget = await fetchPmUpstreamVersion(method.kind);
+                } catch (err) {
+                    reason = err instanceof Error ? err.message : String(err);
+                }
+                if (pmTarget !== undefined) {
+                    const upToDate = !isNewer(pmTarget, VERSION);
+                    note(
+                        `current=${VERSION}  target=${pmTarget}  method=${method.kind}${upToDate ? "  (up to date)" : ""}`,
+                        "atomic update --check",
+                    );
+                } else {
+                    note(
+                        `current=${VERSION}  method=${method.kind}  (target lookup failed: ${reason})`,
+                        "atomic update --check",
+                    );
+                }
+                return 0;
+            }
+            log.info(`Updating via ${method.kind}...`);
+            return runPmUpgrade(method.kind, target);
+
+        case "source":
+            log.error("Cannot auto-update: atomic is running from a source checkout.");
+            log.info("To update: git pull && bun install");
+            log.info(`Detected execPath: ${process.execPath}`);
+            return 1;
+
+        case "unknown":
+            log.error("Cannot auto-update: install method could not be determined.");
+            log.info("Reinstall via the official installer (https://raw.githubusercontent.com/flora131/atomic/main/install.sh) or your package manager.");
+            log.info(`Detected execPath: ${process.execPath}`);
+            return 1;
     }
-
-    log.success(`atomic updated to ${release.tag_name} (${check.stdout.toString().trim()})`);
-    return 0;
 }

--- a/packages/atomic/src/commands/cli/update.ts
+++ b/packages/atomic/src/commands/cli/update.ts
@@ -1,8 +1,14 @@
 /**
  * `atomic update` — self-update entry point.
  *
- * Dispatches to the appropriate upgrade path based on how atomic was
- * installed (binary download, bun, npm, pnpm, yarn, or source checkout).
+ * Only the standalone binary install is updatable from the CLI: the
+ * binary downloads its successor from GitHub Releases, verifies the
+ * sha256, and atomic-moves it into the install path.
+ *
+ * Package-manager installs (bun / npm / pnpm / yarn) deliberately fall
+ * through to a guidance message — those installs are owned by the PM,
+ * so the user runs `<pm> update -g @bastani/atomic` instead and we
+ * don't shell out to the PM ourselves.
  */
 
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -34,8 +40,6 @@ export interface UpdateOptions {
     readonly version?: string;
 }
 
-const PACKAGE_NAME = "@bastani/atomic";
-
 // ── Platform helpers ─────────────────────────────────────────────────────────
 
 const IS_WINDOWS = process.platform === "win32";
@@ -46,74 +50,21 @@ function hostTarget(): string {
     return `${plat}-${process.arch}`;
 }
 
-// ── PM-delegate helper ────────────────────────────────────────────────────────
+// ── PM guidance ──────────────────────────────────────────────────────────────
 
 type PmKind = "bun" | "npm" | "pnpm" | "yarn";
 
-function buildPmViewArgv(pm: PmKind): string[] {
+/**
+ * The actual command users should run to upgrade a global PM install.
+ * Mirrors each PM's idiomatic global-update spelling — yarn keeps its
+ * own `global upgrade` form rather than the `add` aliases.
+ */
+function pmUpdateHint(pm: PmKind): string {
     switch (pm) {
-        case "bun":  return ["bun", "pm", "view", PACKAGE_NAME, "version"];
-        case "npm":  return ["npm", "view", PACKAGE_NAME, "version"];
-        case "pnpm": return ["pnpm", "view", PACKAGE_NAME, "version"];
-        case "yarn": return ["yarn", "info", PACKAGE_NAME, "version", "--json"];
-    }
-}
-
-async function fetchPmUpstreamVersion(pm: PmKind): Promise<string> {
-    const argv = buildPmViewArgv(pm);
-    const proc = Bun.spawn({
-        cmd: argv,
-        stdout: "pipe",
-        stderr: "pipe",
-        signal: AbortSignal.timeout(5000),
-    });
-    const exitCode = await proc.exited;
-    if (exitCode !== 0) {
-        const stderr = await new Response(proc.stderr).text();
-        throw new Error(stderr.trim() || `${pm} view exited with code ${exitCode}`);
-    }
-    const stdout = await new Response(proc.stdout).text();
-    if (pm === "yarn") {
-        // yarn --json outputs `{"type":"inspect","data":"<version>"}` per line
-        for (const line of stdout.split("\n")) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-            try {
-                const parsed = JSON.parse(trimmed) as { data?: string };
-                if (parsed.data) return parsed.data.trim();
-            } catch {
-                // not JSON, skip
-            }
-        }
-        throw new Error("yarn info: could not parse version from JSON output");
-    }
-    return stdout.trim();
-}
-
-function buildPmArgv(pm: PmKind, packageSpec: string): string[] {
-    switch (pm) {
-        case "bun":  return ["bun", "add", "-g", packageSpec];
-        case "npm":  return ["npm", "install", "-g", packageSpec];
-        case "pnpm": return ["pnpm", "add", "-g", packageSpec];
-        case "yarn": return ["yarn", "global", "add", packageSpec];
-    }
-}
-
-async function runPmUpgrade(pm: PmKind, target: string): Promise<number> {
-    const argv = buildPmArgv(pm, `${PACKAGE_NAME}@${target}`);
-    try {
-        const proc = Bun.spawn({ cmd: argv, stdio: ["inherit", "inherit", "inherit"] });
-        return await proc.exited;
-    } catch (err) {
-        const e = err as NodeJS.ErrnoException;
-        if (e.code === "ENOENT") {
-            // Match the actual upgrade command per PM (yarn → "yarn global add").
-            const manualHint = buildPmArgv(pm, PACKAGE_NAME).join(" ");
-            log.error(`${pm} not found on PATH; reinstall it or run: ${manualHint}`);
-        } else {
-            log.error(`Failed to run ${pm}: ${e.message}`);
-        }
-        return 1;
+        case "bun":  return "bun update -g @bastani/atomic";
+        case "npm":  return "npm update -g @bastani/atomic";
+        case "pnpm": return "pnpm update -g @bastani/atomic";
+        case "yarn": return "yarn global upgrade @bastani/atomic";
     }
 }
 
@@ -273,31 +224,19 @@ export async function updateCommand(opts: UpdateOptions = {}): Promise<number> {
         case "bun":
         case "npm":
         case "pnpm":
-        case "yarn":
+        case "yarn": {
+            const hint = pmUpdateHint(method.kind);
             if (opts.check) {
-                let pmTarget: string | undefined;
-                let reason: string | undefined;
-                try {
-                    pmTarget = await fetchPmUpstreamVersion(method.kind);
-                } catch (err) {
-                    reason = err instanceof Error ? err.message : String(err);
-                }
-                if (pmTarget !== undefined) {
-                    const upToDate = !isNewer(pmTarget, VERSION);
-                    note(
-                        `current=${VERSION}  target=${pmTarget}  method=${method.kind}${upToDate ? "  (up to date)" : ""}`,
-                        "atomic update --check",
-                    );
-                } else {
-                    note(
-                        `current=${VERSION}  method=${method.kind}  (target lookup failed: ${reason})`,
-                        "atomic update --check",
-                    );
-                }
+                note(
+                    `atomic was installed via ${method.kind}.\nTo update, run: ${hint}`,
+                    "atomic update --check",
+                );
                 return 0;
             }
-            log.info(`Updating via ${method.kind}...`);
-            return runPmUpgrade(method.kind, target);
+            log.error(`atomic update is not available for ${method.kind} installs.`);
+            log.info(`To update, run: ${hint}`);
+            return 1;
+        }
 
         case "source":
             log.error("Cannot auto-update: atomic is running from a source checkout.");

--- a/packages/atomic/src/services/system/install-method.test.ts
+++ b/packages/atomic/src/services/system/install-method.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for detectInstallMethod — covers every branch per the RFC task spec.
+ *
+ * Strategy: detectInstallMethod accepts `opts.execPath` and `opts.cwd` so we
+ * never mutate `process.execPath` or `process.cwd()`. For PM probes we inject
+ * a mock spawn via `pmListsAtomic`'s second parameter.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    detectInstallMethod,
+    pmListsAtomic,
+    isInsideRepoCheckout,
+    ATOMIC_PACKAGE_NAME,
+} from "./install-method.ts";
+import { getInstallPaths } from "../../commands/cli/install.ts";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+let tmp: string;
+beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "install-method-test-"));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+type SpawnResult = { exitCode: number | null; stdout: string };
+type SpawnFn = (cmd: string[]) => Promise<SpawnResult>;
+
+function mockSpawn(stdout: string, exitCode: number = 0): SpawnFn {
+    return async (_cmd) => ({ exitCode, stdout });
+}
+
+// ── ATOMIC_PACKAGE_NAME constant ───────────────────────────────────────────
+
+test("ATOMIC_PACKAGE_NAME is @bastani/atomic", () => {
+    expect(ATOMIC_PACKAGE_NAME).toBe("@bastani/atomic");
+});
+
+// ── binary detection ───────────────────────────────────────────────────────
+
+describe("binary install detection", () => {
+    test("returns binary kind when execPath equals getInstallPaths().binPath", async () => {
+        const { binPath } = getInstallPaths();
+        const result = await detectInstallMethod({ execPath: binPath, skipProbe: true });
+        expect(result.kind).toBe("binary");
+        if (result.kind === "binary") {
+            expect(result.binPath).toBeTruthy();
+        }
+    });
+
+    test("does not return binary kind for a different path", async () => {
+        const result = await detectInstallMethod({
+            execPath: join(tmp, "other-binary"),
+            skipProbe: true,
+        });
+        expect(result.kind).not.toBe("binary");
+    });
+});
+
+// ── bun global bin detection ───────────────────────────────────────────────
+
+describe("bun install detection", () => {
+    test("returns bun kind when execPath is under ~/.bun/bin/", async () => {
+        const bunBinPath = join(homedir(), ".bun", "bin", "atomic");
+
+        const result = await detectInstallMethod({ execPath: bunBinPath, skipProbe: true });
+        expect(result.kind).toBe("bun");
+        if (result.kind === "bun") {
+            expect(result.binPath).toBeTruthy();
+        }
+    });
+
+    test("returns bun kind when execPath is under $BUN_INSTALL/bin/", async () => {
+        const fakeBunInstall = join(tmp, "bun-install");
+        mkdirSync(join(fakeBunInstall, "bin"), { recursive: true });
+        const bunBinPath = join(fakeBunInstall, "bin", "atomic");
+
+        const origEnv = process.env.BUN_INSTALL;
+        process.env.BUN_INSTALL = fakeBunInstall;
+        try {
+            const result = await detectInstallMethod({ execPath: bunBinPath, skipProbe: true });
+            expect(result.kind).toBe("bun");
+        } finally {
+            if (origEnv === undefined) {
+                delete process.env.BUN_INSTALL;
+            } else {
+                process.env.BUN_INSTALL = origEnv;
+            }
+        }
+    });
+});
+
+// ── node_modules PM heuristic ──────────────────────────────────────────────
+
+describe("node_modules PM heuristic", () => {
+    test("returns npm when no .pnpm or .yarn-state.yml present", async () => {
+        const nmDir = join(tmp, "node_modules", "@bastani", "atomic", "bin");
+        mkdirSync(nmDir, { recursive: true });
+        const fakeExec = join(nmDir, "atomic");
+        writeFileSync(fakeExec, "#!/bin/sh\necho hi");
+
+        const result = await detectInstallMethod({ execPath: fakeExec, skipProbe: true });
+        expect(result.kind).toBe("npm");
+    });
+
+    test("returns pnpm when node_modules/.pnpm is present", async () => {
+        const nmDir = join(tmp, "node_modules", "@bastani", "atomic", "bin");
+        mkdirSync(nmDir, { recursive: true });
+        mkdirSync(join(tmp, "node_modules", ".pnpm"), { recursive: true });
+        const fakeExec = join(nmDir, "atomic");
+        writeFileSync(fakeExec, "#!/bin/sh\necho hi");
+
+        const result = await detectInstallMethod({ execPath: fakeExec, skipProbe: true });
+        expect(result.kind).toBe("pnpm");
+    });
+
+    test("returns yarn when node_modules/.yarn-state.yml is present", async () => {
+        const nmDir = join(tmp, "node_modules", "@bastani", "atomic", "bin");
+        mkdirSync(nmDir, { recursive: true });
+        writeFileSync(join(tmp, "node_modules", ".yarn-state.yml"), "__metadata:\n  version: 6\n");
+        const fakeExec = join(nmDir, "atomic");
+        writeFileSync(fakeExec, "#!/bin/sh\necho hi");
+
+        const result = await detectInstallMethod({ execPath: fakeExec, skipProbe: true });
+        expect(result.kind).toBe("yarn");
+    });
+});
+
+// ── pmListsAtomic probe ────────────────────────────────────────────────────
+
+describe("pmListsAtomic", () => {
+    test("bun: returns true when stdout contains package name", async () => {
+        const stdout = `@bastani/atomic@0.7.8\nsome-other-package@1.0.0\n`;
+        expect(await pmListsAtomic("bun", mockSpawn(stdout))).toBe(true);
+    });
+
+    test("bun: returns false when stdout does not contain package name", async () => {
+        expect(await pmListsAtomic("bun", mockSpawn("other-pkg@1.0.0\n"))).toBe(false);
+    });
+
+    test("bun: returns false when exit code non-zero", async () => {
+        expect(await pmListsAtomic("bun", mockSpawn("@bastani/atomic@0.7.8", 1))).toBe(false);
+    });
+
+    test("npm: returns true when dependencies contain package", async () => {
+        const json = JSON.stringify({
+            dependencies: {
+                "@bastani/atomic": { version: "0.7.8" },
+            },
+        });
+        expect(await pmListsAtomic("npm", mockSpawn(json))).toBe(true);
+    });
+
+    test("npm: returns false when package absent from dependencies", async () => {
+        const json = JSON.stringify({ dependencies: { "other-pkg": {} } });
+        expect(await pmListsAtomic("npm", mockSpawn(json))).toBe(false);
+    });
+
+    test("npm: returns false when exit code non-zero", async () => {
+        const json = JSON.stringify({ dependencies: { "@bastani/atomic": {} } });
+        expect(await pmListsAtomic("npm", mockSpawn(json, 1))).toBe(false);
+    });
+
+    test("pnpm: returns true when any array entry has the package", async () => {
+        const json = JSON.stringify([
+            { dependencies: { "@bastani/atomic": { version: "0.7.8" } } },
+        ]);
+        expect(await pmListsAtomic("pnpm", mockSpawn(json))).toBe(true);
+    });
+
+    test("pnpm: returns false when no entry has the package", async () => {
+        const json = JSON.stringify([{ dependencies: { "other": {} } }]);
+        expect(await pmListsAtomic("pnpm", mockSpawn(json))).toBe(false);
+    });
+
+    test("yarn: returns true when NDJSON contains package name", async () => {
+        const ndjson = JSON.stringify({
+            type: "list",
+            data: { type: "info", trees: [{ name: "@bastani/atomic@0.7.8" }] },
+        });
+        expect(await pmListsAtomic("yarn", mockSpawn(ndjson))).toBe(true);
+    });
+
+    test("yarn: returns false when NDJSON does not contain package name", async () => {
+        const ndjson = JSON.stringify({ type: "list", data: { trees: [{ name: "other@1.0.0" }] } });
+        expect(await pmListsAtomic("yarn", mockSpawn(ndjson))).toBe(false);
+    });
+
+    test("swallows non-zero exit and returns false", async () => {
+        expect(await pmListsAtomic("npm", mockSpawn("{}", 2))).toBe(false);
+    });
+
+    test("swallows thrown errors and returns false", async () => {
+        const throwingSpawn: SpawnFn = async (_cmd) => {
+            throw new Error("spawn failed");
+        };
+        expect(await pmListsAtomic("npm", throwingSpawn)).toBe(false);
+    });
+});
+
+// ── probe fallback via detectInstallMethod ─────────────────────────────────
+
+describe("detectInstallMethod probe behavior", () => {
+    test("skipProbe: true skips probe and goes to source/unknown", async () => {
+        const fakeExec = join(tmp, "some-other-bin", "atomic");
+        mkdirSync(join(tmp, "some-other-bin"), { recursive: true });
+        const result = await detectInstallMethod({
+            execPath: fakeExec,
+            cwd: tmp,
+            skipProbe: true,
+        });
+        expect(result.kind).toBe("unknown");
+    });
+});
+
+// ── source checkout detection ──────────────────────────────────────────────
+
+describe("isInsideRepoCheckout", () => {
+    test("returns true when cwd is inside a dir with .git and package.json name=atomic", () => {
+        const repoDir = join(tmp, "my-atomic-repo");
+        mkdirSync(join(repoDir, ".git"), { recursive: true });
+        writeFileSync(join(repoDir, "package.json"), JSON.stringify({ name: "atomic" }));
+        const subDir = join(repoDir, "packages", "atomic", "src");
+        mkdirSync(subDir, { recursive: true });
+
+        expect(isInsideRepoCheckout(subDir)).toBe(true);
+    });
+
+    test("returns true when workspace root package.json has workspaces including packages/atomic", () => {
+        const repoDir = join(tmp, "monorepo");
+        mkdirSync(join(repoDir, ".git"), { recursive: true });
+        writeFileSync(
+            join(repoDir, "package.json"),
+            JSON.stringify({
+                name: "root",
+                workspaces: ["packages/atomic", "packages/other"],
+            }),
+        );
+        const subDir = join(repoDir, "packages", "atomic");
+        mkdirSync(subDir, { recursive: true });
+
+        expect(isInsideRepoCheckout(subDir)).toBe(true);
+    });
+
+    test("returns false for a non-repo temp dir", () => {
+        const plainDir = join(tmp, "not-a-repo");
+        mkdirSync(plainDir, { recursive: true });
+        expect(isInsideRepoCheckout(plainDir)).toBe(false);
+    });
+
+    test("returns false when .git present but package.json name is not atomic and no workspaces", () => {
+        const repoDir = join(tmp, "other-repo");
+        mkdirSync(join(repoDir, ".git"), { recursive: true });
+        writeFileSync(join(repoDir, "package.json"), JSON.stringify({ name: "not-atomic" }));
+        expect(isInsideRepoCheckout(repoDir)).toBe(false);
+    });
+
+    test("returns false when path walk throws (defensive)", () => {
+        expect(isInsideRepoCheckout(join(tmp, "does-not-exist"))).toBe(false);
+    });
+
+    // ── new cases for patched heuristic ──────────────────────────────────────
+
+    test("returns true when root package.json has name @bastani/atomic-monorepo and workspaces packages/*", () => {
+        // Regression: real monorepo shape was a false-negative before the fix.
+        const repoDir = join(tmp, "bastani-monorepo");
+        mkdirSync(join(repoDir, ".git"), { recursive: true });
+        writeFileSync(
+            join(repoDir, "package.json"),
+            JSON.stringify({
+                name: "@bastani/atomic-monorepo",
+                workspaces: ["packages/*", "examples/*"],
+            }),
+        );
+        const subDir = join(repoDir, "packages", "atomic", "src");
+        mkdirSync(subDir, { recursive: true });
+
+        expect(isInsideRepoCheckout(subDir)).toBe(true);
+    });
+
+    test("returns true for scoped suffix match name @some-org/atomic-monorepo", () => {
+        const repoDir = join(tmp, "scoped-monorepo");
+        mkdirSync(join(repoDir, ".git"), { recursive: true });
+        writeFileSync(
+            join(repoDir, "package.json"),
+            JSON.stringify({ name: "@some-org/atomic-monorepo" }),
+        );
+        const subDir = join(repoDir, "packages", "atomic");
+        mkdirSync(subDir, { recursive: true });
+
+        expect(isInsideRepoCheckout(subDir)).toBe(true);
+    });
+
+    test("returns false for unrelated repo with name other and no workspaces", () => {
+        const repoDir = join(tmp, "unrelated-repo");
+        mkdirSync(join(repoDir, ".git"), { recursive: true });
+        writeFileSync(
+            join(repoDir, "package.json"),
+            JSON.stringify({ name: "other" }),
+        );
+
+        expect(isInsideRepoCheckout(repoDir)).toBe(false);
+    });
+});
+
+// ── bun-tree detection (P1 regression) ────────────────────────────────────
+
+describe("bun-tree detection (P1 regression)", () => {
+    test("returns bun for execPath under ~/.bun/install/global/node_modules/...", async () => {
+        const execPath = join(
+            homedir(),
+            ".bun",
+            "install",
+            "global",
+            "node_modules",
+            "@bastani",
+            "atomic-linux-x64",
+            "bin",
+            "atomic",
+        );
+        const result = await detectInstallMethod({ execPath, skipProbe: true });
+        expect(result.kind).toBe("bun");
+        if (result.kind === "bun") {
+            expect(result.binPath).toBe(execPath);
+        }
+    });
+
+    test("returns bun for execPath under $BUN_INSTALL/install/... when BUN_INSTALL is set", async () => {
+        const origEnv = process.env.BUN_INSTALL;
+        process.env.BUN_INSTALL = "/opt/bun";
+        try {
+            const execPath =
+                "/opt/bun/install/global/node_modules/@bastani/atomic-linux-x64/bin/atomic";
+            const result = await detectInstallMethod({ execPath, skipProbe: true });
+            expect(result.kind).toBe("bun");
+            if (result.kind === "bun") {
+                expect(result.binPath).toBe(execPath);
+            }
+        } finally {
+            if (origEnv === undefined) {
+                delete process.env.BUN_INSTALL;
+            } else {
+                process.env.BUN_INSTALL = origEnv;
+            }
+        }
+    });
+
+    test("bun-tree match wins over node_modules heuristic", async () => {
+        // Regression guard: path contains /node_modules/ but must NOT classify as npm/pnpm/yarn.
+        const execPath = join(
+            homedir(),
+            ".bun",
+            "install",
+            "global",
+            "node_modules",
+            "@bastani",
+            "atomic-linux-x64",
+            "bin",
+            "atomic",
+        );
+        const result = await detectInstallMethod({ execPath, skipProbe: true });
+        expect(result.kind).toBe("bun");
+        expect(result.kind).not.toBe("npm");
+        expect(result.kind).not.toBe("pnpm");
+        expect(result.kind).not.toBe("yarn");
+    });
+});
+
+// ── source / unknown via detectInstallMethod ───────────────────────────────
+
+describe("detectInstallMethod source vs unknown", () => {
+    test("returns source when cwd is inside a repo checkout", async () => {
+        const repoDir = join(tmp, "atomic-source-repo");
+        mkdirSync(join(repoDir, ".git"), { recursive: true });
+        writeFileSync(join(repoDir, "package.json"), JSON.stringify({ name: "atomic" }));
+        const subDir = join(repoDir, "packages", "atomic", "src");
+        mkdirSync(subDir, { recursive: true });
+
+        const result = await detectInstallMethod({
+            execPath: join(tmp, "random-bin", "atomic"),
+            cwd: subDir,
+            skipProbe: true,
+        });
+        expect(result.kind).toBe("source");
+    });
+
+    test("returns unknown for unrecognised exec path with non-repo cwd", async () => {
+        const fakeExec = join(tmp, "random-bin", "atomic");
+        mkdirSync(join(tmp, "random-bin"), { recursive: true });
+
+        const result = await detectInstallMethod({
+            execPath: fakeExec,
+            cwd: tmp,
+            skipProbe: true,
+        });
+        expect(result.kind).toBe("unknown");
+    });
+});

--- a/packages/atomic/src/services/system/install-method.test.ts
+++ b/packages/atomic/src/services/system/install-method.test.ts
@@ -214,6 +214,58 @@ describe("detectInstallMethod probe behavior", () => {
         });
         expect(result.kind).toBe("unknown");
     });
+
+    test("probe loop: all PMs return non-zero → falls through to unknown", async () => {
+        // Stub Bun.spawn so each `<pm> ls -g` returns exitCode=1, stdout="".
+        // This exercises the real `defaultSpawn` and the for-loop in
+        // `detectInstallMethod`, which the skipProbe tests bypass entirely.
+        const { spyOn } = await import("bun:test");
+        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((_opts: { cmd: string[] }) => ({
+            stdout: new Response("").body,
+            stderr: new Response("").body,
+            exited: Promise.resolve(1),
+            kill: () => {},
+        })) as unknown as typeof Bun.spawn);
+
+        try {
+            const fakeExec = join(tmp, "elsewhere", "atomic");
+            mkdirSync(join(tmp, "elsewhere"), { recursive: true });
+            const result = await detectInstallMethod({ execPath: fakeExec, cwd: tmp });
+            expect(result.kind).toBe("unknown");
+            // All four PMs were probed.
+            expect(spawnSpy.mock.calls.length).toBe(4);
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
+
+    test("probe loop: a PM owns the package → returns that PM kind", async () => {
+        const { spyOn } = await import("bun:test");
+        // Order in detectInstallMethod is bun, pnpm, npm, yarn. Make `bun pm ls -g`
+        // succeed and contain the package — first hit short-circuits.
+        const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((opts: { cmd: string[] }) => {
+            const isBun = opts.cmd[0] === "bun";
+            const stdout = isBun ? `${ATOMIC_PACKAGE_NAME}@0.7.8\n` : "";
+            return {
+                stdout: new Response(stdout).body,
+                stderr: new Response("").body,
+                exited: Promise.resolve(isBun ? 0 : 1),
+                kill: () => {},
+            };
+        }) as unknown as typeof Bun.spawn);
+
+        try {
+            const fakeExec = join(tmp, "elsewhere", "atomic");
+            mkdirSync(join(tmp, "elsewhere"), { recursive: true });
+            const result = await detectInstallMethod({ execPath: fakeExec, cwd: tmp });
+            expect(result.kind).toBe("bun");
+            if (result.kind === "bun") {
+                expect(result.binPath).toBe(fakeExec);
+            }
+        } finally {
+            spawnSpy.mockRestore();
+        }
+    });
 });
 
 // ── source checkout detection ──────────────────────────────────────────────

--- a/packages/atomic/src/services/system/install-method.ts
+++ b/packages/atomic/src/services/system/install-method.ts
@@ -1,0 +1,191 @@
+/**
+ * Detect how the running `atomic` binary was installed.
+ *
+ * Two-stage: cheap path-shape heuristics first, then a `<pm> list -g`
+ * probe via `Bun.spawn` (skipped when `opts.skipProbe` is set).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { getInstallPaths } from "../../commands/cli/install.ts";
+
+export const ATOMIC_PACKAGE_NAME = "@bastani/atomic";
+
+export type InstallMethod =
+    | { kind: "binary"; binPath: string }
+    | { kind: "bun"; binPath: string }
+    | { kind: "npm" | "pnpm" | "yarn"; binPath: string }
+    | { kind: "source" }
+    | { kind: "unknown" };
+
+export interface DetectOptions {
+    /** Override `process.execPath` for tests. */
+    readonly execPath?: string;
+    /** Override `process.cwd()` for the source-checkout walk. */
+    readonly cwd?: string;
+    /** Skip the `<pm> list -g` fallback probe. */
+    readonly skipProbe?: boolean;
+}
+
+type SpawnResult = { exitCode: number | null; stdout: string };
+type SpawnFn = (cmd: string[]) => Promise<SpawnResult>;
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+const defaultSpawn: SpawnFn = async (cmd) => {
+    const proc = Bun.spawn({ cmd, stdout: "pipe", stderr: "ignore" });
+    const timer = setTimeout(() => proc.kill(), PROBE_TIMEOUT_MS);
+    try {
+        const stdout = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+        return { exitCode, stdout };
+    } catch {
+        return { exitCode: null, stdout: "" };
+    } finally {
+        clearTimeout(timer);
+    }
+};
+
+// ── Path helpers (case-insensitive to tolerate Windows + symlink quirks) ──
+
+function samePath(a: string, b: string): boolean {
+    return resolve(a).toLowerCase() === resolve(b).toLowerCase();
+}
+
+function isUnder(child: string, parent: string): boolean {
+    const parentR = (resolve(parent) + sep).toLowerCase();
+    return resolve(child).toLowerCase().startsWith(parentR);
+}
+
+// ── PM listing probes ─────────────────────────────────────────────────────
+
+export async function pmListsAtomic(
+    pm: "bun" | "npm" | "pnpm" | "yarn",
+    spawn: SpawnFn = defaultSpawn,
+): Promise<boolean> {
+    try {
+        if (pm === "bun") {
+            const { exitCode, stdout } = await spawn(["bun", "pm", "ls", "-g"]);
+            return exitCode === 0 && stdout.includes(ATOMIC_PACKAGE_NAME);
+        }
+        if (pm === "npm") {
+            const { exitCode, stdout } = await spawn(["npm", "ls", "-g", "--depth=0", "--json"]);
+            if (exitCode !== 0) return false;
+            const parsed = JSON.parse(stdout) as { dependencies?: Record<string, unknown> };
+            return ATOMIC_PACKAGE_NAME in (parsed.dependencies ?? {});
+        }
+        if (pm === "pnpm") {
+            const { exitCode, stdout } = await spawn(["pnpm", "ls", "-g", "--depth=0", "--json"]);
+            if (exitCode !== 0) return false;
+            // pnpm emits an array of project entries.
+            const parsed = JSON.parse(stdout) as Array<{ dependencies?: Record<string, unknown> }>;
+            return parsed.some((entry) => ATOMIC_PACKAGE_NAME in (entry.dependencies ?? {}));
+        }
+        // yarn — NDJSON, one JSON object per line. The package name only ever
+        // appears as a JSON string value, so a substring scan is sufficient.
+        const { exitCode, stdout } = await spawn(["yarn", "global", "list", "--json"]);
+        if (exitCode !== 0) return false;
+        return stdout.split("\n").some((line) => line.includes(ATOMIC_PACKAGE_NAME));
+    } catch {
+        return false;
+    }
+}
+
+// ── node_modules PM heuristic ─────────────────────────────────────────────
+
+function inferPmFromNodeModules(execPath: string): "npm" | "pnpm" | "yarn" | null {
+    const marker = `${sep}node_modules${sep}`;
+    const idx = execPath.indexOf(marker);
+    if (idx === -1) return null;
+
+    const nmRoot = execPath.slice(0, idx + marker.length - 1);
+
+    if (existsSync(`${nmRoot}${sep}.pnpm`)) return "pnpm";
+    if (existsSync(`${nmRoot}${sep}.yarn-state.yml`)) return "yarn";
+    return "npm";
+}
+
+// ── Source checkout detection ─────────────────────────────────────────────
+
+const MAX_WALK_DEPTH = 20;
+
+export function isInsideRepoCheckout(cwd: string = process.cwd()): boolean {
+    let dir = resolve(cwd);
+    for (let i = 0; i < MAX_WALK_DEPTH; i++) {
+        try {
+            if (existsSync(join(dir, ".git"))) {
+                const pkgPath = join(dir, "package.json");
+                if (existsSync(pkgPath)) {
+                    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+                        name?: string;
+                        workspaces?: string[];
+                    };
+                    // Accept legacy synthetic name + real monorepo name.
+                    if (pkg.name === "atomic") return true;
+                    if (pkg.name === "@bastani/atomic-monorepo") return true;
+                    if (pkg.name?.endsWith("/atomic-monorepo")) return true;
+
+                    // Workspace globs: a literal "packages/atomic" entry OR a glob whose
+                    // prefix matches "packages/*" (e.g. "packages/*").
+                    if (pkg.workspaces?.some(
+                        (w) => w.includes("packages/atomic") || w.startsWith("packages/*"),
+                    )) {
+                        return true;
+                    }
+                    // .git found but pkg doesn't match — stop walking.
+                    return false;
+                }
+            }
+            const parent = resolve(dir, "..");
+            if (parent === dir) return false;
+            dir = parent;
+        } catch {
+            return false;
+        }
+    }
+    return false;
+}
+
+// ── Main detector ─────────────────────────────────────────────────────────
+
+export async function detectInstallMethod(opts: DetectOptions = {}): Promise<InstallMethod> {
+    const execPath = resolve(opts.execPath ?? process.execPath);
+
+    // 1a. Standalone binary install.
+    const installPaths = getInstallPaths();
+    if (samePath(execPath, installPaths.binPath)) {
+        return { kind: "binary", binPath: execPath };
+    }
+
+    // 1b. Bun global — `bun add -g` lays the platform binary under
+    //     `~/.bun/install/global/node_modules/...`, NOT `~/.bun/bin`, so accept
+    //     the whole `.bun` tree plus `$BUN_INSTALL` (not just its bin/).
+    const bunHome = join(homedir(), ".bun");
+    const bunRoots = [
+        join(bunHome, "bin"),
+        join(bunHome, "install"),
+        process.env.BUN_INSTALL,
+    ].filter((root): root is string => root !== undefined);
+    if (bunRoots.some((root) => isUnder(execPath, root))) {
+        return { kind: "bun", binPath: execPath };
+    }
+
+    // 1c. node_modules tree (npm/pnpm/yarn). Must run AFTER 1b — bun-global
+    //     paths also contain `node_modules/`. New install channels whose paths
+    //     cross a `node_modules/` boundary must be detected before this step.
+    const nmPm = inferPmFromNodeModules(execPath);
+    if (nmPm) return { kind: nmPm, binPath: execPath };
+
+    // 2. Fallback: ask each PM whether it owns the package.
+    if (!opts.skipProbe) {
+        for (const pm of ["bun", "pnpm", "npm", "yarn"] as const) {
+            if (await pmListsAtomic(pm)) {
+                return { kind: pm, binPath: execPath };
+            }
+        }
+    }
+
+    // 3. Source checkout vs unrecognised.
+    return isInsideRepoCheckout(opts.cwd) ? { kind: "source" } : { kind: "unknown" };
+}

--- a/packages/atomic/src/services/system/release-fetch.test.ts
+++ b/packages/atomic/src/services/system/release-fetch.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Tests for release-fetch.ts
+ *
+ * Uses spyOn(globalThis, "fetch") to intercept HTTP calls without network.
+ */
+
+import {
+    describe,
+    test,
+    expect,
+    beforeEach,
+    afterEach,
+    mock,
+    spyOn,
+} from "bun:test";
+import type { Mock } from "bun:test";
+import * as realNodeFs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+    getLatestRelease,
+    getReleaseByTag,
+    downloadAsset,
+    downloadAssetFromUrl,
+    verifyChecksum,
+    isNewer,
+    normalizeVersion,
+} from "./release-fetch.ts";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeRelease(tag: string) {
+    return {
+        tag_name: tag,
+        assets: [
+            {
+                name: "atomic-linux-x64",
+                browser_download_url: `https://example.com/${tag}/atomic-linux-x64`,
+            },
+        ],
+    };
+}
+
+function fakeJsonResponse(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: {
+            "Content-Type": "application/json",
+            ...extraHeaders,
+        },
+    });
+}
+
+function fakeStreamResponse(bytes: Uint8Array, status = 200): Response {
+    return new Response(bytes.buffer as ArrayBuffer, { status });
+}
+
+// ── setup / teardown ──────────────────────────────────────────────────────────
+
+let fetchSpy: Mock<typeof fetch>;
+let savedGithubToken: string | undefined;
+
+beforeEach(() => {
+    fetchSpy = spyOn(globalThis, "fetch");
+    savedGithubToken = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+});
+
+afterEach(() => {
+    fetchSpy.mockRestore();
+    if (savedGithubToken !== undefined) {
+        process.env.GITHUB_TOKEN = savedGithubToken;
+    } else {
+        delete process.env.GITHUB_TOKEN;
+    }
+});
+
+// ── getLatestRelease ──────────────────────────────────────────────────────────
+
+describe("getLatestRelease", () => {
+    test("happy path — correct URL, headers, and parsed shape", async () => {
+        const release = makeRelease("v0.7.8");
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(release));
+
+        const result = await getLatestRelease();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe("https://api.github.com/repos/flora131/atomic/releases/latest");
+
+        const headers = init.headers as Record<string, string>;
+        expect(headers["Accept"]).toBe("application/vnd.github+json");
+        expect(headers["User-Agent"]).toBe("atomic-cli");
+        expect(headers["Authorization"]).toBeUndefined();
+
+        expect(result.tag_name).toBe("v0.7.8");
+        expect(result.assets).toHaveLength(1);
+        expect(result.assets[0]?.name).toBe("atomic-linux-x64");
+    });
+
+    test("includes Authorization header when GITHUB_TOKEN is set", async () => {
+        process.env.GITHUB_TOKEN = "ghp_testtoken";
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(makeRelease("v0.7.8")));
+
+        await getLatestRelease();
+
+        const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        const headers = init.headers as Record<string, string>;
+        expect(headers["Authorization"]).toBe("Bearer ghp_testtoken");
+    });
+
+    test("rate-limited 403 — throws exact message", async () => {
+        fetchSpy.mockResolvedValueOnce(
+            fakeJsonResponse({ message: "rate limit exceeded" }, 403, {
+                "X-RateLimit-Remaining": "0",
+            }),
+        );
+
+        let msg = "";
+        try {
+            await getLatestRelease();
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toContain(
+            "Set GITHUB_TOKEN to lift the 60 req/h anonymous limit",
+        );
+    });
+
+    test("403 without rate-limit header — throws generic error", async () => {
+        fetchSpy.mockResolvedValueOnce(
+            fakeJsonResponse({ message: "forbidden" }, 403),
+        );
+
+        let msg = "";
+        try {
+            await getLatestRelease();
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toContain("GitHub API error 403");
+    });
+});
+
+// ── getReleaseByTag ───────────────────────────────────────────────────────────
+
+describe("getReleaseByTag", () => {
+    test("encodes tag in URL and returns release info", async () => {
+        const release = makeRelease("v0.7.8");
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(release));
+
+        const result = await getReleaseByTag("v0.7.8");
+
+        const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe(
+            "https://api.github.com/repos/flora131/atomic/releases/tags/v0.7.8",
+        );
+        expect(result.tag_name).toBe("v0.7.8");
+    });
+
+    test("URL-encodes special characters in tag", async () => {
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(makeRelease("v0.7.8-0")));
+
+        await getReleaseByTag("v0.7.8-0");
+
+        const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toContain("/releases/tags/v0.7.8-0");
+    });
+});
+
+// ── downloadAsset ─────────────────────────────────────────────────────────────
+
+describe("downloadAsset", () => {
+    test("writes asset bytes to destPath", async () => {
+        const bytes = new Uint8Array([0x41, 0x42, 0x43, 0x44]); // ABCD
+        const release = makeRelease("v0.7.8");
+
+        // First call: getReleaseByTag
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(release));
+        // Second call: actual asset download
+        fetchSpy.mockResolvedValueOnce(fakeStreamResponse(bytes));
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-test-"));
+        const destPath = join(dir, "atomic-linux-x64");
+
+        try {
+            await downloadAsset("v0.7.8", "atomic-linux-x64", destPath);
+
+            const written = await Bun.file(destPath).bytes();
+            expect(written).toEqual(bytes);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("throws when asset not found in release", async () => {
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(makeRelease("v0.7.8")));
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-test-"));
+        try {
+            let msg = "";
+            try {
+                await downloadAsset(
+                    "v0.7.8",
+                    "nonexistent-asset",
+                    join(dir, "out"),
+                );
+            } catch (e) {
+                msg = (e as Error).message;
+            }
+            expect(msg).toContain(
+                'Asset "nonexistent-asset" not found in release v0.7.8',
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+// ── downloadAssetFromUrl ──────────────────────────────────────────────────────
+
+describe("downloadAssetFromUrl", () => {
+    test("writes bytes from URL to destPath without extra fetch", async () => {
+        const bytes = new Uint8Array([0x61, 0x62, 0x63]); // abc
+        fetchSpy.mockResolvedValueOnce(fakeStreamResponse(bytes));
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-url-"));
+        const destPath = join(dir, "asset");
+
+        try {
+            await downloadAssetFromUrl("https://example.com/asset", destPath);
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+            expect(url).toBe("https://example.com/asset");
+
+            const written = await Bun.file(destPath).bytes();
+            expect(written).toEqual(bytes);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("throws on non-ok HTTP response", async () => {
+        fetchSpy.mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-url-"));
+        try {
+            let msg = "";
+            try {
+                await downloadAssetFromUrl("https://example.com/missing", join(dir, "out"));
+            } catch (e) {
+                msg = (e as Error).message;
+            }
+            expect(msg).toContain("Failed to download asset: HTTP 404");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("downloadAsset delegates to downloadAssetFromUrl (2 fetch calls total)", async () => {
+        const bytes = new Uint8Array([0x78, 0x79]); // xy
+        const release = makeRelease("v0.7.8");
+
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(release));
+        fetchSpy.mockResolvedValueOnce(fakeStreamResponse(bytes));
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-delegate-"));
+        const destPath = join(dir, "atomic-linux-x64");
+
+        try {
+            await downloadAsset("v0.7.8", "atomic-linux-x64", destPath);
+
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+            const [, assetUrl] = fetchSpy.mock.calls.map((c) => (c as [string])[0]);
+            expect(assetUrl).toBe("https://example.com/v0.7.8/atomic-linux-x64");
+
+            const written = await Bun.file(destPath).bytes();
+            expect(written).toEqual(bytes);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    // ── Cluster C — atomic download cleanup on rename failure ─────────────────
+
+    describe("rename failure cleanup", () => {
+        const renameSyncMock = mock((_src: string, _dst: string) => {});
+        const copyFileSyncMock = mock((_src: string, _dst: string) => {});
+        const unlinkSyncMock = mock((_path: string) => {});
+
+        beforeEach(async () => {
+            renameSyncMock.mockReset();
+            copyFileSyncMock.mockReset();
+            unlinkSyncMock.mockReset();
+
+            await mock.module("node:fs", () => ({
+                ...realNodeFs,
+                renameSync: renameSyncMock,
+                copyFileSync: copyFileSyncMock,
+                unlinkSync: unlinkSyncMock,
+            }));
+        });
+
+        afterEach(async () => {
+            // Restore real node:fs so outer tests keep passing.
+            await mock.module("node:fs", () => ({ ...realNodeFs }));
+        });
+
+        test("cleans up tmpPath on EXDEV via copyFileSync fallback", async () => {
+            renameSyncMock.mockImplementation((_src: string, _dst: string) => {
+                throw Object.assign(new Error("EXDEV"), { code: "EXDEV" });
+            });
+
+            const bytes = new Uint8Array([0x41, 0x42]);
+            fetchSpy.mockResolvedValueOnce(fakeStreamResponse(bytes));
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-exdev-"));
+            const destPath = join(dir, "atomic-out");
+
+            try {
+                await downloadAssetFromUrl("https://example.com/asset", destPath);
+
+                // copyFileSync used as EXDEV fallback
+                expect(copyFileSyncMock).toHaveBeenCalledTimes(1);
+                const [copySrc, copyDst] = copyFileSyncMock.mock.calls[0] as [string, string];
+                expect(copyDst).toBe(destPath);
+
+                // unlinkSync called with the same tmpPath used as copySrc
+                expect(unlinkSyncMock).toHaveBeenCalledTimes(1);
+                const [unlinkPath] = unlinkSyncMock.mock.calls[0] as [string];
+                expect(unlinkPath).toBe(copySrc);
+
+                // function did not throw
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        test("rethrows non-EXDEV rename errors but still cleans up tmpPath", async () => {
+            const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" });
+            renameSyncMock.mockImplementation((_src: string, _dst: string) => {
+                throw eacces;
+            });
+
+            const bytes = new Uint8Array([0x43, 0x44]);
+            fetchSpy.mockResolvedValueOnce(fakeStreamResponse(bytes));
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-eacces-"));
+            const destPath = join(dir, "atomic-out");
+
+            let thrown: Error | null = null;
+            try {
+                await downloadAssetFromUrl("https://example.com/asset", destPath);
+            } catch (e) {
+                thrown = e as Error;
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+
+            // must rethrow the EACCES error
+            expect(thrown).not.toBeNull();
+            expect((thrown as NodeJS.ErrnoException).code).toBe("EACCES");
+
+            // cleanup still happened
+            expect(unlinkSyncMock).toHaveBeenCalledTimes(1);
+            // copyFileSync must NOT have been called (EACCES is not EXDEV)
+            expect(copyFileSyncMock).toHaveBeenCalledTimes(0);
+        });
+    });
+});
+
+// ── verifyChecksum ────────────────────────────────────────────────────────────
+
+describe("verifyChecksum", () => {
+    test("no throw when checksum matches", async () => {
+        const content = new Uint8Array([1, 2, 3, 4, 5]);
+        const hasher = new Bun.CryptoHasher("sha256");
+        hasher.update(content);
+        const expected = hasher.digest("hex");
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-cksum-"));
+        const filePath = join(dir, "testfile");
+        try {
+            writeFileSync(filePath, content);
+            const result = await verifyChecksum(filePath, expected);
+            expect(result).toBeUndefined();
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("throws Checksum mismatch on wrong expected hash", async () => {
+        const content = new Uint8Array([1, 2, 3, 4, 5]);
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-cksum-"));
+        const filePath = join(dir, "testfile");
+        try {
+            writeFileSync(filePath, content);
+            let msg = "";
+            try {
+                await verifyChecksum(filePath, "0".repeat(64));
+            } catch (e) {
+                msg = (e as Error).message;
+            }
+            expect(msg).toContain("Checksum mismatch");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("thrown message includes file path and both hashes", async () => {
+        const content = new Uint8Array([9, 8, 7]);
+        const wrong = "a".repeat(64);
+
+        const dir = mkdtempSync(join(tmpdir(), "release-fetch-cksum-"));
+        const filePath = join(dir, "testfile2");
+        try {
+            writeFileSync(filePath, content);
+            let msg = "";
+            try {
+                await verifyChecksum(filePath, wrong);
+            } catch (e) {
+                msg = (e as Error).message;
+            }
+            expect(msg).toContain("Checksum mismatch");
+            expect(msg).toContain(filePath);
+            expect(msg).toContain(wrong);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+// ── isNewer ───────────────────────────────────────────────────────────────────
+
+describe("isNewer", () => {
+    test('("v0.8.0", "0.7.8") === true', () => {
+        expect(isNewer("v0.8.0", "0.7.8")).toBe(true);
+    });
+
+    test('("0.7.8", "0.7.8") === false', () => {
+        expect(isNewer("0.7.8", "0.7.8")).toBe(false);
+    });
+
+    test('("0.7.7", "0.7.8") === false', () => {
+        expect(isNewer("0.7.7", "0.7.8")).toBe(false);
+    });
+
+    test('("v1.0.0", "0.9.9") === true', () => {
+        expect(isNewer("v1.0.0", "0.9.9")).toBe(true);
+    });
+
+    test('prerelease "v0.7.9-0" vs "0.7.8" → true', () => {
+        expect(isNewer("v0.7.9-0", "0.7.8")).toBe(true);
+    });
+
+    test("release is newer than same-version prerelease", () => {
+        expect(isNewer("v0.7.9", "0.7.9-0")).toBe(true);
+    });
+
+    test("prerelease is not newer than release of same version", () => {
+        expect(isNewer("v0.7.9-0", "0.7.9")).toBe(false);
+    });
+
+    test("unparseable target → false", () => {
+        expect(isNewer("not-a-version", "0.7.8")).toBe(false);
+    });
+
+    test("unparseable current → false", () => {
+        expect(isNewer("v0.8.0", "not-a-version")).toBe(false);
+    });
+
+    // ── Cluster B — numeric prerelease compare (SemVer 2.0.0 §11.3 + §11.4) ──
+
+    test("numeric pre IDs compare numerically: 10 > 2 even though '10' < '2' lexically", () => {
+        expect(isNewer("0.7.9-10", "0.7.9-2")).toBe(true);
+    });
+
+    test("numeric component within multi-id prerelease compares numerically: alpha.10 > alpha.2", () => {
+        expect(isNewer("0.7.9-alpha.10", "0.7.9-alpha.2")).toBe(true);
+    });
+
+    test("alphanumeric pre ID > numeric pre ID per §11.4.1: alpha > 1", () => {
+        expect(isNewer("0.7.9-alpha", "0.7.9-1")).toBe(true);
+    });
+
+    test("release > prerelease of same version per §11.3", () => {
+        expect(isNewer("0.7.9", "0.7.9-rc.1")).toBe(true);
+    });
+});
+
+// ── normalizeVersion ──────────────────────────────────────────────────────────
+
+describe("normalizeVersion", () => {
+    test('"latest" → "latest"', () => {
+        expect(normalizeVersion("latest")).toBe("latest");
+    });
+
+    test('"v0.7.9" → "0.7.9"', () => {
+        expect(normalizeVersion("v0.7.9")).toBe("0.7.9");
+    });
+
+    test('"0.7.9" → "0.7.9"', () => {
+        expect(normalizeVersion("0.7.9")).toBe("0.7.9");
+    });
+
+    test('"  v1.0.0  " → "1.0.0"', () => {
+        expect(normalizeVersion("  v1.0.0  ")).toBe("1.0.0");
+    });
+
+    test('"LATEST" → "latest" (case-insensitive)', () => {
+        expect(normalizeVersion("LATEST")).toBe("latest");
+    });
+});

--- a/packages/atomic/src/services/system/release-fetch.test.ts
+++ b/packages/atomic/src/services/system/release-fetch.test.ts
@@ -60,11 +60,14 @@ function fakeStreamResponse(bytes: Uint8Array, status = 200): Response {
 
 let fetchSpy: Mock<typeof fetch>;
 let savedGithubToken: string | undefined;
+let savedApiBase: string | undefined;
 
 beforeEach(() => {
     fetchSpy = spyOn(globalThis, "fetch");
     savedGithubToken = process.env.GITHUB_TOKEN;
     delete process.env.GITHUB_TOKEN;
+    savedApiBase = process.env.ATOMIC_GITHUB_API_BASE;
+    delete process.env.ATOMIC_GITHUB_API_BASE;
 });
 
 afterEach(() => {
@@ -73,6 +76,11 @@ afterEach(() => {
         process.env.GITHUB_TOKEN = savedGithubToken;
     } else {
         delete process.env.GITHUB_TOKEN;
+    }
+    if (savedApiBase !== undefined) {
+        process.env.ATOMIC_GITHUB_API_BASE = savedApiBase;
+    } else {
+        delete process.env.ATOMIC_GITHUB_API_BASE;
     }
 });
 
@@ -140,6 +148,16 @@ describe("getLatestRelease", () => {
             msg = (e as Error).message;
         }
         expect(msg).toContain("GitHub API error 403");
+    });
+
+    test("ATOMIC_GITHUB_API_BASE redirects requests to the override host", async () => {
+        process.env.ATOMIC_GITHUB_API_BASE = "http://localhost:4874/repos/flora131/atomic";
+        fetchSpy.mockResolvedValueOnce(fakeJsonResponse(makeRelease("v0.7.9")));
+
+        await getLatestRelease();
+
+        const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe("http://localhost:4874/repos/flora131/atomic/releases/latest");
     });
 });
 

--- a/packages/atomic/src/services/system/release-fetch.test.ts
+++ b/packages/atomic/src/services/system/release-fetch.test.ts
@@ -10,11 +10,10 @@ import {
     expect,
     beforeEach,
     afterEach,
-    mock,
     spyOn,
 } from "bun:test";
 import type { Mock } from "bun:test";
-import * as realNodeFs from "node:fs";
+import * as nodeFs from "node:fs";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -286,31 +285,29 @@ describe("downloadAssetFromUrl", () => {
 
     // ── Cluster C — atomic download cleanup on rename failure ─────────────────
 
+    // Use spyOn (not mock.module) — `mock.module("node:fs", ...)` is
+    // process-global in Bun and leaks across test files even after a
+    // spread-restore in afterEach. spyOn mutates the export in place and
+    // mockRestore() reverts it cleanly per test.
     describe("rename failure cleanup", () => {
-        const renameSyncMock = mock((_src: string, _dst: string) => {});
-        const copyFileSyncMock = mock((_src: string, _dst: string) => {});
-        const unlinkSyncMock = mock((_path: string) => {});
+        let renameSpy: Mock<typeof nodeFs.renameSync>;
+        let copyFileSpy: Mock<typeof nodeFs.copyFileSync>;
+        let unlinkSpy: Mock<typeof nodeFs.unlinkSync>;
 
-        beforeEach(async () => {
-            renameSyncMock.mockReset();
-            copyFileSyncMock.mockReset();
-            unlinkSyncMock.mockReset();
-
-            await mock.module("node:fs", () => ({
-                ...realNodeFs,
-                renameSync: renameSyncMock,
-                copyFileSync: copyFileSyncMock,
-                unlinkSync: unlinkSyncMock,
-            }));
+        beforeEach(() => {
+            renameSpy = spyOn(nodeFs, "renameSync");
+            copyFileSpy = spyOn(nodeFs, "copyFileSync").mockImplementation(() => {});
+            unlinkSpy = spyOn(nodeFs, "unlinkSync").mockImplementation(() => {});
         });
 
-        afterEach(async () => {
-            // Restore real node:fs so outer tests keep passing.
-            await mock.module("node:fs", () => ({ ...realNodeFs }));
+        afterEach(() => {
+            renameSpy.mockRestore();
+            copyFileSpy.mockRestore();
+            unlinkSpy.mockRestore();
         });
 
         test("cleans up tmpPath on EXDEV via copyFileSync fallback", async () => {
-            renameSyncMock.mockImplementation((_src: string, _dst: string) => {
+            renameSpy.mockImplementation(() => {
                 throw Object.assign(new Error("EXDEV"), { code: "EXDEV" });
             });
 
@@ -324,13 +321,13 @@ describe("downloadAssetFromUrl", () => {
                 await downloadAssetFromUrl("https://example.com/asset", destPath);
 
                 // copyFileSync used as EXDEV fallback
-                expect(copyFileSyncMock).toHaveBeenCalledTimes(1);
-                const [copySrc, copyDst] = copyFileSyncMock.mock.calls[0] as [string, string];
+                expect(copyFileSpy).toHaveBeenCalledTimes(1);
+                const [copySrc, copyDst] = copyFileSpy.mock.calls[0] as [string, string];
                 expect(copyDst).toBe(destPath);
 
                 // unlinkSync called with the same tmpPath used as copySrc
-                expect(unlinkSyncMock).toHaveBeenCalledTimes(1);
-                const [unlinkPath] = unlinkSyncMock.mock.calls[0] as [string];
+                expect(unlinkSpy).toHaveBeenCalledTimes(1);
+                const [unlinkPath] = unlinkSpy.mock.calls[0] as [string];
                 expect(unlinkPath).toBe(copySrc);
 
                 // function did not throw
@@ -341,7 +338,7 @@ describe("downloadAssetFromUrl", () => {
 
         test("rethrows non-EXDEV rename errors but still cleans up tmpPath", async () => {
             const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" });
-            renameSyncMock.mockImplementation((_src: string, _dst: string) => {
+            renameSpy.mockImplementation(() => {
                 throw eacces;
             });
 
@@ -365,9 +362,9 @@ describe("downloadAssetFromUrl", () => {
             expect((thrown as NodeJS.ErrnoException).code).toBe("EACCES");
 
             // cleanup still happened
-            expect(unlinkSyncMock).toHaveBeenCalledTimes(1);
+            expect(unlinkSpy).toHaveBeenCalledTimes(1);
             // copyFileSync must NOT have been called (EACCES is not EXDEV)
-            expect(copyFileSyncMock).toHaveBeenCalledTimes(0);
+            expect(copyFileSpy).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/packages/atomic/src/services/system/release-fetch.ts
+++ b/packages/atomic/src/services/system/release-fetch.ts
@@ -1,0 +1,215 @@
+/**
+ * GitHub Releases helpers for the `atomic update` command.
+ *
+ * Fetches release metadata, downloads assets, verifies checksums, and
+ * compares semver tags. All GitHub API calls respect `GITHUB_TOKEN` when
+ * set and surface a clear error on anonymous rate-limit exhaustion.
+ */
+
+import { copyFileSync, renameSync, unlinkSync } from "node:fs";
+import { pid } from "node:process";
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+export interface ReleaseInfo {
+    readonly tag_name: string;
+    readonly assets: ReadonlyArray<{ name: string; browser_download_url: string }>;
+}
+
+export interface PlatformChecksum {
+    readonly checksum: string;
+}
+
+export interface Manifest {
+    readonly version: string;
+    readonly platforms: Readonly<Record<string, PlatformChecksum>>;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+const GITHUB_API_BASE = "https://api.github.com/repos/flora131/atomic";
+
+function buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "atomic-cli",
+    };
+    const token = process.env.GITHUB_TOKEN;
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    return headers;
+}
+
+async function githubGet(url: string): Promise<ReleaseInfo> {
+    const res = await fetch(url, { headers: buildHeaders() });
+
+    if (res.status === 403 && res.headers.get("X-RateLimit-Remaining") === "0") {
+        throw new Error("Set GITHUB_TOKEN to lift the 60 req/h anonymous limit");
+    }
+    if (!res.ok) {
+        throw new Error(`GitHub API error ${res.status}: ${url}`);
+    }
+
+    return res.json() as Promise<ReleaseInfo>;
+}
+
+// ── Exported functions ────────────────────────────────────────────────────────
+
+/** Fetch the latest release from the flora131/atomic repo. */
+export async function getLatestRelease(): Promise<ReleaseInfo> {
+    return githubGet(`${GITHUB_API_BASE}/releases/latest`);
+}
+
+/** Fetch a specific release by tag name. */
+export async function getReleaseByTag(tag: string): Promise<ReleaseInfo> {
+    return githubGet(`${GITHUB_API_BASE}/releases/tags/${encodeURIComponent(tag)}`);
+}
+
+/**
+ * Stream-download a pre-resolved asset URL to `destPath` — no release-tag fetch.
+ *
+ * Writes to a `.tmp.<pid>.<ts>` sibling first, then atomically renames to
+ * `destPath` on success. Cleans up the partial file on any error.
+ */
+export async function downloadAssetFromUrl(url: string, destPath: string): Promise<void> {
+    const res = await fetch(url, { headers: buildHeaders() });
+    if (!res.ok) {
+        throw new Error(`Failed to download asset: HTTP ${res.status}`);
+    }
+
+    const tmpPath = `${destPath}.tmp.${pid}.${Date.now()}`;
+    let placed = false;
+    try {
+        await Bun.write(tmpPath, res);
+        try {
+            renameSync(tmpPath, destPath);
+            placed = true;
+        } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+                copyFileSync(tmpPath, destPath);
+                placed = true;
+            } else {
+                throw err;
+            }
+        }
+    } finally {
+        // best-effort cleanup. After successful rename tmpPath gone (ENOENT).
+        // After EXDEV fallback we need to remove it. After throw before write we need to remove it.
+        try { unlinkSync(tmpPath); } catch { /* swallow */ }
+    }
+    void placed;
+}
+
+/**
+ * Stream-download a release asset to `destPath`.
+ *
+ * Resolves the asset URL via `getReleaseByTag`, then delegates to
+ * `downloadAssetFromUrl`. Prefer passing the URL directly when you already
+ * have the release info to avoid an extra GitHub API call.
+ */
+export async function downloadAsset(
+    tag: string,
+    assetName: string,
+    destPath: string,
+): Promise<void> {
+    const release = await getReleaseByTag(tag);
+    const asset = release.assets.find((a) => a.name === assetName);
+    if (!asset) {
+        throw new Error(`Asset "${assetName}" not found in release ${tag}`);
+    }
+
+    await downloadAssetFromUrl(asset.browser_download_url, destPath);
+}
+
+/**
+ * Verify that `filePath` matches `expectedSha256`.
+ * Throws with an informative message on mismatch.
+ */
+export async function verifyChecksum(
+    filePath: string,
+    expectedSha256: string,
+): Promise<void> {
+    const hasher = new Bun.CryptoHasher("sha256");
+    for await (const chunk of Bun.file(filePath).stream()) {
+        hasher.update(chunk);
+    }
+
+    const actual = hasher.digest("hex");
+    const expected = expectedSha256.toLowerCase();
+    if (actual !== expected) {
+        throw new Error(
+            `Checksum mismatch for ${filePath}: expected ${expected}, got ${actual}`,
+        );
+    }
+}
+
+// ── Semver compare ────────────────────────────────────────────────────────────
+
+interface SemVer {
+    major: number;
+    minor: number;
+    patch: number;
+    pre: string[];
+}
+
+function parseSemver(s: string): SemVer | null {
+    const m = s.trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
+    if (!m || !m[1] || !m[2] || !m[3]) return null;
+    return {
+        major: parseInt(m[1], 10),
+        minor: parseInt(m[2], 10),
+        patch: parseInt(m[3], 10),
+        pre: m[4] ? m[4].split(".") : [],
+    };
+}
+
+function comparePre(a: string[], b: string[]): number {
+    if (a.length === 0 && b.length === 0) return 0;
+    if (a.length === 0) return 1;
+    if (b.length === 0) return -1;
+    const len = Math.min(a.length, b.length);
+    for (let i = 0; i < len; i++) {
+        const ai = a[i]!, bi = b[i]!;
+        const aNum = /^\d+$/.test(ai);
+        const bNum = /^\d+$/.test(bi);
+        if (aNum && !bNum) return -1;
+        if (!aNum && bNum) return 1;
+        if (aNum && bNum) {
+            const an = parseInt(ai, 10), bn = parseInt(bi, 10);
+            if (an !== bn) return an - bn;
+        } else if (ai !== bi) {
+            return ai < bi ? -1 : 1;
+        }
+    }
+    return a.length - b.length;
+}
+
+/**
+ * Return `true` when `targetTag` represents a semver newer than `currentVersion`.
+ *
+ * Both inputs are normalised (leading `v` stripped) before parsing.
+ * Unparseable inputs → `false` (defensive).
+ */
+export function isNewer(targetTag: string, currentVersion: string): boolean {
+    const target = parseSemver(targetTag);
+    const current = parseSemver(currentVersion);
+    if (!target || !current) return false;
+
+    if (target.major !== current.major) return target.major > current.major;
+    if (target.minor !== current.minor) return target.minor > current.minor;
+    if (target.patch !== current.patch) return target.patch > current.patch;
+
+    // Same X.Y.Z — release beats prerelease; prerelease compared per SemVer 2.0.0 §11.4.
+    return comparePre(target.pre, current.pre) > 0;
+}
+
+/**
+ * Normalise a version string:
+ * - Trim whitespace.
+ * - Return `"latest"` (case-insensitive) as `"latest"`.
+ * - Otherwise strip a single leading `v`.
+ */
+export function normalizeVersion(input: string): string {
+    const trimmed = input.trim();
+    if (trimmed.toLowerCase() === "latest") return "latest";
+    return trimmed.replace(/^v/, "");
+}

--- a/packages/atomic/src/services/system/release-fetch.ts
+++ b/packages/atomic/src/services/system/release-fetch.ts
@@ -27,7 +27,15 @@ export interface Manifest {
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
-const GITHUB_API_BASE = "https://api.github.com/repos/flora131/atomic";
+const DEFAULT_GITHUB_API_BASE = "https://api.github.com/repos/flora131/atomic";
+
+/**
+ * Resolved on each call (not cached) so CI can flip the override mid-process
+ * and so tests don't need to reload the module to pick up env changes.
+ */
+function githubApiBase(): string {
+    return process.env.ATOMIC_GITHUB_API_BASE ?? DEFAULT_GITHUB_API_BASE;
+}
 
 function buildHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
@@ -56,12 +64,12 @@ async function githubGet(url: string): Promise<ReleaseInfo> {
 
 /** Fetch the latest release from the flora131/atomic repo. */
 export async function getLatestRelease(): Promise<ReleaseInfo> {
-    return githubGet(`${GITHUB_API_BASE}/releases/latest`);
+    return githubGet(`${githubApiBase()}/releases/latest`);
 }
 
 /** Fetch a specific release by tag name. */
 export async function getReleaseByTag(tag: string): Promise<ReleaseInfo> {
-    return githubGet(`${GITHUB_API_BASE}/releases/tags/${encodeURIComponent(tag)}`);
+    return githubGet(`${githubApiBase()}/releases/tags/${encodeURIComponent(tag)}`);
 }
 
 /**

--- a/packages/atomic/src/url-placeholders.test.ts
+++ b/packages/atomic/src/url-placeholders.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+import { join } from "node:path";
+
+// Construct the ellipsis character via codepoint so this file's own source
+// bytes never contain a literal U+2026 inside an http URL — self-protecting.
+const ELLIPSIS = String.fromCharCode(0x2026);
+
+// Regex: http(s):// followed by any non-whitespace chars that include U+2026
+const BROKEN_URL_RE = new RegExp(`https?:\\/\\/[^\\s]*${ELLIPSIS}`);
+
+test("no U+2026 (horizontal ellipsis) inside http(s) URLs in src/**/*.ts", async () => {
+  // import.meta.dir = packages/atomic/src — go up 3 levels to repo root
+  const repoRoot = join(import.meta.dir, "..", "..", "..");
+  const srcDir = join(repoRoot, "packages", "atomic", "src");
+
+  const glob = new Bun.Glob("**/*.ts");
+  const offenders: string[] = [];
+
+  for await (const rel of glob.scan({ cwd: srcDir })) {
+    const abs = join(srcDir, rel);
+    const text = await Bun.file(abs).text();
+    if (BROKEN_URL_RE.test(text)) {
+      offenders.push(abs);
+    }
+  }
+
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Adds `atomic update` — a self-update command for standalone binary installs that fetches the latest release from GitHub, verifies the sha256 manifest, and atomically swaps the binary in place. Package-manager installs are intentionally out of scope: those rows print the PM's own upgrade command and exit.

## Key Changes

### New command: `atomic update`
- `--check` prints `current=… target=… method=binary` (binary) or a PM hint via `note()` (PM installs) and exits 0
- `--yes` skips the interactive confirm prompt
- `--version <v>` pins a specific release tag instead of fetching latest
- PM installs (bun / npm / pnpm / yarn) print the idiomatic PM update command (`bun update -g @bastani/atomic`, etc.) and exit 1 — atomic never shells out to the PM
- `source` and `unknown` installs emit targeted guidance and exit 1

### New service: `install-method.ts`
- Two-stage detection: cheap path-shape heuristics (binary install path, `~/.bun` tree, `node_modules` layout) then a `<pm> list -g` probe as fallback
- Returns a discriminated union: `binary | bun | npm | pnpm | yarn | source | unknown`
- Probe has a 5 s timeout; skippable via `skipProbe` for tests
- `isInsideRepoCheckout()` walks up to the `.git` root and matches by `package.json` name / workspace globs to distinguish source checkouts

### New service: `release-fetch.ts`
- `getLatestRelease()` / `getReleaseByTag()` — GitHub Releases API with `GITHUB_TOKEN` support and a clear 403 rate-limit message
- `downloadAssetFromUrl()` — streaming download with atomic rename (EXDEV-safe cross-device fallback)
- `verifyChecksum()` — streaming sha256 via `Bun.CryptoHasher`
- `isNewer()` — full SemVer 2.0.0 comparison including pre-release precedence
- All API calls respect `ATOMIC_GITHUB_API_BASE` so CI can redirect to a local mock without module reloading

### New CI mock: `script/ci/mock-gh-releases.ts`
- Lightweight `Bun.serve()` server driven by `MOCK_PORT`, `MOCK_VERSION`, `MOCK_ASSET_DIR`
- Serves `/releases/latest`, `/releases/tags/<tag>`, `/asset/<name>`, `/manifest.json`
- Emits `READY <port>\n` to stdout so the calling shell can poll before exercising `atomic update`

### CI (`publish.yml` `validate` matrix)
- Added two new steps per matrix row (7 combos: ubuntu x64 glibc, ubuntu arm64, ubuntu x64 musl, macOS Intel, macOS arm64, Windows x64, Windows arm64):
  1. **PM `--check` smoke** — asserts the bun-installed wrapper renders `installed via bun` + PM update hint
  2. **Binary download path** — spins up the mock server, runs the *installed* binary (so `detectInstallMethod` returns `"binary"`), and exercises the full download → verify → swap → sanity-spawn sequence

> **Caveat (binary path test, intentional):** the same compiled binary is served at the `vN+1` asset URL to keep the matrix cheap, so `atomic --version` still reports `vN` after the swap. The test asserts the plumbing succeeded, not that the version string advanced.

## Test Coverage

`bun test --coverage packages tests` — **1817 pass, 0 fail**
- `update.ts`: **95.65%**
- `install-method.ts`: **96.30%**
- Overall coverage threshold (0.85) met

## Test Plan

- [ ] CI `validate` matrix passes on all 7 rows (ubuntu x64/arm64/musl, macOS Intel/arm64, Windows x64/arm64)
- [ ] Every row: PM `--check` smoke renders `installed via bun` + `bun update -g @bastani/atomic`
- [ ] Every row: binary download path exits 0 after mock-server download → sha256 verify → atomic swap → `--version` sanity check
- [ ] Locally smoke-tested on linux-x64: `--check` against PM install renders hint; `--check` against binary renders version metadata; full `update -y` against mock server completes end-to-end