### PR TITLE
fix(workflows): resolve TUI keybinding conflicts and paused-stage Ctrl+D

### DIFF
--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -1696,9 +1696,12 @@ function factory(pi: ExtensionAPI): void {
         stageId = byName.id;
       }
       overlay.open(runId, overlaySurfaceFromContext(ctx), stageId);
+      const attachedStage = stageId ? run?.stages.find((s) => s.id === stageId) : undefined;
       print(
         stageId
-          ? `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d return to graph · esc close.`
+          ? attachedStage?.status === "paused"
+            ? `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d close · esc close.`
+            : `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d return to graph · esc close.`
           : `Attached to ${runId.slice(0, 8)}. ↵ chat · ctrl+d detach.`,
       );
       return true;

--- a/packages/workflows/src/tui/inline-form-card.ts
+++ b/packages/workflows/src/tui/inline-form-card.ts
@@ -25,7 +25,7 @@
  *   ╰──────────────────────────────────────────────────────────────────╯
  *     integer  ·  optional  ·  loop count
  *
- *   ╭ EDIT ╮  tab next  ·  shift+tab prev  ·  ctrl+enter run  ·  esc cancel
+ *   ╭ EDIT ╮  tab next  ·  shift+tab prev  ·  ctrl+x run  ·  esc cancel
  *   │ EDIT │
  *   ╰──────╯
  *
