### PR TITLE
fix(workflows): register workflow tool with renderShell: self

### DIFF
--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -205,6 +205,7 @@ export interface PiToolOpts<TArgs, TDetails> {
   label: string;
   description: string;
   parameters: unknown; // TypeBox TSchema — pi consumes it opaquely
+  renderShell?: "default" | "self";
   /**
    * Pi calls execute positionally: `(toolCallId, params, signal, onUpdate, ctx)`.
    * cross-ref: pi-coding-agent dist/core/extensions/types.d.ts ToolDefinition.execute
@@ -1395,6 +1396,7 @@ function factory(pi: ExtensionAPI): void {
       label: "workflow",
       description: "Run a defined multi-stage workflow by name.",
       parameters: workflowParameters,
+      renderShell: "self",
       execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
         // Overlay is opt-in via F2 / ctrl+h; do not auto-open from a
         // tool-call dispatch path.

--- a/test/integration/mock-extension-api.test.ts
+++ b/test/integration/mock-extension-api.test.ts
@@ -552,6 +552,10 @@ describe("MockExtensionAPI — tool registration", () => {
     assert.equal(typeof mock.tools[0]!.opts.renderResult, "function");
   });
 
+  test("tool renders its own shell", () => {
+    assert.equal(mock.tools[0]!.opts.renderShell, "self");
+  });
+
   test("tool renderCall slot delegates correctly", () => {
     const slot = mock.tools[0]!.opts.renderCall!;
     const out = slot({ workflow: "test-wf", inputs: {}, action: "run" }, {} as never, {} as never);


### PR DESCRIPTION
## Summary

Registers the workflow tool with `renderShell: "self"` so the tool-call UI shell is populated by the tool itself rather than relying on the default renderer shell. Without this, the tool-call UI block renders empty. Closes #1009.

## Changes

- Adds `renderShell?: "default" | "self"` optional field to the `PiToolOpts` interface (`packages/workflows/src/extension/index.ts`)
- Registers the workflow tool with `renderShell: "self"` so it owns its render shell slot
- Adds an integration test asserting the workflow tool registers with `renderShell: "self"` (`test/integration/mock-extension-api.test.ts`)

## Validation

- `bun test test/integration/mock-extension-api.test.ts` — passed
- `bun run typecheck` — passed
- Pre-commit/pre-push hooks (`bun run lint`, `bun run test:unit`) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)