### PR TITLE
fix(workflows): width-aware tool rendering and builtin forwarding for stage sessions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,9 @@ jobs:
           tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
 
           "$smoke_dir/atomic/atomic" --version
+          for builtin in workflows subagents mcp web-access intercom; do
+            test -f "$smoke_dir/atomic/builtin/$builtin/package.json"
+          done
 
           # --version exits before builtin extensions are loaded. Start the
           # non-interactive runtime far enough to surface extension diagnostics,
@@ -109,6 +112,12 @@ jobs:
           & $atomic --version
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
+          }
+          foreach ($builtin in @("workflows", "subagents", "mcp", "web-access", "intercom")) {
+            $packageJson = Join-Path $smokeDir "builtin/$builtin/package.json"
+            if (-not (Test-Path $packageJson)) {
+              throw "Missing builtin package in archive: $builtin"
+            }
           }
 
           # --version exits before builtin extensions are loaded. Start the

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -178,6 +178,7 @@ export type {
 	ResolvedPaths,
 	ResolvedResource,
 } from "./core/package-manager.js";
+export { getBuiltinPackagePaths } from "./core/builtin-packages.js";
 export { DefaultPackageManager } from "./core/package-manager.js";
 export type { ResourceCollision, ResourceDiagnostic, ResourceLoader } from "./core/resource-loader.js";
 export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.js";

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -112,12 +112,16 @@ export interface PiRenderComponent {
 }
 
 function textRenderComponent(text: string): PiRenderComponent {
+  return dynamicTextRenderComponent(() => text);
+}
+
+function dynamicTextRenderComponent(renderText: (width: number) => string): PiRenderComponent {
   return {
-    render(_width: number): string[] {
-      return text.split("\n");
+    render(width: number): string[] {
+      return renderText(width).split("\n");
     },
     includes(searchString: string): boolean {
-      return text.includes(searchString);
+      return renderText(120).includes(searchString);
     },
   };
 }
@@ -1401,9 +1405,15 @@ function factory(pi: ExtensionAPI): void {
         };
       },
       renderCall: (args, _theme, _context) =>
-        textRenderComponent(renderCall(args)),
-      renderResult: (result, opts, _theme, _context) =>
-        textRenderComponent(renderResult(result.details, opts)),
+        dynamicTextRenderComponent((width) => renderCall(args, { width })),
+      renderResult: (result, opts, _theme, context) =>
+        dynamicTextRenderComponent((width) =>
+          renderResult(result.details, {
+            ...opts,
+            width,
+            runInputs: (context as { args?: WorkflowToolArgs }).args?.inputs,
+          }),
+        ),
     });
   }
 

--- a/packages/workflows/src/extension/render-call.ts
+++ b/packages/workflows/src/extension/render-call.ts
@@ -3,39 +3,84 @@
  * cross-ref: pi-subagents src/extension/index.ts renderCall slot
  */
 
+import { truncateToWidth } from "../tui/text-helpers.js";
+
 export interface WorkflowToolArgs {
   workflow?: string;
   inputs?: Record<string, unknown>;
   action?: "run" | "list" | "get" | "status" | "interrupt" | "kill" | "resume" | "inputs";
   runId?: string;
+  task?: { name?: string; prompt?: string; task?: string } | string;
+  tasks?: readonly unknown[];
+  chain?: readonly unknown[];
+}
+
+function runTarget(args: WorkflowToolArgs): string | undefined {
+  if (args.workflow !== undefined && args.workflow.trim().length > 0) return args.workflow;
+  if (args.runId !== undefined && args.runId.trim().length > 0) return args.runId;
+  if (args.task !== undefined) return "direct-task";
+  if (args.tasks !== undefined) return "direct-parallel";
+  if (args.chain !== undefined) return "direct-chain";
+  return undefined;
+}
+
+function quoted(name: string | undefined): string {
+  return name === undefined ? "" : `"${name}"`;
+}
+
+export interface RenderCallOpts {
+  /** Optional host render width in terminal cells. */
+  width?: number;
+}
+
+function fitLine(line: string, width?: number): string {
+  if (width === undefined || width <= 0) return line;
+  return truncateToWidth(line, width, "…");
 }
 
 /**
  * Returns a compact human-readable string describing the tool invocation.
  * Used in the renderCall slot of the workflow tool registration.
  */
