### PR TITLE
fix(dispatch): break host-local-workflows import cycle that crashed binary dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,18 @@ jobs:
             - name: Run linting
               run: bun run lint
 
+            # Build the host-target binary BEFORE `bun test` so the
+            # `describe.skipIf(!builtBinary)` gates in
+            # `packages/atomic-sdk/src/runtime/orchestrator-entry.test.ts`
+            # (and any future binary-gated suites) actually execute. Without
+            # this step these tests silently skip on every PR — exactly how
+            # the host-local-workflows TDZ regression slipped through. The
+            # binary-gated tests now `throw` instead of returning `null`
+            # when `process.env.CI` is set and no binary exists, so a
+            # missing build is a hard failure rather than a silent skip.
+            - name: Build host-target binary
+              run: bun packages/atomic/script/build.ts
+
             - name: Run tests with coverage
               run: |
                   set -o pipefail

--- a/packages/atomic-sdk/src/lib/auto-dispatch.ts
+++ b/packages/atomic-sdk/src/lib/auto-dispatch.ts
@@ -32,136 +32,20 @@
  * matching cases top-level-await the dispatch and exit.
  *
  * `validateDispatchToken`, `findSub`, `parseAtomicRunArgv`, and
- * `AtomicRunArgs` are exported for use by `host-local-workflows.ts` and for
- * unit testing.
+ * `AtomicRunArgs` live in `./dispatch-utils.ts` so `host-local-workflows.ts`
+ * can consume them without creating a static import cycle through this
+ * module's TLA. Re-exported here for backwards compatibility with any
+ * external consumer that imported them via this path.
  */
 
-// ─── Token-gating helper ─────────────────────────────────────────────────────
+export {
+  validateDispatchToken,
+  findSub,
+  parseAtomicRunArgv,
+  type AtomicRunArgs,
+} from "./dispatch-utils.ts";
 
-/** Minimum length of a valid dispatch token (32 hex chars = 16 bytes). */
-const MIN_TOKEN_HEX_LEN = 32;
-
-/** Pattern matching a valid hex token (0-9 a-f only, case-insensitive). */
-const HEX_RE = /^[0-9a-f]+$/i;
-
-/**
- * Validate that the dispatch token is present and consistent between
- * `process.env` and `process.argv`.
- *
- * Rules (all must pass):
- *   1. `env.ATOMIC_HOST === "1"`
- *   2. `env.ATOMIC_DISPATCH_TOKEN` is a hex string >= 32 chars.
- *   3. `argv` contains `--dispatch-token=<hex>` where `<hex>` matches
- *      the env token (case-insensitive) and is >= 32 chars.
- *
- * Exported so it can be unit-tested without spawning a subprocess.
- */
-export function validateDispatchToken(
-  env: Record<string, string | undefined>,
-  argv: readonly string[],
-): boolean {
-  if (env["ATOMIC_HOST"] !== "1") return false;
-
-  const envToken = env["ATOMIC_DISPATCH_TOKEN"] ?? "";
-  if (envToken.length < MIN_TOKEN_HEX_LEN || !HEX_RE.test(envToken)) {
-    return false;
-  }
-
-  const prefix = "--dispatch-token=";
-  const tokenArg = argv.find((a) => a.startsWith(prefix));
-  if (!tokenArg) return false;
-
-  const argToken = tokenArg.slice(prefix.length);
-  if (argToken.length < MIN_TOKEN_HEX_LEN || !HEX_RE.test(argToken)) {
-    return false;
-  }
-
-  return argToken.toLowerCase() === envToken.toLowerCase();
-}
-
-// ─── Subcommand scanning ─────────────────────────────────────────────────────
-
-/**
- * Known internal sub-commands that auto-dispatch.ts handles.
- * A Set lookup is O(1) and avoids false matches on positional arguments that
- * happen to share a name with a sub-command token.
- */
-const SUBS = new Set([
-  "_orchestrator-entry",
-  "_cc-debounce",
-]);
-
-/**
- * Scan `argv` starting at index 2 (the position after the runtime and script
- * tokens) for the first token that matches a known sub-command.
- *
- * Returns the sub-command string and its index, or `null` when none is found.
- *
- * Exported so tests can verify the scan logic directly without spawning a
- * subprocess.
- */
-export function findSub(argv: readonly string[]): { sub: string; index: number } | null {
-  for (let i = 2; i < argv.length; i++) {
-    const tok = argv[i]!;
-    if (SUBS.has(tok)) return { sub: tok, index: i };
-  }
-  return null;
-}
-
-// ─── Argv parser for _atomic-run ─────────────────────────────────────────────
-
-/** Parsed result from `parseAtomicRunArgv`. */
-export interface AtomicRunArgs {
-  name: string | undefined;
-  agent: string | undefined;
-  detach: boolean;
-  inputs: Record<string, string>;
-}
-
-/**
- * Parse the flags that follow the `_atomic-run` subcommand token.
- *
- * `argv` should be the slice of `process.argv` starting immediately after the
- * `_atomic-run` token (i.e. `process.argv.slice(subIndex + 1)`).
- *
- * Contract (mirrors atomic-side dispatcher):
- *   - `--name <value>` — workflow name (required by caller)
- *   - `--agent <value>` — agent name (required by caller)
- *   - `--detach` — boolean flag
- *   - `--dispatch-token=<hex>` — consumed by validateDispatchToken; skipped here
- *   - `--<key> <value>` — workflow input; value consumed unconditionally so that
- *     values starting with `--` (e.g. `--rev origin/main`) are preserved correctly.
- *
- * Reserved flags (`--name`, `--agent`, `--detach`, `--dispatch-token=`) are
- * matched in earlier branches, so the generic input branch only fires for
- * user-defined input names.
- *
- * Exported for unit testing.
- */
-export function parseAtomicRunArgv(argv: readonly string[]): AtomicRunArgs {
-  let name: string | undefined;
-  let agent: string | undefined;
-  let detach = false;
-  const inputs: Record<string, string> = {};
-
-  for (let i = 0; i < argv.length; i++) {
-    const tok = argv[i]!;
-    if (tok === "--name" && i + 1 < argv.length) {
-      name = argv[++i];
-    } else if (tok === "--agent" && i + 1 < argv.length) {
-      agent = argv[++i];
-    } else if (tok === "--detach") {
-      detach = true;
-    } else if (tok.startsWith("--dispatch-token=")) {
-      // Already consumed by validateDispatchToken — skip.
-    } else if (tok.startsWith("--") && i + 1 < argv.length) {
-      // Atomic-side dispatcher always emits --<key> <value>; consume unconditionally.
-      inputs[tok.slice(2)] = argv[++i]!;
-    }
-  }
-
-  return { name, agent, detach, inputs };
-}
+import { findSub } from "./dispatch-utils.ts";
 
 // ─── Argv dispatch ────────────────────────────────────────────────────────────
 

