### PR TITLE
chore(release): bump to v0.8.5

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-05-18
+
+### Changed
+
+- Prepared the 0.8.5 release.
+
 ## [0.8.5-0] - 2026-05-18
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.5-0",
+  "version": "0.8.5",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.5-0",
+  "version": "0.8.5",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.5-0",
+  "version": "0.8.5",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.5-0",
+  "version": "0.8.5",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.5-0",
+  "version": "0.8.5",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.5-0",
+  "version": "0.8.5",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the `0.8.5-0` prerelease to a stable `0.8.5` release, shipping workflow picker keybinding hardening, TUI layout fixes, and new stage chat/run control features.

## Changes

- Bumps all workspace package versions from `0.8.5-0` → `0.8.5` (`coding-agent`, `workflows`, `subagents`, `mcp`, `web-access`, `intercom`)
- Adds the `[0.8.5] - 2026-05-18` changelog section for release note extraction

## What's in 0.8.5

- **fix(workflows):** Harden TUI layout for keybindings and wide text
- **fix(workflows):** Stabilize attached stage chat pause handling
- **fix(workflows):** Make picker key handling terminal-safe
- **feat(workflows):** Refine run control and discovery diagnostics
- **feat(workflows):** Refine stage chat pause and input controls
- **feat(workflows):** Support package resources and direct run options
- **refactor(types):** Tighten model and tool renderer typings
- **style(ui):** Normalize keyboard shortcut labels

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- `bun run lint` (pre-commit)
- `bun run test:unit` (pre-commit)