### PR TITLE
docs(workflow-creator): add run contract and make skill agent-agnostic

### DIFF
--- a/.agents/skills/workflow-creator/SKILL.md
+++ b/.agents/skills/workflow-creator/SKILL.md
@@ -16,7 +16,7 @@ You also serve as a **context engineering advisor** — use the design skills li
 Two user journeys live in this skill:
 
 - **Authoring** a new workflow (or editing/debugging an existing one) → read on below.
-- **Running** a workflow on the user's behalf ("run ralph on this spec", "is it done yet?", "kill it") → go to `references/running-workflows.md`.
+- **Running** a workflow on the user's behalf ("run ralph on this spec", "run workflow x with prompt y", "is it done yet?", "kill it") → go to `references/running-workflows.md`. Treat natural-language run requests as executable tasks: detect the current agent, collect missing inputs, and run the workflow. Do not merely print the `atomic workflow ...` command unless your environment truly cannot execute shell commands.
 
 ## Reference Files
 
@@ -360,7 +360,7 @@ user runs with `bun`. The SDK exposes pure primitives:
 - **Session lifecycle** — `listSessions / getSession / stopSession / attachSession / getSessionStatus / getSessionTranscript` are exported from both the root `@bastani/atomic-sdk` barrel and the `/workflows` sub-barrel. `detachSession` is exported only from the **root** barrel (`@bastani/atomic-sdk`) — not from `/workflows`.
 - **Pane navigation** — `nextWindow / previousWindow / gotoOrchestrator` are exported only from the **root** `@bastani/atomic-sdk` barrel (not from `/workflows`). Pure tmux verbs: they update the session's current-window pointer and return immediately. Never auto-attach — an attached client sees the change live; if no client is watching, the next `attachSession` call lands on the new window. Compose `nextWindow(id) + attachSession(id)` for navigate-then-attach.
 - **Typed errors** (catch with `instanceof` to render friendly CLI messages) — `MissingDependencyError` (tmux/psmux/bun missing), `SessionNotFoundError` (id not on the atomic socket), `WorkflowNotCompiledError` (forgot `.compile()`), `InvalidWorkflowError` (default export not a `WorkflowDefinition`) all live on the `@bastani/atomic-sdk/workflows` barrel. `IncompatibleSDKError` (workflow's `minSDKVersion` newer than the installed `@bastani/atomic-sdk`) and `NoDispatcherError` (SDK can't locate its dispatcher — surfaces only when an explicit empty `pathToAtomicExecutable` defeats the auto-default) are exported separately from `@bastani/atomic-sdk/errors`. All thrown by SDK primitives; all carry the relevant payload field (`dependency`, `id`, `path`, version pair, or `searchedFor` for `NoDispatcherError`).