--- a/packages/atomic-sdk/src/lib/dispatch-utils.ts
+++ b/packages/atomic-sdk/src/lib/dispatch-utils.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure helpers shared by `auto-dispatch.ts` and `host-local-workflows.ts`.
+ *
+ * Lives in its own module — with no top-level await and no other SDK imports —
+ * so both consumers can import it without introducing a static cycle.
+ *
+ * The cycle this avoids: `host-local-workflows.ts` → `auto-dispatch.ts` (whose
+ * module-bottom TLA dynamic-imports `runtime/orchestrator-entry.ts`) →
+ * `host-local-workflows.ts` (still suspended on its first import). When the
+ * orchestrator path called `lookupLocalWorkflow`, `localWorkflowRegistry` was
+ * still in TDZ and the binary crashed with "undefined is not an object".
+ *
+ * `auto-dispatch.ts` re-exports these names so any external consumer that
+ * reached for them via that path keeps working.
+ */
+
+// ─── Token-gating ────────────────────────────────────────────────────────────
+
+/** Minimum length of a valid dispatch token (32 hex chars = 16 bytes). */
+const MIN_TOKEN_HEX_LEN = 32;
+
+/** Pattern matching a valid hex token (0-9 a-f only, case-insensitive). */
+const HEX_RE = /^[0-9a-f]+$/i;
+
+/**
+ * Validate that the dispatch token is present and consistent between
+ * `process.env` and `process.argv`.
+ *
+ * Rules (all must pass):
+ *   1. `env.ATOMIC_HOST === "1"`
+ *   2. `env.ATOMIC_DISPATCH_TOKEN` is a hex string >= 32 chars.
+ *   3. `argv` contains `--dispatch-token=<hex>` where `<hex>` matches
+ *      the env token (case-insensitive) and is >= 32 chars.
+ */
+export function validateDispatchToken(
+  env: Record<string, string | undefined>,
+  argv: readonly string[],
+): boolean {
+  if (env["ATOMIC_HOST"] !== "1") return false;
+
+  const envToken = env["ATOMIC_DISPATCH_TOKEN"] ?? "";
+  if (envToken.length < MIN_TOKEN_HEX_LEN || !HEX_RE.test(envToken)) {
+    return false;
+  }
+
+  const prefix = "--dispatch-token=";
+  const tokenArg = argv.find((a) => a.startsWith(prefix));
+  if (!tokenArg) return false;
+
+  const argToken = tokenArg.slice(prefix.length);
+  if (argToken.length < MIN_TOKEN_HEX_LEN || !HEX_RE.test(argToken)) {
+    return false;
+  }
+
+  return argToken.toLowerCase() === envToken.toLowerCase();
+}
+
+// ─── Subcommand scanning ─────────────────────────────────────────────────────
+
+/**
+ * Known internal sub-commands that auto-dispatch.ts handles.
+ * A Set lookup is O(1) and avoids false matches on positional arguments that
+ * happen to share a name with a sub-command token.
+ */
+const SUBS = new Set([
+  "_orchestrator-entry",
+  "_cc-debounce",
+]);
+
+/**
+ * Scan `argv` starting at index 2 (the position after the runtime and script
+ * tokens) for the first token that matches a known sub-command.
+ *
+ * Returns the sub-command string and its index, or `null` when none is found.
+ */
+export function findSub(argv: readonly string[]): { sub: string; index: number } | null {
+  for (let i = 2; i < argv.length; i++) {
+    const tok = argv[i]!;
+    if (SUBS.has(tok)) return { sub: tok, index: i };
+  }
+  return null;
+}
+
+// ─── Argv parser for _atomic-run ─────────────────────────────────────────────
+
+/** Parsed result from `parseAtomicRunArgv`. */
+export interface AtomicRunArgs {
+  name: string | undefined;
+  agent: string | undefined;
+  detach: boolean;
+  inputs: Record<string, string>;
+}
+
+/**
+ * Parse the flags that follow the `_atomic-run` subcommand token.
+ *
+ * `argv` should be the slice of `process.argv` starting immediately after the
+ * `_atomic-run` token (i.e. `process.argv.slice(subIndex + 1)`).
+ *
+ * Contract (mirrors atomic-side dispatcher):
+ *   - `--name <value>` — workflow name (required by caller)
+ *   - `--agent <value>` — agent name (required by caller)
+ *   - `--detach` — boolean flag
+ *   - `--dispatch-token=<hex>` — consumed by validateDispatchToken; skipped here
+ *   - `--<key> <value>` — workflow input; value consumed unconditionally so that
+ *     values starting with `--` (e.g. `--rev origin/main`) are preserved correctly.
+ *
+ * Reserved flags (`--name`, `--agent`, `--detach`, `--dispatch-token=`) are
+ * matched in earlier branches, so the generic input branch only fires for
+ * user-defined input names.
+ */
+export function parseAtomicRunArgv(argv: readonly string[]): AtomicRunArgs {
+  let name: string | undefined;
+  let agent: string | undefined;
+  let detach = false;
+  const inputs: Record<string, string> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]!;
+    if (tok === "--name" && i + 1 < argv.length) {
+      name = argv[++i];
+    } else if (tok === "--agent" && i + 1 < argv.length) {
+      agent = argv[++i];
+    } else if (tok === "--detach") {
+      detach = true;
+    } else if (tok.startsWith("--dispatch-token=")) {
+      // Already consumed by validateDispatchToken — skip.
+    } else if (tok.startsWith("--") && i + 1 < argv.length) {
+      // Atomic-side dispatcher always emits --<key> <value>; consume unconditionally.
+      inputs[tok.slice(2)] = argv[++i]!;
+    }
+  }
+
+  return { name, agent, detach, inputs };
+}