-export function renderCall(args: WorkflowToolArgs): string {
+export function renderCall(args: WorkflowToolArgs, opts: RenderCallOpts = {}): string {
   const action = args.action ?? "run";
-  const name = args.workflow ?? args.runId ?? "(unnamed)";
+  const name = runTarget(args);
 
+  let line: string;
   switch (action) {
     case "list":
-      return "workflow: list registered workflows";
+      line = "workflow: list registered workflows";
+      break;
     case "status":
-      return "workflow: list in-flight runs";
+      line = "workflow: list in-flight runs";
+      break;
     case "inputs":
-      return `workflow: show inputs for "${name}"`;
+      line = name === undefined
+        ? "workflow: show inputs"
+        : `workflow: show inputs for ${quoted(name)}`;
+      break;
     case "run":
-      return `workflow: run "${name}"`;
+      line = name === undefined ? "workflow: run" : `workflow: run ${quoted(name)}`;
+      break;
     case "interrupt":
-      return `workflow: interrupt run "${name}"`;
+      line = name === undefined
+        ? "workflow: interrupt run"
+        : `workflow: interrupt run ${quoted(name)}`;
+      break;
     case "kill":
-      return `workflow: kill run "${name}"`;
+      line = name === undefined ? "workflow: kill run" : `workflow: kill run ${quoted(name)}`;
+      break;
     case "resume":
-      return `workflow: resume run "${name}"`;
+      line = name === undefined
+        ? "workflow: resume run"
+        : `workflow: resume run ${quoted(name)}`;
+      break;
     case "get":
-      return `workflow: get "${name}"`;
+      line = name === undefined ? "workflow: get" : `workflow: get ${quoted(name)}`;
+      break;
     default:
-      return `workflow: ${action} "${name}"`;
+      line = name === undefined ? `workflow: ${action}` : `workflow: ${action} ${quoted(name)}`;
+      break;
   }
+  return fitLine(line, opts.width);
 }

--- a/packages/workflows/src/extension/render-result.ts
+++ b/packages/workflows/src/extension/render-result.ts
@@ -19,6 +19,8 @@ import { renderStatusList } from "../tui/status-list.js";
 import { renderRunDetail } from "../tui/run-detail.js";
 import { renderWorkflowList } from "../tui/workflow-list.js";
 import { deriveGraphTheme } from "../tui/graph-theme.js";
+import { renderDispatchConfirm } from "../tui/dispatch-confirm.js";
+import { truncateToWidth } from "../tui/text-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Result variants
@@ -113,6 +115,15 @@ export type WorkflowToolResult =
 export interface RenderResultOpts {
   isPartial?: boolean;
   /**
+   * Host-provided render width in terminal cells. Tool renderers pass the
+   * component width here so workflow tool output uses the same sizing path as
+   * `/workflow` slash-command chat surfaces.
+   */
+  width?: number;
+  /** Original workflow inputs from the tool call, used to render the same
+   * dispatch confirmation card as `/workflow <name> ...` for background runs. */
+  runInputs?: Readonly<Record<string, unknown>>;
+  /**
    * Suppress ANSI colour output (CLI flag paths / non-TTY consumers).
    * When false/undefined the canonical Catppuccin chrome is rendered.
    */
@@ -128,6 +139,11 @@ export interface RenderResultOpts {
  * fallback default below (`{ action: string }`) prevents TypeScript from
  * narrowing the union via `switch (result.action)`.
  */
+function fitLine(line: string, width?: number): string {
+  if (width === undefined || width <= 0) return line;
+  return truncateToWidth(line, width, "…");
+}
+
 export function renderResult(result: WorkflowToolResult, opts?: RenderResultOpts): string {
   const partial = opts?.isPartial === true;
   const themed = opts?.plain !== true;
@@ -137,6 +153,7 @@ export function renderResult(result: WorkflowToolResult, opts?: RenderResultOpts
       const r = result as ListResult;
       return renderWorkflowList(r.items, {
         theme: themed ? deriveGraphTheme({}) : undefined,
+        width: opts?.width,
       });
     }
 
@@ -144,78 +161,98 @@ export function renderResult(result: WorkflowToolResult, opts?: RenderResultOpts
       const r = result as StatusResult;
       return renderStatusList(r.snapshots, {
         theme: themed ? deriveGraphTheme({}) : undefined,
+        width: opts?.width,
       });
     }
 
     case "statusDetail": {
       if ("error" in result) {
         const r = result as Extract<StatusDetailResult, { error: string }>;
-        return `workflow status id=${r.runId}: ${r.error}`;
+        return fitLine(`workflow status id=${r.runId}: ${r.error}`, opts?.width);
       }
       const r = result as Extract<StatusDetailResult, { detail: RunDetail }>;
       return renderRunDetail(r.detail, {
         theme: themed ? deriveGraphTheme({}) : undefined,
+        width: opts?.width,
       });
     }
 
     case "inputs": {
       const r = result as InputsResult;
-      return renderInputsSchema(r.name, r.inputs);
+      return renderInputsSchema(r.name, r.inputs, {
+        theme: themed ? deriveGraphTheme({}) : undefined,
+        width: opts?.width,
+      });
     }
 
     case "get": {
       const r = result as GetResult;
-      if (r.error) return `workflow get (${r.workflow}): ${r.error}`;
+      if (r.error) return fitLine(`workflow get (${r.workflow}): ${r.error}`, opts?.width);
       const output = r.details?.output;
       const description = typeof output?.["description"] === "string" ? ` — ${output["description"]}` : "";
-      return `workflow get (${r.workflow}): ${r.details?.status ?? "completed"}${description}`;
+      return fitLine(
+        `workflow get (${r.workflow}): ${r.details?.status ?? "completed"}${description}`,
+        opts?.width,
+      );
     }
 
     case "run": {
       const r = result as RunResult;
-      if (partial) return `workflow run ${r.runId}: ${r.status} (in progress…)`;
+      if (partial) return fitLine(`workflow run ${r.runId}: ${r.status} (in progress…)`, opts?.width);
       if (r.status === "failed" && !r.runId) {
         // Not-found path — render the error verbatim, no fake runId banner.
         const label = r.name ? ` (${r.name})` : "";
-        return `workflow run${label}: ${r.error ?? "workflow not found"}`;
+        return fitLine(`workflow run${label}: ${r.error ?? "workflow not found"}`, opts?.width);
       }
       if (r.error) {
         const label = r.name ? ` (${r.name})` : "";
-        return `workflow run ${r.runId}${label}: ${r.status} — ${r.error}`;
+        return fitLine(`workflow run ${r.runId}${label}: ${r.status} — ${r.error}`, opts?.width);
       }
       if (r.details) {
         const label = r.name ? ` (${r.name})` : "";
-        return `workflow run ${r.runId}${label}: ${r.details.mode} ${r.details.status}`;
+        return fitLine(`workflow run ${r.runId}${label}: ${r.details.mode} ${r.details.status}`, opts?.width);
       }
       if (r.status === "completed" || r.status === "killed") {
         const label = r.name ? ` (${r.name})` : "";
-        return `workflow run ${r.runId}${label}: ${r.status}`;
+        return fitLine(`workflow run ${r.runId}${label}: ${r.status}`, opts?.width);
       }
-      // Background dispatch — `runDetached()` returns status "running" and
-      // a message; the workflow surfaces progress via store / overlay.
+      // Background dispatch — reuse the same confirmation card rendered by
+      // `/workflow <name> ...` when we have the workflow name and run id.
+      if (r.name && r.runId) {
+        return renderDispatchConfirm({
+          workflowName: r.name,
+          runId: r.runId,
+          inputs: opts?.runInputs ?? {},
+          theme: themed ? deriveGraphTheme({}) : undefined,
+          width: opts?.width,
+        });
+      }
       const label = r.name ? ` (${r.name})` : "";
-      return `workflow run ${r.runId}${label}: started in background — ${r.message ?? r.status}`;
+      return fitLine(
+        `workflow run ${r.runId}${label}: started in background — ${r.message ?? r.status}`,
+        opts?.width,
+      );
     }
 
     case "interrupt": {
       const r = result as InterruptResult;
-      return `workflow interrupt ${r.runId}: ${r.message}`;
+      return fitLine(`workflow interrupt ${r.runId}: ${r.message}`, opts?.width);
     }
 
     case "kill": {
       const r = result as KillResult;
-      return `workflow kill ${r.runId}: ${r.message}`;
+      return fitLine(`workflow kill ${r.runId}: ${r.message}`, opts?.width);
     }
 
     case "resume": {
       const r = result as ResumeResult;
-      return `workflow resume ${r.runId}: ${r.message}`;
+      return fitLine(`workflow resume ${r.runId}: ${r.message}`, opts?.width);
     }
 
     default: {
       // Runtime guard — handles values coerced from external sources.
       const fallback = result as { action: string; message?: string };
-      return `workflow: ${fallback.message ?? JSON.stringify(result)}`;
+      return fitLine(`workflow: ${fallback.message ?? JSON.stringify(result)}`, opts?.width);
     }
   }
 }

--- a/packages/workflows/src/extension/wiring.ts
+++ b/packages/workflows/src/extension/wiring.ts
@@ -96,6 +96,7 @@ interface PiSdkSessionManager {
 }
 export interface PiCodingAgentSdk {
   getAgentDir(): string;
+  getBuiltinPackagePaths?: () => string[];
   SettingsManager: {
     create(cwd?: string, agentDir?: string): PiSdkSettingsManager;
   };
@@ -103,6 +104,7 @@ export interface PiCodingAgentSdk {
     cwd: string;
     agentDir: string;
     settingsManager?: PiSdkSettingsManager;
+    builtinPackagePaths?: string[];
   }) => PiSdkResourceLoader;
   createAgentSession(options?: AtomicCreateAgentSessionOptions): Promise<{ session: StageSessionRuntime }>;
 }
@@ -147,6 +149,7 @@ export async function prepareAtomicStageSessionOptions(
     cwd,
     agentDir,
     settingsManager,
+    builtinPackagePaths: sdk.getBuiltinPackagePaths?.() ?? [],
   });
   await resourceLoader.reload();
 

