### PR TITLE
chore(release): prepare v0.8.1-1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.1-0",
+      "version": "0.8.1-1",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.1-0",
+      "version": "0.8.1-1",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -79,7 +79,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.1-0",
+      "version": "0.8.1-1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -103,7 +103,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.1-0",
+      "version": "0.8.1-1",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -125,7 +125,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.1-0",
+      "version": "0.8.1-1",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",
         "linkedom": "^0.16.0",
@@ -146,7 +146,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.1-0",
+      "version": "0.8.1-1",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-coding-agent": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.1-1] - 2026-05-15
+
+### Fixed
+
+- Fixed the Atomic changelog viewer to show only the current release notes instead of including older sections.
+
 ## [0.8.1-0] - 2026-05-15
 
 ### Fixed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.1-0",
+  "version": "0.8.1-1",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.1-0",
+  "version": "0.8.1-1",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.1-0",
+  "version": "0.8.1-1",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.1-0",
+  "version": "0.8.1-1",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.1-0",
+  "version": "0.8.1-1",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.1-0",
+  "version": "0.8.1-1",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Bumps all workspace packages from `0.8.1-0` to `0.8.1-1` and documents the changelog display fix included in this prerelease.

## Changes

- Bumped `@bastani/atomic` and all companion packages (`workflows`, `subagents`, `mcp`, `web-access`, `intercom`) from `0.8.1-0` → `0.8.1-1`
- Refreshed `bun.lock` for the updated versions
- Added `[0.8.1-1]` CHANGELOG entry: fixed the Atomic changelog viewer to show only the current release's notes instead of trailing older sections

## Verification

- `AGENT=1 bun run typecheck` — passed
- `cd packages/coding-agent && AGENT=1 bun run build` — passed
- `AGENT=1 bun run test:unit` — passed
- Pre-commit and pre-push hooks ran successfully

## Notes

After merge, publishing requires creating and pushing the matching git tag:

```sh
git tag v0.8.1-1 && git push origin v0.8.1-1
```

This will trigger `.github/workflows/publish.yml`, publish `@bastani/atomic@0.8.1-1` to npm under the `next` tag, and create a prerelease GitHub Release (not marked latest).