### PR TITLE
fix(claude): drain in-flight subagents in waitForIdle before iteration-done

### DIFF
--- a/packages/atomic-sdk/src/providers/claude.ts
+++ b/packages/atomic-sdk/src/providers/claude.ts
@@ -908,6 +908,15 @@ export async function waitForIdle(
     const sliced = msgs.length > transcriptBeforeCount
       ? msgs.slice(transcriptBeforeCount)
       : [];
+
+    // Stop hook fires on parent end_turn, but backgrounded Agent/Task
+    // sub-agents are launched as void promises in Claude Code (see
+    // src/tools/AgentTool/AgentTool.tsx in mehmoodosman/claude-code) and
+    // may still be running. Drain the inflight dir before signalling
+    // iteration-done so the orchestrator doesn't advance while children
+    // are still holding FDs/PTYs.
+    await waitForInflightDrained(sessionId);
+
     return [true, sliced];
   };
 

--- a/packages/atomic-sdk/src/providers/claude.waitForIdleDrain.test.ts
+++ b/packages/atomic-sdk/src/providers/claude.waitForIdleDrain.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression test: waitForIdle must not resolve while backgrounded Agent/Task
+ * sub-agents are still in the inflight dir.
+ *
+ * Covers the fix in handleMarker: `await waitForInflightDrained(sessionId)`
+ * must drain the inflight dir before returning [true, sliced].
+ *
+ * Strategy:
+ * - mock.module("@anthropic-ai/claude-agent-sdk") to return a terminal
+ *   assistant message so the transcript-poll loop exits immediately.
+ * - Write real marker files under ~/.atomic using a fresh UUID (no collision
+ *   risk). claudeHookDirs() is hardwired to os.homedir(); there is no
+ *   env-var override, so we use the real dir with isolated session IDs.
+ */
+
+import {
+  test,
+  expect,
+  mock,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from "bun:test";
+import { mkdir, writeFile, unlink, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import os from "node:os";
+
+// ---------------------------------------------------------------------------
+// Stub getSessionMessages BEFORE claude.ts is imported.
+// We capture and restore the real SDK to avoid cross-test contamination.
+// ---------------------------------------------------------------------------
+const actualClaudeSdk = await import("@anthropic-ai/claude-agent-sdk");
+
+const fakeEndTurnMessage = {
+  type: "assistant" as const,
+  uuid: "fake-uuid",
+  session_id: "fake-session",
+  parent_tool_use_id: null,
+  message: { stop_reason: "end_turn", content: [] },
+};
+
+beforeAll(() => {
+  mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+    ...actualClaudeSdk,
+    getSessionMessages: async () => [fakeEndTurnMessage],
+  }));
+});
+
+afterAll(() => {
+  mock.module("@anthropic-ai/claude-agent-sdk", () => ({ ...actualClaudeSdk }));
+});
+
+// Dynamic import AFTER mock is installed so claude.ts uses the stub.
+const { waitForIdle } = await import("./claude.ts");
+const { claudeHookDirs } = await import("./claude-stop-hook.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sessionPaths(sessionId: string) {
+  const dirs = claudeHookDirs();
+  return {
+    stopDir: dirs.marker,
+    stopMarker: join(dirs.marker, sessionId),
+    inflightRoot: dirs.inflight,
+    inflightDir: join(dirs.inflight, sessionId),
+    inflightMarker: join(dirs.inflight, sessionId, "fake-agent"),
+  };
+}
+
+const cleanupIds: string[] = [];
+
+afterEach(async () => {
+  for (const id of cleanupIds.splice(0)) {
+    const p = sessionPaths(id);
+    try { await unlink(p.stopMarker); } catch { /* ignore */ }
+    try { await rm(p.inflightDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Regression test
+// ---------------------------------------------------------------------------
+
+test(
+  "waitForIdle blocks while inflight marker is present, resolves after removal",
+  async () => {
+    const sessionId = randomUUID();
+    cleanupIds.push(sessionId);
+    const p = sessionPaths(sessionId);
+
+    // Create parent dirs (normally done by createClaudeSession).
+    await mkdir(p.stopDir, { recursive: true });
+    await mkdir(p.inflightRoot, { recursive: true });
+
+    // Create inflight marker: simulates a backgrounded Agent that fired
+    // SubagentStart but not SubagentStop yet.
+    await mkdir(p.inflightDir, { recursive: true });
+    await writeFile(p.inflightMarker, JSON.stringify({ ts: Date.now() }), "utf-8");
+
+    // Start waitForIdle — it will block on waitForInflightDrained after
+    // seeing the stop marker.
+    let resolved = false;
+    let resolvedValue: unknown;
+    const idlePromise = waitForIdle(sessionId, 0).then((v) => {
+      resolved = true;
+      resolvedValue = v;
+    });
+
+    // Write the stop marker so fs.watch (or the pre-attach existsSync) fires.
+    await writeFile(p.stopMarker, "", "utf-8");
+
+    // Give waitForIdle ~150ms to pick up the marker and enter the drain wait.
+    await Bun.sleep(150);
+
+    // waitForInflightDrained polls every 100ms — must NOT have resolved yet.
+    expect(resolved).toBe(false);
+
+    // Drain: remove the inflight marker.
+    await unlink(p.inflightMarker);
+
+    // waitForInflightDrained should detect the empty dir within ~200ms.
+    await Bun.sleep(250);
+
+    expect(resolved).toBe(true);
+    expect(Array.isArray(resolvedValue)).toBe(true);
+
+    // Consume the promise so Bun doesn't flag an unhandled rejection.
+    await idlePromise;
+  },
+  5000,
+);

--- a/packages/atomic-sdk/src/workflows/builtin/deep-research-codebase/helpers/file-discovery.test.ts
+++ b/packages/atomic-sdk/src/workflows/builtin/deep-research-codebase/helpers/file-discovery.test.ts
@@ -46,8 +46,6 @@ test("listAllFiles: git rung — populated repo returns tracked files", () => {
   try {
     // Init git repo
     Bun.spawnSync({ cmd: ["git", "init"], cwd: root, stdout: "pipe", stderr: "pipe" });
-    Bun.spawnSync({ cmd: ["git", "config", "user.email", "test@test.com"], cwd: root, stdout: "pipe", stderr: "pipe" });
-    Bun.spawnSync({ cmd: ["git", "config", "user.name", "Test"], cwd: root, stdout: "pipe", stderr: "pipe" });
 
     // Write and add files
     writeFileSync(join(root, "alpha.ts"), "export const a = 1;");


### PR DESCRIPTION
## Summary

\`waitForIdle\` was resolving prematurely when backgrounded \`Agent\` (Task) sub-agents were still running, because Claude Code's \`Stop\` hook fires on every parent \`end_turn\` — not when all child sub-agents finish. This caused the orchestrator to advance pipeline stages while sub-agents still held open file descriptors and PTYs.

## Root Cause

\`Stop\` is emitted from \`queryLoop\` on any \`!needsFollowUp\` iteration (\`src/query.ts\`). Backgrounded \`Agent\` invocations are launched as \`void runWithAgentContext(...)\` in \`src/tools/AgentTool/AgentTool.tsx\` — fire-and-forget, never awaited by the parent loop. There is no upstream "all sub-agents drained" hook event, so the drain must live in our runtime.

_(Validated against \`mehmoodosman/claude-code\` deobfuscated source.)_

## Changes

- **\`packages/atomic-sdk/src/providers/claude.ts\`** — \`handleMarker\` in \`waitForIdle\` now calls \`await waitForInflightDrained(sessionId)\` after the Stop marker fires. The drain machinery already existed (used by \`clearClaudeSession\` on teardown); this PR also invokes it on the logical iteration-done path. The Stop hook itself stays cheap and unconditional.

- **\`packages/atomic-sdk/src/providers/claude.waitForIdleDrain.test.ts\`** _(new)_ — Regression test: stubs the Claude SDK to return a terminal \`end_turn\` message, writes a real inflight marker file under \`~/.atomic\` using a fresh UUID, starts \`waitForIdle\`, asserts it blocks while the marker is present, then removes the marker and asserts the promise resolves within 250 ms.

- **\`packages/atomic-sdk/src/workflows/builtin/deep-research-codebase/helpers/file-discovery.test.ts\`** — Removes redundant \`git config user.email/user.name\` writes from the git-run test (not required in CI environments where git identity is already configured globally).

## Test Plan

- [x] \`bun typecheck\` — passes across all 3 workspaces
- [x] \`bun test packages/atomic-sdk/src/providers/\` — 93 tests pass
- [x] New regression test passes: \`claude.waitForIdleDrain.test.ts\`
- [x] E2E via \`examples/claude-background-subagents\` — session \`bd6e4315\` shows dispatch stage holds 27.3 s (≥ the 20 s sub-agent sleep); verify stage starts 48 ms after dispatch ends and reports SUCCESS with all three marker files present. Without the fix, dispatch ends ~immediately at parent \`end_turn\` and verify finds missing markers.

Fixes #904