### PR TITLE
chore(release): bump to v0.8.3-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,14 +7,14 @@
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.74.0",
         "@earendil-works/pi-tui": "^0.74.0",
-        "@j178/prek": "^0.4.0",
+        "@j178/prek": "0.3.13",
         "@types/bun": "^1.3.14",
         "typescript": "^6.0.3",
       },
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.2-0",
+      "version": "0.8.2",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -24,7 +24,7 @@
         "@earendil-works/pi-tui": "^0.74.0",
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "@mozilla/readability": "^0.5.0",
+        "@mozilla/readability": "^0.6.0",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "diff": "^8.0.2",
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.2-0",
+      "version": "0.8.2",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -79,7 +79,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.2-0",
+      "version": "0.8.2",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -103,7 +103,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.2-0",
+      "version": "0.8.2",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -125,9 +125,9 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.2-0",
+      "version": "0.8.2",
       "dependencies": {
-        "@mozilla/readability": "^0.5.0",
+        "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
         "p-limit": "^6.1.0",
         "turndown": "^7.2.0",
@@ -146,7 +146,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.2-0",
+      "version": "0.8.2",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-coding-agent": "*",
@@ -314,41 +314,41 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
-    "@j178/prek": ["@j178/prek@0.4.0", "", { "optionalDependencies": { "@j178/prek-android-arm64": "0.4.0", "@j178/prek-darwin-arm64": "0.4.0", "@j178/prek-darwin-x64": "0.4.0", "@j178/prek-linux-arm-gnueabihf": "0.4.0", "@j178/prek-linux-arm-musleabihf": "0.4.0", "@j178/prek-linux-arm64-gnu": "0.4.0", "@j178/prek-linux-arm64-musl": "0.4.0", "@j178/prek-linux-armv7-musleabihf": "0.4.0", "@j178/prek-linux-ia32-gnu": "0.4.0", "@j178/prek-linux-ia32-musl": "0.4.0", "@j178/prek-linux-riscv64-gnu": "0.4.0", "@j178/prek-linux-s390x-gnu": "0.4.0", "@j178/prek-linux-x64-gnu": "0.4.0", "@j178/prek-linux-x64-musl": "0.4.0", "@j178/prek-win32-arm64-msvc": "0.4.0", "@j178/prek-win32-ia32-msvc": "0.4.0", "@j178/prek-win32-x64-msvc": "0.4.0" }, "bin": { "prek": "bin/prek.js" } }, "sha512-qTD4qGiN06ewv+dG1TRvs+hxyVG7gPbeKBlsi0X5uU4BOubZQ69/1gZBg6JJSGz+n710NSrOK58+sMghTQsq1g=="],
+    "@j178/prek": ["@j178/prek@0.3.13", "", { "optionalDependencies": { "@j178/prek-android-arm64": "0.3.13", "@j178/prek-darwin-arm64": "0.3.13", "@j178/prek-darwin-x64": "0.3.13", "@j178/prek-linux-arm-gnueabihf": "0.3.13", "@j178/prek-linux-arm-musleabihf": "0.3.13", "@j178/prek-linux-arm64-gnu": "0.3.13", "@j178/prek-linux-arm64-musl": "0.3.13", "@j178/prek-linux-armv7-musleabihf": "0.3.13", "@j178/prek-linux-ia32-gnu": "0.3.13", "@j178/prek-linux-ia32-musl": "0.3.13", "@j178/prek-linux-riscv64-gnu": "0.3.13", "@j178/prek-linux-s390x-gnu": "0.3.13", "@j178/prek-linux-x64-gnu": "0.3.13", "@j178/prek-linux-x64-musl": "0.3.13", "@j178/prek-win32-arm64-msvc": "0.3.13", "@j178/prek-win32-ia32-msvc": "0.3.13", "@j178/prek-win32-x64-msvc": "0.3.13" }, "bin": { "prek": "bin/prek.js" } }, "sha512-z5YMyNvyQK0Cfw8ljm/zJu/JswmCQ20e9iVtP18I8iwK7gMUawPYMffTiaGsH6y0p30GNPPstjdkN5STIleQ6Q=="],
 
-    "@j178/prek-android-arm64": ["@j178/prek-android-arm64@0.4.0", "", { "os": "android", "cpu": "arm64" }, "sha512-J0gBKIcgYV+3NM6h18AuEZoYvz6lK/zlsq/Sbvj/UsZPaeBNbUNGZQFrZKk4Sj6gUEmi42HMHHSjo21UMw3K1A=="],
+    "@j178/prek-android-arm64": ["@j178/prek-android-arm64@0.3.13", "", { "os": "android", "cpu": "arm64" }, "sha512-VBr2kIOAY0QpEuk0CrIBaiU8at/Xw5f47ga7Zrpcxzaz2KdJIYeWmbWsiIeNFv6Ko7y4xxY7Ho+EkZd3Pr/5DA=="],
 
-    "@j178/prek-darwin-arm64": ["@j178/prek-darwin-arm64@0.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ybVr2u58DWXgRKXoDtBg3CKg+YlPZXjfG0nyj1oSH7yGVDT/oVUCnD76TDcjJCU22EYHR2cFwRavh7wQ7148cA=="],
+    "@j178/prek-darwin-arm64": ["@j178/prek-darwin-arm64@0.3.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AsuXqvZ/WvV8McGnxMIyU7UeZo7e/BdkkzXAqSGjNM2ZnEW8difbr5H87sgE8YGrzxGsXkujEdkMbAotYgwoiQ=="],
 
-    "@j178/prek-darwin-x64": ["@j178/prek-darwin-x64@0.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-OaULujT3l2Nl2lGmrChgrwZxNbcyrx+jnpwJDc2FRvJa+rohPwanYczh0DdPA8RwTcsRo6enLPUm+Aq0eQ85Cg=="],
+    "@j178/prek-darwin-x64": ["@j178/prek-darwin-x64@0.3.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-CSEI4JDx/+9JECV6gzcHvi6wAFNbsPXZVuEvMaCiuPxc1ajTvmsgxTf5xCdXP3AmMErN6NeUkV0uqgqMFUjVSw=="],
 
-    "@j178/prek-linux-arm-gnueabihf": ["@j178/prek-linux-arm-gnueabihf@0.4.0", "", { "os": "linux", "cpu": "arm" }, "sha512-isP93lHAXLNlJc8Fb4kiMqJf3nuEl1J0X9QPFoAiUu384kMbzfpyCz6Ps4hszlf8nJM2K97hONaMcI6i3EzP0g=="],
+    "@j178/prek-linux-arm-gnueabihf": ["@j178/prek-linux-arm-gnueabihf@0.3.13", "", { "os": "linux", "cpu": "arm" }, "sha512-dQt1onTfbjta+PpUrg0mmKHj60iMUSo/I35t+HFjImV26Ersml6H2Ww9NHJui2Z/bJ6i5MTYXAFWTq2YYtvlYA=="],
 
-    "@j178/prek-linux-arm-musleabihf": ["@j178/prek-linux-arm-musleabihf@0.4.0", "", { "os": "linux", "cpu": "arm" }, "sha512-1oOWn9mBmi57kypN7CH38vMMRf2kuPfxBODAp1Q/xkXH7HEEdB6D6rL4+ckLQY3y31PI7TX1Dgg0Z/Y6nz3iig=="],
+    "@j178/prek-linux-arm-musleabihf": ["@j178/prek-linux-arm-musleabihf@0.3.13", "", { "os": "linux", "cpu": "arm" }, "sha512-iTC580zeHNALrhpIZoesl2ksMozuTV6xiwhBOlnsIpQwKVijcExIZtPnG0zxYAbNfXFgt9mUKatrxsc0aHZmhQ=="],
 
-    "@j178/prek-linux-arm64-gnu": ["@j178/prek-linux-arm64-gnu@0.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-CiQauPIURTTdB+H6d51ogOrV8v3e/upZtYYVwXQYaZEQiuMM+trQBQzBTDsZ8rLi0f72ZpV3Q0xWGqeDa1HFBQ=="],
+    "@j178/prek-linux-arm64-gnu": ["@j178/prek-linux-arm64-gnu@0.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZKa/FfMzQgni1KdSl5hOcaaYa9OvoOqB9DQo0dRSR6nuTIVsi8/G/ZuCl7Jnjel8vZB3LbOp7i2ZS//jDCnvUg=="],
 
-    "@j178/prek-linux-arm64-musl": ["@j178/prek-linux-arm64-musl@0.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPchFFTIiJsr4hk8GhlN3eZPaoW0QP9JfsnMCOWmkLGyeGkF6CMf8GEio4cb9tFbGG1ZWcHGWjMN05lvmhGADg=="],
+    "@j178/prek-linux-arm64-musl": ["@j178/prek-linux-arm64-musl@0.3.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-XdgJCz0wPRR+NoZ1c50v7kVxQoPC2OopPCab32Mr4oFuAddqZZKjUL8k7nJUSHXR61i6fPxQKx8gS44vNRNSuA=="],
 
-    "@j178/prek-linux-armv7-musleabihf": ["@j178/prek-linux-armv7-musleabihf@0.4.0", "", { "os": "linux", "cpu": "arm" }, "sha512-ZSRgB2dHbiFvrlqLo5Z2cRwngMCm7E/94PCygYUKmkkXfhCLo4ZXJsArCdi4VcLL7Ss2fEcdJMinNAGGREVJBg=="],
+    "@j178/prek-linux-armv7-musleabihf": ["@j178/prek-linux-armv7-musleabihf@0.3.13", "", { "os": "linux", "cpu": "arm" }, "sha512-pt+sUUJPsSSIiWHHSluUZ8sVUogro+m9e+9BBzGMDHggpSlHmfaYbTY0WjUDhSCFOS7G+NdF2sENdGpbAqYAdw=="],
 
-    "@j178/prek-linux-ia32-gnu": ["@j178/prek-linux-ia32-gnu@0.4.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-tlTeuQRtU+K4fYbHDeseIKhqnv/UgCqFBcBiizSZdJGqIHnLkVk8JbNQtUVZs8iOXg5zWORG7ZaSZB7ua6PBSg=="],
+    "@j178/prek-linux-ia32-gnu": ["@j178/prek-linux-ia32-gnu@0.3.13", "", { "os": "linux", "cpu": "ia32" }, "sha512-hfjLDcK19FaqZ8IzVWOWFlfzV73wEw00RNgBOC7fJqJW7ckrSzx9CiIcMIrJ1/h0dprGR+iwmBLx7z5a1VDa+Q=="],
 
-    "@j178/prek-linux-ia32-musl": ["@j178/prek-linux-ia32-musl@0.4.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Sj2L4O9LYWpHASGaNvuwXixXETteXpjkPzNZ4BbflHcbG055hcZLK8QCm+iyQHitM3yHmyh2CMm7/rQJdKQIwQ=="],
+    "@j178/prek-linux-ia32-musl": ["@j178/prek-linux-ia32-musl@0.3.13", "", { "os": "linux", "cpu": "ia32" }, "sha512-tCeSRH6rQHgyWtYnlY2RL+DPmCHEjCA9J8TEeOGUfigfuXlPeduqNYCbihfcmUURFASl6AR7g9jOF0mRZyPiHA=="],
 
-    "@j178/prek-linux-riscv64-gnu": ["@j178/prek-linux-riscv64-gnu@0.4.0", "", { "os": "linux", "cpu": "none" }, "sha512-/4cGYbgxOqkPVi4QuXveoZHjZJvFCKWX6q5XdtgwqzRuT9uGKR9C3Gitr8m5zHPV/wvCqeoRitqQCRWTsBmVdw=="],
+    "@j178/prek-linux-riscv64-gnu": ["@j178/prek-linux-riscv64-gnu@0.3.13", "", { "os": "linux", "cpu": "none" }, "sha512-RZvnILVk/iP7e89nBrSP4SLbyllGSMOUpFd5/fdo/FU3mN348umlIlTHVyXJ6Need2uOAJNgQQXZ0EdKnzpLEA=="],
 
-    "@j178/prek-linux-s390x-gnu": ["@j178/prek-linux-s390x-gnu@0.4.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-6a1Q2ENlFMTLVHsndJd8jedGkDcseSlnTNyZ5/Jenl0NWTGM3Y6rp3u/ea7JNSMjCH5Z2NjWc0ToMk2nzqcrvw=="],
+    "@j178/prek-linux-s390x-gnu": ["@j178/prek-linux-s390x-gnu@0.3.13", "", { "os": "linux", "cpu": "s390x" }, "sha512-sAhwUYU2Urfp5HnYhS/iYQ2XHsnJKnAOmuilTlw8jB6Y6zNOpmCNMsgSlPvP6fTN1ntsVarh6LwvuerajWs5Rw=="],
 
-    "@j178/prek-linux-x64-gnu": ["@j178/prek-linux-x64-gnu@0.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IJsSjtFf7LyquDdaQWMSjyK1iZdHKfN3uKeOXDvVckkjw2W84OlpqNwt6fA6M8Is9A3e3/sUVg3hpexGPA5/9Q=="],
+    "@j178/prek-linux-x64-gnu": ["@j178/prek-linux-x64-gnu@0.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-kyBOHaRqnuzF4KrWGxkFkZ/RkwxV6Yyf3DaBU9lgXMBKRs63MwLZRIE6EMKc6JQarEDYcFY5kGe1MNz5q9sflg=="],
 
-    "@j178/prek-linux-x64-musl": ["@j178/prek-linux-x64-musl@0.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1umuGcxoNr0k5qVVZEqL1GmPxNIZ6j0Aq51Kx8jXO4EV2IRXjcG2300zQFy3sx2bsBkyeL+N36z+YcYLGF7XtA=="],
+    "@j178/prek-linux-x64-musl": ["@j178/prek-linux-x64-musl@0.3.13", "", { "os": "linux", "cpu": "x64" }, "sha512-Wo3ogs/OaFD9izZyBP1JsS3rGb+eiuMAiiKuNSsWC+/Lt7XQXSuJ3YVEWYwYNtncuiaxZ9LmDS/4SLOxq/M5BQ=="],
 
-    "@j178/prek-win32-arm64-msvc": ["@j178/prek-win32-arm64-msvc@0.4.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-AsE7XvWPCPsnivr83Dk9eE/TLDrHMwUA4h/FONF0lSXDq4UoCRLBzWdkBJbtYtPeNckhGDwxtDY5D5TcSXa72A=="],
+    "@j178/prek-win32-arm64-msvc": ["@j178/prek-win32-arm64-msvc@0.3.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-y01wCK7u4eH/9ETmiYAOLlOcr38oA453VXNA+PuWcbGCAKeGvDIpsYs4x2uKfAibULWbrveCrRg0tTLjZ5YeBQ=="],
 
-    "@j178/prek-win32-ia32-msvc": ["@j178/prek-win32-ia32-msvc@0.4.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-F9458j6FBJGZvfH2OOzko4sEnxNepwkrakgoQRKU8ia7I1y03x9LESEX4/d1dQTXRDmI86qxoP4JkQ9/pxZHIg=="],
+    "@j178/prek-win32-ia32-msvc": ["@j178/prek-win32-ia32-msvc@0.3.13", "", { "os": "win32", "cpu": "ia32" }, "sha512-nz/6XFNsJ2b/SnVpn/0PAPxBqEQJZGDCDXVt1UyHsGyPFzmxrvHjRIksrbWxXfIhkBv8iyEIlJGk7q8+gG2cZA=="],
 
-    "@j178/prek-win32-x64-msvc": ["@j178/prek-win32-x64-msvc@0.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bO87dRrxPvQqy2NMJ8qa7R1Mkr43lJJtoEpRkDEH0xlXny78THaQQ3tBGCxPHiEgrqzsQ2xi4BLlH/y5Ie7zOA=="],
+    "@j178/prek-win32-x64-msvc": ["@j178/prek-win32-x64-msvc@0.3.13", "", { "os": "win32", "cpu": "x64" }, "sha512-891Ly7bFbbOi9VQfwpb146BiEhDC+oqofXaZ/Hd10Xiv/wYjRzzym2rjThlRvrRv8rj0exeN557YwyRsk5RPCw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
@@ -382,7 +382,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@mozilla/readability": ["@mozilla/readability@0.5.0", "", {}, "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ=="],
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.2",
+      "version": "0.8.3-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.2",
+      "version": "0.8.3-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -79,7 +79,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.2",
+      "version": "0.8.3-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -103,7 +103,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.2",
+      "version": "0.8.3-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -125,7 +125,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.2",
+      "version": "0.8.3-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -146,7 +146,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.2",
+      "version": "0.8.3-0",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-coding-agent": "*",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.74.0",
     "@earendil-works/pi-tui": "^0.74.0",
-    "@j178/prek": "^0.4.0",
+    "@j178/prek": "0.3.13",
     "@types/bun": "^1.3.14",
     "typescript": "^6.0.3"
   }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.3-0] - 2026-05-17
+
+### Changed
+
+- Pinned `@j178/prek` to 0.3.13 to keep hook installation stable.
+
 ## [0.8.2] - 2026-05-16
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.2",
+  "version": "0.8.3-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.2",
+  "version": "0.8.3-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.2",
+  "version": "0.8.3-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.2",
+  "version": "0.8.3-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.2",
+  "version": "0.8.3-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.2",
+  "version": "0.8.3-0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prerelease bump to v0.8.3-0, driven by pinning `@j178/prek` to an exact version to stabilize hook installation across environments.

## Changes

- **`chore(deps)`** — Pin `@j178/prek` from `^0.4.0` to `0.3.13` (exact) in root `package.json` to prevent unintended upgrades that could break git hook installation
- **`chore(release)`** — Bump all workspace package versions to `0.8.3-0` and add the corresponding changelog section

## Notes

- `bun.lock` is updated to reflect the pinned `@j178/prek@0.3.13` resolution
- No source code changes — this is a dependency stabilization + version bump prerelease

## Validation

- `bun run lint` (pre-commit/pre-push)
- `bun run test:unit` (pre-commit/pre-push)
- `bun run typecheck`
- `cd packages/coding-agent && bun run build`