### PR TITLE
fix(ci): run `atomic update --check` before `atomic install` migrates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -430,6 +430,42 @@ jobs:
           }
           $global:LASTEXITCODE = 0
 
+      # ── `atomic update --check` on a PM-managed install: exits 0 with
+      #    a note pointing at the PM's update command. Sister test to the
+      #    refusal above; runs while atomic is still bun-managed (BEFORE
+      #    `atomic install` migrates the launcher to the canonical bin
+      #    dir) so detectInstallMethod returns "bun" naturally without
+      #    PATH gymnastics. The end-to-end download/verify/swap path is
+      #    covered by release-fetch.test.ts at the unit level.
+      - name: atomic update --check on bun install (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          export PATH="$HOME/.bun/bin:$PATH"
+          out=$(atomic update --check 2>&1) || {
+            echo "$out"
+            echo "atomic update --check exited non-zero"
+            exit 1
+          }
+          echo "$out"
+          echo "$out" | grep -q "installed via bun"             || { echo "missing 'installed via bun'"; exit 1; }
+          echo "$out" | grep -q "bun update -g @bastani/atomic" || { echo "missing PM update hint"; exit 1; }
+
+      - name: atomic update --check on bun install (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
+          if ($userPath) { $env:Path = "$env:Path;$userPath" }
+          $out = atomic update --check 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output $out
+            throw "atomic update --check exited $LASTEXITCODE"
+          }
+          Write-Output $out
+          if ($out -notmatch 'installed via bun')             { throw "missing 'installed via bun'" }
+          if ($out -notmatch 'bun update -g @bastani/atomic') { throw "missing PM update hint" }
+
       # ── Round-trip the documented pm uninstall path: `bun remove -g`
       #    is what the refusal message above tells users to run, so we
       #    smoke-test it actually evicts atomic from PATH.
@@ -602,44 +638,6 @@ jobs:
           }
           Write-Output "wrapper OK: $($mux.Name) resolves to $($mux.Source)"
 