--- a/packages/workflows/src/shared/render-inputs-schema.ts
+++ b/packages/workflows/src/shared/render-inputs-schema.ts
@@ -41,11 +41,14 @@
 
 import type { GraphTheme } from "../tui/graph-theme.js";
 import { paint } from "../tui/color-utils.js";
+import { truncateToWidth } from "../tui/text-helpers.js";
 import type { WorkflowInputEntry } from "../extension/render-result.js";
 
 export interface RenderInputsSchemaOptions {
   /** When provided, output uses ANSI colours and the `▎ INPUTS` chrome. */
   theme?: GraphTheme;
+  /** Optional host render width in terminal cells. */
+  width?: number;
 }
 
 /**
@@ -58,9 +61,21 @@ export function renderInputsSchema(
   inputs: WorkflowInputEntry[],
   opts: RenderInputsSchemaOptions = {},
 ): string {
-  if (inputs.length === 0) return `Workflow "${name}" has no declared inputs.`;
-  if (opts.theme === undefined) return renderPlain(name, inputs);
-  return renderPretty(name, inputs, opts.theme);
+  if (inputs.length === 0) {
+    return fitBlock(`Workflow "${name}" has no declared inputs.`, opts.width);
+  }
+  const rendered = opts.theme === undefined
+    ? renderPlain(name, inputs)
+    : renderPretty(name, inputs, opts.theme);
+  return fitBlock(rendered, opts.width);
+}
+
+function fitBlock(block: string, width?: number): string {
+  if (width === undefined || width <= 0) return block;
+  return block
+    .split("\n")
+    .map((line) => truncateToWidth(line, width, "…"))
+    .join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/tui/chat-surface-message.ts
+++ b/packages/workflows/src/tui/chat-surface-message.ts
@@ -227,10 +227,7 @@ function renderPayload(
     case "list":
       return renderWorkflowList(payload.entries, { theme, width });
     case "detail":
-      // run-detail uses a fixed-width band header by design; the width
-      // hint is unused — its surface mirrors the orchestrator panel
-      // (outline-pill chrome), not the flex chat band.
-      return renderRunDetail(payload.detail, { theme });
+      return renderRunDetail(payload.detail, { theme, width });
     case "killed":
       return renderWorkflowKilledNotice({
         width,

--- a/packages/workflows/src/tui/store-widget-installer.ts
+++ b/packages/workflows/src/tui/store-widget-installer.ts
@@ -74,9 +74,9 @@ function isStale(err: unknown): boolean {
  */
 function widgetFactory(snap: StoreSnapshot): WidgetFactory {
   return (_tui, theme) => {
-    const lines = buildThemedWidgetLines(snap, theme as PiTheme | undefined);
     return {
-      render: (_width: number) => lines,
+      render: (width: number) =>
+        buildThemedWidgetLines(snap, theme as PiTheme | undefined, width),
     };
   };
 }

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -114,6 +114,7 @@ for platform in "${PLATFORMS[@]}"; do
     mkdir -p "binaries/$platform/assets"
     cp dist/modes/interactive/assets/* "binaries/$platform/assets/"
     cp -r dist/core/export-html "binaries/$platform/"
+    cp -r dist/builtin "binaries/$platform/"
     cp -r docs "binaries/$platform/"
     cp -r examples "binaries/$platform/"
 done

--- a/test/integration/mock-extension-api.test.ts
+++ b/test/integration/mock-extension-api.test.ts
@@ -27,6 +27,7 @@ import { renderCall } from "../../packages/workflows/src/extension/render-call.j
 import { renderResult } from "../../packages/workflows/src/extension/render-result.js";
 import { waitForRun } from "../support/helpers.ts";
 import { store as defaultStore } from "../../packages/workflows/src/shared/store.ts";
+import { visibleWidth } from "../../packages/workflows/src/tui/text-helpers.js";
 
 // ---------------------------------------------------------------------------
 // MockExtensionAPI
@@ -788,8 +789,20 @@ describe("renderCall — all action branches", () => {
     assert.ok(renderCall({ workflow: "wf-c" }).includes("run"));
   });
 
-  test("falls back to '(unnamed)' when name omitted", () => {
-    assert.ok(renderCall({}).includes("(unnamed)"));
+  test("describes direct task runs instead of an unnamed workflow", () => {
+    assert.equal(
+      renderCall({ task: { name: "subagent-tool-probe", prompt: "probe" } }),
+      'workflow: run "direct-task"',
+    );
+  });
+
+  test("respects host render width", () => {
+    const out = renderCall(
+      { action: "run", workflow: "deep-research-codebase-with-a-long-name" },
+      { width: 24 },
+    );
+    assert.ok(visibleWidth(out) <= 24);
+    assert.match(out, /…/);
   });
 });
 
@@ -816,6 +829,76 @@ describe("renderResult — all action branches", () => {
     assert.ok(out.includes("wf-b"));
     assert.ok(out.includes("Alpha"));
     assert.ok(out.includes("prompt"));
+  });
+
+  test("action='list' respects the host render width", () => {
+    const width = 48;
+    const out = renderResult(
+      {
+        action: "list",
+        items: [
+          {
+            name: "deep-research-codebase-with-a-very-long-name",
+            description: "Scout and aggregate a long codebase research pass.",
+            inputs: [{ name: "prompt", required: true }],
+          },
+        ],
+      },
+      { width },
+    );
+    for (const line of out.split("\n")) {
+      assert.ok(visibleWidth(line) <= width, `line exceeds ${width}: ${visibleWidth(line)} ${JSON.stringify(line)}`);
+    }
+  });
+
+  test("all compact tool results respect the host render width", () => {
+    const width = 46;
+    const cases: WorkflowToolResult[] = [
+      {
+        action: "get",
+        workflow: "deep-research-codebase",
+        details: {
+          action: "get",
+          mode: "inspection",
+          status: "completed",
+          output: { description: "A very long workflow description that must fit in the tool row." },
+          progress: { completed: 0, total: 0 },
+        },
+      },
+      { action: "run", runId: "run-abcdef", status: "running", message: "A very long background dispatch message." },
+      { action: "interrupt", runId: "run-abcdef", status: "paused", message: "A very long interrupt response message." },
+      { action: "kill", runId: "run-abcdef", status: "killed", message: "A very long kill response message." },
+      { action: "resume", runId: "run-abcdef", status: "ok", message: "A very long resume response message." },
+    ];
+
+    for (const result of cases) {
+      const out = renderResult(result, { width });
+      for (const line of out.split("\n")) {
+        assert.ok(visibleWidth(line) <= width, `${result.action} exceeds ${width}: ${visibleWidth(line)} ${JSON.stringify(line)}`);
+      }
+    }
+  });
+
+  test("action='inputs' respects the host render width", () => {
+    const width = 52;
+    const out = renderResult(
+      {
+        action: "inputs",
+        name: "deep-research-codebase-with-a-long-name",
+        inputs: [
+          {
+            name: "prompt_with_a_very_long_name",
+            type: "string",
+            required: true,
+            description: "A long prompt description that should truncate to fit the current tool width.",
+          },
+        ],
+      },
+      { width },
+    );
+    for (const line of out.split("\n")) {
+      assert.ok(visibleWidth(line) <= width, `inputs exceeds ${width}: ${visibleWidth(line)} ${JSON.stringify(line)}`);
+    }
   });
 
   test("action='status' empty snapshots renders empty band", () => {
@@ -868,6 +951,26 @@ describe("renderResult — all action branches", () => {
     );
     assert.ok(out.includes("not yet"));
     assert.ok(out.includes("r42"));
+  });
+
+  test("action='run' background dispatch reuses the slash-command dispatch card", () => {
+    const width = 64;
+    const out = renderResult(
+      {
+        action: "run",
+        name: "deep-research-codebase",
+        runId: "abcdef123456",
+        status: "running",
+        message: "started",
+      },
+      { width, runInputs: { prompt: "map the repo" } },
+    );
+    assert.match(out, /deep-research-codebase/);
+    assert.match(out, /prompt/);
+    assert.match(out, /\/workflow connect abcdef12/);
+    for (const line of out.split("\n")) {
+      assert.ok(visibleWidth(line) <= width, `dispatch exceeds ${width}: ${visibleWidth(line)} ${JSON.stringify(line)}`);
+    }
   });
 
   test("action='run' isPartial shows 'in progress'", () => {

--- a/test/unit/coding-agent-builtin-workflows.test.ts
+++ b/test/unit/coding-agent-builtin-workflows.test.ts
@@ -4,7 +4,7 @@ import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { DefaultResourceLoader } from "../../packages/coding-agent/src/core/resource-loader.js";
 import { SettingsManager } from "../../packages/coding-agent/src/core/settings-manager.js";
 import { getBuiltinPackagePaths } from "../../packages/coding-agent/src/core/builtin-packages.js";
@@ -21,9 +21,40 @@ const expectedBuiltinPackages = [
   resolve("packages/intercom"),
 ];
 
+const builtinPackageFixtures = [
+  { packageName: "@bastani/workflows", dirname: "workflows", requiredEntry: join("src", "extension", "index.ts") },
+  { packageName: "@bastani/subagents", dirname: "subagents", requiredEntry: join("src", "extension", "index.ts") },
+  { packageName: "@bastani/mcp", dirname: "mcp", requiredEntry: "index.ts" },
+  { packageName: "@bastani/web-access", dirname: "web-access", requiredEntry: "index.ts" },
+  { packageName: "@bastani/intercom", dirname: "intercom", requiredEntry: "index.ts" },
+] as const;
+
 describe("coding-agent builtin resources", () => {
   test("discovers bundled companion packages in development", () => {
     assert.deepEqual(getBuiltinPackagePaths(), expectedBuiltinPackages);
+  });
+
+  test("discovers shipped binary adjacent builtin packages", () => {
+    const packageDir = tempDir("atomic-binary-package-dir-");
+    const previousPackageDir = process.env.ATOMIC_PACKAGE_DIR;
+    try {
+      for (const fixture of builtinPackageFixtures) {
+        const builtinDir = join(packageDir, "builtin", fixture.dirname);
+        const entryPath = join(builtinDir, fixture.requiredEntry);
+        mkdirSync(dirname(entryPath), { recursive: true });
+        writeFileSync(join(builtinDir, "package.json"), JSON.stringify({ name: fixture.packageName }), "utf-8");
+        writeFileSync(entryPath, "export default function register() {}\n", "utf-8");
+      }
+      process.env.ATOMIC_PACKAGE_DIR = packageDir;
+
+      assert.deepEqual(
+        getBuiltinPackagePaths(),
+        builtinPackageFixtures.map((fixture) => join(packageDir, "builtin", fixture.dirname)),
+      );
+    } finally {
+      if (previousPackageDir === undefined) delete process.env.ATOMIC_PACKAGE_DIR;
+      else process.env.ATOMIC_PACKAGE_DIR = previousPackageDir;
+    }
   });
 
   test("exposes package workflow resources to extensions", async () => {

--- a/test/unit/coding-agent-builtin-workflows.test.ts
+++ b/test/unit/coding-agent-builtin-workflows.test.ts
@@ -29,6 +29,8 @@ const builtinPackageFixtures = [
   { packageName: "@bastani/intercom", dirname: "intercom", requiredEntry: "index.ts" },
 ] as const;
 
+const fullBuiltinPackageLoadTimeoutMs = 60_000;
+
 describe("coding-agent builtin resources", () => {
   test("discovers bundled companion packages in development", () => {
     assert.deepEqual(getBuiltinPackagePaths(), expectedBuiltinPackages);
@@ -132,5 +134,5 @@ describe("coding-agent builtin resources", () => {
     for (const skillName of ["workflow", "subagent", "intercom"]) {
       assert.ok(skillNames.has(skillName), `expected builtin skill ${skillName}`);
     }
-  }, 20_000);
+  }, fullBuiltinPackageLoadTimeoutMs);
 });

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -5,7 +5,7 @@
  *   - list / inputs are unchanged
  *   - run is always background — dispatch returns synchronously with
  *     `status: "running"`; final state lives on the store
- *   - renderResult for the run variant emits "started in background"
+ *   - renderResult for the run variant emits a dispatch confirmation card
  *   - persistence forwarding still fires the full lifecycle
  *
  * HIL routing (ctx.ui.input/confirm/select/editor) is no longer driven by
@@ -417,7 +417,7 @@ describe("createExtensionRuntime", () => {
 // ---------------------------------------------------------------------------
 
 describe("renderResult — run variant", () => {
-  test("running run renders as 'started in background'", () => {
+  test("running run renders a dispatch confirmation card", () => {
     const out = renderResult({
       action: "run",
       name: "hello-world",
@@ -428,7 +428,8 @@ describe("renderResult — run variant", () => {
     });
     assert.ok(out.includes("abc-123"));
     assert.ok(out.includes("hello-world"));
-    assert.ok(out.includes("started in background"));
+    assert.ok(out.includes("● running"));
+    assert.ok(out.includes("/workflow connect abc-123"));
   });
 
   test("failed run shows error", () => {

--- a/test/unit/store-widget-installer.test.ts
+++ b/test/unit/store-widget-installer.test.ts
@@ -139,6 +139,18 @@ describe("installStoreWidget", () => {
     assert.ok(lines.some((l) => l.includes("my-wf")));
   });
 
+  test("factory reflows the widget against the host render width", () => {
+    const { pi, widgetCalls } = makeMockPi();
+    installStoreWidget(pi, storeInstance);
+    storeInstance.recordRunStart(makeRun("r1", "my-wf"));
+    const factoryCall = widgetCalls.findLast((c) => typeof c.factory === "function")!;
+    const component = factoryCall.factory!(null, undefined) as { render(w: number): string[] };
+
+    const narrowLines = component.render(60);
+
+    assert.deepEqual(narrowLines, [" ▾  1 background · 1 ●"]);
+  });
+
   test("requests a render after each setWidget so pi flushes the change", () => {
     const { pi, widgetCalls, renderRequests } = makeMockPi();
     installStoreWidget(pi, storeInstance);

--- a/test/unit/wiring-adapters.test.ts
+++ b/test/unit/wiring-adapters.test.ts
@@ -44,18 +44,18 @@ function fakeSession(): StageSessionRuntime {
 }
 
 
-function makeFakeAtomicSdk(defaultAgentDir: string): {
+function makeFakeAtomicSdk(defaultAgentDir: string, builtinPackagePaths: string[] = []): {
   readonly sdk: PiCodingAgentSdk;
-  readonly loaderOptions: Array<{ cwd: string; agentDir: string; settingsManager?: PiSdkSettingsManager }>;
+  readonly loaderOptions: Array<{ cwd: string; agentDir: string; settingsManager?: PiSdkSettingsManager; builtinPackagePaths?: string[] }>;
   readonly settingsCalls: Array<{ cwd?: string; agentDir?: string }>;
   readonly reloads: PiSdkResourceLoader[];
 } {
-  const loaderOptions: Array<{ cwd: string; agentDir: string; settingsManager?: PiSdkSettingsManager }> = [];
+  const loaderOptions: Array<{ cwd: string; agentDir: string; settingsManager?: PiSdkSettingsManager; builtinPackagePaths?: string[] }> = [];
   const settingsCalls: Array<{ cwd?: string; agentDir?: string }> = [];
   const reloads: PiSdkResourceLoader[] = [];
 
   class FakeResourceLoader implements PiSdkResourceLoader {
-    constructor(options: { cwd: string; agentDir: string; settingsManager?: PiSdkSettingsManager }) {
+    constructor(options: { cwd: string; agentDir: string; settingsManager?: PiSdkSettingsManager; builtinPackagePaths?: string[] }) {
       loaderOptions.push(options);
     }
 
@@ -66,6 +66,7 @@ function makeFakeAtomicSdk(defaultAgentDir: string): {
 
   const sdk: PiCodingAgentSdk = {
     getAgentDir: () => defaultAgentDir,
+    getBuiltinPackagePaths: () => builtinPackagePaths,
     SettingsManager: {
       create(cwd?: string, agentDir?: string): PiSdkSettingsManager {
         settingsCalls.push({ cwd, agentDir });
@@ -108,6 +109,23 @@ describe("prepareAtomicStageSessionOptions", () => {
 
     assert.equal(options?.agentDir, customAgentDir);
     assert.equal(loaderOptions[0]?.agentDir, customAgentDir);
+  });
+
+  test("loads Atomic builtin package extensions for workflow stage sessions", async () => {
+    const projectDir = join("/tmp", "project");
+    const atomicAgentDir = join("/home", "user", ".atomic", "agent");
+    const builtinPackagePaths = [
+      "/repo/packages/workflows",
+      "/repo/packages/subagents",
+      "/repo/packages/mcp",
+      "/repo/packages/web-access",
+      "/repo/packages/intercom",
+    ];
+    const { sdk, loaderOptions } = makeFakeAtomicSdk(atomicAgentDir, builtinPackagePaths);
+
+    await prepareAtomicStageSessionOptions({ cwd: projectDir }, sdk);
+
+    assert.deepEqual(loaderOptions[0]?.builtinPackagePaths, builtinPackagePaths);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two related gaps in the workflows extension: tool call/result renderers now defer width capture to render time (respecting the host terminal width) instead of capturing a fixed string at registration, and builtin companion packages are correctly forwarded to stage session resource loaders and included in release binaries.

## Key Changes

### Width-aware tool rendering
- Introduced `dynamicTextRenderComponent` that receives the host render width at render time, replacing `textRenderComponent` which captured a fixed string at registration and passed `_width` unused
- `renderCall` and `renderResult` accept an optional `width` parameter and truncate output via `truncateToWidth` with `…` ellipsis
- `renderResult` propagates `width` to all sub-renderers: `renderWorkflowList`, `renderStatusList`, `renderRunDetail`, `renderInputsSchema`, and inline status lines
- `renderCall` now handles direct-task/parallel/chain runs (instead of falling back to `"(unnamed)"`)
- Background dispatch results reuse the `dispatch-confirm` card (matching the `/workflow` slash-command surface) when `name` and `runId` are both present, and respect `width`
- `widgetFactory` in `store-widget-installer` passes the live `width` argument to `buildThemedWidgetLines` instead of computing lines once at factory creation time
- `chat-surface-message` forwards `width` to `renderRunDetail` (previously hardcoded to omit it)
- `renderInputsSchema` gains a `width` option; `fitBlock` truncates each rendered line to the column budget

### Builtin package loading for stage sessions
- Added optional `getBuiltinPackagePaths()` to the `PiCodingAgentSdk` interface
- `prepareAtomicStageSessionOptions` forwards the result to the resource loader as `builtinPackagePaths`, so stage sessions load the same builtin extensions as the top-level session
- `getBuiltinPackagePaths` exported from `packages/coding-agent/src/index.ts` for external consumers

### Binary packaging and CI
- `scripts/build-binaries.sh` copies `dist/builtin/` into each platform archive so shipped binaries include all companion packages
- Publish workflow smoke test verifies `builtin/<name>/package.json` exists in the unpacked archive for all five builtins (Linux and Windows)

## Tests
- Width-bound assertions added for `renderCall`, `renderResult` (list, inputs, compact tool results, background dispatch card)
- New unit test covering binary-adjacent builtin discovery via `ATOMIC_PACKAGE_DIR`
- New test asserting `builtinPackagePaths` is forwarded through `prepareAtomicStageSessionOptions`
- `store-widget-installer` test confirms the factory reflows against the host render width
- Updated `runtime.test.ts` assertions to match the new dispatch confirmation card format

🤖 Generated with [Claude Code](https://claude.com/claude-code)