### PR TITLE
docs(readme): embed atomic-promo gif as in-repo asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Atomic</h1>
 
-<p align="center"><img width="800" height="450" alt="atomic-promo" src="https://github.com/user-attachments/assets/03806ea9-597d-45c8-a356-f1044f767c06" /></p>
+<p align="center"><img width="800" height="450" alt="atomic-promo" src="./assets/atomic-promo.gif" /></p>
 
 <p align="center">
   <b>Turn coding agents into reliable engineering workflows.</b><br>


### PR DESCRIPTION
## Summary

Replace the externally-hosted `user-attachments` GIF in the README with a checked-in copy at `assets/atomic-promo.gif`, consistent with the existing `assets/` convention used for `atomic.png` and the palette files.

## Changes

- `README.md`: Update `<img>` `src` from a `github.com/user-attachments` URL to the relative path `./assets/atomic-promo.gif`
- `assets/atomic-promo.gif`: Add the promo GIF as a tracked repo asset (~41 MB)

## Why

GitHub `user-attachments` URLs are tied to the original upload context and can break on forks, mirrors, offline clones, and GitHub-mirror sites. A relative asset path renders consistently everywhere.

## Notes

- File size is ~41 MB — under GitHub's 100 MB hard limit but above the 50 MB soft warning. No LFS needed; flagged for reviewer awareness.

## Test Plan

- [ ] Confirm the README preview on the PR page renders the GIF inline
- [ ] Verify `assets/atomic-promo.gif` is present in the diff (not LFS-pointered)
- [ ] Sanity-check the ~41 MB file size is acceptable for the repo