### PR TITLE
chore(release): bump to v0.8.15-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.14",
+      "version": "0.8.15-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.14",
+      "version": "0.8.15-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.14",
+      "version": "0.8.15-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.14",
+      "version": "0.8.15-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.14",
+      "version": "0.8.15-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.14",
+      "version": "0.8.15-0",
       "dependencies": {
         "jiti": "^2.7.0",
       },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [0.8.15-0] - 2026-05-25
+
+### Breaking Changes
+
+- Changed workflow `ctx.ui.*` prompts to render as synthetic graph stage nodes with `awaiting_input` status, including new `StageSnapshot.promptAnswerState` metadata.
+- Changed `ctx.ui.select(..., [])` to throw before creating a prompt node instead of returning an empty string.
+
+### Added
+
+- Added live-memory prompt answer replay for workflow continuations.
+- Added workflow control and subagents documentation updates, plus bundled docs link validation.
+
+### Changed
+
+- Updated Ralph around an autonomous goal contract so stages infer verifiable criteria, require receipts, and judge completion against the verification oracle.
+- Updated Ralph to discover project initialization needs from repository evidence before implementation work proceeds.
+
+### Fixed
+
+- Returned the workflow overlay to the graph orchestrator after answering or skipping a `ctx.ui` prompt node.
+- Stopped eagerly starting MCP OAuth callback handling during session startup.
+- Carried forward bundled subagent fixes for nested fanout state, child allowlists, async runner config permissions, fallback models, read-only guard overrides, Windows child process spawning, stable running glyphs, and recovered intermediate child errors.
+
 ## [0.8.14] - 2026-05-25
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.14",
+  "version": "0.8.15-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.14",
+  "version": "0.8.15-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.14",
+  "version": "0.8.15-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.14",
+  "version": "0.8.15-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.14",
+  "version": "0.8.15-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.14",
+  "version": "0.8.15-0",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the v0.8.15-0 prerelease by bumping all workspace package versions from 0.8.14 → 0.8.15-0 and adding the release changelog entry.

## Changes

- **Version bumps**: All six workspace packages (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`) bumped to `0.8.15-0`
- **bun.lock**: Refreshed lockfile to reflect prerelease versions
- **CHANGELOG**: Added `[0.8.15-0]` entry to `packages/coding-agent/CHANGELOG.md`

## Release Notes (v0.8.15-0)

### Breaking Changes

- `ctx.ui.*` workflow prompts now render as synthetic graph stage nodes with `awaiting_input` status, including new `StageSnapshot.promptAnswerState` metadata
- `ctx.ui.select(..., [])` now throws before creating a prompt node instead of returning an empty string

### Added

- Live-memory prompt answer replay for workflow continuations
- Workflow control and subagents documentation updates with bundled docs link validation

### Changed

- Ralph updated around an autonomous goal contract: stages infer verifiable criteria, require receipts, and judge completion against the verification oracle
- Ralph updated to discover project initialization needs from repository evidence before implementation work proceeds

### Fixed

- Workflow overlay returned to graph orchestrator after answering or skipping a `ctx.ui` prompt node
- Stopped eagerly starting MCP OAuth callback handling during session startup
- Bundled subagent fixes: nested fanout state, child allowlists, async runner config permissions, fallback models, read-only guard overrides, Windows child process spawning, stable running glyphs, and recovered intermediate child errors

## Validation

- `bun run typecheck`
- `bun run test:unit`