### PR TITLE
fix(release): make atomic package installable with bun

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,6 +200,20 @@ jobs:
             if (pkg.private) failures.push("@bastani/atomic package.json must not set private=true");
             if (pkg.name !== "@bastani/atomic") failures.push(`unexpected package name: ${pkg.name}`);
             if (pkg.bin?.atomic !== "dist/cli.js") failures.push("bin.atomic must point at dist/cli.js");
+
+            for (const sectionName of ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"]) {
+              const dependencies = pkg[sectionName];
+              if (!dependencies) continue;
+              for (const [dependencyName, dependencyRange] of Object.entries(dependencies)) {
+                if (String(dependencyRange).startsWith("workspace:")) {
+                  failures.push(`${sectionName}.${dependencyName} must not use workspace protocol`);
+                }
+                if (dependencyName.startsWith("@bastani/")) {
+                  failures.push(`${sectionName}.${dependencyName} must not reference a private bundled package`);
+                }
+              }
+            }
+
             requirePath("main", pkg.main);
             requirePath("types", pkg.types);
             requirePath("bin.atomic", pkg.bin?.atomic);

--- a/bun.lock
+++ b/bun.lock
@@ -14,19 +14,17 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.0-0",
+      "version": "0.8.1-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
       "dependencies": {
-        "@bastani/intercom": "workspace:*",
-        "@bastani/mcp": "workspace:*",
-        "@bastani/subagents": "workspace:*",
-        "@bastani/web-access": "workspace:*",
-        "@bastani/workflows": "workspace:*",
         "@earendil-works/pi-agent-core": "^0.74.0",
         "@earendil-works/pi-ai": "^0.74.0",
         "@earendil-works/pi-tui": "^0.74.0",
+        "@modelcontextprotocol/ext-apps": "^1.2.2",
+        "@modelcontextprotocol/sdk": "^1.25.1",
+        "@mozilla/readability": "^0.5.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "diff": "^8.0.2",
@@ -35,11 +33,17 @@
         "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
         "jiti": "^2.7.0",
+        "linkedom": "^0.16.0",
         "minimatch": "^10.2.3",
+        "open": "^10.2.0",
+        "p-limit": "^6.1.0",
         "proper-lockfile": "^4.1.2",
+        "turndown": "^7.2.0",
         "typebox": "^1.1.24",
         "undici": "^7.19.1",
+        "unpdf": "^1.6.2",
         "yaml": "^2.8.2",
+        "zod": "^3.25.0 || ^4.0.0",
       },
       "devDependencies": {
         "@types/diff": "^7.0.2",
@@ -58,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.0-0",
+      "version": "0.8.1-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -75,7 +79,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.0-0",
+      "version": "0.8.1-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +103,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.0-0",
+      "version": "0.8.1-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -121,7 +125,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.0-0",
+      "version": "0.8.1-0",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",
         "linkedom": "^0.16.0",
@@ -142,7 +146,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.0-0",
+      "version": "0.8.1-0",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-coding-agent": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.1-0] - 2026-05-15
+
+### Fixed
+
+- Fixed the published `@bastani/atomic` package manifest so Bun can install it outside the monorepo without resolving private workspace-only bundled packages.
+
 ## [0.8.0] - 2026-05-15
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.0",
+  "version": "0.8.1-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {
@@ -45,6 +45,9 @@
     "@earendil-works/pi-agent-core": "^0.74.0",
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-tui": "^0.74.0",
+    "@modelcontextprotocol/ext-apps": "^1.2.2",
+    "@modelcontextprotocol/sdk": "^1.25.1",
+    "@mozilla/readability": "^0.5.0",
     "@silvia-odwyer/photon-node": "^0.3.4",
     "chalk": "^5.5.0",
     "diff": "^8.0.2",
@@ -53,16 +56,17 @@
     "hosted-git-info": "^9.0.2",
     "ignore": "^7.0.5",
     "jiti": "^2.7.0",
+    "linkedom": "^0.16.0",
     "minimatch": "^10.2.3",
+    "open": "^10.2.0",
+    "p-limit": "^6.1.0",
     "proper-lockfile": "^4.1.2",
+    "turndown": "^7.2.0",
     "typebox": "^1.1.24",
     "undici": "^7.19.1",
+    "unpdf": "^1.6.2",
     "yaml": "^2.8.2",
-    "@bastani/subagents": "workspace:*",
-    "@bastani/mcp": "workspace:*",
-    "@bastani/web-access": "workspace:*",
-    "@bastani/intercom": "workspace:*",
-    "@bastani/workflows": "workspace:*"
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "overrides": {
     "rimraf": "6.1.2",

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.0",
+  "version": "0.8.1-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.0",
+  "version": "0.8.1-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.0",
+  "version": "0.8.1-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.0",
+  "version": "0.8.1-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.0",
+  "version": "0.8.1-0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [

--- a/prek.toml
+++ b/prek.toml
@@ -1,4 +1,4 @@
-default_install_hook_types = ["pre-commit"]
+default_install_hook_types = ["pre-commit", "pre-push"]
 
 [[repos]]
 repo = "builtin"

--- a/test/unit/package-metadata.test.ts
+++ b/test/unit/package-metadata.test.ts
@@ -3,12 +3,27 @@ import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import assert from "node:assert/strict";
 import atomicPackageJson from "../../packages/coding-agent/package.json" with { type: "json" };
+import intercomPackageJson from "../../packages/intercom/package.json" with { type: "json" };
+import mcpPackageJson from "../../packages/mcp/package.json" with { type: "json" };
+import subagentsPackageJson from "../../packages/subagents/package.json" with { type: "json" };
+import webAccessPackageJson from "../../packages/web-access/package.json" with { type: "json" };
 import workflowsPackageJson from "../../packages/workflows/package.json" with { type: "json" };
 
 const STRICT_RELEASE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?$/;
 
-interface WorkspacePackageJson {
+type DependencySectionName = "dependencies" | "optionalDependencies" | "peerDependencies" | "devDependencies";
+
+type DependencyMap = Record<string, string>;
+
+interface PackageDependencySections {
   name: string;
+  dependencies?: DependencyMap;
+  optionalDependencies?: DependencyMap;
+  peerDependencies?: DependencyMap;
+  devDependencies?: DependencyMap;
+}
+
+interface WorkspacePackageJson extends PackageDependencySections {
   version: string;
   private?: boolean;
 }
@@ -35,10 +50,47 @@ async function workspacePackages(): Promise<WorkspacePackage[]> {
     .sort((a, b) => a.manifestPath.localeCompare(b.manifestPath));
 }
 
+const PUBLISHED_DEPENDENCY_SECTIONS: readonly DependencySectionName[] = [
+  "dependencies",
+  "optionalDependencies",
+  "peerDependencies",
+  "devDependencies",
+];
+
+const BUNDLED_PACKAGE_MANIFESTS: readonly PackageDependencySections[] = [
+  workflowsPackageJson,
+  subagentsPackageJson,
+  mcpPackageJson,
+  webAccessPackageJson,
+  intercomPackageJson,
+];
+
+const ATOMIC_RUNTIME_DEPENDENCIES: DependencyMap = {
+  ...atomicPackageJson.dependencies,
+  ...atomicPackageJson.optionalDependencies,
+};
+
 function markdownFiles(dir: string): string[] {
   return readdirSync(dir)
     .filter((name) => name.endsWith(".md"))
     .sort();
+}
+
+function dependencyEntries(
+  packageJson: PackageDependencySections,
+  sections: readonly DependencySectionName[] = PUBLISHED_DEPENDENCY_SECTIONS,
+): [DependencySectionName, string, string][] {
+  return sections.flatMap((sectionName) => {
+    const dependencies = packageJson[sectionName];
+    if (!dependencies) return [];
+    return Object.entries(dependencies).map(
+      ([name, range]): [DependencySectionName, string, string] => [sectionName, name, range],
+    );
+  });
+}
+
+function atomicRuntimeDependencyRange(name: string): string | undefined {
+  return ATOMIC_RUNTIME_DEPENDENCIES[name];
 }
 
 describe("package metadata", () => {
@@ -61,6 +113,32 @@ describe("package metadata", () => {
     for (const { manifestPath, packageJson } of packages) {
       if (packageJson.name === "@bastani/atomic") continue;
       assert.equal(packageJson.private, true, `${manifestPath} must remain private because it is bundled into @bastani/atomic`);
+    }
+  });
+
+  test("@bastani/atomic package manifest is installable outside the workspace", () => {
+    for (const [sectionName, dependencyName, dependencyRange] of dependencyEntries(atomicPackageJson)) {
+      assert.ok(
+        !dependencyRange.startsWith("workspace:"),
+        `${sectionName}.${dependencyName} must not use the workspace protocol in the published manifest`,
+      );
+      assert.ok(
+        !dependencyName.startsWith("@bastani/"),
+        `${sectionName}.${dependencyName} must not point at a private bundled workspace package`,
+      );
+    }
+  });
+
+  test("@bastani/atomic declares runtime dependencies required by bundled packages", () => {
+    for (const bundledPackageJson of BUNDLED_PACKAGE_MANIFESTS) {
+      for (const [, dependencyName, dependencyRange] of dependencyEntries(bundledPackageJson, ["dependencies"])) {
+        if (dependencyName.startsWith("@bastani/")) continue;
+        assert.equal(
+          atomicRuntimeDependencyRange(dependencyName),
+          dependencyRange,
+          `@bastani/atomic must directly depend on ${dependencyName} for bundled ${bundledPackageJson.name}`,
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes the published \`@bastani/atomic\` package manifest so Bun can install the package outside the monorepo. The root cause was that private \`@bastani/*\` companion packages were listed as \`workspace:\*\` dependencies in the published manifest — unresolvable by any external package manager.

## Changes

**Manifest fix**
- Removed all five private \`@bastani/*\` workspace-protocol dependencies (\`subagents\`, \`mcp\`, \`web-access\`, \`intercom\`, \`workflows\`) from the \`@bastani/atomic\` \`package.json\`
- Hoisted the bundled companion packages' third-party runtime dependencies directly onto \`@bastani/atomic\`: \`@modelcontextprotocol/ext-apps\`, \`@modelcontextprotocol/sdk\`, \`@mozilla/readability\`, \`linkedom\`, \`open\`, \`p-limit\`, \`turndown\`, \`unpdf\`, \`zod\`

**Regression prevention**
- Added two new unit tests in \`test/unit/package-metadata.test.ts\`:
  - Asserts no \`workspace:\` protocol or \`@bastani/\` private package appears in any dependency section of the published manifest
  - Asserts \`@bastani/atomic\` directly declares every runtime dep required by its bundled companion packages
- Extended \`publish.yml\` validate-manifest job with the same \`workspace:\` and \`@bastani/\` checks, so CI blocks a bad publish at the gate

**Other**
- Added \`pre-push\` to \`prek.toml\` default hook types so \`bun run test:unit\` runs on push as well as on commit
- Bumped all workspace packages to \`0.8.1-0\` and added CHANGELOG entry

## Verification

```sh
AGENT=1 bun test test/unit/package-metadata.test.ts
bun run typecheck
bun run test:unit
# Packed tarball installed successfully:
# bun add -g ./bastani-atomic-0.8.1-0.tgz
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)