### PR TITLE
chore(release): v0.8.15

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.15] - 2026-05-26
+
+### Changed
+
+- Promoted the 0.8.15 prerelease changes to a stable release.
+
 ## [0.8.15-0] - 2026-05-25
 
 ### Breaking Changes

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.15-0",
+  "version": "0.8.15",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.15] - 2026-05-26
+
+### Changed
+- Promoted the 0.8.15 prerelease package version to a stable release.
+
 ## [0.6.0] - 2026-05-03
 
 ### Added

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.15-0",
+  "version": "0.8.15",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.15] - 2026-05-26
+
 ### Fixed
 - Stopped eagerly starting MCP OAuth callback handling during session startup, preventing non-blocking OAuth initialization failures from surfacing as workflow/orchestrator errors.
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.15-0",
+  "version": "0.8.15",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## [Unreleased]
 
+## [0.8.15] - 2026-05-26
+
 ### Added
 - Synced upstream nested subagent fanout support, including child-safe nested `subagent` registration for explicitly authorized agents, nested status/control metadata, and parent-visible nested summaries.
 

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.15-0",
+  "version": "0.8.15",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.15] - 2026-05-26
+
+### Changed
+- Promoted the 0.8.15 prerelease package version to a stable release.
+
 ## [0.10.7] - 2026-05-02
 
 ### Added

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.15-0",
+  "version": "0.8.15",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.15] - 2026-05-26
+
 ### Breaking Changes
 
 - Changed workflow human-in-the-loop prompts (`ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, and `ctx.ui.editor`) to render as synthetic graph stages with `awaiting_input` status; consumers should handle the new `StageSnapshot.promptAnswerState` metadata and avoid caching `StageSnapshot.parentIds` references across store updates ([#1046](https://github.com/flora131/atomic/issues/1046)).

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.15-0",
+  "version": "0.8.15",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.15 prerelease (`0.8.15-0`) to a stable release across all workspace packages.

## Changes

- Bump all workspace package versions from `0.8.15-0` → `0.8.15`
- Add `[0.8.15]` changelog sections to all six packages (`coding-agent`, `workflows`, `subagents`, `mcp`, `web-access`, `intercom`)

## What's in v0.8.15

### Breaking Changes
- Workflow `ctx.ui.*` human-in-the-loop prompts now render as synthetic graph stages with `awaiting_input` status — consumers must handle the new `StageSnapshot.promptAnswerState` metadata and stop caching `StageSnapshot.parentIds` across store updates ([#1046](https://github.com/flora131/atomic/issues/1046))
- `ctx.ui.select(..., [])` now throws before creating a prompt node instead of silently returning an empty string ([#1046](https://github.com/flora131/atomic/issues/1046))

### Added
- Workflow tool stage introspection and control actions (`stages`, `stage`, `transcript`, `send`, `pause`, `reload`) for inspecting stage state, reading transcripts, answering prompts, and controlling live runs ([#1023](https://github.com/flora131/atomic/issues/1023))
- Live-memory prompt answer replay for workflow continuations via snapshot-safe `promptAnswerState` markers ([#1046](https://github.com/flora131/atomic/issues/1046))
- Nested subagent fanout support with child-safe nested `subagent` registration, nested status/control metadata, and parent-visible nested summaries

### Changed
- Ralph planner now infers verifiable criteria, requires receipts, and judges completion against a verification oracle ([#1053](https://github.com/flora131/atomic/issues/1053))
- Ralph orchestrator discovers project initialization needs from repository evidence before implementation work ([#1048](https://github.com/flora131/atomic/issues/1048))
- Ralph gains a final PR-preparation phase: reviews changes, tries available GitHub credentials, posts notes as a PR comment, and creates a PR when possible
- `deep-research-codebase` output now writes public reports under `research/` and per-run handoff artifacts under `research/.deep-research-<run-id>/`

### Fixed
- MCP OAuth callback handling no longer starts eagerly at session startup, preventing non-blocking failures from surfacing as workflow/orchestrator errors
- Workflow overlay correctly returns to the graph orchestrator after a `ctx.ui` prompt is answered or skipped
- Snapshot transcript fallback entries are ordered chronologically before `tail`/`limit` is applied ([#1023](https://github.com/flora131/atomic/issues/1023))
- Multiple subagent fixes: async runner config permissions, fallback models, read-only guard overrides, Windows child process spawning, stable running glyphs, and recovered intermediate child errors

## Validation

- `bun run typecheck`
- `bun run test:unit`
- `bun run lint`