### PR TITLE
feat(workflows): add `workflow refresh` + `workflow read` CLI primitives

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-creator
-description: Create or run Atomic CLI workflows with the `@bastani/atomic-sdk` npm package — using `defineWorkflow().run().compile()` and `ctx.stage()` across Claude, Copilot, and OpenCode SDKs. Use when authoring, editing, debugging, or designing agent pipelines including multi-stage automations, review/fix loops, parallel fan-out, headless/background stages, `ctx.inputs`, `WorkflowInput` schemas, registries, validation, picker UI, and single or multi-workflow composition roots. Use when running existing workflows to kick off, monitor, check status, gather inputs, or tear down sessions via `atomic workflow -n`, `atomic workflow inputs`, `atomic workflow status`, picker flows, or `atomic session kill`.
+description: Create or run Atomic CLI workflows with the `@bastani/atomic-sdk` npm package — using `defineWorkflow().run().compile()` and `ctx.stage()` across Claude, Copilot, and OpenCode SDKs. Use when authoring, editing, debugging, or designing agent pipelines including multi-stage automations, review/fix loops, parallel fan-out, headless/background stages, `ctx.inputs`, `WorkflowInput` schemas, registries, validation, picker UI, and single or multi-workflow composition roots. Use when scaffolding atomic-managed custom workflows under `.atomic/workflows/<name>/` (or `~/.atomic/workflows/<name>/`), registering them in `settings.json`, and verifying with `atomic workflow refresh`. Use when running existing workflows to kick off, monitor, check status, inspect on-disk state via `atomic workflow read`, gather inputs, or tear down sessions via `atomic workflow -n`, `atomic workflow inputs`, `atomic workflow status`, picker flows, or `atomic session kill`.
 metadata:
   provider: atomic
 ---
@@ -37,11 +37,94 @@ Load references on demand. **Only `getting-started.md` is always-load.** Everyth
 | `user-input.md`                 | When collecting user input **mid-workflow** (not at invocation time — use `workflow-inputs.md` for that)                                                                                                              |
 | `registry-and-validation.md`    | When setting up `createRegistry()` and iterating it via `listWorkflows`, understanding key scheme, validate-on-register rules, and same-name collision detection (only relevant for the multi-workflow cli)           |
 
-## Scaffold a new workflow from scratch
+## Custom workflow modes — pick before you scaffold
 
-When the user asks you to build a new workflow — and especially when they're starting from an empty terminal — **load `references/agent-setup-recipe.md` and follow it as your playbook.** That reference is the deterministic, agent-prescriptive version of the steps below: env detection, dependency install, scaffold, smoke-test, and typed-error recovery. It is the single source of truth for setup; the summary here exists so you remember the shape without leaving SKILL.md.
+Every new workflow lands in one of two layouts. The choice is not stylistic — it determines *where files live*, *how the workflow is invoked*, and *which entry-point pattern you use*. Pick before you write any code; mixing layouts mid-stream means rewriting the scaffold.
 
-The shape:
+| Mode                                       | Where it lives                                                                                                                                                                                                       | How it's invoked                                                                                  | When to pick it                                                                                                                                                                  |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1 · Atomic-managed** (default)           | Project: `.atomic/workflows/<name>/` · Global: `~/.atomic/workflows/<name>/` · Each is a self-contained Bun package (own `package.json`, own `tsconfig.json`, own `node_modules`); registered in `settings.json` | `atomic workflow -n <name> -a <agent> [...]` after `atomic workflow refresh` confirms it loaded | The user asks "build me a workflow that does X" without scoping it to their own CLI. **This is the default.** Defaults to project-level (`.atomic/workflows/`); use `~/.atomic/workflows/` only when they explicitly say "global" or "user-level". |
+| **2 · Dev-owned CLI**                      | `<repo>/src/workflows/<name>/<agent>.ts` + `<repo>/src/<agent>-worker.ts` (or `src/cli.ts` for multi-workflow registries)                                                                                            | `bun run src/<agent>-worker.ts --<flag>=<value>`                                                  | The user is building their *own* CLI surface, an internal tool, an `examples/` reference, or anything where the workflow is not meant to be discoverable by the wider `atomic` CLI |
+| **1 + 2 combined**                         | Same file as Mode 2, plus `await hostLocalWorkflows([wf])` *before* their own `program.parseAsync()`                                                                                                                 | Both surfaces work — `atomic workflow -n …` AND the dev's own flags                               | The dev wants a polished standalone CLI **and** wants the workflow to show up in `atomic workflow list`. Token-gated dispatch means the two paths don't interfere.              |
+
+**Default rule for the model:** if the user does not specify, scaffold Mode 1 in `.atomic/workflows/<name>/`. Confirm scope in one short question only when ambiguous (e.g. "global or project-scope?" when the wording suggests user-wide reuse).
+
+For runnable reference workflows across both modes, study the in-repo examples first: <https://github.com/flora131/atomic/tree/main/examples>. Each example directory under `examples/` ships per-agent files plus a `<agent>-worker.ts` entry — copy the closest-fitting one as your starting point rather than authoring from a blank file.
+
+### Mode 1 — Atomic-managed (project: `.atomic/workflows/<name>/`)
+
+Use this when the user wants a workflow that integrates with `atomic workflow` (list, picker, status, refresh). The detailed playbook lives in `references/agent-setup-recipe.md` §"Mode 1 setup". Shape:
+
+```
+<repo>/
+└── .atomic/
+    ├── settings.json                          # registry of custom workflow entries
+    └── workflows/
+        └── <workflow-name>/                   # ← self-contained Bun package
+            ├── package.json                   # own deps: @bastani/atomic-sdk + provider SDK
+            ├── tsconfig.json
+            ├── node_modules/                  # populated by `bun install` inside this dir
+            └── index.ts                       # defineWorkflow → compile → hostLocalWorkflows
+```
+
+Five-step rhythm:
+
+1. **Verify prerequisites** — Bun, tmux/psmux, an authenticated agent CLI (devcontainers using `ghcr.io/flora131/atomic/<agent>:1` bundle all three).
+2. **Scaffold the package** — `mkdir -p .atomic/workflows/<name> && cd .atomic/workflows/<name> && bun init -y` + `bun add @bastani/atomic-sdk @anthropic-ai/claude-agent-sdk` (or the provider SDK matching the agent the user picked).
+3. **Write the workflow** at `.atomic/workflows/<name>/index.ts`:
+
+   ```ts
+   #!/usr/bin/env bun
+   import { defineWorkflow, hostLocalWorkflows } from "@bastani/atomic-sdk";
+
+   const workflow = defineWorkflow({
+     name: "<workflow-name>",
+     source: import.meta.path,
+     description: "<one-line description>",
+     inputs: [{ name: "prompt", type: "text", required: true, description: "..." }],
+   })
+     .for("claude")
+     .run(async (ctx) => {
+       await ctx.stage({ name: "step-1" }, {}, {}, async (s) => {
+         await s.session.query(ctx.inputs.prompt);
+         s.save(s.sessionId);
+       });
+     })
+     .compile();
+
+   await hostLocalWorkflows([workflow]);
+   ```
+
+   The `source: import.meta.path` is mandatory — the orchestrator re-imports this path. The trailing `await hostLocalWorkflows([wf])` is what makes the file responsive to atomic's token-gated `_emit-workflow-meta` and `_atomic-run` sub-commands.
+
+4. **Register in `settings.json`** — append to `.atomic/settings.json` (project-local) or `~/.atomic/settings.json` (global; create if missing). The schema URL gives JSON intellisense in editors.
+
+   ```jsonc
+   {
+     "$schema": "https://raw.githubusercontent.com/flora131/atomic/main/assets/settings.schema.json",
+     "version": 1,
+     "workflows": {
+       "<workflow-name>": {
+         "command": "bunx",
+         "args": ["./.atomic/workflows/<workflow-name>/index.ts"],
+         "agents": ["claude"]
+       }
+     }
+   }
+   ```
+
+   Use `~/.atomic/workflows/<name>/...` (absolute) in the `args` for global workflows so `cwd` doesn't change resolution.
+
+5. **Refresh and verify** — run `atomic workflow refresh`. This re-spawns the metadata loader for every entry and emits a structured report. Inside an atomic chat session it auto-defaults to JSON; outside, text. Either way:
+
+   - `loaded` entries confirm the workflow is now invocable via `atomic workflow -n <name> -a <agent>`.
+   - `broken` entries surface the exact `reason`, `fix`, and `settings` path on their own lines so the model can self-correct without prose parsing.
+
+   On clean load, smoke-test with `atomic workflow -n <name> -a <agent> "<test prompt>"`.
+
+### Mode 2 — Dev-owned CLI
+
+Use this when the user is building their own CLI (an internal tool, an example, a one-off script). Shape:
 
 ```
 <repo>/
@@ -56,21 +139,17 @@ The shape:
     └── <agent>-worker.ts        # one composition root per agent
 ```
 
-One workflow per directory, one file per agent, one composition-root file per agent. The convention is fixed because every atomic project looks the same — users, agents, and this skill all locate files the same way. Improvising paths makes the next agent's job harder.
+Same five-step rhythm, but the entry point is `runWorkflow({ workflow, inputs })` inside a Commander/citty/yargs handler. Detailed playbook: `references/agent-setup-recipe.md` §"Mode 2 setup".
 
-The five-step rhythm is the same regardless of workflow complexity:
-
-1. **Verify prerequisites** — Bun, tmux/psmux, an authenticated agent CLI. Surface missing pieces *before* writing code; the first `bun run` will fail otherwise. Devcontainers using `ghcr.io/flora131/atomic/<agent>:1` bundle all three.
-2. **Bootstrap** — `bun init -y` (skip if `package.json` exists) + `bun add @bastani/atomic-sdk` + the provider SDK(s) the user targets.
-3. **Write the workflow** at `src/workflows/<name>/<agent>.ts` using `defineWorkflow({ ... source: import.meta.path }).for(agent).run(...).compile()`. The `source: import.meta.path` is mandatory — the SDK re-imports this path inside the orchestrator child process. Per-agent skeletons live in `references/getting-started.md` §"Quick-start example".
-4. **Write the composition root** at `src/<agent>-worker.ts` (single workflow) or `src/cli.ts` (multiple workflows). The SDK exposes pure primitives — Commander/citty/yargs/etc. is the dev's choice; `runWorkflow({ workflow, inputs })` is the action body. Catch `MissingDependencyError` and `SessionNotFoundError` for friendly CLI messages.
-5. **Verify** — `bunx tsc --noEmit`, then a real `bun run src/<agent>-worker.ts --prompt "..."` smoke test. Watch the tmux pane spawn, the agent reply, the session end cleanly.
-
-The when-in-doubt rules:
+The when-in-doubt rules within Mode 2:
 
 - **Single agent, single workflow** — the 90% case. One `<agent>.ts` + one `<agent>-worker.ts`. Done.
 - **Same workflow across agents** — three `<agent>.ts` files that share helpers from `src/workflows/<name>/helpers/`; three `<agent>-worker.ts` files.
 - **Multiple workflows in one CLI** — build a `createRegistry().register(...)` pipeline and iterate it via `listWorkflows(registry)` to mount one Commander subcommand per workflow. Use a `src/cli.ts` composition root instead of per-agent workers.
+
+### Mode 1 + 2 combined
+
+The same workflow file calls `await hostLocalWorkflows([wf])` *before* setting up its own Commander program. Atomic's two internal sub-commands (`_emit-workflow-meta`, `_atomic-run`) are token-gated and `process.exit(0)` after handling, so the dev's own argv parser never sees them on bare invocation. Use this when the workflow needs to be discoverable through `atomic workflow` AND directly runnable as a standalone Bun script.
 
 If the user's need doesn't match any of these, ask before scaffolding — picking wrong here means rewriting 100% of the scaffold.
 
@@ -348,11 +427,13 @@ atomic workflow -n <name> -a <agent> [inputs...]
 | Named, with prompt     | `… -n hello -a claude "fix the bug"`                                             | Requires workflow to declare a `prompt` input                                  |
 | Named, structured      | `… -n gen-spec -a claude --research_doc=notes.md`                                | Structured inputs via `--<field>` flags                                        |
 | Interactive picker     | `atomic workflow -a claude`                                                      | Discovery — fuzzy list + form; this is the intentional no-`-n` path            |
-| List (atomic builtins) | `atomic workflow list`, `atomic workflow list -a <agent>`                        | Browse registered builtins, optionally filtered                                |
+| List (atomic builtins) | `atomic workflow list`, `atomic workflow list -a <agent>`                        | Browse registered builtins + custom workflows, optionally filtered             |
+| Reload custom workflows | `atomic workflow refresh [--format json\|text]`                                  | Re-spawn metadata loaders after editing `.atomic/settings.json` or a workflow file. Auto-defaults to JSON inside an atomic chat session so the model can ingest broken-entry diagnostics directly. |
 | List (user cli)        | Iterate `listWorkflows(registry)` and add a `list` Commander subcommand yourself | No built-in `--list` flag                                                      |
 | List (single-workflow) | Not applicable — the file *is* the workflow                                      |
 | Inspect inputs         | `atomic workflow inputs <name> -a claude`                                        | Print input schema as JSON                                                     |
 | Status (one or all)    | `atomic workflow status [<session-id>]`                                          | Query state — `in_progress`, `error`, `completed`, `needs_review`, `awaiting_input` |
+| Read run/stage on disk | `atomic workflow read --sessionId <id> [--stageId <name>]`                       | Print path under `~/.atomic/sessions/<runId>/` for the run dir or a single stage. The model can then `Read` `messages.json` (raw `s.save()` output), `inbox.md` (rendered transcript), or `metadata.json` directly. Auto-defaults to JSON inside an atomic chat session. |
 | Kill non-interactively | `atomic session kill <id> -y`                                                    | Tear down without confirmation prompt — `-y` is mandatory for agents           |
 | Detached (background)  | `… -d` / `… --detach`                                                            | Runs without attaching; reattach with `atomic workflow session connect <name>` |
 
@@ -530,14 +611,14 @@ SDKs (send/save/extract patterns, idle handling), and
 `references/agent-sessions.md` for per-SDK API details and lifecycle
 caveats.
 
