### PR TITLE
fix(workflows): load text helpers through pi-tui root alias

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,61 @@ env:
   PACKAGE_NAME: "@bastani/atomic"
 
 jobs:
+  windows-binary-smoke:
+    name: Smoke test Windows binary
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Build Windows x64 archive
+        shell: bash
+        run: ./scripts/build-binaries.sh --skip-deps --platform windows-x64
+
+      - name: Smoke test Windows release archive
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $smokeDir = Join-Path $env:RUNNER_TEMP "atomic-windows-binary-smoke"
+          Remove-Item -Recurse -Force $smokeDir -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $smokeDir | Out-Null
+          Expand-Archive -Path "packages/coding-agent/binaries/atomic-windows-x64.zip" -DestinationPath $smokeDir -Force
+
+          $atomic = Join-Path $smokeDir "atomic.exe"
+          & $atomic --version
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          # --version exits before builtin extensions are loaded. Start the
+          # non-interactive runtime far enough to surface extension diagnostics,
+          # but allow the expected no-models exit in CI.
+          $output = "" | & $atomic --no-session 2>&1 | Out-String
+          $status = $LASTEXITCODE
+          Write-Host $output
+          if ($output -match "Failed to load extension") {
+            exit 1
+          }
+          if ($status -ne 0 -and $output -notmatch "No models available|No model selected|No API key found") {
+            exit $status
+          }
+          Write-Host "Runtime smoke test completed with status $status."
+
   publish:
     name: Publish @bastani/atomic
     runs-on: ubuntu-latest
+    needs: windows-binary-smoke
     outputs:
       version: ${{ steps.package.outputs.version }}
       npm_tag: ${{ steps.package.outputs.npm_tag }}
@@ -170,7 +222,24 @@ jobs:
           rm -rf "$smoke_dir"
           mkdir -p "$smoke_dir"
           tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
+
           "$smoke_dir/atomic/atomic" --version
+
+          # --version exits before builtin extensions are loaded. Start the
+          # non-interactive runtime far enough to surface extension diagnostics,
+          # but allow the expected no-models exit in CI.
+          set +e
+          output=$(printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if grep -q 'Failed to load extension' <<<"$output"; then
+            exit 1
+          fi
+          if [ "$status" -ne 0 ] && ! grep -Eq 'No models available|No model selected|No API key found' <<<"$output"; then
+            exit "$status"
+          fi
+          echo "Runtime smoke test completed with status $status."
 
       - name: Verify built package metadata
         working-directory: ${{ env.PACKAGE_DIR }}

--- a/packages/workflows/src/tui/text-helpers.ts
+++ b/packages/workflows/src/tui/text-helpers.ts
@@ -1,14 +1,17 @@
 import {
+  decodeKittyPrintable,
   matchesKey as piMatchesKey,
   truncateToWidth as piTruncateToWidth,
   visibleWidth,
   type KeyId,
 } from "@earendil-works/pi-tui";
-import { decodePrintableKey as piDecodePrintableKey } from "@earendil-works/pi-tui/dist/keys.js";
 
 export { visibleWidth };
 
 const ANSI_ESCAPE_RE = /^\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x1b]*(?:\x1b\\))/;
