### PR TITLE
fix(release-fetch): strip auth from asset downloads to prevent CDN slow-path

### DIFF
--- a/packages/atomic/src/commands/cli/update.ts
+++ b/packages/atomic/src/commands/cli/update.ts
@@ -152,7 +152,28 @@ async function runBinaryUpdate(opts: UpdateOptions, target: string): Promise<num
             `Downloading ${assetName}...`,
             "Downloaded binary",
             "Download failed",
-            () => downloadAssetFromUrl(binaryAsset.browser_download_url, assetDest),
+            () => {
+                let lastTick = -1;
+                return downloadAssetFromUrl(
+                    binaryAsset.browser_download_url,
+                    assetDest,
+                    (received, total) => {
+                        if (total !== null && total > 0) {
+                            const pct = Math.floor((received / total) * 100);
+                            if (pct !== lastTick) {
+                                lastTick = pct;
+                                s.message(`Downloading ${assetName}... ${pct}%`);
+                            }
+                        } else {
+                            const mb = Math.floor(received / 1024 / 1024);
+                            if (mb !== lastTick) {
+                                lastTick = mb;
+                                s.message(`Downloading ${assetName}... ${mb} MB`);
+                            }
+                        }
+                    },
+                );
+            },
         );
         await step(
             s,

--- a/packages/atomic/src/commands/cli/update.ts
+++ b/packages/atomic/src/commands/cli/update.ts
@@ -153,21 +153,23 @@ async function runBinaryUpdate(opts: UpdateOptions, target: string): Promise<num
             "Downloaded binary",
             "Download failed",
             () => {
-                let lastTick = -1;
+                // Tracks pct (0-100) when total is known, otherwise MB. Mutually
+                // exclusive per call because total is constant for the closure's lifetime.
+                let lastTickValue = -1;
                 return downloadAssetFromUrl(
                     binaryAsset.browser_download_url,
                     assetDest,
                     (received, total) => {
                         if (total !== null && total > 0) {
                             const pct = Math.floor((received / total) * 100);
-                            if (pct !== lastTick) {
-                                lastTick = pct;
+                            if (pct !== lastTickValue) {
+                                lastTickValue = pct;
                                 s.message(`Downloading ${assetName}... ${pct}%`);
                             }
                         } else {
                             const mb = Math.floor(received / 1024 / 1024);
-                            if (mb !== lastTick) {
-                                lastTick = mb;
+                            if (mb !== lastTickValue) {
+                                lastTickValue = mb;
                                 s.message(`Downloading ${assetName}... ${mb} MB`);
                             }
                         }

--- a/packages/atomic/src/services/system/release-fetch.test.ts
+++ b/packages/atomic/src/services/system/release-fetch.test.ts
@@ -301,6 +301,72 @@ describe("downloadAssetFromUrl", () => {
         }
     });
 
+    // ── header isolation ──────────────────────────────────────────────────────
+    // Bun's fetch does not strip Authorization on cross-origin 302 redirects
+    // (github.com → release-assets.githubusercontent.com). Forwarding a PAT to
+    // the signed Azure blob URL slow-paths the CDN. Asset downloads must use a
+    // minimal header set distinct from the GitHub API JSON headers.
+    describe("asset download header isolation", () => {
+        test("does NOT send Authorization even when GITHUB_TOKEN is set", async () => {
+            process.env.GITHUB_TOKEN = "ghp_testtoken";
+            fetchSpy.mockResolvedValueOnce(fakeStreamResponse(new Uint8Array([0x00])));
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-hdr-"));
+            try {
+                await downloadAssetFromUrl("https://example.com/asset", join(dir, "out"));
+
+                const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+                const headers = init.headers as Record<string, string>;
+                expect(headers["Authorization"]).toBeUndefined();
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        test("does NOT send Accept: application/vnd.github+json", async () => {
+            fetchSpy.mockResolvedValueOnce(fakeStreamResponse(new Uint8Array([0x00])));
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-hdr-"));
+            try {
+                await downloadAssetFromUrl("https://example.com/asset", join(dir, "out"));
+
+                const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+                const headers = init.headers as Record<string, string>;
+                expect(headers["Accept"]).toBeUndefined();
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        test("still sends User-Agent: atomic-cli", async () => {
+            fetchSpy.mockResolvedValueOnce(fakeStreamResponse(new Uint8Array([0x00])));
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-hdr-"));
+            try {
+                await downloadAssetFromUrl("https://example.com/asset", join(dir, "out"));
+
+                const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+                const headers = init.headers as Record<string, string>;
+                expect(headers["User-Agent"]).toBe("atomic-cli");
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        test("githubGet (via getLatestRelease) still sends Authorization with GITHUB_TOKEN", async () => {
+            // Sanity check: the API path is unaffected by the asset-header split.
+            process.env.GITHUB_TOKEN = "ghp_testtoken";
+            fetchSpy.mockResolvedValueOnce(fakeJsonResponse(makeRelease("v0.7.16")));
+
+            await getLatestRelease();
+
+            const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+            const headers = init.headers as Record<string, string>;
+            expect(headers["Authorization"]).toBe("Bearer ghp_testtoken");
+            expect(headers["Accept"]).toBe("application/vnd.github+json");
+        });
+    });
+
     // ── Cluster C — atomic download cleanup on rename failure ─────────────────
 
     // Use spyOn (not mock.module) — `mock.module("node:fs", ...)` is

--- a/packages/atomic/src/services/system/release-fetch.test.ts
+++ b/packages/atomic/src/services/system/release-fetch.test.ts
@@ -56,6 +56,28 @@ function fakeStreamResponse(bytes: Uint8Array, status = 200): Response {
     return new Response(bytes.buffer as ArrayBuffer, { status });
 }
 
+// Builds a Response whose body is a ReadableStream emitting the given chunks
+// in order. Used to exercise downloadAssetFromUrl's streaming branch where
+// res.body is iterated with `for await`.
+function fakeChunkedResponse(
+    chunks: Uint8Array[],
+    opts: { contentLength?: number | "malformed" } = {},
+): Response {
+    const stream = new ReadableStream({
+        start(controller) {
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+        },
+    });
+    const headers: Record<string, string> = {};
+    if (opts.contentLength === "malformed") {
+        headers["Content-Length"] = "not-a-number";
+    } else if (typeof opts.contentLength === "number") {
+        headers["Content-Length"] = String(opts.contentLength);
+    }
+    return new Response(stream, { status: 200, headers });
+}
+
 // ── setup / teardown ──────────────────────────────────────────────────────────
 
 let fetchSpy: Mock<typeof fetch>;
@@ -364,6 +386,100 @@ describe("downloadAssetFromUrl", () => {
             const headers = init.headers as Record<string, string>;
             expect(headers["Authorization"]).toBe("Bearer ghp_testtoken");
             expect(headers["Accept"]).toBe("application/vnd.github+json");
+        });
+    });
+
+    // ── streaming progress branch ─────────────────────────────────────────────
+    // Exercises the opt-in `onProgress` path: res.body is iterated chunk-by-chunk,
+    // bytes are forwarded to a Bun.file().writer(), and the callback is invoked
+    // with cumulative byte counts plus the parsed Content-Length (or null).
+    describe("streaming onProgress branch", () => {
+        test("invokes onProgress with cumulative received and total when Content-Length is set", async () => {
+            const chunks = [
+                new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+                new Uint8Array([11, 12, 13, 14, 15]),
+                new Uint8Array([16, 17, 18]),
+            ];
+            const total = 18;
+            fetchSpy.mockResolvedValueOnce(fakeChunkedResponse(chunks, { contentLength: total }));
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-stream-"));
+            const destPath = join(dir, "asset");
+
+            try {
+                const calls: Array<[number, number | null]> = [];
+                await downloadAssetFromUrl(
+                    "https://example.com/asset",
+                    destPath,
+                    (received, t) => calls.push([received, t]),
+                );
+
+                expect(calls).toEqual([
+                    [10, total],
+                    [15, total],
+                    [18, total],
+                ]);
+
+                // Bytes on disk match the concatenated stream (regression guard
+                // against writer.end() not flushing).
+                const written = await Bun.file(destPath).bytes();
+                expect(Array.from(written)).toEqual([
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+                ]);
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        test("passes total === null when Content-Length is absent (chunked transfer)", async () => {
+            // This is the production path: GitHub's CDN serves binaries via
+            // chunked transfer encoding without advertising Content-Length.
+            const chunks = [new Uint8Array([0xaa, 0xbb]), new Uint8Array([0xcc])];
+            fetchSpy.mockResolvedValueOnce(fakeChunkedResponse(chunks));
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-stream-"));
+            const destPath = join(dir, "asset");
+
+            try {
+                const totals: Array<number | null> = [];
+                await downloadAssetFromUrl(
+                    "https://example.com/asset",
+                    destPath,
+                    (_received, t) => totals.push(t),
+                );
+
+                expect(totals).toEqual([null, null]);
+
+                const written = await Bun.file(destPath).bytes();
+                expect(Array.from(written)).toEqual([0xaa, 0xbb, 0xcc]);
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        test("malformed Content-Length resolves to total === null (parseInt guard)", async () => {
+            // Locks in the Number.isFinite/>0 guard so a future refactor can't
+            // accidentally pass NaN to Math.floor((received / NaN) * 100).
+            const chunks = [new Uint8Array([0x01, 0x02])];
+            fetchSpy.mockResolvedValueOnce(
+                fakeChunkedResponse(chunks, { contentLength: "malformed" }),
+            );
+
+            const dir = mkdtempSync(join(tmpdir(), "release-fetch-stream-"));
+            const destPath = join(dir, "asset");
+
+            try {
+                const totals: Array<number | null> = [];
+                await downloadAssetFromUrl(
+                    "https://example.com/asset",
+                    destPath,
+                    (_received, t) => totals.push(t),
+                );
+
+                expect(totals).toEqual([null]);
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
         });
     });
 

--- a/packages/atomic/src/services/system/release-fetch.ts
+++ b/packages/atomic/src/services/system/release-fetch.ts
@@ -37,7 +37,7 @@ function githubApiBase(): string {
     return process.env.ATOMIC_GITHUB_API_BASE ?? DEFAULT_GITHUB_API_BASE;
 }
 
-function buildHeaders(): Record<string, string> {
+function buildApiHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
         Accept: "application/vnd.github+json",
         "User-Agent": "atomic-cli",
@@ -47,8 +47,15 @@ function buildHeaders(): Record<string, string> {
     return headers;
 }
 
+// Asset downloads follow a 302 from github.com to release-assets.githubusercontent.com
+// (signed Azure blob). Forwarding Authorization to that signed URL slow-paths the CDN,
+// and Bun's fetch does not strip auth on cross-origin redirects the way curl does.
+function buildAssetDownloadHeaders(): Record<string, string> {
+    return { "User-Agent": "atomic-cli" };
+}
+
 async function githubGet(url: string): Promise<ReleaseInfo> {
-    const res = await fetch(url, { headers: buildHeaders() });
+    const res = await fetch(url, { headers: buildApiHeaders() });
 
     if (res.status === 403 && res.headers.get("X-RateLimit-Remaining") === "0") {
         throw new Error("Set GITHUB_TOKEN to lift the 60 req/h anonymous limit");
@@ -77,34 +84,54 @@ export async function getReleaseByTag(tag: string): Promise<ReleaseInfo> {
  *
  * Writes to a `.tmp.<pid>.<ts>` sibling first, then atomically renames to
  * `destPath` on success. Cleans up the partial file on any error.
+ *
+ * Pass `onProgress` to receive byte counts as the body streams in. `total` is
+ * the value of the `Content-Length` header, or `null` when not advertised
+ * (e.g. chunked transfer encoding).
  */
-export async function downloadAssetFromUrl(url: string, destPath: string): Promise<void> {
-    const res = await fetch(url, { headers: buildHeaders() });
+export async function downloadAssetFromUrl(
+    url: string,
+    destPath: string,
+    onProgress?: (received: number, total: number | null) => void,
+): Promise<void> {
+    const res = await fetch(url, { headers: buildAssetDownloadHeaders() });
     if (!res.ok) {
         throw new Error(`Failed to download asset: HTTP ${res.status}`);
     }
 
     const tmpPath = `${destPath}.tmp.${pid}.${Date.now()}`;
-    let placed = false;
     try {
-        await Bun.write(tmpPath, res);
+        if (onProgress && res.body) {
+            const lenHeader = res.headers.get("content-length");
+            const total = lenHeader ? parseInt(lenHeader, 10) : null;
+            const writer = Bun.file(tmpPath).writer();
+            let received = 0;
+            try {
+                for await (const chunk of res.body) {
+                    writer.write(chunk);
+                    received += chunk.byteLength;
+                    onProgress(received, total);
+                }
+            } finally {
+                await writer.end();
+            }
+        } else {
+            await Bun.write(tmpPath, res);
+        }
         try {
             renameSync(tmpPath, destPath);
-            placed = true;
         } catch (err) {
             if ((err as NodeJS.ErrnoException).code === "EXDEV") {
                 copyFileSync(tmpPath, destPath);
-                placed = true;
             } else {
                 throw err;
             }
         }
     } finally {
-        // best-effort cleanup. After successful rename tmpPath gone (ENOENT).
-        // After EXDEV fallback we need to remove it. After throw before write we need to remove it.
+        // best-effort cleanup. After successful rename tmpPath is gone (ENOENT).
+        // After EXDEV fallback or any error before/during write we need to remove it.
         try { unlinkSync(tmpPath); } catch { /* swallow */ }
     }
-    void placed;
 }
 
 /**

--- a/packages/atomic/src/services/system/release-fetch.ts
+++ b/packages/atomic/src/services/system/release-fetch.ts
@@ -101,9 +101,13 @@ export async function downloadAssetFromUrl(
 
     const tmpPath = `${destPath}.tmp.${pid}.${Date.now()}`;
     try {
+        // Streaming path: opt-in via onProgress so callers wanting live byte counts
+        // get them. The Bun.write fast-path below is preferred when progress isn't
+        // needed — it lets the runtime handle buffering/backpressure natively.
         if (onProgress && res.body) {
             const lenHeader = res.headers.get("content-length");
-            const total = lenHeader ? parseInt(lenHeader, 10) : null;
+            const parsed = lenHeader ? parseInt(lenHeader, 10) : NaN;
+            const total = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
             const writer = Bun.file(tmpPath).writer();
             let received = 0;
             try {


### PR DESCRIPTION
## Summary

Bun's `fetch` does not strip `Authorization` on cross-origin 302 redirects (github.com → release-assets.githubusercontent.com), causing PATs to be forwarded to signed Azure blob URLs and slow-pathing the CDN. This PR isolates asset-download headers from API headers and adds opt-in streaming body reads so the spinner can surface real-time download progress.

## Key Changes

- **Header isolation** (`release-fetch.ts`): Renamed `buildHeaders()` → `buildApiHeaders()` (retains `Authorization` and `Accept`) and added `buildAssetDownloadHeaders()` returning only `{ "User-Agent": "atomic-cli" }` — no `Authorization`, no `Accept`.
- **Streaming progress** (`release-fetch.ts`): `downloadAssetFromUrl()` now accepts an optional `onProgress(received, total)` callback; when provided, the response body is consumed chunk-by-chunk via `Bun.file().writer()` so callers receive live byte counts. `total` is `null` when `Content-Length` is absent or malformed.
- **Download progress UI** (`update.ts`): The update command passes an `onProgress` callback that updates the spinner with `X%` when `Content-Length` is advertised, or `X MB` for chunked transfers. Updates are throttled via a `lastTickValue` guard to avoid redundant spinner messages.
- **Tests** (`release-fetch.test.ts`): Added two new describe blocks:
  - `"asset download header isolation"` — verifies `Authorization` is absent even with `GITHUB_TOKEN` set, `Accept: application/vnd.github+json` is absent, `User-Agent: atomic-cli` is present, and the API path (`githubGet`) still sends both headers correctly.
  - `"streaming onProgress branch"` — covers the known `Content-Length` path, chunked transfer (`total === null`), and malformed `Content-Length` guard (`Number.isFinite` / `> 0`).

## Notes

No breaking changes. The `onProgress` parameter is optional; callers that omit it fall back to the original `Bun.write(tmpPath, res)` fast path.