### PR TITLE
chore(release): bump to v0.8.6-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.5-0",
+      "version": "0.8.6-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -61,7 +61,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.5-0",
+      "version": "0.8.6-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -76,7 +76,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.5-0",
+      "version": "0.8.6-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -98,7 +98,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.5-0",
+      "version": "0.8.6-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -118,7 +118,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.5-0",
+      "version": "0.8.6-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -137,7 +137,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.5-0",
+      "version": "0.8.6-0",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-tui": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.6-0] - 2026-05-18
+
+### Changed
+
+- Prepared the 0.8.6-0 prerelease.
+
 ## [0.8.5] - 2026-05-18
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.5",
+  "version": "0.8.6-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.5",
+  "version": "0.8.6-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.5",
+  "version": "0.8.6-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.5",
+  "version": "0.8.6-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.5",
+  "version": "0.8.6-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.5",
+  "version": "0.8.6-0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepare the Atomic 0.8.6-0 prerelease, capturing two fixes merged since v0.8.5.

## Changes

- Bump all workspace package versions from 0.8.5 → 0.8.6-0.
- Refresh `bun.lock` for the updated prerelease versions.
- Add `[0.8.6-0]` changelog section to `packages/coding-agent/CHANGELOG.md`.

## Included since v0.8.5

- `fix(workflows): expand planner tool access` — broadens the set of tools available to the planner agent.
- `fix: improve extension and TUI compatibility` — hardens extension loading and TUI behaviour.
- `ci: smoke test release binaries` — adds post-publish smoke testing for cross-compiled release binaries.

## Release notes

This is a prerelease (`next` npm tag). Once validated it will be promoted to a stable v0.8.6 release.