### PR TITLE
chore(release): bump to v0.8.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.10-0",
+      "version": "0.8.10",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -61,7 +61,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.10-0",
+      "version": "0.8.10",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -76,7 +76,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.10-0",
+      "version": "0.8.10",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -98,7 +98,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.10-0",
+      "version": "0.8.10",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -118,7 +118,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.10-0",
+      "version": "0.8.10",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -137,7 +137,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.10-0",
+      "version": "0.8.10",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-tui": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.10] - 2026-05-20
+
+### Changed
+
+- Prepared the 0.8.10 release.
+
 ## [0.8.10-0] - 2026-05-20
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.10-0",
+  "version": "0.8.10",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.10-0",
+  "version": "0.8.10",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.10-0",
+  "version": "0.8.10",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.10-0",
+  "version": "0.8.10",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.10-0",
+  "version": "0.8.10",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.10-0",
+  "version": "0.8.10",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the workspace from the `0.8.10-0` prerelease to the stable `0.8.10` release by bumping all package versions and finalizing the changelog entry.

## Changes

- Bumps all workspace packages from `0.8.10-0` → `0.8.10`:
  - `@bastani/atomic` (`packages/coding-agent`)
  - `@bastani/intercom`, `@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`, `@bastani/workflows`
- Updates `bun.lock` to reflect the stable version across all workspace entries
- Adds `## [0.8.10] - 2026-05-20` changelog section to mark the stable release; the features shipped in this release were documented under the `0.8.10-0` prerelease entry:
  - **Added:** Reintroduced `/atomic` as an interactive guide with options for overview, examples, workflows, and release notes

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- `AGENT=1 bun run test:all`

## Release

After this PR merges, tag and push from updated `main` to trigger the publish workflow:

```sh
git tag v0.8.10
git push && git push origin v0.8.10
```

This publishes `@bastani/atomic@0.8.10` to npm with the `latest` tag and creates a non-prerelease GitHub Release with cross-compiled binaries attached.