### PR TITLE
fix(workflows)!: normalize TUI keys and pause timing

### DIFF
--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -1696,9 +1696,12 @@ function factory(pi: ExtensionAPI): void {
         stageId = byName.id;
       }
       overlay.open(runId, overlaySurfaceFromContext(ctx), stageId);
+      const attachedStage = stageId ? run?.stages.find((s) => s.id === stageId) : undefined;
       print(
         stageId
-          ? `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d return to graph · esc close.`
+          ? attachedStage?.status === "paused"
+            ? `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d close · esc close.`
+            : `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d return to graph · esc close.`
           : `Attached to ${runId.slice(0, 8)}. ↵ chat · ctrl+d detach.`,
       );
       return true;

--- a/packages/workflows/src/runs/background/status.ts
+++ b/packages/workflows/src/runs/background/status.ts
@@ -70,6 +70,9 @@ export interface RunDetail {
   readonly startedAt: number;
   readonly endedAt?: number;
   readonly durationMs?: number;
+  readonly pausedDurationMs?: number;
+  readonly pausedAt?: number;
+  readonly resumedAt?: number;
   readonly inputs: Readonly<Record<string, unknown>>;
   readonly stages: readonly RunSnapshot["stages"][number][];
   readonly result?: Record<string, unknown>;
@@ -433,6 +436,9 @@ export function inspectRun(
     startedAt: copy.startedAt,
     endedAt: copy.endedAt,
     durationMs: copy.durationMs,
+    pausedDurationMs: copy.pausedDurationMs,
+    pausedAt: copy.pausedAt,
+    resumedAt: copy.resumedAt,
     inputs: copy.inputs,
     stages: copy.stages,
     result: copy.result,

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -51,6 +51,7 @@ import {
   type WorktreeSetup,
 } from "../shared/worktree.js";
 import { store as defaultStore } from "../../shared/store.js";
+import { elapsedStageMs } from "../../shared/timing.js";
 import {
   appendRunStart,
   appendStageStart,
@@ -1520,10 +1521,7 @@ export async function run<TInputs extends Record<string, unknown>>(
           throw err;
         } finally {
           stageSnapshot.endedAt = Date.now();
-          stageSnapshot.durationMs =
-            stageSnapshot.startedAt !== undefined
-              ? stageSnapshot.endedAt - stageSnapshot.startedAt
-              : undefined;
+          stageSnapshot.durationMs = elapsedStageMs(stageSnapshot, stageSnapshot.endedAt);
 
           const finalModelMeta = innerCtx.__modelFallbackMeta();
           if (finalModelMeta.model !== undefined) stageSnapshot.model = finalModelMeta.model;

--- a/packages/workflows/src/shared/store-types.ts
+++ b/packages/workflows/src/shared/store-types.ts
@@ -101,6 +101,8 @@ export interface StageSnapshot {
   attachable?: boolean;
   /** True while a user pane is actively attached to this stage. */
   attached?: boolean;
+  /** Milliseconds spent paused across completed pause intervals. */
+  pausedDurationMs?: number;
   /** Timestamp set when a controlled pause begins; cleared on resume. */
   pausedAt?: number;
   /** Timestamp recorded on the most recent resume from a paused state. */
@@ -116,6 +118,12 @@ export interface RunSnapshot {
   startedAt: number;
   endedAt?: number;
   durationMs?: number;
+  /** Milliseconds spent paused across completed pause intervals. */
+  pausedDurationMs?: number;
+  /** Timestamp set when a controlled pause begins; cleared on resume. */
+  pausedAt?: number;
+  /** Timestamp recorded on the most recent resume from a paused state. */
+  resumedAt?: number;
   result?: Record<string, unknown>;
   error?: string;
   /**

--- a/packages/workflows/src/shared/store.ts
+++ b/packages/workflows/src/shared/store.ts
@@ -13,6 +13,7 @@ import type {
   RunStatus,
   WorkflowNotice,
 } from "./store-types.js";
+import { accumulatePausedDurationMs, elapsedRunMs } from "./timing.js";
 
 /** Statuses that represent a terminal run state — cannot be overwritten. */
 const TERMINAL_STATUSES: ReadonlySet<RunStatus> = new Set(["completed", "failed", "killed"]);
@@ -263,6 +264,14 @@ export function createStore(): Store {
       if (!existing) return;
       existing.status = stage.status;
       existing.endedAt = stage.endedAt;
+      if (existing.endedAt !== undefined && existing.pausedAt !== undefined) {
+        existing.pausedDurationMs = accumulatePausedDurationMs(
+          existing.pausedDurationMs,
+          existing.pausedAt,
+          existing.endedAt,
+        );
+        existing.pausedAt = undefined;
+      }
       existing.durationMs = stage.durationMs;
       existing.result = stage.result;
       existing.error = stage.error;
@@ -283,7 +292,15 @@ export function createStore(): Store {
       if (TERMINAL_STATUSES.has(run.status)) return false;
       run.status = status;
       run.endedAt = Date.now();
-      run.durationMs = run.endedAt - run.startedAt;
+      if (run.pausedAt !== undefined) {
+        run.pausedDurationMs = accumulatePausedDurationMs(
+          run.pausedDurationMs,
+          run.pausedAt,
+          run.endedAt,
+        );
+        run.pausedAt = undefined;
+      }
+      run.durationMs = elapsedRunMs(run, run.endedAt);
       if (status === "completed" && result !== undefined) {
         run.result = result;
       }
@@ -547,8 +564,16 @@ export function createStore(): Store {
       const stage = findStage(run, stageId);
       if (!stage) return false;
       if (stage.status !== "paused" && stage.status !== "blocked") return false;
+      const resumedTs = resumedAt ?? Date.now();
       stage.status = "running";
-      stage.resumedAt = resumedAt ?? Date.now();
+      if (stage.startedAt !== undefined) {
+        stage.pausedDurationMs = accumulatePausedDurationMs(
+          stage.pausedDurationMs,
+          stage.pausedAt,
+          resumedTs,
+        );
+      }
+      stage.resumedAt = resumedTs;
       stage.pausedAt = undefined;
       delete stage.blockedByStageId;
       delete stage.awaitingInputSince;
@@ -557,23 +582,33 @@ export function createStore(): Store {
       return true;
     },
 
-    recordRunPaused(runId: string, _pausedAt?: number): boolean {
+    recordRunPaused(runId: string, pausedAt?: number): boolean {
       const run = findRun(runId);
       if (!run) return false;
       if (TERMINAL_STATUSES.has(run.status)) return false;
       if (run.status === "paused") return false;
       run.status = "paused";
+      run.pausedAt = pausedAt ?? Date.now();
+      run.resumedAt = undefined;
       _version++;
       notify();
       return true;
     },
 
-    recordRunResumed(runId: string, _resumedAt?: number): boolean {
+    recordRunResumed(runId: string, resumedAt?: number): boolean {
       const run = findRun(runId);
       if (!run) return false;
       if (TERMINAL_STATUSES.has(run.status)) return false;
       if (run.status !== "paused") return false;
+      const resumedTs = resumedAt ?? Date.now();
       run.status = "running";
+      run.pausedDurationMs = accumulatePausedDurationMs(
+        run.pausedDurationMs,
+        run.pausedAt,
+        resumedTs,
+      );
+      run.resumedAt = resumedTs;
+      run.pausedAt = undefined;
       _version++;
       notify();
       return true;

--- a/packages/workflows/src/shared/timing.ts
+++ b/packages/workflows/src/shared/timing.ts
@@ -1,0 +1,48 @@
+interface StageTimerSnapshot {
+  readonly startedAt?: number;
+  readonly durationMs?: number;
+  readonly pausedDurationMs?: number;
+  readonly pausedAt?: number;
+}
+
+interface RunTimerSnapshot {
+  readonly startedAt: number;
+  readonly durationMs?: number;
+  readonly pausedDurationMs?: number;
+  readonly pausedAt?: number;
+}
+
+function nonNegative(ms: number): number {
+  return Math.max(0, ms);
+}
+
+function elapsedFromStart(
+  startedAt: number,
+  now: number,
+  pausedDurationMs: number | undefined,
+  pausedAt: number | undefined,
+): number {
+  const completedPausedSegment = pausedDurationMs ?? 0;
+  const activePausedSegment = pausedAt === undefined ? 0 : nonNegative(now - pausedAt);
+  return nonNegative(now - startedAt - completedPausedSegment - activePausedSegment);
+}
+
+export function accumulatePausedDurationMs(
+  pausedDurationMs: number | undefined,
+  pausedAt: number | undefined,
+  resumedAt: number,
+): number {
+  if (pausedAt === undefined) return pausedDurationMs ?? 0;
+  return (pausedDurationMs ?? 0) + nonNegative(resumedAt - pausedAt);
+}
+
+export function elapsedStageMs(stage: StageTimerSnapshot, now = Date.now()): number | undefined {
+  if (stage.durationMs !== undefined) return nonNegative(stage.durationMs);
+  if (stage.startedAt === undefined) return undefined;
+  return elapsedFromStart(stage.startedAt, now, stage.pausedDurationMs, stage.pausedAt);
+}
+
+export function elapsedRunMs(run: RunTimerSnapshot, now = Date.now()): number {
+  if (run.durationMs !== undefined) return nonNegative(run.durationMs);
+  return elapsedFromStart(run.startedAt, now, run.pausedDurationMs, run.pausedAt);
+}

--- a/packages/workflows/src/tui/graph-view.ts
+++ b/packages/workflows/src/tui/graph-view.ts
@@ -30,6 +30,7 @@ import type {
   StoreSnapshot,
   RunSnapshot,
 } from "../shared/store-types.js";
+import { elapsedStageMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import type { SwitcherState } from "./switcher.js";
 import type { LayoutNode } from "./layout.js";
@@ -146,8 +147,8 @@ const OVERLAY_VERTICAL_MARGIN_ROWS = 1;
 
 /**
  * Animation tick period. Overlay re-renders fire on this cadence so
- * duration counters (rendered from `Date.now() - stage.startedAt`)
- * tick and the running-stage border lerps between `borderDim` and
+ * duration counters tick from active elapsed time (freezing while paused)
+ * and the running-stage border lerps between `borderDim` and
  * `warning` without a key press. The host-supplied `requestRender`
  * gate prevents work while the overlay is hidden or unfocused.
  */
@@ -964,10 +965,8 @@ export class GraphView implements Component {
   }
 
   private _duration(stage: StageSnapshot): string {
-    if (stage.durationMs != null) return fmtDuration(stage.durationMs);
-    if (stage.startedAt != null)
-      return fmtDuration(Date.now() - stage.startedAt);
-    return "";
+    const elapsed = elapsedStageMs(stage);
+    return elapsed === undefined ? "" : fmtDuration(elapsed);
   }
 
   private _counts(run: RunSnapshot): {

--- a/packages/workflows/src/tui/graph-view.ts
+++ b/packages/workflows/src/tui/graph-view.ts
@@ -1092,7 +1092,7 @@ export class GraphView implements Component {
     }
     // `ctrl+d` detaches the whole popup (host hides the overlay). This
     // is the graph-mode counterpart of the in-chat back affordance.
-    if (data === "\x04") {
+    if (matchesKey(data, "ctrl+d")) {
       if (this.onDetach) {
         this.onDetach();
       } else if (this.onHide) {

--- a/packages/workflows/src/tui/graph-view.ts
+++ b/packages/workflows/src/tui/graph-view.ts
@@ -1050,13 +1050,13 @@ export class GraphView implements Component {
     // Vertical-graph navigation: up/down step between depth levels
     // (col), left/right step between siblings at the same depth (row).
     // j/k preserved as a flat-order fallback for muscle memory.
-    if (matchesKey(data, "down") || data === "\x1b[B")
+    if (matchesKey(data, "down"))
       return this._moveByDepth(+1);
-    if (matchesKey(data, "up") || data === "\x1b[A")
+    if (matchesKey(data, "up"))
       return this._moveByDepth(-1);
-    if (matchesKey(data, "right") || data === "\x1b[C")
+    if (matchesKey(data, "right"))
       return this._moveBySibling(+1);
-    if (matchesKey(data, "left") || data === "\x1b[D")
+    if (matchesKey(data, "left"))
       return this._moveBySibling(-1);
     if (matchesKey(data, "j")) {
       this._setFocusedIndex(Math.min(this.focusedIndex + 1, stageCount - 1));
@@ -1081,7 +1081,7 @@ export class GraphView implements Component {
       this.switcherState = { query: "", selectedIndex: 0 };
       return true;
     }
-    if (matchesKey(data, "enter") || data === "\r" || data === "\n") {
+    if (matchesKey(data, "enter")) {
       // Enter attaches the popup interior to the focused stage. The
       // attach shell swaps in the stage-chat view without remounting
       // the overlay; without a callback, fall back to the legacy
@@ -1114,7 +1114,7 @@ export class GraphView implements Component {
       this.onHide();
       return true;
     }
-    if (matchesKey(data, "escape") || data === "\x1b" || data === "\x03") {
+    if (matchesKey(data, "escape") || matchesKey(data, "ctrl+c")) {
       this.onClose?.();
       return true;
     }
@@ -1125,11 +1125,11 @@ export class GraphView implements Component {
     const run = this._getCurrentRun();
     const stages = run?.stages ?? [];
 
-    if (matchesKey(data, "escape") || data === "\x1b") {
+    if (matchesKey(data, "escape")) {
       this.switcherOpen = false;
       return true;
     }
-    if (matchesKey(data, "enter") || data === "\r" || data === "\n") {
+    if (matchesKey(data, "enter")) {
       const filtered = filterStages(stages, this.switcherState.query);
       const selected = filtered[this.switcherState.selectedIndex];
       if (selected) {
@@ -1148,7 +1148,7 @@ export class GraphView implements Component {
       this.switcherOpen = false;
       return true;
     }
-    if (matchesKey(data, "down") || data === "\x1b[B") {
+    if (matchesKey(data, "down")) {
       const filtered = filterStages(stages, this.switcherState.query);
       this.switcherState = {
         ...this.switcherState,
@@ -1159,14 +1159,14 @@ export class GraphView implements Component {
       };
       return true;
     }
-    if (matchesKey(data, "up") || data === "\x1b[A") {
+    if (matchesKey(data, "up")) {
       this.switcherState = {
         ...this.switcherState,
         selectedIndex: Math.max(this.switcherState.selectedIndex - 1, 0),
       };
       return true;
     }
-    if (data === "\x7f" || data === "\b") {
+    if (matchesKey(data, "backspace")) {
       this.switcherState = {
         query: this.switcherState.query.slice(0, -1),
         selectedIndex: 0,

--- a/packages/workflows/src/tui/inline-form-card.ts
+++ b/packages/workflows/src/tui/inline-form-card.ts
@@ -25,7 +25,7 @@
  *   ╰──────────────────────────────────────────────────────────────────╯
  *     integer  ·  optional  ·  loop count
  *
- *   ╭ EDIT ╮  tab next  ·  shift+tab prev  ·  ctrl+enter run  ·  esc cancel
+ *   ╭ EDIT ╮  tab next  ·  shift+tab prev  ·  ctrl+x run  ·  esc cancel
  *   │ EDIT │
  *   ╰──────╯
  *
@@ -193,7 +193,7 @@ function renderFooterBand(theme: GraphTheme, width: number): string[] {
   const hints: Array<{ key: string; label: string }> = [
     { key: "tab", label: "Next" },
     { key: "shift+tab", label: "Prev" },
-    { key: "ctrl+enter", label: "Run" },
+    { key: "ctrl+x", label: "Run" },
     { key: "esc", label: "Cancel" },
   ];
   const sep = `${chromeBg}  ${dim}·${RESET}${chromeBg}  `;

--- a/packages/workflows/src/tui/inline-form-editor.ts
+++ b/packages/workflows/src/tui/inline-form-editor.ts
@@ -16,13 +16,13 @@
  *   space               — boolean toggle
  *   enter               — newline (text) | otherwise next field
  *   printable ASCII     — insert at caret (text/string/number)
- *   ctrl+enter          — submit form (if valid)
+ *   ctrl+x          — submit form (if valid)
  *   esc / ctrl+c        — cancel form
  *
  * Editor-mode keys (cursor movement, word jumps, deletions) route through
  * the Pi `KeybindingsManager` injected by the host at factory time, so any
  * user-configured keybinding overrides surfaces here as well. Form-level
- * keys (tab/shift+tab/ctrl+enter/esc/ctrl+c) stay as raw byte checks because
+ * keys (tab/shift+tab/ctrl+x/esc/ctrl+c) stay as raw byte checks because
  * they are workflow form contract, not Pi-configurable actions.
  *
  * On submit/cancel the editor calls back to the orchestrator which:
@@ -64,7 +64,7 @@ export type FormEditorOutcome = "submit" | "cancel";
 export interface InlineFormEditorOpts {
   formId: string;
   theme: GraphTheme;
-  /** Called when Ctrl+Enter passes validation or cancel fires. */
+  /** Called when Ctrl+X passes validation or cancel fires. */
   onExit: (outcome: FormEditorOutcome) => void;
   /**
    * Pi's `KeybindingsManager` injected as the third arg of the editor
@@ -433,14 +433,14 @@ export class InlineFormEditor implements PiEditorComponent {
     // editor actions, so they stay as raw byte checks:
     //   esc        (\x1b)        — cancel form
     //   ctrl+c     (\x03)        — cancel form
-    //   ctrl+enter                — submit form
+    //   ctrl+x                — submit form
     //   tab        (\t)          — focus next field
     //   shift+tab  (\x1b[Z)      — focus previous field
     if (data === "\x03" || matchesKey(data, "escape")) {
       this.opts.onExit("cancel");
       return true;
     }
-    if (matchesKey(data, "ctrl+enter")) {
+    if (matchesKey(data, "ctrl+x")) {
       if (this.allValid(state)) this.opts.onExit("submit");
       else this.focusFirstInvalid(state);
       return true;

--- a/packages/workflows/src/tui/inline-form-editor.ts
+++ b/packages/workflows/src/tui/inline-form-editor.ts
@@ -57,7 +57,7 @@ import {
   wordLeft,
   wordRight,
 } from "./keybindings-adapter.js";
-import { matchesKey, visibleWidth } from "./text-helpers.js";
+import { decodePrintableKey, matchesKey, visibleWidth } from "./text-helpers.js";
 
 export type FormEditorOutcome = "submit" | "cancel";
 
@@ -654,12 +654,15 @@ export class InlineFormEditor implements PiEditorComponent {
       return true;
     }
 
-    // Printable insertion — no Pi action, raw grapheme check. Numeric
-    // fields accept the same printable range as text; per-field validation
-    // catches non-numeric content at submit time.
-    if (isPrintableGrapheme(data)) {
-      state.rawText[name] = cur.slice(0, caret) + data + cur.slice(caret);
-      state.caret = caret + data.length;
+    // Printable insertion — accept raw graphemes and terminal-encoded
+    // printable keys (CSI-u / Kitty). VSCode's integrated terminal can emit
+    // printable keys as escape sequences when modifyOtherKeys is active.
+    // Numeric fields accept the same printable range as text; per-field
+    // validation catches non-numeric content at submit time.
+    const printable = decodePrintableKey(data) ?? data;
+    if (isPrintableGrapheme(printable)) {
+      state.rawText[name] = cur.slice(0, caret) + printable + cur.slice(caret);
+      state.caret = caret + printable.length;
       return true;
     }
     return false;

--- a/packages/workflows/src/tui/inline-form-editor.ts
+++ b/packages/workflows/src/tui/inline-form-editor.ts
@@ -436,7 +436,7 @@ export class InlineFormEditor implements PiEditorComponent {
     //   ctrl+x                — submit form
     //   tab        (\t)          — focus next field
     //   shift+tab  (\x1b[Z)      — focus previous field
-    if (data === "\x03" || matchesKey(data, "escape")) {
+    if (matchesKey(data, "ctrl+c") || matchesKey(data, "escape")) {
       this.opts.onExit("cancel");
       return true;
     }
@@ -475,7 +475,7 @@ export class InlineFormEditor implements PiEditorComponent {
       state.rawText[field.name] = choices[(i - 1 + choices.length) % choices.length]!;
       return true;
     }
-    if (matchesAction(this.kb, data, "tui.editor.cursorRight") || data === " ") {
+    if (matchesAction(this.kb, data, "tui.editor.cursorRight") || matchesKey(data, "space")) {
       state.rawText[field.name] = choices[(i + 1) % choices.length]!;
       return true;
     }
@@ -499,7 +499,7 @@ export class InlineFormEditor implements PiEditorComponent {
     state: InlineFormState,
   ): boolean {
     if (
-      data === " " ||
+      matchesKey(data, "space") ||
       matchesAction(this.kb, data, "tui.editor.cursorLeft") ||
       matchesAction(this.kb, data, "tui.editor.cursorRight")
     ) {

--- a/packages/workflows/src/tui/inputs-picker.ts
+++ b/packages/workflows/src/tui/inputs-picker.ts
@@ -22,7 +22,7 @@
  *   ╰──────────────────────────────────────────╯
  *     select  ·  required  ·  How aggressively to scope the work.
  *
- *   tab next  ·  shift+tab prev  ·  ctrl+enter run  ·  esc cancel
+ *   tab next  ·  shift+tab prev  ·  ctrl+x run  ·  esc cancel
  *
  * Field-type renderers:
  *   - string / number : single-row text input with blinking cursor
@@ -718,10 +718,10 @@ export function renderInputsPicker(opts: InputsPickerRenderOpts): string[] {
 /**
  * Footer hint row, tier-degraded so it never wraps on resize. Tiers:
  *
- *   wide   (≥ widest):  tab next  ·  shift+tab prev  ·  ctrl+enter run  ·  esc cancel
- *   medium (≥ keys):    tab  ·  shift+tab  ·  ctrl+enter  ·  esc
- *   tight  (≥ short):   tab  ·  ⇧tab  ·  ⌃↵  ·  esc
- *   narrow (else):      ⌃↵  ·  esc
+ *   wide   (≥ widest):  tab next  ·  shift+tab prev  ·  ctrl+x run  ·  esc cancel
+ *   medium (≥ keys):    tab  ·  shift+tab  ·  ctrl+x  ·  esc
+ *   tight  (≥ short):   tab  ·  ⇧tab  ·  ctrl+x  ·  esc
+ *   narrow (else):      ctrl+x  ·  esc
  */
 function renderFooterHints(width: number, theme: GraphTheme, submitDisabled: boolean): string {
   const sep = dimSep(theme);
@@ -735,23 +735,23 @@ function renderFooterHints(width: number, theme: GraphTheme, submitDisabled: boo
   const wide = [
     { width: 8, render: () => hint("tab", "Next") },
     { width: 14, render: () => hint("shift+tab", "Prev") },
-    { width: 14, render: () => hint("ctrl+enter", "Run", submitColor, submitLabelColor) },
+    { width: 10, render: () => hint("ctrl+x", "Run", submitColor, submitLabelColor) },
     { width: 10, render: () => hint("esc", "Cancel") },
   ];
   const medium = [
     { width: 3, render: () => keyOnly("tab") },
     { width: 9, render: () => keyOnly("shift+tab") },
-    { width: 10, render: () => keyOnly("ctrl+enter", submitColor) },
+    { width: 6, render: () => keyOnly("ctrl+x", submitColor) },
     { width: 6, render: () => keyOnly("esc") },
   ];
   const tight = [
     { width: 3, render: () => keyOnly("tab") },
     { width: 4, render: () => keyOnly("⇧tab") },
-    { width: 2, render: () => keyOnly("⌃↵", submitColor) },
+    { width: 6, render: () => keyOnly("ctrl+x", submitColor) },
     { width: 6, render: () => keyOnly("esc") },
   ];
   const narrow = [
-    { width: 2, render: () => keyOnly("⌃↵", submitColor) },
+    { width: 6, render: () => keyOnly("ctrl+x", submitColor) },
     { width: 6, render: () => keyOnly("esc") },
   ];
 
@@ -762,7 +762,7 @@ function renderFooterHints(width: number, theme: GraphTheme, submitDisabled: boo
     }
   }
   // Truly tiny terminal — show just the run+cancel keys joined by a single space.
-  return paint("⌃↵", submitColor) + " " + paint("esc", theme.text);
+  return paint("ctrl+x", submitColor) + " " + paint("esc", theme.text);
 }
 
 /**
@@ -827,7 +827,7 @@ function shortVal(s: string): string {
  *   left / right     — select: cycle choices; boolean: flip; text: caret
  *   space            — boolean: flip
  *   enter            — text: newline; otherwise: next field
- *   ctrl+enter       — open confirm modal (if all required filled)
+ *   ctrl+x       — open confirm modal (if all required filled)
  *   backspace        — delete char left of caret
  *   esc / ctrl+c     — close picker without running
  *
@@ -860,7 +860,7 @@ function handleFormKey(
 ): InputsPickerAction {
   // ── Global navigation (workflow form contract, not Pi actions) ──
   if (isCancelKey(key)) return { kind: "cancel" };
-  if (matchesKey(key, "ctrl+enter")) return attemptPickerSubmit(state, fields);
+  if (matchesKey(key, "ctrl+x")) return attemptPickerSubmit(state, fields);
   if (matchesKey(key, "tab")) {
     moveFocus(state, fields, +1);
     return { kind: "noop" };

--- a/packages/workflows/src/tui/inputs-picker.ts
+++ b/packages/workflows/src/tui/inputs-picker.ts
@@ -40,7 +40,7 @@
 import type { WorkflowInputEntry } from "../extension/render-result.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { paint } from "./color-utils.js";
-import { matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
+import { decodePrintableKey, matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
 import {
   type KeybindingsLike,
   deleteRange,
@@ -989,11 +989,13 @@ function handleFormKey(
     }
     return { kind: "noop" };
   }
-  // Printable insert. Accept exactly one grapheme cluster so CJK, emoji ZWJ
-  // sequences, and combining-mark input follow pi-tui Input semantics.
-  if (isPrintableGrapheme(key)) {
-    state.rawText[name] = cur.slice(0, caret) + key + cur.slice(caret);
-    state.caret = caret + key.length;
+  // Printable insert. Accept raw graphemes and terminal-encoded printable
+  // keys (CSI-u / Kitty). VSCode's integrated terminal can emit printable
+  // keys as escape sequences when modifyOtherKeys is active.
+  const printable = decodePrintableKey(key) ?? key;
+  if (isPrintableGrapheme(printable)) {
+    state.rawText[name] = cur.slice(0, caret) + printable + cur.slice(caret);
+    state.caret = caret + printable.length;
     return { kind: "noop" };
   }
   return { kind: "noop" };

--- a/packages/workflows/src/tui/inputs-picker.ts
+++ b/packages/workflows/src/tui/inputs-picker.ts
@@ -1039,7 +1039,7 @@ function handleBooleanKey(
   kb: KeybindingsLike | undefined,
 ): InputsPickerAction {
   if (
-    key === " " ||
+    matchesKey(key, "space") ||
     matchesAction(kb, key, "tui.input.submit") ||
     matchesAction(kb, key, "tui.editor.cursorLeft") ||
     matchesAction(kb, key, "tui.editor.cursorRight")
@@ -1066,10 +1066,10 @@ function handleConfirmKey(
   // Confirm-modal answers are single-char prompts (`y`/`n`) plus the form's
   // raw esc/enter contract. These do not flow through Pi action ids because
   // they're a confirmation-modal contract, not an editor-mode action.
-  if (key === "y" || key === "Y" || key === "\r" || key === "\n") {
+  if (key === "y" || key === "Y" || matchesKey(key, "enter")) {
     return { kind: "run", values: coerceValues(fields, state.rawText) };
   }
-  if (key === "\x03") return { kind: "cancel" };
+  if (matchesKey(key, "ctrl+c")) return { kind: "cancel" };
   if (key === "n" || key === "N" || matchesKey(key, "escape")) {
     state.confirmOpen = false;
     return { kind: "noop" };
@@ -1078,7 +1078,7 @@ function handleConfirmKey(
 }
 
 function isCancelKey(key: string): boolean {
-  return key === "\x03" || matchesKey(key, "escape");
+  return matchesKey(key, "ctrl+c") || matchesKey(key, "escape");
 }
 
 function attemptPickerSubmit(

--- a/packages/workflows/src/tui/node-card.ts
+++ b/packages/workflows/src/tui/node-card.ts
@@ -26,6 +26,7 @@
  */
 
 import type { StageSnapshot, StageStatus } from "../shared/store-types.js";
+import { elapsedStageMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { fmtDuration, statusIcon } from "./status-helpers.js";
 import { lerpColor, hexToAnsi, hexBg, paint, RESET, BOLD } from "./color-utils.js";
@@ -111,9 +112,8 @@ function blockedBadgeText(
 }
 
 function durationText(stage: StageSnapshot): string {
-  if (stage.durationMs != null) return fmtDuration(stage.durationMs);
-  if (stage.startedAt != null) return fmtDuration(Date.now() - stage.startedAt);
-  return "—";
+  const elapsed = elapsedStageMs(stage);
+  return elapsed === undefined ? "—" : fmtDuration(elapsed);
 }
 
 function metaText(stage: StageSnapshot): string {

--- a/packages/workflows/src/tui/node-card.ts
+++ b/packages/workflows/src/tui/node-card.ts
@@ -253,8 +253,6 @@ export function renderNodeCard(stage: StageSnapshot, opts: NodeCardOpts): string
   const bodyText =
     stage.status === "blocked"
       ? blockedBadgeText(stage, opts.stages, innerWidth)
-      : stage.status === "paused"
-        ? "❚❚ paused"
       : durationText(stage);
   const bodyHex = durationColor(stage.status, theme);
   const statusText = `${statusIcon(stage.status)} ${statusLabel(stage.status)}`;

--- a/packages/workflows/src/tui/prompt-card.ts
+++ b/packages/workflows/src/tui/prompt-card.ts
@@ -99,7 +99,7 @@ export function handlePromptCardInput(
   data: string,
   state: PromptCardState,
 ): PromptCardAction {
-  if (data === "\x03" || matchesKey(data, "escape")) {
+  if (matchesKey(data, "ctrl+c") || matchesKey(data, "escape")) {
     return { kind: "cancel" };
   }
 
@@ -119,7 +119,7 @@ function handleConfirm(
   data: string,
   state: PromptCardState,
 ): PromptCardAction {
-  if (matchesKey(data, "left") || data === "\x1b[D" || matchesKey(data, "right") || data === "\x1b[C" || data === " " || matchesKey(data, "tab")) {
+  if (matchesKey(data, "left") || matchesKey(data, "right") || matchesKey(data, "space") || matchesKey(data, "tab")) {
     state.confirmValue = !state.confirmValue;
     return { kind: "noop" };
   }
@@ -129,7 +129,7 @@ function handleConfirm(
   if (data === "n" || data === "N") {
     return { kind: "submit", response: false };
   }
-  if (matchesKey(data, "enter") || data === "\r" || data === "\n") {
+  if (matchesKey(data, "enter")) {
     return { kind: "submit", response: state.confirmValue };
   }
   return { kind: "noop" };
@@ -138,7 +138,7 @@ function handleConfirm(
 function handleSelect(data: string, state: PromptCardState): PromptCardAction {
   const choices = state.prompt.choices ?? [];
   if (choices.length === 0) {
-    if (matchesKey(data, "enter") || data === "\r" || data === "\n") {
+    if (matchesKey(data, "enter")) {
       return { kind: "submit", response: "" };
     }
     return { kind: "noop" };
@@ -155,7 +155,7 @@ function handleSelect(data: string, state: PromptCardState): PromptCardAction {
 }
 
 function handleInput(data: string, state: PromptCardState): PromptCardAction {
-  if (matchesKey(data, "enter") || data === "\r" || data === "\n") {
+  if (matchesKey(data, "enter")) {
     return { kind: "submit", response: state.rawText };
   }
   return applyTextEdit(data, state);
@@ -172,7 +172,7 @@ function handleEditor(data: string, state: PromptCardState): PromptCardAction {
     }
     return { kind: "noop" };
   }
-  if (data === "\r" || data === "\n") {
+  if (matchesKey(data, "enter")) {
     state.rawText = state.rawText.slice(0, state.caret) + "\n" + state.rawText.slice(state.caret);
     state.caret += 1;
     return { kind: "noop" };
@@ -184,15 +184,15 @@ function applyTextEdit(
   data: string,
   state: PromptCardState,
 ): PromptCardAction {
-  if (data === "\x1b[D") {
+  if (matchesKey(data, "left")) {
     state.caret = previousGraphemeBoundary(state.rawText, state.caret);
     return { kind: "noop" };
   }
-  if (data === "\x1b[C") {
+  if (matchesKey(data, "right")) {
     state.caret = nextGraphemeBoundary(state.rawText, state.caret);
     return { kind: "noop" };
   }
-  if (data === "\x7f" || data === "\b") {
+  if (matchesKey(data, "backspace")) {
     if (state.caret > 0) {
       const prev = previousGraphemeBoundary(state.rawText, state.caret);
       state.rawText = state.rawText.slice(0, prev) + state.rawText.slice(state.caret);
@@ -335,8 +335,8 @@ function normalizeSelectKeyData(data: string): string {
   // The historical prompt card accepted left/right as select aliases; feed the
   // corresponding vertical key into pi-tui's SelectList so it owns the actual
   // wrap/clamp/selection update behavior.
-  if (matchesKey(data, "right") || data === "\x1b[C") return "\x1b[B";
-  if (matchesKey(data, "left") || data === "\x1b[D") return "\x1b[A";
+  if (matchesKey(data, "right")) return "\x1b[B";
+  if (matchesKey(data, "left")) return "\x1b[A";
   return data;
 }
 

--- a/packages/workflows/src/tui/run-detail.ts
+++ b/packages/workflows/src/tui/run-detail.ts
@@ -19,6 +19,7 @@
 
 import type { RunDetail } from "../runs/background/status.js";
 import type { StageSnapshot } from "../shared/store-types.js";
+import { elapsedRunMs, elapsedStageMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { renderBandHeader } from "./header.js";
 import type { BandBadge } from "./header.js";
@@ -201,7 +202,7 @@ function summaryRows(detail: RunDetail, now: number): Array<[string, string | un
   const startedAgo = formatRelative(now - detail.startedAt);
   const updatedAt = detail.endedAt ?? detail.startedAt;
   const updatedAgo = formatRelative(now - updatedAt);
-  const duration = detail.durationMs ?? (detail.endedAt !== undefined ? detail.endedAt - detail.startedAt : now - detail.startedAt);
+  const duration = elapsedRunMs(detail, now);
 
   const rows: Array<[string, string | undefined]> = [
     ["workflow", detail.name],
@@ -276,11 +277,8 @@ function stageLineThemed(stage: StageSnapshot, now: number, theme: GraphTheme, w
 }
 
 function stageDurationString(stage: StageSnapshot, now: number): string | undefined {
-  if (stage.durationMs !== undefined) return fmtDuration(stage.durationMs);
-  if (stage.startedAt !== undefined && stage.endedAt === undefined) {
-    return fmtDuration(now - stage.startedAt);
-  }
-  return undefined;
+  const elapsed = elapsedStageMs(stage, now);
+  return elapsed === undefined ? undefined : fmtDuration(elapsed);
 }
 
 function stageActivityString(stage: StageSnapshot): string | undefined {

--- a/packages/workflows/src/tui/session-confirm.ts
+++ b/packages/workflows/src/tui/session-confirm.ts
@@ -20,6 +20,7 @@
 
 import { keyText } from "@bastani/atomic";
 import type { RunSnapshot } from "../shared/store-types.js";
+import { elapsedRunMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { fmtDuration } from "./status-helpers.js";
 import { hexToAnsi, hexBg, RESET, BOLD } from "./color-utils.js";
@@ -117,9 +118,7 @@ export function renderKillConfirm(opts: KillConfirmRenderOpts): string[] {
   const inner = Math.max(50, width - 2);
 
   const idShort = run.id.slice(0, 8);
-  const elapsed = run.endedAt !== undefined
-    ? fmtDuration(run.durationMs ?? Math.max(0, run.endedAt - run.startedAt))
-    : fmtDuration(Math.max(0, now - run.startedAt));
+  const elapsed = fmtDuration(elapsedRunMs(run, now));
   const stagesRunning = run.stages.filter((s) => s.status === "running").length;
   const stagesTotal = run.stages.length;
 

--- a/packages/workflows/src/tui/session-confirm.ts
+++ b/packages/workflows/src/tui/session-confirm.ts
@@ -24,7 +24,7 @@ import { elapsedRunMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { fmtDuration } from "./status-helpers.js";
 import { hexToAnsi, hexBg, RESET, BOLD } from "./color-utils.js";
-import { truncateToWidth, visibleWidth } from "./text-helpers.js";
+import { matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
 
 export interface KillConfirmState {
   /** 0 = Cancel (focused by default), 1 = Kill. */
@@ -194,14 +194,14 @@ export function handleKillConfirmInput(
   // Direct shortcuts bypass focus.
   if (data === "y" || data === "Y") return { kind: "confirm" };
   if (data === "n" || data === "N") return { kind: "cancel" };
-  if (data === "\x1b") return { kind: "cancel" };
+  if (matchesKey(data, "escape")) return { kind: "cancel" };
 
   // Tab / arrows toggle focus.
-  if (data === "\t" || data === "\x1b[C" || data === "\x1b[D" || data === "h" || data === "l") {
+  if (matchesKey(data, "tab") || matchesKey(data, "right") || matchesKey(data, "left") || data === "h" || data === "l") {
     state.focusedButton = state.focusedButton === 0 ? 1 : 0;
     return { kind: "noop" };
   }
-  if (data === "\r" || data === "\n") {
+  if (matchesKey(data, "enter")) {
     return state.focusedButton === 1 ? { kind: "confirm" } : { kind: "cancel" };
   }
   return { kind: "noop" };

--- a/packages/workflows/src/tui/session-picker.ts
+++ b/packages/workflows/src/tui/session-picker.ts
@@ -19,6 +19,7 @@
  */
 
 import type { RunSnapshot } from "../shared/store-types.js";
+import { elapsedRunMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { keyText } from "@bastani/atomic";
 import { fmtDuration, statusIcon, statusColor } from "./status-helpers.js";
@@ -206,13 +207,7 @@ function renderFilterRow(inner: number, theme: GraphTheme, state: SessionPickerS
 }
 
 function fmtElapsed(run: RunSnapshot, now: number): string {
-  if (run.endedAt !== undefined && run.durationMs !== undefined) {
-    return fmtDuration(run.durationMs);
-  }
-  if (run.endedAt !== undefined) {
-    return fmtDuration(Math.max(0, run.endedAt - run.startedAt));
-  }
-  return fmtDuration(Math.max(0, now - run.startedAt));
+  return fmtDuration(elapsedRunMs(run, now));
 }
 
 function stageProgress(run: RunSnapshot): string {

--- a/packages/workflows/src/tui/session-picker.ts
+++ b/packages/workflows/src/tui/session-picker.ts
@@ -24,7 +24,7 @@ import type { GraphTheme } from "./graph-theme.js";
 import { keyText } from "@bastani/atomic";
 import { fmtDuration, statusIcon, statusColor } from "./status-helpers.js";
 import { hexToAnsi, hexBg, RESET, BOLD } from "./color-utils.js";
-import { truncateToWidth, visibleWidth } from "./text-helpers.js";
+import { matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
 
 // ---------------------------------------------------------------------------
 // State + filtering
@@ -342,15 +342,15 @@ export function handleSessionPickerInput(
 ): SessionPickerAction {
   // Filter mode — typed chars feed the query, Enter/Esc exit.
   if (state.filterFocused) {
-    if (data === "\x1b" || data === "\x1b\x1b") {
+    if (matchesKey(data, "escape") || data === "\x1b\x1b") {
       state.filterFocused = false;
       return { kind: "noop" };
     }
-    if (data === "\r" || data === "\n") {
+    if (matchesKey(data, "enter")) {
       state.filterFocused = false;
       return { kind: "noop" };
     }
-    if (data === "\x7f" || data === "\b") {
+    if (matchesKey(data, "backspace")) {
       state.query = state.query.slice(0, -1);
       state.selectedIndex = 0;
       return { kind: "noop" };
@@ -368,7 +368,7 @@ export function handleSessionPickerInput(
     state.filterFocused = true;
     return { kind: "noop" };
   }
-  if (data === "\x1b") return { kind: "close" };
+  if (matchesKey(data, "escape")) return { kind: "close" };
   if (data === "q" || data === "Q") return { kind: "close" };
   if (data === "a" || data === "A") {
     state.includeAll = !state.includeAll;
@@ -377,17 +377,17 @@ export function handleSessionPickerInput(
   }
 
   // Arrows + j/k.
-  if (data === "\x1b[B" || data === "j") {
+  if (matchesKey(data, "down") || data === "j") {
     state.selectedIndex = Math.min(state.selectedIndex + 1, Math.max(0, rows.length - 1));
     return { kind: "noop" };
   }
-  if (data === "\x1b[A" || data === "k") {
+  if (matchesKey(data, "up") || data === "k") {
     if (rows.length > 0 && state.selectedIndex === 0) return { kind: "noop" };
     state.selectedIndex = Math.max(state.selectedIndex - 1, 0);
     return { kind: "noop" };
   }
 
-  if (data === "\r" || data === "\n") {
+  if (matchesKey(data, "enter")) {
     const row = rows[state.selectedIndex];
     if (!row) return { kind: "noop" };
     return { kind: "connect", runId: row.run.id };

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -66,6 +66,7 @@ import type {
 } from "@earendil-works/pi-tui";
 import type { Store } from "../shared/store.js";
 import type { StageNotice, StageSnapshot } from "../shared/store-types.js";
+import { elapsedStageMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import type { StageControlHandle } from "../runs/foreground/stage-control-registry.js";
 import { BOLD, RESET, hexBg, hexToAnsi, lerpColor } from "./color-utils.js";
@@ -1462,10 +1463,9 @@ function tailStreamingText(text: string): string {
 }
 
 function stageDurationText(stage: StageSnapshot | undefined): string {
-  if (!stage?.startedAt) return "";
-  const end = stage.endedAt ?? Date.now();
-  const ms = Math.max(0, end - stage.startedAt);
-  return formatDuration(ms);
+  if (!stage) return "";
+  const elapsed = elapsedStageMs(stage);
+  return elapsed === undefined ? "" : formatDuration(elapsed);
 }
 
 function formatDuration(ms: number): string {

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -951,7 +951,7 @@ export class StageChatView implements Component, Focusable {
     if (this.bodyViewport.handleInput(data)) {
       return true;
     }
-    if (data === "\x04") {
+    if (matchesKey(data, "ctrl+d")) {
       if (this._isPaused()) this.onClose();
       else this.onDetach();
       return true;

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -22,7 +22,8 @@
  *  - **Escape** mirrors the main coding-agent chat interrupt path for active
  *    live stages: it requests a controlled pause/abort while keeping the
  *    composer active. While paused, Enter calls `handle.resume(text)`.
- *  - **Ctrl+D** detaches (back to graph); **Escape** closes the popup when idle.
+ *  - **Ctrl+D** detaches (back to graph), or closes the popup while paused;
+ *    **Escape** closes the popup when idle.
  *  - **Blocked** stage: keystrokes absorbed; BLOCKED banner names the
  *    upstream awaiter.
  *  - **Settled** stage with a live handle remains a normal chat session:
@@ -86,7 +87,7 @@ export interface StageChatViewOpts {
    * inspect-only (settled stage with no live handle).
    */
   handle?: StageControlHandle;
-  /** Called when the user presses Ctrl+D (back to graph). */
+  /** Called when the user presses Ctrl+D outside a paused stage (back to graph). */
   onDetach: () => void;
   /** Called when the user presses Escape (close the whole popup). */
   onClose: () => void;
@@ -950,7 +951,8 @@ export class StageChatView implements Component, Focusable {
       return true;
     }
     if (data === "\x04") {
-      this.onDetach();
+      if (this._isPaused()) this.onClose();
+      else this.onDetach();
       return true;
     }
     if (matchesKey(data, "escape")) {

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -964,12 +964,12 @@ export class StageChatView implements Component, Focusable {
       }
       return true;
     }
-    if (data === "\x03") {
+    if (matchesKey(data, "ctrl+c")) {
       this.onClose();
       return true;
     }
     const blocked = this._isBlocked();
-    if (data === "\x06") {
+    if (matchesKey(data, "ctrl+f")) {
       if (blocked) return true;
       void this._submit("followUp");
       return true;
@@ -979,12 +979,12 @@ export class StageChatView implements Component, Focusable {
       this.editor.handleInput(data);
       return true;
     }
-    if (data === "\r" || data === "\n") {
+    if (matchesKey(data, "enter")) {
       if (blocked) return true;
       void this._submit("auto");
       return true;
     }
-    if (data === "\x7f" || data === "\b") {
+    if (matchesKey(data, "backspace")) {
       if (blocked) return true;
       this.inputBuffer = this.inputBuffer.slice(0, -1);
       return true;

--- a/packages/workflows/src/tui/status-list.ts
+++ b/packages/workflows/src/tui/status-list.ts
@@ -27,6 +27,7 @@
  */
 
 import type { RunSnapshot, StageSnapshot, StageStatus } from "../shared/store-types.js";
+import { elapsedRunMs, elapsedStageMs } from "../shared/timing.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { fmtDuration } from "./status-helpers.js";
 import {
@@ -211,7 +212,7 @@ function runCardMeta(run: RunSnapshot, now: number): string {
   const ago = run.endedAt !== undefined
     ? `${fmtDuration(now - run.endedAt)} ago`
     : run.startedAt != null
-      ? fmtDuration(now - run.startedAt)
+      ? fmtDuration(elapsedRunMs(run, now))
       : undefined;
 
   if (run.status === "running") {
@@ -264,11 +265,8 @@ function lastStageDuration(run: RunSnapshot, now: number): string | undefined {
 }
 
 function stageDurationString(stage: StageSnapshot, now: number): string | undefined {
-  if (stage.durationMs !== undefined) return fmtDuration(stage.durationMs);
-  if (stage.startedAt !== undefined && stage.endedAt === undefined) {
-    return fmtDuration(now - stage.startedAt);
-  }
-  return undefined;
+  const elapsed = elapsedStageMs(stage, now);
+  return elapsed === undefined ? undefined : fmtDuration(elapsed);
 }
 
 function stageCells(run: RunSnapshot): Array<{ status: StageStatus }> {

--- a/packages/workflows/src/tui/text-helpers.ts
+++ b/packages/workflows/src/tui/text-helpers.ts
@@ -4,6 +4,7 @@ import {
   visibleWidth,
   type KeyId,
 } from "@earendil-works/pi-tui";
+import { decodePrintableKey as piDecodePrintableKey } from "@earendil-works/pi-tui/dist/keys.js";
 
 export { visibleWidth };
 
@@ -36,6 +37,11 @@ export function truncateToWidth(
 /** Use pi-tui's key parser/matcher while preserving the local string API. */
 export function matchesKey(data: string, key: string): boolean {
   return piMatchesKey(data, key as KeyId);
+}
+
+/** Decode CSI-u / Kitty printable-key sequences emitted by terminals such as VSCode. */
+export function decodePrintableKey(data: string): string | undefined {
+  return piDecodePrintableKey(data);
 }
 
 export function sliceColumns(

--- a/packages/workflows/src/tui/widget.ts
+++ b/packages/workflows/src/tui/widget.ts
@@ -29,6 +29,7 @@ import type {
   StoreSnapshot,
   RunSnapshot,
 } from "../shared/store-types.js";
+import { elapsedRunMs } from "../shared/timing.js";
 import type { PiTheme } from "./store-widget-installer.js";
 import { renderBandHeader } from "./header.js";
 import type { BandBadge } from "./header.js";
@@ -166,7 +167,7 @@ function elapsedLabel(run: RunSnapshot, now: number): string {
     if (run.status === "killed") return `killed · ${ago} ago`;
     return `${run.status} · ${ago} ago`;
   }
-  if (run.startedAt != null) return formatDuration(now - run.startedAt);
+  if (run.startedAt != null) return formatDuration(elapsedRunMs(run, now));
   return "";
 }
 

--- a/packages/workflows/src/tui/workflow-attach-pane.ts
+++ b/packages/workflows/src/tui/workflow-attach-pane.ts
@@ -5,7 +5,8 @@
  * between the orchestrator `GraphView` and a stage-scoped
  * `StageChatView`. Pressing Enter on a graph node attaches the popup
  * to that node's chat; Ctrl+D in chat mode swaps back to graph mode
- * with the same node still focused (see ui/attach-mockup.html).
+ * with the same node still focused (see ui/attach-mockup.html), except
+ * paused stage chats close the pane to mirror shell EOF semantics.
  *
  * The shell never remounts the overlay — it only flips a `mode`
  * field and re-renders, so the popup stays in pi-tui's overlay layer

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -111,7 +111,8 @@ test("card (live): shows header pill, workflow chip, all fields, footer hints", 
   assert.doesNotMatch(txt, /Run workflow/);
   assert.match(txt, /EDIT/);
   assert.match(txt, /tab/);
-  assert.match(txt, /ctrl\+enter/);
+  assert.match(txt, /ctrl\+x/);
+  assert.doesNotMatch(txt, /ctrl\+enter/);
   assert.doesNotMatch(txt, /ctrl\+s/);
 });
 
@@ -269,24 +270,26 @@ test("editor: esc variants and ctrl+c fire onExit('cancel')", () => {
   }
 });
 
-test("editor: ctrl+enter with missing required is blocked and focuses invalid", () => {
+test("editor: ctrl+x with missing required is blocked and focuses invalid", () => {
   const e = makeEditor(); // prompt is empty
   e.state.focusedIdx = 2;
-  e.editor.handleInput("\x1b[13;5u");
+  e.editor.handleInput("\x18");
   assert.equal(e.getExited(), null);
   assert.equal(e.state.focusedIdx, 0);
   e.dispose();
 });
 
-test("editor: ctrl+enter with all required filled fires onExit('submit')", () => {
-  const state = makeState({
-    focusedIdx: 0,
-    rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
-  });
-  const e = makeEditor(state);
-  e.editor.handleInput("\x1b[13;5u");
-  assert.deepEqual(e.getExited(), { outcome: "submit" });
-  e.dispose();
+test("editor: ctrl+x with all required filled fires onExit('submit')", () => {
+  for (const key of ["\x18", "\x1b[120;5u"]) {
+    const state = makeState({
+      focusedIdx: 0,
+      rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
+    });
+    const e = makeEditor(state);
+    e.editor.handleInput(key);
+    assert.deepEqual(e.getExited(), { outcome: "submit" }, `key=${JSON.stringify(key)}`);
+    e.dispose();
+  }
 });
 
 test("editor: select field arrow keys cycle, space cycles", () => {
@@ -474,7 +477,7 @@ test("overlay: openInlineInputsForm emits a custom message and swaps editor", as
   // Fill required prompt and submit.
   editor.handleInput("h");
   editor.handleInput("i");
-  editor.handleInput("\x1b[13;5u");
+  editor.handleInput("\x18");
   const result = await pending;
   assert.equal(result.kind, "run");
   if (result.kind === "run") {
@@ -564,7 +567,7 @@ test("overlay: installed editor accepts pi setup before card render", async () =
   assert.equal(editor.getAutocompleteMaxVisible(), 20);
   editor.handleInput("o");
   editor.handleInput("k");
-  editor.handleInput("\x1b[13;5u");
+  editor.handleInput("\x18");
   const result = await pending;
   assert.equal(result.kind, "run");
 });
@@ -1200,7 +1203,7 @@ test("editor: char movement and deletion respect emoji and combining graphemes",
 });
 
 test("editor: user-remapped delete word backward respects injected keybindings", () => {
-  // Drop ctrl+w; remap deleteWordBackward to a hypothetical ctrl+x sequence
+  // Drop ctrl+w; remap deleteWordBackward to a hypothetical ctrl+t sequence
   // and verify the form picks up the new binding via the injected manager.
   const state = makeState({
     rawText: { prompt: "one two", iters: "5", focus: "standard", verbose: "false" },
@@ -1213,11 +1216,11 @@ test("editor: user-remapped delete word backward respects injected keybindings",
     formId: state.formId,
     theme: deriveGraphTheme({}),
     keybindings: makeFakeKeybindings({
-      "tui.editor.deleteWordBackward": ["\x18"], // ctrl+x
+      "tui.editor.deleteWordBackward": ["\x14"], // ctrl+t
     }),
     onExit: (outcome) => { exited = { outcome }; },
   });
-  editor.handleInput("\x18"); // ctrl+x → delete word backward under override
+  editor.handleInput("\x14"); // ctrl+t → delete word backward under override
   assert.equal(state.rawText.prompt, "one ");
   assert.equal(state.caret, 4);
   // Default ctrl+w should NOT trigger the action now (overridden table).

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -251,6 +251,21 @@ test("editor: typing a char inserts at caret on the focused text field", () => {
   e.dispose();
 });
 
+test("editor: accepts encoded printable key sequences", () => {
+  for (const [key, expected] of [
+    ["\x1b[98;1u", "b"], // Kitty / CSI-u plain b
+    ["\x1b[65;2u", "A"], // Kitty / CSI-u shifted A
+    ["\x1b[27;1;98~", "b"], // xterm modifyOtherKeys plain b
+    ["\x1b[27;2;65~", "A"], // xterm modifyOtherKeys shifted A
+  ] as const) {
+    const e = makeEditor();
+    e.editor.handleInput(key);
+    assert.equal(e.state.rawText.prompt, expected, `key=${JSON.stringify(key)}`);
+    assert.equal(e.state.caret, expected.length, `key=${JSON.stringify(key)}`);
+    e.dispose();
+  }
+});
+
 test("editor: tab advances focus, shift+tab retreats", () => {
   const e = makeEditor();
   assert.equal(e.state.focusedIdx, 0);

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -276,8 +276,16 @@ test("editor: tab advances focus, shift+tab retreats", () => {
   e.dispose();
 });
 
-test("editor: esc variants and ctrl+c fire onExit('cancel')", () => {
-  for (const key of ["\x1b", "\x1b[27u", "\x1b[27;1;27~", "\x03"]) {
+test("editor: esc variants and ctrl+c variants fire onExit('cancel')", () => {
+  for (const key of [
+    "\x1b",
+    "\x1b[27u",
+    "\x1b[27;1;27~",
+    "\x03",
+    "\x1b[99;5u",
+    "\x1b[99;5:1u",
+    "\x1b[27;5;99~",
+  ]) {
     const e = makeEditor();
     e.editor.handleInput(key);
     assert.deepEqual(e.getExited(), { outcome: "cancel" }, `key=${JSON.stringify(key)}`);

--- a/test/unit/inputs-picker.test.ts
+++ b/test/unit/inputs-picker.test.ts
@@ -153,22 +153,24 @@ test("esc variants and ctrl+c cancel from form mode", () => {
   }
 });
 
-test("ctrl+enter with missing required fields opens no modal and focuses invalid", () => {
+test("ctrl+x with missing required fields opens no modal and focuses invalid", () => {
   const s = createInputsPickerState(FIELDS);
   s.focusedIdx = 2;
   // prompt is empty (required) — submit should be blocked.
-  const a = handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
+  const a = handleInputsPickerInput("\x18", s, FIELDS, KB);
   assert.deepEqual(a, { kind: "noop" });
   assert.equal(s.confirmOpen, false);
   assert.equal(s.focusedIdx, 0); // jumped to first invalid field
   assert.deepEqual(s.invalidIndices, [0]);
 });
 
-test("ctrl+enter with all required filled opens confirm modal", () => {
-  const s = createInputsPickerState(FIELDS, { prompt: "build something" });
-  s.focusedIdx = 0;
-  handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
-  assert.equal(s.confirmOpen, true);
+test("ctrl+x with all required filled opens confirm modal", () => {
+  for (const key of ["\x18", "\x1b[120;5u"]) {
+    const s = createInputsPickerState(FIELDS, { prompt: "build something" });
+    s.focusedIdx = 0;
+    handleInputsPickerInput(key, s, FIELDS, KB);
+    assert.equal(s.confirmOpen, true, `key=${JSON.stringify(key)}`);
+  }
 });
 
 test("confirm modal: y returns coerced values; n returns to form", () => {
@@ -176,14 +178,14 @@ test("confirm modal: y returns coerced values; n returns to form", () => {
   s.rawText.iters = "8";
   s.rawText.verbose = "true";
   s.focusedIdx = 1;
-  handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
+  handleInputsPickerInput("\x18", s, FIELDS, KB);
   assert.equal(s.confirmOpen, true);
   // n returns to form
   const back = handleInputsPickerInput("n", s, FIELDS, KB);
   assert.deepEqual(back, { kind: "noop" });
   assert.equal(s.confirmOpen, false);
   // Reopen and confirm
-  handleInputsPickerInput("\x1b[13;5u", s, FIELDS, KB);
+  handleInputsPickerInput("\x18", s, FIELDS, KB);
   const run = handleInputsPickerInput("y", s, FIELDS, KB);
   assert.equal(run.kind, "run");
   if (run.kind === "run") {
@@ -257,7 +259,8 @@ test("renderInputsPicker emits header, section label, fields, and hints", () => 
   assert.match(joined, /verbose/);
   assert.doesNotMatch(joined, /Run workflow/);
   assert.match(joined, /tab/);
-  assert.match(joined, /ctrl\+enter/);
+  assert.match(joined, /ctrl\+x/);
+  assert.doesNotMatch(joined, /ctrl\+enter/);
   assert.doesNotMatch(joined, /ctrl\+s/);
   assert.match(joined, /esc/);
 });
@@ -395,8 +398,8 @@ test("renderInputsPicker stays well-formed across a wide range of widths (resize
 test("renderInputsPicker footer degrades gracefully on narrow terminals", () => {
   // Wide: all 4 hints with labels.
   // Medium: keys with labels but shorter — `prev`/`cancel` drop out.
-  // Tight: keys only, including compact `⇧tab` / `⌃↵`.
-  // Narrow: only the essentials — `⌃↵` and `esc`.
+  // Tight: keys only, including compact `⇧tab`.
+  // Narrow: only the essentials — `ctrl+x` and `esc`.
   const theme = deriveGraphTheme({});
   const state = createInputsPickerState(FIELDS);
   // eslint-disable-next-line no-control-regex
@@ -423,7 +426,8 @@ test("renderInputsPicker footer degrades gracefully on narrow terminals", () => 
   const wide = renderAt(120);
   assert.match(wide, /tab Next/);
   assert.match(wide, /shift\+tab Prev/);
-  assert.match(wide, /ctrl\+enter Run/);
+  assert.match(wide, /ctrl\+x Run/);
+  assert.doesNotMatch(wide, /ctrl\+enter/);
   assert.match(wide, /esc Cancel/);
 
   // Medium — keys only, but full key names.
@@ -435,13 +439,13 @@ test("renderInputsPicker footer degrades gracefully on narrow terminals", () => 
   // Tight — compact glyphs.
   const tight = renderAt(35);
   assert.match(tight, /⇧tab/);
-  assert.match(tight, /⌃↵/);
+  assert.match(tight, /ctrl\+x/);
   assert.match(tight, /esc/);
   assert.doesNotMatch(tight, /shift\+tab/);
 
   // Narrow — essentials only.
   const narrow = renderAt(12);
-  assert.match(narrow, /⌃↵/);
+  assert.match(narrow, /ctrl\+x/);
   assert.match(narrow, /esc/);
   assert.doesNotMatch(narrow, /tab/);
 });
@@ -550,11 +554,11 @@ test("picker: ctrl+d deletes the char right of the caret", () => {
 
 test("picker: user-remapped delete word backward respects injected keybindings", () => {
   const kb = makeFakeKeybindings({
-    "tui.editor.deleteWordBackward": ["\x18"], // ctrl+x
+    "tui.editor.deleteWordBackward": ["\x14"], // ctrl+t
   });
   const s = createInputsPickerState(FIELDS, { prompt: "one two" });
   s.caret = 7;
-  handleInputsPickerInput("\x18", s, FIELDS, kb);
+  handleInputsPickerInput("\x14", s, FIELDS, kb);
   assert.equal(s.rawText.prompt, "one ");
   assert.equal(s.caret, 4);
   // Original ctrl+w no longer triggers the action under override.

--- a/test/unit/inputs-picker.test.ts
+++ b/test/unit/inputs-picker.test.ts
@@ -95,6 +95,20 @@ test("text field: typing inserts characters, backspace removes", () => {
   assert.equal(s.caret, 1);
 });
 
+test("text field accepts encoded printable key sequences", () => {
+  for (const [key, expected] of [
+    ["\x1b[98;1u", "b"], // Kitty / CSI-u plain b
+    ["\x1b[65;2u", "A"], // Kitty / CSI-u shifted A
+    ["\x1b[27;1;98~", "b"], // xterm modifyOtherKeys plain b
+    ["\x1b[27;2;65~", "A"], // xterm modifyOtherKeys shifted A
+  ] as const) {
+    const s = createInputsPickerState(FIELDS);
+    handleInputsPickerInput(key, s, FIELDS, KB);
+    assert.equal(s.rawText.prompt, expected, `key=${JSON.stringify(key)}`);
+    assert.equal(s.caret, expected.length, `key=${JSON.stringify(key)}`);
+  }
+});
+
 test("text field: CJK, emoji, and combining-mark edits move by grapheme", () => {
   const s = createInputsPickerState(FIELDS);
   handleInputsPickerInput("漢", s, FIELDS, KB);

--- a/test/unit/inputs-picker.test.ts
+++ b/test/unit/inputs-picker.test.ts
@@ -159,8 +159,16 @@ test("boolean field: space and arrows flip", () => {
   assert.equal(s.rawText.verbose, "false");
 });
 
-test("esc variants and ctrl+c cancel from form mode", () => {
-  for (const key of ["\x1b", "\x1b[27u", "\x1b[27;1;27~", "\x03"]) {
+test("esc variants and ctrl+c variants cancel from form mode", () => {
+  for (const key of [
+    "\x1b",
+    "\x1b[27u",
+    "\x1b[27;1;27~",
+    "\x03",
+    "\x1b[99;5u",
+    "\x1b[99;5:1u",
+    "\x1b[27;5;99~",
+  ]) {
     const state = createInputsPickerState(FIELDS);
     const action = handleInputsPickerInput(key, state, FIELDS, KB);
     assert.deepEqual(action, { kind: "cancel" }, `key=${JSON.stringify(key)}`);

--- a/test/unit/node-card.test.ts
+++ b/test/unit/node-card.test.ts
@@ -241,6 +241,15 @@ describe("renderNodeCard — status border colours", () => {
     assert.match(row, /↑ blocked/);
     assert.doesNotMatch(row, /very-long-upstream-stage/);
   });
+
+  test("paused status renders a single pause icon", () => {
+    const lines = renderNodeCard(makeStage({ status: "paused" }), { theme });
+    const rendered = stripAnsi(lines.join("\n"));
+    const pauseIconCount = rendered.match(/❚❚/g)?.length ?? 0;
+
+    assert.equal(pauseIconCount, 1);
+    assert.match(rendered, /❚❚ paused/);
+  });
 });
 
 describe("renderNodeCard — duration line", () => {

--- a/test/unit/node-card.test.ts
+++ b/test/unit/node-card.test.ts
@@ -36,7 +36,10 @@ function makeStage(opts: Partial<StageSnapshot> = {}): StageSnapshot {
     parentIds: opts.parentIds ?? [],
     toolEvents: opts.toolEvents ?? [],
     durationMs: opts.durationMs,
+    pausedDurationMs: opts.pausedDurationMs,
     startedAt: opts.startedAt,
+    pausedAt: opts.pausedAt,
+    resumedAt: opts.resumedAt,
     blockedByStageId: opts.blockedByStageId,
   };
 }
@@ -267,5 +270,32 @@ describe("renderNodeCard — duration line", () => {
     const body = stripAnsi(lines[1]!);
     // fmtDuration(65000) → "1m 5s" (per status-helpers.ts).
     assert.match(body, /1m 5s/);
+  });
+
+  test("freezes the duration line while paused and resumes active elapsed time", () => {
+    const originalNow = Date.now;
+    try {
+      Date.now = () => 71_000;
+      const paused = renderNodeCard(
+        makeStage({ status: "paused", startedAt: 1_000, pausedAt: 11_000 }),
+        { theme },
+      );
+      assert.match(stripAnsi(paused[1]!), /10s/);
+      assert.doesNotMatch(stripAnsi(paused[1]!), /1m/);
+
+      Date.now = () => 76_000;
+      const resumed = renderNodeCard(
+        makeStage({
+          status: "running",
+          startedAt: 1_000,
+          pausedDurationMs: 60_000,
+          resumedAt: 71_000,
+        }),
+        { theme },
+      );
+      assert.match(stripAnsi(resumed[1]!), /15s/);
+    } finally {
+      Date.now = originalNow;
+    }
   });
 });

--- a/test/unit/overlay-graph.test.ts
+++ b/test/unit/overlay-graph.test.ts
@@ -627,6 +627,33 @@ describe("GraphView keyboard navigation", () => {
     view.dispose();
   });
 
+  it("Ctrl+D variants detach in overlay graph mode", () => {
+    const ctrlDVariants = [
+      "\x04",
+      "\x1b[100;5u",
+      "\x1b[100;5:1u",
+      "\x1b[27;5;100~",
+    ];
+
+    for (const key of ctrlDVariants) {
+      const snap = makeSnap([makeStage("A")]);
+      const store = makeStore(snap);
+      let detached = 0;
+      const view = new GraphView({
+        mode: "overlay",
+        runId: "run-1",
+        store,
+        graphTheme: defaultTheme,
+        onDetach: () => {
+          detached += 1;
+        },
+      });
+      view.handleInput(key);
+      assert.equal(detached, 1, JSON.stringify(key));
+      view.dispose();
+    }
+  });
+
   it("render returns lines in overlay mode", () => {
     const stages = [makeStage("A"), makeStage("B", ["A"])];
     const view = makeView(stages);

--- a/test/unit/overlay-graph.test.ts
+++ b/test/unit/overlay-graph.test.ts
@@ -442,14 +442,23 @@ describe("GraphView keyboard navigation", () => {
     view.dispose();
   });
 
-  it("Escape variants and Ctrl+C call onClose", () => {
+  it("Escape variants and Ctrl+C variants call onClose", () => {
     const stages = [makeStage("A")];
     const onClose = mock(() => {});
     const view = makeView(stages, onClose);
-    for (const key of ["\x1b", "\x1b[27u", "\x1b[27;1;27~", "\x03"]) {
+    const closeKeys = [
+      "\x1b",
+      "\x1b[27u",
+      "\x1b[27;1;27~",
+      "\x03",
+      "\x1b[99;5u",
+      "\x1b[99;5:1u",
+      "\x1b[27;5;99~",
+    ];
+    for (const key of closeKeys) {
       view.handleInput(key);
     }
-    assert.equal(onClose.mock.calls.length, 4);
+    assert.equal(onClose.mock.calls.length, closeKeys.length);
     view.dispose();
   });
 

--- a/test/unit/prompt-card.test.ts
+++ b/test/unit/prompt-card.test.ts
@@ -69,8 +69,16 @@ describe("handlePromptCardInput — confirm", () => {
     assert.deepEqual(handlePromptCardInput("\r", state), { kind: "submit", response: true });
   });
 
-  test("esc variants and ctrl+c cancel", () => {
-    for (const key of ["\x1b", "\x1b[27u", "\x1b[27;1;27~", "\x03"]) {
+  test("esc variants and ctrl+c variants cancel", () => {
+    for (const key of [
+      "\x1b",
+      "\x1b[27u",
+      "\x1b[27;1;27~",
+      "\x03",
+      "\x1b[99;5u",
+      "\x1b[99;5:1u",
+      "\x1b[27;5;99~",
+    ]) {
       const state = createPromptCardState(makePrompt({ kind: "confirm" }));
       assert.deepEqual(handlePromptCardInput(key, state), { kind: "cancel" }, `key=${JSON.stringify(key)}`);
     }

--- a/test/unit/session-confirm-list.test.ts
+++ b/test/unit/session-confirm-list.test.ts
@@ -28,12 +28,14 @@ function makeRun(over: Partial<RunSnapshot>): RunSnapshot {
   };
 }
 
-test("kill confirm: y always confirms, n / esc cancels", () => {
+test("kill confirm: y always confirms, n / esc variants cancel", () => {
   const s = createKillConfirmState();
   assert.deepEqual(handleKillConfirmInput("y", s), { kind: "confirm" });
   assert.deepEqual(handleKillConfirmInput("Y", s), { kind: "confirm" });
   assert.deepEqual(handleKillConfirmInput("n", s), { kind: "cancel" });
-  assert.deepEqual(handleKillConfirmInput("\x1b", s), { kind: "cancel" });
+  for (const key of ["\x1b", "\x1b[27u", "\x1b[27;1;27~"]) {
+    assert.deepEqual(handleKillConfirmInput(key, s), { kind: "cancel" }, JSON.stringify(key));
+  }
 });
 
 test("kill confirm: tab toggles focus, enter commits focused button", () => {

--- a/test/unit/session-picker.test.ts
+++ b/test/unit/session-picker.test.ts
@@ -95,6 +95,15 @@ test("handleSessionPickerInput: / enters filter mode and types into query", () =
   assert.equal(state.filterFocused, false);
 });
 
+test("handleSessionPickerInput: double esc exits filter mode", () => {
+  const state = createSessionPickerState();
+  const rows = [{ run: makeRun({ id: "id-1" }), bucket: "active" as const }];
+  handleSessionPickerInput("/", state, rows);
+  assert.equal(state.filterFocused, true);
+  assert.deepEqual(handleSessionPickerInput("\x1b\x1b", state, rows), { kind: "noop" });
+  assert.equal(state.filterFocused, false);
+});
+
 test("handleSessionPickerInput: a toggles includeAll", () => {
   const state = createSessionPickerState();
   assert.equal(state.includeAll, false);
@@ -104,10 +113,12 @@ test("handleSessionPickerInput: a toggles includeAll", () => {
   assert.equal(state.includeAll, false);
 });
 
-test("handleSessionPickerInput: esc closes", () => {
-  const state = createSessionPickerState();
-  const action = handleSessionPickerInput("\x1b", state, []);
-  assert.deepEqual(action, { kind: "close" });
+test("handleSessionPickerInput: esc variants close", () => {
+  for (const key of ["\x1b", "\x1b[27u", "\x1b[27;1;27~"]) {
+    const state = createSessionPickerState();
+    const action = handleSessionPickerInput(key, state, []);
+    assert.deepEqual(action, { kind: "close" }, JSON.stringify(key));
+  }
 });
 
 test("renderSessionPicker emits header, sections, and footer hints", () => {

--- a/test/unit/stage-chat-view.test.ts
+++ b/test/unit/stage-chat-view.test.ts
@@ -655,6 +655,32 @@ describe("StageChatView", () => {
     view.dispose();
   });
 
+  test("Ctrl+D closes a paused stage chat", () => {
+    const store = createStore();
+    setupRun(store, "run-1", "stage-a", "paused");
+    const { handle } = makeHandle(undefined, [], "paused");
+    let detached = 0;
+    let closed = 0;
+    const view = new StageChatView({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageId: "stage-a",
+      workflowName: "test-wf",
+      handle,
+      onDetach: () => {
+        detached += 1;
+      },
+      onClose: () => {
+        closed += 1;
+      },
+    });
+    view.handleInput("\x04");
+    assert.equal(closed, 1);
+    assert.equal(detached, 0);
+    view.dispose();
+  });
+
   test("Escape variants on settled stages and Ctrl+C call onClose", () => {
     const store = createStore();
     setupRun(store, "run-1", "stage-a", "completed");

--- a/test/unit/stage-chat-view.test.ts
+++ b/test/unit/stage-chat-view.test.ts
@@ -676,52 +676,70 @@ describe("StageChatView", () => {
     view.dispose();
   });
 
-  test("Ctrl+D calls onDetach", () => {
-    const store = createStore();
-    setupRun(store, "run-1", "stage-a");
-    const { handle } = makeHandle();
-    let detached = 0;
-    const view = new StageChatView({
-      store,
-      graphTheme: deriveGraphTheme({}),
-      runId: "run-1",
-      stageId: "stage-a",
-      workflowName: "test-wf",
-      handle,
-      onDetach: () => {
-        detached += 1;
-      },
-      onClose: () => {},
-    });
-    view.handleInput("\x04");
-    assert.equal(detached, 1);
-    view.dispose();
+  test("Ctrl+D variants call onDetach", () => {
+    const ctrlDVariants = [
+      "\x04",
+      "\x1b[100;5u",
+      "\x1b[100;5:1u",
+      "\x1b[27;5;100~",
+    ];
+
+    for (const key of ctrlDVariants) {
+      const store = createStore();
+      setupRun(store, "run-1", "stage-a");
+      const { handle } = makeHandle();
+      let detached = 0;
+      const view = new StageChatView({
+        store,
+        graphTheme: deriveGraphTheme({}),
+        runId: "run-1",
+        stageId: "stage-a",
+        workflowName: "test-wf",
+        handle,
+        onDetach: () => {
+          detached += 1;
+        },
+        onClose: () => {},
+      });
+      view.handleInput(key);
+      assert.equal(detached, 1, JSON.stringify(key));
+      view.dispose();
+    }
   });
 
-  test("Ctrl+D closes a paused stage chat", () => {
-    const store = createStore();
-    setupRun(store, "run-1", "stage-a", "paused");
-    const { handle } = makeHandle(undefined, [], "paused");
-    let detached = 0;
-    let closed = 0;
-    const view = new StageChatView({
-      store,
-      graphTheme: deriveGraphTheme({}),
-      runId: "run-1",
-      stageId: "stage-a",
-      workflowName: "test-wf",
-      handle,
-      onDetach: () => {
-        detached += 1;
-      },
-      onClose: () => {
-        closed += 1;
-      },
-    });
-    view.handleInput("\x04");
-    assert.equal(closed, 1);
-    assert.equal(detached, 0);
-    view.dispose();
+  test("Ctrl+D variants close a paused stage chat", () => {
+    const ctrlDVariants = [
+      "\x04",
+      "\x1b[100;5u",
+      "\x1b[100;5:1u",
+      "\x1b[27;5;100~",
+    ];
+
+    for (const key of ctrlDVariants) {
+      const store = createStore();
+      setupRun(store, "run-1", "stage-a", "paused");
+      const { handle } = makeHandle(undefined, [], "paused");
+      let detached = 0;
+      let closed = 0;
+      const view = new StageChatView({
+        store,
+        graphTheme: deriveGraphTheme({}),
+        runId: "run-1",
+        stageId: "stage-a",
+        workflowName: "test-wf",
+        handle,
+        onDetach: () => {
+          detached += 1;
+        },
+        onClose: () => {
+          closed += 1;
+        },
+      });
+      view.handleInput(key);
+      assert.equal(closed, 1, JSON.stringify(key));
+      assert.equal(detached, 0, JSON.stringify(key));
+      view.dispose();
+    }
   });
 
   test("Escape variants on settled stages and Ctrl+C call onClose", () => {

--- a/test/unit/stage-chat-view.test.ts
+++ b/test/unit/stage-chat-view.test.ts
@@ -190,6 +190,49 @@ function assistantTextMessage(text: string): AgentSession["messages"][number] {
 }
 
 describe("StageChatView", () => {
+  test("header duration freezes while the stage is paused", () => {
+    const originalNow = Date.now;
+    try {
+      Date.now = () => 71_000;
+      const store = createStore();
+      store.recordRunStart({
+        id: "run-1",
+        name: "test-wf",
+        inputs: {},
+        status: "running",
+        stages: [],
+        startedAt: 1_000,
+      });
+      store.recordStageStart("run-1", {
+        id: "stage-a",
+        name: "review-a",
+        status: "paused",
+        parentIds: [],
+        toolEvents: [],
+        startedAt: 1_000,
+        pausedAt: 11_000,
+      });
+      const { handle } = makeHandle(undefined, [], "paused");
+      const view = new StageChatView({
+        store,
+        graphTheme: deriveGraphTheme({}),
+        runId: "run-1",
+        stageId: "stage-a",
+        workflowName: "test-wf",
+        handle,
+        onDetach: () => {},
+        onClose: () => {},
+      });
+
+      const rendered = stripAnsi(view.render(96).join("\n"));
+      assert.match(rendered, /10s/);
+      assert.doesNotMatch(rendered, /1m 10s/);
+      view.dispose();
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
   test("uses coding-agent CustomEditor when pi overlay host objects are provided", async () => {
     const store = createStore();
     setupRun(store, "run-1", "stage-a", "pending");

--- a/test/unit/stage-chat-view.test.ts
+++ b/test/unit/stage-chat-view.test.ts
@@ -391,26 +391,30 @@ describe("StageChatView", () => {
     view.dispose();
   });
 
-  test("ctrl+f sends a follow-up", async () => {
-    const store = createStore();
-    setupRun(store, "run-1", "stage-a");
-    const { handle, state } = makeHandle();
-    const view = new StageChatView({
-      store,
-      graphTheme: deriveGraphTheme({}),
-      runId: "run-1",
-      stageId: "stage-a",
-      workflowName: "test-wf",
-      handle,
-      onDetach: () => {},
-      onClose: () => {},
-    });
-    for (const ch of "afterwards") view.handleInput(ch);
-    view.handleInput("\x06");
-    await flush();
-    await flush();
-    assert.deepEqual(state.followUpCalls, ["afterwards"]);
-    view.dispose();
+  test("ctrl+f variants send a follow-up", async () => {
+    const ctrlFVariants = ["\x06", "\x1b[102;5u", "\x1b[102;5:1u", "\x1b[27;5;102~"];
+
+    for (const key of ctrlFVariants) {
+      const store = createStore();
+      setupRun(store, "run-1", "stage-a");
+      const { handle, state } = makeHandle();
+      const view = new StageChatView({
+        store,
+        graphTheme: deriveGraphTheme({}),
+        runId: "run-1",
+        stageId: "stage-a",
+        workflowName: "test-wf",
+        handle,
+        onDetach: () => {},
+        onClose: () => {},
+      });
+      for (const ch of "afterwards") view.handleInput(ch);
+      view.handleInput(key);
+      await flush();
+      await flush();
+      assert.deepEqual(state.followUpCalls, ["afterwards"], JSON.stringify(key));
+      view.dispose();
+    }
   });
 
   test("Escape interrupts a pending streaming stage without replacing the chat UI", async () => {
@@ -742,7 +746,7 @@ describe("StageChatView", () => {
     }
   });
 
-  test("Escape variants on settled stages and Ctrl+C call onClose", () => {
+  test("Escape variants and Ctrl+C variants on settled stages call onClose", () => {
     const store = createStore();
     setupRun(store, "run-1", "stage-a", "completed");
     let closed = 0;
@@ -757,10 +761,19 @@ describe("StageChatView", () => {
         closed += 1;
       },
     });
-    for (const key of ["\x1b", "\x1b[27u", "\x1b[27;1;27~", "\x03"]) {
+    const closeKeys = [
+      "\x1b",
+      "\x1b[27u",
+      "\x1b[27;1;27~",
+      "\x03",
+      "\x1b[99;5u",
+      "\x1b[99;5:1u",
+      "\x1b[27;5;99~",
+    ];
+    for (const key of closeKeys) {
       view.handleInput(key);
     }
-    assert.equal(closed, 4);
+    assert.equal(closed, closeKeys.length);
     view.dispose();
   });
 

--- a/test/unit/store.test.ts
+++ b/test/unit/store.test.ts
@@ -134,6 +134,70 @@ describe("store stage blocking", () => {
     assert.equal(stage.pausedAt, undefined);
     assert.equal(stage.resumedAt, 222);
   });
+
+  test("stage pause/resume tracks accumulated paused time", () => {
+    const s = createStore();
+    s.recordRunStart(makeRun("r1", [makeStage("a", { status: "running", startedAt: 1_000 })]));
+
+    assert.equal(s.recordStagePaused("r1", "a", 6_000), true);
+    assert.equal(s.recordStageResumed("r1", "a", 16_000), true);
+
+    const stage = s.snapshot().runs[0]!.stages[0]!;
+    assert.equal(stage.status, "running");
+    assert.equal(stage.pausedAt, undefined);
+    assert.equal(stage.resumedAt, 16_000);
+    assert.equal(stage.pausedDurationMs, 10_000);
+  });
+
+  test("pending stage pause/resume does not subtract time before start", () => {
+    const s = createStore();
+    s.recordRunStart(makeRun("r1", [makeStage("a", { status: "pending" })]));
+
+    assert.equal(s.recordStagePaused("r1", "a", 1_000), true);
+    assert.equal(s.recordStageResumed("r1", "a", 6_000), true);
+
+    const stage = s.snapshot().runs[0]!.stages[0]!;
+    assert.equal(stage.status, "running");
+    assert.equal(stage.pausedAt, undefined);
+    assert.equal(stage.resumedAt, 6_000);
+    assert.equal(stage.pausedDurationMs, undefined);
+  });
+});
+
+describe("store run pausing", () => {
+  test("run pause/resume tracks accumulated paused time", () => {
+    const s = createStore();
+    s.recordRunStart({ ...makeRun("r1"), startedAt: 1_000 });
+
+    assert.equal(s.recordRunPaused("r1", 6_000), true);
+    assert.equal(s.recordRunResumed("r1", 16_000), true);
+
+    const run = s.snapshot().runs[0]!;
+    assert.equal(run.status, "running");
+    assert.equal(run.pausedAt, undefined);
+    assert.equal(run.resumedAt, 16_000);
+    assert.equal(run.pausedDurationMs, 10_000);
+  });
+
+  test("recordRunEnd excludes paused time from final duration", () => {
+    const originalNow = Date.now;
+    try {
+      const s = createStore();
+      s.recordRunStart({ ...makeRun("r1"), startedAt: 1_000 });
+      assert.equal(s.recordRunPaused("r1", 6_000), true);
+      assert.equal(s.recordRunResumed("r1", 16_000), true);
+
+      Date.now = () => 21_000;
+      assert.equal(s.recordRunEnd("r1", "completed"), true);
+
+      const run = s.snapshot().runs[0]!;
+      assert.equal(run.durationMs, 10_000);
+      assert.equal(run.pausedAt, undefined);
+      assert.equal(run.pausedDurationMs, 10_000);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
 });
 
 describe("store stage notices", () => {

--- a/test/unit/workflow-attach-pane.test.ts
+++ b/test/unit/workflow-attach-pane.test.ts
@@ -25,7 +25,7 @@ import { createStageControlRegistry } from "../../packages/workflows/src/runs/fo
 import type { StageControlHandle } from "../../packages/workflows/src/runs/foreground/stage-control-registry.js";
 import type { AgentSession } from "@bastani/atomic";
 
-function setupRun(store: ReturnType<typeof createStore>, runId: string, stages: Array<{ id: string; name: string; status?: "pending" | "running" | "completed" }>) {
+function setupRun(store: ReturnType<typeof createStore>, runId: string, stages: Array<{ id: string; name: string; status?: "pending" | "running" | "paused" | "completed" }>) {
   store.recordRunStart({
     id: runId,
     name: "test-wf",
@@ -149,6 +149,34 @@ describe("WorkflowAttachPane", () => {
     assert.equal(pane._hasChatView, false);
     // Stage id is preserved so re-attach lands on the same node.
     assert.equal(pane._lastAttachedStageId, "stage-a");
+    pane.dispose();
+  });
+
+  test("Ctrl+D in paused stage-chat mode closes the pane", () => {
+    const store = createStore();
+    setupRun(store, "run-1", [{ id: "stage-a", name: "A", status: "paused" }]);
+    const registry = createStageControlRegistry();
+    registry.register({ ...makeHandle("run-1", "stage-a"), status: "paused" });
+    let closed = 0;
+    let hidden = 0;
+    const pane = new WorkflowAttachPane({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageControlRegistry: registry,
+      onClose: () => {
+        closed += 1;
+      },
+      onHide: () => {
+        hidden += 1;
+      },
+      initialAttachStageId: "stage-a",
+    });
+    assert.equal(pane._mode, "stage-chat");
+    pane.handleInput("\x04");
+    assert.equal(closed, 1);
+    assert.equal(hidden, 0);
+    assert.equal(pane._mode, "stage-chat");
     pane.dispose();
   });
 


### PR DESCRIPTION
## Summary

Replaces all raw byte checks in workflow TUI key handlers with pi-tui `matchesKey()` helpers for consistent cross-terminal behavior, and introduces a pause-aware timing system so duration counters exclude time spent paused.

## Changes

### Pause-aware timing (`timing.ts`)
- New `timing.ts` module with `elapsedRunMs`, `elapsedStageMs`, and `accumulatePausedDurationMs` helpers.
- Duration counters in status-list, graph-view, stage-chat-view, run-detail, session-picker, and session-confirm now use active elapsed time — paused intervals are excluded from displayed durations.
- `RunSnapshot` and `StageSnapshot` gain `pausedDurationMs`, `pausedAt`, and `resumedAt` fields; store methods (`recordRunPaused`, `recordRunResumed`, `resumeStage`) accumulate pause durations on each transition and propagate them to `RunDetail` via `inspectRun`.
- Timer freezes correctly when a run/stage ends while still paused.

### TUI key normalization
- All raw escape-sequence byte checks (`"\x04"`, `"\x1b[B"`, `"\r"`, `"\n"`, `"\x7f"`, etc.) replaced with `matchesKey()` calls across graph-view, inputs-picker, inline-form-editor, prompt-card, stage-chat-view, session-picker, session-confirm, and workflow-attach-pane.
- `decodePrintableKey` (wrapping pi-tui's CSI-u / Kitty decoder) added to text-helpers and wired into inline-form-editor and inputs-picker so printable characters encoded as escape sequences (e.g. from VSCode's integrated terminal with `modifyOtherKeys`) are handled correctly.

### Paused stage Ctrl+D behavior
- In stage-chat-view, Ctrl+D while the stage is paused now closes the popup (mirrors shell EOF semantics) instead of detaching back to graph view.
- workflow-attach-pane comment updated to document the new behavior.

## Breaking Changes

**Workflow form submission key changed from `Ctrl+Enter` to `Ctrl+X`.**

Update any documentation, scripts, or user muscle memory that relied on `Ctrl+Enter` to submit workflow input forms. All UI hints (wide / medium / tight / narrow width tiers) have been updated to show `ctrl+x`.

## Migration

| Before | After |
|---|---|
| Press `Ctrl+Enter` to submit a workflow form | Press `Ctrl+X` to submit a workflow form |

## Notes

Refs #972
Refs #971

## Testing

```
AGENT=1 bun test test/unit/inline-form.test.ts test/unit/inputs-picker.test.ts test/unit/node-card.test.ts test/unit/overlay-graph.test.ts test/unit/prompt-card.test.ts test/unit/session-confirm-list.test.ts test/unit/session-picker.test.ts test/unit/stage-chat-view.test.ts test/unit/store.test.ts test/unit/workflow-attach-pane.test.ts
```

New unit coverage: terminal key variants, paused duration accumulation, form submission with `ctrl+x`, paused-stage Ctrl+D close behavior.