### PR TITLE
chore(release): bump to v0.8.2-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,13 +8,13 @@
         "@earendil-works/pi-coding-agent": "^0.74.0",
         "@earendil-works/pi-tui": "^0.74.0",
         "@j178/prek": "^0.4.0",
-        "@types/bun": "^1.3.13",
+        "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
       },
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.1-1",
+      "version": "0.8.2-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.1-1",
+      "version": "0.8.2-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -79,7 +79,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.1-1",
+      "version": "0.8.2-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -103,7 +103,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.1-1",
+      "version": "0.8.2-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -125,7 +125,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.1-1",
+      "version": "0.8.2-0",
       "dependencies": {
         "@mozilla/readability": "^0.5.0",
         "linkedom": "^0.16.0",
@@ -146,7 +146,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.1-1",
+      "version": "0.8.2-0",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-coding-agent": "*",
@@ -550,7 +550,7 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -644,7 +644,7 @@
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atomic-monorepo",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.13",
+  "packageManager": "bun@1.3.14",
   "engines": {
     "bun": ">=1.3.14"
   },
@@ -24,7 +24,7 @@
     "@earendil-works/pi-coding-agent": "^0.74.0",
     "@earendil-works/pi-tui": "^0.74.0",
     "@j178/prek": "^0.4.0",
-    "@types/bun": "^1.3.13",
+    "@types/bun": "^1.3.14",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.2-0] - 2026-05-16
+
 ### Changed
 
 - Reduced the Atomic startup banner to a compact three-line mark.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.1",
+  "version": "0.8.2-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.1",
+  "version": "0.8.2-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.1",
+  "version": "0.8.2-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.1",
+  "version": "0.8.2-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.1",
+  "version": "0.8.2-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.1",
+  "version": "0.8.2-0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the \`v0.8.2-0\` prerelease for publishing to npm under the \`next\` tag. The key user-facing change in this release is a compact three-line startup banner replacing the previous verbose banner.

## Changes

- **Version bump**: All workspace packages bumped from \`0.8.1\` → \`0.8.2-0\` across \`@bastani/atomic\`, \`@bastani/workflows\`, \`@bastani/subagents\`, \`@bastani/mcp\`, \`@bastani/web-access\`, and \`@bastani/intercom\`
- **Bun runtime pin**: \`packageManager\` field updated from \`bun@1.3.13\` to \`bun@1.3.14\`
- **Dev dependency**: \`@types/bun\` bumped from \`^1.3.13\` to \`^1.3.14\`
- **Changelog**: \`[0.8.2-0] - 2026-05-16\` section added documenting the compact startup banner change
- **Lockfile**: \`bun.lock\` refreshed to reflect updated package versions

## Release notes (v0.8.2-0)

### Changed

- Reduced the Atomic startup banner to a compact three-line mark.

## Notes

- This is a **prerelease** — tagging \`v0.8.2-0\` after merge publishes \`@bastani/atomic@0.8.2-0\` to npm under the \`next\` tag, not \`latest\`.
- No breaking changes.
- Validation: \`bun run typecheck\`, \`bun run lint\`, and \`bun run test:unit\` all passed via git hooks.