-**Reference implementations** — two categories live in-repo:
+**Reference implementations** — two categories live in-repo, browsable at <https://github.com/flora131/atomic/tree/main/examples>:
 
 - **Builtins** (`packages/atomic-sdk/src/workflows/builtin/`) — production patterns,
   registered via `createBuiltinRegistry()` inside the `atomic` CLI:
   - `ralph` — iterative plan → orchestrate → review → debug loop.
   - `deep-research-codebase` — scout → parallel explorer fan-out → aggregator.
   - `open-claude-design` — design-system init flow.
-- **User-app examples** (`examples/<name>/`) — minimal runnable user apps
+- **User-app examples** ([`examples/<name>/`](https://github.com/flora131/atomic/tree/main/examples)) — minimal runnable Mode-2 (dev-owned-CLI) apps
   you can copy-paste as a starting point. Each example directory contains
   `claude/index.ts`, `copilot/index.ts`, `opencode/index.ts`, and one
   `<agent>-worker.ts` entrypoint per agent — each a small Commander
@@ -549,7 +630,9 @@ caveats.
   `hil-favorite-color-headless`, `structured-output-demo`,
   `reviewer-tool-test` (copilot only), `review-fix-loop`,
   `multi-workflow`, `commander-embed`, `pane-navigation` (driver CLI for
-  the navigation primitives).
+  the navigation primitives), and `custom-workflow-bunx` (Mode-1 entry
+  shape — single file ending in `await hostLocalWorkflows([wf])`,
+  registered as a `workflows.<alias>` entry in `settings.json`).
 
 Both sets demonstrate shared helpers, context-aware prompt building,
 deterministic heuristics, and cross-SDK adaptation.
@@ -591,9 +674,12 @@ to invoke it correctly. That's a different playbook from authoring.
 
 - Three invocation paths: user's own app (per-input `--<flag>` flags wired
   by the dev, using Commander or another CLI library), repo-shipped examples
-  (same pattern), and atomic builtins (`atomic workflow -n … -a …`).
+  at <https://github.com/flora131/atomic/tree/main/examples>, and atomic
+  builtins + custom workflows (`atomic workflow -n … -a …`).
 - Why atomic builtins use `-n` + `-a` and how to add `-d` for background runs.
-- Why you must list workflows first.
+- Why you must list workflows first — and why `atomic workflow refresh`
+  is the right verification step right after editing `settings.json` or
+  a Mode-1 workflow file.
 - How to handle missing workflows (offer to author, not fabricate).
 - Using `atomic workflow inputs <name> -a <agent>` to discover the schema
   and drive AskUserQuestion.

--- a/.agents/skills/workflow-creator/references/agent-setup-recipe.md
+++ b/.agents/skills/workflow-creator/references/agent-setup-recipe.md
@@ -2,6 +2,16 @@
 
 A deterministic recipe for getting a user from "empty terminal" to "first workflow runs" in one session. This is the path to follow whenever the user signals they want to start using the workflow SDK from zero — phrases like *"set me up with the workflow SDK"*, *"I want to write workflows"*, *"bootstrap a workflow project"*, *"how do I get started"*, or any equivalent. If the user already has `@bastani/atomic-sdk` installed and a workflow file exists, jump to step 5.
 
