### PR TITLE
fix(tui): refresh header when model changes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Carried forward upstream fixes for managed extension installs, git package ref reconciliation, async file tools, export HTML escaping, OpenCode session headers, OAuth device-code login, footer path abbreviation, clipboard native loading, and collapsed read output rendering.
+- Refreshed the built-in header model label whenever the active model changes, matching the footer below the chat box.
 
 ## [0.8.13] - 2026-05-21
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -156,6 +156,12 @@ export type AgentSessionEvent =
 	  }
 	| { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
 	| { type: "session_info_changed"; name: string | undefined }
+	| {
+			type: "model_changed";
+			model: Model<Api>;
+			previousModel: Model<Api> | undefined;
+			source: "set" | "cycle" | "restore";
+	  }
 	| { type: "thinking_level_changed"; level: ThinkingLevel }
 	| {
 			type: "compaction_end";
@@ -1472,6 +1478,20 @@ export class AgentSession {
 	// Model Management
 	// =========================================================================
 
+	private _emitModelChanged(
+		nextModel: Model<Api>,
+		previousModel: Model<Api> | undefined,
+		source: "set" | "cycle" | "restore",
+	): void {
+		if (modelsAreEqual(previousModel, nextModel)) return;
+		this._emit({
+			type: "model_changed",
+			model: nextModel,
+			previousModel,
+			source,
+		});
+	}
+
 	private async _emitModelSelect(
 		nextModel: Model<Api>,
 		previousModel: Model<Api> | undefined,
@@ -1506,6 +1526,7 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 		this._refreshBaseSystemPromptFromActiveTools();
 
+		this._emitModelChanged(model, previousModel, "set");
 		await this._emitModelSelect(model, previousModel, "set");
 	}
 
@@ -1547,6 +1568,7 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 		this._refreshBaseSystemPromptFromActiveTools();
 
+		this._emitModelChanged(next.model, currentModel, "cycle");
 		await this._emitModelSelect(next.model, currentModel, "cycle");
 
 		return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };
@@ -1573,6 +1595,7 @@ export class AgentSession {
 		this.setThinkingLevel(thinkingLevel);
 		this._refreshBaseSystemPromptFromActiveTools();
 
+		this._emitModelChanged(nextModel, currentModel, "cycle");
 		await this._emitModelSelect(nextModel, currentModel, "cycle");
 
 		return { model: nextModel, thinkingLevel: this.thinkingLevel, isScoped: false };

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3217,6 +3217,11 @@ export class InteractiveMode {
         this.ui.requestRender();
         break;
 
+      case "model_changed":
+        this.refreshBuiltInHeader();
+        this.updateEditorBorderColor();
+        break;
+
       case "thinking_level_changed":
         this.footer.invalidate();
         this.refreshBuiltInHeader();

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -100,6 +100,28 @@ describe("InteractiveMode.setToolsExpanded", () => {
 	});
 });
 
+describe("InteractiveMode.handleEvent model changes", () => {
+	test("refreshes the built-in header when the active model changes", async () => {
+		const fakeThis: any = {
+			isInitialized: true,
+			footer: { invalidate: vi.fn() },
+			refreshBuiltInHeader: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
+		};
+
+		await (InteractiveMode as any).prototype.handleEvent.call(fakeThis, {
+			type: "model_changed",
+			model: { id: "faux-2", provider: "faux" },
+			previousModel: { id: "faux-1", provider: "faux" },
+			source: "set",
+		});
+
+		expect(fakeThis.footer.invalidate).toHaveBeenCalledTimes(1);
+		expect(fakeThis.refreshBuiltInHeader).toHaveBeenCalledTimes(1);
+		expect(fakeThis.updateEditorBorderColor).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe("InteractiveMode.createExtensionUIContext setTheme", () => {
 	test("persists theme changes to settings manager", () => {
 		initTheme("dark");

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -14,8 +14,9 @@ describe("AgentSession model and extension characterization", () => {
 		}
 	});
 
-	it("setModel saves the model and emits model_select", async () => {
+	it("setModel saves the model and emits model change events", async () => {
 		const modelEvents: string[] = [];
+		const sessionEvents: string[] = [];
 		const harness = await createHarness({
 			models: [
 				{ id: "faux-1", name: "One", reasoning: true },
@@ -31,11 +32,17 @@ describe("AgentSession model and extension characterization", () => {
 		});
 		harnesses.push(harness);
 		const nextModel = harness.getModel("faux-2")!;
+		harness.session.subscribe((event) => {
+			if (event.type === "model_changed") {
+				sessionEvents.push(`${event.previousModel?.id ?? "none"}->${event.model.id}:${event.source}`);
+			}
+		});
 
 		await harness.session.setModel(nextModel);
 
 		expect(harness.session.model?.id).toBe("faux-2");
 		expect(modelEvents).toEqual(["faux-1->faux-2:set"]);
+		expect(sessionEvents).toEqual(["faux-1->faux-2:set"]);
 		expect(
 			harness.sessionManager
 				.getEntries()
@@ -67,6 +74,29 @@ describe("AgentSession model and extension characterization", () => {
 		await harness.session.cycleModel();
 		expect(harness.session.model?.id).toBe("faux-1");
 		expect(harness.session.thinkingLevel).toBe("high");
+	});
+
+	it("emits model_changed when cycling models without changing thinking level", async () => {
+		const sessionEvents: string[] = [];
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		harness.session.setThinkingLevel("high");
+		harness.session.subscribe((event) => {
+			if (event.type === "model_changed") {
+				sessionEvents.push(`${event.previousModel?.id ?? "none"}->${event.model.id}:${event.source}`);
+			}
+		});
+
+		await harness.session.cycleModel();
+
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.session.thinkingLevel).toBe("high");
+		expect(sessionEvents).toEqual(["faux-1->faux-2:cycle"]);
 	});
 
 	it("clamps thinking levels to model capabilities and cycles available levels", async () => {


### PR DESCRIPTION
## Summary

Fixes a stale model indicator in the Atomic TUI header: previously, switching or cycling the active model updated the footer and editor border but left the logo-side header label unchanged. Now all three indicators stay in sync.

Closes #968

## Changes

- **New `model_changed` session event** — `AgentSessionEvent` gains a `{ type: "model_changed"; model; previousModel; source: "set" | "cycle" | "restore" }` variant. A private `_emitModelChanged` helper guards against no-op emissions via `modelsAreEqual` and fires on every `setModel` and `cycleModel` path.
- **Header refresh in interactive mode** — `InteractiveMode.handleEvent` handles `model_changed` by calling `refreshBuiltInHeader()` and `updateEditorBorderColor()`, mirroring the existing `thinking_level_changed` handler.
- **Regression tests** — `interactive-mode-status.test.ts` asserts header/border refresh on `model_changed`; `agent-session-model-extension.test.ts` adds a `cycleModel` case and extends the existing `setModel` test to assert the new session-level event alongside `model_select`.
- **Changelog** — entry added under `### Fixed` in `packages/coding-agent/CHANGELOG.md`.

## Validation

```sh
AGENT=1 bun test packages/coding-agent/test/interactive-mode-status.test.ts -t "InteractiveMode.handleEvent model changes"
AGENT=1 bun test packages/coding-agent/test/suite/agent-session-model-extension.test.ts
bun run lint
bun run test:unit
```