### PR TITLE
fix(workflows): keep switcher ellipsis highlighted

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Preserve the selected workflow switcher row highlight through truncation ellipses on long stage names.
+
 ## [0.0.1] — 2026-05-15
 
 ### Added

--- a/packages/workflows/src/tui/switcher.ts
+++ b/packages/workflows/src/tui/switcher.ts
@@ -15,7 +15,7 @@ import type { StageSnapshot } from "../shared/store-types.js";
 import type { GraphTheme } from "./graph-theme.js";
 import { statusIcon, statusColor } from "./status-helpers.js";
 import { hexToAnsi, hexBg, RESET, BOLD } from "./color-utils.js";
-import { truncateToWidth, visibleWidth } from "./text-helpers.js";
+import { sliceColumns, truncateToWidth, visibleWidth } from "./text-helpers.js";
 
 export interface SwitcherState {
   query: string;
@@ -43,6 +43,25 @@ const COMPACT_HINT = "↵ attach · esc close";
 function padVisible(s: string, width: number): string {
   const clipped = visibleWidth(s) > width ? truncateToWidth(s, width, "…", true) : s;
   return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+/**
+ * Truncate without appending any ANSI reset before the suffix.
+ *
+ * Selected rows are wrapped in a single accent run after row text is composed;
+ * inserting RESET before the ellipsis would prematurely end that highlight.
+ */
+function truncateToWidthWithoutReset(text: string, width: number, suffix = ""): string {
+  const targetWidth = Math.max(0, width);
+  if (visibleWidth(text) <= targetWidth) return text;
+  if (targetWidth === 0) return "";
+
+  const suffixWidth = visibleWidth(suffix);
+  if (suffixWidth >= targetWidth) {
+    return sliceColumns(suffix, 0, targetWidth, true);
+  }
+
+  return `${sliceColumns(text, 0, targetWidth - suffixWidth, true)}${suffix}`;
 }
 
 function statusText(status: StageSnapshot["status"]): string {
@@ -119,7 +138,7 @@ export function renderSwitcher(
     if (isSelected) {
       const metaWidth = visibleWidth(label);
       const nameBudget = Math.max(4, innerWidth - visibleWidth(`  ${icon} `) - metaWidth - 2);
-      const selectedName = truncateToWidth(stage.name, nameBudget, "…");
+      const selectedName = truncateToWidthWithoutReset(stage.name, nameBudget, "…");
       const prefix = `  ${icon} ${selectedName}`;
       const visibleRow = `${prefix}${" ".repeat(Math.max(1, innerWidth - visibleWidth(`${prefix}${label}`) - 1))}${label} `;
       const padded = padVisible(visibleRow, innerWidth);

--- a/test/unit/overlay-graph.test.ts
+++ b/test/unit/overlay-graph.test.ts
@@ -13,6 +13,7 @@ import { deriveGraphTheme } from "../../packages/workflows/src/tui/graph-theme.j
 import { renderHeader } from "../../packages/workflows/src/tui/header.js";
 import { renderNodeCard } from "../../packages/workflows/src/tui/node-card.js";
 import { renderSwitcher } from "../../packages/workflows/src/tui/switcher.js";
+import { BOLD, RESET } from "../../packages/workflows/src/tui/color-utils.js";
 import { visibleWidth } from "../../packages/workflows/src/tui/text-helpers.js";
 
 // ---------------------------------------------------------------------------
@@ -590,6 +591,44 @@ describe("GraphView keyboard navigation", () => {
       }),
       width,
     );
+  });
+
+  it("keeps selected switcher row styling active through truncated names", () => {
+    const stages = [makeStage("branch-with-a-very-long-name-that-should-truncate")];
+    const width = 40;
+    const lines = renderSwitcher(stages, { query: "", selectedIndex: 0 }, {
+      width,
+      theme: defaultTheme,
+    });
+    const selectedRow = lines[3]!;
+    const selectedText = visibleText([selectedRow]);
+
+    assert.equal(visibleWidth(selectedRow), width);
+    assert.match(selectedText, /branch-with-a-very-long-…/);
+
+    const boldIndex = selectedRow.indexOf(BOLD);
+    const ellipsisIndex = selectedRow.indexOf("…", boldIndex);
+    const firstResetAfterBold = selectedRow.indexOf(RESET, boldIndex + BOLD.length);
+
+    assert.notEqual(boldIndex, -1);
+    assert.notEqual(ellipsisIndex, -1);
+    assert.ok(
+      firstResetAfterBold > ellipsisIndex,
+      "selected row should not reset ANSI styling before the truncation ellipsis",
+    );
+  });
+
+  it("does not add ellipsis to non-truncated selected switcher rows", () => {
+    const stages = [makeStage("short")];
+    const width = 40;
+    const lines = renderSwitcher(stages, { query: "", selectedIndex: 0 }, {
+      width,
+      theme: defaultTheme,
+    });
+    const selectedText = visibleText([lines[3]!]);
+
+    assert.doesNotMatch(selectedText, /…/);
+    assert.match(selectedText, /│  ○ short\s+pending │/);
   });
 
   it("renders the switcher as a focused modal body for long workflows", () => {


### PR DESCRIPTION
## Summary

Fixes the workflow switcher so long selected stage names keep the row highlight through the truncation ellipsis instead of resetting styling early.

Fixes #1010

## Changes

- Added selected-row truncation that avoids inserting an ANSI reset before the ellipsis.
- Covered truncated and non-truncated selected switcher rows with unit tests.
- Documented the workflow switcher highlight fix in the workflows changelog.

## Notes

Validation passed:
- `bun test test/unit/overlay-graph.test.ts`
- `bun run typecheck`
- `bun run test:unit`

A first pre-push attempt hit a transient failure in `GraphView animation timer > running-stage border pulse advances with wall-clock time`; rerunning that targeted test passed, and the subsequent pre-push hook passed `bun run test:unit`.