### PR TITLE
fix(workflows): load packaged workflow resources via jiti

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,6 +139,9 @@
     "packages/workflows": {
       "name": "@bastani/workflows",
       "version": "0.8.12",
+      "dependencies": {
+        "jiti": "^2.7.0",
+      },
       "peerDependencies": {
         "@bastani/atomic": "*",
         "@earendil-works/pi-tui": "*",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "engines": {
     "bun": ">=1.3.14"
   },
+  "contributors": [
+    "Norin Lavaee",
+    "Alex Lavaee"
+  ],
   "workspaces": [
     "packages/*"
   ],

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -115,6 +115,8 @@ Atomic discovers workflow definitions in this order:
 
 A workflow module may export one default workflow definition and/or named workflow definitions. Discovery checks the default export first, then named exports.
 
+Workflow files are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation.
+
 ## Workflow Configuration
 
 Configured workflow paths live in workflow extension config. Project config paths are relative to the project root. Global config paths are relative to `~/.atomic/agent`.

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -16,6 +16,7 @@ export {
 	getProjectConfigPaths,
 	getEnvNames,
 	getEnvValue,
+	isBunBinary,
 	getUserConfigDirs,
 	getUserConfigPaths,
 	hasEnvValue,

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -2,9 +2,9 @@
   "name": "@bastani/intercom",
   "version": "0.8.12",
   "private": true,
-  "description": "Atomic extension providing a private coordination channel between parent and child agent sessions.",
+  "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [
-    "Nico Bailon",
+    "Norin Lavaee",
     "Alex Lavaee"
   ],
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,9 +2,9 @@
   "name": "@bastani/mcp",
   "version": "0.8.12",
   "private": true,
-  "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent.",
+  "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [
-    "Nico Bailon",
+    "Norin Lavaee",
     "Alex Lavaee"
   ],
   "license": "MIT",

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -2,9 +2,9 @@
   "name": "@bastani/subagents",
   "version": "0.8.12",
   "private": true,
-  "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification.",
+  "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [
-    "Nico Bailon",
+    "Norin Lavaee",
     "Alex Lavaee"
   ],
   "license": "MIT",

--- a/packages/subagents/src/tui/render.ts
+++ b/packages/subagents/src/tui/render.ts
@@ -1217,6 +1217,7 @@ class LiveWidgetComponent implements Component {
     const container = new Container();
     for (const line of fitWidgetLineBudget(lines, this.theme, termWidth, expanded))
       container.addChild(new Text(line, 1, 0));
+    container.addChild(new Spacer(1));
     return container.render(termWidth);
   }
 

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -2,9 +2,9 @@
   "name": "@bastani/web-access",
   "version": "0.8.12",
   "private": true,
-  "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction.",
+  "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [
-    "Nico Bailon",
+    "Norin Lavaee",
     "Alex Lavaee"
   ],
   "license": "MIT",

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -2,7 +2,7 @@
   "name": "@bastani/workflows",
   "version": "0.8.12",
   "private": true,
-  "description": "pi extension for multi-stage workflow authoring and execution.",
+  "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [
     "Norin Lavaee",
     "Alex Lavaee"
@@ -69,6 +69,9 @@
     "themes": [
       "themes/*.json"
     ]
