### PR TITLE
fix(subagents): append current model as final fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ MIT — see [LICENSE](LICENSE).
 
 ## Credits
 
+- [Pi](https://pi.dev)
 - [Superpowers](https://github.com/obra/superpowers)
 - [Anthropic Skills](https://github.com/anthropics/skills)
 - [Ralph Wiggum Method](https://ghuntley.com/ralph/)

--- a/examples/model-fallback.ts
+++ b/examples/model-fallback.ts
@@ -11,7 +11,11 @@ export default defineWorkflow("model-fallback-example")
     const review = await ctx.task("reviewer", {
       prompt: `Review this topic and call out risks: ${String(ctx.inputs.topic)}`,
       model: "anthropic/claude-sonnet-4",
-      fallbackModels: ["openai/gpt-5-mini", "github-copilot/gpt-5-mini"],
+      fallbackModels: [
+        "openai/gpt-5-mini",
+        "openai-codex/gpt-5-mini",
+        "github-copilot/gpt-5-mini",
+      ],
     });
 
     return {

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Added
 
 ### Fixed
+- Append the current user-selected model as the final subagent fallback candidate, so retryable provider/model failures still get one last attempt after configured `fallbackModels` are exhausted.
 
 ## [0.24.2] - 2026-05-10
 

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -448,7 +448,7 @@ Important fields:
 | `tools` | Builtin tool allowlist. `mcp:` entries select direct MCP tools when `pi-mcp-adapter` is installed. |
 | `extensions` | Omitted means normal extensions; empty means no extensions; comma-separated values allowlist specific extensions. |
 | `model` | Default model. Bare ids prefer the current provider when possible, then unique registry matches. |
-| `fallbackModels` | Ordered backup models for provider/model failures such as quota, auth, timeout, or unavailable model. Ordinary task failures do not trigger fallback. |
+| `fallbackModels` | Ordered backup models for provider/model failures such as quota, auth, timeout, or unavailable model. The current user-selected model is automatically appended as the last fallback and de-duplicated. Ordinary task failures do not trigger fallback. |
 | `thinking` | Appended as a `:level` suffix at runtime unless a suffix is already present. |
 | `systemPromptMode` | `replace` by default; `append` keeps Pi’s base prompt. |
 | `inheritProjectContext` | Keeps or strips inherited project instruction blocks. |

--- a/packages/subagents/agents/code-simplifier.md
+++ b/packages/subagents/agents/code-simplifier.md
@@ -9,7 +9,7 @@ description: |
   - Code that has gotten messy after several iterations.
 tools: read, edit, write, grep, find, ls, bash
 model: openai/gpt-5.5
-fallbackModels: github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
+fallbackModels: openai-codex/gpt-5.5, github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
 thinking: low
 ---
 

--- a/packages/subagents/agents/codebase-analyzer.md
+++ b/packages/subagents/agents/codebase-analyzer.md
@@ -3,7 +3,7 @@ name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components.
 tools: read, grep, find, ls, bash
 model: openai/gpt-5.5
-fallbackModels: github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
+fallbackModels: openai-codex/gpt-5.5, github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
 thinking: low
 ---
 

--- a/packages/subagents/agents/codebase-locator.md
+++ b/packages/subagents/agents/codebase-locator.md
@@ -3,7 +3,7 @@ name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Basically a "super search/find/ls tool."
 tools: read, grep, find, ls, bash
 model: openai/gpt-5.4-mini
-fallbackModels: github-copilot/gpt-5.4-mini, anthropic/claude-haiku-4-5, github-copilot/claude-haiku-4.5
+fallbackModels: openai-codex/gpt-5.4-mini, github-copilot/gpt-5.4-mini, anthropic/claude-haiku-4-5, github-copilot/claude-haiku-4.5
 thinking: low
 ---
 

--- a/packages/subagents/agents/codebase-online-researcher.md
+++ b/packages/subagents/agents/codebase-online-researcher.md
@@ -3,7 +3,7 @@ name: codebase-online-researcher
 description: Online research for up-to-date documentation and library-source knowledge. Use when you need authoritative external information — official docs, ecosystem context, version-specific behavior, GitHub permalinks into open-source libraries, or video tutorials.
 tools: read, grep, find, ls, bash, write, web_search, fetch_content, get_search_content
 model: openai/gpt-5.5
-fallbackModels: github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
+fallbackModels: openai-codex/gpt-5.5, github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
 thinking: low
 skills: playwright-cli
 ---
@@ -27,11 +27,11 @@ For JS-heavy or auth-gated pages, fall back to invoking `playwright-cli` through
 
 Pi executes tool calls sequentially, even when you emit multiple calls in one turn. But batching independent calls in a single turn still saves LLM round-trips (~5-10s each). Use these patterns:
 
-| Pattern                          | When                                                      | Actually parallel?            |
-| -------------------------------- | --------------------------------------------------------- | ----------------------------- |
-| Batch tool calls in one turn     | Independent ops (web_search + fetch_content + read)       | No, but saves round-trips     |
-| `fetch_content({ urls: [...] })` | Multiple URLs to fetch                                    | Yes (3 concurrent)            |
-| Bash with `&` + `wait`           | Multiple git/gh commands                                  | Yes (OS-level)                |
+| Pattern                          | When                                                | Actually parallel?        |
+| -------------------------------- | --------------------------------------------------- | ------------------------- |
+| Batch tool calls in one turn     | Independent ops (web_search + fetch_content + read) | No, but saves round-trips |
+| `fetch_content({ urls: [...] })` | Multiple URLs to fetch                              | Yes (3 concurrent)        |
+| Bash with `&` + `wait`           | Multiple git/gh commands                            | Yes (OS-level)            |
 
 ## Web Fetch Strategy (token-efficient order)
 
@@ -63,12 +63,12 @@ When the question is about an open-source library — its internals, why somethi
 
 ### Step 1: Classify the request
 
-| Type                  | Trigger                                                                | Primary approach                                                |
-| --------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------- |
-| **Conceptual**        | "How do I use X?", "Best practice for Y?"                              | `web_search` + `fetch_content` on README/docs                   |
-| **Implementation**    | "How does X implement Y?", "Show me the source"                        | `fetch_content` (clone) + `grep`/`read` + permalinks            |
-| **Context / History** | "Why was this changed?", "History of X?"                               | `git log`, `git blame`, `git show` + `gh search issues/prs`     |
-| **Comprehensive**     | Complex or ambiguous "deep dive"                                       | All of the above                                                |
+| Type                  | Trigger                                         | Primary approach                                            |
+| --------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
+| **Conceptual**        | "How do I use X?", "Best practice for Y?"       | `web_search` + `fetch_content` on README/docs               |
+| **Implementation**    | "How does X implement Y?", "Show me the source" | `fetch_content` (clone) + `grep`/`read` + permalinks        |
+| **Context / History** | "Why was this changed?", "History of X?"        | `git log`, `git blame`, `git show` + `gh search issues/prs` |
+| **Comprehensive**     | Complex or ambiguous "deep dive"                | All of the above                                            |
 
 ### Step 2: Research by type
 
@@ -303,15 +303,15 @@ For library-source answers, every code claim should look like the citation examp
 
 ## Failure Recovery
 
-| Failure                                | Recovery                                                                                                              |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `grep` finds nothing                   | Broaden the query; try concept names instead of exact function names.                                                 |
-| `gh` CLI rate limited                  | Use the already-cloned repo under `/tmp/pi-github-repos/` for git operations instead.                                 |
-| Repo too large to clone                | `fetch_content` returns an API-only view automatically; use that, or add `forceClone: true` if you must clone.        |
-| File not found in the clone            | A branch name with slashes may have misresolved; list the repo tree and navigate manually.                            |
-| Uncertain about implementation         | State your uncertainty explicitly, propose a hypothesis, and show what evidence you did find.                         |
-| Video extraction fails                 | Ensure Chrome is signed into gemini.google.com (free) or set `GEMINI_API_KEY`.                                        |
-| Page returns 403 / bot block           | Gemini fallback triggers automatically; no action needed if Gemini is configured.                                     |
-| `web_search` fails                     | Check provider config; try explicit `provider: "gemini"` if a Perplexity key is missing.                              |
+| Failure                        | Recovery                                                                                                       |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `grep` finds nothing           | Broaden the query; try concept names instead of exact function names.                                          |
+| `gh` CLI rate limited          | Use the already-cloned repo under `/tmp/pi-github-repos/` for git operations instead.                          |
+| Repo too large to clone        | `fetch_content` returns an API-only view automatically; use that, or add `forceClone: true` if you must clone. |
+| File not found in the clone    | A branch name with slashes may have misresolved; list the repo tree and navigate manually.                     |
+| Uncertain about implementation | State your uncertainty explicitly, propose a hypothesis, and show what evidence you did find.                  |
+| Video extraction fails         | Ensure Chrome is signed into gemini.google.com (free) or set `GEMINI_API_KEY`.                                 |
+| Page returns 403 / bot block   | Gemini fallback triggers automatically; no action needed if Gemini is configured.                              |
+| `web_search` fails             | Check provider config; try explicit `provider: "gemini"` if a Perplexity key is missing.                       |
 
 Remember: you are the user's expert guide to technical research. Lean on `fetch_content` first with the `/llms.txt` → `Accept: text/markdown` → `playwright-cli` fallback chain to efficiently pull authoritative content, clone open-source repos when implementation evidence is needed, store anything reusable under `research/web/`, and deliver comprehensive, up-to-date answers with exact citations and GitHub permalinks. Answer directly — skip preamble like "I'll help you with…" and go straight to findings.

--- a/packages/subagents/agents/codebase-pattern-finder.md
+++ b/packages/subagents/agents/codebase-pattern-finder.md
@@ -3,7 +3,7 @@ name: codebase-pattern-finder
 description: Find similar implementations, usage examples, or existing patterns in the codebase that can be modeled after.
 tools: read, grep, find, ls, bash
 model: openai/gpt-5.4-mini
-fallbackModels: github-copilot/gpt-5.4-mini, anthropic/claude-haiku-4-5, github-copilot/claude-haiku-4.5
+fallbackModels: openai-codex/gpt-5.4-mini, github-copilot/gpt-5.4-mini, anthropic/claude-haiku-4-5, github-copilot/claude-haiku-4.5
 thinking: low
 ---
 

--- a/packages/subagents/agents/codebase-research-analyzer.md
+++ b/packages/subagents/agents/codebase-research-analyzer.md
@@ -3,7 +3,7 @@ name: codebase-research-analyzer
 description: Analyzes local research documents to extract high-value insights, decisions, and technical details while filtering out noise. Use this when you want to deep dive on a research topic or understand the rationale behind decisions.
 tools: read, grep, find, ls, bash
 model: openai/gpt-5.5
-fallbackModels: github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
+fallbackModels: openai-codex/gpt-5.5, github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
 thinking: low
 ---
 

--- a/packages/subagents/agents/codebase-research-locator.md
+++ b/packages/subagents/agents/codebase-research-locator.md
@@ -3,7 +3,7 @@ name: codebase-research-locator
 description: Discovers local research documents that are relevant to the current research task.
 tools: read, grep, find, ls, bash
 model: openai/gpt-5.4-mini
-fallbackModels: github-copilot/gpt-5.4-mini, anthropic/claude-haiku-4-5, github-copilot/claude-haiku-4.5
+fallbackModels: openai-codex/gpt-5.4-mini, github-copilot/gpt-5.4-mini, anthropic/claude-haiku-4-5, github-copilot/claude-haiku-4.5
 thinking: low
 ---
 

--- a/packages/subagents/agents/debugger.md
+++ b/packages/subagents/agents/debugger.md
@@ -3,7 +3,7 @@ name: debugger
 description: Debug errors, test failures, and unexpected behavior. Use PROACTIVELY when encountering issues, analyzing stack traces, or investigating system problems.
 tools: read, edit, write, grep, find, ls, bash, web_search, fetch_content, get_search_content
 model: openai/gpt-5.5
-fallbackModels: github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
+fallbackModels: openai-codex/gpt-5.5, github-copilot/gpt-5.5, anthropic/claude-opus-4-7, github-copilot/claude-opus-4.7
 thinking: high
 skills: tdd, playwright-cli
 ---

--- a/packages/subagents/skills/subagent/SKILL.md
+++ b/packages/subagents/skills/subagent/SKILL.md
@@ -129,7 +129,7 @@ Builtin agents load at the lowest priority. Project agents override user agents,
 | `code-simplifier` | Clean up recently changed code without changing behavior | `openai/gpt-5.5` | low | read, edit, write, grep, find, ls, bash | **Writer.** Scopes to recently modified code by default; preserves all observable behavior. |
 | `debugger` | Reproduce, diagnose, and fix failing behavior | `openai/gpt-5.5` | high | read, edit, write, grep, find, ls, bash, web_search, fetch_content, get_search_content | **Writer.** Has the `tdd` and `playwright-cli` skills. Inspect-only mode requires an explicit instruction. |
 
-Each builtin declares an explicit `model` and `fallbackModels` chain (typically `github-copilot/<same>`, then `anthropic/claude-opus-4-7`, then `github-copilot/claude-opus-4.7`). Override per run with inline config:
+Each builtin declares an explicit `model` and `fallbackModels` chain (typically `github-copilot/<same>`, then `anthropic/claude-opus-4-7`, then `github-copilot/claude-opus-4.7`). The current user-selected model is automatically appended as the last fallback and de-duplicated. Override per run with inline config:
 
 ```text
 /run codebase-analyzer[model=anthropic/claude-sonnet-4] "Trace the auth flow"

--- a/packages/subagents/src/runs/background/async-execution.ts
+++ b/packages/subagents/src/runs/background/async-execution.ts
@@ -88,6 +88,7 @@ interface AsyncExecutionContext {
 	cwd: string;
 	currentSessionId: string;
 	currentModelProvider?: string;
+	currentModel?: string;
 }
 
 interface AsyncChainParams {
@@ -317,7 +318,7 @@ export function executeAsyncChain(
 			cwd: stepCwd,
 			model,
 			thinking: resolveEffectiveThinking(model, a.thinking),
-			modelCandidates: buildModelCandidates(behavior.model ?? a.model, a.fallbackModels, availableModels, ctx.currentModelProvider).map((candidate) =>
+			modelCandidates: buildModelCandidates(behavior.model ?? a.model, a.fallbackModels, availableModels, ctx.currentModelProvider, ctx.currentModel).map((candidate) =>
 				applyThinkingSuffix(candidate, a.thinking),
 			),
 			tools: a.tools,
@@ -544,7 +545,7 @@ export function executeAsyncSingle(
 						cwd: runnerCwd,
 						model,
 						thinking: resolveEffectiveThinking(model, agentConfig.thinking),
-						modelCandidates: buildModelCandidates(params.modelOverride ?? agentConfig.model, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider).map((candidate) =>
+						modelCandidates: buildModelCandidates(params.modelOverride ?? agentConfig.model, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, ctx.currentModel).map((candidate) =>
 							applyThinkingSuffix(candidate, agentConfig.thinking),
 						),
 						tools: agentConfig.tools,

--- a/packages/subagents/src/runs/foreground/chain-execution.ts
+++ b/packages/subagents/src/runs/foreground/chain-execution.ts
@@ -56,7 +56,7 @@ import {
 	MAX_CONCURRENCY,
 	resolveChildMaxSubagentDepth,
 } from "../../shared/types.ts";
-import { resolveModelCandidate } from "../shared/model-fallback.ts";
+import { currentModelFullId, resolveModelCandidate } from "../shared/model-fallback.ts";
 import { validateFileOnlyOutputMode } from "../shared/single-output.ts";
 
 interface ChainExecutionDetailsInput {
@@ -247,6 +247,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				modelOverride: effectiveModel,
 				availableModels: input.availableModels,
 				preferredModelProvider: input.ctx.model?.provider,
+				currentModel: currentModelFullId(input.ctx.model),
 				skills: behavior.skills === false ? [] : behavior.skills,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
@@ -796,6 +797,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				modelOverride: effectiveModel,
 				availableModels,
 				preferredModelProvider: ctx.model?.provider,
+				currentModel: currentModelFullId(ctx.model),
 				skills: behavior.skills === false ? [] : behavior.skills,
 				onUpdate: onUpdate
 					? (p) => {

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -773,6 +773,7 @@ export async function runSync(
 		agent.fallbackModels,
 		options.availableModels,
 		options.preferredModelProvider,
+		options.currentModel,
 	);
 	const attemptedModels: string[] = [];
 	const modelAttempts: ModelAttempt[] = [];

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -13,7 +13,7 @@ import { handleManagementAction } from "../../agents/agent-management.ts";
 import { buildDoctorReport } from "../../extension/doctor.ts";
 import { clearPendingForegroundControlNotices } from "../../extension/control-notices.ts";
 import { runSync } from "./execution.ts";
-import { resolveModelCandidate } from "../shared/model-fallback.ts";
+import { currentModelFullId, resolveModelCandidate } from "../shared/model-fallback.ts";
 import { aggregateParallelOutputs } from "../shared/parallel-utils.ts";
 import { recordRun } from "../shared/run-history.ts";
 import {
@@ -481,6 +481,7 @@ async function resumeAsyncRun(input: {
 			cwd: input.requestCwd,
 			currentSessionId: input.deps.state.currentSessionId,
 			currentModelProvider: input.ctx.model?.provider,
+			currentModel: currentModelFullId(input.ctx.model),
 		},
 		cwd: effectiveCwd,
 		maxOutput: input.params.maxOutput,
@@ -891,6 +892,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		cwd: ctx.cwd,
 		currentSessionId: deps.state.currentSessionId!,
 		currentModelProvider: ctx.model?.provider,
+		currentModel: currentModelFullId(ctx.model),
 	};
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth);
@@ -1081,6 +1083,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			cwd: ctx.cwd,
 			currentSessionId: deps.state.currentSessionId!,
 			currentModelProvider: ctx.model?.provider,
+			currentModel: currentModelFullId(ctx.model),
 		};
 		const asyncChain = wrapChainTasksForFork(chainResult.requestedAsync.chain, params.context);
 		return executeAsyncChain(id, {
@@ -1314,6 +1317,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			modelOverride: input.modelOverrides[index],
 			availableModels: input.availableModels,
 			preferredModelProvider: input.ctx.model?.provider,
+			currentModel: currentModelFullId(input.ctx.model),
 			skills: effectiveSkills === false ? [] : effectiveSkills,
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
@@ -1490,6 +1494,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 				cwd: ctx.cwd,
 				currentSessionId: deps.state.currentSessionId!,
 				currentModelProvider: ctx.model?.provider,
+				currentModel: currentModelFullId(ctx.model),
 			};
 			const parallelTasks = tasks.map((t, i) => {
 				const taskText = params.context === "fork" ? wrapForkTask(taskTexts[i]!) : taskTexts[i]!;
@@ -1767,6 +1772,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				cwd: ctx.cwd,
 				currentSessionId: deps.state.currentSessionId!,
 				currentModelProvider: ctx.model?.provider,
+				currentModel: currentModelFullId(ctx.model),
 			};
 			return executeAsyncSingle(id, {
 				agent: params.agent!,
@@ -1873,6 +1879,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		modelOverride,
 		availableModels,
 		preferredModelProvider: currentProvider,
+		currentModel: currentModelFullId(ctx.model),
 		skills: effectiveSkills,
 	});
 	if (foregroundControl?.currentIndex === 0) {

--- a/packages/subagents/src/runs/shared/model-fallback.ts
+++ b/packages/subagents/src/runs/shared/model-fallback.ts
@@ -44,10 +44,11 @@ export function buildModelCandidates(
 	fallbackModels: string[] | undefined,
 	availableModels: AvailableModelInfo[] | undefined,
 	preferredProvider?: string,
+	currentModel?: string,
 ): string[] {
 	const seen = new Set<string>();
 	const candidates: string[] = [];
-	for (const raw of [primaryModel, ...(fallbackModels ?? [])]) {
+	for (const raw of [primaryModel, ...(fallbackModels ?? []), currentModel]) {
 		if (!raw) continue;
 		const normalized = resolveModelCandidate(raw.trim(), availableModels, preferredProvider);
 		if (!normalized || seen.has(normalized)) continue;
@@ -55,6 +56,11 @@ export function buildModelCandidates(
 		candidates.push(normalized);
 	}
 	return candidates;
+}
+
+export function currentModelFullId(model: { provider: string; id: string } | undefined): string | undefined {
+	if (!model) return undefined;
+	return `${String(model.provider)}/${model.id}`;
 }
 
 const RETRYABLE_MODEL_FAILURE_PATTERNS = [

--- a/packages/subagents/src/shared/types.ts
+++ b/packages/subagents/src/shared/types.ts
@@ -484,6 +484,8 @@ export interface RunSyncOptions {
 	availableModels?: Array<{ provider: string; id: string; fullId: string }>;
 	/** Current parent-session provider to prefer for ambiguous bare model ids */
 	preferredModelProvider?: string;
+	/** Current parent-session model to try after configured fallback models */
+	currentModel?: string;
 	/** Skills to inject (overrides agent default if provided) */
 	skills?: string[];
 }

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -190,6 +190,7 @@ export default defineWorkflow("deep-research-codebase")
     let plannerModelConfig = {
       model: "openai/gpt-5.5",
       fallbackModels: [
+        "openai-codex/gpt-5.5",
         "github-copilot/gpt-5.5",
         "anthropic/claude-opus-4-7",
         "github-copilot/claude-opus-4.7",
@@ -201,6 +202,7 @@ export default defineWorkflow("deep-research-codebase")
     let explorerModelConfig = {
       model: "openai/gpt-5.4-mini",
       fallbackModels: [
+        "openai-codex/gpt-5.4-mini",
         "github-copilot/gpt-5.4-mini",
         "anthropic/claude-haiku-4-5",
         "github-copilot/claude-haiku-4.5",

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -157,6 +157,7 @@ export default defineWorkflow("ralph")
     let plannerModelConfig = {
       model: "openai/gpt-5.5",
       fallbackModels: [
+        "openai-codex/gpt-5.5",
         "github-copilot/gpt-5.5",
         "anthropic/claude-opus-4-7",
         "github-copilot/claude-opus-4.7",
@@ -168,6 +169,7 @@ export default defineWorkflow("ralph")
     let orchestratorModelConfig = {
       model: "openai/gpt-5.5",
       fallbackModels: [
+        "openai-codex/gpt-5.5",
         "github-copilot/gpt-5.5",
         "anthropic/claude-sonnet-4-6",
         "github-copilot/claude-sonnet-4.6",
@@ -179,6 +181,7 @@ export default defineWorkflow("ralph")
     let simplifierModelConfig = {
       model: "openai/gpt-5.5",
       fallbackModels: [
+        "openai-codex/gpt-5.5",
         "github-copilot/gpt-5.5",
         "anthropic/claude-sonnet-4-6",
         "github-copilot/claude-sonnet-4.6",
@@ -190,6 +193,7 @@ export default defineWorkflow("ralph")
     let reviewerModelConfig = {
       model: "openai/gpt-5.5",
       fallbackModels: [
+        "openai-codex/gpt-5.5",
         "github-copilot/gpt-5.5",
         "anthropic/claude-opus-4-7",
         "github-copilot/claude-opus-4.7",
@@ -201,6 +205,7 @@ export default defineWorkflow("ralph")
     let explorerModelConfig = {
       model: "openai/gpt-5.4-mini",
       fallbackModels: [
+        "openai-codex/gpt-5.4-mini",
         "github-copilot/gpt-5.4-mini",
         "anthropic/claude-haiku-4-5",
         "github-copilot/claude-haiku-4.5",

--- a/test/unit/subagents-model-fallback.test.ts
+++ b/test/unit/subagents-model-fallback.test.ts
@@ -1,0 +1,48 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+  buildModelCandidates,
+  currentModelFullId,
+} from "../../packages/subagents/src/runs/shared/model-fallback.js";
+import type { AvailableModelInfo } from "../../packages/subagents/src/runs/shared/model-fallback.js";
+
+const models: AvailableModelInfo[] = [
+  { provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+  { provider: "github-copilot", id: "claude-sonnet-4", fullId: "github-copilot/claude-sonnet-4" },
+  { provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+];
+
+describe("subagent model fallback helpers", () => {
+  test("appends the current selected model after configured fallbacks", () => {
+    assert.deepEqual(
+      buildModelCandidates(
+        "anthropic/primary",
+        ["openai/fallback"],
+        models,
+        "github-copilot",
+        "github-copilot/claude-sonnet-4",
+      ),
+      ["anthropic/primary", "openai/fallback", "github-copilot/claude-sonnet-4"],
+    );
+  });
+
+  test("de-duplicates the current selected model when already attempted", () => {
+    assert.deepEqual(
+      buildModelCandidates(
+        "claude-sonnet-4",
+        ["openai/gpt-5-mini"],
+        models,
+        "github-copilot",
+        "github-copilot/claude-sonnet-4",
+      ),
+      ["github-copilot/claude-sonnet-4", "openai/gpt-5-mini"],
+    );
+  });
+
+  test("formats the selected model from the runtime model object", () => {
+    assert.equal(
+      currentModelFullId({ provider: "openai", id: "gpt-5-mini" }),
+      "openai/gpt-5-mini",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Ensures subagent fallback chains always end with the user's active parent-session model, so retryable provider/model failures (quota, auth, timeout, unavailability) get one last attempt after all configured `fallbackModels` are exhausted.

## Changes

### Core fix
- `buildModelCandidates()` now accepts an optional `currentModel` parameter and appends it (de-duplicated) as the final fallback candidate after the configured `fallbackModels` list.
- New `currentModelFullId()` helper formats a runtime model object into `provider/id` string form.

### Execution path wiring
- Threads `currentModel` through all subagent execution paths: foreground single, foreground parallel, async single, async chain, chain fork, and chain resume.
- Adds `currentModel?: string` to the `RunSyncOptions` interface.

### Built-in agent and workflow updates
- Inserts `openai-codex/<model>` as an additional fallback before `github-copilot/<model>` across all built-in agent definitions (`code-simplifier`, `codebase-analyzer`, `codebase-locator`, `codebase-online-researcher`, `codebase-pattern-finder`, `codebase-research-analyzer`, `codebase-research-locator`, `debugger`).
- Updates built-in workflow model configs in `ralph` and `deep-research-codebase` with the same `openai-codex` candidates.

### Documentation
- Updated `packages/subagents/README.md` and `skills/subagent/SKILL.md` to document the automatic current-model append and de-duplication behavior.
- Added `CHANGELOG.md` entry.

### Tests
- New unit tests in `test/unit/subagents-model-fallback.test.ts` cover fallback ordering, de-duplication when the current model was already attempted, and `currentModelFullId` formatting.

## Notes

- Tested with `bun test test/unit/subagents-model-fallback.test.ts`.
- No breaking changes — `currentModel` is an optional parameter/field throughout.