+## Pick the mode first (see SKILL.md §"Custom workflow modes")
+
+Two distinct setup tracks share Steps 1–3, then branch at Step 4:
+
+- **Mode 1 — Atomic-managed.** The default. Workflow lives in `.atomic/workflows/<name>/` (project) or `~/.atomic/workflows/<name>/` (global) as a self-contained Bun package, registered in `settings.json`, invoked via `atomic workflow -n <name>`. Branch to **Step 4-Mode1** and **Step 5-Mode1**.
+- **Mode 2 — Dev-owned CLI.** Workflow lives in `<repo>/src/workflows/<name>/<agent>.ts` with a Commander composition root in `<repo>/src/<agent>-worker.ts`. Branch to **Step 4-Mode2** and **Step 5-Mode2**.
+- **Combined.** Author as Mode 2 but call `await hostLocalWorkflows([wf])` *before* the `program.parseAsync()` so the file is also discoverable by `atomic workflow`.
+
+If the user does not specify, **default to Mode 1**. Confirm in one short question only when the wording is ambiguous (e.g. user says "a workflow I can reuse across projects" — that's a global Mode 1, not project-local).
+
 ## Why this recipe exists
 
 Bootstrapping is the highest-friction moment of the SDK because three of the runtime dependencies live outside `bun add`:
@@ -47,17 +57,26 @@ Ask the user which agent they're targeting and whether they want one or multiple
 
 Don't guess. Use `AskUserQuestion` (or the equivalent) when intent is unclear — picking wrong here means rewriting 100% of the scaffold.
 
-## Step 3 — Bootstrap the project
+## Step 3 — Bootstrap the package
 
-If `package.json` already exists, skip `bun init`. Otherwise:
+For **Mode 1**, the package lives at `.atomic/workflows/<name>/` (or `~/.atomic/workflows/<name>/` for global) and is fully self-contained — its own `package.json`, `tsconfig.json`, and `node_modules`. Do this *inside* that directory, not in the repo root:
 
 ```bash
+mkdir -p .atomic/workflows/<name>
+cd .atomic/workflows/<name>
 bun init -y
+bun add @bastani/atomic-sdk
+bun add @anthropic-ai/claude-agent-sdk     # only if Claude
+bun add @github/copilot-sdk                # only if Copilot
+bun add @opencode-ai/sdk                   # only if OpenCode
 ```
 
-Add the SDK plus only the provider package(s) the user picked:
+The atomic CLI spawns this package as a subprocess (via `bunx <path>` or `bun <path>`) — keeping its dependencies isolated means the host project's deps never collide with the workflow's, and global workflows under `~/.atomic/workflows/<name>/` work identically because they ship their own deps.
+
+For **Mode 2**, work in the repo root:
 
 ```bash
+bun init -y                                # skip if package.json exists
 bun add @bastani/atomic-sdk
 bun add @anthropic-ai/claude-agent-sdk     # only if Claude
 bun add @github/copilot-sdk                # only if Copilot
@@ -69,11 +88,44 @@ If the user has `npm install`, `yarn add`, or any non-Bun command on file, gentl
 
 ## Step 4 — Scaffold the workflow file
 
-Drop into `src/workflows/<name>/<agent>.ts`. The convention is one directory per workflow, one file per agent — this keeps `src/workflows/<name>/helpers/` available for SDK-agnostic logic when the user does want cross-agent support later. The naming matters because every reference doc and every agent looking at the codebase finds files the same way.
-
 Always include `source: import.meta.path` — the runtime re-imports the module from this path inside the orchestrator child process. Forget it and the workflow loads fine but `runWorkflow` blows up at spawn time with `InvalidWorkflowError`.
 
-### Claude template
+### Step 4-Mode1 — Atomic-managed entry (`.atomic/workflows/<name>/index.ts`)
+
+Single file per workflow package. The trailing `await hostLocalWorkflows([…])` is what makes the file responsive to atomic's two token-gated sub-commands (`_emit-workflow-meta` and `_atomic-run`); without it, the loader will time out and surface a `BROKEN` entry on `atomic workflow refresh`. Add an executable shebang so the file can be invoked via `bunx <path>`.
+
+```ts
+// .atomic/workflows/<name>/index.ts
+#!/usr/bin/env bun
+import { defineWorkflow, hostLocalWorkflows } from "@bastani/atomic-sdk";
+
+const workflow = defineWorkflow({
+  name: "<workflow-name>",
+  source: import.meta.path,
+  description: "<one-line description>",
+  inputs: [
+    { name: "prompt", type: "text", required: true, description: "what the user supplies" },
+  ],
+})
+  .for("claude") // or .for("copilot") / .for("opencode") — pick the agent the user named
+  .run(async (ctx) => {
+    await ctx.stage({ name: "step-1" }, {}, {}, async (s) => {
+      await s.session.query(ctx.inputs.prompt);
+      s.save(s.sessionId);
+    });
+  })
+  .compile();
+
+await hostLocalWorkflows([workflow]);
+```
+
+For Copilot / OpenCode session bodies, use the same `.for(...)` + `.run(...)` shape as Mode 2 templates below — only the directory layout, package boundary, and `hostLocalWorkflows` call change between modes.
+
+### Step 4-Mode2 — Dev-owned files (`src/workflows/<name>/<agent>.ts`)
+
+Drop into `src/workflows/<name>/<agent>.ts`. The convention is one directory per workflow, one file per agent — this keeps `src/workflows/<name>/helpers/` available for SDK-agnostic logic when the user does want cross-agent support later. The naming matters because every reference doc and every agent looking at the codebase finds files the same way.
+
+#### Claude template
 
 ```ts
 // src/workflows/<name>/claude.ts
@@ -97,7 +149,7 @@ export default defineWorkflow({
   .compile();
 ```
 
-### Copilot template
+#### Copilot template
 
 ```ts
 .for("copilot")
@@ -110,7 +162,7 @@ export default defineWorkflow({
 .compile();
 ```
 
-### OpenCode template
+#### OpenCode template
 
 ```ts
 .for("opencode")
@@ -128,11 +180,58 @@ export default defineWorkflow({
 
 The `s.save(...)` call shape differs per agent on purpose — see `getting-started.md` "Saving Transcripts" for the per-provider rationale.
 
-## Step 5 — Scaffold the composition root
+## Step 5 — Wire the entry point
+
+### Step 5-Mode1 — Register in `settings.json` and refresh
+
+Mode 1 has no separate composition root; the workflow file *is* the entry point because `hostLocalWorkflows([wf])` doubles as the host-dispatch handler. Instead, you register the package in atomic's settings file:
+
+- **Project-local** → `.atomic/settings.json` (recommended default)
+- **Global** → `~/.atomic/settings.json` (use absolute paths in `args` so `cwd` doesn't matter)
+
+```jsonc
+// .atomic/settings.json
+{
+  "$schema": "https://raw.githubusercontent.com/flora131/atomic/main/assets/settings.schema.json",
+  "version": 1,
+  "workflows": {
+    "<workflow-name>": {
+      "command": "bunx",
+      "args": ["./.atomic/workflows/<workflow-name>/index.ts"],
+      "agents": ["claude"]
+    }
+  }
+}
+```
+
+If the user already has a `settings.json`, *merge* into the existing `workflows` object — do not overwrite it. Use `Read` first, then `Edit` the JSON in place.
+
+Then verify the registration:
+
+```bash
+atomic workflow refresh
+```
+
+Inside an atomic chat session this auto-defaults to JSON; outside, it prints colourised text. Either way, every diagnostic field is on its own `key · value` line so the model can self-correct without prose parsing:
+
+- `loaded` entries confirm the workflow is invocable as `atomic workflow -n <workflow-name> -a claude`.
+- `broken` entries spell out `reason · …`, `fix · …`, `settings · <path> (workflows.<alias>)` so you know exactly which file and which JSON path to repair before re-running.
+
+Common Mode-1 broken-entry causes the model should self-diagnose:
+
+| Symptom (`reason` field starts with…)                                 | Fix                                                                                                     |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `metadata emission timed out`                                         | Ensure `await hostLocalWorkflows([wf])` is the *last* statement in the file (after `.compile()`).        |
+| `expected ATOMIC_WORKFLOW_META line`                                  | The file is not importing `@bastani/atomic-sdk`, OR `hostLocalWorkflows` is never called.               |
+| `command "<x>" not found on PATH`                                     | Use `bunx` + a path under `args`, not a bare command — or supply an absolute path.                      |
+| `command did not register a workflow for agent "<a>"`                 | The `.for(...)` chain targets a different agent than `agents` in `settings.json` declares.              |
+| `failed to parse ATOMIC_WORKFLOW_META JSON`                           | A `console.log` or `process.stdout.write` is racing with the meta line — keep the file output-clean.    |
+
+### Step 5-Mode2 — Composition root with Commander
 
 The SDK ships pure primitives, not a CLI wrapper. The user composes them into whatever CLI library they prefer. Default to Commander unless they say otherwise.
 
-### Single workflow worker
+#### Single workflow worker
 
 ```ts
 // src/<agent>-worker.ts
@@ -165,7 +264,7 @@ await program.parseAsync();
 
 The typed-error catch is small but it pays for itself the first time `tmux` is missing — the user gets one actionable line instead of an SDK stack trace. Add more `instanceof` branches as the surface grows (see Step 8).
 
-### Multi-workflow CLI
+#### Multi-workflow CLI
 
 When the user picks "multiple workflows, one CLI", swap the worker for a registry-driven composition root:
 
@@ -198,6 +297,10 @@ await program.parseAsync();
 
 Every `(agent, name)` key must be unique across the registry — registering a duplicate throws immediately at startup, which is intentional. Agents reading the codebase rely on stable keys.
 
+#### Mode 1 + 2 combined
+
+Add `await hostLocalWorkflows([wf])` *before* `program.parseAsync()` in either of the templates above. Atomic's two internal sub-commands are token-gated and `process.exit(0)` after handling, so Commander never sees them on bare invocation. Then ALSO register the file in `settings.json` (Step 5-Mode1) so `atomic workflow -n …` discovers it. The example at <https://github.com/flora131/atomic/tree/main/examples/custom-workflow-bunx> shows the minimal Mode-1 shape; combine its `hostLocalWorkflows([wf])` call with the Commander setup above to get both surfaces in one file.
+
 ## Step 6 — Add a `typecheck` script
 
 The biggest payoff for catching mistakes early is `bunx tsc --noEmit`. Wire it into `package.json`:
@@ -220,7 +323,18 @@ If this fails, fix the errors before moving on — typecheck failures here usual
 
 ## Step 7 — Smoke test
 
-Run the workflow attached the first time so the user can watch a tmux pane spawn and see Claude/Copilot/OpenCode actually respond:
+Run the workflow attached the first time so the user can watch a tmux pane spawn and see Claude/Copilot/OpenCode actually respond.
+
+**Mode 1:**
+
+```bash
+atomic workflow refresh                  # confirm registration succeeds
+atomic workflow -n <workflow-name> -a <agent> "Reply with the single word 'ok'"
+```
+
+If `refresh` reports the workflow as `BROKEN`, fix the issue surfaced in the `fix · …` line *before* trying to invoke — the dispatcher will hard-block with the same diagnostic.
+
+**Mode 2:**
 
 ```bash
 bun run src/<agent>-worker.ts --prompt "Reply with the single word 'ok'"
@@ -258,9 +372,13 @@ Don't catch errors you don't know how to render — let them throw. A blanket `c
 
 Once the smoke test passes, the user owns the project. Tell them:
 
-- **Where the workflow lives** — `src/workflows/<name>/<agent>.ts`. Edits there change the pipeline shape.
-- **Where the entry point lives** — `src/<agent>-worker.ts` (or `src/cli.ts` for the registry shape). Edits there change the user-facing flag surface.
-- **How to monitor** — `atomic session list` for a system-wide view, `atomic workflow status <id>` for one run, or wire `listSessions` / `getSessionStatus` into their own CLI's subcommands. The pane-navigation primitives (`nextWindow`, `previousWindow`, `gotoOrchestrator`, `detachSession`) drive tmux directly without taking over the user's terminal — import them from the **root** `@bastani/atomic-sdk` barrel (not `/workflows`); see `examples/pane-navigation/` for a reference driver CLI.
-- **What to read next** — `references/getting-started.md` for the SDK exports table, `references/control-flow.md` for loops/parallel/headless, `references/state-and-data-flow.md` for `s.save`/`s.transcript` patterns, `references/failure-modes.md` before shipping any multi-stage workflow.
+- **Where the workflow lives** —
+    - Mode 1: `.atomic/workflows/<name>/index.ts` (project) or `~/.atomic/workflows/<name>/index.ts` (global). Edits there change the pipeline shape.
+    - Mode 2: `src/workflows/<name>/<agent>.ts`. Edits there change the pipeline shape.
+- **Where the entry point lives** —
+    - Mode 1: `.atomic/settings.json` (or `~/.atomic/settings.json`). Edits there change which workflows the `atomic` CLI registers — run `atomic workflow refresh` after any settings.json edit to surface broken-entry diagnostics immediately.
+    - Mode 2: `src/<agent>-worker.ts` (or `src/cli.ts` for the registry shape). Edits there change the user-facing flag surface.
+- **How to monitor** — `atomic session list` for a system-wide view, `atomic workflow status <id>` for one run (returns `awaiting_input` / `needs_review` when a HiL prompt is pending — surface that to the user immediately), or wire `listSessions` / `getSessionStatus` into their own CLI's subcommands. The pane-navigation primitives (`nextWindow`, `previousWindow`, `gotoOrchestrator`, `detachSession`) drive tmux directly without taking over the user's terminal — import them from the **root** `@bastani/atomic-sdk` barrel (not `/workflows`); see [`examples/pane-navigation/`](https://github.com/flora131/atomic/tree/main/examples/pane-navigation) for a reference driver CLI.
+- **What to read next** — `references/getting-started.md` for the SDK exports table, `references/control-flow.md` for loops/parallel/headless, `references/state-and-data-flow.md` for `s.save`/`s.transcript` patterns, `references/running-workflows.md` for HiL handling and teardown, `references/failure-modes.md` before shipping any multi-stage workflow.
 
 If the user is now stuck on workflow design rather than setup ("how do I do a review-fix loop?", "what's the right shape for parallel research?"), pivot to the authoring guidance in `SKILL.md` §"Authoring Process" and the `Design Advisory Skills` table. Setup is done.

--- a/.agents/skills/workflow-creator/references/running-workflows.md
+++ b/.agents/skills/workflow-creator/references/running-workflows.md
@@ -210,6 +210,133 @@ Skip AskUserQuestion entirely when:
 7. **Report the session name** the CLI printed and tell the user: "attach any
    time with `atomic workflow session connect <session>` — or
    `atomic workflow session list` to see what's running."
+8. **If you started the workflow detached (`-d` or `detach: true`), poll
+   status until it terminates or pauses for input** — see "Polling rhythm
+   after spawning" below. Surfacing a HIL pause to the user immediately is
+   non-negotiable; an unattended `awaiting_input` / `needs_review` state
+   means the workflow is wedged and the user doesn't know.
+
+## Polling rhythm after spawning
+
+When the workflow runs detached (you spawned it with `-d` or the user wants
+to keep working while it executes), the model is responsible for tracking
+its progress. The pattern is a small loop around `atomic workflow status`:
+
+```bash
+atomic workflow status <session-id>
+# JSON envelope; key field is `overall`:
+#   in_progress    → keep polling at a sensible cadence
+#   awaiting_input → surface to user *now* — see HIL response below
+#   needs_review   → surface to user *now* — same handling
+#   completed      → report success + summarize the snapshot's `sessions[]` results
+#   error          → report `fatalError` + offer to investigate
+```
+
+Polling cadence: every 30–60s for runs that should take minutes; every 2–5
+minutes for long runs (e.g. `ralph` iterating). Don't busy-poll. If the
+user asks "is it done yet?" mid-run, run `status` once and answer from the
+result — don't kick off a new poll loop on every question.
+
+### What to do on `awaiting_input` or `needs_review`
+
+These states mean a stage is waiting on a typed answer (an `AskUserQuestion`
+elicitation, a Copilot `ask_user`, an OpenCode `question.asked`, or a
+review-marker handoff). The workflow will sit forever unless the user
+responds.
+
+The current send-back path is **interactive attach only**:
+
+```bash
+atomic workflow session connect <session-id>
+# user lands inside the tmux pane, types their answer into the agent's TUI,
+# detaches with the agent's standard binding (Ctrl-b d for tmux)
+```
+
+There is **no `atomic workflow send <id> --message "..."`** today — the
+agent CLI panes accept input only through the live TUI. If the model needs
+to forward a typed answer back into a session non-interactively, that's a
+known gap; surface it to the user and let them attach. (The SDK does use
+`tmux send-keys` internally for orchestration, but there is no public CLI
+surface that exposes it for HIL responses.)
+
+So when you see `awaiting_input` or `needs_review`:
+
+1. Stop polling.
+2. Read the snapshot's `sessions[]` to find which stage is paused (`status: "awaiting_input"`).
+3. Tell the user **plainly and immediately**: "Workflow `<name>` is paused on stage `<stage-name>` waiting for your input. Attach with `atomic workflow session connect <session-id>` to respond." Include the stage name so the user knows what they're answering.
+4. Wait for the user to confirm they've responded (or for the next status poll to show `in_progress` again) before resuming the polling rhythm.
+
+### Inspecting on-disk state with `atomic workflow read`
+
+When the model needs to actually *read* what a workflow has produced —
+the saved transcript of a stage, the orchestrator's `status.json`, the
+captured `inbox.md` rendering — `atomic workflow read` resolves the
+on-disk path under `~/.atomic/sessions/<runId>/` so you don't have to
+guess the opaque `<stageName>-<8hex>` directory suffix.
+
+Two shapes:
+
+```bash
+# Run-level: list the run dir and discover available stages.
+atomic workflow read --sessionId atomic-wf-claude-ralph-a1b2c3d4
+# Inside an atomic chat session this auto-defaults to JSON:
+# {
+#   "ok": true,
+#   "runId": "a1b2c3d4",
+#   "path": "/home/u/.atomic/sessions/a1b2c3d4",
+#   "stages": ["scout", "explore", "synth"],
+#   "files": [{"name":"status.json","kind":"file","size":1234}, …]
+# }
+
+# Stage-level: resolve the single stage subdir + list its saved artifacts.
+atomic workflow read --sessionId atomic-wf-claude-ralph-a1b2c3d4 --stageId scout
+# {
+#   "ok": true,
+#   "runId": "a1b2c3d4",
+#   "stageName": "scout",
+#   "path": "/home/u/.atomic/sessions/a1b2c3d4/scout-9f8e7d6c",
+#   "files": [
+#     {"name":"messages.json","kind":"file","size":8123},   ← s.save() raw JSON
+#     {"name":"inbox.md","kind":"file","size":3401},        ← human-readable transcript
+#     {"name":"metadata.json","kind":"file","size":312}
+#   ]
+# }
+```
+
+**Key fields under `<runId>/`:**
+
+| File / dir                                     | What's in it                                                                                                                          |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `status.json`                                  | Live panel snapshot — same JSON `atomic workflow status <id>` returns                                                                |
+| `metadata.json`                                | Workflow-level metadata: name, agent, prompt, project root, `startedAt`                                                              |
+| `orchestrator.log`                             | Stdout/stderr of the orchestrator pane                                                                                                |
+| `<stageName>-<stageSessionId>/messages.json`   | The `SavedMessage[]` array produced by `s.save(...)` calls in that stage. Schema is provider-specific.                               |
+| `<stageName>-<stageSessionId>/inbox.md`        | A plain-text rendering of `messages.json`. Cheaper to read than the JSON when you just want to see what the agent said.              |
+| `<stageName>-<stageSessionId>/metadata.json`   | Stage metadata: name, description, agent, paneId, `startedAt`                                                                         |
+| `<stageName>-<stageSessionId>/error.txt`       | Present **only** when the stage failed; contains the error message.                                                                  |
+
+**Typical model flow** when investigating a stalled or completed run:
+
+1. `atomic workflow status <session-id>` — see overall + per-stage states.
+2. Pick a stage of interest (`needs_review` / `error` / `completed`).
+3. `atomic workflow read --sessionId <session-id> --stageId <stage>` — get its absolute dir.
+4. `Read` the file you actually want (`inbox.md` for human-readable, `messages.json` for raw, `error.txt` for a failure trace).
+
+This avoids two anti-patterns: (a) attaching to the tmux pane just to read transcripts (interactive-only, breaks scripted flows), and (b) globbing `~/.atomic/sessions/` blind.
+
+### Tracking multiple workflows
+
+`atomic workflow status` (no id) returns every workflow on the atomic socket:
+
+```bash
+atomic workflow status
+# {"workflows":[{"id":"…","overall":"in_progress",...},
+#               {"id":"…","overall":"needs_review",...}]}
+```
+
+Useful when the user has several runs going. Sort by `overall` priority —
+surface every `needs_review` / `awaiting_input` first, then `error`, then
+`in_progress`. `completed` workflows can be reported in summary.
 
 ## Monitoring a running workflow
 

--- a/README.md
+++ b/README.md
@@ -1230,6 +1230,10 @@ During `atomic chat`, there is no Atomic-owned TUI — `atomic chat -a <agent>` 
 | `atomic chat`                   | Spawn the native agent CLI inside a tmux session                  |
 | `atomic workflow`               | Run a named multi-session workflow with the Atomic workflow panel |
 | `atomic workflow list`          | List available workflows, grouped by source                       |
+| `atomic workflow refresh`       | Reload custom workflows from `settings.json` and report loaded + broken entries (auto-defaults to JSON inside an atomic chat session) |
+| `atomic workflow read`          | Print the on-disk path under `~/.atomic/sessions/<runId>/` for a workflow run or a single stage so you can inspect saved transcripts |
+| `atomic workflow status [<id>]` | Query workflow state (`in_progress` / `awaiting_input` / `needs_review` / `completed` / `error`) |
+| `atomic workflow inputs <name> -a <agent>` | Print a workflow's declared input schema as JSON              |
 | `atomic session list`           | List all running sessions on the atomic tmux socket               |
 | `atomic session connect [name]` | Attach to a session (interactive picker when no name given)       |
 | `atomic session kill [name]`    | Kill one session, or pick sessions interactively when no name is given |
@@ -1581,6 +1585,74 @@ atomic workflow -n open-claude-design -a claude
 
 These are not affected by your own `createRegistry()` — they are separate.
 
+### Registering your own workflows with `atomic workflow`
+
+If you want a custom workflow to be discoverable through `atomic workflow list`, the picker, and `atomic workflow -n <name> -a <agent>`, add an entry to `settings.json` under a `workflows` map. Each entry points at an external command that exposes its workflow definition via `hostLocalWorkflows([wf])`.
+
+```jsonc
+// .atomic/settings.json (project-local) or ~/.atomic/settings.json (global)
+{
+  "$schema": "https://raw.githubusercontent.com/flora131/atomic/main/assets/settings.schema.json",
+  "version": 1,
+  "workflows": {
+    "pr-review": {
+      "command": "bunx",
+      "args": ["./.atomic/workflows/pr-review/index.ts"],
+      "agents": ["claude"]
+    }
+  }
+}
+```
+
+The recommended layout for the workflow itself is a self-contained Bun package under `.atomic/workflows/<name>/` (or `~/.atomic/workflows/<name>/` for global) — its own `package.json`, own `tsconfig.json`, own `node_modules` — with the entry file ending in `await hostLocalWorkflows([wf])`:
+
+```ts
+// .atomic/workflows/pr-review/index.ts
+#!/usr/bin/env bun
+import { defineWorkflow, hostLocalWorkflows } from "@bastani/atomic-sdk";
+
+const workflow = defineWorkflow({
+  name: "pr-review",
+  source: import.meta.path,
+  description: "Review the diff on the current branch",
+  inputs: [
+    { name: "target_branch", type: "string", required: true, description: "branch to diff against" },
+  ],
+})
+  .for("claude")
+  .run(async (ctx) => {
+    await ctx.stage({ name: "review" }, {}, {}, async (s) => {
+      await s.session.query(`Review changes vs ${ctx.inputs.target_branch}`);
+      s.save(s.sessionId);
+    });
+  })
+  .compile();
+
+await hostLocalWorkflows([workflow]);
+```
+
+After editing `settings.json` or any registered workflow file, run:
+
+```bash
+atomic workflow refresh
+```
+
+This re-spawns the metadata loader for every entry and reports loaded + broken entries with field-by-field diagnostics (`reason`, `fix`, `settings` path) on each broken-entry line — so you (or an LM authoring the workflow) can self-correct without prose parsing. Inside an atomic chat session it auto-defaults to JSON. Once an entry shows as `LOADED`, invoke it with `atomic workflow -n pr-review -a claude --target_branch=main`.
+
+To inspect what a workflow has produced after it runs (saved transcripts, stage metadata, status snapshots), use:
+
+```bash
+# Run-level: discover stages + run-level files
+atomic workflow read --sessionId atomic-wf-claude-pr-review-a1b2c3d4
+
+# Stage-level: locate a single stage's saved artifacts
+atomic workflow read --sessionId atomic-wf-claude-pr-review-a1b2c3d4 --stageId review
+```
+
+The path it prints points at `~/.atomic/sessions/<runId>/[<stageName>-<sessionId>/]` — read `messages.json` (raw `s.save()` output), `inbox.md` (human-readable transcript), or `status.json` (live panel snapshot) directly from there.
+
+For the full authoring playbook (modes, scaffolding, broken-entry symptom→fix table) see the [`workflow-creator` skill](.agents/skills/workflow-creator/SKILL.md). Runnable references live under [`examples/`](https://github.com/flora131/atomic/tree/main/examples) — `custom-workflow-bunx` is the minimal Mode-1 reference.
+
 <details id="migration-from-0x-directory-scanning-and-the-createworkflowcli-wrapper">
 <summary><b>Migration from 0.x (directory-scanning) and the <code>createWorkflowCli</code> wrapper</b></summary>
 
@@ -1614,6 +1686,13 @@ Resolution order:
       "chatFlags": ["--model", "claude-sonnet-4-6"],
       "envVars": { "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "16384" }
     }
+  },
+  "workflows": {
+    "pr-review": {
+      "command": "bunx",
+      "args": ["./.atomic/workflows/pr-review/index.ts"],
+      "agents": ["claude"]
+    }
   }
 }
 ```
@@ -1625,6 +1704,7 @@ Resolution order:
 | `version`   | number | Config schema version (currently `1`)                                                                                                           |
 | `scm`       | string | Source control provider — `github`, `azure-devops`, or `sapling`. Reconciles the GitHub / Azure DevOps MCP servers in agent configs on startup. |
 | `providers` | object | Per-provider overrides for `claude`, `opencode`, `copilot`. `chatFlags` replaces built-in defaults entirely; `envVars` are merged               |
+| `workflows` | object | Custom workflow registry — each key is the alias the `atomic` CLI exposes; each value is `{ command, args?, agents }` pointing at an external entry that calls `hostLocalWorkflows([wf])`. Local entries override global ones with the same alias. Run `atomic workflow refresh` after editing. |
 
 > Model selection and reasoning effort are managed by each underlying agent CLI (e.g. Claude Code's `/model`), not Atomic. Atomic's chat command spawns the agent's native TUI — use the agent's own controls.
 

--- a/packages/atomic/src/cli.ts
+++ b/packages/atomic/src/cli.ts
@@ -10,6 +10,8 @@
  *   atomic chat session connect <id>          Attach to a session
  *   atomic workflow list                      List available workflows
  *   atomic workflow inputs <name> -a <agent>  Print a workflow's input schema (JSON)
+ *   atomic workflow refresh                   Reload custom workflows from settings.json
+ *   atomic workflow read --sessionId <id> [--stageId <name>]  Print on-disk path to a run / stage
  *   atomic workflow status [<id>]             Query workflow status (JSON)
  *   atomic workflow session list              List running sessions
  *   atomic workflow session connect <id>      Attach to a session
@@ -157,6 +159,9 @@ Examples:
   $ atomic workflow -n ralph -a claude "fix bug"    Run a free-form workflow
   $ atomic workflow -n ralph -a claude -d "fix bug" Run detached in the background
   $ atomic workflow inputs <name> -a claude         Print a workflow's input schema (JSON)
+  $ atomic workflow refresh                         Reload custom workflows from settings.json
+  $ atomic workflow read --sessionId <id>           Print path to a workflow run dir on disk
+  $ atomic workflow read --sessionId <id> --stageId scout  Print path to a single stage's saved artifacts
   $ atomic workflow status                          List status for all running workflows
   $ atomic workflow status <id>                     Query a single workflow's status
   $ atomic workflow session list                    List running sessions
@@ -200,6 +205,53 @@ Examples:
                 name,
                 agent: localOpts.agent,
                 format: localOpts.format === "text" ? "text" : "json",
+            });
+            process.exit(exitCode);
+        });
+
+    // Workflow refresh subcommand: atomic workflow refresh [--format json|text]
+    // Re-spawns metadata loaders for every entry in settings.json and reports
+    // the result. Defaults to JSON when ATOMIC_AGENT is set (i.e. the LM is
+    // the consumer) so the model can ingest the result without screen-scraping.
+    workflowCommand
+        .command("refresh")
+        .description(
+            "Reload custom workflows from settings.json and report loaded + broken entries",
+        )
+        .option("--format <format>", "Output format: json | text (defaults to json inside an atomic chat session, text otherwise)")
+        .action(async (localOpts) => {
+            const { workflowRefreshCommand } = await import(
+                "./commands/cli/workflow-refresh.ts"
+            );
+            const fmt = localOpts.format;
+            const exitCode = await workflowRefreshCommand({
+                format: fmt === "json" || fmt === "text" ? fmt : undefined,
+            });
+            process.exit(exitCode);
+        });
+
+    // Workflow read subcommand: atomic workflow read --sessionId <id> [--stageId <name>]
+    // Prints the on-disk path under ~/.atomic/sessions for a workflow run or a
+    // single stage subdir, plus a listing of files inside. Lets the model find
+    // saved transcripts (messages.json / inbox.md / status.json) without
+    // guessing the opaque stage-session-id suffix the runtime appends.
+    workflowCommand
+        .command("read")
+        .description(
+            "Print the on-disk path to a workflow run or stage under ~/.atomic/sessions",
+        )
+        .requiredOption("--sessionId <id>", "Tmux session name (atomic-wf-…) or bare 8-hex run id")
+        .option("--stageId <name>", "Stage name as it appears in `atomic workflow status` output")
+        .option("--format <format>", "Output format: json | text (defaults to json inside an atomic chat session, text otherwise)")
+        .action(async (localOpts) => {
+            const { workflowReadCommand } = await import(
+                "./commands/cli/workflow-read.ts"
+            );
+            const fmt = localOpts.format;
+            const exitCode = await workflowReadCommand({
+                sessionId: localOpts.sessionId,
+                stageId: localOpts.stageId,
+                format: fmt === "json" || fmt === "text" ? fmt : undefined,
             });
             process.exit(exitCode);
         });
@@ -490,43 +542,22 @@ export const program = createProgram();
 /**
  * Discover and merge custom workflows from global + local settings into the
  * active workflow command registry. Failures are non-fatal — atomic works
- * without custom workflows.
+ * without custom workflows. The data-loading flow lives in
+ * `commands/custom-workflows.ts`; this wrapper just rebuilds the singleton
+ * Commander tree from its result.
  */
-async function bootstrapCustomWorkflows(): Promise<void> {
+async function bootstrapCustomWorkflowsAndRebuild(): Promise<void> {
     try {
         const [
-            { readAtomicConfigSplit, getGlobalSettingsPath, getLocalSettingsPath },
-            { loadCustomWorkflows, mergeIntoRegistry },
-            { createBuiltinRegistry },
+            { bootstrapCustomWorkflows },
             { rebuildWorkflowCommand },
         ] = await Promise.all([
-            import("@bastani/atomic-sdk/services/config/atomic-config"),
             import("./commands/custom-workflows.ts"),
-            import("./commands/builtin-registry.ts"),
             import("./commands/cli/workflow.ts"),
         ]);
 
-        const { global: globalCfg, local: localCfg } =
-            await readAtomicConfigSplit(process.cwd());
-
-        const [globalRes, localRes] = await Promise.all([
-            loadCustomWorkflows(
-                globalCfg?.workflows,
-                "global",
-                getGlobalSettingsPath(),
-            ),
-            loadCustomWorkflows(
-                localCfg?.workflows,
-                "local",
-                getLocalSettingsPath(process.cwd()),
-            ),
-        ]);
-
-        const { registry, brokenList, brokenIndex, summary } = mergeIntoRegistry(
-            createBuiltinRegistry(),
-            globalRes,
-            localRes,
-        );
+        const { registry, brokenList, brokenIndex, summary } =
+            await bootstrapCustomWorkflows(process.cwd());
         if (summary) process.stderr.write(summary + "\n");
 
         rebuildWorkflowCommand(registry, brokenIndex, brokenList);
@@ -576,7 +607,7 @@ async function main(): Promise<void> {
         // ./.atomic/settings.json (local) into the workflow command registry.
         // Skipped for info-only commands to avoid spawn cost.
         if (!isInfoCommand) {
-            await bootstrapCustomWorkflows();
+            await bootstrapCustomWorkflowsAndRebuild();
         }
 
         await program.parseAsync();

--- a/packages/atomic/src/commands/cli/workflow-read.test.ts
+++ b/packages/atomic/src/commands/cli/workflow-read.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for `atomic workflow read`.
+ *
+ * Strategy: drive a real tempdir laid out as `~/.atomic/sessions/<runId>/...`
+ * and point the command at it via injected `sessionsBaseDir`. This exercises
+ * the actual `readdir` / `stat` / glob path the runtime uses, not a mock —
+ * cheaper than spinning up a workflow and far harder to drift from on-disk
+ * reality.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { readdir, stat } from "node:fs/promises";
+import {
+  workflowReadCommand,
+  resolveRunId,
+  formatSize,
+  type WorkflowReadDeps,
+  type ReadJsonPayload,
+  type ReadJsonError,
+} from "./workflow-read.ts";
+
+// ─── Output capture ──────────────────────────────────────────────────────────
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  restore: () => void;
+}
+
+function captureOutput(): Captured {
+  const c: Captured = { stdout: "", stderr: "", restore: () => {} };
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origStderr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    c.stdout += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    c.stderr += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  c.restore = () => {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+  };
+  return c;
+}
+
+// ─── Color disable ───────────────────────────────────────────────────────────
+
+let originalNoColor: string | undefined;
+beforeAll(() => {
+  originalNoColor = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+});
+afterAll(() => {
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+});
+
+// ─── Fixture builder ─────────────────────────────────────────────────────────
+
+let tmpRoot: string;
+let sessionsDir: string;
+const RUN_ID = "a1b2c3d4";
+const STAGE_NAME = "scout";
+const STAGE_SUFFIX = "9f8e7d6c";
+const STAGE_DIR_NAME = `${STAGE_NAME}-${STAGE_SUFFIX}`;
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "atomic-wf-read-test-"));
+  sessionsDir = join(tmpRoot, "sessions");
+
+  // Run dir with stage subdir + run-level files
+  const runDir = join(sessionsDir, RUN_ID);
+  await mkdir(runDir, { recursive: true });
+  await writeFile(join(runDir, "status.json"), JSON.stringify({ overall: "in_progress" }));
+  await writeFile(join(runDir, "metadata.json"), JSON.stringify({ workflow: "demo" }));
+  await writeFile(join(runDir, "orchestrator.log"), "log line\n");
+
+  const stageDir = join(runDir, STAGE_DIR_NAME);
+  await mkdir(stageDir, { recursive: true });
+  await writeFile(join(stageDir, "metadata.json"), JSON.stringify({ name: STAGE_NAME }));
+  await writeFile(join(stageDir, "messages.json"), JSON.stringify([{ role: "user", text: "hi" }]));
+  await writeFile(join(stageDir, "inbox.md"), "# inbox\n\nhi");
+
+  // A second stage so the run-level "stages" listing has more than one entry
+  await mkdir(join(runDir, "explore-1a2b3c4d"), { recursive: true });
+  await writeFile(join(runDir, "explore-1a2b3c4d", "messages.json"), "[]");
+});
+
+afterAll(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+// ─── Dep factory ─────────────────────────────────────────────────────────────
+
+function makeDeps(envOverrides: Record<string, string> = {}): WorkflowReadDeps {
+  return {
+    sessionsBaseDir: () => sessionsDir,
+    env: (name) => envOverrides[name],
+    readdir,
+    stat,
+  };
+}
+
+let captured: Captured;
+beforeEach(() => { captured = captureOutput(); });
+afterEach(() => { captured.restore(); });
+
+// ─── resolveRunId unit tests ─────────────────────────────────────────────────
+
+describe("resolveRunId", () => {
+  test("accepts a bare 8-hex run id", () => {
+    expect(resolveRunId("a1b2c3d4")).toBe("a1b2c3d4");
+  });
+
+  test("normalises uppercase hex to lowercase", () => {
+    expect(resolveRunId("A1B2C3D4")).toBe("a1b2c3d4");
+  });
+
+  test("extracts run id from a full tmux name", () => {
+    expect(resolveRunId("atomic-wf-claude-ralph-a1b2c3d4")).toBe("a1b2c3d4");
+  });
+
+  test("rejects non-atomic-wf names", () => {
+    expect(resolveRunId("nginx-server")).toBe(null);
+  });
+
+  test("rejects malformed run ids (wrong length)", () => {
+    expect(resolveRunId("a1b2c3")).toBe(null);
+  });
+
+  test("rejects non-hex characters", () => {
+    expect(resolveRunId("zzzzzzzz")).toBe(null);
+  });
+});
+
+// ─── formatSize unit tests ───────────────────────────────────────────────────
+
+describe("formatSize", () => {
+  test("bytes under 1024 stay as B", () => {
+    expect(formatSize(0)).toBe("0 B");
+    expect(formatSize(512)).toBe("512 B");
+  });
+
+  test("KB / MB / GB units scale and use one decimal", () => {
+    expect(formatSize(1024)).toBe("1.0 KB");
+    expect(formatSize(1024 * 1024)).toBe("1.0 MB");
+    expect(formatSize(1024 * 1024 * 1024)).toBe("1.0 GB");
+  });
+
+  test("negative or non-finite values render as em-dash", () => {
+    expect(formatSize(-1)).toBe("—");
+    expect(formatSize(Number.NaN)).toBe("—");
+  });
+});
+
+// ─── workflowReadCommand: happy paths ────────────────────────────────────────
+
+describe("workflowReadCommand — happy paths", () => {
+  test("run dir lookup by bare run id returns path + files + stages", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: RUN_ID, format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(0);
+    const payload: ReadJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(true);
+    expect(payload.runId).toBe(RUN_ID);
+    expect(payload.path).toBe(join(sessionsDir, RUN_ID));
+    expect(payload.stageName).toBeUndefined();
+    expect(payload.stages).toEqual(["explore", "scout"]);
+
+    // Files should include the stage dirs (kind=dir) and run-level files (kind=file).
+    const fileNames = payload.files.map((f) => f.name);
+    expect(fileNames).toContain("status.json");
+    expect(fileNames).toContain("metadata.json");
+    expect(fileNames).toContain(STAGE_DIR_NAME);
+  });
+
+  test("run dir lookup by full tmux name resolves to the same run id", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: `atomic-wf-claude-ralph-${RUN_ID}`, format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(0);
+    const payload: ReadJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.runId).toBe(RUN_ID);
+  });
+
+  test("stage lookup resolves the <name>-<8hex> dir and lists stage files", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: RUN_ID, stageId: STAGE_NAME, format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(0);
+    const payload: ReadJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.stageName).toBe(STAGE_NAME);
+    expect(payload.path).toBe(join(sessionsDir, RUN_ID, STAGE_DIR_NAME));
+    const names = payload.files.map((f) => f.name);
+    expect(names).toEqual(["inbox.md", "messages.json", "metadata.json"]);
+    // Sizes are populated on file entries.
+    for (const f of payload.files) {
+      expect(f.kind).toBe("file");
+      expect(typeof f.size).toBe("number");
+    }
+  });
+});
+
+// ─── workflowReadCommand: error paths ────────────────────────────────────────
+
+describe("workflowReadCommand — error paths", () => {
+  test("missing --sessionId returns exit 1 with helpful hint (json envelope)", async () => {
+    const code = await workflowReadCommand({ format: "json" }, makeDeps());
+    expect(code).toBe(1);
+    const payload: ReadJsonError = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("--sessionId");
+    expect(payload.hint).toBeDefined();
+  });
+
+  test("malformed sessionId returns exit 1", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: "not-a-real-name", format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(1);
+    const payload: ReadJsonError = JSON.parse(captured.stdout);
+    expect(payload.error).toContain("not-a-real-name");
+  });
+
+  test("nonexistent run dir returns exit 1", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: "deadbeef", format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(1);
+    const payload: ReadJsonError = JSON.parse(captured.stdout);
+    expect(payload.error).toContain("no session directory");
+  });
+
+  test("missing stage returns exit 1 + lists available stages as candidates", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: RUN_ID, stageId: "nonexistent", format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(1);
+    const payload: ReadJsonError = JSON.parse(captured.stdout);
+    expect(payload.error).toContain("nonexistent");
+    expect(payload.hint).toContain("scout");
+    expect(payload.hint).toContain("explore");
+  });
+
+  test("stage with similar prefix doesn't match (regex anchors on -<8hex>)", async () => {
+    // `scou` is a prefix of `scout`; the regex requires the full name.
+    const code = await workflowReadCommand(
+      { sessionId: RUN_ID, stageId: "scou", format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(1);
+    const payload: ReadJsonError = JSON.parse(captured.stdout);
+    expect(payload.error).toContain('"scou"');
+  });
+});
+
+// ─── workflowReadCommand: format auto-detection ──────────────────────────────
+
+describe("workflowReadCommand — format resolution", () => {
+  test("ATOMIC_AGENT in env defaults to json", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: RUN_ID },
+      makeDeps({ ATOMIC_AGENT: "claude" }),
+    );
+    expect(code).toBe(0);
+    expect(() => JSON.parse(captured.stdout)).not.toThrow();
+  });
+
+  test("no ATOMIC_AGENT defaults to text", async () => {
+    const code = await workflowReadCommand({ sessionId: RUN_ID }, makeDeps());
+    expect(code).toBe(0);
+    expect(() => JSON.parse(captured.stdout)).toThrow();
+    // Text format puts the path on its own labelled line.
+    expect(captured.stdout).toMatch(/path\s+·\s+/);
+    expect(captured.stdout).toContain(RUN_ID);
+  });
+
+  test("explicit --format=text wins over ATOMIC_AGENT", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: RUN_ID, format: "text" },
+      makeDeps({ ATOMIC_AGENT: "claude" }),
+    );
+    expect(code).toBe(0);
+    expect(captured.stdout).toMatch(/path\s+·\s+/);
+  });
+});
+
+// ─── workflowReadCommand: text output structure ──────────────────────────────
+
+describe("workflowReadCommand — text output", () => {
+  test("stage lookup includes stage / run / path / files lines", async () => {
+    await workflowReadCommand(
+      { sessionId: RUN_ID, stageId: STAGE_NAME, format: "text" },
+      makeDeps(),
+    );
+    expect(captured.stdout).toMatch(/stage\s+·\s+scout/);
+    expect(captured.stdout).toMatch(/run\s+·\s+a1b2c3d4/);
+    expect(captured.stdout).toMatch(/path\s+·\s+/);
+    expect(captured.stdout).toContain("messages.json");
+    expect(captured.stdout).toContain("inbox.md");
+  });
+
+  test("run dir lookup splits stages from run-level files", async () => {
+    await workflowReadCommand(
+      { sessionId: RUN_ID, format: "text" },
+      makeDeps(),
+    );
+    expect(captured.stdout).toContain("stages");
+    expect(captured.stdout).toContain("scout");
+    expect(captured.stdout).toContain("explore");
+    expect(captured.stdout).toContain("status.json");
+    // Stage dirs should NOT appear in the run-level files list (they have
+    // already been pulled into the `stages` section).
+    expect(captured.stdout).not.toContain(STAGE_DIR_NAME);
+  });
+});

