### PR TITLE
chore(release): bump to v0.8.7

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.7] - 2026-05-19
+
+### Changed
+
+- Prepared the 0.8.7 release.
+
 ## [0.8.7-0] - 2026-05-19
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.7-0",
+  "version": "0.8.7",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.7-0",
+  "version": "0.8.7",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.7-0",
+  "version": "0.8.7",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.7-0",
+  "version": "0.8.7",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.7-0",
+  "version": "0.8.7",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.7-0",
+  "version": "0.8.7",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.7-0 prerelease to a stable v0.8.7 release. Bumps all workspace packages from `0.8.7-0` to `0.8.7` and adds the release section to the coding-agent changelog.

## Changes

- Bumped all workspace package versions from `0.8.7-0` → `0.8.7` (`coding-agent`, `workflows`, `subagents`, `mcp`, `web-access`, `intercom`)
- Added `[0.8.7] - 2026-05-19` section to `packages/coding-agent/CHANGELOG.md`

## What's in this release (since v0.8.6)

**Features**
- `feat(workflows)`: Harden ralph reviewer prompts for more reliable code review
- `feat(workflows)`: Show a notice when a workflow is killed

**Bug Fixes**
- `fix(workflows)`: Preserve stage chat while mid-workflow steering
- `fix(workflows)`: Normalize terminal key matching
- `fix(workflows)`: Match terminal Ctrl+D variants correctly
- `fix(workflows)`: Freeze timers while workflow is paused
- `fix(workflows)`: Avoid duplicate paused-node icon in TUI
- `fix(workflows)`: Decode VSCode printable keys properly
- `fix(workflows)`: Avoid TUI keybinding conflicts

**Docs**
- Clarify getting-started prerequisites in README

## Validation

- Pre-commit hooks ran `bun run lint` and `bun run test:unit` during commit/push
- Publishing is triggered by the `v0.8.7` git tag push to CI