### PR TITLE
chore(release): bump to v0.8.8

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.8] - 2026-05-19
+
+### Changed
+
+- Prepared the 0.8.8 release.
+
 ## [0.8.8-0] - 2026-05-19
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.8-0",
+  "version": "0.8.8",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.8-0",
+  "version": "0.8.8",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.8-0",
+  "version": "0.8.8",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.8-0",
+  "version": "0.8.8",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.8-0",
+  "version": "0.8.8",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.8-0",
+  "version": "0.8.8",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the workspace from the `0.8.8-0` prerelease to the stable `0.8.8` release across all packages.

## Changes

- Bumped all six workspace packages (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`) from `0.8.8-0` → `0.8.8`.
- Added `[0.8.8] - 2026-05-19` section to `packages/coding-agent/CHANGELOG.md`; moved the 0.8.8-0 prerelease notes under the stable entry.

## Release notes

> Prepared the 0.8.8 release.

## Notes

- Pre-commit and pre-push hooks ran `bun run lint` and `bun run test:unit` successfully.
- Merging this PR and pushing the `v0.8.8` tag triggers `.github/workflows/publish.yml`, which will publish `@bastani/atomic@0.8.8` to npm with the `latest` tag and create a non-prerelease GitHub Release with cross-compiled binaries attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)