### PR TITLE
docs(readme): expand tagline with control plane description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center"><img width="800" height="450" alt="atomic-promo" src="./assets/atomic-promo.gif" /></p>
 
 <p align="center">
-  <b>Atomic is the workflow layer for coding agents.</b><br>
+  <b>Atomic is the workflow layer for coding agents, giving developers a programmable control plane for complex engineering work.</b><br>
   The model-backed agent session does the work. Atomic makes sure it follows the process.
 </p>
 


### PR DESCRIPTION
## Summary

- Expands the README hero tagline to clarify Atomic's value proposition: *"giving developers a programmable control plane for complex engineering work."*
- Adds missing newline at end of file.