### PR TITLE
fix(release): bundle runtime deps in binary archives

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,8 +57,23 @@ jobs:
           tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
 
           "$smoke_dir/atomic/atomic" --version
-          for builtin in workflows subagents mcp web-access intercom; do
-            test -f "$smoke_dir/atomic/builtin/$builtin/package.json"
+          for required_path in \
+            builtin/workflows/package.json \
+            builtin/workflows/src/extension/index.ts \
+            builtin/subagents/package.json \
+            builtin/subagents/src/extension/index.ts \
+            builtin/mcp/package.json \
+            builtin/mcp/index.ts \
+            builtin/web-access/package.json \
+            builtin/web-access/index.ts \
+            builtin/intercom/package.json \
+            builtin/intercom/index.ts \
+            node_modules/@modelcontextprotocol/ext-apps/package.json \
+            node_modules/@mozilla/readability/package.json; do
+            test -f "$smoke_dir/atomic/$required_path" || {
+              echo "Missing release archive path: $required_path" >&2
+              exit 1
+            }
           done
 
           # --version exits before builtin extensions are loaded. Start the
@@ -113,10 +128,23 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
-          foreach ($builtin in @("workflows", "subagents", "mcp", "web-access", "intercom")) {
-            $packageJson = Join-Path $smokeDir "builtin/$builtin/package.json"
-            if (-not (Test-Path $packageJson)) {
-              throw "Missing builtin package in archive: $builtin"
+          foreach ($requiredPath in @(
+            "builtin/workflows/package.json",
+            "builtin/workflows/src/extension/index.ts",
+            "builtin/subagents/package.json",
+            "builtin/subagents/src/extension/index.ts",
+            "builtin/mcp/package.json",
+            "builtin/mcp/index.ts",
+            "builtin/web-access/package.json",
+            "builtin/web-access/index.ts",
+            "builtin/intercom/package.json",
+            "builtin/intercom/index.ts",
+            "node_modules/@modelcontextprotocol/ext-apps/package.json",
+            "node_modules/@mozilla/readability/package.json"
+          )) {
+            $archivePath = Join-Path $smokeDir $requiredPath
+            if (-not (Test-Path $archivePath)) {
+              throw "Missing release archive path: $requiredPath"
             }
           }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,35 @@ jobs:
           mkdir -p "$smoke_dir"
           tar -xzf packages/coding-agent/binaries/atomic-linux-x64.tar.gz -C "$smoke_dir"
           "$smoke_dir/atomic/atomic" --version
+          for required_path in \
+            builtin/workflows/package.json \
+            builtin/workflows/src/extension/index.ts \
+            builtin/subagents/package.json \
+            builtin/subagents/src/extension/index.ts \
+            builtin/mcp/package.json \
+            builtin/mcp/index.ts \
+            builtin/web-access/package.json \
+            builtin/web-access/index.ts \
+            builtin/intercom/package.json \
+            builtin/intercom/index.ts \
+            node_modules/@modelcontextprotocol/ext-apps/package.json \
+            node_modules/@mozilla/readability/package.json; do
+            test -f "$smoke_dir/atomic/$required_path" || {
+              echo "Missing release archive path: $required_path" >&2
+              exit 1
+            }
+          done
+          set +e
+          output=$(printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if grep -q 'Failed to load extension' <<<"$output"; then
+            exit 1
+          fi
+          if [ "$status" -ne 0 ] && ! grep -Eq 'No models available|No model selected|No API key found' <<<"$output"; then
+            exit "$status"
+          fi
       - name: Smoke test Windows release archive
         if: runner.os == 'Windows'
         shell: pwsh
@@ -61,4 +90,36 @@ jobs:
           Remove-Item -Recurse -Force $smokeDir -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Path $smokeDir | Out-Null
           Expand-Archive -Path packages/coding-agent/binaries/atomic-windows-x64.zip -DestinationPath $smokeDir
-          & (Join-Path $smokeDir "atomic.exe") --version
+          $atomic = Join-Path $smokeDir "atomic.exe"
+          & $atomic --version
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          foreach ($requiredPath in @(
+            "builtin/workflows/package.json",
+            "builtin/workflows/src/extension/index.ts",
+            "builtin/subagents/package.json",
+            "builtin/subagents/src/extension/index.ts",
+            "builtin/mcp/package.json",
+            "builtin/mcp/index.ts",
+            "builtin/web-access/package.json",
+            "builtin/web-access/index.ts",
+            "builtin/intercom/package.json",
+            "builtin/intercom/index.ts",
+            "node_modules/@modelcontextprotocol/ext-apps/package.json",
+            "node_modules/@mozilla/readability/package.json"
+          )) {
+            $archivePath = Join-Path $smokeDir $requiredPath
+            if (-not (Test-Path $archivePath)) {
+              throw "Missing release archive path: $requiredPath"
+            }
+          }
+          $output = "" | & $atomic --no-session 2>&1 | Out-String
+          $status = $LASTEXITCODE
+          Write-Host $output
+          if ($output -match "Failed to load extension") {
+            exit 1
+          }
+          if ($status -ne 0 -and $output -notmatch "No models available|No model selected|No API key found") {
+            exit $status
+          }

--- a/packages/coding-agent/scripts/copy-runtime-dependencies.ts
+++ b/packages/coding-agent/scripts/copy-runtime-dependencies.ts
@@ -1,0 +1,124 @@
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+interface PackageJson {
+	readonly dependencies?: Record<string, string>;
+	readonly optionalDependencies?: Record<string, string>;
+}
+
+interface DependencyRequest {
+	readonly packageName: string;
+	readonly optional: boolean;
+}
+
+interface CopyRuntimeDependenciesOptions {
+	readonly packageJsonPath?: string;
+	readonly nodeModulesRoot?: string;
+	readonly destinationNodeModules?: string;
+}
+
+const defaultPackageRoot = resolve(import.meta.dir, "..");
+
+function readPackageJson(packageJsonPath: string): PackageJson {
+	return JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PackageJson;
+}
+
+function packagePath(nodeModulesRoot: string, packageName: string): string {
+	return join(nodeModulesRoot, ...packageName.split("/"));
+}
+
+function dependencyRequests(packageJson: PackageJson, optional: boolean): DependencyRequest[] {
+	const dependencies = Object.keys(packageJson.dependencies ?? {}).map((packageName) => ({ packageName, optional }));
+	const optionalDependencies = Object.keys(packageJson.optionalDependencies ?? {}).map((packageName) => ({
+		packageName,
+		optional: true,
+	}));
+	return [...dependencies, ...optionalDependencies];
+}
+
+function shouldSkipPackageEntry(name: string): boolean {
+	return (
+		name === "node_modules" ||
+		name === ".git" ||
+		name === ".github" ||
+		name === "coverage" ||
+		name === ".nyc_output" ||
+		name === ".DS_Store" ||
+		name === ".turbo" ||
+		name === ".vite" ||
+		name === ".vitest" ||
+		name === "test" ||
+		name === "tests" ||
+		name.endsWith(".test.ts") ||
+		name.endsWith(".test.mjs") ||
+		name.endsWith(".test.js") ||
+		name.endsWith(".spec.ts") ||
+		name.endsWith(".spec.js") ||
+		name.endsWith(".map")
+	);
+}
+
+function copyPackageDirectory(sourceDir: string, destinationDir: string): void {
+	mkdirSync(destinationDir, { recursive: true });
+	for (const entry of readdirSync(sourceDir)) {
+		if (shouldSkipPackageEntry(entry)) {
+			continue;
+		}
+
+		const sourcePath = join(sourceDir, entry);
+		const destinationPath = join(destinationDir, entry);
+		const stats = statSync(sourcePath);
+		if (stats.isDirectory()) {
+			copyPackageDirectory(sourcePath, destinationPath);
+			continue;
+		}
+		if (stats.isFile()) {
+			cpSync(sourcePath, destinationPath, { force: true, preserveTimestamps: true });
+		}
+	}
+}
+
+export function copyRuntimeDependencies(options: CopyRuntimeDependenciesOptions = {}): void {
+	const packageJsonPath = options.packageJsonPath ?? join(defaultPackageRoot, "package.json");
+	const nodeModulesRoot = options.nodeModulesRoot ?? resolve(defaultPackageRoot, "..", "..", "node_modules");
+	const destinationNodeModules = options.destinationNodeModules;
+	if (!destinationNodeModules) {
+		throw new Error("destinationNodeModules is required");
+	}
+
+	rmSync(destinationNodeModules, { recursive: true, force: true });
+	mkdirSync(destinationNodeModules, { recursive: true });
+
+	const copied = new Set<string>();
+	const queue = dependencyRequests(readPackageJson(packageJsonPath), false);
+	while (queue.length > 0) {
+		const request = queue.shift();
+		if (!request || copied.has(request.packageName)) {
+			continue;
+		}
+
+		const sourceDir = packagePath(nodeModulesRoot, request.packageName);
+		if (!existsSync(sourceDir)) {
+			if (request.optional) {
+				continue;
+			}
+			throw new Error(`Required runtime dependency not found: ${request.packageName} at ${sourceDir}`);
+		}
+
+		const sourcePackageJsonPath = join(sourceDir, "package.json");
+		if (!existsSync(sourcePackageJsonPath)) {
+			throw new Error(`Runtime dependency is missing package metadata: ${sourceDir}`);
+		}
+
+		const destinationDir = packagePath(destinationNodeModules, request.packageName);
+		mkdirSync(dirname(destinationDir), { recursive: true });
+		copyPackageDirectory(sourceDir, destinationDir);
+		copied.add(request.packageName);
+		queue.push(...dependencyRequests(readPackageJson(sourcePackageJsonPath), false));
+	}
+}
+
+if (import.meta.main) {
+	const destinationNodeModules = process.argv[2];
+	copyRuntimeDependencies({ destinationNodeModules });
+}

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -103,6 +103,11 @@ for platform in "${PLATFORMS[@]}"; do
     fi
 done
 
+echo "==> Copying runtime dependencies..."
+runtime_deps_dir="binaries/.runtime-node_modules"
+rm -rf "$runtime_deps_dir"
+bun run scripts/copy-runtime-dependencies.ts "$runtime_deps_dir"
+
 echo "==> Copying shared assets..."
 for platform in "${PLATFORMS[@]}"; do
     cp package.json "binaries/$platform/"
@@ -115,9 +120,12 @@ for platform in "${PLATFORMS[@]}"; do
     cp dist/modes/interactive/assets/* "binaries/$platform/assets/"
     cp -r dist/core/export-html "binaries/$platform/"
     cp -r dist/builtin "binaries/$platform/"
+    cp -r "$runtime_deps_dir" "binaries/$platform/node_modules"
     cp -r docs "binaries/$platform/"
     cp -r examples "binaries/$platform/"
 done
+
+rm -rf "$runtime_deps_dir"
 
 echo "==> Creating release archives..."
 cd binaries

--- a/test/unit/runtime-dependency-copy.test.ts
+++ b/test/unit/runtime-dependency-copy.test.ts
@@ -1,0 +1,61 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { copyRuntimeDependencies } from "../../packages/coding-agent/scripts/copy-runtime-dependencies.js";
+
+function tempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+function writePackage(packageDir: string, packageJson: Record<string, unknown>): void {
+  mkdirSync(packageDir, { recursive: true });
+  writeJson(join(packageDir, "package.json"), packageJson);
+  writeFileSync(join(packageDir, "index.js"), "export {};\n", "utf-8");
+}
+
+describe("runtime dependency copy", () => {
+  test("copies required dependency closure for binary archives", () => {
+    const root = tempDir("atomic-runtime-deps-");
+    const packageJsonPath = join(root, "package.json");
+    const nodeModulesRoot = join(root, "node_modules");
+    const destinationNodeModules = join(root, "archive", "node_modules");
+
+    writeJson(packageJsonPath, {
+      dependencies: { "@example/direct": "1.0.0" },
+      optionalDependencies: { "optional-missing": "1.0.0" },
+    });
+    writePackage(join(nodeModulesRoot, "@example", "direct"), {
+      name: "@example/direct",
+      dependencies: { transitive: "1.0.0" },
+    });
+    writePackage(join(nodeModulesRoot, "transitive"), { name: "transitive" });
+
+    copyRuntimeDependencies({ packageJsonPath, nodeModulesRoot, destinationNodeModules });
+
+    assert.ok(existsSync(join(destinationNodeModules, "@example", "direct", "package.json")));
+    assert.ok(existsSync(join(destinationNodeModules, "transitive", "package.json")));
+    assert.equal(existsSync(join(destinationNodeModules, "optional-missing")), false);
+  });
+
+  test("throws when a required dependency is missing", () => {
+    const root = tempDir("atomic-runtime-deps-missing-");
+    const packageJsonPath = join(root, "package.json");
+    writeJson(packageJsonPath, { dependencies: { missing: "1.0.0" } });
+
+    assert.throws(
+      () =>
+        copyRuntimeDependencies({
+          packageJsonPath,
+          nodeModulesRoot: join(root, "node_modules"),
+          destinationNodeModules: join(root, "archive", "node_modules"),
+        }),
+      /Required runtime dependency not found: missing/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a runtime failure in standalone binary archives where raw TypeScript builtin extensions could not resolve their npm dependencies at load time. Interactive and source-tree runs worked because the workspace \`node_modules\` was already on the resolution path, but extracted archives contained no filesystem deps alongside the binary.

## Changes

- **New \`packages/coding-agent/scripts/copy-runtime-dependencies.ts\`**: BFS traversal of the production dependency closure from \`packages/coding-agent/package.json\`; copies each package from the workspace \`node_modules\`, silently skips missing optional dependencies, and strips dev artifacts (tests, source maps, coverage dirs) from copied packages to keep archives lean.
- **\`scripts/build-binaries.sh\`**: Invokes the new script to stage runtime deps into \`binaries/.runtime-node_modules\`, then copies them as \`node_modules/\` alongside the binary in every platform archive before archiving; cleans up the staging dir afterward.
- **Smoke checks hardened** (both \`publish.yml\` and \`test.yml\`): Now assert builtin extension entry points (\`src/extension/index.ts\`, \`index.ts\`) and key runtime dependencies (\`@modelcontextprotocol/ext-apps\`, \`@mozilla/readability\`) exist in the extracted archive, and run \`atomic --no-session\` to validate live extension loading (failing on any "Failed to load extension" output).
- **New unit tests** (\`test/unit/runtime-dependency-copy.test.ts\`): Cover transitive closure copy, silent skip of missing optional deps, and error thrown on missing required deps.

## Root Cause

Binary archives previously shipped the compiled binary and builtin \`.ts\` extension sources but no \`node_modules\`. When pi loaded those extensions at runtime it resolved \`import\` specifiers relative to the binary directory — with no \`node_modules\` present, dependency resolution failed silently or with a hard error. The new \`node_modules/\` directory bundled beside the binary gives the runtime dep resolver a valid module root.

## Notes

- The previous smoke check (existence of \`builtin/*/package.json\`) was a false positive: a package manifest present does not mean the package's dependencies are loadable. The hardened checks assert both manifest presence and live extension loading via \`--no-session\`.
- Validation: \`bun run typecheck\`, \`bun run test:unit\`, and local Linux archive smoke passed.