### PR TITLE
chore(release): bump to v0.8.9

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.9] - 2026-05-19
+
+### Changed
+
+- Prepared the 0.8.9 release.
+
 ## [0.8.9-0] - 2026-05-19
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.9-0",
+  "version": "0.8.9",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.9-0",
+  "version": "0.8.9",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.9-0",
+  "version": "0.8.9",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.9-0",
+  "version": "0.8.9",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.9-0",
+  "version": "0.8.9",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.9-0",
+  "version": "0.8.9",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.9-0 prerelease to the final v0.8.9 stable release. Bumps all workspace package versions and adds the changelog entry for release-note extraction.

## Changes

- Bumped all workspace package versions from `0.8.9-0` → `0.8.9` (`packages/coding-agent`, `packages/workflows`, `packages/subagents`, `packages/mcp`, `packages/web-access`, `packages/intercom`)
- Added `## [0.8.9] - 2026-05-19` changelog section in `packages/coding-agent/CHANGELOG.md` for CI release-note extraction

## What's in v0.8.9

Changes promoted from the prerelease cycle:

- **fix(workflows):** align tool rendering and builtin loading (#991) — resolves a rendering regression where workflow tools were not correctly displayed
- **test:** increase builtin package load timeout to improve test reliability
- **fix(release):** bundle runtime deps in binary archives (#993) — ensures distributed binaries include all required runtime dependencies

## Validation

- `bun run typecheck` passed
- `cd packages/coding-agent && bun run build` succeeded
- Pre-commit/pre-push hooks ran lint and unit tests