### PR TITLE
fix: improve extension loading, TUI rendering, planner tools, and release binary coverage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,16 @@ jobs:
       - name: Build @bastani/atomic package and binaries
         run: ./scripts/build-binaries.sh
 
+      - name: Smoke test Linux release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_dir="$RUNNER_TEMP/atomic-binary-smoke"
+          rm -rf "$smoke_dir"
+          mkdir -p "$smoke_dir"
+          tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
+          "$smoke_dir/atomic/atomic" --version
+
       - name: Verify built package metadata
         working-directory: ${{ env.PACKAGE_DIR }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            binary_platform: linux-x64
+          - os: windows-latest
+            binary_platform: windows-x64
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -35,3 +39,26 @@ jobs:
         run: bun run test:unit
       - name: Integration tests
         run: bun run test:integration
+      - name: Build native release binary
+        shell: bash
+        run: ./scripts/build-binaries.sh --platform "${{ matrix.binary_platform }}"
+      - name: Smoke test Linux release archive
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_dir="$RUNNER_TEMP/atomic-binary-smoke"
+          rm -rf "$smoke_dir"
+          mkdir -p "$smoke_dir"
+          tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
+          "$smoke_dir/atomic/atomic" --version
+      - name: Smoke test Windows release archive
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $smokeDir = Join-Path $env:RUNNER_TEMP "atomic-binary-smoke"
+          Remove-Item -Recurse -Force $smokeDir -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $smokeDir | Out-Null
+          Expand-Archive -Path packages/coding-agent/binaries/atomic-windows-x64.zip -DestinationPath $smokeDir
+          & (Join-Path $smokeDir "atomic.exe") --version

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,13 +14,15 @@ Pull request / push
   ├─ bun run typecheck
   ├─ cd packages/coding-agent && bun run build
   ├─ bun run test:unit
-  └─ bun run test:integration
+  ├─ bun run test:integration
+  └─ scripts/build-binaries.sh --platform <native-x64> + atomic --version smoke test
 
 v<version> tag pushed
   ├─ validate tag matches packages/coding-agent/package.json
   ├─ validate packages/workflows is private
   ├─ bun run typecheck && bun run test:all
   ├─ scripts/build-binaries.sh (regular build + cross-compile 6 targets)
+  ├─ smoke test the Linux release archive with atomic --version
   ├─ validate dist/builtin contains all bundled extensions
   ├─ extract release notes from packages/coding-agent/CHANGELOG.md
   ├─ bun pm pack --dry-run from packages/coding-agent
@@ -60,8 +62,8 @@ Runs on pushes to `main` and PRs targeting `main`.
 
 Matrix:
 
-- `ubuntu-latest`
-- `windows-latest`
+- `ubuntu-latest` with native `linux-x64` binary smoke coverage
+- `windows-latest` with native `windows-x64` binary smoke coverage
 
 Steps:
 
@@ -72,6 +74,8 @@ Steps:
 5. Build `@bastani/atomic` with `cd packages/coding-agent && bun run build`.
 6. Run `bun run test:unit`.
 7. Run `bun run test:integration`.
+8. Build the native release binary with `scripts/build-binaries.sh --platform <native-x64>`.
+9. Extract the generated release archive and run `atomic --version` from the extracted binary.
 
 ### Code Review (`code-review.yml`)
 
@@ -135,6 +139,7 @@ Publish @bastani/atomic
       - bun build --compile --target=bun-<platform> for all 6 targets
       - assemble per-platform asset trees
       - produce atomic-<platform>.tar.gz / .zip in packages/coding-agent/binaries/
+  · extract atomic-linux-x64.tar.gz and run atomic --version as a release-binary smoke check
   · validate dist/builtin has workflows, pi-subagents, pi-mcp-adapter, pi-web-access, pi-intercom
   · extract release notes from packages/coding-agent/CHANGELOG.md
   · determine npm tag: latest or next

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -20,7 +20,12 @@ import { createJiti } from "jiti/static";
 import * as _bundledTypebox from "typebox";
 import * as _bundledTypeboxCompile from "typebox/compile";
 import * as _bundledTypeboxValue from "typebox/value";
-import { APP_NAME, CONFIG_DIR_NAME, getAgentDir, isBunBinary } from "../../config.js";
+import {
+  APP_NAME,
+  CONFIG_DIR_NAME,
+  getAgentDir,
+  isBunBinary,
+} from "../../config.js";
 // NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 // avoiding a circular dependency. Extensions can import from the Atomic package
 // name (or upstream-compatible pi package names).
@@ -31,34 +36,34 @@ import type { ResolvedResource } from "../package-manager.js";
 import { execCommand } from "../exec.js";
 import { createSyntheticSourceInfo } from "../source-info.js";
 import type {
-	Extension,
-	ExtensionAPI,
-	ExtensionFactory,
-	ExtensionRuntime,
-	LoadExtensionsResult,
-	MessageRenderer,
-	ProviderConfig,
-	RegisteredCommand,
-	ToolDefinition,
+  Extension,
+  ExtensionAPI,
+  ExtensionFactory,
+  ExtensionRuntime,
+  LoadExtensionsResult,
+  MessageRenderer,
+  ProviderConfig,
+  RegisteredCommand,
+  ToolDefinition,
 } from "./types.js";
 
 /** Modules available to extensions via virtualModules (for compiled Bun binary) */
 const VIRTUAL_MODULES: Record<string, unknown> = {
-	typebox: _bundledTypebox,
-	"typebox/compile": _bundledTypeboxCompile,
-	"typebox/value": _bundledTypeboxValue,
-	"@sinclair/typebox": _bundledTypebox,
-	"@sinclair/typebox/compile": _bundledTypeboxCompile,
-	"@sinclair/typebox/value": _bundledTypeboxValue,
-	"@earendil-works/pi-agent-core": _bundledPiAgentCore,
-	"@earendil-works/pi-tui": _bundledPiTui,
-	"@earendil-works/pi-ai": _bundledPiAi,
-	"@earendil-works/pi-ai/oauth": _bundledPiAiOauth,
-	"@bastani/atomic": _bundledPiCodingAgent,
-	"@mariozechner/pi-agent-core": _bundledPiAgentCore,
-	"@mariozechner/pi-tui": _bundledPiTui,
-	"@mariozechner/pi-ai": _bundledPiAi,
-	"@mariozechner/pi-ai/oauth": _bundledPiAiOauth,
+  typebox: _bundledTypebox,
+  "typebox/compile": _bundledTypeboxCompile,
+  "typebox/value": _bundledTypeboxValue,
+  "@sinclair/typebox": _bundledTypebox,
+  "@sinclair/typebox/compile": _bundledTypeboxCompile,
+  "@sinclair/typebox/value": _bundledTypeboxValue,
+  "@earendil-works/pi-agent-core": _bundledPiAgentCore,
+  "@earendil-works/pi-tui": _bundledPiTui,
+  "@earendil-works/pi-ai": _bundledPiAi,
+  "@earendil-works/pi-ai/oauth": _bundledPiAiOauth,
+  "@bastani/atomic": _bundledPiCodingAgent,
+  "@mariozechner/pi-agent-core": _bundledPiAgentCore,
+  "@mariozechner/pi-tui": _bundledPiTui,
+  "@mariozechner/pi-ai": _bundledPiAi,
+  "@mariozechner/pi-ai/oauth": _bundledPiAiOauth,
 };
 
 const require = createRequire(import.meta.url);
@@ -70,74 +75,90 @@ const require = createRequire(import.meta.url);
 let _aliases: Record<string, string> | null = null;
 
 function getAliases(): Record<string, string> {
-	if (_aliases) return _aliases;
+  if (_aliases) return _aliases;
 
-	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	const packageIndex = path.resolve(__dirname, "../..", "index.js");
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const packageIndex = path.resolve(__dirname, "../..", "index.js");
 
-	const typeboxEntry = require.resolve("typebox");
-	const typeboxCompileEntry = require.resolve("typebox/compile");
-	const typeboxValueEntry = require.resolve("typebox/value");
+  const typeboxEntry = require.resolve("typebox");
+  const typeboxCompileEntry = require.resolve("typebox/compile");
+  const typeboxValueEntry = require.resolve("typebox/value");
 
-	const packagesRoot = path.resolve(__dirname, "../../../../");
-	const resolveWorkspaceOrImport = (workspaceRelativePath: string, specifier: string): string => {
-		const workspacePath = path.join(packagesRoot, workspaceRelativePath);
-		if (fs.existsSync(workspacePath)) {
-			return workspacePath;
-		}
-		return fileURLToPath(import.meta.resolve(specifier));
-	};
+  const packagesRoot = path.resolve(__dirname, "../../../../");
+  const resolveWorkspaceOrImport = (
+    workspaceRelativePath: string,
+    specifier: string,
+  ): string => {
+    const workspacePath = path.join(packagesRoot, workspaceRelativePath);
+    if (fs.existsSync(workspacePath)) {
+      return workspacePath;
+    }
+    return fileURLToPath(import.meta.resolve(specifier));
+  };
 
-	const piCodingAgentEntry = packageIndex;
-	const piAgentCoreEntry = resolveWorkspaceOrImport("agent/dist/index.js", "@earendil-works/pi-agent-core");
-	const piTuiEntry = resolveWorkspaceOrImport("tui/dist/index.js", "@earendil-works/pi-tui");
-	const piAiEntry = resolveWorkspaceOrImport("ai/dist/index.js", "@earendil-works/pi-ai");
-	const piAiOauthEntry = resolveWorkspaceOrImport("ai/dist/oauth.js", "@earendil-works/pi-ai/oauth");
+  const piCodingAgentEntry = packageIndex;
+  const piAgentCoreEntry = resolveWorkspaceOrImport(
+    "agent/dist/index.js",
+    "@earendil-works/pi-agent-core",
+  );
+  const piTuiEntry = resolveWorkspaceOrImport(
+    "tui/dist/index.js",
+    "@earendil-works/pi-tui",
+  );
+  const piAiEntry = resolveWorkspaceOrImport(
+    "ai/dist/index.js",
+    "@earendil-works/pi-ai",
+  );
+  const piAiOauthEntry = resolveWorkspaceOrImport(
+    "ai/dist/oauth.js",
+    "@earendil-works/pi-ai/oauth",
+  );
 
-	_aliases = {
-		"@bastani/atomic": piCodingAgentEntry,
-		"@earendil-works/pi-agent-core": piAgentCoreEntry,
-		"@earendil-works/pi-tui": piTuiEntry,
-		"@earendil-works/pi-ai": piAiEntry,
-		"@earendil-works/pi-ai/oauth": piAiOauthEntry,
-		"@mariozechner/pi-agent-core": piAgentCoreEntry,
-		"@mariozechner/pi-tui": piTuiEntry,
-		"@mariozechner/pi-ai": piAiEntry,
-		"@mariozechner/pi-ai/oauth": piAiOauthEntry,
-		typebox: typeboxEntry,
-		"typebox/compile": typeboxCompileEntry,
-		"typebox/value": typeboxValueEntry,
-		"@sinclair/typebox": typeboxEntry,
-		"@sinclair/typebox/compile": typeboxCompileEntry,
-		"@sinclair/typebox/value": typeboxValueEntry,
-	};
+  _aliases = {
+    "@bastani/atomic": piCodingAgentEntry,
+    "@earendil-works/pi-coding-agent": piCodingAgentEntry,
+    "@earendil-works/pi-agent-core": piAgentCoreEntry,
+    "@earendil-works/pi-tui": piTuiEntry,
+    "@earendil-works/pi-ai": piAiEntry,
+    "@earendil-works/pi-ai/oauth": piAiOauthEntry,
+    "@mariozechner/pi-agent-core": piAgentCoreEntry,
+    "@mariozechner/pi-tui": piTuiEntry,
+    "@mariozechner/pi-ai": piAiEntry,
+    "@mariozechner/pi-ai/oauth": piAiOauthEntry,
+    typebox: typeboxEntry,
+    "typebox/compile": typeboxCompileEntry,
+    "typebox/value": typeboxValueEntry,
+    "@sinclair/typebox": typeboxEntry,
+    "@sinclair/typebox/compile": typeboxCompileEntry,
+    "@sinclair/typebox/value": typeboxValueEntry,
+  };
 
-	return _aliases;
+  return _aliases;
 }
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 
 function normalizeUnicodeSpaces(str: string): string {
-	return str.replace(UNICODE_SPACES, " ");
+  return str.replace(UNICODE_SPACES, " ");
 }
 
 function expandPath(p: string): string {
-	const normalized = normalizeUnicodeSpaces(p);
-	if (normalized.startsWith("~/")) {
-		return path.join(os.homedir(), normalized.slice(2));
-	}
-	if (normalized.startsWith("~")) {
-		return path.join(os.homedir(), normalized.slice(1));
-	}
-	return normalized;
+  const normalized = normalizeUnicodeSpaces(p);
+  if (normalized.startsWith("~/")) {
+    return path.join(os.homedir(), normalized.slice(2));
+  }
+  if (normalized.startsWith("~")) {
+    return path.join(os.homedir(), normalized.slice(1));
+  }
+  return normalized;
 }
 
 function resolvePath(extPath: string, cwd: string): string {
-	const expanded = expandPath(extPath);
-	if (path.isAbsolute(expanded)) {
-		return expanded;
-	}
-	return path.resolve(cwd, expanded);
+  const expanded = expandPath(extPath);
+  if (path.isAbsolute(expanded)) {
+    return expanded;
+  }
+  return path.resolve(cwd, expanded);
 }
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
@@ -147,51 +168,59 @@ type HandlerFn = (...args: unknown[]) => Promise<unknown>;
  * Runner.bindCore() replaces these with real implementations.
  */
 export function createExtensionRuntime(): ExtensionRuntime {
-	const notInitialized = () => {
-		throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
-	};
-	const state: { staleMessage?: string } = {};
-	const assertActive = () => {
-		if (state.staleMessage) {
-			throw new Error(state.staleMessage);
-		}
-	};
+  const notInitialized = () => {
+    throw new Error(
+      "Extension runtime not initialized. Action methods cannot be called during extension loading.",
+    );
+  };
+  const state: { staleMessage?: string } = {};
+  const assertActive = () => {
+    if (state.staleMessage) {
+      throw new Error(state.staleMessage);
+    }
+  };
 
-	const runtime: ExtensionRuntime = {
-		sendMessage: notInitialized,
-		sendUserMessage: notInitialized,
-		appendEntry: notInitialized,
-		setSessionName: notInitialized,
-		getSessionName: notInitialized,
-		setLabel: notInitialized,
-		getActiveTools: notInitialized,
-		getAllTools: notInitialized,
-		setActiveTools: notInitialized,
-		// registerTool() is valid during extension load; refresh is only needed post-bind.
-		refreshTools: () => {},
-		getCommands: notInitialized,
-		setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
-		getThinkingLevel: notInitialized,
-		setThinkingLevel: notInitialized,
-		flagValues: new Map(),
-		pendingProviderRegistrations: [],
-		assertActive,
-		invalidate: (message) => {
-			state.staleMessage ??=
-				message ??
-				"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
-		},
-		// Pre-bind: queue registrations so bindCore() can flush them once the
-		// model registry is available. bindCore() replaces both with direct calls.
-		registerProvider: (name, config, extensionPath = "<unknown>") => {
-			runtime.pendingProviderRegistrations.push({ name, config, extensionPath });
-		},
-		unregisterProvider: (name) => {
-			runtime.pendingProviderRegistrations = runtime.pendingProviderRegistrations.filter((r) => r.name !== name);
-		},
-	};
+  const runtime: ExtensionRuntime = {
+    sendMessage: notInitialized,
+    sendUserMessage: notInitialized,
+    appendEntry: notInitialized,
+    setSessionName: notInitialized,
+    getSessionName: notInitialized,
+    setLabel: notInitialized,
+    getActiveTools: notInitialized,
+    getAllTools: notInitialized,
+    setActiveTools: notInitialized,
+    // registerTool() is valid during extension load; refresh is only needed post-bind.
+    refreshTools: () => {},
+    getCommands: notInitialized,
+    setModel: () =>
+      Promise.reject(new Error("Extension runtime not initialized")),
+    getThinkingLevel: notInitialized,
+    setThinkingLevel: notInitialized,
+    flagValues: new Map(),
+    pendingProviderRegistrations: [],
+    assertActive,
+    invalidate: (message) => {
+      state.staleMessage ??=
+        message ??
+        "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().";
+    },
+    // Pre-bind: queue registrations so bindCore() can flush them once the
+    // model registry is available. bindCore() replaces both with direct calls.
+    registerProvider: (name, config, extensionPath = "<unknown>") => {
+      runtime.pendingProviderRegistrations.push({
+        name,
+        config,
+        extensionPath,
+      });
+    },
+    unregisterProvider: (name) => {
+      runtime.pendingProviderRegistrations =
+        runtime.pendingProviderRegistrations.filter((r) => r.name !== name);
+    },
+  };
 
-	return runtime;
+  return runtime;
 }
 
 /**
@@ -200,310 +229,368 @@ export function createExtensionRuntime(): ExtensionRuntime {
  * Action methods delegate to the shared runtime.
  */
 function createExtensionAPI(
-	extension: Extension,
-	runtime: ExtensionRuntime,
-	cwd: string,
-	eventBus: EventBus,
-	workflowResources: ResolvedResource[] = [],
+  extension: Extension,
+  runtime: ExtensionRuntime,
+  cwd: string,
+  eventBus: EventBus,
+  workflowResources: ResolvedResource[] = [],
 ): ExtensionAPI {
-	const api = {
-		// Registration methods - write to extension
-		on(event: string, handler: HandlerFn): void {
-			runtime.assertActive();
-			const list = extension.handlers.get(event) ?? [];
-			list.push(handler);
-			extension.handlers.set(event, list);
-		},
+  const api = {
+    // Registration methods - write to extension
+    on(event: string, handler: HandlerFn): void {
+      runtime.assertActive();
+      const list = extension.handlers.get(event) ?? [];
+      list.push(handler);
+      extension.handlers.set(event, list);
+    },
 
-		registerTool(tool: ToolDefinition): void {
-			runtime.assertActive();
-			extension.tools.set(tool.name, {
-				definition: tool,
-				sourceInfo: extension.sourceInfo,
-			});
-			runtime.refreshTools();
-		},
+    registerTool(tool: ToolDefinition): void {
+      runtime.assertActive();
+      extension.tools.set(tool.name, {
+        definition: tool,
+        sourceInfo: extension.sourceInfo,
+      });
+      runtime.refreshTools();
+    },
 
-		registerCommand(name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">): void {
-			runtime.assertActive();
-			extension.commands.set(name, {
-				name,
-				sourceInfo: extension.sourceInfo,
-				...options,
-			});
-		},
+    registerCommand(
+      name: string,
+      options: Omit<RegisteredCommand, "name" | "sourceInfo">,
+    ): void {
+      runtime.assertActive();
+      extension.commands.set(name, {
+        name,
+        sourceInfo: extension.sourceInfo,
+        ...options,
+      });
+    },
 
-		registerShortcut(
-			shortcut: KeyId,
-			options: {
-				description?: string;
-				handler: (ctx: import("./types.js").ExtensionContext) => Promise<void> | void;
-			},
-		): void {
-			runtime.assertActive();
-			extension.shortcuts.set(shortcut, { shortcut, extensionPath: extension.path, ...options });
-		},
+    registerShortcut(
+      shortcut: KeyId,
+      options: {
+        description?: string;
+        handler: (
+          ctx: import("./types.js").ExtensionContext,
+        ) => Promise<void> | void;
+      },
+    ): void {
+      runtime.assertActive();
+      extension.shortcuts.set(shortcut, {
+        shortcut,
+        extensionPath: extension.path,
+        ...options,
+      });
+    },
 
-		registerFlag(
-			name: string,
-			options: { description?: string; type: "boolean" | "string"; default?: boolean | string },
-		): void {
-			runtime.assertActive();
-			extension.flags.set(name, { name, extensionPath: extension.path, ...options });
-			if (options.default !== undefined && !runtime.flagValues.has(name)) {
-				runtime.flagValues.set(name, options.default);
-			}
-		},
+    registerFlag(
+      name: string,
+      options: {
+        description?: string;
+        type: "boolean" | "string";
+        default?: boolean | string;
+      },
+    ): void {
+      runtime.assertActive();
+      extension.flags.set(name, {
+        name,
+        extensionPath: extension.path,
+        ...options,
+      });
+      if (options.default !== undefined && !runtime.flagValues.has(name)) {
+        runtime.flagValues.set(name, options.default);
+      }
+    },
 
-		registerMessageRenderer<T>(customType: string, renderer: MessageRenderer<T>): void {
-			runtime.assertActive();
-			extension.messageRenderers.set(customType, renderer as MessageRenderer);
-		},
+    registerMessageRenderer<T>(
+      customType: string,
+      renderer: MessageRenderer<T>,
+    ): void {
+      runtime.assertActive();
+      extension.messageRenderers.set(customType, renderer as MessageRenderer);
+    },
 
-		// Flag access - checks extension registered it, reads from runtime
-		getFlag(name: string): boolean | string | undefined {
-			runtime.assertActive();
-			if (!extension.flags.has(name)) return undefined;
-			return runtime.flagValues.get(name);
-		},
+    // Flag access - checks extension registered it, reads from runtime
+    getFlag(name: string): boolean | string | undefined {
+      runtime.assertActive();
+      if (!extension.flags.has(name)) return undefined;
+      return runtime.flagValues.get(name);
+    },
 
-		getWorkflowResources(): ResolvedResource[] {
-			runtime.assertActive();
-			return [...workflowResources];
-		},
+    getWorkflowResources(): ResolvedResource[] {
+      runtime.assertActive();
+      return [...workflowResources];
+    },
 
-		// Action methods - delegate to shared runtime
-		sendMessage(message, options): void {
-			runtime.assertActive();
-			runtime.sendMessage(message, options);
-		},
+    // Action methods - delegate to shared runtime
+    sendMessage(message, options): void {
+      runtime.assertActive();
+      runtime.sendMessage(message, options);
+    },
 
-		sendUserMessage(content, options): void {
-			runtime.assertActive();
-			runtime.sendUserMessage(content, options);
-		},
+    sendUserMessage(content, options): void {
+      runtime.assertActive();
+      runtime.sendUserMessage(content, options);
+    },
 
-		appendEntry(customType: string, data?: unknown): void {
-			runtime.assertActive();
-			runtime.appendEntry(customType, data);
-		},
+    appendEntry(customType: string, data?: unknown): void {
+      runtime.assertActive();
+      runtime.appendEntry(customType, data);
+    },
 
-		setSessionName(name: string): void {
-			runtime.assertActive();
-			runtime.setSessionName(name);
-		},
+    setSessionName(name: string): void {
+      runtime.assertActive();
+      runtime.setSessionName(name);
+    },
 
-		getSessionName(): string | undefined {
-			runtime.assertActive();
-			return runtime.getSessionName();
-		},
+    getSessionName(): string | undefined {
+      runtime.assertActive();
+      return runtime.getSessionName();
+    },
 
-		setLabel(entryId: string, label: string | undefined): void {
-			runtime.assertActive();
-			runtime.setLabel(entryId, label);
-		},
+    setLabel(entryId: string, label: string | undefined): void {
+      runtime.assertActive();
+      runtime.setLabel(entryId, label);
+    },
 
-		exec(command: string, args: string[], options?: ExecOptions) {
-			runtime.assertActive();
-			return execCommand(command, args, options?.cwd ?? cwd, options);
-		},
+    exec(command: string, args: string[], options?: ExecOptions) {
+      runtime.assertActive();
+      return execCommand(command, args, options?.cwd ?? cwd, options);
+    },
 
-		getActiveTools(): string[] {
-			runtime.assertActive();
-			return runtime.getActiveTools();
-		},
+    getActiveTools(): string[] {
+      runtime.assertActive();
+      return runtime.getActiveTools();
+    },
 
-		getAllTools() {
-			runtime.assertActive();
-			return runtime.getAllTools();
-		},
+    getAllTools() {
+      runtime.assertActive();
+      return runtime.getAllTools();
+    },
 
-		setActiveTools(toolNames: string[]): void {
-			runtime.assertActive();
-			runtime.setActiveTools(toolNames);
-		},
+    setActiveTools(toolNames: string[]): void {
+      runtime.assertActive();
+      runtime.setActiveTools(toolNames);
+    },
 
-		getCommands() {
-			runtime.assertActive();
-			return runtime.getCommands();
-		},
+    getCommands() {
+      runtime.assertActive();
+      return runtime.getCommands();
+    },
 
-		setModel(model) {
-			runtime.assertActive();
-			return runtime.setModel(model);
-		},
+    setModel(model) {
+      runtime.assertActive();
+      return runtime.setModel(model);
+    },
 
-		getThinkingLevel() {
-			runtime.assertActive();
-			return runtime.getThinkingLevel();
-		},
+    getThinkingLevel() {
+      runtime.assertActive();
+      return runtime.getThinkingLevel();
+    },
 
-		setThinkingLevel(level) {
-			runtime.assertActive();
-			runtime.setThinkingLevel(level);
-		},
+    setThinkingLevel(level) {
+      runtime.assertActive();
+      runtime.setThinkingLevel(level);
+    },
 
-		registerProvider(name: string, config: ProviderConfig) {
-			runtime.assertActive();
-			runtime.registerProvider(name, config, extension.path);
-		},
+    registerProvider(name: string, config: ProviderConfig) {
+      runtime.assertActive();
+      runtime.registerProvider(name, config, extension.path);
+    },
 
-		unregisterProvider(name: string) {
-			runtime.assertActive();
-			runtime.unregisterProvider(name, extension.path);
-		},
+    unregisterProvider(name: string) {
+      runtime.assertActive();
+      runtime.unregisterProvider(name, extension.path);
+    },
 
-		events: eventBus,
-	} as ExtensionAPI;
+    events: eventBus,
+  } as ExtensionAPI;
 
-	return api;
+  return api;
 }
 
 async function loadExtensionModule(extensionPath: string) {
-	const jiti = createJiti(import.meta.url, {
-		moduleCache: false,
-		// In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
-		// Also disable tryNative so jiti handles ALL imports (not just the entry point)
-		// In Node.js/dev: use aliases to resolve to node_modules paths
-		...(isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() }),
-	});
+  const jiti = createJiti(import.meta.url, {
+    moduleCache: false,
+    // In Bun binary: use virtualModules for bundled packages (no filesystem resolution)
+    // Also disable tryNative so jiti handles ALL imports (not just the entry point)
+    // In Node.js/dev: use aliases to resolve to node_modules paths
+    ...(isBunBinary
+      ? { virtualModules: VIRTUAL_MODULES, tryNative: false }
+      : { alias: getAliases() }),
+  });
 
-	const module = await jiti.import(extensionPath, { default: true });
-	const factory = module as ExtensionFactory;
-	return typeof factory !== "function" ? undefined : factory;
+  const module = await jiti.import(extensionPath, { default: true });
+  const factory = module as ExtensionFactory;
+  return typeof factory !== "function" ? undefined : factory;
 }
 
 /**
  * Create an Extension object with empty collections.
  */
