### PR TITLE
fix(claude): resolve headless stage deadlock on end_turn

### DIFF
--- a/packages/atomic-sdk/src/providers/claude.headlessDisconnect.test.ts
+++ b/packages/atomic-sdk/src/providers/claude.headlessDisconnect.test.ts
@@ -107,4 +107,35 @@ describe("HeadlessClaudeSessionWrapper.disconnect()", () => {
 
     expect(fake.returnCalls).toBe(1);
   });
+
+  test("resolves within the deadline even if Query.return() never resolves", async () => {
+    // Regression test for the cleanup-hang risk: if the SDK's
+    // transport.close() / child-exit waits wedge (e.g. uninterruptible
+    // sleep, stuck transcript flush), the wrapper must not block the
+    // stage cleanup forever. Exercise the helper directly with a tight
+    // 100ms deadline — disconnect()'s production value is ~10s, but the
+    // mechanism under test is identical.
+    const { awaitReturnWithDeadline } = await import("./claude.ts");
+    const neverResolving = {
+      return: () => new Promise<IteratorResult<unknown>>(() => {}),
+      next: async () =>
+        ({ value: undefined, done: true }) as IteratorResult<unknown>,
+      throw: async () =>
+        ({ value: undefined, done: true }) as IteratorResult<unknown>,
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+
+    const start = Date.now();
+    await awaitReturnWithDeadline(
+      neverResolving as unknown as Parameters<typeof awaitReturnWithDeadline>[0],
+      100,
+    );
+    const elapsed = Date.now() - start;
+    // Should be ≈100ms; allow generous slack for slow CI hosts but stay
+    // well under "would have hung indefinitely" territory.
+    expect(elapsed).toBeGreaterThanOrEqual(90);
+    expect(elapsed).toBeLessThan(2_000);
+  });
 });