-      # ────────────────────────────────────────────────────────────────────
-      # ── `atomic update` lifecycle ──────────────────────────────────────
-      # ────────────────────────────────────────────────────────────────────
-      # `atomic update` is only a real upgrade path for the standalone
-      # binary install. PM-managed installs (bun/npm/pnpm/yarn) print
-      # guidance pointing at the PM's own update command, which is what
-      # we exercise here via `--check` against the bun-installed wrapper.
-      # The end-to-end download/verify/swap path is covered by
-      # release-fetch.test.ts at the unit level.
-      - name: atomic update --check (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          export PATH="$HOME/.bun/bin:$PATH"
-          out=$(atomic update --check 2>&1) || {
-            echo "$out"
-            echo "atomic update --check exited non-zero"
-            exit 1
-          }
-          echo "$out"
-          echo "$out" | grep -q "installed via bun"           || { echo "missing 'installed via bun'"; exit 1; }
-          echo "$out" | grep -q "bun update -g @bastani/atomic" || { echo "missing PM update hint"; exit 1; }
-
-      - name: atomic update --check (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $userPath = [Environment]::GetEnvironmentVariable('Path','User')
-          if ($userPath) { $env:Path = "$env:Path;$userPath" }
-          $out = atomic update --check 2>&1 | Out-String
-          if ($LASTEXITCODE -ne 0) {
-            Write-Output $out
-            throw "atomic update --check exited $LASTEXITCODE"
-          }
-          Write-Output $out
-          if ($out -notmatch 'installed via bun')             { throw "missing 'installed via bun'" }
-          if ($out -notmatch 'bun update -g @bastani/atomic') { throw "missing PM update hint" }
-
       # ── `atomic uninstall`: removes launcher / rc snippets / completions
       #    cache but preserves ~/.atomic (no --purge flag).
       - name: atomic uninstall (Unix)
@@ -662,10 +660,15 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # Invoke the canonical binary directly so detectInstallMethod
+          # returns "binary" — Unix prepends ~/.local/bin via `export PATH=…`
+          # for the same reason. Bare `atomic` could resolve to bun's
+          # leftover shim (oven-sh/bun#11970) and refuse the uninstall.
           $userPath = [Environment]::GetEnvironmentVariable('Path','User')
           if ($userPath) { $env:Path = "$env:Path;$userPath" }
-          atomic uninstall
           $binary = Join-Path $env:LOCALAPPDATA "atomic\bin\atomic.exe"
+          & $binary uninstall
+          if ($LASTEXITCODE -ne 0) { throw "atomic uninstall exited $LASTEXITCODE" }
           $cache = Join-Path $env:USERPROFILE ".atomic\completions"
           $atomicHome = Join-Path $env:USERPROFILE ".atomic"
           $userPath2 = [Environment]::GetEnvironmentVariable('Path','User')
@@ -713,9 +716,14 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # Direct invocation, same rationale as the non-purge step above:
+          # canonical bin path forces method=binary detection regardless
+          # of any bun-shim leftover on PATH.
           $userPath = [Environment]::GetEnvironmentVariable('Path','User')
           if ($userPath) { $env:Path = "$env:Path;$userPath" }
-          atomic uninstall --purge
+          $binary = Join-Path $env:LOCALAPPDATA "atomic\bin\atomic.exe"
+          & $binary uninstall --purge
+          if ($LASTEXITCODE -ne 0) { throw "atomic uninstall --purge exited $LASTEXITCODE" }
           $atomicHome = Join-Path $env:USERPROFILE ".atomic"
           if (Test-Path $atomicHome) {
             throw "~/.atomic was NOT purged (still at $atomicHome)"


### PR DESCRIPTION
## Diagnosis

Two related Windows failures, both caused by the same PATH-disambiguation gap.

### 1. `atomic update --check (Windows)` failed with `method=binary`

After `atomic install` migrates the launcher to `%LOCALAPPDATA%\atomic\bin\atomic.exe`, that bin dir lands on user PATH alongside `~/.bun/bin`, and a fresh pwsh step (which doesn't load the wrapper function from `$PROFILE`) ends up resolving `atomic` to the canonical binary — so `detectInstallMethod` returns `binary` instead of the expected `installed via bun` hint.

The Unix counterpart papered over this with `export PATH="$HOME/.bun/bin:$PATH"` to force bun first, but Windows had no equivalent.

### 2. `atomic uninstall (Windows)` and `--purge (Windows)` are vulnerable to the same ambiguity (preemptive)

After `atomic install` migrates, both bun's leftover shim (oven-sh/bun#11970) and the canonical binary are on PATH. Bare `atomic uninstall` could resolve to bun's shim and refuse with the bun-managed-install message — flaking the test. Unix forces canonical via `export PATH="$HOME/.local/bin:$PATH"`; Windows had no equivalent.

## Fix

**For `atomic update --check`:** rather than mirror the PATH gymnastics on Windows, move both `--check` tests to run **before** `atomic install` migrates anything. Atomic is still purely bun-managed at that point, so detection returns `bun` naturally on every platform — no `export PATH` / `$env:Path` manipulation required.

**For `atomic uninstall` + `--purge` (Windows):** invoke the canonical binary directly via `& $binary uninstall …`. Eliminates PATH ambiguity entirely; equivalent to Unix's `export PATH="$HOME/.local/bin:$PATH"` but more explicit.

Step order is now:

```
install via bun
  → smoke
  → bun-managed assertions:
       atomic uninstall refuses on bun
       atomic update refuses on bun
       atomic update --check on bun       ← moved here
  → bun-remove round-trip
  → re-install
  → atomic install (migration)
  → binary lifecycle:
       Verify launcher prod location
       Verify completions cache
       Verify mux auto-install
       atomic uninstall                    ← Windows now invokes canonical directly
       atomic uninstall --purge            ← Windows now invokes canonical directly
```

## Failing run

https://github.com/flora131/atomic/actions/runs/25478892501

## Test plan

- [x] YAML valid
- [ ] Validate matrix on this PR runs to completion on every row (no Windows fail at `atomic update --check`, `atomic uninstall`, or `atomic uninstall --purge`)
- [ ] After merge, re-trigger `Publish` workflow via `workflow_dispatch` with tag `v0.7.10-0`