### PR TITLE
chore(release): promote v0.8.14-0 prerelease to stable v0.8.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.14-0",
+      "version": "0.8.14",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.14-0",
+      "version": "0.8.14",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.14-0",
+      "version": "0.8.14",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.14-0",
+      "version": "0.8.14",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.14-0",
+      "version": "0.8.14",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.14-0",
+      "version": "0.8.14",
       "dependencies": {
         "jiti": "^2.7.0",
       },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.8.14] - 2026-05-25
+
+### Changed
+
+- Promoted the 0.8.14 prerelease changes to a stable release.
+- Synced Atomic's coding-agent fork with upstream Pi patches since v0.75.4 and updated bundled Pi libraries to 0.75.5.
+
+### Fixed
+
+- Carried forward upstream fixes for managed extension installs, git package ref reconciliation, async file tools, export HTML escaping, OpenCode session headers, OAuth device-code login, footer path abbreviation, clipboard native loading, and collapsed read output rendering.
+- Refreshed the built-in header model label whenever the active model changes, matching the footer below the chat box.
+
 ## [0.8.14-0] - 2026-05-25
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.14-0",
+  "version": "0.8.14",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.14-0",
+  "version": "0.8.14",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.14-0",
+  "version": "0.8.14",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.14-0",
+  "version": "0.8.14",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.14-0",
+  "version": "0.8.14",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.14-0",
+  "version": "0.8.14",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [

--- a/test/unit/overlay-graph.test.ts
+++ b/test/unit/overlay-graph.test.ts
@@ -1065,30 +1065,33 @@ describe("GraphView animation timer", () => {
     // locks at the peak colour by design (see `pickBorder`), so we
     // need at least two nodes — focus stays on the first and the
     // second carries the animation we observe.
-    const startedAt = Date.now() - 100;
-    const stages: StageSnapshot[] = [
-      { ...makeStage("A"), status: "running" as const, startedAt },
-      { ...makeStage("B", ["A"]), status: "running" as const, startedAt },
-    ];
-    const snap = makeSnap(stages);
-    const store = makeStore(snap);
-    const view = new GraphView({
-      mode: "overlay",
-      runId: "run-1",
-      store,
-      graphTheme: defaultTheme,
-    });
-    const frameA = view.render(96).join("\n");
-    // Wait long enough to land at a clearly different point in the
-    // 2s pulse cycle (~25% of period). The sine eased lerp inside
-    // `pickBorder` produces a visibly different RGB triple.
-    const sleepUntil = Date.now() + 500;
-    while (Date.now() < sleepUntil) {
-      // busy-wait to advance Date.now() without yielding the event
-      // loop; we want a synchronous render with a newer timestamp.
+    const originalNow = Date.now;
+    let view: GraphView | undefined;
+    try {
+      Date.now = () => 4_000;
+      const startedAt = 0;
+      const stages: StageSnapshot[] = [
+        { ...makeStage("A"), status: "running" as const, startedAt },
+        { ...makeStage("B", ["A"]), status: "running" as const, startedAt },
+      ];
+      const snap = makeSnap(stages);
+      const store = makeStore(snap);
+      view = new GraphView({
+        mode: "overlay",
+        runId: "run-1",
+        store,
+        graphTheme: defaultTheme,
+      });
+      const frameA = view.render(96).join("\n");
+      // Advance to a deterministic point in the 2s pulse cycle (~25%
+      // of period) without crossing a duration-formatting boundary,
+      // so the frame delta specifically covers the border pulse.
+      Date.now = () => 4_500;
+      const frameB = view.render(96).join("\n");
+      assert.notEqual(frameA, frameB, "pulse phase must change between renders");
+    } finally {
+      view?.dispose();
+      Date.now = originalNow;
     }
-    const frameB = view.render(96).join("\n");
-    view.dispose();
-    assert.notEqual(frameA, frameB, "pulse phase must change between renders");
   });
 });


### PR DESCRIPTION
## Summary

Promotes the v0.8.14-0 prerelease to a stable v0.8.14 release across all workspace packages. Also includes a deterministic fix for the graph pulse timing test.

## Changes

- **Version bump**: Promoted all workspace package manifests from `0.8.14-0` → `0.8.14`:
  - `@bastani/atomic` (`packages/coding-agent`)
  - `@bastani/intercom` (`packages/intercom`)
  - `@bastani/mcp` (`packages/mcp`)
  - `@bastani/subagents` (`packages/subagents`)
  - `@bastani/web-access` (`packages/web-access`)
  - `@bastani/workflows` (`packages/workflows`)
- **CHANGELOG**: Added `[0.8.14] - 2026-05-25` release section to `packages/coding-agent/CHANGELOG.md` documenting upstream Pi patches and bug fixes carried into this stable release.
- **Lock file**: Updated `bun.lock` workspace version metadata to reflect stable versions.
- **Tests**: Stabilized `overlay-graph` pulse timing test by mocking `Date.now` deterministically instead of busy-waiting, eliminating flakiness from real-time clock drift.

## What's in this release (from prerelease)

### Changed
- Synced Atomic's coding-agent fork with upstream Pi patches since v0.75.4; bundled Pi libraries updated to 0.75.5.

### Fixed
- Upstream fixes for managed extension installs, git package ref reconciliation, async file tools, export HTML escaping, OpenCode session headers, OAuth device-code login, footer path abbreviation, clipboard native loading, and collapsed read output rendering.
- Header model label now refreshes whenever the active model changes, matching the footer behavior below the chat box.

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run lint`
- `bun run test:unit`