-function createExtension(extensionPath: string, resolvedPath: string): Extension {
-	const source =
-		extensionPath.startsWith("<") && extensionPath.endsWith(">")
-			? extensionPath.slice(1, -1).split(":")[0] || "temporary"
-			: "local";
-	const baseDir = extensionPath.startsWith("<") ? undefined : path.dirname(resolvedPath);
+function createExtension(
+  extensionPath: string,
+  resolvedPath: string,
+): Extension {
+  const source =
+    extensionPath.startsWith("<") && extensionPath.endsWith(">")
+      ? extensionPath.slice(1, -1).split(":")[0] || "temporary"
+      : "local";
+  const baseDir = extensionPath.startsWith("<")
+    ? undefined
+    : path.dirname(resolvedPath);
 
-	return {
-		path: extensionPath,
-		resolvedPath,
-		sourceInfo: createSyntheticSourceInfo(extensionPath, { source, baseDir }),
-		handlers: new Map(),
-		tools: new Map(),
-		messageRenderers: new Map(),
-		commands: new Map(),
-		flags: new Map(),
-		shortcuts: new Map(),
-	};
+  return {
+    path: extensionPath,
+    resolvedPath,
+    sourceInfo: createSyntheticSourceInfo(extensionPath, { source, baseDir }),
+    handlers: new Map(),
+    tools: new Map(),
+    messageRenderers: new Map(),
+    commands: new Map(),
+    flags: new Map(),
+    shortcuts: new Map(),
+  };
 }
 
 async function loadExtension(
-	extensionPath: string,
-	cwd: string,
-	eventBus: EventBus,
-	runtime: ExtensionRuntime,
-	workflowResources: ResolvedResource[] = [],
+  extensionPath: string,
+  cwd: string,
+  eventBus: EventBus,
+  runtime: ExtensionRuntime,
+  workflowResources: ResolvedResource[] = [],
 ): Promise<{ extension: Extension | null; error: string | null }> {
-	const resolvedPath = resolvePath(extensionPath, cwd);
+  const resolvedPath = resolvePath(extensionPath, cwd);
 
-	try {
-		const factory = await loadExtensionModule(resolvedPath);
-		if (!factory) {
-			return { extension: null, error: `Extension does not export a valid factory function: ${extensionPath}` };
-		}
+  try {
+    const factory = await loadExtensionModule(resolvedPath);
+    if (!factory) {
+      return {
+        extension: null,
+        error: `Extension does not export a valid factory function: ${extensionPath}`,
+      };
+    }
 
-		const extension = createExtension(extensionPath, resolvedPath);
-		const api = createExtensionAPI(extension, runtime, cwd, eventBus, workflowResources);
-		await factory(api);
+    const extension = createExtension(extensionPath, resolvedPath);
+    const api = createExtensionAPI(
+      extension,
+      runtime,
+      cwd,
+      eventBus,
+      workflowResources,
+    );
+    await factory(api);
 
-		return { extension, error: null };
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return { extension: null, error: `Failed to load extension: ${message}` };
-	}
+    return { extension, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { extension: null, error: `Failed to load extension: ${message}` };
+  }
 }
 
 /**
  * Create an Extension from an inline factory function.
  */
 export async function loadExtensionFromFactory(
-	factory: ExtensionFactory,
-	cwd: string,
-	eventBus: EventBus,
-	runtime: ExtensionRuntime,
-	extensionPath = "<inline>",
-	workflowResources: ResolvedResource[] = [],
+  factory: ExtensionFactory,
+  cwd: string,
+  eventBus: EventBus,
+  runtime: ExtensionRuntime,
+  extensionPath = "<inline>",
+  workflowResources: ResolvedResource[] = [],
 ): Promise<Extension> {
-	const extension = createExtension(extensionPath, extensionPath);
-	const api = createExtensionAPI(extension, runtime, cwd, eventBus, workflowResources);
-	await factory(api);
-	return extension;
+  const extension = createExtension(extensionPath, extensionPath);
+  const api = createExtensionAPI(
+    extension,
+    runtime,
+    cwd,
+    eventBus,
+    workflowResources,
+  );
+  await factory(api);
+  return extension;
 }
 
 /**
  * Load extensions from paths.
  */
 export async function loadExtensions(
-	paths: string[],
-	cwd: string,
-	eventBus?: EventBus,
-	workflowResources: ResolvedResource[] = [],
+  paths: string[],
+  cwd: string,
+  eventBus?: EventBus,
+  workflowResources: ResolvedResource[] = [],
 ): Promise<LoadExtensionsResult> {
-	const extensions: Extension[] = [];
-	const errors: Array<{ path: string; error: string }> = [];
-	const resolvedEventBus = eventBus ?? createEventBus();
-	const runtime = createExtensionRuntime();
+  const extensions: Extension[] = [];
+  const errors: Array<{ path: string; error: string }> = [];
+  const resolvedEventBus = eventBus ?? createEventBus();
+  const runtime = createExtensionRuntime();
 
-	for (const extPath of paths) {
-		const { extension, error } = await loadExtension(extPath, cwd, resolvedEventBus, runtime, workflowResources);
+  for (const extPath of paths) {
+    const { extension, error } = await loadExtension(
+      extPath,
+      cwd,
+      resolvedEventBus,
+      runtime,
+      workflowResources,
+    );
 
-		if (error) {
-			errors.push({ path: extPath, error });
-			continue;
-		}
+    if (error) {
+      errors.push({ path: extPath, error });
+      continue;
+    }
 
-		if (extension) {
-			extensions.push(extension);
-		}
-	}
+    if (extension) {
+      extensions.push(extension);
+    }
+  }
 
-	return {
-		extensions,
-		errors,
-		runtime,
-	};
+  return {
+    extensions,
+    errors,
+    runtime,
+  };
 }
 
 interface PiManifest {
-	extensions?: string[];
-	themes?: string[];
-	skills?: string[];
-	prompts?: string[];
+  extensions?: string[];
+  themes?: string[];
+  skills?: string[];
+  prompts?: string[];
 }
 
-function manifestFromPackageJson(pkg: Record<string, unknown>): PiManifest | null {
-	const appManifest = pkg[APP_NAME];
-	if (appManifest && typeof appManifest === "object" && !Array.isArray(appManifest)) {
-		return appManifest as PiManifest;
-	}
-	const legacyManifest = pkg.pi;
-	if (legacyManifest && typeof legacyManifest === "object" && !Array.isArray(legacyManifest)) {
-		return legacyManifest as PiManifest;
-	}
-	return null;
+function manifestFromPackageJson(
+  pkg: Record<string, unknown>,
+): PiManifest | null {
+  const appManifest = pkg[APP_NAME];
+  if (
+    appManifest &&
+    typeof appManifest === "object" &&
+    !Array.isArray(appManifest)
+  ) {
+    return appManifest as PiManifest;
+  }
+  const legacyManifest = pkg.pi;
+  if (
+    legacyManifest &&
+    typeof legacyManifest === "object" &&
+    !Array.isArray(legacyManifest)
+  ) {
+    return legacyManifest as PiManifest;
+  }
+  return null;
 }
 
 function readPiManifest(packageJsonPath: string): PiManifest | null {
-	try {
-		const content = fs.readFileSync(packageJsonPath, "utf-8");
-		const pkg = JSON.parse(content) as Record<string, unknown>;
-		return manifestFromPackageJson(pkg);
-	} catch {
-		return null;
-	}
+  try {
+    const content = fs.readFileSync(packageJsonPath, "utf-8");
+    const pkg = JSON.parse(content) as Record<string, unknown>;
+    return manifestFromPackageJson(pkg);
+  } catch {
+    return null;
+  }
 }
 
 function isExtensionFile(name: string): boolean {
-	return name.endsWith(".ts") || name.endsWith(".js");
+  return name.endsWith(".ts") || name.endsWith(".js");
 }
 
 /**
@@ -516,35 +603,35 @@ function isExtensionFile(name: string): boolean {
  * Returns resolved paths or null if no entry points found.
  */
 function resolveExtensionEntries(dir: string): string[] | null {
-	// Check for package.json with "pi" field first
-	const packageJsonPath = path.join(dir, "package.json");
-	if (fs.existsSync(packageJsonPath)) {
-		const manifest = readPiManifest(packageJsonPath);
-		if (manifest?.extensions?.length) {
-			const entries: string[] = [];
-			for (const extPath of manifest.extensions) {
-				const resolvedExtPath = path.resolve(dir, extPath);
-				if (fs.existsSync(resolvedExtPath)) {
-					entries.push(resolvedExtPath);
-				}
-			}
-			if (entries.length > 0) {
-				return entries;
-			}
-		}
-	}
+  // Check for package.json with "pi" field first
+  const packageJsonPath = path.join(dir, "package.json");
+  if (fs.existsSync(packageJsonPath)) {
+    const manifest = readPiManifest(packageJsonPath);
+    if (manifest?.extensions?.length) {
+      const entries: string[] = [];
+      for (const extPath of manifest.extensions) {
+        const resolvedExtPath = path.resolve(dir, extPath);
+        if (fs.existsSync(resolvedExtPath)) {
+          entries.push(resolvedExtPath);
+        }
+      }
+      if (entries.length > 0) {
+        return entries;
+      }
+    }
+  }
 
-	// Check for index.ts or index.js
-	const indexTs = path.join(dir, "index.ts");
-	const indexJs = path.join(dir, "index.js");
-	if (fs.existsSync(indexTs)) {
-		return [indexTs];
-	}
-	if (fs.existsSync(indexJs)) {
-		return [indexJs];
-	}
+  // Check for index.ts or index.js
+  const indexTs = path.join(dir, "index.ts");
+  const indexJs = path.join(dir, "index.js");
+  if (fs.existsSync(indexTs)) {
+    return [indexTs];
+  }
+  if (fs.existsSync(indexJs)) {
+    return [indexJs];
+  }
 
-	return null;
+  return null;
 }
 
 /**
@@ -558,86 +645,89 @@ function resolveExtensionEntries(dir: string): string[] | null {
  * No recursion beyond one level. Complex packages must use package.json manifest.
  */
 function discoverExtensionsInDir(dir: string): string[] {
-	if (!fs.existsSync(dir)) {
-		return [];
-	}
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
 
-	const discovered: string[] = [];
+  const discovered: string[] = [];
 
-	try {
-		const entries = fs.readdirSync(dir, { withFileTypes: true });
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
 
-		for (const entry of entries) {
-			const entryPath = path.join(dir, entry.name);
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
 
-			// 1. Direct files: *.ts or *.js
-			if ((entry.isFile() || entry.isSymbolicLink()) && isExtensionFile(entry.name)) {
-				discovered.push(entryPath);
-				continue;
-			}
+      // 1. Direct files: *.ts or *.js
+      if (
+        (entry.isFile() || entry.isSymbolicLink()) &&
+        isExtensionFile(entry.name)
+      ) {
+        discovered.push(entryPath);
+        continue;
+      }
 
-			// 2 & 3. Subdirectories
-			if (entry.isDirectory() || entry.isSymbolicLink()) {
-				const entries = resolveExtensionEntries(entryPath);
-				if (entries) {
-					discovered.push(...entries);
-				}
-			}
-		}
-	} catch {
-		return [];
-	}
+      // 2 & 3. Subdirectories
+      if (entry.isDirectory() || entry.isSymbolicLink()) {
+        const entries = resolveExtensionEntries(entryPath);
+        if (entries) {
+          discovered.push(...entries);
+        }
+      }
+    }
+  } catch {
+    return [];
+  }
 
-	return discovered;
+  return discovered;
 }
 
 /**
  * Discover and load extensions from standard locations.
  */
 export async function discoverAndLoadExtensions(
-	configuredPaths: string[],
-	cwd: string,
-	agentDir: string = getAgentDir(),
-	eventBus?: EventBus,
+  configuredPaths: string[],
+  cwd: string,
+  agentDir: string = getAgentDir(),
+  eventBus?: EventBus,
 ): Promise<LoadExtensionsResult> {
-	const allPaths: string[] = [];
-	const seen = new Set<string>();
+  const allPaths: string[] = [];
+  const seen = new Set<string>();
 
-	const addPaths = (paths: string[]) => {
-		for (const p of paths) {
-			const resolved = path.resolve(p);
-			if (!seen.has(resolved)) {
-				seen.add(resolved);
-				allPaths.push(p);
-			}
-		}
-	};
+  const addPaths = (paths: string[]) => {
+    for (const p of paths) {
+      const resolved = path.resolve(p);
+      if (!seen.has(resolved)) {
+        seen.add(resolved);
+        allPaths.push(p);
+      }
+    }
+  };
 
-	// 1. Project-local extensions: cwd/${CONFIG_DIR_NAME}/extensions/
-	const localExtDir = path.join(cwd, CONFIG_DIR_NAME, "extensions");
-	addPaths(discoverExtensionsInDir(localExtDir));
+  // 1. Project-local extensions: cwd/${CONFIG_DIR_NAME}/extensions/
+  const localExtDir = path.join(cwd, CONFIG_DIR_NAME, "extensions");
+  addPaths(discoverExtensionsInDir(localExtDir));
 
-	// 2. Global extensions: agentDir/extensions/
-	const globalExtDir = path.join(agentDir, "extensions");
-	addPaths(discoverExtensionsInDir(globalExtDir));
+  // 2. Global extensions: agentDir/extensions/
+  const globalExtDir = path.join(agentDir, "extensions");
+  addPaths(discoverExtensionsInDir(globalExtDir));
 
-	// 3. Explicitly configured paths
-	for (const p of configuredPaths) {
-		const resolved = resolvePath(p, cwd);
-		if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
-			// Check for package.json with pi manifest or index.ts
-			const entries = resolveExtensionEntries(resolved);
-			if (entries) {
-				addPaths(entries);
-				continue;
-			}
-			// No explicit entries - discover individual files in directory
-			addPaths(discoverExtensionsInDir(resolved));
-			continue;
-		}
+  // 3. Explicitly configured paths
+  for (const p of configuredPaths) {
+    const resolved = resolvePath(p, cwd);
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+      // Check for package.json with pi manifest or index.ts
+      const entries = resolveExtensionEntries(resolved);
+      if (entries) {
+        addPaths(entries);
+        continue;
+      }
+      // No explicit entries - discover individual files in directory
+      addPaths(discoverExtensionsInDir(resolved));
+      continue;
+    }
 
-		addPaths([resolved]);
-	}
+    addPaths([resolved]);
+  }
 