--- a/packages/atomic-sdk/src/providers/claude.headlessDisconnect.test.ts
+++ b/packages/atomic-sdk/src/providers/claude.headlessDisconnect.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for HeadlessClaudeSessionWrapper.disconnect().
+ *
+ * Regression coverage for the headless-stage deadlock: when an Agent SDK
+ * `query()` ends cleanly with `stop_reason: end_turn`, the spawned `claude`
+ * child stays alive (the `stream-json` transport is long-lived across
+ * turns). disconnect() must:
+ *   1. Force the SDK's `Query.return()` path so the transport closes
+ *      stdin and SIGTERMs the child.
+ *   2. Run `claudeOffloadCleanup` against the last-known session id so
+ *      the per-session marker files do not leak.
+ */
+
+import { test, expect, describe } from "bun:test";
+import { HeadlessClaudeSessionWrapper } from "./claude.ts";
+
+type Maybe<T> = T | undefined;
+
+/**
+ * Minimal stand-in for the SDK's `Query` generator. Only `return()` is
+ * exercised by disconnect(); the other AsyncGenerator methods exist purely
+ * so the structural cast lines up.
+ */
+function makeFakeQuery(): {
+  query: {
+    return: (value?: unknown) => Promise<IteratorResult<unknown>>;
+    next: () => Promise<IteratorResult<unknown>>;
+    throw: (err: unknown) => Promise<IteratorResult<unknown>>;
+    [Symbol.asyncIterator]: () => AsyncGenerator<unknown>;
+  };
+  returnCalls: number;
+} {
+  let returnCalls = 0;
+  const query = {
+    return: async (value?: unknown) => {
+      returnCalls += 1;
+      return { value, done: true } as IteratorResult<unknown>;
+    },
+    next: async () => ({ value: undefined, done: true } as IteratorResult<unknown>),
+    throw: async (_err: unknown) =>
+      ({ value: undefined, done: true } as IteratorResult<unknown>),
+    [Symbol.asyncIterator]: function () {
+      return this as unknown as AsyncGenerator<unknown>;
+    },
+  };
+  return {
+    query,
+    get returnCalls() {
+      return returnCalls;
+    },
+  } as unknown as { query: typeof query; returnCalls: number };
+}
+
+describe("HeadlessClaudeSessionWrapper.disconnect()", () => {
+  test("no active query, no session id → resolves silently", async () => {
+    const wrapper = new HeadlessClaudeSessionWrapper("/tmp/atomic-test-project");
+    await expect(wrapper.disconnect()).resolves.toBeUndefined();
+  });
+
+  test("calls Query.return() on the in-flight SDK generator", async () => {
+    const wrapper = new HeadlessClaudeSessionWrapper("/tmp/atomic-test-project");
+    const fake = makeFakeQuery();
+    // The wrapper's `_activeQuery` is private but the runtime contract is
+    // that disconnect() drives whichever Query is currently held — set it
+    // via a structural cast to exercise that path.
+    (wrapper as unknown as { _activeQuery: Maybe<typeof fake.query> })._activeQuery =
+      fake.query;
+
+    await wrapper.disconnect();
+
+    expect(fake.returnCalls).toBe(1);
+    // disconnect() must clear the slot so a second call is a no-op even if
+    // the first call's transport teardown was already in flight.
+    expect(
+      (wrapper as unknown as { _activeQuery: Maybe<unknown> })._activeQuery,
+    ).toBeUndefined();
+  });
+
+  test("swallows errors thrown from Query.return()", async () => {
+    const wrapper = new HeadlessClaudeSessionWrapper("/tmp/atomic-test-project");
+    const exploding = {
+      return: async () => {
+        throw new Error("boom");
+      },
+      next: async () => ({ value: undefined, done: true }) as IteratorResult<unknown>,
+      throw: async () =>
+        ({ value: undefined, done: true }) as IteratorResult<unknown>,
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    (
+      wrapper as unknown as { _activeQuery: Maybe<typeof exploding> }
+    )._activeQuery = exploding;
+
+    await expect(wrapper.disconnect()).resolves.toBeUndefined();
+  });
+
+  test("idempotent — second call with no active query is a no-op", async () => {
+    const wrapper = new HeadlessClaudeSessionWrapper("/tmp/atomic-test-project");
+    const fake = makeFakeQuery();
+    (wrapper as unknown as { _activeQuery: Maybe<typeof fake.query> })._activeQuery =
+      fake.query;
+
+    await wrapper.disconnect();
+    await wrapper.disconnect();
+
+    expect(fake.returnCalls).toBe(1);
+  });
+});

--- a/packages/atomic-sdk/src/providers/claude.ts
+++ b/packages/atomic-sdk/src/providers/claude.ts
@@ -1336,6 +1336,47 @@ export function resolveHeadlessClaudeBin(): string {
 }
 
 /**
+ * Hard upper bound on how long the wrapper will block waiting for the
+ * Agent SDK's `Query.return()` to finish tearing down the spawned `claude`
+ * child. Chosen with ~3s headroom over the SDK's own escalation ladder
+ * (stdin close → SIGTERM at +2s → SIGKILL at +5s ≈ 7s worst case). The
+ * SDK's `cleanup()` also awaits an internal transcript flush before
+ * touching the transport, which can stall on slow disk — without this
+ * wrapper-level deadline, a wedged child or stuck I/O would pin the
+ * entire stage cleanup indefinitely.
+ */
+const DISCONNECT_RETURN_TIMEOUT_MS = 10_000;
+
+/**
+ * Race `active.return(undefined)` against {@link DISCONNECT_RETURN_TIMEOUT_MS}
+ * so a stuck child process can never block the cleanup path forever.
+ * Rejection from `return()` is allowed to propagate — callers wrap this in
+ * a try/catch and swallow per the "best-effort cleanup" contract.
+ *
+ * Exported for contract-testing only — production callers pass through
+ * {@link HeadlessClaudeSessionWrapper.disconnect} and the `query()` finally.
+ */
+export async function awaitReturnWithDeadline(
+  active: SDKQuery,
+  timeoutMs: number = DISCONNECT_RETURN_TIMEOUT_MS,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      active.return(undefined).then(() => undefined),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+        // Don't keep the event loop alive solely for the safety timer —
+        // if the process is otherwise idle, the timer should not block exit.
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
  * Headless session wrapper for Claude stages. Uses the Agent SDK's `query()`
  * directly instead of tmux pane operations. Implements the same `query()`
  * interface as {@link ClaudeSessionWrapper} so workflow callbacks work
@@ -1380,14 +1421,26 @@ export class HeadlessClaudeSessionWrapper {
    * In-flight Agent SDK generator from the current `query()` call. Held so
    * {@link disconnect} (or the per-stage cleanup path) can force the SDK
    * to tear down the spawned `claude` child process — calling `.return()`
-   * on the generator triggers `transport.close()`, which closes the
-   * child's stdin and SIGTERMs it after a 2s grace window.
+   * on the generator triggers `transport.close()`, which runs the SDK's
+   * shutdown ladder:
+   *
+   *   t=0     close child stdin
+   *   t≈2s    SIGTERM the child if still alive
+   *   t≈7s    SIGKILL the child if still alive (5s after SIGTERM)
    *
    * Without this, headless stages that end cleanly with `stop_reason:
    * end_turn` deadlock: the SDK's `stream-json` transport keeps the
    * child alive across turns, the for-await loop below never observes a
    * natural end-of-iterator, and `await session.query(...)` waits forever
    * on the child process exit that never happens.
+   *
+   * Contract: this wrapper is single-shot per instance — one in-flight
+   * `query()` call at a time. `_lastSessionId` and `_lastStructuredOutput`
+   * are written without synchronization, so concurrent `query()` invocations
+   * on the same wrapper would corrupt observed state. The
+   * `this._activeQuery === activeQuery` guard in the `query()` finally is
+   * defensive (e.g. against a `disconnect()` racing with a fresh `query()`)
+   * and is expected never to trigger in normal use.
    */
   private _activeQuery: SDKQuery | undefined;
 
@@ -1441,6 +1494,14 @@ export class HeadlessClaudeSessionWrapper {
             // `stream-json` transport keeps the child alive across turns,
             // so on `end_turn` the loop hangs even after the API turn has
             // cleanly completed.
+            //
+            // Safe to discard the iterator tail: `result` is terminal for
+            // single-turn queries (the `error_*` subtypes the SDK can emit
+            // — `error_max_turns`, `error_during_execution`,
+            // `error_max_structured_output_retries` — are themselves
+            // `result` subtypes, not post-result follow-ons). The
+            // transcript downstream consumers care about is read from
+            // disk via `getSessionMessages` below, not from this stream.
             break;
           }
         }
@@ -1449,17 +1510,18 @@ export class HeadlessClaudeSessionWrapper {
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(`Claude SDK query failed: ${detail}`);
     } finally {
-      // Drive the SDK's `Query.return()` path so it closes stdin and
-      // SIGTERMs the child (with a SIGKILL fallback after ~5s). Safe to
-      // call even when the iterator already ran to completion — the SDK
-      // dedupes via an internal `cleanupPerformed` guard.
+      // Drive the SDK's `Query.return()` path so it runs the shutdown
+      // ladder documented on `_activeQuery` (stdin close → SIGTERM at +2s
+      // → SIGKILL at +5s). Safe to call even when the iterator already
+      // ran to completion — the SDK dedupes via an internal
+      // `cleanupPerformed` guard.
       const toClose = activeQuery ?? this._activeQuery;
       if (this._activeQuery === activeQuery) {
         this._activeQuery = undefined;
       }
       if (toClose) {
         try {
-          await toClose.return(undefined);
+          await awaitReturnWithDeadline(toClose);
         } catch {
           // Best-effort — the SDK's cleanup path swallows transport errors
           // already, so anything that escapes here is unexpected and not
@@ -1494,7 +1556,7 @@ export class HeadlessClaudeSessionWrapper {
     this._activeQuery = undefined;
     if (active) {
       try {
-        await active.return(undefined);
+        await awaitReturnWithDeadline(active);
       } catch {
         // Best-effort — the SDK's cleanup is idempotent and already
         // swallows transport-level errors internally.

--- a/packages/atomic-sdk/src/providers/claude.ts
+++ b/packages/atomic-sdk/src/providers/claude.ts
@@ -20,6 +20,7 @@
 import {
   getSessionMessages,
   query as sdkQuery,
+  type Query as SDKQuery,
   type SessionMessage,
   type SDKUserMessage,
   type Options as SDKOptions,
@@ -1375,6 +1376,21 @@ export class HeadlessClaudeSessionWrapper {
    */
   private _lastStructuredOutput: unknown = undefined;
 
+  /**
+   * In-flight Agent SDK generator from the current `query()` call. Held so
+   * {@link disconnect} (or the per-stage cleanup path) can force the SDK
+   * to tear down the spawned `claude` child process — calling `.return()`
+   * on the generator triggers `transport.close()`, which closes the
+   * child's stdin and SIGTERMs it after a 2s grace window.
+   *
+   * Without this, headless stages that end cleanly with `stop_reason:
+   * end_turn` deadlock: the SDK's `stream-json` transport keeps the
+   * child alive across turns, the for-await loop below never observes a
+   * natural end-of-iterator, and `await session.query(...)` waits forever
+   * on the child process exit that never happens.
+   */
+  private _activeQuery: SDKQuery | undefined;
+
   get sessionId(): string {
     return this._lastSessionId;
   }
@@ -1406,21 +1422,50 @@ export class HeadlessClaudeSessionWrapper {
 
     let sdkSessionId = "";
     let structuredOutput: unknown = undefined;
+    let activeQuery: SDKQuery | undefined;
     try {
       await withAtomicTempEnv(async () => {
-        for await (const msg of sdkQuery({ prompt, options: headlessSdkOpts })) {
+        activeQuery = sdkQuery({ prompt, options: headlessSdkOpts });
+        this._activeQuery = activeQuery;
+        for await (const msg of activeQuery) {
           if (msg.type === "result") {
             const record = msg as Record<string, unknown>;
             sdkSessionId = String(record.session_id ?? "");
             if (record.subtype === "success" && "structured_output" in record) {
               structuredOutput = record.structured_output;
             }
+            // The wrapper's contract is one query → one result. Break here
+            // so the `finally` block can force the SDK to tear down the
+            // spawned `claude` child. Without breaking, the for-await loop
+            // would wait for the SDK's natural end-of-stream — but the
+            // `stream-json` transport keeps the child alive across turns,
+            // so on `end_turn` the loop hangs even after the API turn has
+            // cleanly completed.
+            break;
           }
         }
       });
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(`Claude SDK query failed: ${detail}`);
+    } finally {
+      // Drive the SDK's `Query.return()` path so it closes stdin and
+      // SIGTERMs the child (with a SIGKILL fallback after ~5s). Safe to
+      // call even when the iterator already ran to completion — the SDK
+      // dedupes via an internal `cleanupPerformed` guard.
+      const toClose = activeQuery ?? this._activeQuery;
+      if (this._activeQuery === activeQuery) {
+        this._activeQuery = undefined;
+      }
+      if (toClose) {
+        try {
+          await toClose.return(undefined);
+        } catch {
+          // Best-effort — the SDK's cleanup path swallows transport errors
+          // already, so anything that escapes here is unexpected and not
+          // actionable from the wrapper.
+        }
+      }
     }
     if (!sdkSessionId) {
       throw new Error(
@@ -1435,7 +1480,35 @@ export class HeadlessClaudeSessionWrapper {
     return getSessionMessages(sdkSessionId, { dir: process.cwd() });
   }
 
-  async disconnect(): Promise<void> {}
+  /**
+   * Tear down any in-flight SDK query and clear the per-session marker
+   * files/dirs that interactive stages clean up via `clearClaudeSession`.
+   *
+   * Idempotent. Called by the runtime's `cleanupProvider` after a headless
+   * stage callback resolves or throws, so the spawned `claude` child does
+   * not outlive the stage (the upstream SDK bug — `query()` waits on child
+   * exit, but the `stream-json` child waits forever after `end_turn`).
+   */
+  async disconnect(): Promise<void> {
+    const active = this._activeQuery;
+    this._activeQuery = undefined;
+    if (active) {
+      try {
+        await active.return(undefined);
+      } catch {
+        // Best-effort — the SDK's cleanup is idempotent and already
+        // swallows transport-level errors internally.
+      }
+    }
+    if (this._lastSessionId) {
+      try {
+        await claudeOffloadCleanup(this._lastSessionId);
+      } catch {
+        // Best-effort — `claudeOffloadCleanup` is already non-throwing,
+        // but guard here in case the helper signature changes.
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/atomic-sdk/src/runtime/executor.ts
+++ b/packages/atomic-sdk/src/runtime/executor.ts
@@ -1785,6 +1785,13 @@ async function cleanupProvider<A extends AgentType>(
         // `HeadlessClaudeSessionWrapper.disconnect` for the rationale —
         // without this, headless stages that end cleanly with
         // `stop_reason: end_turn` deadlock waiting for child exit.
+        //
+        // The cast narrows to `ProviderSession<"claude">` (the interactive
+        // wrapper type), but at runtime this is actually a
+        // `HeadlessClaudeSessionWrapper` (see the unknown-cast at the
+        // headless branch of `connectAgent`). The two wrappers share the
+        // `disconnect(): Promise<void>` shape, so the call is sound by
+        // structural duck-typing.
         const session = providerSession as ProviderSession<"claude">;
         try {
           await session.disconnect();

--- a/packages/atomic-sdk/src/runtime/executor.ts
+++ b/packages/atomic-sdk/src/runtime/executor.ts
@@ -1777,8 +1777,23 @@ async function cleanupProvider<A extends AgentType>(
       // Stateless HTTP client — no cleanup needed
       break;
     case "claude":
-      // Headless Claude stages have no tmux pane to clear.
-      if (!paneId.startsWith("headless-")) {
+      if (paneId.startsWith("headless-")) {
+        // Headless Claude has no tmux pane; instead, force the SDK to
+        // tear down its spawned `claude` child (closes stdin → SIGTERM
+        // after 2s → SIGKILL after 5s) and clear the per-session marker
+        // files that `claudeOffloadCleanup` manages. See
+        // `HeadlessClaudeSessionWrapper.disconnect` for the rationale —
+        // without this, headless stages that end cleanly with
+        // `stop_reason: end_turn` deadlock waiting for child exit.
+        const session = providerSession as ProviderSession<"claude">;
+        try {
+          await session.disconnect();
+        } catch (e) {
+          console.warn(
+            `[cleanup] claude headless disconnect failed: ${errorMessage(e)}`,
+          );
+        }
+      } else {
         try {
           await clearClaudeSession(paneId);
         } catch (e) {


### PR DESCRIPTION
## Summary

Fixes a deadlock in headless Claude stages where queries ending cleanly with `stop_reason: end_turn` hung indefinitely. The Agent SDK's `stream-json` transport keeps spawned `claude` child processes alive across turns, so the `for-await` loop in `HeadlessClaudeSessionWrapper.query()` never observed end-of-iterator and the stage awaited a child exit that never happened.

## Root Cause

The Agent SDK's `stream-json` transport is long-lived by design — it persists a child process across multiple turns. After receiving a `result` message with `stop_reason: end_turn`, the iterator does **not** signal natural completion; the child only exits if explicitly torn down via `Query.return()`. Without this call, `query()` waited indefinitely for a child exit that never came.

## Key Changes

### `claude.ts` — `HeadlessClaudeSessionWrapper`
- Added `_activeQuery: SDKQuery | undefined` to track the in-flight Agent SDK generator
- Break out of the `for-await` loop immediately after the first `result` message so the `finally` block can drive cleanup
- Added `finally` block in `query()` that calls `awaitReturnWithDeadline()` to close child stdin and escalate to SIGTERM/SIGKILL
- Implemented `disconnect()`: clears `_activeQuery`, calls `.return()` on the in-flight generator (best-effort), and runs `claudeOffloadCleanup` against the last-known session ID to prevent marker file leaks; idempotent

### `claude.ts` — `awaitReturnWithDeadline()` (new)
- Races `Query.return(undefined)` against a 10 s deadline so a stuck child process or wedged I/O can never block the cleanup path indefinitely
- Exported for contract-testing only; production callers go through `HeadlessClaudeSessionWrapper.disconnect()` and the `query()` finally block

### `executor.ts` — `cleanupProvider`
- Inverts the headless branch: headless panes now call `session.disconnect()` instead of being silently skipped, ensuring SDK child teardown is always triggered on stage completion or failure
- Non-headless panes continue to use `clearClaudeSession` as before

### `claude.headlessDisconnect.test.ts` (new)
- Regression tests for `disconnect()` covering:
  - No active query — resolves silently
  - Calls `Query.return()` on the in-flight generator and clears `_activeQuery`
  - Swallows errors thrown from `Query.return()`
  - Idempotency — second call with no active query is a no-op
  - Resolves within a timeout deadline even if `Query.return()` never resolves

## Breaking Changes

None.