### PR TITLE
chore(release): bump to v0.8.12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.12-0",
+      "version": "0.8.12",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.12-0",
+      "version": "0.8.12",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.12-0",
+      "version": "0.8.12",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.12-0",
+      "version": "0.8.12",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.12-0",
+      "version": "0.8.12",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.12-0",
+      "version": "0.8.12",
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-tui": "*",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [0.8.12] - 2026-05-20
+
+### Added
+
+- Added a configurable HTTP idle timeout for long-running model and web requests, with selectable presets from 30 seconds through 30 minutes and an option to disable the timeout.
+- Added the Atomic workflows documentation page and navigation so users can discover workflow authoring and execution guidance from the Atomic docs.
+
+### Changed
+
+- Promoted the 0.8.12 prerelease changes to a stable release.
+- Updated the bundled Pi libraries to 0.75.4.
+- Migrated internal runtime, tool, TUI, tests, and extension example imports to explicit `.ts` specifiers to improve raw-TypeScript extension compatibility.
+- Refreshed Atomic documentation for package usage, customization, workflows, and release guidance.
+- Included selected model reasoning level metadata in generated system prompts and project context markup.
+
+### Fixed
+
+- Improved Windows self-update behavior for package-manager installs, including native dependency cleanup, quarantine handling, and clearer messaging when updates are unavailable.
+- Stabilized subagent live result rendering, async render updates, transient child-error recovery, and live widget animations.
+- Detached settled workflow stages from run-control tracking and centered the empty workflow graph waiting state.
+- Normalized negative and fractional duration displays across bash, subagent, and workflow UI renderers.
+
 ## [0.8.12-0] - 2026-05-20
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.12-0",
+  "version": "0.8.12",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.12-0",
+  "version": "0.8.12",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.12-0",
+  "version": "0.8.12",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.12-0",
+  "version": "0.8.12",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.12-0",
+  "version": "0.8.12",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.12-0",
+  "version": "0.8.12",
   "private": true,
   "description": "pi extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.12-0 prerelease to a stable v0.8.12 release by bumping all workspace package versions and adding final release notes to the changelog.

## Changes

- Bumps all Atomic workspace packages (`@bastani/atomic`, `workflows`, `subagents`, `mcp`, `web-access`, `intercom`) from `0.8.12-0` → `0.8.12`
- Refreshes `bun.lock` workspace version entries for the stable release
- Adds v0.8.12 release notes to `CHANGELOG.md` covering:
  - **Added:** Configurable HTTP idle timeout presets; Atomic workflows docs page and navigation
  - **Changed:** Pi 0.75.4 update; `.ts` specifier migration for raw-TypeScript extension compatibility; refreshed Atomic docs; model reasoning level in system prompts
  - **Fixed:** Windows self-update improvements; subagent live render stability; workflow stage tracking and empty-state centering; duration display normalization across renderers

## Validation

- `bun run typecheck` passed
- `cd packages/coding-agent && bun run build` passed
- Pre-commit/pre-push hooks ran lint and unit tests