### PR TITLE
feat(tui): render workflow inputs as question cards

### DIFF
--- a/packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts
@@ -10,9 +10,18 @@ import { computeFocusedOptionHasPreview } from "./selectors/derivations.ts";
 import type { QuestionnaireRuntime, QuestionnaireState } from "./state.ts";
 import { type ApplyContext, type Effect, reduce } from "./state-reducer.ts";
 
-// Module-level constant; reused for cursor-end mutations after setValue rehydration.
-// Ctrl-E → tui.editor.cursorLineEnd (public path; pi-tui keybindings.js:25-28).
-const CURSOR_END = "\x05";
+function readInputCursor(input: Input): number {
+	const value = input.getValue();
+	const raw = Reflect.get(input, "cursor");
+	return typeof raw === "number" && Number.isFinite(raw)
+		? Math.max(0, Math.min(raw, value.length))
+		: value.length;
+}
+
+function writeInputCursor(input: Input, cursor: number): void {
+	const value = input.getValue();
+	Reflect.set(input, "cursor", Math.max(0, Math.min(cursor, value.length)));
+}
 
 export interface QuestionnaireSessionConfig {
 	tui: { terminal: { columns: number }; requestRender(): void };
@@ -41,6 +50,8 @@ function initialState(): QuestionnaireState {
 		focusedOptionHasPreview: false,
 		submitChoiceIndex: 0,
 		notesDraft: "",
+		customDraftByTab: new Map(),
+		customCaretByTab: new Map(),
 	};
 }
 
