### PR TITLE
ci(publish): fix OIDC provenance and builtin directory validation for prerelease

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -172,7 +171,7 @@ jobs:
             import pkg from "./package.json" with { type: "json" };
 
             const failures = [];
-            const expectedBuiltins = ["workflows", "pi-subagents", "pi-mcp-adapter", "pi-web-access", "pi-intercom"];
+            const expectedBuiltins = ["workflows", "subagents", "mcp", "web-access", "intercom"];
             const clean = (value) => String(value).replace(/^\.\//, "").replace(/\/$/, "");
             const walk = (dir) => {
               if (!existsSync(dir)) return [];


### PR DESCRIPTION
## Summary

Fix the publish workflow so prerelease tags (e.g. \`v0.8.0-0\`) complete successfully using OIDC provenance/trusted publishing and Atomic's actual bundled package layout.

## Changes

- **Remove `registry-url` from `setup-node`** — `npm publish --provenance` relies on OIDC trusted publishing and must not have a `NODE_AUTH_TOKEN`/`NPM_TOKEN` configured via `setup-node`'s registry auth; the presence of `registry-url` caused npm to require a token and abort the OIDC flow.
- **Correct expected builtin directory names** — the built package validation was checking for upstream pi directory names (`pi-subagents`, `pi-mcp-adapter`, `pi-web-access`, `pi-intercom`) instead of the Atomic-branded names (`subagents`, `mcp`, `web-access`, `intercom`), causing spurious validation failures.

## Breaking Changes

None. These are CI-only fixes with no changes to package code or public API.

## Validation

- Pre-commit hooks: `bun run lint`, `bun run test:unit`
- Local `cd packages/coding-agent && bun run build`
- Local workflow metadata verification with the corrected builtin directory list

## Notes

The first `v0.8.0-0` publish run failed before reaching the npm publish step. After this lands, rerun via workflow dispatch (using the `tag` input) or recreate the tag to trigger the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)