### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-15
+
+### Added
+
+- Added Together AI to built-in provider setup, `/login` API-key auth, and default model resolution ([#3624](https://github.com/earendil-works/pi-mono/pull/3624) by [@Nutlope](https://github.com/Nutlope)).
+- Added Windows ARM64 standalone binary release artifacts ([#4458](https://github.com/earendil-works/pi/pull/4458) by [@brianmichel](https://github.com/brianmichel)).
+
+### Fixed
+
+- Fixed interactive error messages to render with trailing spacing so reload errors do not run into resource listings ([#4510](https://github.com/earendil-works/pi/issues/4510)).
+- Fixed nested code fences in the Termux setup documentation so the example AGENTS.md renders correctly ([#4503](https://github.com/earendil-works/pi/issues/4503)).
+- Fixed tool output expansion while extension confirmation dialogs are focused ([#4429](https://github.com/earendil-works/pi/issues/4429)).
+- Fixed auto-retry for Anthropic streams that end before `message_stop` ([#4433](https://github.com/earendil-works/pi/issues/4433)).
+- Fixed theme sharing across package scopes so extensions do not crash with `Theme not initialized` ([#4333](https://github.com/earendil-works/pi/issues/4333)).
+- Fixed keybinding hints to show Option instead of Alt on macOS ([#4289](https://github.com/earendil-works/pi/issues/4289)).
+- Fixed the interactive update notification to render the changelog as an OSC 8 hyperlink when the terminal supports hyperlinks ([#4280](https://github.com/earendil-works/pi/issues/4280)).
+
 ## [0.8.0-0] - 2026-05-15
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.0-0",
+  "version": "0.8.0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.0-0",
+  "version": "0.8.0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.0-0",
+  "version": "0.8.0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.0-0",
+  "version": "0.8.0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.0-0",
+  "version": "0.8.0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.0-0",
+  "version": "0.8.0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promote all workspace packages from the `0.8.0-0` prerelease to the stable `0.8.0` release and document the full changelog so the tag-driven publish workflow can extract release notes.

## Changes

- Bumped all workspace package versions from `0.8.0-0` → `0.8.0` (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`).
- Added `## [0.8.0] - 2026-05-15` changelog section to `packages/coding-agent/CHANGELOG.md`.

## Release Notes (v0.8.0)

### Added
- Together AI built-in provider, `/login` API-key auth, and default model resolution.
- Windows ARM64 standalone binary release artifact.

### Fixed
- Interactive error messages now render with trailing spacing so reload errors don't run into resource listings.
- Nested code fences in Termux setup docs render correctly.
- Tool output expansion works while extension confirmation dialogs are focused.
- Auto-retry for Anthropic streams that end before `message_stop`.
- Theme sharing across package scopes (fixes `Theme not initialized` crash in extensions).
- Keybinding hints show **Option** instead of **Alt** on macOS.
- Interactive update notification renders the changelog as an OSC 8 hyperlink when the terminal supports it.

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- `AGENT=1 bun run test:all`

## Post-merge

After this PR merges to `main`, tag and push `v0.8.0` from the merged commit to trigger the publish workflow:

```sh
git tag v0.8.0
git push origin v0.8.0
```

This publishes `@bastani/atomic@0.8.0` with the npm `latest` tag and creates the stable GitHub Release with cross-compiled binaries.