### PR TITLE
chore(release): prepare v0.8.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-15
+
+### Fixed
+
+- Fixed the Atomic changelog viewer to show only the current release notes instead of including older sections.
+- Fixed the published `@bastani/atomic` package manifest so Bun can install it outside the monorepo without resolving private workspace-only bundled packages.
+
 ## [0.8.1-1] - 2026-05-15
 
 ### Fixed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.1-1",
+  "version": "0.8.1",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.1-1",
+  "version": "0.8.1",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.1-1",
+  "version": "0.8.1",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.1-1",
+  "version": "0.8.1",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.1-1",
+  "version": "0.8.1",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.1-1",
+  "version": "0.8.1",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the workspace from `0.8.1-1` (prerelease) to the stable `v0.8.1` release, incorporating two bug fixes surfaced during the prerelease cycle.

## Changes

- Bumped all workspace package versions (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`) from `0.8.1-1` → `0.8.1`.
- Added `[0.8.1] - 2026-05-15` section to `packages/coding-agent/CHANGELOG.md` with the following fixes:
  - **Changelog viewer**: Fixed the Atomic changelog viewer to show only the current release notes instead of including older sections.
  - **Package manifest**: Fixed the published `@bastani/atomic` manifest so Bun can install it outside the monorepo without attempting to resolve private workspace-only bundled packages.

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- `AGENT=1 bun run test:unit`
- `bun run lint`

## Release

After this PR merges to `main`, publish by tagging the release commit and pushing the tag:

```sh
git tag v0.8.1
git push origin v0.8.1
```

The `v0.8.1` tag triggers `.github/workflows/publish.yml`, which publishes `@bastani/atomic@0.8.1` to npm with the `latest` tag and creates a non-prerelease GitHub Release with cross-compiled binaries attached.