+const MODIFY_OTHER_KEYS_RE = /^\x1b\[27;(\d+);(\d+)~$/;
+const SHIFT_MODIFIER = 1;
+const LOCK_MODIFIER_MASK = 64 + 128;
 const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 function readAnsiCode(text: string, offset: number): string | null {
@@ -39,9 +42,29 @@ export function matchesKey(data: string, key: string): boolean {
   return data === key || piMatchesKey(data, key as KeyId);
 }
 
+function decodeModifyOtherKeysPrintable(data: string): string | undefined {
+  const match = MODIFY_OTHER_KEYS_RE.exec(data);
+  if (!match) return undefined;
+
+  const modifierValue = Number.parseInt(match[1] ?? "", 10);
+  const codepoint = Number.parseInt(match[2] ?? "", 10);
+  const modifier = Number.isFinite(modifierValue)
+    ? (modifierValue - 1) & ~LOCK_MODIFIER_MASK
+    : 0;
+
+  if ((modifier & ~SHIFT_MODIFIER) !== 0) return undefined;
+  if (!Number.isFinite(codepoint) || codepoint < 32) return undefined;
+
+  try {
+    return String.fromCodePoint(codepoint);
+  } catch {
+    return undefined;
+  }
+}
+
 /** Decode CSI-u / Kitty printable-key sequences emitted by terminals such as VSCode. */
 export function decodePrintableKey(data: string): string | undefined {
-  return piDecodePrintableKey(data);
+  return decodeKittyPrintable(data) ?? decodeModifyOtherKeysPrintable(data);
 }
 
 export function sliceColumns(

--- a/test/unit/text-helpers-loader.test.ts
+++ b/test/unit/text-helpers-loader.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "bun:test";
+import { createJiti } from "jiti/static";
+import assert from "node:assert/strict";
+
+type TextHelpers = typeof import("../../packages/workflows/src/tui/text-helpers.ts");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test("workflows text helpers load through extension-loader pi-tui aliases", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "atomic-pi-tui-alias-"));
+
+  try {
+    const piTuiShimPath = path.join(tempDir, "pi-tui-root.mjs");
+    await writeFile(
+      piTuiShimPath,
+      `export function decodeKittyPrintable(data) {
+  return data === "\\x1b[65;2u" ? "A" : undefined;
+}
+export function matchesKey(data, key) {
+  return data === key;
+}
+export function truncateToWidth(text, width, suffix = "") {
+  return text.length > width ? text.slice(0, Math.max(0, width - suffix.length)) + suffix : text;
+}
+export function visibleWidth(text) {
+  return [...text].length;
+}
+`,
+    );
+
+    const jiti = createJiti(import.meta.url, {
+      moduleCache: false,
+      alias: {
+        "@earendil-works/pi-tui": piTuiShimPath,
+      },
+    });
+
+    const helpers = (await jiti.import(
+      path.resolve(__dirname, "../../packages/workflows/src/tui/text-helpers.ts"),
+    )) as TextHelpers;
+
+    assert.equal(typeof helpers.decodePrintableKey, "function");
+    assert.equal(helpers.decodePrintableKey("\x1b[65;2u"), "A");
+    assert.equal(helpers.decodePrintableKey("\x1b[27;2;65~"), "A");
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fix `text-helpers.ts` to import from the root `@earendil-works/pi-tui` entrypoint rather than the internal `dist/keys.js` path, making it compatible with the extension loader's module aliasing. Also adds `modifyOtherKeys` fallback decoding and hardens CI smoke tests to catch extension-load failures.

## Changes

### Bug Fix
- Replace `decodePrintableKey` import from `@earendil-works/pi-tui/dist/keys.js` with `decodeKittyPrintable` from the root `@earendil-works/pi-tui` entrypoint — the extension loader only aliases the root, so the internal path was unresolvable at runtime.

### Enhancement
- Add `decodeModifyOtherKeysPrintable()` to handle `modifyOtherKeys` sequences (`\x1b[27;<mod>;<codepoint>~`) emitted by terminals such as VS Code. `decodePrintableKey` now tries the Kitty decoder first, then falls back to this new handler.

### Tests
- Add `test/unit/text-helpers-loader.test.ts`: loads `text-helpers.ts` via `jiti` with only the root pi-tui alias wired up (matching the extension-loader environment) and asserts both Kitty (`\x1b[65;2u`) and modifyOtherKeys (`\x1b[27;2;65~`) sequences decode correctly.

### CI
- Add `windows-binary-smoke` job to `.github/workflows/publish.yml` that builds and extracts the Windows x64 archive, runs `atomic.exe --version`, and then boots the non-interactive runtime to surface any extension-load failures.
- Extend the existing Linux smoke test with the same non-interactive runtime probe — `--version` exits before extensions are loaded, so this is needed to catch load errors.
- The `publish` job now depends on `windows-binary-smoke` passing first.

## Testing

```sh
bun test test/unit/text-helpers-loader.test.ts
bun run lint
bun run test:unit
```