### PR TITLE
chore(release): prepare v0.8.0-0

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.0-0] - 2026-05-15
+
 ### Added
 
 - Added Together AI to built-in provider setup, `/login` API-key auth, and default model resolution ([#3624](https://github.com/earendil-works/pi-mono/pull/3624) by [@Nutlope](https://github.com/Nutlope)).


### PR DESCRIPTION
## Summary

Inserts the `[0.8.0-0] - 2026-05-15` version header in `CHANGELOG.md` so the tag-driven publish workflow can extract release notes for the prerelease.

## Changes

- `packages/coding-agent/CHANGELOG.md`: added `## [0.8.0-0] - 2026-05-15` section header between the empty `[Unreleased]` section and the existing changelog entries, promoting them to the versioned prerelease section.

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- `AGENT=1 bun run test:unit`

## Release Notes

After this PR lands on `main`, tag the merged commit with `v0.8.0-0` and push the tag to trigger prerelease publishing:

```sh
git tag v0.8.0-0
git push origin v0.8.0-0
```

This publishes `@bastani/atomic@0.8.0-0` to npm under the `next` dist-tag and creates a prerelease GitHub Release.