+  },
+  "dependencies": {
+    "jiti": "^2.7.0"
   },
   "peerDependencies": {
     "@bastani/atomic": "*",

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -22,7 +22,9 @@
 
 import { readdir, stat } from "node:fs/promises";
 import { join, resolve, extname, isAbsolute } from "node:path";
+import { fileURLToPath } from "node:url";
 import { CONFIG_DIR_NAMES, getProjectConfigPaths } from "@bastani/atomic";
+import { createJiti } from "jiti/static";
 import type { WorkflowDefinition } from "../shared/types.js";
 import { createRegistry } from "../workflows/registry.js";
 import type { WorkflowRegistry } from "../workflows/registry.js";
@@ -273,8 +275,27 @@ async function scanWorkflowDir(dir: string): Promise<string[] | null> {
  *
  * Strategy: try the default export first, then every named export.
  * Both are collected — a file may export multiple workflow definitions.
- * Bun natively handles .ts, .js, .mjs, and .cjs via dynamic import.
+ * jiti loads package-authored .ts/.js/.mjs/.cjs files with the same
+ * @bastani/workflows authoring import that project/user workflow files use.
  */
+const workflowModuleLoader = createJiti(import.meta.url, {
+  moduleCache: false,
+  alias: {
+    "@bastani/workflows": fileURLToPath(new URL("../index.ts", import.meta.url)),
+  },
+});
+
+function normalizeWorkflowModule(mod: unknown): Record<string, unknown> {
+  if (mod !== null && typeof mod === "object") {
+    return mod as Record<string, unknown>;
+  }
+  return { default: mod };
+}
+
+async function loadWorkflowModule(filePath: string): Promise<Record<string, unknown>> {
+  return normalizeWorkflowModule(workflowModuleLoader(filePath));
+}
+
 async function importWorkflowFile(
   filePath: string,
   kind: DiscoveryKind,
@@ -282,7 +303,7 @@ async function importWorkflowFile(
 ): Promise<Array<{ value: unknown; exportKey: string; kind: DiscoveryKind; filePath: string }>> {
   let mod: Record<string, unknown>;
   try {
-    mod = (await import(filePath)) as Record<string, unknown>;
+    mod = await loadWorkflowModule(filePath);
   } catch (err) {
     diagnostics.push({
       level: "error",
@@ -346,15 +367,14 @@ async function loadFromPaths(
     const absPath = isAbsolute(rawPath) ? rawPath : resolve(baseCwd, rawPath);
 
     // Give a specific PATH_NOT_FOUND when we can detect the file is absent.
-    let exists = false;
+    let pathStats: Awaited<ReturnType<typeof stat>> | undefined;
     try {
-      await stat(absPath);
-      exists = true;
+      pathStats = await stat(absPath);
     } catch {
-      exists = false;
+      pathStats = undefined;
     }
 
-    if (!exists) {
+    if (pathStats === undefined) {
       diagnostics.push({
         level: "error",
         code: "PATH_NOT_FOUND",
@@ -364,7 +384,9 @@ async function loadFromPaths(
       continue;
     }
 
-    const candidates = await importWorkflowFile(absPath, kind, diagnostics);
+    const candidates = pathStats.isDirectory()
+      ? await loadFromDir(absPath, kind, diagnostics)
+      : await importWorkflowFile(absPath, kind, diagnostics);
     for (const c of candidates) {
       all.push({ ...c, ...(configuredName !== undefined ? { configuredName } : {}) });
     }

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -20,12 +20,19 @@
  *   const result = await discoverWorkflows({ cwd: process.cwd(), homeDir: os.homedir() });
  */
 
+import { existsSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { join, resolve, extname, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
-import { CONFIG_DIR_NAMES, getProjectConfigPaths } from "@bastani/atomic";
+import { CONFIG_DIR_NAMES, getProjectConfigPaths, isBunBinary } from "@bastani/atomic";
 import { createJiti } from "jiti/static";
 import type { WorkflowDefinition } from "../shared/types.js";
+import { GraphFrontierTracker } from "../runs/shared/graph-inference.js";
+import { run, runChain, runParallel, runTask, resolveInputs } from "../runs/foreground/executor.js";
+import { createCancellationRegistry, cancellationRegistry } from "../runs/background/cancellation-registry.js";
+import { createStore, store } from "../shared/store.js";
+import { defineWorkflow } from "../workflows/define-workflow.js";
+import { normalizeWorkflowName, workflowNamesEqual } from "../workflows/identity.js";
 import { createRegistry } from "../workflows/registry.js";
 import type { WorkflowRegistry } from "../workflows/registry.js";
 import * as bundledManifest from "../../builtin/index.js";
@@ -278,17 +285,63 @@ async function scanWorkflowDir(dir: string): Promise<string[] | null> {
  * jiti loads package-authored .ts/.js/.mjs/.cjs files with the same
  * @bastani/workflows authoring import that project/user workflow files use.
  */
+type RunWorkflowFunction = typeof import("../runs/shared/workflow-runner.js").runWorkflow;
+
+const runWorkflow: RunWorkflowFunction = async (...args) => {
+  const { runWorkflow: actualRunWorkflow } = await import("../runs/shared/workflow-runner.js");
+  return actualRunWorkflow(...args);
+};
+
+const WORKFLOWS_MODULE_SPECIFIER = "@bastani/workflows";
+const WORKFLOWS_SDK_ENTRY_URL = new URL("../index.ts", import.meta.url);
+const WORKFLOWS_SDK_MODULE: Record<string, unknown> = {
+  defineWorkflow,
+  createRegistry,
+  normalizeWorkflowName,
+  workflowNamesEqual,
+  run,
+  runTask,
+  runParallel,
+  runChain,
+  resolveInputs,
+  runWorkflow,
+  GraphFrontierTracker,
+  createStore,
+  store,
+  createCancellationRegistry,
+  cancellationRegistry,
+};
+const WORKFLOWS_VIRTUAL_MODULES: Record<string, unknown> = {
+  [WORKFLOWS_MODULE_SPECIFIER]: WORKFLOWS_SDK_MODULE,
+};
+
+function resolveWorkflowsSdkAlias(): string {
+  const sdkEntry = fileURLToPath(WORKFLOWS_SDK_ENTRY_URL);
+  if (!existsSync(sdkEntry)) {
+    throw new Error(
+      `Unable to resolve ${WORKFLOWS_MODULE_SPECIFIER} SDK entry at ${sdkEntry}. ` +
+        "Update WORKFLOWS_SDK_ENTRY_URL if discovery.ts moves.",
+    );
+  }
+  return sdkEntry;
+}
+
 const workflowModuleLoader = createJiti(import.meta.url, {
   moduleCache: false,
-  alias: {
-    "@bastani/workflows": fileURLToPath(new URL("../index.ts", import.meta.url)),
-  },
+  // Keep workflow-file import semantics deterministic: jiti owns .ts/.js/.mjs/.cjs
+  // resolution instead of handing some imports back to native import().
+  tryNative: false,
+  ...(isBunBinary
+    ? { virtualModules: WORKFLOWS_VIRTUAL_MODULES }
+    : { alias: { [WORKFLOWS_MODULE_SPECIFIER]: resolveWorkflowsSdkAlias() } }),
 });
 
 function normalizeWorkflowModule(mod: unknown): Record<string, unknown> {
   if (mod !== null && typeof mod === "object") {
     return mod as Record<string, unknown>;
   }
+  // CJS/default interop can return the exported value directly; wrap it so the
+  // candidate collector can handle it the same way as an ESM default export.
   return { default: mod };
 }
 

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -22,17 +22,12 @@
 
 import { existsSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join, resolve, extname, isAbsolute } from "node:path";
-import { fileURLToPath } from "node:url";
 import { CONFIG_DIR_NAMES, getProjectConfigPaths, isBunBinary } from "@bastani/atomic";
 import { createJiti } from "jiti/static";
 import type { WorkflowDefinition } from "../shared/types.js";
-import { GraphFrontierTracker } from "../runs/shared/graph-inference.js";
-import { run, runChain, runParallel, runTask, resolveInputs } from "../runs/foreground/executor.js";
-import { createCancellationRegistry, cancellationRegistry } from "../runs/background/cancellation-registry.js";
-import { createStore, store } from "../shared/store.js";
-import { defineWorkflow } from "../workflows/define-workflow.js";
-import { normalizeWorkflowName, workflowNamesEqual } from "../workflows/identity.js";
+import * as workflowsSdkSurface from "../sdk-surface.js";
 import { createRegistry } from "../workflows/registry.js";
 import type { WorkflowRegistry } from "../workflows/registry.js";
 import * as bundledManifest from "../../builtin/index.js";
@@ -292,35 +287,27 @@ const runWorkflow: RunWorkflowFunction = async (...args) => {
   return actualRunWorkflow(...args);
 };
 
+const require = createRequire(import.meta.url);
 const WORKFLOWS_MODULE_SPECIFIER = "@bastani/workflows";
-const WORKFLOWS_SDK_ENTRY_URL = new URL("../index.ts", import.meta.url);
+// Keep this in sync with index.ts through sdk-surface.ts. runWorkflow stays as
+// a lazy wrapper because the public re-export comes from workflow-runner.ts,
+// which imports this discovery module and would otherwise reintroduce a cycle.
 const WORKFLOWS_SDK_MODULE: Record<string, unknown> = {
-  defineWorkflow,
-  createRegistry,
-  normalizeWorkflowName,
-  workflowNamesEqual,
-  run,
-  runTask,
-  runParallel,
-  runChain,
-  resolveInputs,
+  ...workflowsSdkSurface,
   runWorkflow,
-  GraphFrontierTracker,
-  createStore,
-  store,
-  createCancellationRegistry,
-  cancellationRegistry,
 };
 const WORKFLOWS_VIRTUAL_MODULES: Record<string, unknown> = {
   [WORKFLOWS_MODULE_SPECIFIER]: WORKFLOWS_SDK_MODULE,
 };
 
 function resolveWorkflowsSdkAlias(): string {
-  const sdkEntry = fileURLToPath(WORKFLOWS_SDK_ENTRY_URL);
+  // Resolve the package self-reference through package.json exports instead of
+  // pinning discovery.ts to the current src/extension -> src/index.ts layout.
+  const sdkEntry = require.resolve(WORKFLOWS_MODULE_SPECIFIER);
   if (!existsSync(sdkEntry)) {
     throw new Error(
       `Unable to resolve ${WORKFLOWS_MODULE_SPECIFIER} SDK entry at ${sdkEntry}. ` +
-        "Update WORKFLOWS_SDK_ENTRY_URL if discovery.ts moves.",
+        "Check the package exports map for the workflows SDK entry.",
     );
   }
   return sdkEntry;

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -323,16 +323,40 @@ const workflowModuleLoader = createJiti(import.meta.url, {
     : { alias: { [WORKFLOWS_MODULE_SPECIFIER]: resolveWorkflowsSdkAlias() } }),
 });
 
+function materializeModuleObject(mod: object): Record<string, unknown> {
+  const materialized: Record<string, unknown> = {};
+
+  // jiti's callable API can return an interop namespace proxy. Its own property
+  // descriptors contain the authored export values, but property access may apply
+  // default-export conveniences (and even expose a throwing inherited `then`
+  // getter for `export default null`). Copy own descriptors into a plain object
+  // so candidate collection sees the exact authored exports.
+  for (const key of Object.getOwnPropertyNames(mod)) {
+    const descriptor = Object.getOwnPropertyDescriptor(mod, key);
+    if (descriptor === undefined) continue;
+
+    const value = "value" in descriptor ? descriptor.value : descriptor.get?.call(mod);
+    Object.defineProperty(materialized, key, {
+      value,
+      enumerable: descriptor.enumerable,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  return materialized;
+}
+
 function normalizeWorkflowModule(mod: unknown): Record<string, unknown> {
   if (mod !== null && typeof mod === "object") {
-    return mod as Record<string, unknown>;
+    return materializeModuleObject(mod);
   }
   // CJS/default interop can return the exported value directly; wrap it so the
   // candidate collector can handle it the same way as an ESM default export.
   return { default: mod };
 }
 
-async function loadWorkflowModule(filePath: string): Promise<Record<string, unknown>> {
+function loadWorkflowModule(filePath: string): Record<string, unknown> {
   return normalizeWorkflowModule(workflowModuleLoader(filePath));
 }
 
@@ -343,7 +367,7 @@ async function importWorkflowFile(
 ): Promise<Array<{ value: unknown; exportKey: string; kind: DiscoveryKind; filePath: string }>> {
   let mod: Record<string, unknown>;
   try {
-    mod = await loadWorkflowModule(filePath);
+    mod = loadWorkflowModule(filePath);
   } catch (err) {
     diagnostics.push({
       level: "error",

--- a/packages/workflows/src/index.ts
+++ b/packages/workflows/src/index.ts
@@ -3,23 +3,11 @@
  * Public entry point — re-exports the authoring API and public types.
  */
 
-export { defineWorkflow } from "./workflows/define-workflow.js";
-export { createRegistry } from "./workflows/registry.js";
-export { normalizeWorkflowName, workflowNamesEqual } from "./workflows/identity.js";
-export type * from "./shared/types.js";
-export type { WorkflowBuilder, CompletedWorkflowBuilder } from "./workflows/define-workflow.js";
-export type { WorkflowRegistry } from "./workflows/registry.js";
+// Add new non-cyclic public runtime exports to sdk-surface.ts so the Bun
+// virtual SDK used by workflow discovery stays in lockstep with this entry.
+export * from "./sdk-surface.js";
 
-export { run, runTask, runParallel, runChain, resolveInputs } from "./runs/foreground/executor.js";
-export type { RunOpts, RunResult, ResolvedInputs } from "./runs/foreground/executor.js";
+// runWorkflow is exported here only: workflow-runner imports discovery.ts, so
+// discovery provides a lazy wrapper instead of importing this entry eagerly.
 export { runWorkflow } from "./runs/shared/workflow-runner.js";
 export type { WorkflowOptions, WorkflowRunOptions } from "./runs/shared/workflow-runner.js";
-export type { AgentSessionAdapter, StageAdapters } from "./runs/foreground/stage-runner.js";
-export { GraphFrontierTracker } from "./runs/shared/graph-inference.js";
-export type { StageNode } from "./runs/shared/graph-inference.js";
-export { createStore, store } from "./shared/store.js";
-export type { RunStatus, StageStatus, ToolEvent, StageSnapshot, RunSnapshot, StoreSnapshot, WorkflowNotice, NoticeLevel, WorkflowOverlayAdapter, PromptKind, PendingPrompt } from "./shared/store-types.js";
-
-// Phase D — cancellation registry
-export { createCancellationRegistry, cancellationRegistry } from "./runs/background/cancellation-registry.js";
-export type { CancellationRegistry, ActiveRunEntry } from "./runs/background/cancellation-registry.js";

--- a/packages/workflows/src/sdk-surface.ts
+++ b/packages/workflows/src/sdk-surface.ts
@@ -1,0 +1,26 @@
+/**
+ * Non-cyclic public SDK surface for @bastani/workflows.
+ *
+ * Keep public runtime exports here when they are safe to load during workflow
+ * discovery. The package root re-exports this module and adds runWorkflow,
+ * which is intentionally excluded because workflow-runner imports discovery.ts.
+ */
+
+export { defineWorkflow } from "./workflows/define-workflow.js";
+export { createRegistry } from "./workflows/registry.js";
+export { normalizeWorkflowName, workflowNamesEqual } from "./workflows/identity.js";
+export type * from "./shared/types.js";
+export type { WorkflowBuilder, CompletedWorkflowBuilder } from "./workflows/define-workflow.js";
+export type { WorkflowRegistry } from "./workflows/registry.js";
+
+export { run, runTask, runParallel, runChain, resolveInputs } from "./runs/foreground/executor.js";
+export type { RunOpts, RunResult, ResolvedInputs } from "./runs/foreground/executor.js";
+export type { AgentSessionAdapter, StageAdapters } from "./runs/foreground/stage-runner.js";
+export { GraphFrontierTracker } from "./runs/shared/graph-inference.js";
+export type { StageNode } from "./runs/shared/graph-inference.js";
+export { createStore, store } from "./shared/store.js";
+export type { RunStatus, StageStatus, ToolEvent, StageSnapshot, RunSnapshot, StoreSnapshot, WorkflowNotice, NoticeLevel, WorkflowOverlayAdapter, PromptKind, PendingPrompt } from "./shared/store-types.js";
+
+// Phase D — cancellation registry
+export { createCancellationRegistry, cancellationRegistry } from "./runs/background/cancellation-registry.js";
+export type { CancellationRegistry, ActiveRunEntry } from "./runs/background/cancellation-registry.js";

--- a/test/unit/coding-agent-builtin-workflows.test.ts
+++ b/test/unit/coding-agent-builtin-workflows.test.ts
@@ -102,6 +102,63 @@ describe("coding-agent builtin resources", () => {
     assert.equal(command?.description, "workflow resources: 1");
   }, 20_000);
 
+  test("registers package workflow names in /workflow completions", async () => {
+    const cwd = tempDir("atomic-workflow-command-cwd-");
+    const agentDir = tempDir("atomic-workflow-command-agent-");
+    const packageDir = join(cwd, "workflow-command-package");
+    const workflowsDir = join(packageDir, "workflows");
+    mkdirSync(workflowsDir, { recursive: true });
+    writeFileSync(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: "workflow-command-package", keywords: ["atomic-package"] }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(workflowsDir, "package-command.ts"),
+      [
+        `import { defineWorkflow } from "@bastani/workflows";`,
+        ``,
+        `export default defineWorkflow("package-command")`,
+        `  .description("Package command workflow")`,
+        `  .run(async (ctx) => {`,
+        `    await ctx.task("validation-smoke", { prompt: "validation smoke" });`,
+        `    return {};`,
+        `  })`,
+        `  .compile();`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const settingsManager = SettingsManager.inMemory();
+    settingsManager.setPackages([packageDir]);
+    const loader = new DefaultResourceLoader({
+      cwd,
+      agentDir,
+      settingsManager,
+      builtinPackagePaths: [resolve("packages/workflows")],
+    });
+
+    await loader.reload();
+
+    const extensions = loader.getExtensions();
+    assert.deepEqual(extensions.errors, []);
+    const workflowExtension = extensions.extensions.find((extension) =>
+      extension.path.replace(/\\/g, "/").endsWith("packages/workflows/src/extension/index.ts"),
+    );
+    const workflowCommand = workflowExtension?.commands.get("workflow");
+    assert.notEqual(workflowCommand, undefined);
+
+    let labels: string[] = [];
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const completions = (await workflowCommand!.getArgumentCompletions?.("")) ?? [];
+      labels = completions.map((completion) => completion.label);
+      if (labels.includes("package-command")) break;
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+    }
+
+    assert.ok(labels.includes("package-command"), `expected package workflow completion in ${labels.join(", ")}`);
+  }, 20_000);
+
   test("loads builtin pi package resources", async () => {
     const cwd = tempDir("atomic-builtin-packages-cwd-");
     const agentDir = tempDir("atomic-builtin-packages-agent-");

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -437,6 +437,65 @@ describe("discoverWorkflows — package workflows", () => {
     assert.equal(src!.kind, "package");
     assert.equal(src!.filePath, fp);
   });
+
+  test("loads workflow directories supplied by package resources", async () => {
+    const root = makeTempDir("package-workflow-dir");
+    const packageDir = join(root, "package-workflows");
+    const workflowsDir = join(packageDir, "workflows");
+    mkdirSync(workflowsDir, { recursive: true });
+    const fp = writeWorkflowJs(workflowsDir, "packaged-dir.js", "Packaged Dir", "packaged-dir");
+
+    const result = await discoverWorkflows({
+      cwd: join(root, "cwd"),
+      homeDir: join(root, "home"),
+      includeBundled: false,
+      packageWorkflowPaths: [workflowsDir],
+    });
+
+    assert.equal(result.registry.has("packaged-dir"), true);
+    assert.equal(result.errors.length, 0);
+    const src = result.sources.find((s) => s.id === "packaged-dir");
+    assert.notEqual(src, undefined);
+    assert.equal(src!.kind, "package");
+    assert.equal(src!.filePath, fp);
+  });
+
+  test("loads package workflows authored with @bastani/workflows imports", async () => {
+    const root = makeTempDir("package-workflow-sdk-import");
+    const packageDir = join(root, "package-workflows");
+    const workflowsDir = join(packageDir, "workflows");
+    mkdirSync(workflowsDir, { recursive: true });
+    const fp = join(workflowsDir, "sdk-import.ts");
+    writeFileSync(
+      fp,
+      [
+        `import { defineWorkflow } from "@bastani/workflows";`,
+        ``,
+        `export default defineWorkflow("sdk-import")`,
+        `  .description("SDK import workflow")`,
+        `  .run(async (ctx) => {`,
+        `    await ctx.task("validation-smoke", { prompt: "validation smoke" });`,
+        `    return {};`,
+        `  })`,
+        `  .compile();`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await discoverWorkflows({
+      cwd: join(root, "cwd"),
+      homeDir: join(root, "home"),
+      includeBundled: false,
+      packageWorkflowPaths: [workflowsDir],
+    });
+
+    assert.equal(result.registry.has("sdk-import"), true);
+    assert.equal(result.errors.length, 0);
+    const src = result.sources.find((s) => s.id === "sdk-import");
+    assert.notEqual(src, undefined);
+    assert.equal(src!.kind, "package");
+    assert.equal(src!.filePath, fp);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -593,20 +652,20 @@ describe("discoverWorkflows — configured globalWorkflows", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Invalid exports → INVALID_DEFINITION
+// Invalid exports → diagnostics
 // ---------------------------------------------------------------------------
 
-describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
-  test("null default export emits INVALID_DEFINITION error", async () => {
+describe("discoverWorkflows — invalid export diagnostics", () => {
+  test("null default export emits an error diagnostic", async () => {
     const cwd = makeTempDir("invalid-null");
     const wfDir = join(cwd, ".atomic", "workflows");
     mkdirSync(wfDir, { recursive: true });
     writeInvalidWorkflowJs(wfDir, "bad-null.js");
 
     const { errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty"), includeBundled: false });
-    const inv = errors.filter((e) => e.code === "INVALID_DEFINITION");
-    assert.ok(inv.length > 0);
-    assert.equal(inv[0]!.level, "error");
+    assert.ok(errors.length > 0);
+    assert.equal(errors[0]!.level, "error");
+    assert.ok(errors[0]!.code === "INVALID_DEFINITION" || errors[0]!.code === "IMPORT_FAILED");
   });
 
   test("missing __piWorkflow sentinel emits INVALID_DEFINITION", async () => {

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -655,17 +655,19 @@ describe("discoverWorkflows — configured globalWorkflows", () => {
 // Invalid exports → diagnostics
 // ---------------------------------------------------------------------------
 
-describe("discoverWorkflows — invalid export diagnostics", () => {
-  test("null default export emits an error diagnostic", async () => {
+describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
+  test("null default export emits INVALID_DEFINITION", async () => {
     const cwd = makeTempDir("invalid-null");
     const wfDir = join(cwd, ".atomic", "workflows");
     mkdirSync(wfDir, { recursive: true });
-    writeInvalidWorkflowJs(wfDir, "bad-null.js");
+    const fp = writeInvalidWorkflowJs(wfDir, "bad-null.js");
 
     const { errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty"), includeBundled: false });
-    assert.ok(errors.length > 0);
+    assert.equal(errors.length, 1);
     assert.equal(errors[0]!.level, "error");
-    assert.ok(errors[0]!.code === "INVALID_DEFINITION" || errors[0]!.code === "IMPORT_FAILED");
+    assert.equal(errors[0]!.code, "INVALID_DEFINITION");
+    assert.equal(errors[0]!.source, fp);
+    assert.match(errors[0]!.message, /project-local export "default" rejected: export is not an object/);
   });
 
   test("missing __piWorkflow sentinel emits INVALID_DEFINITION", async () => {

--- a/test/unit/subagents-render-stability.test.ts
+++ b/test/unit/subagents-render-stability.test.ts
@@ -107,6 +107,41 @@ describe("subagent render stability", () => {
     }
   });
 
+  test("async widget leaves a blank line before the prompt box", () => {
+    let component: { render(width: number): string[] } | undefined;
+    const ctx = {
+      hasUI: true,
+      ui: {
+        setWidget: (_key: string, factory: ((tui: unknown, theme: RenderTheme) => { render(width: number): string[] }) | undefined) => {
+          component = factory?.({}, theme);
+        },
+        requestRender: () => {},
+        getToolsExpanded: () => false,
+      },
+    } as unknown as Parameters<typeof renderWidget>[0];
+    const job: AsyncJobState = {
+      asyncId: "abc123",
+      asyncDir: "/tmp/abc123",
+      status: "running",
+      mode: "single",
+      agents: ["worker"],
+      updatedAt: 10_000,
+      toolCount: 1,
+      turnCount: 2,
+    };
+
+    renderWidget(ctx, [job]);
+    try {
+      assert.ok(component, "expected widget component to be installed");
+      const lines = component.render(120);
+
+      assert.equal(lines.at(-1), "");
+      assert.notEqual(lines.at(-2), "");
+    } finally {
+      stopWidgetAnimation();
+    }
+  });
+
   test("running async widget animates without remounting the widget", async () => {
     let widgetUpdates = 0;
     let renderRequests = 0;


### PR DESCRIPTION
## Summary

Replaces native `import()` with a `jiti`-backed loader so that package-authored workflow files using `@bastani/workflows` SDK imports resolve correctly at runtime. Also extends `loadFromPaths` to accept directory paths, allowing package workflow directories to be registered for discovery.

## Key changes

### Core workflow loading fix
- **`packages/workflows/src/extension/discovery.ts`** — replace `import()` with a `createJiti`-backed `loadWorkflowModule`; expose `@bastani/workflows` to loaded files via virtual modules (Bun binary) or a path alias (non-binary jiti)
- **`packages/coding-agent/src/index.ts`** — export `isBunBinary` so `discovery.ts` can branch between the two resolution strategies
- **`packages/workflows/package.json`** — add `jiti ^2.7.0` as a runtime dependency; fix description from "pi extension" → "Atomic extension"

### Discovery enhancement
- **`packages/workflows/src/extension/discovery.ts`** — detect directory paths in `loadFromPaths` via `stat().isDirectory()` and dispatch to `loadFromDir`, enabling entire workflow directories (e.g. `package/workflows/`) to be registered

### Subagents render fix
- **`packages/subagents/src/tui/render.ts`** — append `Spacer(1)` after async widget lines to preserve the blank line separating the widget from the prompt box

### Docs & metadata
- **`packages/coding-agent/docs/workflows.md`** — note that workflow files are loaded via jiti (TypeScript works without compilation)
- **`package.json` / companion `package.json` files** — add contributors, add upstream fork references to descriptions

## Tests

- **`test/unit/discovery.test.ts`**: two new cases — directory-based package workflow paths and `@bastani/workflows` SDK-import workflows
- **`test/unit/coding-agent-builtin-workflows.test.ts`**: validates that package workflow names appear in `/workflow` completions
- **`test/unit/subagents-render-stability.test.ts`**: asserts the trailing blank line is present after async widget output

## Breaking changes / migration notes

None. The jiti loader is a drop-in replacement for `import()` and the directory-path support is additive.