### PR TITLE
chore(release): prepare v0.8.0-0 prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,36 +66,13 @@ See [Providers & Models](./packages/coding-agent/README.md#providers--models) fo
 > ⚠️ Workflows run with agent permission checks **disabled** so pipelines don't block on prompts. Run autonomous workflows inside a devcontainer, VM, or remote dev machine — not your host machine.
 
 <details>
-<summary><b>Prerequisites, version pinning, devcontainer, SDK-only</b></summary>
+<summary><b>Prerequisites, devcontainer</b></summary>
 
 **Prerequisites** — Atomic is a self-contained coding-agent binary. The only requirement is access to a supported model provider: either an API key (Anthropic, OpenAI, Google, Azure, Bedrock, Vertex, …) or an existing subscription (Claude Pro/Max, ChatGPT Plus/Pro, GitHub Copilot) via `/login`. See [Providers & Models](./packages/coding-agent/README.md#providers--models).
 
-**Pin a version:** `bash install.sh 0.8.0` (same trailing-arg form works for `.ps1`).
-
 **Devcontainer / VM** — recommended for autonomous workflows. Atomic runs in any standard devcontainer or VM image; install it inside the container with `npm install -g @bastani/atomic` (or the install script) and supply provider credentials via environment variables.
 
-**SDK-only** — embed Atomic in your own app via the published package:
-
-```bash
-bun init -y && bun add @bastani/atomic
-```
-
 See [Programmatic Usage](./packages/coding-agent/README.md#programmatic-usage) for the SDK and RPC entry points.
-
-</details>
-
-<details>
-<summary><b>Upgrading from a previous version</b></summary>
-
-**From 0.6.x or earlier (SDK users):** the SDK moved from `@bastani/atomic` to `@bastani/atomic-sdk`.
-
-```bash
-bun remove @bastani/atomic && bun add @bastani/atomic-sdk
-```
-
-Update imports: `from "@bastani/atomic/workflows"` → `from "@bastani/atomic-sdk/workflows"`. The CLI keeps the same package name.
-
-For SDK API changes (`createWorkflowCli` removal, `source: import.meta.path`, etc.), see [SDK migration](#migration-from-0x).
 
 </details>
 
@@ -150,8 +127,6 @@ Structured capability modules that give agents best practices and reusable patte
 | `tdd`               | Red-green-refactor loop with a built-in testing-anti-patterns guide                                                                                                   |
 | `playwright-cli`    | Automate browser interactions, tests, and screenshots                                                                                                                 |
 | `impeccable`        | Design, redesign, audit, or polish frontend interfaces (Anthropic's frontend-design skill, vendored from [pbakaus/impeccable](https://github.com/pbakaus/impeccable)) |
-
-Source on disk: `ls packages/workflows/skills/`, `ls packages/subagents/skills/`, and `ls packages/intercom/skills/`. All three skill directories are bundled into `@bastani/atomic` at build time and loaded as builtin pi packages.
 
 ### 3. Specialized sub-agents
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.0",
+      "version": "0.8.0-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -58,7 +58,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.0",
+      "version": "0.8.0-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -75,7 +75,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.0",
+      "version": "0.8.0-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.0",
+      "version": "0.8.0-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -121,7 +121,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.0",
+      "version": "0.8.0-0",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",
         "linkedom": "^0.16.0",
@@ -142,7 +142,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.0",
+      "version": "0.8.0-0",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-coding-agent": "*",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,105 +1,105 @@
 {
-	"name": "@bastani/atomic",
-	"version": "0.8.0",
-	"description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
-	"type": "module",
-	"piConfig": {
-		"name": "atomic",
-		"configDir": ".atomic",
-		"changelogUrl": "https://github.com/flora131/atomic/blob/main/packages/coding-agent/CHANGELOG.md"
-	},
-	"bin": {
-		"atomic": "dist/cli.js"
-	},
-	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
-		},
-		"./hooks": {
-			"types": "./dist/core/hooks/index.d.ts",
-			"import": "./dist/core/hooks/index.js"
-		}
-	},
-	"files": [
-		"dist",
-		"docs",
-		"examples",
-		"CHANGELOG.md"
-	],
-	"scripts": {
-		"clean": "shx rm -rf dist",
-		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
-		"build": "tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js && bun run copy-assets",
-		"build:binary": "bun --cwd ../tui run build && bun --cwd ../ai run build && bun --cwd ../agent run build && bun run build && bun build --compile ./dist/bun/cli.js --outfile dist/atomic && bun run copy-binary-assets",
-		"copy-assets": "shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/ && bun run copy-builtin-packages",
-		"copy-binary-assets": "shx cp package.json dist/ && shx cp README.md dist/ && shx cp CHANGELOG.md dist/ && shx mkdir -p dist/theme && shx cp src/modes/interactive/theme/*.json dist/theme/ && shx mkdir -p dist/assets && shx cp src/modes/interactive/assets/*.png dist/assets/ && shx mkdir -p dist/export-html/vendor && shx cp src/core/export-html/template.html dist/export-html/ && shx cp src/core/export-html/vendor/*.js dist/export-html/vendor/ && shx cp -r docs dist/ && shx cp -r examples dist/ && shx cp ../../node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm dist/ && bun run copy-builtin-packages",
-		"copy-builtin-packages": "bun run scripts/copy-builtin-packages.ts",
-		"copy-builtin-workflows": "bun run copy-builtin-packages",
-		"test": "vitest --run",
-		"prepublishOnly": "bun run clean && bun run build"
-	},
-	"dependencies": {
-		"@earendil-works/pi-agent-core": "^0.74.0",
-		"@earendil-works/pi-ai": "^0.74.0",
-		"@earendil-works/pi-tui": "^0.74.0",
-		"@silvia-odwyer/photon-node": "^0.3.4",
-		"chalk": "^5.5.0",
-		"diff": "^8.0.2",
-		"glob": "^13.0.1",
-		"highlight.js": "^10.7.3",
-		"hosted-git-info": "^9.0.2",
-		"ignore": "^7.0.5",
-		"jiti": "^2.7.0",
-		"minimatch": "^10.2.3",
-		"proper-lockfile": "^4.1.2",
-		"typebox": "^1.1.24",
-		"undici": "^7.19.1",
-		"yaml": "^2.8.2",
-		"@bastani/subagents": "workspace:*",
-		"@bastani/mcp": "workspace:*",
-		"@bastani/web-access": "workspace:*",
-		"@bastani/intercom": "workspace:*",
-		"@bastani/workflows": "workspace:*"
-	},
-	"overrides": {
-		"rimraf": "6.1.2",
-		"gaxios": {
-			"rimraf": "6.1.2"
-		}
-	},
-	"optionalDependencies": {
-		"@mariozechner/clipboard": "^0.3.5"
-	},
-	"devDependencies": {
-		"@types/diff": "^7.0.2",
-		"@types/hosted-git-info": "^3.0.5",
-		"@types/ms": "^2.1.0",
-		"@types/node": "^24.3.0",
-		"@types/proper-lockfile": "^4.1.4",
-		"@typescript/native-preview": "7.0.0-dev.20260511.1",
-		"shx": "^0.4.0",
-		"typescript": "^5.7.3",
-		"vitest": "^3.2.4"
-	},
-	"keywords": [
-		"coding-agent",
-		"ai",
-		"llm",
-		"cli",
-		"tui",
-		"agent"
-	],
-	"author": "Mario Zechner",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/flora131/atomic.git",
-		"directory": "packages/coding-agent"
-	},
-	"engines": {
-		"node": ">=20.6.0"
-	}
+  "name": "@bastani/atomic",
+  "version": "0.8.0-0",
+  "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
+  "type": "module",
+  "piConfig": {
+    "name": "atomic",
+    "configDir": ".atomic",
+    "changelogUrl": "https://github.com/flora131/atomic/blob/main/packages/coding-agent/CHANGELOG.md"
+  },
+  "bin": {
+    "atomic": "dist/cli.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./hooks": {
+      "types": "./dist/core/hooks/index.d.ts",
+      "import": "./dist/core/hooks/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "docs",
+    "examples",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "clean": "shx rm -rf dist",
+    "dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+    "build": "tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js && bun run copy-assets",
+    "build:binary": "bun --cwd ../tui run build && bun --cwd ../ai run build && bun --cwd ../agent run build && bun run build && bun build --compile ./dist/bun/cli.js --outfile dist/atomic && bun run copy-binary-assets",
+    "copy-assets": "shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/ && bun run copy-builtin-packages",
+    "copy-binary-assets": "shx cp package.json dist/ && shx cp README.md dist/ && shx cp CHANGELOG.md dist/ && shx mkdir -p dist/theme && shx cp src/modes/interactive/theme/*.json dist/theme/ && shx mkdir -p dist/assets && shx cp src/modes/interactive/assets/*.png dist/assets/ && shx mkdir -p dist/export-html/vendor && shx cp src/core/export-html/template.html dist/export-html/ && shx cp src/core/export-html/vendor/*.js dist/export-html/vendor/ && shx cp -r docs dist/ && shx cp -r examples dist/ && shx cp ../../node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm dist/ && bun run copy-builtin-packages",
+    "copy-builtin-packages": "bun run scripts/copy-builtin-packages.ts",
+    "copy-builtin-workflows": "bun run copy-builtin-packages",
+    "test": "vitest --run",
+    "prepublishOnly": "bun run clean && bun run build"
+  },
+  "dependencies": {
+    "@earendil-works/pi-agent-core": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
+    "@silvia-odwyer/photon-node": "^0.3.4",
+    "chalk": "^5.5.0",
+    "diff": "^8.0.2",
+    "glob": "^13.0.1",
+    "highlight.js": "^10.7.3",
+    "hosted-git-info": "^9.0.2",
+    "ignore": "^7.0.5",
+    "jiti": "^2.7.0",
+    "minimatch": "^10.2.3",
+    "proper-lockfile": "^4.1.2",
+    "typebox": "^1.1.24",
+    "undici": "^7.19.1",
+    "yaml": "^2.8.2",
+    "@bastani/subagents": "workspace:*",
+    "@bastani/mcp": "workspace:*",
+    "@bastani/web-access": "workspace:*",
+    "@bastani/intercom": "workspace:*",
+    "@bastani/workflows": "workspace:*"
+  },
+  "overrides": {
+    "rimraf": "6.1.2",
+    "gaxios": {
+      "rimraf": "6.1.2"
+    }
+  },
+  "optionalDependencies": {
+    "@mariozechner/clipboard": "^0.3.5"
+  },
+  "devDependencies": {
+    "@types/diff": "^7.0.2",
+    "@types/hosted-git-info": "^3.0.5",
+    "@types/ms": "^2.1.0",
+    "@types/node": "^24.3.0",
+    "@types/proper-lockfile": "^4.1.4",
+    "@typescript/native-preview": "7.0.0-dev.20260511.1",
+    "shx": "^0.4.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
+  },
+  "keywords": [
+    "coding-agent",
+    "ai",
+    "llm",
+    "cli",
+    "tui",
+    "agent"
+  ],
+  "author": "Mario Zechner",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/flora131/atomic.git",
+    "directory": "packages/coding-agent"
+  },
+  "engines": {
+    "node": ">=20.6.0"
+  }
 }

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.0",
+  "version": "0.8.0-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.0",
+  "version": "0.8.0-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.0",
+  "version": "0.8.0-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.0",
+  "version": "0.8.0-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.0",
+  "version": "0.8.0-0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the `v0.8.0-0` prerelease by bumping all workspace package versions from `0.8.0` to `0.8.0-0` and trimming stale getting-started content from the README.

## Changes

- Bump version to `0.8.0-0` across all workspace packages: `@bastani/atomic`, `@bastani/workflows`, `@bastani/intercom`, `@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`
- Refresh `bun.lock` to match the updated prerelease versions
- Remove version-pinning instructions from README (pin-by-version install form is no longer documented at the top level)
- Remove SDK-only installation section from README (moved to package-level docs)
- Remove "Upgrading from a previous version" section from README (0.6.x migration guidance is now stale)
- Remove skills source-on-disk note from README (implementation detail not relevant to end users)

## Notes

- This is a prerelease tag (`v0.8.0-0`); CI will publish to npm under the `next` tag and create a prerelease GitHub Release (not marked as latest).
- Pre-commit hooks (`bun run lint`, `bun run test:unit`) passed during all commits.