-	return loadExtensions(allPaths, cwd, eventBus);
+  return loadExtensions(allPaths, cwd, eventBus);
 }

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -197,7 +197,19 @@ export default defineWorkflow("deep-research-codebase")
       codebaseLines,
     );
 
-    let noAskQuestionToolSet = ["read", "bash", "edit", "write", "todo"];
+    let noAskQuestionToolSet = [
+      "read",
+      "bash",
+      "edit",
+      "write",
+      "todo",
+      "subagent",
+      "web_search",
+      "code_search",
+      "fetch_content",
+      "get_search_content",
+      "intercom",
+    ];
 
     let plannerModelConfig = {
       model: "openai/gpt-5.5",

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -152,7 +152,19 @@ export default defineWorkflow("ralph")
     let approved = false;
     let iterationsCompleted = 0;
 
-    let noAskQuestionToolSet = ["read", "bash", "edit", "write", "todo"];
+    let noAskQuestionToolSet = [
+      "read",
+      "bash",
+      "edit",
+      "write",
+      "todo",
+      "subagent",
+      "web_search",
+      "code_search",
+      "fetch_content",
+      "get_search_content",
+      "intercom",
+    ];
 
     let plannerModelConfig = {
       model: "openai/gpt-5.5",

--- a/packages/workflows/src/tui/graph-view.ts
+++ b/packages/workflows/src/tui/graph-view.ts
@@ -17,9 +17,9 @@
  *   - DESIGN.md §4 (Elevation), §5 (Components)
  */
 import type { Component } from "@earendil-works/pi-tui";
-import { sliceByColumn } from "@earendil-works/pi-tui/dist/utils.js";
 import {
   matchesKey,
+  sliceColumns,
   truncateToWidth,
   visibleWidth,
 } from "./text-helpers.js";
@@ -842,7 +842,7 @@ export class GraphView implements Component {
 
   private _sliceColumns(line: string, fromCol: number, toCol: number): string {
     if (fromCol >= toCol) return "";
-    return sliceByColumn(line, fromCol, toCol - fromCol, true);
+    return sliceColumns(line, fromCol, toCol - fromCol, true);
   }
 
   // -------------------------------------------------------------------------

--- a/packages/workflows/src/tui/text-helpers.ts
+++ b/packages/workflows/src/tui/text-helpers.ts
@@ -7,6 +7,14 @@ import {
 
 export { visibleWidth };
 
+const ANSI_ESCAPE_RE = /^\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x1b]*(?:\x1b\\))/;
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function readAnsiCode(text: string, offset: number): string | null {
+  const match = ANSI_ESCAPE_RE.exec(text.slice(offset));
+  return match?.[0] ?? null;
+}
+
 /**
  * Compatibility wrapper over pi-tui's ANSI-aware truncation helper.
  *
@@ -28,4 +36,59 @@ export function truncateToWidth(
 /** Use pi-tui's key parser/matcher while preserving the local string API. */
 export function matchesKey(data: string, key: string): boolean {
   return piMatchesKey(data, key as KeyId);
+}
+
+export function sliceColumns(
+  line: string,
+  startCol: number,
+  length: number,
+  strict = false,
+): string {
+  if (length <= 0) return "";
+
+  const endCol = startCol + length;
+  let result = "";
+  let currentCol = 0;
+  let offset = 0;
+  let pendingAnsi = "";
+
+  while (offset < line.length) {
+    const ansiCode = readAnsiCode(line, offset);
+    if (ansiCode) {
+      if (currentCol >= startCol && currentCol < endCol) {
+        result += ansiCode;
+      } else if (currentCol < startCol) {
+        pendingAnsi += ansiCode;
+      }
+      offset += ansiCode.length;
+      continue;
+    }
+
+    let textEnd = offset;
+    while (textEnd < line.length && !readAnsiCode(line, textEnd)) {
+      textEnd++;
+    }
+
+    for (const { segment } of segmenter.segment(line.slice(offset, textEnd))) {
+      const width = visibleWidth(segment);
+      const inRange = currentCol >= startCol && currentCol < endCol;
+      const fits = !strict || currentCol + width <= endCol;
+
+      if (inRange && fits) {
+        if (pendingAnsi) {
+          result += pendingAnsi;
+          pendingAnsi = "";
+        }
+        result += segment;
+      }
+
+      currentCol += width;
+      if (currentCol >= endCol) break;
+    }
+
+    offset = textEnd;
+    if (currentCol >= endCol) break;
+  }
+
+  return result;
 }

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -121,10 +121,38 @@ done
 echo "==> Creating release archives..."
 cd binaries
 
+create_zip_archive() {
+    local platform="$1"
+    local archive="atomic-$platform.zip"
+
+    if command -v zip >/dev/null 2>&1; then
+        (cd "$platform" && zip -rq "../$archive" .)
+        return
+    fi
+
+    local powershell_cmd=""
+    if command -v pwsh >/dev/null 2>&1; then
+        powershell_cmd="pwsh"
+    elif command -v powershell.exe >/dev/null 2>&1; then
+        powershell_cmd="powershell.exe"
+    elif command -v powershell >/dev/null 2>&1; then
+        powershell_cmd="powershell"
+    fi
+
+    if [[ -n "$powershell_cmd" ]]; then
+        "$powershell_cmd" -NoProfile -Command \
+            "\$ErrorActionPreference = 'Stop'; Compress-Archive -Path '$platform/*' -DestinationPath '$archive' -Force"
+        return
+    fi
+
+    echo "Neither zip nor PowerShell is available to create $archive" >&2
+    exit 1
+}
+
 for platform in "${PLATFORMS[@]}"; do
     if [[ "$platform" == windows-* ]]; then
         echo "Creating atomic-$platform.zip..."
-        (cd "$platform" && zip -rq "../atomic-$platform.zip" .)
+        create_zip_archive "$platform"
     else
         echo "Creating atomic-$platform.tar.gz..."
         mv "$platform" atomic && tar -czf "atomic-$platform.tar.gz" atomic && mv atomic "$platform"


### PR DESCRIPTION
## Summary

Improves Atomic reliability across four areas: extension loading compatibility for all pi package name variants, TUI graph rendering independence from pi-tui internals, broader planner tool access in built-in workflows, and CI binary build/smoke test coverage. Addresses https://github.com/flora131/atomic/issues/964.

## Changes

**Extension loader (`packages/coding-agent/src/core/extensions/loader.ts`)**
- Add `@earendil-works/pi-coding-agent` and `@mariozechner/*` aliases to both the virtual module map (compiled binary) and the jiti alias table (dev/Node.js), so extensions written against any pi package name variant resolve correctly.

**TUI graph rendering (`packages/workflows/src/tui/`)**
- Remove deep import `@earendil-works/pi-tui/dist/utils.js` (`sliceByColumn`) which broke when pi-tui changed its build layout.
- Implement a local ANSI/Unicode-aware `sliceColumns` helper in `text-helpers.ts` using `Intl.Segmenter` and a correct ANSI escape regex — no pi-tui internal dependency needed.

**Workflow planner tool access (`packages/workflows/builtin/ralph.ts`, `deep-research-codebase.ts`)**
- Expand `noAskQuestionToolSet` with `subagent`, `web_search`, `code_search`, `fetch_content`, `get_search_content`, and `intercom` so planning agents can leverage the same research and coordination tools available in execution flows.

**CI / release binaries (`.github/workflows/`, `scripts/build-binaries.sh`, `docs/ci.md`)**
- Add native binary build + `atomic --version` smoke tests to `test.yml` for both `ubuntu-latest` (Linux x64) and `windows-latest` (Windows x64).
- Add a Linux archive smoke test to `publish.yml` after cross-compiled binaries are built.
- Add a `create_zip_archive` helper in `build-binaries.sh` with PowerShell (`pwsh`/`powershell.exe`) fallback for Windows environments where `zip` is unavailable.
- Update `docs/ci.md` to reflect the new build and smoke-test steps.

## Breaking changes

None.