--- a/packages/atomic/src/commands/cli/workflow-read.test.ts
+++ b/packages/atomic/src/commands/cli/workflow-read.test.ts
@@ -17,6 +17,7 @@ import {
   workflowReadCommand,
   resolveRunId,
   formatSize,
+  defaultDeps as readDefaultDeps,
   type WorkflowReadDeps,
   type ReadJsonPayload,
   type ReadJsonError,
@@ -264,6 +265,63 @@ describe("workflowReadCommand — error paths", () => {
     expect(code).toBe(1);
     const payload: ReadJsonError = JSON.parse(captured.stdout);
     expect(payload.error).toContain('"scou"');
+  });
+
+  test("text-format errors go to stderr, not stdout", async () => {
+    const code = await workflowReadCommand(
+      { sessionId: "deadbeef", format: "text" },
+      makeDeps(),
+    );
+    expect(code).toBe(1);
+    expect(captured.stderr).toContain("no session directory");
+    expect(captured.stdout).toBe("");
+  });
+
+  test("text-format renders hint line when failure has a hint", async () => {
+    const code = await workflowReadCommand(
+      { format: "text" }, // no sessionId → triggers hint
+      makeDeps(),
+    );
+    expect(code).toBe(1);
+    expect(captured.stderr).toContain("--sessionId");
+    expect(captured.stderr).toContain("Hint");
+  });
+
+  test("missing stage in a run with no stage subdirs reports empty-candidates hint", async () => {
+    // Build a fresh run dir with only run-level files (no stage subdirs).
+    const emptyRunId = "deadbee0";
+    const emptyRunDir = join(sessionsDir, emptyRunId);
+    await mkdir(emptyRunDir, { recursive: true });
+    await writeFile(join(emptyRunDir, "status.json"), "{}");
+
+    const code = await workflowReadCommand(
+      { sessionId: emptyRunId, stageId: "any-stage", format: "json" },
+      makeDeps(),
+    );
+    expect(code).toBe(1);
+    const payload: ReadJsonError = JSON.parse(captured.stdout);
+    expect(payload.hint).toContain("no stage subdirectories");
+  });
+});
+
+// ─── defaultDeps unit tests ──────────────────────────────────────────────────
+
+describe("defaultDeps", () => {
+  test("sessionsBaseDir resolves under the user's home directory", () => {
+    const path = readDefaultDeps.sessionsBaseDir();
+    expect(path).toContain(".atomic");
+    expect(path).toContain("sessions");
+  });
+
+  test("env(name) reads from process.env", () => {
+    const original = process.env.ATOMIC_READ_DEPS_TEST;
+    process.env.ATOMIC_READ_DEPS_TEST = "ok";
+    try {
+      expect(readDefaultDeps.env("ATOMIC_READ_DEPS_TEST")).toBe("ok");
+    } finally {
+      if (original === undefined) delete process.env.ATOMIC_READ_DEPS_TEST;
+      else process.env.ATOMIC_READ_DEPS_TEST = original;
+    }
   });
 });
 