--- a/packages/atomic-sdk/src/lib/host-local-workflows.ts
+++ b/packages/atomic-sdk/src/lib/host-local-workflows.ts
@@ -34,7 +34,7 @@ import type { runWorkflow as RealRunWorkflow } from "../primitives/run.ts";
 import {
   validateDispatchToken,
   parseAtomicRunArgv,
-} from "./auto-dispatch.ts";
+} from "./dispatch-utils.ts";
 
 /**
  * Structural shape accepted by `hostLocalWorkflows()`.

--- a/packages/atomic-sdk/src/runtime/orchestrator-entry.test.ts
+++ b/packages/atomic-sdk/src/runtime/orchestrator-entry.test.ts
@@ -1,27 +1,33 @@
 /**
  * Integration test: `_orchestrator-entry` against the real compiled binary.
  *
- * Regression guard for the dev-vs-binary divergence where Bun's
- * `bun build --compile` collapses every bundled module's
- * `import.meta.path` to the binary's bunfs entry path
- * (`/$bunfs/root/<binary>`), so the `definition.source` captured at
- * workflow-module-eval time pointed at the binary itself. Before the
- * fix, dynamic-importing that path re-loaded `cli.ts` (no default
- * export) and the orchestrator pane died with
- * `"does not export a valid WorkflowDefinition"` while the launcher
- * shell exited 0 — invisible to the chat-style smoke tests.
+ * Catches dev-vs-binary divergences in the orchestrator dispatch path.
+ * Two known prior regressions this guards against:
  *
- * The fix routes binary-mode invocations through the builtin registry
- * by `name + agent`, falling back to dynamic-import for dev /
- * installed-package mode. This test exec's the real binary with the
- * post-fix launcher contract and asserts:
- *   1. The bug signature ("does not export a valid WorkflowDefinition")
- *      does not appear.
- *   2. The action gets past workflow resolution (it complains about
- *      missing ATOMIC_WF_* env, which is the next failure mode in
- *      `runOrchestrator`).
- *   3. An unknown workflow name surfaces a clean registry-miss error,
- *      not the old import-failure error.
+ *   1. `import.meta.path` collapse (bunfs): `bun build --compile`
+ *      points every bundled module's `import.meta.path` at the binary
+ *      entry, so the captured `definition.source` re-imported cli.ts
+ *      and the pane died with "does not export a valid WorkflowDefinition"
+ *      while the launcher exited 0 (silent failure).
+ *
+ *   2. Static import cycle in the SDK barrel: `host-local-workflows.ts`
+ *      → `auto-dispatch.ts` (TLA) → `orchestrator-entry.ts` →
+ *      `host-local-workflows.ts` (still suspended). The orchestrator
+ *      called `lookupLocalWorkflow` while `localWorkflowRegistry` was in
+ *      TDZ → "TypeError: undefined is not an object". Same silent-exit
+ *      shape (parent CLI returns 0). Fixed by extracting helpers into
+ *      `lib/dispatch-utils.ts` so the cycle is broken.
+ *
+ * Both bugs only manifest in compiled binaries because dev mode
+ * dispatches through the SDK's standalone cli.ts (no barrel re-export),
+ * and both surface as the orchestrator pane crashing while the parent
+ * exits 0. The assertions below combine the two bug signatures: any new
+ * "TypeError"/"ReferenceError" / "is not an object" / "does not export
+ * a valid WorkflowDefinition" output means a regression.
+ *
+ * `locateBuiltBinary()` throws (rather than returning null) when run
+ * under CI without a built binary — otherwise these tests would silently
+ * skip on every PR and the regression class would slip through.
  */
 import { test, expect, describe } from "bun:test";
 import { existsSync } from "node:fs";
