### PR TITLE
chore(release): bump to v0.8.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -61,7 +61,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -76,7 +76,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -98,7 +98,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -118,7 +118,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -137,7 +137,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-tui": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## [Unreleased]
 
-## [0.8.10] - 2026-05-20
+## [0.8.11] - 2026-05-20
 
 ### Changed
 
-- Prepared the 0.8.10 release.
+- Updated the What's New release notes to highlight the new `/atomic` onboarding guide, including overview, examples, workflows, and release notes from inside the CLI.
+
+## [0.8.10] - 2026-05-20
+
+### Added
+
+- Added the `/atomic` onboarding guide, with built-in overview, examples, workflows, and release notes to help users discover Atomic from inside the CLI.
 
 ## [0.8.10-0] - 2026-05-20
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Bumps all workspace packages from v0.8.10 to v0.8.11 and updates the changelog to accurately document both releases.

## Key Changes

- **Version bump**: All workspace packages (`@bastani/atomic`, `@bastani/intercom`, `@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`, `@bastani/workflows`) updated from `0.8.10` → `0.8.11`
- **`bun.lock` updated** to reflect the new versions across all workspace entries
- **Changelog corrections**:
  - `[0.8.11]`: Documents the What's New copy fix — updated release notes to highlight the `/atomic` onboarding guide (overview, examples, workflows, release notes)
  - `[0.8.10]`: Retroactively corrected from a placeholder entry ("Prepared the 0.8.10 release") to accurately describe the actual feature shipped: the `/atomic` onboarding guide with built-in overview, examples, workflows, and release notes

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test test/unit/changelog.test.ts test/unit/bump-version-script.test.ts`
- Pre-commit hook ran lint and unit tests successfully