-- `WorkflowPickerPanel` (from `@bastani/atomic-sdk/workflows/components`) — the interactive picker `atomic workflow -a claude` uses.
+- `WorkflowPickerPanel` (from `@bastani/atomic-sdk/workflows/components`) — the interactive picker `atomic workflow -a <agent>` uses.
 
 You compose them into whatever CLI library you prefer. In `bun run` mode
 the SDK ships its own orchestrator entry script (bundled inside
@@ -467,8 +467,8 @@ Two invocation paths:
 
 ```bash
 # Single-workflow worker — flags match the workflow's declared inputs
-bun run src/claude-worker.ts --prompt "fix the bug"
-bun run src/claude-worker.ts --research_doc=notes.md --focus=standard
+bun run src/<agent>-worker.ts --prompt "fix the bug"
+bun run src/<agent>-worker.ts --research_doc=notes.md --focus=standard
 
 # Multi-workflow CLI — one subcommand per workflow
 bun run src/cli.ts review --target_branch=main
@@ -490,7 +490,7 @@ if (result) {
 
 **No boilerplate in the dev's file.** In `bun run` mode the SDK re-execs its own internal orchestrator entry script (bundled inside `@bastani/atomic-sdk`); in `bun build --compile`d hosts it re-execs the consumer's own binary, but the SDK's `@bastani/atomic-sdk/workflows` barrel intercepts the internal sub-command via a top-level argv handler at module-load time, so the dev's command tree never sees those argv tokens. No env-var dance, no manual `handleSelfDispatch`-style entry-point hook, and no peer dependency on the user-facing `@bastani/atomic` CLI package.
 
-**Atomic builtins** — workflows shipped inside `@bastani/atomic-sdk`, registered by atomic's internal `createBuiltinRegistry()`:
+**Atomic registry** — builtins shipped inside `@bastani/atomic-sdk` plus custom workflows registered in `.atomic/settings.json` or `~/.atomic/settings.json`:
 
 ```bash
 atomic workflow -n <name> -a <agent> [inputs...]
@@ -498,14 +498,14 @@ atomic workflow -n <name> -a <agent> [inputs...]
 
 | Surface                | Command                                                                          | When                                                                           |
 | ---------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Named, with prompt     | `… -n hello -a claude "fix the bug"`                                             | Requires workflow to declare a `prompt` input                                  |
-| Named, structured      | `… -n gen-spec -a claude --research_doc=notes.md`                                | Structured inputs via `--<field>` flags                                        |
-| Interactive picker     | `atomic workflow -a claude`                                                      | Discovery — fuzzy list + form; this is the intentional no-`-n` path            |
-| List (atomic builtins) | `atomic workflow list`, `atomic workflow list -a <agent>`                        | Browse registered builtins + custom workflows, optionally filtered             |
+| Named, with prompt     | `… -n hello -a <agent> "fix the bug"`                                           | Requires workflow to declare a `prompt` input                                  |
+| Named, structured      | `… -n gen-spec -a <agent> --research_doc=notes.md`                              | Structured inputs via `--<field>` flags                                        |
+| Interactive picker     | `atomic workflow -a <agent>`                                                    | Discovery — fuzzy list + form; this is the intentional no-`-n` path            |
+| List (atomic registry) | `atomic workflow list`, `atomic workflow list -a <agent>`                       | Browse registered builtins + custom workflows, optionally filtered             |
 | Reload custom workflows | `atomic workflow refresh [--format json\|text]`                                  | Re-spawn metadata loaders after editing `.atomic/settings.json` or a workflow file. Auto-defaults to JSON inside an atomic chat session so the model can ingest broken-entry diagnostics directly. |
 | List (user cli)        | Iterate `listWorkflows(registry)` and add a `list` Commander subcommand yourself | No built-in `--list` flag                                                      |
 | List (single-workflow) | Not applicable — the file *is* the workflow                                      |
-| Inspect inputs         | `atomic workflow inputs <name> -a claude`                                        | Print input schema as JSON                                                     |
+| Inspect inputs         | `atomic workflow inputs <name> -a <agent>`                                      | Print input schema as JSON                                                     |
 | Status (one or all)    | `atomic workflow status [<session-id>]`                                          | Query state — `in_progress`, `error`, `completed`, `needs_review`, `awaiting_input` |
 | Read run/stage on disk | `atomic workflow read --sessionId <id> [--stageId <name>]`                       | Print path under `~/.atomic/sessions/<runId>/` for the run dir or a single stage. The model can then `Read` `messages.json` (raw `s.save()` output), `inbox.md` (rendered transcript), or `metadata.json` directly. Auto-defaults to JSON inside an atomic chat session. |
 | Kill non-interactively | `atomic session kill <id> -y`                                                    | Tear down without confirmation prompt — `-y` is mandatory for agents           |
@@ -768,12 +768,12 @@ bun run src/<agent>-worker.ts "free-form prompt text"       # positional fallbac
 bun run src/cli.ts <workflow-name> --<field>=<value>        # structured
 bun run src/cli.ts <workflow-name> "free-form prompt text"  # positional fallback (if wired)
 
-# Atomic builtins — these use -n/-a/-d (atomic CLI's own flags, not user-app flags)
+# Atomic registry — these use -n/-a/-d (atomic CLI's own flags, not user-app flags)
 atomic workflow -n <name> -a <agent> "<prompt>"             # attached run
 atomic workflow -n <name> -a <agent> -d "<prompt>"          # detached (background)
 ```
 
-For detached user-app runs, pass `detach: true` to `runWorkflow` or wire your own `--detach` flag in your Commander entrypoint. For the atomic builtins (`ralph`, `deep-research-codebase`, `open-claude-design`), see `references/running-workflows.md` for monitoring and teardown.
+For detached user-app runs, pass `detach: true` to `runWorkflow` or wire your own `--detach` flag in your Commander entrypoint. For atomic registry workflows (builtins plus registered custom workflows), see `references/running-workflows.md` for monitoring and teardown.
 
 ## Running an Existing Workflow
 
@@ -787,7 +787,7 @@ to invoke it correctly. That's a different playbook from authoring.
   by the dev, using Commander or another CLI library), repo-shipped examples
   at <https://github.com/flora131/atomic/tree/main/examples>, and atomic
   builtins + custom workflows (`atomic workflow -n … -a …`).
-- Why atomic builtins use `-n` + `-a` and how to add `-d` for background runs.
+- Why atomic registry workflows use `-n` + `-a` and how to add `-d` for background runs.
 - Why you must list workflows first — and why `atomic workflow refresh`
   is the right verification step right after editing `settings.json` or
   a Mode-1 workflow file.

--- a/.agents/skills/workflow-creator/references/agent-setup-recipe.md
+++ b/.agents/skills/workflow-creator/references/agent-setup-recipe.md
@@ -214,7 +214,7 @@ atomic workflow refresh
 
 Inside an atomic chat session this auto-defaults to JSON; outside, it prints colourised text. Either way, every diagnostic field is on its own `key · value` line so the model can self-correct without prose parsing:
 
-- `loaded` entries confirm the workflow is invocable as `atomic workflow -n <workflow-name> -a claude`.
+- `loaded` entries confirm the workflow is invocable as `atomic workflow -n <workflow-name> -a <agent>`.
 - `broken` entries spell out `reason · …`, `fix · …`, `settings · <path> (workflows.<alias>)` so you know exactly which file and which JSON path to repair before re-running.
 
 Common Mode-1 broken-entry causes the model should self-diagnose:

--- a/.agents/skills/workflow-creator/references/getting-started.md
+++ b/.agents/skills/workflow-creator/references/getting-started.md
@@ -98,7 +98,7 @@ const { id, tmuxSessionName } = await runWorkflow({
 
 ### Interactive picker
 
-The same picker `atomic workflow -a claude` opens is exposed as a component:
+The same picker `atomic workflow -a <agent>` opens is exposed as a component:
 
 ```ts
 import { WorkflowPickerPanel } from "@bastani/atomic-sdk/workflows/components";

--- a/.agents/skills/workflow-creator/references/running-workflows.md
+++ b/.agents/skills/workflow-creator/references/running-workflows.md
@@ -15,7 +15,7 @@ tool to invoke the workflow yourself.
 Follow this contract whenever the user asks to run a workflow:
 
 1. **Run, don't recite.** If you have shell/tool access, execute the workflow command. Do not answer "I can't run it" or only print `atomic workflow -n ...`.
-2. **Use the current agent by default.** Resolve the agent in this order: user explicitly named an agent → `ATOMIC_AGENT` (`claude`, `copilot`, `opencode`) → ask once. Never silently default to Claude.
+2. **Use the current agent by default.** Resolve the agent in this order: user explicitly named an agent → `ATOMIC_AGENT` (`claude`, `copilot`, `opencode`) → ask once. Never silently default to a specific agent — every supported agent (Claude, Copilot, OpenCode) is a first-class target.
 3. **Prefer the atomic registry first.** Run `atomic workflow list -a <agent>` before probing examples or app-specific CLIs. This list includes builtins and registered custom workflows from `.atomic/settings.json` and `~/.atomic/settings.json`.
 4. **Inspect inputs before running.** Run `atomic workflow inputs <name> -a <agent>` for registered atomic workflows; parse the schema and ask only for required values the user did not provide.
 5. **Run detached from agent chats.** Add `-d` when starting via `atomic workflow` from a coding-agent chat unless the user explicitly wants to attach immediately.
@@ -27,7 +27,8 @@ Agent resolution details:
 printenv ATOMIC_AGENT   # "claude" | "copilot" | "opencode" when launched by atomic chat
 ```
 
-If `ATOMIC_AGENT=copilot`, run the Copilot variant (`-a copilot`). If
+If `ATOMIC_AGENT=claude`, run the Claude variant (`-a claude`). If
+`ATOMIC_AGENT=copilot`, run the Copilot variant (`-a copilot`). If
 `ATOMIC_AGENT=opencode`, run the OpenCode variant (`-a opencode`). Only use a
 different agent when the user explicitly requests it or confirms a switch.
 
@@ -512,24 +513,24 @@ in-scope session — only do that when the user has asked to stop everything.
 
 *(Note: `gen-spec` is a hypothetical builtin used here for pedagogical purposes. Real atomic builtins are `ralph`, `deep-research-codebase`, and `open-claude-design`.)*
 
-1. Resolve the agent from the user request or `ATOMIC_AGENT` (example: `copilot`).
-2. Path C (atomic registry). Run `atomic workflow list -a copilot`. Output includes `gen-spec`. Good.
+1. Resolve the agent from the user request or `ATOMIC_AGENT` (example: `claude`).
+2. Path C (atomic registry). Run `atomic workflow list -a claude`. Output includes `gen-spec`. Good.
 3. Target resolved exactly: `gen-spec`.
-4. Run `atomic workflow inputs gen-spec -a copilot`. Parse the JSON:
+4. Run `atomic workflow inputs gen-spec -a claude`. Parse the JSON:
    `research_doc` (required string — already given), `focus` (required enum
    of `minimal|standard|exhaustive`, default `standard`), `notes`
    (optional text).
 5. Ask via AskUserQuestion once: "What focus level for the spec?" with
    choices `minimal`, `standard`, `exhaustive`. User picks `standard`. Skip
    `notes` since it's optional.
-6. Run: `atomic workflow -n gen-spec -a copilot -d --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
-7. The CLI prints a session name like `atomic-wf-copilot-gen-spec-a1b2c3d4`.
+6. Run: `atomic workflow -n gen-spec -a claude -d --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
+7. The CLI prints a session name like `atomic-wf-claude-gen-spec-a1b2c3d4`.
    Tell the user, using the §"After starting" template:
-   "Started workflow `gen-spec` (session id: `atomic-wf-copilot-gen-spec-a1b2c3d4`).
+   "Started workflow `gen-spec` (session id: `atomic-wf-claude-gen-spec-a1b2c3d4`).
    To watch it run interactively, **open a new terminal** and run:
-   `atomic workflow session connect atomic-wf-copilot-gen-spec-a1b2c3d4`.
-   Status: `atomic workflow status atomic-wf-copilot-gen-spec-a1b2c3d4`.
-   Stop: `atomic session kill atomic-wf-copilot-gen-spec-a1b2c3d4 -y`."
+   `atomic workflow session connect atomic-wf-claude-gen-spec-a1b2c3d4`.
+   Status: `atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4`.
+   Stop: `atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y`."
 
 **Example B — user app, free-form prompt**
 

--- a/.agents/skills/workflow-creator/references/running-workflows.md
+++ b/.agents/skills/workflow-creator/references/running-workflows.md
@@ -2,11 +2,34 @@
 
 When the user asks you to **run** (or "kick off" / "start" / "execute") a
 workflow — *not* author one — your job is to translate their request into the
-correct invocation and run it. This is the playbook for that flow. It is
-different from the authoring playbook in `SKILL.md`: the workflow already
-exists in a registry; you just need to invoke it correctly.
+correct invocation and run it. This includes natural-language requests such as
+"run ralph on this repo", "run workflow x with prompt y", or "start the release
+workflow with version 1.2.3". Do not reply with instructions for the user to run
+unless shell execution is unavailable in your environment; use your terminal
+tool to invoke the workflow yourself.
 
-**This playbook works from any context.** Whether you're running in a fresh terminal, inside `atomic chat -a <agent>`, or from a CI script, the decision tree below is the same — atomic builtins, repo examples, and user SDK workflows are all discoverable and invokable. If the user is chatting with you through `atomic chat` and says "start my hello-world workflow", walk the same three paths; the shared tmux socket means the workflow you spawn will be visible to every monitoring surface (the worker CLI's own `status` / `session` subcommands, `atomic workflow status`, and `bunx atomic …`) regardless of which path you used to start it.
+**This playbook works from any context.** Whether you're running in a fresh terminal, inside `atomic chat -a <agent>`, or from a CI script, the decision tree below is the same — registered atomic workflows, repo examples, and user SDK workflows are all discoverable and invokable. If the user is chatting with you through `atomic chat` and says "start my hello-world workflow", walk the same paths; the shared tmux socket means the workflow you spawn will be visible to every monitoring surface (the worker CLI's own `status` / `session` subcommands, `atomic workflow status`, and `bunx atomic …`) regardless of which path you used to start it.
+
+## Natural-language run contract
+
+Follow this contract whenever the user asks to run a workflow:
+
+1. **Run, don't recite.** If you have shell/tool access, execute the workflow command. Do not answer "I can't run it" or only print `atomic workflow -n ...`.
+2. **Use the current agent by default.** Resolve the agent in this order: user explicitly named an agent → `ATOMIC_AGENT` (`claude`, `copilot`, `opencode`) → ask once. Never silently default to Claude.
+3. **Prefer the atomic registry first.** Run `atomic workflow list -a <agent>` before probing examples or app-specific CLIs. This list includes builtins and registered custom workflows from `.atomic/settings.json` and `~/.atomic/settings.json`.
+4. **Inspect inputs before running.** Run `atomic workflow inputs <name> -a <agent>` for registered atomic workflows; parse the schema and ask only for required values the user did not provide.
+5. **Run detached from agent chats.** Add `-d` when starting via `atomic workflow` from a coding-agent chat unless the user explicitly wants to attach immediately.
+6. **Report the session id and attach command.** On successful spawn, give the exact session id and tell the user to open a new terminal and run `atomic workflow session connect <sessionId>`.
+
+Agent resolution details:
+
+```bash
+printenv ATOMIC_AGENT   # "claude" | "copilot" | "opencode" when launched by atomic chat
+```
+
+If `ATOMIC_AGENT=copilot`, run the Copilot variant (`-a copilot`). If
+`ATOMIC_AGENT=opencode`, run the OpenCode variant (`-a opencode`). Only use a
+different agent when the user explicitly requests it or confirms a switch.
 
 ## Three invocation paths
 
@@ -16,11 +39,11 @@ roots. Two shapes exist — pick based on what the file calls:
 - **Single-workflow worker** (`runWorkflow({ workflow, inputs })`) —
   one file per agent, bound to one `WorkflowDefinition`. The dev wires
   `--<input>` Commander options for each declared input using
-  `getInputSchema(wf)`. Typical name: `claude-worker.ts`.
+  `getInputSchema(wf)`. Typical name: `<agent>-worker.ts`.
 
   ```bash
-  bun run src/claude-worker.ts --<field>=<value>      # structured inputs
-  bun run src/claude-worker.ts "<prompt>"             # positional (if the worker wired [prompt...])
+  bun run src/<agent>-worker.ts --<field>=<value>      # structured inputs
+  bun run src/<agent>-worker.ts "<prompt>"             # positional (if the worker wired [prompt...])
   ```
 
   For detached runs, the dev passes `detach: true` to `runWorkflow` or
@@ -43,8 +66,8 @@ directory ships one worker file per agent (`claude-worker.ts`,
 built with `getInputSchema(wf)`:
 
 ```bash
-bun run examples/<name>/claude-worker.ts --<field>=<value>
-bun run examples/<name>/copilot-worker.ts "<prompt>"    # if the worker wires [prompt...]
+bun run examples/<name>/<agent>-worker.ts --<field>=<value>
+bun run examples/<name>/<agent>-worker.ts "<prompt>"    # if the worker wires [prompt...]
 ```
 
 Available examples: `hello-world`, `parallel-hello-world`, `headless-test`,
@@ -52,12 +75,14 @@ Available examples: `hello-world`, `parallel-hello-world`, `headless-test`,
 `reviewer-tool-test` (copilot only). Use these to demonstrate a specific SDK
 feature or as a copy-paste starting point.
 
-**Path C — atomic builtins.** Workflows shipped inside `@bastani/atomic-sdk`
-and registered via `createBuiltinRegistry()` inside the `atomic` CLI:
+**Path C — atomic registry.** Workflows registered with the `atomic` CLI. This
+includes builtins shipped inside `@bastani/atomic-sdk` and custom workflows
+declared in project/global settings (`.atomic/settings.json` and
+`~/.atomic/settings.json`):
 
 ```bash
 atomic workflow -n <name> -a <agent> [inputs...]
-atomic workflow list
+atomic workflow list -a <agent>
 ```
 
 Builtin names: `ralph`, `deep-research-codebase`, `open-claude-design`.
@@ -68,8 +93,8 @@ the command to return after spawning the workflow.
 
 **Identify the path before anything else.** Decision order:
 
-1. Is the name one of the three builtins (`ralph`, `deep-research-codebase`,
-   `open-claude-design`)? → **Path C** (`atomic workflow`).
+1. Does `atomic workflow list -a <agent>` include the requested name? →
+   **Path C** (`atomic workflow`). This covers builtins and custom workflows.
 2. Does `examples/<name>/<agent>-worker.ts` exist in the current repo? →
    **Path B** (`bun run examples/<name>/<agent>-worker.ts`).
 3. Does a composition root exist in `src/` (single-workflow
@@ -84,8 +109,8 @@ the command to return after spawning the workflow.
 call that confirms whether the named workflow actually exists:
 
 ```bash
-# Atomic builtins
-atomic workflow list
+# Atomic registry: builtins + registered custom workflows
+atomic workflow list -a <agent>
 
 # Repo-shipped examples (when inside the atomic repo)
 bun run examples/<name>/<agent>-worker.ts --help
@@ -139,11 +164,11 @@ its invocation shape:
 2. **Does it declare structured inputs?** If so, you pass `--<field>=<value>`
    flags, one per required field.
 
-**Use `atomic workflow inputs <name> -a <agent>` to get the schema for atomic builtins.** This prints a JSON envelope with every field's `name`, `type`, `required`, `default`, `description`, and (for enums) `values` — exactly what AskUserQuestion needs. The `freeform: true` flag tells you whether the workflow takes a positional prompt vs. structured flags, with a synthetic `prompt` field included so the JSON shape is uniform either way.
+**Use `atomic workflow inputs <name> -a <agent>` to get the schema for registered atomic workflows.** This works for builtins and registered custom workflows. It prints a JSON envelope with every field's `name`, `type`, `required`, `default`, `description`, and (for enums) `values` — exactly what AskUserQuestion needs. The `freeform: true` flag tells you whether the workflow takes a positional prompt vs. structured flags, with a synthetic `prompt` field included so the JSON shape is uniform either way.
 
 ```bash
-atomic workflow inputs gen-spec -a claude
-# {"workflow":"gen-spec","agent":"claude","freeform":false,
+atomic workflow inputs gen-spec -a copilot
+# {"workflow":"gen-spec","agent":"copilot","freeform":false,
 #  "inputs":[{"name":"research_doc","type":"string","required":true,...},
 #            {"name":"focus","type":"enum","values":["minimal","standard","exhaustive"],"default":"standard"}]}
 ```
@@ -153,9 +178,10 @@ inspect the TypeScript source — the schema is inline in `defineWorkflow({
 inputs: [...] })`. Reading the source is always in sync because `defineWorkflow`
 validates the schema at definition time.
 
-`atomic workflow inputs` is a builtin-only command — it queries the
-internal builtin registry and is not available for user apps. For user
-app workflows, always read the `defineWorkflow` source directly.
+`atomic workflow inputs` is for workflows visible to the atomic registry
+(builtins plus settings-registered custom workflows). For standalone user-app
+workers that are not registered with `atomic workflow list`, read the
+`defineWorkflow` source directly.
 
 Once you have the schema, use the **AskUserQuestion tool** to collect any
 values the user hasn't already provided in their message. One question per
@@ -171,22 +197,23 @@ Skip AskUserQuestion entirely when:
 
 ## End-to-end recipe
 
-1. **Identify the invocation path** — atomic builtin (`atomic workflow`),
+1. **Resolve the agent** — explicit user request, then `ATOMIC_AGENT`, then ask once. Do not default to Claude.
+2. **Identify the invocation path** — atomic registry (`atomic workflow`),
    repo-shipped example (`bun run examples/<name>/<agent>-worker.ts`), or
    the user's own app (single-workflow `src/<agent>-worker.ts` or
    multi-workflow `src/cli.ts`)?
