### PR TITLE
chore(release): bump to v0.8.3

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-05-17
+
+### Changed
+
+- Pinned `@j178/prek` to 0.3.13 to keep hook installation stable.
+
 ## [0.8.3-0] - 2026-05-17
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.3-0",
+  "version": "0.8.3",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.3-0",
+  "version": "0.8.3",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.3-0",
+  "version": "0.8.3",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.3-0",
+  "version": "0.8.3",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.3-0",
+  "version": "0.8.3",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.3-0",
+  "version": "0.8.3",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the workspace from the `0.8.3-0` prerelease to the stable `v0.8.3` release, and documents the one functional change included in this version.

## Changes

- Bumped all workspace package versions from `0.8.3-0` → `0.8.3`.
- Added `## [0.8.3] - 2026-05-17` changelog section with the single change: pinning `@j178/prek` to `0.3.13` for stable hook installation.

## Release notes

> **Changed**
> - Pinned `@j178/prek` to `0.3.13` to keep hook installation stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)