### PR TITLE
chore(release): bump to v0.8.13-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.12",
+      "version": "0.8.13-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.12",
+      "version": "0.8.13-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.12",
+      "version": "0.8.13-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.12",
+      "version": "0.8.13-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.12",
+      "version": "0.8.13-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.12",
+      "version": "0.8.13-0",
       "dependencies": {
         "jiti": "^2.7.0",
       },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.8.13-0] - 2026-05-21
+
+### Fixed
+
+- Fixed packaged workflow discovery so package-authored workflow resources load through `jiti` with the same `@bastani/workflows` SDK imports used by project and user workflows.
+- Preserved workflow discovery diagnostics for invalid default exports and supported SDK imports when running from the Bun binary.
+- Preserved spacing for async subagent widgets before the prompt box.
+
 ## [0.8.12] - 2026-05-20
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.12",
+  "version": "0.8.13-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.12",
+  "version": "0.8.13-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.12",
+  "version": "0.8.13-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.12",
+  "version": "0.8.13-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.12",
+  "version": "0.8.13-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.12",
+  "version": "0.8.13-0",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the v0.8.13-0 prerelease, which fixes packaged workflow resource loading via `jiti` and preserves workflow discovery diagnostics and subagent widget spacing.

## Changes

- Bumps all workspace package versions from `0.8.12` → `0.8.13-0`
- Adds CHANGELOG entry for v0.8.13-0 covering the three fixes below
- Refreshes `bun.lock` with the updated prerelease versions

## Fixes in this release

- **Packaged workflow loading** — workflow resources authored inside packages now load through `jiti` using the same `@bastani/workflows` SDK imports as project/user workflows (fixes the regression from v0.8.12)
- **Workflow discovery diagnostics** — invalid default exports and unsupported SDK imports are still reported correctly when running from the Bun binary
- **Async subagent widget spacing** — spacing before the prompt box is preserved for async subagent widgets

## Validation

- `bun run typecheck`
- `bun run test:unit`
- `bun run lint`

## Notes

- This is a prerelease (`0.8.13-0`); it will publish to npm with the `next` tag and create a prerelease GitHub Release (not marked latest).
- Existing uncommitted `CLAUDE.md` changes were intentionally left out of this PR.