### PR TITLE
chore(release): bump to v0.8.6

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-05-18
+
+### Changed
+
+- Prepared the 0.8.6 release.
+
 ## [0.8.6-0] - 2026-05-18
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.6-0",
+  "version": "0.8.6",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.6-0",
+  "version": "0.8.6",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.6-0",
+  "version": "0.8.6",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.6-0",
+  "version": "0.8.6",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.6-0",
+  "version": "0.8.6",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.6-0",
+  "version": "0.8.6",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the 0.8.6-0 prerelease to the stable 0.8.6 release. Bumps all workspace package versions and moves the changelog entry from unreleased to the dated release section.

## Changes

- Bumped all workspace package versions from `0.8.6-0` → `0.8.6`
- Added `[0.8.6] - 2026-05-18` changelog entry in `packages/coding-agent/CHANGELOG.md`

## What's in this release (since v0.8.5)

- **ci:** smoke test release binaries to validate cross-compiled artifacts
- **fix(workflows):** expand planner tool access
- **fix:** improve extension and TUI compatibility

## Release notes

No breaking changes. No migration steps required.

Tagging `v0.8.6` triggers the publish workflow, which cross-compiles binaries, publishes `@bastani/atomic@0.8.6` to npm with the `latest` tag, and creates a non-prerelease GitHub Release.