### PR TITLE
docs(claude): fix bump-version.ts path in release instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,11 +147,11 @@ Use the `bump-version.ts` script to update the version across all tracked files 
 
 ```sh
 # Explicit version
-bun run src/scripts/bump-version.ts 0.4.47
-bun run src/scripts/bump-version.ts 0.4.47-0
+bun run packages/atomic-sdk/script/bump-version.ts 0.4.47
+bun run packages/atomic-sdk/script/bump-version.ts 0.4.47-0
 
 # Auto-detect version from current branch name
-bun run src/scripts/bump-version.ts --from-branch
+bun run packages/atomic-sdk/script/bump-version.ts --from-branch
 ```
 
 The `--from-branch` flag extracts the version from the current branch name, so check out the release or prerelease branch first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,11 +147,11 @@ Use the `bump-version.ts` script to update the version across all tracked files 
 
 ```sh
 # Explicit version
-bun run packages/atomic-sdk/script/bump-version.ts 0.4.47
-bun run packages/atomic-sdk/script/bump-version.ts 0.4.47-0
+bun run packages/atomic/script/bump-version.ts 0.4.47
+bun run packages/atomic/script/bump-version.ts 0.4.47-0
 
 # Auto-detect version from current branch name
-bun run packages/atomic-sdk/script/bump-version.ts --from-branch
+bun run packages/atomic/script/bump-version.ts --from-branch
 ```
 
 The `--from-branch` flag extracts the version from the current branch name, so check out the release or prerelease branch first.

--- a/packages/atomic-sdk/src/providers/claude.waitForIdleDrain.test.ts
+++ b/packages/atomic-sdk/src/providers/claude.waitForIdleDrain.test.ts
@@ -121,8 +121,12 @@ test(
     // Drain: remove the inflight marker.
     await unlink(p.inflightMarker);
 
-    // waitForInflightDrained should detect the empty dir within ~200ms.
-    await Bun.sleep(250);
+    // waitForInflightDrained polls every 100ms; under coverage + parallel load
+    // a fixed sleep is flaky. Poll for resolution with a generous budget.
+    const deadline = Date.now() + 2500;
+    while (!resolved && Date.now() < deadline) {
+      await Bun.sleep(50);
+    }
 
     expect(resolved).toBe(true);
     expect(Array.isArray(resolvedValue)).toBe(true);


### PR DESCRIPTION
## Summary

Corrects the `bump-version.ts` script path in `CLAUDE.md` release instructions from the stale `src/scripts/` location to the actual `packages/atomic/script/` location. Also replaces a fixed sleep with a poll loop in a flaky test.

## Changes

- `CLAUDE.md`: Update three `bun run` examples (explicit version, prerelease, and `--from-branch`) to reference `packages/atomic/script/bump-version.ts`
- `packages/atomic-sdk/src/providers/claude.waitForIdleDrain.test.ts`: Replace fixed 250ms sleep with a poll loop (50ms intervals, 2500ms budget) to eliminate flakiness under coverage and parallel load

## Motivation

Anyone — human or AI agent — following the release docs would hit:

```
error: Module not found "src/scripts/bump-version.ts"
```

and need to manually locate the script. The fix was verified via `bun run packages/atomic/script/bump-version.ts --from-branch` during the v0.7.16-0 release.

The test fix addresses intermittent failures where `waitForInflightDrained` would not resolve within the fixed sleep window under CI load.