### PR TITLE
fix(workflows): defer detached body start and expand agent docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,14 @@
 
 This repo is the private `atomic-monorepo` Bun workspace. It currently houses:
 
-- `@bastani/atomic` in `packages/coding-agent` — the Atomic-branded fork of pi's coding-agent CLI.
+- `@bastani/atomic` in `packages/coding-agent` — the Atomic-branded fork of pi's coding-agent CLI and the only independently published package.
 - `@bastani/workflows` in `packages/workflows` — a first-party extension for Atomic/pi that brings multi-stage, DAG-driven workflow execution to agent sessions.
+- `@bastani/subagents` in `packages/subagents` — builtin subagent orchestration, reusable agent definitions, skills, prompts, chains, and TUI clarification support.
+- `@bastani/mcp` in `packages/mcp` — builtin MCP adapter extension that exposes MCP servers as agent tools.
+- `@bastani/web-access` in `packages/web-access` — builtin web search, URL fetching, GitHub repository, PDF, and video extraction tools.
+- `@bastani/intercom` in `packages/intercom` — builtin coordination channel for parent/child and cross-session agent communication.
 
-`@bastani/workflows` ships as **raw TypeScript** (no compile step) and is loaded directly by the host. The coding-agent package follows upstream pi's compiled-package layout.
+Companion packages under `packages/*` ship as **raw TypeScript** (no compile step) and are bundled into `@bastani/atomic` at build time rather than published independently. The coding-agent package follows upstream pi's compiled-package layout.
 
 ## Tech Stack
 
@@ -119,6 +123,14 @@ pi:
 ## Releasing
 
 Atomic mirrors pi's tag-driven release flow: bump versions locally, commit, push a `v<version>` git tag, and CI publishes to npm with OIDC provenance and creates the GitHub Release with cross-compiled binaries attached.
+
+### Agent publishing requests
+
+If a user asks you to publish the package:
+
+- Ask the user with the `ask_user_question`/ask-question tool what version to publish if they have not supplied a version.
+- Ask whether they want a release or prerelease if that cannot be inferred from the supplied version, or if the version is in an incorrect format. Valid formats are `MAJOR.MINOR.PATCH` for releases and `MAJOR.MINOR.PATCH-NUMBER` for prereleases.
+- Remember that publishing is triggered by the git tag flow: create `git tag v<version>` and push it with `git push origin v<version>` after the version bump commit is on the branch. A branch push or PR merge alone does not publish.
 
 ### Bumping Versions
 

--- a/packages/workflows/src/runs/background/runner.ts
+++ b/packages/workflows/src/runs/background/runner.ts
@@ -44,7 +44,7 @@ export interface DetachedAccepted {
 }
 
 export interface DetachedRunOpts
