### PR TITLE
fix(ci): clear $LASTEXITCODE after asserting on expected refusal exit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -356,11 +356,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          # GitHub Actions pwsh sets $PSNativeCommandUseErrorActionPreference=$true
-          # plus $ErrorActionPreference='Stop', which turns any non-zero exit
-          # from a native command into a terminating error before we can read
-          # $LASTEXITCODE. Disable for this step so the deliberate exit-1
-          # refusal can be asserted against, not propagated.
+          # The GitHub Actions pwsh wrapper template ends with
+          # `exit $LASTEXITCODE`, which propagates the last native-command
+          # exit code as the step's exit code — so atomic's deliberate
+          # exit-1 here would fail the step even if every assertion below
+          # passes. Disable $PSNativeCommandUseErrorActionPreference so
+          # the non-zero exit doesn't ALSO throw mid-script, then reset
+          # $LASTEXITCODE to 0 once the assertions pass.
           $PSNativeCommandUseErrorActionPreference = $false
           $userPath = [Environment]::GetEnvironmentVariable('Path','User')
           if ($userPath) { $env:Path = "$env:Path;$userPath" }
@@ -379,6 +381,7 @@ jobs:
           if (-not (Get-Command atomic -ErrorAction SilentlyContinue)) {
             throw "atomic disappeared after refusal — must touch nothing"
           }
+          $global:LASTEXITCODE = 0
 
       # ── `atomic update` on a PM-managed install (no --check): refuses
       #    with exit 1 and tells the user to run `bun update -g`. Sister
@@ -405,6 +408,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # See the prior step's comment for why we both disable
+          # $PSNativeCommandUseErrorActionPreference and clear $LASTEXITCODE.
           $PSNativeCommandUseErrorActionPreference = $false
           $userPath = [Environment]::GetEnvironmentVariable('Path','User')
           if ($userPath) { $env:Path = "$env:Path;$userPath" }
@@ -423,6 +428,7 @@ jobs:
           if (-not (Get-Command atomic -ErrorAction SilentlyContinue)) {
             throw "atomic disappeared after refusal — must touch nothing"
           }
+          $global:LASTEXITCODE = 0
 
       # ── Round-trip the documented pm uninstall path: `bun remove -g`
       #    is what the refusal message above tells users to run, so we


### PR DESCRIPTION
## Summary

After PR #860 disabled `$PSNativeCommandUseErrorActionPreference`, the assertion script could read `$LASTEXITCODE` itself rather than throwing mid-pipeline — but that only fixed half the trap. The GitHub Actions pwsh wrapper template ends with `exit $LASTEXITCODE`, so even when every assertion passes, the runner sees `$LASTEXITCODE = 1` left behind by `atomic`'s deliberate refusal and propagates it as the step's exit code.

## Key changes

- Add `$global:LASTEXITCODE = 0` at the end of both Windows refusal-assertion steps (`atomic uninstall refuses on bun install` and `atomic update refuses on bun install`) to reset the exit code after all assertions succeed.
- Update the comment in the first step to explain both mitigations together: disabling `$PSNativeCommandUseErrorActionPreference` prevents a mid-script throw on the non-zero exit, and resetting `$LASTEXITCODE` prevents the pwsh wrapper from propagating that exit code to the runner.
- Add a cross-reference comment in the second step pointing back to the first step's explanation to avoid duplication.

Bash steps are unaffected: on the success path the last command is `command -v atomic`, which exits 0 when `atomic` is still on `PATH`.

## Failing run

https://github.com/flora131/atomic/actions/runs/25477535482 — Windows steps failed at `atomic uninstall refuses on bun install (Windows)` despite assertions passing inside the script.

## Test plan

- [x] YAML valid
- [ ] Re-trigger publish (`workflow_dispatch` on `main`) once merged — both the uninstall and update refusal steps should now pass on Windows