### PR TITLE
feat(workflows): resume failed runs with continuations

### DIFF
--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -956,16 +956,34 @@ type ToolStageTarget =
   | { ok: true; stageId?: string }
   | { ok: false; message: string };
 
-function resolveToolStageTarget(runId: string, stageTarget?: string): ToolStageTarget {
+function stageMatchesIdentifier(stage: { readonly id: string; readonly name: string }, target: string): boolean {
+  return stage.id === target || stage.name === target || stage.id.startsWith(target);
+}
+
+function stageMatchLabel(stage: { readonly id: string; readonly name: string }): string {
+  return `${stage.name} (${stage.id.slice(0, 12)})`;
+}
+
+function resolveStageTarget(runId: string, stageTarget?: string): ToolStageTarget {
   const target = stageTarget?.trim();
   if (!target) return { ok: true };
 
   const run = store.runs().find((r) => r.id === runId);
-  const stage = run?.stages.find(
-    (s) => s.id === target || s.id.startsWith(target) || s.name === target,
-  );
-  if (!stage) return { ok: false, message: `Stage not found in run ${runId.slice(0, 8)}: ${target}` };
-  return { ok: true, stageId: stage.id };
+  const exactId = run?.stages.find((stage) => stage.id === target);
+  if (exactId !== undefined) return { ok: true, stageId: exactId.id };
+
+  const exactNames = run?.stages.filter((stage) => stage.name === target) ?? [];
+  if (exactNames.length === 1) return { ok: true, stageId: exactNames[0]!.id };
+  if (exactNames.length > 1) return { ok: false, message: `Ambiguous stage identifier "${target}" matches: ${exactNames.map(stageMatchLabel).join(", ")}` };
+
+  const matches = run?.stages.filter((stage) => stageMatchesIdentifier(stage, target)) ?? [];
+  if (matches.length === 0) return { ok: false, message: `Stage not found in run ${runId.slice(0, 8)}: ${target}` };
+  if (matches.length > 1) return { ok: false, message: `Ambiguous stage identifier "${target}" matches: ${matches.map(stageMatchLabel).join(", ")}` };
+  return { ok: true, stageId: matches[0]!.id };
+}
+
+function resolveToolStageTarget(runId: string, stageTarget?: string): ToolStageTarget {
+  return resolveStageTarget(runId, stageTarget);
 }
 
 function ambiguousRunMessage(target: string, matches: readonly string[]): string {
@@ -1864,19 +1882,12 @@ function factory(pi: ExtensionAPI): void {
       }
       let stageId: string | undefined;
       const run = store.runs().find((r) => r.id === runId);
-      if (stageTarget) {
-        const stage = run?.stages.find(
-          (s) =>
-            s.id === stageTarget ||
-            s.id.startsWith(stageTarget) ||
-            s.name === stageTarget,
-        );
-        if (!stage) {
-          print(`Stage not found in run ${runId.slice(0, 8)}: ${stageTarget}`);
-          return true;
-        }
-        stageId = stage.id;
+      const resolvedStage = resolveStageTarget(runId, stageTarget);
+      if (!resolvedStage.ok) {
+        print(resolvedStage.message);
+        return true;
       }
+      stageId = resolvedStage.stageId;
       const isPaused =
         run?.status === "paused" ||
         (run?.stages.some((s) => s.status === "paused") ?? false);

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -730,13 +730,22 @@ export function makeExecuteWorkflowTool(
         const isPaused =
           run?.status === "paused" ||
           (run?.stages.some((s) => s.status === "paused") ?? false);
+        if (!isPaused && run?.status === "failed" && run.endedAt !== undefined && run.resumable !== false) {
+          const continuation = activeRuntime.resumeFailedRun(target.runId, stage.stageId);
+          return {
+            action: "resume",
+            runId: continuation.ok ? continuation.runId : target.runId,
+            status: continuation.ok ? "running" : "noop",
+            message: continuation.message,
+          };
+        }
         const result = resumeRun(target.runId, { stageId: stage.stageId, message: args.message });
         if (result.ok) {
-          const message = isPaused
+          const message = result.message ?? (isPaused
             ? result.resumed.length === 0
               ? `No paused stages on run ${result.runId.slice(0, 8)}.`
               : `Resumed ${result.resumed.length} stage(s) on run ${result.runId.slice(0, 8)}${args.message ? ` with message: "${args.message}"` : ""}.`
-            : `Snapshot available: run ${result.runId} (${result.snapshot.name}) — status: ${result.snapshot.status}, stages: ${result.snapshot.stages.length}`;
+            : `Snapshot available: run ${result.runId} (${result.snapshot.name}) — status: ${result.snapshot.status}, stages: ${result.snapshot.stages.length}`);
           return {
             action: "resume",
             runId: result.runId,
@@ -1255,6 +1264,9 @@ function factory(pi: ExtensionAPI): void {
     },
     runDirect(args) {
       return runtimeRef.current.runDirect(args);
+    },
+    resumeFailedRun(sourceRunId, stageId) {
+      return runtimeRef.current.resumeFailedRun(sourceRunId, stageId);
     },
   };
 
@@ -1868,6 +1880,11 @@ function factory(pi: ExtensionAPI): void {
       const isPaused =
         run?.status === "paused" ||
         (run?.stages.some((s) => s.status === "paused") ?? false);
+      if (!isPaused && run?.status === "failed" && run.endedAt !== undefined && run.resumable !== false) {
+        const continuation = runtimeForContext(ctx).resumeFailedRun(runId, stageId);
+        print(continuation.message);
+        return true;
+      }
       const result = resumeRun(runId, { stageId, message });
       if (!result.ok) {
         print(`Run not found: ${runId.slice(0, 8)}`);
@@ -1877,7 +1894,7 @@ function factory(pi: ExtensionAPI): void {
         // Non-paused fallback: reopen the orchestrator overlay as before.
         overlay.open(result.runId, overlaySurfaceFromContext(ctx));
         print(
-          `Snapshot available: run ${result.runId} (${result.snapshot.name}) \u2014 status: ${result.snapshot.status}, stages: ${result.snapshot.stages.length}`,
+          result.message ?? `Snapshot available: run ${result.runId} (${result.snapshot.name}) \u2014 status: ${result.snapshot.status}, stages: ${result.snapshot.stages.length}`,
         );
         return true;
       }

--- a/packages/workflows/src/extension/runtime.ts
+++ b/packages/workflows/src/extension/runtime.ts
@@ -41,6 +41,7 @@ import {
 } from "../intercom/result-intercom.js";
 import { validateWorkflowModels } from "../runs/shared/model-fallback.js";
 import { runDetached } from "../runs/background/runner.js";
+import { classifyWorkflowFailure } from "../shared/workflow-failures.js";
 
 // ---------------------------------------------------------------------------
 // Options
@@ -325,10 +326,33 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
     return stage.id === identifier || stage.name === identifier || stage.id.startsWith(identifier);
   }
 
+  function stageLabel(stage: RunSnapshot["stages"][number]): string {
+    return `${stage.name} (${stage.id.slice(0, 12)})`;
+  }
+
+  function resolveUniqueResumeStage(source: RunSnapshot, identifier: string): { ok: true; stage: RunSnapshot["stages"][number] } | { ok: false; message: string } {
+    const exactId = source.stages.find((stage) => stage.id === identifier);
+    if (exactId !== undefined) return { ok: true, stage: exactId };
+
+    const exactNames = source.stages.filter((stage) => stage.name === identifier);
+    if (exactNames.length === 1) return { ok: true, stage: exactNames[0]! };
+    if (exactNames.length > 1) {
+      return { ok: false, message: `insufficient_state: ambiguous stage identifier "${identifier}" matches: ${exactNames.map(stageLabel).join(", ")}` };
+    }
+
+    const matches = source.stages.filter((stage) => matchesResumeStageIdentifier(stage, identifier));
+    if (matches.length === 0) return { ok: false, message: `insufficient_state: stage not found in source run ${source.id}: ${identifier}` };
+    if (matches.length > 1) {
+      return { ok: false, message: `insufficient_state: ambiguous stage identifier "${identifier}" matches: ${matches.map(stageLabel).join(", ")}` };
+    }
+    return { ok: true, stage: matches[0]! };
+  }
+
   function resolveResumeStage(source: RunSnapshot, stageId?: string): { ok: true; stageId: string } | { ok: false; message: string } {
     if (stageId !== undefined) {
-      const stage = source.stages.find((candidate) => matchesResumeStageIdentifier(candidate, stageId));
-      if (stage === undefined) return { ok: false, message: `insufficient_state: stage not found in source run ${source.id}: ${stageId}` };
+      const resolved = resolveUniqueResumeStage(source, stageId);
+      if (!resolved.ok) return { ok: false, message: resolved.message };
+      const stage = resolved.stage;
       if (stage.status !== "failed") return { ok: false, message: `insufficient_state: stage ${stage.name} is ${stage.status}, not failed` };
       return { ok: true, stageId: stage.id };
     }
@@ -392,7 +416,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
         runId,
         status: "failed",
         progress: { completed: 0, total: directProgressTotal(args) },
-        error: error instanceof Error ? error.message : String(error),
+        error: classifyWorkflowFailure(error).userMessage,
       }, delivery, parentSession);
     }
     const background = runDirectForeground(args, runId);
@@ -407,7 +431,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
           runId,
           status: "failed",
           progress: { completed: 0, total: directProgressTotal(args) },
-          error: error instanceof Error ? error.message : String(error),
+          error: classifyWorkflowFailure(error).userMessage,
         }, delivery, parentSession);
         emitDirectIntercom(details, delivery, parentSession);
       },

--- a/packages/workflows/src/extension/runtime.ts
+++ b/packages/workflows/src/extension/runtime.ts
@@ -24,8 +24,9 @@ import type {
   WorkflowModelCatalogPort,
 } from "../shared/types.js";
 import type { StageAdapters } from "../runs/foreground/stage-runner.js";
-import { runChain, runParallel, runTask, type RunOpts } from "../runs/foreground/executor.js";
+import { resolveInputs, runChain, runParallel, runTask, type RunOpts } from "../runs/foreground/executor.js";
 import type { Store } from "../shared/store.js";
+import type { RunSnapshot } from "../shared/store-types.js";
 import type { CancellationRegistry } from "../runs/background/cancellation-registry.js";
 import { store as defaultStore } from "../shared/store.js";
 import { dispatch } from "./dispatcher.js";
@@ -39,6 +40,7 @@ import {
   type WorkflowResultIntercomPort,
 } from "../intercom/result-intercom.js";
 import { validateWorkflowModels } from "../runs/shared/model-fallback.js";
+import { runDetached } from "../runs/background/runner.js";
 
 // ---------------------------------------------------------------------------
 // Options
@@ -81,6 +83,10 @@ export interface ExtensionRuntimeOpts {
 // Public interface
 // ---------------------------------------------------------------------------
 
+export type ResumeFailedRunResult =
+  | { ok: true; runId: string; sourceRunId: string; resumeFromStageId: string; message: string }
+  | { ok: false; reason: "run_not_found" | "not_resumable" | "workflow_not_found" | "insufficient_state"; message: string };
+
 export interface ExtensionRuntime {
   /**
    * Live registry — read-only reference.
@@ -96,6 +102,9 @@ export interface ExtensionRuntime {
 
   /** Execute direct single/parallel/chain workflow tool modes. */
   runDirect(args: WorkflowToolArgs): Promise<WorkflowDetails>;
+
+  /** Start a linked continuation for a failed resumable named workflow run. */
+  resumeFailedRun(sourceRunId: string, stageId?: string): ResumeFailedRunResult;
 }
 
 // ---------------------------------------------------------------------------
@@ -312,6 +321,59 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
     throw new Error("WorkflowRuntime.runDirect: no direct execution mode supplied");
   }
 
+  function matchesResumeStageIdentifier(stage: RunSnapshot["stages"][number], identifier: string): boolean {
+    return stage.id === identifier || stage.name === identifier || stage.id.startsWith(identifier);
+  }
+
+  function resolveResumeStage(source: RunSnapshot, stageId?: string): { ok: true; stageId: string } | { ok: false; message: string } {
+    if (stageId !== undefined) {
+      const stage = source.stages.find((candidate) => matchesResumeStageIdentifier(candidate, stageId));
+      if (stage === undefined) return { ok: false, message: `insufficient_state: stage not found in source run ${source.id}: ${stageId}` };
+      if (stage.status !== "failed") return { ok: false, message: `insufficient_state: stage ${stage.name} is ${stage.status}, not failed` };
+      return { ok: true, stageId: stage.id };
+    }
+    const failedStageId = source.failedStageId ?? source.stages.find((stage) => stage.status === "failed")?.id;
+    if (failedStageId === undefined) {
+      return { ok: false, message: `insufficient_state: failed run ${source.id} does not identify a failed stage` };
+    }
+    return { ok: true, stageId: failedStageId };
+  }
+
+  function resumeFailedRun(sourceRunId: string, stageId?: string): ResumeFailedRunResult {
+    const source = activeStore.runs().find((run) => run.id === sourceRunId);
+    if (source === undefined) {
+      return { ok: false, reason: "run_not_found", message: `run not found: ${sourceRunId}` };
+    }
+    if (source.status !== "failed" || source.endedAt === undefined || source.resumable === false) {
+      return { ok: false, reason: "not_resumable", message: `run ${sourceRunId} is not a failed resumable workflow run` };
+    }
+    const def = registry.get(source.name);
+    if (def === undefined) {
+      return { ok: false, reason: "workflow_not_found", message: `workflow_not_found: ${source.name}` };
+    }
+    const resolvedStage = resolveResumeStage(source, stageId);
+    if (!resolvedStage.ok) {
+      return { ok: false, reason: "insufficient_state", message: resolvedStage.message };
+    }
+    const sourceInputs = { ...source.inputs };
+    try {
+      resolveInputs(def.inputs, sourceInputs);
+    } catch (err) {
+      return { ok: false, reason: "insufficient_state", message: `insufficient_state: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    const accepted = runDetached(def, sourceInputs, {
+      ...runOptions({ workflow: def.name, inputs: sourceInputs }),
+      continuation: { source, resumeFromStageId: resolvedStage.stageId },
+    });
+    return {
+      ok: true,
+      runId: accepted.runId,
+      sourceRunId: source.id,
+      resumeFromStageId: resolvedStage.stageId,
+      message: `Resuming failed workflow "${def.name}" from run ${source.id.slice(0, 8)} at stage ${resolvedStage.stageId.slice(0, 8)} (new run ${accepted.runId}).`,
+    };
+  }
+
   async function runDirectAsync(args: WorkflowToolArgs): Promise<WorkflowDetails> {
     const runId = crypto.randomUUID();
     const mode = directMode(args);
@@ -382,5 +444,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
         return summarized;
       });
     },
+
+    resumeFailedRun,
   };
 }

--- a/packages/workflows/src/runs/background/runner.ts
+++ b/packages/workflows/src/runs/background/runner.ts
@@ -44,7 +44,7 @@ export interface DetachedAccepted {
 }
 
 export interface DetachedRunOpts
-  extends Omit<RunOpts, "runId" | "signal" | "cancellation" | "deferWorkflowStart"> {
+  extends Omit<RunOpts, "signal" | "cancellation" | "deferWorkflowStart"> {
   /**
    * Override CancellationRegistry (default: singleton cancellationRegistry).
    */
@@ -92,8 +92,8 @@ export function runDetached<TInputs extends Record<string, unknown>>(
   const registry = opts.cancellation ?? defaultCancellationRegistry;
   const tracker = opts.jobs ?? defaultJobTracker;
 
-  // 1. Pre-allocate runId
-  const runId = crypto.randomUUID();
+  // 1. Pre-allocate runId unless the caller supplied one for continuation/tests.
+  const runId = opts.runId ?? crypto.randomUUID();
 
   // 2. Create AbortController for this run
   const controller = new AbortController();

--- a/packages/workflows/src/runs/background/status.ts
+++ b/packages/workflows/src/runs/background/status.ts
@@ -39,7 +39,14 @@ export type DestroyRunResult =
   | { ok: false; runId: string; reason: "not_found" };
 
 export type ResumeResult =
-  | { ok: true; runId: string; snapshot: RunSnapshot; resumed: readonly StageSnapshot[] }
+  | {
+      ok: true;
+      runId: string;
+      snapshot: RunSnapshot;
+      resumed: readonly StageSnapshot[];
+      mode?: "snapshot" | "paused" | "not_resumable";
+      message?: string;
+    }
   | { ok: false; runId: string; reason: "not_found" };
 
 export type PauseResult =
@@ -289,7 +296,23 @@ export function resumeRun(
   // Return a deep copy of the snapshot for safe consumption
   const snapshot: RunSnapshot = JSON.parse(JSON.stringify(run)) as RunSnapshot;
   const resumedCopy: StageSnapshot[] = JSON.parse(JSON.stringify(resumed)) as StageSnapshot[];
-  return { ok: true, runId, snapshot, resumed: resumedCopy };
+  if (run.status === "failed" && run.endedAt !== undefined && run.resumable === false) {
+    return {
+      ok: true,
+      runId,
+      snapshot,
+      resumed: resumedCopy,
+      mode: "not_resumable",
+      message: "This failed workflow is not resumable; inspect the snapshot and rerun the workflow when ready.",
+    };
+  }
+  return {
+    ok: true,
+    runId,
+    snapshot,
+    resumed: resumedCopy,
+    mode: resumedCopy.length > 0 ? "paused" : "snapshot",
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -759,6 +759,10 @@ async function writeDirectOutput(
   };
 }
 
+function directFailureMessage(error: unknown): string {
+  return classifyWorkflowFailure(error).userMessage;
+}
+
 function failedDirectDetails(
   mode: WorkflowDetails["mode"],
   runId: string,
@@ -774,7 +778,7 @@ function failedDirectDetails(
     ...(options.context !== undefined ? { context: options.context } : {}),
     results: [],
     progress: { completed: 0, total },
-    error: error instanceof Error ? error.message : String(error),
+    error: directFailureMessage(error),
   };
 }
 
@@ -1086,7 +1090,7 @@ function runFailureMetadata(err: unknown, stages: readonly StageSnapshot[]): Run
     failureKind,
     failureMessage: failedStage?.failureMessage ?? classified.message,
     ...(failedStage !== undefined ? { failedStageId: failedStage.id } : {}),
-    resumable: failureKind !== "cancelled",
+    resumable: classified.resumable,
   };
 }
 

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -1082,7 +1082,7 @@ function runFailureMetadata(err: unknown, stages: readonly StageSnapshot[]): Run
   const failureKind = failedStage?.failureKind ?? classified.kind;
 
   return {
-    errorMessage: failedStage?.error ?? classified.userMessage,
+    errorMessage: classified.userMessage,
     failureKind,
     failureMessage: failedStage?.failureMessage ?? classified.message,
     ...(failedStage !== undefined ? { failedStageId: failedStage.id } : {}),

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -33,7 +33,14 @@ import type {
   WorkflowModelCatalogPort,
 } from "../../shared/types.js";
 import type { InternalStageContext, StageAdapters } from "./stage-runner.js";
-import type { RunStatus, StageNotice, StageSnapshot, RunSnapshot, WorkflowOverlayAdapter } from "../../shared/store-types.js";
+import type {
+  RunStatus,
+  StageNotice,
+  StageSnapshot,
+  RunSnapshot,
+  WorkflowOverlayAdapter,
+  WorkflowFailureKind,
+} from "../../shared/store-types.js";
 import type { StageControlHandle, StageControlRegistry, AgentSessionEventListener } from "./stage-control-registry.js";
 import type { Store } from "../../shared/store.js";
 import type { CancellationRegistry } from "../background/cancellation-registry.js";
@@ -59,8 +66,15 @@ import {
   appendRunEnd,
 } from "../../shared/persistence-session-entries.js";
 import { validateWorkflowModels } from "../shared/model-fallback.js";
+import type { WorkflowFailure } from "../../shared/workflow-failures.js";
+import { classifyWorkflowFailure } from "../../shared/workflow-failures.js";
 
 export interface ResolvedInputs extends Record<string, unknown> {}
+
+export interface RunContinuationOpts {
+  readonly source: RunSnapshot;
+  readonly resumeFromStageId: string;
+}
 
 export interface RunOpts {
   adapters?: StageAdapters;
@@ -113,6 +127,8 @@ export interface RunOpts {
    * the runId before starting the background promise.
    */
   runId?: string;
+  /** Replay completed stages from a failed source run, then resume at this stage. */
+  continuation?: RunContinuationOpts;
   onRunStart?: (snapshot: RunSnapshot) => void;
   onStageStart?: (runId: string, snapshot: StageSnapshot) => void;
   onStageEnd?: (runId: string, snapshot: StageSnapshot) => void;
@@ -519,16 +535,22 @@ async function mapParallelSteps<T>(
   concurrency: number | undefined,
   failFast: boolean | undefined,
   mapper: (step: WorkflowTaskStep) => Promise<T>,
+  onFirstFailure?: (error: unknown) => void,
 ): Promise<T[]> {
   const limit = positiveConcurrency(concurrency) ?? steps.length;
+  const failFastEnabled = failFast !== false;
   const results = new Array<T>(steps.length);
   const failures: Array<{ readonly index: number; readonly error: unknown }> = [];
   let nextIndex = 0;
   let firstFailure: unknown;
+  let rejectFirstFailure: (reason: unknown) => void = () => {};
+  const firstFailurePromise = new Promise<never>((_, reject) => {
+    rejectFirstFailure = reject;
+  });
 
   async function worker(): Promise<void> {
     while (true) {
-      if (failFast !== false && firstFailure !== undefined) return;
+      if (failFastEnabled && firstFailure !== undefined) return;
       const index = nextIndex;
       nextIndex += 1;
       const step = steps[index];
@@ -537,15 +559,29 @@ async function mapParallelSteps<T>(
         results[index] = await mapper(step);
       } catch (err) {
         failures.push({ index, error: err });
-        firstFailure ??= err;
-        if (failFast !== false) throw err;
+        if (firstFailure === undefined) {
+          firstFailure = err;
+          onFirstFailure?.(err);
+          if (failFastEnabled) rejectFirstFailure(err);
+        }
+        if (failFastEnabled) return;
       }
     }
   }
 
-  await Promise.all(
-    Array.from({ length: Math.min(limit, steps.length) }, () => worker()),
-  );
+  const workers = Array.from({ length: Math.min(limit, steps.length) }, () => worker());
+  const allWorkers = Promise.all(workers);
+
+  if (!failFastEnabled) {
+    await allWorkers;
+  } else {
+    try {
+      await Promise.race([allWorkers, firstFailurePromise]);
+    } catch (err) {
+      void allWorkers.catch(() => {});
+      throw err;
+    }
+  }
 
   if (failures.length > 0) {
     throw new AggregateError(
@@ -1013,11 +1049,93 @@ function appendRunEndWhenRecorded(
     readonly runId: string;
     readonly status: RunStatus;
     readonly result?: Record<string, unknown>;
+    readonly error?: string;
+    readonly failureKind?: WorkflowFailureKind;
+    readonly failureMessage?: string;
+    readonly failedStageId?: string;
+    readonly resumable?: boolean;
     readonly ts: number;
   },
 ): void {
   if (!persistence || !recorded) return;
   appendRunEnd(persistence, payload);
+}
+
+interface RunFailureMetadata {
+  readonly errorMessage: string;
+  readonly failureKind: WorkflowFailureKind;
+  readonly failureMessage: string;
+  readonly failedStageId?: string;
+  readonly resumable: boolean;
+}
+
+function applyFailureToStage(stage: StageSnapshot, failure: WorkflowFailure): void {
+  stage.status = "failed";
+  stage.error = failure.userMessage;
+  stage.failureKind = failure.kind;
+  stage.failureMessage = failure.message;
+}
+
+function runFailureMetadata(err: unknown, stages: readonly StageSnapshot[]): RunFailureMetadata {
+  const classified = classifyWorkflowFailure(err);
+  const failedStage = stages.find((stage) => stage.status === "failed");
+  const failureKind = failedStage?.failureKind ?? classified.kind;
+
+  return {
+    errorMessage: failedStage?.error ?? classified.userMessage,
+    failureKind,
+    failureMessage: failedStage?.failureMessage ?? classified.message,
+    ...(failedStage !== undefined ? { failedStageId: failedStage.id } : {}),
+    resumable: failureKind !== "cancelled",
+  };
+}
+
+type ContinuationReplayDecision =
+  | { readonly kind: "execute" }
+  | { readonly kind: "replay"; readonly source: StageSnapshot };
+
+interface ContinuationReplayIndex {
+  decide(stageName: string): ContinuationReplayDecision;
+}
+
+function createContinuationReplayIndex(continuation: RunContinuationOpts | undefined): ContinuationReplayIndex {
+  if (continuation === undefined) return { decide: () => ({ kind: "execute" }) };
+  const resumeStage = continuation.source.stages.find((stage) => stage.id === continuation.resumeFromStageId);
+  if (resumeStage === undefined) {
+    throw new Error(`pi-workflows: insufficient_state: resume stage ${continuation.resumeFromStageId} was not found in source run ${continuation.source.id}`);
+  }
+
+  const stagesByName = new Map<string, StageSnapshot[]>();
+  for (const stage of continuation.source.stages) {
+    const stages = stagesByName.get(stage.name);
+    if (stages === undefined) {
+      stagesByName.set(stage.name, [stage]);
+    } else {
+      stages.push(stage);
+    }
+  }
+
+  const consumedByName = new Map<string, number>();
+  return {
+    decide(stageName: string): ContinuationReplayDecision {
+      const stages = stagesByName.get(stageName);
+      const index = consumedByName.get(stageName) ?? 0;
+      consumedByName.set(stageName, index + 1);
+      const source = stages?.[index];
+      if (source?.status === "completed") return { kind: "replay", source };
+      return { kind: "execute" };
+    },
+  };
+}
+
+interface ParallelFailFastStage {
+  readonly skip: () => void;
+}
+
+interface ParallelFailFastScope {
+  failed: boolean;
+  firstFailure?: unknown;
+  readonly activeStages: Map<string, ParallelFailFastStage>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1031,17 +1149,25 @@ function finalizeKilled(
   persistence: WorkflowPersistencePort | undefined,
   onRunEnd: RunOpts["onRunEnd"],
 ): RunResult {
-  const recorded = activeStore.recordRunEnd(runId, "killed", undefined, "workflow killed");
-  onRunEnd?.(runId, "killed", undefined, "workflow killed");
+  const errorMessage = "workflow killed";
+  const metadata = {
+    failureKind: "cancelled" as const,
+    failureMessage: errorMessage,
+    resumable: false,
+  };
+  const recorded = activeStore.recordRunEnd(runId, "killed", undefined, errorMessage, metadata);
+  onRunEnd?.(runId, "killed", undefined, errorMessage);
   appendRunEndWhenRecorded(persistence, recorded, {
     runId,
     status: "killed",
+    error: errorMessage,
+    ...metadata,
     ts: Date.now(),
   });
   return {
     runId,
     status: "killed",
-    error: "workflow killed",
+    error: errorMessage,
     stages: [...runSnapshot.stages],
   };
 }
@@ -1080,6 +1206,7 @@ export async function run<TInputs extends Record<string, unknown>>(
 
   // 2. Generate runId (or use pre-allocated seam from caller)
   const runId = opts.runId ?? crypto.randomUUID();
+  const replayIndex = createContinuationReplayIndex(opts.continuation);
 
   // 2a. Create own AbortController; forward caller signal if provided
   const ownController = new AbortController();
@@ -1100,6 +1227,10 @@ export async function run<TInputs extends Record<string, unknown>>(
     status: "running",
     stages: [],
     startedAt: Date.now(),
+    ...(opts.continuation !== undefined ? {
+      resumedFromRunId: opts.continuation.source.id,
+      resumeFromStageId: opts.continuation.resumeFromStageId,
+    } : {}),
   };
 
   activeStore.recordRunStart(runSnapshot);
@@ -1120,6 +1251,8 @@ export async function run<TInputs extends Record<string, unknown>>(
       runId,
       name: def.name,
       inputs: resolvedInputs,
+      ...(runSnapshot.resumedFromRunId !== undefined ? { resumedFromRunId: runSnapshot.resumedFromRunId } : {}),
+      ...(runSnapshot.resumeFromStageId !== undefined ? { resumeFromStageId: runSnapshot.resumeFromStageId } : {}),
       ts: runSnapshot.startedAt,
     });
   }
@@ -1147,7 +1280,7 @@ export async function run<TInputs extends Record<string, unknown>>(
   };
 
   const isTerminalStage = (stage: StageSnapshot): boolean =>
-    stage.status === "completed" || stage.status === "failed";
+    stage.status === "completed" || stage.status === "failed" || stage.status === "skipped";
 
   const stageById = (stageId: string): StageSnapshot | undefined =>
     runSnapshot.stages.find((stage) => stage.id === stageId);
@@ -1280,7 +1413,7 @@ export async function run<TInputs extends Record<string, unknown>>(
     inputs: resolvedInputs as TInputs,
     ui: opts.ui ?? makeUnavailableUIContext(),
 
-    stage(name: string, options?: StageOptions) {
+    stage(name: string, options?: StageOptions, stageFailFastScope?: ParallelFailFastScope) {
       // a. Generate stageId
       const stageId = crypto.randomUUID();
 
@@ -1288,12 +1421,24 @@ export async function run<TInputs extends Record<string, unknown>>(
       const parentIds = tracker.onSpawn(stageId, name);
 
       // c. Create StageSnapshot as "pending"
+      const replayDecision = replayIndex.decide(name);
+      const replaySource = replayDecision.kind === "replay" ? replayDecision.source : undefined;
+      const shouldReplay = replaySource !== undefined;
+
       const stageSnapshot: StageSnapshot = {
         id: stageId,
         name,
-        status: "pending",
+        status: shouldReplay ? "completed" : "pending",
         parentIds: Object.freeze(parentIds),
         toolEvents: [],
+        ...(shouldReplay ? {
+          startedAt: Date.now(),
+          endedAt: Date.now(),
+          durationMs: 0,
+          ...(replaySource.result !== undefined ? { result: replaySource.result } : {}),
+          replayedFromStageId: replaySource.id,
+          replayed: true,
+        } : {}),
         // Store mcp scope options on snapshot when provided
         ...(options?.mcp !== undefined
           ? { mcpScope: { allow: options.mcp.allow ?? null, deny: options.mcp.deny ?? null } }
@@ -1301,8 +1446,73 @@ export async function run<TInputs extends Record<string, unknown>>(
         // Mark attachable up-front: the live stage handle is registered
         // below before the first onStageStart fires, so consumers that
         // hook onStageStart see `attachable: true` for the pending stage.
-        attachable: true,
+        attachable: !shouldReplay,
       };
+
+      let stageStartEntryAppended = false;
+      const appendStageStartOnce = (): void => {
+        if (!opts.persistence || stageStartEntryAppended) return;
+        stageStartEntryAppended = true;
+        appendStageStart(opts.persistence, {
+          runId,
+          stageId,
+          name,
+          parentIds: stageSnapshot.parentIds,
+          ...(stageSnapshot.replayedFromStageId !== undefined ? { replayedFromStageId: stageSnapshot.replayedFromStageId } : {}),
+          ...(stageSnapshot.replayed !== undefined ? { replayed: stageSnapshot.replayed } : {}),
+          ts: stageSnapshot.startedAt ?? Date.now(),
+        });
+      };
+
+      if (shouldReplay) {
+        activeStore.recordStageStart(runId, stageSnapshot);
+        opts.onStageStart?.(runId, stageSnapshot);
+        appendStageStartOnce();
+        activeStore.recordStageEnd(runId, stageSnapshot);
+        opts.onStageEnd?.(runId, stageSnapshot);
+        if (opts.persistence) {
+          appendStageEnd(opts.persistence, {
+            runId,
+            stageId,
+            status: "completed",
+            durationMs: 0,
+            ...(stageSnapshot.result !== undefined ? { summary: stageSnapshot.result } : {}),
+            replayedFromStageId: replaySource.id,
+            replayed: true,
+          });
+        }
+        tracker.onSettle(stageId);
+        const replayResult = replaySource.result ?? "";
+        const replayContext: StageContext & Pick<InternalStageContext, "__modelFallbackMeta"> = {
+          name,
+          prompt: async () => replayResult,
+          complete: async () => replayResult,
+          steer: async () => {},
+          followUp: async () => {},
+          subscribe: () => () => {},
+          get sessionFile() { return replaySource.sessionFile; },
+          get sessionId() { return replaySource.sessionId ?? ""; },
+          setModel: async () => {},
+          setThinkingLevel: () => {},
+          cycleModel: async () => undefined,
+          cycleThinkingLevel: () => undefined,
+          get agent() { return undefined as never; },
+          get model() { return replaySource.model as never; },
+          get thinkingLevel() { return undefined as never; },
+          get messages() { return [] as never; },
+          get isStreaming() { return false; },
+          navigateTree: async () => ({ cancelled: false }),
+          compact: async () => ({}) as never,
+          abortCompaction: () => {},
+          abort: async () => {},
+          __modelFallbackMeta: () => ({
+            ...(replaySource.model !== undefined ? { model: replaySource.model } : {}),
+            ...(replaySource.attemptedModels !== undefined ? { attemptedModels: replaySource.attemptedModels } : {}),
+            ...(replaySource.modelAttempts !== undefined ? { modelAttempts: replaySource.modelAttempts } : {}),
+          }),
+        };
+        return replayContext;
+      }
 
       // d. Create inner AgentSession-like StageContext (raw, without lifecycle wrapping).
       //    Must come before the registry registration because the handle
@@ -1465,6 +1675,59 @@ export async function run<TInputs extends Record<string, unknown>>(
           return innerCtx.subscribe(listener);
         },
       };
+      let stageFinalized = false;
+      const finalizeStageSnapshot = (): boolean => {
+        if (stageFinalized) return false;
+        stageFinalized = true;
+        stageSnapshot.endedAt = Date.now();
+        stageSnapshot.durationMs = elapsedStageMs(stageSnapshot, stageSnapshot.endedAt);
+
+        const finalModelMeta = innerCtx.__modelFallbackMeta();
+        if (finalModelMeta.model !== undefined) stageSnapshot.model = finalModelMeta.model;
+        if (finalModelMeta.attemptedModels !== undefined) stageSnapshot.attemptedModels = finalModelMeta.attemptedModels;
+        if (finalModelMeta.modelAttempts !== undefined) stageSnapshot.modelAttempts = finalModelMeta.modelAttempts;
+
+        activeStore.recordStageEnd(runId, stageSnapshot);
+        opts.onStageEnd?.(runId, stageSnapshot);
+
+        if (opts.persistence) {
+          appendStageStartOnce();
+          appendStageEnd(opts.persistence, {
+            runId,
+            stageId,
+            status: stageSnapshot.status,
+            durationMs: stageSnapshot.durationMs,
+            ...(stageSnapshot.error !== undefined ? { error: stageSnapshot.error } : {}),
+            ...(stageSnapshot.failureKind !== undefined ? { failureKind: stageSnapshot.failureKind } : {}),
+            ...(stageSnapshot.failureMessage !== undefined ? { failureMessage: stageSnapshot.failureMessage } : {}),
+            ...(stageSnapshot.skippedReason !== undefined ? { skippedReason: stageSnapshot.skippedReason } : {}),
+            ...(stageSnapshot.result !== undefined && stageSnapshot.status === "completed" ? { summary: stageSnapshot.result } : {}),
+            ...(stageSnapshot.replayedFromStageId !== undefined ? { replayedFromStageId: stageSnapshot.replayedFromStageId } : {}),
+            ...(stageSnapshot.replayed !== undefined ? { replayed: stageSnapshot.replayed } : {}),
+          });
+        }
+
+        stageFailFastScope?.activeStages.delete(stageId);
+        tracker.onSettle(stageId);
+        return true;
+      };
+      let skippedForParallelFailFast = false;
+      const markSkippedForParallelFailFast = (): void => {
+        skippedForParallelFailFast = true;
+        stageSnapshot.status = "skipped";
+        stageSnapshot.skippedReason = "fail-fast";
+      };
+      const parallelFailFastError = (): unknown =>
+        stageFailFastScope?.firstFailure ?? new Error("pi-workflows: skipped after parallel fail-fast");
+      const skipForParallelFailFast = (): void => {
+        if (isTerminalStage(stageSnapshot)) return;
+        markSkippedForParallelFailFast();
+        finalizeStageSnapshot();
+        void innerCtx.abort().catch(() => {});
+        void releaseLiveHandleWhenIdle().catch(() => {});
+      };
+      stageFailFastScope?.activeStages.set(stageId, { skip: skipForParallelFailFast });
+
       let stageControlDropped = false;
       dropStageControlHandle = (): void => {
         if (stageControlDropped) return;
@@ -1498,12 +1761,18 @@ export async function run<TInputs extends Record<string, unknown>>(
 
       const runTrackedStageCall = async (call: () => Promise<string>): Promise<string> => {
         await waitForStageRelease();
+        if (stageFinalized) {
+          throw parallelFailFastError();
+        }
 
         // Block here until a concurrency slot is available for this run.
         await limiter.acquire();
 
         try {
           await waitForStageRelease();
+          if (stageFinalized) {
+            throw parallelFailFastError();
+          }
         } catch (err) {
           limiter.release();
           throw err;
@@ -1514,15 +1783,7 @@ export async function run<TInputs extends Record<string, unknown>>(
         activeStore.recordStageStart(runId, stageSnapshot);
 
         // Persistence: append stage.start entry
-        if (opts.persistence) {
-          appendStageStart(opts.persistence, {
-            runId,
-            stageId,
-            name,
-            parentIds: stageSnapshot.parentIds,
-            ts: stageSnapshot.startedAt,
-          });
-        }
+        appendStageStartOnce();
 
         const mcpAllow = options?.mcp?.allow ?? null;
         const mcpDeny = options?.mcp?.deny ?? null;
@@ -1557,6 +1818,13 @@ export async function run<TInputs extends Record<string, unknown>>(
             if (modelMeta.attemptedModels !== undefined) stageSnapshot.attemptedModels = modelMeta.attemptedModels;
             if (modelMeta.modelAttempts !== undefined) stageSnapshot.modelAttempts = modelMeta.modelAttempts;
           }
+          if (stageFailFastScope?.failed === true && stageFailFastScope.activeStages.has(stageId)) {
+            markSkippedForParallelFailFast();
+            throw parallelFailFastError();
+          }
+          if (stageFinalized) {
+            throw parallelFailFastError();
+          }
           stageSnapshot.status = "completed";
           const assistantText = innerCtx.__getLastAssistantText();
           if (assistantText !== undefined) {
@@ -1564,38 +1832,16 @@ export async function run<TInputs extends Record<string, unknown>>(
           }
           return result;
         } catch (err) {
-          if (!ownController.signal.aborted) {
-            stageSnapshot.status = "failed";
-            stageSnapshot.error = err instanceof Error ? err.message : String(err);
+          if (!ownController.signal.aborted && !skippedForParallelFailFast) {
+            applyFailureToStage(stageSnapshot, classifyWorkflowFailure(err));
           }
           throw err;
         } finally {
-          stageSnapshot.endedAt = Date.now();
-          stageSnapshot.durationMs = elapsedStageMs(stageSnapshot, stageSnapshot.endedAt);
-
-          const finalModelMeta = innerCtx.__modelFallbackMeta();
-          if (finalModelMeta.model !== undefined) stageSnapshot.model = finalModelMeta.model;
-          if (finalModelMeta.attemptedModels !== undefined) stageSnapshot.attemptedModels = finalModelMeta.attemptedModels;
-          if (finalModelMeta.modelAttempts !== undefined) stageSnapshot.modelAttempts = finalModelMeta.modelAttempts;
-
           if (opts.mcp && hasMcpScope) {
             opts.mcp.clearScope(stageId);
           }
 
-          activeStore.recordStageEnd(runId, stageSnapshot);
-          opts.onStageEnd?.(runId, stageSnapshot);
-
-          // Persistence: append stage.end entry
-          if (opts.persistence) {
-            appendStageEnd(opts.persistence, {
-              runId,
-              stageId,
-              status: stageSnapshot.status,
-              durationMs: stageSnapshot.durationMs,
-            });
-          }
-
-          tracker.onSettle(stageId);
+          finalizeStageSnapshot();
           // The stage has finished participating in workflow scheduling. Drop it
           // from run-level pause/resume and cascade-pause lookups immediately.
           // If no SDK queue/active input remains, release the live chat handle so
@@ -1691,9 +1937,13 @@ export async function run<TInputs extends Record<string, unknown>>(
       return stageContext;
     },
 
-    async task(name: string, options: WorkflowTaskOptions): Promise<WorkflowTaskResult> {
+    async task(name: string, options: WorkflowTaskOptions, stageFailFastScope?: ParallelFailFastScope): Promise<WorkflowTaskResult> {
       const runTaskOnce = async (taskOptions: WorkflowTaskOptions): Promise<WorkflowTaskResult> => {
-        const stage = ctx.stage(name, taskStageOptions(taskOptions));
+        const stage = (ctx.stage as typeof ctx.stage & ((stageName: string, stageOptions?: StageOptions, scope?: ParallelFailFastScope) => StageContext))(
+          name,
+          taskStageOptions(taskOptions),
+          stageFailFastScope,
+        );
         const rawText = await stage.prompt(
           applyTaskContext(`${taskReadInstruction(taskOptions)}${taskPrompt(taskOptions)}`, taskPrevious(taskOptions)),
           taskPromptOptions(taskOptions),
@@ -1757,12 +2007,23 @@ export async function run<TInputs extends Record<string, unknown>>(
 
     async parallel(steps: readonly WorkflowTaskStep[], options: WorkflowParallelOptions = {}): Promise<WorkflowTaskResult[]> {
       const fallback = parallelFallbackTask(steps, options);
+      const failFastScope: ParallelFailFastScope | undefined = options.failFast === false
+        ? undefined
+        : { failed: false, activeStages: new Map<string, ParallelFailFastStage>() };
       return mapParallelSteps(steps, options.concurrency, options.failFast, async (step) => {
         const prompt = replaceTaskPlaceholder(step.prompt ?? step.task ?? fallback, options.task ?? fallback);
-        return ctx.task(
+        return await (ctx.task as typeof ctx.task & ((taskName: string, taskOptions: WorkflowTaskOptions, scope?: ParallelFailFastScope) => Promise<WorkflowTaskResult>))(
           step.name,
           taskWithSharedDefaults(taskOptionsFromStep(step, prompt, taskPrevious(step)), options),
+          failFastScope,
         );
+      }, (error) => {
+        if (failFastScope === undefined) return;
+        failFastScope.failed = true;
+        failFastScope.firstFailure = error;
+        for (const stage of failFastScope.activeStages.values()) {
+          stage.skip();
+        }
       });
     },
   };
@@ -1805,21 +2066,25 @@ export async function run<TInputs extends Record<string, unknown>>(
       return finalizeKilled(runId, runSnapshot, activeStore, opts.persistence, opts.onRunEnd);
     }
 
-    const errorMessage = err instanceof Error ? err.message : String(err);
-
-    const recorded = activeStore.recordRunEnd(runId, "failed", undefined, errorMessage);
-    opts.onRunEnd?.(runId, "failed", undefined, errorMessage);
+    const metadata = runFailureMetadata(err, runSnapshot.stages);
+    const recorded = activeStore.recordRunEnd(runId, "failed", undefined, metadata.errorMessage, metadata);
+    opts.onRunEnd?.(runId, "failed", undefined, metadata.errorMessage);
 
     appendRunEndWhenRecorded(opts.persistence, recorded, {
       runId,
       status: "failed",
+      error: metadata.errorMessage,
+      failureKind: metadata.failureKind,
+      failureMessage: metadata.failureMessage,
+      ...(metadata.failedStageId !== undefined ? { failedStageId: metadata.failedStageId } : {}),
+      resumable: metadata.resumable,
       ts: Date.now(),
     });
 
     return {
       runId,
       status: "failed",
-      error: errorMessage,
+      error: metadata.errorMessage,
       stages: [...runSnapshot.stages],
     };
   } finally {

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -1091,11 +1091,17 @@ function runFailureMetadata(err: unknown, stages: readonly StageSnapshot[]): Run
 }
 
 type ContinuationReplayDecision =
-  | { readonly kind: "execute" }
+  | { readonly kind: "execute"; readonly source?: StageSnapshot }
   | { readonly kind: "replay"; readonly source: StageSnapshot };
 
 interface ContinuationReplayIndex {
-  decide(stageName: string): ContinuationReplayDecision;
+  decide(stageName: string, parentIds: readonly string[], stageId: string): ContinuationReplayDecision;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
 }
 
 function createContinuationReplayIndex(continuation: RunContinuationOpts | undefined): ContinuationReplayIndex {
@@ -1115,15 +1121,29 @@ function createContinuationReplayIndex(continuation: RunContinuationOpts | undef
     }
   }
 
-  const consumedByName = new Map<string, number>();
+  const consumedSourceStageIds = new Set<string>();
+  const sourceStageIdByContinuationStageId = new Map<string, string>();
   return {
-    decide(stageName: string): ContinuationReplayDecision {
-      const stages = stagesByName.get(stageName);
-      const index = consumedByName.get(stageName) ?? 0;
-      consumedByName.set(stageName, index + 1);
-      const source = stages?.[index];
-      if (source?.status === "completed") return { kind: "replay", source };
-      return { kind: "execute" };
+    decide(stageName: string, parentIds: readonly string[], stageId: string): ContinuationReplayDecision {
+      const candidates = stagesByName.get(stageName)?.filter((stage) => !consumedSourceStageIds.has(stage.id)) ?? [];
+      if (candidates.length === 0) return { kind: "execute" };
+
+      const translatedParentIds = parentIds.map((parentId) => sourceStageIdByContinuationStageId.get(parentId));
+      const hasUnmappedParent = translatedParentIds.some((parentId) => parentId === undefined);
+      const matches = hasUnmappedParent
+        ? []
+        : candidates.filter((stage) => sameStringSet(translatedParentIds as string[], stage.parentIds));
+
+      if (matches.length !== 1) {
+        const reason = matches.length === 0 ? "mismatch" : "ambiguous";
+        throw new Error(`pi-workflows: insufficient_state: replay topology ${reason} for stage "${stageName}" in source run ${continuation.source.id}`);
+      }
+
+      const source = matches[0]!;
+      consumedSourceStageIds.add(source.id);
+      sourceStageIdByContinuationStageId.set(stageId, source.id);
+      if (source.status === "completed") return { kind: "replay", source };
+      return { kind: "execute", source };
     },
   };
 }
@@ -1421,7 +1441,7 @@ export async function run<TInputs extends Record<string, unknown>>(
       const parentIds = tracker.onSpawn(stageId, name);
 
       // c. Create StageSnapshot as "pending"
-      const replayDecision = replayIndex.decide(name);
+      const replayDecision = replayIndex.decide(name, parentIds, stageId);
       const replaySource = replayDecision.kind === "replay" ? replayDecision.source : undefined;
       const shouldReplay = replaySource !== undefined;
 
@@ -1468,43 +1488,56 @@ export async function run<TInputs extends Record<string, unknown>>(
         activeStore.recordStageStart(runId, stageSnapshot);
         opts.onStageStart?.(runId, stageSnapshot);
         appendStageStartOnce();
-        activeStore.recordStageEnd(runId, stageSnapshot);
-        opts.onStageEnd?.(runId, stageSnapshot);
-        if (opts.persistence) {
-          appendStageEnd(opts.persistence, {
-            runId,
-            stageId,
-            status: "completed",
-            durationMs: 0,
-            ...(stageSnapshot.result !== undefined ? { summary: stageSnapshot.result } : {}),
-            replayedFromStageId: replaySource.id,
-            replayed: true,
-          });
-        }
-        tracker.onSettle(stageId);
+        let replayFinalized = false;
+        const finalizeReplayStage = (): void => {
+          if (replayFinalized) return;
+          replayFinalized = true;
+          activeStore.recordStageEnd(runId, stageSnapshot);
+          opts.onStageEnd?.(runId, stageSnapshot);
+          if (opts.persistence) {
+            appendStageEnd(opts.persistence, {
+              runId,
+              stageId,
+              status: "completed",
+              durationMs: 0,
+              ...(stageSnapshot.result !== undefined ? { summary: stageSnapshot.result } : {}),
+              replayedFromStageId: replaySource.id,
+              replayed: true,
+            });
+          }
+          tracker.onSettle(stageId);
+        };
         const replayResult = replaySource.result ?? "";
+        const replayText = async (): Promise<string> => {
+          await Promise.resolve();
+          finalizeReplayStage();
+          return replayResult;
+        };
+        const rejectReplayMutation = (action: string): never => {
+          throw new Error(`pi-workflows: replayed stage "${name}" cannot ${action}`);
+        };
         const replayContext: StageContext & Pick<InternalStageContext, "__modelFallbackMeta"> = {
           name,
-          prompt: async () => replayResult,
-          complete: async () => replayResult,
-          steer: async () => {},
-          followUp: async () => {},
+          prompt: replayText,
+          complete: replayText,
+          steer: async () => rejectReplayMutation("steer"),
+          followUp: async () => rejectReplayMutation("follow up"),
           subscribe: () => () => {},
           get sessionFile() { return replaySource.sessionFile; },
           get sessionId() { return replaySource.sessionId ?? ""; },
-          setModel: async () => {},
-          setThinkingLevel: () => {},
-          cycleModel: async () => undefined,
-          cycleThinkingLevel: () => undefined,
+          setModel: async () => rejectReplayMutation("set model"),
+          setThinkingLevel: () => rejectReplayMutation("set thinking level"),
+          cycleModel: async () => rejectReplayMutation("cycle model"),
+          cycleThinkingLevel: () => rejectReplayMutation("cycle thinking level"),
           get agent() { return undefined as never; },
           get model() { return replaySource.model as never; },
           get thinkingLevel() { return undefined as never; },
           get messages() { return [] as never; },
           get isStreaming() { return false; },
-          navigateTree: async () => ({ cancelled: false }),
-          compact: async () => ({}) as never,
-          abortCompaction: () => {},
-          abort: async () => {},
+          navigateTree: async () => rejectReplayMutation("navigate conversation tree"),
+          compact: async () => rejectReplayMutation("compact"),
+          abortCompaction: () => rejectReplayMutation("abort compaction"),
+          abort: async () => rejectReplayMutation("abort"),
           __modelFallbackMeta: () => ({
             ...(replaySource.model !== undefined ? { model: replaySource.model } : {}),
             ...(replaySource.attemptedModels !== undefined ? { attemptedModels: replaySource.attemptedModels } : {}),

--- a/packages/workflows/src/runs/foreground/stage-control-registry.ts
+++ b/packages/workflows/src/runs/foreground/stage-control-registry.ts
@@ -34,7 +34,8 @@ export type StageControlStatus =
   | "paused"
   | "blocked"
   | "completed"
-  | "failed";
+  | "failed"
+  | "skipped";
 
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
 
@@ -192,7 +193,7 @@ export function createStageControlRegistry(): StageControlRegistry {
         );
         for (const handle of targets) {
           if (handle.status === "paused") continue;
-          if (handle.status === "completed" || handle.status === "failed") continue;
+          if (handle.status === "completed" || handle.status === "failed" || handle.status === "skipped") continue;
           await handle.pause();
         }
         return controlledEntries(runId)

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -214,13 +214,15 @@ export async function validateWorkflowModels(input: {
   };
 
   const failures: ModelResolutionFailure[] = [];
-  const availableModels = input.catalog === undefined ? undefined : await input.catalog.listModels().catch(() => undefined);
-  if (input.catalog !== undefined && availableModels === undefined) {
-    if (input.catalog.currentModel !== undefined) {
+  let availableModels: readonly WorkflowModelInfo[] | undefined;
+  if (input.catalog !== undefined) {
+    try {
+      availableModels = await input.catalog.listModels();
+    } catch (err) {
+      if (input.catalog.currentModel === undefined) throw err;
       recordWarning(catalogUnavailableWarning());
       return warnings;
     }
-    throw new WorkflowModelValidationError([{ input: "model catalog", reason: "unavailable and no current model is configured" }]);
   }
 
   for (const request of relevant) {

--- a/packages/workflows/src/shared/persistence-restore.ts
+++ b/packages/workflows/src/shared/persistence-restore.ts
@@ -7,7 +7,8 @@
  */
 
 import type { Store } from "./store.js";
-import type { RunSnapshot, StageSnapshot } from "./store-types.js";
+import type { RunSnapshot, StageSnapshot, StageStatus } from "./store-types.js";
+import { isWorkflowFailureKind } from "./workflow-failures.js";
 
 // ---------------------------------------------------------------------------
 // Config option
@@ -161,10 +162,15 @@ export function restoreOnSessionStart(
   if (typeof getEntries !== "function") return;
 
   const entries = getEntries.call(sessionManager);
-  const inFlight = scanInFlightRuns(entries as readonly SessionEntry[]);
+  const sessionEntries = entries as readonly SessionEntry[];
+  restoreEndedFailedRuns(sessionEntries, store);
+  const inFlight = scanInFlightRuns(sessionEntries);
   if (inFlight.length === 0) return;
 
   for (const run of inFlight) {
+    const runMeta = findRunStartMetadata(sessionEntries, run.runId);
+    const stages = _buildStageSnapshots(sessionEntries, run.runId);
+
     if (config.resumeInFlight === "auto") {
       // Re-hydrate the run into the store as "running"
       const runSnapshot: RunSnapshot = {
@@ -172,8 +178,10 @@ export function restoreOnSessionStart(
         name: run.name,
         inputs: run.inputs,
         status: "running",
-        stages: _buildStageSnapshots(entries as readonly SessionEntry[], run.runId),
+        stages,
         startedAt: run.startTs,
+        ...(runMeta.resumedFromRunId !== undefined ? { resumedFromRunId: runMeta.resumedFromRunId } : {}),
+        ...(runMeta.resumeFromStageId !== undefined ? { resumeFromStageId: runMeta.resumeFromStageId } : {}),
       };
       store.recordRunStart(runSnapshot);
       callbacks.onResume?.(run);
@@ -184,10 +192,14 @@ export function restoreOnSessionStart(
         name: run.name,
         inputs: run.inputs,
         status: "failed",
-        stages: _buildStageSnapshots(entries as readonly SessionEntry[], run.runId),
+        stages,
         startedAt: run.startTs,
         endedAt: Date.now(),
         error: "Run did not complete — process was interrupted.",
+        failureKind: "unknown",
+        resumable: false,
+        ...(runMeta.resumedFromRunId !== undefined ? { resumedFromRunId: runMeta.resumedFromRunId } : {}),
+        ...(runMeta.resumeFromStageId !== undefined ? { resumeFromStageId: runMeta.resumeFromStageId } : {}),
       };
       store.recordRunStart(runSnapshot);
       store.recordRunEnd(run.runId, "failed");
@@ -224,6 +236,7 @@ function _buildStageSnapshots(
           status: "running",
           parentIds: Array.isArray(parentIds) ? (parentIds as string[]) : [],
           startedAt: typeof ts === "number" ? ts : undefined,
+          ...replayMetadata(entry.payload),
           toolEvents: [],
         });
       }
@@ -234,13 +247,22 @@ function _buildStageSnapshots(
       const status = entry.payload["status"];
       const durationMs = entry.payload["durationMs"];
       const summary = entry.payload["summary"];
+      const error = entry.payload["error"];
+      const failureKind = entry.payload["failureKind"];
+      const failureMessage = entry.payload["failureMessage"];
+      const skippedReason = entry.payload["skippedReason"];
       if (typeof stageId !== "string") continue;
       endedStages.add(stageId);
       const snap = stageMap.get(stageId);
       if (snap) {
-        snap.status = (status === "completed" || status === "failed") ? status : "failed";
+        snap.status = restoreStageStatus(status);
         if (typeof durationMs === "number") snap.durationMs = durationMs;
         if (typeof summary === "string") snap.result = summary;
+        if (typeof error === "string") snap.error = error;
+        if (typeof failureKind === "string" && isWorkflowFailureKind(failureKind)) snap.failureKind = failureKind;
+        if (typeof failureMessage === "string") snap.failureMessage = failureMessage;
+        if (typeof skippedReason === "string") snap.skippedReason = skippedReason;
+        Object.assign(snap, replayMetadata(entry.payload));
       }
     }
   }
@@ -254,4 +276,115 @@ function _buildStageSnapshots(
   }
 
   return [...stageMap.values()];
+}
+
+function replayMetadata(payload: Record<string, unknown>): Pick<StageSnapshot, "replayedFromStageId" | "replayed"> {
+  const replayedFromStageId = payload["replayedFromStageId"];
+  const replayed = payload["replayed"];
+  return {
+    ...(typeof replayedFromStageId === "string" ? { replayedFromStageId } : {}),
+    ...(typeof replayed === "boolean" ? { replayed } : {}),
+  };
+}
+
+function restoreStageStatus(status: unknown): StageStatus {
+  switch (status) {
+    case "completed":
+    case "failed":
+    case "skipped":
+      return status;
+    default:
+      return "failed";
+  }
+}
+
+function restoreEndedFailedRuns(entries: readonly SessionEntry[], store: Store): void {
+  const started = new Map<string, { readonly name: string; readonly inputs: Readonly<Record<string, unknown>>; readonly startTs: number }>();
+  const ended = new Map<string, Record<string, unknown>>();
+
+  for (const entry of entries) {
+    if (entry.type === "workflow.run.start") {
+      const runId = entry.payload["runId"];
+      const name = entry.payload["name"];
+      const inputs = entry.payload["inputs"];
+      const ts = entry.payload["ts"];
+      if (typeof runId === "string" && typeof name === "string" && typeof ts === "number") {
+        started.set(runId, {
+          name,
+          inputs: (inputs !== null && typeof inputs === "object" && !Array.isArray(inputs))
+            ? (inputs as Record<string, unknown>)
+            : {},
+          startTs: ts,
+        });
+      }
+    }
+    if (entry.type === "workflow.run.end") {
+      const runId = entry.payload["runId"];
+      if (typeof runId === "string") ended.set(runId, entry.payload);
+    }
+  }
+
+  for (const [runId, start] of started) {
+    if (store.runs().some((run) => run.id === runId)) continue;
+    const end = ended.get(runId);
+    const status = restoreTerminalRunStatus(end?.["status"]);
+    if (end === undefined || status === undefined) continue;
+
+    const runMeta = findRunStartMetadata(entries, runId);
+    const stages = _buildStageSnapshots(entries, runId);
+    store.recordRunStart({
+      id: runId,
+      name: start.name,
+      inputs: start.inputs,
+      status: "running",
+      stages,
+      startedAt: start.startTs,
+      ...(runMeta.resumedFromRunId !== undefined ? { resumedFromRunId: runMeta.resumedFromRunId } : {}),
+      ...(runMeta.resumeFromStageId !== undefined ? { resumeFromStageId: runMeta.resumeFromStageId } : {}),
+    });
+
+    const error = end["error"];
+    const failureKind = end["failureKind"];
+    const failureMessage = end["failureMessage"];
+    const failedStageId = end["failedStageId"];
+    const resumable = end["resumable"];
+    store.recordRunEnd(
+      runId,
+      status,
+      undefined,
+      typeof error === "string" ? error : undefined,
+      {
+        ...(typeof failureKind === "string" && isWorkflowFailureKind(failureKind) ? { failureKind } : {}),
+        ...(typeof failureMessage === "string" ? { failureMessage } : {}),
+        ...(typeof failedStageId === "string" ? { failedStageId } : {}),
+        ...(typeof resumable === "boolean" ? { resumable } : {}),
+      },
+    );
+  }
+}
+
+function restoreTerminalRunStatus(status: unknown): "failed" | "killed" | undefined {
+  switch (status) {
+    case "failed":
+    case "killed":
+      return status;
+    default:
+      return undefined;
+  }
+}
+
+function findRunStartMetadata(
+  entries: readonly SessionEntry[],
+  runId: string,
+): { readonly resumedFromRunId?: string; readonly resumeFromStageId?: string } {
+  for (const entry of entries) {
+    if (entry.type !== "workflow.run.start" || entry.payload["runId"] !== runId) continue;
+    const resumedFromRunId = entry.payload["resumedFromRunId"];
+    const resumeFromStageId = entry.payload["resumeFromStageId"];
+    return {
+      ...(typeof resumedFromRunId === "string" ? { resumedFromRunId } : {}),
+      ...(typeof resumeFromStageId === "string" ? { resumeFromStageId } : {}),
+    };
+  }
+  return {};
 }

--- a/packages/workflows/src/shared/persistence-session-entries.ts
+++ b/packages/workflows/src/shared/persistence-session-entries.ts
@@ -31,6 +31,8 @@ export interface RunStartPayload {
   readonly runId: string;
   readonly name: string;
   readonly inputs: Readonly<Record<string, unknown>>;
+  readonly resumedFromRunId?: string;
+  readonly resumeFromStageId?: string;
   readonly ts: number;
 }
 
@@ -40,6 +42,8 @@ export interface StageStartPayload {
   readonly name: string;
   readonly parentIds: readonly string[];
   readonly model?: string;
+  readonly replayedFromStageId?: string;
+  readonly replayed?: boolean;
   readonly ts: number;
 }
 
@@ -56,12 +60,23 @@ export interface StageEndPayload {
   readonly status: string;
   readonly durationMs?: number;
   readonly summary?: string;
+  readonly error?: string;
+  readonly failureKind?: string;
+  readonly failureMessage?: string;
+  readonly skippedReason?: string;
+  readonly replayedFromStageId?: string;
+  readonly replayed?: boolean;
 }
 
 export interface RunEndPayload {
   readonly runId: string;
   readonly status: string;
   readonly result?: unknown;
+  readonly error?: string;
+  readonly failureKind?: string;
+  readonly failureMessage?: string;
+  readonly failedStageId?: string;
+  readonly resumable?: boolean;
   readonly ts: number;
 }
 
@@ -79,6 +94,8 @@ export function appendRunStart(api: PersistenceAPI, payload: RunStartPayload): v
     runId: payload.runId,
     name: payload.name,
     inputs: payload.inputs,
+    ...(payload.resumedFromRunId !== undefined ? { resumedFromRunId: payload.resumedFromRunId } : {}),
+    ...(payload.resumeFromStageId !== undefined ? { resumeFromStageId: payload.resumeFromStageId } : {}),
     ts: payload.ts,
   });
   if (entryId && typeof api.setLabel === "function") {
@@ -96,6 +113,8 @@ export function appendStageStart(api: PersistenceAPI, payload: StageStartPayload
     name: payload.name,
     parentIds: [...payload.parentIds],
     ...(payload.model !== undefined ? { model: payload.model } : {}),
+    ...(payload.replayedFromStageId !== undefined ? { replayedFromStageId: payload.replayedFromStageId } : {}),
+    ...(payload.replayed !== undefined ? { replayed: payload.replayed } : {}),
     ts: payload.ts,
   });
 }
@@ -124,6 +143,12 @@ export function appendStageEnd(
     status: payload.status,
     ...(payload.durationMs !== undefined ? { durationMs: payload.durationMs } : {}),
     ...(payload.summary !== undefined ? { summary: payload.summary } : {}),
+    ...(payload.error !== undefined ? { error: payload.error } : {}),
+    ...(payload.failureKind !== undefined ? { failureKind: payload.failureKind } : {}),
+    ...(payload.failureMessage !== undefined ? { failureMessage: payload.failureMessage } : {}),
+    ...(payload.skippedReason !== undefined ? { skippedReason: payload.skippedReason } : {}),
+    ...(payload.replayedFromStageId !== undefined ? { replayedFromStageId: payload.replayedFromStageId } : {}),
+    ...(payload.replayed !== undefined ? { replayed: payload.replayed } : {}),
   });
   if (opts?.emitMessage === true && payload.summary && typeof api.appendCustomMessageEntry === "function") {
     api.appendCustomMessageEntry(
@@ -140,6 +165,11 @@ export function appendRunEnd(api: PersistenceAPI, payload: RunEndPayload): void 
     runId: payload.runId,
     status: payload.status,
     ...(payload.result !== undefined ? { result: payload.result as Record<string, unknown> } : {}),
+    ...(payload.error !== undefined ? { error: payload.error } : {}),
+    ...(payload.failureKind !== undefined ? { failureKind: payload.failureKind } : {}),
+    ...(payload.failureMessage !== undefined ? { failureMessage: payload.failureMessage } : {}),
+    ...(payload.failedStageId !== undefined ? { failedStageId: payload.failedStageId } : {}),
+    ...(payload.resumable !== undefined ? { resumable: payload.resumable } : {}),
     ts: payload.ts,
   });
 }

--- a/packages/workflows/src/shared/store-types.ts
+++ b/packages/workflows/src/shared/store-types.ts
@@ -11,7 +11,10 @@ export type StageStatus =
   | "paused"
   | "blocked"
   | "completed"
-  | "failed";
+  | "failed"
+  | "skipped";
+
+export type WorkflowFailureKind = "auth" | "rate_limit" | "provider" | "cancelled" | "unknown";
 
 /**
  * Human-in-the-loop prompt kind. Mirrors the four `WorkflowUIContext` methods.
@@ -66,6 +69,16 @@ export interface StageSnapshot {
   durationMs?: number;
   result?: string;
   error?: string;
+  /** Structured workflow failure category for failed stages. */
+  failureKind?: WorkflowFailureKind;
+  /** Original unsanitized error text when different from `error`. */
+  failureMessage?: string;
+  /** Reason for stages skipped by fail-fast/cascade handling. */
+  skippedReason?: string;
+  /** Source stage id when this stage was replayed during failed-run continuation. */
+  replayedFromStageId?: string;
+  /** True when provider work was skipped by continuation replay. */
+  replayed?: boolean;
   readonly toolEvents: ToolEvent[];
   /** True while an in-stage ask_user_question tool is waiting on the user. */
   awaitingInputSince?: number;
@@ -127,6 +140,16 @@ export interface RunSnapshot {
   resumedAt?: number;
   result?: Record<string, unknown>;
   error?: string;
+  /** Structured workflow failure category for failed runs. */
+  failureKind?: WorkflowFailureKind;
+  /** Original unsanitized error text when different from `error`. */
+  failureMessage?: string;
+  failedStageId?: string;
+  resumable?: boolean;
+  /** Source failed run when this run is a continuation. */
+  resumedFromRunId?: string;
+  /** Source stage id where continuation resumes real execution. */
+  resumeFromStageId?: string;
   /**
    * Pending human-in-the-loop prompt. Set when a background workflow calls
    * `ctx.ui.input/confirm/select/editor`; cleared when the user responds via

--- a/packages/workflows/src/shared/store.ts
+++ b/packages/workflows/src/shared/store.ts
@@ -11,12 +11,37 @@ import type {
   StoreSnapshot,
   ToolEvent,
   RunStatus,
+  StageStatus,
+  WorkflowFailureKind,
   WorkflowNotice,
 } from "./store-types.js";
 import { accumulatePausedDurationMs, elapsedRunMs } from "./timing.js";
 
 /** Statuses that represent a terminal run state — cannot be overwritten. */
 const TERMINAL_STATUSES: ReadonlySet<RunStatus> = new Set(["completed", "failed", "killed"]);
+
+function isTerminalStageStatus(status: StageStatus): boolean {
+  return status === "completed" || status === "failed" || status === "skipped";
+}
+
+function cannotAwaitInput(status: StageStatus): boolean {
+  return isTerminalStageStatus(status) || status === "paused" || status === "blocked";
+}
+
+function cannotBlock(status: StageStatus): boolean {
+  return isTerminalStageStatus(status) || status === "paused";
+}
+
+function cannotPause(status: StageStatus): boolean {
+  return isTerminalStageStatus(status) || status === "paused" || status === "blocked";
+}
+
+export interface RunEndMetadata {
+  readonly failureKind?: WorkflowFailureKind;
+  readonly failureMessage?: string;
+  readonly failedStageId?: string;
+  readonly resumable?: boolean;
+}
 
 export interface Store {
   runs(): readonly RunSnapshot[];
@@ -39,6 +64,7 @@ export interface Store {
     status: RunStatus,
     result?: Record<string, unknown>,
     error?: string,
+    metadata?: RunEndMetadata,
   ): boolean;
   /**
    * Remove a run from live workflow history/status. Any pending HIL prompt
@@ -305,6 +331,11 @@ export function createStore(): Store {
       existing.durationMs = stage.durationMs;
       existing.result = stage.result;
       existing.error = stage.error;
+      existing.failureKind = stage.failureKind;
+      existing.failureMessage = stage.failureMessage;
+      existing.skippedReason = stage.skippedReason;
+      existing.replayedFromStageId = stage.replayedFromStageId;
+      existing.replayed = stage.replayed;
       delete existing.awaitingInputSince;
       rejectStagePrompt(existing, `pi-workflows: stage ${stage.id} ended before prompt resolved`);
       _version++;
@@ -316,6 +347,7 @@ export function createStore(): Store {
       status: RunStatus,
       result?: Record<string, unknown>,
       error?: string,
+      metadata?: RunEndMetadata,
     ): boolean {
       const run = findRun(runId);
       if (!run) return false;
@@ -337,6 +369,12 @@ export function createStore(): Store {
       }
       if ((status === "failed" || status === "killed") && error !== undefined) {
         run.error = error;
+      }
+      if (metadata !== undefined) {
+        if (metadata.failureKind !== undefined) run.failureKind = metadata.failureKind;
+        if (metadata.failureMessage !== undefined) run.failureMessage = metadata.failureMessage;
+        if (metadata.failedStageId !== undefined) run.failedStageId = metadata.failedStageId;
+        if (metadata.resumable !== undefined) run.resumable = metadata.resumable;
       }
       // Abandon any waiting HIL prompt — workflow body never resumed past
       // it, but the awaiter promise must reject so the executor's catch
@@ -444,7 +482,7 @@ export function createStore(): Store {
       if (TERMINAL_STATUSES.has(run.status)) return false;
       const stage = findStage(run, stageId);
       if (!stage) return false;
-      if (stage.status === "completed" || stage.status === "failed") return false;
+      if (isTerminalStageStatus(stage.status)) return false;
       if (stage.pendingPrompt !== undefined) return false;
       stage.pendingPrompt = { ...prompt };
       stage.status = "awaiting_input";
@@ -570,7 +608,7 @@ export function createStore(): Store {
       if (TERMINAL_STATUSES.has(run.status)) return false;
       const stage = findStage(run, stageId);
       if (!stage) return false;
-      if (stage.status === "completed" || stage.status === "failed" || stage.status === "paused" || stage.status === "blocked") return false;
+      if (cannotAwaitInput(stage.status)) return false;
 
       if (awaiting) {
         if (stage.status === "awaiting_input") return false;
@@ -592,7 +630,7 @@ export function createStore(): Store {
       if (TERMINAL_STATUSES.has(run.status)) return false;
       const stage = findStage(run, stageId);
       if (!stage) return false;
-      if (stage.status === "completed" || stage.status === "failed" || stage.status === "paused") return false;
+      if (cannotBlock(stage.status)) return false;
       if (stage.status === "blocked") {
         if (stage.blockedByStageId === blockedBy) return false;
         stage.blockedByStageId = blockedBy;
@@ -637,7 +675,7 @@ export function createStore(): Store {
       if (TERMINAL_STATUSES.has(run.status)) return false;
       const stage = findStage(run, stageId);
       if (!stage) return false;
-      if (stage.status === "paused" || stage.status === "blocked" || stage.status === "completed" || stage.status === "failed") return false;
+      if (cannotPause(stage.status)) return false;
       stage.status = "paused";
       stage.pausedAt = pausedAt ?? Date.now();
       stage.resumedAt = undefined;

--- a/packages/workflows/src/shared/workflow-failures.ts
+++ b/packages/workflows/src/shared/workflow-failures.ts
@@ -1,0 +1,125 @@
+import type { WorkflowFailureKind } from "./store-types.js";
+
+export interface WorkflowFailure {
+  readonly kind: WorkflowFailureKind;
+  /** Original error text, preserved for diagnostics. */
+  readonly message: string;
+  /** Sanitized workflow-facing text shown on run/stage snapshots. */
+  readonly userMessage: string;
+  readonly retryable: boolean;
+  readonly resumable: boolean;
+  readonly cause?: unknown;
+}
+
+export const WORKFLOW_AUTH_FAILURE_MESSAGE =
+  "You must be logged in to run workflows. Run /login and try again.";
+
+const WORKFLOW_FAILURE_KINDS: ReadonlySet<WorkflowFailureKind> = new Set([
+  "auth",
+  "rate_limit",
+  "provider",
+  "cancelled",
+  "unknown",
+]);
+
+export function isWorkflowFailureKind(kind: string): kind is WorkflowFailureKind {
+  return WORKFLOW_FAILURE_KINDS.has(kind as WorkflowFailureKind);
+}
+
+function makeWorkflowFailure(
+  kind: WorkflowFailureKind,
+  message: string,
+  opts: {
+    readonly retryable: boolean;
+    readonly resumable: boolean;
+    readonly cause: unknown;
+    readonly userMessage?: string;
+  },
+): WorkflowFailure {
+  return {
+    kind,
+    message,
+    userMessage: opts.userMessage ?? message,
+    retryable: opts.retryable,
+    resumable: opts.resumable,
+    cause: opts.cause,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && typeof error.message === "string") return error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+}
+
+function errorName(error: unknown): string | undefined {
+  return error instanceof Error ? error.name : undefined;
+}
+
+function includesAny(value: string, terms: readonly string[]): boolean {
+  return terms.some((term) => value.includes(term));
+}
+
+export function classifyWorkflowFailure(error: unknown): WorkflowFailure {
+  const message = errorMessage(error);
+  const lower = message.toLowerCase();
+  const name = errorName(error)?.toLowerCase();
+
+  if (includesAny(lower, [
+    "no api key",
+    "api key not found",
+    "missing api key",
+    "no model selected",
+    "no models available",
+    "not logged in",
+    "log in",
+    "login required",
+    "authentication required",
+    "unauthorized",
+    "oauth",
+  ])) {
+    return makeWorkflowFailure("auth", message, {
+      userMessage: WORKFLOW_AUTH_FAILURE_MESSAGE,
+      retryable: true,
+      resumable: true,
+      cause: error,
+    });
+  }
+
+  if (includesAny(lower, ["rate limit", "rate-limit", "429", "quota", "too many requests"])) {
+    return makeWorkflowFailure("rate_limit", message, {
+      retryable: true,
+      resumable: true,
+      cause: error,
+    });
+  }
+
+  if (name === "aborterror" || includesAny(lower, ["aborted", "cancelled", "canceled"])) {
+    return makeWorkflowFailure("cancelled", message, {
+      retryable: false,
+      resumable: false,
+      cause: error,
+    });
+  }
+
+  if (includesAny(lower, [
+    "model",
+    "provider",
+    "overloaded",
+    "temporarily unavailable",
+    "service unavailable",
+    "503",
+  ])) {
+    return makeWorkflowFailure("provider", message, {
+      retryable: true,
+      resumable: true,
+      cause: error,
+    });
+  }
+
+  return makeWorkflowFailure("unknown", message, {
+    retryable: false,
+    resumable: true,
+    cause: error,
+  });
+}

--- a/packages/workflows/src/shared/workflow-failures.ts
+++ b/packages/workflows/src/shared/workflow-failures.ts
@@ -46,98 +46,330 @@ function makeWorkflowFailure(
   };
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" ? value as Record<string, unknown> : undefined;
+}
+
+function field(value: unknown, key: string): unknown {
+  return asRecord(value)?.[key];
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const raw = field(value, key);
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}
+
 function errorMessage(error: unknown): string {
+  const structuredMessage = structuredErrorMessage(error);
+  if (structuredMessage !== undefined) return structuredMessage;
   if (error instanceof Error && typeof error.message === "string") return error.message;
   if (typeof error === "string") return error;
   return String(error);
 }
 
 function errorName(error: unknown): string | undefined {
-  return error instanceof Error ? error.name : undefined;
+  return error instanceof Error ? error.name : stringField(error, "name");
 }
 
-function matchesAny(value: string, patterns: readonly RegExp[]): boolean {
-  return patterns.some((pattern) => pattern.test(value));
+function structuredErrorMessage(error: unknown): string | undefined {
+  return stringField(error, "errorMessage")
+    ?? stringField(error, "message")
+    ?? stringField(error, "statusText");
 }
 
-const AUTH_FAILURE_PATTERNS: readonly RegExp[] = [
-  /\bno api key\b/,
-  /\bapi key not found\b/,
-  /\bmissing api key\b/,
-  /\bno model selected\b/,
-  /\bno models available\b/,
-  /\bnot logged in\b/,
-  /\blog\s+in\b/,
-  /\blogin required\b/,
-  /\bauthentication required\b/,
-  /\bunauthorized\b/,
-  /\boauth(?:2)?\b[^\n.?!]{0,120}\b(?:token|credential|credentials|required|expired|invalid|missing|unauthorized|login|log\s+in|sign[-\s]?in)\b/,
-  /\b(?:token|credential|credentials|required|expired|invalid|missing|unauthorized|login|log\s+in|sign[-\s]?in)\b[^\n.?!]{0,120}\boauth(?:2)?\b/,
+type StructuredSignal = {
+  readonly status?: number;
+  readonly code?: string | number;
+  readonly name?: string;
+  readonly stopReason?: string;
+};
+
+function integerFrom(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value !== "string" || value.trim().length === 0) return undefined;
+  const parsed = Number(value.trim());
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function structuredSignal(error: unknown): StructuredSignal {
+  const status = integerFrom(field(error, "status"))
+    ?? integerFrom(field(error, "statusCode"))
+    ?? integerFrom(field(error, "httpStatus"));
+  const rawCode = field(error, "code");
+  const code = typeof rawCode === "string" || typeof rawCode === "number" ? rawCode : undefined;
+  return {
+    ...(status !== undefined ? { status } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(errorName(error) !== undefined ? { name: errorName(error)! } : {}),
+    ...(stringField(error, "stopReason") !== undefined ? { stopReason: stringField(error, "stopReason")! } : {}),
+  };
+}
+
+function causeOf(error: unknown): unknown {
+  if (error instanceof Error) return error.cause;
+  return field(error, "cause");
+}
+
+function diagnosticErrors(error: unknown): readonly unknown[] {
+  const diagnostics = field(error, "diagnostics");
+  if (!Array.isArray(diagnostics)) return [];
+  const errors: unknown[] = [];
+  for (const diagnostic of diagnostics) {
+    const diagnosticError = field(diagnostic, "error");
+    errors.push(diagnosticError ?? diagnostic);
+  }
+  return errors;
+}
+
+function normalizeCode(value: string | number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return String(value).trim().toLowerCase().replaceAll("-", "_");
+}
+
+function kindFromStatus(status: number | undefined): WorkflowFailureKind | undefined {
+  switch (status) {
+    case 401:
+    case 403:
+      return "auth";
+    case 429:
+      return "rate_limit";
+    case 500:
+    case 502:
+    case 503:
+    case 504:
+      return "provider";
+    default:
+      return undefined;
+  }
+}
+
+function kindFromCode(code: string | number | undefined): WorkflowFailureKind | undefined {
+  const normalized = normalizeCode(code);
+  switch (normalized) {
+    case undefined:
+      return undefined;
+    case "401":
+    case "403":
+    case "auth":
+    case "auth_required":
+    case "authentication_required":
+    case "unauthorized":
+    case "forbidden":
+    case "invalid_api_key":
+    case "missing_api_key":
+      return "auth";
+    case "429":
+    case "rate_limit":
+    case "rate_limit_exceeded":
+    case "too_many_requests":
+    case "quota_exceeded":
+      return "rate_limit";
+    case "aborterror":
+    case "aborted":
+    case "cancelled":
+    case "canceled":
+      return "cancelled";
+    case "500":
+    case "502":
+    case "503":
+    case "504":
+    case "provider_error":
+    case "service_unavailable":
+    case "temporarily_unavailable":
+    case "overloaded":
+      return "provider";
+    default:
+      return undefined;
+  }
+}
+
+function structuredKind(error: unknown, seen = new Set<unknown>()): WorkflowFailureKind | undefined {
+  if (error === undefined || error === null || seen.has(error)) return undefined;
+  if (typeof error === "object") seen.add(error);
+
+  const signal = structuredSignal(error);
+  if (signal.stopReason?.toLowerCase() === "aborted") return "cancelled";
+  const statusKind = kindFromStatus(signal.status);
+  if (statusKind !== undefined) return statusKind;
+  const codeKind = kindFromCode(signal.code) ?? kindFromCode(signal.name);
+  if (codeKind !== undefined) return codeKind;
+
+  for (const diagnosticError of diagnosticErrors(error)) {
+    const diagnosticKind = structuredKind(diagnosticError, seen);
+    if (diagnosticKind !== undefined) return diagnosticKind;
+  }
+
+  return structuredKind(causeOf(error), seen);
+}
+
+function failureForKind(kind: WorkflowFailureKind, message: string, cause: unknown): WorkflowFailure {
+  switch (kind) {
+    case "auth":
+      return makeWorkflowFailure("auth", message, {
+        userMessage: WORKFLOW_AUTH_FAILURE_MESSAGE,
+        retryable: true,
+        resumable: true,
+        cause,
+      });
+    case "rate_limit":
+      return makeWorkflowFailure("rate_limit", message, {
+        retryable: true,
+        resumable: true,
+        cause,
+      });
+    case "cancelled":
+      return makeWorkflowFailure("cancelled", message, {
+        retryable: false,
+        resumable: false,
+        cause,
+      });
+    case "provider":
+      return makeWorkflowFailure("provider", message, {
+        retryable: true,
+        resumable: true,
+        cause,
+      });
+    case "unknown":
+      return makeWorkflowFailure("unknown", message, {
+        retryable: false,
+        resumable: true,
+        cause,
+      });
+  }
+}
+
+type TokenMatch = readonly string[];
+
+function tokenize(value: string): readonly string[] {
+  const tokens: string[] = [];
+  let current = "";
+  for (const char of value.toLowerCase()) {
+    if ((char >= "a" && char <= "z") || (char >= "0" && char <= "9")) {
+      current += char;
+    } else if (current.length > 0) {
+      tokens.push(current);
+      current = "";
+    }
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function hasPhrase(tokens: readonly string[], phrase: TokenMatch): boolean {
+  if (phrase.length === 0 || phrase.length > tokens.length) return false;
+  for (let index = 0; index <= tokens.length - phrase.length; index += 1) {
+    let matched = true;
+    for (let offset = 0; offset < phrase.length; offset += 1) {
+      if (tokens[index + offset] !== phrase[offset]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return true;
+  }
+  return false;
+}
+
+function hasAnyPhrase(tokens: readonly string[], phrases: readonly TokenMatch[]): boolean {
+  return phrases.some((phrase) => hasPhrase(tokens, phrase));
+}
+
+function tokenNearAny(tokens: readonly string[], anchor: string, candidates: ReadonlySet<string>, distance: number): boolean {
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index] !== anchor) continue;
+    const start = Math.max(0, index - distance);
+    const end = Math.min(tokens.length - 1, index + distance);
+    for (let cursor = start; cursor <= end; cursor += 1) {
+      if (cursor !== index && candidates.has(tokens[cursor]!)) return true;
+    }
+  }
+  return false;
+}
+
+const AUTH_PHRASES: readonly TokenMatch[] = [
+  ["no", "api", "key"],
+  ["api", "key", "not", "found"],
+  ["missing", "api", "key"],
+  ["no", "model", "selected"],
+  ["no", "models", "available"],
+  ["not", "logged", "in"],
+  ["log", "in"],
+  ["login", "required"],
+  ["authentication", "required"],
+  ["unauthorized"],
 ];
 
-const RATE_LIMIT_FAILURE_PATTERNS: readonly RegExp[] = [
-  /\brate\s*limit\b/,
-  /\brate-limit\b/,
-  /\b429\b/,
-  /\bquota\b/,
-  /\btoo many requests\b/,
+const RATE_LIMIT_PHRASES: readonly TokenMatch[] = [
+  ["rate", "limit"],
+  ["429"],
+  ["quota"],
+  ["too", "many", "requests"],
 ];
 
-const CANCELLED_FAILURE_PATTERNS: readonly RegExp[] = [
-  /\baborted\b/,
-  /\bcancelled\b/,
-  /\bcanceled\b/,
+const CANCELLED_PHRASES: readonly TokenMatch[] = [
+  ["aborted"],
+  ["cancelled"],
+  ["canceled"],
 ];
 
-const PROVIDER_FAILURE_PATTERNS: readonly RegExp[] = [
-  /\bmodel\b[^\n.?!]{0,120}\b(?:not found|unavailable|overloaded|temporarily unavailable|service unavailable)\b/,
-  /\b(?:not found|unavailable|overloaded|temporarily unavailable|service unavailable)\b[^\n.?!]{0,120}\bmodel\b/,
-  /\bprovider\b[^\n.?!]{0,120}\b(?:error|failure|failed|overloaded|unavailable|temporarily unavailable|service unavailable|returned error)\b/,
-  /\b(?:overloaded|temporarily unavailable|service unavailable)\b/,
-  /\b503\b/,
+const PROVIDER_PHRASES: readonly TokenMatch[] = [
+  ["model", "not", "found"],
+  ["overloaded"],
+  ["temporarily", "unavailable"],
+  ["service", "unavailable"],
+  ["503"],
 ];
+
+const AUTH_CONTEXT = new Set([
+  "token",
+  "credential",
+  "credentials",
+  "required",
+  "expired",
+  "invalid",
+  "missing",
+  "unauthorized",
+  "login",
+  "signin",
+]);
+
+const MODEL_PROVIDER_CONTEXT = new Set([
+  "unavailable",
+  "overloaded",
+  "temporarily",
+  "service",
+]);
+
+const PROVIDER_CONTEXT = new Set([
+  "error",
+  "failure",
+  "failed",
+  "overloaded",
+  "unavailable",
+  "temporarily",
+  "service",
+]);
+
+function fallbackKindFromMessage(message: string, name: string | undefined): WorkflowFailureKind | undefined {
+  const tokens = tokenize(message);
+  if (hasAnyPhrase(tokens, AUTH_PHRASES) || tokenNearAny(tokens, "oauth", AUTH_CONTEXT, 8)) return "auth";
+  if (hasAnyPhrase(tokens, RATE_LIMIT_PHRASES)) return "rate_limit";
+  if (name?.toLowerCase() === "aborterror" || hasAnyPhrase(tokens, CANCELLED_PHRASES)) return "cancelled";
+  if (
+    hasAnyPhrase(tokens, PROVIDER_PHRASES)
+    || tokenNearAny(tokens, "model", MODEL_PROVIDER_CONTEXT, 8)
+    || tokenNearAny(tokens, "provider", PROVIDER_CONTEXT, 8)
+  ) return "provider";
+  return undefined;
+}
 
 export function classifyWorkflowFailure(error: unknown): WorkflowFailure {
   const message = errorMessage(error);
-  const lower = message.toLowerCase();
-  const name = errorName(error)?.toLowerCase();
+  const structured = structuredKind(error);
+  if (structured !== undefined) return failureForKind(structured, message, error);
 
-  if (matchesAny(lower, AUTH_FAILURE_PATTERNS)) {
-    return makeWorkflowFailure("auth", message, {
-      userMessage: WORKFLOW_AUTH_FAILURE_MESSAGE,
-      retryable: true,
-      resumable: true,
-      cause: error,
-    });
-  }
+  const fallback = fallbackKindFromMessage(message, errorName(error));
+  if (fallback !== undefined) return failureForKind(fallback, message, error);
 
-  if (matchesAny(lower, RATE_LIMIT_FAILURE_PATTERNS)) {
-    return makeWorkflowFailure("rate_limit", message, {
-      retryable: true,
-      resumable: true,
-      cause: error,
-    });
-  }
-
-  if (name === "aborterror" || matchesAny(lower, CANCELLED_FAILURE_PATTERNS)) {
-    return makeWorkflowFailure("cancelled", message, {
-      retryable: false,
-      resumable: false,
-      cause: error,
-    });
-  }
-
-  if (matchesAny(lower, PROVIDER_FAILURE_PATTERNS)) {
-    return makeWorkflowFailure("provider", message, {
-      retryable: true,
-      resumable: true,
-      cause: error,
-    });
-  }
-
-  return makeWorkflowFailure("unknown", message, {
-    retryable: false,
-    resumable: true,
-    cause: error,
-  });
+  return failureForKind("unknown", message, error);
 }

--- a/packages/workflows/src/shared/workflow-failures.ts
+++ b/packages/workflows/src/shared/workflow-failures.ts
@@ -56,28 +56,53 @@ function errorName(error: unknown): string | undefined {
   return error instanceof Error ? error.name : undefined;
 }
 
-function includesAny(value: string, terms: readonly string[]): boolean {
-  return terms.some((term) => value.includes(term));
+function matchesAny(value: string, patterns: readonly RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(value));
 }
+
+const AUTH_FAILURE_PATTERNS: readonly RegExp[] = [
+  /\bno api key\b/,
+  /\bapi key not found\b/,
+  /\bmissing api key\b/,
+  /\bno model selected\b/,
+  /\bno models available\b/,
+  /\bnot logged in\b/,
+  /\blog\s+in\b/,
+  /\blogin required\b/,
+  /\bauthentication required\b/,
+  /\bunauthorized\b/,
+  /\boauth(?:2)?\b[^\n.?!]{0,120}\b(?:token|credential|credentials|required|expired|invalid|missing|unauthorized|login|log\s+in|sign[-\s]?in)\b/,
+  /\b(?:token|credential|credentials|required|expired|invalid|missing|unauthorized|login|log\s+in|sign[-\s]?in)\b[^\n.?!]{0,120}\boauth(?:2)?\b/,
+];
+
+const RATE_LIMIT_FAILURE_PATTERNS: readonly RegExp[] = [
+  /\brate\s*limit\b/,
+  /\brate-limit\b/,
+  /\b429\b/,
+  /\bquota\b/,
+  /\btoo many requests\b/,
+];
+
+const CANCELLED_FAILURE_PATTERNS: readonly RegExp[] = [
+  /\baborted\b/,
+  /\bcancelled\b/,
+  /\bcanceled\b/,
+];
+
+const PROVIDER_FAILURE_PATTERNS: readonly RegExp[] = [
+  /\bmodel\b[^\n.?!]{0,120}\b(?:not found|unavailable|overloaded|temporarily unavailable|service unavailable)\b/,
+  /\b(?:not found|unavailable|overloaded|temporarily unavailable|service unavailable)\b[^\n.?!]{0,120}\bmodel\b/,
+  /\bprovider\b[^\n.?!]{0,120}\b(?:error|failure|failed|overloaded|unavailable|temporarily unavailable|service unavailable|returned error)\b/,
+  /\b(?:overloaded|temporarily unavailable|service unavailable)\b/,
+  /\b503\b/,
+];
 
 export function classifyWorkflowFailure(error: unknown): WorkflowFailure {
   const message = errorMessage(error);
   const lower = message.toLowerCase();
   const name = errorName(error)?.toLowerCase();
 
-  if (includesAny(lower, [
-    "no api key",
-    "api key not found",
-    "missing api key",
-    "no model selected",
-    "no models available",
-    "not logged in",
-    "log in",
-    "login required",
-    "authentication required",
-    "unauthorized",
-    "oauth",
-  ])) {
+  if (matchesAny(lower, AUTH_FAILURE_PATTERNS)) {
     return makeWorkflowFailure("auth", message, {
       userMessage: WORKFLOW_AUTH_FAILURE_MESSAGE,
       retryable: true,
@@ -86,7 +111,7 @@ export function classifyWorkflowFailure(error: unknown): WorkflowFailure {
     });
   }
 
-  if (includesAny(lower, ["rate limit", "rate-limit", "429", "quota", "too many requests"])) {
+  if (matchesAny(lower, RATE_LIMIT_FAILURE_PATTERNS)) {
     return makeWorkflowFailure("rate_limit", message, {
       retryable: true,
       resumable: true,
@@ -94,7 +119,7 @@ export function classifyWorkflowFailure(error: unknown): WorkflowFailure {
     });
   }
 
-  if (name === "aborterror" || includesAny(lower, ["aborted", "cancelled", "canceled"])) {
+  if (name === "aborterror" || matchesAny(lower, CANCELLED_FAILURE_PATTERNS)) {
     return makeWorkflowFailure("cancelled", message, {
       retryable: false,
       resumable: false,
@@ -102,14 +127,7 @@ export function classifyWorkflowFailure(error: unknown): WorkflowFailure {
     });
   }
 
-  if (includesAny(lower, [
-    "model",
-    "provider",
-    "overloaded",
-    "temporarily unavailable",
-    "service unavailable",
-    "503",
-  ])) {
+  if (matchesAny(lower, PROVIDER_FAILURE_PATTERNS)) {
     return makeWorkflowFailure("provider", message, {
       retryable: true,
       resumable: true,

--- a/packages/workflows/src/tui/chat-surface.ts
+++ b/packages/workflows/src/tui/chat-surface.ts
@@ -504,6 +504,7 @@ function stageGlyph(status: StageStatus): string {
     case "completed": return "✓";
     case "running":   return "●";
     case "failed":    return "✗";
+    case "skipped":   return "⊘";
     case "pending":
     default:          return "○";
   }
@@ -514,6 +515,7 @@ function stageColor(status: StageStatus, theme: GraphTheme): string {
     case "completed": return hexToAnsi(theme.success);
     case "running":   return hexToAnsi(theme.warning);
     case "failed":    return hexToAnsi(theme.error);
+    case "skipped":   return hexToAnsi(theme.dim);
     case "pending":
     default:          return hexToAnsi(theme.dim);
   }

--- a/packages/workflows/src/tui/graph-view.ts
+++ b/packages/workflows/src/tui/graph-view.ts
@@ -989,6 +989,7 @@ export class GraphView implements Component {
     blocked: number;
     completed: number;
     failed: number;
+    skipped: number;
   } {
     const c = {
       pending: 0,
@@ -998,6 +999,7 @@ export class GraphView implements Component {
       blocked: 0,
       completed: 0,
       failed: 0,
+      skipped: 0,
     };
     for (const s of run.stages) c[s.status]++;
     return c;

--- a/packages/workflows/src/tui/header.ts
+++ b/packages/workflows/src/tui/header.ts
@@ -202,6 +202,7 @@ export function renderHeader(run: RunSnapshot, opts: HeaderOpts): string[] {
     blocked: 0,
     completed: 0,
     failed: 0,
+    skipped: 0,
   };
   for (const s of run.stages) counts[s.status]++;
 
@@ -211,6 +212,7 @@ export function renderHeader(run: RunSnapshot, opts: HeaderOpts): string[] {
   if (counts.awaiting_input > 0) badges.push({ text: `↵ ${counts.awaiting_input}`, fg: theme.info });
   if (counts.paused > 0) badges.push({ text: `❚❚ ${counts.paused}`, fg: theme.warning });
   if (counts.pending > 0) badges.push({ text: `○ ${counts.pending}`, fg: theme.dim });
+  if (counts.skipped > 0) badges.push({ text: `⊘ ${counts.skipped}`, fg: theme.dim });
   if (counts.failed > 0) badges.push({ text: `✗ ${counts.failed}`, fg: theme.error });
 
   return renderBandHeader({

--- a/packages/workflows/src/tui/node-card.ts
+++ b/packages/workflows/src/tui/node-card.ts
@@ -71,6 +71,8 @@ function pickBorder(
       return theme.error;
     case "blocked":
       return theme.dim;
+    case "skipped":
+      return theme.dim;
     case "pending":
     default:
       // Pending has no semantic colour; the focused-tab carries the

--- a/packages/workflows/src/tui/status-helpers.ts
+++ b/packages/workflows/src/tui/status-helpers.ts
@@ -28,6 +28,8 @@ export function statusColor(
       return theme.error;
     case "blocked":
       return theme.dim;
+    case "skipped":
+      return theme.dim;
     case "pending":
     default:
       return theme.dim;
@@ -41,6 +43,8 @@ export function statusIcon(status: StageStatus | RunStatus): string {
       return "○";
     case "blocked":
       return "↑";
+    case "skipped":
+      return "⊘";
     case "running":
       return "●";
     case "paused":

--- a/packages/workflows/src/tui/status-list.ts
+++ b/packages/workflows/src/tui/status-list.ts
@@ -188,7 +188,7 @@ function runCardMeta(run: RunSnapshot, now: number): string {
   const isChain = run.stages.length > 1;
   const total = run.stages.length;
   const done = run.stages.filter(
-    (s) => s.status === "completed" || s.status === "failed",
+    (s) => s.status === "completed" || s.status === "failed" || s.status === "skipped",
   ).length;
   const ago = run.endedAt !== undefined
     ? `${fmtDuration(now - run.endedAt)} ago`
@@ -239,7 +239,7 @@ function lastStageDuration(run: RunSnapshot, now: number): string | undefined {
   // Pick a representative stage duration: the most-recent terminal stage,
   // or the running stage if everything's still in flight.
   const candidate =
-    [...run.stages].reverse().find((s) => s.status === "completed" || s.status === "failed") ??
+    [...run.stages].reverse().find((s) => s.status === "completed" || s.status === "failed" || s.status === "skipped") ??
     run.stages.find((s) => s.status === "running");
   if (!candidate) return undefined;
   return stageDurationString(candidate, now);

--- a/test/unit/background-status.test.ts
+++ b/test/unit/background-status.test.ts
@@ -248,6 +248,40 @@ describe("resumeRun", () => {
       assert.equal(stored!.name, "my-wf");
     }
   });
+
+  test("failed resumable terminal run returns snapshot mode for continuation callers", () => {
+    const st = createStore();
+    st.recordRunStart(makeRun({ id: "r1" }));
+    st.recordRunEnd("r1", "failed", undefined, "boom", {
+      failureKind: "unknown",
+      failedStageId: "s1",
+      resumable: true,
+    });
+    const result = resumeRun("r1", { store: st });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.mode, "snapshot");
+      assert.equal(result.snapshot.status, "failed");
+      assert.equal(result.message, undefined);
+    }
+  });
+
+  test("failed non-resumable terminal run returns a clear non-resumable snapshot mode", () => {
+    const st = createStore();
+    st.recordRunStart(makeRun({ id: "r1" }));
+    st.recordRunEnd("r1", "failed", undefined, "boom", {
+      failureKind: "cancelled",
+      failedStageId: "s1",
+      resumable: false,
+    });
+    const result = resumeRun("r1", { store: st });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.mode, "not_resumable");
+      assert.equal(result.snapshot.status, "failed");
+      assert.match(result.message ?? "", /not resumable/);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { run, runChain, runParallel, runTask, resolveInputs } from "../../packages/workflows/src/runs/foreground/executor.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
+import { WORKFLOW_AUTH_FAILURE_MESSAGE } from "../../packages/workflows/src/shared/workflow-failures.js";
 import { defineWorkflow } from "../../packages/workflows/src/workflows/define-workflow.js";
 import type { AgentSession, CreateAgentSessionOptions } from "@bastani/atomic";
 
@@ -1190,6 +1191,31 @@ describe("direct SDK helpers", () => {
     assert.equal(details.results?.[0]?.text, "fallback ok");
     assert.deepEqual(details.results?.[0]?.attemptedModels, ["anthropic/primary", "openai/fallback"]);
     assert.deepEqual(details.results?.[0]?.modelAttempts?.map((attempt) => attempt.success), [false, true]);
+  });
+
+  test("runTask reports classified auth guidance for direct stage failures", async () => {
+    const details = await runTask(
+      { name: "scout", prompt: "inspect repo" },
+      {},
+      {
+        adapters: {
+          agentSession: {
+            async create() {
+              return {
+                ...mockSession(),
+                async prompt() {
+                  throw { message: "request failed", status: 401 };
+                },
+              };
+            },
+          },
+        },
+        store: createStore(),
+      },
+    );
+
+    assert.equal(details.status, "failed");
+    assert.equal(details.error, WORKFLOW_AUTH_FAILURE_MESSAGE);
   });
 
   test("runTask invalid fallback model fails before session and output side effects", async () => {

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -425,6 +425,272 @@ describe("executor.run", () => {
     assert.ok(wfResult.error!.includes("stage error"));
   });
 
+  test("continuation replays completed stages and resumes at failed stage", async () => {
+    const st = createStore();
+    const def = defineWorkflow("resume-failed-wf")
+      .run(async (ctx) => {
+        const first = await ctx.stage("first").prompt("first");
+        const second = await ctx.stage("second").prompt(`second:${first}`);
+        const third = await ctx.stage("third").prompt(`third:${second}`);
+        return { first, second, third };
+      })
+      .compile();
+
+    const firstRunCalls: string[] = [];
+    const firstRun = await run(def, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            firstRunCalls.push(text);
+            if (text.startsWith("second:")) throw new Error("rate limit exceeded");
+            return "first-result";
+          },
+        },
+      },
+    });
+
+    assert.equal(firstRun.status, "failed");
+    assert.deepEqual(firstRunCalls, ["first", "second:first-result"]);
+    const source = st.runs().find((candidate) => candidate.id === firstRun.runId)!;
+    const failedStageId = source.failedStageId!;
+
+    const continuationCalls: string[] = [];
+    const continued = await run(def, {}, {
+      store: st,
+      continuation: { source, resumeFromStageId: failedStageId },
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            continuationCalls.push(text);
+            if (text.startsWith("second:")) return "second-result";
+            return "third-result";
+          },
+        },
+      },
+    });
+
+    assert.equal(continued.status, "completed");
+    assert.deepEqual(continuationCalls, ["second:first-result", "third:second-result"]);
+    const replayed = continued.stages[0]!;
+    assert.equal(replayed.status, "completed");
+    assert.equal(replayed.replayed, true);
+    assert.equal(replayed.replayedFromStageId, source.stages[0]!.id);
+    assert.equal(continued.result?.["first"], "first-result");
+    const continuedRun = st.runs().find((candidate) => candidate.id === continued.runId)!;
+    assert.equal(continuedRun.resumedFromRunId, source.id);
+    assert.equal(continuedRun.resumeFromStageId, failedStageId);
+    assert.equal(source.status, "failed", "source failed run remains terminal/immutable");
+  });
+
+  test("auth stage failures surface workflow login guidance and preserve details", async () => {
+    const st = createStore();
+    const def = defineWorkflow("auth-fail-wf")
+      .run(async (ctx) => {
+        await ctx.stage("needs-login").prompt("x");
+        return {};
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      adapters: {
+        prompt: {
+          prompt: async () => {
+            throw new Error("No API key found for provider");
+          },
+        },
+      },
+      store: st,
+    });
+
+    assert.equal(wfResult.status, "failed");
+    assert.equal(wfResult.error, "You must be logged in to run workflows. Run /login and try again.");
+    const storedRun = st.runs()[0]!;
+    const stage = storedRun.stages[0]!;
+    assert.equal(stage.error, "You must be logged in to run workflows. Run /login and try again.");
+    assert.equal(stage.failureKind, "auth");
+    assert.equal(stage.failureMessage, "No API key found for provider");
+    assert.equal(storedRun.failureKind, "auth");
+    assert.equal(storedRun.failureMessage, "No API key found for provider");
+    assert.equal(storedRun.failedStageId, stage.id);
+    assert.equal(storedRun.resumable, true);
+  });
+
+  test("parallel fail-fast marks slow sibling skipped instead of completed", async () => {
+    const st = createStore();
+    const def = defineWorkflow("parallel-fail-fast-skip-wf")
+      .run(async (ctx) => {
+        await ctx.parallel([
+          { name: "fast", prompt: "fail" },
+          { name: "slow", prompt: "slow" },
+        ], { concurrency: 2 });
+        return {};
+      })
+      .compile();
+
+    const result = await run(def, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            if (text === "fail") throw new Error("boom");
+            await new Promise<void>((resolve) => setTimeout(resolve, 20));
+            return "slow-ok";
+          },
+        },
+      },
+    });
+
+    assert.equal(result.status, "failed");
+    const stages = st.runs().find((runSnap) => runSnap.id === result.runId)!.stages;
+    assert.equal(stages.find((stage) => stage.name === "fast")?.status, "failed");
+    const slow = stages.find((stage) => stage.name === "slow")!;
+    assert.equal(slow.status, "skipped");
+    assert.equal(slow.skippedReason, "fail-fast");
+  });
+
+  test("caught parallel fail-fast failure does not skip later normal task", async () => {
+    const st = createStore();
+    const def = defineWorkflow("parallel-fail-fast-catch-then-task-wf")
+      .run(async (ctx) => {
+        try {
+          await ctx.parallel([
+            { name: "fast", prompt: "fail" },
+            { name: "slow", prompt: "slow" },
+          ], { concurrency: 2 });
+        } catch {
+          // The workflow intentionally recovers and continues with normal work.
+        }
+
+        const after = await ctx.task("after", { prompt: "after" });
+        return { after: after.text };
+      })
+      .compile();
+
+    const result = await run(def, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            if (text === "fail") throw new Error("boom");
+            if (text === "slow") {
+              await new Promise((resolve) => setTimeout(resolve, 50));
+              return "slow-ok";
+            }
+            return "after-ok";
+          },
+        },
+      },
+    });
+
+    assert.equal(result.status, "completed");
+    assert.equal(result.result?.["after"], "after-ok");
+    const stages = st.runs().find((runSnap) => runSnap.id === result.runId)!.stages;
+    const after = stages.find((stage) => stage.name === "after")!;
+    assert.equal(after.status, "completed");
+    assert.equal(after.skippedReason, undefined);
+    assert.equal(stages.find((stage) => stage.name === "slow")?.status, "skipped");
+  });
+
+  test("parallel fail-fast fails without waiting for a hung sibling", async () => {
+    const st = createStore();
+    const def = defineWorkflow("parallel-fail-fast-hung-wf")
+      .run(async (ctx) => {
+        await ctx.parallel([
+          { name: "fast", prompt: "fail" },
+          { name: "hung", prompt: "hang" },
+        ], { concurrency: 2 });
+        return {};
+      })
+      .compile();
+
+    const result = await Promise.race([
+      run(def, {}, {
+        store: st,
+        adapters: {
+          prompt: {
+            prompt: async (text) => {
+              if (text === "fail") throw new Error("boom");
+              await new Promise<string>(() => {});
+              return "unreachable";
+            },
+          },
+        },
+      }),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
+    ]);
+
+    assert.notEqual(result, "timeout");
+    if (result === "timeout") return;
+    assert.equal(result.status, "failed");
+    const stages = st.runs().find((runSnap) => runSnap.id === result.runId)!.stages;
+    assert.equal(stages.find((stage) => stage.name === "fast")?.status, "failed");
+    const hung = stages.find((stage) => stage.name === "hung")!;
+    assert.equal(hung.status, "skipped");
+    assert.equal(hung.skippedReason, "fail-fast");
+  });
+
+  test("continuation replays completed parallel sibling after failed source stage", async () => {
+    const st = createStore();
+    let failOnce = true;
+    const def = defineWorkflow("resume-parallel-sibling-wf")
+      .run(async (ctx) => {
+        const results = await ctx.parallel([
+          { name: "failed-first", prompt: "fail-once" },
+          { name: "completed-second", prompt: "already-done" },
+        ], { concurrency: 2, failFast: false });
+        return { results: results.map((result) => result.text).join(",") };
+      })
+      .compile();
+
+    const firstRunCalls: string[] = [];
+    const firstRun = await run(def, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            firstRunCalls.push(text);
+            if (text === "fail-once" && failOnce) {
+              failOnce = false;
+              throw new Error("rate limit exceeded");
+            }
+            return `${text}:ok`;
+          },
+        },
+      },
+    });
+
+    assert.equal(firstRun.status, "failed");
+    assert.deepEqual(firstRunCalls.sort(), ["already-done", "fail-once"]);
+    const source = st.runs().find((candidate) => candidate.id === firstRun.runId)!;
+    const failed = source.stages.find((stage) => stage.name === "failed-first")!;
+    const completed = source.stages.find((stage) => stage.name === "completed-second")!;
+    assert.equal(failed.status, "failed");
+    assert.equal(completed.status, "completed");
+    assert.ok(source.stages.indexOf(completed) > source.stages.indexOf(failed));
+
+    const continuationCalls: string[] = [];
+    const continued = await run(def, {}, {
+      store: st,
+      continuation: { source, resumeFromStageId: failed.id },
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            continuationCalls.push(text);
+            return `${text}:resumed`;
+          },
+        },
+      },
+    });
+
+    assert.equal(continued.status, "completed");
+    assert.deepEqual(continuationCalls, ["fail-once"]);
+    const replayed = continued.stages.find((stage) => stage.name === "completed-second")!;
+    assert.equal(replayed.status, "completed");
+    assert.equal(replayed.replayed, true);
+    assert.equal(replayed.replayedFromStageId, completed.id);
+  });
+
   test("failed fallback attempts are recorded on the stage snapshot", async () => {
     const def = defineWorkflow("failed-fallback-metadata")
       .run(async (ctx) => {
@@ -1259,9 +1525,79 @@ describe("executor.run — lifecycle persistence", () => {
 
     const stageEnd = calls.find((c) => c.type === "workflow.stage.end");
     assert.equal(stageEnd?.payload["status"], "failed");
+    assert.equal(stageEnd.payload["error"], "boom");
+    assert.equal(stageEnd.payload["failureKind"], "unknown");
+    assert.equal(stageEnd.payload["failureMessage"], "boom");
 
     const runEnd = calls.find((c) => c.type === "workflow.run.end");
     assert.equal(runEnd?.payload["status"], "failed");
+    assert.equal(runEnd.payload["error"], "boom");
+    assert.equal(runEnd.payload["failureKind"], "unknown");
+    assert.equal(runEnd.payload["failureMessage"], "boom");
+    assert.equal(runEnd.payload["failedStageId"], stageEnd.payload["stageId"]);
+    assert.equal(runEnd.payload["resumable"], true);
+  });
+
+  test("fail-fast skipped queued parallel stages persist start before end", async () => {
+    const { persistence, calls } = makePersistence();
+    const st = createStore();
+    const promptCalls: string[] = [];
+
+    const def = defineWorkflow("fail-fast-pending-persist-wf")
+      .run(async (ctx) => {
+        await ctx.parallel([
+          { name: "first", prompt: "fail" },
+          { name: "queued-a", prompt: "queued-a" },
+          { name: "queued-b", prompt: "queued-b" },
+        ], { concurrency: 3 });
+        return {};
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      config: { defaultConcurrency: 1, maxDepth: 10, persistRuns: false, statusFile: false, resumeInFlight: "never" },
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            promptCalls.push(text);
+            await Promise.resolve();
+            if (text === "fail") throw new Error("boom");
+            await new Promise<string>(() => {});
+            return `unexpected:${text}`;
+          },
+        },
+      },
+      store: st,
+      persistence,
+    });
+
+    assert.equal(wfResult.status, "failed");
+    assert.equal(promptCalls[0], "fail");
+
+    const stages = st.runs().find((runSnap) => runSnap.id === wfResult.runId)!.stages;
+    for (const name of ["queued-a", "queued-b"]) {
+      const stage = stages.find((candidate) => candidate.name === name)!;
+      assert.equal(stage.status, "skipped");
+      assert.equal(stage.skippedReason, "fail-fast");
+    }
+
+    const stageEntryKey = (payload: Record<string, unknown>): string =>
+      `${String(payload["runId"])}:${String(payload["stageId"])}`;
+    const startsByStage = new Map<string, number>();
+    for (const call of calls) {
+      if (call.type === "workflow.stage.start") {
+        const key = stageEntryKey(call.payload);
+        startsByStage.set(key, (startsByStage.get(key) ?? 0) + 1);
+        continue;
+      }
+      if (call.type !== "workflow.stage.end") continue;
+      const key = stageEntryKey(call.payload);
+      assert.equal(startsByStage.get(key) ?? 0, 1, `stage ${key} ended without exactly one preceding start`);
+    }
+
+    const stageStartCount = calls.filter((call) => call.type === "workflow.stage.start").length;
+    const stageEndCount = calls.filter((call) => call.type === "workflow.stage.end").length;
+    assert.equal(stageStartCount, stageEndCount);
   });
 
   test("no appendEntry calls when persistence not provided", async () => {

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -630,6 +630,202 @@ describe("executor.run", () => {
     assert.equal(hung.skippedReason, "fail-fast");
   });
 
+  test("continuation rejects replay when stage topology changes", async () => {
+    const st = createStore();
+    const sourceDef = defineWorkflow("resume-topology-source-wf")
+      .run(async (ctx) => {
+        const first = await ctx.stage("first").prompt("first");
+        await ctx.stage("second").prompt(`second:${first}`);
+        return {};
+      })
+      .compile();
+
+    const firstRun = await run(sourceDef, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            if (text.startsWith("second:")) throw new Error("rate limit exceeded");
+            return "first-result";
+          },
+        },
+      },
+    });
+    assert.equal(firstRun.status, "failed");
+    const source = st.runs().find((candidate) => candidate.id === firstRun.runId)!;
+    const failedStageId = source.failedStageId!;
+
+    const changedDef = defineWorkflow("resume-topology-source-wf")
+      .run(async (ctx) => {
+        await ctx.stage("second").prompt("second-without-parent");
+        return {};
+      })
+      .compile();
+
+    const calls: string[] = [];
+    const continued = await run(changedDef, {}, {
+      store: st,
+      continuation: { source, resumeFromStageId: failedStageId },
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            calls.push(text);
+            return "unexpected";
+          },
+        },
+      },
+    });
+
+    assert.equal(continued.status, "failed");
+    assert.match(continued.error ?? "", /insufficient_state: replay topology mismatch/);
+    assert.deepEqual(calls, []);
+  });
+
+  test("continuation replays multiple completed parallel siblings without topology drift", async () => {
+    const st = createStore();
+    const def = defineWorkflow("resume-parallel-roots-wf")
+      .run(async (ctx) => {
+        const results = await ctx.parallel([
+          { name: "alpha", prompt: "alpha" },
+          { name: "beta", prompt: "beta" },
+        ], { concurrency: 2, failFast: false });
+        await ctx.stage("fail-after-parallel").prompt(results.map((result) => result.text).join(","));
+        return {};
+      })
+      .compile();
+
+    const firstRun = await run(def, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            if (text === "alpha" || text === "beta") return `${text}:done`;
+            throw new Error("rate limit exceeded");
+          },
+        },
+      },
+    });
+    assert.equal(firstRun.status, "failed");
+    const source = st.runs().find((candidate) => candidate.id === firstRun.runId)!;
+    const failedStageId = source.failedStageId!;
+
+    const continuationCalls: string[] = [];
+    const continued = await run(def, {}, {
+      store: st,
+      continuation: { source, resumeFromStageId: failedStageId },
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            continuationCalls.push(text);
+            return "resumed";
+          },
+        },
+      },
+    });
+
+    assert.equal(continued.status, "completed");
+    assert.deepEqual(continuationCalls, ["alpha:done,beta:done"]);
+    assert.equal(continued.stages.find((stage) => stage.name === "alpha")?.replayed, true);
+    assert.equal(continued.stages.find((stage) => stage.name === "beta")?.replayed, true);
+  });
+
+  test("continuation rejects ambiguous duplicate-name replay topology", async () => {
+    const st = createStore();
+    const def = defineWorkflow("resume-ambiguous-duplicate-wf")
+      .run(async (ctx) => {
+        await ctx.parallel([
+          { name: "duplicate", prompt: "one" },
+          { name: "duplicate", prompt: "two" },
+        ], { concurrency: 2, failFast: false });
+        await ctx.stage("fail-after-duplicates").prompt("fail");
+        return {};
+      })
+      .compile();
+
+    const firstRun = await run(def, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            if (text === "fail") throw new Error("rate limit exceeded");
+            return `${text}:done`;
+          },
+        },
+      },
+    });
+    assert.equal(firstRun.status, "failed");
+    const source = st.runs().find((candidate) => candidate.id === firstRun.runId)!;
+    const failedStageId = source.failedStageId!;
+
+    const ambiguousReplayDef = defineWorkflow("resume-ambiguous-duplicate-wf")
+      .run(async (ctx) => {
+        await ctx.stage("duplicate").prompt("one-of-two-roots");
+        return {};
+      })
+      .compile();
+
+    const continued = await run(ambiguousReplayDef, {}, {
+      store: st,
+      continuation: { source, resumeFromStageId: failedStageId },
+      adapters: {
+        prompt: {
+          prompt: async () => "unexpected",
+        },
+      },
+    });
+
+    assert.equal(continued.status, "failed");
+    assert.match(continued.error ?? "", /insufficient_state: replay topology ambiguous/);
+  });
+
+  test("replayed stage contexts reject mutation methods", async () => {
+    const st = createStore();
+    const sourceDef = defineWorkflow("resume-replay-mutation-source-wf")
+      .run(async (ctx) => {
+        const first = await ctx.stage("first").prompt("first");
+        await ctx.stage("second").prompt(`second:${first}`);
+        return {};
+      })
+      .compile();
+
+    const firstRun = await run(sourceDef, {}, {
+      store: st,
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            if (text.startsWith("second:")) throw new Error("rate limit exceeded");
+            return "first-result";
+          },
+        },
+      },
+    });
+    assert.equal(firstRun.status, "failed");
+    const source = st.runs().find((candidate) => candidate.id === firstRun.runId)!;
+    const failedStageId = source.failedStageId!;
+
+    const mutationDef = defineWorkflow("resume-replay-mutation-source-wf")
+      .run(async (ctx) => {
+        await ctx.stage("first").setModel("openai/example" as never);
+        return {};
+      })
+      .compile();
+
+    const continued = await run(mutationDef, {}, {
+      store: st,
+      continuation: { source, resumeFromStageId: failedStageId },
+      adapters: {
+        prompt: {
+          prompt: async () => "unexpected",
+        },
+      },
+    });
+
+    assert.equal(continued.status, "failed");
+    assert.match(continued.error ?? "", /replayed stage "first" cannot set model/);
+    const replayed = continued.stages.find((stage) => stage.name === "first")!;
+    assert.equal(replayed.replayed, true);
+  });
+
   test("continuation replays completed parallel sibling after failed source stage", async () => {
     const st = createStore();
     let failOnce = true;

--- a/test/unit/node-card.test.ts
+++ b/test/unit/node-card.test.ts
@@ -156,6 +156,16 @@ describe("renderNodeCard — status border colours", () => {
     );
   });
 
+  test("skipped status uses dim, not success or error", () => {
+    const lines = renderNodeCard(
+      makeStage({ status: "skipped", durationMs: 800 }),
+      { theme },
+    );
+    assert.ok(lines[0]!.includes(hexToAnsi(theme.dim)));
+    assert.equal(lines[0]!.includes(hexToAnsi(theme.success)), false);
+    assert.equal(lines[0]!.includes(hexToAnsi(theme.error)), false);
+  });
+
   test("focused running stage locks the border to warning (not pulsing lerp)", () => {
     const lines = renderNodeCard(
       makeStage({ status: "running", startedAt: Date.now() - 500 }),

--- a/test/unit/persistence-restore.test.ts
+++ b/test/unit/persistence-restore.test.ts
@@ -219,4 +219,108 @@ describe("restoreOnSessionStart", () => {
     assert.equal(s2!.status, "failed");
     assert.notEqual(s2!.error, undefined);
   });
+
+  test("restores continuation and replay metadata", () => {
+    const st = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "r2", name: "wf", inputs: {}, resumedFromRunId: "r1", resumeFromStageId: "old-failed", ts: 1 } },
+      { id: "e2", type: "workflow.stage.start", payload: { runId: "r2", stageId: "s-new", name: "first", parentIds: [], replayedFromStageId: "s-old", replayed: true, ts: 2 } },
+      { id: "e3", type: "workflow.stage.end", payload: { runId: "r2", stageId: "s-new", status: "completed", summary: "old result", replayedFromStageId: "s-old", replayed: true } },
+    ];
+    restoreOnSessionStart(makeSessionManager(entries), { resumeInFlight: "never", persistRuns: true }, st);
+    const run = st.runs()[0]!;
+    assert.equal(run.resumedFromRunId, "r1");
+    assert.equal(run.resumeFromStageId, "old-failed");
+    const stage = run.stages[0]!;
+    assert.equal(stage.result, "old result");
+    assert.equal(stage.replayedFromStageId, "s-old");
+    assert.equal(stage.replayed, true);
+  });
+
+  test("restores malformed and non-terminal stage.end statuses as failed", () => {
+    const st = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "r1", name: "wf", inputs: {}, ts: 1 } },
+      { id: "e2", type: "workflow.stage.start", payload: { runId: "r1", stageId: "s1", name: "one", parentIds: [], ts: 2 } },
+      { id: "e3", type: "workflow.stage.end", payload: { runId: "r1", stageId: "s1", status: "running" } },
+      { id: "e4", type: "workflow.stage.start", payload: { runId: "r1", stageId: "s2", name: "two", parentIds: [], ts: 3 } },
+      { id: "e5", type: "workflow.stage.end", payload: { runId: "r1", stageId: "s2", status: "nonsense" } },
+    ];
+    restoreOnSessionStart(makeSessionManager(entries), { resumeInFlight: "never", persistRuns: true }, st);
+    assert.equal(st.runs()[0]!.stages[0]!.status, "failed");
+    assert.equal(st.runs()[0]!.stages[1]!.status, "failed");
+  });
+
+  test("restores failed terminal run metadata from run.end entries", () => {
+    const st = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "r1", name: "wf", inputs: {}, ts: 1 } },
+      { id: "e2", type: "workflow.stage.start", payload: { runId: "r1", stageId: "s1", name: "fetch", parentIds: [], ts: 2 } },
+      { id: "e3", type: "workflow.stage.end", payload: { runId: "r1", stageId: "s1", status: "failed", error: "rate limit", failureKind: "rate_limit" } },
+      {
+        id: "e4",
+        type: "workflow.run.end",
+        payload: {
+          runId: "r1",
+          status: "failed",
+          error: "rate limit",
+          failureKind: "rate_limit",
+          failureMessage: "429 too many requests",
+          failedStageId: "s1",
+          resumable: true,
+          ts: 3,
+        },
+      },
+    ];
+
+    restoreOnSessionStart(makeSessionManager(entries), { resumeInFlight: "never", persistRuns: true }, st);
+    const run = st.runs()[0]!;
+    assert.equal(run.status, "failed");
+    assert.equal(run.error, "rate limit");
+    assert.equal(run.failureKind, "rate_limit");
+    assert.equal(run.failureMessage, "429 too many requests");
+    assert.equal(run.failedStageId, "s1");
+    assert.equal(run.resumable, true);
+  });
+
+  test("ignores invalid run failureKind from run.end entries", () => {
+    const st = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "r1", name: "wf", inputs: {}, ts: 1 } },
+      { id: "e2", type: "workflow.run.end", payload: { runId: "r1", status: "failed", error: "boom", failureKind: "not-real", resumable: true, ts: 2 } },
+    ];
+
+    restoreOnSessionStart(makeSessionManager(entries), { resumeInFlight: "never", persistRuns: true }, st);
+    const run = st.runs()[0]!;
+    assert.equal(run.status, "failed");
+    assert.equal(run.failureKind, undefined);
+    assert.equal(run.resumable, true);
+  });
+
+  test("restores stage failure metadata from stage.end entries", () => {
+    const st = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "r1", name: "wf", inputs: {}, ts: 1 } },
+      { id: "e2", type: "workflow.stage.start", payload: { runId: "r1", stageId: "s1", name: "fetch", parentIds: [], ts: 2 } },
+      {
+        id: "e3",
+        type: "workflow.stage.end",
+        payload: {
+          runId: "r1",
+          stageId: "s1",
+          status: "failed",
+          error: "You must be logged in to run workflows. Run /login and try again.",
+          failureKind: "auth",
+          failureMessage: "No API key found",
+          durationMs: 100,
+        },
+      },
+    ];
+    restoreOnSessionStart(makeSessionManager(entries), { resumeInFlight: "never", persistRuns: true }, st);
+    const stage = st.runs()[0]!.stages[0]!;
+    assert.equal(stage.status, "failed");
+    assert.equal(stage.error, "You must be logged in to run workflows. Run /login and try again.");
+    assert.equal(stage.failureKind, "auth");
+    assert.equal(stage.failureMessage, "No API key found");
+  });
 });

--- a/test/unit/persistence-session-entries.test.ts
+++ b/test/unit/persistence-session-entries.test.ts
@@ -84,6 +84,21 @@ describe("appendRunStart", () => {
     assert.equal(label, "wf:my-workflow:abcdefgh");
   });
 
+  test("includes continuation metadata when provided", () => {
+    const api = makeMockApi();
+    appendRunStart(api, {
+      runId: "r2",
+      name: "wf",
+      inputs: {},
+      resumedFromRunId: "r1",
+      resumeFromStageId: "s2",
+      ts: 1,
+    });
+    const p = api._entries[0]!.payload;
+    assert.equal(p["resumedFromRunId"], "r1");
+    assert.equal(p["resumeFromStageId"], "s2");
+  });
+
   test("no-op when appendEntry absent", () => {
     const api: PersistenceAPI = {};
     // Should not throw
@@ -147,6 +162,22 @@ describe("appendStageStart", () => {
     assert.equal("model" in api._entries[0]!.payload, false);
   });
 
+  test("includes replay metadata when provided", () => {
+    const api = makeMockApi();
+    appendStageStart(api, {
+      runId: "r2",
+      stageId: "s-new",
+      name: "first",
+      parentIds: [],
+      replayedFromStageId: "s-old",
+      replayed: true,
+      ts: 1,
+    });
+    const p = api._entries[0]!.payload;
+    assert.equal(p["replayedFromStageId"], "s-old");
+    assert.equal(p["replayed"], true);
+  });
+
   test("no-op when appendEntry absent", () => {
     const api: PersistenceAPI = {};
     appendStageStart(api, { runId: "r1", stageId: "s1", name: "n", parentIds: [], ts: 1 });
@@ -203,6 +234,40 @@ describe("appendStageEnd", () => {
     assert.equal("summary" in p, false);
   });
 
+  test("includes optional failure metadata when provided", () => {
+    const api = makeMockApi();
+    appendStageEnd(api, {
+      runId: "r1",
+      stageId: "s1",
+      status: "failed",
+      error: "login required",
+      failureKind: "auth",
+      failureMessage: "No API key found",
+      skippedReason: "fail-fast",
+    });
+    const p = api._entries[0]!.payload;
+    assert.equal(p["error"], "login required");
+    assert.equal(p["failureKind"], "auth");
+    assert.equal(p["failureMessage"], "No API key found");
+    assert.equal(p["skippedReason"], "fail-fast");
+  });
+
+  test("includes optional replay metadata when provided", () => {
+    const api = makeMockApi();
+    appendStageEnd(api, {
+      runId: "r2",
+      stageId: "s-new",
+      status: "completed",
+      summary: "old result",
+      replayedFromStageId: "s-old",
+      replayed: true,
+    });
+    const p = api._entries[0]!.payload;
+    assert.equal(p["summary"], "old result");
+    assert.equal(p["replayedFromStageId"], "s-old");
+    assert.equal(p["replayed"], true);
+  });
+
   test("emitMessage=true calls appendCustomMessageEntry when summary provided", () => {
     const api = makeMockApi();
     appendStageEnd(
@@ -250,6 +315,26 @@ describe("appendRunEnd", () => {
     const api = makeMockApi();
     appendRunEnd(api, { runId: "r1", status: "completed", result: { out: 42 }, ts: 1 });
     assert.equal((api._entries[0]!.payload["result"] as Record<string, unknown>)["out"], 42);
+  });
+
+  test("includes optional run failure metadata when provided", () => {
+    const api = makeMockApi();
+    appendRunEnd(api, {
+      runId: "r1",
+      status: "failed",
+      error: "login required",
+      failureKind: "auth",
+      failureMessage: "No API key found",
+      failedStageId: "s1",
+      resumable: true,
+      ts: 1,
+    });
+    const p = api._entries[0]!.payload;
+    assert.equal(p["error"], "login required");
+    assert.equal(p["failureKind"], "auth");
+    assert.equal(p["failureMessage"], "No API key found");
+    assert.equal(p["failedStageId"], "s1");
+    assert.equal(p["resumable"], true);
   });
 
   test("no-op when appendEntry absent", () => {

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -31,6 +31,7 @@ import { defineWorkflow } from "../../packages/workflows/src/workflows/define-wo
 import type { WorkflowDefinition } from "../../packages/workflows/src/shared/types.js";
 import { createExtensionRuntime } from "../../packages/workflows/src/extension/runtime.js";
 import { store } from "../../packages/workflows/src/shared/store.js";
+import { WORKFLOW_AUTH_FAILURE_MESSAGE } from "../../packages/workflows/src/shared/workflow-failures.js";
 import type {
   PiCustomComponent,
   PiCustomOverlayFactoryTui,
@@ -1006,6 +1007,56 @@ describe("tool run-control actions", () => {
     const r = result as { action: string; status: string; runId: string };
     assert.equal(r.status, "ok");
     assert.equal(r.runId, runId);
+  });
+
+  test("runtime runDirect classifies direct pre-run model auth failures", async () => {
+    const runtime = createExtensionRuntime({
+      registry: createRegistry([]),
+      models: {
+        async listModels() {
+          throw { message: "request failed", status: 401 };
+        },
+      },
+    });
+
+    const result = await runtime.runDirect({ task: { name: "scout", task: "inspect repo", model: "openai/gpt" }, async: true });
+
+    assert.equal(result.status, "failed");
+    assert.equal(result.error, WORKFLOW_AUTH_FAILURE_MESSAGE);
+  });
+
+  test("makeExecuteWorkflowTool resume rejects ambiguous stage prefixes", async () => {
+    const runId = `resume-tool-ambiguous-stage-${Date.now()}`;
+    store.recordRunStart(makeInflightRun(runId));
+    for (const stageId of ["ambiguous-stage-aaa", "ambiguous-stage-bbb"]) {
+      store.recordStageStart(runId, {
+        id: stageId,
+        name: stageId,
+        status: "failed",
+        parentIds: [],
+        toolEvents: [],
+      });
+      store.recordStageEnd(runId, {
+        id: stageId,
+        name: stageId,
+        status: "failed",
+        parentIds: [],
+        toolEvents: [],
+        error: "boom",
+      });
+    }
+    store.recordRunEnd(runId, "failed", undefined, "boom", { resumable: true, failedStageId: "ambiguous-stage-aaa" });
+    const handler = makeToolHandler();
+
+    const result = await handler({ action: "resume", runId, stageId: "ambiguous-stage" }, {} as never);
+
+    assert.equal(result.action, "resume");
+    const r = result as { action: string; status: string; runId: string; message: string };
+    assert.equal(r.status, "noop");
+    assert.equal(r.runId, runId);
+    assert.match(r.message, /Ambiguous stage identifier/);
+    assert.match(r.message, /ambiguous-stage-aaa/);
+    assert.match(r.message, /ambiguous-stage-bbb/);
   });
 
   test("makeExecuteWorkflowTool resume starts linked continuation for failed resumable workflow", async () => {

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -1007,4 +1007,86 @@ describe("tool run-control actions", () => {
     assert.equal(r.status, "ok");
     assert.equal(r.runId, runId);
   });
+
+  test("makeExecuteWorkflowTool resume starts linked continuation for failed resumable workflow", async () => {
+    const sourceRunId = `resume-tool-source-${Date.now()}`;
+    const def = defineWorkflow("tool-resume-wf")
+      .run(async (ctx) => {
+        const first = await ctx.stage("first").prompt("first");
+        const second = await ctx.stage("second").prompt(`second:${first}`);
+        return { first, second };
+      })
+      .compile();
+
+    store.recordRunStart({
+      id: sourceRunId,
+      name: def.name,
+      inputs: {},
+      status: "running",
+      startedAt: Date.now(),
+      stages: [],
+    });
+    store.recordStageStart(sourceRunId, { id: "old-first", name: "first", status: "completed", parentIds: [], toolEvents: [], result: "first-old" });
+    store.recordStageEnd(sourceRunId, { id: "old-first", name: "first", status: "completed", parentIds: [], toolEvents: [], result: "first-old" });
+    store.recordStageStart(sourceRunId, { id: "old-second", name: "second", status: "failed", parentIds: ["old-first"], toolEvents: [], error: "rate limit" });
+    store.recordStageEnd(sourceRunId, { id: "old-second", name: "second", status: "failed", parentIds: ["old-first"], toolEvents: [], error: "rate limit" });
+    store.recordRunEnd(sourceRunId, "failed", undefined, "rate limit", { resumable: true, failedStageId: "old-second", failureKind: "rate_limit" });
+
+    const calls: string[] = [];
+    const runtime = createExtensionRuntime({
+      registry: createRegistry([def]),
+      store,
+      adapters: { prompt: { prompt: async (text) => { calls.push(text); return "second-new"; } } },
+    });
+    const handler = makeExecuteWorkflowTool(runtime, () => undefined);
+
+    const result = await handler({ action: "resume", runId: sourceRunId }, {} as never);
+
+    assert.equal(result.action, "resume");
+    const r = result as { action: string; status: string; runId: string; message: string };
+    assert.equal(r.status, "running");
+    assert.notEqual(r.runId, sourceRunId);
+    assert.match(r.message, /Resuming failed workflow/);
+    await jobTracker.get(r.runId)?.promise;
+    assert.deepEqual(calls, ["second:first-old"]);
+    const continued = store.runs().find((run) => run.id === r.runId)!;
+    assert.equal(continued.status, "completed");
+    assert.equal(continued.resumedFromRunId, sourceRunId);
+    assert.equal(continued.stages[0]!.replayed, true);
+    assert.equal(store.runs().find((run) => run.id === sourceRunId)!.status, "failed");
+  });
+
+  test("makeExecuteWorkflowTool resume surfaces workflow_not_found for failed resumable run without registry definition", async () => {
+    const runId = `resume-tool-failed-${Date.now()}`;
+    store.recordRunStart(makeInflightRun(runId));
+    store.recordStageStart(runId, {
+      id: "stage-a",
+      name: "stage-a",
+      status: "failed",
+      parentIds: [],
+      toolEvents: [],
+    });
+    store.recordStageEnd(runId, {
+      id: "stage-a",
+      name: "stage-a",
+      status: "failed",
+      parentIds: [],
+      toolEvents: [],
+      error: "boom",
+    });
+    store.recordRunEnd(runId, "failed", undefined, "boom", { resumable: true, failedStageId: "stage-a" });
+
+    const handler = makeToolHandler();
+
+    const result = await handler(
+      { action: "resume", runId },
+      {} as never,
+    );
+
+    assert.equal(result.action, "resume");
+    const r = result as { action: string; status: string; runId: string; message: string };
+    assert.equal(r.status, "noop");
+    assert.equal(r.runId, runId);
+    assert.match(r.message, /workflow_not_found/);
+  });
 });

--- a/test/unit/store-pending-prompt.test.ts
+++ b/test/unit/store-pending-prompt.test.ts
@@ -112,6 +112,16 @@ describe("store.recordPendingPrompt", () => {
 });
 
 describe("store.recordStagePendingPrompt", () => {
+  test("returns false for skipped terminal stages", () => {
+    const s = createStore();
+    s.recordRunStart(makeRun("r1"));
+    s.recordStageStart("r1", { ...makeStage("s1"), status: "skipped", skippedReason: "fail-fast" });
+
+    assert.equal(s.recordStagePendingPrompt("r1", "s1", makePrompt("p1")), false);
+    assert.equal(getRun(s, "r1").stages[0]?.pendingPrompt, undefined);
+    assert.equal(getRun(s, "r1").stages[0]?.status, "skipped");
+  });
+
   test("rejects a stage prompt waiter when that stage ends", async () => {
     const s = createStore();
     s.recordRunStart(makeRun("r1"));

--- a/test/unit/store.test.ts
+++ b/test/unit/store.test.ts
@@ -57,11 +57,13 @@ describe("store stage blocking", () => {
       makeStage("paused", { status: "paused" }),
       makeStage("completed", { status: "completed" }),
       makeStage("failed", { status: "failed" }),
+      makeStage("skipped", { status: "skipped" }),
     ]));
 
     assert.equal(s.recordStageAwaitingInput("r1", "paused", true), false);
     assert.equal(s.recordStageAwaitingInput("r1", "completed", true), false);
     assert.equal(s.recordStageAwaitingInput("r1", "failed", true), false);
+    assert.equal(s.recordStageAwaitingInput("r1", "skipped", true), false);
   });
 
   test("transitions pending → blocked → pending and snapshots only include blockedByStageId while set", () => {
@@ -79,13 +81,15 @@ describe("store stage blocking", () => {
     assert.equal("blockedByStageId" in stage, false);
   });
 
-  test("blocked stage cannot be paused again", () => {
+  test("blocked and skipped stages cannot be paused", () => {
     const s = createStore();
-    s.recordRunStart(makeRun("r1", [makeStage("a")]));
+    s.recordRunStart(makeRun("r1", [makeStage("a"), makeStage("skipped", { status: "skipped" })]));
 
     assert.equal(s.recordStageBlocked("r1", "a", "root"), true);
     assert.equal(s.recordStagePaused("r1", "a"), false);
+    assert.equal(s.recordStagePaused("r1", "skipped"), false);
     assert.equal(s.snapshot().runs[0]!.stages[0]!.status, "blocked");
+    assert.equal(s.snapshot().runs[0]!.stages[1]!.status, "skipped");
   });
 
   test("refuses terminal and paused stage blocked transitions", () => {
@@ -93,11 +97,13 @@ describe("store stage blocking", () => {
     s.recordRunStart(makeRun("r1", [
       makeStage("completed", { status: "completed" }),
       makeStage("failed", { status: "failed" }),
+      makeStage("skipped", { status: "skipped" }),
       makeStage("paused", { status: "paused" }),
     ]));
 
     assert.equal(s.recordStageBlocked("r1", "completed", "root"), false);
     assert.equal(s.recordStageBlocked("r1", "failed", "root"), false);
+    assert.equal(s.recordStageBlocked("r1", "skipped", "root"), false);
     assert.equal(s.recordStageBlocked("r1", "paused", "root"), false);
   });
 

--- a/test/unit/workflow-failures.test.ts
+++ b/test/unit/workflow-failures.test.ts
@@ -41,6 +41,51 @@ describe("classifyWorkflowFailure", () => {
     assert.equal(failure.resumable, true);
   });
 
+  test("uses structured HTTP statuses before message fallback", () => {
+    const auth = classifyWorkflowFailure({ message: "request failed", status: 401 });
+    assert.equal(auth.kind, "auth");
+    assert.equal(auth.userMessage, WORKFLOW_AUTH_FAILURE_MESSAGE);
+
+    const rateLimit = classifyWorkflowFailure({ message: "request failed", statusCode: 429 });
+    assert.equal(rateLimit.kind, "rate_limit");
+    assert.equal(rateLimit.retryable, true);
+
+    const provider = classifyWorkflowFailure({ message: "request failed", status: 503 });
+    assert.equal(provider.kind, "provider");
+    assert.equal(provider.retryable, true);
+  });
+
+  test("uses structured codes and causes before message fallback", () => {
+    const auth = classifyWorkflowFailure({ message: "provider error", code: "AUTH_REQUIRED" });
+    assert.equal(auth.kind, "auth");
+
+    const rateLimit = classifyWorkflowFailure(new Error("outer failure", {
+      cause: { message: "inner failure", code: "rate_limit_exceeded" },
+    }));
+    assert.equal(rateLimit.kind, "rate_limit");
+
+    const cancelled = classifyWorkflowFailure({ message: "stopped", code: "AbortError" });
+    assert.equal(cancelled.kind, "cancelled");
+  });
+
+  test("uses SDK assistant error shapes", () => {
+    const failure = classifyWorkflowFailure({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "provider request failed",
+      diagnostics: [{ error: { code: 429, message: "quota exceeded" } }],
+    });
+    assert.equal(failure.kind, "rate_limit");
+    assert.equal(failure.message, "provider request failed");
+
+    const cancelled = classifyWorkflowFailure({
+      role: "assistant",
+      stopReason: "aborted",
+      errorMessage: "stream aborted",
+    });
+    assert.equal(cancelled.kind, "cancelled");
+  });
+
   test("does not treat log information/input errors as auth failures", () => {
     for (const message of [
       "failed to log information about request",
@@ -70,10 +115,12 @@ describe("classifyWorkflowFailure", () => {
     }
   });
 
-  test("still treats unavailable model errors as provider outages", () => {
-    const failure = classifyWorkflowFailure(new Error("model unavailable"));
-    assert.equal(failure.kind, "provider");
-    assert.equal(failure.retryable, true);
+  test("still treats unavailable or missing model errors as provider outages", () => {
+    for (const message of ["model unavailable", "model not found"]) {
+      const failure = classifyWorkflowFailure(new Error(message));
+      assert.equal(failure.kind, "provider");
+      assert.equal(failure.retryable, true);
+    }
   });
 
   test("does not treat generic OAuth metadata errors as auth failures", () => {

--- a/test/unit/workflow-failures.test.ts
+++ b/test/unit/workflow-failures.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for workflow-local failure classification.
+ */
+
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+  WORKFLOW_AUTH_FAILURE_MESSAGE,
+  classifyWorkflowFailure,
+} from "../../packages/workflows/src/shared/workflow-failures.js";
+
+describe("classifyWorkflowFailure", () => {
+  test("normalizes auth/no-key failures to workflow login guidance", () => {
+    const failure = classifyWorkflowFailure(new Error("No API key found for provider"));
+    assert.equal(failure.kind, "auth");
+    assert.equal(failure.userMessage, WORKFLOW_AUTH_FAILURE_MESSAGE);
+    assert.equal(failure.message, "No API key found for provider");
+    assert.equal(failure.retryable, true);
+    assert.equal(failure.resumable, true);
+  });
+
+  test("classifies 429/quota failures as resumable rate limits", () => {
+    const failure = classifyWorkflowFailure(new Error("HTTP 429 quota exceeded"));
+    assert.equal(failure.kind, "rate_limit");
+    assert.equal(failure.userMessage, "HTTP 429 quota exceeded");
+    assert.equal(failure.retryable, true);
+    assert.equal(failure.resumable, true);
+  });
+
+  test("classifies abort errors as non-resumable cancellation", () => {
+    const failure = classifyWorkflowFailure(new DOMException("workflow killed", "AbortError"));
+    assert.equal(failure.kind, "cancelled");
+    assert.equal(failure.retryable, false);
+    assert.equal(failure.resumable, false);
+  });
+
+  test("classifies provider/model outages separately from auth", () => {
+    const failure = classifyWorkflowFailure(new Error("model provider service unavailable"));
+    assert.equal(failure.kind, "provider");
+    assert.equal(failure.retryable, true);
+    assert.equal(failure.resumable, true);
+  });
+});

--- a/test/unit/workflow-failures.test.ts
+++ b/test/unit/workflow-failures.test.ts
@@ -40,4 +40,51 @@ describe("classifyWorkflowFailure", () => {
     assert.equal(failure.retryable, true);
     assert.equal(failure.resumable, true);
   });
+
+  test("does not treat log information/input errors as auth failures", () => {
+    for (const message of [
+      "failed to log information about request",
+      "failed to log input before validation",
+    ]) {
+      const failure = classifyWorkflowFailure(new Error(message));
+      assert.equal(failure.kind, "unknown");
+      assert.equal(failure.userMessage, message);
+      assert.equal(failure.retryable, false);
+    }
+  });
+
+  test("still treats bounded log in guidance as auth failure", () => {
+    const failure = classifyWorkflowFailure(new Error("Please log in to continue"));
+    assert.equal(failure.kind, "auth");
+    assert.equal(failure.userMessage, WORKFLOW_AUTH_FAILURE_MESSAGE);
+  });
+
+  test("does not treat generic domain/tool model errors as provider outages", () => {
+    for (const message of [
+      "domain model validation failed",
+      "invalid model parameter passed to tool",
+    ]) {
+      const failure = classifyWorkflowFailure(new Error(message));
+      assert.equal(failure.kind, "unknown");
+      assert.equal(failure.retryable, false);
+    }
+  });
+
+  test("still treats unavailable model errors as provider outages", () => {
+    const failure = classifyWorkflowFailure(new Error("model unavailable"));
+    assert.equal(failure.kind, "provider");
+    assert.equal(failure.retryable, true);
+  });
+
+  test("does not treat generic OAuth metadata errors as auth failures", () => {
+    const failure = classifyWorkflowFailure(new Error("OAuth callback metadata parse failed"));
+    assert.equal(failure.kind, "unknown");
+    assert.equal(failure.userMessage, "OAuth callback metadata parse failed");
+  });
+
+  test("still treats OAuth token errors as auth failures", () => {
+    const failure = classifyWorkflowFailure(new Error("OAuth token expired"));
+    assert.equal(failure.kind, "auth");
+    assert.equal(failure.userMessage, WORKFLOW_AUTH_FAILURE_MESSAGE);
+  });
 });


### PR DESCRIPTION
## Summary

Adds resumable workflow execution to \`@bastani/workflows\`. When a run fails, it can be continued by replaying all previously completed stages in-memory (no provider re-invocation) and retrying from the exact point of failure. The \`executeWorkflow\` tool and \`/resume\` slash command automatically detect failed-resumable runs and route to the new continuation path.

## Key Changes

### Failure classification — \`workflow-failures.ts\` (new)
- \`classifyWorkflowFailure()\` maps arbitrary errors to typed \`WorkflowFailure\` objects with \`kind\` (\`auth\` | \`rate_limit\` | \`provider\` | \`cancelled\` | \`unknown\`), sanitized \`userMessage\`, and \`retryable\`/\`resumable\` flags
- Auth errors surface a consistent login prompt; cancellations are marked non-resumable; all others default to resumable
- \`isWorkflowFailureKind()\` type guard for safe narrowing from persisted strings

### Type extensions — \`store-types.ts\`
- Added \`skipped\` to \`StageStatus\` for parallel fail-fast siblings
- Extended \`StageSnapshot\` with \`failureKind\`, \`failureMessage\`, \`skippedReason\`, \`replayedFromStageId\`, and \`replayed\`
- Extended \`RunSnapshot\` with \`failureKind\`, \`failureMessage\`, \`failedStageId\`, \`resumable\`, \`resumedFromRunId\`, and \`resumeFromStageId\`
- New \`WorkflowFailureKind\` union type

### Executor continuation — \`executor.ts\`
- \`RunContinuationOpts\` + continuation replay: replays previously completed stages in-memory (no provider re-invocation); real execution resumes at the failed stage
- Parallel fail-fast: on first parallel failure, still-active sibling stages are synchronously marked \`skipped\` (reason: \`fail-fast\`) and aborted using \`Promise.race\` with an eager reject signal, instead of being left in an indeterminate state
- \`runFailureMetadata()\` — extracts and classifies structured failure info from stage snapshots, written to the run-end persistence entry
- \`appendStageStartOnce\` guard — prevents duplicate \`stage.start\` persistence entries for replayed stages

### Persistence & restore — \`persistence-restore.ts\`, \`persistence-session-entries.ts\`
- \`restoreEndedFailedRuns()\` — on session start, previously completed failed runs are restored into the store (not just in-flight runs), enabling the continuation flow to locate source snapshots across sessions
- \`findRunStartMetadata()\` — reads continuation linkage fields (\`resumedFromRunId\`, \`resumeFromStageId\`) from persisted \`workflow.run.start\` entries
- Stage restore correctly handles \`skipped\` status and persists \`failureKind\`, \`failureMessage\`, \`skippedReason\`, and replay metadata

### Stage target resolution — \`index.ts\`
- \`resolveStageTarget()\` replaces ad-hoc inline lookups with an exact-ID-first strategy: exact ID → unique name match → prefix match, with explicit ambiguity errors when multiple stages match a given identifier

### Extension runtime — \`runtime.ts\`, \`index.ts\`
- \`resumeFailedRun(sourceRunId, stageId?)\` — resolves the failed stage, reuses source run inputs, and launches a detached continuation run linked back via \`resumedFromRunId\`/\`resumeFromStageId\`
- \`executeWorkflow\` tool and \`/resume\` slash command detect \`failed + resumable\` runs and automatically route to \`resumeFailedRun()\` instead of the standard HIL resume path
- \`ResumeFailedRunResult\` discriminated union for typed caller error handling

### TUI — \`chat-surface.ts\`, \`graph-view.ts\`, \`header.ts\`, \`node-card.ts\`, \`status-helpers.ts\`, \`status-list.ts\`
- \`skipped\` stage status rendered across all TUI and status surfaces

### Tests
- 8 new test files covering: \`workflow-failures\`, \`executor\` (resume/replay/continuation flows), \`persistence-restore\`, \`persistence-session-entries\`, \`slash-dispatch\`, \`background-status\`, \`node-card\`, and \`store\` — 700+ lines of new coverage

Refs #990