### PR TITLE
chore(release): bump to v0.8.4

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-05-17
+
+### Added
+
+- Added selected model details to the system prompt for assistant model attribution.
+
+### Changed
+
+- Aligned package references with Atomic branding.
+
 ## [0.8.4-0] - 2026-05-17
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.4-0",
+  "version": "0.8.4",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "piConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.4-0",
+  "version": "0.8.4",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.4-0",
+  "version": "0.8.4",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.4-0",
+  "version": "0.8.4",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.4-0",
+  "version": "0.8.4",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.4-0",
+  "version": "0.8.4",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.4-0 prerelease to a stable v0.8.4 release by bumping all workspace package versions and adding the finalized CHANGELOG section for CI release-note extraction.

## Changes

- Bumped all 6 workspace package versions from `0.8.4-0` → `0.8.4`:
  - `@bastani/atomic` (`packages/coding-agent`)
  - `@bastani/workflows`
  - `@bastani/subagents`
  - `@bastani/mcp`
  - `@bastani/web-access`
  - `@bastani/intercom`
- Added `[0.8.4] - 2026-05-17` section to `packages/coding-agent/CHANGELOG.md` (used by `publish.yml` for GitHub Release notes)

## Release Notes (v0.8.4)

### Added
- Selected model details included in the system prompt for assistant model attribution

### Changed
- Aligned package references with Atomic branding

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- `bun run lint` (pre-commit/pre-push)
- `bun run test:unit` (pre-commit/pre-push)