### PR TITLE
feat(orchestrator-panel): hide orchestrator node, surface duration in header

### DIFF
--- a/packages/atomic-sdk/src/components/compact-switcher.tsx
+++ b/packages/atomic-sdk/src/components/compact-switcher.tsx
@@ -17,7 +17,9 @@ export function CompactSwitcher({ selectedIndex }: CompactSwitcherProps) {
   const theme = useGraphTheme();
   useStoreVersion(store);
 
-  const agents = store.sessions;
+  // Filter the synthetic orchestrator entry — it has no node in the graph
+  // and selecting it would no-op inside doAttach.
+  const agents = store.sessions.filter((s) => s.name !== "orchestrator");
   const headerHint = "\u2191\u2193 select \u00B7 \u21B5 jump \u00B7 Esc close";
 
   return (

--- a/packages/atomic-sdk/src/components/compact-switcher.tsx
+++ b/packages/atomic-sdk/src/components/compact-switcher.tsx
@@ -19,7 +19,7 @@ export function CompactSwitcher({ selectedIndex }: CompactSwitcherProps) {
 
   // Filter the synthetic orchestrator entry — it has no node in the graph
   // and selecting it would no-op inside doAttach.
-  const agents = store.sessions.filter((s) => s.name !== "orchestrator");
+  const agents = store.getStageSessions();
   const headerHint = "\u2191\u2193 select \u00B7 \u21B5 jump \u00B7 Esc close";
 
   return (

--- a/packages/atomic-sdk/src/components/connectors.test.ts
+++ b/packages/atomic-sdk/src/components/connectors.test.ts
@@ -664,17 +664,18 @@ describe("buildMergeConnector", () => {
 // ─── Integration tests: connectors with computeLayout-produced nodes ──────
 
 describe("integration with computeLayout", () => {
-  test("connector from orchestrator to reclassified orphan child", () => {
+  test("orchestrator entry never reaches the connector layer", () => {
     const { computeLayout } = require("./layout.ts");
     const layout = computeLayout([
       { name: "orchestrator", status: "running", parents: [], startedAt: null, endedAt: null },
       { name: "orphan", status: "pending", parents: ["nonexistent"], startedAt: null, endedAt: null },
     ]);
-    const orch = layout.map["orchestrator"];
-    expect(orch.children).toHaveLength(1);
-    const conn = buildConnector(orch, layout.rowH, mockTheme);
-    expect(conn).not.toBeNull();
-    expect(conn!.height).toBeGreaterThan(0);
+    // Orchestrator is filtered out at layout time, so it has no node and
+    // contributes no connectors. Orphan collapses to a true root.
+    expect(layout.map["orchestrator"]).toBeUndefined();
+    const orphan = layout.map["orphan"];
+    expect(orphan.children).toHaveLength(0);
+    expect(buildConnector(orphan, layout.rowH, mockTheme)).toBeNull();
   });
 
   test("connector from parent to reclassified merge-to-single-parent node", () => {

--- a/packages/atomic-sdk/src/components/header.tsx
+++ b/packages/atomic-sdk/src/components/header.tsx
@@ -35,7 +35,7 @@ export function Header() {
   const tmuxSession = useContext(TmuxSessionContext);
   const storeVersion = useStoreVersion(store);
 
-  // Exclude the synthetic orchestrator entry from status counts \u2014 it's
+  // Exclude the synthetic orchestrator entry from status counts — it's
   // workflow-timing bookkeeping, not a user-defined stage, and surfaces
   // separately as the workflow duration on the right.
   const counts = useMemo(() => {
@@ -57,7 +57,7 @@ export function Header() {
       ? ` \u2713 ${store.workflowName} `
       : " Orchestrator ";
 
-  // Workflow duration \u2014 derived from the orchestrator session's timing
+  // Workflow duration — derived from the orchestrator session's timing
   // (startedAt set on workflow start, endedAt set on completion/failure).
   // While running, a 1s ticker drives re-renders so the display stays live;
   // when terminal, the value freezes at endedAt and the ticker stops.

--- a/packages/atomic-sdk/src/components/header.tsx
+++ b/packages/atomic-sdk/src/components/header.tsx
@@ -40,8 +40,7 @@ export function Header() {
   // separately as the workflow duration on the right.
   const counts = useMemo(() => {
     const c: Record<SessionStatus, number> = { complete: 0, running: 0, pending: 0, error: 0, awaiting_input: 0, offloaded: 0, resuming: 0 };
-    for (const s of store.sessions) {
-      if (s.name === "orchestrator") continue;
+    for (const s of store.getStageSessions()) {
       c[s.status]++;
     }
     return c;
@@ -62,7 +61,7 @@ export function Header() {
   // While running, a 1s ticker drives re-renders so the display stays live;
   // when terminal, the value freezes at endedAt and the ticker stops.
   const orchestrator = useMemo(
-    () => store.sessions.find((s) => s.name === "orchestrator"),
+    () => store.getOrchestratorSession(),
     [storeVersion],
   );
   const [tickNow, setTickNow] = useState(() => Date.now());

--- a/packages/atomic-sdk/src/components/header.tsx
+++ b/packages/atomic-sdk/src/components/header.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 
-import { useContext, useMemo } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import type { SessionStatus } from "./orchestrator-panel-types.ts";
 import {
   useStore,
@@ -8,6 +8,7 @@ import {
   useStoreVersion,
   TmuxSessionContext,
 } from "./orchestrator-panel-contexts.ts";
+import { fmtDuration } from "./status-helpers.ts";
 
 function CountBadge({
   color,
@@ -34,20 +35,53 @@ export function Header() {
   const tmuxSession = useContext(TmuxSessionContext);
   const storeVersion = useStoreVersion(store);
 
+  // Exclude the synthetic orchestrator entry from status counts \u2014 it's
+  // workflow-timing bookkeeping, not a user-defined stage, and surfaces
+  // separately as the workflow duration on the right.
   const counts = useMemo(() => {
     const c: Record<SessionStatus, number> = { complete: 0, running: 0, pending: 0, error: 0, awaiting_input: 0, offloaded: 0, resuming: 0 };
-    for (const s of store.sessions) c[s.status]++;
+    for (const s of store.sessions) {
+      if (s.name === "orchestrator") continue;
+      c[s.status]++;
+    }
     return c;
   }, [storeVersion]);
 
   const isFailed = store.fatalError !== null;
   const isDone = store.completionInfo !== null;
+  const isRunning = !isFailed && !isDone;
   const badgeColor = isFailed ? theme.error : isDone ? theme.success : theme.info;
   const badgeText = isFailed
     ? " \u2717 Failed "
     : isDone
       ? ` \u2713 ${store.workflowName} `
       : " Orchestrator ";
+
+  // Workflow duration \u2014 derived from the orchestrator session's timing
+  // (startedAt set on workflow start, endedAt set on completion/failure).
+  // While running, a 1s ticker drives re-renders so the display stays live;
+  // when terminal, the value freezes at endedAt and the ticker stops.
+  const orchestrator = useMemo(
+    () => store.sessions.find((s) => s.name === "orchestrator"),
+    [storeVersion],
+  );
+  const [tickNow, setTickNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isRunning || !orchestrator?.startedAt) return;
+    const id = setInterval(() => setTickNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [isRunning, orchestrator?.startedAt]);
+
+  const durationText = useMemo(() => {
+    if (!orchestrator?.startedAt) return "";
+    const end = orchestrator.endedAt ?? tickNow;
+    return fmtDuration(end - orchestrator.startedAt);
+  }, [orchestrator?.startedAt, orchestrator?.endedAt, tickNow]);
+  const durationColor = isFailed
+    ? theme.error
+    : isDone
+      ? theme.success
+      : theme.textMuted;
 
   return (
     <box
@@ -73,7 +107,7 @@ export function Header() {
         </box>
       ) : null}
 
-      <box flexGrow={1} justifyContent="flex-end" flexDirection="row" gap={2}>
+      <box flexGrow={1} justifyContent="flex-end" flexDirection="row" gap={2} alignItems="center">
         <CountBadge color={theme.success} backgroundColor={theme.backgroundElement} icon={"\u2713"} count={counts.complete} />
         <CountBadge color={theme.warning} backgroundColor={theme.backgroundElement} icon={"\u25CF"} count={counts.running} />
         <CountBadge color={theme.info} backgroundColor={theme.backgroundElement} icon={"?"} count={counts.awaiting_input} />
@@ -81,6 +115,11 @@ export function Header() {
         <CountBadge color={theme.error} backgroundColor={theme.backgroundElement} icon={"\u2717"} count={counts.error} />
         <CountBadge color={theme.textDim} backgroundColor={theme.backgroundElement} icon={"\u25cc"} count={counts.offloaded} />
         <CountBadge color={theme.warning} backgroundColor={theme.backgroundElement} icon={"\u25d0"} count={counts.resuming} />
+        {durationText ? (
+          <text>
+            <span fg={durationColor} bg={theme.backgroundElement}>{durationText}</span>
+          </text>
+        ) : null}
       </box>
     </box>
   );

--- a/packages/atomic-sdk/src/components/layout.test.ts
+++ b/packages/atomic-sdk/src/components/layout.test.ts
@@ -924,26 +924,33 @@ describe("computeLayout", () => {
 
   // ─── Edge cases: parent normalization ─────────
 
-  describe("missing parent fallback", () => {
-    test("session with missing parent falls back to orchestrator child", () => {
+  describe("orchestrator filtering + missing parents", () => {
+    test("orchestrator entry is never placed in the layout map", () => {
+      const r = computeLayout([
+        session("orchestrator"),
+        session("step-1", ["orchestrator"]),
+      ]);
+      expect(r.map["orchestrator"]).toBeUndefined();
+      // step-1 declared "orchestrator" as its parent, but since orchestrator
+      // is filtered, the reference dissolves and step-1 becomes a true root.
+      expect(r.roots.map((n) => n.name)).toEqual(["step-1"]);
+      expect(r.map["step-1"]!.depth).toBe(0);
+    });
+
+    test("session with a missing parent becomes a root", () => {
       const r = computeLayout([
         session("orchestrator"),
         session("orphan", ["nonexistent"]),
       ]);
-      // orphan should be a child of orchestrator, not a root
-      expect(r.roots).toHaveLength(1);
-      expect(r.roots[0]!.name).toBe("orchestrator");
-      expect(r.map["orchestrator"]!.children).toHaveLength(1);
-      expect(r.map["orchestrator"]!.children[0]!.name).toBe("orphan");
-      expect(r.map["orphan"]!.depth).toBe(1);
+      expect(r.roots.map((n) => n.name)).toEqual(["orphan"]);
+      expect(r.map["orphan"]!.depth).toBe(0);
     });
 
-    test("session with missing parent and no orchestrator becomes root", () => {
+    test("session with a missing parent and no orchestrator becomes a root", () => {
       const r = computeLayout([
         session("A"),
         session("orphan", ["nonexistent"]),
       ]);
-      // Without orchestrator, orphan becomes a root alongside A
       expect(r.roots).toHaveLength(2);
       expect(r.roots.map((n) => n.name)).toContain("orphan");
     });
@@ -957,35 +964,33 @@ describe("computeLayout", () => {
       expect(r.map["orphan"]!.parents).toEqual(["nonexistent"]);
     });
 
-    test("multiple orphans all fall back to orchestrator", () => {
+    test("multiple orphans each become their own root", () => {
       const r = computeLayout([
         session("orchestrator"),
         session("a", ["ghost-1"]),
         session("b", ["ghost-2"]),
       ]);
-      expect(r.roots).toHaveLength(1);
-      expect(r.map["orchestrator"]!.children).toHaveLength(2);
-      expect(r.map["a"]!.depth).toBe(1);
-      expect(r.map["b"]!.depth).toBe(1);
+      expect(r.roots).toHaveLength(2);
+      expect(r.map["a"]!.depth).toBe(0);
+      expect(r.map["b"]!.depth).toBe(0);
     });
 
-    test("valid parent takes priority over orchestrator fallback", () => {
+    test("real ancestor chain is preserved across orchestrator filtering", () => {
       const r = computeLayout([
         session("orchestrator"),
         session("step-1", ["orchestrator"]),
         session("child", ["step-1"]),
       ]);
-      // child should be under step-1, not orchestrator
+      // child stays under step-1; the orchestrator hop is collapsed
       expect(r.map["step-1"]!.children).toHaveLength(1);
       expect(r.map["step-1"]!.children[0]!.name).toBe("child");
-      expect(r.map["child"]!.depth).toBe(2);
+      expect(r.map["child"]!.depth).toBe(1);
     });
 
-    test("orchestrator itself does not get reparented to itself", () => {
+    test("workflow with only an orchestrator entry has an empty layout", () => {
       const r = computeLayout([session("orchestrator")]);
-      expect(r.roots).toHaveLength(1);
-      expect(r.roots[0]!.name).toBe("orchestrator");
-      expect(r.map["orchestrator"]!.children).toHaveLength(0);
+      expect(r.roots).toEqual([]);
+      expect(r.map).toEqual({});
     });
   });
 
@@ -999,18 +1004,17 @@ describe("computeLayout", () => {
       // M should become a single-parent child of A (not a merge node)
       expect(r.map["A"]!.children).toHaveLength(1);
       expect(r.map["A"]!.children[0]!.name).toBe("M");
-      expect(r.map["M"]!.depth).toBe(2);
+      expect(r.map["M"]!.depth).toBe(1);
     });
 
-    test("merge with all missing parents falls back to orchestrator child", () => {
+    test("merge with all missing parents becomes a root", () => {
       const r = computeLayout([
         session("orchestrator"),
         session("M", ["ghost-1", "ghost-2"]),
       ]);
-      // All parents missing → falls back to orchestrator
-      expect(r.map["orchestrator"]!.children).toHaveLength(1);
-      expect(r.map["orchestrator"]!.children[0]!.name).toBe("M");
-      expect(r.map["M"]!.depth).toBe(1);
+      // Every declared parent is filtered → M is a root
+      expect(r.roots.map((n) => n.name)).toEqual(["M"]);
+      expect(r.map["M"]!.depth).toBe(0);
     });
 
     test("merge with duplicate parents after filtering is deduplicated", () => {
@@ -1069,7 +1073,7 @@ describe("computeLayout", () => {
   });
 
   describe("deeply nested tree", () => {
-    test("four levels of nesting with orchestrator", () => {
+    test("four-step chain shifts depths down once orchestrator is filtered", () => {
       const r = computeLayout([
         session("orchestrator"),
         session("step-1", ["orchestrator"]),
@@ -1077,14 +1081,14 @@ describe("computeLayout", () => {
         session("step-3", ["step-2"]),
         session("step-4", ["step-3"]),
       ]);
-      expect(r.map["orchestrator"]!.depth).toBe(0);
-      expect(r.map["step-1"]!.depth).toBe(1);
-      expect(r.map["step-2"]!.depth).toBe(2);
-      expect(r.map["step-3"]!.depth).toBe(3);
-      expect(r.map["step-4"]!.depth).toBe(4);
+      expect(r.map["orchestrator"]).toBeUndefined();
+      expect(r.map["step-1"]!.depth).toBe(0);
+      expect(r.map["step-2"]!.depth).toBe(1);
+      expect(r.map["step-3"]!.depth).toBe(2);
+      expect(r.map["step-4"]!.depth).toBe(3);
       // All share x (single chain)
-      const x0 = r.map["orchestrator"]!.x;
-      for (const name of ["step-1", "step-2", "step-3", "step-4"]) {
+      const x0 = r.map["step-1"]!.x;
+      for (const name of ["step-2", "step-3", "step-4"]) {
         expect(r.map[name]!.x).toBe(x0);
       }
     });
@@ -1114,10 +1118,10 @@ describe("computeLayout", () => {
         session("c2", ["parent"]),
         session("c3", ["parent"]),
       ]);
-      expect(r.map["parent"]!.depth).toBe(1);
-      expect(r.map["c1"]!.depth).toBe(2);
-      expect(r.map["c2"]!.depth).toBe(2);
-      expect(r.map["c3"]!.depth).toBe(2);
+      expect(r.map["parent"]!.depth).toBe(0);
+      expect(r.map["c1"]!.depth).toBe(1);
+      expect(r.map["c2"]!.depth).toBe(1);
+      expect(r.map["c3"]!.depth).toBe(1);
       // parent centered over children
       const parentX = r.map["parent"]!.x;
       const c1X = r.map["c1"]!.x;

--- a/packages/atomic-sdk/src/components/layout.ts
+++ b/packages/atomic-sdk/src/components/layout.ts
@@ -74,26 +74,19 @@ function resolveOverlaps(map: Record<string, LayoutNode>): void {
 
 /**
  * Compute effective parents for each session by filtering out references
- * to sessions that don't exist in the map and deduplicating.  Orphaned
- * sessions (all parents missing) fall back to the "orchestrator" node
- * when one is present, instead of becoming disconnected roots.
+ * to sessions that don't exist in the map (including the runtime
+ * "orchestrator" pseudo-node, which the graph never renders) and
+ * deduplicating. Stages whose only declared parent was the orchestrator
+ * collapse to true roots with `parents: []`.
  */
 function normalizeParents(
   sessions: SessionData[],
   map: Record<string, LayoutNode>,
 ): Map<string, string[]> {
-  const hasOrchestrator = "orchestrator" in map;
   const effective = new Map<string, string[]>();
-
   for (const s of sessions) {
     const valid = [...new Set(s.parents)].filter((p) => p in map);
-    if (valid.length > 0) {
-      effective.set(s.name, valid);
-    } else if (hasOrchestrator && s.name !== "orchestrator") {
-      effective.set(s.name, ["orchestrator"]);
-    } else {
-      effective.set(s.name, []);
-    }
+    effective.set(s.name, valid);
   }
   return effective;
 }
@@ -103,7 +96,13 @@ export function computeLayout(sessions: SessionData[]): LayoutResult {
   const roots: LayoutNode[] = [];
   const mergeNodes: LayoutNode[] = [];
 
-  for (const s of sessions) {
+  // The runtime "orchestrator" entry is workflow-timing bookkeeping, not a
+  // user-defined stage — the graph treats it as invisible. Filter it before
+  // building the node map so every downstream pass (depths, placement,
+  // overlaps, connectors) operates only on real stages.
+  const visible = sessions.filter((s) => s.name !== "orchestrator");
+
+  for (const s of visible) {
     map[s.name] = {
       name: s.name,
       status: s.status,
@@ -118,11 +117,11 @@ export function computeLayout(sessions: SessionData[]): LayoutResult {
     };
   }
 
-  // Normalize parents: filter missing refs, dedupe, orchestrator fallback
-  const effective = normalizeParents(sessions, map);
+  // Normalize parents: drop refs to filtered/missing sessions, dedupe.
+  const effective = normalizeParents(visible, map);
 
   // Classify using effective parents (preserves LayoutNode.parents as raw metadata)
-  for (const s of sessions) {
+  for (const s of visible) {
     const ep = effective.get(s.name) ?? [];
     if (ep.length > 1) {
       mergeNodes.push(map[s.name]!);
@@ -146,7 +145,7 @@ export function computeLayout(sessions: SessionData[]): LayoutResult {
     depthCache.set(name, depth);
     return depth;
   }
-  for (const s of sessions) {
+  for (const s of visible) {
     map[s.name]!.depth = resolveDepth(s.name);
   }
 

--- a/packages/atomic-sdk/src/components/layout.ts
+++ b/packages/atomic-sdk/src/components/layout.ts
@@ -1,5 +1,6 @@
 // ─── Layout ───────────────────────────────────────
 
+import { SYNTHETIC_ORCHESTRATOR_NAME } from "./orchestrator-panel-types.ts";
 import type { SessionData, SessionStatus } from "./orchestrator-panel-types.ts";
 
 // ─── Layout Constants ─────────────────────────────
@@ -75,8 +76,8 @@ function resolveOverlaps(map: Record<string, LayoutNode>): void {
 /**
  * Compute effective parents for each session by filtering out references
  * to sessions that don't exist in the map (including the runtime
- * "orchestrator" pseudo-node, which the graph never renders) and
- * deduplicating. Stages whose only declared parent was the orchestrator
+ * `SYNTHETIC_ORCHESTRATOR_NAME` pseudo-node, which the graph never renders)
+ * and deduplicating. Stages whose only declared parent was the orchestrator
  * collapse to true roots with `parents: []`.
  */
 function normalizeParents(
@@ -96,11 +97,11 @@ export function computeLayout(sessions: SessionData[]): LayoutResult {
   const roots: LayoutNode[] = [];
   const mergeNodes: LayoutNode[] = [];
 
-  // The runtime "orchestrator" entry is workflow-timing bookkeeping, not a
+  // The runtime orchestrator entry is workflow-timing bookkeeping, not a
   // user-defined stage — the graph treats it as invisible. Filter it before
   // building the node map so every downstream pass (depths, placement,
   // overlaps, connectors) operates only on real stages.
-  const visible = sessions.filter((s) => s.name !== "orchestrator");
+  const visible = sessions.filter((s) => s.name !== SYNTHETIC_ORCHESTRATOR_NAME);
 
   for (const s of visible) {
     map[s.name] = {

--- a/packages/atomic-sdk/src/components/orchestrator-panel-store.ts
+++ b/packages/atomic-sdk/src/components/orchestrator-panel-store.ts
@@ -1,6 +1,7 @@
 // ─── State Store ──────────────────────────────────
 // Bridges the imperative OrchestratorPanel API with the React component tree.
 
+import { SYNTHETIC_ORCHESTRATOR_NAME } from "./orchestrator-panel-types.ts";
 import type { SessionData, SessionStatus, PanelSession, ViewMode } from "./orchestrator-panel-types.ts";
 
 type Listener = () => void;
@@ -65,7 +66,7 @@ export class PanelStore {
     this.prompt = prompt;
     this.sessions = [
       {
-        name: "orchestrator",
+        name: SYNTHETIC_ORCHESTRATOR_NAME,
         status: "running",
         parents: [],
         startedAt: Date.now(),
@@ -74,7 +75,7 @@ export class PanelStore {
       ...sessions.map((s) => ({
         name: s.name,
         status: "pending" as SessionStatus,
-        parents: s.parents.length > 0 ? s.parents : ["orchestrator"],
+        parents: s.parents.length > 0 ? s.parents : [SYNTHETIC_ORCHESTRATOR_NAME],
         startedAt: null,
         endedAt: null,
       })),
@@ -135,9 +136,28 @@ export class PanelStore {
     this.emit();
   }
 
+  /**
+   * The synthetic orchestrator session — the timing bookkeeping entry
+   * prepended by `setWorkflowInfo`. Single source of truth for header
+   * duration and completion/failure timestamps.
+   */
+  getOrchestratorSession(): SessionData | undefined {
+    return this.sessions.find((s) => s.name === SYNTHETIC_ORCHESTRATOR_NAME);
+  }
+
+  /**
+   * Sessions excluding the synthetic orchestrator entry — i.e. the
+   * user-defined stages that render as nodes in the graph and appear in
+   * the agent switcher. Single source of truth for everything that wants
+   * "the real stages".
+   */
+  getStageSessions(): SessionData[] {
+    return this.sessions.filter((s) => s.name !== SYNTHETIC_ORCHESTRATOR_NAME);
+  }
+
   setCompletion(workflowName: string, transcriptsPath: string): void {
     this.completionInfo = { workflowName, transcriptsPath };
-    const orch = this.sessions.find((s) => s.name === "orchestrator");
+    const orch = this.getOrchestratorSession();
     if (orch) {
       orch.status = "complete";
       orch.endedAt = Date.now();
@@ -148,7 +168,7 @@ export class PanelStore {
   setFatalError(message: string): void {
     this.fatalError = message;
     this.completionReached = true;
-    const orch = this.sessions.find((s) => s.name === "orchestrator");
+    const orch = this.getOrchestratorSession();
     if (orch) {
       orch.status = "error";
       orch.endedAt = Date.now();

--- a/packages/atomic-sdk/src/components/orchestrator-panel-types.ts
+++ b/packages/atomic-sdk/src/components/orchestrator-panel-types.ts
@@ -1,5 +1,15 @@
 // ─── Orchestrator Panel Types ─────────────────────
 
+/**
+ * Name of the synthetic orchestrator session prepended by
+ * `PanelStore.setWorkflowInfo`. It carries workflow-timing bookkeeping
+ * (startedAt/endedAt) but is not a user-defined stage — the layout filters
+ * it out and the header surfaces its duration separately. A rename here
+ * silently breaks every filter downstream, so every consumer imports this
+ * constant rather than spelling the string.
+ */
+export const SYNTHETIC_ORCHESTRATOR_NAME = "orchestrator";
+
 export type SessionStatus = "pending" | "running" | "complete" | "error" | "awaiting_input" | "offloaded" | "resuming";
 
 export type ViewMode = "graph" | "attached" | "resuming";

--- a/packages/atomic-sdk/src/components/session-graph-panel.test.tsx
+++ b/packages/atomic-sdk/src/components/session-graph-panel.test.tsx
@@ -18,22 +18,16 @@ import type { OffloadManager } from "../runtime/offload-manager.ts";
 // ─── decideAttachAction ───────────────────────────────────────────────────────
 
 describe("decideAttachAction", () => {
-  test("id=orchestrator → graphView regardless of offloadStatus", () => {
-    expect(decideAttachAction("orchestrator", "alive")).toEqual({ kind: "graphView" });
-    expect(decideAttachAction("orchestrator", "offloaded")).toEqual({ kind: "graphView" });
-    expect(decideAttachAction("orchestrator", "resuming")).toEqual({ kind: "graphView" });
-  });
-
   test("status=alive → switchClient", () => {
-    expect(decideAttachAction("agent-1", "alive")).toEqual({ kind: "switchClient" });
+    expect(decideAttachAction("alive")).toEqual({ kind: "switchClient" });
   });
 
   test("status=offloaded → resume", () => {
-    expect(decideAttachAction("agent-1", "offloaded")).toEqual({ kind: "resume" });
+    expect(decideAttachAction("offloaded")).toEqual({ kind: "resume" });
   });
 
   test("status=resuming → resume (coalesces onto in-flight op)", () => {
-    expect(decideAttachAction("agent-1", "resuming")).toEqual({ kind: "resume" });
+    expect(decideAttachAction("resuming")).toEqual({ kind: "resume" });
   });
 });
 
@@ -73,12 +67,6 @@ async function runDoAttach(opts: {
   // Mirrors session guard
   const session = store.sessions.find((s) => s.name === id);
   if (!session || session.status === "pending") return;
-
-  // Mirrors orchestrator guard
-  if (id === "orchestrator") {
-    store.setViewMode("graph");
-    return;
-  }
 
   setFocusedId(id);
 

--- a/packages/atomic-sdk/src/components/session-graph-panel.tsx
+++ b/packages/atomic-sdk/src/components/session-graph-panel.tsx
@@ -51,22 +51,16 @@ const GG_DOUBLE_TAP_MS = 300;
  * Pure function — no side effects, fully testable in isolation.
  *
  * Returns:
- *   { kind: "skip" }              — node not found or session pending
- *   { kind: "graphView" }         — id === "orchestrator"
  *   { kind: "resume" }            — session is offloaded or resuming
  *   { kind: "switchClient" }      — session is alive; issue switch-client
  */
 export type AttachDecision =
-  | { kind: "skip" }
-  | { kind: "graphView" }
   | { kind: "resume" }
   | { kind: "switchClient" };
 
 export function decideAttachAction(
-  id: string,
   offloadStatus: "alive" | "offloaded" | "resuming",
 ): AttachDecision {
-  if (id === "orchestrator") return { kind: "graphView" };
   if (offloadStatus === "offloaded" || offloadStatus === "resuming") return { kind: "resume" };
   return { kind: "switchClient" };
 }
@@ -84,6 +78,13 @@ export function SessionGraphPanel() {
   // Compute layout from current session data
   const layout = useMemo(() => computeLayout(store.sessions), [storeVersion]);
   const nodeList = useMemo(() => Object.values(layout.map), [layout]);
+
+  // Sessions visible in the switcher — same filter the switcher itself applies.
+  // The synthetic orchestrator has no graph node and isn't attachable.
+  const visibleSessions = useMemo(
+    () => store.sessions.filter((s) => s.name !== "orchestrator"),
+    [storeVersion],
+  );
 
   const connectors = useMemo(() => {
     const result: ConnectorResult[] = [];
@@ -144,12 +145,6 @@ export function SessionGraphPanel() {
       const session = store.sessions.find((s) => s.name === id);
       if (!session || session.status === "pending") return;
 
-      // Orchestrator = the graph view itself
-      if (id === "orchestrator") {
-        store.setViewMode("graph");
-        return;
-      }
-
       setFocusedId(id);
 
       // RFC §5.5 — gate switch-client on resume completion when offloaded.
@@ -182,10 +177,10 @@ export function SessionGraphPanel() {
   const openSwitcher = useCallback(() => {
     // Pre-select the current agent or focused node
     const currentId = store.viewMode === "attached" ? store.activeAgentId : focusedIdRef.current;
-    const idx = store.sessions.findIndex((s) => s.name === currentId);
+    const idx = visibleSessions.findIndex((s) => s.name === currentId);
     setSwitcherSel(Math.max(0, idx));
     setSwitcherOpen(true);
-  }, []);
+  }, [visibleSessions]);
 
   const closeSwitcher = useCallback(() => {
     setSwitcherOpen(false);
@@ -248,11 +243,11 @@ export function SessionGraphPanel() {
         return;
       }
       if (key.name === "down" || key.name === "j") {
-        setSwitcherSel((s) => Math.min(store.sessions.length - 1, s + 1));
+        setSwitcherSel((s) => Math.min(visibleSessions.length - 1, s + 1));
         return;
       }
       if (key.name === "return") {
-        const agent = store.sessions[switcherSel];
+        const agent = visibleSessions[switcherSel];
         closeSwitcher();
         if (agent) void doAttach(agent.name);
         return;
@@ -322,7 +317,10 @@ export function SessionGraphPanel() {
     if (key.name === "g" && !key.shift) {
       const now = Date.now();
       if (lastKeyRef.current.key === "g" && now - lastKeyRef.current.time < GG_DOUBLE_TAP_MS) {
-        setFocusedId(store.sessions[0]?.name ?? "");
+        // sessions[0] is the synthetic orchestrator, which is filtered out
+        // of layout.map. Pick the first session that actually has a node.
+        const firstVisible = store.sessions.find((s) => layout.map[s.name]);
+        setFocusedId(firstVisible?.name ?? "");
         lastKeyRef.current.key = "";
       } else {
         lastKeyRef.current.key = "g";

--- a/packages/atomic-sdk/src/components/session-graph-panel.tsx
+++ b/packages/atomic-sdk/src/components/session-graph-panel.tsx
@@ -35,6 +35,7 @@ import { Edge } from "./edge.tsx";
 import { Header } from "./header.tsx";
 import { CompactSwitcher } from "./compact-switcher.tsx";
 import { ToastStack } from "./toast.tsx";
+import { SYNTHETIC_ORCHESTRATOR_NAME } from "./orchestrator-panel-types.ts";
 import type { ViewMode } from "./orchestrator-panel-types.ts";
 
 /** Interval (ms) between pulse animation frames — ~60fps feel. */
@@ -82,7 +83,7 @@ export function SessionGraphPanel() {
   // Sessions visible in the switcher — same filter the switcher itself applies.
   // The synthetic orchestrator has no graph node and isn't attachable.
   const visibleSessions = useMemo(
-    () => store.sessions.filter((s) => s.name !== "orchestrator"),
+    () => store.getStageSessions(),
     [storeVersion],
   );
 
@@ -115,7 +116,7 @@ export function SessionGraphPanel() {
   // in the graph rather than blindly picking sessions[0].
   useEffect(() => {
     if (layout.map[focusedId]) return;
-    const firstVisible = store.sessions.find((s) => layout.map[s.name]);
+    const firstVisible = visibleSessions.find((s) => layout.map[s.name]);
     if (firstVisible) setFocusedId(firstVisible.name);
   }, [storeVersion]);
 
@@ -125,9 +126,10 @@ export function SessionGraphPanel() {
     [storeVersion],
   );
   const [pulsePhase, setPulsePhase] = useState(0);
-  // Pulse animation doubles as a live timer refresh — 60ms updates keep
-  // both the pulse animation and duration displays current, so a separate
-  // 1s tick interval is unnecessary.
+  // Pulse animation is paused while no stage is running. The header runs
+  // its own independent 1s ticker for the workflow duration so the timer
+  // keeps advancing between stages and after the graph panel unmounts —
+  // do not collapse the two intervals into one.
   useEffect(() => {
     if (!hasRunning) return;
     const pulseId = setInterval(
@@ -148,8 +150,10 @@ export function SessionGraphPanel() {
       setFocusedId(id);
 
       // RFC §5.5 — gate switch-client on resume completion when offloaded.
-      const status = offloadManager.getStatus(id);
-      if (status === "offloaded" || status === "resuming") {
+      // The branching is delegated to `decideAttachAction` so the production
+      // code path is the one covered by the helper's unit tests.
+      const decision = decideAttachAction(offloadManager.getStatus(id));
+      if (decision.kind === "resume") {
         store.setViewMode("resuming", id);
         try {
           await offloadManager.requestResume(id);
@@ -319,7 +323,7 @@ export function SessionGraphPanel() {
       if (lastKeyRef.current.key === "g" && now - lastKeyRef.current.time < GG_DOUBLE_TAP_MS) {
         // sessions[0] is the synthetic orchestrator, which is filtered out
         // of layout.map. Pick the first session that actually has a node.
-        const firstVisible = store.sessions.find((s) => layout.map[s.name]);
+        const firstVisible = visibleSessions.find((s) => layout.map[s.name]);
         setFocusedId(firstVisible?.name ?? "");
         lastKeyRef.current.key = "";
       } else {
@@ -385,7 +389,7 @@ export function SessionGraphPanel() {
   // never receives them.  Poll the active window to sync viewMode
   // with tmux-level navigation in both directions.
   const hasStartedAgent = useMemo(
-    () => store.sessions.some((s) => s.name !== "orchestrator" && s.status !== "pending"),
+    () => store.getStageSessions().some((s) => s.status !== "pending"),
     [storeVersion],
   );
 
@@ -410,7 +414,7 @@ export function SessionGraphPanel() {
 
       // Logical name: window index 0 is always the orchestrator regardless
       // of its tmux window name.
-      const currentName = idx === "0" ? "orchestrator" : windowName;
+      const currentName = idx === "0" ? SYNTHETIC_ORCHESTRATOR_NAME : windowName;
 
       // Update viewMode FIRST so offloadSession (called below) reads the
       // already-updated activeAgentId. Without this ordering, the focus
@@ -443,7 +447,7 @@ export function SessionGraphPanel() {
       // eligibility check filters out running/headless/already-offloaded
       // sessions, so we can fire unconditionally.
       const prevName = prevActiveRef.current;
-      if (prevName !== "" && prevName !== currentName && prevName !== "orchestrator") {
+      if (prevName !== "" && prevName !== currentName && prevName !== SYNTHETIC_ORCHESTRATOR_NAME) {
         void offloadManager.offloadSession(prevName).catch(() => {});
       }
 

--- a/packages/atomic-sdk/src/components/session-graph-panel.tsx
+++ b/packages/atomic-sdk/src/components/session-graph-panel.tsx
@@ -109,11 +109,13 @@ export function SessionGraphPanel() {
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [switcherSel, setSwitcherSel] = useState(0);
 
-  // Update focus when sessions first appear
+  // Update focus when sessions first appear. The orchestrator is filtered
+  // from the layout, so prefer the first session that actually has a node
+  // in the graph rather than blindly picking sessions[0].
   useEffect(() => {
-    if (store.sessions.length > 0 && !layout.map[focusedId]) {
-      setFocusedId(store.sessions[0]!.name);
-    }
+    if (layout.map[focusedId]) return;
+    const firstVisible = store.sessions.find((s) => layout.map[s.name]);
+    if (firstVisible) setFocusedId(firstVisible.name);
   }, [storeVersion]);
 
   // Pulse animation for running nodes — paused when nothing is running

--- a/packages/atomic-sdk/src/tui/attached-statusline.tsx
+++ b/packages/atomic-sdk/src/tui/attached-statusline.tsx
@@ -58,7 +58,11 @@ export const BACKGROUND_TASKS_OPTION = "bg-tasks";
 export function backgroundTasksValue(count: number, theme: GraphTheme): string {
   if (count <= 0) return "";
   const bg = theme.backgroundElement;
-  return ` #[fg=${theme.warning} bg=${bg}]◆ #[fg=${theme.textMuted} bg=${bg}]${count} background`;
+  // Two leading spaces: separates the indicator from the GRAPH pill that
+  // precedes it on the orchestrator window. One space looked cramped
+  // because the pill's own padding-right=1 only puts a single column
+  // outside the colored background.
+  return `  #[fg=${theme.warning} bg=${bg}]◆ #[fg=${theme.textMuted} bg=${bg}]${count} background`;
 }
 
 /**

--- a/tests/sdk/components/header.test.tsx
+++ b/tests/sdk/components/header.test.tsx
@@ -86,6 +86,96 @@ describe("Header", () => {
     expect(frame).toContain("\u2713");
   });
 
+  test("excludes the synthetic orchestrator entry from status counts", async () => {
+    const store = new PanelStore();
+    // Two user-defined stages, both pending. Orchestrator is also "running"
+    // internally but must NOT appear in any status badge.
+    store.setWorkflowInfo("wf", "claude", [
+      { name: "s1", parents: [] },
+      { name: "s2", parents: [] },
+    ], "p");
+
+    testSetup = await renderReact(
+      <TestProviders store={store}>
+        <Header />
+      </TestProviders>,
+      { width: 80, height: 5 },
+    );
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    // Pending badge shows the empty circle + count. Orchestrator-as-running
+    // would inflate the running count to 1; if exclusion works, the badge
+    // for running is absent entirely.
+    expect(frame).toContain("\u25cb 2"); // 2 pending stages, not 3
+    expect(frame).not.toContain("\u25cf 1"); // no running count from orchestrator
+  });
+
+  test("shows live workflow duration while running", async () => {
+    const store = new PanelStore();
+    store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
+    // Force a known elapsed floor so we don't depend on render timing.
+    // sec = floor(ms / 1000); ms in [5000, 6000) → "0m 05s".
+    const orchestrator = store.sessions.find((s) => s.name === "orchestrator")!;
+    orchestrator.startedAt = Date.now() - 5_100;
+
+    testSetup = await renderReact(
+      <TestProviders store={store}>
+        <Header />
+      </TestProviders>,
+      { width: 80, height: 5 },
+    );
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    // Match either 5s or 6s — render latency can push us into the next bucket
+    // on slow CI hosts. The point is that *some* live duration is shown.
+    expect(frame).toMatch(/0m 0[56]s/);
+  });
+
+  test("freezes duration at the terminal value after completion", async () => {
+    const store = new PanelStore();
+    store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
+    store.startSession("s1");
+    store.completeSession("s1");
+    // Pin startedAt and endedAt to a fixed delta — setCompletion will set
+    // endedAt to Date.now(), so override both after.
+    const orchestrator = store.sessions.find((s) => s.name === "orchestrator")!;
+    const start = Date.now();
+    orchestrator.startedAt = start;
+    store.setCompletion("wf", "/tmp/transcripts");
+    orchestrator.endedAt = start + 12_000; // exactly 12s elapsed
+
+    testSetup = await renderReact(
+      <TestProviders store={store}>
+        <Header />
+      </TestProviders>,
+      { width: 80, height: 5 },
+    );
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    // Frozen at endedAt - startedAt = 12s, regardless of wall-clock drift.
+    expect(frame).toContain("0m 12s");
+  });
+
+  test("freezes duration at the terminal value after fatal error", async () => {
+    const store = new PanelStore();
+    store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
+    const orchestrator = store.sessions.find((s) => s.name === "orchestrator")!;
+    const start = Date.now();
+    orchestrator.startedAt = start;
+    store.setFatalError("kaboom");
+    orchestrator.endedAt = start + 7_000;
+
+    testSetup = await renderReact(
+      <TestProviders store={store}>
+        <Header />
+      </TestProviders>,
+      { width: 80, height: 5 },
+    );
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("0m 07s");
+  });
+
   test("shows tmux session name next to badge", async () => {
     const store = new PanelStore();
     store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");

--- a/tests/sdk/components/header.test.tsx
+++ b/tests/sdk/components/header.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 
-import { test, expect, describe, afterEach } from "bun:test";
+import { test, expect, describe, afterEach, setSystemTime } from "bun:test";
 import { PanelStore } from "../../../packages/atomic-sdk/src/components/orchestrator-panel-store.ts";
 import { Header } from "../../../packages/atomic-sdk/src/components/header.tsx";
 import { renderReact, TestProviders, type ReactTestSetup } from "./test-helpers.tsx";
@@ -10,6 +10,8 @@ let testSetup: ReactTestSetup | null = null;
 afterEach(() => {
   testSetup?.renderer.destroy();
   testSetup = null;
+  // Reset any test-controlled system clock so the next test sees real time.
+  setSystemTime();
 });
 
 describe("Header", () => {
@@ -103,20 +105,23 @@ describe("Header", () => {
     );
     await testSetup.renderOnce();
     const frame = testSetup.captureCharFrame();
-    // Pending badge shows the empty circle + count. Orchestrator-as-running
-    // would inflate the running count to 1; if exclusion works, the badge
-    // for running is absent entirely.
+    // Pending badge shows exactly 2 (two user-defined stages); the running
+    // badge is rendered as null when the count is zero (CountBadge returns
+    // null on count <= 0), so the filled-circle glyph must be absent
+    // entirely. Asserting absence of the glyph itself \u2014 rather than `\u25cf 1`
+    // \u2014 survives any future test that adds a real running stage.
     expect(frame).toContain("\u25cb 2"); // 2 pending stages, not 3
-    expect(frame).not.toContain("\u25cf 1"); // no running count from orchestrator
+    expect(frame).not.toContain("\u25cf"); // running badge is null, glyph absent
   });
 
   test("shows live workflow duration while running", async () => {
+    // Set the clock back 5.1s before startup so startedAt lands there;
+    // restore real time before render so the live ticker reads "now".
+    const start = new Date("2026-01-01T00:00:00Z");
+    setSystemTime(start);
     const store = new PanelStore();
     store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
-    // Force a known elapsed floor so we don't depend on render timing.
-    // sec = floor(ms / 1000); ms in [5000, 6000) → "0m 05s".
-    const orchestrator = store.sessions.find((s) => s.name === "orchestrator")!;
-    orchestrator.startedAt = Date.now() - 5_100;
+    setSystemTime(new Date(start.getTime() + 5_100));
 
     testSetup = await renderReact(
       <TestProviders store={store}>
@@ -132,17 +137,20 @@ describe("Header", () => {
   });
 
   test("freezes duration at the terminal value after completion", async () => {
+    // Drive Date.now() so setWorkflowInfo's startedAt and setCompletion's
+    // endedAt land at controlled values. Avoids mutating the session record
+    // directly (would silently bypass a future copy-on-write store layer).
+    const start = new Date("2026-01-01T00:00:00Z");
+    setSystemTime(start);
+
     const store = new PanelStore();
     store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
     store.startSession("s1");
     store.completeSession("s1");
-    // Pin startedAt and endedAt to a fixed delta — setCompletion will set
-    // endedAt to Date.now(), so override both after.
-    const orchestrator = store.sessions.find((s) => s.name === "orchestrator")!;
-    const start = Date.now();
-    orchestrator.startedAt = start;
+
+    // Advance the clock 12s before setCompletion stamps endedAt.
+    setSystemTime(new Date(start.getTime() + 12_000));
     store.setCompletion("wf", "/tmp/transcripts");
-    orchestrator.endedAt = start + 12_000; // exactly 12s elapsed
 
     testSetup = await renderReact(
       <TestProviders store={store}>
@@ -157,13 +165,14 @@ describe("Header", () => {
   });
 
   test("freezes duration at the terminal value after fatal error", async () => {
+    const start = new Date("2026-01-01T00:00:00Z");
+    setSystemTime(start);
+
     const store = new PanelStore();
     store.setWorkflowInfo("wf", "claude", [{ name: "s1", parents: [] }], "p");
-    const orchestrator = store.sessions.find((s) => s.name === "orchestrator")!;
-    const start = Date.now();
-    orchestrator.startedAt = start;
+
+    setSystemTime(new Date(start.getTime() + 7_000));
     store.setFatalError("kaboom");
-    orchestrator.endedAt = start + 7_000;
 
     testSetup = await renderReact(
       <TestProviders store={store}>

--- a/tests/sdk/components/layout.test.ts
+++ b/tests/sdk/components/layout.test.ts
@@ -204,6 +204,10 @@ describe("computeLayout", () => {
   // ralph), each stage's parents array points at the prior stage instead
   // of the root "orchestrator". These tests assert that the layout treats
   // that shape as a linear chain (not a fan-out of siblings under the root).
+  //
+  // The orchestrator entry is filtered out of the layout — stages that
+  // declared it as their parent collapse to true roots — so depths shift
+  // down by one relative to the raw input order.
   describe("auto-inferred ralph chain", () => {
     test("single-iteration chain: plan → orch → review → debug", () => {
       const result = computeLayout([
@@ -213,21 +217,20 @@ describe("computeLayout", () => {
         makeSession("reviewer-1", ["orchestrator-1"]),
         makeSession("debugger-1", ["reviewer-1"]),
       ]);
-      expect(result.map["orchestrator"]!.depth).toBe(0);
-      expect(result.map["planner-1"]!.depth).toBe(1);
-      expect(result.map["orchestrator-1"]!.depth).toBe(2);
-      expect(result.map["reviewer-1"]!.depth).toBe(3);
-      expect(result.map["debugger-1"]!.depth).toBe(4);
+      expect(result.map["orchestrator"]).toBeUndefined();
+      expect(result.map["planner-1"]!.depth).toBe(0);
+      expect(result.map["orchestrator-1"]!.depth).toBe(1);
+      expect(result.map["reviewer-1"]!.depth).toBe(2);
+      expect(result.map["debugger-1"]!.depth).toBe(3);
 
       // Every node in a single chain lines up on the same x column.
-      const rootX = result.map["orchestrator"]!.x;
-      for (const n of ["planner-1", "orchestrator-1", "reviewer-1", "debugger-1"]) {
+      const rootX = result.map["planner-1"]!.x;
+      for (const n of ["orchestrator-1", "reviewer-1", "debugger-1"]) {
         expect(result.map[n]!.x).toBe(rootX);
       }
 
       // y increases monotonically as we descend the chain.
       const ys = [
-        result.map["orchestrator"]!.y,
         result.map["planner-1"]!.y,
         result.map["orchestrator-1"]!.y,
         result.map["reviewer-1"]!.y,
@@ -248,10 +251,10 @@ describe("computeLayout", () => {
         makeSession("planner-2", ["debugger-1"]),
         makeSession("orchestrator-2", ["planner-2"]),
       ]);
-      expect(result.map["planner-2"]!.depth).toBe(5);
-      expect(result.map["orchestrator-2"]!.depth).toBe(6);
+      expect(result.map["planner-2"]!.depth).toBe(4);
+      expect(result.map["orchestrator-2"]!.depth).toBe(5);
       // Still a single column.
-      const rootX = result.map["orchestrator"]!.x;
+      const rootX = result.map["planner-1"]!.x;
       expect(result.map["planner-2"]!.x).toBe(rootX);
       expect(result.map["orchestrator-2"]!.x).toBe(rootX);
     });
@@ -265,23 +268,24 @@ describe("computeLayout", () => {
         makeSession("reviewer-1", ["orchestrator-1"]),
         makeSession("reviewer-1-confirm", ["reviewer-1"]),
       ]);
-      expect(result.map["reviewer-1-confirm"]!.depth).toBe(4);
+      expect(result.map["reviewer-1-confirm"]!.depth).toBe(3);
       // No fan-out: reviewer-1 has exactly one child (reviewer-1-confirm)
       expect(result.map["reviewer-1"]!.children).toHaveLength(1);
       expect(result.map["reviewer-1"]!.children[0]!.name).toBe("reviewer-1-confirm");
     });
 
-    test("ralph chain never produces sibling fan-outs under orchestrator", () => {
+    test("ralph chain never produces sibling fan-outs at the root", () => {
       // Regression for the bug where planner-1 and orchestrator-1 appeared
-      // side by side under orchestrator because both used the default parent.
+      // side by side because both used the default parent. With orchestrator
+      // filtered, the chain must still resolve to a single-root linear
+      // spine (planner-1 → orchestrator-1) rather than two parallel roots.
       const result = computeLayout([
         makeSession("orchestrator"),
         makeSession("planner-1", ["orchestrator"]),
         makeSession("orchestrator-1", ["planner-1"]),
       ]);
-      // orchestrator has exactly one child (planner-1), not two.
-      expect(result.map["orchestrator"]!.children).toHaveLength(1);
-      expect(result.map["orchestrator"]!.children[0]!.name).toBe("planner-1");
+      expect(result.roots).toHaveLength(1);
+      expect(result.roots[0]!.name).toBe("planner-1");
       expect(result.map["planner-1"]!.children).toHaveLength(1);
       expect(result.map["planner-1"]!.children[0]!.name).toBe("orchestrator-1");
     });

--- a/tests/sdk/components/session-graph-panel.test.tsx
+++ b/tests/sdk/components/session-graph-panel.test.tsx
@@ -39,7 +39,8 @@ describe("SessionGraphPanel", () => {
       const store = createPopulatedStore();
       const setup = await renderPanel(store);
       const frame = setup.captureCharFrame();
-      expect(frame).toContain("orchestrator");
+      // The runtime "orchestrator" entry is filtered from the graph; only
+      // user-defined stages appear as nodes.
       expect(frame).toContain("worker-1");
       expect(frame).toContain("worker-2");
       expect(frame).toContain("merge");
@@ -91,16 +92,17 @@ describe("SessionGraphPanel", () => {
       const store = createPopulatedStore();
       const setup = await renderPanel(store);
 
-      // Initial focus is on "orchestrator"
+      // Initial focus lands on the first visible stage (worker-1 — the
+      // synthetic orchestrator entry is filtered before layout).
       let frame = setup.captureCharFrame();
-      expect(frame).toContain("orchestrator");
+      expect(frame).toContain("worker-1");
 
       // Press right arrow to move focus
       setup.mockInput.pressArrow("right");
       await setup.renderOnce();
       // Frame should still render (focus changed internally)
       frame = setup.captureCharFrame();
-      expect(frame).toContain("orchestrator");
+      expect(frame).toContain("worker-2");
     });
 
     test("arrow down moves focus to child node", async () => {
@@ -136,7 +138,8 @@ describe("SessionGraphPanel", () => {
       await setup.renderOnce();
 
       const frame = setup.captureCharFrame();
-      expect(frame).toContain("orchestrator");
+      // After a hjkl round-trip the graph still renders its stages.
+      expect(frame).toContain("worker-1");
     });
 
     test("G (shift+g) moves to deepest node", async () => {
@@ -165,7 +168,9 @@ describe("SessionGraphPanel", () => {
       await setup.renderOnce();
 
       const frame = setup.captureCharFrame();
-      expect(frame).toContain("orchestrator");
+      // gg returns to the first visible root stage rather than the
+      // (filtered) orchestrator entry.
+      expect(frame).toContain("worker-1");
     });
 
     test("enter triggers attach flash message", async () => {
@@ -324,7 +329,8 @@ describe("SessionGraphPanel", () => {
       await setup.renderOnce();
 
       const frame = setup.captureCharFrame();
-      expect(frame).toContain("orchestrator");
+      // After resize the visible stages still render somewhere on screen.
+      expect(frame).toContain("worker-1");
     });
   });
 });


### PR DESCRIPTION
## Summary

Removes the synthetic \"orchestrator\" node from the session graph DAG and surfaces its only useful signal — workflow duration — directly in the panel header instead. The orchestrator entry is filtered at the layout layer only; the underlying store data and session model are unchanged.

## Changes

### `orchestrator-panel-types.ts`
- Extracts the orchestrator name into a `SYNTHETIC_ORCHESTRATOR_NAME` constant so every filter downstream imports the constant rather than spelling the magic string — a rename here now updates all consumers in one place

### `orchestrator-panel-store.ts`
- Adds `getOrchestratorSession()` — single source of truth for reading the timing bookkeeping entry (startedAt/endedAt) used by the header duration display
- Adds `getStageSessions()` — returns all sessions except the orchestrator; used by the header badge counts, compact switcher, and `gg` navigation as the authoritative \"real stages\" list
- Replaces inline `sessions.find(s => s.name === "orchestrator")` calls in `setCompletion` and `setFatalError` with the new accessor

### `layout.ts`
- Filters the `orchestrator` entry before building the node map, so all downstream passes (depth resolution, placement, overlap detection, connectors) operate only on user-defined stages
- Removes the orphan-reparenting fallback: stages with missing or unknown parents now become true roots (`parents: []`, `depth: 0`) instead of being attached to the orchestrator node as a synthetic anchor
- `normalizeParents` simplified — no more `hasOrchestrator` branch, just filter missing refs and dedupe

### `header.tsx`
- Adds a live workflow duration display at the right end of the header, derived from the orchestrator session's `startedAt`/`endedAt` timestamps
- Ticks once per second while running via `setInterval`; freezes at the terminal value on completion or failure
- Duration color reflects workflow state: red on failure, green on success, muted while running
- Status badge counts now exclude the orchestrator entry — all badges reflect real user-defined stages only

### `session-graph-panel.tsx`
- `visibleSessions` computed from `store.getStageSessions()` — switcher selection index and keyboard navigation operate on this instead of raw `store.sessions`
- Initial focus skips the filtered orchestrator and lands on the first session that actually has a node in the layout
- Removes orchestrator-specific guard in `doAttach` — the orchestrator is never selectable so the guard was dead code
- `decideAttachAction` drops the `id` parameter (the orchestrator case it handled is gone) and its return type loses the `graphView` variant
- `gg` keybinding (go to top) now resolves to the first visible root stage rather than `sessions[0]` which was the hidden orchestrator

### `compact-switcher.tsx`
- Filters the orchestrator entry out of the session list via `store.getStageSessions()` — it has no graph node and selecting it would silently no-op inside `doAttach`

### `attached-statusline.tsx`
- Increases leading space on the background-tasks indicator from one space to two, fixing a cramped layout against the GRAPH pill on the orchestrator window

### Tests
- Updated throughout to match new semantics: depths shift down by one (orchestrator removed from root), `layout.map["orchestrator"]` is `undefined`, and orphans become true roots rather than orchestrator children
- Integration test in `connectors.test.ts` updated: orchestrator node never reaches the connector layer; orphan becomes a root with no connectors
- New `header.test.tsx` tests cover: orchestrator exclusion from status counts, live duration display while running, and frozen duration after completion and fatal error

## Breaking Changes

None — the orchestrator entry is filtered at the layout layer only; the underlying store data and session model are unchanged.