### PR TITLE
feat(workflows): add language-agnostic project init preflight to Ralph

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Updated Ralph's orchestrator prompt to discover project initialization needs from repository evidence before implementation work proceeds ([#1048](https://github.com/flora131/atomic/issues/1048)).
 - Added a final Ralph PR-preparation phase that reviews changes against the configured base branch, tries available GitHub credentials using local git identity as a hint, posts implementation notes as a PR comment, and creates a pull request when possible.
 - Updated Ralph to persist planner RFCs under `specs/`, keep OS-temp implementation notes during orchestration, and pass file paths rather than the full plan text to later stages ([#1037](https://github.com/flora131/atomic/issues/1037)).
 - Updated `deep-research-codebase` output layout to write public reports under `research/` and hidden per-run handoff artifacts under `research/.deep-research-<run-id>/`.

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -615,6 +615,20 @@ export default defineWorkflow("ralph")
             ].join("\n"),
           ],
           [
+            "project_initialization_preflight",
+            [
+              "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
+              "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
+              "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
+              "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
+              "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
+              "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
+              "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
+              "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
+              "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
+            ].join("\n"),
+          ],
+          [
             "delegation_policy",
             [
               "You are not the implementer. You are the supervisor that spawns subagents to do the implementation, investigation, edits, and validation.",
@@ -650,6 +664,7 @@ export default defineWorkflow("ralph")
             "instructions",
             [
               `Start by reading the spec file at ${specPath}.`,
+              "Perform the project_initialization_preflight before decomposing implementation work; complete or delegate required setup before implementation delegation when the checkout appears uninitialized.",
               "Decompose the work into delegated subagent tasks based on that spec file.",
               "Pass each subagent the relevant task, constraints, files, validation expectations, any prior review findings from the spec, and instructions to report implementation-note-worthy decisions or tradeoffs.",
               "Coordinate subagent results into the smallest coherent set of changes that satisfies the spec.",

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -631,6 +631,38 @@ describe("ralph", () => {
     assert.doesNotMatch(reviewerPrompt, /echo pwn/);
   });
 
+  test("prompts orchestrator to discover project initialization generically", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const ctx = makeMockCtx(
+      { prompt: "Refactor tests", max_loops: 1 },
+      {
+        task: (name) => {
+          if (name.startsWith("reviewer-")) return approvedReviewJson();
+          return undefined;
+        },
+      },
+    );
+
+    const result = await d.run(ctx);
+
+    const orchestratorPrompt = ctx.calls.prompts["orchestrator-1"]?.[0] ?? "";
+    assert.equal(ctx.calls.task.includes("project-setup-1"), false);
+    assert.match(orchestratorPrompt, /project_initialization_preflight/);
+    assert.match(orchestratorPrompt, /actual language, framework, and build system/);
+    assert.match(orchestratorPrompt, /Do not rely on hard-coded assumptions/);
+    assert.match(orchestratorPrompt, /Infer the project type and setup requirements from repository evidence/);
+    assert.match(orchestratorPrompt, /source layout, setup docs, package\/build manifests/);
+    assert.match(orchestratorPrompt, /dependencies, generated files, local toolchains, submodules/);
+    assert.match(orchestratorPrompt, /When repository evidence shows missing initialization/);
+    assert.match(orchestratorPrompt, /run or delegate the appropriate documented setup command/);
+    assert.match(orchestratorPrompt, /You are responsible for initializing the checkout/);
+    assert.match(orchestratorPrompt, /not user handoff work/);
+    assert.match(orchestratorPrompt, /delegate a focused discovery task before implementation instead of guessing/);
+    assert.match(orchestratorPrompt, /complete or delegate required setup before implementation delegation/);
+    assert.equal("project_readiness" in result, false);
+  });
+
   test("writes planner spec to specs and passes only the path to orchestrator", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;


### PR DESCRIPTION
## Summary

Adds a `project_initialization_preflight` context section to Ralph's orchestrator prompt so that project setup needs are inferred autonomously from repository evidence before implementation delegation begins — with no hard-coded ecosystem assumptions.

Closes #1048

## Key Changes

- **`packages/workflows/builtin/ralph.ts`** — new `project_initialization_preflight` orchestrator context block that instructs the orchestrator to infer project type and setup requirements from repository evidence (source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, and task definitions) instead of assuming any specific ecosystem (JS/TS, Python, Rust, Go, Java, etc.)
- **Preflight-first ordering** — a new `instructions` directive tells the orchestrator to complete or delegate required setup before decomposing implementation work, preventing failures caused by uninitialized checkouts
- **Autonomous responsibility** — the orchestrator owns running or delegating safe, documented setup commands; missing dependencies, generated files, or local toolchains are treated as setup work, not user handoff work
- **Graceful fallback** — if setup requirements cannot be confidently determined, the orchestrator delegates a focused discovery task; if setup remains blocked, it reports the exact blocker with commands tried and evidence needed to continue
- **`test/unit/builtin-workflows.test.ts`** — unit test verifying that the generic preflight prompt strings appear in the orchestrator context and that no deterministic `project-setup` task or `project_readiness` stage is emitted
- **`packages/workflows/CHANGELOG.md`** — entry added under `[Unreleased] → Changed`

## Validation

```sh
AGENT=1 bun test test/unit/builtin-workflows.test.ts
AGENT=1 bun run typecheck
AGENT=1 bun run test:unit
AGENT=1 bun run test:integration
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)