-2. **List available workflows** — run the list command for the chosen path.
+3. **List available workflows** — run the list command for the chosen path.
    This is your ground truth.
-3. **Resolve the target**:
+4. **Resolve the target**:
    - Exact match in the list → continue.
    - Close match → confirm via AskUserQuestion before proceeding.
    - No match → tell the user what's available and offer to author it (see
      previous section). If they decline, stop.
-4. **Discover the inputs schema** — for builtins use `atomic workflow inputs
-   <name> -a <agent>`; for user apps inspect the `defineWorkflow` source.
-5. **Ask for missing inputs** — use AskUserQuestion, one question per
+5. **Discover the inputs schema** — for registered atomic workflows use
+   `atomic workflow inputs <name> -a <agent>`; for unregistered user apps inspect the `defineWorkflow` source.
+6. **Ask for missing inputs** — use AskUserQuestion, one question per
    unanswered required field. Enums become multiple-choice.
-6. **Invoke** — build one of these commands:
+7. **Invoke** — build and execute one of these commands:
 
    User's own app — single-workflow worker:
    - Free-form: `bun run src/<agent>-worker.ts "<prompt>"` (only if the worker wires `[prompt...]`)
@@ -202,19 +229,19 @@ Skip AskUserQuestion entirely when:
    - Free-form: `bun run examples/<name>/<agent>-worker.ts "<prompt>"` (only if wired)
    - Structured: `bun run examples/<name>/<agent>-worker.ts --field1=val1`
 
