### PR TITLE
fix(ci,update): handle pwsh exit-1 propagation; drop -y flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,17 @@ jobs:
             - name: Install psmux (Windows)
               if: runner.os == 'Windows'
               shell: pwsh
+              env:
+                  # Authenticated requests get the 1000/hr per-repo rate limit; the
+                  # unauthenticated 60/hr limit is shared across all GitHub-hosted
+                  # runners on the same egress IP and trips intermittently on busy days.
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  $latest = Invoke-RestMethod -Headers @{ Accept = 'application/vnd.github+json' } `
+                  $latest = Invoke-RestMethod `
+                      -Headers @{
+                          Accept        = 'application/vnd.github+json'
+                          Authorization = "Bearer $env:GH_TOKEN"
+                      } `
                       -Uri 'https://api.github.com/repos/psmux/psmux/releases/latest'
                   $asset = $latest.assets | Where-Object { $_.name -like '*windows-x64.zip' } | Select-Object -First 1
                   if (-not $asset) { throw 'No psmux windows-x64 release asset found' }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -356,6 +356,12 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # GitHub Actions pwsh sets $PSNativeCommandUseErrorActionPreference=$true
+          # plus $ErrorActionPreference='Stop', which turns any non-zero exit
+          # from a native command into a terminating error before we can read
+          # $LASTEXITCODE. Disable for this step so the deliberate exit-1
+          # refusal can be asserted against, not propagated.
+          $PSNativeCommandUseErrorActionPreference = $false
           $userPath = [Environment]::GetEnvironmentVariable('Path','User')
           if ($userPath) { $env:Path = "$env:Path;$userPath" }
           $out = atomic uninstall 2>&1 | Out-String
@@ -369,6 +375,50 @@ jobs:
           }
           if ($out -notmatch 'bun remove -g @bastani/atomic') {
             throw "missing 'bun remove -g' hint"
+          }
+          if (-not (Get-Command atomic -ErrorAction SilentlyContinue)) {
+            throw "atomic disappeared after refusal — must touch nothing"
+          }
+
+      # ── `atomic update` on a PM-managed install (no --check): refuses
+      #    with exit 1 and tells the user to run `bun update -g`. Sister
+      #    test to the uninstall refusal above; covers the second exit-1
+      #    branch in the PM-detection path of update.ts.
+      - name: atomic update refuses on bun install (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          export PATH="$HOME/.bun/bin:$PATH"
+          out=$(atomic update 2>&1) && rc=0 || rc=$?
+          echo "$out"
+          if [ "$rc" -eq 0 ]; then
+            echo "expected non-zero exit on a bun-managed install"; exit 1
+          fi
+          echo "$out" | grep -q "atomic update is not available for bun" \
+            || { echo "missing 'not available for bun' hint"; exit 1; }
+          echo "$out" | grep -q "bun update -g @bastani/atomic" \
+            || { echo "missing 'bun update -g' hint"; exit 1; }
+          command -v atomic >/dev/null 2>&1 \
+            || { echo "atomic disappeared after refusal — must touch nothing"; exit 1; }
+
+      - name: atomic update refuses on bun install (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $false
+          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+          if ($userPath) { $env:Path = "$env:Path;$userPath" }
+          $out = atomic update 2>&1 | Out-String
+          $rc = $LASTEXITCODE
+          Write-Output $out
+          if ($rc -eq 0) {
+            throw "expected non-zero exit on a bun-managed install"
+          }
+          if ($out -notmatch 'atomic update is not available for bun') {
+            throw "missing 'not available for bun' hint"
+          }
+          if ($out -notmatch 'bun update -g @bastani/atomic') {
+            throw "missing 'bun update -g' hint"
           }
           if (-not (Get-Command atomic -ErrorAction SilentlyContinue)) {
             throw "atomic disappeared after refusal — must touch nothing"
@@ -611,7 +661,7 @@ jobs:
       # Uses port 4874 (verdaccio is on 4873). MOCK_VERSION=999.0.0 forces
       # the `isNewer` check inside `runBinaryUpdate` to return true so the
       # download/verify/swap path actually runs.
-      - name: atomic update -y via mock GitHub server (Unix)
+      - name: atomic update via mock GitHub server (Unix)
         if: runner.os != 'Windows'
         shell: bash
         env:
@@ -647,11 +697,11 @@ jobs:
 
           # Run the update via the *installed* binary so detectInstallMethod
           # returns "binary" (process.execPath == getInstallPaths().binPath).
-          "$binary" update -y --version 999.0.0
+          "$binary" update --version 999.0.0
           # Sanity: post-update binary still runs.
           "$binary" --version
 
-      - name: atomic update -y via mock GitHub server (Windows)
+      - name: atomic update via mock GitHub server (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         env:
@@ -690,8 +740,8 @@ jobs:
             $binary = Join-Path $env:LOCALAPPDATA "atomic\bin\atomic.exe"
             if (-not (Test-Path $binary)) { throw "expected installed binary at $binary" }
 
-            & $binary update -y --version 999.0.0
-            if ($LASTEXITCODE -ne 0) { throw "atomic update -y exited $LASTEXITCODE" }
+            & $binary update --version 999.0.0
+            if ($LASTEXITCODE -ne 0) { throw "atomic update exited $LASTEXITCODE" }
             & $binary --version
             if ($LASTEXITCODE -ne 0) { throw "atomic --version exited $LASTEXITCODE post-update" }
           } finally {

--- a/.github/workflows/sdk-fixture-smoke.yml
+++ b/.github/workflows/sdk-fixture-smoke.yml
@@ -212,8 +212,17 @@ jobs:
       - name: Install psmux (windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          # Authenticated requests get the 1000/hr per-repo rate limit; the
+          # unauthenticated 60/hr limit is shared across all GitHub-hosted
+          # runners on the same egress IP and trips intermittently on busy days.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $latest = Invoke-RestMethod -Headers @{ Accept = 'application/vnd.github+json' } `
+          $latest = Invoke-RestMethod `
+              -Headers @{
+                  Accept        = 'application/vnd.github+json'
+                  Authorization = "Bearer $env:GH_TOKEN"
+              } `
               -Uri 'https://api.github.com/repos/psmux/psmux/releases/latest'
           $asset = $latest.assets | Where-Object { $_.name -like '*windows-x64.zip' } | Select-Object -First 1
           if (-not $asset) { throw 'No psmux windows-x64 release asset found' }

