### PR TITLE
chore(release): bump to v0.8.13

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.13-0",
+      "version": "0.8.13",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.13-0",
+      "version": "0.8.13",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.13-0",
+      "version": "0.8.13",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.13-0",
+      "version": "0.8.13",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.13-0",
+      "version": "0.8.13",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.13-0",
+      "version": "0.8.13",
       "dependencies": {
         "jiti": "^2.7.0",
       },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.8.13] - 2026-05-21
+
+### Changed
+
+- Promoted the 0.8.13 prerelease changes to a stable release.
+- Updated Atomic agent guidance.
+
+### Fixed
+
+- Fixed packaged workflow discovery so package-authored workflow resources load through `jiti` with the same `@bastani/workflows` SDK imports used by project and user workflows.
+- Preserved workflow discovery diagnostics for invalid default exports and supported SDK imports when running from the Bun binary.
+- Preserved spacing for async subagent widgets before the prompt box.
+
 ## [0.8.13-0] - 2026-05-21
 
 ### Fixed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.13-0",
+  "version": "0.8.13",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.13-0",
+  "version": "0.8.13",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.13-0",
+  "version": "0.8.13",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.13-0",
+  "version": "0.8.13",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.13-0",
+  "version": "0.8.13",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.13-0",
+  "version": "0.8.13",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes all workspace packages from prerelease `0.8.13-0` to stable `0.8.13`, updates `bun.lock`, and adds the `v0.8.13` release section to the changelog.

## Changes

- Bumped version from `0.8.13-0` → `0.8.13` across all workspace packages:
  - `@bastani/atomic` (`packages/coding-agent`)
  - `@bastani/intercom`, `@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`, `@bastani/workflows`
- Updated `bun.lock` workspace entries to reflect stable version
- Added `packages/coding-agent/CHANGELOG.md` section for `[0.8.13]` with the following notes:
  - **Changed:** Promoted 0.8.13 prerelease changes to stable; updated Atomic agent guidance
  - **Fixed:** Packaged workflow discovery now loads `@bastani/workflows` SDK imports via `jiti` correctly
  - **Fixed:** Workflow discovery diagnostics for invalid default exports preserved when running from the Bun binary
  - **Fixed:** Spacing for async subagent widgets before the prompt box

## Validation

- `bun run typecheck`
- `cd packages/coding-agent && bun run build`
- `bun run test:unit`
- `bun run test:integration`
- `./scripts/build-binaries.sh --platform linux-x64`
- Linux x64 smoke test: `atomic --version` → `0.8.13`

## Notes

After this PR merges, create and push tag `v0.8.13` to trigger npm publishing with OIDC provenance.