### PR TITLE
docs(readme): replace local image with hosted promotional image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-<p align="center">
-  <img src="assets/atomic.png" alt="Atomic" width="800">
-</p>
-
 <h1 align="center">Atomic</h1>
+
+<p align="center"><img width="800" height="450" alt="atomic-promo" src="https://github.com/user-attachments/assets/03806ea9-597d-45c8-a356-f1044f767c06" /></p>
 
 <p align="center">
   <b>Turn coding agents into reliable engineering workflows.</b><br>


### PR DESCRIPTION
## Summary

Replaces the locally-referenced `assets/atomic.png` with a GitHub-hosted promotional image (`atomic-promo`) in the README header.

## Key Changes

- Removed the `<p>` wrapper around the old local image (`assets/atomic.png`)
- Added a new centered `<img>` tag pointing to the GitHub-uploaded promotional asset with explicit `800x450` dimensions
- Repositioned the image to appear directly below the `<h1>` title