--- a/packages/atomic/src/commands/cli/workflow-read.ts
+++ b/packages/atomic/src/commands/cli/workflow-read.ts
@@ -72,7 +72,7 @@ export interface WorkflowReadDeps {
   stat: typeof stat;
 }
 
-const defaultDeps: WorkflowReadDeps = {
+export const defaultDeps: WorkflowReadDeps = {
   sessionsBaseDir: () => join(homedir(), ".atomic", "sessions"),
   env: (name) => process.env[name],
   readdir,

--- a/packages/atomic/src/commands/cli/workflow-read.ts
+++ b/packages/atomic/src/commands/cli/workflow-read.ts
@@ -1,0 +1,394 @@
+/**
+ * `atomic workflow read --sessionId <id> [--stageId <name>]` — print the
+ * on-disk path to a workflow run directory (or a single stage subdirectory)
+ * under `~/.atomic/sessions/`, plus a brief listing of the files inside.
+ *
+ * Why this exists: the model-facing skill teaches workflows that persist
+ * stage data via `s.save(...)` to `messages.json` / `inbox.md` and
+ * orchestrator status to `status.json`. Once the model has called
+ * `atomic workflow status <id>` and seen a stage name, it needs a stable
+ * way to find the corresponding directory on disk so it can `Read` the
+ * artifacts directly without guessing the run id or globbing for the
+ * stage's opaque session-id suffix.
+ *
+ * On-disk layout (executor.ts:514-1789, status-writer.ts:144):
+ *
+ *   ~/.atomic/sessions/<runId>/
+ *     status.json            ← live panel snapshot
+ *     metadata.json          ← workflow-level metadata
+ *     orchestrator.{sh,ps1}  ← launcher script
+ *     orchestrator.log       ← orchestrator stdout/stderr
+ *     <stageName>-<stageSessionId>/
+ *       metadata.json        ← stage metadata
+ *       messages.json        ← s.save() output (JSON)
+ *       inbox.md             ← human-readable transcript rendering
+ *       error.txt            ← present only when the stage failed
+ *
+ * Stage names are written verbatim (no slugification, executor.ts:1728);
+ * the trailing `-<stageSessionId>` is opaque, so this command resolves a
+ * stage by name via a `<name>-*` glob.
+ *
+ * `--sessionId` accepts both forms:
+ *   - the full tmux name `atomic-wf-<agent>-<workflow>-<runId>` (what
+ *     `atomic workflow status` prints), or
+ *   - the bare 8-hex run id (the trailing segment).
+ *
+ * `--format` mirrors `atomic workflow refresh` — text default outside an
+ * atomic chat session, JSON default inside one (detected via the
+ * `ATOMIC_AGENT` env var that every chat-launcher bakes into the agent's
+ * environment).
+ *
+ * Exit codes:
+ *   0 — path resolved cleanly.
+ *   1 — sessionId is malformed, run dir doesn't exist, or stage name has
+ *       0 / >1 matches under the run dir.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readdir, stat } from "node:fs/promises";
+import { COLORS, createPainter } from "@bastani/atomic-sdk/theme/colors";
+import { workflowRunIdFromTmuxName } from "@bastani/atomic-sdk/runtime/status-writer";
+
+export type ReadFormat = "text" | "json";
+
+export interface WorkflowReadOptions {
+  /**
+   * Either the full tmux name `atomic-wf-<agent>-<workflow>-<runId>` or
+   * the bare 8-hex run id.
+   */
+  sessionId?: string;
+  /** Stage name as it appears in `atomic workflow status` output. */
+  stageId?: string;
+  /** Defaults to json when ATOMIC_AGENT is set, text otherwise. */
+  format?: ReadFormat;
+}
+
+export interface WorkflowReadDeps {
+  /** Returns the base sessions dir; defaults to `~/.atomic/sessions`. */
+  sessionsBaseDir: () => string;
+  env: (name: string) => string | undefined;
+  readdir: typeof readdir;
+  stat: typeof stat;
+}
+
+const defaultDeps: WorkflowReadDeps = {
+  sessionsBaseDir: () => join(homedir(), ".atomic", "sessions"),
+  env: (name) => process.env[name],
+  readdir,
+  stat,
+};
+
+// ─── JSON payload shape ──────────────────────────────────────────────────────
+
+export interface ReadFileEntry {
+  name: string;
+  /** "file" | "dir" — same vocabulary the model would get from `ls -F`. */
+  kind: "file" | "dir";
+  /** Bytes for files, undefined for dirs. */
+  size?: number;
+}
+
+export interface ReadJsonPayload {
+  ok: true;
+  runId: string;
+  /** When --stageId resolves, the stage name (verbatim from status output). */
+  stageName?: string;
+  /** Resolved absolute path. */
+  path: string;
+  /** Immediate children of `path`. */
+  files: ReadFileEntry[];
+  /**
+   * When this is a run directory, the stage subdir names (with the
+   * `-<stageSessionId>` suffix stripped) so the model can pick a stage
+   * for a follow-up `--stageId` call without re-running status.
+   */
+  stages?: string[];
+}
+
+export interface ReadJsonError {
+  ok: false;
+  error: string;
+  /** Set when the failure mode has an actionable fix (e.g. "use atomic workflow status"). */
+  hint?: string;
+}
+
+// ─── Format resolution ───────────────────────────────────────────────────────
+
+function resolveFormat(
+  explicit: ReadFormat | undefined,
+  env: WorkflowReadDeps["env"],
+): ReadFormat {
+  if (explicit) return explicit;
+  return env("ATOMIC_AGENT") ? "json" : "text";
+}
+
+// ─── runId resolution ────────────────────────────────────────────────────────
+
+const RUN_ID_RE = /^[0-9a-f]{8}$/i;
+
+/**
+ * Accept either the full tmux name or the bare run id. Returns null when
+ * the input is neither.
+ */
+export function resolveRunId(sessionId: string): string | null {
+  if (RUN_ID_RE.test(sessionId)) return sessionId.toLowerCase();
+  return workflowRunIdFromTmuxName(sessionId);
+}
+
+// ─── Directory introspection ─────────────────────────────────────────────────
+
+async function listEntries(
+  dir: string,
+  deps: WorkflowReadDeps,
+): Promise<ReadFileEntry[]> {
+  const names = await deps.readdir(dir);
+  // Sort deterministically so output is stable across runs.
+  names.sort((a, b) => a.localeCompare(b));
+  const out: ReadFileEntry[] = [];
+  for (const name of names) {
+    let st;
+    try {
+      st = await deps.stat(join(dir, name));
+    } catch {
+      // Race / permission failure — list the entry without size.
+      out.push({ name, kind: "file" });
+      continue;
+    }
+    if (st.isDirectory()) {
+      out.push({ name, kind: "dir" });
+    } else {
+      out.push({ name, kind: "file", size: st.size });
+    }
+  }
+  return out;
+}
+
+/**
+ * From the immediate children of a run dir, pick subdirs that look like
+ * `<stageName>-<8hex>` and return the bare stage names (suffix stripped).
+ */
+function extractStageNames(entries: readonly ReadFileEntry[]): string[] {
+  const names = new Set<string>();
+  for (const e of entries) {
+    if (e.kind !== "dir") continue;
+    // The session-id suffix is always 8 hex chars preceded by a `-`.
+    const m = /^(.+)-([0-9a-f]{8})$/i.exec(e.name);
+    if (m && m[1]) names.add(m[1]);
+  }
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+// ─── Stage resolution ────────────────────────────────────────────────────────
+
+interface StageMatchResult {
+  ok: true;
+  dirName: string;
+}
+
+interface StageMatchFail {
+  ok: false;
+  reason: "missing" | "ambiguous";
+  candidates: string[];
+}
+
+async function findStageDir(
+  runDir: string,
+  stageName: string,
+  deps: WorkflowReadDeps,
+): Promise<StageMatchResult | StageMatchFail> {
+  let entries: string[];
+  try {
+    entries = await deps.readdir(runDir);
+  } catch {
+    return { ok: false, reason: "missing", candidates: [] };
+  }
+  // Match `<exactName>-<8hex>` so a stage named `step-1` isn't shadowed by
+  // a stage named `step-1-extra` (whose suffix `extra-XXXXXXXX` would match
+  // a loose `<name>-*` glob).
+  const re = new RegExp(
+    `^${escapeRegExp(stageName)}-[0-9a-f]{8}$`,
+    "i",
+  );
+  const matches = entries.filter((n) => re.test(n));
+  if (matches.length === 0) {
+    return { ok: false, reason: "missing", candidates: extractStageNamesFromList(entries) };
+  }
+  if (matches.length > 1) {
+    return { ok: false, reason: "ambiguous", candidates: matches };
+  }
+  return { ok: true, dirName: matches[0]! };
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractStageNamesFromList(entries: readonly string[]): string[] {
+  const names = new Set<string>();
+  for (const e of entries) {
+    const m = /^(.+)-([0-9a-f]{8})$/i.exec(e);
+    if (m && m[1]) names.add(m[1]);
+  }
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+// ─── Text renderer ───────────────────────────────────────────────────────────
+
+const SIZE_UNITS = ["B", "KB", "MB", "GB"] as const;
+
+export function formatSize(bytes: number): string {
+  if (bytes < 0 || !Number.isFinite(bytes)) return "—";
+  let n = bytes;
+  let i = 0;
+  while (n >= 1024 && i < SIZE_UNITS.length - 1) {
+    n /= 1024;
+    i += 1;
+  }
+  return i === 0
+    ? `${Math.round(n)} ${SIZE_UNITS[i]}`
+    : `${n.toFixed(1)} ${SIZE_UNITS[i]}`;
+}
+
+function renderText(payload: ReadJsonPayload): string {
+  const paint = createPainter();
+  const lines: string[] = [];
+  lines.push("");
+  if (payload.stageName !== undefined) {
+    lines.push("  " + paint("dim", "stage  · ") + paint("text", payload.stageName, { bold: true }));
+  }
+  lines.push("  " + paint("dim", "run    · ") + paint("text", payload.runId));
+  lines.push("  " + paint("dim", "path   · ") + paint("text", payload.path));
+
+  if (payload.stages && payload.stages.length > 0) {
+    lines.push("  " + paint("dim", "stages"));
+    for (const name of payload.stages) {
+      lines.push("    " + paint("accent", name));
+    }
+  }
+
+  if (payload.files.length > 0) {
+    // For run dirs, "files" means the run-level files only (the stage
+    // dirs are listed under `stages` above). Filter accordingly.
+    const fileEntries = payload.stages !== undefined
+      ? payload.files.filter((f) => f.kind === "file")
+      : payload.files;
+    if (fileEntries.length > 0) {
+      lines.push("  " + paint("dim", "files"));
+      const widest = Math.max(...fileEntries.map((f) => f.name.length));
+      for (const f of fileEntries) {
+        const sizeStr = f.size === undefined ? "" : formatSize(f.size);
+        const padded = f.name.padEnd(widest, " ");
+        lines.push("    " + paint("text", padded) + "  " + paint("dim", sizeStr));
+      }
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n") + "\n";
+}
+
+function renderError(format: ReadFormat, error: string, hint?: string): void {
+  if (format === "json") {
+    const payload: ReadJsonError = { ok: false, error };
+    if (hint) payload.hint = hint;
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+  } else {
+    process.stderr.write(`${COLORS.red}Error: ${error}${COLORS.reset}\n`);
+    if (hint) process.stderr.write(`${COLORS.dim}Hint: ${hint}${COLORS.reset}\n`);
+  }
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+export async function workflowReadCommand(
+  options: WorkflowReadOptions,
+  deps: WorkflowReadDeps = defaultDeps,
+): Promise<number> {
+  const format = resolveFormat(options.format, deps.env);
+
+  // ── Validate sessionId ───────────────────────────────────────────────────
+  if (!options.sessionId) {
+    renderError(
+      format,
+      "missing required flag --sessionId",
+      "pass either the full tmux name (atomic-wf-<agent>-<name>-<runId>) or the bare 8-hex run id; use 'atomic workflow status' to discover it",
+    );
+    return 1;
+  }
+
+  const runId = resolveRunId(options.sessionId);
+  if (!runId) {
+    renderError(
+      format,
+      `"${options.sessionId}" is not a valid session id`,
+      "expected either an 'atomic-wf-…' tmux name or a bare 8-hex run id",
+    );
+    return 1;
+  }
+
+  // ── Locate run dir ───────────────────────────────────────────────────────
+  const runDir = join(deps.sessionsBaseDir(), runId);
+  try {
+    await deps.readdir(runDir);
+  } catch {
+    renderError(
+      format,
+      `no session directory at ${runDir}`,
+      "the workflow may have been killed and reaped; check 'atomic workflow status' for live runs",
+    );
+    return 1;
+  }
+
+  // ── Branch on --stageId ──────────────────────────────────────────────────
+  if (options.stageId) {
+    const match = await findStageDir(runDir, options.stageId, deps);
+    if (!match.ok) {
+      if (match.reason === "missing") {
+        const hint = match.candidates.length > 0
+          ? `available stages in this run: ${match.candidates.join(", ")}`
+          : "this run has no stage subdirectories yet — check 'atomic workflow status' for stage names";
+        renderError(format, `no stage named "${options.stageId}" in run ${runId}`, hint);
+      } else {
+        renderError(
+          format,
+          `stage "${options.stageId}" matches multiple directories in run ${runId}: ${match.candidates.join(", ")}`,
+          "this should not happen — workflow rule 4 requires unique stage names. File a bug.",
+        );
+      }
+      return 1;
+    }
+    const stageDir = join(runDir, match.dirName);
+    const files = await listEntries(stageDir, deps);
+    const payload: ReadJsonPayload = {
+      ok: true,
+      runId,
+      stageName: options.stageId,
+      path: stageDir,
+      files,
+    };
+    if (format === "json") {
+      process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+    } else {
+      process.stdout.write(renderText(payload));
+    }
+    return 0;
+  }
+
+  // ── Run dir output (no --stageId) ────────────────────────────────────────
+  const files = await listEntries(runDir, deps);
+  const stages = extractStageNames(files);
+  const payload: ReadJsonPayload = {
+    ok: true,
+    runId,
+    path: runDir,
+    files,
+    stages,
+  };
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+  } else {
+    process.stdout.write(renderText(payload));
+  }
+  return 0;
+}

--- a/packages/atomic/src/commands/cli/workflow-refresh.test.ts
+++ b/packages/atomic/src/commands/cli/workflow-refresh.test.ts
@@ -14,6 +14,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import {
   workflowRefreshCommand,
+  defaultDeps as refreshDefaultDeps,
   type WorkflowRefreshDeps,
   type RefreshJsonPayload,
 } from "./workflow-refresh.ts";
@@ -248,6 +249,25 @@ describe("workflowRefreshCommand — exit codes", () => {
     expect(payload.ok).toBe(false);
     expect(payload.error).toContain("settings.json is malformed");
   });
+
+  test("exit 1 and stderr message when bootstrap throws (text format)", async () => {
+    const deps = makeDeps(() => Promise.reject(new Error("settings.json is malformed")));
+    const exitCode = await workflowRefreshCommand({ format: "text" }, deps);
+    expect(exitCode).toBe(1);
+    expect(captured.stderr).toContain("failed to read settings");
+    expect(captured.stderr).toContain("settings.json is malformed");
+    // stdout should be untouched in text-error mode (errors go to stderr).
+    expect(captured.stdout).toBe("");
+  });
+
+  test("non-Error thrown values are coerced to strings", async () => {
+    // eslint-disable-next-line prefer-promise-reject-errors
+    const deps = makeDeps(() => Promise.reject("string-only failure"));
+    const exitCode = await workflowRefreshCommand({ format: "json" }, deps);
+    expect(exitCode).toBe(1);
+    const payload = JSON.parse(captured.stdout);
+    expect(payload.error).toContain("string-only failure");
+  });
 });
 
 describe("workflowRefreshCommand — format resolution", () => {
@@ -318,6 +338,23 @@ describe("workflowRefreshCommand — text output (LM-scrapeable lines)", () => {
     await workflowRefreshCommand({ format: "text" }, makeDeps(result));
     expect(captured.stdout).toContain("/work/proj/.atomic/settings.json");
     expect(captured.stdout).toContain("/home/u/.atomic/settings.json");
+  });
+});
+
+describe("defaultDeps", () => {
+  test("cwd() returns process.cwd()", () => {
+    expect(refreshDefaultDeps.cwd()).toBe(process.cwd());
+  });
+
+  test("env(name) reads from process.env", () => {
+    const original = process.env.ATOMIC_REFRESH_DEPS_TEST;
+    process.env.ATOMIC_REFRESH_DEPS_TEST = "ok";
+    try {
+      expect(refreshDefaultDeps.env("ATOMIC_REFRESH_DEPS_TEST")).toBe("ok");
+    } finally {
+      if (original === undefined) delete process.env.ATOMIC_REFRESH_DEPS_TEST;
+      else process.env.ATOMIC_REFRESH_DEPS_TEST = original;
+    }
   });
 });
 

--- a/packages/atomic/src/commands/cli/workflow-refresh.test.ts
+++ b/packages/atomic/src/commands/cli/workflow-refresh.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Unit tests for `atomic workflow refresh`.
+ *
+ * The command is a thin renderer over `bootstrapCustomWorkflows()`.  These
+ * tests inject a fake bootstrap result so we don't spawn real subprocesses,
+ * and assert:
+ *   - format auto-detection (ATOMIC_AGENT → json, otherwise → text)
+ *   - explicit `--format` overrides
+ *   - exit-code rules (loaded vs broken vs all-broken vs bootstrap-throws)
+ *   - JSON payload shape (the LM-facing contract)
+ *   - text output line shape (each diagnostic field on its own `key · value` line)
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import {
+  workflowRefreshCommand,
+  type WorkflowRefreshDeps,
+  type RefreshJsonPayload,
+} from "./workflow-refresh.ts";
+import type { BootstrapResult, LoadedWorkflow } from "../custom-workflows.ts";
+import type { AgentType, BrokenWorkflow, ExternalWorkflow } from "@bastani/atomic-sdk";
+import { createBuiltinRegistry } from "../builtin-registry.ts";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function loaded(
+  alias: string,
+  origin: "local" | "global",
+  agent: AgentType,
+  name = alias,
+): LoadedWorkflow {
+  const wf: ExternalWorkflow = {
+    kind: "external",
+    name,
+    agent,
+    description: `desc for ${name}`,
+    inputs: [
+      { name: "target", type: "text", required: true, description: "the target" },
+    ],
+    source: { command: "bunx", args: [`./.atomic/workflows/${alias}/index.ts`] },
+  };
+  return { alias, origin, workflow: wf };
+}
+
+function broken(
+  alias: string,
+  origin: "local" | "global",
+  agents: AgentType[],
+  source: string,
+): BrokenWorkflow {
+  return {
+    alias,
+    origin,
+    agents,
+    reason: `"${alias}": metadata emission timed out`,
+    fix: `add 'await hostLocalWorkflows([wf])' after .compile() in ${alias}`,
+    source,
+  };
+}
+
+function fakeBootstrapResult(opts: {
+  loaded?: LoadedWorkflow[];
+  broken?: BrokenWorkflow[];
+  globalPath?: string;
+  localPath?: string;
+}): BootstrapResult {
+  const brokenList = opts.broken ?? [];
+  const brokenIndex = new Map<string, BrokenWorkflow>();
+  for (const b of brokenList) {
+    for (const a of b.agents) brokenIndex.set(`${a}/${b.alias}`, b);
+  }
+  return {
+    registry: createBuiltinRegistry(),
+    brokenList,
+    brokenIndex,
+    summary: null,
+    loaded: opts.loaded ?? [],
+    paths: {
+      global: opts.globalPath ?? "/home/u/.atomic/settings.json",
+      local: opts.localPath ?? "/work/proj/.atomic/settings.json",
+    },
+  };
+}
+
+// ─── Output capture ──────────────────────────────────────────────────────────
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  restore: () => void;
+}
+
+function captureOutput(): Captured {
+  const c: Captured = { stdout: "", stderr: "", restore: () => {} };
+  const origStdout = process.stdout.write.bind(process.stdout);
+  const origStderr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    c.stdout += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    c.stderr += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  c.restore = () => {
+    process.stdout.write = origStdout;
+    process.stderr.write = origStderr;
+  };
+  return c;
+}
+
+// ─── Color disable so text-mode assertions stay simple ───────────────────────
+
+let originalNoColor: string | undefined;
+beforeAll(() => {
+  originalNoColor = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+});
+afterAll(() => {
+  if (originalNoColor === undefined) delete process.env.NO_COLOR;
+  else process.env.NO_COLOR = originalNoColor;
+});
+
+// ─── Dep factory ─────────────────────────────────────────────────────────────
+
+function makeDeps(
+  result: BootstrapResult | (() => Promise<BootstrapResult>),
+  envOverrides: Record<string, string> = {},
+): WorkflowRefreshDeps {
+  const bootstrapFn = typeof result === "function"
+    ? result
+    : () => Promise.resolve(result);
+  return {
+    bootstrap: bootstrapFn,
+    rebuild: () => {},
+    cwd: () => "/work/proj",
+    env: (name) => envOverrides[name],
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+let captured: Captured;
+beforeEach(() => { captured = captureOutput(); });
+afterEach(() => { captured.restore(); });
+
+describe("workflowRefreshCommand — JSON payload", () => {
+  test("loaded entries shape: alias, origin, name, agent, inputs, command, settingsKey, settingsPath", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("pr-review", "local", "claude")],
+    });
+    const exitCode = await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+    expect(exitCode).toBe(0);
+
+    const payload: RefreshJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(true);
+    expect(payload.counts).toEqual({ loaded: 1, broken: 0 });
+    expect(payload.loaded).toHaveLength(1);
+
+    const entry = payload.loaded[0]!;
+    expect(entry.alias).toBe("pr-review");
+    expect(entry.origin).toBe("local");
+    expect(entry.name).toBe("pr-review");
+    expect(entry.agent).toBe("claude");
+    expect(entry.command).toBe("bunx");
+    expect(entry.args).toEqual(["./.atomic/workflows/pr-review/index.ts"]);
+    expect(entry.settingsKey).toBe("workflows.pr-review");
+    expect(entry.settingsPath).toBe("/work/proj/.atomic/settings.json");
+    expect(entry.inputs).toHaveLength(1);
+  });
+
+  test("broken entry includes reason / fix / settingsKey / settingsPath / agents", async () => {
+    const b = broken("stale-flow", "local", ["claude"], "/work/proj/.atomic/settings.json");
+    const result = fakeBootstrapResult({ broken: [b] });
+    await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+
+    const payload: RefreshJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.broken).toHaveLength(1);
+    const entry = payload.broken[0]!;
+    expect(entry.alias).toBe("stale-flow");
+    expect(entry.origin).toBe("local");
+    expect(entry.agents).toEqual(["claude"]);
+    expect(entry.reason).toBe(b.reason);
+    expect(entry.fix).toBe(b.fix);
+    expect(entry.settingsKey).toBe("workflows.stale-flow");
+    expect(entry.settingsPath).toBe("/work/proj/.atomic/settings.json");
+  });
+
+  test("loaded settingsPath uses global path for global-origin entries", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("g-flow", "global", "copilot")],
+      globalPath: "/home/u/.atomic/settings.json",
+    });
+    await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+    const payload: RefreshJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.loaded[0]!.settingsPath).toBe("/home/u/.atomic/settings.json");
+  });
+});
+
+describe("workflowRefreshCommand — exit codes", () => {
+  test("ok=true and exit 0 when only loaded entries", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("a", "local", "claude")],
+    });
+    const exitCode = await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+    expect(exitCode).toBe(0);
+    const payload: RefreshJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(true);
+  });
+
+  test("ok=true and exit 0 when partial: some loaded + some broken", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("a", "local", "claude")],
+      broken: [broken("b", "local", ["claude"], "/x")],
+    });
+    const exitCode = await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+    // Partial success — model can still act on `a`; `b` is surfaced as a warning.
+    expect(exitCode).toBe(0);
+    const payload: RefreshJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(true);
+    expect(payload.counts).toEqual({ loaded: 1, broken: 1 });
+  });
+
+  test("ok=false and exit 1 when ALL broken", async () => {
+    const result = fakeBootstrapResult({
+      broken: [broken("b", "local", ["claude"], "/x")],
+    });
+    const exitCode = await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+    expect(exitCode).toBe(1);
+    const payload: RefreshJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(false);
+  });
+
+  test("ok=true and exit 0 when settings.json has no workflows (empty result)", async () => {
+    const result = fakeBootstrapResult({});
+    const exitCode = await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+    expect(exitCode).toBe(0);
+    const payload: RefreshJsonPayload = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(true);
+    expect(payload.counts).toEqual({ loaded: 0, broken: 0 });
+  });
+
+  test("exit 1 and JSON error envelope when bootstrap throws", async () => {
+    const deps = makeDeps(() => Promise.reject(new Error("settings.json is malformed")));
+    const exitCode = await workflowRefreshCommand({ format: "json" }, deps);
+    expect(exitCode).toBe(1);
+    const payload = JSON.parse(captured.stdout);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("settings.json is malformed");
+  });
+});
+
+describe("workflowRefreshCommand — format resolution", () => {
+  test("ATOMIC_AGENT in env auto-defaults to json (no explicit --format)", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("a", "local", "claude")],
+    });
+    const deps = makeDeps(result, { ATOMIC_AGENT: "claude" });
+    await workflowRefreshCommand({}, deps);
+    // JSON output is parseable; text output has a "Reloaded" header line.
+    expect(() => JSON.parse(captured.stdout)).not.toThrow();
+  });
+
+  test("no ATOMIC_AGENT defaults to text", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("a", "local", "claude")],
+    });
+    await workflowRefreshCommand({}, makeDeps(result));
+    expect(captured.stdout).toContain("Reloaded 1 workflow(s)");
+    expect(() => JSON.parse(captured.stdout)).toThrow();
+  });
+
+  test("explicit --format=text wins over ATOMIC_AGENT", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("a", "local", "claude")],
+    });
+    const deps = makeDeps(result, { ATOMIC_AGENT: "claude" });
+    await workflowRefreshCommand({ format: "text" }, deps);
+    expect(captured.stdout).toContain("Reloaded 1 workflow(s)");
+  });
+
+  test("explicit --format=json wins when no ATOMIC_AGENT set", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("a", "local", "claude")],
+    });
+    await workflowRefreshCommand({ format: "json" }, makeDeps(result));
+    expect(() => JSON.parse(captured.stdout)).not.toThrow();
+  });
+});
+
+describe("workflowRefreshCommand — text output (LM-scrapeable lines)", () => {
+  test("each broken-entry diagnostic sits on its own `key · value` line", async () => {
+    const b = broken("stale-flow", "local", ["claude"], "/work/proj/.atomic/settings.json");
+    const result = fakeBootstrapResult({ broken: [b] });
+    await workflowRefreshCommand({ format: "text" }, makeDeps(result));
+
+    // Each field is on its own line so an LM screen-scraping the output can
+    // match `^    reason · ` etc. without prose parsing.
+    expect(captured.stdout).toMatch(/reason\s+·\s+"stale-flow": metadata emission timed out/);
+    expect(captured.stdout).toMatch(/fix\s+·\s+add 'await hostLocalWorkflows/);
+    expect(captured.stdout).toMatch(/settings\s+·\s+\/work\/proj\/.atomic\/settings.json \(workflows\.stale-flow\)/);
+  });
+
+  test("loaded-entry detail includes alias, name, agent, command, settings line", async () => {
+    const result = fakeBootstrapResult({
+      loaded: [loaded("pr-review", "local", "claude")],
+    });
+    await workflowRefreshCommand({ format: "text" }, makeDeps(result));
+    expect(captured.stdout).toContain("pr-review");
+    expect(captured.stdout).toMatch(/name\s+·\s+pr-review/);
+    expect(captured.stdout).toMatch(/agent\s+·\s+claude/);
+    expect(captured.stdout).toMatch(/command\s+·\s+bunx \.\/\.atomic\/workflows\/pr-review\/index\.ts/);
+    expect(captured.stdout).toMatch(/settings\s+·\s+\/work\/proj\/.atomic\/settings.json \(workflows\.pr-review\)/);
+  });
+
+  test("empty state names both candidate settings paths", async () => {
+    const result = fakeBootstrapResult({});
+    await workflowRefreshCommand({ format: "text" }, makeDeps(result));
+    expect(captured.stdout).toContain("/work/proj/.atomic/settings.json");
+    expect(captured.stdout).toContain("/home/u/.atomic/settings.json");
+  });
+});
+
+describe("workflowRefreshCommand — registry hot-swap", () => {
+  test("calls deps.rebuild with the merged registry + brokenIndex + brokenList", async () => {
+    const calls: Parameters<WorkflowRefreshDeps["rebuild"]>[] = [];
+    const rebuild: WorkflowRefreshDeps["rebuild"] = (registry, brokenIndex, brokenList) => {
+      calls.push([registry, brokenIndex, brokenList]);
+    };
+    const b = broken("b", "local", ["claude"], "/x");
+    const result = fakeBootstrapResult({
+      loaded: [loaded("a", "local", "claude")],
+      broken: [b],
+    });
+    const deps: WorkflowRefreshDeps = {
+      bootstrap: () => Promise.resolve(result),
+      rebuild,
+      cwd: () => "/work/proj",
+      env: () => undefined,
+    };
+    await workflowRefreshCommand({ format: "json" }, deps);
+
+    expect(calls).toHaveLength(1);
+    const args = calls[0]!;
+    expect(args[0]).toBe(result.registry);
+    expect(args[1]).toBe(result.brokenIndex);
+    expect(args[2]).toBe(result.brokenList);
+  });
+});

--- a/packages/atomic/src/commands/cli/workflow-refresh.ts
+++ b/packages/atomic/src/commands/cli/workflow-refresh.ts
@@ -68,7 +68,7 @@ export interface WorkflowRefreshDeps {
   env: (name: string) => string | undefined;
 }
 
-const defaultDeps: WorkflowRefreshDeps = {
+export const defaultDeps: WorkflowRefreshDeps = {
   bootstrap: bootstrapCustomWorkflows,
   rebuild: rebuildWorkflowCommand,
   cwd: () => process.cwd(),

--- a/packages/atomic/src/commands/cli/workflow-refresh.ts
+++ b/packages/atomic/src/commands/cli/workflow-refresh.ts
@@ -1,0 +1,347 @@
+/**
+ * `atomic workflow refresh` — re-spawn the metadata loaders for every
+ * `workflows.<alias>` entry in `~/.atomic/settings.json` (global) and
+ * `<cwd>/.atomic/settings.json` (local), merge them into the active
+ * registry, and report the result.
+ *
+ * Why this exists: when an LM authors a new custom workflow under
+ * `.atomic/workflows/<name>/` and edits `settings.json`, it needs an
+ * explicit confirmation that the entry parsed, the metadata subprocess
+ * succeeded, and the workflow is now invocable via
+ * `atomic workflow -n <name> -a <agent>`. Bootstrap runs on every CLI
+ * invocation, so technically the refresh is a no-op in terms of process
+ * state — but it produces a single, structured, LM-actionable report
+ * that ends the "did this work?" conversation in one command.
+ *
+ * Output is engineered for an LM consumer:
+ *   - `--format text` (TTY default) — colourised, but every diagnostic
+ *     line is a `key · value` pair so an LM screen-scraping the output
+ *     can extract reason / fix / source / command without parsing prose.
+ *   - `--format json` (default inside an atomic chat session, detected
+ *     via `ATOMIC_AGENT`) — fully structured payload with the same
+ *     fields as the text view.
+ *
+ * Exit codes:
+ *   0 — every entry loaded clean, OR there were broken entries but at
+ *       least one entry loaded (broken entries are surfaced as warnings
+ *       so the model can fix them without aborting follow-up work).
+ *   1 — every entry was broken, OR there were broken entries and zero
+ *       loaded (i.e. nothing the model can run yet).
+ *
+ * Note: an empty settings.json (no `workflows` map) returns 0 with an
+ * empty payload — that's a valid state, not an error.
+ */
+
+import {
+  COLORS,
+  createPainter,
+} from "@bastani/atomic-sdk/theme/colors";
+import type {
+  BrokenWorkflow,
+  ExternalWorkflow,
+  WorkflowInput,
+} from "@bastani/atomic-sdk";
+import {
+  bootstrapCustomWorkflows,
+  type BootstrapResult,
+  type LoadedWorkflow,
+} from "../custom-workflows.ts";
+import { rebuildWorkflowCommand } from "./workflow.ts";
+
+export type RefreshFormat = "text" | "json";
+
+export interface WorkflowRefreshOptions {
+  /**
+   * `text` for human consumption, `json` for LMs / scripts. When omitted,
+   * defaults to `json` if `ATOMIC_AGENT` is set in the env (i.e. the caller
+   * is running inside an atomic chat session and the consumer is an LM),
+   * otherwise `text`.
+   */
+  format?: RefreshFormat;
+}
+
+export interface WorkflowRefreshDeps {
+  bootstrap: (projectDir: string) => Promise<BootstrapResult>;
+  rebuild: typeof rebuildWorkflowCommand;
+  cwd: () => string;
+  /** Read an env var. Injected so tests can simulate ATOMIC_AGENT presence. */
+  env: (name: string) => string | undefined;
+}
+
+const defaultDeps: WorkflowRefreshDeps = {
+  bootstrap: bootstrapCustomWorkflows,
+  rebuild: rebuildWorkflowCommand,
+  cwd: () => process.cwd(),
+  env: (name) => process.env[name],
+};
+
+// ─── JSON payload shape (stable contract — LMs parse this) ───────────────────
+
+export interface RefreshLoadedJson {
+  alias: string;
+  origin: "local" | "global";
+  name: string;
+  agent: string;
+  description: string;
+  inputs: WorkflowInput[];
+  command: string;
+  args: string[];
+  /** `workflows.<alias>` — the JSON Pointer-ish key the model edits in settings.json. */
+  settingsKey: string;
+  /** Absolute path of the settings.json the entry was read from. */
+  settingsPath: string;
+}
+
+export interface RefreshBrokenJson {
+  alias: string;
+  origin: "local" | "global";
+  agents: readonly string[];
+  reason: string;
+  fix: string;
+  settingsKey: string;
+  settingsPath: string;
+}
+
+export interface RefreshJsonPayload {
+  ok: boolean;
+  counts: { loaded: number; broken: number };
+  paths: { global: string; local: string };
+  loaded: RefreshLoadedJson[];
+  broken: RefreshBrokenJson[];
+}
+
+// ─── Format resolution ───────────────────────────────────────────────────────
+
+function resolveFormat(
+  explicit: RefreshFormat | undefined,
+  env: WorkflowRefreshDeps["env"],
+): RefreshFormat {
+  if (explicit) return explicit;
+  // Inside an atomic chat session the agent (LM) is the consumer; emit
+  // structured JSON by default so it can ingest results without prose
+  // parsing. ATOMIC_AGENT is baked into every chat-launcher env (see
+  // `commands/cli/chat/index.ts`) and the workflow runtime env (see
+  // `sdk/runtime/executor.ts`).
+  return env("ATOMIC_AGENT") ? "json" : "text";
+}
+
+// ─── Payload assembly ────────────────────────────────────────────────────────
+
+function pickSettingsPath(
+  origin: "local" | "global",
+  paths: BootstrapResult["paths"],
+): string {
+  return origin === "local" ? paths.local : paths.global;
+}
+
+function loadedToJson(
+  entry: LoadedWorkflow,
+  paths: BootstrapResult["paths"],
+): RefreshLoadedJson {
+  const wf: ExternalWorkflow = entry.workflow;
+  return {
+    alias: entry.alias,
+    origin: entry.origin,
+    name: wf.name,
+    agent: wf.agent,
+    description: wf.description ?? "",
+    inputs: [...wf.inputs],
+    command: wf.source.command,
+    args: [...wf.source.args],
+    settingsKey: `workflows.${entry.alias}`,
+    settingsPath: pickSettingsPath(entry.origin, paths),
+  };
+}
+
+function brokenToJson(entry: BrokenWorkflow): RefreshBrokenJson {
+  return {
+    alias: entry.alias,
+    origin: entry.origin,
+    agents: entry.agents,
+    reason: entry.reason,
+    fix: entry.fix,
+    settingsKey: `workflows.${entry.alias}`,
+    settingsPath: entry.source,
+  };
+}
+
+function buildPayload(result: BootstrapResult): RefreshJsonPayload {
+  const loaded = result.loaded.map((l) => loadedToJson(l, result.paths));
+  const broken = result.brokenList.map(brokenToJson);
+  // ok = "the model can act on at least one workflow and isn't blocked
+  // entirely by load failures". An all-empty result is also ok (valid
+  // empty state — nothing to fix, nothing to run).
+  const ok = broken.length === 0 || loaded.length > 0;
+  return {
+    ok,
+    counts: { loaded: loaded.length, broken: broken.length },
+    paths: result.paths,
+    loaded,
+    broken,
+  };
+}
+
+// ─── Text renderer ───────────────────────────────────────────────────────────
+
+function formatInputForDisplay(input: WorkflowInput): string {
+  const requiredTag = input.required ? "required" : "optional";
+  const typeTag = input.type === "enum"
+    ? `enum[${(input.values ?? []).join("|")}]`
+    : input.type;
+  const defaultTag =
+    "default" in input && input.default !== undefined
+      ? `, default=${JSON.stringify(input.default)}`
+      : "";
+  return `${input.name} (${typeTag}, ${requiredTag}${defaultTag})`;
+}
+
+function renderText(payload: RefreshJsonPayload): string {
+  const paint = createPainter();
+  const lines: string[] = [];
+
+  // ── Header ────────────────────────────────────────────────────────────────
+  lines.push("");
+  lines.push(
+    "  " +
+      paint("text", `Reloaded ${payload.counts.loaded} workflow(s)`, { bold: true }) +
+      paint("dim", " · ") +
+      paint(
+        payload.counts.broken > 0 ? "warning" : "dim",
+        `${payload.counts.broken} broken`,
+      ),
+  );
+
+  // ── Loaded section ────────────────────────────────────────────────────────
+  if (payload.loaded.length > 0) {
+    lines.push("");
+    lines.push("  " + paint("dim", "LOADED"));
+    for (const w of payload.loaded) {
+      lines.push("");
+      lines.push(
+        "  " +
+          paint("success", "✓") +
+          " " +
+          paint("text", w.alias, { bold: true }) +
+          "  " +
+          paint("dim", `(${w.origin})`),
+      );
+      lines.push("    " + paint("dim", "name    · ") + paint("text", w.name));
+      lines.push("    " + paint("dim", "agent   · ") + paint("accent", w.agent));
+      if (w.description) {
+        lines.push("    " + paint("dim", "desc    · ") + paint("text", w.description));
+      }
+      const inputsLine =
+        w.inputs.length === 0
+          ? paint("dim", "(none)")
+          : w.inputs.map(formatInputForDisplay).join(", ");
+      lines.push("    " + paint("dim", "inputs  · ") + inputsLine);
+      const cmdLine = [w.command, ...w.args].join(" ");
+      lines.push("    " + paint("dim", "command · ") + paint("text", cmdLine));
+      lines.push(
+        "    " +
+          paint("dim", "settings · ") +
+          paint("text", `${w.settingsPath} (${w.settingsKey})`),
+      );
+    }
+  }
+
+  // ── Broken section ────────────────────────────────────────────────────────
+  if (payload.broken.length > 0) {
+    lines.push("");
+    lines.push("  " + paint("error", "BROKEN"));
+    for (const b of payload.broken) {
+      lines.push("");
+      lines.push(
+        "  " +
+          paint("error", "✗") +
+          " " +
+          paint("error", b.alias) +
+          "  " +
+          paint("dim", `(${b.origin})`) +
+          "  " +
+          paint("dim", `agents: ${b.agents.join(", ")}`),
+      );
+      // Reason / fix / settings on their own lines so an LM screen-scraping
+      // the output can match `^    reason · ` etc. without prose parsing.
+      lines.push("    " + paint("dim", "reason   · ") + paint("text", b.reason));
+      lines.push("    " + paint("dim", "fix      · ") + paint("text", b.fix));
+      lines.push(
+        "    " +
+          paint("dim", "settings · ") +
+          paint("text", `${b.settingsPath} (${b.settingsKey})`),
+      );
+    }
+  }
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+  if (payload.loaded.length === 0 && payload.broken.length === 0) {
+    lines.push("");
+    lines.push(
+      "  " +
+        paint("dim", "No custom workflows registered. ") +
+        paint("text", "Edit ") +
+        paint("text", payload.paths.local, { bold: true }) +
+        paint("text", " (project) or ") +
+        paint("text", payload.paths.global, { bold: true }) +
+        paint("text", " (global) to add one."),
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n") + "\n";
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+/**
+ * Re-load custom workflows and render the report. Returns the process
+ * exit code.
+ */
+export async function workflowRefreshCommand(
+  options: WorkflowRefreshOptions = {},
+  deps: WorkflowRefreshDeps = defaultDeps,
+): Promise<number> {
+  const format = resolveFormat(options.format, deps.env);
+
+  let result: BootstrapResult;
+  try {
+    result = await deps.bootstrap(deps.cwd());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (format === "json") {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            ok: false,
+            error: `failed to read settings: ${message}`,
+            counts: { loaded: 0, broken: 0 },
+            loaded: [],
+            broken: [],
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+    } else {
+      process.stderr.write(
+        `${COLORS.red}Error: failed to read settings: ${message}${COLORS.reset}\n`,
+      );
+    }
+    return 1;
+  }
+
+  // Hot-swap the singleton command tree so any subsequent in-process
+  // calls (currently none — the CLI exits after this — but reserved for
+  // future REPL-style hosts) see the freshly-merged registry.
+  deps.rebuild(result.registry, result.brokenIndex, result.brokenList);
+
+  const payload = buildPayload(result);
+
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+  } else {
+    process.stdout.write(renderText(payload));
+  }
+
+  return payload.ok ? 0 : 1;
+}

--- a/packages/atomic/src/commands/custom-workflows.ts
+++ b/packages/atomic/src/commands/custom-workflows.ts
@@ -9,10 +9,15 @@
  */
 
 import { randomBytes } from "node:crypto";
-import type { CustomWorkflowEntry } from "@bastani/atomic-sdk/services/config/atomic-config";
+import {
+  getGlobalSettingsPath,
+  getLocalSettingsPath,
+  readAtomicConfigSplit,
+  type CustomWorkflowEntry,
+} from "@bastani/atomic-sdk/services/config/atomic-config";
 import type { AgentType, BrokenWorkflow, ExternalWorkflow, WorkflowInput } from "@bastani/atomic-sdk";
 import { listWorkflows } from "@bastani/atomic-sdk";
-import type { createBuiltinRegistry } from "./builtin-registry.ts";
+import { createBuiltinRegistry } from "./builtin-registry.ts";
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -357,4 +362,51 @@ export function mergeIntoRegistry(
       : null;
 
   return { registry, brokenList, brokenIndex, summary };
+}
+
+// ─── Bootstrap (read settings → load → merge) ────────────────────────────────
+
+/**
+ * Result of `bootstrapCustomWorkflows`. Extends `MergeResult` with the raw
+ * `LoadedWorkflow` list so callers (refresh CLI, telemetry) can render
+ * per-entry detail (alias, origin) that isn't preserved on the merged registry.
+ *
+ * Also includes the resolved settings paths so diagnostics can name the
+ * exact file the user must edit to fix a broken entry.
+ */
+export interface BootstrapResult extends MergeResult {
+  loaded: LoadedWorkflow[];
+  paths: { global: string; local: string };
+}
+
+/**
+ * Read global + local `settings.json`, spawn each entry's metadata
+ * subprocess, and merge the results into a builtin-seeded registry.
+ *
+ * Pure data flow — does not mutate the active workflow command. Callers
+ * are responsible for invoking `rebuildWorkflowCommand(...)` with the
+ * returned `registry` and `brokenIndex` if they need the singleton CLI
+ * to reflect the new state.
+ */
+export async function bootstrapCustomWorkflows(
+  projectDir: string = process.cwd(),
+): Promise<BootstrapResult> {
+  const globalPath = getGlobalSettingsPath();
+  const localPath = getLocalSettingsPath(projectDir);
+
+  const { global: globalCfg, local: localCfg } =
+    await readAtomicConfigSplit(projectDir);
+
+  const [globalRes, localRes] = await Promise.all([
+    loadCustomWorkflows(globalCfg?.workflows, "global", globalPath),
+    loadCustomWorkflows(localCfg?.workflows, "local", localPath),
+  ]);
+
+  const merge = mergeIntoRegistry(createBuiltinRegistry(), globalRes, localRes);
+
+  return {
+    ...merge,
+    loaded: [...globalRes.loaded, ...localRes.loaded],
+    paths: { global: globalPath, local: localPath },
+  };
 }


### PR DESCRIPTION
## Summary

Adds two new `atomic workflow` subcommands designed for LM consumers, extracts bootstrap logic into a shared helper, rewrites the workflow-creator skill around two explicit custom-workflow modes, and extends the README with registration docs and CLI reference rows.

## Changes

### New commands

- **`atomic workflow refresh [--format json|text]`** — re-spawns the metadata loader for every `workflows.<alias>` entry in `~/.atomic/settings.json` and `<cwd>/.atomic/settings.json` and reports loaded + broken entries. Each broken entry exposes `reason`, `fix`, and `settings · <path> (workflows.<alias>)` on its own line so an LM can self-correct without prose parsing. Auto-defaults to JSON when `ATOMIC_AGENT` is set.
- **`atomic workflow read --sessionId <id> [--stageId <name>]`** — resolves the on-disk directory under `~/.atomic/sessions/<runId>/` for a workflow run or a single stage and prints `stage / run / path / files`. Accepts both the full tmux name (`atomic-wf-claude-ralph-a1b2c3d4`) and the bare 8-hex run id; `--stageId` globs `<name>-<8hex>` to avoid prefix collisions. Same `ATOMIC_AGENT`-aware format auto-detection.

### Refactoring

- **Bootstrap extracted** — `bootstrapCustomWorkflows()` moves to `commands/custom-workflows.ts` and returns a `BootstrapResult` (extends `MergeResult` with `loaded[]` and `paths`) so `cli.ts:main()` and the `refresh` subcommand share one data flow without duplication.

### Docs / skill updates

- **Workflow-creator skill rewritten** around two explicit modes: Mode 1 (atomic-managed under `.atomic/workflows/<name>/`, registered in `settings.json`, verified via `atomic workflow refresh`) is the default; Mode 2 (dev-owned CLI in `src/workflows/<name>/<agent>.ts`) is fully covered. `running-workflows.md` gains a polling-rhythm section and an "Inspecting on-disk state with `atomic workflow read`" walkthrough; `agent-setup-recipe.md` Steps 3/4/5 split into Mode-1/Mode-2 branches with a broken-entry symptom→fix table.
- **README** — `refresh`, `read`, `status`, `inputs` rows added to the CLI Commands Reference; new "Registering your own workflows" section with package shape, `settings.json` entry, and verification step; `workflows` field added to the settings schema table.

### Tests

45 new tests (18 refresh + 27 read) covering format auto-detection, exit-code rules, runId resolution (bare-hex vs tmux-name), stage glob matching, error envelopes, empty-state hints, and the exported `defaultDeps`.

## Test plan

- [x] `bun typecheck` clean across all workspaces
- [x] `bun run lint` clean (oxlint + lint-custom-workflows)
- [x] `bun run test:coverage` — 2185 pass / 0 fail; per-file function coverage 100% on both new files; repo-wide threshold of 85% holds
- [x] Manual smoke: `atomic workflow refresh --format text` and `--format json` against an empty `settings.json`
- [x] Manual smoke: `atomic workflow read --sessionId deadbeef` (missing dir) renders both formats correctly
- [x] Confirmed `ATOMIC_AGENT`-driven format auto-detection with and without the env var set

> Note: `specs/2026-05-07-atomic-workflow-send-command.md` is excluded — that's a separate spec for sending messages to running workflows.