@@ -108,6 +119,7 @@ export class QuestionnaireSession {
 	}
 
 	private commit(action: QuestionnaireAction): void {
+		this.state = this.mirrorInlineInputDraft(this.state);
 		const result = reduce(this.state, action, this.applyContext());
 		this.state = result.state;
 		for (const effect of result.effects) this.runEffect(effect);
@@ -120,14 +132,25 @@ export class QuestionnaireSession {
 		return s.notesDraft === draft ? s : { ...s, notesDraft: draft };
 	}
 
+	private mirrorInlineInputDraft(s: QuestionnaireState): QuestionnaireState {
+		if (!s.inputMode) return s;
+		const value = this.inlineInput.getValue();
+		const caret = readInputCursor(this.inlineInput);
+		if (s.customDraftByTab.get(s.currentTab) === value && s.customCaretByTab.get(s.currentTab) === caret) {
+			return s;
+		}
+		const customDraftByTab = new Map(s.customDraftByTab);
+		const customCaretByTab = new Map(s.customCaretByTab);
+		customDraftByTab.set(s.currentTab, value);
+		customCaretByTab.set(s.currentTab, caret);
+		return { ...s, customDraftByTab, customCaretByTab };
+	}
+
 	private runEffect(effect: Effect): void {
 		switch (effect.kind) {
 			case "set_input_buffer":
 				this.inlineInput.setValue(effect.value);
-				this.inlineInput.handleInput(CURSOR_END);
-				return;
-			case "clear_input_buffer":
-				this.inlineInput.setValue("");
+				writeInputCursor(this.inlineInput, effect.caret);
 				return;
 			case "set_notes_value":
 				this.notesInput.setValue(effect.value);
@@ -151,15 +174,16 @@ export class QuestionnaireSession {
 	 * doing so would corrupt split-chunk pastes (a `\x05` byte mid-paste lands
 	 * verbatim in `pasteBuffer` and survives `handlePaste`'s narrow strip).
 	 * Cursor advances naturally via `insertCharacter` on typing/paste; cursor-
-	 * movement keys (Left/Right/Home/End/word-jumps) are now functional, with
-	 * the always-end visual cursor marker drawn independently by
-	 * `WrappingSelect.renderInlineInputRow`. `viewAdapter.apply` is called
-	 * directly without a reducer round-trip — preserves the D3 fast-path
+	 * movement keys (Left/Right/Home/End/word-jumps) are now functional, and
+	 * the live buffer/caret are mirrored into canonical state so rendering can
+	 * draw the same thick cursor at the editing caret. `viewAdapter.apply` is
+	 * called directly without a reducer round-trip — preserves the D3 fast-path
 	 * latency profile from Phase 11.
 	 */
 	private handleIgnoreInline(data: string): void {
 		if (!this.state.inputMode) return;
 		this.inlineInput.handleInput(data);
+		this.state = this.mirrorInlineInputDraft(this.state);
 		this.viewAdapter.apply(this.state);
 	}
 

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/contract.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/contract.ts
@@ -11,6 +11,7 @@ export interface BindingContext {
 	readonly totalQuestions: number;
 	readonly activeView: ActiveView;
 	readonly inputBuffer: string;
+	readonly inputCaret: number;
 	readonly activePreviewPane: StatefulView<PreviewPaneProps>;
 }
 

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/projections.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/projections.ts
@@ -34,6 +34,7 @@ export const selectOptionListProps: PerTabSelector<OptionListViewProps> = (state
 		selectedIndex: state.optionIndex,
 		focused,
 		inputBuffer: ctx.inputBuffer,
+		inputCaret: ctx.inputCaret,
 		...(confirmed ? { confirmed } : {}),
 	};
 };

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/state-reducer.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/state-reducer.ts
@@ -18,8 +18,7 @@ export interface ApplyContext {
  * (compiler-enforced exhaustive). No string-keyed escape hatch.
  */
 export type Effect =
-	| { kind: "set_input_buffer"; value: string }
-	| { kind: "clear_input_buffer" }
+	| { kind: "set_input_buffer"; value: string; caret: number }
 	| { kind: "set_notes_value"; value: string }
 	| { kind: "set_notes_focused"; focused: boolean }
 	| { kind: "forward_notes_keystroke"; data: string }
@@ -88,6 +87,31 @@ function persistMultiSelectAnswer(state: QuestionnaireState, ctx: ApplyContext):
 	return out;
 }
 
+function clampCaret(value: string, caret: number | undefined): number {
+	if (caret === undefined || !Number.isFinite(caret)) return value.length;
+	return Math.max(0, Math.min(caret, value.length));
+}
+
+function customDraftValue(state: QuestionnaireState): string {
+	const draft = state.customDraftByTab.get(state.currentTab);
+	if (draft !== undefined) return draft;
+	const prior = state.answers.get(state.currentTab);
+	return prior?.kind === "custom" && typeof prior.answer === "string" ? prior.answer : "";
+}
+
+function hydrateCustomInputResult(state: QuestionnaireState): ApplyResult {
+	const value = customDraftValue(state);
+	const caret = clampCaret(value, state.customCaretByTab.get(state.currentTab));
+	const customDraftByTab = new Map(state.customDraftByTab);
+	const customCaretByTab = new Map(state.customCaretByTab);
+	customDraftByTab.set(state.currentTab, value);
+	customCaretByTab.set(state.currentTab, caret);
+	return {
+		state: { ...state, customDraftByTab, customCaretByTab },
+		effects: [{ kind: "set_input_buffer", value, caret }],
+	};
+}
+
 function switchTabResult(state: QuestionnaireState, nextTab: number, ctx: ApplyContext): ApplyResult {
 	const notesValue = state.notesByTab.get(nextTab) ?? state.answers.get(nextTab)?.notes ?? "";
 	const transitioned: QuestionnaireState = {
@@ -131,14 +155,7 @@ const navHandler: Handler<"nav"> = (state, action, ctx) => {
 	const item = items[action.nextIndex];
 	const inputMode = item ? ROW_INTENT_META[item.kind].activatesInputMode : false;
 	const next = withFocusedOptionHasPreview({ ...state, optionIndex: action.nextIndex, inputMode }, ctx.questions);
-	if (!inputMode) {
-		return { state: next, effects: [{ kind: "clear_input_buffer" }] };
-	}
-	const prior = state.answers.get(state.currentTab);
-	if (prior?.kind === "custom" && typeof prior.answer === "string") {
-		return { state: next, effects: [{ kind: "set_input_buffer", value: prior.answer }] };
-	}
-	return { state: next, effects: [] };
+	return inputMode ? hydrateCustomInputResult(next) : { state: next, effects: [] };
 };
 
 const tabSwitchHandler: Handler<"tab_switch"> = (state, action, ctx) => switchTabResult(state, action.nextTab, ctx);
@@ -237,7 +254,7 @@ const focusOptionsHandler: Handler<"focus_options"> = (state, action, ctx) => {
 		{ ...state, chatFocused: false, optionIndex: action.optionIndex, inputMode },
 		ctx.questions,
 	);
-	return { state: next, effects: inputMode ? [] : [{ kind: "clear_input_buffer" }] };
+	return inputMode ? hydrateCustomInputResult(next) : { state: next, effects: [] };
 };
 
 const cancelHandler: Handler<"cancel"> = (s, _a, c) => doneFor(s, c, true);

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/state.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/state.ts
@@ -25,6 +25,10 @@ export interface QuestionnaireState {
 	submitChoiceIndex: number;
 	/** Canonical mirror of the in-flight notes editor; runtime mirrors after `forward_notes_keystroke`. */
 	notesDraft: string;
+	/** In-flight custom "Type something." drafts keyed by question tab. Preserved when focus leaves the row. */
+	customDraftByTab: ReadonlyMap<number, string>;
+	/** Caret offsets for in-flight custom drafts keyed by question tab. */
+	customCaretByTab: ReadonlyMap<number, number>;
 }
 
 /**

--- a/packages/coding-agent/src/core/tools/ask-user-question/view/components/option-list-view.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/view/components/option-list-view.ts
@@ -23,6 +23,7 @@ export interface OptionListViewProps {
 	selectedIndex: number;
 	focused: boolean;
 	inputBuffer: string;
+	inputCaret: number;
 	/** Optional previously-confirmed indicator. Omit when no marker should be drawn. */
 	confirmed?: { index: number; labelOverride?: string };
 }
@@ -51,6 +52,7 @@ export class OptionListView implements StatefulView<OptionListViewProps> {
 		this.select.setFocused(props.focused);
 		this.select.setConfirmedIndex(props.confirmed?.index, props.confirmed?.labelOverride);
 		this.select.setInputBuffer(props.inputBuffer);
+		this.select.setInputCursor(props.inputCaret);
 	}
 
 	handleInput(_data: string): void {}

--- a/packages/coding-agent/src/core/tools/ask-user-question/view/components/wrapping-select.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/view/components/wrapping-select.ts
@@ -47,7 +47,8 @@ export class WrappingSelect implements Component {
 	private static readonly ACTIVE_POINTER = "❯ ";
 	private static readonly INACTIVE_POINTER = "  ";
 	private static readonly NUMBER_SEPARATOR = ". ";
-	private static readonly INPUT_CURSOR = "▌";
+	private static readonly CURSOR_INVERSE_START = "\x1b[7m";
+	private static readonly CURSOR_INVERSE_END = "\x1b[0m";
 	private static readonly CONFIRMED_MARK = " ✔";
 	private static readonly MIN_CONTENT_WIDTH = 1;
 
@@ -60,6 +61,7 @@ export class WrappingSelect implements Component {
 	private selectedIndex = 0;
 	private focused = true;
 	private inputBuffer = "";
+	private inputCursor: number | undefined = undefined;
 	/**
 	 * Index of the row that was previously confirmed for this list (e.g. the user's prior
 	 * answer when re-entering a multi-question tab). Renders `<label> ✔` in the active-row
@@ -123,6 +125,11 @@ export class WrappingSelect implements Component {
 
 	setInputBuffer(text: string): void {
 		this.inputBuffer = text;
+		if (this.inputCursor !== undefined) this.inputCursor = this.clampInputCursor(this.inputCursor);
+	}
+
+	setInputCursor(cursor: number): void {
+		this.inputCursor = this.clampInputCursor(cursor);
 	}
 
 	/** Intentionally empty — input is routed at the container level. */
@@ -210,19 +217,34 @@ export class WrappingSelect implements Component {
 	 * so long input doesn't run off the right edge or trip the parent renderer's
 	 * width invariant. Mirrors `renderLabelBlock`'s contract: first line carries
 	 * `rowPrefix`, continuation lines carry `continuationPrefix` (spaces), and every
-	 * emitted line passes through `theme.selectedText`. The trailing cursor glyph
-	 * `▌` is appended to the buffer pre-wrap so it lands at the visual end of the
-	 * input — `Input` only exposes `getValue()` (cursor offset is private), so
-	 * cursor-mid-string is intentionally not rendered here; that would require
-	 * either an `Input.getCursorOffset()` API or delegating to `Input.render`.
+	 * emitted line passes through `theme.selectedText`. The cursor mirrors the
+	 * main chat editor: inverse-video over the character at the caret, or an
+	 * inverse-video space at end-of-line.
 	 */
 	private renderInlineInputRow(rowPrefix: string, continuationPrefix: string, contentWidth: number): string[] {
-		const raw = `${this.inputBuffer}${WrappingSelect.INPUT_CURSOR}`;
+		const raw = this.inputTextWithCursor();
 		const wrapped = wrapTextWithAnsi(raw, contentWidth);
 		return wrapped.map((segment, index) => {
 			const prefix = index === 0 ? rowPrefix : continuationPrefix;
 			return this.theme.selectedText(`${prefix}${segment}`);
 		});
+	}
+
+	private inputTextWithCursor(): string {
+		const cursor = this.clampInputCursor(this.inputCursor ?? this.inputBuffer.length);
+		const before = this.inputBuffer.slice(0, cursor);
+		const after = this.inputBuffer.slice(cursor);
+		const [at = ""] = Array.from(after);
+		if (at === "") {
+			return `${before}${WrappingSelect.CURSOR_INVERSE_START} ${WrappingSelect.CURSOR_INVERSE_END}`;
+		}
+		const rest = after.slice(at.length);
+		return `${before}${WrappingSelect.CURSOR_INVERSE_START}${at}${WrappingSelect.CURSOR_INVERSE_END}${rest}`;
+	}
+
+	private clampInputCursor(cursor: number): number {
+		if (!Number.isFinite(cursor)) return this.inputBuffer.length;
+		return Math.max(0, Math.min(cursor, this.inputBuffer.length));
 	}
 
 	private renderLabelBlock(

--- a/packages/coding-agent/src/core/tools/ask-user-question/view/props-adapter.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/view/props-adapter.ts
@@ -65,12 +65,15 @@ export class QuestionnairePropsAdapter {
 		const paneIndex = selectActivePreviewPaneIndex(state.currentTab, totalQuestions);
 		const activePreviewPane = this.tabsByIndex[paneIndex]?.preview ?? this.tabsByIndex[0]!.preview;
 
+		const inputBuffer = state.customDraftByTab.get(state.currentTab) ?? this.inlineInput.getValue();
+		const inputCaret = state.customCaretByTab.get(state.currentTab) ?? inputBuffer.length;
 		const ctx: BindingContext = {
 			questions: this.questions,
 			itemsByTab: this.itemsByTab,
 			totalQuestions,
 			activeView,
-			inputBuffer: this.inlineInput.getValue(),
+			inputBuffer,
+			inputCaret,
 			activePreviewPane,
 		};
 

--- a/packages/workflows/src/tui/header.ts
+++ b/packages/workflows/src/tui/header.ts
@@ -49,6 +49,8 @@ export interface BandHeaderOpts {
   theme: GraphTheme;
 }
 
+export interface CompactBandHeaderOpts extends BandHeaderOpts {}
+
 interface PillStyle {
   border: string;
   label: string;
@@ -88,6 +90,40 @@ export function renderOutlinePill(
  * Always returns exactly 3 lines. When `badges` is empty the right
  * column is whitespace only.
  */
+export function renderCompactBandHeader(opts: CompactBandHeaderOpts): string[] {
+  const { label, subtitle = "", badges = [], width, theme } = opts;
+  const accentHex = opts.accent ?? theme.accent;
+  const chromeBg = hexBg(theme.backgroundPanel);
+  const accent = hexToAnsi(accentHex);
+  const muted = hexToAnsi(theme.textMuted);
+
+  const rightVisible = badges.map((b) => b.text).join("  ");
+  const rightW = visibleWidth(rightVisible);
+  const rightStyled = badges
+    .map((b) => `${hexToAnsi(b.fg)}${b.text}${RESET}${chromeBg}`)
+    .join(`${chromeBg}  `);
+
+  const labelVisible = ` ${label} `;
+  const labelW = visibleWidth(labelVisible);
+  const rightEdgePad = 2;
+  const subtitleBudget = Math.max(0, width - labelW - rightW - rightEdgePad - 2);
+  const subtitleText = subtitle.length > 0 && subtitleBudget > 0
+    ? truncateToWidth(subtitle, subtitleBudget, "…")
+    : "";
+  const subtitleVisible = subtitleText.length > 0 ? `  ${subtitleText}` : "";
+  const subtitleW = visibleWidth(subtitleVisible);
+  const filler = Math.max(0, width - labelW - subtitleW - rightW - rightEdgePad);
+
+  const labelStyled = `${chromeBg}${accent}${BOLD}${labelVisible}${RESET}${chromeBg}`;
+  const subtitleStyled = subtitleText.length > 0
+    ? `${chromeBg}  ${muted}${subtitleText}${RESET}${chromeBg}`
+    : `${chromeBg}`;
+  const line = `${labelStyled}${subtitleStyled}${" ".repeat(filler)}${rightStyled}${chromeBg}${" ".repeat(rightEdgePad)}${RESET}`;
+  const fitted = truncateToWidth(line, width, "", true);
+  const pad = Math.max(0, width - visibleWidth(fitted));
+  return [`${fitted}${chromeBg}${" ".repeat(pad)}${RESET}`];
+}
+
 export function renderBandHeader(opts: BandHeaderOpts): string[] {
   const { label, subtitle = "", badges = [], width, theme } = opts;
   const accentHex = opts.accent ?? theme.accent;

--- a/packages/workflows/src/tui/inline-form-card.ts
+++ b/packages/workflows/src/tui/inline-form-card.ts
@@ -5,8 +5,8 @@
  *   - Top/bottom dynamic border rules wrap the live form.
  *   - A compact tab row shows each input (`■` valid / `□` missing) plus Submit,
  *     matching the multi-question tab bar affordance.
- *   - The active field description is the question heading.
- *   - The field name lives in the checkbox tab pane.
+ *   - Every declared input is rendered on one page as a question block.
+ *   - The focused field owns the ask-style pointer/caret.
  *   - Footer hints sit below the bottom rule, like ask_user_question hints.
  *
  *   ───────────────────────────────────────────────────────────────────
@@ -34,8 +34,9 @@
 import type { InlineFormState } from "./inline-form-store.js";
 import type { WorkflowInputEntry } from "../extension/render-result.js";
 import type { GraphTheme } from "./graph-theme.js";
-import { computeInvalid, invalidForField } from "./inputs-picker.js";
+import { computeInvalid } from "./inputs-picker.js";
 import { paint } from "./color-utils.js";
+import { renderCompactBandHeader } from "./header.js";
 import {
   truncateToWidth,
   visibleWidth,
@@ -44,8 +45,6 @@ import {
 import {
   renderAskChoiceRows,
   renderSubmitControls,
-  renderSubmitReview,
-  renderWorkflowFormFooterHints,
 } from "./submit-pane.js";
 
 export interface InlineCardOpts {
@@ -118,21 +117,13 @@ function renderEditingCard(opts: InlineCardOpts): string[] {
   const { state, theme, width } = opts;
   const lines: string[] = [];
 
-  lines.push(...renderHeaderBand(state, theme, width));
+  lines.push(...renderWorkflowHeader(state.workflowName, state.fields.length, state.focusedIdx, theme, width));
+  lines.push("");
 
-  const activeField = state.fields[state.focusedIdx];
-  if (activeField) {
-    const raw = state.rawText[activeField.name] ?? "";
-    lines.push(...renderActiveField(activeField, raw, state.caret, theme, width));
-    lines.push("");
-  } else {
-    lines.push(...renderSubmitReview({
-      workflowName: state.workflowName,
-      fields: state.fields,
-      rawText: state.rawText,
-      theme,
-      width,
-    }));
+  for (let i = 0; i < state.fields.length; i += 1) {
+    const field = state.fields[i]!;
+    const raw = state.rawText[field.name] ?? "";
+    lines.push(...renderField(field, raw, state.caret, state.focusedIdx === i, theme, width));
     lines.push("");
   }
 
@@ -144,127 +135,148 @@ function renderEditingCard(opts: InlineCardOpts): string[] {
 // Header / footer chrome bands
 // ---------------------------------------------------------------------------
 
-function renderHeaderBand(state: InlineFormState, theme: GraphTheme, width: number): string[] {
-  return [
-    renderDialogRule(theme, width),
-    renderInputTabBar(state, theme, width),
-    "",
-  ];
-}
-
-function renderFooterBand(state: InlineFormState, theme: GraphTheme, width: number): string[] {
-  if (state.focusedIdx === state.fields.length) {
-    return [renderDialogRule(theme, width), ...renderInlineSubmitControls(state, theme, width)];
-  }
-  return [renderDialogRule(theme, width), renderFooterHints(theme, width)];
-}
-
-function renderDialogRule(theme: GraphTheme, width: number): string {
-  return paint("─".repeat(Math.max(1, width)), theme.accent);
-}
-
-function renderInputTabBar(state: InlineFormState, theme: GraphTheme, width: number): string {
-  const fieldPieces: string[] = [" ← "];
-  for (let i = 0; i < state.fields.length; i++) {
-    const field = state.fields[i]!;
-    const raw = state.rawText[field.name] ?? "";
-    const valid = invalidForField(field, raw, i) === null;
-    const box = valid ? "■" : "□";
-    const rawSeg = ` ${box} ${field.name} `;
-    const styled = i === state.focusedIdx
-      ? paint(rawSeg, theme.text, { bg: theme.selection, bold: true })
-      : paint(rawSeg, valid ? theme.success : theme.dim);
-    fieldPieces.push(styled, " ");
-  }
-  const allValid = state.fields.every((field, i) => invalidForField(field, state.rawText[field.name] ?? "", i) === null);
-  const submitText = " ✓ Submit ";
-  const submitStyled = state.focusedIdx === state.fields.length
-    ? paint(submitText, theme.text, { bg: theme.selection, bold: true })
-    : paint(submitText, allValid ? theme.success : theme.dim);
-  const submitSuffix = submitStyled + " →";
-  const fieldBudget = Math.max(0, width - visibleWidth(" ✓ Submit  →"));
-  return truncateToWidth(truncateToWidth(fieldPieces.join(""), fieldBudget, "", true) + submitSuffix, width, "", true);
-}
-
-function renderFooterHints(theme: GraphTheme, width: number): string {
-  return renderWorkflowFormFooterHints(theme, width);
-}
-
-// ---------------------------------------------------------------------------
-// Active field body (ask_user_question-style list/input rows)
-// ---------------------------------------------------------------------------
-
-function renderActiveField(
-  field: WorkflowInputEntry,
-  raw: string,
-  caret: number,
+function renderWorkflowHeader(
+  workflowName: string,
+  fieldCount: number,
+  focusedIdx: number,
   theme: GraphTheme,
   width: number,
 ): string[] {
-  const heading = field.description && field.description.length > 0 ? field.description : field.name;
-  const lines = wrapPlainText(heading, width).map((line) => paint(line, theme.text, { bold: true }));
-  lines.push("", ...renderAskStyleFieldBody(field, raw, caret, theme, width));
-  return lines;
+  const current = Math.min(fieldCount, Math.max(1, focusedIdx + 1));
+  return renderCompactBandHeader({
+    label: "WORKFLOW",
+    subtitle: workflowName,
+    badges: fieldCount > 0 ? [{ text: `${current} / ${fieldCount}`, fg: theme.dim }] : [],
+    width,
+    theme,
+  });
+}
+
+function renderFooterBand(state: InlineFormState, theme: GraphTheme, width: number): string[] {
+  return renderInlineSubmitControls(state, theme, width);
+}
+
+// ---------------------------------------------------------------------------
+// Field body (ask_user_question-style list/input rows)
+// ---------------------------------------------------------------------------
+
+function renderField(
+  field: WorkflowInputEntry,
+  raw: string,
+  caret: number,
+  focused: boolean,
+  theme: GraphTheme,
+  width: number,
+): string[] {
+  const boxWidth = Math.max(4, width);
+  const contentWidth = Math.max(1, boxWidth - 2);
+  const borderColor = focused ? theme.accent : theme.borderDim;
+  const rows = renderAskStyleFieldBody(field, raw, focused ? caret : raw.length, focused, theme, contentWidth);
+  return [
+    renderFieldTop(field.name, boxWidth, borderColor, focused, theme),
+    ...rows.map((row) => renderFieldRow(row, contentWidth, borderColor)),
+    renderFieldBottom(boxWidth, borderColor),
+    ...renderFieldMeta(field, theme, width),
+  ];
 }
 
 function renderAskStyleFieldBody(
   field: WorkflowInputEntry,
   raw: string,
   caret: number,
+  focused: boolean,
   theme: GraphTheme,
   width: number,
 ): string[] {
   if (field.type === "select" && field.choices && field.choices.length > 0) {
     const selected = Math.max(0, field.choices.indexOf(raw));
-    return field.choices.flatMap((choice, i) => renderAskChoiceRows(i + 1, choice, i === selected, theme, width));
+    return field.choices.flatMap((choice, i) =>
+      renderAskChoiceRows(i + 1, focused || i !== selected ? choice : `✓ ${choice}`, focused && i === selected, theme, width),
+    );
   }
 
   if (field.type === "boolean") {
-    const on = raw === "true";
+    const normalized = raw.trim().toLowerCase();
+    const hasValue = normalized.length > 0;
+    const on = normalized === "true" || normalized === "1";
     return [
-      ...renderAskChoiceRows(1, "on", on, theme, width),
-      ...renderAskChoiceRows(2, "off", !on, theme, width),
+      ...renderAskChoiceRows(1, focused || !hasValue || !on ? "on" : "✓ on", focused && hasValue && on, theme, width),
+      ...renderAskChoiceRows(2, focused || !hasValue || on ? "off" : "✓ off", focused && hasValue && !on, theme, width),
     ];
   }
 
-  return renderAskInputRows(raw, caret, field.placeholder, theme, width);
+  return renderAskInputRows(raw, caret, focused, field.placeholder, theme, width);
 }
 
 function renderInlineSubmitControls(state: InlineFormState, theme: GraphTheme, width: number): string[] {
   const invalid = computeInvalid(state.fields, state.rawText);
   return renderSubmitControls({
     invalidFieldNames: invalid.map((i) => state.fields[i]!.name),
-    submitChoiceIdx: state.submitChoiceIdx,
+    submitFocused: state.focusedIdx === state.fields.length,
     theme,
     width,
   });
 }
 
+function renderFieldTop(
+  title: string,
+  width: number,
+  borderColor: string,
+  focused: boolean,
+  theme: GraphTheme,
+): string {
+  const label = ` ${title} `;
+  const labelText = paint(label, focused ? theme.accent : theme.textMuted, { bold: focused });
+  const fill = Math.max(0, width - visibleWidth(label) - 2);
+  return paint("╭", borderColor) + labelText + paint("─".repeat(fill) + "╮", borderColor);
+}
+
+function renderFieldRow(row: string, contentWidth: number, borderColor: string): string {
+  const clipped = truncateToWidth(row, contentWidth, "", true);
+  const padded = clipped + " ".repeat(Math.max(0, contentWidth - visibleWidth(clipped)));
+  return paint("│", borderColor) + padded + paint("│", borderColor);
+}
+
+function renderFieldBottom(width: number, borderColor: string): string {
+  return paint("╰" + "─".repeat(Math.max(0, width - 2)) + "╯", borderColor);
+}
+
+function renderFieldMeta(field: WorkflowInputEntry, theme: GraphTheme, width: number): string[] {
+  const required = field.required ? "required" : "optional";
+  const text = field.description && field.description.length > 0
+    ? `${field.type} · ${required} · ${field.description}`
+    : `${field.type} · ${required}`;
+  return wrapPlainText(text, width).map((line) => paintRequiredMetaLine(line, field.required === true, theme));
+}
+
+function paintRequiredMetaLine(line: string, required: boolean, theme: GraphTheme): string {
+  if (!required) return paint(line, theme.textMuted);
+  return line
+    .split(/(\brequired\b)/g)
+    .map((part) => part === "required" ? paint(part, theme.warning) : paint(part, theme.textMuted))
+    .join("");
+}
+
 function renderAskInputRows(
   raw: string,
   caret: number,
+  focused: boolean,
   placeholder: string | undefined,
   theme: GraphTheme,
   width: number,
 ): string[] {
-  const prefix = "❯ 1. ";
-  const continuationPrefix = " ".repeat(visibleWidth(prefix));
-  const usable = Math.max(1, width - visibleWidth(prefix));
+  const usable = Math.max(1, width);
   if (raw === "") {
     const value = placeholder && placeholder.length > 0
-      ? paint(placeholder, theme.dim) + cursorBlock()
-      : cursorBlock();
-    return [paint(prefix, theme.accent) + truncateToWidth(value, usable, "…", true)];
+      ? paint(placeholder, theme.dim) + (focused ? cursorBlock() : "")
+      : focused ? cursorBlock() : "";
+    return [truncateToWidth(value, usable, "…", true)];
   }
 
   const layout = layoutTextField(raw, usable, caret);
-  return layout.lines.map((line, row) => {
-    const linePrefix = row === 0 ? prefix : continuationPrefix;
-    const content = row === layout.cursorRow
-      ? renderCaretLine(line, layout.cursorOffset ?? line.length, usable, theme, theme.text)
-      : truncateToWidth(paint(line, theme.text), usable, "…", true);
-    return paint(linePrefix, row === 0 ? theme.accent : theme.dim) + content;
-  });
+  return layout.lines.map((line, row) => focused && row === layout.cursorRow
+    ? renderCaretLine(line, layout.cursorOffset ?? line.length, usable, theme, theme.text)
+    : truncateToWidth(paint(line, theme.text), usable, "…", true));
 }
 
 function renderCaretLine(

--- a/packages/workflows/src/tui/inline-form-editor.ts
+++ b/packages/workflows/src/tui/inline-form-editor.ts
@@ -2,7 +2,7 @@
  * Custom `EditorComponent` swapped in via `ctx.ui.setEditorComponent` while
  * an inline workflow form is active. Owns ALL keystrokes during fill-out:
  *
- *   tab / shift+tab     — move focus across form fields and Submit section
+ *   tab / shift+tab     — move focus across form fields and the final Submit action
  *   ↑/↓                 — move focus (or caret between logical lines in `text`)
  *   ←/→                 — caret nav (text) | choice cycle (select) | flip (bool)
  *   alt/ctrl+←/→        — word movement in text/string/number fields
@@ -16,7 +16,7 @@
  *   space               — boolean toggle
  *   enter               — newline (text) | otherwise next field
  *   printable ASCII     — insert at caret (text/string/number)
- *   submit section      — ↑/↓ moves rows; 1 submits, 2 cancels immediately; enter commits row
+ *   submit action       — ↑/↓ returns to questions; enter submits
  *   esc / ctrl+c        — cancel form
  *
  * Editor-mode keys (cursor movement, word jumps, deletions) route through
@@ -134,11 +134,6 @@ function isPrintableGrapheme(data: string): boolean {
     if (code === undefined || code < 0x20 || code === 0x7f) return false;
   }
   return graphemes(data).length === 1;
-}
-
-function nextSubmitChoiceIdx(current: number, delta: number): number {
-  const count = 2;
-  return (current + delta + count) % count;
 }
 
 /**
@@ -440,8 +435,8 @@ export class InlineFormEditor implements PiEditorComponent {
     // editor actions, so they stay as raw byte checks:
     //   esc        (\x1b)        — cancel form
     //   ctrl+c     (\x03)        — cancel form
-    //   tab        (\t)          — focus next field / Submit section
-    //   shift+tab  (\x1b[Z)      — focus previous field / Submit section
+    //   tab        (\t)          — focus next field / final Submit action
+    //   shift+tab  (\x1b[Z)      — focus previous field / final Submit action
     if (matchesKey(data, Key.ctrl("c")) || matchesKey(data, Key.escape)) {
       this.opts.onExit("cancel");
       return true;
@@ -467,20 +462,11 @@ export class InlineFormEditor implements PiEditorComponent {
 
   private handleSubmit(data: string, state: InlineFormState): boolean {
     if (matchesAction(this.kb, data, TUI_ACTION.selectUp) || matchesAction(this.kb, data, TUI_ACTION.editorCursorUp)) {
-      state.submitChoiceIdx = nextSubmitChoiceIdx(state.submitChoiceIdx, -1);
+      this.moveFocus(state, -1);
       return true;
     }
     if (matchesAction(this.kb, data, TUI_ACTION.selectDown) || matchesAction(this.kb, data, TUI_ACTION.editorCursorDown)) {
-      state.submitChoiceIdx = nextSubmitChoiceIdx(state.submitChoiceIdx, +1);
-      return true;
-    }
-    if (matchesKey(data, "1")) {
-      state.submitChoiceIdx = 0;
-      return this.submitOrFocusInvalid(state);
-    }
-    if (matchesKey(data, "2")) {
-      state.submitChoiceIdx = 1;
-      this.opts.onExit("cancel");
+      this.moveFocus(state, +1);
       return true;
     }
     if (
@@ -488,9 +474,7 @@ export class InlineFormEditor implements PiEditorComponent {
       matchesAction(this.kb, data, TUI_ACTION.selectConfirm) ||
       matchesAction(this.kb, data, TUI_ACTION.inputSubmit)
     ) {
-      if (state.submitChoiceIdx === 0) return this.submitOrFocusInvalid(state);
-      this.opts.onExit("cancel");
-      return true;
+      return this.submitOrFocusInvalid(state);
     }
     return false;
   }

--- a/packages/workflows/src/tui/inline-form-store.ts
+++ b/packages/workflows/src/tui/inline-form-store.ts
@@ -36,7 +36,7 @@ export interface InlineFormState {
   /** Raw string per field; mirrors `inputs-picker.ts` semantics. */
   rawText: Record<string, string>;
   focusedIdx: number;
-  /** Active row while focusedIdx === fields.length: 0 = submit, 1 = cancel. */
+  /** Reserved for older form snapshots; Submit is now a single final action. */
   submitChoiceIdx: number;
   caret: number;
   status: FormStatus;

--- a/packages/workflows/src/tui/inputs-picker.ts
+++ b/packages/workflows/src/tui/inputs-picker.ts
@@ -4,8 +4,8 @@
  * Opens when the user types `/workflow <name>` in the TUI without enough
  * key=value tokens to satisfy the declared schema. Mirrors the
  * `ask_user_question` dialog shape: a top rule, a compact field tab bar,
- * one active input at a time, ask-style pointer rows, and dim footer hints.
- * The workflow is already chosen, so there is no fuzzy-list pane.
+ * one page of ask-style question rows, and dim footer hints. The workflow is
+ * already chosen, so there is no fuzzy-list pane.
  *
  *   ───────────────────────────────────────────
  *    ←  ■ prompt   ■ focus   ✓ Submit  →
@@ -43,11 +43,10 @@ import {
   visibleWidth,
   wrapPlainText,
 } from "./text-helpers.js";
+import { renderCompactBandHeader } from "./header.js";
 import {
   renderAskChoiceRows,
   renderSubmitControls,
-  renderSubmitReview,
-  renderWorkflowFormFooterHints,
 } from "./submit-pane.js";
 import {
   type KeybindingsLike,
@@ -80,7 +79,7 @@ export interface InputsPickerState {
    * `coerceValues()` converts these into typed objects at submit time.
    */
   rawText: Record<string, string>;
-  /** Active row while the focus is on the Submit tab: 0 = submit, 1 = cancel. */
+  /** Reserved for older form snapshots; Submit is now a single final action. */
   submitChoiceIdx: number;
   /**
    * Set of field indices that failed validation on the most recent submit
@@ -480,66 +479,43 @@ function fitLine(line: string, width: number): string {
   return truncateToWidth(line, Math.max(0, width), "…", true);
 }
 
-function renderPickerHeader(
-  fields: readonly WorkflowInputEntry[],
-  state: InputsPickerState,
+function renderWorkflowHeader(
+  workflowName: string,
+  fieldCount: number,
+  focusedIdx: number,
   theme: GraphTheme,
   width: number,
 ): string[] {
-  return [
-    renderPickerRule(theme, width),
-    renderInputTabBar(fields, state, theme, width),
-    "",
-  ];
+  const current = Math.min(fieldCount, Math.max(1, focusedIdx + 1));
+  return renderCompactBandHeader({
+    label: "WORKFLOW",
+    subtitle: workflowName,
+    badges: fieldCount > 0 ? [{ text: `${current} / ${fieldCount}`, fg: theme.dim }] : [],
+    width,
+    theme,
+  });
 }
 
-function renderPickerRule(theme: GraphTheme, width: number): string {
-  return paint("─".repeat(Math.max(1, width)), theme.accent);
-}
-
-function renderInputTabBar(
-  fields: readonly WorkflowInputEntry[],
-  state: InputsPickerState,
-  theme: GraphTheme,
-  width: number,
-): string {
-  const fieldPieces: string[] = [" ← "];
-  for (let i = 0; i < fields.length; i++) {
-    const field = fields[i]!;
-    const raw = state.rawText[field.name] ?? "";
-    const valid = invalidForField(field, raw, i) === null;
-    const box = valid ? "■" : "□";
-    const rawSeg = ` ${box} ${field.name} `;
-    const styled = i === state.focusedIdx
-      ? paint(rawSeg, theme.text, { bg: theme.selection, bold: true })
-      : paint(rawSeg, valid ? theme.success : theme.dim);
-    fieldPieces.push(styled, " ");
-  }
-  const allValid = fields.every((field, i) => invalidForField(field, state.rawText[field.name] ?? "", i) === null);
-  const submitText = " ✓ Submit ";
-  const submitStyled = state.focusedIdx === fields.length
-    ? paint(submitText, theme.text, { bg: theme.selection, bold: true })
-    : paint(submitText, allValid ? theme.success : theme.dim);
-  const submitSuffix = submitStyled + " →";
-  const fieldBudget = Math.max(0, width - visibleWidth(" ✓ Submit  →"));
-  return truncateToWidth(truncateToWidth(fieldPieces.join(""), fieldBudget, "", true) + submitSuffix, width, "", true);
-}
-
-function renderActiveInputField(
+function renderInputField(
   field: WorkflowInputEntry,
   raw: string,
   caret: number,
   cursorOn: boolean,
   invalid: string | null,
+  focused: boolean,
   theme: GraphTheme,
   width: number,
 ): string[] {
-  const heading = field.description && field.description.length > 0 ? field.description : field.name;
-  const lines = wrapPlainText(heading, width).map((line) => paint(line, theme.text, { bold: true }));
-  if (invalid) {
-    lines.push(...wrapPlainText(invalid, width).map((line) => paint(line, theme.error)));
-  }
-  lines.push("", ...renderAskStyleInputBody(field, raw, caret, cursorOn, theme, width));
+  const boxWidth = Math.max(4, width);
+  const contentWidth = Math.max(1, boxWidth - 2);
+  const borderColor = focused ? theme.accent : theme.borderDim;
+  const rows = renderAskStyleInputBody(field, raw, focused ? caret : raw.length, cursorOn, focused, theme, contentWidth);
+  const lines = [
+    renderFieldTop(field.name, boxWidth, borderColor, focused, theme),
+    ...rows.map((row) => renderFieldRow(row, contentWidth, borderColor, theme)),
+    renderFieldBottom(boxWidth, borderColor),
+    ...renderFieldMeta(field, invalid, theme, width),
+  ];
   return lines;
 }
 
@@ -548,23 +524,28 @@ function renderAskStyleInputBody(
   raw: string,
   caret: number,
   cursorOn: boolean,
+  focused: boolean,
   theme: GraphTheme,
   width: number,
 ): string[] {
   if (field.type === "select" && field.choices && field.choices.length > 0) {
     const selected = Math.max(0, field.choices.indexOf(raw));
-    return field.choices.flatMap((choice, i) => renderAskChoiceRows(i + 1, choice, i === selected, theme, width));
+    return field.choices.flatMap((choice, i) =>
+      renderAskChoiceRows(i + 1, focused || i !== selected ? choice : `✓ ${choice}`, focused && i === selected, theme, width),
+    );
   }
 
   if (field.type === "boolean") {
-    const on = raw === "true";
+    const normalized = raw.trim().toLowerCase();
+    const hasValue = normalized.length > 0;
+    const on = normalized === "true" || normalized === "1";
     return [
-      ...renderAskChoiceRows(1, "on", on, theme, width),
-      ...renderAskChoiceRows(2, "off", !on, theme, width),
+      ...renderAskChoiceRows(1, focused || !hasValue || !on ? "on" : "✓ on", focused && hasValue && on, theme, width),
+      ...renderAskChoiceRows(2, focused || !hasValue || on ? "off" : "✓ off", focused && hasValue && !on, theme, width),
     ];
   }
 
-  return renderAskInputRows(field, raw, caret, cursorOn, theme, width);
+  return renderAskInputRows(field, raw, caret, cursorOn, focused, theme, width);
 }
 
 function renderAskInputRows(
@@ -572,23 +553,21 @@ function renderAskInputRows(
   raw: string,
   caret: number,
   cursorOn: boolean,
+  focused: boolean,
   theme: GraphTheme,
   width: number,
 ): string[] {
-  const prefix = "❯ 1. ";
-  const styledPrefix = paint(prefix, theme.accent);
-  const continuationPrefix = " ".repeat(visibleWidth(prefix));
-  const usable = Math.max(1, width - visibleWidth(prefix));
+  const usable = Math.max(1, width);
 
   if (field.type !== "text") {
-    return [styledPrefix + renderInlineText(raw, true, cursorOn, usable, theme, field.placeholder, raw === "", caret)];
+    return [renderInlineText(raw, focused, cursorOn, usable, theme, field.placeholder, raw === "", caret)];
   }
 
   const ROWS = 3;
   if (raw === "") {
     return [
-      styledPrefix + renderInlineText("", true, cursorOn, usable, theme, field.placeholder, true),
-      ...Array.from({ length: ROWS - 1 }, () => continuationPrefix + padLine("", usable)),
+      renderInlineText("", focused, cursorOn, usable, theme, field.placeholder, true),
+      ...Array.from({ length: ROWS - 1 }, () => padLine("", usable)),
     ];
   }
 
@@ -612,26 +591,24 @@ function renderAskInputRows(
   for (let i = 0; i < ROWS; i++) {
     const rowIdx = start + i;
     const line = layout[rowIdx];
-    const rowPrefix = rowIdx === 0 ? styledPrefix : continuationPrefix;
     if (!line) {
-      rows.push(rowPrefix + padLine("", usable));
+      rows.push(padLine("", usable));
       continue;
     }
     const lineCaret = safeCaret >= line.start && safeCaret <= line.end
       ? safeCaret - line.start
       : line.text.length;
     rows.push(
-      rowPrefix +
-        renderInlineText(
-          line.text,
-          rowIdx === cursorRow,
-          cursorOn,
-          usable,
-          theme,
-          field.placeholder,
-          false,
-          lineCaret,
-        ),
+      renderInlineText(
+        line.text,
+        focused && rowIdx === cursorRow,
+        cursorOn,
+        usable,
+        theme,
+        field.placeholder,
+        false,
+        lineCaret,
+      ),
     );
   }
   return rows;
@@ -640,38 +617,69 @@ function renderAskInputRows(
 export function renderInputsPicker(opts: InputsPickerRenderOpts): string[] {
   const { theme, workflowName, fields, state, width, cursorOn } = opts;
   const lines: string[] = [];
-  const isOnSubmitTab = state.focusedIdx === fields.length;
 
-  lines.push(...renderPickerHeader(fields, state, theme, width));
+  lines.push(...renderWorkflowHeader(workflowName, fields.length, state.focusedIdx, theme, width));
+  lines.push("");
 
-  if (isOnSubmitTab) {
-    lines.push(...renderSubmitReview({ workflowName, fields, rawText: state.rawText, theme, width }));
+  for (let i = 0; i < fields.length; i += 1) {
+    const field = fields[i]!;
+    const raw = state.rawText[field.name] ?? "";
+    const invalid = state.invalidIndices.includes(i)
+      ? invalidForField(field, raw, i)
+      : null;
+    lines.push(...renderInputField(field, raw, state.caret, cursorOn, invalid, state.focusedIdx === i, theme, width));
     lines.push("");
-  } else {
-    const activeField = fields[state.focusedIdx];
-    if (activeField) {
-      const raw = state.rawText[activeField.name] ?? "";
-      const invalid = state.invalidIndices.includes(state.focusedIdx)
-        ? invalidForField(activeField, raw, state.focusedIdx)
-        : null;
-      lines.push(...renderActiveInputField(activeField, raw, state.caret, cursorOn, invalid, theme, width));
-      lines.push("");
-    }
   }
 
-  lines.push(renderPickerRule(theme, width));
-  if (isOnSubmitTab) {
-    lines.push(...renderPickerSubmitControls(fields, state, theme, width));
-  } else {
-    lines.push(renderFooterHints(width, theme));
-  }
+  lines.push(...renderPickerSubmitControls(fields, state, theme, width));
 
   return lines.map((line) => fitLine(line, width));
 }
 
-/** Footer hint copied from ask_user_question, with workflow-specific tab copy. */
-function renderFooterHints(width: number, theme: GraphTheme): string {
-  return renderWorkflowFormFooterHints(theme, width);
+function renderFieldTop(
+  title: string,
+  width: number,
+  borderColor: string,
+  focused: boolean,
+  theme: GraphTheme,
+): string {
+  const label = ` ${title} `;
+  const labelText = paint(label, focused ? theme.accent : theme.textMuted, { bold: focused });
+  const fill = Math.max(0, width - visibleWidth(label) - 2);
+  return paint("╭", borderColor) + labelText + paint("─".repeat(fill) + "╮", borderColor);
+}
+
+function renderFieldRow(row: string, contentWidth: number, borderColor: string, _theme: GraphTheme): string {
+  const clipped = truncateToWidth(row, contentWidth, "", true);
+  const padded = clipped + " ".repeat(Math.max(0, contentWidth - visibleWidth(clipped)));
+  return paint("│", borderColor) + padded + paint("│", borderColor);
+}
+
+function renderFieldBottom(width: number, borderColor: string): string {
+  return paint("╰" + "─".repeat(Math.max(0, width - 2)) + "╯", borderColor);
+}
+
+function renderFieldMeta(
+  field: WorkflowInputEntry,
+  invalid: string | null,
+  theme: GraphTheme,
+  width: number,
+): string[] {
+  const required = field.required ? "required" : "optional";
+  const text = field.description && field.description.length > 0
+    ? `${field.type} · ${required} · ${field.description}`
+    : `${field.type} · ${required}`;
+  const lines = wrapPlainText(text, width).map((line) => paintRequiredMetaLine(line, field.required === true, theme));
+  if (invalid) lines.push(...wrapPlainText(invalid, width).map((line) => paint(line, theme.error)));
+  return lines;
+}
+
+function paintRequiredMetaLine(line: string, required: boolean, theme: GraphTheme): string {
+  if (!required) return paint(line, theme.textMuted);
+  return line
+    .split(/(\brequired\b)/g)
+    .map((part) => part === "required" ? paint(part, theme.warning) : paint(part, theme.textMuted))
+    .join("");
 }
 
 function renderPickerSubmitControls(
@@ -683,7 +691,7 @@ function renderPickerSubmitControls(
   const invalid = computeInvalid(fields, state.rawText);
   return renderSubmitControls({
     invalidFieldNames: invalid.map((i) => fields[i]!.name),
-    submitChoiceIdx: state.submitChoiceIdx,
+    submitFocused: state.focusedIdx === fields.length,
     theme,
     width,
   });
@@ -700,19 +708,17 @@ function renderPickerSubmitControls(
  * with the coerced typed value map.
  *
  * Keys (form mode):
- *   tab              — switch input fields and the Submit section
- *   shift+tab        — previous input field / Submit section
+ *   tab              — switch input fields, then the final Submit action
+ *   shift+tab        — previous input field / final Submit action
  *   left / right     — select: cycle choices; boolean: flip; text: caret
  *   space            — boolean: flip
  *   enter            — text: newline; otherwise: next field
  *   backspace        — delete char left of caret
  *   esc / ctrl+c     — close picker without running
  *
- * Keys (Submit pane):
- *   up / down        — move between Submit answers and Cancel rows
- *   1                — submit immediately, or focus the first invalid field
- *   2                — cancel immediately without requiring Enter
- *   enter            — commit the active Submit/Cancel row
+ * Keys (Submit action):
+ *   up / down        — move back into the question list
+ *   enter            — submit immediately, or focus the first invalid field
  */
 export function handleInputsPickerInput(
   key: string,
@@ -936,34 +942,21 @@ function handleSubmitKey(
   kb: KeybindingsLike | undefined,
 ): InputsPickerAction {
   if (matchesAction(kb, key, TUI_ACTION.selectUp) || matchesAction(kb, key, TUI_ACTION.editorCursorUp)) {
-    state.submitChoiceIdx = nextSubmitChoiceIdx(state.submitChoiceIdx, -1);
+    moveFocus(state, fields, -1);
     return { kind: "noop" };
   }
   if (matchesAction(kb, key, TUI_ACTION.selectDown) || matchesAction(kb, key, TUI_ACTION.editorCursorDown)) {
-    state.submitChoiceIdx = nextSubmitChoiceIdx(state.submitChoiceIdx, +1);
+    moveFocus(state, fields, +1);
     return { kind: "noop" };
-  }
-  if (matchesKey(key, "1")) {
-    state.submitChoiceIdx = 0;
-    return attemptPickerSubmit(state, fields);
-  }
-  if (matchesKey(key, "2")) {
-    state.submitChoiceIdx = 1;
-    return { kind: "cancel" };
   }
   if (
     matchesKey(key, Key.enter) ||
     matchesAction(kb, key, TUI_ACTION.selectConfirm) ||
     matchesAction(kb, key, TUI_ACTION.inputSubmit)
   ) {
-    return state.submitChoiceIdx === 0 ? attemptPickerSubmit(state, fields) : { kind: "cancel" };
+    return attemptPickerSubmit(state, fields);
   }
   return { kind: "noop" };
-}
-
-function nextSubmitChoiceIdx(current: number, delta: number): number {
-  const count = 2;
-  return (current + delta + count) % count;
 }
 
 function isCancelKey(key: string): boolean {

--- a/packages/workflows/src/tui/submit-pane.ts
+++ b/packages/workflows/src/tui/submit-pane.ts
@@ -1,6 +1,6 @@
 import type { WorkflowInputEntry } from "../extension/render-result.js";
 import type { GraphTheme } from "./graph-theme.js";
-import { paint } from "./color-utils.js";
+import { BOLD, hexBg, hexToAnsi, paint, RESET } from "./color-utils.js";
 import {
   formatReviewValue,
   renderWrappedPrefixedLines,
@@ -19,15 +19,15 @@ export interface SubmitPaneRenderOpts {
 
 export interface SubmitControlsRenderOpts {
   invalidFieldNames: readonly string[];
-  submitChoiceIdx: number;
+  submitFocused: boolean;
   theme: GraphTheme;
   width: number;
 }
 
 export function renderWorkflowFormFooterHints(theme: GraphTheme, width: number): string {
   const hints = [
-    "Enter to select · ↑/↓ to navigate · Tab to switch input fields · Esc to cancel",
-    "Enter · ↑/↓ · Tab · Esc",
+    "Enter to select · ↑/↓ to navigate · Tab through questions to Submit · Esc to cancel",
+    "Enter · ↑/↓ · Tab to Submit · Esc",
     "Enter · Tab · Esc",
     "Esc",
   ];
@@ -67,23 +67,74 @@ export function renderSubmitReview(opts: SubmitPaneRenderOpts): string[] {
 }
 
 export function renderSubmitControls(opts: SubmitControlsRenderOpts): string[] {
-  const { invalidFieldNames, submitChoiceIdx, theme, width } = opts;
+  const { invalidFieldNames, submitFocused, theme, width } = opts;
   const invalidCount = invalidFieldNames.length;
-  const promptText = invalidCount === 0
-    ? "Ready to submit your inputs?"
-    : `Answer remaining inputs before submitting: ${invalidFieldNames.join(", ")}`;
-  const promptColor = invalidCount === 0 ? theme.textMuted : theme.warning;
-  const submitLabel = invalidCount === 0
-    ? "Submit answers"
-    : `Submit answers (${invalidCount} missing)`;
-  return [
-    ...wrapPlainText(promptText, width).map((line) => paint(line, promptColor)),
-    "",
-    ...renderAskChoiceRows(1, submitLabel, submitChoiceIdx === 0, theme, width),
-    ...renderAskChoiceRows(2, "Cancel", submitChoiceIdx === 1, theme, width),
-    "",
-    renderWorkflowFormFooterHints(theme, width),
-  ];
+  const submitLabel = "SUBMIT";
+  const lines: string[] = [];
+  if (invalidCount > 0) {
+    lines.push(
+      ...wrapPlainText(
+        `Answer remaining inputs before submitting: ${invalidFieldNames.join(", ")}`,
+        width,
+      ).map((line) => paint(line, theme.warning)),
+      "",
+    );
+  }
+  lines.push(...renderSubmitToolbar(submitLabel, submitFocused, theme, width));
+  return lines;
+}
+
+function renderSubmitToolbar(
+  label: string,
+  focused: boolean,
+  theme: GraphTheme,
+  width: number,
+): string[] {
+  const chromeBg = hexBg(theme.backgroundPanel);
+  const button = renderCompactSubmitButton(label, focused, theme, chromeBg);
+  const textFg = hexToAnsi(theme.text);
+  const mutedFg = hexToAnsi(theme.textMuted);
+  const dimFg = hexToAnsi(theme.dim);
+  const hint = (key: string, description: string): string =>
+    `${chromeBg}${textFg}${BOLD}${key}${RESET}${chromeBg}${mutedFg} ${description}${RESET}${chromeBg}`;
+  const hints = [
+    hint("enter", "Submit"),
+    hint("tab", "Next"),
+    hint("shift+tab", "Prev"),
+    hint("esc", "Cancel"),
+  ].join(`${chromeBg}${dimFg}  ·  ${RESET}${chromeBg}`);
+  const leftPad = 1;
+  const gap = 2;
+  const rightPad = 1;
+  const hintBudget = Math.max(0, width - leftPad - button.visibleWidth - gap - rightPad);
+  const fittedHints = truncateToWidth(hints, hintBudget, "…", true);
+  const hintWidth = visibleWidth(fittedHints);
+  const filler = Math.max(0, width - leftPad - button.visibleWidth - gap - hintWidth - rightPad);
+  const line = `${chromeBg} ${button.text}${chromeBg}${" ".repeat(gap)}${fittedHints}${chromeBg}${" ".repeat(filler)} ${RESET}`;
+  const clipped = truncateToWidth(line, width, "", true);
+  return [`${clipped}${chromeBg}${" ".repeat(Math.max(0, width - visibleWidth(clipped)))}${RESET}`];
+}
+
+function renderCompactSubmitButton(
+  label: string,
+  focused: boolean,
+  theme: GraphTheme,
+  chromeBg: string,
+): { text: string; visibleWidth: number } {
+  const plain = ` ${label} `;
+  if (focused) {
+    const accentBg = hexBg(theme.accent);
+    const fg = hexToAnsi(theme.backgroundPanel);
+    return {
+      text: `${accentBg}${fg}${BOLD}${plain}${RESET}${chromeBg}`,
+      visibleWidth: visibleWidth(plain),
+    };
+  }
+  const labelFg = hexToAnsi(theme.accent);
+  return {
+    text: `${chromeBg}${labelFg}${BOLD}${plain}${RESET}${chromeBg}`,
+    visibleWidth: visibleWidth(plain),
+  };
 }
 
 function renderReviewValueRows(

--- a/test/unit/ask-user-question-tui.test.ts
+++ b/test/unit/ask-user-question-tui.test.ts
@@ -1,0 +1,88 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { buildItemsForQuestion } from "../../packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts";
+import { QuestionnaireSession } from "../../packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts";
+import type { QuestionParams } from "../../packages/coding-agent/src/core/tools/ask-user-question/tool/types.ts";
+import { WrappingSelect, type WrappingSelectItem } from "../../packages/coding-agent/src/core/tools/ask-user-question/view/components/wrapping-select.ts";
+import { initTheme, theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI_RE, "");
+
+const DOWN = "\x1b[B";
+const UP = "\x1b[A";
+const LEFT = "\x1b[D";
+
+function makeParams(): QuestionParams {
+	return {
+		questions: [
+			{
+				question: "Which option?",
+				header: "Choice",
+				options: [
+					{ label: "Alpha", description: "First option" },
+					{ label: "Beta", description: "Second option" },
+				],
+			},
+		],
+	};
+}
+
+test("ask_user_question custom response draft survives moving to another option", () => {
+	initTheme("dark");
+	const params = makeParams();
+	const session = new QuestionnaireSession({
+		tui: { terminal: { columns: 100 }, requestRender() {} },
+		theme,
+		params,
+		itemsByTab: params.questions.map((q) => buildItemsForQuestion(q)),
+		done() {},
+	});
+
+	// Move from Alpha -> Beta -> Type something.
+	session.component.handleInput(DOWN);
+	session.component.handleInput(DOWN);
+	for (const ch of "custom") session.component.handleInput(ch);
+
+	// Leave the custom row, then return to it. The draft should still be there.
+	session.component.handleInput(UP);
+	session.component.handleInput(DOWN);
+
+	const rendered = stripAnsi(session.component.render(100).join("\n"));
+	assert.match(rendered, /custom/);
+});
+
+test("ask_user_question custom response renders the main chat cursor at the editing caret", () => {
+	const items: WrappingSelectItem[] = [{ kind: "other", label: "Type something." }];
+	const select = new WrappingSelect(items, 1, {
+		selectedText: (s) => s,
+		description: (s) => s,
+		scrollInfo: (s) => s,
+	});
+	select.setInputBuffer("abc");
+	select.setInputCursor(2);
+
+	const rendered = select.render(40).join("\n");
+	assert.match(rendered, /ab\x1b\[7mc\x1b\[0m/);
+});
+
+test("ask_user_question custom response editor keeps typing at the moved caret", () => {
+	initTheme("dark");
+	const params = makeParams();
+	const session = new QuestionnaireSession({
+		tui: { terminal: { columns: 100 }, requestRender() {} },
+		theme,
+		params,
+		itemsByTab: params.questions.map((q) => buildItemsForQuestion(q)),
+		done() {},
+	});
+
+	session.component.handleInput(DOWN);
+	session.component.handleInput(DOWN);
+	for (const ch of "abc") session.component.handleInput(ch);
+	session.component.handleInput(LEFT);
+	session.component.handleInput("X");
+
+	const rendered = stripAnsi(session.component.render(100).join("\n"));
+	assert.match(rendered, /abXc/);
+});

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -100,91 +100,84 @@ function ansi(lines: string[]): string {
   return lines.join("\n");
 }
 
-test("card (live): uses ask-user-question style tab chrome, not workflow/edit panels", () => {
+test("card (live): renders workflow header and continuous footer chrome", () => {
   const state = makeState();
   const lines = renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) });
   const txt = plain(lines);
-  assert.doesNotMatch(txt, /WORKFLOW/);
-  assert.doesNotMatch(txt, /EDIT/);
+  assert.match(txt, /WORKFLOW/);
+  assert.match(txt, /ralph/);
+  assert.match(txt, /1 \/ 4/);
+  assert.doesNotMatch(txt, /←/);
+  assert.doesNotMatch(txt, /✓ Submit/);
   assert.doesNotMatch(txt, /loop a thinker/);
-  assert.match(txt, /prompt/);
-  assert.match(txt, /iters/);
-  assert.match(txt, /focus/);
-  assert.match(txt, /verbose/);
-  assert.match(txt, /task/);
-  assert.doesNotMatch(txt, /1 \/ 4/);
-  assert.doesNotMatch(txt, /Run workflow/);
-  assert.match(txt, /Tab to switch input fields/);
+  assert.match(txt, /╭ prompt /);
+  assert.match(txt, /╭ iters /);
+  assert.match(txt, /╭ focus /);
+  assert.match(txt, /╭ verbose /);
+  assert.doesNotMatch(txt, /╭────────╮/);
+  assert.match(txt, / SUBMIT /);
+  assert.doesNotMatch(txt, /EDIT/);
+  assert.match(txt, /enter Submit/);
+  assert.match(txt, /tab Next/);
+  assert.match(txt, /shift\+tab Prev/);
+  assert.match(txt, /esc Cancel/);
   assert.doesNotMatch(txt, /ctrl\+x/);
   assert.doesNotMatch(txt, /ctrl\+enter/);
   assert.doesNotMatch(txt, /ctrl\+s/);
-
-  const plainLines = lines.map((line) => plain([line]));
-  assert.match(plainLines[0] ?? "", /^─+$/);
-  assert.match(plainLines[1] ?? "", /^ ← /);
-  assert.match(plainLines[1] ?? "", /□ prompt/);
-  assert.match(plainLines[1] ?? "", /■ iters/);
-  assert.match(plainLines[1] ?? "", /■ focus/);
-  assert.match(plainLines[1] ?? "", /■ verbose/);
-  assert.match(plainLines[1] ?? "", /✓ Submit/);
-  assert.match(plainLines[1] ?? "", / →$/);
-  assert.ok(plainLines.slice(1).some((line) => /^─+$/.test(line)), "expected bottom dialog border");
-  assert.doesNotMatch(txt, /╭─ WORKFLOW ─/);
-  assert.doesNotMatch(txt, /╭─ EDIT ─/);
 });
 
-test("card (live): hint row is anchored at the bottom of the widget", () => {
+test("card (live): compact hint row is anchored at the bottom of the widget", () => {
   const state = makeState();
   const lines = renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) });
-  // The footer band is the trailing lines; hints live beneath the bottom rule.
-  const tail = lines.slice(-3).map((l) => plain([l]));
-  assert.match(tail.join("\n"), /Enter to select/);
-  assert.match(tail.join("\n"), /Tab to switch input fields/);
-  assert.match(tail.join("\n"), /Esc to cancel/);
-  assert.doesNotMatch(tail.join("\n"), /ctrl\+x/);
+  const tail = plain([lines.at(-1) ?? ""]);
+  assert.match(tail, / SUBMIT /);
+  assert.doesNotMatch(tail, /EDIT/);
+  assert.match(tail, /enter Submit/);
+  assert.match(tail, /tab Next/);
+  assert.match(tail, /esc Cancel/);
+  assert.doesNotMatch(tail, /ctrl\+x/);
 });
 
-test("card (live): active field body uses ask-user-question input rows, not inner boxes", () => {
+test("card (live): active field body uses boxed field styling", () => {
   const state = makeState();
   const lines = renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) });
   const visible = plain(lines);
-  assert.match(visible, /task\n\n❯ 1\.  /);
+  assert.match(visible, /╭ prompt ─+╮/);
+  assert.match(visible, /│\s+│/);
+  assert.match(visible, /text · required · task/);
   assert.match(ansi(lines), /\x1b\[7m \x1b\[0m/);
-  assert.doesNotMatch(visible, /╭─+ prompt ─+╮/);
-  assert.doesNotMatch(visible, /│\s+│/);
 });
 
-test("card (live): Submit section reviews inputs and offers visible actions", () => {
+test("card (live): shows all questions with Submit at the end", () => {
   const state = makeState({
     rawText: { prompt: "build me a tui", iters: "5", focus: "minimal", verbose: "false" },
     focusedIdx: FIELDS.length,
   });
   const txt = plain(renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) }));
-  assert.match(txt, /✓ Submit/);
-  assert.match(txt, /Review your inputs/);
-  assert.match(txt, /\/workflow ralph/);
-  assert.match(txt, /● prompt/);
-  assert.match(txt, /→ build me a tui/);
-  assert.match(txt, /Ready to submit your inputs\?/);
-  assert.match(txt, /● verbose\n\s+→ off/);
-  assert.doesNotMatch(txt, /→ false/);
-  assert.match(txt, /❯ 1\. Submit answers/);
-  assert.match(txt, /2\. Cancel/);
+  assert.match(txt, / SUBMIT /);
+  assert.match(txt, /╭ prompt ─+╮\n│build me a tui/);
+  assert.match(txt, /╭ iters ─+╮\n│5/);
+  assert.match(txt, /╭ focus ─+╮\n│\s+1\. ✓ minimal/);
+  assert.match(txt, /╭ verbose ─+╮\n│\s+1\. on\s+│\n│\s+2\. ✓ off/);
+  assert.doesNotMatch(txt, /❯ Submit answers/);
+  assert.doesNotMatch(txt, /Review your inputs/);
+  assert.doesNotMatch(txt, /Ready to submit your inputs\?/);
+  assert.doesNotMatch(txt, /2\. Cancel/);
   assert.doesNotMatch(txt, /Chat about this/);
   assert.doesNotMatch(txt, /ctrl\+x/);
 });
 
-test("card (live): normalizes true-like boolean review values", () => {
+test("card (live): normalizes true-like boolean field values", () => {
   const state = makeState({
     rawText: { prompt: "build me a tui", iters: "5", focus: "minimal", verbose: "1" },
     focusedIdx: FIELDS.length,
   });
   const txt = plain(renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) }));
-  assert.match(txt, /● verbose\n\s+→ on/);
-  assert.doesNotMatch(txt, /→ 1/);
+  assert.match(txt, /╭ verbose ─+╮\n│\s+1\. ✓ on\s+│\n│\s+2\. off/);
+  assert.doesNotMatch(txt, /✓ off/);
 });
 
-test("card (live): shows empty boolean review values as empty", () => {
+test("card (live): shows empty boolean fields without selecting off", () => {
   const fields: readonly WorkflowInputEntry[] = [
     { name: "enabled", type: "boolean", required: true },
   ];
@@ -195,8 +188,8 @@ test("card (live): shows empty boolean review values as empty", () => {
     caret: 0,
   });
   const txt = plain(renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) }));
-  assert.match(txt, /● enabled\n\s+→ <empty>/);
-  assert.doesNotMatch(txt, /→ off/);
+  assert.match(txt, /╭ enabled ─+╮\n│\s+1\. on\s+│\n│\s+2\. off/);
+  assert.doesNotMatch(txt, /✓ off/);
 });
 
 test("card (live): wraps invalid Submit prompt instead of clipping", () => {
@@ -218,20 +211,20 @@ test("card (live): wraps invalid Submit prompt instead of clipping", () => {
   assert.match(txt, /submitting:/);
   assert.match(txt, /alpha_required_prompt/);
   assert.match(txt, /beta_required_context/);
-  assert.match(txt, /Submit answers \(2 missing\)/);
+  assert.match(txt, / SUBMIT /);
   const promptStart = plainLines.findIndex((line) => line.startsWith("Answer remaining"));
   const promptLines = plainLines.slice(promptStart, promptStart + 4).join("\n");
   assert.doesNotMatch(promptLines, /…/);
   assertLinesWithinWidth(lines, width);
 });
 
-test("card (live): Submit review preserves multiline values", () => {
+test("card (live): single-page form preserves multiline values", () => {
   const state = makeState({
     rawText: { prompt: "line one\nline two", iters: "5", focus: "minimal", verbose: "false" },
     focusedIdx: FIELDS.length,
   });
   const txt = plain(renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) }));
-  assert.match(txt, /→ line one\n\s+line two/);
+  assert.match(txt, /│line one\s+│\n│line two/);
   assert.doesNotMatch(txt, /line one line two/);
 });
 
@@ -273,9 +266,9 @@ test("card: keeps Submit visible in a narrow tab bar", () => {
     caret: 0,
   });
   const lines = renderInlineCard({ width: 16, state, theme: deriveGraphTheme({}) });
-  const tab = plain([lines[1] ?? ""]);
-  assert.match(tab, /Submit/);
-  assert.ok(tab.length <= 16);
+  const footer = plain([lines.at(-1) ?? ""]);
+  assert.match(footer, /SUBMIT/);
+  assert.ok(footer.length <= 16);
 });
 
 test("card: select field renders choices as ask-user-question numbered rows", () => {
@@ -326,8 +319,8 @@ test("card: wraps long descriptions and choice labels without ellipses", () => {
     caret: 0,
   });
   const txt = plain(renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) }));
-  assert.match(txt, /prioritizes safety across multiple/);
-  assert.match(txt, /production regions and rollback windows/);
+  assert.match(txt, /prioritizes safety/);
+  assert.match(txt, /across multiple production regions and rollback windows/);
   assert.match(txt, /roll out gradually across production regions/);
   assert.match(txt, /automated rollback and/);
   assert.match(txt, /operator checkpoints/);
@@ -463,52 +456,28 @@ test("editor: Submit section validates and submits via visible row", () => {
   e.dispose();
 });
 
-test("editor: Submit section cancel row exits on Enter", () => {
-  const state = makeState({
-    focusedIdx: FIELDS.length,
-    submitChoiceIdx: 1,
-    rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
-  });
-  const e = makeEditor(state);
-  e.editor.handleInput("\r");
-  assert.deepEqual(e.getExited(), { outcome: "cancel" });
-  e.dispose();
-});
-
-test("editor: Submit section number hotkeys submit or cancel immediately", () => {
+test("editor: Submit button ignores numeric hotkeys", () => {
   const submitState = makeState({
     focusedIdx: FIELDS.length,
     rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
   });
   const submit = makeEditor(submitState);
   submit.editor.handleInput("1");
-  assert.deepEqual(submit.getExited(), { outcome: "submit" });
+  assert.equal(submit.getExited(), null);
   submit.dispose();
-
-  const cancelState = makeState({
-    formId: "wf-cancel-hotkey",
-    focusedIdx: FIELDS.length,
-    rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
-  });
-  const cancel = makeEditor(cancelState);
-  cancel.editor.handleInput("2");
-  assert.deepEqual(cancel.getExited(), { outcome: "cancel" });
-  assert.equal(cancelState.submitChoiceIdx, 1);
-  cancel.dispose();
 });
 
-test("editor: Submit section arrow keys move between submit and cancel rows", () => {
+test("editor: Submit button arrow keys return to questions", () => {
   const state = makeState({
     focusedIdx: FIELDS.length,
     rawText: { prompt: "build", iters: "5", focus: "standard", verbose: "false" },
   });
   const e = makeEditor(state);
+  e.editor.handleInput("\x1b[A");
+  assert.equal(state.focusedIdx, FIELDS.length - 1);
+  state.focusedIdx = FIELDS.length;
   e.editor.handleInput("\x1b[B");
-  assert.equal(state.submitChoiceIdx, 1);
-  e.editor.handleInput("\x1b[A");
-  assert.equal(state.submitChoiceIdx, 0);
-  e.editor.handleInput("\x1b[A");
-  assert.equal(state.submitChoiceIdx, 1);
+  assert.equal(state.focusedIdx, 0);
   e.dispose();
 });
 
@@ -1068,16 +1037,16 @@ test("card: focused multi-line text field renders newlines as real rows, no `⏎
   assert.doesNotMatch(txt, /⏎/);
 });
 
-test("card: inactive filled fields are summarized in the tab row while only the active field body renders", () => {
+test("card: inactive filled fields remain visible on the single page", () => {
   const state = makeState({
     rawText: { prompt: "first line\nsecond line", iters: "5", focus: "standard", verbose: "false" },
-    focusedIdx: 1, // focus on iters, prompt is represented by the answered tab
+    focusedIdx: 1,
     caret: 1,
   });
   const txt = plain(renderInlineCard({ width: 80, state, theme: deriveGraphTheme({}) }));
-  assert.match(txt, /■ prompt/);
-  assert.match(txt, /iters\n\n❯ 1\. 5/);
-  assert.doesNotMatch(txt, /first line/);
+  assert.match(txt, /╭ prompt /);
+  assert.match(txt, /│first line\s+│\n│second line/);
+  assert.match(txt, /╭ iters ─+╮\n│5/);
   assert.doesNotMatch(txt, /⏎/);
 });
 

--- a/test/unit/inputs-picker.test.ts
+++ b/test/unit/inputs-picker.test.ts
@@ -230,17 +230,12 @@ test("Submit tab with missing required fields focuses invalid", () => {
   assert.deepEqual(s.invalidIndices, [0]);
 });
 
-test("Submit tab returns coerced values and Cancel row cancels", () => {
+test("Submit button returns coerced values", () => {
   const s = createInputsPickerState(FIELDS, { prompt: "hi", focus: "minimal" });
   s.rawText.iters = "8";
   s.rawText.verbose = "true";
   s.focusedIdx = FIELDS.length;
 
-  handleInputsPickerInput("\x1b[B", s, FIELDS, KB);
-  assert.equal(s.submitChoiceIdx, 1);
-  assert.deepEqual(handleInputsPickerInput("\r", s, FIELDS, KB), { kind: "cancel" });
-
-  s.submitChoiceIdx = 0;
   const run = handleInputsPickerInput("\r", s, FIELDS, KB);
   assert.equal(run.kind, "run");
   if (run.kind === "run") {
@@ -253,28 +248,22 @@ test("Submit tab returns coerced values and Cancel row cancels", () => {
   }
 });
 
-test("Submit tab number hotkeys submit or cancel immediately", () => {
+test("Submit button ignores numeric hotkeys", () => {
   const submit = createInputsPickerState(FIELDS, { prompt: "hi", focus: "minimal" });
   submit.focusedIdx = FIELDS.length;
   const run = handleInputsPickerInput("1", submit, FIELDS, KB);
-  assert.equal(run.kind, "run");
-
-  const cancel = createInputsPickerState(FIELDS, { prompt: "hi", focus: "minimal" });
-  cancel.focusedIdx = FIELDS.length;
-  assert.deepEqual(handleInputsPickerInput("2", cancel, FIELDS, KB), { kind: "cancel" });
-  assert.equal(cancel.submitChoiceIdx, 1);
+  assert.equal(run.kind, "noop");
 });
 
-test("Submit tab arrow keys move between submit and cancel rows", () => {
+test("Submit button arrow keys return to the questions", () => {
   const s = createInputsPickerState(FIELDS, { prompt: "hi", focus: "minimal" });
   s.focusedIdx = FIELDS.length;
 
+  handleInputsPickerInput("\x1b[A", s, FIELDS, KB);
+  assert.equal(s.focusedIdx, FIELDS.length - 1);
+  s.focusedIdx = FIELDS.length;
   handleInputsPickerInput("\x1b[B", s, FIELDS, KB);
-  assert.equal(s.submitChoiceIdx, 1);
-  handleInputsPickerInput("\x1b[A", s, FIELDS, KB);
-  assert.equal(s.submitChoiceIdx, 0);
-  handleInputsPickerInput("\x1b[A", s, FIELDS, KB);
-  assert.equal(s.submitChoiceIdx, 1);
+  assert.equal(s.focusedIdx, 0);
 });
 
 // ── Coercion ──────────────────────────────────────────────────────────────
@@ -323,7 +312,7 @@ test("wrapPlainText preserves empty rows for empty and whitespace-only input", (
   assert.deepEqual(wrapPlainText("   \t  ", 80), [""]);
 });
 
-test("renderInputsPicker mirrors ask-question list style for the active field", () => {
+test("renderInputsPicker uses boxed field styling for the active field", () => {
   const theme = deriveGraphTheme({});
   const state = createInputsPickerState(FIELDS, { prompt: "build" });
   const lines = renderInputsPicker({
@@ -336,24 +325,25 @@ test("renderInputsPicker mirrors ask-question list style for the active field", 
   });
   // eslint-disable-next-line no-control-regex
   const joined = lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(joined, /←\s+■ prompt/);
-  assert.match(joined, /■ iters/);
-  assert.match(joined, /✓ Submit/);
-  assert.match(joined, /task to do/);
-  assert.match(joined, /❯ 1\. build/);
+  assert.doesNotMatch(joined, /←\s+■ prompt/);
+  assert.doesNotMatch(joined, /✓ Submit/);
+  assert.match(joined, /╭ prompt ─+╮/);
+  assert.match(joined, /│build/);
+  assert.match(joined, /text · required · task to do/);
   assert.doesNotMatch(joined, /loop a thinker/);
-  assert.doesNotMatch(joined, /1 \/ 4/);
-  assert.doesNotMatch(joined, /text\s+·\s+required/);
-  assert.doesNotMatch(joined, /╭/);
-  assert.doesNotMatch(joined, /╰/);
+  assert.match(joined, /WORKFLOW/);
+  assert.match(joined, /ralph/);
+  assert.match(joined, /1 \/ 4/);
+  assert.match(joined, /╭/);
+  assert.match(joined, /╰/);
   assert.doesNotMatch(joined, /Run workflow/);
-  assert.match(joined, /Tab to switch input fields/);
+  assert.match(joined, /enter Submit/);
   assert.doesNotMatch(joined, /ctrl\+x/);
   assert.doesNotMatch(joined, /Chat about this/);
-  assert.match(joined, /Esc to cancel/);
+  assert.match(joined, /esc Cancel/);
 });
 
-test("renderInputsPicker shows a Submit section instead of a confirm modal", () => {
+test("renderInputsPicker shows all questions with Submit at the end", () => {
   const theme = deriveGraphTheme({});
   const state = createInputsPickerState(FIELDS, { prompt: "build a tui" });
   state.focusedIdx = FIELDS.length;
@@ -367,20 +357,18 @@ test("renderInputsPicker shows a Submit section instead of a confirm modal", () 
   });
   // eslint-disable-next-line no-control-regex
   const joined = lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(joined, /Review your inputs/);
-  assert.match(joined, /\/workflow ralph/);
-  assert.match(joined, /● prompt/);
-  assert.match(joined, /→ build a tui/);
-  assert.match(joined, /Ready to submit your inputs\?/);
-  assert.match(joined, /● verbose\n\s+→ off/);
-  assert.doesNotMatch(joined, /→ false/);
-  assert.match(joined, /❯ 1\. Submit answers/);
-  assert.match(joined, /2\. Cancel/);
-  assert.doesNotMatch(joined, /ready to run/);
+  assert.match(joined, /╭ prompt ─+╮\n│build a tui/);
+  assert.match(joined, /╭ iters ─+╮\n│5/);
+  assert.match(joined, /╭ focus ─+╮\n│\s+1\. minimal\s+│\n│\s+2\. ✓ standard/);
+  assert.match(joined, /╭ verbose ─+╮\n│\s+1\. on\s+│\n│\s+2\. ✓ off/);
+  assert.match(joined, / SUBMIT /);
+  assert.doesNotMatch(joined, /Review your inputs/);
+  assert.doesNotMatch(joined, /Ready to submit your inputs\?/);
+  assert.doesNotMatch(joined, /2\. Cancel/);
   assert.doesNotMatch(joined, /ctrl\+x/);
 });
 
-test("renderInputsPicker normalizes true-like boolean review values", () => {
+test("renderInputsPicker normalizes true-like boolean field values", () => {
   const theme = deriveGraphTheme({});
   const state = createInputsPickerState(FIELDS, { prompt: "build a tui", verbose: 1 });
   state.focusedIdx = FIELDS.length;
@@ -394,11 +382,11 @@ test("renderInputsPicker normalizes true-like boolean review values", () => {
   });
   // eslint-disable-next-line no-control-regex
   const joined = lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(joined, /● verbose\n\s+→ on/);
-  assert.doesNotMatch(joined, /→ 1/);
+  assert.match(joined, /╭ verbose ─+╮\n│\s+1\. ✓ on\s+│\n│\s+2\. off/);
+  assert.doesNotMatch(joined, /✓ off/);
 });
 
-test("renderInputsPicker shows empty boolean review values as empty", () => {
+test("renderInputsPicker shows empty boolean fields without selecting off", () => {
   const theme = deriveGraphTheme({});
   const fields: WorkflowInputEntry[] = [
     { name: "enabled", type: "boolean", required: true },
@@ -416,8 +404,8 @@ test("renderInputsPicker shows empty boolean review values as empty", () => {
   });
   // eslint-disable-next-line no-control-regex
   const joined = lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(joined, /● enabled\n\s+→ <empty>/);
-  assert.doesNotMatch(joined, /→ off/);
+  assert.match(joined, /╭ enabled ─+╮\n│\s+1\. on\s+│\n│\s+2\. off/);
+  assert.doesNotMatch(joined, /✓ off/);
 });
 
 test("renderInputsPicker wraps invalid Submit prompt instead of clipping", () => {
@@ -444,14 +432,14 @@ test("renderInputsPicker wraps invalid Submit prompt instead of clipping", () =>
   assert.match(joined, /submitting:/);
   assert.match(joined, /alpha_required_prompt/);
   assert.match(joined, /beta_required_context/);
-  assert.match(joined, /Submit answers \(2 missing\)/);
+  assert.match(joined, / SUBMIT /);
   const promptStart = plainLines.findIndex((line) => line.startsWith("Answer remaining"));
   const promptLines = plainLines.slice(promptStart, promptStart + 4).join("\n");
   assert.doesNotMatch(promptLines, /…/);
   for (const line of plainLines) assert.ok(line.length <= width, `row exceeds width: ${JSON.stringify(line)}`);
 });
 
-test("renderInputsPicker preserves multiline values in Submit review", () => {
+test("renderInputsPicker preserves multiline values on the single page", () => {
   const theme = deriveGraphTheme({});
   const state = createInputsPickerState(FIELDS, { prompt: "line one\nline two" });
   state.focusedIdx = FIELDS.length;
@@ -465,7 +453,7 @@ test("renderInputsPicker preserves multiline values in Submit review", () => {
   });
   // eslint-disable-next-line no-control-regex
   const joined = lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(joined, /→ line one\n\s+line two/);
+  assert.match(joined, /│line one\s+│\n│line two/);
   assert.doesNotMatch(joined, /line one line two/);
 });
 
@@ -486,12 +474,12 @@ test("renderInputsPicker keeps Submit visible in a narrow tab bar", () => {
     cursorOn: true,
   });
   // eslint-disable-next-line no-control-regex
-  const tab = (lines[1] ?? "").replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(tab, /Submit/);
-  assert.ok(tab.length <= 16);
+  const footer = (lines.at(-1) ?? "").replace(/\x1b\[[0-9;]*m/g, "");
+  assert.match(footer, /SUBMIT/);
+  assert.ok(footer.length <= 16);
 });
 
-test("renderInputsPicker renders only the active input as ask-style rows", () => {
+test("renderInputsPicker renders all inputs as boxed fields", () => {
   const theme = deriveGraphTheme({});
   const width = 80;
   const state = createInputsPickerState(FIELDS);
@@ -507,8 +495,9 @@ test("renderInputsPicker renders only the active input as ask-style rows", () =>
   const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
   const plain = lines.map(stripAnsi);
 
-  assert.ok(plain.some((row) => row.startsWith("❯ 1.")), "active field should render with ask-style pointer");
-  assert.ok(plain.every((row) => !row.startsWith("╭") && !row.startsWith("╰")), "field cards should not render");
+  assert.ok(plain.some((row) => row.startsWith("╭ prompt ")), "prompt should render as a field box");
+  assert.ok(plain.some((row) => /^│5\s+│$/.test(row)), "scalar fields should render without numbering");
+  assert.ok(plain.some((row) => /^│\s+1\. minimal/.test(row)), "choice lists should keep numbering");
   for (const row of plain) {
     assert.ok(row.length <= width, `row exceeds width: ${JSON.stringify(row)}`);
   }
@@ -536,8 +525,8 @@ test("renderInputsPicker wraps long descriptions and choice labels without ellip
   });
   // eslint-disable-next-line no-control-regex
   const joined = lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
-  assert.match(joined, /prioritizes safety across multiple/);
-  assert.match(joined, /production regions and rollback windows/);
+  assert.match(joined, /prioritizes safety/);
+  assert.match(joined, /across multiple production regions and rollback windows/);
   assert.match(joined, /roll out gradually across production regions/);
   assert.match(joined, /automated rollback and/);
   assert.match(joined, /operator checkpoints/);
@@ -567,46 +556,38 @@ test("renderInputsPicker stays well-formed across a wide range of widths (resize
         row.length <= width,
         `width=${width}: row exceeds budget (${row.length} > ${width}): ${JSON.stringify(row)}`,
       );
-      assert.ok(!row.startsWith("╭") && !row.startsWith("╰"), `width=${width}: field card border rendered`);
+
     }
   }
 });
 
-test("renderInputsPicker footer uses ask-question input-field copy", () => {
+test("renderInputsPicker footer uses compact static submit button", () => {
   const theme = deriveGraphTheme({});
   const state = createInputsPickerState(FIELDS);
   // eslint-disable-next-line no-control-regex
   const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
-  const lastNonEmpty = (lines: string[]): string => {
-    for (let i = lines.length - 1; i >= 0; i -= 1) {
-      if (lines[i] && stripAnsi(lines[i]!).trim() !== "") return stripAnsi(lines[i]!);
-    }
-    return "";
-  };
-  const renderAt = (width: number): string =>
-    lastNonEmpty(
-      renderInputsPicker({
-        width,
-        theme,
-        workflowName: "ralph",
-        fields: FIELDS,
-        state,
-        cursorOn: true,
-      }),
-    );
+  const renderFooterAt = (width: number): string =>
+    stripAnsi(renderInputsPicker({
+      width,
+      theme,
+      workflowName: "ralph",
+      fields: FIELDS,
+      state,
+      cursorOn: true,
+    }).at(-1) ?? "");
 
-  const wide = renderAt(120);
-  assert.match(wide, /Enter to select/);
-  assert.match(wide, /↑\/↓ to navigate/);
-  assert.match(wide, /Tab to switch input fields/);
-  assert.match(wide, /Esc to cancel/);
+  const wide = renderFooterAt(120);
+  assert.match(wide, / SUBMIT /);
+  assert.doesNotMatch(wide, /EDIT/);
+  assert.match(wide, /enter Submit/);
+  assert.match(wide, /tab Next/);
+  assert.match(wide, /shift\+tab Prev/);
+  assert.match(wide, /esc Cancel/);
   assert.doesNotMatch(wide, /ctrl\+x/);
 
-  const narrow = renderAt(24);
+  const narrow = renderFooterAt(24);
   assert.ok(narrow.length <= 24);
-  assert.match(narrow, /Enter/);
-  assert.match(narrow, /Tab/);
-  assert.match(narrow, /Esc/);
+  assert.match(narrow, /SUBMIT|…/);
 });
 
 // ── renderInputsSchema ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Render workflow input forms as all-fields-visible question cards with compact workflow chrome, and preserve `ask_user_question` custom-answer drafts and caret positions across navigation.

## Changes

- Render workflow fields as stacked, bordered question cards in both the interactive input picker and inline chat-history form views.
- Add compact workflow header chrome with progress badges for the updated form layout.
- Replace the numbered submit/cancel pane with a single toolbar-style Submit action and validation-focused submit behavior.
- Track custom `ask_user_question` draft text and caret offsets per tab so typed custom answers survive tab changes and reducer updates.
- Update unit coverage for workflow form rendering, submit focus behavior, and ask-user-question TUI custom input handling.

## Notes

- Esc/Ctrl+C remain the cancel path for workflow forms.
- Submit now validates in place and focuses the first invalid field.
- Validation run: `AGENT=1 bun test test/unit/ask-user-question-tui.test.ts test/unit/inline-form.test.ts test/unit/inputs-picker.test.ts`
- Validation run: `bun run typecheck`
