### PR TITLE
chore(release): bump version to v0.7.10

### DIFF
--- a/examples/claude-background-subagents/package.json
+++ b/examples/claude-background-subagents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-claude-background-subagents",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Stage 1 spawns 3 background subagents and ends its turn immediately; stage 2 verifies they all finished before it started.",
   "scripts": {

--- a/examples/commander-embed/package.json
+++ b/examples/commander-embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-commander-embed",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Mount an atomic workflow under a parent Commander CLI alongside plain Commander commands",
   "scripts": {

--- a/examples/headless-test/package.json
+++ b/examples/headless-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-headless-test",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Visible seed -> 3 parallel headless stages -> visible merge -> headless verdict",
   "scripts": {

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-hello-world",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Minimal single-session workflow with structured inputs (greeting, style, optional notes)",
   "scripts": {

--- a/examples/hil-favorite-color-headless/package.json
+++ b/examples/hil-favorite-color-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-hil-favorite-color-headless",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "HIL pause inside a headless stage",
   "scripts": {

--- a/examples/hil-favorite-color/package.json
+++ b/examples/hil-favorite-color/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-hil-favorite-color",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Human-in-the-loop prompt mid-workflow",
   "scripts": {

--- a/examples/multi-workflow/package.json
+++ b/examples/multi-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-multi-workflow",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Two Claude workflows (hello, goodbye) under one cli.ts — Commander subcommand per registered workflow",
   "scripts": {

--- a/examples/pane-navigation/package.json
+++ b/examples/pane-navigation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-pane-navigation",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Driver CLI for the SDK pane-navigation primitives (start / list / status / next / prev / home / attach / stop)",
   "scripts": {

--- a/examples/parallel-hello-world/package.json
+++ b/examples/parallel-hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-parallel-hello-world",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Promise.all() fan-out and transcript merge across parallel stages",
   "scripts": {

--- a/examples/review-fix-loop/package.json
+++ b/examples/review-fix-loop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-review-fix-loop",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Draft -> loop(review -> fix) with bounded iterations and early exit on a CLEAN verdict",
   "scripts": {

--- a/examples/reviewer-tool-test/package.json
+++ b/examples/reviewer-tool-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-reviewer-tool-test",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Custom reviewer tool wiring (Copilot)",
   "scripts": {

--- a/examples/sequential-describe-summarize/package.json
+++ b/examples/sequential-describe-summarize/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-sequential-describe-summarize",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Two stages passing data via s.save() -> s.transcript(handle) — the canonical handoff pattern",
   "scripts": {

--- a/examples/structured-output-demo/package.json
+++ b/examples/structured-output-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/example-structured-output-demo",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "description": "Per-SDK structured output (JSON-schema validation, Zod)",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic-monorepo",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "description": "Configuration management CLI and SDK for coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/atomic-sdk/package.json
+++ b/packages/atomic-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-sdk",
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "license": "MIT",
   "description": "TypeScript SDK for atomic — defineWorkflow, schemas, components",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bastani/atomic",
   "private": true,
-  "version": "0.7.10-0",
+  "version": "0.7.10",
   "type": "module",
   "license": "MIT",
   "description": "Configuration management CLI for coding agents",


### PR DESCRIPTION
## Summary

Promotes the prerelease `v0.7.10-0` to a stable `v0.7.10` release by updating version strings across the entire monorepo.

## Changes

- **Root** `package.json`: `0.7.10-0` → `0.7.10`
- **`packages/atomic`**: `0.7.10-0` → `0.7.10`
- **`packages/atomic-sdk`**: `0.7.10-0` → `0.7.10`
- **12 example packages** (`claude-background-subagents`, `commander-embed`, `headless-test`, `hello-world`, `hil-favorite-color`, `hil-favorite-color-headless`, `multi-workflow`, `pane-navigation`, `parallel-hello-world`, `review-fix-loop`, `reviewer-tool-test`, `sequential-describe-summarize`, `structured-output-demo`): `0.7.10-0` → `0.7.10`

## Notes

- No source code changes — version strings only.
- Merging to `main` will trigger the automated GitHub Release and npm publish workflow for `v0.7.10`.

## Test plan

- [ ] CI passes (typecheck, lint, tests)
- [ ] Merge triggers automated GitHub Release + npm publish for `v0.7.10`