--- a/packages/atomic/src/cli.ts
+++ b/packages/atomic/src/cli.ts
@@ -435,13 +435,11 @@ Examples:
         .description("Update atomic to the latest release (or a pinned version)")
         .option("--check", "Print current vs target without installing")
         .option("--version <v>", "Pin a target version (default: latest)")
-        .option("-y, --yes", "Skip the confirmation prompt")
-        .action(async (localOpts: { check?: boolean; version?: string; yes?: boolean }) => {
+        .action(async (localOpts: { check?: boolean; version?: string }) => {
             const { updateCommand } = await import("./commands/cli/update.ts");
             const exitCode = await updateCommand({
                 check: localOpts.check === true,
                 version: localOpts.version,
-                yes: localOpts.yes === true,
             });
             process.exit(exitCode);
         });

--- a/packages/atomic/src/commands/cli/update.test.ts
+++ b/packages/atomic/src/commands/cli/update.test.ts
@@ -50,7 +50,6 @@ const logInfoMock = mock((_msg: string) => {});
 const logErrorMock = mock((_msg: string) => {});
 const logSuccessMock = mock((_msg: string) => {});
 const noteMock = mock((_msg: string, _title?: string) => {});
-const confirmMock = mock(async (): Promise<boolean | symbol> => true);
 const spinnerStartMock = mock((_msg: string) => {});
 const spinnerStopMock = mock((_msg: string) => {});
 const spinnerMock = mock(() => ({ start: spinnerStartMock, stop: spinnerStopMock }));
@@ -69,7 +68,6 @@ await mock.module("@clack/prompts", () => ({
         success: logSuccessMock,
     },
     note: noteMock,
-    confirm: confirmMock,
     spinner: spinnerMock,
 }));
 
@@ -181,7 +179,6 @@ beforeEach(() => {
     logErrorMock.mockClear();
     logSuccessMock.mockClear();
     noteMock.mockClear();
-    confirmMock.mockClear();
     spinnerStartMock.mockClear();
     spinnerStopMock.mockClear();
     spinnerMock.mockClear();
@@ -211,7 +208,6 @@ beforeEach(() => {
     getInstallPathsMock.mockImplementation(() => FAKE_PATHS);
     copyBinaryMock.mockImplementation(() => {});
     cleanupOldArtifactsMock.mockImplementation(() => ({ oldBinariesRemoved: 0, tempFilesRemoved: 0 }));
-    confirmMock.mockImplementation(async () => true);
 });
 
 // ── describe block ────────────────────────────────────────────────────────────
@@ -224,7 +220,7 @@ describe("updateCommand", () => {
         const spawnSpy = spyOn(Bun, "spawn");
 
         try {
-            const code = await updateCommand({ yes: true });
+            const code = await updateCommand({});
             expect(code).toBe(0);
             expect(spawnSpy).not.toHaveBeenCalled();
             const allInfoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
@@ -267,7 +263,7 @@ describe("updateCommand", () => {
         } as ReturnType<typeof Bun.spawnSync>);
 
         try {
-            const code = await updateCommand({ yes: true });
+            const code = await updateCommand({});
             expect(code).toBe(0);
             expect(copyBinaryMock).toHaveBeenCalledTimes(1);
             // copyBinary first arg is paths, second is assetDest
@@ -294,7 +290,7 @@ describe("updateCommand", () => {
             detectInstallMethodResult = { kind, binPath: `/fake/${kind}/atomic` };
             const spawnSpy = spyOn(Bun, "spawn");
             try {
-                const code = await updateCommand({ yes: true });
+                const code = await updateCommand({});
                 expect(code).toBe(1);
                 expect(spawnSpy).not.toHaveBeenCalled();
                 const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
@@ -328,7 +324,7 @@ describe("updateCommand", () => {
         const spawnSpy = spyOn(Bun, "spawn");
 
         try {
-            const code = await updateCommand({ yes: true });
+            const code = await updateCommand({});
             expect(code).toBe(1);
             expect(spawnSpy).not.toHaveBeenCalled();
             const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
@@ -346,7 +342,7 @@ describe("updateCommand", () => {
         const spawnSpy = spyOn(Bun, "spawn");
 
         try {
-            const code = await updateCommand({ yes: true });
+            const code = await updateCommand({});
             expect(code).toBe(1);
             expect(spawnSpy).not.toHaveBeenCalled();
             const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
@@ -359,19 +355,6 @@ describe("updateCommand", () => {
         }
     });
 
-    test("binary path: confirm cancel returns 0 without downloading", async () => {
-        detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
-        isNewerMock.mockImplementation(() => true);
-        confirmMock.mockImplementation(async () => false);
-
-        const code = await updateCommand({});
-        expect(code).toBe(0);
-        expect(downloadAssetFromUrlMock).not.toHaveBeenCalled();
-        expect(copyBinaryMock).not.toHaveBeenCalled();
-        const infoCalls = logInfoMock.mock.calls.map((c) => String(c[0]));
-        expect(infoCalls.some((m) => m.includes("cancelled"))).toBe(true);
-    });
-
     test("binary path: missing host asset returns 1 with error", async () => {
         detectInstallMethodResult = { kind: "binary", binPath: FAKE_PATHS.binPath };
         isNewerMock.mockImplementation(() => true);
@@ -381,7 +364,7 @@ describe("updateCommand", () => {
             assets: [{ name: "manifest.json", browser_download_url: "https://example.com/manifest.json" }],
         }));
 
-        const code = await updateCommand({ yes: true });
+        const code = await updateCommand({});
         expect(code).toBe(1);
         const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
         expect(errorCalls.some((m) => m.includes(HOST_ASSET) && m.includes("not found"))).toBe(true);
@@ -395,7 +378,7 @@ describe("updateCommand", () => {
             assets: [{ name: HOST_ASSET, browser_download_url: `https://example.com/${HOST_ASSET}` }],
         }));
 
-        const code = await updateCommand({ yes: true });
+        const code = await updateCommand({});
         expect(code).toBe(1);
         const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
         expect(errorCalls.some((m) => m.includes("manifest.json") && m.includes("not found"))).toBe(true);
@@ -425,7 +408,7 @@ describe("updateCommand", () => {
         } as ReturnType<typeof Bun.spawnSync>);
 
         try {
-            const code = await updateCommand({ yes: true, version: "0.7.5" });
+            const code = await updateCommand({ version: "0.7.5" });
             expect(code).toBe(0);
             // copyBinary must have been called — pinned version skips isNewer
             expect(copyBinaryMock).toHaveBeenCalledTimes(1);
@@ -452,7 +435,7 @@ describe("updateCommand", () => {
         } as ReturnType<typeof Bun.spawnSync>);
 
         try {
-            const code = await updateCommand({ yes: true });
+            const code = await updateCommand({});
             expect(code).toBe(1);
             const errorCalls = logErrorMock.mock.calls.map((c) => String(c[0]));
             expect(errorCalls.some((m) => m.includes("Sanity check failed"))).toBe(true);

--- a/packages/atomic/src/commands/cli/update.ts
+++ b/packages/atomic/src/commands/cli/update.ts
@@ -14,7 +14,7 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { confirm, spinner, log, note } from "@clack/prompts";
+import { spinner, log, note } from "@clack/prompts";
 
 import { VERSION } from "../../version.ts";
 import { detectInstallMethod } from "../../services/system/install-method.ts";
@@ -35,7 +35,6 @@ import {
 } from "./install.ts";
 
 export interface UpdateOptions {
-    readonly yes?: boolean;
     readonly check?: boolean;
     readonly version?: string;
 }
@@ -127,16 +126,6 @@ async function runBinaryUpdate(opts: UpdateOptions, target: string): Promise<num
     if (target === "latest" && !isNewer(release.tag_name, VERSION)) {
         log.info(`Already up to date (${VERSION})`);
         return 0;
-    }
-
-    if (!opts.yes) {
-        const ok = await confirm({
-            message: `Update atomic from ${VERSION} to ${release.tag_name}?`,
-        });
-        if (ok !== true) {
-            log.info("Update cancelled.");
-            return 0;
-        }
     }
 
     const host = hostTarget();


### PR DESCRIPTION
## Summary

Fix two Windows CI reliability issues and remove the unnecessary \`--yes\` flag from \`atomic update\`: add \`\$PSNativeCommandUseErrorActionPreference = \$false\` to prevent pwsh from swallowing deliberate \`exit 1\` exits, authenticate psmux GitHub API requests to avoid anonymous rate-limit failures, and simplify the update UX by dropping the confirmation prompt entirely.

## Changes

### CI (\`publish.yml\`)
- **Fix \`atomic uninstall refuses on bun install (Windows)\`** — GitHub Actions pwsh sets \`\$PSNativeCommandUseErrorActionPreference = \$true\` and \`\$ErrorActionPreference = 'Stop'\` by default, turning any native non-zero exit into a terminating error before \`\$LASTEXITCODE\` can be read. Added \`\$PSNativeCommandUseErrorActionPreference = \$false\` to the assertion step so the deliberate \`exit 1\` refusal is captured rather than propagated (root cause: [run 25476439939](https://github.com/flora131/atomic/actions/runs/25476439939/job/74750877641)).
- **New steps: \`atomic update refuses on bun install\` (Unix + Windows)** — covers the previously-untested \`exit 1\` branch in \`update.ts\`'s PM-detection path. Asserts non-zero exit, correct hint messages, and that the binary is untouched.
- **Drop \`-y\` from mock-server step names and invocations** — aligns with the removed flag.

### CI (\`ci.yml\`, \`sdk-fixture-smoke.yml\`)
- **Authenticate psmux release fetch** — pass \`GITHUB_TOKEN\` in the \`Authorization\` header of the psmux \`Invoke-RestMethod\` call. Unauthenticated requests share the 60 req/hr anonymous limit across all GitHub-hosted runners on the same egress IP and trip intermittently on busy days; authenticated requests get 1 000 req/hr per-repo.

### \`cli.ts\`
- Remove \`-y/--yes\` option from the \`update\` command. A user invoking \`atomic update\` has already expressed intent; the extra prompt adds friction without meaningful protection (the only mutation is replacing the launcher binary, reversible via \`atomic install\`). Symmetric with \`atomic uninstall\`, which has never had a confirmation flag.

### \`update.ts\`
- Remove \`yes\` from \`UpdateOptions\` interface.
- Remove \`confirm\` import and the confirmation-prompt block from \`runBinaryUpdate\`.

### \`update.test.ts\`
- Remove \`confirmMock\` and all related setup/teardown.
- Replace \`updateCommand({ yes: true })\` → \`updateCommand({})\` throughout.
- Remove the now-deleted "confirm cancel returns 0" test.

## Test plan

- [x] \`bun typecheck\` clean
- [x] \`bun lint\` clean
- [x] \`bun test packages/atomic/src/commands/cli/update.test.ts\` — 17 pass
- [x] \`bun test packages/atomic/src/commands/cli/{update,uninstall,install}.test.ts\` — 67 pass
- [ ] Validate matrix on this PR exercises the fixed Windows pwsh assertion + the new \`atomic update refuses\` step
- [ ] After merge, re-trigger \`Publish\` workflow via \`workflow_dispatch\` with tag \`v0.7.10-0\` to publish to npm (prior run's validate failure short-circuited publish)