@@ -48,10 +54,17 @@ describe.skipIf(!builtBinary)("compiled binary _orchestrator-entry", () => {
 
     const out = result.stdout.toString() + result.stderr.toString();
 
-    // Bug signature: pre-fix, the dynamic import re-loaded cli.ts and
-    // threw InvalidWorkflowError. The new path never imports the
-    // source, so this string must not appear.
+    // Bug signatures from the two known prior regressions (see file header).
+    // Pre-fix #1: the dynamic import re-loaded cli.ts and threw
+    // InvalidWorkflowError → "does not export a valid WorkflowDefinition".
     expect(out).not.toContain("does not export a valid WorkflowDefinition");
+    // Pre-fix #2: TDZ in localWorkflowRegistry due to static import cycle
+    // through the SDK barrel.
+    expect(out).not.toContain("undefined is not an object");
+    // Catch-all for any new module-evaluation crash on the dispatch path —
+    // a clean miss should surface a domain error (registry/env), not a
+    // runtime exception class.
+    expect(out).not.toMatch(/TypeError|ReferenceError/);
 
     // Positive signal: we got past workflow resolution into
     // runOrchestrator → validateOrchestratorEnv. The next failure mode
@@ -73,6 +86,11 @@ describe.skipIf(!builtBinary)("compiled binary _orchestrator-entry", () => {
     expect(out).toContain("no-such-workflow");
     expect(out).toContain("builtin registry");
     expect(result.exitCode).not.toBe(0);
+    // Same module-evaluation regression guards as the registry-hit case —
+    // a registry miss must come back as a clean domain error, not a
+    // runtime exception thrown from a broken import graph.
+    expect(out).not.toContain("undefined is not an object");
+    expect(out).not.toMatch(/TypeError|ReferenceError/);
   });
 });
 
