### PR TITLE
feat(tui): pulse bg-tasks diamond + fix timer color and bg-tasks spacing

### DIFF
--- a/packages/atomic-sdk/src/components/header.tsx
+++ b/packages/atomic-sdk/src/components/header.tsx
@@ -78,7 +78,7 @@ export function Header() {
   }, [orchestrator?.startedAt, orchestrator?.endedAt, tickNow]);
   const durationColor = isFailed
     ? theme.error
-    : isDone
+    : isRunning
       ? theme.success
       : theme.textMuted;
 

--- a/packages/atomic-sdk/src/components/orchestrator-panel.tsx
+++ b/packages/atomic-sdk/src/components/orchestrator-panel.tsx
@@ -25,7 +25,10 @@ import {
   BACKGROUND_TASKS_OPTION,
   backgroundTasksValue,
 } from "../tui/attached-statusline.tsx";
-import { setStatuslineState } from "../tui/mux.ts";
+import { refreshStatusline, setStatuslineState } from "../tui/mux.ts";
+
+/** Frame period (ms) of the background-tasks "breathing" pulse. */
+const BG_PULSE_INTERVAL_MS = 850;
 
 export class OrchestratorPanel {
   private store: PanelStore;
@@ -38,6 +41,12 @@ export class OrchestratorPanel {
   private tmuxSession: string;
   private offloadManager: OffloadManager | null = null;
   private rerender: () => void = () => {};
+  // Drives the bottom-left bg-tasks indicator pulse: alternates the ◆
+  // between its warning colour and a muted one while at least one
+  // headless background task is in flight, so a settled-looking graph
+  // still reads as "work in progress". Null when nothing is running.
+  private bgPulseTimer: ReturnType<typeof setInterval> | null = null;
+  private bgPulseDim = false;
 
   private constructor(
     renderer: CliRenderer,
@@ -175,13 +184,39 @@ export class OrchestratorPanel {
   /** Increment the background task counter (shown in the statusline footer). */
   backgroundTaskStarted(): void {
     this.store.incrementBackgroundTasks();
+    this.startBackgroundPulse();
     this.pushBackgroundTasksIndicator();
   }
 
   /** Decrement the background task counter (shown in the statusline footer). */
   backgroundTaskFinished(): void {
     this.store.decrementBackgroundTasks();
+    if (this.store.backgroundTaskCount <= 0) this.stopBackgroundPulse();
     this.pushBackgroundTasksIndicator();
+  }
+
+  /**
+   * Start the bg-tasks pulse if it isn't already running. The timer is
+   * `unref`'d so a stray frame can never keep the process alive — when
+   * tasks are genuinely in flight the workflow is still running anyway,
+   * and `stopBackgroundPulse` clears it the moment the count hits zero.
+   */
+  private startBackgroundPulse(): void {
+    if (this.bgPulseTimer) return;
+    const timer = setInterval(() => {
+      this.bgPulseDim = !this.bgPulseDim;
+      this.pushBackgroundTasksIndicator();
+    }, BG_PULSE_INTERVAL_MS);
+    timer.unref?.();
+    this.bgPulseTimer = timer;
+  }
+
+  private stopBackgroundPulse(): void {
+    if (this.bgPulseTimer) {
+      clearInterval(this.bgPulseTimer);
+      this.bgPulseTimer = null;
+    }
+    this.bgPulseDim = false;
   }
 
   /**
@@ -189,13 +224,19 @@ export class OrchestratorPanel {
    * orchestrator branch of the status-line references inline. Pushing
    * scopes to this workflow's tmux session so concurrent atomic
    * sessions on the shared socket don't clobber each other's count.
+   * Forces a status redraw afterwards so each pulse frame (and the
+   * count itself) surfaces immediately instead of on the next
+   * `status-interval` tick.
    */
   private pushBackgroundTasksIndicator(): void {
     setStatuslineState(
       BACKGROUND_TASKS_OPTION,
-      backgroundTasksValue(this.store.backgroundTaskCount, this.graphTheme),
+      backgroundTasksValue(this.store.backgroundTaskCount, this.graphTheme, {
+        pulseDim: this.bgPulseDim,
+      }),
       this.tmuxSession,
     );
+    refreshStatusline();
   }
 
   /** Show the workflow-complete banner with a link to saved transcripts. */
@@ -233,6 +274,7 @@ export class OrchestratorPanel {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    this.stopBackgroundPulse();
     this.unsubscribeDiagnostics?.();
     this.unsubscribeDiagnostics = null;
     this.diagnostics?.capture("destroy");

--- a/packages/atomic-sdk/src/components/orchestrator-panel.tsx
+++ b/packages/atomic-sdk/src/components/orchestrator-panel.tsx
@@ -205,7 +205,10 @@ export class OrchestratorPanel {
     if (this.bgPulseTimer) return;
     const timer = setInterval(() => {
       this.bgPulseDim = !this.bgPulseDim;
-      this.pushBackgroundTasksIndicator();
+      // Pulse frames ride the 1s `status-interval` redraw rather than
+      // forcing one — a sub-second jitter on a "breathing" glyph is
+      // invisible, and it keeps a tmux process-spawn off the timer path.
+      this.pushBackgroundTasksIndicator({ refresh: false });
     }, BG_PULSE_INTERVAL_MS);
     timer.unref?.();
     this.bgPulseTimer = timer;
@@ -224,11 +227,11 @@ export class OrchestratorPanel {
    * orchestrator branch of the status-line references inline. Pushing
    * scopes to this workflow's tmux session so concurrent atomic
    * sessions on the shared socket don't clobber each other's count.
-   * Forces a status redraw afterwards so each pulse frame (and the
-   * count itself) surfaces immediately instead of on the next
-   * `status-interval` tick.
+   * Pass `refresh: false` to skip the forced redraw and let the next
+   * `status-interval` tick surface the value — used by the pulse timer
+   * so only genuine count changes pay for an extra tmux spawn.
    */
-  private pushBackgroundTasksIndicator(): void {
+  private pushBackgroundTasksIndicator({ refresh = true }: { refresh?: boolean } = {}): void {
     setStatuslineState(
       BACKGROUND_TASKS_OPTION,
       backgroundTasksValue(this.store.backgroundTaskCount, this.graphTheme, {
@@ -236,7 +239,7 @@ export class OrchestratorPanel {
       }),
       this.tmuxSession,
     );
-    refreshStatusline();
+    if (refresh) refreshStatusline();
   }
 
   /** Show the workflow-complete banner with a link to saved transcripts. */

--- a/packages/atomic-sdk/src/runtime/attached-footer.test.ts
+++ b/packages/atomic-sdk/src/runtime/attached-footer.test.ts
@@ -156,6 +156,26 @@ describe("backgroundTasksValue", () => {
     expect(value).toContain(`bg=${THEME.backgroundElement}`);
     expect(value).toContain(`fg=${THEME.warning}`);
   });
+
+  test("bright frame paints the diamond in the warning colour", () => {
+    expect(backgroundTasksValue(2, THEME, { pulseDim: false })).toContain(
+      `fg=${THEME.warning}`,
+    );
+  });
+
+  test("dim frame fades only the diamond, label stays muted", () => {
+    const value = backgroundTasksValue(2, THEME, { pulseDim: true });
+    expect(value).toContain("2 background");
+    // The diamond glyph is repainted with the dim colour…
+    expect(value).toContain(`fg=${THEME.textDim}`);
+    expect(value).toContain("◆");
+    // …and the warning colour no longer appears anywhere.
+    expect(value).not.toContain(`fg=${THEME.warning}`);
+    // The label keeps its own muted colour regardless of the frame.
+    expect(value).toContain(`fg=${THEME.textMuted}`);
+    // Still comma-free so the conditional expansion stays psmux-safe.
+    expect(value).not.toMatch(/#\[[^\]]*,[^\]]*\]/);
+  });
 });
 
 describe("attachedStatusline (chat variant)", () => {

--- a/packages/atomic-sdk/src/runtime/tmux.conf
+++ b/packages/atomic-sdk/src/runtime/tmux.conf
@@ -16,7 +16,7 @@ set-option -g allow-rename off
 set -g escape-time 0
 set -g history-limit 50000
 set -g display-time 4000
-set -g status-interval 5
+set -g status-interval 1
 set -g focus-events on
 setw -g aggressive-resize on
 

--- a/packages/atomic-sdk/src/tui/attached-statusline.tsx
+++ b/packages/atomic-sdk/src/tui/attached-statusline.tsx
@@ -58,11 +58,12 @@ export const BACKGROUND_TASKS_OPTION = "bg-tasks";
 export function backgroundTasksValue(count: number, theme: GraphTheme): string {
   if (count <= 0) return "";
   const bg = theme.backgroundElement;
-  // Two leading spaces: separates the indicator from the GRAPH pill that
-  // precedes it on the orchestrator window. One space looked cramped
-  // because the pill's own padding-right=1 only puts a single column
-  // outside the colored background.
-  return `  #[fg=${theme.warning} bg=${bg}]◆ #[fg=${theme.textMuted} bg=${bg}]${count} background`;
+  // Lead with an explicit `bg` reset *before* the spacer columns so the
+  // gap renders in the footer colour rather than inheriting the GRAPH
+  // pill's background (which made the pill look wider and left the
+  // diamond visually flush against it). Two spacer columns then keep the
+  // indicator clear of the pill's own padding-right=1.
+  return `#[bg=${bg}]  #[fg=${theme.warning} bg=${bg}]◆ #[fg=${theme.textMuted} bg=${bg}]${count} background`;
 }
 
 /**

--- a/packages/atomic-sdk/src/tui/attached-statusline.tsx
+++ b/packages/atomic-sdk/src/tui/attached-statusline.tsx
@@ -54,16 +54,26 @@ export const BACKGROUND_TASKS_OPTION = "bg-tasks";
  * count is zero so the status line collapses cleanly. Style attributes
  * are space-separated to keep psmux 3.3.3's render parser happy
  * (commas inside `#[…]` inside `#{?…}` leak fragments across branches).
+ *
+ * `pulseDim` repaints just the ◆ glyph in the muted colour for the
+ * "off" half of the breathing pulse the orchestrator panel drives
+ * while headless background tasks are still running; the count label
+ * keeps its own muted colour either way so only the diamond animates.
  */
-export function backgroundTasksValue(count: number, theme: GraphTheme): string {
+export function backgroundTasksValue(
+  count: number,
+  theme: GraphTheme,
+  opts?: { pulseDim?: boolean },
+): string {
   if (count <= 0) return "";
   const bg = theme.backgroundElement;
+  const diamondFg = opts?.pulseDim ? theme.textDim : theme.warning;
   // Lead with an explicit `bg` reset *before* the spacer columns so the
   // gap renders in the footer colour rather than inheriting the GRAPH
   // pill's background (which made the pill look wider and left the
   // diamond visually flush against it). Two spacer columns then keep the
   // indicator clear of the pill's own padding-right=1.
-  return `#[bg=${bg}]  #[fg=${theme.warning} bg=${bg}]◆ #[fg=${theme.textMuted} bg=${bg}]${count} background`;
+  return `#[bg=${bg}]  #[fg=${diamondFg} bg=${bg}]◆ #[fg=${theme.textMuted} bg=${bg}]${count} background`;
 }
 
 /**

--- a/packages/atomic-sdk/src/tui/mux.ts
+++ b/packages/atomic-sdk/src/tui/mux.ts
@@ -88,9 +88,9 @@ export function setStatuslineState(
  * Force psmux to redraw the status line for every attached client on
  * Atomic's dedicated socket *now*, rather than waiting for the next
  * `status-interval` tick. Needed when a freshly pushed
- * `setStatuslineState` value must surface immediately — e.g. the
- * background-tasks pulse, which re-pushes a new frame several times a
- * second. A no-op (and harmless) when no client is attached.
+ * `setStatuslineState` value must surface immediately — e.g. a change
+ * to the background-tasks count. A no-op (and harmless) when no client
+ * is attached.
  */
 export function refreshStatusline(): TmuxResult {
   return tmuxRun(["refresh-client", "-S"]);

--- a/packages/atomic-sdk/src/tui/mux.ts
+++ b/packages/atomic-sdk/src/tui/mux.ts
@@ -83,3 +83,15 @@ export function setStatuslineState(
 ): TmuxResult {
   return setOption(`@atomic-${id}`, value, sessionName);
 }
+
+/**
+ * Force psmux to redraw the status line for every attached client on
+ * Atomic's dedicated socket *now*, rather than waiting for the next
+ * `status-interval` tick. Needed when a freshly pushed
+ * `setStatuslineState` value must surface immediately — e.g. the
+ * background-tasks pulse, which re-pushes a new frame several times a
+ * second. A no-op (and harmless) when no client is attached.
+ */
+export function refreshStatusline(): TmuxResult {
+  return tmuxRun(["refresh-client", "-S"]);
+}


### PR DESCRIPTION
## Summary

Three TUI polish changes on the workflow graph: the elapsed-time counter now shows accent green while a run is in-progress (reverting to muted grey on completion), the bg-tasks status-line indicator correctly resets its background before the spacer columns so the GRAPH pill renders at the right width, and the ◆ bg-tasks diamond now breathes (pulses between warning and dim colour) while headless background tasks are running.

## Changes

- **`components/header.tsx`**: Fix `durationColor` logic — swap `isDone` → `isRunning` in the ternary so the timer is green while the workflow is active, muted grey when it finishes, and error red on failure. The original logic had the colours inverted: `theme.success` only applied after completion, never during a live run.

- **`tui/attached-statusline.tsx`**: Prefix the `backgroundTasksValue` string with `#[bg=${bg}]` before the two spacer columns. Without this explicit reset the spacers inherited the GRAPH pill's background color, making the pill appear visually wider and leaving the ◆ glyph flush against it. Also adds a `pulseDim` option that alternates the diamond between `theme.warning` and `theme.textDim` while keeping the count label in its own muted colour, so only the diamond animates.

- **`components/orchestrator-panel.tsx`**: Introduces `startBackgroundPulse` / `stopBackgroundPulse` driven by an 850 ms `setInterval`. The timer starts when the first background task is registered and stops when the count reaches zero (and is cleaned up in `destroy`). The interval is `unref`'d so a stray frame can never keep the process alive. Pulse frames call `pushBackgroundTasksIndicator({ refresh: false })` — they write state but rely on tmux's own `status-interval` tick to surface it, so only genuine count changes pay for a forced `refresh-client` spawn.

- **`tui/mux.ts`**: Adds `refreshStatusline()` — a thin wrapper around `tmux refresh-client -S` — called when the background-task count actually changes (start/stop) so those transitions surface immediately rather than waiting for the next `status-interval` tick.

- **`runtime/tmux.conf`**: Reduces `status-interval` from 5 s → 1 s. The pulse timer writes a new frame every 850 ms but lets tmux's own interval pick it up; with a 5 s interval the diamond would barely move, so 1 s gives a smooth breathing effect without spawning a tmux process per frame.

- **`runtime/attached-footer.test.ts`**: Adds two tests covering the `pulseDim` option: bright frame keeps the diamond in `theme.warning`, dim frame repaints it to `theme.textDim` while the label stays `theme.textMuted`, and no commas appear inside `#[…]` attributes (psmux 3.3.3 parser safety).

## Test plan

- [x] `bun typecheck`
- [x] `bun test packages/atomic-sdk/src/runtime/attached-footer.test.ts` (15 pass → now 17 pass)
- [ ] Visual check in TUI: timer shows accent green while running, muted grey when done; GRAPH pill separated cleanly from the ◆ bg-tasks indicator; diamond pulses while background tasks are in flight