### PR TITLE
chore(release): bump to v0.8.12-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.11",
+      "version": "0.8.12-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.11",
+      "version": "0.8.12-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.11",
+      "version": "0.8.12-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.11",
+      "version": "0.8.12-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.11",
+      "version": "0.8.12-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.11",
+      "version": "0.8.12-0",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-tui": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+## [0.8.12-0] - 2026-05-20
+
+### Added
+
+- Added a configurable HTTP idle timeout for long-running model and web requests, with presets from 30 seconds through 30 minutes plus a disabled option.
+- Added the Atomic workflows documentation page and navigation so `/atomic` and project guidance can point users to workflow authoring and execution details.
+
+### Changed
+
+- Updated the bundled Pi libraries to 0.75.4.
+- Migrated internal runtime, tool, TUI, tests, and extension example imports to explicit `.ts` specifiers for better raw-TypeScript extension compatibility.
+- Rebranded and refreshed the coding-agent documentation for Atomic, including package, customization, and workflow guidance.
+- Included the selected model reasoning level in generated system prompts and project context markup.
+
+### Fixed
+
+- Improved Windows self-update handling for package-manager installs, including native dependency cleanup/quarantine and clearer unavailable-update messaging.
+- Stabilized subagent live result rendering, async render updates, transient child-error recovery, and live widget animations.
+- Detached settled workflow stages from run-control tracking and centered the empty graph waiting state.
+- Normalized negative and fractional duration displays across bash, subagent, and workflow UI renderers.
+
 ## [0.8.11] - 2026-05-20
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.11",
+  "version": "0.8.12-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.11",
+  "version": "0.8.12-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.11",
+  "version": "0.8.12-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.11",
+  "version": "0.8.12-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.11",
+  "version": "0.8.12-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.11",
+  "version": "0.8.12-0",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Bumps all workspace packages from v0.8.11 to v0.8.12-0 (prerelease) and adds the corresponding CHANGELOG entries documenting features merged since the last release.

## Changes

- **Version bump:** All `packages/*/package.json` versions updated from `0.8.11` → `0.8.12-0`
- **`bun.lock`:** Refreshed to reflect new workspace package versions
- **CHANGELOG:** Adds `[0.8.12-0] - 2026-05-20` release notes covering:
  - *Added:* Configurable HTTP idle timeout for model/web requests; Atomic workflows documentation page and `/atomic` navigation
  - *Changed:* Bundled Pi libraries updated to 0.75.4; internal imports migrated to explicit `.ts` specifiers; coding-agent docs rebranded for Atomic; model reasoning level included in system prompts
  - *Fixed:* Windows self-update handling for package-manager installs; subagent live result rendering and async update stability; workflow stage run-control tracking and empty-graph centering; duration display normalization across bash/subagent/workflow UIs

## Notes

- This is a prerelease (`0.8.12-0`); publishing to npm will use the `next` tag and create a non-latest GitHub Release.
- No source logic changes — this is a pure version/changelog housekeeping commit.