@@ -193,7 +193,7 @@ function renderFooterBand(theme: GraphTheme, width: number): string[] {
   const hints: Array<{ key: string; label: string }> = [
     { key: "tab", label: "Next" },
     { key: "shift+tab", label: "Prev" },
-    { key: "ctrl+enter", label: "Run" },
+    { key: "ctrl+x", label: "Run" },
     { key: "esc", label: "Cancel" },
   ];
   const sep = `${chromeBg}  ${dim}·${RESET}${chromeBg}  `;

--- a/packages/workflows/src/tui/inline-form-editor.ts
+++ b/packages/workflows/src/tui/inline-form-editor.ts
@@ -16,13 +16,13 @@
  *   space               — boolean toggle
  *   enter               — newline (text) | otherwise next field
  *   printable ASCII     — insert at caret (text/string/number)
- *   ctrl+enter          — submit form (if valid)
+ *   ctrl+x          — submit form (if valid)
  *   esc / ctrl+c        — cancel form
  *
  * Editor-mode keys (cursor movement, word jumps, deletions) route through
  * the Pi `KeybindingsManager` injected by the host at factory time, so any
  * user-configured keybinding overrides surfaces here as well. Form-level
- * keys (tab/shift+tab/ctrl+enter/esc/ctrl+c) stay as raw byte checks because
+ * keys (tab/shift+tab/ctrl+x/esc/ctrl+c) stay as raw byte checks because
  * they are workflow form contract, not Pi-configurable actions.
  *
  * On submit/cancel the editor calls back to the orchestrator which:
@@ -64,7 +64,7 @@ export type FormEditorOutcome = "submit" | "cancel";
 export interface InlineFormEditorOpts {
   formId: string;
   theme: GraphTheme;
-  /** Called when Ctrl+Enter passes validation or cancel fires. */
+  /** Called when Ctrl+X passes validation or cancel fires. */
   onExit: (outcome: FormEditorOutcome) => void;
   /**
    * Pi's `KeybindingsManager` injected as the third arg of the editor
@@ -433,14 +433,14 @@ export class InlineFormEditor implements PiEditorComponent {
     // editor actions, so they stay as raw byte checks:
     //   esc        (\x1b)        — cancel form
     //   ctrl+c     (\x03)        — cancel form
-    //   ctrl+enter                — submit form
+    //   ctrl+x                — submit form
     //   tab        (\t)          — focus next field
     //   shift+tab  (\x1b[Z)      — focus previous field
     if (data === "\x03" || matchesKey(data, "escape")) {
       this.opts.onExit("cancel");
       return true;
     }
-    if (matchesKey(data, "ctrl+enter")) {
+    if (matchesKey(data, "ctrl+x")) {
       if (this.allValid(state)) this.opts.onExit("submit");
       else this.focusFirstInvalid(state);
       return true;

--- a/packages/workflows/src/tui/inline-form-editor.ts
+++ b/packages/workflows/src/tui/inline-form-editor.ts
@@ -57,7 +57,7 @@ import {
   wordLeft,
   wordRight,
 } from "./keybindings-adapter.js";
-import { matchesKey, visibleWidth } from "./text-helpers.js";
+import { decodePrintableKey, matchesKey, visibleWidth } from "./text-helpers.js";
 
 export type FormEditorOutcome = "submit" | "cancel";
 
@@ -654,12 +654,15 @@ export class InlineFormEditor implements PiEditorComponent {
       return true;
     }
 
-    // Printable insertion — no Pi action, raw grapheme check. Numeric
-    // fields accept the same printable range as text; per-field validation
-    // catches non-numeric content at submit time.
-    if (isPrintableGrapheme(data)) {
-      state.rawText[name] = cur.slice(0, caret) + data + cur.slice(caret);
-      state.caret = caret + data.length;
+    // Printable insertion — accept raw graphemes and terminal-encoded
+    // printable keys (CSI-u / Kitty). VSCode's integrated terminal can emit
+    // printable keys as escape sequences when modifyOtherKeys is active.
+    // Numeric fields accept the same printable range as text; per-field
+    // validation catches non-numeric content at submit time.
+    const printable = decodePrintableKey(data) ?? data;
+    if (isPrintableGrapheme(printable)) {
+      state.rawText[name] = cur.slice(0, caret) + printable + cur.slice(caret);
+      state.caret = caret + printable.length;
       return true;
     }
     return false;

--- a/packages/workflows/src/tui/inputs-picker.ts
+++ b/packages/workflows/src/tui/inputs-picker.ts
@@ -22,7 +22,7 @@
  *   ╰──────────────────────────────────────────╯
  *     select  ·  required  ·  How aggressively to scope the work.
  *
- *   tab next  ·  shift+tab prev  ·  ctrl+enter run  ·  esc cancel
+ *   tab next  ·  shift+tab prev  ·  ctrl+x run  ·  esc cancel
  *
  * Field-type renderers:
  *   - string / number : single-row text input with blinking cursor
@@ -718,10 +718,10 @@ export function renderInputsPicker(opts: InputsPickerRenderOpts): string[] {
 /**
  * Footer hint row, tier-degraded so it never wraps on resize. Tiers:
  *
- *   wide   (≥ widest):  tab next  ·  shift+tab prev  ·  ctrl+enter run  ·  esc cancel
- *   medium (≥ keys):    tab  ·  shift+tab  ·  ctrl+enter  ·  esc
- *   tight  (≥ short):   tab  ·  ⇧tab  ·  ⌃↵  ·  esc
- *   narrow (else):      ⌃↵  ·  esc
+ *   wide   (≥ widest):  tab next  ·  shift+tab prev  ·  ctrl+x run  ·  esc cancel
+ *   medium (≥ keys):    tab  ·  shift+tab  ·  ctrl+x  ·  esc
+ *   tight  (≥ short):   tab  ·  ⇧tab  ·  ctrl+x  ·  esc
+ *   narrow (else):      ctrl+x  ·  esc
  */
 function renderFooterHints(width: number, theme: GraphTheme, submitDisabled: boolean): string {
   const sep = dimSep(theme);
@@ -735,23 +735,23 @@ function renderFooterHints(width: number, theme: GraphTheme, submitDisabled: boo
   const wide = [
     { width: 8, render: () => hint("tab", "Next") },
     { width: 14, render: () => hint("shift+tab", "Prev") },
-    { width: 14, render: () => hint("ctrl+enter", "Run", submitColor, submitLabelColor) },
+    { width: 10, render: () => hint("ctrl+x", "Run", submitColor, submitLabelColor) },
     { width: 10, render: () => hint("esc", "Cancel") },
   ];
   const medium = [
     { width: 3, render: () => keyOnly("tab") },
     { width: 9, render: () => keyOnly("shift+tab") },
-    { width: 10, render: () => keyOnly("ctrl+enter", submitColor) },
+    { width: 6, render: () => keyOnly("ctrl+x", submitColor) },
     { width: 6, render: () => keyOnly("esc") },
   ];
   const tight = [
     { width: 3, render: () => keyOnly("tab") },
     { width: 4, render: () => keyOnly("⇧tab") },
-    { width: 2, render: () => keyOnly("⌃↵", submitColor) },
+    { width: 6, render: () => keyOnly("ctrl+x", submitColor) },
     { width: 6, render: () => keyOnly("esc") },
   ];
   const narrow = [
-    { width: 2, render: () => keyOnly("⌃↵", submitColor) },
+    { width: 6, render: () => keyOnly("ctrl+x", submitColor) },
     { width: 6, render: () => keyOnly("esc") },
   ];
 
@@ -762,7 +762,7 @@ function renderFooterHints(width: number, theme: GraphTheme, submitDisabled: boo
     }
   }
   // Truly tiny terminal — show just the run+cancel keys joined by a single space.
-  return paint("⌃↵", submitColor) + " " + paint("esc", theme.text);
+  return paint("ctrl+x", submitColor) + " " + paint("esc", theme.text);
 }
 
 /**
@@ -827,7 +827,7 @@ function shortVal(s: string): string {
  *   left / right     — select: cycle choices; boolean: flip; text: caret
  *   space            — boolean: flip
  *   enter            — text: newline; otherwise: next field
- *   ctrl+enter       — open confirm modal (if all required filled)
+ *   ctrl+x       — open confirm modal (if all required filled)
  *   backspace        — delete char left of caret
  *   esc / ctrl+c     — close picker without running
  *
@@ -860,7 +860,7 @@ function handleFormKey(
 ): InputsPickerAction {
   // ── Global navigation (workflow form contract, not Pi actions) ──
   if (isCancelKey(key)) return { kind: "cancel" };
-  if (matchesKey(key, "ctrl+enter")) return attemptPickerSubmit(state, fields);
+  if (matchesKey(key, "ctrl+x")) return attemptPickerSubmit(state, fields);
   if (matchesKey(key, "tab")) {
     moveFocus(state, fields, +1);
     return { kind: "noop" };

--- a/packages/workflows/src/tui/inputs-picker.ts
+++ b/packages/workflows/src/tui/inputs-picker.ts
@@ -40,7 +40,7 @@
 import type { WorkflowInputEntry } from "../extension/render-result.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { paint } from "./color-utils.js";
-import { matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
+import { decodePrintableKey, matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
 import {
   type KeybindingsLike,
   deleteRange,
@@ -989,11 +989,13 @@ function handleFormKey(
     }
     return { kind: "noop" };
   }
-  // Printable insert. Accept exactly one grapheme cluster so CJK, emoji ZWJ
-  // sequences, and combining-mark input follow pi-tui Input semantics.
-  if (isPrintableGrapheme(key)) {
-    state.rawText[name] = cur.slice(0, caret) + key + cur.slice(caret);
-    state.caret = caret + key.length;
+  // Printable insert. Accept raw graphemes and terminal-encoded printable
+  // keys (CSI-u / Kitty). VSCode's integrated terminal can emit printable
+  // keys as escape sequences when modifyOtherKeys is active.
+  const printable = decodePrintableKey(key) ?? key;
+  if (isPrintableGrapheme(printable)) {
+    state.rawText[name] = cur.slice(0, caret) + printable + cur.slice(caret);
+    state.caret = caret + printable.length;
     return { kind: "noop" };
   }
   return { kind: "noop" };

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -22,7 +22,8 @@
  *  - **Escape** mirrors the main coding-agent chat interrupt path for active
  *    live stages: it requests a controlled pause/abort while keeping the
  *    composer active. While paused, Enter calls `handle.resume(text)`.
- *  - **Ctrl+D** detaches (back to graph); **Escape** closes the popup when idle.
+ *  - **Ctrl+D** detaches (back to graph), or closes the popup while paused;
+ *    **Escape** closes the popup when idle.
  *  - **Blocked** stage: keystrokes absorbed; BLOCKED banner names the
  *    upstream awaiter.
  *  - **Settled** stage with a live handle remains a normal chat session:
@@ -86,7 +87,7 @@ export interface StageChatViewOpts {
    * inspect-only (settled stage with no live handle).
    */
   handle?: StageControlHandle;
-  /** Called when the user presses Ctrl+D (back to graph). */
+  /** Called when the user presses Ctrl+D outside a paused stage (back to graph). */
   onDetach: () => void;
   /** Called when the user presses Escape (close the whole popup). */
   onClose: () => void;
@@ -950,7 +951,8 @@ export class StageChatView implements Component, Focusable {
       return true;
     }
     if (data === "\x04") {
-      this.onDetach();
+      if (this._isPaused()) this.onClose();
+      else this.onDetach();
       return true;
     }
     if (matchesKey(data, "escape")) {

--- a/packages/workflows/src/tui/text-helpers.ts
+++ b/packages/workflows/src/tui/text-helpers.ts
@@ -4,6 +4,7 @@ import {
   visibleWidth,
   type KeyId,
 } from "@earendil-works/pi-tui";
+import { decodePrintableKey as piDecodePrintableKey } from "@earendil-works/pi-tui/dist/keys.js";
 
 export { visibleWidth };
 
@@ -36,6 +37,11 @@ export function truncateToWidth(
 /** Use pi-tui's key parser/matcher while preserving the local string API. */
 export function matchesKey(data: string, key: string): boolean {
   return piMatchesKey(data, key as KeyId);
+}
+
+/** Decode CSI-u / Kitty printable-key sequences emitted by terminals such as VSCode. */
+export function decodePrintableKey(data: string): string | undefined {
+  return piDecodePrintableKey(data);
 }
 
 export function sliceColumns(

--- a/packages/workflows/src/tui/workflow-attach-pane.ts
+++ b/packages/workflows/src/tui/workflow-attach-pane.ts
@@ -5,7 +5,8 @@
  * between the orchestrator `GraphView` and a stage-scoped
  * `StageChatView`. Pressing Enter on a graph node attaches the popup
  * to that node's chat; Ctrl+D in chat mode swaps back to graph mode
- * with the same node still focused (see ui/attach-mockup.html).
+ * with the same node still focused (see ui/attach-mockup.html), except
+ * paused stage chats close the pane to mirror shell EOF semantics.
  *
  * The shell never remounts the overlay — it only flips a `mode`
  * field and re-renders, so the popup stays in pi-tui's overlay layer

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -111,7 +111,8 @@ test("card (live): shows header pill, workflow chip, all fields, footer hints", 
   assert.doesNotMatch(txt, /Run workflow/);
   assert.match(txt, /EDIT/);
   assert.match(txt, /tab/);
-  assert.match(txt, /ctrl\+enter/);
+  assert.match(txt, /ctrl\+x/);
+  assert.doesNotMatch(txt, /ctrl\+enter/);
   assert.doesNotMatch(txt, /ctrl\+s/);
 });
 
@@ -269,24 +270,26 @@ test("editor: esc variants and ctrl+c fire onExit('cancel')", () => {
   }
 });
 
-test("editor: ctrl+enter with missing required is blocked and focuses invalid", () => {
+test("editor: ctrl+x with missing required is blocked and focuses invalid", () => {
   const e = makeEditor(); // prompt is empty
   e.state.focusedIdx = 2;
-  e.editor.handleInput("\x1b[13;5u");
+  e.editor.handleInput("\x18");
   assert.equal(e.getExited(), null);
   assert.equal(e.state.focusedIdx, 0);
   e.dispose();
 });
 
-test("editor: ctrl+enter with all required filled fires onExit('submit')", () => {
-  const state = makeState({
-    focusedIdx: 0,
-    rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
-  });
-  const e = makeEditor(state);
-  e.editor.handleInput("\x1b[13;5u");
-  assert.deepEqual(e.getExited(), { outcome: "submit" });
-  e.dispose();
+test("editor: ctrl+x with all required filled fires onExit('submit')", () => {
+  for (const key of ["\x18", "\x1b[120;5u"]) {
+    const state = makeState({
+      focusedIdx: 0,
+      rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
+    });
+    const e = makeEditor(state);
+    e.editor.handleInput(key);
+    assert.deepEqual(e.getExited(), { outcome: "submit" }, `key=${JSON.stringify(key)}`);
+    e.dispose();
+  }
 });
 
 test("editor: select field arrow keys cycle, space cycles", () => {
@@ -474,7 +477,7 @@ test("overlay: openInlineInputsForm emits a custom message and swaps editor", as
   // Fill required prompt and submit.
   editor.handleInput("h");
   editor.handleInput("i");
-  editor.handleInput("\x1b[13;5u");
+  editor.handleInput("\x18");
   const result = await pending;
   assert.equal(result.kind, "run");
   if (result.kind === "run") {
@@ -564,7 +567,7 @@ test("overlay: installed editor accepts pi setup before card render", async () =
   assert.equal(editor.getAutocompleteMaxVisible(), 20);
   editor.handleInput("o");
   editor.handleInput("k");
-  editor.handleInput("\x1b[13;5u");
+  editor.handleInput("\x18");
   const result = await pending;
   assert.equal(result.kind, "run");
 });
@@ -1200,7 +1203,7 @@ test("editor: char movement and deletion respect emoji and combining graphemes",
 });
 
 test("editor: user-remapped delete word backward respects injected keybindings", () => {
-  // Drop ctrl+w; remap deleteWordBackward to a hypothetical ctrl+x sequence
+  // Drop ctrl+w; remap deleteWordBackward to a hypothetical ctrl+t sequence
   // and verify the form picks up the new binding via the injected manager.
   const state = makeState({
     rawText: { prompt: "one two", iters: "5", focus: "standard", verbose: "false" },
@@ -1213,11 +1216,11 @@ test("editor: user-remapped delete word backward respects injected keybindings",
     formId: state.formId,
     theme: deriveGraphTheme({}),
     keybindings: makeFakeKeybindings({
-      "tui.editor.deleteWordBackward": ["\x18"], // ctrl+x
+      "tui.editor.deleteWordBackward": ["\x14"], // ctrl+t
     }),
     onExit: (outcome) => { exited = { outcome }; },
   });
-  editor.handleInput("\x18"); // ctrl+x → delete word backward under override
+  editor.handleInput("\x14"); // ctrl+t → delete word backward under override
   assert.equal(state.rawText.prompt, "one ");
   assert.equal(state.caret, 4);
   // Default ctrl+w should NOT trigger the action now (overridden table).

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -251,6 +251,21 @@ test("editor: typing a char inserts at caret on the focused text field", () => {
   e.dispose();
 });
 
+test("editor: accepts encoded printable key sequences", () => {
+  for (const [key, expected] of [
+    ["\x1b[98;1u", "b"], // Kitty / CSI-u plain b
+    ["\x1b[65;2u", "A"], // Kitty / CSI-u shifted A
+    ["\x1b[27;1;98~", "b"], // xterm modifyOtherKeys plain b
+    ["\x1b[27;2;65~", "A"], // xterm modifyOtherKeys shifted A
+  ] as const) {
+    const e = makeEditor();
+    e.editor.handleInput(key);
+    assert.equal(e.state.rawText.prompt, expected, `key=${JSON.stringify(key)}`);
+    assert.equal(e.state.caret, expected.length, `key=${JSON.stringify(key)}`);
+    e.dispose();
+  }
+});
+
 test("editor: tab advances focus, shift+tab retreats", () => {
   const e = makeEditor();
   assert.equal(e.state.focusedIdx, 0);

--- a/test/unit/inputs-picker.test.ts
+++ b/test/unit/inputs-picker.test.ts
@@ -153,22 +153,24 @@ test("esc variants and ctrl+c cancel from form mode", () => {
   }
 });
 
-test("ctrl+enter with missing required fields opens no modal and focuses invalid", () => {
+test("ctrl+x with missing required fields opens no modal and focuses invalid", () => {
   const s = createInputsPickerState(FIELDS);
   s.focusedIdx = 2;
   // prompt is empty (required) — submit should be blocked.
-  const a = handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
+  const a = handleInputsPickerInput("\x18", s, FIELDS, KB);
   assert.deepEqual(a, { kind: "noop" });
   assert.equal(s.confirmOpen, false);
   assert.equal(s.focusedIdx, 0); // jumped to first invalid field
   assert.deepEqual(s.invalidIndices, [0]);
 });
 
-test("ctrl+enter with all required filled opens confirm modal", () => {
-  const s = createInputsPickerState(FIELDS, { prompt: "build something" });
-  s.focusedIdx = 0;
-  handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
-  assert.equal(s.confirmOpen, true);
+test("ctrl+x with all required filled opens confirm modal", () => {
+  for (const key of ["\x18", "\x1b[120;5u"]) {
+    const s = createInputsPickerState(FIELDS, { prompt: "build something" });
+    s.focusedIdx = 0;
+    handleInputsPickerInput(key, s, FIELDS, KB);
+    assert.equal(s.confirmOpen, true, `key=${JSON.stringify(key)}`);
+  }
 });
 
 test("confirm modal: y returns coerced values; n returns to form", () => {
@@ -176,14 +178,14 @@ test("confirm modal: y returns coerced values; n returns to form", () => {
   s.rawText.iters = "8";
   s.rawText.verbose = "true";
   s.focusedIdx = 1;
-  handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
+  handleInputsPickerInput("\x18", s, FIELDS, KB);
   assert.equal(s.confirmOpen, true);
   // n returns to form
   const back = handleInputsPickerInput("n", s, FIELDS, KB);
   assert.deepEqual(back, { kind: "noop" });
   assert.equal(s.confirmOpen, false);
   // Reopen and confirm
-  handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
+  handleInputsPickerInput("\x18", s, FIELDS, KB);
   const run = handleInputsPickerInput("y", s, FIELDS, KB);
   assert.equal(run.kind, "run");
   if (run.kind === "run") {
@@ -257,7 +259,8 @@ test("renderInputsPicker emits header, section label, fields, and hints", () => 
   assert.match(joined, /verbose/);
   assert.doesNotMatch(joined, /Run workflow/);
   assert.match(joined, /tab/);
-  assert.match(joined, /ctrl\+enter/);
+  assert.match(joined, /ctrl\+x/);
+  assert.doesNotMatch(joined, /ctrl\+enter/);
   assert.doesNotMatch(joined, /ctrl\+s/);
   assert.match(joined, /esc/);
 });
@@ -395,8 +398,8 @@ test("renderInputsPicker stays well-formed across a wide range of widths (resize
 test("renderInputsPicker footer degrades gracefully on narrow terminals", () => {
   // Wide: all 4 hints with labels.
   // Medium: keys with labels but shorter — `prev`/`cancel` drop out.
-  // Tight: keys only, including compact `⇧tab` / `⌃↵`.
-  // Narrow: only the essentials — `⌃↵` and `esc`.
+  // Tight: keys only, including compact `⇧tab`.
+  // Narrow: only the essentials — `ctrl+x` and `esc`.
   const theme = deriveGraphTheme({});
   const state = createInputsPickerState(FIELDS);
   // eslint-disable-next-line no-control-regex
@@ -423,7 +426,8 @@ test("renderInputsPicker footer degrades gracefully on narrow terminals", () => 
   const wide = renderAt(120);
   assert.match(wide, /tab Next/);
   assert.match(wide, /shift\+tab Prev/);
-  assert.match(wide, /ctrl\+enter Run/);
+  assert.match(wide, /ctrl\+x Run/);
+  assert.doesNotMatch(wide, /ctrl\+enter/);
   assert.match(wide, /esc Cancel/);
 
   // Medium — keys only, but full key names.
@@ -435,13 +439,13 @@ test("renderInputsPicker footer degrades gracefully on narrow terminals", () => 
   // Tight — compact glyphs.
   const tight = renderAt(35);
   assert.match(tight, /⇧tab/);
-  assert.match(tight, /⌃↵/);
+  assert.match(tight, /ctrl\+x/);
   assert.match(tight, /esc/);
   assert.doesNotMatch(tight, /shift\+tab/);
 
   // Narrow — essentials only.
   const narrow = renderAt(12);
-  assert.match(narrow, /⌃↵/);
+  assert.match(narrow, /ctrl\+x/);
   assert.match(narrow, /esc/);
   assert.doesNotMatch(narrow, /tab/);
 });
@@ -550,11 +554,11 @@ test("picker: ctrl+d deletes the char right of the caret", () => {
 
 test("picker: user-remapped delete word backward respects injected keybindings", () => {
   const kb = makeFakeKeybindings({
-    "tui.editor.deleteWordBackward": ["\x18"], // ctrl+x
+    "tui.editor.deleteWordBackward": ["\x14"], // ctrl+t
   });
   const s = createInputsPickerState(FIELDS, { prompt: "one two" });
   s.caret = 7;
-  handleInputsPickerInput("\x18", s, FIELDS, kb);
+  handleInputsPickerInput("\x14", s, FIELDS, kb);
   assert.equal(s.rawText.prompt, "one ");
   assert.equal(s.caret, 4);
   // Original ctrl+w no longer triggers the action under override.

--- a/test/unit/inputs-picker.test.ts
+++ b/test/unit/inputs-picker.test.ts
@@ -95,6 +95,20 @@ test("text field: typing inserts characters, backspace removes", () => {
   assert.equal(s.caret, 1);
 });
 
+test("text field accepts encoded printable key sequences", () => {
+  for (const [key, expected] of [
+    ["\x1b[98;1u", "b"], // Kitty / CSI-u plain b
+    ["\x1b[65;2u", "A"], // Kitty / CSI-u shifted A
+    ["\x1b[27;1;98~", "b"], // xterm modifyOtherKeys plain b
+    ["\x1b[27;2;65~", "A"], // xterm modifyOtherKeys shifted A
+  ] as const) {
+    const s = createInputsPickerState(FIELDS);
+    handleInputsPickerInput(key, s, FIELDS, KB);
+    assert.equal(s.rawText.prompt, expected, `key=${JSON.stringify(key)}`);
+    assert.equal(s.caret, expected.length, `key=${JSON.stringify(key)}`);
+  }
+});
+
 test("text field: CJK, emoji, and combining-mark edits move by grapheme", () => {
   const s = createInputsPickerState(FIELDS);
   handleInputsPickerInput("漢", s, FIELDS, KB);

--- a/test/unit/stage-chat-view.test.ts
+++ b/test/unit/stage-chat-view.test.ts
@@ -655,6 +655,32 @@ describe("StageChatView", () => {
     view.dispose();
   });
 
+  test("Ctrl+D closes a paused stage chat", () => {
+    const store = createStore();
+    setupRun(store, "run-1", "stage-a", "paused");
+    const { handle } = makeHandle(undefined, [], "paused");
+    let detached = 0;
+    let closed = 0;
+    const view = new StageChatView({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageId: "stage-a",
+      workflowName: "test-wf",
+      handle,
+      onDetach: () => {
+        detached += 1;
+      },
+      onClose: () => {
+        closed += 1;
+      },
+    });
+    view.handleInput("\x04");
+    assert.equal(closed, 1);
+    assert.equal(detached, 0);
+    view.dispose();
+  });
+
   test("Escape variants on settled stages and Ctrl+C call onClose", () => {
     const store = createStore();
     setupRun(store, "run-1", "stage-a", "completed");

--- a/test/unit/workflow-attach-pane.test.ts
+++ b/test/unit/workflow-attach-pane.test.ts
@@ -25,7 +25,7 @@ import { createStageControlRegistry } from "../../packages/workflows/src/runs/fo
 import type { StageControlHandle } from "../../packages/workflows/src/runs/foreground/stage-control-registry.js";
 import type { AgentSession } from "@bastani/atomic";
 
-function setupRun(store: ReturnType<typeof createStore>, runId: string, stages: Array<{ id: string; name: string; status?: "pending" | "running" | "completed" }>) {
+function setupRun(store: ReturnType<typeof createStore>, runId: string, stages: Array<{ id: string; name: string; status?: "pending" | "running" | "paused" | "completed" }>) {
   store.recordRunStart({
     id: runId,
     name: "test-wf",
@@ -149,6 +149,34 @@ describe("WorkflowAttachPane", () => {
     assert.equal(pane._hasChatView, false);
     // Stage id is preserved so re-attach lands on the same node.
     assert.equal(pane._lastAttachedStageId, "stage-a");
+    pane.dispose();
+  });
+
+  test("Ctrl+D in paused stage-chat mode closes the pane", () => {
+    const store = createStore();
+    setupRun(store, "run-1", [{ id: "stage-a", name: "A", status: "paused" }]);
+    const registry = createStageControlRegistry();
+    registry.register({ ...makeHandle("run-1", "stage-a"), status: "paused" });
+    let closed = 0;
+    let hidden = 0;
+    const pane = new WorkflowAttachPane({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageControlRegistry: registry,
+      onClose: () => {
+        closed += 1;
+      },
+      onHide: () => {
+        hidden += 1;
+      },
+      initialAttachStageId: "stage-a",
+    });
+    assert.equal(pane._mode, "stage-chat");
+    pane.handleInput("\x04");
+    assert.equal(closed, 1);
+    assert.equal(hidden, 0);
+    assert.equal(pane._mode, "stage-chat");
     pane.dispose();
   });
 


### PR DESCRIPTION
## Summary

Fixes workflow TUI keybinding issues reported in #971 by replacing the VSCode-conflicting `Ctrl+Enter` submit chord with `Ctrl+X`, decoding terminal-encoded printable key sequences, and making `Ctrl+D` close paused stage chats instead of detaching to the graph.

## Changes

### Keybinding: `Ctrl+Enter` → `Ctrl+X` for form submission
- Remaps the workflow form submit action from `Ctrl+Enter` to `Ctrl+X` across `InlineFormEditor` and `InputsPicker`.
- Updates all footer hint renders (`inline-form-card.ts`, `inputs-picker.ts`) and the narrow/tight tier degradation hints.
- `Ctrl+Enter` was intercepted by VSCode's keybinding layer before reaching the terminal, making it unreachable in the integrated terminal.

### Printable key decoding for VSCode / CSI-u terminals
- Adds `decodePrintableKey` re-export in `text-helpers.ts`, wrapping `pi-tui`'s CSI-u / Kitty decoder.
- Both `InlineFormEditor` and `InputsPicker` now run the raw input through `decodePrintableKey` before the `isPrintableGrapheme` check, so escape-sequence-encoded printable characters (e.g. `\x1b[98;1u` → `b`) are accepted in text fields when `modifyOtherKeys` is active in VSCode's integrated terminal.

### `Ctrl+D` closes paused stage chats
- In `StageChatView`, `\x04` (Ctrl+D) now calls `onClose()` instead of `onDetach()` when the stage is paused — mirroring shell EOF semantics.
- For non-paused stages the existing detach-to-graph behavior is preserved.
- `extension/index.ts` shows a context-sensitive hint: paused stages show `ctrl+d close` while running stages retain `ctrl+d return to graph`.
- `workflow-attach-pane.ts` comment updated to document the paused-stage exception.

## Tests

New regression tests added in:
- `test/unit/inline-form.test.ts` — encodes printable key sequences, `ctrl+x` submit (raw `\x18` and CSI-u `\x1b[120;5u`), re-labels existing ctrl+enter tests.
- `test/unit/inputs-picker.test.ts` — same coverage for `InputsPicker`, narrow/tight tier hint assertions updated.
- `test/unit/stage-chat-view.test.ts` — `Ctrl+D` closes a paused stage chat.
- `test/unit/workflow-attach-pane.test.ts` — `Ctrl+D` in paused stage-chat mode closes the pane.

Also updates the `user-remapped delete word backward` keybinding test fixture from `ctrl+x` → `ctrl+t` to avoid a collision with the newly assigned submit shortcut.

Run with:
```
AGENT=1 bun test test/unit/inline-form.test.ts test/unit/inputs-picker.test.ts test/unit/stage-chat-view.test.ts test/unit/workflow-attach-pane.test.ts
```

Fixes #971