### PR TITLE
chore(release): v0.8.16

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.16] - 2026-05-26
+
+### Changed
+
+- Promoted the 0.8.16 prerelease changes to a stable release.
+
 ## [0.8.16-0] - 2026-05-26
 
 ### Breaking Changes

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.16-0",
+  "version": "0.8.16",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.16] - 2026-05-26
+
+### Changed
+- Promoted the 0.8.16 prerelease package version to a stable release.
+
 ## [0.8.15] - 2026-05-26
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.16-0",
+  "version": "0.8.16",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.16] - 2026-05-26
+
+### Changed
+- Promoted the 0.8.16 prerelease package version to a stable release.
+
 ## [0.8.15] - 2026-05-26
 
 ### Fixed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.16-0",
+  "version": "0.8.16",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 ## [Unreleased]
 
+## [0.8.16] - 2026-05-26
+
+### Changed
+- Promoted the 0.8.16 prerelease package version to a stable release.
+
 ## [0.8.15] - 2026-05-26
 
 ### Added

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.16-0",
+  "version": "0.8.16",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.16] - 2026-05-26
+
+### Changed
+- Promoted the 0.8.16 prerelease package version to a stable release.
+
 ## [0.8.15] - 2026-05-26
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.16-0",
+  "version": "0.8.16",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.16] - 2026-05-26
+
+### Changed
+
+- Promoted the 0.8.16 prerelease changes to a stable release.
+
 ## [0.8.16-0] - 2026-05-26
 
 ### Breaking Changes

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.16-0",
+  "version": "0.8.16",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the `0.8.16-0` prerelease to a stable `0.8.16` release across all workspace packages.

## Changes

- Bumped all workspace package versions from `0.8.16-0` to `0.8.16` (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`)
- Added stable `[0.8.16]` changelog sections to all packages

## What's in v0.8.16

### Breaking Changes

- **Removed Ralph's `prompt` and `max_loops` compatibility inputs** — use the canonical `objective` and `max_turns` inputs instead ([#1061](https://github.com/flora131/atomic/issues/1061))

### Changed

- **Ralph reworked as a Goal Runner workflow** with a persisted goal ledger, bounded worker turns, parallel structured reviewers, reviewer-quorum completion, repeated-blocker gating, and final status reporting ([#1061](https://github.com/flora131/atomic/issues/1061))

### Fixed

- Hardened Ralph's goal-runner edge cases around base-branch sanitization, worker/reviewer failure handling, cross-turn review context, bounded blocker-threshold handling, and unused ledger state ([#1061](https://github.com/flora131/atomic/issues/1061))