### PR TITLE
fix(workflows): return to graph after prompt responses

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Returned the workflow overlay to the graph orchestrator after answering or skipping a `ctx.ui` prompt node, and preserved the prompt's question footprint for read-only prompt-node views.
 - Removed biasing stage-output and iteration-count context from Ralph reviewer prompts while making the comparison base branch explicit ([#1037](https://github.com/flora131/atomic/issues/1037)).
 - Ordered snapshot transcript fallback entries chronologically before applying `tail`/`limit`, preserving terminal result/error entries after tools for missing or tied timestamps ([#1023](https://github.com/flora131/atomic/issues/1023)).
 - Reloaded workflow resources directly for `workflow({ action: "reload" })` instead of queuing a literal `/workflow reload` follow-up ([#1023](https://github.com/flora131/atomic/issues/1023)).

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -1678,6 +1678,7 @@ export async function run<TInputs extends Record<string, unknown>>(
         status: shouldReplay ? "completed" : "running",
         parentIds: Object.freeze(parentIds),
         startedAt: prompt.createdAt,
+        promptFootprint: { ...prompt },
         toolEvents: [],
         attachable: !shouldReplay,
         ...(shouldReplay ? {

--- a/packages/workflows/src/shared/store-types.ts
+++ b/packages/workflows/src/shared/store-types.ts
@@ -84,6 +84,8 @@ export interface StageSnapshot {
   replayKey?: string;
   /** Snapshot-safe prompt answer availability marker; never contains the raw answer. */
   promptAnswerState?: "available" | "unavailable" | "ambiguous";
+  /** Snapshot-safe descriptor of the prompt UI shown by this stage; never contains the raw answer. */
+  promptFootprint?: PendingPrompt;
   /** Source stage id when this stage was replayed during failed-run continuation. */
   replayedFromStageId?: string;
   /** True when provider work was skipped by continuation replay. */

--- a/packages/workflows/src/shared/store.ts
+++ b/packages/workflows/src/shared/store.ts
@@ -524,6 +524,7 @@ export function createStore(): Store {
       if (isTerminalStageStatus(stage.status)) return false;
       if (stage.pendingPrompt !== undefined) return false;
       stage.pendingPrompt = { ...prompt };
+      stage.promptFootprint = { ...prompt };
       stage.status = "awaiting_input";
       stage.awaitingInputSince = prompt.createdAt;
       _version++;

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -498,6 +498,7 @@ export class StageChatView implements Component, Focusable {
     // the least surprising recovery path.
     this.store.resolveStagePendingPrompt(this.runId, this.stageId, prompt.id, response);
     this.requestRender?.();
+    this.onDetach();
   }
 
   // -------------------------------------------------------------------------
@@ -686,6 +687,10 @@ export class StageChatView implements Component, Focusable {
     budget: number,
     stage: StageSnapshot | undefined,
   ): string[] {
+    if (stage?.promptFootprint) {
+      return this._renderReadOnlyPromptArchiveBody(width, budget, stage);
+    }
+
     const t = this.theme;
     const calloutRows = 6;
     const transcriptBudget = Math.max(1, budget - calloutRows);
@@ -723,6 +728,78 @@ export class StageChatView implements Component, Focusable {
     while (lines.length < budget) lines.push(this._blank(width));
     if (lines.length > budget) lines.length = budget;
     return lines;
+  }
+
+  private _renderReadOnlyPromptArchiveBody(
+    width: number,
+    budget: number,
+    stage: StageSnapshot,
+  ): string[] {
+    const t = this.theme;
+    const prompt = stage.promptFootprint;
+    if (!prompt) return this._fitBodyLines([], width, budget);
+
+    const innerWidth = Math.max(2, width - 2);
+    const bodyLines: string[] = [];
+    const messageBox = new Box(2, 1);
+    messageBox.addChild(new Text(paint(prompt.message, t.text), 0, 0));
+    bodyLines.push(...messageBox.render(innerWidth));
+    bodyLines.push(...new Text(paint("prompt type", t.textMuted, { bold: true }) + paint(`  ${prompt.kind}`, t.text), 2, 0).render(innerWidth));
+
+    if (prompt.kind === "select" && prompt.choices && prompt.choices.length > 0) {
+      bodyLines.push(...new Text(paint("choices", t.textMuted, { bold: true }), 2, 0).render(innerWidth));
+      for (const choice of prompt.choices) {
+        bodyLines.push(...new Text(paint("• ", t.dim) + paint(choice, t.text), 4, 0).render(innerWidth));
+      }
+    } else if (prompt.kind === "confirm") {
+      bodyLines.push(...new Text(paint("choices", t.textMuted, { bold: true }) + paint("  yes / no", t.text), 2, 0).render(innerWidth));
+    }
+
+    if ((prompt.kind === "input" || prompt.kind === "editor") && prompt.initial && prompt.initial.length > 0) {
+      bodyLines.push(...new Text(paint("initial value shown", t.textMuted, { bold: true }), 2, 0).render(innerWidth));
+      bodyLines.push(...new Text(paint(prompt.initial, t.dim), 4, 0).render(innerWidth));
+    }
+
+    const answer = this._readOnlyPromptAnswer(stage, prompt);
+    bodyLines.push("");
+    bodyLines.push(...new Text(paint("your response", t.textMuted, { bold: true }), 2, 0).render(innerWidth));
+    bodyLines.push(...new Text(paint(answer, answer.startsWith("(") ? t.dim : t.text), 4, 0).render(innerWidth));
+    bodyLines.push(...new Text(
+      paint("esc", t.accent, { bold: true }) +
+        paint(" close", t.textMuted) +
+        paint("  ·  ", t.dim) +
+        paint("ctrl+d", t.accent, { bold: true }) +
+        paint(" return to graph", t.textMuted),
+      2,
+      0,
+    ).render(innerWidth));
+
+    const title = stage.status === "skipped" ? "QUESTION SKIPPED" : "QUESTION ASKED";
+    const cardLines = renderRoundedBoxLines({
+      title,
+      bodyLines,
+      width,
+      theme: t,
+      accent: t.border,
+    });
+    return this._fitPromptBodyLines(cardLines, width, budget);
+  }
+
+  private _readOnlyPromptAnswer(stage: StageSnapshot, prompt: PendingPrompt): string {
+    const answer = this.store.getStagePromptAnswer(this.runId, stage.id);
+    if (answer && answer.promptId === prompt.id) {
+      return formatReadOnlyPromptAnswer(answer.value, prompt.kind);
+    }
+    switch (stage.promptAnswerState) {
+      case "ambiguous":
+        return "(response replay is ambiguous)";
+      case "unavailable":
+        return "(response unavailable)";
+      case "available":
+        return "(response no longer in live memory)";
+      default:
+        return "(no response saved)";
+    }
   }
 
   private _renderBlockedBody(
@@ -1151,6 +1228,18 @@ interface TranscriptDebugEntry {
   readonly toolCallId: string;
   readonly state: string;
   readonly output: string;
+}
+
+function formatReadOnlyPromptAnswer(value: unknown, kind: PendingPrompt["kind"]): string {
+  if (kind === "confirm") return value === true ? "yes" : "no";
+  if (typeof value === "string") return value.length > 0 ? value : "(empty response)";
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return String(value);
+  try {
+    const encoded = JSON.stringify(value);
+    return encoded ?? String(value);
+  } catch {
+    return String(value);
+  }
 }
 
 function transcriptDebugEntries(entry: TranscriptEntry): TranscriptDebugEntry[] {

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -848,6 +848,8 @@ describe("executor.run", () => {
     assert.equal(replayedPrompt.replayed, true);
     assert.equal(replayedPrompt.replayedFromStageId, sourcePrompt.id);
     assert.equal(replayedPrompt.promptAnswerState, "available");
+    assert.equal(replayedPrompt.promptFootprint?.kind, "confirm");
+    assert.equal(replayedPrompt.promptFootprint?.message, "continue?");
     assert.equal(replayedPrompt.result, undefined);
     assert.deepEqual(continuedAfter.parentIds, [replayedPrompt.id]);
   });

--- a/test/unit/stage-chat-view.test.ts
+++ b/test/unit/stage-chat-view.test.ts
@@ -321,6 +321,84 @@ describe("StageChatView", () => {
     view.dispose();
   });
 
+  test("read-only completed prompt node keeps the question and response visible", () => {
+    const store = createStore();
+    setupRun(store, "run-1", "stage-a");
+    const prompt = makePendingPrompt({
+      kind: "input",
+      message: "What should we call this release?",
+    });
+    assert.equal(store.recordStagePendingPrompt("run-1", "stage-a", prompt), true);
+    assert.equal(store.resolveStagePendingPrompt("run-1", "stage-a", prompt.id, "Nebula"), true);
+    const resolvedStage = store.runs()[0]!.stages[0]!;
+    store.recordStageEnd("run-1", {
+      ...resolvedStage,
+      status: "completed",
+      endedAt: Date.now(),
+      durationMs: 1,
+    });
+
+    const view = new StageChatView({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageId: "stage-a",
+      workflowName: "test-wf",
+      handle: undefined,
+      onDetach: () => {},
+      onClose: () => {},
+    });
+
+    const visible = stripAnsi(view.render(80).join("\n"));
+    assert.match(visible, /QUESTION ASKED/);
+    assert.match(visible, /What should we call this release\?/);
+    assert.match(visible, /prompt type\s+input/);
+    assert.match(visible, /your response/);
+    assert.match(visible, /Nebula/);
+    assert.doesNotMatch(visible, /READ-ONLY SESSION/);
+    assert.equal(JSON.stringify(store.snapshot()).includes("Nebula"), false);
+    view.dispose();
+  });
+
+  test("read-only select prompt node shows choices and selected response", () => {
+    const store = createStore();
+    setupRun(store, "run-1", "stage-a");
+    const prompt = makePendingPrompt({
+      kind: "select",
+      message: "Which path should we take?",
+      choices: ["alpha", "beta"],
+    });
+    assert.equal(store.recordStagePendingPrompt("run-1", "stage-a", prompt), true);
+    assert.equal(store.resolveStagePendingPrompt("run-1", "stage-a", prompt.id, "beta"), true);
+    const resolvedStage = store.runs()[0]!.stages[0]!;
+    store.recordStageEnd("run-1", {
+      ...resolvedStage,
+      status: "completed",
+      endedAt: Date.now(),
+      durationMs: 1,
+    });
+
+    const view = new StageChatView({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageId: "stage-a",
+      workflowName: "test-wf",
+      handle: undefined,
+      onDetach: () => {},
+      onClose: () => {},
+    });
+
+    const visible = stripAnsi(view.render(80).join("\n"));
+    assert.match(visible, /QUESTION ASKED/);
+    assert.match(visible, /Which path should we take\?/);
+    assert.match(visible, /prompt type\s+select/);
+    assert.match(visible, /alpha/);
+    assert.match(visible, /beta/);
+    assert.match(visible, /your response/);
+    view.dispose();
+  });
+
   test("lets the host prompt editor handle page keys", () => {
     const store = createStore();
     setupRun(store, "run-1", "stage-a");

--- a/test/unit/store-pending-prompt.test.ts
+++ b/test/unit/store-pending-prompt.test.ts
@@ -162,7 +162,11 @@ describe("store.recordStagePendingPrompt", () => {
     assert.equal(answer?.value, "super-secret-value");
     assert.equal(answer?.kind, "input");
     assert.equal(JSON.stringify(s.snapshot()).includes("super-secret-value"), false);
-    assert.equal(getRun(s, "r1").stages[0]?.promptAnswerState, "available");
+    const stage = getRun(s, "r1").stages[0];
+    assert.equal(stage?.promptAnswerState, "available");
+    assert.equal(stage?.promptFootprint?.id, "p1");
+    assert.equal(stage?.promptFootprint?.message, "Secret?");
+    assert.equal(stage?.pendingPrompt, undefined);
 
     assert.equal(s.removeRun("r1"), true);
     assert.equal(s.getStagePromptAnswer("r1", "s1"), undefined);

--- a/test/unit/workflow-attach-pane.test.ts
+++ b/test/unit/workflow-attach-pane.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { Key } from "@earendil-works/pi-tui";
+import { Key, type EditorComponent, type TUI } from "@earendil-works/pi-tui";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import {
   WorkflowAttachPane,
@@ -24,6 +24,7 @@ import {
 import { deriveGraphTheme } from "../../packages/workflows/src/tui/graph-theme.js";
 import { createStageControlRegistry } from "../../packages/workflows/src/runs/foreground/stage-control-registry.js";
 import type { StageControlHandle } from "../../packages/workflows/src/runs/foreground/stage-control-registry.js";
+import type { PendingPrompt } from "../../packages/workflows/src/shared/store-types.js";
 import type { AgentSession } from "@bastani/atomic";
 
 function setupRun(store: ReturnType<typeof createStore>, runId: string, stages: Array<{ id: string; name: string; status?: "pending" | "running" | "paused" | "completed" }>) {
@@ -43,6 +44,46 @@ function setupRun(store: ReturnType<typeof createStore>, runId: string, stages: 
       parentIds: [],
       toolEvents: [],
     });
+  }
+}
+
+function makePendingPrompt(overrides: Partial<PendingPrompt> = {}): PendingPrompt {
+  return {
+    id: "prompt-1",
+    kind: "input",
+    message: "What should the workflow use?",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+class FakePromptEditor implements EditorComponent {
+  text = "";
+  focused = false;
+  onSubmit?: (text: string) => void;
+  onChange?: (text: string) => void;
+
+  render(): string[] {
+    return [`fake-prompt-editor:${this.text}`];
+  }
+
+  handleInput(data: string): void {
+    if (data === Key.enter || data === "\r" || data === "\n") {
+      this.onSubmit?.(this.text);
+      return;
+    }
+    this.text += data;
+    this.onChange?.(this.text);
+  }
+
+  invalidate(): void {}
+
+  getText(): string {
+    return this.text;
+  }
+
+  setText(text: string): void {
+    this.text = text;
   }
 }
 
@@ -127,6 +168,98 @@ describe("WorkflowAttachPane", () => {
     assert.equal(pane._mode, "stage-chat");
     assert.equal(pane._lastAttachedStageId, "stage-b");
     assert.equal(pane._hasChatView, true);
+    pane.dispose();
+  });
+
+  test("answering a stage prompt returns to the graph", async () => {
+    const store = createStore();
+    setupRun(store, "run-1", [{ id: "stage-a", name: "A" }]);
+    const registry = createStageControlRegistry();
+    registry.register(makeHandle("run-1", "stage-a"));
+    const prompt = makePendingPrompt();
+    assert.equal(store.recordStagePendingPrompt("run-1", "stage-a", prompt), true);
+    const pending = store.awaitStagePendingPrompt("run-1", "stage-a", prompt.id);
+    const pane = new WorkflowAttachPane({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageControlRegistry: registry,
+      onClose: () => {},
+      initialAttachStageId: "stage-a",
+    });
+
+    assert.equal(pane._mode, "stage-chat");
+    for (const ch of "answer") pane.handleInput(ch);
+    pane.handleInput(Key.enter);
+
+    assert.equal(await pending, "answer");
+    assert.equal(pane._mode, "graph");
+    assert.equal(pane._hasChatView, false);
+    assert.equal(pane._lastAttachedStageId, "stage-a");
+    pane.dispose();
+  });
+
+  test("answering a stage prompt through the host editor returns to the graph", async () => {
+    const store = createStore();
+    setupRun(store, "run-1", [{ id: "stage-a", name: "A" }]);
+    const registry = createStageControlRegistry();
+    registry.register(makeHandle("run-1", "stage-a"));
+    const prompt = makePendingPrompt({ initial: "seed" });
+    assert.equal(store.recordStagePendingPrompt("run-1", "stage-a", prompt), true);
+    const pending = store.awaitStagePendingPrompt("run-1", "stage-a", prompt.id);
+    let createdEditor: FakePromptEditor | undefined;
+    const pane = new WorkflowAttachPane({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageControlRegistry: registry,
+      onClose: () => {},
+      initialAttachStageId: "stage-a",
+      piTui: { requestRender: () => {}, terminal: { rows: 32, columns: 80 } } as unknown as TUI,
+      piTheme: {},
+      piKeybindings: {},
+      piEditorFactory: () => {
+        createdEditor = new FakePromptEditor();
+        return createdEditor;
+      },
+    });
+
+    assert.equal(pane._mode, "stage-chat");
+    assert.equal(createdEditor?.getText(), "seed");
+    pane.handleInput("!");
+    pane.handleInput(Key.enter);
+
+    assert.equal(await pending, "seed!");
+    assert.equal(pane._mode, "graph");
+    assert.equal(pane._hasChatView, false);
+    assert.equal(pane._lastAttachedStageId, "stage-a");
+    pane.dispose();
+  });
+
+  test("declining a stage prompt returns to the graph", async () => {
+    const store = createStore();
+    setupRun(store, "run-1", [{ id: "stage-a", name: "A" }]);
+    const registry = createStageControlRegistry();
+    registry.register(makeHandle("run-1", "stage-a"));
+    const prompt = makePendingPrompt({ initial: "default" });
+    assert.equal(store.recordStagePendingPrompt("run-1", "stage-a", prompt), true);
+    const pending = store.awaitStagePendingPrompt("run-1", "stage-a", prompt.id);
+    const pane = new WorkflowAttachPane({
+      store,
+      graphTheme: deriveGraphTheme({}),
+      runId: "run-1",
+      stageControlRegistry: registry,
+      onClose: () => {},
+      initialAttachStageId: "stage-a",
+    });
+
+    assert.equal(pane._mode, "stage-chat");
+    pane.handleInput(Key.escape);
+
+    assert.equal(await pending, "default");
+    assert.equal(pane._mode, "graph");
+    assert.equal(pane._hasChatView, false);
+    assert.equal(pane._lastAttachedStageId, "stage-a");
     pane.dispose();
   });
 


### PR DESCRIPTION
## Summary

Fixes `ctx.ui` prompt nodes so that answering or skipping a prompt dismisses the stage chat overlay and returns the user to the workflow graph. Adds a `promptFootprint` field to stage snapshots so completed/skipped prompt nodes can render a read-only view of the original question and response without leaking the raw answer into the snapshot.

## Changes

### Bug fix
- Call `onDetach()` in `StageChatView` after `resolveStagePendingPrompt` so the overlay returns to the graph on both answer and skip (escape).

### Prompt footprint
- Add `promptFootprint?: PendingPrompt` to `StageSnapshot` — a snapshot-safe copy of the prompt descriptor that never contains the raw answer.
- Populate `promptFootprint` in `store.recordStagePendingPrompt` alongside `pendingPrompt`.
- Populate `promptFootprint` in the executor when constructing prompt stage nodes for replayed prompts.

### Read-only prompt node rendering
- New `_renderReadOnlyPromptArchiveBody` method renders completed/skipped prompt nodes with the original question, prompt `kind`, available choices (select), initial value (input/editor), and the user's response.
- New `formatReadOnlyPromptAnswer` helper normalises prompt responses to display strings (handles confirm booleans, empty strings, JSON-serialisable values).
- Navigation hint `esc close  ·  ctrl+d return to graph` shown in read-only prompt cards.

### Tests
- **`stage-chat-view.test.ts`** — read-only completed input prompt node shows question, type, and answer; read-only select prompt node shows choices.
- **`workflow-attach-pane.test.ts`** — answering a prompt (inline input, host editor, and escape/skip) all transition `_mode` back to `"graph"` and clear the chat view.
- **`store-pending-prompt.test.ts`** — `promptFootprint` is persisted to the stage snapshot and excluded from `store.snapshot()` serialisation.
- **`executor.test.ts`** — replayed prompt stages carry `promptFootprint` with correct `kind` and `message`.

## Validation

```
AGENT=1 bun test test/unit/executor.test.ts test/unit/stage-chat-view.test.ts test/unit/store-pending-prompt.test.ts test/unit/workflow-attach-pane.test.ts
bun run typecheck
bun run lint
bun run test:unit
```