### PR TITLE
fix(workflows): remove model metadata from node cards

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Fixed completed workflow node cards hiding stale model metadata while retaining fallback dependency metadata ([#1011](https://github.com/flora131/atomic/issues/1011)).
+- Removed model metadata from workflow node cards while retaining fallback dependency metadata ([#1011](https://github.com/flora131/atomic/issues/1011)).
 
 ## [0.0.1] — 2026-05-15
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed completed workflow node cards hiding stale model metadata while retaining fallback dependency metadata ([#1011](https://github.com/flora131/atomic/issues/1011)).
+
 ## [0.0.1] — 2026-05-15
 
 ### Added

--- a/packages/workflows/src/tui/node-card.ts
+++ b/packages/workflows/src/tui/node-card.ts
@@ -117,7 +117,7 @@ function durationText(stage: StageSnapshot): string {
 }
 
 function metaText(stage: StageSnapshot): string {
-  if (stage.model) return stage.model;
+  if (stage.status !== "completed" && stage.model) return stage.model;
   const deps = stage.parentIds.length;
   if (deps === 0) return "root";
   return deps === 1 ? "1 dep" : `${deps} deps`;

--- a/packages/workflows/src/tui/node-card.ts
+++ b/packages/workflows/src/tui/node-card.ts
@@ -117,7 +117,6 @@ function durationText(stage: StageSnapshot): string {
 }
 
 function metaText(stage: StageSnapshot): string {
-  if (stage.status !== "completed" && stage.model) return stage.model;
   const deps = stage.parentIds.length;
   if (deps === 0) return "root";
   return deps === 1 ? "1 dep" : `${deps} deps`;

--- a/test/unit/node-card.test.ts
+++ b/test/unit/node-card.test.ts
@@ -274,7 +274,11 @@ describe("renderNodeCard — metadata line", () => {
 
   test("running stages continue to show model metadata", () => {
     const lines = renderNodeCard(
-      makeStage({ status: "running", startedAt: Date.now() - 1000, model: "gpt-5-mini" }),
+      makeStage({
+        status: "running",
+        startedAt: Date.now() - 1000,
+        model: "gpt-5-mini",
+      }),
       { theme },
     );
 

--- a/test/unit/node-card.test.ts
+++ b/test/unit/node-card.test.ts
@@ -41,6 +41,7 @@ function makeStage(opts: Partial<StageSnapshot> = {}): StageSnapshot {
     pausedAt: opts.pausedAt,
     resumedAt: opts.resumedAt,
     blockedByStageId: opts.blockedByStageId,
+    model: opts.model,
   };
 }
 
@@ -252,6 +253,32 @@ describe("renderNodeCard — status border colours", () => {
 
     assert.equal(pauseIconCount, 1);
     assert.match(rendered, /❚❚ paused/);
+  });
+});
+
+describe("renderNodeCard — metadata line", () => {
+  test("completed stages hide model metadata and keep fallback geometry", () => {
+    const lines = renderNodeCard(
+      makeStage({ status: "completed", durationMs: 1200, model: "gpt-5-mini" }),
+      { theme },
+    );
+    const rendered = stripAnsi(lines.join("\n"));
+
+    assert.doesNotMatch(rendered, /gpt-5-mini/);
+    assert.match(stripAnsi(lines[3]!), /root/);
+    assert.equal(lines.length, NODE_H);
+    for (const line of lines) {
+      assert.equal(stripAnsi(line).length, NODE_W);
+    }
+  });
+
+  test("running stages continue to show model metadata", () => {
+    const lines = renderNodeCard(
+      makeStage({ status: "running", startedAt: Date.now() - 1000, model: "gpt-5-mini" }),
+      { theme },
+    );
+
+    assert.match(stripAnsi(lines[3]!), /gpt-5-mini/);
   });
 });
 

--- a/test/unit/node-card.test.ts
+++ b/test/unit/node-card.test.ts
@@ -257,7 +257,7 @@ describe("renderNodeCard — status border colours", () => {
 });
 
 describe("renderNodeCard — metadata line", () => {
-  test("completed stages hide model metadata and keep fallback geometry", () => {
+  test("stages hide model metadata and keep fallback geometry", () => {
     const lines = renderNodeCard(
       makeStage({ status: "completed", durationMs: 1200, model: "gpt-5-mini" }),
       { theme },
@@ -272,17 +272,20 @@ describe("renderNodeCard — metadata line", () => {
     }
   });
 
-  test("running stages continue to show model metadata", () => {
+  test("running stages use dependency metadata instead of model metadata", () => {
     const lines = renderNodeCard(
       makeStage({
         status: "running",
+        parentIds: ["build"],
         startedAt: Date.now() - 1000,
         model: "gpt-5-mini",
       }),
       { theme },
     );
 
-    assert.match(stripAnsi(lines[3]!), /gpt-5-mini/);
+    const rendered = stripAnsi(lines.join("\n"));
+    assert.doesNotMatch(rendered, /gpt-5-mini/);
+    assert.match(stripAnsi(lines[3]!), /1 dep/);
   });
 });
 


### PR DESCRIPTION
## Summary

Removes stale model metadata from workflow node card display in the TUI. Node cards now consistently show dependency geometry (root / N deps) instead of the configured model name, which becomes irrelevant once a stage is queued or running.

Closes #1011

## Changes

- **`packages/workflows/src/tui/node-card.ts`**: Remove the `stage.model` early-return from `metaText` — all node cards now fall through to the root/dep-count geometry label.
- **`test/unit/node-card.test.ts`**: Thread `model` through the `makeStage` factory and add two `metadata line` tests — one verifying completed cards suppress the model in favour of "root", another verifying running cards suppress the model in favour of "1 dep".
- **`packages/workflows/CHANGELOG.md`**: Document the fix under `[Unreleased] → Fixed`.

## Test Plan

```sh
bun test test/unit/node-card.test.ts test/unit/overlay-graph.test.ts
bun run typecheck
git diff --check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)