-  extends Omit<RunOpts, "runId" | "signal" | "cancellation"> {
+  extends Omit<RunOpts, "runId" | "signal" | "cancellation" | "deferWorkflowStart"> {
   /**
    * Override CancellationRegistry (default: singleton cancellationRegistry).
    */
@@ -125,6 +125,7 @@ export function runDetached(
     cancellation: registry,
     store,
     ui: buildBackgroundUIAdapter(store, runId, controller.signal),
+    deferWorkflowStart: true,
   };
 
   // 5. Start background promise

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -76,6 +76,12 @@ export interface RunOpts {
   /** AbortSignal that requests cancellation from the caller side. */
   signal?: AbortSignal;
   /**
+   * Internal background-runner seam. When true, the executor records the run
+   * synchronously, then yields to the next event-loop turn before invoking user
+   * workflow code so detached dispatch cannot be blocked by pre-await work.
+   */
+  deferWorkflowStart?: boolean;
+  /**
    * Resolved runtime configuration. Injected by the composition root after
    * merging file config with defaults. Downstream tasks (maxDepth, concurrency,
    * status writer) consume this; values are threaded here but not yet acted on.
@@ -890,6 +896,10 @@ function finalizeKilled(
 // Main executor
 // ---------------------------------------------------------------------------
 
+function nextEventLoopTurn(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 export async function run(
   def: WorkflowDefinition,
   inputs: Record<string, unknown>,
@@ -1453,6 +1463,13 @@ export async function run(
 
   // 6. Call def.run(ctx)
   try {
+    if (opts.deferWorkflowStart === true) {
+      await nextEventLoopTurn();
+      if (ownController.signal.aborted) {
+        return finalizeKilled(runId, runSnapshot, activeStore, opts.persistence, opts.onRunEnd);
+      }
+    }
+
     const result = await def.run(ctx);
 
     // Post-body abort check: if signal was aborted at any point before we record

--- a/test/integration/overlay-entrypoints.test.ts
+++ b/test/integration/overlay-entrypoints.test.ts
@@ -60,6 +60,21 @@ interface CapturedCustomCall {
   handle: PiOverlayHandle;
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForRenderCount(
+  count: () => number,
+  target: number,
+  polls = 80,
+  pollMs = 25,
+): Promise<void> {
+  for (let i = 0; i < polls && count() < target; i++) {
+    await delay(pollMs);
+  }
+}
+
 /** A controllable in-memory `PiOverlayHandle` used by the mock. */
 function buildOverlayHandle(): {
   handle: PiOverlayHandle;
@@ -875,13 +890,18 @@ describe("buildGraphOverlayAdapter — animation tick visibility gating", () => 
     const adapter = buildGraphOverlayAdapter({ ui: { custom: customFn } }, store);
     adapter.open(runId);
     assert.ok(component, "factory should return a component");
-    // Animation tick is 100ms; 250ms wall-clock gives at least two ticks.
-    await new Promise((r) => setTimeout(r, 250));
-    component!.dispose?.();
-    assert.ok(
-      renderCalls >= 2,
-      `expected tui.requestRender to fire on the animation tick (got ${renderCalls})`,
-    );
+    // Animation tick is 100ms, but Windows CI can starve the event loop long
+    // enough that a single wall-clock sleep observes only one interval turn.
+    // Poll across scheduler turns instead of assuming 250ms means two ticks.
+    try {
+      await waitForRenderCount(() => renderCalls, 2);
+      assert.ok(
+        renderCalls >= 2,
+        `expected tui.requestRender to fire on the animation tick (got ${renderCalls})`,
+      );
+    } finally {
+      component!.dispose?.();
+    }
   });
 
   test("requestRender suppresses tui.requestRender while overlay is hidden", async () => {

--- a/test/unit/background-runner.test.ts
+++ b/test/unit/background-runner.test.ts
@@ -65,6 +65,14 @@ function makeThrowingWorkflow(name: string): WorkflowDefinition {
     .compile() as WorkflowDefinition;
 }
 
+function busyWait(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // Intentional synchronous work used to prove detached dispatch does not
+    // run user workflow code before returning the accepted result.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // RFC §4 (runner-level) — runDetached returns before background settles
 // ---------------------------------------------------------------------------
@@ -114,6 +122,62 @@ describe("runDetached — returns immediately", () => {
     const accepted = runDetached(def, {}, { store, cancellation, jobs });
     assert.ok(accepted.message.includes("named-wf-result"));
     assert.deepEqual(accepted.stages, []);
+  });
+
+  test("accepted result returns before synchronous workflow body prefix starts", async () => {
+    const store = createStore();
+    const cancellation = createCancellationRegistry();
+    const jobs = createJobTracker();
+    let bodyStarted = false;
+    const def = defineWorkflow("sync-prefix-wf")
+      .run(async () => {
+        bodyStarted = true;
+        busyWait(100);
+        return { done: true };
+      })
+      .compile() as WorkflowDefinition;
+
+    async function dispatchLike(): Promise<ReturnType<typeof runDetached>> {
+      return runDetached(def, {}, { store, cancellation, jobs });
+    }
+
+    const accepted = await dispatchLike();
+
+    assert.equal(bodyStarted, false);
+    assert.equal(accepted.status, "running");
+    assert.equal(jobs.has(accepted.runId), true);
+    assert.notEqual(store.runs().find((run) => run.id === accepted.runId), undefined);
+
+    const job = jobs.get(accepted.runId);
+    if (job === undefined) throw new Error("expected background job to be registered");
+    await job.promise;
+    assert.equal(bodyStarted, true);
+  });
+
+  test("killing before deferred workflow body starts prevents body execution", async () => {
+    const store = createStore();
+    const cancellation = createCancellationRegistry();
+    const jobs = createJobTracker();
+    let bodyStarted = false;
+    const def = defineWorkflow("killed-before-start-wf")
+      .run(async () => {
+        bodyStarted = true;
+        return { unreached: true };
+      })
+      .compile() as WorkflowDefinition;
+
+    const accepted = runDetached(def, {}, { store, cancellation, jobs });
+    const killed = killRun(accepted.runId, { store, cancellation });
+
+    assert.equal(killed.ok, true);
+
+    const job = jobs.get(accepted.runId);
+    if (job === undefined) throw new Error("expected background job to be registered");
+    await job.promise;
+
+    assert.equal(bodyStarted, false);
+    const run = store.runs().find((snapshot) => snapshot.id === accepted.runId);
+    assert.equal(run?.status, "killed");
   });
 });
 

--- a/test/unit/overlay-graph.test.ts
+++ b/test/unit/overlay-graph.test.ts
@@ -79,6 +79,21 @@ function makeStore(snap: StoreSnapshot): Store {
 
 const defaultTheme = deriveGraphTheme({});
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForRenderCount(
+  count: () => number,
+  target: number,
+  polls = 80,
+  pollMs = 25,
+): Promise<void> {
+  for (let i = 0; i < polls && count() < target; i++) {
+    await delay(pollMs);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Layout tests
 // ---------------------------------------------------------------------------
@@ -574,16 +589,18 @@ describe("GraphView animation timer", () => {
       graphTheme: defaultTheme,
       requestRender,
     });
-    // Tick is 100ms; wait long enough for at least two ticks. Use real
-    // timers — Bun's interval scheduler runs concurrently with the
-    // test, so a small wall-clock wait is the simplest way to observe
-    // the steady cadence without introducing a fake-timer dependency.
-    await new Promise((r) => setTimeout(r, 250));
-    view.dispose();
-    assert.ok(
-      requestRender.mock.calls.length >= 2,
-      `expected ≥ 2 ticks in 250ms, got ${requestRender.mock.calls.length}`,
-    );
+    // Tick is 100ms, but Windows CI can starve the event loop long enough
+    // that one wall-clock sleep observes only one interval turn. Poll across
+    // scheduler turns instead of assuming 250ms means two ticks.
+    try {
+      await waitForRenderCount(() => requestRender.mock.calls.length, 2);
+      assert.ok(
+        requestRender.mock.calls.length >= 2,
+        `expected ≥ 2 ticks, got ${requestRender.mock.calls.length}`,
+      );
+    } finally {
+      view.dispose();
+    }
   });
 
   it("does not start the timer in widget mode", async () => {


### PR DESCRIPTION
## Summary

Fixes a race condition in the background workflow runner where user workflow body code could begin executing before \`runDetached\` returned, and expands the \`CLAUDE.md\` docs with companion package descriptions and an agent-oriented publishing guide.

## Key Changes

### Fix: defer detached workflow body start (`packages/workflows`)
- Added `deferWorkflowStart?: boolean` option to `RunOpts` in the executor
- Background runner passes `deferWorkflowStart: true`, yielding to the next event-loop turn before invoking user workflow code — ensuring `runDetached` always resolves before any synchronous workflow body prefix runs
- Added `nextEventLoopTurn()` helper (zero-delay `setTimeout` promise) in the executor
- Aborted/killed runs are correctly finalized if the signal fires during the deferred turn

### Tests (`packages/workflows`, `test/`)
- Added two new unit tests covering the deferred-start guarantee and kill-before-start behavior
- Hardened overlay timer assertions in both unit and integration tests: replaced fixed wall-clock sleeps with polling helpers (`waitForRenderCount`) to avoid flakiness on Windows CI where the event loop can be starved

### Documentation (`CLAUDE.md`)
- Expanded the monorepo overview to list all companion packages (`@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`) with descriptions
- Clarified that companion packages ship as raw TypeScript and are bundled into `@bastani/atomic` at build time (not published independently)
- Added **Agent publishing requests** section with step-by-step guidance for agents handling publish requests, including version format validation and the git tag–driven flow