### PR TITLE
docs: update atomic-promo.gif

### DIFF
--- a/assets/atomic-promo.gif
+++ b/assets/atomic-promo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd7865e4f3ede49002b8fbfa29789fd8100eb73bba3c75007ee46e9dda94240b
-size 43367916
+oid sha256:6bee759fc85a86cb5f89e773e41b7f39267a76ac981f54d934661877b5a89011
+size 47851803


### PR DESCRIPTION
## Summary

Updates the LFS pointer for `assets/atomic-promo.gif` to a newer cut of the promo video (~47MB, up from ~43MB).

## Changes

- **`assets/atomic-promo.gif`** — LFS pointer updated to new blob (`6bee759f…`); file size increases from ~43MB to ~47MB
  - Source: `atomic-product-hunt/promo-video/out/atomic-promo.gif`
  - LFS blob already uploaded to GitHub's LFS server

## Notes

- The README `<img>` tag path (`./assets/atomic-promo.gif`) is unchanged — no README edits required
- Viewers will see the updated gif automatically once merged