### PR TITLE
fix(changelog): show only current atomic release notes

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -111,6 +111,7 @@ import { isInstallTelemetryEnabled } from "../../core/telemetry.js";
 import type { TruncationResult } from "../../core/tools/truncate.js";
 import {
   getChangelogPath,
+  getEntriesForVersion,
   getNewEntries,
   parseChangelog,
 } from "../../utils/changelog.js";
@@ -663,7 +664,7 @@ export class InteractiveMode {
     this.chatContainer.addChild(new DynamicBorder());
     if (this.settingsManager.getCollapseChangelog()) {
       const versionMatch = this.changelogMarkdown.match(
-        /##\s+\[?(\d+\.\d+\.\d+)\]?/,
+        /##\s+\[?((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*))?)\]?/,
       );
       const latestVersion = versionMatch ? versionMatch[1] : this.version;
       const condensedText = `Updated to v${latestVersion}. Use ${theme.bold("/changelog")} to view full changelog.`;
@@ -1003,11 +1004,12 @@ export class InteractiveMode {
       return undefined;
     }
 
-    const newEntries = getNewEntries(entries, lastVersion);
-    if (newEntries.length > 0) {
+    const newEntries = getNewEntries(entries, lastVersion, VERSION);
+    const currentEntries = getEntriesForVersion(newEntries, VERSION);
+    if (currentEntries.length > 0) {
       this.settingsManager.setLastChangelogVersion(VERSION);
       this.reportInstallTelemetry(VERSION);
-      return newEntries.map((e) => e.content).join("\n\n");
+      return currentEntries.map((e) => e.content).join("\n\n");
     }
 
     return undefined;

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -1,10 +1,50 @@
 import { existsSync, readFileSync } from "fs";
 
-export interface ChangelogEntry {
+export interface VersionParts {
 	major: number;
 	minor: number;
 	patch: number;
+	prerelease: number | null;
+}
+
+export interface ChangelogEntry extends VersionParts {
+	version: string;
 	content: string;
+}
+
+const RELEASE_VERSION_RE = /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?$/;
+const CHANGELOG_VERSION_HEADER_RE = /^##\s+\[?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?\]?/;
+
+function formatVersion(parts: VersionParts): string {
+	const base = `${parts.major}.${parts.minor}.${parts.patch}`;
+	return parts.prerelease === null ? base : `${base}-${parts.prerelease}`;
+}
+
+function partsFromMatch(match: RegExpMatchArray): VersionParts {
+	return {
+		major: Number.parseInt(match[1] as string, 10),
+		minor: Number.parseInt(match[2] as string, 10),
+		patch: Number.parseInt(match[3] as string, 10),
+		prerelease: match[4] === undefined ? null : Number.parseInt(match[4], 10),
+	};
+}
+
+function parseVersion(version: string): VersionParts | null {
+	const match = version.trim().match(RELEASE_VERSION_RE);
+	return match ? partsFromMatch(match) : null;
+}
+
+function parseVersionHeader(line: string): VersionParts | null {
+	const match = line.match(CHANGELOG_VERSION_HEADER_RE);
+	return match ? partsFromMatch(match) : null;
+}
+
+function createChangelogEntry(version: VersionParts, lines: string[]): ChangelogEntry {
+	return {
+		...version,
+		version: formatVersion(version),
+		content: lines.join("\n").trim(),
+	};
 }
 
 /**
@@ -22,27 +62,20 @@ export function parseChangelog(changelogPath: string): ChangelogEntry[] {
 		const entries: ChangelogEntry[] = [];
 
 		let currentLines: string[] = [];
-		let currentVersion: { major: number; minor: number; patch: number } | null = null;
+		let currentVersion: VersionParts | null = null;
 
 		for (const line of lines) {
 			// Check if this is a version header (## [x.y.z] ...)
 			if (line.startsWith("## ")) {
 				// Save previous entry if exists
 				if (currentVersion && currentLines.length > 0) {
-					entries.push({
-						...currentVersion,
-						content: currentLines.join("\n").trim(),
-					});
+					entries.push(createChangelogEntry(currentVersion, currentLines));
 				}
 
 				// Try to parse version from this line
-				const versionMatch = line.match(/##\s+\[?(\d+)\.(\d+)\.(\d+)\]?/);
-				if (versionMatch) {
-					currentVersion = {
-						major: Number.parseInt(versionMatch[1], 10),
-						minor: Number.parseInt(versionMatch[2], 10),
-						patch: Number.parseInt(versionMatch[3], 10),
-					};
+				const versionParts = parseVersionHeader(line);
+				if (versionParts) {
+					currentVersion = versionParts;
 					currentLines = [line];
 				} else {
 					// Reset if we can't parse version
@@ -57,10 +90,7 @@ export function parseChangelog(changelogPath: string): ChangelogEntry[] {
 
 		// Save last entry
 		if (currentVersion && currentLines.length > 0) {
-			entries.push({
-				...currentVersion,
-				content: currentLines.join("\n").trim(),
-			});
+			entries.push(createChangelogEntry(currentVersion, currentLines));
 		}
 
 		return entries;
@@ -73,26 +103,57 @@ export function parseChangelog(changelogPath: string): ChangelogEntry[] {
 /**
  * Compare versions. Returns: -1 if v1 < v2, 0 if v1 === v2, 1 if v1 > v2
  */
-export function compareVersions(v1: ChangelogEntry, v2: ChangelogEntry): number {
+export function compareVersions(v1: VersionParts, v2: VersionParts): number {
 	if (v1.major !== v2.major) return v1.major - v2.major;
 	if (v1.minor !== v2.minor) return v1.minor - v2.minor;
-	return v1.patch - v2.patch;
+	if (v1.patch !== v2.patch) return v1.patch - v2.patch;
+	if (v1.prerelease === v2.prerelease) return 0;
+	if (v1.prerelease === null) return 1;
+	if (v2.prerelease === null) return -1;
+	return v1.prerelease - v2.prerelease;
 }
 
 /**
- * Get entries newer than lastVersion
+ * Get entries newer than lastVersion, optionally bounded by currentVersion.
+ *
+ * Atomic uses numeric prereleases (for example, 0.8.1-0) and started its own
+ * version line above the upstream Pi changelog history. When currentVersion is
+ * provided, changelog order wins over semantic version filtering so historical
+ * upstream entries like 0.74.0 or an old 0.10.0 section are not treated as
+ * newer Atomic releases.
  */
-export function getNewEntries(entries: ChangelogEntry[], lastVersion: string): ChangelogEntry[] {
-	// Parse lastVersion
-	const parts = lastVersion.split(".").map(Number);
-	const last: ChangelogEntry = {
-		major: parts[0] || 0,
-		minor: parts[1] || 0,
-		patch: parts[2] || 0,
-		content: "",
-	};
+function findVersionIndex(entries: ChangelogEntry[], version: string): number {
+	const target = parseVersion(version);
+	if (!target) return -1;
+	return entries.findIndex((entry) => compareVersions(entry, target) === 0);
+}
 
+export function getNewEntries(
+	entries: ChangelogEntry[],
+	lastVersion: string,
+	currentVersion?: string,
+): ChangelogEntry[] {
+	if (currentVersion) {
+		const currentIndex = findVersionIndex(entries, currentVersion);
+		if (currentIndex === -1) return [];
+
+		const lastIndex = findVersionIndex(entries, lastVersion);
+		if (lastIndex !== -1) {
+			return currentIndex < lastIndex ? entries.slice(currentIndex, lastIndex) : [];
+		}
+
+		const currentEntry = entries[currentIndex];
+		return currentIndex === 0 && currentEntry ? [currentEntry] : [];
+	}
+
+	const last = parseVersion(lastVersion) ?? { major: 0, minor: 0, patch: 0, prerelease: null };
 	return entries.filter((entry) => compareVersions(entry, last) > 0);
+}
+
+export function getEntriesForVersion(entries: ChangelogEntry[], version: string): ChangelogEntry[] {
+	const target = parseVersion(version);
+	if (!target) return [];
+	return entries.filter((entry) => compareVersions(entry, target) === 0);
 }
 
 // Re-export getChangelogPath from paths.ts for convenience

--- a/test/unit/changelog.test.ts
+++ b/test/unit/changelog.test.ts
@@ -1,0 +1,85 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { getEntriesForVersion, getNewEntries, parseChangelog } from "../../packages/coding-agent/src/utils/changelog.js";
+
+function writeChangelog(content: string): string {
+  const root = mkdtempSync(join(tmpdir(), "atomic-changelog-"));
+  const changelogPath = join(root, "CHANGELOG.md");
+  writeFileSync(changelogPath, content);
+  return changelogPath;
+}
+
+describe("changelog parsing", () => {
+  test("parses numeric prerelease versions as distinct changelog entries", () => {
+    const changelogPath = writeChangelog(`# Changelog
+
+## [0.8.1] - 2026-05-15
+
+### Fixed
+
+- Stable fix.
+
+## [0.8.1-0] - 2026-05-15
+
+### Fixed
+
+- Prerelease fix.
+`);
+
+    try {
+      const entries = parseChangelog(changelogPath);
+      assert.deepEqual(
+        entries.map((entry) => entry.version),
+        ["0.8.1", "0.8.1-0"],
+      );
+      assert.equal(entries[0]?.prerelease, null);
+      assert.equal(entries[1]?.prerelease, 0);
+    } finally {
+      rmSync(dirname(changelogPath), { recursive: true, force: true });
+    }
+  });
+
+  test("bounds update entries to the current Atomic version", () => {
+    const changelogPath = writeChangelog(`# Changelog
+
+## [0.10.0] - 2026-05-20
+
+- Current release.
+
+## [0.9.0] - 2026-05-18
+
+- Previous Atomic release.
+
+## [0.8.1-0] - 2026-05-15
+
+- First Atomic prerelease.
+
+## [0.74.0] - 2026-05-07
+
+- Historical upstream Pi release after the version reset.
+
+## [0.10.0] - 2025-01-01
+
+- Historical upstream Pi section with the same version number.
+`);
+
+    try {
+      const entries = parseChangelog(changelogPath);
+      const newEntries = getNewEntries(entries, "0.8.1-0", "0.10.0");
+
+      assert.deepEqual(
+        newEntries.map((entry) => entry.version),
+        ["0.10.0", "0.9.0"],
+      );
+      assert.deepEqual(
+        getEntriesForVersion(newEntries, "0.10.0").map((entry) => entry.version),
+        ["0.10.0"],
+      );
+    } finally {
+      rmSync(dirname(changelogPath), { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where Atomic's update notification showed all changelog entries newer than the last-seen version, which could include historical upstream Pi entries (e.g. `0.74.0` or a duplicate `0.10.0` section) misidentified as newer Atomic releases. Now only the exact current version's release notes are surfaced.

## Key Changes

- **Prerelease version support** — Version parsing now handles `MAJOR.MINOR.PATCH-NUMBER` format (e.g. `0.8.1-0`) in both the changelog parser and the interactive-mode version regex.
- **Position-bounded `getNewEntries`** — Accepts an optional `currentVersion` parameter; when provided, filtering uses changelog document order rather than raw semver comparison, preventing upstream Pi entries from leaking into Atomic's update notifications.
- **New `getEntriesForVersion` helper** — Filters a list of changelog entries down to those matching an exact version string; used in interactive mode to show only the current release's notes.
- **Interactive mode update** — `getChangelogToShow` now calls `getNewEntries(..., VERSION)` to bound the candidate set, then `getEntriesForVersion(..., VERSION)` to show only the current version's content.
- **Unit tests** — New `test/unit/changelog.test.ts` covers numeric-prerelease parsing and the version-bounding logic against a changelog that mixes Atomic and upstream Pi sections.

## Notes

No breaking changes. The `compareVersions` signature is widened from `ChangelogEntry` to `VersionParts`, but all existing callers continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)