### PR TITLE
chore(release): bump to v0.8.7-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.6-0",
+      "version": "0.8.7-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -61,7 +61,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.6-0",
+      "version": "0.8.7-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -76,7 +76,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.6-0",
+      "version": "0.8.7-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -98,7 +98,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.6-0",
+      "version": "0.8.7-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -118,7 +118,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.6-0",
+      "version": "0.8.7-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -137,7 +137,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.6-0",
+      "version": "0.8.7-0",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-tui": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.7-0] - 2026-05-19
+
+### Changed
+
+- Prepared the 0.8.7-0 prerelease.
+
 ## [0.8.6] - 2026-05-18
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.6",
+  "version": "0.8.7-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.6",
+  "version": "0.8.7-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.6",
+  "version": "0.8.7-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.6",
+  "version": "0.8.7-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.6",
+  "version": "0.8.7-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.6",
+  "version": "0.8.7-0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepare the **v0.8.7-0** prerelease of `@bastani/atomic`. Bumps all workspace package versions from `0.8.6` → `0.8.7-0`, refreshes `bun.lock`, and adds the changelog entry.

## Changes

- Bump all workspace package versions to `0.8.7-0` (`coding-agent`, `workflows`, `subagents`, `mcp`, `web-access`, `intercom`).
- Refresh `bun.lock` to reflect updated package versions.
- Add `[0.8.7-0]` changelog section in `packages/coding-agent/CHANGELOG.md`.

## What's included in this prerelease (since v0.8.6)

**Features**
- `feat(workflows)`: harden ralph reviewer prompts — stricter scoring rubric and output-format guidance (#982)
- `feat(workflows)`: show a notice when a workflow is killed mid-run

**Fixes**
- `fix(workflows)`: preserve stage chat history while mid-run steering (#981)
- `fix(workflows)`: freeze stage timers while workflow is paused (#980)
- `fix(workflows)`: avoid duplicate paused-node icon in the TUI (#980)
- `fix(workflows)`: normalize terminal key matching for cross-platform consistency (#974)
- `fix(workflows)`: match terminal `Ctrl+D` variants correctly (#974)
- `fix(workflows)`: decode VSCode printable keys in TUI keybinding handler (#974)
- `fix(workflows)`: avoid TUI keybinding conflicts with host shell (#974)

**Docs**
- `docs`: clarify getting-started prerequisites in README (#970)

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- Pre-commit: `bun run lint`, `bun run test:unit`
- Pre-push: `bun run lint`, `bun run test:unit`