-   Atomic builtins:
+   Atomic registry:
    - Free-form: `atomic workflow -n <name> -a <agent> "<prompt>"`
    - Structured: `atomic workflow -n <name> -a <agent> --<field1>=<value1>`
    - Detached: add `-d`
 
-7. **Tell the user how to attach interactively** — the runtime printed a
-   session name like `atomic-wf-claude-<workflow>-a1b2c3d4`. Immediately
+8. **Tell the user how to attach interactively** — the runtime printed a
+   session name like `atomic-wf-<agent>-<workflow>-a1b2c3d4`. Immediately
    echo it back with the **new-terminal attach instruction** described in
    §"After starting: tell the user how to view it interactively" below.
    This is non-negotiable on every successful spawn. Also surface
    `atomic workflow status <sessionId>` (poll) and
    `atomic session kill <sessionId> -y` (stop).
-8. **If you started the workflow detached (`-d` or `detach: true`), poll
+9. **If you started the workflow detached (`-d` or `detach: true`), poll
    status until it terminates or pauses for input** — see "Polling rhythm
    after spawning" below. Surfacing a HIL pause to the user immediately is
    non-negotiable; an unattended `awaiting_input` / `needs_review` state
@@ -415,7 +442,7 @@ import {
 
 Because every workflow lands on the same atomic tmux socket regardless of
 which path spawned it, the `atomic` CLI commands work for Path A and B
-workflows just as well as for atomic builtins.
+workflows just as well as for registered atomic workflows.
 
 Detached workflows return immediately with a session name; the actual work
 runs in the background. Use `status` to check whether the workflow is still
@@ -479,54 +506,56 @@ in-scope session — only do that when the user has asked to stop everything.
 
 ## Worked examples
 
-**Example A — atomic builtin, structured inputs**
+**Example A — atomic registry, structured inputs**
 
 > **User:** "run gen-spec on research/docs/2026-04-11-auth.md"
 
 *(Note: `gen-spec` is a hypothetical builtin used here for pedagogical purposes. Real atomic builtins are `ralph`, `deep-research-codebase`, and `open-claude-design`.)*
 
-1. Path C (atomic builtin). Run `atomic workflow list`. Output includes `gen-spec`. Good.
-2. Target resolved exactly: `gen-spec`.
-3. Run `atomic workflow inputs gen-spec -a claude`. Parse the JSON:
+1. Resolve the agent from the user request or `ATOMIC_AGENT` (example: `copilot`).
+2. Path C (atomic registry). Run `atomic workflow list -a copilot`. Output includes `gen-spec`. Good.
+3. Target resolved exactly: `gen-spec`.
+4. Run `atomic workflow inputs gen-spec -a copilot`. Parse the JSON:
    `research_doc` (required string — already given), `focus` (required enum
    of `minimal|standard|exhaustive`, default `standard`), `notes`
    (optional text).
-4. Ask via AskUserQuestion once: "What focus level for the spec?" with
+5. Ask via AskUserQuestion once: "What focus level for the spec?" with
    choices `minimal`, `standard`, `exhaustive`. User picks `standard`. Skip
    `notes` since it's optional.
-5. Run: `atomic workflow -n gen-spec -a claude --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
-6. The CLI prints a session name like `atomic-wf-claude-gen-spec-a1b2c3d4`.
+6. Run: `atomic workflow -n gen-spec -a copilot -d --research_doc=research/docs/2026-04-11-auth.md --focus=standard`
+7. The CLI prints a session name like `atomic-wf-copilot-gen-spec-a1b2c3d4`.
    Tell the user, using the §"After starting" template:
-   "Started workflow `gen-spec` (session id: `atomic-wf-claude-gen-spec-a1b2c3d4`).
+   "Started workflow `gen-spec` (session id: `atomic-wf-copilot-gen-spec-a1b2c3d4`).
    To watch it run interactively, **open a new terminal** and run:
-   `atomic workflow session connect atomic-wf-claude-gen-spec-a1b2c3d4`.
-   Status: `atomic workflow status atomic-wf-claude-gen-spec-a1b2c3d4`.
-   Stop: `atomic session kill atomic-wf-claude-gen-spec-a1b2c3d4 -y`."
+   `atomic workflow session connect atomic-wf-copilot-gen-spec-a1b2c3d4`.
+   Status: `atomic workflow status atomic-wf-copilot-gen-spec-a1b2c3d4`.
+   Stop: `atomic session kill atomic-wf-copilot-gen-spec-a1b2c3d4 -y`."
 
 **Example B — user app, free-form prompt**
 
 > **User:** "run the summarize-pr workflow on 'add OAuth to the API'"
 
-1. Path A. `src/claude-worker.ts` exists and calls `runWorkflow(summarizePrClaude)`.
+1. Resolve the agent from the user request or `ATOMIC_AGENT` (example: `opencode`).
+2. Path A. `src/opencode-worker.ts` exists and calls `runWorkflow(summarizePrOpenCode)`.
    (If instead the user had a `src/cli.ts` with `createRegistry()` + `listWorkflows`,
    run `bun run src/cli.ts --help` to see the registered subcommands and confirm `summarize-pr`.)
-2. Target resolved exactly: `summarize-pr`, agent `claude`.
-3. Prompt already given in user's message. No AskUserQuestion needed. Check
+3. Target resolved exactly: `summarize-pr`, agent `opencode`.
+4. Prompt already given in user's message. No AskUserQuestion needed. Check
    `defineWorkflow` source to confirm `prompt` is a declared input.
-4. Run: `bun run src/claude-worker.ts --prompt="add OAuth to the API"`.
+5. Run: `bun run src/opencode-worker.ts --prompt="add OAuth to the API"`.
    (If the worker was built with a `[prompt...]` Commander argument, the positional
-   form `bun run src/claude-worker.ts "add OAuth to the API"` works too.)
-   The runtime prints a session name like `atomic-wf-claude-summarize-pr-a1b2c3d4`.
+   form `bun run src/opencode-worker.ts "add OAuth to the API"` works too.)
+   The runtime prints a session name like `atomic-wf-opencode-summarize-pr-a1b2c3d4`.
    For a detached run, the worker must wire `detach: true` to `runWorkflow` or
    expose its own `--detach` Commander option — there is no built-in `-d` on
    user-app workers.
-5. Apply the §"After starting" rule. Tell the user:
-   "Started workflow `summarize-pr` (session id: `atomic-wf-claude-summarize-pr-a1b2c3d4`).
+6. Apply the §"After starting" rule. Tell the user:
+   "Started workflow `summarize-pr` (session id: `atomic-wf-opencode-summarize-pr-a1b2c3d4`).
    To watch it run interactively, **open a new terminal** and run:
-   `atomic workflow session connect atomic-wf-claude-summarize-pr-a1b2c3d4`.
-   Status: `atomic workflow status atomic-wf-claude-summarize-pr-a1b2c3d4`.
-   Stop: `atomic session kill atomic-wf-claude-summarize-pr-a1b2c3d4 -y`."
-6. `bunx atomic …` is equivalent if the global binary is not installed. Both
+   `atomic workflow session connect atomic-wf-opencode-summarize-pr-a1b2c3d4`.
+   Status: `atomic workflow status atomic-wf-opencode-summarize-pr-a1b2c3d4`.
+   Stop: `atomic session kill atomic-wf-opencode-summarize-pr-a1b2c3d4 -y`."
+7. `bunx atomic …` is equivalent if the global binary is not installed. Both
    talk to the same atomic tmux socket regardless of which path spawned the
    workflow.
 
@@ -534,30 +563,32 @@ in-scope session — only do that when the user has asked to stop everything.
 
 > **User:** "run the hello-world example with a formal greeting"
 
-1. Not a builtin name. Check `examples/hello-world/claude-worker.ts` — it exists.
+1. Resolve the agent from the user request or `ATOMIC_AGENT` (example: `copilot`).
+2. Not in the atomic registry for `copilot`. Check `examples/hello-world/copilot-worker.ts` — it exists.
    Path B.
-2. Target resolved: `hello-world`, via `examples/hello-world/claude-worker.ts`.
-3. Read `examples/hello-world/claude/index.ts` for the input schema:
+3. Target resolved: `hello-world`, via `examples/hello-world/copilot-worker.ts`.
+4. Read `examples/hello-world/copilot/index.ts` for the input schema:
    `greeting` (string, required), `style` (enum: formal/casual/robotic,
    default casual), `notes` (text, optional).
-4. Ask via AskUserQuestion: "What should the greeting text be?" User
+5. Ask via AskUserQuestion: "What should the greeting text be?" User
    supplies `"Hello there"`. `style=formal` is implied by the message.
-5. Run: `bun run examples/hello-world/claude-worker.ts --greeting="Hello there" --style=formal`
-6. Apply the §"After starting" rule. Tell the user:
+6. Run: `bun run examples/hello-world/copilot-worker.ts --greeting="Hello there" --style=formal`
+7. Apply the §"After starting" rule. Tell the user:
    "Started workflow `hello-world` (session id: `<sessionId from CLI>`).
    To watch it run interactively, **open a new terminal** and run:
    `atomic workflow session connect <sessionId>`."
 
-**Example B2 — atomic builtin, free-form prompt**
+**Example B2 — atomic registry, free-form prompt**
 
 > **User:** "run ralph on 'add OAuth to the API'"
 
-1. Path C (atomic builtin — `ralph` is shipped inside `@bastani/atomic-sdk`).
-   Run `atomic workflow list`. Confirms `ralph` is registered.
-2. Target resolved exactly: `ralph`, agent `claude`.
-3. Prompt already given in user's message. No AskUserQuestion needed.
-4. Run: `atomic workflow -n ralph -a claude "add OAuth to the API"`.
-5. Apply the §"After starting" rule. Tell the user:
+1. Resolve the agent from the user request or `ATOMIC_AGENT` (example: `copilot`).
+2. Path C (atomic registry — `ralph` is shipped inside `@bastani/atomic-sdk`).
+   Run `atomic workflow list -a copilot`. Confirms `ralph` is registered for Copilot.
+3. Target resolved exactly: `ralph`, agent `copilot`.
+4. Prompt already given in user's message. No AskUserQuestion needed.
+5. Run: `atomic workflow -n ralph -a copilot -d "add OAuth to the API"`.
+6. Apply the §"After starting" rule. Tell the user:
    "Started workflow `ralph` (session id: `<sessionId from CLI>`).
    To watch it run interactively, **open a new terminal** and run:
    `atomic workflow session connect <sessionId>`."
@@ -581,18 +612,18 @@ in-scope session — only do that when the user has asked to stop everything.
 ## Common mistakes to avoid
 
 - **Not identifying the invocation path** — using `atomic workflow` for a
-  user app, or `bun run src/worker.ts` for a builtin or a repo-shipped
-  example, leads to "not found". Check the three paths in order (builtin
-  → examples/ → user app) first.
+  user app, or `bun run src/worker.ts` for a registry workflow or a
+  repo-shipped example, leads to "not found". Check the three paths in order
+  (atomic registry → examples/ → user app) first.
 - **Skipping the list command** — leads to guessing and `workflow not found`
   errors. Always list first.
 - **Using `-n`/`-a`/`-d` on user-app workers** — these flags only exist on
-  the `atomic` binary for builtins. User-app workers expose per-input `--<flag>`
+  the `atomic` binary for registry workflows. User-app workers expose per-input `--<flag>`
   options and (optionally) a positional `[prompt...]` argument. There is no
   `-n`, `-a`, or `-d` built into user-app workers.
 - **Inventing a workflow name** — if it's not in the list, it doesn't exist.
   Say so and offer to author it.
-- **For builtins: reading the source to discover inputs** — use
+- **For registered atomic workflows: reading the source to discover inputs** — use
   `atomic workflow inputs <name> -a <agent>` instead. JSON, always in sync.
 - **Asking everything at once** — let AskUserQuestion drive one question per
   field. Enum fields are multiple-choice, not free text.

--- a/.agents/skills/workflow-creator/references/workflow-inputs.md
+++ b/.agents/skills/workflow-creator/references/workflow-inputs.md
@@ -37,10 +37,10 @@ higher-precedence value supplies one.
 
 | Surface | How values are supplied | How they land in `ctx.inputs` |
 |---|---|---|
-| **Single-worker, positional** — `bun run src/claude-worker.ts "fix the bug"` | The dev wires a `[prompt...]` Commander argument; the collected string is passed as `prompt` | `{ prompt: "fix the bug" }` |
-| **Single-worker, structured** — `bun run src/claude-worker.ts --research_doc=notes.md --focus=standard` | The dev registers one `--<field> <value>` option per declared input via `getInputSchema(wf)` | `{ research_doc: "notes.md", focus: "standard" }` |
+| **Single-worker, positional** — `bun run src/<agent>-worker.ts "fix the bug"` | The dev wires a `[prompt...]` Commander argument; the collected string is passed as `prompt` | `{ prompt: "fix the bug" }` |
+| **Single-worker, structured** — `bun run src/<agent>-worker.ts --research_doc=notes.md --focus=standard` | The dev registers one `--<field> <value>` option per declared input via `getInputSchema(wf)` | `{ research_doc: "notes.md", focus: "standard" }` |
 | **Multi-workflow CLI** — `bun run src/cli.ts gen-spec --research_doc=notes.md` | The dev registers one Commander subcommand per workflow; the subcommand's `--<field>` options match the workflow's declared inputs | Same as above |
-| **Interactive picker** — `atomic workflow -a claude` (atomic builtins only) | User fills in a form rendered from the declared schema | Whatever the user typed, keyed by field name |
+| **Interactive picker** — `atomic workflow -a <agent>` (atomic registry) | User fills in a form rendered from the declared schema | Whatever the user typed, keyed by field name |
 | **Picker in user app** — dev mounts `WorkflowPickerPanel` from `@bastani/atomic-sdk/workflows/components` | Same form-based collection, against the dev's own registry | Same as above |
 | **Programmatic** — `runWorkflow({ workflow, inputs })` | Plain `Record<string, string>` passed directly — no argv parsing | Top-of-chain value; falls back to `defineWorkflow` defaults |
 
@@ -226,7 +226,7 @@ inputs: [
 ]
 ```
 
-Declaring `prompt` explicitly gives compile-time safety — `ctx.inputs.prompt` is typed and accessing an undeclared key is a type error. For atomic builtins you can still pass a positional string (`atomic workflow -n ralph -a claude "fix the bug"`); user-app workers handle positional args however the dev wired their Commander entrypoint (e.g., `program.argument("[prompt...]", ...)`), and the collected string is passed as the `prompt` input value.
+Declaring `prompt` explicitly gives compile-time safety — `ctx.inputs.prompt` is typed and accessing an undeclared key is a type error. For atomic registry workflows you can still pass a positional string (`atomic workflow -n ralph -a <agent> "fix the bug"`); user-app workers handle positional args however the dev wired their Commander entrypoint (e.g., `program.argument("[prompt...]", ...)`), and the collected string is passed as the `prompt` input value.
 
 For workflows that need both a free-form prompt AND structured parameters,
 declare all fields in the schema:
@@ -272,11 +272,11 @@ to the atomic CLI without needing to rename inputs later.
 
 ## The interactive picker
 
-### Atomic builtins — `atomic workflow -a <agent>`
+### Atomic registry — `atomic workflow -a <agent>`
 
 `atomic workflow -a <agent>` (no `-n`) launches the interactive picker for
-atomic builtins (TTY only — non-interactive contexts skip straight to
-`--help`). All direct attached or detached builtin runs should include
+registered atomic workflows (TTY only — non-interactive contexts skip straight to
+`--help`). All direct attached or detached registry runs should include
 `-n <workflow-name>` explicitly; omitting `-n` is the intentional
 picker-discovery path.
 
@@ -352,15 +352,15 @@ their own `--detach` Commander option.
 
 ```bash
 # User's own app — single-workflow worker
-bun run src/claude-worker.ts --focus=standard --research_doc=notes.md
-bun run src/claude-worker.ts --focus standard --research_doc notes.md
+bun run src/<agent>-worker.ts --focus=standard --research_doc=notes.md
+bun run src/<agent>-worker.ts --focus standard --research_doc notes.md
 
 # User's own app — multi-workflow CLI
 bun run src/cli.ts gen-spec --focus=standard --research_doc=notes.md
 
-# Atomic builtins — use atomic CLI's -n/-a/-d flags
-atomic workflow -n gen-spec -a claude --focus=standard --research_doc=notes.md
-atomic workflow -n gen-spec -a claude -d --focus=standard    # detached
+# Atomic registry — use atomic CLI's -n/-a/-d flags
+atomic workflow -n gen-spec -a <agent> --focus=standard --research_doc=notes.md
+atomic workflow -n gen-spec -a <agent> -d --focus=standard    # detached
 ```
 
 ## Pitfalls


### PR DESCRIPTION
## Summary

Upgrades the `workflow-creator` skill to be fully agent-agnostic and adds an explicit natural-language run contract so agents execute workflows directly instead of just printing the command.

## Key Changes

### Natural-language run contract (new)
- Added a `## Natural-language run contract` section to `running-workflows.md` with six rules agents must follow:
  1. **Run, don't recite** — use shell/tool access to execute; never just print the command
  2. **Resolve the agent** — priority order: explicit user request → `ATOMIC_AGENT` env var → ask once (never silently default to Claude)
  3. **Prefer the atomic registry first** — run `atomic workflow list -a <agent>` before other paths
  4. **Inspect inputs before running** — use `atomic workflow inputs <name> -a <agent>`
  5. **Run detached from agent chats** — always add `-d` from a coding-agent chat unless the user opts in
  6. **Report the session id and attach command** on every successful spawn

### Agent-agnostic placeholders
- Replaced all hardcoded `claude` agent references with `<agent>` placeholders across `SKILL.md`, `running-workflows.md`, `getting-started.md`, `agent-setup-recipe.md`, and `workflow-inputs.md`
- Worker filename examples updated from `claude-worker.ts` to `<agent>-worker.ts`

### "Atomic builtins" → "Atomic registry"
- Reframed the concept throughout: the registry includes both builtins shipped inside `@bastani/atomic-sdk` **and** custom workflows registered in `.atomic/settings.json` / `~/.atomic/settings.json`
- Path C decision logic updated: check `atomic workflow list -a <agent>` instead of testing against a hardcoded list of three builtin names

### Updated worked examples
- All worked examples (A, B, B2, C) now include an explicit agent-resolution step as step 1
- Example commands updated to use `<agent>` placeholders (e.g., `copilot`, `opencode`) to show the contract in action
- `atomic workflow list` calls updated to include `-a <agent>` for correct scoping

## Files Changed

- `.agents/skills/workflow-creator/SKILL.md`
- `.agents/skills/workflow-creator/references/running-workflows.md`
- `.agents/skills/workflow-creator/references/getting-started.md`
- `.agents/skills/workflow-creator/references/agent-setup-recipe.md`
- `.agents/skills/workflow-creator/references/workflow-inputs.md`