### PR TITLE
fix(tui): hide INPUTS header when workflow has no inputs

### DIFF
--- a/packages/atomic-sdk/src/components/workflow-picker-panel.tsx
+++ b/packages/atomic-sdk/src/components/workflow-picker-panel.tsx
@@ -1028,22 +1028,26 @@ function InputPhase({
         </text>
       </box>
 
-      <box height={2} />
+      {isStructured ? (
+        <>
+          <box height={2} />
 
-      <box flexDirection="row" height={1}>
-        <text>
-          <span fg={theme.textDim}>
-            <strong>INPUTS</strong>
-          </span>
-        </text>
-        <box flexGrow={1} />
-        <text>
-          <span fg={theme.textDim}>
-            {isStructured ? `${focusedFieldIdx + 1} / ${fields.length}` : ""}
-          </span>
-        </text>
-      </box>
-      <box height={1} />
+          <box flexDirection="row" height={1}>
+            <text>
+              <span fg={theme.textDim}>
+                <strong>INPUTS</strong>
+              </span>
+            </text>
+            <box flexGrow={1} />
+            <text>
+              <span fg={theme.textDim}>
+                {`${focusedFieldIdx + 1} / ${fields.length}`}
+              </span>
+            </text>
+          </box>
+          <box height={1} />
+        </>
+      ) : null}
 
       <scrollbox
         ref={scrollboxRef}

--- a/tests/sdk/components/workflow-picker-panel.test.tsx
+++ b/tests/sdk/components/workflow-picker-panel.test.tsx
@@ -717,8 +717,8 @@ describe("WorkflowPicker PROMPT keyboard", () => {
     }
     await press(setup, (i) => i.pressEnter());
     const frame = setup.captureCharFrame();
-    // Free-form uses the same INPUTS section label as structured workflows.
-    expect(frame).toContain("INPUTS");
+    // Workflows that declare zero inputs should not render the INPUTS header.
+    expect(frame).not.toContain("INPUTS");
     // Default field name is "prompt".
     expect(frame).toContain("prompt");
   });
@@ -1562,4 +1562,3 @@ describe("RFC §8.3 three-row snapshot: healthy + broken + healthy-selected", ()
     expect(frame).toContain("@acme/mmm-broken is installed");
   });
 });
-


### PR DESCRIPTION
Fixes #873.

When a workflow declares zero inputs, the picker was still rendering the `INPUTS` header (plus spacer rows) above an empty prompt scrollbox. This gates the whole header row + spacers on `workflow.inputs.length > 0`, so input-less workflows keep the same layout but without the dead space.

Tests: updated the existing workflow picker panel test to assert the header is absent for input-less workflows.