@@ -92,6 +110,17 @@ function stripWorkflowEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   return out;
 }
 
+/**
+ * Resolve the host's built atomic binary, or return `null` so the
+ * `describe.skipIf(!builtBinary)` gate skips the suite locally.
+ *
+ * In CI we throw instead of returning `null`. These tests are the only
+ * regression guard for an entire class of dev-vs-binary divergence
+ * (silent orchestrator-pane crashes while the parent exits 0); a silent
+ * skip on a CI runner that forgot the build step would re-open that
+ * gap. The `checks` job in `.github/workflows/ci.yml` is responsible
+ * for running `bun packages/atomic/script/build.ts` before `bun test`.
+ */
 function locateBuiltBinary(): string | null {
   const ext = process.platform === "win32" ? ".exe" : "";
   let dir = import.meta.dir;
@@ -109,9 +138,23 @@ function locateBuiltBinary(): string | null {
         const candidate = join(distRoot, target, "bin", `atomic${ext}`);
         if (existsSync(candidate)) return candidate;
       }
+      if (process.env.CI) {
+        throw new Error(
+          `[orchestrator-entry.test] No built atomic binary found under ${distRoot}. ` +
+            `Run \`bun packages/atomic/script/build.ts\` before \`bun test\` in CI — ` +
+            `silently skipping these tests on a CI runner re-opens the dev-vs-binary ` +
+            `regression gap they exist to catch.`,
+        );
+      }
       return null;
     }
     dir = dirname(dir);
+  }
+  if (process.env.CI) {
+    throw new Error(
+      `[orchestrator-entry.test] Could not locate workspace root from ${import.meta.dir}; ` +
+        `binary-gated tests cannot run in CI without a build.`,
+    );
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Fixes a silent orchestrator-pane crash caused by a static import cycle — \`host-local-workflows.ts\` → \`auto-dispatch.ts\` (TLA) → \`orchestrator-entry.ts\` → \`host-local-workflows.ts\` (still suspended) — that left \`localWorkflowRegistry\` in TDZ during compiled-binary dispatch, surfacing as \`TypeError: undefined is not an object\` while the parent CLI exited 0. Also closes the CI gap that allowed this regression class to slip through undetected on every PR.

## Changes

### Bug fix: break static import cycle
- Extract pure dispatch helpers (`validateDispatchToken`, `findSub`, `parseAtomicRunArgv`, `AtomicRunArgs`) from `packages/atomic-sdk/src/lib/auto-dispatch.ts` into a new `lib/dispatch-utils.ts` — no top-level await, no other SDK imports — so `host-local-workflows.ts` can consume them without re-entering `auto-dispatch.ts`'s TLA
- Re-export the helpers from `auto-dispatch.ts` for backwards compatibility with any external consumer that imported via that path
- Repoint `host-local-workflows.ts` at `dispatch-utils.ts` to actually break the cycle

### Tests: expand regression guards
- Expand `runtime/orchestrator-entry.test.ts` assertions to cover both known prior regressions: the `import.meta.path` bunfs collapse (`"does not export a valid WorkflowDefinition"`) and the TDZ cycle crash (`"undefined is not an object"` / `TypeError` / `ReferenceError`)
- Document the bug taxonomy in the file header so future contributors understand why the binary-integration test exists and what each assertion guards
- `locateBuiltBinary()` now throws under `process.env.CI` instead of returning `null`, so a CI runner that missed the build step hard-fails rather than silently skipping the only regression guard for this class of dev-vs-binary divergence

### CI: build binary before tests
- Add a `Build host-target binary` step to `.github/workflows/ci.yml` before `bun test` so the `describe.skipIf(!builtBinary)`-gated suite actually executes on every PR

## Notes

- Both bugs only manifest in the compiled binary — dev mode dispatches through the SDK's standalone `cli.ts` (no barrel re-export), so unit tests against source modules cannot catch them. The integration test against the real built binary is the load-bearing regression guard.
- No public API change: the helpers remain importable from `auto-dispatch.ts` via re-export.

🤖 AI-assisted authorship: this change was prepared with Claude Code.