### PR TITLE
feat(workflows): run Ralph stages from optional git worktree

### DIFF
--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -79,7 +79,7 @@ Atomic ships with four workflows you can run immediately. Use `/workflow list` t
 
 <p align="center"><img src="images/workflow-list.png" alt="Workflow List" width="600" /></p>
 
-Inputs are bare `key=value` tokens. Values are JSON-parsed when possible, so `count=5`, `flag=true`, and `objective="multi word value"` preserve useful types. If you call `/workflow <name>` without required inputs, the TUI opens an inline picker; pass `--no-picker` to skip it.
+Inputs are bare `key=value` tokens. Values are JSON-parsed when possible, so `count=5`, `flag=true`, and `objective="multi word value"` preserve useful types. Some workflows expose reusable worktree inputs; for example, add `git_worktree_dir=../atomic-ralph-wt` to `ralph` to run its stages in a created/reused Git worktree while preserving your current repo-relative cwd. If you call `/workflow <name>` without required inputs, the TUI opens an inline picker; pass `--no-picker` to skip it.
 
 You can also launch workflows with **natural language** — just describe the task in chat and ask Atomic to run the matching workflow:
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -237,16 +237,20 @@ Inputs:
 |---|---|---|---|---|
 | `prompt` | text | yes | — | Task, feature request, issue summary, or spec path to plan, execute, refine, review, and prepare for PR. |
 | `max_loops` | number | no | `10` | Maximum plan/orchestrate/review iterations before the workflow proceeds to PR handoff without reviewer approval. |
-| `base_branch` | string | no | `origin/main` | Branch reviewers and the PR-prep stage compare the current code delta against. |
+| `base_branch` | string | no | `origin/main` | Branch reviewers and the PR-prep stage compare the current code delta against; also used to create a missing worktree. |
+| `git_worktree_dir` | string | no | `""` | Optional reusable Git worktree root. Empty runs in the invoking checkout; non-empty values run Ralph stages in the created/reused worktree. |
 
 Run examples:
 
 ```text
 /workflow ralph prompt="Plan and migrate the database layer to Drizzle" max_loops=3 base_branch=develop
 /workflow ralph prompt="Refactor authentication across the API, CLI, and web UI, then prepare the PR"
+/workflow ralph prompt="Safely implement the API refactor" git_worktree_dir=../atomic-ralph-api-wt base_branch=main
 ```
 
 Each `ralph` iteration writes an RFC-style technical design document under `specs/`, initializes an OS-temp implementation notes file, delegates implementation through sub-agents, runs a behavior-preserving code simplifier, discovers review infrastructure, and asks two reviewers to inspect the patch against `base_branch`. The loop stops when every reviewer approves or `max_loops` is reached, then runs a pull-request preparation stage.
+
+Set `git_worktree_dir` when you want Ralph's worker stages isolated in a reusable Git worktree. Relative paths resolve from the invoking repository root, existing same-repository worktree roots are reused, and missing paths are created from `base_branch`. Ralph preserves the invoking repo-relative cwd inside the worktree, so launching from `repo/packages/api` with `git_worktree_dir=../repo-wt` runs stages from `../repo-wt/packages/api`.
 
 Result fields:
 
@@ -663,7 +667,7 @@ workflow({
 })
 ```
 
-Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `tools`, `noTools`, `customTools`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
+Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `tools`, `noTools`, `customTools`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
 
 For large fan-outs, prefer `outputMode: "file-only"` so the parent result contains compact file references instead of full output. Treat intercom payloads from async direct runs as user-visible workflow output.
 
@@ -713,6 +717,7 @@ Builder basics:
 - Workflow names normalize for lookup: trim, lowercase, convert whitespace/underscore to hyphen, remove other punctuation, and collapse hyphens.
 - `.description(text)` sets the listing text.
 - `.input(key, schema)` declares typed user inputs.
+- `.worktreeFromInputs({ gitWorktreeDir, baseBranch })` optionally maps input names to workflow-wide reusable Git worktree defaults.
 - `.run(async (ctx) => { ... })` defines the workflow body.
 - `.compile()` returns the workflow definition for discovery.
 
@@ -773,8 +778,27 @@ Common task/stage options include:
 - `context: "fresh" | "fork"`, `forkFromSessionFile`
 - `model`, `fallbackModels`, `thinkingLevel`, `scopedModels`, `modelRegistry`
 - `tools`, `noTools`, `customTools`, `mcp: { allow?: string[], deny?: string[] }`
-- `output`, `outputMode`, `reads`, `worktree`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, `agentDir`
+- `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, `agentDir`
 - advanced host-supplied SDK seams: `authStorage`, `resourceLoader`, `sessionManager`, `settingsManager`, `sessionStartEvent`
+
+`gitWorktreeDir` selects a reusable Git worktree root for `ctx.stage`, `ctx.task`, `ctx.chain`, and `ctx.parallel`. If the path is missing, Atomic creates it with `git worktree add --detach <path> <baseBranch>`; if it exists, it must be a same-repository worktree root. The default stage cwd becomes the matching cwd inside the worktree and preserves the invoking repo-relative subdirectory. Explicit `cwd` still wins; relative `cwd` values resolve from the worktree cwd, while absolute `cwd` values are used as provided. `gitWorktreeDir` is mutually exclusive with `worktree: true`: use `gitWorktreeDir` for named/reusable worktrees and `worktree: true` for temporary direct-mode worktrees that are cleaned up after the run.
+
+To bind user inputs to a workflow-wide worktree default, use the builder method:
+
+```ts
+export default defineWorkflow("safe-implementation")
+  .input("task", { type: "text", required: true })
+  .input("git_worktree_dir", { type: "string", default: "" })
+  .input("base_branch", { type: "string", default: "origin/main" })
+  .worktreeFromInputs({ gitWorktreeDir: "git_worktree_dir", baseBranch: "base_branch" })
+  .run(async (ctx) => {
+    const result = await ctx.task("implement", { task: String(ctx.inputs.task) });
+    return { result: result.text };
+  })
+  .compile();
+```
+
+For lower-level integrations, `@bastani/workflows` also exports `setupGitWorktree({ gitWorktreeDir, baseBranch, cwd })`, returning `{ worktreeRoot, cwd, repositoryRoot, created }` with the same validation, symlink-preserving path handling, and cwd-preservation behavior used by workflow stages.
 
 `fallbackModels` retries transient provider/model failures with the primary `model` first, then each fallback, then the current Atomic-selected model when available. It is for rate limits, quota/auth/provider outages, unavailable models, network timeouts, and 5xx errors — not workflow-code errors, tool failures, validation failures, or cancellations.
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -13,12 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Replaced regex-based workflow discovery stage validation with source-free startup validation based on stage-primitive observation plus runtime empty-graph validation based on actual stage creation.
+- Threaded named workflow invocation cwd into workflow run contexts so workflow-owned artifacts can use the explicit runner cwd.
 - Split worker project-initialization preflight guidance from Goal receipt/reporting instructions.
 
 ### Fixed
 
 - Avoided blank deep-research display paths when a displayed artifact path equals the workflow invocation directory.
 - Warned when workflow startup stage-validation probes throw before observing stage creation instead of silently accepting the workflow.
+- Avoided validation-probe warnings for required text inputs that validate non-empty values before creating stages.
 - Distinguished Ralph same-repository worktree classification failures from definitely non-Git existing `git_worktree_dir` paths.
 - Updated Ralph to revise a stable original spec file across planner iterations and clarified `git_worktree_dir` null-byte diagnostics.
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees as-is and leaving worktrees in place for retries.
+- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees as-is, preventing concurrent reuse with an active `.ralph.lock` PID/timestamp file, and leaving worktrees in place for retries.
 
 ### Changed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Replaced regex-based workflow discovery stage validation with runtime empty-graph validation based on actual stage creation.
 - Split worker project-initialization preflight guidance from Goal receipt/reporting instructions.
 
 ## [0.8.17] - 2026-05-26

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Avoided blank deep-research display paths when a displayed artifact path equals the workflow invocation directory.
 - Warned when workflow startup stage-validation probes throw before observing stage creation instead of silently accepting the workflow.
 - Distinguished Ralph same-repository worktree classification failures from definitely non-Git existing `git_worktree_dir` paths.
+- Updated Ralph to revise a stable original spec file across planner iterations and clarified `git_worktree_dir` null-byte diagnostics.
 
 ## [0.8.17] - 2026-05-26
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees as-is and leaving worktrees in place for retries.
+- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees from the invoking repository as-is and leaving worktrees in place for retries.
 
 ### Changed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -12,15 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Replaced regex-based workflow discovery stage validation with source-free startup validation based on stage-primitive observation plus runtime empty-graph validation based on actual stage creation.
+- Replaced regex-based workflow discovery stage validation with runtime empty-graph validation based on actual stage creation while keeping discovery side-effect-free.
 - Threaded named workflow invocation cwd into workflow run contexts so workflow-owned artifacts can use the explicit runner cwd.
 - Split worker project-initialization preflight guidance from Goal receipt/reporting instructions.
 
 ### Fixed
 
 - Avoided blank deep-research display paths when a displayed artifact path equals the workflow invocation directory.
-- Warned when workflow startup stage-validation probes throw before observing stage creation instead of silently accepting the workflow.
-- Avoided validation-probe warnings for required text inputs that validate non-empty values before creating stages.
 - Distinguished Ralph same-repository worktree classification and canonicalization failures from definitely non-Git existing `git_worktree_dir` paths.
 - Updated Ralph to revise a stable original spec file across planner iterations and clarified `git_worktree_dir` null-byte diagnostics.
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Replaced regex-based workflow discovery stage validation with runtime empty-graph validation based on actual stage creation.
+- Replaced regex-based workflow discovery stage validation with source-free startup validation based on stage-primitive observation plus runtime empty-graph validation based on actual stage creation.
 - Split worker project-initialization preflight guidance from Goal receipt/reporting instructions.
 
 ## [0.8.17] - 2026-05-26

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Avoided blank deep-research display paths when a displayed artifact path equals the workflow invocation directory.
 - Warned when workflow startup stage-validation probes throw before observing stage creation instead of silently accepting the workflow.
 - Avoided validation-probe warnings for required text inputs that validate non-empty values before creating stages.
-- Distinguished Ralph same-repository worktree classification failures from definitely non-Git existing `git_worktree_dir` paths.
+- Distinguished Ralph same-repository worktree classification and canonicalization failures from definitely non-Git existing `git_worktree_dir` paths.
 - Updated Ralph to revise a stable original spec file across planner iterations and clarified `git_worktree_dir` null-byte diagnostics.
 
 ## [0.8.17] - 2026-05-26

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added Ralph `git_worktree_dir` support for running stages from an optional detached Git worktree.
+- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees as-is and leaving worktrees in place for retries.
 
 ### Changed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees from the invoking repository as-is and leaving worktrees in place for retries.
+- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing/sharing existing worktrees from the invoking repository as-is and leaving worktrees in place for retries.
 
 ### Changed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees as-is, preventing concurrent reuse with an active `.ralph.lock` PID/timestamp file, and leaving worktrees in place for retries.
+- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing existing worktrees as-is and leaving worktrees in place for retries.
 
 ### Changed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Replaced regex-based workflow discovery stage validation with source-free startup validation based on stage-primitive observation plus runtime empty-graph validation based on actual stage creation.
 - Split worker project-initialization preflight guidance from Goal receipt/reporting instructions.
 
+### Fixed
+
+- Avoided blank deep-research display paths when a displayed artifact path equals the workflow invocation directory.
+- Warned when workflow startup stage-validation probes throw before observing stage creation instead of silently accepting the workflow.
+- Distinguished Ralph same-repository worktree classification failures from definitely non-Git existing `git_worktree_dir` paths.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added Ralph `git_worktree_dir` support for running stages from an optional detached Git worktree.
+
+### Changed
+
+- Split worker project-initialization preflight guidance from Goal receipt/reporting instructions.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -105,6 +105,64 @@ export default defineWorkflow("review-and-merge")
   .compile();
 ```
 
+### Reusable Git worktrees
+
+Use `gitWorktreeDir` when a workflow should run stages in a reusable Git worktree instead of the invoking checkout. The executor creates the worktree if it is missing, reuses it when it already exists as a same-repository worktree root, and defaults the stage/task `cwd` to the matching path inside that worktree.
+
+```typescript
+import { defineWorkflow } from "@bastani/workflows";
+
+export default defineWorkflow("safe-implementation")
+  .description("Run implementation stages in a reusable worktree.")
+  .input("task", { type: "text", required: true })
+  .input("worktree", { type: "string", default: "" })
+  .input("base_branch", { type: "string", default: "origin/main" })
+  .worktreeFromInputs({
+    gitWorktreeDir: "worktree",
+    baseBranch: "base_branch",
+  })
+  .run(async (ctx) => {
+    const result = await ctx.task("implement", {
+      task: String(ctx.inputs.task),
+      // No cwd needed: when `worktree` is non-empty, this task runs from the
+      // corresponding cwd inside that reusable Git worktree.
+    });
+    return { result: result.text };
+  })
+  .compile();
+```
+
+You can also pass worktree options per stage/task or as shared chain/parallel defaults:
+
+```typescript
+await ctx.stage("review", {
+  gitWorktreeDir: "../review-worktree",
+  baseBranch: "origin/main",
+}).prompt("Review the current changes.");
+
+await ctx.parallel([
+  { name: "security", task: "Security review" },
+  { name: "runtime", task: "Runtime review" },
+], {
+  gitWorktreeDir: "../review-worktree",
+  baseBranch: "origin/main",
+  failFast: false,
+});
+```
+
+Worktree semantics:
+
+- `gitWorktreeDir` must be used from inside a Git repository. Relative paths resolve from the logical invoking repository root; absolute paths are used as-is.
+- If the requested path exists, it must be an actual Git worktree/checkout root belonging to the invoking repository. Existing subdirectories are rejected so writes do not silently land in the main checkout.
+- If the path is missing, the parent directory is created and Git runs `git worktree add --detach <path> <baseBranch>`. `baseBranch` defaults to `HEAD` when omitted.
+- The default execution cwd preserves the caller's repo-relative cwd inside the worktree. For example, invoking a workflow from `repo/packages/api` with `gitWorktreeDir=../repo-wt` runs stages from `../repo-wt/packages/api`.
+- Symlinked repo/worktree paths preserve their logical spelling in the default cwd, matching Codex-style worktree behavior.
+- Explicit `cwd` still wins. Relative `cwd` values are resolved against the worktree default cwd; absolute `cwd` values are used as provided.
+
+`worktree: true` is different: it creates temporary isolated worktrees for direct task/parallel/chain execution and cleans them up afterward. It is mutually exclusive with `gitWorktreeDir`, which is intended for named/reusable worktrees that remain available across retries.
+
+For advanced integrations, the SDK also exports `setupGitWorktree(options)`, which returns `{ worktreeRoot, cwd, repositoryRoot, created }` and uses the same validation/path behavior as the executor.
+
 ### Model fallbacks
 
 Stages and high-level task helpers can retry transient provider/model failures with an ordered `fallbackModels` list. The primary `model` is tried first, then each fallback, and finally the current pi-selected model when available. Fallbacks are only used for retryable model/provider failures such as rate limits, quota/auth/provider outages, unavailable models, network timeouts, and 5xx errors — ordinary tool, shell, validation, cancellation, and workflow-code failures are not retried.
@@ -280,7 +338,7 @@ await runWorkflow({
 });
 ```
 
-The programmatic definition object mirrors the workflow tool: named workflow runs, single-task runs, parallel `tasks`, and mixed `chain` runs accept the same direct options (`reads`, `output`, `outputMode`, `worktree`, `maxOutput`, `artifacts`, `concurrency`, `failFast`, and stage/session options such as `cwd`, `agentDir`, `model`, `tools`, `context`, and `sessionDir`). `chainDir` is chain-only: it provides the shared artifact directory for chain reads, outputs, and worktree diffs.
+The programmatic definition object mirrors the workflow tool: named workflow runs, single-task runs, parallel `tasks`, and mixed `chain` runs accept the same direct options (`reads`, `output`, `outputMode`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `concurrency`, `failFast`, and stage/session options such as `cwd`, `agentDir`, `model`, `tools`, `context`, and `sessionDir`). `chainDir` is chain-only: it provides the shared artifact directory for chain reads, outputs, and worktree diffs.
 
 Workflow stage sessions follow Atomic SDK directory defaults: `DefaultResourceLoader` is initialized with the project `cwd` and the Atomic default `~/.atomic/agent` directory, while legacy `.pi` paths remain readable where the SDK supports multiple config directories. A stage-supplied `agentDir` is treated as an explicit user override; a stage-supplied `resourceLoader` owns discovery, with `cwd`/`agentDir` left for session naming and tool path resolution.
 
@@ -333,8 +391,9 @@ Plan → orchestrate → simplify → discover → review → PR-handoff workflo
 | Input         | Type     | Required | Default       | Description                                                   |
 | ------------- | -------- | -------- | ------------- | ------------------------------------------------------------- |
 | `prompt`      | `text`   | ✓        | —             | Task, feature request, issue summary, or spec path to plan, execute, refine, review, and prepare for PR. |
-| `max_loops`   | `number` | —        | `10`          | Maximum plan/orchestrate/review iterations before PR handoff. |
-| `base_branch` | `string` | —        | `origin/main` | Branch reviewers and PR-prep compare the current delta with.  |
+| `max_loops`        | `number` | —        | `10`          | Maximum plan/orchestrate/review iterations before PR handoff. |
+| `base_branch`      | `string` | —        | `origin/main` | Branch reviewers and PR-prep compare the current delta with; also used to create a missing worktree. |
+| `git_worktree_dir` | `string` | —        | `""`          | Optional reusable Git worktree root. Empty runs in the invoking checkout; non-empty values run Ralph stages in the created/reused worktree. |
 
 ### `open-claude-design`
 

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -9,10 +9,11 @@
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, extname, join } from "node:path";
+import { dirname, extname, isAbsolute, join, relative } from "node:path";
 import { defineWorkflow } from "../src/index.js";
 import type {
   WorkflowOutputMode,
+  WorkflowRunContext,
   WorkflowTaskResult,
   WorkflowTaskStep,
 } from "../src/shared/types.js";
@@ -73,12 +74,13 @@ function positiveInteger(value: number | undefined, fallback: number): number {
     : fallback;
 }
 
-function countCodebaseLines(): number {
+function countCodebaseLines(cwd = process.cwd()): number {
   try {
     const gitFiles = Bun.spawnSync({
       cmd: ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
       stdout: "pipe",
       stderr: "pipe",
+      cwd,
     });
     const files =
       gitFiles.success && gitFiles.stdout
@@ -98,6 +100,7 @@ function countCodebaseLines(): number {
         cmd: ["wc", "-l", "--", ...batch],
         stdout: "pipe",
         stderr: "pipe",
+        cwd,
       });
       if (!wc.stdout) continue;
 
@@ -180,13 +183,14 @@ interface DeepResearchArtifactRoot {
   readonly artifactRoot: string;
 }
 
-async function createArtifactRoot(startedAt: Date): Promise<DeepResearchArtifactRoot> {
-  await mkdir(DEFAULT_RESEARCH_DOC_DIR, { recursive: true });
+async function createArtifactRoot(startedAt: Date, cwd = process.cwd()): Promise<DeepResearchArtifactRoot> {
+  const researchDocDir = join(cwd, DEFAULT_RESEARCH_DOC_DIR);
+  await mkdir(researchDocDir, { recursive: true });
   const baseRunId = timestampRunId(startedAt);
   for (let suffix = 0; ; suffix += 1) {
     const runId = suffix === 0 ? baseRunId : `${baseRunId}-${suffix + 1}`;
     const artifactRoot = join(
-      DEFAULT_RESEARCH_DOC_DIR,
+      researchDocDir,
       `${DEEP_RESEARCH_RUN_DIR_PREFIX}${runId}`,
     );
     try {
@@ -270,12 +274,13 @@ async function specialistHandoffFromArtifacts(
 function manifestArtifactPaths(
   artifactPathsByStage: ReadonlyMap<string, string>,
   manifestPath: string,
+  display: (path: string) => string,
 ): Record<string, string> {
   const artifacts: Record<string, string> = {};
   for (const [stage, path] of artifactPathsByStage) {
-    artifacts[stage] = displayPath(path);
+    artifacts[stage] = display(path);
   }
-  artifacts.manifest = displayPath(manifestPath);
+  artifacts.manifest = display(manifestPath);
   return artifacts;
 }
 
@@ -292,32 +297,22 @@ function displayPath(path: string): string {
   return path.replace(/\\/g, "/");
 }
 
+function displayPathFrom(cwd: string, path: string): string {
+  const relativePath = relative(cwd, path);
+  if (relativePath.length === 0 || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+    return displayPath(relativePath);
+  }
+  return displayPath(path);
+}
+
 function displayPaths(paths: readonly string[]): string {
   return paths.map(displayPath).join(", ");
 }
 
-export default defineWorkflow("deep-research-codebase")
-  .description(
-    "Scout + research-history chain → parallel specialist waves → aggregator for deep codebase research.",
-  )
-  .input("prompt", {
-    type: "text",
-    required: true,
-    description: "Research question or investigation focus for the codebase.",
-  })
-  .input("max_partitions", {
-    type: "number",
-    default: DEFAULT_MAX_PARTITIONS,
-    description:
-      "Maximum number of codebase partitions to explore in parallel. Actual partitions scale by one per 10K LoC, capped by this value.",
-  })
-  .input("max_concurrency", {
-    type: "number",
-    default: DEFAULT_MAX_CONCURRENCY,
-    description:
-      "Maximum number of workflow stages to run concurrently during deep research.",
-  })
-  .run(async (ctx) => {
+export async function runDeepResearchCodebaseWorkflow(
+  ctx: WorkflowRunContext<Record<string, unknown>>,
+  workflowStartCwd = process.cwd(),
+): Promise<DeepResearchCodebaseResult> {
     const inputs = ctx.inputs as {
       prompt?: string;
       max_partitions?: number;
@@ -333,13 +328,13 @@ export default defineWorkflow("deep-research-codebase")
       DEFAULT_MAX_CONCURRENCY,
     );
     const startedAt = new Date();
-    const finalResearchDocPath = defaultResearchDocPath(prompt);
-    const codebaseLines = countCodebaseLines();
+    const finalResearchDocPath = join(workflowStartCwd, defaultResearchDocPath(prompt));
+    const codebaseLines = countCodebaseLines(workflowStartCwd);
     const partitionCap = calculatePartitionCap(
       requestedMaxPartitions,
       codebaseLines,
     );
-    const { runId, artifactRoot } = await createArtifactRoot(startedAt);
+    const { runId, artifactRoot } = await createArtifactRoot(startedAt, workflowStartCwd);
     const artifactPathsByStage = new Map<string, string>();
     const addArtifact = (stage: string, path: string) => {
       artifactPathsByStage.set(stage, path);
@@ -352,6 +347,8 @@ export default defineWorkflow("deep-research-codebase")
       output,
       outputMode: FILE_ONLY_OUTPUT,
     });
+    const displayWorkflowPath = (path: string): string => displayPathFrom(workflowStartCwd, path);
+    const displayWorkflowPaths = (paths: readonly string[]): string => paths.map(displayWorkflowPath).join(", ");
 
     const scoutPath = addArtifact(
       "codebase-scout",
@@ -579,7 +576,7 @@ export default defineWorkflow("deep-research-codebase")
               ["research_question", prompt],
               [
                 "scout_context",
-                `Read the scout artifact before making evidence claims: ${displayPath(scoutPath)}\nCompact saved-output reference: {previous}`,
+                `Read the scout artifact before making evidence claims: ${displayWorkflowPath(scoutPath)}\nCompact saved-output reference: {previous}`,
               ],
               ["codebase_skills", codebaseSkillGuidance("locator")],
               [
@@ -618,7 +615,7 @@ export default defineWorkflow("deep-research-codebase")
               ["research_question", prompt],
               [
                 "scout_context",
-                `Read the scout artifact before making evidence claims: ${displayPath(scoutPath)}\nCompact saved-output reference: {previous}`,
+                `Read the scout artifact before making evidence claims: ${displayWorkflowPath(scoutPath)}\nCompact saved-output reference: {previous}`,
               ],
               ["codebase_skills", codebaseSkillGuidance("patternFinder")],
               [
@@ -667,8 +664,8 @@ export default defineWorkflow("deep-research-codebase")
           locatorPath === undefined ? [scoutPath] : [locatorPath];
         const onlineResearcherLocalContext =
           locatorPath === undefined
-            ? `Read scout context before researching: ${displayPath(scoutPath)}\nCompact saved-output reference: {previous}`
-            : `Read local artifact context before researching: ${displayPath(locatorPath)}\nCompact saved-output reference: {previous}`;
+            ? `Read scout context before researching: ${displayWorkflowPath(scoutPath)}\nCompact saved-output reference: {previous}`
+            : `Read local artifact context before researching: ${displayWorkflowPath(locatorPath)}\nCompact saved-output reference: {previous}`;
         const analyzerPath = addArtifact(
           `analyzer-${i}`,
           join(artifactRoot, `analyzer-${i}.md`),
@@ -692,7 +689,7 @@ export default defineWorkflow("deep-research-codebase")
               ["research_question", prompt],
               [
                 "context",
-                `Read these artifacts before analyzing: ${displayPaths(analyzerReads)}\nCompact saved-output reference: {previous}`,
+                `Read these artifacts before analyzing: ${displayWorkflowPaths(analyzerReads)}\nCompact saved-output reference: {previous}`,
               ],
               ["codebase_skills", codebaseSkillGuidance("analyzer")],
               [
@@ -804,22 +801,22 @@ export default defineWorkflow("deep-research-codebase")
         [
           "context_artifacts",
           [
-            `Read the scout artifact at ${displayPath(scoutPath)}.`,
-            `Read the partition plan artifact at ${displayPath(partitionPlanPath)}.`,
+            `Read the scout artifact at ${displayWorkflowPath(scoutPath)}.`,
+            `Read the partition plan artifact at ${displayWorkflowPath(partitionPlanPath)}.`,
             historyOverview === ""
               ? "No prior research overview artifact is available."
-              : `Read the prior research overview artifact at ${displayPath(historyAnalyzerPath)}.`,
+              : `Read the prior research overview artifact at ${displayWorkflowPath(historyAnalyzerPath)}.`,
           ].join("\n"),
         ],
         [
           "prior_research_overview",
           historyOverview === ""
             ? "(no prior research found)"
-            : `Read the prior research overview artifact at ${displayPath(historyAnalyzerPath)}.`,
+            : `Read the prior research overview artifact at ${displayWorkflowPath(historyAnalyzerPath)}.`,
         ],
         [
           "specialist_reports",
-          `Read the complete explorer handoff artifact(s) at ${displayPaths(explorerPaths)}. They preserve every partition's Locator, Pattern Finder, Analyzer, and Online Researcher output from the original inline specialist handoff while keeping this prompt bounded.`,
+          `Read the complete explorer handoff artifact(s) at ${displayWorkflowPaths(explorerPaths)}. They preserve every partition's Locator, Pattern Finder, Analyzer, and Online Researcher output from the original inline specialist handoff while keeping this prompt bounded.`,
         ],
         [
           "codebase_skills",
@@ -867,15 +864,15 @@ export default defineWorkflow("deep-research-codebase")
       startedAt: startedAt.toISOString(),
       completedAt: completedAt.toISOString(),
       researchQuestion: prompt,
-      finalAsset: displayPath(writtenResearchDocPath),
-      artifacts: manifestArtifactPaths(artifactPathsByStage, manifestPath),
+      finalAsset: displayWorkflowPath(writtenResearchDocPath),
+      artifacts: manifestArtifactPaths(artifactPathsByStage, manifestPath, displayWorkflowPath),
     });
 
     const result: DeepResearchCodebaseResult = {
       findings: aggregate.text,
-      research_doc_path: displayPath(writtenResearchDocPath),
-      artifact_dir: displayPath(artifactRoot),
-      manifest_path: displayPath(manifestPath),
+      research_doc_path: displayWorkflowPath(writtenResearchDocPath),
+      artifact_dir: displayWorkflowPath(artifactRoot),
+      manifest_path: displayWorkflowPath(manifestPath),
       partitions,
       explorer_count: partitions.length,
       specialist_count: wave1.length + wave2.length,
@@ -883,5 +880,29 @@ export default defineWorkflow("deep-research-codebase")
       history: historyOverview,
     };
     return result;
+
+}
+
+export default defineWorkflow("deep-research-codebase")
+  .description(
+    "Scout + research-history chain → parallel specialist waves → aggregator for deep codebase research.",
+  )
+  .input("prompt", {
+    type: "text",
+    required: true,
+    description: "Research question or investigation focus for the codebase.",
   })
+  .input("max_partitions", {
+    type: "number",
+    default: DEFAULT_MAX_PARTITIONS,
+    description:
+      "Maximum number of codebase partitions to explore in parallel. Actual partitions scale by one per 10K LoC, capped by this value.",
+  })
+  .input("max_concurrency", {
+    type: "number",
+    default: DEFAULT_MAX_CONCURRENCY,
+    description:
+      "Maximum number of workflow stages to run concurrently during deep research.",
+  })
+  .run(async (ctx) => runDeepResearchCodebaseWorkflow(ctx))
   .compile();

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -905,5 +905,5 @@ export default defineWorkflow("deep-research-codebase")
     description:
       "Maximum number of workflow stages to run concurrently during deep research.",
   })
-  .run(async (ctx) => runDeepResearchCodebaseWorkflow(ctx))
+  .run(async (ctx) => runDeepResearchCodebaseWorkflow(ctx, ctx.cwd))
   .compile();

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -299,7 +299,8 @@ function displayPath(path: string): string {
 
 function displayPathFrom(cwd: string, path: string): string {
   const relativePath = relative(cwd, path);
-  if (relativePath.length === 0 || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+  if (relativePath.length === 0) return ".";
+  if (!relativePath.startsWith("..") && !isAbsolute(relativePath)) {
     return displayPath(relativePath);
   }
   return displayPath(path);

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -283,6 +283,8 @@ const GOAL_CONTINUATION_REFERENCE = [
   "Do not report the goal as done unless the goal is complete. Do not mark a goal complete merely because the workflow turn is ending.",
 ].join("\n");
 
+// Intentionally duplicated with Ralph's stage prompt: goal owns a reusable worker
+// contract, while Ralph keeps equivalent guidance inline with its orchestration context.
 const WORKER_PREFLIGHT_CONTRACT = [
   "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
   "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defineWorkflow } from "../src/index.js";
 import type { WorkflowTaskResult } from "../src/shared/types.js";
+import { WORKER_PREFLIGHT_CONTRACT } from "./shared-prompts.js";
 
 const DEFAULT_MAX_TURNS = 10;
 // Goal Runner runs three independent reviewer personas; two approvals form a majority.
@@ -281,20 +282,6 @@ const GOAL_CONTINUATION_REFERENCE = [
   "- Never use blocked merely because the work is hard, slow, uncertain, incomplete, or would benefit from clarification.",
   "",
   "Do not report the goal as done unless the goal is complete. Do not mark a goal complete merely because the workflow turn is ending.",
-].join("\n");
-
-// Intentionally duplicated with Ralph's stage prompt: goal owns a reusable worker
-// contract, while Ralph keeps equivalent guidance inline with its orchestration context.
-const WORKER_PREFLIGHT_CONTRACT = [
-  "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
-  "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
-  "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
-  "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
-  "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
-  "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
-  "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
-  "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
-  "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
 ].join("\n");
 
 const WORKER_RECEIPT_CONTRACT = [

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -293,6 +293,15 @@ const WORKER_RECEIPT_CONTRACT = [
   "For every explicit requirement, numbered item, named artifact, command, test, gate, invariant, and deliverable, identify authoritative evidence from files, command output, test results, PR state, rendered artifacts, runtime behavior, or other current-state proof.",
   "Classify evidence honestly: proves completion, contradicts completion, shows incomplete work, is too weak or indirect, is merely consistent with completion, or is missing.",
   "Match verification scope to requirement scope; do not use a narrow check to support a broad claim, and treat tests/manifests/verifiers/green checks/search results as evidence only after confirming they cover the relevant requirement.",
+  "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
+  "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
+  "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
+  "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
+  "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
+  "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
+  "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
+  "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
+  "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
   "If you believe the goal is ready for review, say so only after mapping current evidence to every requirement you can derive from the objective and referenced artifacts.",
   "Return a receipt with files changed, commands run and outcomes, evidence gathered, blockers encountered, residual risks, and verification still needed.",
 ].join("\n");
@@ -406,7 +415,8 @@ function reviewerErrorDecision(message: string): ReviewDecision {
     goal_oracle_satisfied: false,
     receipt_assessment:
       "No reviewer receipt could be produced because reviewer execution failed.",
-    verification_remaining: "Recover reviewer execution and re-run oracle validation.",
+    verification_remaining:
+      "Recover reviewer execution and re-run oracle validation.",
     stop_review_loop: false,
     reviewer_error: {
       kind: "reviewer_failure",
@@ -447,19 +457,26 @@ function reviewDecisionToRecord(args: {
   const blocker = blockerFromReviewDecision(args.decision);
   const approved = reviewApproved(args.decision);
   const gaps = [
-    ...args.decision.findings.map((finding) => `${finding.title}: ${finding.body}`),
+    ...args.decision.findings.map(
+      (finding) => `${finding.title}: ${finding.body}`,
+    ),
     ...(verificationRemainingIsNone(args.decision.verification_remaining)
       ? []
       : [args.decision.verification_remaining]),
     ...(args.decision.reviewer_error == null
       ? []
-      : [`${args.decision.reviewer_error.kind}: ${args.decision.reviewer_error.message}`]),
+      : [
+          `${args.decision.reviewer_error.kind}: ${args.decision.reviewer_error.message}`,
+        ]),
   ];
 
   return {
     ...args.decision,
     decision: approved ? "complete" : blocker === null ? "continue" : "blocked",
-    evidence: [args.decision.receipt_assessment, args.decision.overall_explanation],
+    evidence: [
+      args.decision.receipt_assessment,
+      args.decision.overall_explanation,
+    ],
     gaps,
     blocker,
     confidence_score: args.decision.overall_confidence_score,
@@ -524,8 +541,9 @@ function renderReviewHistory(ledger: GoalLedger): string {
     return "No previous reviewer findings; this is the first worker turn.";
   }
 
-  const recentTurns = [...new Set(ledger.reviews.map((review) => review.turn))]
-    .slice(-REVIEW_HISTORY_TURN_COUNT);
+  const recentTurns = [
+    ...new Set(ledger.reviews.map((review) => review.turn)),
+  ].slice(-REVIEW_HISTORY_TURN_COUNT);
   const recentTurnSet = new Set(recentTurns);
   const recentReviews = ledger.reviews.filter((review) =>
     recentTurnSet.has(review.turn),
@@ -600,14 +618,20 @@ function blockerCandidate(
       continue;
     }
     const key = normalizeBlocker(decision.blocker);
-    const existing = counts.get(key) ?? { blocker: decision.blocker.trim(), reviewers: [] };
+    const existing = counts.get(key) ?? {
+      blocker: decision.blocker.trim(),
+      reviewers: [],
+    };
     existing.reviewers.push(decision.reviewer);
     counts.set(key, existing);
   }
 
   let selected: { blocker: string; reviewers: string[] } | undefined;
   for (const entry of counts.values()) {
-    if (selected === undefined || entry.reviewers.length > selected.reviewers.length) {
+    if (
+      selected === undefined ||
+      entry.reviewers.length > selected.reviewers.length
+    ) {
       selected = entry;
     }
   }
@@ -641,9 +665,14 @@ function collectRemainingWork(reviews: readonly ReviewRecord[]): string {
   const gaps = reviews.flatMap((review) => review.gaps);
   const blockers = reviews
     .map((review) => review.blocker)
-    .filter((blocker): blocker is string => typeof blocker === "string" && blocker.trim().length > 0);
+    .filter(
+      (blocker): blocker is string =>
+        typeof blocker === "string" && blocker.trim().length > 0,
+    );
   const items = [...gaps, ...blockers];
-  return items.length > 0 ? items.join("; ") : "Reviewer quorum did not prove completion.";
+  return items.length > 0
+    ? items.join("; ")
+    : "Reviewer quorum did not prove completion.";
 }
 
 function reduceGoalDecision(
@@ -674,13 +703,14 @@ function reduceGoalDecision(
   }
 
   const observation = blockerCandidate(options.turn, turnReviews);
-  const blockerCount = observation === undefined
-    ? 0
-    : consecutiveBlockerTurns(
-        [...ledger.blockers, observation],
-        observation.blocker,
-        options.turn,
-      );
+  const blockerCount =
+    observation === undefined
+      ? 0
+      : consecutiveBlockerTurns(
+          [...ledger.blockers, observation],
+          observation.blocker,
+          options.turn,
+        );
 
   if (observation !== undefined && blockerCount >= options.blockerThreshold) {
     return {
@@ -911,7 +941,10 @@ function renderReviewerPrompt(args: {
 
 function formatReviewReport(reviews: readonly ReviewRecord[]): string {
   return reviews
-    .map((review) => `### ${review.reviewer} (turn ${review.turn})\n\n${review.raw_text}`)
+    .map(
+      (review) =>
+        `### ${review.reviewer} (turn ${review.turn})\n\n${review.raw_text}`,
+    )
     .join("\n\n---\n\n");
 }
 
@@ -920,12 +953,13 @@ function renderFinalReport(
   ledgerPath: string,
   remainingWork: string,
 ): string {
-  const receiptLines = ledger.receipts.length > 0
-    ? ledger.receipts.map(
-        (receipt) =>
-          `- Turn ${receipt.turn}: ${receipt.summary} (artifact: ${receipt.artifact_path})`,
-      )
-    : ["- No receipts captured."];
+  const receiptLines =
+    ledger.receipts.length > 0
+      ? ledger.receipts.map(
+          (receipt) =>
+            `- Turn ${receipt.turn}: ${receipt.summary} (artifact: ${receipt.artifact_path})`,
+        )
+      : ["- No receipts captured."];
 
   const lastDecision = ledger.decisions.at(-1);
   return [
@@ -988,8 +1022,12 @@ export default defineWorkflow("goal")
     const maxTurns = positiveInteger(inputs.max_turns, DEFAULT_MAX_TURNS);
     const reviewQuorum = DEFAULT_REVIEW_QUORUM;
     const blockerThreshold = Math.min(DEFAULT_BLOCKER_THRESHOLD, maxTurns);
-    const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
-    const { ledger, ledgerPath, artifactDir } = await createGoalLedger(objective);
+    const comparisonBaseBranch = normalizeBranchInput(
+      inputs.base_branch,
+      "origin/main",
+    );
+    const { ledger, ledgerPath, artifactDir } =
+      await createGoalLedger(objective);
 
     const workerModelConfig = {
       model: "openai/gpt-5.5",
@@ -1019,8 +1057,17 @@ export default defineWorkflow("goal")
     let latestReviews: ReviewRecord[] = [];
     let terminalRemainingWork: string | undefined;
 
-    for (let turn = 1; turn <= maxTurns && ledger.status === "active"; turn += 1) {
-      appendLifecycleEvent(ledger, "work_turn_started", `Worker turn ${turn} started.`, turn);
+    for (
+      let turn = 1;
+      turn <= maxTurns && ledger.status === "active";
+      turn += 1
+    ) {
+      appendLifecycleEvent(
+        ledger,
+        "work_turn_started",
+        `Worker turn ${turn} started.`,
+        turn,
+      );
       await writeGoalLedger(ledgerPath, ledger);
 
       const workTurnPath = join(artifactDir, `work-turn-${turn}.md`);
@@ -1061,7 +1108,12 @@ export default defineWorkflow("goal")
           complete_votes: 0,
           review_quorum: reviewQuorum,
         });
-        appendLifecycleEvent(ledger, "status_decided", terminalRemainingWork, turn);
+        appendLifecycleEvent(
+          ledger,
+          "status_decided",
+          terminalRemainingWork,
+          turn,
+        );
         await writeGoalLedger(ledgerPath, ledger);
         break;
       }
@@ -1073,7 +1125,12 @@ export default defineWorkflow("goal")
         artifact_path: workTurnPath,
         summary: summarizeText(worker.text),
       });
-      appendLifecycleEvent(ledger, "receipt_recorded", `Worker turn ${turn} receipt recorded.`, turn);
+      appendLifecycleEvent(
+        ledger,
+        "receipt_recorded",
+        `Worker turn ${turn} receipt recorded.`,
+        turn,
+      );
       await writeGoalLedger(ledgerPath, ledger);
 
       const reviewerSteps = [
@@ -1152,7 +1209,8 @@ export default defineWorkflow("goal")
 
       latestReviews = reviewResults.map((result) => {
         const reviewerName = result.name ?? result.stageName;
-        const parsed = parseReviewDecision(result.text) ??
+        const parsed =
+          parseReviewDecision(result.text) ??
           reviewerErrorDecision(
             `Reviewer ${reviewerName} returned invalid structured JSON.`,
           );
@@ -1191,9 +1249,10 @@ export default defineWorkflow("goal")
       await writeGoalLedger(ledgerPath, ledger);
     }
 
-    const remainingWork = ledger.status === "complete"
-      ? "none"
-      : terminalRemainingWork ?? collectRemainingWork(latestReviews);
+    const remainingWork =
+      ledger.status === "complete"
+        ? "none"
+        : (terminalRemainingWork ?? collectRemainingWork(latestReviews));
     const finalReport = renderFinalReport(ledger, ledgerPath, remainingWork);
     const reviewReport = formatReviewReport(latestReviews);
 

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -418,8 +418,7 @@ function reviewerErrorDecision(message: string): ReviewDecision {
     goal_oracle_satisfied: false,
     receipt_assessment:
       "No reviewer receipt could be produced because reviewer execution failed.",
-    verification_remaining:
-      "Recover reviewer execution and re-run oracle validation.",
+    verification_remaining: "Recover reviewer execution and re-run oracle validation.",
     stop_review_loop: false,
     reviewer_error: {
       kind: "reviewer_failure",
@@ -460,26 +459,19 @@ function reviewDecisionToRecord(args: {
   const blocker = blockerFromReviewDecision(args.decision);
   const approved = reviewApproved(args.decision);
   const gaps = [
-    ...args.decision.findings.map(
-      (finding) => `${finding.title}: ${finding.body}`,
-    ),
+    ...args.decision.findings.map((finding) => `${finding.title}: ${finding.body}`),
     ...(verificationRemainingIsNone(args.decision.verification_remaining)
       ? []
       : [args.decision.verification_remaining]),
     ...(args.decision.reviewer_error == null
       ? []
-      : [
-          `${args.decision.reviewer_error.kind}: ${args.decision.reviewer_error.message}`,
-        ]),
+      : [`${args.decision.reviewer_error.kind}: ${args.decision.reviewer_error.message}`]),
   ];
 
   return {
     ...args.decision,
     decision: approved ? "complete" : blocker === null ? "continue" : "blocked",
-    evidence: [
-      args.decision.receipt_assessment,
-      args.decision.overall_explanation,
-    ],
+    evidence: [args.decision.receipt_assessment, args.decision.overall_explanation],
     gaps,
     blocker,
     confidence_score: args.decision.overall_confidence_score,
@@ -544,9 +536,8 @@ function renderReviewHistory(ledger: GoalLedger): string {
     return "No previous reviewer findings; this is the first worker turn.";
   }
 
-  const recentTurns = [
-    ...new Set(ledger.reviews.map((review) => review.turn)),
-  ].slice(-REVIEW_HISTORY_TURN_COUNT);
+  const recentTurns = [...new Set(ledger.reviews.map((review) => review.turn))]
+    .slice(-REVIEW_HISTORY_TURN_COUNT);
   const recentTurnSet = new Set(recentTurns);
   const recentReviews = ledger.reviews.filter((review) =>
     recentTurnSet.has(review.turn),
@@ -621,20 +612,14 @@ function blockerCandidate(
       continue;
     }
     const key = normalizeBlocker(decision.blocker);
-    const existing = counts.get(key) ?? {
-      blocker: decision.blocker.trim(),
-      reviewers: [],
-    };
+    const existing = counts.get(key) ?? { blocker: decision.blocker.trim(), reviewers: [] };
     existing.reviewers.push(decision.reviewer);
     counts.set(key, existing);
   }
 
   let selected: { blocker: string; reviewers: string[] } | undefined;
   for (const entry of counts.values()) {
-    if (
-      selected === undefined ||
-      entry.reviewers.length > selected.reviewers.length
-    ) {
+    if (selected === undefined || entry.reviewers.length > selected.reviewers.length) {
       selected = entry;
     }
   }
@@ -668,14 +653,9 @@ function collectRemainingWork(reviews: readonly ReviewRecord[]): string {
   const gaps = reviews.flatMap((review) => review.gaps);
   const blockers = reviews
     .map((review) => review.blocker)
-    .filter(
-      (blocker): blocker is string =>
-        typeof blocker === "string" && blocker.trim().length > 0,
-    );
+    .filter((blocker): blocker is string => typeof blocker === "string" && blocker.trim().length > 0);
   const items = [...gaps, ...blockers];
-  return items.length > 0
-    ? items.join("; ")
-    : "Reviewer quorum did not prove completion.";
+  return items.length > 0 ? items.join("; ") : "Reviewer quorum did not prove completion.";
 }
 
 function reduceGoalDecision(
@@ -706,14 +686,13 @@ function reduceGoalDecision(
   }
 
   const observation = blockerCandidate(options.turn, turnReviews);
-  const blockerCount =
-    observation === undefined
-      ? 0
-      : consecutiveBlockerTurns(
-          [...ledger.blockers, observation],
-          observation.blocker,
-          options.turn,
-        );
+  const blockerCount = observation === undefined
+    ? 0
+    : consecutiveBlockerTurns(
+        [...ledger.blockers, observation],
+        observation.blocker,
+        options.turn,
+      );
 
   if (observation !== undefined && blockerCount >= options.blockerThreshold) {
     return {
@@ -944,10 +923,7 @@ function renderReviewerPrompt(args: {
 
 function formatReviewReport(reviews: readonly ReviewRecord[]): string {
   return reviews
-    .map(
-      (review) =>
-        `### ${review.reviewer} (turn ${review.turn})\n\n${review.raw_text}`,
-    )
+    .map((review) => `### ${review.reviewer} (turn ${review.turn})\n\n${review.raw_text}`)
     .join("\n\n---\n\n");
 }
 
@@ -956,13 +932,12 @@ function renderFinalReport(
   ledgerPath: string,
   remainingWork: string,
 ): string {
-  const receiptLines =
-    ledger.receipts.length > 0
-      ? ledger.receipts.map(
-          (receipt) =>
-            `- Turn ${receipt.turn}: ${receipt.summary} (artifact: ${receipt.artifact_path})`,
-        )
-      : ["- No receipts captured."];
+  const receiptLines = ledger.receipts.length > 0
+    ? ledger.receipts.map(
+        (receipt) =>
+          `- Turn ${receipt.turn}: ${receipt.summary} (artifact: ${receipt.artifact_path})`,
+      )
+    : ["- No receipts captured."];
 
   const lastDecision = ledger.decisions.at(-1);
   return [
@@ -1025,12 +1000,8 @@ export default defineWorkflow("goal")
     const maxTurns = positiveInteger(inputs.max_turns, DEFAULT_MAX_TURNS);
     const reviewQuorum = DEFAULT_REVIEW_QUORUM;
     const blockerThreshold = Math.min(DEFAULT_BLOCKER_THRESHOLD, maxTurns);
-    const comparisonBaseBranch = normalizeBranchInput(
-      inputs.base_branch,
-      "origin/main",
-    );
-    const { ledger, ledgerPath, artifactDir } =
-      await createGoalLedger(objective);
+    const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
+    const { ledger, ledgerPath, artifactDir } = await createGoalLedger(objective);
 
     const workerModelConfig = {
       model: "openai/gpt-5.5",
@@ -1060,17 +1031,8 @@ export default defineWorkflow("goal")
     let latestReviews: ReviewRecord[] = [];
     let terminalRemainingWork: string | undefined;
 
-    for (
-      let turn = 1;
-      turn <= maxTurns && ledger.status === "active";
-      turn += 1
-    ) {
-      appendLifecycleEvent(
-        ledger,
-        "work_turn_started",
-        `Worker turn ${turn} started.`,
-        turn,
-      );
+    for (let turn = 1; turn <= maxTurns && ledger.status === "active"; turn += 1) {
+      appendLifecycleEvent(ledger, "work_turn_started", `Worker turn ${turn} started.`, turn);
       await writeGoalLedger(ledgerPath, ledger);
 
       const workTurnPath = join(artifactDir, `work-turn-${turn}.md`);
@@ -1115,12 +1077,7 @@ export default defineWorkflow("goal")
           complete_votes: 0,
           review_quorum: reviewQuorum,
         });
-        appendLifecycleEvent(
-          ledger,
-          "status_decided",
-          terminalRemainingWork,
-          turn,
-        );
+        appendLifecycleEvent(ledger, "status_decided", terminalRemainingWork, turn);
         await writeGoalLedger(ledgerPath, ledger);
         break;
       }
@@ -1132,12 +1089,7 @@ export default defineWorkflow("goal")
         artifact_path: workTurnPath,
         summary: summarizeText(worker.text),
       });
-      appendLifecycleEvent(
-        ledger,
-        "receipt_recorded",
-        `Worker turn ${turn} receipt recorded.`,
-        turn,
-      );
+      appendLifecycleEvent(ledger, "receipt_recorded", `Worker turn ${turn} receipt recorded.`, turn);
       await writeGoalLedger(ledgerPath, ledger);
 
       const reviewerSteps = [
@@ -1216,8 +1168,7 @@ export default defineWorkflow("goal")
 
       latestReviews = reviewResults.map((result) => {
         const reviewerName = result.name ?? result.stageName;
-        const parsed =
-          parseReviewDecision(result.text) ??
+        const parsed = parseReviewDecision(result.text) ??
           reviewerErrorDecision(
             `Reviewer ${reviewerName} returned invalid structured JSON.`,
           );
@@ -1256,10 +1207,9 @@ export default defineWorkflow("goal")
       await writeGoalLedger(ledgerPath, ledger);
     }
 
-    const remainingWork =
-      ledger.status === "complete"
-        ? "none"
-        : (terminalRemainingWork ?? collectRemainingWork(latestReviews));
+    const remainingWork = ledger.status === "complete"
+      ? "none"
+      : terminalRemainingWork ?? collectRemainingWork(latestReviews);
     const finalReport = renderFinalReport(ledger, ledgerPath, remainingWork);
     const reviewReport = formatReviewReport(latestReviews);
 

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -283,6 +283,18 @@ const GOAL_CONTINUATION_REFERENCE = [
   "Do not report the goal as done unless the goal is complete. Do not mark a goal complete merely because the workflow turn is ending.",
 ].join("\n");
 
+const WORKER_PREFLIGHT_CONTRACT = [
+  "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
+  "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
+  "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
+  "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
+  "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
+  "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
+  "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
+  "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
+  "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
+].join("\n");
+
 const WORKER_RECEIPT_CONTRACT = [
   "Produce concrete progress toward the full objective in this turn.",
   "Inspect current files, commands, artifacts, and repository guidance before relying on prior summaries.",
@@ -293,15 +305,6 @@ const WORKER_RECEIPT_CONTRACT = [
   "For every explicit requirement, numbered item, named artifact, command, test, gate, invariant, and deliverable, identify authoritative evidence from files, command output, test results, PR state, rendered artifacts, runtime behavior, or other current-state proof.",
   "Classify evidence honestly: proves completion, contradicts completion, shows incomplete work, is too weak or indirect, is merely consistent with completion, or is missing.",
   "Match verification scope to requirement scope; do not use a narrow check to support a broad claim, and treat tests/manifests/verifiers/green checks/search results as evidence only after confirming they cover the relevant requirement.",
-  "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
-  "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
-  "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
-  "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
-  "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
-  "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
-  "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
-  "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
-  "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
   "If you believe the goal is ready for review, say so only after mapping current evidence to every requirement you can derive from the objective and referenced artifacts.",
   "Return a receipt with files changed, commands run and outcomes, evidence gathered, blockers encountered, residual risks, and verification still needed.",
 ].join("\n");
@@ -1084,6 +1087,10 @@ export default defineWorkflow("goal")
         worker = await ctx.task(`work-turn-${turn}`, {
           prompt: [
             goalContext,
+            "",
+            "<project_initialization_preflight>",
+            WORKER_PREFLIGHT_CONTRACT,
+            "</project_initialization_preflight>",
             "",
             "<worker_turn_contract>",
             WORKER_RECEIPT_CONTRACT,

--- a/packages/workflows/builtin/open-claude-design.ts
+++ b/packages/workflows/builtin/open-claude-design.ts
@@ -114,7 +114,7 @@ function joinResults(results: readonly WorkflowTaskResult[]): string {
  * stay next to the project and are discoverable by pi. Falls back to the OS
  * tmpdir when the project tree is not writable (CI sandboxes, mocks, etc.).
  */
-function prepareArtifactDir(): {
+function prepareArtifactDir(cwd = process.cwd()): {
   readonly runId: string;
   readonly artifactDir: string;
   readonly previewPath: string;
@@ -122,7 +122,7 @@ function prepareArtifactDir(): {
 } {
   const runId = `${new Date().toISOString().replace(/[:.]/g, "-")}-${Math.random().toString(36).slice(2, 8)}`;
   const candidates = [
-    join(process.cwd(), "specs", "design", runId),
+    join(cwd, "specs", "design", runId),
     join(tmpdir(), "open-claude-design", runId),
   ];
   for (const candidate of candidates) {
@@ -222,7 +222,7 @@ export default defineWorkflow("open-claude-design")
       DEFAULT_MAX_REFINEMENTS,
     );
 
-    const { runId, artifactDir, previewPath, specPath } = prepareArtifactDir();
+    const { runId, artifactDir, previewPath, specPath } = prepareArtifactDir(ctx.cwd);
     const previewFileUrl = `file://${previewPath}`;
     const specFileUrl = `file://${specPath}`;
 

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -11,7 +11,7 @@ import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, extname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
 import type { WorkflowRunContext, WorkflowTaskResult } from "../src/shared/types.js";
 import { WORKER_PREFLIGHT_CONTRACT } from "./shared-prompts.js";
@@ -263,32 +263,12 @@ function defaultSpecPath(prompt: string, now = new Date()): string {
   return join(DEFAULT_SPEC_DIR, `${date}-${slugifySpecTopic(prompt)}.md`);
 }
 
-function suffixedPath(path: string, suffix: number): string {
-  const extension = extname(path);
-  const stem = extension.length === 0 ? path : path.slice(0, -extension.length);
-  return `${stem}-${suffix}${extension}`;
-}
-
-function isFileExistsError(error: unknown): boolean {
-  return error instanceof Error && (error as { readonly code?: string }).code === "EEXIST";
-}
-
 async function writeSpecFile(path: string, content: string): Promise<string> {
   await mkdir(dirname(path), { recursive: true });
-
-  for (let suffix = 0; ; suffix += 1) {
-    const candidate = suffix === 0 ? path : suffixedPath(path, suffix + 1);
-    try {
-      await writeFile(candidate, content.endsWith("\n") ? content : `${content}\n`, {
-        encoding: "utf8",
-        flag: "wx",
-      });
-      return candidate;
-    } catch (error) {
-      if (isFileExistsError(error)) continue;
-      throw error;
-    }
-  }
+  await writeFile(path, content.endsWith("\n") ? content : `${content}\n`, {
+    encoding: "utf8",
+  });
+  return path;
 }
 
 type GitCommandResult = {
@@ -354,7 +334,7 @@ function gitFailureMessage(result: GitCommandResult): string {
 function resolveWorktreePath(value: string, cwd = process.cwd()): string {
   const trimmed = value.trim();
   if (trimmed.includes("\0")) {
-    throw new Error("git_worktree_dir contains an unusable null byte path segment; provide a valid path or omit git_worktree_dir.");
+    throw new Error("git_worktree_dir contains an unusable null byte; provide a valid path or omit git_worktree_dir.");
   }
   return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
 }
@@ -657,6 +637,9 @@ async function runRalphWorkflow(
   let finalPlanPath = "";
   let finalResult = "";
   let finalPrReport = "";
+  // Keep generated specs under the directory where Ralph was invoked, not in
+  // the worktree, so plan artifacts remain easy to find across retries.
+  const workflowSpecPath = resolve(workflowStartCwd, defaultSpecPath(prompt));
   const implementationNotesPath = await createImplementationNotesFile(prompt);
   let approved = false;
   let iterationsCompleted = 0;
@@ -764,6 +747,19 @@ async function runRalphWorkflow(
             : "No prior review findings; this is the first iteration.",
         ],
         [
+          "spec_revision_target",
+          iteration === 1
+            ? [
+                `Ralph will write your final RFC markdown for this workflow run to: ${workflowSpecPath}`,
+                "Treat this as the original spec file for the run.",
+              ].join("\n")
+            : [
+                `The existing RFC/spec file for this workflow run is: ${workflowSpecPath}`,
+                "Read that original spec before drafting; revise it in response to review findings and current repository evidence.",
+                "Your final output must be the full updated RFC markdown that should replace the original spec, not a diff, patch, or commentary.",
+              ].join("\n"),
+        ],
+        [
           "input_spec_files",
           [
             "If the user specification is a file path instead of raw prose, read that file and use it as source material for the RFC.",
@@ -821,13 +817,12 @@ async function runRalphWorkflow(
       ...(reviewReport
         ? { previous: { name: "review-report", text: reviewReport } }
         : {}),
+      ...(iteration > 1 ? { reads: [workflowSpecPath] } : {}),
       ...plannerModelConfig,
       ...cwdOption,
     });
     finalPlan = planner.text;
-    // Keep generated specs under the directory where Ralph was invoked, not in
-    // the worktree, so plan artifacts remain easy to find across retries.
-    const specPath = await writeSpecFile(resolve(workflowStartCwd, defaultSpecPath(prompt)), planner.text);
+    const specPath = await writeSpecFile(workflowSpecPath, planner.text);
     finalPlanPath = specPath;
 
     const orchestrator = await ctx.task(`orchestrator-${iteration}`, {
@@ -843,7 +838,7 @@ async function runRalphWorkflow(
         [
           "spec_file",
           [
-            `The technical specification for this iteration was written to: ${specPath}`,
+            `The current technical specification for this workflow run is written to: ${specPath}`,
             "This is an absolute host-repository path and may be outside the worktree cwd; read it exactly as provided, not as a path relative to the worktree.",
             "Read this file before delegating or implementing anything.",
             "Do not rely on an inline planner transcript; the spec file is the authoritative plan for this iteration.",

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -8,6 +8,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
@@ -389,9 +390,46 @@ async function addGitWorktree(
   return runGit(["worktree", "add", "--detach", worktreeDir, baseBranch], cwd);
 }
 
-function existingPathIsGitWorktree(worktreeDir: string): boolean {
-  const result = runGit(["-C", worktreeDir, "rev-parse", "--is-inside-work-tree"]);
-  return result.status === 0 && result.stdout.trim() === "true";
+type ExistingGitWorktreeStatus = "same-repository" | "foreign-repository" | "not-git-worktree";
+
+function comparableGitPath(path: string): string {
+  let canonical = path;
+  try {
+    canonical = realpathSync.native(path);
+  } catch {
+    canonical = resolve(path);
+  }
+  const normalized = canonical.replace(/\\/g, "/");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function resolveGitPath(value: string, cwd: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
+}
+
+function gitCommonDir(cwd: string): string | undefined {
+  const result = runGit(["-C", cwd, "rev-parse", "--git-common-dir"]);
+  if (result.status !== 0) return undefined;
+  return resolveGitPath(result.stdout, cwd);
+}
+
+function existingPathGitWorktreeStatus(worktreeDir: string, repoRoot: string): ExistingGitWorktreeStatus {
+  const insideWorkTreeResult = runGit(["-C", worktreeDir, "rev-parse", "--is-inside-work-tree"]);
+  if (insideWorkTreeResult.status !== 0 || insideWorkTreeResult.stdout.trim() !== "true") {
+    return "not-git-worktree";
+  }
+
+  const repoCommonDir = gitCommonDir(repoRoot);
+  const worktreeCommonDir = gitCommonDir(worktreeDir);
+  if (repoCommonDir === undefined || worktreeCommonDir === undefined) {
+    return "not-git-worktree";
+  }
+
+  return comparableGitPath(repoCommonDir) === comparableGitPath(worktreeCommonDir)
+    ? "same-repository"
+    : "foreign-repository";
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -425,8 +463,12 @@ async function createGitWorktreeIfRequested(
 
   const requestedWorktreeDir = resolveWorktreePath(trimmed, repoRoot);
   if (await pathExists(requestedWorktreeDir)) {
-    if (existingPathIsGitWorktree(requestedWorktreeDir)) {
+    const existingStatus = existingPathGitWorktreeStatus(requestedWorktreeDir, repoRoot);
+    if (existingStatus === "same-repository") {
       return { cwd: requestedWorktreeDir };
+    }
+    if (existingStatus === "foreign-repository") {
+      throw new Error(`git_worktree_dir already exists but does not belong to the invoking Git repository: ${requestedWorktreeDir}`);
     }
     throw new Error(`git_worktree_dir already exists but is not a Git worktree: ${requestedWorktreeDir}`);
   }
@@ -1348,7 +1390,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees are reused as-is, and missing paths are created from base_branch."
+      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees from the invoking repository are reused as-is, and missing paths are created from base_branch."
   })
   .run(async (ctx) => {
     const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -1370,6 +1370,24 @@ async function runRalphWorkflow(
   };
 }
 
+export async function runRalphWorkflowFromCwd(
+  ctx: WorkflowRunContext<RalphInputs>,
+  workflowStartCwd = process.cwd(),
+): Promise<RalphWorkflowResult> {
+  const inputs = ctx.inputs;
+  const prompt = inputs.prompt ?? "";
+  const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
+  const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
+  const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
+  return await runRalphWorkflow(ctx, {
+    prompt,
+    maxLoops,
+    comparisonBaseBranch,
+    workflowStartCwd,
+    workflowCwd: worktree.cwd,
+  });
+}
+
 export default defineWorkflow("ralph")
   .description(
     "Plan → orchestrate → simplify → parallel review loop with bounded iteration.",
@@ -1396,20 +1414,5 @@ export default defineWorkflow("ralph")
     description:
       "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees from the invoking repository are reused/shared as-is, and missing paths are created from base_branch."
   })
-  .run(async (ctx) => {
-    const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;
-    const inputs = ralphCtx.inputs;
-    const workflowStartCwd = process.cwd();
-    const prompt = inputs.prompt ?? "";
-    const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
-    const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
-    const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
-    return await runRalphWorkflow(ralphCtx, {
-      prompt,
-      maxLoops,
-      comparisonBaseBranch,
-      workflowStartCwd,
-      workflowCwd: worktree.cwd,
-    });
-  })
+  .run(async (ctx) => runRalphWorkflowFromCwd(ctx as WorkflowRunContext<RalphInputs>))
   .compile();

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
@@ -368,8 +368,16 @@ function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
   return repoRootResult.stdout.trim();
 }
 
+const RALPH_WORKTREE_LOCK_FILENAME = ".ralph.lock";
+
+type RalphWorktreeLock = {
+  readonly path: string;
+  readonly content: string;
+};
+
 type GitWorktreeSetup = {
   readonly cwd?: string;
+  readonly lock?: RalphWorktreeLock;
 };
 
 async function addGitWorktree(
@@ -399,8 +407,111 @@ async function pathExists(path: string): Promise<boolean> {
     await stat(path);
     return true;
   } catch (error) {
-    if ((error as { readonly code?: string }).code === "ENOENT") return false;
+    if (errorCode(error) === "ENOENT") return false;
     throw error;
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+  const code = (error as { readonly code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function processIdIsAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) !== "ESRCH";
+  }
+}
+
+function parseRalphWorktreeLock(content: string): { readonly pid?: number; readonly createdAt?: string } {
+  const [pidLine, createdAtLine] = content.trimEnd().split(/\r?\n/);
+  const pid = Number.parseInt(pidLine ?? "", 10);
+  return {
+    ...(Number.isSafeInteger(pid) && pid > 0 ? { pid } : {}),
+    ...(createdAtLine === undefined || createdAtLine.trim() === "" ? {} : { createdAt: createdAtLine.trim() }),
+  };
+}
+
+function activeRalphWorktreeLockError(lockPath: string, content: string): Error | undefined {
+  const existingLock = parseRalphWorktreeLock(content);
+  if (existingLock.pid === undefined || !processIdIsAlive(existingLock.pid)) return undefined;
+
+  const createdAt = existingLock.createdAt ?? "unknown time";
+  return new Error(
+    [
+      `git_worktree_dir is already locked by active Ralph process ${existingLock.pid} since ${createdAt}: ${lockPath}`,
+      "Use a different git_worktree_dir, wait for that run to exit, or remove the lock only after confirming the process is gone.",
+    ].join("\n"),
+  );
+}
+
+function staleRalphWorktreeLockError(lockPath: string, content: string): Error {
+  const existingLock = parseRalphWorktreeLock(content);
+  const pid = existingLock.pid === undefined ? "unknown PID" : `PID ${existingLock.pid}`;
+  const createdAt = existingLock.createdAt ?? "unknown time";
+  return new Error(
+    [
+      `git_worktree_dir has a stale Ralph lock for ${pid} since ${createdAt}: ${lockPath}`,
+      "Remove the lock only after confirming no Ralph run is active for this worktree, then retry.",
+    ].join("\n"),
+  );
+}
+
+async function acquireRalphWorktreeLock(worktreeDir: string): Promise<RalphWorktreeLock> {
+  const lockPath = join(worktreeDir, RALPH_WORKTREE_LOCK_FILENAME);
+  const content = `${process.pid}\n${new Date().toISOString()}\n`;
+
+  try {
+    await writeFile(lockPath, content, { encoding: "utf8", flag: "wx" });
+    return { path: lockPath, content };
+  } catch (error) {
+    if (errorCode(error) !== "EEXIST") {
+      throw new Error(`Failed to create Ralph worktree lock at ${lockPath}: ${errorMessage(error)}`);
+    }
+  }
+
+  let existingContent: string;
+  try {
+    existingContent = await readFile(lockPath, "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return await acquireRalphWorktreeLock(worktreeDir);
+    throw new Error(`git_worktree_dir lock already exists at ${lockPath}, but Ralph could not read it: ${errorMessage(error)}`);
+  }
+
+  const activeLockError = activeRalphWorktreeLockError(lockPath, existingContent);
+  if (activeLockError !== undefined) throw activeLockError;
+  throw staleRalphWorktreeLockError(lockPath, existingContent);
+}
+
+async function releaseRalphWorktreeLock(lock: RalphWorktreeLock | undefined): Promise<void> {
+  if (lock === undefined) return;
+
+  let currentContent: string;
+  try {
+    currentContent = await readFile(lock.path, "utf8");
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      console.warn(`Failed to read Ralph worktree lock during cleanup at ${lock.path}: ${errorMessage(error)}`);
+    }
+    return;
+  }
+
+  if (currentContent !== lock.content) {
+    console.warn(`Preserving Ralph worktree lock because it no longer belongs to this run: ${lock.path}`);
+    return;
+  }
+
+  try {
+    await unlink(lock.path);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      console.warn(`Failed to remove Ralph worktree lock at ${lock.path}: ${errorMessage(error)}`);
+    }
   }
 }
 
@@ -426,7 +537,8 @@ async function createGitWorktreeIfRequested(
   const requestedWorktreeDir = resolveWorktreePath(trimmed, repoRoot);
   if (await pathExists(requestedWorktreeDir)) {
     if (existingPathIsGitWorktree(requestedWorktreeDir)) {
-      return { cwd: requestedWorktreeDir };
+      const lock = await acquireRalphWorktreeLock(requestedWorktreeDir);
+      return { cwd: requestedWorktreeDir, lock };
     }
     throw new Error(`git_worktree_dir already exists but is not a Git worktree: ${requestedWorktreeDir}`);
   }
@@ -440,7 +552,8 @@ async function createGitWorktreeIfRequested(
       ].join("\n"),
     );
   }
-  return { cwd: requestedWorktreeDir };
+  const lock = await acquireRalphWorktreeLock(requestedWorktreeDir);
+  return { cwd: requestedWorktreeDir, lock };
 }
 
 function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
@@ -827,6 +940,7 @@ async function runRalphWorkflow(
           [
             `Start by reading the spec file at ${specPath}.`,
             "Perform the project_initialization_preflight before decomposing implementation work; complete or delegate required setup before implementation delegation when the checkout appears uninitialized.",
+            "If `.ralph.lock` exists in the workspace, treat it as Ralph's concurrency lock: do not edit, stage, commit, report, or delegate it as part of the requested code change.",
             "Decompose the work into delegated subagent tasks based on that spec file.",
             "Pass each subagent the relevant task, constraints, files, validation expectations, any prior review findings from the spec, and instructions to report implementation-note-worthy decisions or tradeoffs.",
             "Coordinate subagent results into the smallest coherent set of changes that satisfies the spec.",
@@ -1286,7 +1400,7 @@ async function runRalphWorkflow(
           "If no logged-in account can access the repository or create the PR, do not fake success; report each credential/account tried, what failed, and provide the command the user can run later.",
           "When you successfully create or update the PR, create a PR comment containing the implementation notes file contents as the last action of this workflow stage.",
           "Ralph-created worktrees are detached HEAD checkouts. If you are preparing a PR from a detached HEAD, create and push a branch from the current HEAD, for example with `git checkout -b <branch>` or `git push origin HEAD:refs/heads/<branch>`, before opening the PR.",
-          "Ralph does not remove git_worktree_dir automatically. Leave the worktree intact for retries or user recovery.",
+          "Ralph writes a `.ralph.lock` file while a git_worktree_dir run is active, removes that lock on exit, and does not remove git_worktree_dir automatically. Treat `.ralph.lock` as internal run state: do not stage, commit, or describe it as a meaningful change. Leave the worktree intact for retries or user recovery.",
           "If PR creation is not possible, do not create a standalone comment elsewhere; include the implementation notes path and summary in your report instead.",
           "If the review loop did not approve, prefer reporting the remaining blockers over creating a PR unless the changes are still intentionally ready for human review.",
           "Do not make unrelated code edits in this phase. Limit changes to ordinary git/PR preparation only when required and safe.",
@@ -1348,7 +1462,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees are reused as-is, and missing paths are created from base_branch."
+      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees are reused as-is, active .ralph.lock files prevent concurrent use, and missing paths are created from base_branch."
   })
   .run(async (ctx) => {
     const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;
@@ -1368,12 +1482,16 @@ export default defineWorkflow("ralph")
       task: (name, options) => ralphCtx.task(name, options),
       parallel: (steps, options) => ralphCtx.parallel(steps, options),
     };
-    return await runRalphWorkflow(workflowCtx, {
-      prompt,
-      maxLoops,
-      comparisonBaseBranch,
-      workflowStartCwd,
-      workflowCwd: worktree.cwd,
-    });
+    try {
+      return await runRalphWorkflow(workflowCtx, {
+        prompt,
+        maxLoops,
+        comparisonBaseBranch,
+        workflowStartCwd,
+        workflowCwd: worktree.cwd,
+      });
+    } finally {
+      await releaseRalphWorktreeLock(worktree.lock);
+    }
   })
   .compile();

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -1436,5 +1436,5 @@ export default defineWorkflow("ralph")
     description:
       "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees from the invoking repository are reused/shared as-is, and missing paths are created from base_branch."
   })
-  .run(async (ctx) => runRalphWorkflowFromCwd(ctx as WorkflowRunContext<RalphInputs>))
+  .run(async (ctx) => runRalphWorkflowFromCwd(ctx as WorkflowRunContext<RalphInputs>, ctx.cwd))
   .compile();

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -1358,17 +1358,7 @@ export default defineWorkflow("ralph")
     const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
     const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
     const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
-    // Discovery's static workflowRunCreatesStage guard in
-    // packages/workflows/src/extension/discovery.ts checks this run function
-    // for direct stage primitive calls without executing helper bodies. Keep
-    // this live adapter explicit so Ralph remains discoverable while
-    // runRalphWorkflow owns the real orchestration body.
-    const workflowCtx: WorkflowRunContext<RalphInputs> = {
-      ...ralphCtx,
-      task: (name, options) => ralphCtx.task(name, options),
-      parallel: (steps, options) => ralphCtx.parallel(steps, options),
-    };
-    return await runRalphWorkflow(workflowCtx, {
+    return await runRalphWorkflow(ralphCtx, {
       prompt,
       maxLoops,
       comparisonBaseBranch,

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -360,6 +360,15 @@ function safeWorktreePathSegment(value: string): string {
   return segment.length > 0 ? segment.slice(0, 60) : "worktree";
 }
 
+function requireGitRepositoryForWorktree(cwd = process.cwd()): void {
+  const repoRootResult = runGit(["rev-parse", "--show-toplevel"], cwd);
+  if (repoRootResult.status !== 0) {
+    throw new Error(
+      `git_worktree_dir requires Ralph to be invoked from inside a Git repository. Start Ralph from a Git checkout or omit git_worktree_dir. Git reported: ${gitFailureMessage(repoRootResult)}`,
+    );
+  }
+}
+
 function defaultGitWorktreePath(baseBranch: string, cwd = process.cwd()): string {
   const repoRootResult = runGit(["rev-parse", "--show-toplevel"], cwd);
   if (repoRootResult.status !== 0) {
@@ -411,6 +420,8 @@ async function createGitWorktreeIfRequested(
 ): Promise<GitWorktreeSetup> {
   const trimmed = value?.trim();
   if (!trimmed) return { created: false };
+
+  requireGitRepositoryForWorktree(cwd);
 
   const requestedWorktreeDir = resolveOptionalWorktreePath(value, cwd);
   if (requestedWorktreeDir !== undefined) {
@@ -1351,7 +1362,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional git worktree checkout path. Ralph assumes it is invoked from inside the host repository; relative paths resolve from that repository cwd. When set, all Ralph stages run from a detached-HEAD worktree created from base_branch. Successful runs remove the worktree; failed runs preserve it for recovery. Do not share one worktree path across concurrent runs.",
+      "Optional git worktree checkout path. Ralph must be invoked from inside a Git repository when this is set; otherwise it fails fast. Relative paths resolve from that repository cwd. When set, all Ralph stages run from a detached-HEAD worktree created from base_branch. Successful runs remove the worktree; failed runs preserve it for recovery. Do not share one worktree path across concurrent runs.",
   })
   .run(async (ctx) => {
     const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -7,9 +7,11 @@
  * iteration feeds review findings into the next planner with ctx.task().
  */
 
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, extname, join } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
 import type { WorkflowTaskResult } from "../src/shared/types.js";
 
@@ -288,6 +290,128 @@ async function writeSpecFile(path: string, content: string): Promise<string> {
   }
 }
 
+type GitCommandResult = {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number | null;
+  readonly error?: Error;
+};
+
+const GIT_LOCAL_ENV_VARS = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE",
+] as const;
+
+function gitProcessEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of GIT_LOCAL_ENV_VARS) {
+    delete env[key];
+  }
+  return env;
+}
+
+function runGit(args: readonly string[], cwd = process.cwd()): GitCommandResult {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: gitProcessEnv(),
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    status: result.status,
+    ...(result.error === undefined ? {} : { error: result.error }),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function gitFailureMessage(result: GitCommandResult): string {
+  if (result.error !== undefined) return result.error.message;
+  return result.stderr.trim() || result.stdout.trim() || `git exited with status ${result.status}`;
+}
+
+function resolveOptionalWorktreePath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.includes("\0")) return undefined;
+  return isAbsolute(trimmed) ? resolve(trimmed) : resolve(process.cwd(), trimmed);
+}
+
+function safeWorktreePathSegment(value: string): string {
+  const segment = value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return segment.length > 0 ? segment.slice(0, 60) : "worktree";
+}
+
+function defaultGitWorktreePath(baseBranch: string): string {
+  const repoRootResult = runGit(["rev-parse", "--show-toplevel"]);
+  if (repoRootResult.status !== 0) {
+    throw new Error(`Failed to resolve repository root for git_worktree_dir fallback: ${gitFailureMessage(repoRootResult)}`);
+  }
+
+  const repoRoot = repoRootResult.stdout.trim();
+  const repoName = safeWorktreePathSegment(basename(repoRoot) || "repo");
+  const branchName = safeWorktreePathSegment(baseBranch.replace(/^refs\/heads\//, ""));
+  const digest = createHash("sha256").update(`${repoRoot}\0${baseBranch}`).digest("hex").slice(0, 12);
+  return join(tmpdir(), "atomic-ralph-worktrees", `${repoName}-${branchName}-${digest}`);
+}
+
+async function addGitWorktree(worktreeDir: string, baseBranch: string): Promise<GitCommandResult> {
+  try {
+    await mkdir(dirname(worktreeDir), { recursive: true });
+  } catch (error) {
+    return {
+      stdout: "",
+      stderr: `failed to create worktree parent directory: ${errorMessage(error)}`,
+      status: 1,
+    };
+  }
+  return runGit(["worktree", "add", "--detach", worktreeDir, baseBranch]);
+}
+
+async function createGitWorktreeIfRequested(
+  value: string | undefined,
+  baseBranch: string,
+): Promise<string | undefined> {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+
+  const requestedWorktreeDir = resolveOptionalWorktreePath(value);
+  if (requestedWorktreeDir !== undefined) {
+    const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch);
+    if (requestedResult.status === 0) return requestedWorktreeDir;
+  }
+
+  const fallbackWorktreeDir = defaultGitWorktreePath(baseBranch);
+  const fallbackResult = await addGitWorktree(fallbackWorktreeDir, baseBranch);
+  if (fallbackResult.status === 0) return fallbackWorktreeDir;
+
+  throw new Error(`Failed to create fallback git worktree at ${fallbackWorktreeDir} from ${baseBranch}: ${gitFailureMessage(fallbackResult)}`);
+}
+
+function pathInWorkflowCwd(filePath: string, workflowCwd: string | undefined): string {
+  if (workflowCwd === undefined || isAbsolute(filePath)) return filePath;
+  return join(workflowCwd, filePath);
+}
+
+function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
+  return workflowCwd === undefined ? {} : { cwd: workflowCwd };
+}
+
 async function createImplementationNotesFile(prompt: string): Promise<string> {
   const notesDir = await mkdtemp(join(tmpdir(), "atomic-ralph-notes-"));
   const notesPath = join(notesDir, IMPLEMENTATION_NOTES_FILENAME);
@@ -401,15 +525,24 @@ export default defineWorkflow("ralph")
     description:
       "Branch reviewers compare the current code delta against (default origin/main).",
   })
+  .input("git_worktree_dir", {
+    type: "string",
+    default: "",
+    description:
+      "Optional git worktree checkout path. Relative paths resolve from the current working directory; when set, all Ralph stages run from this worktree created from base_branch.",
+  })
   .run(async (ctx) => {
     const inputs = ctx.inputs as {
       prompt?: string;
       max_loops?: number;
       base_branch?: string;
+      git_worktree_dir?: string;
     };
     const prompt = inputs.prompt ?? "";
     const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
     const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
+    const workflowCwd = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch);
+    const cwdOption = workflowCwdOption(workflowCwd);
 
     let reviewReport = "";
     let finalPlan = "";
@@ -581,9 +714,10 @@ export default defineWorkflow("ralph")
           ? { previous: { name: "review-report", text: reviewReport } }
           : {}),
         ...plannerModelConfig,
+        ...cwdOption,
       });
       finalPlan = planner.text;
-      const specPath = await writeSpecFile(defaultSpecPath(prompt), planner.text);
+      const specPath = await writeSpecFile(pathInWorkflowCwd(defaultSpecPath(prompt), workflowCwd), planner.text);
       finalPlanPath = specPath;
 
       const orchestrator = await ctx.task(`orchestrator-${iteration}`, {
@@ -691,6 +825,7 @@ export default defineWorkflow("ralph")
         ]),
         reads: [specPath, implementationNotesPath],
         ...orchestratorModelConfig,
+        ...cwdOption,
       });
       finalResult = orchestrator.text;
 
@@ -789,6 +924,7 @@ export default defineWorkflow("ralph")
         ]),
         previous: [planner, orchestrator],
         ...simplifierModelConfig,
+        ...cwdOption,
       });
 
       const discovery = await ctx.parallel(
@@ -828,6 +964,7 @@ export default defineWorkflow("ralph")
               ],
             ]),
             ...explorerModelConfig,
+            ...cwdOption,
           },
           {
             name: `infra-analyze-${iteration}`,
@@ -868,6 +1005,7 @@ export default defineWorkflow("ralph")
               ],
             ]),
             ...explorerModelConfig,
+            ...cwdOption,
           },
           {
             name: `infra-patterns-${iteration}`,
@@ -909,9 +1047,10 @@ export default defineWorkflow("ralph")
               ],
             ]),
             ...explorerModelConfig,
+            ...cwdOption,
           },
         ],
-        { task: prompt },
+        { task: prompt, ...cwdOption },
       );
 
       const discoveryContext = formatDiscovery(discovery);
@@ -1056,14 +1195,16 @@ export default defineWorkflow("ralph")
               name: "reviewer-a",
               task: reviewPrompt,
               ...reviewerModelConfig,
+              ...cwdOption,
             },
             {
               name: "reviewer-b",
               task: reviewPrompt,
               ...reviewerModelConfig,
+              ...cwdOption,
             },
           ],
-          { task: prompt, failFast: false },
+          { task: prompt, failFast: false, ...cwdOption },
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -1137,6 +1278,7 @@ export default defineWorkflow("ralph")
         ? [finalPlanPath, implementationNotesPath]
         : [implementationNotesPath],
       ...orchestratorModelConfig,
+      ...cwdOption,
     });
     finalPrReport = prResult.text;
 

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -380,15 +380,22 @@ type GitCommonDirResult =
   | { readonly ok: true; readonly path: string }
   | { readonly ok: false; readonly reason: string };
 
-function comparableGitPath(path: string): string {
-  let canonical = path;
+type ComparableGitPathResult =
+  | { readonly ok: true; readonly path: string }
+  | { readonly ok: false; readonly reason: string };
+
+function comparableGitPath(path: string): ComparableGitPathResult {
+  let canonical: string;
   try {
     canonical = realpathSync.native(path);
-  } catch {
-    canonical = resolve(path);
+  } catch (error) {
+    return {
+      ok: false,
+      reason: `could not resolve canonical Git path ${path}: ${errorMessage(error)}`,
+    };
   }
   const normalized = canonical.replace(/\\/g, "/");
-  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+  return { ok: true, path: process.platform === "win32" ? normalized.toLowerCase() : normalized };
 }
 
 function resolveGitPath(value: string, cwd: string): string | undefined {
@@ -431,7 +438,23 @@ function existingPathGitWorktreeStatus(worktreeDir: string, repoRoot: string): E
     };
   }
 
-  return comparableGitPath(repoCommonDir.path) === comparableGitPath(worktreeCommonDir.path)
+  const comparableRepoCommonDir = comparableGitPath(repoCommonDir.path);
+  if (!comparableRepoCommonDir.ok) {
+    return {
+      kind: "unclassified",
+      reason: `could not canonicalize invoking Git repository common directory at ${repoCommonDir.path}: ${comparableRepoCommonDir.reason}`,
+    };
+  }
+
+  const comparableWorktreeCommonDir = comparableGitPath(worktreeCommonDir.path);
+  if (!comparableWorktreeCommonDir.ok) {
+    return {
+      kind: "unclassified",
+      reason: `could not canonicalize existing git_worktree_dir common directory at ${worktreeCommonDir.path}: ${comparableWorktreeCommonDir.reason}`,
+    };
+  }
+
+  return comparableRepoCommonDir.path === comparableWorktreeCommonDir.path
     ? { kind: "same-repository" }
     : { kind: "foreign-repository" };
 }

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -465,6 +465,10 @@ async function createGitWorktreeIfRequested(
   if (await pathExists(requestedWorktreeDir)) {
     const existingStatus = existingPathGitWorktreeStatus(requestedWorktreeDir, repoRoot);
     if (existingStatus === "same-repository") {
+      // Match Claude Code's named-worktree model: an existing same-repository
+      // worktree is resumed/shared as-is rather than guarded by an app-level
+      // lock. Users choose distinct git_worktree_dir values when they need
+      // isolation between concurrent Ralph runs.
       return { cwd: requestedWorktreeDir };
     }
     if (existingStatus === "foreign-repository") {
@@ -478,7 +482,7 @@ async function createGitWorktreeIfRequested(
     throw new Error(
       [
         `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
-        `If another active Ralph run is using this path, wait for it to finish. If this is an orphaned worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(repoRoot, requestedWorktreeDir)}`,
+        `If another process just created this same-repository worktree, rerun Ralph to resume it. If this is an orphaned worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(repoRoot, requestedWorktreeDir)}`,
       ].join("\n"),
     );
   }
@@ -1390,7 +1394,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees from the invoking repository are reused as-is, and missing paths are created from base_branch."
+      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees from the invoking repository are reused/shared as-is, and missing paths are created from base_branch."
   })
   .run(async (ctx) => {
     const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
 import type { WorkflowRunContext, WorkflowTaskResult } from "../src/shared/types.js";
+import { WORKER_PREFLIGHT_CONTRACT } from "./shared-prompts.js";
 
 const DEFAULT_MAX_LOOPS = 10;
 const DEFAULT_SPEC_DIR = "specs";
@@ -365,11 +366,13 @@ function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
   return repoRootResult.stdout.trim();
 }
 
-type GitWorktreeSetup = {
-  readonly cwd?: string;
-  readonly created: boolean;
-  readonly repositoryCwd?: string;
-};
+type GitWorktreeSetup =
+  | { readonly cwd?: undefined; readonly created: false }
+  | {
+      readonly cwd: string;
+      readonly created: true;
+      readonly repositoryRoot: string;
+    };
 
 async function addGitWorktree(
   worktreeDir: string,
@@ -393,19 +396,26 @@ function removeGitWorktree(worktreeDir: string, cwd = process.cwd()): GitCommand
 }
 
 function quoteRecoveryCommandArgument(value: string): string {
-  if (process.platform === "win32") return `'${value.replace(/'/g, "''")}'`;
+  if (process.platform === "win32") return `"${value.replace(/"/g, "\"\"")}"`;
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-function formatWorktreeRecoveryCommand(repositoryCwd: string, worktreeDir: string): string {
-  return `git -C ${quoteRecoveryCommandArgument(repositoryCwd)} worktree remove --force ${quoteRecoveryCommandArgument(worktreeDir)}`;
+function formatWorktreeRecoveryCommand(repositoryRoot: string, worktreeDir: string): string {
+  return `git -C ${quoteRecoveryCommandArgument(repositoryRoot)} worktree remove --force ${quoteRecoveryCommandArgument(worktreeDir)}`;
 }
 
 const WORKTREE_CLEANUP_SAFE_MARKER = "Worktree cleanup: safe-to-remove";
 const WORKTREE_CLEANUP_PRESERVE_MARKER = "Worktree cleanup: preserve";
 
 function prReportAllowsWorktreeCleanup(report: string): boolean {
-  return report.includes(WORKTREE_CLEANUP_SAFE_MARKER);
+  const cleanupLines = report
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) =>
+      line === WORKTREE_CLEANUP_SAFE_MARKER ||
+      line === WORKTREE_CLEANUP_PRESERVE_MARKER,
+    );
+  return cleanupLines.at(-1) === WORKTREE_CLEANUP_SAFE_MARKER;
 }
 
 async function createGitWorktreeIfRequested(
@@ -416,19 +426,19 @@ async function createGitWorktreeIfRequested(
   const trimmed = value?.trim();
   if (!trimmed) return { created: false };
 
-  requireGitRepositoryForWorktree(cwd);
+  const repoRoot = requireGitRepositoryForWorktree(cwd);
 
-  const requestedWorktreeDir = resolveWorktreePath(trimmed, cwd);
-  const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, cwd);
+  const requestedWorktreeDir = resolveWorktreePath(trimmed, repoRoot);
+  const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, repoRoot);
   if (requestedResult.status !== 0) {
     throw new Error(
       [
         `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
-        `If another active Ralph run is using this path, wait for it to finish. If this is an orphaned worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(cwd, requestedWorktreeDir)}`,
+        `If another active Ralph run is using this path, wait for it to finish. If this is an orphaned worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(repoRoot, requestedWorktreeDir)}`,
       ].join("\n"),
     );
   }
-  return { cwd: requestedWorktreeDir, created: true, repositoryCwd: cwd };
+  return { cwd: requestedWorktreeDir, created: true, repositoryRoot: repoRoot };
 }
 
 function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
@@ -774,19 +784,7 @@ async function runRalphWorkflow(
         ],
         [
           "project_initialization_preflight",
-          [
-            // Intentionally duplicated from goal.ts: Ralph keeps its worker preflight inline
-            // because this prompt is stage-specific and includes Ralph-only orchestration context.
-            "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
-            "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
-            "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
-            "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
-            "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
-            "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
-            "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
-            "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
-            "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
-          ].join("\n"),
+          WORKER_PREFLIGHT_CONTRACT,
         ],
         [
           "delegation_policy",
@@ -1347,7 +1345,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional git worktree checkout path. Ralph must be invoked from inside a Git repository when this is set; otherwise it fails fast. Relative paths resolve from that repository cwd. When set, all Ralph stages run from a detached-HEAD worktree created from base_branch. Successful runs remove the worktree; failed runs preserve it for recovery. Do not share one worktree path across concurrent runs.",
+      "Optional Git worktree path; when set, Ralph must start inside a Git repo and runs stages from a detached worktree created at this repo-root-relative path."
   })
   .run(async (ctx) => {
     const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;
@@ -1380,7 +1378,7 @@ export default defineWorkflow("ralph")
       return result;
     } finally {
       if (worktree.created && worktree.cwd !== undefined) {
-        const recoveryCommand = formatWorktreeRecoveryCommand(worktree.repositoryCwd ?? workflowStartCwd, worktree.cwd);
+        const recoveryCommand = formatWorktreeRecoveryCommand(worktree.repositoryRoot, worktree.cwd);
         if (result === undefined) {
           console.warn(
             [
@@ -1396,7 +1394,7 @@ export default defineWorkflow("ralph")
             ].join("\n"),
           );
         } else {
-          const cleanupResult = removeGitWorktree(worktree.cwd, worktree.repositoryCwd);
+          const cleanupResult = removeGitWorktree(worktree.cwd, worktree.repositoryRoot);
           if (cleanupResult.status !== 0) {
             console.warn(
               [

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -297,6 +297,8 @@ type GitCommandResult = {
   readonly error?: Error;
 };
 
+// Scrub only Git's local repository/worktree-scoping environment so internal
+// Git commands operate from the cwd we pass instead of an inherited checkout.
 const GIT_LOCAL_ENV_VARS = [
   "GIT_ALTERNATE_OBJECT_DIRECTORIES",
   "GIT_COMMON_DIR",
@@ -346,10 +348,10 @@ function gitFailureMessage(result: GitCommandResult): string {
   return result.stderr.trim() || result.stdout.trim() || `git exited with status ${result.status}`;
 }
 
-function resolveOptionalWorktreePath(value: string | undefined): string | undefined {
+function resolveOptionalWorktreePath(value: string | undefined, cwd = process.cwd()): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || trimmed.includes("\0")) return undefined;
-  return isAbsolute(trimmed) ? resolve(trimmed) : resolve(process.cwd(), trimmed);
+  return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
 }
 
 function safeWorktreePathSegment(value: string): string {
@@ -357,8 +359,8 @@ function safeWorktreePathSegment(value: string): string {
   return segment.length > 0 ? segment.slice(0, 60) : "worktree";
 }
 
-function defaultGitWorktreePath(baseBranch: string): string {
-  const repoRootResult = runGit(["rev-parse", "--show-toplevel"]);
+function defaultGitWorktreePath(baseBranch: string, cwd = process.cwd()): string {
+  const repoRootResult = runGit(["rev-parse", "--show-toplevel"], cwd);
   if (repoRootResult.status !== 0) {
     throw new Error(`Failed to resolve repository root for git_worktree_dir fallback: ${gitFailureMessage(repoRootResult)}`);
   }
@@ -370,7 +372,17 @@ function defaultGitWorktreePath(baseBranch: string): string {
   return join(tmpdir(), "atomic-ralph-worktrees", `${repoName}-${branchName}-${digest}`);
 }
 
-async function addGitWorktree(worktreeDir: string, baseBranch: string): Promise<GitCommandResult> {
+type GitWorktreeSetup = {
+  readonly cwd?: string;
+  readonly created: boolean;
+  readonly repositoryCwd?: string;
+};
+
+async function addGitWorktree(
+  worktreeDir: string,
+  baseBranch: string,
+  cwd = process.cwd(),
+): Promise<GitCommandResult> {
   try {
     await mkdir(dirname(worktreeDir), { recursive: true });
   } catch (error) {
@@ -380,32 +392,39 @@ async function addGitWorktree(worktreeDir: string, baseBranch: string): Promise<
       status: 1,
     };
   }
-  return runGit(["worktree", "add", "--detach", worktreeDir, baseBranch]);
+  return runGit(["worktree", "add", "--detach", worktreeDir, baseBranch], cwd);
+}
+
+function removeGitWorktree(worktreeDir: string, cwd = process.cwd()): GitCommandResult {
+  return runGit(["worktree", "remove", "--force", worktreeDir], cwd);
 }
 
 async function createGitWorktreeIfRequested(
   value: string | undefined,
   baseBranch: string,
-): Promise<string | undefined> {
+  cwd = process.cwd(),
+): Promise<GitWorktreeSetup> {
   const trimmed = value?.trim();
-  if (!trimmed) return undefined;
+  if (!trimmed) return { created: false };
 
-  const requestedWorktreeDir = resolveOptionalWorktreePath(value);
+  const requestedWorktreeDir = resolveOptionalWorktreePath(value, cwd);
   if (requestedWorktreeDir !== undefined) {
-    const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch);
-    if (requestedResult.status === 0) return requestedWorktreeDir;
+    const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, cwd);
+    if (requestedResult.status !== 0) {
+      throw new Error(
+        `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
+      );
+    }
+    return { cwd: requestedWorktreeDir, created: true, repositoryCwd: cwd };
   }
 
-  const fallbackWorktreeDir = defaultGitWorktreePath(baseBranch);
-  const fallbackResult = await addGitWorktree(fallbackWorktreeDir, baseBranch);
-  if (fallbackResult.status === 0) return fallbackWorktreeDir;
+  const fallbackWorktreeDir = defaultGitWorktreePath(baseBranch, cwd);
+  const fallbackResult = await addGitWorktree(fallbackWorktreeDir, baseBranch, cwd);
+  if (fallbackResult.status === 0) {
+    return { cwd: fallbackWorktreeDir, created: true, repositoryCwd: cwd };
+  }
 
   throw new Error(`Failed to create fallback git worktree at ${fallbackWorktreeDir} from ${baseBranch}: ${gitFailureMessage(fallbackResult)}`);
-}
-
-function pathInWorkflowCwd(filePath: string, workflowCwd: string | undefined): string {
-  if (workflowCwd === undefined || isAbsolute(filePath)) return filePath;
-  return join(workflowCwd, filePath);
 }
 
 function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
@@ -529,7 +548,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional git worktree checkout path. Relative paths resolve from the current working directory; when set, all Ralph stages run from this worktree created from base_branch.",
+      "Optional git worktree checkout path. Ralph assumes it is invoked from inside the host repository; relative paths resolve from that repository cwd. When set, all Ralph stages run from a temporary worktree created from base_branch and removed when the workflow finishes.",
   })
   .run(async (ctx) => {
     const inputs = ctx.inputs as {
@@ -538,12 +557,16 @@ export default defineWorkflow("ralph")
       base_branch?: string;
       git_worktree_dir?: string;
     };
+    const workflowStartCwd = process.cwd();
     const prompt = inputs.prompt ?? "";
     const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
     const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
-    const workflowCwd = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch);
+    const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
+    const workflowCwd = worktree.cwd;
     const cwdOption = workflowCwdOption(workflowCwd);
+    let runError: unknown;
 
+    try {
     let reviewReport = "";
     let finalPlan = "";
     let finalPlanPath = "";
@@ -717,7 +740,7 @@ export default defineWorkflow("ralph")
         ...cwdOption,
       });
       finalPlan = planner.text;
-      const specPath = await writeSpecFile(pathInWorkflowCwd(defaultSpecPath(prompt), workflowCwd), planner.text);
+      const specPath = await writeSpecFile(resolve(workflowStartCwd, defaultSpecPath(prompt)), planner.text);
       finalPlanPath = specPath;
 
       const orchestrator = await ctx.task(`orchestrator-${iteration}`, {
@@ -1292,5 +1315,16 @@ export default defineWorkflow("ralph")
       iterations_completed: iterationsCompleted,
       review_report: reviewReport,
     };
+    } catch (error) {
+      runError = error;
+      throw error;
+    } finally {
+      if (worktree.created && worktree.cwd !== undefined) {
+        const cleanupResult = removeGitWorktree(worktree.cwd, worktree.repositoryCwd);
+        if (cleanupResult.status !== 0 && runError === undefined) {
+          throw new Error(`Failed to remove git worktree at ${worktree.cwd}: ${gitFailureMessage(cleanupResult)}`);
+        }
+      }
+    }
   })
   .compile();

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -7,11 +7,9 @@
  * iteration feeds review findings into the next planner with ctx.task().
  */
 
-import { spawnSync } from "node:child_process";
-import { realpathSync } from "node:fs";
-import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
 import type { WorkflowRunContext, WorkflowTaskResult } from "../src/shared/types.js";
 import { WORKER_PREFLIGHT_CONTRACT } from "./shared-prompts.js";
@@ -271,258 +269,6 @@ async function writeSpecFile(path: string, content: string): Promise<string> {
   return path;
 }
 
-type GitCommandResult = {
-  readonly stdout: string;
-  readonly stderr: string;
-  readonly status: number | null;
-  readonly error?: Error;
-};
-
-// Scrub only Git's local repository/worktree-scoping environment so internal
-// Git commands operate from the cwd we pass instead of an inherited checkout.
-const GIT_LOCAL_ENV_VARS = [
-  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  "GIT_COMMON_DIR",
-  "GIT_CONFIG",
-  "GIT_CONFIG_COUNT",
-  "GIT_CONFIG_PARAMETERS",
-  "GIT_DIR",
-  "GIT_GRAFT_FILE",
-  "GIT_IMPLICIT_WORK_TREE",
-  "GIT_INDEX_FILE",
-  "GIT_NO_REPLACE_OBJECTS",
-  "GIT_OBJECT_DIRECTORY",
-  "GIT_PREFIX",
-  "GIT_REPLACE_REF_BASE",
-  "GIT_SHALLOW_FILE",
-  "GIT_WORK_TREE",
-] as const;
-
-function gitProcessEnv(): NodeJS.ProcessEnv {
-  // Only Ralph's internal bookkeeping Git commands use this scrubbed env;
-  // worker stages keep the host/CI credential configuration they inherit.
-  const env = { ...process.env };
-  for (const key of GIT_LOCAL_ENV_VARS) {
-    delete env[key];
-  }
-  return env;
-}
-
-function runGit(args: readonly string[], cwd = process.cwd()): GitCommandResult {
-  const result = spawnSync("git", args, {
-    cwd,
-    encoding: "utf8",
-    env: gitProcessEnv(),
-  });
-  return {
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
-    status: result.status,
-    ...(result.error === undefined ? {} : { error: result.error }),
-  };
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function gitFailureMessage(result: GitCommandResult): string {
-  if (result.error !== undefined) return result.error.message;
-  return result.stderr.trim() || result.stdout.trim() || `git exited with status ${result.status}`;
-}
-
-function resolveWorktreePath(value: string, cwd = process.cwd()): string {
-  const trimmed = value.trim();
-  if (trimmed.includes("\0")) {
-    throw new Error("git_worktree_dir contains an unusable null byte; provide a valid path or omit git_worktree_dir.");
-  }
-  return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
-}
-
-function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
-  const repoRootResult = runGit(["rev-parse", "--show-toplevel"], cwd);
-  if (repoRootResult.status !== 0) {
-    throw new Error(
-      `git_worktree_dir requires Ralph to be invoked from inside a Git repository. Start Ralph from a Git checkout or omit git_worktree_dir. Git reported: ${gitFailureMessage(repoRootResult)}`,
-    );
-  }
-  return repoRootResult.stdout.trim();
-}
-
-type GitWorktreeSetup = {
-  readonly cwd?: string;
-};
-
-async function addGitWorktree(
-  worktreeDir: string,
-  baseBranch: string,
-  cwd = process.cwd(),
-): Promise<GitCommandResult> {
-  try {
-    await mkdir(dirname(worktreeDir), { recursive: true });
-  } catch (error) {
-    return {
-      stdout: "",
-      stderr: `mkdir: failed to create worktree parent directory: ${errorMessage(error)}`,
-      status: 1,
-    };
-  }
-  return runGit(["worktree", "add", "--detach", worktreeDir, baseBranch], cwd);
-}
-
-type ExistingGitWorktreeStatus =
-  | { readonly kind: "same-repository" }
-  | { readonly kind: "foreign-repository" }
-  | { readonly kind: "not-git-worktree" }
-  | { readonly kind: "unclassified"; readonly reason: string };
-
-type GitCommonDirResult =
-  | { readonly ok: true; readonly path: string }
-  | { readonly ok: false; readonly reason: string };
-
-type ComparableGitPathResult =
-  | { readonly ok: true; readonly path: string }
-  | { readonly ok: false; readonly reason: string };
-
-function comparableGitPath(path: string): ComparableGitPathResult {
-  let canonical: string;
-  try {
-    canonical = realpathSync.native(path);
-  } catch (error) {
-    return {
-      ok: false,
-      reason: `could not resolve canonical Git path ${path}: ${errorMessage(error)}`,
-    };
-  }
-  const normalized = canonical.replace(/\\/g, "/");
-  return { ok: true, path: process.platform === "win32" ? normalized.toLowerCase() : normalized };
-}
-
-function resolveGitPath(value: string, cwd: string): string | undefined {
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
-}
-
-function gitCommonDir(cwd: string): GitCommonDirResult {
-  const result = runGit(["rev-parse", "--git-common-dir"], cwd);
-  if (result.status !== 0) {
-    return { ok: false, reason: gitFailureMessage(result) };
-  }
-  const path = resolveGitPath(result.stdout, cwd);
-  if (path === undefined) {
-    return { ok: false, reason: "git rev-parse --git-common-dir returned an empty path" };
-  }
-  return { ok: true, path };
-}
-
-function existingPathGitWorktreeStatus(worktreeDir: string, repoRoot: string): ExistingGitWorktreeStatus {
-  const insideWorkTreeResult = runGit(["rev-parse", "--is-inside-work-tree"], worktreeDir);
-  if (insideWorkTreeResult.status !== 0 || insideWorkTreeResult.stdout.trim() !== "true") {
-    return { kind: "not-git-worktree" };
-  }
-
-  const repoCommonDir = gitCommonDir(repoRoot);
-  if (!repoCommonDir.ok) {
-    return {
-      kind: "unclassified",
-      reason: `could not inspect invoking Git repository common directory at ${repoRoot}: ${repoCommonDir.reason}`,
-    };
-  }
-
-  const worktreeCommonDir = gitCommonDir(worktreeDir);
-  if (!worktreeCommonDir.ok) {
-    return {
-      kind: "unclassified",
-      reason: `could not inspect existing git_worktree_dir common directory at ${worktreeDir}: ${worktreeCommonDir.reason}`,
-    };
-  }
-
-  const comparableRepoCommonDir = comparableGitPath(repoCommonDir.path);
-  if (!comparableRepoCommonDir.ok) {
-    return {
-      kind: "unclassified",
-      reason: `could not canonicalize invoking Git repository common directory at ${repoCommonDir.path}: ${comparableRepoCommonDir.reason}`,
-    };
-  }
-
-  const comparableWorktreeCommonDir = comparableGitPath(worktreeCommonDir.path);
-  if (!comparableWorktreeCommonDir.ok) {
-    return {
-      kind: "unclassified",
-      reason: `could not canonicalize existing git_worktree_dir common directory at ${worktreeCommonDir.path}: ${comparableWorktreeCommonDir.reason}`,
-    };
-  }
-
-  return comparableRepoCommonDir.path === comparableWorktreeCommonDir.path
-    ? { kind: "same-repository" }
-    : { kind: "foreign-repository" };
-}
-
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch (error) {
-    if ((error as { readonly code?: string }).code === "ENOENT") return false;
-    throw error;
-  }
-}
-
-function quoteRecoveryCommandArgument(value: string): string {
-  if (process.platform === "win32") return `"${value.replace(/"/g, "\"\"")}"`;
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
-function formatWorktreeRecoveryCommand(repositoryRoot: string, worktreeDir: string): string {
-  return `git -C ${quoteRecoveryCommandArgument(repositoryRoot)} worktree remove --force ${quoteRecoveryCommandArgument(worktreeDir)}`;
-}
-
-async function createGitWorktreeIfRequested(
-  value: string | undefined,
-  baseBranch: string,
-  cwd = process.cwd(),
-): Promise<GitWorktreeSetup> {
-  const trimmed = value?.trim();
-  if (!trimmed) return {};
-
-  const repoRoot = requireGitRepositoryForWorktree(cwd);
-
-  const requestedWorktreeDir = resolveWorktreePath(trimmed, repoRoot);
-  if (await pathExists(requestedWorktreeDir)) {
-    const existingStatus = existingPathGitWorktreeStatus(requestedWorktreeDir, repoRoot);
-    if (existingStatus.kind === "same-repository") {
-      // Match Claude Code's named-worktree model: an existing same-repository
-      // worktree is resumed/shared as-is rather than guarded by an app-level
-      // lock. Users choose distinct git_worktree_dir values when they need
-      // isolation between concurrent Ralph runs.
-      return { cwd: requestedWorktreeDir };
-    }
-    if (existingStatus.kind === "foreign-repository") {
-      throw new Error(`git_worktree_dir already exists but does not belong to the invoking Git repository: ${requestedWorktreeDir}`);
-    }
-    if (existingStatus.kind === "unclassified") {
-      throw new Error(`git_worktree_dir already exists but Ralph could not verify whether it belongs to the invoking Git repository: ${requestedWorktreeDir}. ${existingStatus.reason}`);
-    }
-    throw new Error(`git_worktree_dir already exists but is not a Git worktree: ${requestedWorktreeDir}`);
-  }
-
-  const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, repoRoot);
-  if (requestedResult.status !== 0) {
-    throw new Error(
-      [
-        `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
-        `If another process just created this same-repository worktree, rerun Ralph to resume it. If this is an orphaned worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(repoRoot, requestedWorktreeDir)}`,
-      ].join("\n"),
-    );
-  }
-  return { cwd: requestedWorktreeDir };
-}
-
-function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
-  return workflowCwd === undefined ? {} : { cwd: workflowCwd };
-}
-
 async function createImplementationNotesFile(prompt: string): Promise<string> {
   const notesDir = await mkdtemp(join(tmpdir(), "atomic-ralph-notes-"));
   const notesPath = join(notesDir, IMPLEMENTATION_NOTES_FILENAME);
@@ -628,7 +374,6 @@ type RalphWorkflowOptions = {
   readonly maxLoops: number;
   readonly comparisonBaseBranch: string;
   readonly workflowStartCwd: string;
-  readonly workflowCwd?: string;
 };
 
 type RalphWorkflowResult = {
@@ -651,9 +396,7 @@ async function runRalphWorkflow(
     maxLoops,
     comparisonBaseBranch,
     workflowStartCwd,
-    workflowCwd,
   } = options;
-  const cwdOption = workflowCwdOption(workflowCwd);
 
   let reviewReport = "";
   let finalPlan = "";
@@ -842,7 +585,6 @@ async function runRalphWorkflow(
         : {}),
       ...(iteration > 1 ? { reads: [workflowSpecPath] } : {}),
       ...plannerModelConfig,
-      ...cwdOption,
     });
     finalPlan = planner.text;
     const specPath = await writeSpecFile(workflowSpecPath, planner.text);
@@ -944,7 +686,6 @@ async function runRalphWorkflow(
       ]),
       reads: [specPath, implementationNotesPath],
       ...orchestratorModelConfig,
-      ...cwdOption,
     });
     finalResult = orchestrator.text;
 
@@ -1043,7 +784,6 @@ async function runRalphWorkflow(
       ]),
       previous: [planner, orchestrator],
       ...simplifierModelConfig,
-      ...cwdOption,
     });
 
     const discovery = await ctx.parallel(
@@ -1083,7 +823,6 @@ async function runRalphWorkflow(
             ],
           ]),
           ...explorerModelConfig,
-          ...cwdOption,
         },
         {
           name: `infra-analyze-${iteration}`,
@@ -1124,7 +863,6 @@ async function runRalphWorkflow(
             ],
           ]),
           ...explorerModelConfig,
-          ...cwdOption,
         },
         {
           name: `infra-patterns-${iteration}`,
@@ -1166,10 +904,9 @@ async function runRalphWorkflow(
             ],
           ]),
           ...explorerModelConfig,
-          ...cwdOption,
         },
       ],
-      { task: prompt, ...cwdOption },
+      { task: prompt },
     );
 
     const discoveryContext = formatDiscovery(discovery);
@@ -1314,16 +1051,14 @@ async function runRalphWorkflow(
             name: "reviewer-a",
             task: reviewPrompt,
             ...reviewerModelConfig,
-            ...cwdOption,
           },
           {
             name: "reviewer-b",
             task: reviewPrompt,
             ...reviewerModelConfig,
-            ...cwdOption,
           },
         ],
-        { task: prompt, failFast: false, ...cwdOption },
+        { task: prompt, failFast: false },
       );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -1399,7 +1134,6 @@ async function runRalphWorkflow(
       ? [finalPlanPath, implementationNotesPath]
       : [implementationNotesPath],
     ...orchestratorModelConfig,
-    ...cwdOption,
   });
   finalPrReport = prResult.text;
 
@@ -1413,24 +1147,6 @@ async function runRalphWorkflow(
     iterations_completed: iterationsCompleted,
     review_report: reviewReport,
   };
-}
-
-export async function runRalphWorkflowFromCwd(
-  ctx: WorkflowRunContext<RalphInputs>,
-  workflowStartCwd = process.cwd(),
-): Promise<RalphWorkflowResult> {
-  const inputs = ctx.inputs;
-  const prompt = inputs.prompt ?? "";
-  const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
-  const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
-  const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
-  return await runRalphWorkflow(ctx, {
-    prompt,
-    maxLoops,
-    comparisonBaseBranch,
-    workflowStartCwd,
-    workflowCwd: worktree.cwd,
-  });
 }
 
 export default defineWorkflow("ralph")
@@ -1459,5 +1175,19 @@ export default defineWorkflow("ralph")
     description:
       "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees from the invoking repository are reused/shared as-is, and missing paths are created from base_branch."
   })
-  .run(async (ctx) => runRalphWorkflowFromCwd(ctx as WorkflowRunContext<RalphInputs>, ctx.cwd))
+  .worktreeFromInputs({ gitWorktreeDir: "git_worktree_dir", baseBranch: "base_branch" })
+  .run(async (ctx) => {
+    const workflowCtx = ctx as WorkflowRunContext<RalphInputs>;
+    const workflowStartCwd = workflowCtx.cwd ?? process.cwd();
+    const inputs = workflowCtx.inputs;
+    const prompt = inputs.prompt ?? "";
+    const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
+    const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
+    return await runRalphWorkflow(workflowCtx, {
+      prompt,
+      maxLoops,
+      comparisonBaseBranch,
+      workflowStartCwd,
+    });
+  })
   .compile();

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -350,32 +350,30 @@ function gitFailureMessage(result: GitCommandResult): string {
 
 function resolveOptionalWorktreePath(value: string | undefined, cwd = process.cwd()): string | undefined {
   const trimmed = value?.trim();
-  if (!trimmed || trimmed.includes("\0")) return undefined;
+  if (!trimmed) return undefined;
+  if (trimmed.includes("\0")) {
+    throw new Error("git_worktree_dir contains an unusable null byte path segment; provide a valid path or omit git_worktree_dir.");
+  }
   return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
 }
 
 function safeWorktreePathSegment(value: string): string {
   const segment = value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  // The readable segment is clipped; default path uniqueness comes from the digest.
+  // This is only a filename segment; the clipped readable text is made unique by the digest.
   return segment.length > 0 ? segment.slice(0, 60) : "worktree";
 }
 
-function requireGitRepositoryForWorktree(cwd = process.cwd()): void {
+function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
   const repoRootResult = runGit(["rev-parse", "--show-toplevel"], cwd);
   if (repoRootResult.status !== 0) {
     throw new Error(
       `git_worktree_dir requires Ralph to be invoked from inside a Git repository. Start Ralph from a Git checkout or omit git_worktree_dir. Git reported: ${gitFailureMessage(repoRootResult)}`,
     );
   }
+  return repoRootResult.stdout.trim();
 }
 
-function defaultGitWorktreePath(baseBranch: string, cwd = process.cwd()): string {
-  const repoRootResult = runGit(["rev-parse", "--show-toplevel"], cwd);
-  if (repoRootResult.status !== 0) {
-    throw new Error(`Failed to resolve repository root for git_worktree_dir fallback: ${gitFailureMessage(repoRootResult)}`);
-  }
-
-  const repoRoot = repoRootResult.stdout.trim();
+function defaultGitWorktreePath(baseBranch: string, repoRoot: string): string {
   const repoName = safeWorktreePathSegment(basename(repoRoot) || "repo");
   const branchName = safeWorktreePathSegment(baseBranch.replace(/^refs\/heads\//, ""));
   const digest = createHash("sha256").update(`${repoRoot}\0${baseBranch}`).digest("hex").slice(0, 12);
@@ -409,8 +407,13 @@ function removeGitWorktree(worktreeDir: string, cwd = process.cwd()): GitCommand
   return runGit(["worktree", "remove", "--force", worktreeDir], cwd);
 }
 
+function quoteRecoveryCommandArgument(value: string): string {
+  if (process.platform === "win32") return `'${value.replace(/'/g, "''")}'`;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 function formatWorktreeRecoveryCommand(repositoryCwd: string, worktreeDir: string): string {
-  return `git -C ${JSON.stringify(repositoryCwd)} worktree remove --force ${JSON.stringify(worktreeDir)}`;
+  return `git -C ${quoteRecoveryCommandArgument(repositoryCwd)} worktree remove --force ${quoteRecoveryCommandArgument(worktreeDir)}`;
 }
 
 async function createGitWorktreeIfRequested(
@@ -421,7 +424,7 @@ async function createGitWorktreeIfRequested(
   const trimmed = value?.trim();
   if (!trimmed) return { created: false };
 
-  requireGitRepositoryForWorktree(cwd);
+  const repoRoot = requireGitRepositoryForWorktree(cwd);
 
   const requestedWorktreeDir = resolveOptionalWorktreePath(value, cwd);
   if (requestedWorktreeDir !== undefined) {
@@ -437,7 +440,7 @@ async function createGitWorktreeIfRequested(
     return { cwd: requestedWorktreeDir, created: true, repositoryCwd: cwd };
   }
 
-  const fallbackWorktreeDir = defaultGitWorktreePath(baseBranch, cwd);
+  const fallbackWorktreeDir = defaultGitWorktreePath(baseBranch, repoRoot);
   const fallbackResult = await addGitWorktree(fallbackWorktreeDir, baseBranch, cwd);
   if (fallbackResult.status === 0) {
     return { cwd: fallbackWorktreeDir, created: true, repositoryCwd: cwd };
@@ -794,6 +797,8 @@ async function runRalphWorkflow(
         [
           "project_initialization_preflight",
           [
+            // Intentionally duplicated from goal.ts: Ralph keeps its worker preflight inline
+            // because this prompt is stage-specific and includes Ralph-only orchestration context.
             "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
             "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
             "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
@@ -1372,16 +1377,18 @@ export default defineWorkflow("ralph")
     const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
     const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
     const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
-    // Discovery validates workflow shape without executing helpers, so keep an
-    // unreachable direct stage call in this wrapper while runRalphWorkflow owns
-    // the real ctx.task()/ctx.parallel() orchestration.
-    if (Date.now() < 0) {
-      await ralphCtx.task("__discovery-stage-guard__", { prompt: "unused static guard" });
-    }
+    // Discovery validates workflow shape without executing helpers, so this
+    // live adapter keeps direct stage primitive calls visible while the helper
+    // owns the real orchestration body.
+    const workflowCtx: WorkflowRunContext<RalphInputs> = {
+      ...ralphCtx,
+      task: (name, options) => ralphCtx.task(name, options),
+      parallel: (steps, options) => ralphCtx.parallel(steps, options),
+    };
     let runSucceeded = false;
 
     try {
-      const result = await runRalphWorkflow(ralphCtx, {
+      const result = await runRalphWorkflow(workflowCtx, {
         prompt,
         maxLoops,
         comparisonBaseBranch,
@@ -1402,7 +1409,13 @@ export default defineWorkflow("ralph")
         } else {
           const cleanupResult = removeGitWorktree(worktree.cwd, worktree.repositoryCwd);
           if (cleanupResult.status !== 0) {
-            throw new Error(`Failed to remove git worktree at ${worktree.cwd}: ${gitFailureMessage(cleanupResult)}`);
+            console.warn(
+              [
+                `Failed to remove Ralph git worktree after successful run: ${worktree.cwd}`,
+                `Git reported: ${gitFailureMessage(cleanupResult)}`,
+                `Recover or remove it manually with: ${formatWorktreeRecoveryCommand(worktree.repositoryCwd ?? workflowStartCwd, worktree.cwd)}`,
+              ].join("\n"),
+            );
           }
         }
       }

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -390,7 +390,15 @@ async function addGitWorktree(
   return runGit(["worktree", "add", "--detach", worktreeDir, baseBranch], cwd);
 }
 
-type ExistingGitWorktreeStatus = "same-repository" | "foreign-repository" | "not-git-worktree";
+type ExistingGitWorktreeStatus =
+  | { readonly kind: "same-repository" }
+  | { readonly kind: "foreign-repository" }
+  | { readonly kind: "not-git-worktree" }
+  | { readonly kind: "unclassified"; readonly reason: string };
+
+type GitCommonDirResult =
+  | { readonly ok: true; readonly path: string }
+  | { readonly ok: false; readonly reason: string };
 
 function comparableGitPath(path: string): string {
   let canonical = path;
@@ -409,27 +417,43 @@ function resolveGitPath(value: string, cwd: string): string | undefined {
   return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
 }
 
-function gitCommonDir(cwd: string): string | undefined {
-  const result = runGit(["-C", cwd, "rev-parse", "--git-common-dir"]);
-  if (result.status !== 0) return undefined;
-  return resolveGitPath(result.stdout, cwd);
+function gitCommonDir(cwd: string): GitCommonDirResult {
+  const result = runGit(["rev-parse", "--git-common-dir"], cwd);
+  if (result.status !== 0) {
+    return { ok: false, reason: gitFailureMessage(result) };
+  }
+  const path = resolveGitPath(result.stdout, cwd);
+  if (path === undefined) {
+    return { ok: false, reason: "git rev-parse --git-common-dir returned an empty path" };
+  }
+  return { ok: true, path };
 }
 
 function existingPathGitWorktreeStatus(worktreeDir: string, repoRoot: string): ExistingGitWorktreeStatus {
-  const insideWorkTreeResult = runGit(["-C", worktreeDir, "rev-parse", "--is-inside-work-tree"]);
+  const insideWorkTreeResult = runGit(["rev-parse", "--is-inside-work-tree"], worktreeDir);
   if (insideWorkTreeResult.status !== 0 || insideWorkTreeResult.stdout.trim() !== "true") {
-    return "not-git-worktree";
+    return { kind: "not-git-worktree" };
   }
 
   const repoCommonDir = gitCommonDir(repoRoot);
-  const worktreeCommonDir = gitCommonDir(worktreeDir);
-  if (repoCommonDir === undefined || worktreeCommonDir === undefined) {
-    return "not-git-worktree";
+  if (!repoCommonDir.ok) {
+    return {
+      kind: "unclassified",
+      reason: `could not inspect invoking Git repository common directory at ${repoRoot}: ${repoCommonDir.reason}`,
+    };
   }
 
-  return comparableGitPath(repoCommonDir) === comparableGitPath(worktreeCommonDir)
-    ? "same-repository"
-    : "foreign-repository";
+  const worktreeCommonDir = gitCommonDir(worktreeDir);
+  if (!worktreeCommonDir.ok) {
+    return {
+      kind: "unclassified",
+      reason: `could not inspect existing git_worktree_dir common directory at ${worktreeDir}: ${worktreeCommonDir.reason}`,
+    };
+  }
+
+  return comparableGitPath(repoCommonDir.path) === comparableGitPath(worktreeCommonDir.path)
+    ? { kind: "same-repository" }
+    : { kind: "foreign-repository" };
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -464,15 +488,18 @@ async function createGitWorktreeIfRequested(
   const requestedWorktreeDir = resolveWorktreePath(trimmed, repoRoot);
   if (await pathExists(requestedWorktreeDir)) {
     const existingStatus = existingPathGitWorktreeStatus(requestedWorktreeDir, repoRoot);
-    if (existingStatus === "same-repository") {
+    if (existingStatus.kind === "same-repository") {
       // Match Claude Code's named-worktree model: an existing same-repository
       // worktree is resumed/shared as-is rather than guarded by an app-level
       // lock. Users choose distinct git_worktree_dir values when they need
       // isolation between concurrent Ralph runs.
       return { cwd: requestedWorktreeDir };
     }
-    if (existingStatus === "foreign-repository") {
+    if (existingStatus.kind === "foreign-repository") {
       throw new Error(`git_worktree_dir already exists but does not belong to the invoking Git repository: ${requestedWorktreeDir}`);
+    }
+    if (existingStatus.kind === "unclassified") {
+      throw new Error(`git_worktree_dir already exists but Ralph could not verify whether it belongs to the invoking Git repository: ${requestedWorktreeDir}. ${existingStatus.reason}`);
     }
     throw new Error(`git_worktree_dir already exists but is not a Git worktree: ${requestedWorktreeDir}`);
   }

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -8,10 +8,9 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
+import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
 import type { WorkflowRunContext, WorkflowTaskResult } from "../src/shared/types.js";
 
@@ -348,19 +347,12 @@ function gitFailureMessage(result: GitCommandResult): string {
   return result.stderr.trim() || result.stdout.trim() || `git exited with status ${result.status}`;
 }
 
-function resolveOptionalWorktreePath(value: string | undefined, cwd = process.cwd()): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) return undefined;
+function resolveWorktreePath(value: string, cwd = process.cwd()): string {
+  const trimmed = value.trim();
   if (trimmed.includes("\0")) {
     throw new Error("git_worktree_dir contains an unusable null byte path segment; provide a valid path or omit git_worktree_dir.");
   }
   return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
-}
-
-function safeWorktreePathSegment(value: string): string {
-  const segment = value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  // This is only a filename segment; the clipped readable text is made unique by the digest.
-  return segment.length > 0 ? segment.slice(0, 60) : "worktree";
 }
 
 function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
@@ -371,13 +363,6 @@ function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
     );
   }
   return repoRootResult.stdout.trim();
-}
-
-function defaultGitWorktreePath(baseBranch: string, repoRoot: string): string {
-  const repoName = safeWorktreePathSegment(basename(repoRoot) || "repo");
-  const branchName = safeWorktreePathSegment(baseBranch.replace(/^refs\/heads\//, ""));
-  const digest = createHash("sha256").update(`${repoRoot}\0${baseBranch}`).digest("hex").slice(0, 12);
-  return join(tmpdir(), "atomic-ralph-worktrees", `${repoName}-${branchName}-${digest}`);
 }
 
 type GitWorktreeSetup = {
@@ -416,6 +401,13 @@ function formatWorktreeRecoveryCommand(repositoryCwd: string, worktreeDir: strin
   return `git -C ${quoteRecoveryCommandArgument(repositoryCwd)} worktree remove --force ${quoteRecoveryCommandArgument(worktreeDir)}`;
 }
 
+const WORKTREE_CLEANUP_SAFE_MARKER = "Worktree cleanup: safe-to-remove";
+const WORKTREE_CLEANUP_PRESERVE_MARKER = "Worktree cleanup: preserve";
+
+function prReportAllowsWorktreeCleanup(report: string): boolean {
+  return report.includes(WORKTREE_CLEANUP_SAFE_MARKER);
+}
+
 async function createGitWorktreeIfRequested(
   value: string | undefined,
   baseBranch: string,
@@ -424,34 +416,19 @@ async function createGitWorktreeIfRequested(
   const trimmed = value?.trim();
   if (!trimmed) return { created: false };
 
-  const repoRoot = requireGitRepositoryForWorktree(cwd);
+  requireGitRepositoryForWorktree(cwd);
 
-  const requestedWorktreeDir = resolveOptionalWorktreePath(value, cwd);
-  if (requestedWorktreeDir !== undefined) {
-    const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, cwd);
-    if (requestedResult.status !== 0) {
-      throw new Error(
-        [
-          `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
-          `If this path is an orphaned Ralph worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(cwd, requestedWorktreeDir)}`,
-        ].join("\n"),
-      );
-    }
-    return { cwd: requestedWorktreeDir, created: true, repositoryCwd: cwd };
+  const requestedWorktreeDir = resolveWorktreePath(trimmed, cwd);
+  const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, cwd);
+  if (requestedResult.status !== 0) {
+    throw new Error(
+      [
+        `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
+        `If another active Ralph run is using this path, wait for it to finish. If this is an orphaned worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(cwd, requestedWorktreeDir)}`,
+      ].join("\n"),
+    );
   }
-
-  const fallbackWorktreeDir = defaultGitWorktreePath(baseBranch, repoRoot);
-  const fallbackResult = await addGitWorktree(fallbackWorktreeDir, baseBranch, cwd);
-  if (fallbackResult.status === 0) {
-    return { cwd: fallbackWorktreeDir, created: true, repositoryCwd: cwd };
-  }
-
-  throw new Error(
-    [
-      `Failed to create fallback git worktree at ${fallbackWorktreeDir} from ${baseBranch}: ${gitFailureMessage(fallbackResult)}`,
-      `If this path is an orphaned Ralph worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(cwd, fallbackWorktreeDir)}`,
-    ].join("\n"),
-  );
+  return { cwd: requestedWorktreeDir, created: true, repositoryCwd: cwd };
 }
 
 function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
@@ -599,7 +576,7 @@ async function runRalphWorkflow(
   let approved = false;
   let iterationsCompleted = 0;
 
-  let noAskQuestionToolSet = [
+  const noAskQuestionToolSet = [
     "read",
     "bash",
     "edit",
@@ -613,7 +590,7 @@ async function runRalphWorkflow(
     "intercom",
   ];
 
-  let plannerModelConfig = {
+  const plannerModelConfig = {
     model: "openai/gpt-5.5",
     fallbackModels: [
       "openai-codex/gpt-5.5",
@@ -625,7 +602,7 @@ async function runRalphWorkflow(
     tools: noAskQuestionToolSet,
   };
 
-  let orchestratorModelConfig = {
+  const orchestratorModelConfig = {
     model: "openai/gpt-5.5",
     fallbackModels: [
       "openai-codex/gpt-5.5",
@@ -637,7 +614,7 @@ async function runRalphWorkflow(
     tools: noAskQuestionToolSet,
   };
 
-  let simplifierModelConfig = {
+  const simplifierModelConfig = {
     model: "openai/gpt-5.5",
     fallbackModels: [
       "openai-codex/gpt-5.5",
@@ -649,7 +626,7 @@ async function runRalphWorkflow(
     tools: noAskQuestionToolSet,
   };
 
-  let reviewerModelConfig = {
+  const reviewerModelConfig = {
     model: "openai/gpt-5.5",
     fallbackModels: [
       "openai-codex/gpt-5.5",
@@ -662,7 +639,7 @@ async function runRalphWorkflow(
     customTools: [reviewDecisionTool],
   };
 
-  let explorerModelConfig = {
+  const explorerModelConfig = {
     model: "openai/gpt-5.4-mini",
     fallbackModels: [
       "openai-codex/gpt-5.4-mini",
@@ -780,6 +757,7 @@ async function runRalphWorkflow(
           "spec_file",
           [
             `The technical specification for this iteration was written to: ${specPath}`,
+            "This is an absolute host-repository path and may be outside the worktree cwd; read it exactly as provided, not as a path relative to the worktree.",
             "Read this file before delegating or implementing anything.",
             "Do not rely on an inline planner transcript; the spec file is the authoritative plan for this iteration.",
           ].join("\n"),
@@ -1306,6 +1284,7 @@ async function runRalphWorkflow(
           "If no logged-in account can access the repository or create the PR, do not fake success; report each credential/account tried, what failed, and provide the command the user can run later.",
           "When you successfully create or update the PR, create a PR comment containing the implementation notes file contents as the last action of this workflow stage.",
           "Ralph worktrees are detached HEAD checkouts. If you are preparing a PR from a detached HEAD, create and push a branch from the current HEAD, for example with `git checkout -b <branch>` or `git push origin HEAD:refs/heads/<branch>`, before opening the PR.",
+          `Include an exact cleanup signal line in your final report: \`${WORKTREE_CLEANUP_SAFE_MARKER}\` only if a PR branch was pushed or there are no meaningful changes to preserve; otherwise include \`${WORKTREE_CLEANUP_PRESERVE_MARKER}\` so Ralph keeps the worktree for recovery.`,
           "If PR creation is not possible, do not create a standalone comment elsewhere; include the implementation notes path and summary in your report instead.",
           "If the review loop did not approve, prefer reporting the remaining blockers over creating a PR unless the changes are still intentionally ready for human review.",
           "Do not make unrelated code edits in this phase. Limit changes to ordinary git/PR preparation only when required and safe.",
@@ -1320,6 +1299,7 @@ async function runRalphWorkflow(
           "3. Implementation notes comment — whether the PR comment was created as the last action, or why it could not be created",
           "4. Commands run — include exit status or clear outcome",
           "5. Follow-up for the user — exact next steps if credentials or repository state blocked PR creation",
+          `6. Worktree cleanup — include exactly one cleanup signal line: \`${WORKTREE_CLEANUP_SAFE_MARKER}\` or \`${WORKTREE_CLEANUP_PRESERVE_MARKER}\`.`,
         ].join("\n"),
       ],
     ]),
@@ -1377,33 +1357,42 @@ export default defineWorkflow("ralph")
     const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
     const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
     const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
-    // Discovery validates workflow shape without executing helpers, so this
-    // live adapter keeps direct stage primitive calls visible while the helper
-    // owns the real orchestration body.
+    // Discovery's static workflowRunCreatesStage guard in
+    // packages/workflows/src/extension/discovery.ts checks this run function
+    // for direct stage primitive calls without executing helper bodies. Keep
+    // this live adapter explicit so Ralph remains discoverable while
+    // runRalphWorkflow owns the real orchestration body.
     const workflowCtx: WorkflowRunContext<RalphInputs> = {
       ...ralphCtx,
       task: (name, options) => ralphCtx.task(name, options),
       parallel: (steps, options) => ralphCtx.parallel(steps, options),
     };
-    let runSucceeded = false;
+    let result: RalphWorkflowResult | undefined;
 
     try {
-      const result = await runRalphWorkflow(workflowCtx, {
+      result = await runRalphWorkflow(workflowCtx, {
         prompt,
         maxLoops,
         comparisonBaseBranch,
         workflowStartCwd,
         workflowCwd: worktree.cwd,
       });
-      runSucceeded = true;
       return result;
     } finally {
       if (worktree.created && worktree.cwd !== undefined) {
-        if (!runSucceeded) {
+        const recoveryCommand = formatWorktreeRecoveryCommand(worktree.repositoryCwd ?? workflowStartCwd, worktree.cwd);
+        if (result === undefined) {
           console.warn(
             [
               `Preserving Ralph git worktree after failed run: ${worktree.cwd}`,
-              `Recover work there, then remove it with: ${formatWorktreeRecoveryCommand(worktree.repositoryCwd ?? workflowStartCwd, worktree.cwd)}`,
+              `Recover work there, then remove it with: ${recoveryCommand}`,
+            ].join("\n"),
+          );
+        } else if (!prReportAllowsWorktreeCleanup(result.pr_report)) {
+          console.warn(
+            [
+              `Preserving Ralph git worktree because the PR stage did not confirm pushed or empty changes: ${worktree.cwd}`,
+              `Recover or remove it manually with: ${recoveryCommand}`,
             ].join("\n"),
           );
         } else {
@@ -1413,7 +1402,7 @@ export default defineWorkflow("ralph")
               [
                 `Failed to remove Ralph git worktree after successful run: ${worktree.cwd}`,
                 `Git reported: ${gitFailureMessage(cleanupResult)}`,
-                `Recover or remove it manually with: ${formatWorktreeRecoveryCommand(worktree.repositoryCwd ?? workflowStartCwd, worktree.cwd)}`,
+                `Recover or remove it manually with: ${recoveryCommand}`,
               ].join("\n"),
             );
           }

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
@@ -368,16 +368,8 @@ function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
   return repoRootResult.stdout.trim();
 }
 
-const RALPH_WORKTREE_LOCK_FILENAME = ".ralph.lock";
-
-type RalphWorktreeLock = {
-  readonly path: string;
-  readonly content: string;
-};
-
 type GitWorktreeSetup = {
   readonly cwd?: string;
-  readonly lock?: RalphWorktreeLock;
 };
 
 async function addGitWorktree(
@@ -407,111 +399,8 @@ async function pathExists(path: string): Promise<boolean> {
     await stat(path);
     return true;
   } catch (error) {
-    if (errorCode(error) === "ENOENT") return false;
+    if ((error as { readonly code?: string }).code === "ENOENT") return false;
     throw error;
-  }
-}
-
-function errorCode(error: unknown): string | undefined {
-  if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
-  const code = (error as { readonly code?: unknown }).code;
-  return typeof code === "string" ? code : undefined;
-}
-
-function processIdIsAlive(pid: number): boolean {
-  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return errorCode(error) !== "ESRCH";
-  }
-}
-
-function parseRalphWorktreeLock(content: string): { readonly pid?: number; readonly createdAt?: string } {
-  const [pidLine, createdAtLine] = content.trimEnd().split(/\r?\n/);
-  const pid = Number.parseInt(pidLine ?? "", 10);
-  return {
-    ...(Number.isSafeInteger(pid) && pid > 0 ? { pid } : {}),
-    ...(createdAtLine === undefined || createdAtLine.trim() === "" ? {} : { createdAt: createdAtLine.trim() }),
-  };
-}
-
-function activeRalphWorktreeLockError(lockPath: string, content: string): Error | undefined {
-  const existingLock = parseRalphWorktreeLock(content);
-  if (existingLock.pid === undefined || !processIdIsAlive(existingLock.pid)) return undefined;
-
-  const createdAt = existingLock.createdAt ?? "unknown time";
-  return new Error(
-    [
-      `git_worktree_dir is already locked by active Ralph process ${existingLock.pid} since ${createdAt}: ${lockPath}`,
-      "Use a different git_worktree_dir, wait for that run to exit, or remove the lock only after confirming the process is gone.",
-    ].join("\n"),
-  );
-}
-
-function staleRalphWorktreeLockError(lockPath: string, content: string): Error {
-  const existingLock = parseRalphWorktreeLock(content);
-  const pid = existingLock.pid === undefined ? "unknown PID" : `PID ${existingLock.pid}`;
-  const createdAt = existingLock.createdAt ?? "unknown time";
-  return new Error(
-    [
-      `git_worktree_dir has a stale Ralph lock for ${pid} since ${createdAt}: ${lockPath}`,
-      "Remove the lock only after confirming no Ralph run is active for this worktree, then retry.",
-    ].join("\n"),
-  );
-}
-
-async function acquireRalphWorktreeLock(worktreeDir: string): Promise<RalphWorktreeLock> {
-  const lockPath = join(worktreeDir, RALPH_WORKTREE_LOCK_FILENAME);
-  const content = `${process.pid}\n${new Date().toISOString()}\n`;
-
-  try {
-    await writeFile(lockPath, content, { encoding: "utf8", flag: "wx" });
-    return { path: lockPath, content };
-  } catch (error) {
-    if (errorCode(error) !== "EEXIST") {
-      throw new Error(`Failed to create Ralph worktree lock at ${lockPath}: ${errorMessage(error)}`);
-    }
-  }
-
-  let existingContent: string;
-  try {
-    existingContent = await readFile(lockPath, "utf8");
-  } catch (error) {
-    if (errorCode(error) === "ENOENT") return await acquireRalphWorktreeLock(worktreeDir);
-    throw new Error(`git_worktree_dir lock already exists at ${lockPath}, but Ralph could not read it: ${errorMessage(error)}`);
-  }
-
-  const activeLockError = activeRalphWorktreeLockError(lockPath, existingContent);
-  if (activeLockError !== undefined) throw activeLockError;
-  throw staleRalphWorktreeLockError(lockPath, existingContent);
-}
-
-async function releaseRalphWorktreeLock(lock: RalphWorktreeLock | undefined): Promise<void> {
-  if (lock === undefined) return;
-
-  let currentContent: string;
-  try {
-    currentContent = await readFile(lock.path, "utf8");
-  } catch (error) {
-    if (errorCode(error) !== "ENOENT") {
-      console.warn(`Failed to read Ralph worktree lock during cleanup at ${lock.path}: ${errorMessage(error)}`);
-    }
-    return;
-  }
-
-  if (currentContent !== lock.content) {
-    console.warn(`Preserving Ralph worktree lock because it no longer belongs to this run: ${lock.path}`);
-    return;
-  }
-
-  try {
-    await unlink(lock.path);
-  } catch (error) {
-    if (errorCode(error) !== "ENOENT") {
-      console.warn(`Failed to remove Ralph worktree lock at ${lock.path}: ${errorMessage(error)}`);
-    }
   }
 }
 
@@ -537,8 +426,7 @@ async function createGitWorktreeIfRequested(
   const requestedWorktreeDir = resolveWorktreePath(trimmed, repoRoot);
   if (await pathExists(requestedWorktreeDir)) {
     if (existingPathIsGitWorktree(requestedWorktreeDir)) {
-      const lock = await acquireRalphWorktreeLock(requestedWorktreeDir);
-      return { cwd: requestedWorktreeDir, lock };
+      return { cwd: requestedWorktreeDir };
     }
     throw new Error(`git_worktree_dir already exists but is not a Git worktree: ${requestedWorktreeDir}`);
   }
@@ -552,8 +440,7 @@ async function createGitWorktreeIfRequested(
       ].join("\n"),
     );
   }
-  const lock = await acquireRalphWorktreeLock(requestedWorktreeDir);
-  return { cwd: requestedWorktreeDir, lock };
+  return { cwd: requestedWorktreeDir };
 }
 
 function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
@@ -940,7 +827,6 @@ async function runRalphWorkflow(
           [
             `Start by reading the spec file at ${specPath}.`,
             "Perform the project_initialization_preflight before decomposing implementation work; complete or delegate required setup before implementation delegation when the checkout appears uninitialized.",
-            "If `.ralph.lock` exists in the workspace, treat it as Ralph's concurrency lock: do not edit, stage, commit, report, or delegate it as part of the requested code change.",
             "Decompose the work into delegated subagent tasks based on that spec file.",
             "Pass each subagent the relevant task, constraints, files, validation expectations, any prior review findings from the spec, and instructions to report implementation-note-worthy decisions or tradeoffs.",
             "Coordinate subagent results into the smallest coherent set of changes that satisfies the spec.",
@@ -1400,7 +1286,7 @@ async function runRalphWorkflow(
           "If no logged-in account can access the repository or create the PR, do not fake success; report each credential/account tried, what failed, and provide the command the user can run later.",
           "When you successfully create or update the PR, create a PR comment containing the implementation notes file contents as the last action of this workflow stage.",
           "Ralph-created worktrees are detached HEAD checkouts. If you are preparing a PR from a detached HEAD, create and push a branch from the current HEAD, for example with `git checkout -b <branch>` or `git push origin HEAD:refs/heads/<branch>`, before opening the PR.",
-          "Ralph writes a `.ralph.lock` file while a git_worktree_dir run is active, removes that lock on exit, and does not remove git_worktree_dir automatically. Treat `.ralph.lock` as internal run state: do not stage, commit, or describe it as a meaningful change. Leave the worktree intact for retries or user recovery.",
+          "Ralph does not remove git_worktree_dir automatically. Leave the worktree intact for retries or user recovery.",
           "If PR creation is not possible, do not create a standalone comment elsewhere; include the implementation notes path and summary in your report instead.",
           "If the review loop did not approve, prefer reporting the remaining blockers over creating a PR unless the changes are still intentionally ready for human review.",
           "Do not make unrelated code edits in this phase. Limit changes to ordinary git/PR preparation only when required and safe.",
@@ -1462,7 +1348,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees are reused as-is, active .ralph.lock files prevent concurrent use, and missing paths are created from base_branch."
+      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees are reused as-is, and missing paths are created from base_branch."
   })
   .run(async (ctx) => {
     const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;
@@ -1482,16 +1368,12 @@ export default defineWorkflow("ralph")
       task: (name, options) => ralphCtx.task(name, options),
       parallel: (steps, options) => ralphCtx.parallel(steps, options),
     };
-    try {
-      return await runRalphWorkflow(workflowCtx, {
-        prompt,
-        maxLoops,
-        comparisonBaseBranch,
-        workflowStartCwd,
-        workflowCwd: worktree.cwd,
-      });
-    } finally {
-      await releaseRalphWorktreeLock(worktree.lock);
-    }
+    return await runRalphWorkflow(workflowCtx, {
+      prompt,
+      maxLoops,
+      comparisonBaseBranch,
+      workflowStartCwd,
+      workflowCwd: worktree.cwd,
+    });
   })
   .compile();

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
@@ -318,6 +318,8 @@ const GIT_LOCAL_ENV_VARS = [
 ] as const;
 
 function gitProcessEnv(): NodeJS.ProcessEnv {
+  // Only Ralph's internal bookkeeping Git commands use this scrubbed env;
+  // worker stages keep the host/CI credential configuration they inherit.
   const env = { ...process.env };
   for (const key of GIT_LOCAL_ENV_VARS) {
     delete env[key];
@@ -366,13 +368,9 @@ function requireGitRepositoryForWorktree(cwd = process.cwd()): string {
   return repoRootResult.stdout.trim();
 }
 
-type GitWorktreeSetup =
-  | { readonly cwd?: undefined; readonly created: false }
-  | {
-      readonly cwd: string;
-      readonly created: true;
-      readonly repositoryRoot: string;
-    };
+type GitWorktreeSetup = {
+  readonly cwd?: string;
+};
 
 async function addGitWorktree(
   worktreeDir: string,
@@ -384,15 +382,26 @@ async function addGitWorktree(
   } catch (error) {
     return {
       stdout: "",
-      stderr: `failed to create worktree parent directory: ${errorMessage(error)}`,
+      stderr: `mkdir: failed to create worktree parent directory: ${errorMessage(error)}`,
       status: 1,
     };
   }
   return runGit(["worktree", "add", "--detach", worktreeDir, baseBranch], cwd);
 }
 
-function removeGitWorktree(worktreeDir: string, cwd = process.cwd()): GitCommandResult {
-  return runGit(["worktree", "remove", "--force", worktreeDir], cwd);
+function existingPathIsGitWorktree(worktreeDir: string): boolean {
+  const result = runGit(["-C", worktreeDir, "rev-parse", "--is-inside-work-tree"]);
+  return result.status === 0 && result.stdout.trim() === "true";
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as { readonly code?: string }).code === "ENOENT") return false;
+    throw error;
+  }
 }
 
 function quoteRecoveryCommandArgument(value: string): string {
@@ -404,31 +413,24 @@ function formatWorktreeRecoveryCommand(repositoryRoot: string, worktreeDir: stri
   return `git -C ${quoteRecoveryCommandArgument(repositoryRoot)} worktree remove --force ${quoteRecoveryCommandArgument(worktreeDir)}`;
 }
 
-const WORKTREE_CLEANUP_SAFE_MARKER = "Worktree cleanup: safe-to-remove";
-const WORKTREE_CLEANUP_PRESERVE_MARKER = "Worktree cleanup: preserve";
-
-function prReportAllowsWorktreeCleanup(report: string): boolean {
-  const cleanupLines = report
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) =>
-      line === WORKTREE_CLEANUP_SAFE_MARKER ||
-      line === WORKTREE_CLEANUP_PRESERVE_MARKER,
-    );
-  return cleanupLines.at(-1) === WORKTREE_CLEANUP_SAFE_MARKER;
-}
-
 async function createGitWorktreeIfRequested(
   value: string | undefined,
   baseBranch: string,
   cwd = process.cwd(),
 ): Promise<GitWorktreeSetup> {
   const trimmed = value?.trim();
-  if (!trimmed) return { created: false };
+  if (!trimmed) return {};
 
   const repoRoot = requireGitRepositoryForWorktree(cwd);
 
   const requestedWorktreeDir = resolveWorktreePath(trimmed, repoRoot);
+  if (await pathExists(requestedWorktreeDir)) {
+    if (existingPathIsGitWorktree(requestedWorktreeDir)) {
+      return { cwd: requestedWorktreeDir };
+    }
+    throw new Error(`git_worktree_dir already exists but is not a Git worktree: ${requestedWorktreeDir}`);
+  }
+
   const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, repoRoot);
   if (requestedResult.status !== 0) {
     throw new Error(
@@ -438,7 +440,7 @@ async function createGitWorktreeIfRequested(
       ].join("\n"),
     );
   }
-  return { cwd: requestedWorktreeDir, created: true, repositoryRoot: repoRoot };
+  return { cwd: requestedWorktreeDir };
 }
 
 function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
@@ -750,6 +752,8 @@ async function runRalphWorkflow(
       ...cwdOption,
     });
     finalPlan = planner.text;
+    // Keep generated specs under the directory where Ralph was invoked, not in
+    // the worktree, so plan artifacts remain easy to find across retries.
     const specPath = await writeSpecFile(resolve(workflowStartCwd, defaultSpecPath(prompt)), planner.text);
     finalPlanPath = specPath;
 
@@ -1281,8 +1285,8 @@ async function runRalphWorkflow(
           "Create a PR only if there are meaningful changes, a remote/branch target is available, credentials are available, and the current state is suitable for review.",
           "If no logged-in account can access the repository or create the PR, do not fake success; report each credential/account tried, what failed, and provide the command the user can run later.",
           "When you successfully create or update the PR, create a PR comment containing the implementation notes file contents as the last action of this workflow stage.",
-          "Ralph worktrees are detached HEAD checkouts. If you are preparing a PR from a detached HEAD, create and push a branch from the current HEAD, for example with `git checkout -b <branch>` or `git push origin HEAD:refs/heads/<branch>`, before opening the PR.",
-          `Include an exact cleanup signal line in your final report: \`${WORKTREE_CLEANUP_SAFE_MARKER}\` only if a PR branch was pushed or there are no meaningful changes to preserve; otherwise include \`${WORKTREE_CLEANUP_PRESERVE_MARKER}\` so Ralph keeps the worktree for recovery.`,
+          "Ralph-created worktrees are detached HEAD checkouts. If you are preparing a PR from a detached HEAD, create and push a branch from the current HEAD, for example with `git checkout -b <branch>` or `git push origin HEAD:refs/heads/<branch>`, before opening the PR.",
+          "Ralph does not remove git_worktree_dir automatically. Leave the worktree intact for retries or user recovery.",
           "If PR creation is not possible, do not create a standalone comment elsewhere; include the implementation notes path and summary in your report instead.",
           "If the review loop did not approve, prefer reporting the remaining blockers over creating a PR unless the changes are still intentionally ready for human review.",
           "Do not make unrelated code edits in this phase. Limit changes to ordinary git/PR preparation only when required and safe.",
@@ -1297,7 +1301,6 @@ async function runRalphWorkflow(
           "3. Implementation notes comment — whether the PR comment was created as the last action, or why it could not be created",
           "4. Commands run — include exit status or clear outcome",
           "5. Follow-up for the user — exact next steps if credentials or repository state blocked PR creation",
-          `6. Worktree cleanup — include exactly one cleanup signal line: \`${WORKTREE_CLEANUP_SAFE_MARKER}\` or \`${WORKTREE_CLEANUP_PRESERVE_MARKER}\`.`,
         ].join("\n"),
       ],
     ]),
@@ -1345,7 +1348,7 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional Git worktree path; when set, Ralph must start inside a Git repo and runs stages from a detached worktree created at this repo-root-relative path."
+      "Optional Git worktree path. Ralph must start inside a Git repo; absolute paths are used as-is, relative paths resolve from the repo root, existing Git worktrees are reused as-is, and missing paths are created from base_branch."
   })
   .run(async (ctx) => {
     const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;
@@ -1365,47 +1368,12 @@ export default defineWorkflow("ralph")
       task: (name, options) => ralphCtx.task(name, options),
       parallel: (steps, options) => ralphCtx.parallel(steps, options),
     };
-    let result: RalphWorkflowResult | undefined;
-
-    try {
-      result = await runRalphWorkflow(workflowCtx, {
-        prompt,
-        maxLoops,
-        comparisonBaseBranch,
-        workflowStartCwd,
-        workflowCwd: worktree.cwd,
-      });
-      return result;
-    } finally {
-      if (worktree.created && worktree.cwd !== undefined) {
-        const recoveryCommand = formatWorktreeRecoveryCommand(worktree.repositoryRoot, worktree.cwd);
-        if (result === undefined) {
-          console.warn(
-            [
-              `Preserving Ralph git worktree after failed run: ${worktree.cwd}`,
-              `Recover work there, then remove it with: ${recoveryCommand}`,
-            ].join("\n"),
-          );
-        } else if (!prReportAllowsWorktreeCleanup(result.pr_report)) {
-          console.warn(
-            [
-              `Preserving Ralph git worktree because the PR stage did not confirm pushed or empty changes: ${worktree.cwd}`,
-              `Recover or remove it manually with: ${recoveryCommand}`,
-            ].join("\n"),
-          );
-        } else {
-          const cleanupResult = removeGitWorktree(worktree.cwd, worktree.repositoryRoot);
-          if (cleanupResult.status !== 0) {
-            console.warn(
-              [
-                `Failed to remove Ralph git worktree after successful run: ${worktree.cwd}`,
-                `Git reported: ${gitFailureMessage(cleanupResult)}`,
-                `Recover or remove it manually with: ${recoveryCommand}`,
-              ].join("\n"),
-            );
-          }
-        }
-      }
-    }
+    return await runRalphWorkflow(workflowCtx, {
+      prompt,
+      maxLoops,
+      comparisonBaseBranch,
+      workflowStartCwd,
+      workflowCwd: worktree.cwd,
+    });
   })
   .compile();

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -13,7 +13,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { defineWorkflow } from "../src/index.js";
-import type { WorkflowTaskResult } from "../src/shared/types.js";
+import type { WorkflowRunContext, WorkflowTaskResult } from "../src/shared/types.js";
 
 const DEFAULT_MAX_LOOPS = 10;
 const DEFAULT_SPEC_DIR = "specs";
@@ -356,6 +356,7 @@ function resolveOptionalWorktreePath(value: string | undefined, cwd = process.cw
 
 function safeWorktreePathSegment(value: string): string {
   const segment = value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  // The readable segment is clipped; default path uniqueness comes from the digest.
   return segment.length > 0 ? segment.slice(0, 60) : "worktree";
 }
 
@@ -399,6 +400,10 @@ function removeGitWorktree(worktreeDir: string, cwd = process.cwd()): GitCommand
   return runGit(["worktree", "remove", "--force", worktreeDir], cwd);
 }
 
+function formatWorktreeRecoveryCommand(repositoryCwd: string, worktreeDir: string): string {
+  return `git -C ${JSON.stringify(repositoryCwd)} worktree remove --force ${JSON.stringify(worktreeDir)}`;
+}
+
 async function createGitWorktreeIfRequested(
   value: string | undefined,
   baseBranch: string,
@@ -412,7 +417,10 @@ async function createGitWorktreeIfRequested(
     const requestedResult = await addGitWorktree(requestedWorktreeDir, baseBranch, cwd);
     if (requestedResult.status !== 0) {
       throw new Error(
-        `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
+        [
+          `Failed to create git worktree at requested git_worktree_dir ${requestedWorktreeDir} from ${baseBranch}: ${gitFailureMessage(requestedResult)}`,
+          `If this path is an orphaned Ralph worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(cwd, requestedWorktreeDir)}`,
+        ].join("\n"),
       );
     }
     return { cwd: requestedWorktreeDir, created: true, repositoryCwd: cwd };
@@ -424,7 +432,12 @@ async function createGitWorktreeIfRequested(
     return { cwd: fallbackWorktreeDir, created: true, repositoryCwd: cwd };
   }
 
-  throw new Error(`Failed to create fallback git worktree at ${fallbackWorktreeDir} from ${baseBranch}: ${gitFailureMessage(fallbackResult)}`);
+  throw new Error(
+    [
+      `Failed to create fallback git worktree at ${fallbackWorktreeDir} from ${baseBranch}: ${gitFailureMessage(fallbackResult)}`,
+      `If this path is an orphaned Ralph worktree from an interrupted run, recover or remove it with: ${formatWorktreeRecoveryCommand(cwd, fallbackWorktreeDir)}`,
+    ].join("\n"),
+  );
 }
 
 function workflowCwdOption(workflowCwd: string | undefined): { cwd?: string } {
@@ -524,6 +537,796 @@ function formatReview(results: readonly WorkflowTaskResult[]): string {
     .join("\n\n---\n\n");
 }
 
+type RalphInputs = {
+  readonly prompt?: string;
+  readonly max_loops?: number;
+  readonly base_branch?: string;
+  readonly git_worktree_dir?: string;
+};
+
+type RalphWorkflowOptions = {
+  readonly prompt: string;
+  readonly maxLoops: number;
+  readonly comparisonBaseBranch: string;
+  readonly workflowStartCwd: string;
+  readonly workflowCwd?: string;
+};
+
+type RalphWorkflowResult = {
+  readonly result: string;
+  readonly plan: string;
+  readonly plan_path: string;
+  readonly implementation_notes_path: string;
+  readonly pr_report: string;
+  readonly approved: boolean;
+  readonly iterations_completed: number;
+  readonly review_report: string;
+};
+
+async function runRalphWorkflow(
+  ctx: WorkflowRunContext<RalphInputs>,
+  options: RalphWorkflowOptions,
+): Promise<RalphWorkflowResult> {
+  const {
+    prompt,
+    maxLoops,
+    comparisonBaseBranch,
+    workflowStartCwd,
+    workflowCwd,
+  } = options;
+  const cwdOption = workflowCwdOption(workflowCwd);
+
+  let reviewReport = "";
+  let finalPlan = "";
+  let finalPlanPath = "";
+  let finalResult = "";
+  let finalPrReport = "";
+  const implementationNotesPath = await createImplementationNotesFile(prompt);
+  let approved = false;
+  let iterationsCompleted = 0;
+
+  let noAskQuestionToolSet = [
+    "read",
+    "bash",
+    "edit",
+    "write",
+    "todo",
+    "subagent",
+    "web_search",
+    "code_search",
+    "fetch_content",
+    "get_search_content",
+    "intercom",
+  ];
+
+  let plannerModelConfig = {
+    model: "openai/gpt-5.5",
+    fallbackModels: [
+      "openai-codex/gpt-5.5",
+      "github-copilot/gpt-5.5",
+      "anthropic/claude-opus-4-7",
+      "github-copilot/claude-opus-4.7",
+    ],
+    thinkingLevel: "high" as const,
+    tools: noAskQuestionToolSet,
+  };
+
+  let orchestratorModelConfig = {
+    model: "openai/gpt-5.5",
+    fallbackModels: [
+      "openai-codex/gpt-5.5",
+      "github-copilot/gpt-5.5",
+      "anthropic/claude-sonnet-4-6",
+      "github-copilot/claude-sonnet-4.6",
+    ],
+    thinkingLevel: "medium" as const,
+    tools: noAskQuestionToolSet,
+  };
+
+  let simplifierModelConfig = {
+    model: "openai/gpt-5.5",
+    fallbackModels: [
+      "openai-codex/gpt-5.5",
+      "github-copilot/gpt-5.5",
+      "anthropic/claude-sonnet-4-6",
+      "github-copilot/claude-sonnet-4.6",
+    ],
+    thinkingLevel: "medium" as const,
+    tools: noAskQuestionToolSet,
+  };
+
+  let reviewerModelConfig = {
+    model: "openai/gpt-5.5",
+    fallbackModels: [
+      "openai-codex/gpt-5.5",
+      "github-copilot/gpt-5.5",
+      "anthropic/claude-opus-4-7",
+      "github-copilot/claude-opus-4.7",
+    ],
+    thinkingLevel: "high" as const,
+    tools: noAskQuestionToolSet,
+    customTools: [reviewDecisionTool],
+  };
+
+  let explorerModelConfig = {
+    model: "openai/gpt-5.4-mini",
+    fallbackModels: [
+      "openai-codex/gpt-5.4-mini",
+      "github-copilot/gpt-5.4-mini",
+      "anthropic/claude-haiku-4-5",
+      "github-copilot/claude-haiku-4.5",
+    ],
+    thinkingLevel: "low" as const,
+    tools: noAskQuestionToolSet,
+  };
+
+  for (let iteration = 1; iteration <= maxLoops; iteration += 1) {
+    iterationsCompleted = iteration;
+
+    const planner = await ctx.task(`planner-${iteration}`, {
+      prompt: taggedPrompt([
+        [
+          "role",
+          "You are a technical architect. Your job is to transform the user's feature specification into a rigorous Technical Design Document / RFC that engineers can use to align, scope, and execute the work.",
+        ],
+        [
+          "critical_deliverable",
+          [
+            "Your final output is a filled-in RFC rendered as markdown text.",
+            "Render the RFC Template in this prompt with every section populated by feature-specific content drawn from the user's specification and your codebase investigation.",
+            "Do not implement code changes in this stage; this stage only investigates and authors the RFC.",
+          ].join("\n"),
+        ],
+        [
+          "task",
+          `Plan iteration ${iteration}/${maxLoops} for this user specification:\n${prompt}`,
+        ],
+        [
+          "previous_review_findings",
+          reviewReport
+            ? "Previous review findings:\n{previous}"
+            : "No prior review findings; this is the first iteration.",
+        ],
+        [
+          "input_spec_files",
+          [
+            "If the user specification is a file path instead of raw prose, read that file and use it as source material for the RFC.",
+            "Still author the RFC normally; do not output only a forwarded path.",
+          ].join("\n"),
+        ],
+        [
+          "investigation_phase",
+          [
+            "Before drafting, read the specification carefully and identify the concrete problem, success criteria, hard constraints, and non-goals.",
+            "Survey the codebase using file/search tools such as read plus grep/rg/find/glob-style shell commands to ground the RFC in current architecture.",
+            "Name concrete services, modules, files, tests, data models, APIs, CLIs, config files, and external integrations this work will touch.",
+            "Capture metadata with bash: `git config user.name` for Author(s), and `date '+%Y-%m-%d'` for Created / Last Updated.",
+            "Look for prior art: existing RFCs, ADRs, README files, specs, docs, tests, or code comments that explain why the current state exists.",
+          ].join("\n"),
+        ],
+        [
+          "authoring_principles",
+          [
+            "Be specific: `src/server/auth.ts:42` beats `the auth layer`.",
+            "Trade-offs over conclusions: Alternatives Considered must include at least two real alternatives with honest pros, cons, and rejection reasons.",
+            "Non-goals matter: explicitly exclude work that is out of scope to prevent scope creep.",
+            "Diagrams are load-bearing: Section 4.1 must include a Mermaid system architecture diagram grounded in real components.",
+            "Surface open questions in Section 9 with owner placeholders such as `[OWNER: infra team]`; do not paper over uncertainty.",
+            "Match depth to stakes: a small refactor can be concise, but every template section header must remain present.",
+            "If prior review findings are present, explicitly address each finding or explain why it is obsolete.",
+          ].join("\n"),
+        ],
+        [
+          "stage_contract",
+          [
+            "This stage is investigation-first RFC authoring. The RFC is only valid if it is grounded in repository inspection performed during this stage.",
+            "Do not fill the template from generic architecture guesses. Before writing the final RFC, inspect relevant code, docs, tests, configs, and prior design material.",
+            "Treat the output format as the report after investigation, not a substitute for investigation.",
+          ].join("\n"),
+        ],
+        [
+          "evidence_expectations",
+          [
+            "Every major design claim should be traceable to concrete evidence: file paths, symbols, commands, docs, tests, configs, or prior RFCs.",
+            "Include those concrete references inside the RFC sections where they support the design.",
+            "If expected evidence cannot be found, say so in the relevant RFC section or Open Questions rather than papering over the gap.",
+          ].join("\n"),
+        ],
+        [
+          "output_discipline",
+          [
+            "Render the RFC Template exactly as the final document structure: preserve every header and the metadata table.",
+            "Replace instructional placeholders with real, feature-specific content; do not leave template guidance in the final RFC.",
+            "Output nothing after the RFC: no meta-commentary, no summary of what you wrote, no implementation log.",
+          ].join("\n"),
+        ],
+        ["rfc_template", PLANNER_RFC_TEMPLATE],
+      ]),
+      ...(reviewReport
+        ? { previous: { name: "review-report", text: reviewReport } }
+        : {}),
+      ...plannerModelConfig,
+      ...cwdOption,
+    });
+    finalPlan = planner.text;
+    const specPath = await writeSpecFile(resolve(workflowStartCwd, defaultSpecPath(prompt)), planner.text);
+    finalPlanPath = specPath;
+
+    const orchestrator = await ctx.task(`orchestrator-${iteration}`, {
+      prompt: taggedPrompt([
+        [
+          "role",
+          "You are a sub-agent orchestrator with many tools available. Your primary implementation tool is the `subagent` tool.",
+        ],
+        [
+          "objective",
+          `Implement iteration ${iteration}/${maxLoops} for the task: ${prompt}`,
+        ],
+        [
+          "spec_file",
+          [
+            `The technical specification for this iteration was written to: ${specPath}`,
+            "Read this file before delegating or implementing anything.",
+            "Do not rely on an inline planner transcript; the spec file is the authoritative plan for this iteration.",
+          ].join("\n"),
+        ],
+        [
+          "implementation_notes",
+          [
+            `Keep a running Markdown implementation notes file at this OS temp directory path: ${implementationNotesPath}`,
+            "The file has already been initialized for this workflow run; update it while you implement the spec.",
+            "Record decisions you had to make that were not in the spec, things you had to change from the spec, tradeoffs you had to make, blockers, validation outcomes, and anything else the user should know.",
+            "Ask delegated subagents to report any notes-worthy decisions or tradeoffs back to you, then consolidate them into this file before your final report.",
+            "Do not include secrets, credentials, tokens, or unrelated environment details in the notes file.",
+          ].join("\n"),
+        ],
+        [
+          "project_initialization_preflight",
+          [
+            "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
+            "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
+            "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
+            "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
+            "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
+            "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
+            "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
+            "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
+            "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
+          ].join("\n"),
+        ],
+        [
+          "delegation_policy",
+          [
+            "You are not the implementer. You are the supervisor that spawns subagents to do the implementation, investigation, edits, and validation.",
+            "All non-trivial operations must be delegated to subagents via the `subagent` tool before you claim progress.",
+            "Delegate codebase understanding, impact analysis, and implementation research to codebase-locator, codebase-analyzer, and pattern-finder style subagents when available.",
+            "Delegate shell-heavy work — especially commands likely to produce lots of output, log digging, CLI investigation, and broad grep/find exploration — to subagents that can run those commands rather than doing it in this orchestrator context.",
+            "Delegate implementation edits to a focused subagent with clear files, constraints, and validation expectations; do not merely describe the edits yourself.",
+            "Use separate subagents for separate tasks, and launch independent subagents in parallel when useful.",
+            "Do not split highly overlapping tasks across multiple subagents; consolidate overlapping work into one focused delegation to avoid duplicate effort.",
+            "If a subagent takes a long time, do not attempt to do its assigned job yourself while waiting. Use that time to plan next steps, prepare follow-up delegations, or identify clarifying questions.",
+          ].join("\n"),
+        ],
+        [
+          "execution_contract",
+          [
+            "The required output format is a completion report, not the task itself.",
+            "Do not jump straight to the report. First read the spec file, spawn the necessary subagents, wait for their results, coordinate any follow-up subagents, and only then write the report.",
+            "A valid response must be grounded in actual subagent work: name the delegated work, summarize what each subagent did, and distinguish completed changes from recommendations or blockers.",
+            "If you cannot read the spec file, spawn subagents, or use subagents, treat that as a blocker and report it honestly instead of pretending the requested work was done.",
+          ].join("\n"),
+        ],
+        [
+          "subagent_tracking",
+          [
+            "Use the `todo` tool as your active control ledger for subagent work.",
+            "Before launching subagents, create todo items for each delegated task with enough detail to identify owner, purpose, and expected output.",
+            "Mark todo items in_progress when the corresponding subagent starts, append progress/results as subagents report back, and close them only after you have incorporated or explicitly rejected their result.",
+            "Keep pending, in_progress, blocked, and completed work accurate so you do not lose track of parallel subagents or unresolved follow-ups.",
+            "Before writing the final report, review the todo list and resolve every pending/in_progress item as completed, blocked, or deferred with an explanation.",
+          ].join("\n"),
+        ],
+        [
+          "instructions",
+          [
+            `Start by reading the spec file at ${specPath}.`,
+            "Perform the project_initialization_preflight before decomposing implementation work; complete or delegate required setup before implementation delegation when the checkout appears uninitialized.",
+            "Decompose the work into delegated subagent tasks based on that spec file.",
+            "Pass each subagent the relevant task, constraints, files, validation expectations, any prior review findings from the spec, and instructions to report implementation-note-worthy decisions or tradeoffs.",
+            "Coordinate subagent results into the smallest coherent set of changes that satisfies the spec.",
+            "Preserve existing architecture and repository conventions unless the spec explicitly justifies a change.",
+            "Run or delegate the most relevant validation commands available in the repository.",
+            `Before your final report, update the running implementation notes file at ${implementationNotesPath} with decisions, spec deviations, tradeoffs, blockers, and validation outcomes from this iteration.`,
+            "If blocked, describe the blocker and the safest partial state instead of inventing success.",
+            "Do not hide failures; reviewers need accurate status.",
+          ].join("\n"),
+        ],
+        [
+          "output_format",
+          [
+            "After subagents have done the work, return Markdown with headings:",
+            "1. Spec file — the path you read",
+            "2. Delegations performed — subagents spawned and what each completed",
+            "3. Changes made — concrete changes from subagent work, not intentions",
+            "4. Files touched",
+            "5. Validation run / recommended",
+            "6. Deferred work or blockers",
+            "7. Implementation notes — confirm the OS temp notes path was updated",
+          ].join("\n"),
+        ],
+      ]),
+      reads: [specPath, implementationNotesPath],
+      ...orchestratorModelConfig,
+      ...cwdOption,
+    });
+    finalResult = orchestrator.text;
+
+    await ctx.task(`code-simplifier-${iteration}`, {
+      prompt: taggedPrompt([
+        [
+          "role",
+          [
+            "You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality.",
+            "Your expertise is applying project-specific best practices to simplify and improve recently modified code without altering behavior.",
+            "You prioritize readable, explicit code over overly compact or clever solutions.",
+          ].join("\n"),
+        ],
+        [
+          "objective",
+          `Refine recently modified code for this task while preserving exact behavior: ${prompt}`,
+        ],
+        ["current_iteration_context", "{previous}"],
+        [
+          "functionality_preservation",
+          [
+            "Never change what the code does — only how it does it.",
+            "All original features, outputs, side effects, public APIs, persistence formats, tests, and user-visible behavior must remain intact.",
+            "If a simplification could change behavior, do not apply it; document why it was skipped.",
+          ].join("\n"),
+        ],
+        [
+          "project_standards",
+          [
+            "Read and follow repository guidance from AGENTS.md and/or CLAUDE.md when present.",
+            "Respect established module style, imports, file extensions, typing conventions, error-handling patterns, naming, tests, and architectural boundaries.",
+            "For this TypeScript workflow repo, preserve ESM .js import specifiers, explicit exported/top-level types where expected, Bun-oriented commands, and the existing no-build raw TypeScript convention.",
+            "Do not impose standards that conflict with local project guidance.",
+          ].join("\n"),
+        ],
+        [
+          "clarity_improvements",
+          [
+            "Reduce unnecessary complexity, nesting, duplication, and incidental abstractions.",
+            "Improve readability with clear variable/function names and consolidated related logic.",
+            "Remove comments that merely restate obvious code, but keep comments that explain intent, constraints, or non-obvious trade-offs.",
+            "Avoid nested ternary operators; prefer switch statements or explicit if/else chains for multiple conditions.",
+            "Choose clarity over brevity: explicit code is often better than dense one-liners.",
+          ].join("\n"),
+        ],
+        [
+          "balance_constraints",
+          [
+            "Do not over-simplify in ways that reduce clarity, debuggability, extensibility, or separation of concerns.",
+            "Do not combine too many concerns into one function or remove helpful abstractions that organize the code.",
+            "Do not prioritize fewer lines over maintainability.",
+            "Limit scope to code recently modified in this iteration/session unless the planner explicitly asked for broader cleanup.",
+          ].join("\n"),
+        ],
+        [
+          "stage_contract",
+          [
+            "This is an active code-refinement stage, not just a commentary stage.",
+            "Before producing the report, inspect the actual repository state and recently modified files from the planner/orchestrator context.",
+            "Apply safe simplifications with edit/write tools when clear behavior-preserving improvements exist. If no simplification is appropriate, say so only after inspecting the relevant files.",
+          ].join("\n"),
+        ],
+        [
+          "required_actions_before_output",
+          [
+            "1. Identify the concrete files/sections changed in this iteration.",
+            "2. Read those files before deciding whether to simplify.",
+            "3. Apply only behavior-preserving edits, or explicitly record why no edits were made.",
+            "4. Run or recommend focused validation tied to the touched files.",
+          ].join("\n"),
+        ],
+        [
+          "handoff_expectations",
+          "In the final report, distinguish edits actually applied from observations only. Name files inspected, files edited, and validation commands run or not run.",
+        ],
+        [
+          "process",
+          [
+            "Identify recently modified code sections from the iteration context and repository state.",
+            "Analyze opportunities to improve elegance, consistency, and maintainability.",
+            "Apply project-specific best practices while preserving behavior.",
+            "Run or recommend focused validation when appropriate.",
+            "Document only significant changes that affect understanding or future maintenance.",
+          ].join("\n"),
+        ],
+        [
+          "output_format",
+          [
+            "Markdown with headings:",
+            "1. Simplifications applied",
+            "2. Behavior-preservation notes",
+            "3. Validation run / recommended",
+            "4. Skipped risky simplifications",
+          ].join("\n"),
+        ],
+      ]),
+      previous: [planner, orchestrator],
+      ...simplifierModelConfig,
+      ...cwdOption,
+    });
+
+    const discovery = await ctx.parallel(
+      [
+        {
+          name: `infra-locate-${iteration}`,
+          task: taggedPrompt([
+            [
+              "role",
+              "You locate project infrastructure needed for patch review.",
+            ],
+            [
+              "objective",
+              `Find review-relevant infrastructure for the task: ${prompt}`,
+            ],
+            [
+              "stage_contract",
+              [
+                "This is a repository-discovery stage. Do not answer from assumptions or common project layouts.",
+                "Before output, inspect the repository for each infrastructure category: package scripts, test configs, CI workflows, generated artifacts, lint/typecheck setup, and release gates.",
+                "The table is a compact handoff after discovery, not a substitute for discovery.",
+              ].join("\n"),
+            ],
+            [
+              "instructions",
+              [
+                "Locate package scripts, test configs, CI workflows, generated artifacts, lint/typecheck setup, and release gates.",
+                "Search/read relevant files such as package manifests, CI workflow directories, test configs, lint/typecheck configs, build scripts, release configs, and generated-artifact markers.",
+                "Prefer exact file paths and commands.",
+                "Explain how each item should influence review or validation.",
+                "If a category does not exist, report `not found` and briefly name the paths or patterns checked.",
+              ].join("\n"),
+            ],
+            [
+              "output_format",
+              "Markdown table: Area | Path/command | Why it matters | Confidence.",
+            ],
+          ]),
+          ...explorerModelConfig,
+          ...cwdOption,
+        },
+        {
+          name: `infra-analyze-${iteration}`,
+          task: taggedPrompt([
+            [
+              "role",
+              "You analyze integration risks in project infrastructure.",
+            ],
+            [
+              "objective",
+              `Assess infrastructure and changed-code risks for the task: ${prompt}`,
+            ],
+            [
+              "stage_contract",
+              [
+                "This stage analyzes actual repository coupling, not generic integration risks.",
+                "Before output, inspect the changed-code context plus relevant infrastructure/configuration files discovered or inferable from the repo.",
+                "Classify a risk as confirmed only when repository evidence shows the coupling; otherwise mark it speculative.",
+              ].join("\n"),
+            ],
+            [
+              "instructions",
+              [
+                "Identify hidden coupling with build, tests, linting, runtime config, release automation, or generated files.",
+                "Name the exact validations that would most efficiently detect regressions.",
+                "Separate confirmed risks from speculative risks.",
+                "Do not repeat generic review advice; ground findings in repository evidence.",
+                "Copy validation commands from actual repository scripts/configs when available; do not invent commands that are not supported by the repo.",
+              ].join("\n"),
+            ],
+            [
+              "evidence_expectations",
+              "Each confirmed risk must include concrete evidence: path, command, symbol, config key, script name, or file relationship.",
+            ],
+            [
+              "output_format",
+              "Markdown with sections: Confirmed risks, Speculative risks, Validation commands, Evidence.",
+            ],
+          ]),
+          ...explorerModelConfig,
+          ...cwdOption,
+        },
+        {
+          name: `infra-patterns-${iteration}`,
+          task: taggedPrompt([
+            [
+              "role",
+              "You find repository patterns that a patch must follow.",
+            ],
+            [
+              "objective",
+              `Extract conventions relevant to reviewing this task: ${prompt}`,
+            ],
+            [
+              "stage_contract",
+              [
+                "This is an evidence-gathering stage for repository conventions. Do not describe generic best practices.",
+                "Before output, find concrete examples in the repository that demonstrate conventions relevant to this task.",
+                "Read enough of each example to understand the convention before reporting it.",
+              ].join("\n"),
+            ],
+            [
+              "instructions",
+              [
+                "Find examples of build/test/style/release/architecture patterns the patch should mirror.",
+                "Search for nearby or analogous implementations, tests, configs, scripts, and docs.",
+                "Use concrete paths, commands, or symbols as evidence.",
+                "Highlight conventions that commonly cause subtle review failures.",
+                "If examples conflict, describe the conflict instead of forcing a single rule.",
+                "If no relevant example exists, state what was searched and that no pattern was found.",
+              ].join("\n"),
+            ],
+            [
+              "handoff_expectations",
+              "For every required convention or useful example, include the supporting path, command, symbol, or file relationship so reviewers can verify it quickly.",
+            ],
+            [
+              "output_format",
+              "Markdown with sections: Required conventions, Useful examples, Exceptions, Review implications.",
+            ],
+          ]),
+          ...explorerModelConfig,
+          ...cwdOption,
+        },
+      ],
+      { task: prompt, ...cwdOption },
+    );
+
+    const discoveryContext = formatDiscovery(discovery);
+    const reviewPrompt = taggedPrompt([
+      [
+        "role",
+        [
+          "You are acting as a reviewer for a proposed code change made by another engineer.",
+          "Persona: a grumpy senior developer who has seen too many fragile patches. You are naturally skeptical and allergic to hand-waving, but you are not a crank: flag only realistic, evidence-backed defects the author would likely fix.",
+          "Be terse, concrete, and technically fair. Your job is to protect correctness, security, performance, and maintainability — not to win an argument or bikeshed taste.",
+        ].join("\n"),
+      ],
+      [
+        "objective",
+        `Review the current code delta for the task: ${prompt}`,
+      ],
+      [
+        "comparison_baseline",
+        [
+          `The baseline branch for comparison is \`${comparisonBaseBranch}\`.`,
+          "Compare the current working tree against this baseline branch, not against previous workflow reasoning or expected loop progress.",
+          `Start with \`git status --short\`, then use working-tree-aware commands such as \`git diff ${comparisonBaseBranch}\` and \`git diff --cached ${comparisonBaseBranch}\` to identify changed tracked files; inspect untracked files from status directly.`,
+        ].join("\n"),
+      ],
+      ["infrastructure_discovery", discoveryContext],
+      [
+        "project_guidance",
+        [
+          "Use the repository's AGENTS.md and/or CLAUDE.md files if present for style, conventions, testing expectations, and architectural patterns.",
+          "Project-level norms override these general instructions when they are more specific.",
+          "Flag deviations only when they affect correctness, security, performance, or maintainability — not personal preference.",
+          "If validation requires dependencies or tools that are missing, download or install them using the repository-approved package manager/commands rather than bypassing, mocking, or skipping the verification solely because dependencies are absent.",
+        ].join("\n"),
+      ],
+      [
+        "validation_expectations",
+        [
+          "Inspect the actual diff/repository state rather than trusting stage summaries.",
+          "Run or delegate focused validation when it is necessary to distinguish a real bug from a hunch.",
+          "If tests or typechecks fail because dependencies are missing, install/download the missing dependencies with the repo's documented package manager instead of bypassing the check.",
+          "If validation cannot be completed after reasonable recovery, record the limitation in overall_explanation and reviewer_error; do not use missing dependencies as a reason to approve.",
+        ].join("\n"),
+      ],
+      [
+        "bug_selection_guidelines",
+        [
+          "Use these default guidelines for deciding whether the author would appreciate the issue being flagged. More specific user, project, or file-level guidance overrides them.",
+          "Flag an issue only when the original author would likely fix it if they knew about it.",
+          "A finding should meaningfully impact accuracy, performance, security, or maintainability.",
+          "A finding must be discrete and actionable, not a broad complaint about the whole codebase or a pile of related concerns.",
+          "Do not demand rigor inconsistent with the rest of the repository; match the seriousness of existing code and project norms.",
+          "Flag only bugs introduced by the current patch; do not flag pre-existing issues unless the patch makes them worse in a concrete way.",
+          "Do not rely on unstated assumptions about author intent or codebase behavior.",
+          "Speculation is insufficient: identify the code path, scenario, environment, or input that is provably affected.",
+          "Do not flag intentional behavior changes as bugs unless they clearly violate the task or documented contract.",
+          "Ignore trivial style unless it obscures meaning or violates documented standards in a way that affects correctness/security/maintainability.",
+          "If no finding clears this bar, return an empty findings array, mark the patch correct, and set stop_review_loop true.",
+        ].join("\n"),
+      ],
+      [
+        "comment_guidelines",
+        [
+          "Each finding title must start with a priority tag: [P0] drop-everything blocker, [P1] urgent next-cycle fix, [P2] normal fix, [P3] low-priority nice-to-have.",
+          "Also include numeric priority: 0 for P0, 1 for P1, 2 for P2, 3 for P3; use null only if priority genuinely cannot be determined.",
+          "The body must be one concise paragraph explaining why this is a bug and the exact scenario, environment, or inputs required for it to arise.",
+          "Use a matter-of-fact, non-accusatory tone. Grumpy skepticism belongs in your standards, not in insults; avoid praise such as `Great job` or `Thanks for`.",
+          "Keep code_location ranges as short as possible, ideally one line and never longer than 5-10 lines unless unavoidable.",
+          "The code_location must overlap the diff/change under review.",
+          "Use one finding per distinct issue. Do not generate a PR fix.",
+          "Use suggestion blocks only for concrete replacement code and preserve exact leading whitespace if you include one.",
+        ].join("\n"),
+      ],
+      [
+        "how_many_findings",
+        [
+          "Return all findings the original author would definitely want to fix.",
+          "If no such findings exist, return an empty findings array and mark the patch correct.",
+          "Do not stop after the first qualifying finding; continue until every qualifying finding is listed.",
+        ].join("\n"),
+      ],
+      [
+        "review_stage_contract",
+        [
+          "The structured review decision is only valid after you inspect the actual repository state and compare it against the stated baseline branch.",
+          "Do not approve based solely on workflow stage summaries or prior agent reasoning.",
+          "The tool call is the final verdict after review work, not a shortcut around review work.",
+        ].join("\n"),
+      ],
+      [
+        "required_actions_before_tool_call",
+        [
+          "1. Identify the changed files or diff under review.",
+          "2. Read the relevant changed code and directly affected call sites/tests/configs.",
+          "3. Run or delegate focused validation when needed to resolve uncertainty.",
+          "4. If you cannot inspect or validate enough to approve safely, populate reviewer_error and set stop_review_loop=false.",
+        ].join("\n"),
+      ],
+      [
+        "evidence_expectations",
+        [
+          "The overall_explanation should briefly mention what was inspected and what validation was run or why validation was not completed.",
+          "Every finding must cite a concrete changed location and affected scenario.",
+        ].join("\n"),
+      ],
+      [
+        "structured_output_contract",
+        [
+          "You have a structured-output tool named review_decision. Use it after your investigation and validation attempts.",
+          "The tool terminates the turn and provides the structured data; do not emit a separate final assistant response after calling it.",
+          "The review loop decides whether to stop only by parsing the JSON object returned by this tool; invalid JSON, missing fields, reviewer_error, or stop_review_loop=false are treated as not approved for safety.",
+          "Set stop_review_loop=true only when findings is empty, overall_correctness is patch is correct, and reviewer_error is null/omitted.",
+          "If you hit a reviewer/tool/validation error, still return the object with stop_review_loop=false and reviewer_error populated instead of pretending the patch is approved.",
+          "The JSON must match this schema exactly:",
+          "{",
+          '  "findings": [',
+          "    {",
+          '      "title": "<≤ 80 chars, imperative, starts with [P0]/[P1]/[P2]/[P3]>",',
+          '      "body": "<one paragraph of valid Markdown explaining why this is a problem; cite files/lines/functions>",',
+          '      "confidence_score": <float 0.0-1.0>,',
+          '      "priority": <int 0-3 or null>,',
+          '      "code_location": {',
+          '        "absolute_file_path": "<absolute file path>",',
+          '        "line_range": {"start": <int>, "end": <int>}',
+          "      }",
+          "    }",
+          "  ],",
+          '  "overall_correctness": "patch is correct" | "patch is incorrect",',
+          '  "overall_explanation": "<1-3 sentence explanation justifying the verdict>",',
+          '  "overall_confidence_score": <float 0.0-1.0>,',
+          '  "stop_review_loop": <boolean>,',
+          '  "reviewer_error": null | {"kind": "validation_unavailable" | "dependency_unavailable" | "tool_failure" | "reviewer_failure", "message": "<what failed>", "attempted_recovery": "<what you tried>"}',
+          "}",
+        ].join("\n"),
+      ],
+    ]);
+
+    let reviews: WorkflowTaskResult[];
+    try {
+      reviews = await ctx.parallel(
+        [
+          {
+            name: "reviewer-a",
+            task: reviewPrompt,
+            ...reviewerModelConfig,
+            ...cwdOption,
+          },
+          {
+            name: "reviewer-b",
+            task: reviewPrompt,
+            ...reviewerModelConfig,
+            ...cwdOption,
+          },
+        ],
+        { task: prompt, failFast: false, ...cwdOption },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      reviews = [reviewerErrorResult(iteration, message)];
+    }
+
+    approved =
+      reviews.length > 0 &&
+      reviews.every((review) => reviewApproved(review.text));
+    reviewReport = formatReview(reviews);
+    if (approved) break;
+  }
+
+  const prResult = await ctx.task("pull-request", {
+    prompt: taggedPrompt([
+      [
+        "role",
+        "You are a careful release engineer preparing a pull request from the current workspace state.",
+      ],
+      [
+        "objective",
+        `Review the changes since the base branch \`${comparisonBaseBranch}\` and create a pull request if possible and credentials are available.`,
+      ],
+      [
+        "workflow_context",
+        [
+          `Original task: ${prompt}`,
+          `Review loop approved: ${approved ? "yes" : "no"}`,
+          finalPlanPath
+            ? `Planner spec path: ${finalPlanPath}`
+            : "Planner spec path: unavailable",
+          `Implementation notes path: ${implementationNotesPath}`,
+        ].join("\n"),
+      ],
+      [
+        "required_checks",
+        [
+          "Start by inspecting `git status --short` so unstaged, staged, and untracked changes are all visible.",
+          `Review the patch against \`${comparisonBaseBranch}\` with working-tree-aware commands such as \`git diff ${comparisonBaseBranch}\` and \`git diff --cached ${comparisonBaseBranch}\`.`,
+          "If untracked files are present, inspect them directly before deciding whether they belong in the PR.",
+          "Read the implementation notes file and use its full contents as the body of a PR comment after the pull request exists.",
+          "Check the local Git identity with `git config user.name` and `git config user.email` so you can prefer the matching GitHub account when multiple accounts are logged in.",
+          "Check whether GitHub credentials are available with non-destructive commands such as `gh auth status` and `gh auth status --show-token-scopes` before attempting PR creation.",
+          "If multiple GitHub accounts or hosts are logged in, use the git config username/email as a heuristic to choose the most likely identity, but try each available credential/account and use the first one that can read the repository and create the PR.",
+        ].join("\n"),
+      ],
+      [
+        "pr_policy",
+        [
+          "Create a PR only if there are meaningful changes, a remote/branch target is available, credentials are available, and the current state is suitable for review.",
+          "If no logged-in account can access the repository or create the PR, do not fake success; report each credential/account tried, what failed, and provide the command the user can run later.",
+          "When you successfully create or update the PR, create a PR comment containing the implementation notes file contents as the last action of this workflow stage.",
+          "Ralph worktrees are detached HEAD checkouts. If you are preparing a PR from a detached HEAD, create and push a branch from the current HEAD, for example with `git checkout -b <branch>` or `git push origin HEAD:refs/heads/<branch>`, before opening the PR.",
+          "If PR creation is not possible, do not create a standalone comment elsewhere; include the implementation notes path and summary in your report instead.",
+          "If the review loop did not approve, prefer reporting the remaining blockers over creating a PR unless the changes are still intentionally ready for human review.",
+          "Do not make unrelated code edits in this phase. Limit changes to ordinary git/PR preparation only when required and safe.",
+        ].join("\n"),
+      ],
+      [
+        "output_format",
+        [
+          "Return Markdown with headings:",
+          "1. Change review — summary of files and diff scope inspected",
+          "2. PR status — created PR URL, or why no PR was created",
+          "3. Implementation notes comment — whether the PR comment was created as the last action, or why it could not be created",
+          "4. Commands run — include exit status or clear outcome",
+          "5. Follow-up for the user — exact next steps if credentials or repository state blocked PR creation",
+        ].join("\n"),
+      ],
+    ]),
+    reads: finalPlanPath
+      ? [finalPlanPath, implementationNotesPath]
+      : [implementationNotesPath],
+    ...orchestratorModelConfig,
+    ...cwdOption,
+  });
+  finalPrReport = prResult.text;
+
+  return {
+    result: finalResult,
+    plan: finalPlan,
+    plan_path: finalPlanPath,
+    implementation_notes_path: implementationNotesPath,
+    pr_report: finalPrReport,
+    approved,
+    iterations_completed: iterationsCompleted,
+    review_report: reviewReport,
+  };
+}
+
 export default defineWorkflow("ralph")
   .description(
     "Plan → orchestrate → simplify → parallel review loop with bounded iteration.",
@@ -548,781 +1351,48 @@ export default defineWorkflow("ralph")
     type: "string",
     default: "",
     description:
-      "Optional git worktree checkout path. Ralph assumes it is invoked from inside the host repository; relative paths resolve from that repository cwd. When set, all Ralph stages run from a temporary worktree created from base_branch and removed when the workflow finishes.",
+      "Optional git worktree checkout path. Ralph assumes it is invoked from inside the host repository; relative paths resolve from that repository cwd. When set, all Ralph stages run from a detached-HEAD worktree created from base_branch. Successful runs remove the worktree; failed runs preserve it for recovery. Do not share one worktree path across concurrent runs.",
   })
   .run(async (ctx) => {
-    const inputs = ctx.inputs as {
-      prompt?: string;
-      max_loops?: number;
-      base_branch?: string;
-      git_worktree_dir?: string;
-    };
+    const ralphCtx = ctx as WorkflowRunContext<RalphInputs>;
+    const inputs = ralphCtx.inputs;
     const workflowStartCwd = process.cwd();
     const prompt = inputs.prompt ?? "";
     const maxLoops = positiveInteger(inputs.max_loops, DEFAULT_MAX_LOOPS);
     const comparisonBaseBranch = normalizeBranchInput(inputs.base_branch, "origin/main");
     const worktree = await createGitWorktreeIfRequested(inputs.git_worktree_dir, comparisonBaseBranch, workflowStartCwd);
-    const workflowCwd = worktree.cwd;
-    const cwdOption = workflowCwdOption(workflowCwd);
-    let runError: unknown;
+    // Discovery validates workflow shape without executing helpers, so keep an
+    // unreachable direct stage call in this wrapper while runRalphWorkflow owns
+    // the real ctx.task()/ctx.parallel() orchestration.
+    if (Date.now() < 0) {
+      await ralphCtx.task("__discovery-stage-guard__", { prompt: "unused static guard" });
+    }
+    let runSucceeded = false;
 
     try {
-    let reviewReport = "";
-    let finalPlan = "";
-    let finalPlanPath = "";
-    let finalResult = "";
-    let finalPrReport = "";
-    const implementationNotesPath = await createImplementationNotesFile(prompt);
-    let approved = false;
-    let iterationsCompleted = 0;
-
-    let noAskQuestionToolSet = [
-      "read",
-      "bash",
-      "edit",
-      "write",
-      "todo",
-      "subagent",
-      "web_search",
-      "code_search",
-      "fetch_content",
-      "get_search_content",
-      "intercom",
-    ];
-
-    let plannerModelConfig = {
-      model: "openai/gpt-5.5",
-      fallbackModels: [
-        "openai-codex/gpt-5.5",
-        "github-copilot/gpt-5.5",
-        "anthropic/claude-opus-4-7",
-        "github-copilot/claude-opus-4.7",
-      ],
-      thinkingLevel: "high" as const,
-      tools: noAskQuestionToolSet,
-    };
-
-    let orchestratorModelConfig = {
-      model: "openai/gpt-5.5",
-      fallbackModels: [
-        "openai-codex/gpt-5.5",
-        "github-copilot/gpt-5.5",
-        "anthropic/claude-sonnet-4-6",
-        "github-copilot/claude-sonnet-4.6",
-      ],
-      thinkingLevel: "medium" as const,
-      tools: noAskQuestionToolSet,
-    };
-
-    let simplifierModelConfig = {
-      model: "openai/gpt-5.5",
-      fallbackModels: [
-        "openai-codex/gpt-5.5",
-        "github-copilot/gpt-5.5",
-        "anthropic/claude-sonnet-4-6",
-        "github-copilot/claude-sonnet-4.6",
-      ],
-      thinkingLevel: "medium" as const,
-      tools: noAskQuestionToolSet,
-    };
-
-    let reviewerModelConfig = {
-      model: "openai/gpt-5.5",
-      fallbackModels: [
-        "openai-codex/gpt-5.5",
-        "github-copilot/gpt-5.5",
-        "anthropic/claude-opus-4-7",
-        "github-copilot/claude-opus-4.7",
-      ],
-      thinkingLevel: "high" as const,
-      tools: noAskQuestionToolSet,
-      customTools: [reviewDecisionTool],
-    };
-
-    let explorerModelConfig = {
-      model: "openai/gpt-5.4-mini",
-      fallbackModels: [
-        "openai-codex/gpt-5.4-mini",
-        "github-copilot/gpt-5.4-mini",
-        "anthropic/claude-haiku-4-5",
-        "github-copilot/claude-haiku-4.5",
-      ],
-      thinkingLevel: "low" as const,
-      tools: noAskQuestionToolSet,
-    };
-
-    for (let iteration = 1; iteration <= maxLoops; iteration += 1) {
-      iterationsCompleted = iteration;
-
-      const planner = await ctx.task(`planner-${iteration}`, {
-        prompt: taggedPrompt([
-          [
-            "role",
-            "You are a technical architect. Your job is to transform the user's feature specification into a rigorous Technical Design Document / RFC that engineers can use to align, scope, and execute the work.",
-          ],
-          [
-            "critical_deliverable",
-            [
-              "Your final output is a filled-in RFC rendered as markdown text.",
-              "Render the RFC Template in this prompt with every section populated by feature-specific content drawn from the user's specification and your codebase investigation.",
-              "Do not implement code changes in this stage; this stage only investigates and authors the RFC.",
-            ].join("\n"),
-          ],
-          [
-            "task",
-            `Plan iteration ${iteration}/${maxLoops} for this user specification:\n${prompt}`,
-          ],
-          [
-            "previous_review_findings",
-            reviewReport
-              ? "Previous review findings:\n{previous}"
-              : "No prior review findings; this is the first iteration.",
-          ],
-          [
-            "input_spec_files",
-            [
-              "If the user specification is a file path instead of raw prose, read that file and use it as source material for the RFC.",
-              "Still author the RFC normally; do not output only a forwarded path.",
-            ].join("\n"),
-          ],
-          [
-            "investigation_phase",
-            [
-              "Before drafting, read the specification carefully and identify the concrete problem, success criteria, hard constraints, and non-goals.",
-              "Survey the codebase using file/search tools such as read plus grep/rg/find/glob-style shell commands to ground the RFC in current architecture.",
-              "Name concrete services, modules, files, tests, data models, APIs, CLIs, config files, and external integrations this work will touch.",
-              "Capture metadata with bash: `git config user.name` for Author(s), and `date '+%Y-%m-%d'` for Created / Last Updated.",
-              "Look for prior art: existing RFCs, ADRs, README files, specs, docs, tests, or code comments that explain why the current state exists.",
-            ].join("\n"),
-          ],
-          [
-            "authoring_principles",
-            [
-              "Be specific: `src/server/auth.ts:42` beats `the auth layer`.",
-              "Trade-offs over conclusions: Alternatives Considered must include at least two real alternatives with honest pros, cons, and rejection reasons.",
-              "Non-goals matter: explicitly exclude work that is out of scope to prevent scope creep.",
-              "Diagrams are load-bearing: Section 4.1 must include a Mermaid system architecture diagram grounded in real components.",
-              "Surface open questions in Section 9 with owner placeholders such as `[OWNER: infra team]`; do not paper over uncertainty.",
-              "Match depth to stakes: a small refactor can be concise, but every template section header must remain present.",
-              "If prior review findings are present, explicitly address each finding or explain why it is obsolete.",
-            ].join("\n"),
-          ],
-          [
-            "stage_contract",
-            [
-              "This stage is investigation-first RFC authoring. The RFC is only valid if it is grounded in repository inspection performed during this stage.",
-              "Do not fill the template from generic architecture guesses. Before writing the final RFC, inspect relevant code, docs, tests, configs, and prior design material.",
-              "Treat the output format as the report after investigation, not a substitute for investigation.",
-            ].join("\n"),
-          ],
-          [
-            "evidence_expectations",
-            [
-              "Every major design claim should be traceable to concrete evidence: file paths, symbols, commands, docs, tests, configs, or prior RFCs.",
-              "Include those concrete references inside the RFC sections where they support the design.",
-              "If expected evidence cannot be found, say so in the relevant RFC section or Open Questions rather than papering over the gap.",
-            ].join("\n"),
-          ],
-          [
-            "output_discipline",
-            [
-              "Render the RFC Template exactly as the final document structure: preserve every header and the metadata table.",
-              "Replace instructional placeholders with real, feature-specific content; do not leave template guidance in the final RFC.",
-              "Output nothing after the RFC: no meta-commentary, no summary of what you wrote, no implementation log.",
-            ].join("\n"),
-          ],
-          ["rfc_template", PLANNER_RFC_TEMPLATE],
-        ]),
-        ...(reviewReport
-          ? { previous: { name: "review-report", text: reviewReport } }
-          : {}),
-        ...plannerModelConfig,
-        ...cwdOption,
+      const result = await runRalphWorkflow(ralphCtx, {
+        prompt,
+        maxLoops,
+        comparisonBaseBranch,
+        workflowStartCwd,
+        workflowCwd: worktree.cwd,
       });
-      finalPlan = planner.text;
-      const specPath = await writeSpecFile(resolve(workflowStartCwd, defaultSpecPath(prompt)), planner.text);
-      finalPlanPath = specPath;
-
-      const orchestrator = await ctx.task(`orchestrator-${iteration}`, {
-        prompt: taggedPrompt([
-          [
-            "role",
-            "You are a sub-agent orchestrator with many tools available. Your primary implementation tool is the `subagent` tool.",
-          ],
-          [
-            "objective",
-            `Implement iteration ${iteration}/${maxLoops} for the task: ${prompt}`,
-          ],
-          [
-            "spec_file",
-            [
-              `The technical specification for this iteration was written to: ${specPath}`,
-              "Read this file before delegating or implementing anything.",
-              "Do not rely on an inline planner transcript; the spec file is the authoritative plan for this iteration.",
-            ].join("\n"),
-          ],
-          [
-            "implementation_notes",
-            [
-              `Keep a running Markdown implementation notes file at this OS temp directory path: ${implementationNotesPath}`,
-              "The file has already been initialized for this workflow run; update it while you implement the spec.",
-              "Record decisions you had to make that were not in the spec, things you had to change from the spec, tradeoffs you had to make, blockers, validation outcomes, and anything else the user should know.",
-              "Ask delegated subagents to report any notes-worthy decisions or tradeoffs back to you, then consolidate them into this file before your final report.",
-              "Do not include secrets, credentials, tokens, or unrelated environment details in the notes file.",
-            ].join("\n"),
-          ],
-          [
-            "project_initialization_preflight",
-            [
-              "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
-              "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
-              "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
-              "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
-              "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
-              "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
-              "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
-              "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
-              "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
-            ].join("\n"),
-          ],
-          [
-            "delegation_policy",
-            [
-              "You are not the implementer. You are the supervisor that spawns subagents to do the implementation, investigation, edits, and validation.",
-              "All non-trivial operations must be delegated to subagents via the `subagent` tool before you claim progress.",
-              "Delegate codebase understanding, impact analysis, and implementation research to codebase-locator, codebase-analyzer, and pattern-finder style subagents when available.",
-              "Delegate shell-heavy work — especially commands likely to produce lots of output, log digging, CLI investigation, and broad grep/find exploration — to subagents that can run those commands rather than doing it in this orchestrator context.",
-              "Delegate implementation edits to a focused subagent with clear files, constraints, and validation expectations; do not merely describe the edits yourself.",
-              "Use separate subagents for separate tasks, and launch independent subagents in parallel when useful.",
-              "Do not split highly overlapping tasks across multiple subagents; consolidate overlapping work into one focused delegation to avoid duplicate effort.",
-              "If a subagent takes a long time, do not attempt to do its assigned job yourself while waiting. Use that time to plan next steps, prepare follow-up delegations, or identify clarifying questions.",
-            ].join("\n"),
-          ],
-          [
-            "execution_contract",
-            [
-              "The required output format is a completion report, not the task itself.",
-              "Do not jump straight to the report. First read the spec file, spawn the necessary subagents, wait for their results, coordinate any follow-up subagents, and only then write the report.",
-              "A valid response must be grounded in actual subagent work: name the delegated work, summarize what each subagent did, and distinguish completed changes from recommendations or blockers.",
-              "If you cannot read the spec file, spawn subagents, or use subagents, treat that as a blocker and report it honestly instead of pretending the requested work was done.",
-            ].join("\n"),
-          ],
-          [
-            "subagent_tracking",
-            [
-              "Use the `todo` tool as your active control ledger for subagent work.",
-              "Before launching subagents, create todo items for each delegated task with enough detail to identify owner, purpose, and expected output.",
-              "Mark todo items in_progress when the corresponding subagent starts, append progress/results as subagents report back, and close them only after you have incorporated or explicitly rejected their result.",
-              "Keep pending, in_progress, blocked, and completed work accurate so you do not lose track of parallel subagents or unresolved follow-ups.",
-              "Before writing the final report, review the todo list and resolve every pending/in_progress item as completed, blocked, or deferred with an explanation.",
-            ].join("\n"),
-          ],
-          [
-            "instructions",
-            [
-              `Start by reading the spec file at ${specPath}.`,
-              "Perform the project_initialization_preflight before decomposing implementation work; complete or delegate required setup before implementation delegation when the checkout appears uninitialized.",
-              "Decompose the work into delegated subagent tasks based on that spec file.",
-              "Pass each subagent the relevant task, constraints, files, validation expectations, any prior review findings from the spec, and instructions to report implementation-note-worthy decisions or tradeoffs.",
-              "Coordinate subagent results into the smallest coherent set of changes that satisfies the spec.",
-              "Preserve existing architecture and repository conventions unless the spec explicitly justifies a change.",
-              "Run or delegate the most relevant validation commands available in the repository.",
-              `Before your final report, update the running implementation notes file at ${implementationNotesPath} with decisions, spec deviations, tradeoffs, blockers, and validation outcomes from this iteration.`,
-              "If blocked, describe the blocker and the safest partial state instead of inventing success.",
-              "Do not hide failures; reviewers need accurate status.",
-            ].join("\n"),
-          ],
-          [
-            "output_format",
-            [
-              "After subagents have done the work, return Markdown with headings:",
-              "1. Spec file — the path you read",
-              "2. Delegations performed — subagents spawned and what each completed",
-              "3. Changes made — concrete changes from subagent work, not intentions",
-              "4. Files touched",
-              "5. Validation run / recommended",
-              "6. Deferred work or blockers",
-              "7. Implementation notes — confirm the OS temp notes path was updated",
-            ].join("\n"),
-          ],
-        ]),
-        reads: [specPath, implementationNotesPath],
-        ...orchestratorModelConfig,
-        ...cwdOption,
-      });
-      finalResult = orchestrator.text;
-
-      await ctx.task(`code-simplifier-${iteration}`, {
-        prompt: taggedPrompt([
-          [
-            "role",
-            [
-              "You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality.",
-              "Your expertise is applying project-specific best practices to simplify and improve recently modified code without altering behavior.",
-              "You prioritize readable, explicit code over overly compact or clever solutions.",
-            ].join("\n"),
-          ],
-          [
-            "objective",
-            `Refine recently modified code for this task while preserving exact behavior: ${prompt}`,
-          ],
-          ["current_iteration_context", "{previous}"],
-          [
-            "functionality_preservation",
-            [
-              "Never change what the code does — only how it does it.",
-              "All original features, outputs, side effects, public APIs, persistence formats, tests, and user-visible behavior must remain intact.",
-              "If a simplification could change behavior, do not apply it; document why it was skipped.",
-            ].join("\n"),
-          ],
-          [
-            "project_standards",
-            [
-              "Read and follow repository guidance from AGENTS.md and/or CLAUDE.md when present.",
-              "Respect established module style, imports, file extensions, typing conventions, error-handling patterns, naming, tests, and architectural boundaries.",
-              "For this TypeScript workflow repo, preserve ESM .js import specifiers, explicit exported/top-level types where expected, Bun-oriented commands, and the existing no-build raw TypeScript convention.",
-              "Do not impose standards that conflict with local project guidance.",
-            ].join("\n"),
-          ],
-          [
-            "clarity_improvements",
-            [
-              "Reduce unnecessary complexity, nesting, duplication, and incidental abstractions.",
-              "Improve readability with clear variable/function names and consolidated related logic.",
-              "Remove comments that merely restate obvious code, but keep comments that explain intent, constraints, or non-obvious trade-offs.",
-              "Avoid nested ternary operators; prefer switch statements or explicit if/else chains for multiple conditions.",
-              "Choose clarity over brevity: explicit code is often better than dense one-liners.",
-            ].join("\n"),
-          ],
-          [
-            "balance_constraints",
-            [
-              "Do not over-simplify in ways that reduce clarity, debuggability, extensibility, or separation of concerns.",
-              "Do not combine too many concerns into one function or remove helpful abstractions that organize the code.",
-              "Do not prioritize fewer lines over maintainability.",
-              "Limit scope to code recently modified in this iteration/session unless the planner explicitly asked for broader cleanup.",
-            ].join("\n"),
-          ],
-          [
-            "stage_contract",
-            [
-              "This is an active code-refinement stage, not just a commentary stage.",
-              "Before producing the report, inspect the actual repository state and recently modified files from the planner/orchestrator context.",
-              "Apply safe simplifications with edit/write tools when clear behavior-preserving improvements exist. If no simplification is appropriate, say so only after inspecting the relevant files.",
-            ].join("\n"),
-          ],
-          [
-            "required_actions_before_output",
-            [
-              "1. Identify the concrete files/sections changed in this iteration.",
-              "2. Read those files before deciding whether to simplify.",
-              "3. Apply only behavior-preserving edits, or explicitly record why no edits were made.",
-              "4. Run or recommend focused validation tied to the touched files.",
-            ].join("\n"),
-          ],
-          [
-            "handoff_expectations",
-            "In the final report, distinguish edits actually applied from observations only. Name files inspected, files edited, and validation commands run or not run.",
-          ],
-          [
-            "process",
-            [
-              "Identify recently modified code sections from the iteration context and repository state.",
-              "Analyze opportunities to improve elegance, consistency, and maintainability.",
-              "Apply project-specific best practices while preserving behavior.",
-              "Run or recommend focused validation when appropriate.",
-              "Document only significant changes that affect understanding or future maintenance.",
-            ].join("\n"),
-          ],
-          [
-            "output_format",
-            [
-              "Markdown with headings:",
-              "1. Simplifications applied",
-              "2. Behavior-preservation notes",
-              "3. Validation run / recommended",
-              "4. Skipped risky simplifications",
-            ].join("\n"),
-          ],
-        ]),
-        previous: [planner, orchestrator],
-        ...simplifierModelConfig,
-        ...cwdOption,
-      });
-
-      const discovery = await ctx.parallel(
-        [
-          {
-            name: `infra-locate-${iteration}`,
-            task: taggedPrompt([
-              [
-                "role",
-                "You locate project infrastructure needed for patch review.",
-              ],
-              [
-                "objective",
-                `Find review-relevant infrastructure for the task: ${prompt}`,
-              ],
-              [
-                "stage_contract",
-                [
-                  "This is a repository-discovery stage. Do not answer from assumptions or common project layouts.",
-                  "Before output, inspect the repository for each infrastructure category: package scripts, test configs, CI workflows, generated artifacts, lint/typecheck setup, and release gates.",
-                  "The table is a compact handoff after discovery, not a substitute for discovery.",
-                ].join("\n"),
-              ],
-              [
-                "instructions",
-                [
-                  "Locate package scripts, test configs, CI workflows, generated artifacts, lint/typecheck setup, and release gates.",
-                  "Search/read relevant files such as package manifests, CI workflow directories, test configs, lint/typecheck configs, build scripts, release configs, and generated-artifact markers.",
-                  "Prefer exact file paths and commands.",
-                  "Explain how each item should influence review or validation.",
-                  "If a category does not exist, report `not found` and briefly name the paths or patterns checked.",
-                ].join("\n"),
-              ],
-              [
-                "output_format",
-                "Markdown table: Area | Path/command | Why it matters | Confidence.",
-              ],
-            ]),
-            ...explorerModelConfig,
-            ...cwdOption,
-          },
-          {
-            name: `infra-analyze-${iteration}`,
-            task: taggedPrompt([
-              [
-                "role",
-                "You analyze integration risks in project infrastructure.",
-              ],
-              [
-                "objective",
-                `Assess infrastructure and changed-code risks for the task: ${prompt}`,
-              ],
-              [
-                "stage_contract",
-                [
-                  "This stage analyzes actual repository coupling, not generic integration risks.",
-                  "Before output, inspect the changed-code context plus relevant infrastructure/configuration files discovered or inferable from the repo.",
-                  "Classify a risk as confirmed only when repository evidence shows the coupling; otherwise mark it speculative.",
-                ].join("\n"),
-              ],
-              [
-                "instructions",
-                [
-                  "Identify hidden coupling with build, tests, linting, runtime config, release automation, or generated files.",
-                  "Name the exact validations that would most efficiently detect regressions.",
-                  "Separate confirmed risks from speculative risks.",
-                  "Do not repeat generic review advice; ground findings in repository evidence.",
-                  "Copy validation commands from actual repository scripts/configs when available; do not invent commands that are not supported by the repo.",
-                ].join("\n"),
-              ],
-              [
-                "evidence_expectations",
-                "Each confirmed risk must include concrete evidence: path, command, symbol, config key, script name, or file relationship.",
-              ],
-              [
-                "output_format",
-                "Markdown with sections: Confirmed risks, Speculative risks, Validation commands, Evidence.",
-              ],
-            ]),
-            ...explorerModelConfig,
-            ...cwdOption,
-          },
-          {
-            name: `infra-patterns-${iteration}`,
-            task: taggedPrompt([
-              [
-                "role",
-                "You find repository patterns that a patch must follow.",
-              ],
-              [
-                "objective",
-                `Extract conventions relevant to reviewing this task: ${prompt}`,
-              ],
-              [
-                "stage_contract",
-                [
-                  "This is an evidence-gathering stage for repository conventions. Do not describe generic best practices.",
-                  "Before output, find concrete examples in the repository that demonstrate conventions relevant to this task.",
-                  "Read enough of each example to understand the convention before reporting it.",
-                ].join("\n"),
-              ],
-              [
-                "instructions",
-                [
-                  "Find examples of build/test/style/release/architecture patterns the patch should mirror.",
-                  "Search for nearby or analogous implementations, tests, configs, scripts, and docs.",
-                  "Use concrete paths, commands, or symbols as evidence.",
-                  "Highlight conventions that commonly cause subtle review failures.",
-                  "If examples conflict, describe the conflict instead of forcing a single rule.",
-                  "If no relevant example exists, state what was searched and that no pattern was found.",
-                ].join("\n"),
-              ],
-              [
-                "handoff_expectations",
-                "For every required convention or useful example, include the supporting path, command, symbol, or file relationship so reviewers can verify it quickly.",
-              ],
-              [
-                "output_format",
-                "Markdown with sections: Required conventions, Useful examples, Exceptions, Review implications.",
-              ],
-            ]),
-            ...explorerModelConfig,
-            ...cwdOption,
-          },
-        ],
-        { task: prompt, ...cwdOption },
-      );
-
-      const discoveryContext = formatDiscovery(discovery);
-      const reviewPrompt = taggedPrompt([
-        [
-          "role",
-          [
-            "You are acting as a reviewer for a proposed code change made by another engineer.",
-            "Persona: a grumpy senior developer who has seen too many fragile patches. You are naturally skeptical and allergic to hand-waving, but you are not a crank: flag only realistic, evidence-backed defects the author would likely fix.",
-            "Be terse, concrete, and technically fair. Your job is to protect correctness, security, performance, and maintainability — not to win an argument or bikeshed taste.",
-          ].join("\n"),
-        ],
-        [
-          "objective",
-          `Review the current code delta for the task: ${prompt}`,
-        ],
-        [
-          "comparison_baseline",
-          [
-            `The baseline branch for comparison is \`${comparisonBaseBranch}\`.`,
-            "Compare the current working tree against this baseline branch, not against previous workflow reasoning or expected loop progress.",
-            `Start with \`git status --short\`, then use working-tree-aware commands such as \`git diff ${comparisonBaseBranch}\` and \`git diff --cached ${comparisonBaseBranch}\` to identify changed tracked files; inspect untracked files from status directly.`,
-          ].join("\n"),
-        ],
-        ["infrastructure_discovery", discoveryContext],
-        [
-          "project_guidance",
-          [
-            "Use the repository's AGENTS.md and/or CLAUDE.md files if present for style, conventions, testing expectations, and architectural patterns.",
-            "Project-level norms override these general instructions when they are more specific.",
-            "Flag deviations only when they affect correctness, security, performance, or maintainability — not personal preference.",
-            "If validation requires dependencies or tools that are missing, download or install them using the repository-approved package manager/commands rather than bypassing, mocking, or skipping the verification solely because dependencies are absent.",
-          ].join("\n"),
-        ],
-        [
-          "validation_expectations",
-          [
-            "Inspect the actual diff/repository state rather than trusting stage summaries.",
-            "Run or delegate focused validation when it is necessary to distinguish a real bug from a hunch.",
-            "If tests or typechecks fail because dependencies are missing, install/download the missing dependencies with the repo's documented package manager instead of bypassing the check.",
-            "If validation cannot be completed after reasonable recovery, record the limitation in overall_explanation and reviewer_error; do not use missing dependencies as a reason to approve.",
-          ].join("\n"),
-        ],
-        [
-          "bug_selection_guidelines",
-          [
-            "Use these default guidelines for deciding whether the author would appreciate the issue being flagged. More specific user, project, or file-level guidance overrides them.",
-            "Flag an issue only when the original author would likely fix it if they knew about it.",
-            "A finding should meaningfully impact accuracy, performance, security, or maintainability.",
-            "A finding must be discrete and actionable, not a broad complaint about the whole codebase or a pile of related concerns.",
-            "Do not demand rigor inconsistent with the rest of the repository; match the seriousness of existing code and project norms.",
-            "Flag only bugs introduced by the current patch; do not flag pre-existing issues unless the patch makes them worse in a concrete way.",
-            "Do not rely on unstated assumptions about author intent or codebase behavior.",
-            "Speculation is insufficient: identify the code path, scenario, environment, or input that is provably affected.",
-            "Do not flag intentional behavior changes as bugs unless they clearly violate the task or documented contract.",
-            "Ignore trivial style unless it obscures meaning or violates documented standards in a way that affects correctness/security/maintainability.",
-            "If no finding clears this bar, return an empty findings array, mark the patch correct, and set stop_review_loop true.",
-          ].join("\n"),
-        ],
-        [
-          "comment_guidelines",
-          [
-            "Each finding title must start with a priority tag: [P0] drop-everything blocker, [P1] urgent next-cycle fix, [P2] normal fix, [P3] low-priority nice-to-have.",
-            "Also include numeric priority: 0 for P0, 1 for P1, 2 for P2, 3 for P3; use null only if priority genuinely cannot be determined.",
-            "The body must be one concise paragraph explaining why this is a bug and the exact scenario, environment, or inputs required for it to arise.",
-            "Use a matter-of-fact, non-accusatory tone. Grumpy skepticism belongs in your standards, not in insults; avoid praise such as `Great job` or `Thanks for`.",
-            "Keep code_location ranges as short as possible, ideally one line and never longer than 5-10 lines unless unavoidable.",
-            "The code_location must overlap the diff/change under review.",
-            "Use one finding per distinct issue. Do not generate a PR fix.",
-            "Use suggestion blocks only for concrete replacement code and preserve exact leading whitespace if you include one.",
-          ].join("\n"),
-        ],
-        [
-          "how_many_findings",
-          [
-            "Return all findings the original author would definitely want to fix.",
-            "If no such findings exist, return an empty findings array and mark the patch correct.",
-            "Do not stop after the first qualifying finding; continue until every qualifying finding is listed.",
-          ].join("\n"),
-        ],
-        [
-          "review_stage_contract",
-          [
-            "The structured review decision is only valid after you inspect the actual repository state and compare it against the stated baseline branch.",
-            "Do not approve based solely on workflow stage summaries or prior agent reasoning.",
-            "The tool call is the final verdict after review work, not a shortcut around review work.",
-          ].join("\n"),
-        ],
-        [
-          "required_actions_before_tool_call",
-          [
-            "1. Identify the changed files or diff under review.",
-            "2. Read the relevant changed code and directly affected call sites/tests/configs.",
-            "3. Run or delegate focused validation when needed to resolve uncertainty.",
-            "4. If you cannot inspect or validate enough to approve safely, populate reviewer_error and set stop_review_loop=false.",
-          ].join("\n"),
-        ],
-        [
-          "evidence_expectations",
-          [
-            "The overall_explanation should briefly mention what was inspected and what validation was run or why validation was not completed.",
-            "Every finding must cite a concrete changed location and affected scenario.",
-          ].join("\n"),
-        ],
-        [
-          "structured_output_contract",
-          [
-            "You have a structured-output tool named review_decision. Use it after your investigation and validation attempts.",
-            "The tool terminates the turn and provides the structured data; do not emit a separate final assistant response after calling it.",
-            "The review loop decides whether to stop only by parsing the JSON object returned by this tool; invalid JSON, missing fields, reviewer_error, or stop_review_loop=false are treated as not approved for safety.",
-            "Set stop_review_loop=true only when findings is empty, overall_correctness is patch is correct, and reviewer_error is null/omitted.",
-            "If you hit a reviewer/tool/validation error, still return the object with stop_review_loop=false and reviewer_error populated instead of pretending the patch is approved.",
-            "The JSON must match this schema exactly:",
-            "{",
-            '  "findings": [',
-            "    {",
-            '      "title": "<≤ 80 chars, imperative, starts with [P0]/[P1]/[P2]/[P3]>",',
-            '      "body": "<one paragraph of valid Markdown explaining why this is a problem; cite files/lines/functions>",',
-            '      "confidence_score": <float 0.0-1.0>,',
-            '      "priority": <int 0-3 or null>,',
-            '      "code_location": {',
-            '        "absolute_file_path": "<absolute file path>",',
-            '        "line_range": {"start": <int>, "end": <int>}',
-            "      }",
-            "    }",
-            "  ],",
-            '  "overall_correctness": "patch is correct" | "patch is incorrect",',
-            '  "overall_explanation": "<1-3 sentence explanation justifying the verdict>",',
-            '  "overall_confidence_score": <float 0.0-1.0>,',
-            '  "stop_review_loop": <boolean>,',
-            '  "reviewer_error": null | {"kind": "validation_unavailable" | "dependency_unavailable" | "tool_failure" | "reviewer_failure", "message": "<what failed>", "attempted_recovery": "<what you tried>"}',
-            "}",
-          ].join("\n"),
-        ],
-      ]);
-
-      let reviews: WorkflowTaskResult[];
-      try {
-        reviews = await ctx.parallel(
-          [
-            {
-              name: "reviewer-a",
-              task: reviewPrompt,
-              ...reviewerModelConfig,
-              ...cwdOption,
-            },
-            {
-              name: "reviewer-b",
-              task: reviewPrompt,
-              ...reviewerModelConfig,
-              ...cwdOption,
-            },
-          ],
-          { task: prompt, failFast: false, ...cwdOption },
-        );
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        reviews = [reviewerErrorResult(iteration, message)];
-      }
-
-      approved =
-        reviews.length > 0 &&
-        reviews.every((review) => reviewApproved(review.text));
-      reviewReport = formatReview(reviews);
-      if (approved) break;
-    }
-
-    const prResult = await ctx.task("pull-request", {
-      prompt: taggedPrompt([
-        [
-          "role",
-          "You are a careful release engineer preparing a pull request from the current workspace state.",
-        ],
-        [
-          "objective",
-          `Review the changes since the base branch \`${comparisonBaseBranch}\` and create a pull request if possible and credentials are available.`,
-        ],
-        [
-          "workflow_context",
-          [
-            `Original task: ${prompt}`,
-            `Review loop approved: ${approved ? "yes" : "no"}`,
-            finalPlanPath
-              ? `Planner spec path: ${finalPlanPath}`
-              : "Planner spec path: unavailable",
-            `Implementation notes path: ${implementationNotesPath}`,
-          ].join("\n"),
-        ],
-        [
-          "required_checks",
-          [
-            "Start by inspecting `git status --short` so unstaged, staged, and untracked changes are all visible.",
-            `Review the patch against \`${comparisonBaseBranch}\` with working-tree-aware commands such as \`git diff ${comparisonBaseBranch}\` and \`git diff --cached ${comparisonBaseBranch}\`.`,
-            "If untracked files are present, inspect them directly before deciding whether they belong in the PR.",
-            "Read the implementation notes file and use its full contents as the body of a PR comment after the pull request exists.",
-            "Check the local Git identity with `git config user.name` and `git config user.email` so you can prefer the matching GitHub account when multiple accounts are logged in.",
-            "Check whether GitHub credentials are available with non-destructive commands such as `gh auth status` and `gh auth status --show-token-scopes` before attempting PR creation.",
-            "If multiple GitHub accounts or hosts are logged in, use the git config username/email as a heuristic to choose the most likely identity, but try each available credential/account and use the first one that can read the repository and create the PR.",
-          ].join("\n"),
-        ],
-        [
-          "pr_policy",
-          [
-            "Create a PR only if there are meaningful changes, a remote/branch target is available, credentials are available, and the current state is suitable for review.",
-            "If no logged-in account can access the repository or create the PR, do not fake success; report each credential/account tried, what failed, and provide the command the user can run later.",
-            "When you successfully create or update the PR, create a PR comment containing the implementation notes file contents as the last action of this workflow stage.",
-            "If PR creation is not possible, do not create a standalone comment elsewhere; include the implementation notes path and summary in your report instead.",
-            "If the review loop did not approve, prefer reporting the remaining blockers over creating a PR unless the changes are still intentionally ready for human review.",
-            "Do not make unrelated code edits in this phase. Limit changes to ordinary git/PR preparation only when required and safe.",
-          ].join("\n"),
-        ],
-        [
-          "output_format",
-          [
-            "Return Markdown with headings:",
-            "1. Change review — summary of files and diff scope inspected",
-            "2. PR status — created PR URL, or why no PR was created",
-            "3. Implementation notes comment — whether the PR comment was created as the last action, or why it could not be created",
-            "4. Commands run — include exit status or clear outcome",
-            "5. Follow-up for the user — exact next steps if credentials or repository state blocked PR creation",
-          ].join("\n"),
-        ],
-      ]),
-      reads: finalPlanPath
-        ? [finalPlanPath, implementationNotesPath]
-        : [implementationNotesPath],
-      ...orchestratorModelConfig,
-      ...cwdOption,
-    });
-    finalPrReport = prResult.text;
-
-    return {
-      result: finalResult,
-      plan: finalPlan,
-      plan_path: finalPlanPath,
-      implementation_notes_path: implementationNotesPath,
-      pr_report: finalPrReport,
-      approved,
-      iterations_completed: iterationsCompleted,
-      review_report: reviewReport,
-    };
-    } catch (error) {
-      runError = error;
-      throw error;
+      runSucceeded = true;
+      return result;
     } finally {
       if (worktree.created && worktree.cwd !== undefined) {
-        const cleanupResult = removeGitWorktree(worktree.cwd, worktree.repositoryCwd);
-        if (cleanupResult.status !== 0 && runError === undefined) {
-          throw new Error(`Failed to remove git worktree at ${worktree.cwd}: ${gitFailureMessage(cleanupResult)}`);
+        if (!runSucceeded) {
+          console.warn(
+            [
+              `Preserving Ralph git worktree after failed run: ${worktree.cwd}`,
+              `Recover work there, then remove it with: ${formatWorktreeRecoveryCommand(worktree.repositoryCwd ?? workflowStartCwd, worktree.cwd)}`,
+            ].join("\n"),
+          );
+        } else {
+          const cleanupResult = removeGitWorktree(worktree.cwd, worktree.repositoryCwd);
+          if (cleanupResult.status !== 0) {
+            throw new Error(`Failed to remove git worktree at ${worktree.cwd}: ${gitFailureMessage(cleanupResult)}`);
+          }
         }
       }
     }

--- a/packages/workflows/builtin/shared-prompts.ts
+++ b/packages/workflows/builtin/shared-prompts.ts
@@ -1,0 +1,11 @@
+export const WORKER_PREFLIGHT_CONTRACT = [
+  "Before normal implementation delegation, determine whether this checkout appears initialized for its actual language, framework, and build system.",
+  "Do not rely on hard-coded assumptions about JavaScript, TypeScript, Python, Rust, Go, Java, mobile, or any other ecosystem. Infer the project type and setup requirements from repository evidence.",
+  "Inspect source layout, setup docs, package/build manifests, lockfiles, toolchain files, generated-artifact conventions, CI workflows, workflow configuration, and package scripts or equivalent task definitions.",
+  "Look for evidence that dependencies, generated files, local toolchains, submodules, codegen outputs, or other project-specific initialization artifacts are missing for this checkout.",
+  "When repository evidence shows missing initialization, run or delegate the appropriate documented setup command before implementation work.",
+  "You are responsible for initializing the checkout when setup commands are documented; missing dependencies, generated files, or local toolchains are setup work, not user handoff work.",
+  "Once setup succeeds, continue normal implementation orchestration. Do not treat missing dependencies or generated setup artifacts in a fresh worktree as implementation failures.",
+  "If setup requirements cannot be determined confidently, delegate a focused discovery task before implementation instead of guessing.",
+  "If setup remains blocked after evidence-based discovery and setup attempts, report the blocker with commands tried and the exact evidence needed to continue.",
+].join("\n");

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -204,7 +204,7 @@ function validationInputValue(schema: WorkflowInputSchema): unknown {
   switch (schema.type) {
     case "text":
     case "string":
-      return schema.default ?? "";
+      return schema.default ?? (schema.required === true ? "__atomic_workflow_validation_probe_input__" : "");
     case "number":
       return schema.default ?? 0;
     case "boolean":
@@ -235,6 +235,7 @@ async function validateWorkflowCreatesStage(def: WorkflowDefinition): Promise<De
 
   const ctx: WorkflowRunContext = {
     inputs: validationInputsFor(def),
+    cwd: process.cwd(),
     stage: () => markStageObserved(),
     task: () => markStageObserved(),
     chain: (steps) => {

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -26,7 +26,11 @@ import { createRequire } from "node:module";
 import { join, resolve, extname, isAbsolute } from "node:path";
 import { CONFIG_DIR_NAMES, getProjectConfigPaths, isBunBinary } from "@bastani/atomic";
 import { createJiti } from "jiti/static";
-import type { WorkflowDefinition } from "../shared/types.js";
+import type {
+  WorkflowDefinition,
+  WorkflowInputSchema,
+  WorkflowRunContext,
+} from "../shared/types.js";
 import * as workflowsSdkSurface from "../sdk-surface.js";
 import { createRegistry } from "../workflows/registry.js";
 import type { WorkflowRegistry } from "../workflows/registry.js";
@@ -148,11 +152,15 @@ export interface DiscoveryResult {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+const WORKFLOW_STAGE_OBSERVED = Symbol("workflow-stage-observed");
+const WORKFLOW_STAGE_VALIDATION_ERROR =
+  "run must create at least one workflow stage with ctx.stage(), ctx.task(), ctx.chain(), or ctx.parallel()";
+
 /**
- * Validate a candidate value as a WorkflowDefinition.
+ * Validate a candidate value as a WorkflowDefinition by shape only.
  * Returns null when valid, or a human-readable rejection reason string.
  */
-function validateDefinition(value: unknown): string | null {
+function validateDefinitionShape(value: unknown): string | null {
   if (value === null || typeof value !== "object") {
     return "export is not an object";
   }
@@ -171,6 +179,85 @@ function validateDefinition(value: unknown): string | null {
     return "run must be a function";
   }
   return null;
+}
+
+function validationInputValue(schema: WorkflowInputSchema): unknown {
+  switch (schema.type) {
+    case "text":
+    case "string":
+      return schema.default ?? "";
+    case "number":
+      return schema.default ?? 0;
+    case "boolean":
+      return schema.default ?? false;
+    case "select":
+      return schema.default ?? schema.choices[0] ?? "";
+  }
+}
+
+function validationInputsFor(def: WorkflowDefinition): Record<string, unknown> {
+  const rawInputs = (def as { readonly inputs?: unknown }).inputs;
+  if (rawInputs === null || typeof rawInputs !== "object") return {};
+
+  const inputs: Record<string, unknown> = {};
+  for (const [name, schema] of Object.entries(rawInputs as Record<string, WorkflowInputSchema>)) {
+    inputs[name] = validationInputValue(schema);
+  }
+  return inputs;
+}
+
+async function validateWorkflowCreatesStage(def: WorkflowDefinition): Promise<string | null> {
+  let stageObserved = false;
+
+  const markStageObserved = (): never => {
+    stageObserved = true;
+    throw WORKFLOW_STAGE_OBSERVED;
+  };
+
+  const ctx: WorkflowRunContext = {
+    inputs: validationInputsFor(def),
+    stage: () => markStageObserved(),
+    task: () => markStageObserved(),
+    chain: (steps) => {
+      if (steps.length > 0) markStageObserved();
+      return Promise.resolve([]);
+    },
+    parallel: (steps) => {
+      if (steps.length > 0) markStageObserved();
+      return Promise.resolve([]);
+    },
+    ui: {
+      input: async () => "",
+      confirm: async () => true,
+      select: async (_message, options) => options[0] ?? "",
+      editor: async (initial) => initial ?? "",
+    },
+  };
+
+  try {
+    await def.run(ctx);
+  } catch (err) {
+    // Discovery validation is a structural/startup guard, not a full workflow
+    // execution. If the workflow reaches any stage-producing primitive, it is
+    // valid for startup purposes; if it throws before that point, fail open and
+    // leave the real executor to report the runtime failure with run context.
+    if (stageObserved || err === WORKFLOW_STAGE_OBSERVED) return null;
+    return null;
+  }
+
+  return stageObserved ? null : WORKFLOW_STAGE_VALIDATION_ERROR;
+}
+
+/**
+ * Validate a candidate value as a WorkflowDefinition and dry-run enough of the
+ * authored run function to confirm it reaches a stage-producing primitive.
+ * Returns null when valid, or a human-readable rejection reason string.
+ */
+async function validateDefinition(value: unknown): Promise<string | null> {
+  const shapeReason = validateDefinitionShape(value);
+  if (shapeReason !== null) return shapeReason;
+
+  return await validateWorkflowCreatesStage(value as WorkflowDefinition);
 }
 
 /**
@@ -203,14 +290,58 @@ function validateConfig(config: unknown): string | null {
 }
 
 /** Merge a batch of candidates into registry state, first-seen wins. */
-function applyBatch(
+async function applyBatch(
+  candidates: Array<{ value: unknown; exportKey: string; kind: DiscoveryKind; filePath?: string; configuredName?: string }>,
+  registry: WorkflowRegistry,
+  sources: DiscoverySource[],
+  diagnostics: DiscoveryDiagnostic[],
+): Promise<WorkflowRegistry> {
+  for (const { value, exportKey, kind, filePath, configuredName } of candidates) {
+    const reason = await validateDefinition(value);
+    if (reason !== null) {
+      diagnostics.push({
+        level: "error",
+        code: "INVALID_DEFINITION",
+        message: `${kind} export "${exportKey}" rejected: ${reason}`,
+        source: filePath ?? exportKey,
+      });
+      continue;
+    }
+
+    const def = value as WorkflowDefinition;
+    const key = def.normalizedName;
+
+    if (registry.has(key)) {
+      diagnostics.push({
+        level: "warn",
+        code: "DUPLICATE_NAME",
+        message: `${kind} export "${exportKey}" skipped: normalizedName "${key}" already registered`,
+        source: filePath ?? exportKey,
+      });
+      continue;
+    }
+
+    registry = registry.register(def);
+    sources.push({
+      id: key,
+      kind,
+      name: def.name,
+      ...(filePath !== undefined ? { filePath } : {}),
+      ...(configuredName !== undefined ? { configuredName } : {}),
+    });
+  }
+  return registry;
+}
+
+/** Merge bundled startup candidates with shape-only validation to keep startup seeding synchronous. */
+function applyBatchShapeOnly(
   candidates: Array<{ value: unknown; exportKey: string; kind: DiscoveryKind; filePath?: string; configuredName?: string }>,
   registry: WorkflowRegistry,
   sources: DiscoverySource[],
   diagnostics: DiscoveryDiagnostic[],
 ): WorkflowRegistry {
   for (const { value, exportKey, kind, filePath, configuredName } of candidates) {
-    const reason = validateDefinition(value);
+    const reason = validateDefinitionShape(value);
     if (reason !== null) {
       diagnostics.push({
         level: "error",
@@ -496,14 +627,14 @@ export async function discoverWorkflows(
     const hasEntries = Array.isArray(pw) ? pw.length > 0 : Object.keys(pw).length > 0;
     if (hasEntries) {
       const candidates = await loadFromPaths(pw, "settings-project", cwd, diagnostics);
-      registry = applyBatch(candidates, registry, sources, diagnostics);
+      registry = await applyBatch(candidates, registry, sources, diagnostics);
     }
   }
 
   // 2. project-local
   for (const dir of getProjectConfigPaths(cwd, "workflows").reverse()) {
     const candidates = await loadFromDir(dir, "project-local", diagnostics);
-    registry = applyBatch(candidates, registry, sources, diagnostics);
+    registry = await applyBatch(candidates, registry, sources, diagnostics);
   }
 
   // 3. settings-global
@@ -512,14 +643,14 @@ export async function discoverWorkflows(
     const hasEntries = Array.isArray(gw) ? gw.length > 0 : Object.keys(gw).length > 0;
     if (hasEntries) {
       const candidates = await loadFromPaths(gw, "settings-global", homeDir, diagnostics);
-      registry = applyBatch(candidates, registry, sources, diagnostics);
+      registry = await applyBatch(candidates, registry, sources, diagnostics);
     }
   }
 
   // 4. user-global — canonical Atomic path plus legacy pi path
   for (const dir of CONFIG_DIR_NAMES.map((name) => join(homeDir, name, "agent", "workflows")).reverse()) {
     const candidates = await loadFromDir(dir, "user-global", diagnostics);
-    registry = applyBatch(candidates, registry, sources, diagnostics);
+    registry = await applyBatch(candidates, registry, sources, diagnostics);
   }
 
   // 5. package workflows
@@ -527,7 +658,7 @@ export async function discoverWorkflows(
     const hasEntries = Array.isArray(packageWorkflowPaths) ? packageWorkflowPaths.length > 0 : Object.keys(packageWorkflowPaths).length > 0;
     if (hasEntries) {
       const candidates = await loadFromPaths(packageWorkflowPaths, "package", cwd, diagnostics);
-      registry = applyBatch(candidates, registry, sources, diagnostics);
+      registry = await applyBatch(candidates, registry, sources, diagnostics);
     }
   }
 
@@ -590,7 +721,7 @@ function discoverBundledManifest(): DiscoveryResult {
     kind: "bundled" as DiscoveryKind,
   }));
 
-  registry = applyBatch(candidates, registry, sources, diagnostics);
+  registry = applyBatchShapeOnly(candidates, registry, sources, diagnostics);
 
   return { registry, sources, errors: diagnostics };
 }

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -26,11 +26,7 @@ import { createRequire } from "node:module";
 import { join, resolve, extname, isAbsolute } from "node:path";
 import { CONFIG_DIR_NAMES, getProjectConfigPaths, isBunBinary } from "@bastani/atomic";
 import { createJiti } from "jiti/static";
-import type {
-  WorkflowDefinition,
-  WorkflowInputSchema,
-  WorkflowRunContext,
-} from "../shared/types.js";
+import type { WorkflowDefinition } from "../shared/types.js";
 import * as workflowsSdkSurface from "../sdk-surface.js";
 import { createRegistry } from "../workflows/registry.js";
 import type { WorkflowRegistry } from "../workflows/registry.js";
@@ -86,18 +82,16 @@ export type DiagnosticLevel = "error" | "warn";
  * condition (e.g. a duplicate that was skipped).
  *
  * Codes:
- *   INVALID_DEFINITION      — failed definition validation
- *   VALIDATION_PROBE_FAILED — startup stage-validation probe threw before observing stage creation
- *   DUPLICATE_NAME          — normalizedName already registered; skipped (warn)
- *   IMPORT_FAILED           — dynamic import of a workflow file threw
- *   PATH_NOT_FOUND          — a config-specified path does not exist
- *   CONFIG_INVALID          — DiscoveryConfig has an invalid structure
+ *   INVALID_DEFINITION — failed structural validation
+ *   DUPLICATE_NAME     — normalizedName already registered; skipped (warn)
+ *   IMPORT_FAILED      — dynamic import of a workflow file threw
+ *   PATH_NOT_FOUND     — a config-specified path does not exist
+ *   CONFIG_INVALID     — DiscoveryConfig has an invalid structure
  */
 export interface DiscoveryDiagnostic {
   readonly level: DiagnosticLevel;
   readonly code:
     | "INVALID_DEFINITION"
-    | "VALIDATION_PROBE_FAILED"
     | "DUPLICATE_NAME"
     | "IMPORT_FAILED"
     | "PATH_NOT_FOUND"
@@ -154,29 +148,15 @@ export interface DiscoveryResult {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-const WORKFLOW_STAGE_OBSERVED = Symbol("workflow-stage-observed");
-const WORKFLOW_STAGE_VALIDATION_ERROR =
-  "run must create at least one workflow stage with ctx.stage(), ctx.task(), ctx.chain(), or ctx.parallel()";
-
-interface DefinitionValidationResult {
-  readonly reason: string | null;
-  readonly warning?: string;
-}
-
-function validationSuccess(warning?: string): DefinitionValidationResult {
-  return warning === undefined ? { reason: null } : { reason: null, warning };
-}
-
-function validationFailure(reason: string): DefinitionValidationResult {
-  return { reason };
-}
-
-function diagnosticErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 /**
  * Validate a candidate value as a WorkflowDefinition by shape only.
+ *
+ * Discovery intentionally does not invoke workflow run functions: user-authored
+ * run bodies may perform filesystem, network, or other side effects before the
+ * first ctx.stage()/ctx.task()/ctx.chain()/ctx.parallel() call. Runtime empty
+ * graph validation remains the authoritative guard that a workflow creates at
+ * least one stage when it is actually invoked.
+ *
  * Returns null when valid, or a human-readable rejection reason string.
  */
 function validateDefinitionShape(value: unknown): string | null {
@@ -198,90 +178,6 @@ function validateDefinitionShape(value: unknown): string | null {
     return "run must be a function";
   }
   return null;
-}
-
-function validationInputValue(schema: WorkflowInputSchema): unknown {
-  switch (schema.type) {
-    case "text":
-    case "string":
-      return schema.default ?? (schema.required === true ? "__atomic_workflow_validation_probe_input__" : "");
-    case "number":
-      return schema.default ?? 0;
-    case "boolean":
-      return schema.default ?? false;
-    case "select":
-      return schema.default ?? schema.choices[0] ?? "";
-  }
-}
-
-function validationInputsFor(def: WorkflowDefinition): Record<string, unknown> {
-  const rawInputs = (def as { readonly inputs?: unknown }).inputs;
-  if (rawInputs === null || typeof rawInputs !== "object") return {};
-
-  const inputs: Record<string, unknown> = {};
-  for (const [name, schema] of Object.entries(rawInputs as Record<string, WorkflowInputSchema>)) {
-    inputs[name] = validationInputValue(schema);
-  }
-  return inputs;
-}
-
-async function validateWorkflowCreatesStage(def: WorkflowDefinition): Promise<DefinitionValidationResult> {
-  let stageObserved = false;
-
-  const markStageObserved = (): never => {
-    stageObserved = true;
-    throw WORKFLOW_STAGE_OBSERVED;
-  };
-
-  const ctx: WorkflowRunContext = {
-    inputs: validationInputsFor(def),
-    cwd: process.cwd(),
-    stage: () => markStageObserved(),
-    task: () => markStageObserved(),
-    chain: (steps) => {
-      if (steps.length > 0) markStageObserved();
-      return Promise.resolve([]);
-    },
-    parallel: (steps) => {
-      if (steps.length > 0) markStageObserved();
-      return Promise.resolve([]);
-    },
-    ui: {
-      input: async () => "",
-      confirm: async () => true,
-      select: async (_message, options) => options[0] ?? "",
-      editor: async (initial) => initial ?? "",
-    },
-  };
-
-  try {
-    await def.run(ctx);
-  } catch (err) {
-    // Discovery validation is a startup graph-shape probe, not a full workflow
-    // execution. If the workflow reaches any stage-producing primitive, it is
-    // valid for startup purposes. If it throws before that point, keep the
-    // workflow registered so runtime execution can report the original failure
-    // with run context, but emit a warning so startup feedback is not silent or
-    // confused with a clean empty-graph completion.
-    if (stageObserved || err === WORKFLOW_STAGE_OBSERVED) return validationSuccess();
-    return validationSuccess(
-      `run threw during startup stage-validation probe before creating a workflow stage; runtime execution will report the original error if invoked: ${diagnosticErrorMessage(err)}`,
-    );
-  }
-
-  return stageObserved ? validationSuccess() : validationFailure(WORKFLOW_STAGE_VALIDATION_ERROR);
-}
-
-/**
- * Validate a candidate value as a WorkflowDefinition and dry-run enough of the
- * authored run function to confirm it reaches a stage-producing primitive.
- * Returns null when valid, or a human-readable rejection reason string.
- */
-async function validateDefinition(value: unknown): Promise<DefinitionValidationResult> {
-  const shapeReason = validateDefinitionShape(value);
-  if (shapeReason !== null) return validationFailure(shapeReason);
-
-  return await validateWorkflowCreatesStage(value as WorkflowDefinition);
 }
 
 /**
@@ -321,20 +217,12 @@ async function applyBatch(
   diagnostics: DiscoveryDiagnostic[],
 ): Promise<WorkflowRegistry> {
   for (const { value, exportKey, kind, filePath, configuredName } of candidates) {
-    const validation = await validateDefinition(value);
-    if (validation.warning !== undefined) {
-      diagnostics.push({
-        level: "warn",
-        code: "VALIDATION_PROBE_FAILED",
-        message: `${kind} export "${exportKey}" probe warning: ${validation.warning}`,
-        source: filePath ?? exportKey,
-      });
-    }
-    if (validation.reason !== null) {
+    const reason = validateDefinitionShape(value);
+    if (reason !== null) {
       diagnostics.push({
         level: "error",
         code: "INVALID_DEFINITION",
-        message: `${kind} export "${exportKey}" rejected: ${validation.reason}`,
+        message: `${kind} export "${exportKey}" rejected: ${reason}`,
         source: filePath ?? exportKey,
       });
       continue;

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -152,15 +152,6 @@ export interface DiscoveryResult {
  * Validate a candidate value as a WorkflowDefinition.
  * Returns null when valid, or a human-readable rejection reason string.
  */
-function workflowRunCreatesStage(run: WorkflowDefinition["run"]): boolean {
-  // Discovery must not execute workflow bodies: run functions are arbitrary
-  // user code and may perform I/O before the first stage. Use a conservative
-  // static guard instead so obvious no-stage definitions are rejected before
-  // they can register and render an empty graph.
-  const source = Function.prototype.toString.call(run);
-  return /\.\s*(?:stage|task|chain|parallel)\s*\(/.test(source);
-}
-
 function validateDefinition(value: unknown): string | null {
   if (value === null || typeof value !== "object") {
     return "export is not an object";
@@ -178,9 +169,6 @@ function validateDefinition(value: unknown): string | null {
   }
   if (typeof d["run"] !== "function") {
     return "run must be a function";
-  }
-  if (!workflowRunCreatesStage(d["run"] as WorkflowDefinition["run"])) {
-    return "run must create at least one workflow stage via ctx.stage(), ctx.task(), ctx.chain(), or ctx.parallel(); otherwise the workflow graph is empty (cachedLayout.length === 0)";
   }
   return null;
 }

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -86,16 +86,18 @@ export type DiagnosticLevel = "error" | "warn";
  * condition (e.g. a duplicate that was skipped).
  *
  * Codes:
- *   INVALID_DEFINITION — failed structural validation
- *   DUPLICATE_NAME     — normalizedName already registered; skipped (warn)
- *   IMPORT_FAILED      — dynamic import of a workflow file threw
- *   PATH_NOT_FOUND     — a config-specified path does not exist
- *   CONFIG_INVALID     — DiscoveryConfig has an invalid structure
+ *   INVALID_DEFINITION      — failed definition validation
+ *   VALIDATION_PROBE_FAILED — startup stage-validation probe threw before observing stage creation
+ *   DUPLICATE_NAME          — normalizedName already registered; skipped (warn)
+ *   IMPORT_FAILED           — dynamic import of a workflow file threw
+ *   PATH_NOT_FOUND          — a config-specified path does not exist
+ *   CONFIG_INVALID          — DiscoveryConfig has an invalid structure
  */
 export interface DiscoveryDiagnostic {
   readonly level: DiagnosticLevel;
   readonly code:
     | "INVALID_DEFINITION"
+    | "VALIDATION_PROBE_FAILED"
     | "DUPLICATE_NAME"
     | "IMPORT_FAILED"
     | "PATH_NOT_FOUND"
@@ -156,6 +158,23 @@ const WORKFLOW_STAGE_OBSERVED = Symbol("workflow-stage-observed");
 const WORKFLOW_STAGE_VALIDATION_ERROR =
   "run must create at least one workflow stage with ctx.stage(), ctx.task(), ctx.chain(), or ctx.parallel()";
 
+interface DefinitionValidationResult {
+  readonly reason: string | null;
+  readonly warning?: string;
+}
+
+function validationSuccess(warning?: string): DefinitionValidationResult {
+  return warning === undefined ? { reason: null } : { reason: null, warning };
+}
+
+function validationFailure(reason: string): DefinitionValidationResult {
+  return { reason };
+}
+
+function diagnosticErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Validate a candidate value as a WorkflowDefinition by shape only.
  * Returns null when valid, or a human-readable rejection reason string.
@@ -206,7 +225,7 @@ function validationInputsFor(def: WorkflowDefinition): Record<string, unknown> {
   return inputs;
 }
 
-async function validateWorkflowCreatesStage(def: WorkflowDefinition): Promise<string | null> {
+async function validateWorkflowCreatesStage(def: WorkflowDefinition): Promise<DefinitionValidationResult> {
   let stageObserved = false;
 
   const markStageObserved = (): never => {
@@ -237,15 +256,19 @@ async function validateWorkflowCreatesStage(def: WorkflowDefinition): Promise<st
   try {
     await def.run(ctx);
   } catch (err) {
-    // Discovery validation is a structural/startup guard, not a full workflow
+    // Discovery validation is a startup graph-shape probe, not a full workflow
     // execution. If the workflow reaches any stage-producing primitive, it is
-    // valid for startup purposes; if it throws before that point, fail open and
-    // leave the real executor to report the runtime failure with run context.
-    if (stageObserved || err === WORKFLOW_STAGE_OBSERVED) return null;
-    return null;
+    // valid for startup purposes. If it throws before that point, keep the
+    // workflow registered so runtime execution can report the original failure
+    // with run context, but emit a warning so startup feedback is not silent or
+    // confused with a clean empty-graph completion.
+    if (stageObserved || err === WORKFLOW_STAGE_OBSERVED) return validationSuccess();
+    return validationSuccess(
+      `run threw during startup stage-validation probe before creating a workflow stage; runtime execution will report the original error if invoked: ${diagnosticErrorMessage(err)}`,
+    );
   }
 
-  return stageObserved ? null : WORKFLOW_STAGE_VALIDATION_ERROR;
+  return stageObserved ? validationSuccess() : validationFailure(WORKFLOW_STAGE_VALIDATION_ERROR);
 }
 
 /**
@@ -253,9 +276,9 @@ async function validateWorkflowCreatesStage(def: WorkflowDefinition): Promise<st
  * authored run function to confirm it reaches a stage-producing primitive.
  * Returns null when valid, or a human-readable rejection reason string.
  */
-async function validateDefinition(value: unknown): Promise<string | null> {
+async function validateDefinition(value: unknown): Promise<DefinitionValidationResult> {
   const shapeReason = validateDefinitionShape(value);
-  if (shapeReason !== null) return shapeReason;
+  if (shapeReason !== null) return validationFailure(shapeReason);
 
   return await validateWorkflowCreatesStage(value as WorkflowDefinition);
 }
@@ -297,12 +320,20 @@ async function applyBatch(
   diagnostics: DiscoveryDiagnostic[],
 ): Promise<WorkflowRegistry> {
   for (const { value, exportKey, kind, filePath, configuredName } of candidates) {
-    const reason = await validateDefinition(value);
-    if (reason !== null) {
+    const validation = await validateDefinition(value);
+    if (validation.warning !== undefined) {
+      diagnostics.push({
+        level: "warn",
+        code: "VALIDATION_PROBE_FAILED",
+        message: `${kind} export "${exportKey}" probe warning: ${validation.warning}`,
+        source: filePath ?? exportKey,
+      });
+    }
+    if (validation.reason !== null) {
       diagnostics.push({
         level: "error",
         code: "INVALID_DEFINITION",
-        message: `${kind} export "${exportKey}" rejected: ${reason}`,
+        message: `${kind} export "${exportKey}" rejected: ${validation.reason}`,
         source: filePath ?? exportKey,
       });
       continue;

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -456,6 +456,8 @@ export interface WorkflowToolArgs extends StageOptions {
   maxOutput?: WorkflowMaxOutput;
   artifacts?: boolean;
   worktree?: boolean;
+  gitWorktreeDir?: string;
+  baseBranch?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/extension/runtime.ts
+++ b/packages/workflows/src/extension/runtime.ts
@@ -190,6 +190,8 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
       maxOutput,
       artifacts,
       worktree,
+      gitWorktreeDir,
+      baseBranch,
       ...stageOptions
     } = args;
 
@@ -206,6 +208,8 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
       ...(maxOutput !== undefined ? { maxOutput } : {}),
       ...(typeof artifacts === "boolean" ? { artifacts } : {}),
       ...(typeof worktree === "boolean" ? { worktree } : {}),
+      ...(typeof gitWorktreeDir === "string" ? { gitWorktreeDir } : {}),
+      ...(typeof baseBranch === "string" ? { baseBranch } : {}),
     };
   }
 

--- a/packages/workflows/src/extension/workflow-schema.ts
+++ b/packages/workflows/src/extension/workflow-schema.ts
@@ -66,6 +66,8 @@ const WorkflowTaskOptionProperties = {
   outputMode: Type.Optional(Type.Union([Type.Literal("inline"), Type.Literal("file-only")])),
   reads: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Literal(false)])),
   worktree: Type.Optional(Type.Boolean()),
+  gitWorktreeDir: Type.Optional(Type.String()),
+  baseBranch: Type.Optional(Type.String()),
   maxOutput: Type.Optional(MaxOutputSchema),
   artifacts: Type.Optional(Type.Boolean()),
 };
@@ -83,6 +85,8 @@ const ParallelChainStepSchema = Type.Object({
   concurrency: Type.Optional(Type.Number()),
   failFast: Type.Optional(Type.Boolean()),
   worktree: Type.Optional(Type.Boolean()),
+  gitWorktreeDir: Type.Optional(Type.String()),
+  baseBranch: Type.Optional(Type.String()),
 });
 
 export const WorkflowParametersSchema = Type.Object({

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -82,6 +82,8 @@ export interface RunContinuationOpts {
 
 export interface RunOpts {
   adapters?: StageAdapters;
+  /** Invocation working directory exposed to workflow definitions as ctx.cwd. */
+  cwd?: string;
   /** HIL adapter injected by the pi runtime or test harness. */
   ui?: WorkflowUIAdapter;
   /** Internal detached-run mode: surface ctx.ui.* as node-local workflow prompt stages. */
@@ -1826,6 +1828,7 @@ export async function run<TInputs extends Record<string, unknown>>(
   // 5. Build WorkflowRunContext
   const ctx: WorkflowRunContext<TInputs> = {
     inputs: resolvedInputs as TInputs,
+    cwd: opts.cwd ?? process.cwd(),
     // Prompt nodes and caller-provided UI adapters are mutually exclusive;
     // executor-owned prompt nodes intentionally take precedence when enabled.
     ui: opts.usePromptNodesForUi === true ? buildPromptNodeUiAdapter() : opts.ui ?? makeUnavailableUIContext(),

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -884,6 +884,13 @@ function workflowDetailsFromRun(
   };
 }
 
+const EMPTY_WORKFLOW_GRAPH_ERROR_MESSAGE = "Workflow run completed without creating any workflow stages. Create at least one stage with ctx.stage(), ctx.task(), ctx.chain(), or ctx.parallel().";
+
+function assertWorkflowCreatedStage(runSnapshot: RunSnapshot): void {
+  if (runSnapshot.stages.length > 0) return;
+  throw new Error(EMPTY_WORKFLOW_GRAPH_ERROR_MESSAGE);
+}
+
 function defineDirectWorkflow(
   name: string,
   runFn: WorkflowDefinition["run"],
@@ -2474,6 +2481,8 @@ export async function run<TInputs extends Record<string, unknown>>(
     if (ownController.signal.aborted) {
       return finalizeKilled(runId, runSnapshot, activeStore, opts.persistence, opts.onRunEnd);
     }
+
+    assertWorkflowCreatedStage(runSnapshot);
 
     const recorded = activeStore.recordRunEnd(runId, "completed", result);
     opts.onRunEnd?.(runId, "completed", result);

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -56,6 +56,7 @@ import {
   createWorktrees,
   diffWorktrees,
   findWorktreeTaskCwdConflict,
+  setupGitWorktree,
   formatWorktreeDiffSummary,
   formatWorktreeTaskCwdConflict,
   type WorktreeSetup,
@@ -186,6 +187,23 @@ function resolveInputConcurrency(
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return undefined;
 
   return Math.floor(value);
+}
+
+function resolveInputRuntimeDefaults(
+  def: Pick<WorkflowDefinition, "inputBindings">,
+  resolvedInputs: ResolvedInputs,
+): Partial<StageOptions> {
+  const defaults: Partial<StageOptions> = {};
+  const worktree = def.inputBindings?.worktree;
+  if (worktree !== undefined) {
+    const gitWorktreeDir = resolvedInputs[worktree.gitWorktreeDir];
+    if (typeof gitWorktreeDir === "string" && gitWorktreeDir.trim().length > 0) {
+      defaults.gitWorktreeDir = gitWorktreeDir;
+      const baseBranch = worktree.baseBranch === undefined ? undefined : resolvedInputs[worktree.baseBranch];
+      if (typeof baseBranch === "string") defaults.baseBranch = baseBranch;
+    }
+  }
+  return defaults;
 }
 
 // ---------------------------------------------------------------------------
@@ -399,6 +417,8 @@ function taskStageOptions(options: WorkflowTaskExecutionOptions): StageOptions {
     outputMode: _outputMode,
     reads: _reads,
     worktree: _worktree,
+    gitWorktreeDir: _gitWorktreeDir,
+    baseBranch: _baseBranch,
     maxOutput: _maxOutput,
     artifacts: _artifacts,
     ...stageOptions
@@ -552,6 +572,8 @@ function directTaskWithDefaults(
     output,
     outputMode,
     worktree,
+    gitWorktreeDir,
+    baseBranch,
     maxOutput,
     artifacts,
     ...stageDefaults
@@ -569,6 +591,8 @@ function directTaskWithDefaults(
     ...(item.output === undefined && output !== undefined ? { output } : {}),
     ...(item.outputMode === undefined && outputMode !== undefined ? { outputMode } : {}),
     ...(item.worktree === undefined && worktree !== undefined ? { worktree } : {}),
+    ...(item.gitWorktreeDir === undefined && gitWorktreeDir !== undefined ? { gitWorktreeDir } : {}),
+    ...(item.baseBranch === undefined && baseBranch !== undefined ? { baseBranch } : {}),
     ...(item.maxOutput === undefined && maxOutput !== undefined ? { maxOutput } : {}),
     ...(item.artifacts === undefined && artifacts !== undefined ? { artifacts } : {}),
   };
@@ -716,6 +740,31 @@ function normalizeDirectTaskCwd(cwd: string | undefined): string | undefined {
   return isAbsolute(cwd) ? cwd : resolve(process.cwd(), cwd);
 }
 
+function resolveWorktreeCwdOverride(cwd: string | undefined, worktreeCwd: string): string | undefined {
+  if (cwd === undefined || cwd.length === 0) return undefined;
+  return isAbsolute(cwd) ? cwd : resolve(worktreeCwd, cwd);
+}
+
+function stageOptionsWithInputDefaults<T extends StageOptions>(options: T | undefined, inputDefaults: Partial<StageOptions>): T | undefined {
+  const defaults = withoutUndefinedProperties(inputDefaults);
+  if (Object.keys(defaults).length === 0) return options;
+  return { ...defaults, ...withoutUndefinedProperties(options ?? {}) } as T;
+}
+
+function stageOptionsWithGitWorktree<T extends StageOptions>(options: T | undefined, workflowCwd: string): T | undefined {
+  if (options === undefined) return undefined;
+  if (typeof options.gitWorktreeDir !== "string" || options.gitWorktreeDir.trim().length === 0) {
+    return options;
+  }
+  const setup = setupGitWorktree({
+    gitWorktreeDir: options.gitWorktreeDir,
+    baseBranch: options.baseBranch,
+    cwd: workflowCwd,
+  });
+  const explicitCwd = resolveWorktreeCwdOverride(options.cwd, setup.cwd);
+  return { ...options, gitWorktreeDir: undefined, baseBranch: undefined, cwd: explicitCwd ?? setup.cwd };
+}
+
 function directWorktreeDiffsDir(options: WorkflowDirectOptions, setup: WorktreeSetup, runId: string, scope: string): string {
   const baseDir = options.chainDir ?? join(setup.cwd, CONFIG_DIR_NAME, "workflows");
   return join(baseDir, "worktree-diffs", runId, scope);
@@ -732,6 +781,10 @@ function prepareDirectWorktrees(
       tasks: [...tasks],
       agents: tasks.map((task) => task.name),
     };
+  }
+
+  if (typeof options.gitWorktreeDir === "string" || tasks.some((task) => typeof task.gitWorktreeDir === "string")) {
+    throw new Error("pi-workflows: worktree and gitWorktreeDir are mutually exclusive; use gitWorktreeDir for a reusable worktree or worktree:true for temporary isolated worktrees.");
   }
 
   const sharedCwd = resolveSharedDirectWorktreeCwd(tasks);
@@ -1019,8 +1072,13 @@ async function runDirectChainStep(
   runId: string,
 ): Promise<{ results: WorkflowTaskResult[]; artifacts: WorkflowArtifact[] }> {
   if ("parallel" in step) {
-    const expanded = expandedParallelTasks(step.parallel.map((item) => directTaskWithDefaults(item, options)));
-    const stepOptions = { ...options, worktree: options.worktree === true || step.worktree === true };
+    const stepOptions = {
+      ...options,
+      worktree: options.worktree === true || step.worktree === true,
+      ...(step.gitWorktreeDir !== undefined ? { gitWorktreeDir: step.gitWorktreeDir } : {}),
+      ...(step.baseBranch !== undefined ? { baseBranch: step.baseBranch } : {}),
+    };
+    const expanded = expandedParallelTasks(step.parallel.map((item) => directTaskWithDefaults(item, stepOptions)));
     const prepared = prepareDirectWorktrees(expanded, stepOptions, `${runId}-s${index}`, `step-${index}`);
     try {
       const steps = prepared.tasks.map((item) =>
@@ -1494,6 +1552,7 @@ export async function run<TInputs extends Record<string, unknown>>(
   // 4. Create GraphFrontierTracker and per-run ConcurrencyLimiter
   const tracker = new GraphFrontierTracker();
   const inputConcurrency = resolveInputConcurrency(def.inputs, resolvedInputs);
+  const inputRuntimeDefaults = resolveInputRuntimeDefaults(def, resolvedInputs);
   const limiter = createRunLimiter(inputConcurrency ?? opts.config?.defaultConcurrency);
   interface ReleaseBarrier {
     readonly promise: Promise<void>;
@@ -1826,14 +1885,16 @@ export async function run<TInputs extends Record<string, unknown>>(
   };
 
   // 5. Build WorkflowRunContext
+  const workflowCwd = opts.cwd ?? process.cwd();
   const ctx: WorkflowRunContext<TInputs> = {
     inputs: resolvedInputs as TInputs,
-    cwd: opts.cwd ?? process.cwd(),
+    cwd: workflowCwd,
     // Prompt nodes and caller-provided UI adapters are mutually exclusive;
     // executor-owned prompt nodes intentionally take precedence when enabled.
     ui: opts.usePromptNodesForUi === true ? buildPromptNodeUiAdapter() : opts.ui ?? makeUnavailableUIContext(),
 
     stage(name: string, options?: StageOptions, stageFailFastScope?: ParallelFailFastScope) {
+      options = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(options, inputRuntimeDefaults), workflowCwd);
       // a. Generate stageId
       const stageId = crypto.randomUUID();
 
@@ -2379,16 +2440,17 @@ export async function run<TInputs extends Record<string, unknown>>(
 
     async task(name: string, options: WorkflowTaskOptions, stageFailFastScope?: ParallelFailFastScope): Promise<WorkflowTaskResult> {
       const runTaskOnce = async (taskOptions: WorkflowTaskOptions): Promise<WorkflowTaskResult> => {
+        const resolvedTaskOptions = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(taskOptions, inputRuntimeDefaults), workflowCwd) ?? taskOptions;
         const stage = (ctx.stage as typeof ctx.stage & ((stageName: string, stageOptions?: StageOptions, scope?: ParallelFailFastScope) => StageContext))(
           name,
-          taskStageOptions(taskOptions),
+          taskStageOptions(resolvedTaskOptions),
           stageFailFastScope,
         );
         const rawText = await stage.prompt(
-          applyTaskContext(`${taskReadInstruction(taskOptions)}${taskPrompt(taskOptions)}`, taskPrevious(taskOptions)),
-          taskPromptOptions(taskOptions),
+          applyTaskContext(`${taskReadInstruction(resolvedTaskOptions)}${taskPrompt(resolvedTaskOptions)}`, taskPrevious(resolvedTaskOptions)),
+          taskPromptOptions(resolvedTaskOptions),
         );
-        const text = truncateTaskOutput(rawText, taskOptions.maxOutput);
+        const text = truncateTaskOutput(rawText, resolvedTaskOptions.maxOutput);
         const sessionId = (() => {
           try {
             return stage.sessionId;

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -144,6 +144,8 @@ function stripWorkflowOnlyOptions(options: StageOptions | undefined): CreateAgen
     context,
     forkFromSessionFile,
     sessionDir,
+    gitWorktreeDir: _gitWorktreeDir,
+    baseBranch: _baseBranch,
     ...sessionOptions
   } = options;
   if (sessionOptions.sessionManager === undefined) {

--- a/packages/workflows/src/runs/shared/workflow-runner.ts
+++ b/packages/workflows/src/runs/shared/workflow-runner.ts
@@ -91,6 +91,7 @@ function runOptionsWithAdapters(
 
   return {
     ...options.runOptions,
+    cwd: options.cwd ?? options.runOptions?.cwd,
     ...(config !== undefined ? { config } : {}),
     adapters: buildRuntimeAdapters(options.pi ?? {}, adapterOptions),
     store: createStore(),

--- a/packages/workflows/src/runs/shared/workflow-runner.ts
+++ b/packages/workflows/src/runs/shared/workflow-runner.ts
@@ -45,6 +45,8 @@ export interface WorkflowDefinition extends StageOptions {
   output?: string | false;
   outputMode?: WorkflowOutputMode;
   worktree?: boolean;
+  gitWorktreeDir?: string;
+  baseBranch?: string;
   maxOutput?: WorkflowMaxOutput;
   artifacts?: boolean;
 }
@@ -165,6 +167,8 @@ function directOptions(definition: WorkflowDefinition): WorkflowDirectOptions {
     output,
     outputMode,
     worktree,
+    gitWorktreeDir,
+    baseBranch,
     maxOutput,
     artifacts,
     ...stageOptions
@@ -181,6 +185,8 @@ function directOptions(definition: WorkflowDefinition): WorkflowDirectOptions {
     ...(output !== undefined ? { output } : {}),
     ...(outputMode !== undefined ? { outputMode } : {}),
     ...(typeof worktree === "boolean" ? { worktree } : {}),
+    ...(typeof gitWorktreeDir === "string" ? { gitWorktreeDir } : {}),
+    ...(typeof baseBranch === "string" ? { baseBranch } : {}),
     ...(maxOutput !== undefined ? { maxOutput } : {}),
     ...(typeof artifacts === "boolean" ? { artifacts } : {}),
   };

--- a/packages/workflows/src/runs/shared/worktree.ts
+++ b/packages/workflows/src/runs/shared/worktree.ts
@@ -71,6 +71,24 @@ interface GitResult {
 	stdout: string;
 	stderr: string;
 	status: number | null;
+	error?: Error;
+}
+
+export interface GitWorktreeSetupOptions {
+	gitWorktreeDir: string;
+	baseBranch?: string;
+	cwd: string;
+}
+
+export interface GitWorktreeSetupResult {
+	/** Root checkout path that was requested/created/reused. */
+	worktreeRoot: string;
+	/** Effective workflow cwd, preserving the caller's repo-relative subdirectory inside the worktree. */
+	cwd: string;
+	/** Invoking checkout root reported by Git. */
+	repositoryRoot: string;
+	/** Whether this call created a new linked worktree. Existing roots are reused as-is. */
+	created: boolean;
 }
 
 interface RepoState {
@@ -80,13 +98,26 @@ interface RepoState {
 }
 
 const DEFAULT_WORKTREE_SETUP_HOOK_TIMEOUT_MS = 30000;
+const DISABLED_GIT_HOOKS_PATH = process.platform === "win32" ? "NUL" : "/dev/null";
 
 function runGit(cwd: string, args: string[]): GitResult {
-	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+	const result = spawnSync("git", [
+		"-c",
+		`core.hooksPath=${DISABLED_GIT_HOOKS_PATH}`,
+		"-c",
+		"core.fsmonitor=false",
+		...args,
+	], {
+		cwd,
+		encoding: "utf-8",
+		env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+		timeout: 5000,
+	});
 	return {
 		stdout: result.stdout ?? "",
 		stderr: result.stderr ?? "",
 		status: result.status,
+		...(result.error === undefined ? {} : { error: result.error }),
 	};
 }
 
@@ -98,6 +129,188 @@ function runGitChecked(cwd: string, args: string[]): string {
 		throw new Error(message);
 	}
 	return result.stdout;
+}
+
+function gitFailureMessage(result: GitResult): string {
+	if (result.error !== undefined) return result.error.message;
+	return result.stderr.trim() || result.stdout.trim() || `git exited with status ${result.status}`;
+}
+
+function quoteShellArg(value: string): string {
+	if (process.platform === "win32") return `"${value.replace(/"/g, "\"\"")}"`;
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function worktreeRecoveryCommand(repositoryRoot: string, worktreeDir: string): string {
+	return `git -C ${quoteShellArg(repositoryRoot)} worktree remove --force ${quoteShellArg(worktreeDir)}`;
+}
+
+function hasGrandparent(value: string): boolean {
+	const parent = path.dirname(value);
+	if (parent === value) return false;
+	const grandparent = path.dirname(parent);
+	return grandparent !== parent;
+}
+
+function pathAncestors(value: string): string[] {
+	const ancestors: string[] = [];
+	let current = value;
+	while (true) {
+		ancestors.push(current);
+		const parent = path.dirname(current);
+		if (parent === current) return ancestors;
+		current = parent;
+	}
+}
+
+function shouldPreserveLogicalPath(logicalPath: string): boolean {
+	return pathAncestors(logicalPath).some((ancestor) => {
+		try {
+			return fs.lstatSync(ancestor).isSymbolicLink() && hasGrandparent(ancestor);
+		} catch {
+			return false;
+		}
+	});
+}
+
+function canonicalizePreservingSymlinks(value: string): string {
+	const logicalPath = path.resolve(value);
+	const preserveLogicalPath = shouldPreserveLogicalPath(logicalPath);
+	try {
+		const canonical = fs.realpathSync.native(logicalPath);
+		return preserveLogicalPath && canonical !== logicalPath ? logicalPath : canonical;
+	} catch {
+		return logicalPath;
+	}
+}
+
+function resolveGitWorktreePath(value: string, repoRoot: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) throw new Error("gitWorktreeDir cannot be empty");
+	if (trimmed.includes("\0")) {
+		throw new Error("gitWorktreeDir contains an unusable null byte; provide a valid path or omit gitWorktreeDir.");
+	}
+	return canonicalizePreservingSymlinks(path.isAbsolute(trimmed) ? trimmed : path.resolve(repoRoot, trimmed));
+}
+
+function comparableRealPath(value: string): string {
+	const realpath = fs.realpathSync.native(value).replace(/\\/g, "/");
+	return process.platform === "win32" ? realpath.toLowerCase() : realpath;
+}
+
+function gitPathFromOutput(value: string, cwd: string): string | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	return path.isAbsolute(trimmed) ? path.resolve(trimmed) : path.resolve(cwd, trimmed);
+}
+
+function pathExistsSync(value: string): boolean {
+	try {
+		fs.statSync(value);
+		return true;
+	} catch (error) {
+		const code = error && typeof error === "object" && "code" in error ? (error as { code?: unknown }).code : undefined;
+		if (code === "ENOENT" || code === "ENOTDIR") return false;
+		throw error;
+	}
+}
+
+function repositoryRootForGitWorktree(cwd: string): string {
+	const result = runGit(cwd, ["rev-parse", "--show-toplevel"]);
+	if (result.status !== 0) {
+		throw new Error(`gitWorktreeDir requires the workflow to be invoked from inside a Git repository. Start from a Git checkout or omit gitWorktreeDir. Git reported: ${gitFailureMessage(result)}`);
+	}
+	return result.stdout.trim();
+}
+
+function gitTopLevel(cwd: string): string | undefined {
+	const result = runGit(cwd, ["rev-parse", "--show-toplevel"]);
+	if (result.status !== 0) return undefined;
+	return gitPathFromOutput(result.stdout, cwd);
+}
+
+function gitCommonDirForWorktree(cwd: string): string {
+	const result = runGit(cwd, ["rev-parse", "--git-common-dir"]);
+	if (result.status !== 0) throw new Error(gitFailureMessage(result));
+	const gitPath = gitPathFromOutput(result.stdout, cwd);
+	if (gitPath === undefined) throw new Error("git rev-parse --git-common-dir returned an empty path");
+	return gitPath;
+}
+
+function dirnameForEachRelativeComponent(base: string, relativePath: string): string | undefined {
+	if (relativePath === "") return base;
+	let current = base;
+	for (const component of relativePath.split(/[\\/]+/).filter(Boolean)) {
+		if (component === ".") continue;
+		if (component === "..") return undefined;
+		current = path.dirname(current);
+	}
+	return current;
+}
+
+function cwdWithinGitRepository(cwd: string, repoRoot: string): { relativeCwd: string; logicalRepoRoot: string } {
+	const sourceCwd = fs.realpathSync.native(cwd);
+	const sourceRepoRoot = fs.realpathSync.native(repoRoot);
+	const relativeCwd = path.relative(sourceRepoRoot, sourceCwd);
+	const safeRelativeCwd = relativeCwd === "" || relativeCwd.startsWith("..") || path.isAbsolute(relativeCwd) ? "" : relativeCwd;
+	const logicalCwd = canonicalizePreservingSymlinks(cwd);
+	return {
+		relativeCwd: safeRelativeCwd,
+		logicalRepoRoot: dirnameForEachRelativeComponent(logicalCwd, safeRelativeCwd) ?? repoRoot,
+	};
+}
+
+function workspaceCwdForGitWorktreeRoot(worktreeRoot: string, relativeCwd: string): string {
+	return relativeCwd === "" ? worktreeRoot : path.join(worktreeRoot, relativeCwd);
+}
+
+function validateExistingGitWorktreeRoot(worktreeRoot: string, repoRoot: string): void {
+	const topLevel = gitTopLevel(worktreeRoot);
+	if (topLevel === undefined) {
+		throw new Error(`gitWorktreeDir already exists but is not a Git worktree: ${worktreeRoot}`);
+	}
+	if (comparableRealPath(worktreeRoot) !== comparableRealPath(topLevel)) {
+		throw new Error(`gitWorktreeDir already exists but is not a Git worktree root: ${worktreeRoot}. Git top-level checkout is ${topLevel}`);
+	}
+	if (comparableRealPath(gitCommonDirForWorktree(repoRoot)) !== comparableRealPath(gitCommonDirForWorktree(topLevel))) {
+		throw new Error(`gitWorktreeDir already exists but does not belong to the invoking Git repository: ${worktreeRoot}`);
+	}
+}
+
+export function setupGitWorktree(options: GitWorktreeSetupOptions): GitWorktreeSetupResult {
+	const repoRoot = repositoryRootForGitWorktree(options.cwd);
+	const { relativeCwd, logicalRepoRoot } = cwdWithinGitRepository(options.cwd, repoRoot);
+	const worktreeRoot = resolveGitWorktreePath(options.gitWorktreeDir, logicalRepoRoot);
+	if (pathExistsSync(worktreeRoot)) {
+		validateExistingGitWorktreeRoot(worktreeRoot, repoRoot);
+		return {
+			worktreeRoot,
+			cwd: workspaceCwdForGitWorktreeRoot(worktreeRoot, relativeCwd),
+			repositoryRoot: repoRoot,
+			created: false,
+		};
+	}
+
+	try {
+		fs.mkdirSync(path.dirname(worktreeRoot), { recursive: true });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Failed to create parent directory for requested gitWorktreeDir ${worktreeRoot}: ${message}`);
+	}
+	const baseRef = options.baseBranch?.trim() || "HEAD";
+	const result = runGit(repoRoot, ["worktree", "add", "--detach", worktreeRoot, baseRef]);
+	if (result.status !== 0) {
+		throw new Error([
+			`Failed to create git worktree at requested gitWorktreeDir ${worktreeRoot} from ${baseRef}. Git reported: ${gitFailureMessage(result)}`,
+			`If another process just created this same-repository worktree, rerun the workflow to resume it. If this is an orphaned worktree from an interrupted run, recover or remove it with: ${worktreeRecoveryCommand(repoRoot, worktreeRoot)}`,
+		].join("\n"));
+	}
+	return {
+		worktreeRoot,
+		cwd: workspaceCwdForGitWorktreeRoot(worktreeRoot, relativeCwd),
+		repositoryRoot: repoRoot,
+		created: true,
+	};
 }
 
 function resolveRepoState(cwd: string): RepoState {

--- a/packages/workflows/src/sdk-surface.ts
+++ b/packages/workflows/src/sdk-surface.ts
@@ -18,6 +18,8 @@ export type { RunOpts, RunResult, ResolvedInputs } from "./runs/foreground/execu
 export type { AgentSessionAdapter, StageAdapters } from "./runs/foreground/stage-runner.js";
 export { GraphFrontierTracker } from "./runs/shared/graph-inference.js";
 export type { StageNode } from "./runs/shared/graph-inference.js";
+export { setupGitWorktree } from "./runs/shared/worktree.js";
+export type { GitWorktreeSetupOptions, GitWorktreeSetupResult } from "./runs/shared/worktree.js";
 export { createStore, store } from "./shared/store.js";
 export type { RunStatus, StageStatus, ToolEvent, StageSnapshot, RunSnapshot, StoreSnapshot, WorkflowNotice, NoticeLevel, WorkflowOverlayAdapter, PromptKind, PendingPrompt } from "./shared/store-types.js";
 

--- a/packages/workflows/src/shared/types.ts
+++ b/packages/workflows/src/shared/types.ts
@@ -505,6 +505,8 @@ export interface StageContext {
 export interface WorkflowRunContext<TInputs extends Record<string, unknown> = Record<string, unknown>> {
   /** Typed inputs provided by the caller, validated against the input schema. */
   readonly inputs: TInputs;
+  /** Invocation working directory for workflow-owned artifacts. Defaults to the host process cwd when omitted. */
+  readonly cwd?: string;
   /**
    * Create and register a named stage synchronously. Stage work starts when
    * a stage method such as prompt() or complete() is awaited; the executor

--- a/packages/workflows/src/shared/types.ts
+++ b/packages/workflows/src/shared/types.ts
@@ -140,13 +140,17 @@ export interface StageMcpOptions {
 /**
  * Options accepted by WorkflowRunContext.stage(name, options?).
  * All pi SDK createAgentSession options are forwarded to the stage session;
- * `mcp` remains workflow-owned and is stripped before SDK session creation.
+ * workflow-owned options such as `mcp` and `gitWorktreeDir` are stripped before SDK session creation.
  */
 export interface StageOptions extends Omit<CreateAgentSessionOptions, "model">, WorkflowModelFallbackFields {
   /** Model id or pi SDK model object used as the primary stage model. */
   model?: WorkflowModelValue;
   /** Per-stage MCP server gating. No-op when no WorkflowMcpPort is configured. */
   mcp?: StageMcpOptions;
+  /** Reusable Git worktree root. Defaults this stage cwd to the corresponding worktree cwd unless cwd is explicitly provided. */
+  gitWorktreeDir?: string;
+  /** Git ref used when creating gitWorktreeDir. Defaults to HEAD. */
+  baseBranch?: string;
   /**
    * Override the session log directory for this stage.
    * Converted to a pi SessionManager before createAgentSession() is called.
@@ -271,8 +275,12 @@ export interface WorkflowSharedTaskDefaults extends StageOptions {
   outputMode?: WorkflowOutputMode;
   /** Files the task should read before responding; relative paths resolve via chainDir for chains, otherwise cwd. */
   reads?: readonly string[] | false;
-  /** Workflow-owned isolation flag; not forwarded to createAgentSession(). */
+  /** Workflow-owned temporary isolation flag; not forwarded to createAgentSession(). */
   worktree?: boolean;
+  /** Reusable Git worktree root. Defaults cwd to the corresponding worktree cwd unless cwd is explicitly provided. */
+  gitWorktreeDir?: string;
+  /** Git ref used when creating gitWorktreeDir. Defaults to HEAD. */
+  baseBranch?: string;
   /** Default output truncation limits for steps that do not set one. */
   maxOutput?: WorkflowMaxOutput;
   /** Whether to include debug artifacts such as sessions and worktree diffs. */
@@ -400,8 +408,12 @@ export interface WorkflowTaskSessionFields {
   output?: string | false;
   outputMode?: WorkflowOutputMode;
   reads?: readonly string[] | false;
-  /** Workflow-owned isolation flag; not forwarded to createAgentSession(). */
+  /** Workflow-owned temporary isolation flag; not forwarded to createAgentSession(). */
   worktree?: boolean;
+  /** Reusable Git worktree root. Defaults cwd to the corresponding worktree cwd unless cwd is explicitly provided. */
+  gitWorktreeDir?: string;
+  /** Git ref used when creating gitWorktreeDir. Defaults to HEAD. */
+  baseBranch?: string;
   maxOutput?: WorkflowMaxOutput;
   /** Whether to include debug artifacts such as sessions and worktree diffs. */
   artifacts?: boolean;
@@ -421,6 +433,8 @@ export interface WorkflowParallelChainStep {
   readonly concurrency?: number;
   readonly failFast?: boolean;
   readonly worktree?: boolean;
+  readonly gitWorktreeDir?: string;
+  readonly baseBranch?: string;
 }
 
 export type WorkflowChainStep = WorkflowDirectTaskItem | WorkflowParallelChainStep;
@@ -438,6 +452,8 @@ export interface WorkflowDirectOptions extends StageOptions {
   output?: string | false;
   outputMode?: WorkflowOutputMode;
   worktree?: boolean;
+  gitWorktreeDir?: string;
+  baseBranch?: string;
   maxOutput?: WorkflowMaxOutput;
   artifacts?: boolean;
 }
@@ -573,6 +589,15 @@ export type WorkflowRunFn<TInputs extends Record<string, unknown> = Record<strin
 // Compiled workflow definition
 // ---------------------------------------------------------------------------
 
+export interface WorkflowWorktreeInputBinding {
+  readonly gitWorktreeDir: string;
+  readonly baseBranch?: string;
+}
+
+export interface WorkflowInputBindings {
+  readonly worktree?: WorkflowWorktreeInputBinding;
+}
+
 export interface WorkflowDefinition<TInputs extends Record<string, unknown> = Record<string, unknown>> {
   /** Sentinel consumed by the registry loader to validate the export. */
   readonly __piWorkflow: true;
@@ -581,5 +606,7 @@ export interface WorkflowDefinition<TInputs extends Record<string, unknown> = Re
   readonly normalizedName: string;
   readonly description: string;
   readonly inputs: Readonly<Record<string, WorkflowInputSchema>>;
+  /** Optional input-to-runtime defaults declared by the workflow builder. */
+  readonly inputBindings?: WorkflowInputBindings;
   readonly run: WorkflowRunFn<TInputs>;
 }

--- a/packages/workflows/src/workflows/define-workflow.ts
+++ b/packages/workflows/src/workflows/define-workflow.ts
@@ -8,7 +8,7 @@
  * cross-ref: v0.x packages/atomic-sdk/src/define-workflow.ts
  */
 
-import type { WorkflowDefinition, WorkflowInputSchema, WorkflowRunFn } from "../shared/types.js";
+import type { WorkflowDefinition, WorkflowInputBindings, WorkflowInputSchema, WorkflowRunFn, WorkflowWorktreeInputBinding } from "../shared/types.js";
 import { normalizeWorkflowName } from "./identity.js";
 
 // ---------------------------------------------------------------------------
@@ -19,6 +19,7 @@ interface BuilderState<TInputs extends Record<string, unknown>> {
   readonly name: string;
   readonly description: string;
   readonly inputs: Readonly<Record<string, WorkflowInputSchema>>;
+  readonly inputBindings: WorkflowInputBindings;
   readonly runFn: WorkflowRunFn<TInputs> | undefined;
 }
 
@@ -45,6 +46,8 @@ export interface WorkflowBuilder<TInputs extends Record<string, unknown> = Recor
     key: K,
     schema: WorkflowInputSchema,
   ): WorkflowBuilder<TInputs & Record<K, unknown>>;
+  /** Bind workflow inputs to reusable git worktree runtime defaults. */
+  worktreeFromInputs(binding: WorkflowWorktreeInputBinding): WorkflowBuilder<TInputs>;
   /** Seal the run function.  Returns a builder on which .compile() is available. */
   run(fn: WorkflowRunFn<TInputs>): CompletedWorkflowBuilder<TInputs>;
 }
@@ -59,6 +62,7 @@ export interface CompletedWorkflowBuilder<TInputs extends Record<string, unknown
     key: K,
     schema: WorkflowInputSchema,
   ): CompletedWorkflowBuilder<TInputs & Record<K, unknown>>;
+  worktreeFromInputs(binding: WorkflowWorktreeInputBinding): CompletedWorkflowBuilder<TInputs>;
   run(fn: WorkflowRunFn<TInputs>): CompletedWorkflowBuilder<TInputs>;
   /** Freeze and return the completed WorkflowDefinition. */
   compile(): WorkflowDefinition<TInputs>;
@@ -83,6 +87,16 @@ function makeBuilder<TInputs extends Record<string, unknown>>(
       } as BuilderState<TInputs & Record<K, unknown>>);
     },
 
+    worktreeFromInputs(binding: WorkflowWorktreeInputBinding) {
+      return makeBuilder<TInputs>({
+        ...state,
+        inputBindings: {
+          ...state.inputBindings,
+          worktree: { ...binding },
+        },
+      });
+    },
+
     run(fn: WorkflowRunFn<TInputs>) {
       return makeBuilder<TInputs>({ ...state, runFn: fn });
     },
@@ -98,6 +112,7 @@ function makeBuilder<TInputs extends Record<string, unknown>>(
 
       // Deep-freeze inputs map first, then the top-level definition.
       const frozenInputs = Object.freeze({ ...state.inputs });
+      const inputBindings = Object.freeze({ ...state.inputBindings });
 
       const definition: WorkflowDefinition<TInputs> = {
         __piWorkflow: true,
@@ -105,6 +120,7 @@ function makeBuilder<TInputs extends Record<string, unknown>>(
         normalizedName,
         description: state.description,
         inputs: frozenInputs,
+        ...(Object.keys(inputBindings).length > 0 ? { inputBindings } : {}),
         run: state.runFn,
       };
 
@@ -143,6 +159,7 @@ export function defineWorkflow(name: string): WorkflowBuilder {
     name,
     description: "",
     inputs: {},
+    inputBindings: {},
     runFn: undefined,
   };
 

--- a/research/docs/2026-05-12-workflow-authoring-registry-core.md
+++ b/research/docs/2026-05-12-workflow-authoring-registry-core.md
@@ -21,7 +21,7 @@ Scout context included adjacent areas: tests (`test/unit`, `test/integration`, `
 
 ## Summary
 
-The workflow authoring core is a small TypeScript DSL centered on `defineWorkflow(name).description(...).input(...).run(fn).compile()`. A compiled workflow is a frozen `WorkflowDefinition` object with a `__piWorkflow: true` sentinel, authored name, normalized registry key, input schema map, and async run function. Registry state is immutable-style: operations return a new registry backed by an ordered `Map` keyed by normalized workflow name.
+The workflow authoring core is a small TypeScript DSL centered on `defineWorkflow(name).description(...).input(...).run(fn).compile()`. A compiled workflow is a frozen `WorkflowDefinition` object with a `__piWorkflow: true` sentinel, authored name, normalized registry key, input schema map, optional input bindings such as `.worktreeFromInputs(...)`, and async run function. Registry state is immutable-style: operations return a new registry backed by an ordered `Map` keyed by normalized workflow name.
 
 Builtin workflows are authored using the same public DSL under `workflows/` and re-exported from `workflows/index.ts`. The extension discovery layer imports that manifest for bundled workflows and also discovers project/user/settings workflow files, validates exported workflow definitions structurally, applies source precedence, and returns a populated `WorkflowRegistry` plus source records and diagnostics. Runtime dispatch uses the registry for `list`, `inputs`, and `run`, then forwards execution to foreground or background runners.
 
@@ -34,17 +34,18 @@ Builtin workflows are authored using the same public DSL under `workflows/` and 
 - The builder is typed in two phases:
   - `WorkflowBuilder` exposes `description()`, `input()`, and `run()` before compilation (`src/workflows/define-workflow.ts:37-50`).
   - `CompletedWorkflowBuilder` exposes `compile()` only after `run()` has been called at the type level (`src/workflows/define-workflow.ts:56-64`).
-- Builder methods are immutable/chained. `description()`, `input()`, and `run()` call `makeBuilder()` with copied state rather than mutating the previous builder (`src/workflows/define-workflow.ts:71-88`).
+- Builder methods are immutable/chained. `description()`, `input()`, `worktreeFromInputs()`, and `run()` call `makeBuilder()` with copied state rather than mutating the previous builder (`src/workflows/define-workflow.ts:71-88`).
 - Runtime `compile()` still guards against missing `.run(fn)` and throws `defineWorkflow("..."): .run(fn) must be called before .compile()` (`src/workflows/define-workflow.ts:90-95`).
 - `compile()` computes `normalizedName`, freezes a shallow copy of the inputs map, constructs the sentinel-bearing definition, and freezes the top-level definition (`src/workflows/define-workflow.ts:97-111`).
 
 ### 2. Workflow definition and context shape
 
-- `WorkflowDefinition` is defined in shared types and consists of `__piWorkflow: true`, `name`, `normalizedName`, `description`, readonly `inputs`, and async `run` (`src/shared/types.ts:291-300`).
+- `WorkflowDefinition` is defined in shared types and consists of `__piWorkflow: true`, `name`, `normalizedName`, `description`, readonly `inputs`, optional `inputBindings`, and async `run` (`src/shared/types.ts:291-300`).
 - Input schemas support `text`/`string`, `number`, `boolean`, and `select`, with optional `description`, `required`, and type-specific defaults. `select` includes a readonly `choices` array (`src/shared/types.ts:21-56`).
 - Workflow run functions receive a `WorkflowRunContext<TInputs>` with readonly `inputs`, a `stage(name, options?)` factory, and HIL `ui` primitives (`src/shared/types.ts:231-245`).
 - `StageContext` intentionally mirrors much of pi's `AgentSession` surface while wrapping `prompt()` and `subscribe()` and retaining deprecated `subagent()` and `complete()` helpers (`src/shared/types.ts:177-225`).
-- `StageOptions` extends pi `CreateAgentSessionOptions` and adds optional per-stage MCP gating (`src/shared/types.ts:89-109`).
+- `StageOptions` extends pi `CreateAgentSessionOptions` and adds optional per-stage MCP gating plus reusable Git worktree defaults (`gitWorktreeDir`, `baseBranch`) (`src/shared/types.ts:89-109`).
+- `.worktreeFromInputs({ gitWorktreeDir, baseBranch })` binds resolved workflow input values to workflow-wide worktree defaults. When the bound worktree input is non-empty, `ctx.stage`, `ctx.task`, `ctx.chain`, and `ctx.parallel` default their cwd to the corresponding reusable Git worktree cwd unless explicitly overridden.
 
 ### 3. Identity normalization
 

--- a/research/docs/2026-05-14-local-workflow-patterns.md
+++ b/research/docs/2026-05-14-local-workflow-patterns.md
@@ -155,12 +155,13 @@ const definition: WorkflowDefinition<TInputs> = {
   normalizedName,
   description: state.description,
   inputs: frozenInputs,
+  inputBindings,
   run: state.runFn,
 };
 ```
 
 **Key aspects**:
-- Definitions carry a `__piWorkflow: true` sentinel, authored name, normalized registry key, description, input schema map, and run function.
+- Definitions carry a `__piWorkflow: true` sentinel, authored name, normalized registry key, description, input schema map, optional input bindings, and run function.
 - Registry operations include `register`, `upsert`, `merge`, `get`, `has`, `remove`, `names`, and `all`.
 - Discovery supports bundled, project-local, user-global, settings-project, and settings-global sources.
 - Discovery validates exported workflow definitions before registering them.
@@ -218,6 +219,8 @@ const specialistResults = await Promise.all(
 - `chain` passes prior task output via `{previous}` / context handoff semantics.
 - `parallel` uses `Promise.all` over task/stage operations.
 - Built-in workflows show sequential pipelines and parallel fan-out/fan-in.
+- Reusable Git worktree defaults can be declared once with `defineWorkflow(...).worktreeFromInputs({ gitWorktreeDir, baseBranch })`; the executor applies the resolved inputs as workflow-wide defaults for `ctx.stage`, `ctx.task`, `ctx.chain`, and `ctx.parallel`.
+- Per-stage/task `gitWorktreeDir` and `baseBranch` can still be supplied directly. `gitWorktreeDir` creates/reuses a named worktree, preserves the invoking repo-relative cwd inside it, and differs from temporary `worktree: true` isolation.
 
 ### Pattern 7: Subagent tool-call adapter shape
 **Found in**: `src/shared/types.ts:91-106`, `src/extension/wiring.ts:213-239`, `test/unit/executor-subagent-call-shape.test.ts:1-124`

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -135,16 +135,36 @@ describe("ralph git worktree integration", () => {
     }
   }
 
-  function assertWorktreeRegistered(repo: string, worktreePath: string): void {
+  function worktreeListEntries(repo: string): readonly string[] {
+    return execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"])
+      .toString()
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("worktree "))
+      .map((line) => line.slice("worktree ".length));
+  }
+
+  function normalizePathForComparison(path: string): string {
+    const normalized = path.replace(/\\/g, "/");
+    return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+  }
+
+  function assertWorktreeRegistered(_repo: string, worktreePath: string): void {
     assert.equal(existsSync(join(worktreePath, ".git")), true, "expected git worktree checkout");
-    const worktreeList = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"]).toString();
-    assert.equal(worktreeList.includes(worktreePath), true, "expected git worktree metadata to be present");
+    assert.equal(
+      execFileSync("git", ["-C", worktreePath, "rev-parse", "--is-inside-work-tree"]).toString().trim(),
+      "true",
+      "expected git to recognize the worktree checkout",
+    );
   }
 
   function assertWorktreeWasRemoved(repo: string, worktreePath: string): void {
     assert.equal(existsSync(worktreePath), false, "expected Ralph-created worktree checkout to be removed");
-    const worktreeList = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"]).toString();
-    assert.equal(worktreeList.includes(worktreePath), false, "expected git worktree metadata to be removed");
+    const expectedPath = normalizePathForComparison(worktreePath);
+    assert.equal(
+      worktreeListEntries(repo).some((entry) => normalizePathForComparison(entry) === expectedPath),
+      false,
+      "expected git worktree metadata to be removed",
+    );
   }
 
   test("creates a relative git_worktree_dir and removes it after success", async () => {

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -203,6 +203,25 @@ describe("ralph git worktree integration", () => {
     assertWorktreeWasRemoved(repo, expectedWorktree);
   });
 
+  test("fails fast outside a git repo when git_worktree_dir is requested", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const requestedWorktree = join(requireTempRoot(), "outside-repo-worktree");
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: requestedWorktree,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /git_worktree_dir requires Ralph to be invoked from inside a Git repository/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+    assert.equal(existsSync(requestedWorktree), false);
+  });
+
   test("creates an absolute git_worktree_dir and removes it after success", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -402,7 +402,7 @@ describe("ralph git worktree integration", () => {
 
     await assert.rejects(
       () => mod.runRalphWorkflowFromCwd(ctx, repo),
-      /git_worktree_dir contains an unusable null byte path segment/,
+      /git_worktree_dir contains an unusable null byte/,
     );
     assert.deepEqual(ctx.calls.task, []);
   });

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import type {
@@ -92,6 +92,8 @@ function makeMockCtx<TInputs extends Record<string, unknown>>(
     ui,
   };
 }
+
+const RALPH_LOCK_FILENAME = ".ralph.lock";
 
 describe("ralph git worktree integration", () => {
   let previousCwd: string;
@@ -190,6 +192,21 @@ describe("ralph git worktree integration", () => {
     execFileSync("git", ["worktree", "add", "--detach", worktreePath, "main"], { cwd: repo, stdio: "ignore" });
   }
 
+  function ralphLockPath(worktreePath: string): string {
+    return join(worktreePath, RALPH_LOCK_FILENAME);
+  }
+
+  function assertNoRalphLock(worktreePath: string): void {
+    assert.equal(existsSync(ralphLockPath(worktreePath)), false, "expected Ralph lock to be removed");
+  }
+
+  function assertOwnedRalphLock(worktreePath: string): void {
+    const content = readFileSync(ralphLockPath(worktreePath), "utf8");
+    const [pidLine, createdAtLine] = content.trimEnd().split(/\r?\n/);
+    assert.equal(Number.parseInt(pidLine ?? "", 10), process.pid, "expected lock to be owned by this process");
+    assert.match(createdAtLine ?? "", /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  }
+
   test("creates a relative git_worktree_dir from repo root and leaves it after success", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
@@ -214,6 +231,7 @@ describe("ralph git worktree integration", () => {
               execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
               execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
             );
+            assertOwnedRalphLock(expectedWorktree);
           }
           return undefined;
         },
@@ -229,6 +247,7 @@ describe("ralph git worktree integration", () => {
     assert.ok(Array.isArray(orchestratorReads) && orchestratorReads.includes(planPath));
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
+    assertNoRalphLock(expectedWorktree);
   });
 
   test("fails fast outside a git repo when git_worktree_dir is requested", async () => {
@@ -292,6 +311,62 @@ describe("ralph git worktree integration", () => {
     assertWorktreeRegistered(repo, expectedWorktree);
   });
 
+  test("fails fast when an existing git worktree has an active Ralph lock", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "locked-worktree");
+    addDetachedWorktree(repo, expectedWorktree);
+    const activeLockContent = `${process.pid}\n${new Date().toISOString()}\n`;
+    writeFileSync(ralphLockPath(expectedWorktree), activeLockContent, "utf8");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /git_worktree_dir is already locked by active Ralph process/,
+    );
+
+    assert.deepEqual(ctx.calls.task, []);
+    assert.equal(readFileSync(ralphLockPath(expectedWorktree), "utf8"), activeLockContent);
+  });
+
+  test("fails fast with recovery guidance when an existing Ralph lock is stale", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "stale-locked-worktree");
+    addDetachedWorktree(repo, expectedWorktree);
+    const exited = spawnSync(process.execPath, ["--version"], { stdio: "ignore" });
+    assert.equal(exited.status, 0);
+    const exitedPid = exited.pid;
+    if (typeof exitedPid !== "number" || exitedPid <= 0) {
+      throw new Error("expected exited child process to have a PID");
+    }
+    const staleLockContent = `${exitedPid}\n2024-01-01T00:00:00.000Z\n`;
+    writeFileSync(ralphLockPath(expectedWorktree), staleLockContent, "utf8");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /git_worktree_dir has a stale Ralph lock/,
+    );
+
+    assert.deepEqual(ctx.calls.task, []);
+    assert.equal(readFileSync(ralphLockPath(expectedWorktree), "utf8"), staleLockContent);
+  });
+
   test("can re-run with the same git_worktree_dir without cleanup", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
@@ -314,11 +389,13 @@ describe("ralph git worktree integration", () => {
 
     await d.run(firstCtx);
     assertWorktreeRegistered(repo, expectedWorktree);
+    assertNoRalphLock(expectedWorktree);
     await d.run(secondCtx);
 
     assertEveryRalphStageCwd(firstCtx, expectedWorktree);
     assertEveryRalphStageCwd(secondCtx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
+    assertNoRalphLock(expectedWorktree);
   });
 
   test("fails fast when base_branch does not exist for a missing worktree path", async () => {
@@ -424,6 +501,7 @@ describe("ralph git worktree integration", () => {
     }
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
+    assertNoRalphLock(expectedWorktree);
   });
 
   test("leaves the worktree for recovery when the workflow fails", async () => {
@@ -441,7 +519,10 @@ describe("ralph git worktree integration", () => {
       },
       {
         task: (name) => {
-          if (name === "planner-1") throw new Error("planner failed");
+          if (name === "planner-1") {
+            assertOwnedRalphLock(expectedWorktree);
+            throw new Error("planner failed");
+          }
           return undefined;
         },
       },
@@ -450,5 +531,6 @@ describe("ralph git worktree integration", () => {
     await assert.rejects(() => d.run(ctx), /planner failed/);
 
     assertWorktreeRegistered(repo, expectedWorktree);
+    assertNoRalphLock(expectedWorktree);
   });
 });

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -6,7 +6,6 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import type {
   WorkflowChainOptions,
-  WorkflowDefinition,
   WorkflowParallelOptions,
   WorkflowRunContext,
   WorkflowTaskOptions,
@@ -14,6 +13,13 @@ import type {
   WorkflowTaskStep,
   WorkflowUIContext,
 } from "../../packages/workflows/src/shared/types.js";
+
+type RalphTestModule = {
+  runRalphWorkflowFromCwd(
+    ctx: WorkflowRunContext<Record<string, unknown>>,
+    workflowStartCwd: string,
+  ): Promise<Record<string, unknown>>;
+};
 
 interface MockCalls {
   readonly task: string[];
@@ -94,17 +100,13 @@ function makeMockCtx<TInputs extends Record<string, unknown>>(
 }
 
 describe("ralph git worktree integration", () => {
-  let previousCwd: string;
   let tempRoot: string | undefined;
 
   beforeEach(() => {
-    previousCwd = process.cwd();
     tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-integration-"));
-    process.chdir(tempRoot);
   });
 
   afterEach(() => {
-    process.chdir(previousCwd);
     if (tempRoot !== undefined) {
       rmSync(tempRoot, { recursive: true, force: true });
       tempRoot = undefined;
@@ -191,13 +193,11 @@ describe("ralph git worktree integration", () => {
   }
 
   test("creates a relative git_worktree_dir from repo root and leaves it after success", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const subdir = join(repo, "nested");
     mkdirSync(subdir, { recursive: true });
     const expectedWorktree = join(repo, "worktrees", "ralph");
-    process.chdir(subdir);
     const ctx = makeMockCtx(
       {
         prompt: "Add a small feature",
@@ -220,7 +220,7 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    const result = await d.run(ctx);
+    const result = await mod.runRalphWorkflowFromCwd(ctx, subdir);
 
     assertRalphResultShape(result, subdir);
     const planPath = String(result["plan_path"]);
@@ -232,8 +232,7 @@ describe("ralph git worktree integration", () => {
   });
 
   test("fails fast outside a git repo when git_worktree_dir is requested", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const requestedWorktree = join(requireTempRoot(), "outside-repo-worktree");
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
@@ -243,7 +242,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => d.run(ctx),
+      () => mod.runRalphWorkflowFromCwd(ctx, requireTempRoot()),
       /git_worktree_dir requires Ralph to be invoked from inside a Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -251,11 +250,9 @@ describe("ralph git worktree integration", () => {
   });
 
   test("creates an absolute git_worktree_dir and leaves it after success", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "absolute-worktrees", "ralph");
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
@@ -263,21 +260,19 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await d.run(ctx);
+    await mod.runRalphWorkflowFromCwd(ctx, repo);
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
   });
 
   test("reuses an existing git worktree in its current state", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "existing-worktree");
     addDetachedWorktree(repo, expectedWorktree);
     const uncommittedPath = join(expectedWorktree, "uncommitted.txt");
     writeFileSync(uncommittedPath, "keep me\n", "utf8");
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
@@ -285,7 +280,7 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await d.run(ctx);
+    await mod.runRalphWorkflowFromCwd(ctx, repo);
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assert.equal(existsSync(uncommittedPath), true);
@@ -293,13 +288,11 @@ describe("ralph git worktree integration", () => {
   });
 
   test("fails fast when existing git_worktree_dir is a worktree from another repository", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository("repo");
     const otherRepo = initializeGitRepository("other-repo");
     const foreignWorktree = join(requireTempRoot(), "foreign-worktree");
     addDetachedWorktree(otherRepo, foreignWorktree);
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
@@ -308,18 +301,16 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => d.run(ctx),
+      () => mod.runRalphWorkflowFromCwd(ctx, repo),
       /git_worktree_dir already exists but does not belong to the invoking Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
   });
 
   test("fails fast when existing git_worktree_dir is another repository checkout", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository("repo");
     const otherRepo = initializeGitRepository("other-repo");
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
@@ -328,18 +319,16 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => d.run(ctx),
+      () => mod.runRalphWorkflowFromCwd(ctx, repo),
       /git_worktree_dir already exists but does not belong to the invoking Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
   });
 
   test("can re-run with the same git_worktree_dir without cleanup", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "repeat-worktree");
-    process.chdir(repo);
 
     const firstCtx = makeMockCtx({
       prompt: "Add a small feature",
@@ -354,9 +343,9 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await d.run(firstCtx);
+    await mod.runRalphWorkflowFromCwd(firstCtx, repo);
     assertWorktreeRegistered(repo, expectedWorktree);
-    await d.run(secondCtx);
+    await mod.runRalphWorkflowFromCwd(secondCtx, repo);
 
     assertEveryRalphStageCwd(firstCtx, expectedWorktree);
     assertEveryRalphStageCwd(secondCtx, expectedWorktree);
@@ -364,11 +353,9 @@ describe("ralph git worktree integration", () => {
   });
 
   test("fails fast when base_branch does not exist for a missing worktree path", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const requestedWorktree = join(requireTempRoot(), "missing-base-worktree");
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
@@ -377,20 +364,18 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => d.run(ctx),
+      () => mod.runRalphWorkflowFromCwd(ctx, repo),
       /Failed to create git worktree at requested git_worktree_dir/,
     );
     assert.deepEqual(ctx.calls.task, []);
   });
 
   test("fails fast when requested git_worktree_dir is a non-empty non-git directory", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const requestedWorktree = join(requireTempRoot(), "non-empty-directory");
     mkdirSync(requestedWorktree, { recursive: true });
     writeFileSync(join(requestedWorktree, "README.md"), "already here\n", "utf8");
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
@@ -399,17 +384,15 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => d.run(ctx),
+      () => mod.runRalphWorkflowFromCwd(ctx, repo),
       /git_worktree_dir already exists but is not a Git worktree/,
     );
     assert.deepEqual(ctx.calls.task, []);
   });
 
   test("fails fast when git_worktree_dir is unusable", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
@@ -418,18 +401,16 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => d.run(ctx),
+      () => mod.runRalphWorkflowFromCwd(ctx, repo),
       /git_worktree_dir contains an unusable null byte path segment/,
     );
     assert.deepEqual(ctx.calls.task, []);
   });
 
   test("propagates worktree cwd across multiple iterations", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "multi-iteration-worktree");
-    process.chdir(repo);
     const ctx = makeMockCtx(
       {
         prompt: "Add a small feature",
@@ -459,7 +440,7 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    await d.run(ctx);
+    await mod.runRalphWorkflowFromCwd(ctx, repo);
 
     for (const name of ["planner-1", "orchestrator-1", "code-simplifier-1", "planner-2", "orchestrator-2", "code-simplifier-2"]) {
       assertSamePath(ctx.calls.taskOptions[name]?.[0]?.cwd, expectedWorktree, `unexpected cwd for ${name}`);
@@ -469,11 +450,9 @@ describe("ralph git worktree integration", () => {
   });
 
   test("leaves the worktree for recovery when the workflow fails", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "failed-run-worktree");
-    process.chdir(repo);
     const ctx = makeMockCtx(
       {
         prompt: "Add a small feature",
@@ -489,7 +468,7 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    await assert.rejects(() => d.run(ctx), /planner failed/);
+    await assert.rejects(() => mod.runRalphWorkflowFromCwd(ctx, repo), /planner failed/);
 
     assertWorktreeRegistered(repo, expectedWorktree);
   });

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -372,7 +372,7 @@ describe("ralph git worktree integration", () => {
       prompt: "Add a small feature",
       max_loops: 1,
       base_branch: "main",
-      git_worktree_dir: "invalid path",
+      git_worktree_dir: "invalid\0path",
     });
 
     await assert.rejects(

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -292,6 +292,48 @@ describe("ralph git worktree integration", () => {
     assertWorktreeRegistered(repo, expectedWorktree);
   });
 
+  test("fails fast when existing git_worktree_dir is a worktree from another repository", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository("repo");
+    const otherRepo = initializeGitRepository("other-repo");
+    const foreignWorktree = join(requireTempRoot(), "foreign-worktree");
+    addDetachedWorktree(otherRepo, foreignWorktree);
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: foreignWorktree,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /git_worktree_dir already exists but does not belong to the invoking Git repository/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
+  test("fails fast when existing git_worktree_dir is another repository checkout", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository("repo");
+    const otherRepo = initializeGitRepository("other-repo");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: otherRepo,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /git_worktree_dir already exists but does not belong to the invoking Git repository/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
   test("can re-run with the same git_worktree_dir without cleanup", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import type {
+  WorkflowChainOptions,
+  WorkflowDefinition,
+  WorkflowParallelOptions,
+  WorkflowRunContext,
+  WorkflowTaskOptions,
+  WorkflowTaskResult,
+  WorkflowTaskStep,
+  WorkflowUIContext,
+} from "../../packages/workflows/src/shared/types.js";
+
+interface MockCalls {
+  readonly task: string[];
+  readonly parallelOptions: WorkflowParallelOptions[];
+  readonly taskOptions: Record<string, WorkflowTaskOptions[]>;
+}
+
+interface MockResponders {
+  task?: (name: string, options: WorkflowTaskOptions, calls: MockCalls) => string | undefined;
+}
+
+function promptText(options: WorkflowTaskOptions): string {
+  return options.prompt ?? options.task ?? "";
+}
+
+function makeTaskResult(name: string, text: string): WorkflowTaskResult {
+  return { name, stageName: name, text };
+}
+
+function makeMockCtx<TInputs extends Record<string, unknown>>(
+  inputs: TInputs,
+  responders: MockResponders = {},
+): WorkflowRunContext<TInputs> & { calls: MockCalls } {
+  const calls: MockCalls = {
+    task: [],
+    parallelOptions: [],
+    taskOptions: {},
+  };
+
+  const ui: WorkflowUIContext = {
+    input: async (prompt: string) => `mock-input:${prompt.slice(0, 20)}`,
+    confirm: async () => false,
+    select: async <T extends string>(_message: string, options: readonly T[]) => options[0]!,
+    editor: async (initial?: string) => initial ?? "mock-editor-content",
+  };
+
+  const runTask = async (name: string, options: WorkflowTaskOptions): Promise<WorkflowTaskResult> => {
+    calls.task.push(name);
+    calls.taskOptions[name] = [...(calls.taskOptions[name] ?? []), options];
+    const text = promptText(options);
+    const override = responders.task?.(name, options, calls);
+    return makeTaskResult(name, override ?? `[mock-task:${name}] ${text.slice(0, 80)}`);
+  };
+
+  return {
+    inputs,
+    calls,
+    stage: (name: string) => {
+      throw new Error(`ctx.stage should not be used by builtin workflow ${name}`);
+    },
+    task: runTask,
+    chain: async (
+      steps: readonly WorkflowTaskStep[],
+      _options?: WorkflowChainOptions,
+    ): Promise<WorkflowTaskResult[]> => {
+      const results: WorkflowTaskResult[] = [];
+      for (const step of steps) {
+        results.push(await runTask(step.name, step));
+      }
+      return results;
+    },
+    parallel: async (
+      steps: readonly WorkflowTaskStep[],
+      options: WorkflowParallelOptions = {},
+    ): Promise<WorkflowTaskResult[]> => {
+      calls.parallelOptions.push(options);
+      return Promise.all(steps.map((step) => runTask(step.name, step)));
+    },
+    ui,
+  };
+}
+
+describe("ralph git worktree integration", () => {
+  let previousCwd: string;
+  let tempRoot: string | undefined;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-integration-"));
+    process.chdir(tempRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    if (tempRoot !== undefined) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = undefined;
+    }
+  });
+
+  function requireTempRoot(): string {
+    if (tempRoot === undefined) throw new Error("expected Ralph integration temp root");
+    return tempRoot;
+  }
+
+  function initializeGitRepository(name = "repo"): string {
+    const repo = join(requireTempRoot(), name);
+    mkdirSync(repo, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "README.md"), "# test repo\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    return repo;
+  }
+
+  function assertEveryRalphStageCwd(
+    ctx: { readonly calls: MockCalls },
+    expectedCwd: string | undefined,
+  ): void {
+    for (const [taskName, entries] of Object.entries(ctx.calls.taskOptions)) {
+      for (const options of entries) {
+        assert.equal(options.cwd, expectedCwd, `unexpected cwd for ${taskName}`);
+      }
+    }
+    for (const options of ctx.calls.parallelOptions) {
+      assert.equal(options.cwd, expectedCwd, "unexpected cwd for parallel stage");
+    }
+  }
+
+  function assertWorktreeRegistered(repo: string, worktreePath: string): void {
+    assert.equal(existsSync(join(worktreePath, ".git")), true, "expected git worktree checkout");
+    const worktreeList = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"]).toString();
+    assert.equal(worktreeList.includes(worktreePath), true, "expected git worktree metadata to be present");
+  }
+
+  function assertWorktreeWasRemoved(repo: string, worktreePath: string): void {
+    assert.equal(existsSync(worktreePath), false, "expected Ralph-created worktree checkout to be removed");
+    const worktreeList = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"]).toString();
+    assert.equal(worktreeList.includes(worktreePath), false, "expected git worktree metadata to be removed");
+  }
+
+  test("creates a relative git_worktree_dir and removes it after success", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "worktrees", "ralph");
+    process.chdir(repo);
+    const ctx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: join("..", "worktrees", "ralph"),
+      },
+      {
+        task: (name, options) => {
+          if (name === "planner-1") {
+            assert.equal(options.cwd, expectedWorktree);
+            assertWorktreeRegistered(repo, expectedWorktree);
+            assert.equal(
+              execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
+              execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
+            );
+          }
+          return undefined;
+        },
+      },
+    );
+
+    const result = await d.run(ctx);
+
+    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
+    assert.equal(String(result["plan_path"]).startsWith(expectedWorktree), false);
+    assertEveryRalphStageCwd(ctx, expectedWorktree);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
+  test("creates an absolute git_worktree_dir and removes it after success", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "absolute-worktrees", "ralph");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+
+    await d.run(ctx);
+
+    assertEveryRalphStageCwd(ctx, expectedWorktree);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
+  test("fails fast with recovery guidance when requested git_worktree_dir cannot be created", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const occupiedWorktreePath = join(requireTempRoot(), "occupied-worktree");
+    mkdirSync(occupiedWorktreePath, { recursive: true });
+    writeFileSync(join(occupiedWorktreePath, "README.md"), "already here\n", "utf8");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: occupiedWorktreePath,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      (error) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /Failed to create git worktree at requested git_worktree_dir/);
+        assert.match(error.message, /git -C .* worktree remove --force/);
+        return true;
+      },
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
+  test("can re-run with the same git_worktree_dir after successful cleanup", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "repeat-worktree");
+    process.chdir(repo);
+
+    const firstCtx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+    const secondCtx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+
+    await d.run(firstCtx);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+    await d.run(secondCtx);
+
+    assertEveryRalphStageCwd(firstCtx, expectedWorktree);
+    assertEveryRalphStageCwd(secondCtx, expectedWorktree);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
+  test("falls back to a default worktree path when git_worktree_dir is invalid", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    process.chdir(repo);
+    let fallbackWorktree: string | undefined;
+    const ctx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: "invalid\0path",
+      },
+      {
+        task: (name, options) => {
+          if (name === "planner-1") {
+            const cwd = options.cwd;
+            if (cwd === undefined) throw new Error("expected planner cwd to use fallback worktree");
+            fallbackWorktree = cwd;
+            assertWorktreeRegistered(repo, cwd);
+            assert.equal(
+              execFileSync("git", ["-C", cwd, "rev-parse", "HEAD"]).toString().trim(),
+              execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
+            );
+          }
+          return undefined;
+        },
+      },
+    );
+
+    const result = await d.run(ctx);
+    if (fallbackWorktree === undefined) throw new Error("expected planner cwd to use fallback worktree");
+
+    assert.ok(isAbsolute(fallbackWorktree));
+    assert.ok(fallbackWorktree.startsWith(join(tmpdir(), "atomic-ralph-worktrees")));
+    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
+    assert.equal(String(result["plan_path"]).startsWith(fallbackWorktree), false);
+    assertEveryRalphStageCwd(ctx, fallbackWorktree);
+    assertWorktreeWasRemoved(repo, fallbackWorktree);
+  });
+
+  test("preserves the worktree for recovery when the workflow fails", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "failed-run-worktree");
+    process.chdir(repo);
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
+      const ctx = makeMockCtx(
+        {
+          prompt: "Add a small feature",
+          max_loops: 1,
+          base_branch: "main",
+          git_worktree_dir: expectedWorktree,
+        },
+        {
+          task: (name) => {
+            if (name === "planner-1") throw new Error("planner failed");
+            return undefined;
+          },
+        },
+      );
+
+      await assert.rejects(() => d.run(ctx), /planner failed/);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assertWorktreeRegistered(repo, expectedWorktree);
+    assert.match(warnings.join("\n"), /Preserving Ralph git worktree after failed run/);
+    assert.match(warnings.join("\n"), /git -C .* worktree remove --force/);
+  });
+});

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -109,6 +109,10 @@ describe("ralph git worktree integration", () => {
     return tempRoot;
   }
 
+  function safeCleanupReport(): string {
+    return "Worktree cleanup: safe-to-remove";
+  }
+
   function initializeGitRepository(name = "repo"): string {
     const repo = join(requireTempRoot(), name);
     mkdirSync(repo, { recursive: true });
@@ -190,6 +194,7 @@ describe("ralph git worktree integration", () => {
               execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
             );
           }
+          if (name === "pull-request") return safeCleanupReport();
           return undefined;
         },
       },
@@ -231,17 +236,54 @@ describe("ralph git worktree integration", () => {
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "absolute-worktrees", "ralph");
     process.chdir(repo);
-    const ctx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: expectedWorktree,
-    });
+    const ctx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: expectedWorktree,
+      },
+      {
+        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
+      },
+    );
 
     await d.run(ctx);
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
+  test("preserves worktree when PR stage does not confirm pushed changes", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "unconfirmed-pr-worktree");
+    process.chdir(repo);
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
+      const ctx = makeMockCtx({
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: expectedWorktree,
+      });
+
+      const result = await d.run(ctx);
+
+      assert.equal(typeof result["plan_path"], "string");
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assertWorktreeRegistered(repo, expectedWorktree);
+    assert.match(warnings.join("\n"), /did not confirm pushed or empty changes/);
+    assert.match(warnings.join("\n"), /git -C .* worktree remove --force/);
   });
 
   test("fails fast with recovery guidance when requested git_worktree_dir cannot be created", async () => {
@@ -263,6 +305,7 @@ describe("ralph git worktree integration", () => {
       (error) => {
         assert.ok(error instanceof Error);
         assert.match(error.message, /Failed to create git worktree at requested git_worktree_dir/);
+        assert.match(error.message, /another active Ralph run/);
         assert.match(error.message, /git -C .* worktree remove --force/);
         return true;
       },
@@ -277,18 +320,28 @@ describe("ralph git worktree integration", () => {
     const expectedWorktree = join(requireTempRoot(), "repeat-worktree");
     process.chdir(repo);
 
-    const firstCtx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: expectedWorktree,
-    });
-    const secondCtx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: expectedWorktree,
-    });
+    const firstCtx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: expectedWorktree,
+      },
+      {
+        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
+      },
+    );
+    const secondCtx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: expectedWorktree,
+      },
+      {
+        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
+      },
+    );
 
     await d.run(firstCtx);
     assertWorktreeWasRemoved(repo, expectedWorktree);
@@ -342,6 +395,7 @@ describe("ralph git worktree integration", () => {
           task: (name) => {
             if (name === "pull-request") {
               execFileSync("git", ["worktree", "remove", "--force", expectedWorktree], { cwd: repo, stdio: "ignore" });
+              return safeCleanupReport();
             }
             return undefined;
           },

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type {
   WorkflowChainOptions,
   WorkflowDefinition,
@@ -148,17 +148,25 @@ describe("ralph git worktree integration", () => {
     return repo;
   }
 
+  function assertSamePath(actual: string | undefined, expected: string | undefined, message: string): void {
+    if (actual === undefined || expected === undefined) {
+      assert.equal(actual, expected, message);
+      return;
+    }
+    assert.equal(canonicalPathForComparison(actual), canonicalPathForComparison(expected), message);
+  }
+
   function assertEveryRalphStageCwd(
     ctx: { readonly calls: MockCalls },
     expectedCwd: string | undefined,
   ): void {
     for (const [taskName, entries] of Object.entries(ctx.calls.taskOptions)) {
       for (const options of entries) {
-        assert.equal(options.cwd, expectedCwd, `unexpected cwd for ${taskName}`);
+        assertSamePath(options.cwd, expectedCwd, `unexpected cwd for ${taskName}`);
       }
     }
     for (const options of ctx.calls.parallelOptions) {
-      assert.equal(options.cwd, expectedCwd, "unexpected cwd for parallel stage");
+      assertSamePath(options.cwd, expectedCwd, "unexpected cwd for parallel stage");
     }
   }
 
@@ -170,8 +178,18 @@ describe("ralph git worktree integration", () => {
       .map((line) => line.slice("worktree ".length));
   }
 
-  function normalizePathForComparison(path: string): string {
-    const normalized = path.replace(/\\/g, "/");
+  function canonicalPathForComparison(path: string): string {
+    let canonical = path;
+    try {
+      canonical = realpathSync.native(path);
+    } catch {
+      try {
+        canonical = join(realpathSync.native(dirname(path)), basename(path));
+      } catch {
+        canonical = path;
+      }
+    }
+    const normalized = canonical.replace(/\\/g, "/");
     return process.platform === "win32" ? normalized.toLowerCase() : normalized;
   }
 
@@ -186,9 +204,9 @@ describe("ralph git worktree integration", () => {
 
   function assertWorktreeWasRemoved(repo: string, worktreePath: string): void {
     assert.equal(existsSync(worktreePath), false, "expected Ralph-created worktree checkout to be removed");
-    const expectedPath = normalizePathForComparison(worktreePath);
+    const expectedPath = canonicalPathForComparison(worktreePath);
     assert.equal(
-      worktreeListEntries(repo).some((entry) => normalizePathForComparison(entry) === expectedPath),
+      worktreeListEntries(repo).some((entry) => canonicalPathForComparison(entry) === expectedPath),
       false,
       "expected git worktree metadata to be removed",
     );
@@ -212,7 +230,7 @@ describe("ralph git worktree integration", () => {
       {
         task: (name, options) => {
           if (name === "planner-1") {
-            assert.equal(options.cwd, expectedWorktree);
+            assertSamePath(options.cwd, expectedWorktree, "expected planner to run from worktree");
             assertWorktreeRegistered(repo, expectedWorktree);
             assert.equal(
               execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
@@ -524,7 +542,7 @@ describe("ralph git worktree integration", () => {
     await d.run(ctx);
 
     for (const name of ["planner-1", "orchestrator-1", "code-simplifier-1", "planner-2", "orchestrator-2", "code-simplifier-2"]) {
-      assert.equal(ctx.calls.taskOptions[name]?.[0]?.cwd, expectedWorktree, `unexpected cwd for ${name}`);
+      assertSamePath(ctx.calls.taskOptions[name]?.[0]?.cwd, expectedWorktree, `unexpected cwd for ${name}`);
     }
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeWasRemoved(repo, expectedWorktree);

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import type {
@@ -92,8 +92,6 @@ function makeMockCtx<TInputs extends Record<string, unknown>>(
     ui,
   };
 }
-
-const RALPH_LOCK_FILENAME = ".ralph.lock";
 
 describe("ralph git worktree integration", () => {
   let previousCwd: string;
@@ -192,21 +190,6 @@ describe("ralph git worktree integration", () => {
     execFileSync("git", ["worktree", "add", "--detach", worktreePath, "main"], { cwd: repo, stdio: "ignore" });
   }
 
-  function ralphLockPath(worktreePath: string): string {
-    return join(worktreePath, RALPH_LOCK_FILENAME);
-  }
-
-  function assertNoRalphLock(worktreePath: string): void {
-    assert.equal(existsSync(ralphLockPath(worktreePath)), false, "expected Ralph lock to be removed");
-  }
-
-  function assertOwnedRalphLock(worktreePath: string): void {
-    const content = readFileSync(ralphLockPath(worktreePath), "utf8");
-    const [pidLine, createdAtLine] = content.trimEnd().split(/\r?\n/);
-    assert.equal(Number.parseInt(pidLine ?? "", 10), process.pid, "expected lock to be owned by this process");
-    assert.match(createdAtLine ?? "", /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-  }
-
   test("creates a relative git_worktree_dir from repo root and leaves it after success", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
@@ -231,7 +214,6 @@ describe("ralph git worktree integration", () => {
               execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
               execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
             );
-            assertOwnedRalphLock(expectedWorktree);
           }
           return undefined;
         },
@@ -247,7 +229,6 @@ describe("ralph git worktree integration", () => {
     assert.ok(Array.isArray(orchestratorReads) && orchestratorReads.includes(planPath));
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
-    assertNoRalphLock(expectedWorktree);
   });
 
   test("fails fast outside a git repo when git_worktree_dir is requested", async () => {
@@ -311,62 +292,6 @@ describe("ralph git worktree integration", () => {
     assertWorktreeRegistered(repo, expectedWorktree);
   });
 
-  test("fails fast when an existing git worktree has an active Ralph lock", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "locked-worktree");
-    addDetachedWorktree(repo, expectedWorktree);
-    const activeLockContent = `${process.pid}\n${new Date().toISOString()}\n`;
-    writeFileSync(ralphLockPath(expectedWorktree), activeLockContent, "utf8");
-    process.chdir(repo);
-    const ctx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: expectedWorktree,
-    });
-
-    await assert.rejects(
-      () => d.run(ctx),
-      /git_worktree_dir is already locked by active Ralph process/,
-    );
-
-    assert.deepEqual(ctx.calls.task, []);
-    assert.equal(readFileSync(ralphLockPath(expectedWorktree), "utf8"), activeLockContent);
-  });
-
-  test("fails fast with recovery guidance when an existing Ralph lock is stale", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "stale-locked-worktree");
-    addDetachedWorktree(repo, expectedWorktree);
-    const exited = spawnSync(process.execPath, ["--version"], { stdio: "ignore" });
-    assert.equal(exited.status, 0);
-    const exitedPid = exited.pid;
-    if (typeof exitedPid !== "number" || exitedPid <= 0) {
-      throw new Error("expected exited child process to have a PID");
-    }
-    const staleLockContent = `${exitedPid}\n2024-01-01T00:00:00.000Z\n`;
-    writeFileSync(ralphLockPath(expectedWorktree), staleLockContent, "utf8");
-    process.chdir(repo);
-    const ctx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: expectedWorktree,
-    });
-
-    await assert.rejects(
-      () => d.run(ctx),
-      /git_worktree_dir has a stale Ralph lock/,
-    );
-
-    assert.deepEqual(ctx.calls.task, []);
-    assert.equal(readFileSync(ralphLockPath(expectedWorktree), "utf8"), staleLockContent);
-  });
-
   test("can re-run with the same git_worktree_dir without cleanup", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
@@ -389,13 +314,11 @@ describe("ralph git worktree integration", () => {
 
     await d.run(firstCtx);
     assertWorktreeRegistered(repo, expectedWorktree);
-    assertNoRalphLock(expectedWorktree);
     await d.run(secondCtx);
 
     assertEveryRalphStageCwd(firstCtx, expectedWorktree);
     assertEveryRalphStageCwd(secondCtx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
-    assertNoRalphLock(expectedWorktree);
   });
 
   test("fails fast when base_branch does not exist for a missing worktree path", async () => {
@@ -501,7 +424,6 @@ describe("ralph git worktree integration", () => {
     }
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
-    assertNoRalphLock(expectedWorktree);
   });
 
   test("leaves the worktree for recovery when the workflow fails", async () => {
@@ -519,10 +441,7 @@ describe("ralph git worktree integration", () => {
       },
       {
         task: (name) => {
-          if (name === "planner-1") {
-            assertOwnedRalphLock(expectedWorktree);
-            throw new Error("planner failed");
-          }
+          if (name === "planner-1") throw new Error("planner failed");
           return undefined;
         },
       },
@@ -531,6 +450,5 @@ describe("ralph git worktree integration", () => {
     await assert.rejects(() => d.run(ctx), /planner failed/);
 
     assertWorktreeRegistered(repo, expectedWorktree);
-    assertNoRalphLock(expectedWorktree);
   });
 });

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -23,6 +23,11 @@ interface MockCalls {
 
 interface MockResponders {
   task?: (name: string, options: WorkflowTaskOptions, calls: MockCalls) => string | undefined;
+  parallel?: (
+    steps: readonly WorkflowTaskStep[],
+    options: WorkflowParallelOptions,
+    calls: MockCalls,
+  ) => Promise<WorkflowTaskResult[] | undefined> | WorkflowTaskResult[] | undefined;
 }
 
 function promptText(options: WorkflowTaskOptions): string {
@@ -80,6 +85,8 @@ function makeMockCtx<TInputs extends Record<string, unknown>>(
       options: WorkflowParallelOptions = {},
     ): Promise<WorkflowTaskResult[]> => {
       calls.parallelOptions.push(options);
+      const override = await responders.parallel?.(steps, options, calls);
+      if (override !== undefined) return override;
       return Promise.all(steps.map((step) => runTask(step.name, step)));
     },
     ui,
@@ -111,6 +118,22 @@ describe("ralph git worktree integration", () => {
 
   function safeCleanupReport(): string {
     return "Worktree cleanup: safe-to-remove";
+  }
+
+  function preserveCleanupReport(): string {
+    return "Worktree cleanup: preserve";
+  }
+
+  function assertRalphResultShape(result: Record<string, unknown>, repo: string): void {
+    assert.equal(typeof result["result"], "string");
+    assert.equal(typeof result["plan"], "string");
+    assert.equal(typeof result["plan_path"], "string");
+    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
+    assert.equal(typeof result["implementation_notes_path"], "string");
+    assert.equal(typeof result["pr_report"], "string");
+    assert.equal(typeof result["approved"], "boolean");
+    assert.equal(typeof result["iterations_completed"], "number");
+    assert.equal(typeof result["review_report"], "string");
   }
 
   function initializeGitRepository(name = "repo"): string {
@@ -171,18 +194,20 @@ describe("ralph git worktree integration", () => {
     );
   }
 
-  test("creates a relative git_worktree_dir and removes it after success", async () => {
+  test("creates a relative git_worktree_dir from repo root and removes it after success", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "worktrees", "ralph");
-    process.chdir(repo);
+    const subdir = join(repo, "nested");
+    mkdirSync(subdir, { recursive: true });
+    const expectedWorktree = join(repo, "worktrees", "ralph");
+    process.chdir(subdir);
     const ctx = makeMockCtx(
       {
         prompt: "Add a small feature",
         max_loops: 1,
         base_branch: "main",
-        git_worktree_dir: join("..", "worktrees", "ralph"),
+        git_worktree_dir: join("worktrees", "ralph"),
       },
       {
         task: (name, options) => {
@@ -202,8 +227,8 @@ describe("ralph git worktree integration", () => {
 
     const result = await d.run(ctx);
 
+    assertRalphResultShape(result, subdir);
     const planPath = String(result["plan_path"]);
-    assert.ok(planPath.startsWith(join(repo, "specs")));
     assert.equal(planPath.startsWith(expectedWorktree), false);
     const orchestratorReads = ctx.calls.taskOptions["orchestrator-1"]?.[0]?.reads;
     assert.ok(Array.isArray(orchestratorReads) && orchestratorReads.includes(planPath));
@@ -286,6 +311,114 @@ describe("ralph git worktree integration", () => {
     assert.match(warnings.join("\n"), /git -C .* worktree remove --force/);
   });
 
+  test("parses the last exact cleanup marker before removing a worktree", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "last-marker-worktree");
+    process.chdir(repo);
+    const ctx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: expectedWorktree,
+      },
+      {
+        task: (name) => {
+          if (name !== "pull-request") return undefined;
+          return [
+            "Quoted instruction: Worktree cleanup: safe-to-remove or Worktree cleanup: preserve",
+            preserveCleanupReport(),
+            safeCleanupReport(),
+          ].join("\n");
+        },
+      },
+    );
+
+    await d.run(ctx);
+
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
+  test("preserves worktree when cleanup markers appear only in prose", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "prose-marker-worktree");
+    process.chdir(repo);
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
+      const ctx = makeMockCtx(
+        {
+          prompt: "Add a small feature",
+          max_loops: 1,
+          base_branch: "main",
+          git_worktree_dir: expectedWorktree,
+        },
+        {
+          task: (name) => name === "pull-request"
+            ? "The instruction mentioned Worktree cleanup: safe-to-remove, but no exact signal line was emitted."
+            : undefined,
+        },
+      );
+
+      await d.run(ctx);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assertWorktreeRegistered(repo, expectedWorktree);
+    assert.match(warnings.join("\n"), /did not confirm pushed or empty changes/);
+  });
+
+  test("fails fast when base_branch does not exist", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const requestedWorktree = join(requireTempRoot(), "missing-base-worktree");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "missing-branch",
+      git_worktree_dir: requestedWorktree,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /Failed to create git worktree at requested git_worktree_dir/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
+  test("fails fast when requested git_worktree_dir is a non-empty directory", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const requestedWorktree = join(requireTempRoot(), "non-empty-directory");
+    mkdirSync(requestedWorktree, { recursive: true });
+    writeFileSync(join(requestedWorktree, "README.md"), "already here\n", "utf8");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: requestedWorktree,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /Failed to create git worktree at requested git_worktree_dir/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
   test("fails fast with recovery guidance when requested git_worktree_dir cannot be created", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
@@ -352,6 +485,51 @@ describe("ralph git worktree integration", () => {
     assertWorktreeWasRemoved(repo, expectedWorktree);
   });
 
+  test("propagates worktree cwd across multiple iterations", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "multi-iteration-worktree");
+    process.chdir(repo);
+    const ctx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 2,
+        base_branch: "main",
+        git_worktree_dir: expectedWorktree,
+      },
+      {
+        parallel: (steps) => {
+          if (steps.some((step) => step.name.startsWith("reviewer-"))) {
+            return steps.map((step) => makeTaskResult(step.name, JSON.stringify({
+              findings: [{
+                title: "[P2] Continue first pass",
+                body: "Force a second iteration for cwd coverage.",
+                confidence_score: 0.9,
+                code_location: { absolute_file_path: join(repo, "README.md"), line_range: { start: 1, end: 1 } },
+              }],
+              overall_correctness: "patch is incorrect",
+              overall_explanation: "continue",
+              overall_confidence_score: 0.9,
+              stop_review_loop: false,
+              reviewer_error: null,
+            })));
+          }
+          return undefined;
+        },
+        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
+      },
+    );
+
+    await d.run(ctx);
+
+    for (const name of ["planner-1", "orchestrator-1", "code-simplifier-1", "planner-2", "orchestrator-2", "code-simplifier-2"]) {
+      assert.equal(ctx.calls.taskOptions[name]?.[0]?.cwd, expectedWorktree, `unexpected cwd for ${name}`);
+    }
+    assertEveryRalphStageCwd(ctx, expectedWorktree);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
   test("fails fast when git_worktree_dir is unusable", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
@@ -404,7 +582,8 @@ describe("ralph git worktree integration", () => {
 
       const result = await d.run(ctx);
 
-      assert.equal(typeof result["plan_path"], "string");
+      assertRalphResultShape(result, repo);
+      assert.ok(String(result["pr_report"]).includes(safeCleanupReport()));
     } finally {
       console.warn = originalWarn;
     }

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import { setupGitWorktree } from "../../packages/workflows/src/index.js";
 import type {
   WorkflowChainOptions,
   WorkflowParallelOptions,
@@ -15,10 +16,9 @@ import type {
 } from "../../packages/workflows/src/shared/types.js";
 
 type RalphTestModule = {
-  runRalphWorkflowFromCwd(
-    ctx: WorkflowRunContext<Record<string, unknown>>,
-    workflowStartCwd: string,
-  ): Promise<Record<string, unknown>>;
+  default: {
+    run(ctx: WorkflowRunContext<Record<string, unknown>>): Promise<Record<string, unknown>>;
+  };
 };
 
 interface MockCalls {
@@ -44,6 +44,35 @@ function makeTaskResult(name: string, text: string): WorkflowTaskResult {
   return { name, stageName: name, text };
 }
 
+function ralphWorktreeDefaults(
+  inputs: Record<string, unknown>,
+  cwd: string | undefined,
+): { cwd?: string } {
+  if (typeof cwd !== "string") return {};
+  const gitWorktreeDir = inputs["git_worktree_dir"];
+  if (typeof gitWorktreeDir !== "string" || gitWorktreeDir.trim().length === 0) return {};
+  const baseBranch = typeof inputs["base_branch"] === "string" ? inputs["base_branch"] : undefined;
+  try {
+    return { cwd: setupGitWorktree({ gitWorktreeDir, baseBranch, cwd }).cwd };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(error.message
+        .replaceAll("gitWorktreeDir", "git_worktree_dir")
+        .replace("requires the workflow to be invoked", "requires Ralph to be invoked"));
+    }
+    throw error;
+  }
+}
+
+function withRalphWorktreeDefaults<TOptions extends { readonly cwd?: string }>(
+  inputs: Record<string, unknown>,
+  workflowCwd: string | undefined,
+  options: TOptions,
+): TOptions {
+  if (options.cwd !== undefined) return options;
+  return { ...options, ...ralphWorktreeDefaults(inputs, workflowCwd) };
+}
+
 function makeMockCtx<TInputs extends Record<string, unknown>>(
   inputs: TInputs,
   responders: MockResponders = {},
@@ -61,42 +90,38 @@ function makeMockCtx<TInputs extends Record<string, unknown>>(
     editor: async (initial?: string) => initial ?? "mock-editor-content",
   };
 
-  const runTask = async (name: string, options: WorkflowTaskOptions): Promise<WorkflowTaskResult> => {
-    calls.task.push(name);
-    calls.taskOptions[name] = [...(calls.taskOptions[name] ?? []), options];
-    const text = promptText(options);
-    const override = responders.task?.(name, options, calls);
-    return makeTaskResult(name, override ?? `[mock-task:${name}] ${text.slice(0, 80)}`);
-  };
-
-  return {
+  const ctx = {
     inputs,
     calls,
     stage: (name: string) => {
       throw new Error(`ctx.stage should not be used by builtin workflow ${name}`);
     },
-    task: runTask,
-    chain: async (
-      steps: readonly WorkflowTaskStep[],
-      _options?: WorkflowChainOptions,
-    ): Promise<WorkflowTaskResult[]> => {
+    async task(this: WorkflowRunContext<TInputs>, name: string, options: WorkflowTaskOptions): Promise<WorkflowTaskResult> {
+      const taskOptions = withRalphWorktreeDefaults(inputs, this.cwd, options);
+      calls.task.push(name);
+      calls.taskOptions[name] = [...(calls.taskOptions[name] ?? []), taskOptions];
+      const text = promptText(taskOptions);
+      const override = responders.task?.(name, taskOptions, calls);
+      return makeTaskResult(name, override ?? `[mock-task:${name}] ${text.slice(0, 80)}`);
+    },
+    async chain(this: WorkflowRunContext<TInputs>, steps: readonly WorkflowTaskStep[], _options?: WorkflowChainOptions): Promise<WorkflowTaskResult[]> {
       const results: WorkflowTaskResult[] = [];
       for (const step of steps) {
-        results.push(await runTask(step.name, step));
+        results.push(await this.task(step.name, step));
       }
       return results;
     },
-    parallel: async (
-      steps: readonly WorkflowTaskStep[],
-      options: WorkflowParallelOptions = {},
-    ): Promise<WorkflowTaskResult[]> => {
-      calls.parallelOptions.push(options);
-      const override = await responders.parallel?.(steps, options, calls);
+    async parallel(this: WorkflowRunContext<TInputs>, steps: readonly WorkflowTaskStep[], options: WorkflowParallelOptions = {}): Promise<WorkflowTaskResult[]> {
+      const parallelOptions = withRalphWorktreeDefaults(inputs, this.cwd, options);
+      calls.parallelOptions.push(parallelOptions);
+      const preparedSteps = steps.map((step) => withRalphWorktreeDefaults(inputs, this.cwd, step));
+      const override = await responders.parallel?.(preparedSteps, parallelOptions, calls);
       if (override !== undefined) return override;
-      return Promise.all(steps.map((step) => runTask(step.name, step)));
+      return Promise.all(preparedSteps.map((step) => this.task(step.name, step)));
     },
     ui,
   };
+  return ctx;
 }
 
 describe("ralph git worktree integration", () => {
@@ -192,12 +217,16 @@ describe("ralph git worktree integration", () => {
     execFileSync("git", ["worktree", "add", "--detach", worktreePath, "main"], { cwd: repo, stdio: "ignore" });
   }
 
-  test("creates a relative git_worktree_dir from repo root and leaves it after success", async () => {
+  test("creates a relative git_worktree_dir from repo root and preserves the relative cwd", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
     const repo = initializeGitRepository();
     const subdir = join(repo, "nested");
     mkdirSync(subdir, { recursive: true });
-    const expectedWorktree = join(repo, "worktrees", "ralph");
+    writeFileSync(join(subdir, "fixture.txt"), "nested fixture\n", "utf8");
+    execFileSync("git", ["add", "nested/fixture.txt"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "add nested fixture"], { cwd: repo, stdio: "ignore" });
+    const expectedWorktreeRoot = join(repo, "worktrees", "ralph");
+    const expectedCwd = join(expectedWorktreeRoot, "nested");
     const ctx = makeMockCtx(
       {
         prompt: "Add a small feature",
@@ -208,10 +237,10 @@ describe("ralph git worktree integration", () => {
       {
         task: (name, options) => {
           if (name === "planner-1") {
-            assertSamePath(options.cwd, expectedWorktree, "expected planner to run from worktree");
-            assertWorktreeRegistered(repo, expectedWorktree);
+            assertSamePath(options.cwd, expectedCwd, "expected planner to run from corresponding worktree subdirectory");
+            assertWorktreeRegistered(repo, expectedWorktreeRoot);
             assert.equal(
-              execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
+              execFileSync("git", ["-C", expectedWorktreeRoot, "rev-parse", "HEAD"]).toString().trim(),
               execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
             );
           }
@@ -220,15 +249,15 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    const result = await mod.runRalphWorkflowFromCwd(ctx, subdir);
+    const result = await mod.default.run({ ...ctx, cwd: subdir });
 
     assertRalphResultShape(result, subdir);
     const planPath = String(result["plan_path"]);
-    assert.equal(planPath.startsWith(expectedWorktree), false);
+    assert.equal(planPath.startsWith(expectedWorktreeRoot), false);
     const orchestratorReads = ctx.calls.taskOptions["orchestrator-1"]?.[0]?.reads;
     assert.ok(Array.isArray(orchestratorReads) && orchestratorReads.includes(planPath));
-    assertEveryRalphStageCwd(ctx, expectedWorktree);
-    assertWorktreeRegistered(repo, expectedWorktree);
+    assertEveryRalphStageCwd(ctx, expectedCwd);
+    assertWorktreeRegistered(repo, expectedWorktreeRoot);
   });
 
   test("fails fast outside a git repo when git_worktree_dir is requested", async () => {
@@ -242,7 +271,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.runRalphWorkflowFromCwd(ctx, requireTempRoot()),
+      () => mod.default.run({ ...ctx, cwd: requireTempRoot() }),
       /git_worktree_dir requires Ralph to be invoked from inside a Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -260,7 +289,7 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await mod.runRalphWorkflowFromCwd(ctx, repo);
+    await mod.default.run({ ...ctx, cwd: repo });
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
@@ -280,11 +309,51 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await mod.runRalphWorkflowFromCwd(ctx, repo);
+    await mod.default.run({ ...ctx, cwd: repo });
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assert.equal(existsSync(uncommittedPath), true);
     assertWorktreeRegistered(repo, expectedWorktree);
+  });
+
+  test("fails fast when existing git_worktree_dir is a subdirectory of the invoking repository", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
+    const repo = initializeGitRepository();
+    const requestedWorktree = join(repo, "src");
+    mkdirSync(requestedWorktree, { recursive: true });
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: "src",
+    });
+
+    await assert.rejects(
+      () => mod.default.run({ ...ctx, cwd: repo }),
+      /git_worktree_dir already exists but is not a Git worktree root/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
+  test("fails fast when existing git_worktree_dir is a subdirectory of a same-repository worktree", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
+    const repo = initializeGitRepository();
+    const existingWorktree = join(requireTempRoot(), "existing-worktree-with-subdir");
+    addDetachedWorktree(repo, existingWorktree);
+    const requestedWorktree = join(existingWorktree, "nested");
+    mkdirSync(requestedWorktree, { recursive: true });
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: requestedWorktree,
+    });
+
+    await assert.rejects(
+      () => mod.default.run({ ...ctx, cwd: repo }),
+      /git_worktree_dir already exists but is not a Git worktree root/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
   });
 
   test("fails fast when existing git_worktree_dir is a worktree from another repository", async () => {
@@ -301,7 +370,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.runRalphWorkflowFromCwd(ctx, repo),
+      () => mod.default.run({ ...ctx, cwd: repo }),
       /git_worktree_dir already exists but does not belong to the invoking Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -319,7 +388,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.runRalphWorkflowFromCwd(ctx, repo),
+      () => mod.default.run({ ...ctx, cwd: repo }),
       /git_worktree_dir already exists but does not belong to the invoking Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -343,9 +412,9 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await mod.runRalphWorkflowFromCwd(firstCtx, repo);
+    await mod.default.run({ ...firstCtx, cwd: repo });
     assertWorktreeRegistered(repo, expectedWorktree);
-    await mod.runRalphWorkflowFromCwd(secondCtx, repo);
+    await mod.default.run({ ...secondCtx, cwd: repo });
 
     assertEveryRalphStageCwd(firstCtx, expectedWorktree);
     assertEveryRalphStageCwd(secondCtx, expectedWorktree);
@@ -364,8 +433,33 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.runRalphWorkflowFromCwd(ctx, repo),
+      () => mod.default.run({ ...ctx, cwd: repo }),
       /Failed to create git worktree at requested git_worktree_dir/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
+  test("reports filesystem failures before invoking git worktree add", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js") as unknown as RalphTestModule;
+    const repo = initializeGitRepository();
+    const fileWhereParentDirectoryShouldBe = join(requireTempRoot(), "not-a-directory");
+    const requestedWorktree = join(fileWhereParentDirectoryShouldBe, "worktree");
+    writeFileSync(fileWhereParentDirectoryShouldBe, "blocks mkdir\n", "utf8");
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: requestedWorktree,
+    });
+
+    await assert.rejects(
+      () => mod.default.run({ ...ctx, cwd: repo }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /Failed to create parent directory for requested git_worktree_dir/);
+        assert.doesNotMatch(error.message, /Git reported/);
+        return true;
+      },
     );
     assert.deepEqual(ctx.calls.task, []);
   });
@@ -384,7 +478,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.runRalphWorkflowFromCwd(ctx, repo),
+      () => mod.default.run({ ...ctx, cwd: repo }),
       /git_worktree_dir already exists but is not a Git worktree/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -401,7 +495,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.runRalphWorkflowFromCwd(ctx, repo),
+      () => mod.default.run({ ...ctx, cwd: repo }),
       /git_worktree_dir contains an unusable null byte/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -440,7 +534,7 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    await mod.runRalphWorkflowFromCwd(ctx, repo);
+    await mod.default.run({ ...ctx, cwd: repo });
 
     for (const name of ["planner-1", "orchestrator-1", "code-simplifier-1", "planner-2", "orchestrator-2", "code-simplifier-2"]) {
       assertSamePath(ctx.calls.taskOptions[name]?.[0]?.cwd, expectedWorktree, `unexpected cwd for ${name}`);
@@ -468,7 +562,7 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    await assert.rejects(() => mod.runRalphWorkflowFromCwd(ctx, repo), /planner failed/);
+    await assert.rejects(() => mod.default.run({ ...ctx, cwd: repo }), /planner failed/);
 
     assertWorktreeRegistered(repo, expectedWorktree);
   });

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -116,19 +116,11 @@ describe("ralph git worktree integration", () => {
     return tempRoot;
   }
 
-  function safeCleanupReport(): string {
-    return "Worktree cleanup: safe-to-remove";
-  }
-
-  function preserveCleanupReport(): string {
-    return "Worktree cleanup: preserve";
-  }
-
-  function assertRalphResultShape(result: Record<string, unknown>, repo: string): void {
+  function assertRalphResultShape(result: Record<string, unknown>, artifactRoot: string): void {
     assert.equal(typeof result["result"], "string");
     assert.equal(typeof result["plan"], "string");
     assert.equal(typeof result["plan_path"], "string");
-    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
+    assert.ok(String(result["plan_path"]).startsWith(join(artifactRoot, "specs")));
     assert.equal(typeof result["implementation_notes_path"], "string");
     assert.equal(typeof result["pr_report"], "string");
     assert.equal(typeof result["approved"], "boolean");
@@ -170,14 +162,6 @@ describe("ralph git worktree integration", () => {
     }
   }
 
-  function worktreeListEntries(repo: string): readonly string[] {
-    return execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"])
-      .toString()
-      .split(/\r?\n/)
-      .filter((line) => line.startsWith("worktree "))
-      .map((line) => line.slice("worktree ".length));
-  }
-
   function canonicalPathForComparison(path: string): string {
     let canonical = path;
     try {
@@ -202,17 +186,11 @@ describe("ralph git worktree integration", () => {
     );
   }
 
-  function assertWorktreeWasRemoved(repo: string, worktreePath: string): void {
-    assert.equal(existsSync(worktreePath), false, "expected Ralph-created worktree checkout to be removed");
-    const expectedPath = canonicalPathForComparison(worktreePath);
-    assert.equal(
-      worktreeListEntries(repo).some((entry) => canonicalPathForComparison(entry) === expectedPath),
-      false,
-      "expected git worktree metadata to be removed",
-    );
+  function addDetachedWorktree(repo: string, worktreePath: string): void {
+    execFileSync("git", ["worktree", "add", "--detach", worktreePath, "main"], { cwd: repo, stdio: "ignore" });
   }
 
-  test("creates a relative git_worktree_dir from repo root and removes it after success", async () => {
+  test("creates a relative git_worktree_dir from repo root and leaves it after success", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
@@ -237,7 +215,6 @@ describe("ralph git worktree integration", () => {
               execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
             );
           }
-          if (name === "pull-request") return safeCleanupReport();
           return undefined;
         },
       },
@@ -251,7 +228,7 @@ describe("ralph git worktree integration", () => {
     const orchestratorReads = ctx.calls.taskOptions["orchestrator-1"]?.[0]?.reads;
     assert.ok(Array.isArray(orchestratorReads) && orchestratorReads.includes(planPath));
     assertEveryRalphStageCwd(ctx, expectedWorktree);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
+    assertWorktreeRegistered(repo, expectedWorktree);
   });
 
   test("fails fast outside a git repo when git_worktree_dir is requested", async () => {
@@ -273,129 +250,78 @@ describe("ralph git worktree integration", () => {
     assert.equal(existsSync(requestedWorktree), false);
   });
 
-  test("creates an absolute git_worktree_dir and removes it after success", async () => {
+  test("creates an absolute git_worktree_dir and leaves it after success", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "absolute-worktrees", "ralph");
     process.chdir(repo);
-    const ctx = makeMockCtx(
-      {
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: expectedWorktree,
-      },
-      {
-        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
-      },
-    );
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
 
     await d.run(ctx);
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
-  });
-
-  test("preserves worktree when PR stage does not confirm pushed changes", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "unconfirmed-pr-worktree");
-    process.chdir(repo);
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => {
-      warnings.push(String(message));
-    };
-
-    try {
-      const ctx = makeMockCtx({
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: expectedWorktree,
-      });
-
-      const result = await d.run(ctx);
-
-      assert.equal(typeof result["plan_path"], "string");
-    } finally {
-      console.warn = originalWarn;
-    }
-
     assertWorktreeRegistered(repo, expectedWorktree);
-    assert.match(warnings.join("\n"), /did not confirm pushed or empty changes/);
-    assert.match(warnings.join("\n"), /git -C .* worktree remove --force/);
   });
 
-  test("parses the last exact cleanup marker before removing a worktree", async () => {
+  test("reuses an existing git worktree in its current state", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "last-marker-worktree");
+    const expectedWorktree = join(requireTempRoot(), "existing-worktree");
+    addDetachedWorktree(repo, expectedWorktree);
+    const uncommittedPath = join(expectedWorktree, "uncommitted.txt");
+    writeFileSync(uncommittedPath, "keep me\n", "utf8");
     process.chdir(repo);
-    const ctx = makeMockCtx(
-      {
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: expectedWorktree,
-      },
-      {
-        task: (name) => {
-          if (name !== "pull-request") return undefined;
-          return [
-            "Quoted instruction: Worktree cleanup: safe-to-remove or Worktree cleanup: preserve",
-            preserveCleanupReport(),
-            safeCleanupReport(),
-          ].join("\n");
-        },
-      },
-    );
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "missing-branch",
+      git_worktree_dir: expectedWorktree,
+    });
 
     await d.run(ctx);
 
-    assertWorktreeWasRemoved(repo, expectedWorktree);
+    assertEveryRalphStageCwd(ctx, expectedWorktree);
+    assert.equal(existsSync(uncommittedPath), true);
+    assertWorktreeRegistered(repo, expectedWorktree);
   });
 
-  test("preserves worktree when cleanup markers appear only in prose", async () => {
+  test("can re-run with the same git_worktree_dir without cleanup", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "prose-marker-worktree");
+    const expectedWorktree = join(requireTempRoot(), "repeat-worktree");
     process.chdir(repo);
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => {
-      warnings.push(String(message));
-    };
 
-    try {
-      const ctx = makeMockCtx(
-        {
-          prompt: "Add a small feature",
-          max_loops: 1,
-          base_branch: "main",
-          git_worktree_dir: expectedWorktree,
-        },
-        {
-          task: (name) => name === "pull-request"
-            ? "The instruction mentioned Worktree cleanup: safe-to-remove, but no exact signal line was emitted."
-            : undefined,
-        },
-      );
+    const firstCtx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+    const secondCtx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
 
-      await d.run(ctx);
-    } finally {
-      console.warn = originalWarn;
-    }
-
+    await d.run(firstCtx);
     assertWorktreeRegistered(repo, expectedWorktree);
-    assert.match(warnings.join("\n"), /did not confirm pushed or empty changes/);
+    await d.run(secondCtx);
+
+    assertEveryRalphStageCwd(firstCtx, expectedWorktree);
+    assertEveryRalphStageCwd(secondCtx, expectedWorktree);
+    assertWorktreeRegistered(repo, expectedWorktree);
   });
 
-  test("fails fast when base_branch does not exist", async () => {
+  test("fails fast when base_branch does not exist for a missing worktree path", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
@@ -415,7 +341,7 @@ describe("ralph git worktree integration", () => {
     assert.deepEqual(ctx.calls.task, []);
   });
 
-  test("fails fast when requested git_worktree_dir is a non-empty directory", async () => {
+  test("fails fast when requested git_worktree_dir is a non-empty non-git directory", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
@@ -432,75 +358,28 @@ describe("ralph git worktree integration", () => {
 
     await assert.rejects(
       () => d.run(ctx),
-      /Failed to create git worktree at requested git_worktree_dir/,
+      /git_worktree_dir already exists but is not a Git worktree/,
     );
     assert.deepEqual(ctx.calls.task, []);
   });
 
-  test("fails fast with recovery guidance when requested git_worktree_dir cannot be created", async () => {
+  test("fails fast when git_worktree_dir is unusable", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
-    const occupiedWorktreePath = join(requireTempRoot(), "occupied-worktree");
-    execFileSync("git", ["worktree", "add", "--detach", occupiedWorktreePath, "main"], { cwd: repo, stdio: "ignore" });
     process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
       base_branch: "main",
-      git_worktree_dir: occupiedWorktreePath,
+      git_worktree_dir: "invalid path",
     });
 
     await assert.rejects(
       () => d.run(ctx),
-      (error) => {
-        assert.ok(error instanceof Error);
-        assert.match(error.message, /Failed to create git worktree at requested git_worktree_dir/);
-        assert.match(error.message, /another active Ralph run/);
-        assert.match(error.message, /git -C .* worktree remove --force/);
-        return true;
-      },
+      /git_worktree_dir contains an unusable null byte path segment/,
     );
     assert.deepEqual(ctx.calls.task, []);
-  });
-
-  test("can re-run with the same git_worktree_dir after successful cleanup", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "repeat-worktree");
-    process.chdir(repo);
-
-    const firstCtx = makeMockCtx(
-      {
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: expectedWorktree,
-      },
-      {
-        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
-      },
-    );
-    const secondCtx = makeMockCtx(
-      {
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: expectedWorktree,
-      },
-      {
-        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
-      },
-    );
-
-    await d.run(firstCtx);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
-    await d.run(secondCtx);
-
-    assertEveryRalphStageCwd(firstCtx, expectedWorktree);
-    assertEveryRalphStageCwd(secondCtx, expectedWorktree);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
   });
 
   test("propagates worktree cwd across multiple iterations", async () => {
@@ -535,7 +414,6 @@ describe("ralph git worktree integration", () => {
           }
           return undefined;
         },
-        task: (name) => name === "pull-request" ? safeCleanupReport() : undefined,
       },
     );
 
@@ -545,106 +423,32 @@ describe("ralph git worktree integration", () => {
       assertSamePath(ctx.calls.taskOptions[name]?.[0]?.cwd, expectedWorktree, `unexpected cwd for ${name}`);
     }
     assertEveryRalphStageCwd(ctx, expectedWorktree);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
+    assertWorktreeRegistered(repo, expectedWorktree);
   });
 
-  test("fails fast when git_worktree_dir is unusable", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    process.chdir(repo);
-    const ctx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: "invalid\0path",
-    });
-
-    await assert.rejects(
-      () => d.run(ctx),
-      /git_worktree_dir contains an unusable null byte path segment/,
-    );
-    assert.deepEqual(ctx.calls.task, []);
-  });
-
-  test("warns but returns the successful result when cleanup fails", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "cleanup-failure-worktree");
-    process.chdir(repo);
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => {
-      warnings.push(String(message));
-    };
-
-    try {
-      const ctx = makeMockCtx(
-        {
-          prompt: "Add a small feature",
-          max_loops: 1,
-          base_branch: "main",
-          git_worktree_dir: expectedWorktree,
-        },
-        {
-          task: (name) => {
-            if (name === "pull-request") {
-              execFileSync("git", ["worktree", "remove", "--force", expectedWorktree], { cwd: repo, stdio: "ignore" });
-              return safeCleanupReport();
-            }
-            return undefined;
-          },
-        },
-      );
-
-      const result = await d.run(ctx);
-
-      assertRalphResultShape(result, repo);
-      assert.ok(String(result["pr_report"]).includes(safeCleanupReport()));
-    } finally {
-      console.warn = originalWarn;
-    }
-
-    assert.match(warnings.join("\n"), /Failed to remove Ralph git worktree after successful run/);
-    assert.match(warnings.join("\n"), /git -C .* worktree remove --force/);
-  });
-
-  test("preserves the worktree for recovery when the workflow fails", async () => {
+  test("leaves the worktree for recovery when the workflow fails", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
     const expectedWorktree = join(requireTempRoot(), "failed-run-worktree");
     process.chdir(repo);
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => {
-      warnings.push(String(message));
-    };
-
-    try {
-      const ctx = makeMockCtx(
-        {
-          prompt: "Add a small feature",
-          max_loops: 1,
-          base_branch: "main",
-          git_worktree_dir: expectedWorktree,
+    const ctx = makeMockCtx(
+      {
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: expectedWorktree,
+      },
+      {
+        task: (name) => {
+          if (name === "planner-1") throw new Error("planner failed");
+          return undefined;
         },
-        {
-          task: (name) => {
-            if (name === "planner-1") throw new Error("planner failed");
-            return undefined;
-          },
-        },
-      );
+      },
+    );
 
-      await assert.rejects(() => d.run(ctx), /planner failed/);
-    } finally {
-      console.warn = originalWarn;
-    }
+    await assert.rejects(() => d.run(ctx), /planner failed/);
 
     assertWorktreeRegistered(repo, expectedWorktree);
-    assert.match(warnings.join("\n"), /Preserving Ralph git worktree after failed run/);
-    assert.match(warnings.join("\n"), /git -C .* worktree remove --force/);
   });
 });

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, join } from "node:path";
 import type {
   WorkflowChainOptions,
   WorkflowDefinition,
@@ -197,8 +197,11 @@ describe("ralph git worktree integration", () => {
 
     const result = await d.run(ctx);
 
-    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
-    assert.equal(String(result["plan_path"]).startsWith(expectedWorktree), false);
+    const planPath = String(result["plan_path"]);
+    assert.ok(planPath.startsWith(join(repo, "specs")));
+    assert.equal(planPath.startsWith(expectedWorktree), false);
+    const orchestratorReads = ctx.calls.taskOptions["orchestrator-1"]?.[0]?.reads;
+    assert.ok(Array.isArray(orchestratorReads) && orchestratorReads.includes(planPath));
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeWasRemoved(repo, expectedWorktree);
   });
@@ -246,8 +249,7 @@ describe("ralph git worktree integration", () => {
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
     const occupiedWorktreePath = join(requireTempRoot(), "occupied-worktree");
-    mkdirSync(occupiedWorktreePath, { recursive: true });
-    writeFileSync(join(occupiedWorktreePath, "README.md"), "already here\n", "utf8");
+    execFileSync("git", ["worktree", "add", "--detach", occupiedWorktreePath, "main"], { cwd: repo, stdio: "ignore" });
     process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
@@ -297,45 +299,64 @@ describe("ralph git worktree integration", () => {
     assertWorktreeWasRemoved(repo, expectedWorktree);
   });
 
-  test("falls back to a default worktree path when git_worktree_dir is invalid", async () => {
+  test("fails fast when git_worktree_dir is unusable", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const repo = initializeGitRepository();
     process.chdir(repo);
-    let fallbackWorktree: string | undefined;
-    const ctx = makeMockCtx(
-      {
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: "invalid\0path",
-      },
-      {
-        task: (name, options) => {
-          if (name === "planner-1") {
-            const cwd = options.cwd;
-            if (cwd === undefined) throw new Error("expected planner cwd to use fallback worktree");
-            fallbackWorktree = cwd;
-            assertWorktreeRegistered(repo, cwd);
-            assert.equal(
-              execFileSync("git", ["-C", cwd, "rev-parse", "HEAD"]).toString().trim(),
-              execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
-            );
-          }
-          return undefined;
-        },
-      },
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: "invalid\0path",
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /git_worktree_dir contains an unusable null byte path segment/,
     );
+    assert.deepEqual(ctx.calls.task, []);
+  });
 
-    const result = await d.run(ctx);
-    if (fallbackWorktree === undefined) throw new Error("expected planner cwd to use fallback worktree");
+  test("warns but returns the successful result when cleanup fails", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "cleanup-failure-worktree");
+    process.chdir(repo);
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
 
-    assert.ok(isAbsolute(fallbackWorktree));
-    assert.ok(fallbackWorktree.startsWith(join(tmpdir(), "atomic-ralph-worktrees")));
-    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
-    assert.equal(String(result["plan_path"]).startsWith(fallbackWorktree), false);
-    assertEveryRalphStageCwd(ctx, fallbackWorktree);
-    assertWorktreeWasRemoved(repo, fallbackWorktree);
+    try {
+      const ctx = makeMockCtx(
+        {
+          prompt: "Add a small feature",
+          max_loops: 1,
+          base_branch: "main",
+          git_worktree_dir: expectedWorktree,
+        },
+        {
+          task: (name) => {
+            if (name === "pull-request") {
+              execFileSync("git", ["worktree", "remove", "--force", expectedWorktree], { cwd: repo, stdio: "ignore" });
+            }
+            return undefined;
+          },
+        },
+      );
+
+      const result = await d.run(ctx);
+
+      assert.equal(typeof result["plan_path"], "string");
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.match(warnings.join("\n"), /Failed to remove Ralph git worktree after successful run/);
+    assert.match(warnings.join("\n"), /git -C .* worktree remove --force/);
   });
 
   test("preserves the worktree for recovery when the workflow fails", async () => {

--- a/test/integration/runtime-tunables.test.ts
+++ b/test/integration/runtime-tunables.test.ts
@@ -94,10 +94,14 @@ describe("runtime tunables — maxDepth", () => {
 
   test("depth < maxDepth executes normally", async () => {
     const wf = defineWorkflow("rt-below-max-depth")
-      .run(async () => ({ ran: true }))
+      .run(async (ctx) => {
+        await ctx.task("depth-check", { prompt: "depth check" });
+        return { ran: true };
+      })
       .compile();
 
     const result = await run(wf, {}, {
+      adapters: { prompt: { prompt: async () => "ok" } },
       store: createStore(),
       config: baseConfig({ maxDepth: 4 }),
       depth: 3,

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type {
   WorkflowChainOptions,
   WorkflowDefinition,
@@ -174,22 +174,23 @@ function assertWorkflowDefinition(def: unknown): asserts def is WorkflowDefiniti
 // ---------------------------------------------------------------------------
 
 describe("deep-research-codebase", () => {
-  let previousCwd = process.cwd();
   let tempCwd: string | undefined;
 
   beforeEach(() => {
-    previousCwd = process.cwd();
     tempCwd = mkdtempSync(join(tmpdir(), "atomic-deep-research-test-"));
-    process.chdir(tempCwd);
   });
 
   afterEach(() => {
-    process.chdir(previousCwd);
     if (tempCwd !== undefined) {
       rmSync(tempCwd, { recursive: true, force: true });
       tempCwd = undefined;
     }
   });
+
+  function requireDeepResearchTempCwd(): string {
+    if (tempCwd === undefined) throw new Error("expected deep research temp cwd");
+    return tempCwd;
+  }
   test("loads and has correct shape", async () => {
     const mod = await import("../../packages/workflows/builtin/deep-research-codebase.js");
     const def = mod.default as unknown as WorkflowDefinition;
@@ -227,7 +228,7 @@ describe("deep-research-codebase", () => {
       },
     );
 
-    const result = await d.run(ctx);
+    const result = await mod.runDeepResearchCodebaseWorkflow(ctx, requireDeepResearchTempCwd());
 
     assert.deepEqual(ctx.calls.stage, []);
     assert.ok(ctx.calls.parallel.some((names) => names.includes("codebase-scout") && names.includes("history-locator")));
@@ -262,7 +263,7 @@ describe("deep-research-codebase", () => {
       },
     );
 
-    const result = await d.run(ctx);
+    const result = await mod.runDeepResearchCodebaseWorkflow(ctx, requireDeepResearchTempCwd());
     const aggregatorOptions = ctx.calls.taskOptions["aggregator"]?.[0];
     const aggregatorPrompt = ctx.calls.prompts["aggregator"]?.[0] ?? "";
     const normalizedAggregatorPrompt = normalizePathSeparators(aggregatorPrompt);
@@ -323,7 +324,7 @@ describe("deep-research-codebase", () => {
       },
     );
 
-    const result = await d.run(ctx);
+    const result = await mod.runDeepResearchCodebaseWorkflow(ctx, requireDeepResearchTempCwd());
     const aggregatorPrompt = ctx.calls.prompts["aggregator"]?.[0] ?? "";
 
     assert.doesNotMatch(aggregatorPrompt, /Output saved to:/);
@@ -345,7 +346,7 @@ describe("deep-research-codebase", () => {
       },
     );
 
-    await d.run(ctx);
+    await mod.runDeepResearchCodebaseWorkflow(ctx, requireDeepResearchTempCwd());
 
     const analyzerOptions = ctx.calls.taskOptions["analyzer-1"]?.[0];
     const onlineOptions = ctx.calls.taskOptions["online-researcher-1"]?.[0];
@@ -386,20 +387,21 @@ describe("deep-research-codebase", () => {
       },
     );
 
-    const result = await d.run(ctx);
+    const result = await mod.runDeepResearchCodebaseWorkflow(ctx, requireDeepResearchTempCwd());
 
     assert.equal(result["findings"], "final synthesized findings");
     assert.equal(result["research_doc_path"], normalizePathSeparators(join("research", `${new Date().toISOString().slice(0, 10)}-trace-auth-behavior.md`)));
-    assert.equal(readFileSync(result["research_doc_path"] as string, "utf8"), "final synthesized findings");
-    assert.equal(existsSync("context-build"), false);
+    assert.equal(readFileSync(join(requireDeepResearchTempCwd(), result["research_doc_path"] as string), "utf8"), "final synthesized findings");
+    assert.equal(existsSync(join(requireDeepResearchTempCwd(), "context-build")), false);
 
     const artifactDirValue = result["artifact_dir"];
     if (typeof artifactDirValue !== "string") {
       throw new Error("expected artifact_dir to be a string");
     }
     const artifactDir = artifactDirValue;
+    const artifactDirFsPath = join(requireDeepResearchTempCwd(), artifactDir);
     assert.match(normalizePathSeparators(artifactDir), /^research\/\.deep-research-/);
-    assert.equal(existsSync(artifactDir), true);
+    assert.equal(existsSync(artifactDirFsPath), true);
 
     for (const filename of [
       "00-codebase-scout.md",
@@ -413,14 +415,14 @@ describe("deep-research-codebase", () => {
       "explorer-1.md",
       "manifest.json",
     ]) {
-      assert.equal(existsSync(join(artifactDir, filename)), true, `expected ${filename}`);
+      assert.equal(existsSync(join(artifactDirFsPath, filename)), true, `expected ${filename}`);
     }
     for (const path of aggregatorReadPaths) {
       assert.equal(existsSync(path), true, `expected handoff artifact to persist: ${path}`);
       assert.equal(/(^|\/)context-build\//.test(normalizePathSeparators(path)), false);
     }
 
-    const manifest = JSON.parse(readFileSync(join(artifactDir, "manifest.json"), "utf8")) as {
+    const manifest = JSON.parse(readFileSync(join(artifactDirFsPath, "manifest.json"), "utf8")) as {
       runId?: string;
       startedAt?: string;
       completedAt?: string;
@@ -428,7 +430,7 @@ describe("deep-research-codebase", () => {
       finalAsset?: string;
       artifacts?: Record<string, string>;
     };
-    assert.equal(manifest.runId, artifactDir.replace(/^research\/\.deep-research-/, ""));
+    assert.equal(manifest.runId, basename(artifactDir).replace(/^\.deep-research-/, ""));
     assert.equal(typeof manifest.startedAt, "string");
     assert.equal(typeof manifest.completedAt, "string");
     assert.equal(manifest.researchQuestion, "Trace auth behavior");
@@ -451,7 +453,7 @@ describe("deep-research-codebase", () => {
     const mod = await import("../../packages/workflows/builtin/deep-research-codebase.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const date = new Date().toISOString().slice(0, 10);
-    const existingPath = join("research", `${date}-trace-auth-behavior.md`);
+    const existingPath = join(requireDeepResearchTempCwd(), "research", `${date}-trace-auth-behavior.md`);
     mkdirSync(dirname(existingPath), { recursive: true });
     writeFileSync(existingPath, "existing research", "utf8");
     const ctx = makeMockCtx(
@@ -465,13 +467,13 @@ describe("deep-research-codebase", () => {
       },
     );
 
-    const result = await d.run(ctx);
+    const result = await mod.runDeepResearchCodebaseWorkflow(ctx, requireDeepResearchTempCwd());
     const researchDocPath = result["research_doc_path"];
 
     assert.equal(readFileSync(existingPath, "utf8"), "existing research");
     assert.ok(typeof researchDocPath === "string");
     assert.ok(normalizePathSeparators(researchDocPath).endsWith(`${date}-trace-auth-behavior-2.md`));
-    assert.equal(readFileSync(researchDocPath, "utf8"), "final synthesized findings");
+    assert.equal(readFileSync(join(requireDeepResearchTempCwd(), researchDocPath), "utf8"), "final synthesized findings");
   });
 
   test("does not create a top-level context-build directory", async () => {
@@ -488,10 +490,10 @@ describe("deep-research-codebase", () => {
       },
     );
 
-    await d.run(ctx);
+    await mod.runDeepResearchCodebaseWorkflow(ctx, requireDeepResearchTempCwd());
 
-    assert.equal(existsSync("context-build"), false);
-    assert.deepEqual(readdirSync("research").filter((entry) => entry === "context-build"), []);
+    assert.equal(existsSync(join(requireDeepResearchTempCwd(), "context-build")), false);
+    assert.deepEqual(readdirSync(join(requireDeepResearchTempCwd(), "research")).filter((entry) => entry === "context-build"), []);
   });
 });
 
@@ -500,22 +502,6 @@ describe("deep-research-codebase", () => {
 // ---------------------------------------------------------------------------
 
 describe("goal", () => {
-  let previousCwd = process.cwd();
-  let tempCwd: string | undefined;
-
-  beforeEach(() => {
-    previousCwd = process.cwd();
-    tempCwd = mkdtempSync(join(tmpdir(), "atomic-goal-test-"));
-    process.chdir(tempCwd);
-  });
-
-  afterEach(() => {
-    process.chdir(previousCwd);
-    if (tempCwd !== undefined) {
-      rmSync(tempCwd, { recursive: true, force: true });
-      tempCwd = undefined;
-    }
-  });
 
   type ReviewJsonFinding = {
     readonly title: string;
@@ -1267,24 +1253,23 @@ describe("goal", () => {
 // ---------------------------------------------------------------------------
 
 describe("ralph", () => {
-  let previousCwd: string;
   let tempCwd: string | undefined;
 
-  // These cwd-sensitive mock tests run serially in this file; keep future Ralph
-  // tests here from relying on concurrent process.chdir behavior.
   beforeEach(() => {
-    previousCwd = process.cwd();
     tempCwd = mkdtempSync(join(tmpdir(), "atomic-ralph-unit-"));
-    process.chdir(tempCwd);
   });
 
   afterEach(() => {
-    process.chdir(previousCwd);
     if (tempCwd !== undefined) {
       rmSync(tempCwd, { recursive: true, force: true });
       tempCwd = undefined;
     }
   });
+
+  function requireRalphTempCwd(): string {
+    if (tempCwd === undefined) throw new Error("expected Ralph temp cwd");
+    return tempCwd;
+  }
 
   function assertEveryRalphStageCwd(
     ctx: { readonly calls: MockCalls },
@@ -1335,28 +1320,26 @@ describe("ralph", () => {
 
   test("leaves stage cwd unset when git_worktree_dir is not provided", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
       base_branch: "main",
     });
 
-    await d.run(ctx);
+    await mod.runRalphWorkflowFromCwd(ctx, requireRalphTempCwd());
 
     assertEveryRalphStageCwd(ctx, undefined);
   });
 
   test("pull-request stage documents detached HEAD branch handoff without cleanup markers", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
       base_branch: "main",
     });
 
-    await d.run(ctx);
+    await mod.runRalphWorkflowFromCwd(ctx, requireRalphTempCwd());
 
     const prompt = ctx.calls.prompts["pull-request"]?.[0] ?? "";
     assert.match(prompt, /detached HEAD/);

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1349,6 +1349,41 @@ describe("ralph", () => {
     assert.equal(prompt.includes("Worktree cleanup: safe-to-remove"), false);
     assert.equal(prompt.includes("Worktree cleanup: preserve"), false);
   });
+
+  test("revises the original Ralph spec file across planner iterations", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const prompt = "Collision spec";
+    const cwd = requireRalphTempCwd();
+    const specsDir = join(cwd, "specs");
+    const date = new Date().toISOString().slice(0, 10);
+    const expectedSpecPath = join(specsDir, `${date}-collision-spec.md`);
+    mkdirSync(specsDir, { recursive: true });
+    writeFileSync(expectedSpecPath, "pre-existing spec\n", "utf8");
+
+    const ctx = makeMockCtx(
+      {
+        prompt,
+        max_loops: 2,
+        base_branch: "main",
+      },
+      {
+        task: (name) => {
+          if (name === "planner-1") return "first generated spec";
+          if (name === "planner-2") return "second revised spec";
+          return undefined;
+        },
+      },
+    );
+
+    const result = await mod.runRalphWorkflowFromCwd(ctx, cwd);
+
+    assert.equal(result["plan_path"], expectedSpecPath);
+    assert.equal(readFileSync(expectedSpecPath, "utf8"), "second revised spec\n");
+    assert.deepEqual(readPaths(ctx.calls.taskOptions["planner-1"]?.[0]), []);
+    assert.deepEqual(readPaths(ctx.calls.taskOptions["planner-2"]?.[0]), [expectedSpecPath]);
+    assert.match(ctx.calls.prompts["planner-2"]?.[0] ?? "", /full updated RFC markdown that should replace the original spec/);
+    assert.equal(existsSync(join(specsDir, `${date}-collision-spec-2.md`)), false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1329,7 +1329,7 @@ describe("ralph", () => {
     assert.match(description, /inside a Git repo/);
     assert.match(description, /absolute paths are used as-is/);
     assert.match(description, /relative paths resolve from the repo root/);
-    assert.match(description, /existing Git worktrees are reused as-is/);
+    assert.match(description, /existing Git worktrees from the invoking repository are reused as-is/);
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
   });
 

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1330,6 +1330,7 @@ describe("ralph", () => {
     assert.match(description, /absolute paths are used as-is/);
     assert.match(description, /relative paths resolve from the repo root/);
     assert.match(description, /existing Git worktrees are reused as-is/);
+    assert.match(description, /active \.ralph\.lock files prevent concurrent use/);
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
   });
 
@@ -1362,6 +1363,8 @@ describe("ralph", () => {
     assert.match(prompt, /detached HEAD/);
     assert.match(prompt, /git checkout -b <branch>/);
     assert.ok(prompt.includes("git push origin HEAD:refs/heads/<branch>"));
+    assert.match(prompt, /`\.ralph\.lock` file while a git_worktree_dir run is active/);
+    assert.match(prompt, /do not stage, commit, or describe it as a meaningful change/);
     assert.match(prompt, /does not remove git_worktree_dir automatically/);
     assert.equal(prompt.includes("Worktree cleanup: safe-to-remove"), false);
     assert.equal(prompt.includes("Worktree cleanup: preserve"), false);

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1324,7 +1324,7 @@ describe("ralph", () => {
       "",
     );
     const description = mod.default.inputs["git_worktree_dir"]?.description ?? "";
-    assert.match(description, /host repository/);
+    assert.match(description, /inside a Git repository/);
     assert.match(description, /detached-HEAD worktree/);
     assert.match(description, /failed runs preserve it for recovery/);
     assert.match(description, /concurrent runs/);

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1270,6 +1270,8 @@ describe("ralph", () => {
   let previousCwd: string;
   let tempCwd: string | undefined;
 
+  // These cwd-sensitive mock tests run serially in this file; keep future Ralph
+  // tests here from relying on concurrent process.chdir behavior.
   beforeEach(() => {
     previousCwd = process.cwd();
     tempCwd = mkdtempSync(join(tmpdir(), "atomic-ralph-unit-"));

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1324,9 +1324,10 @@ describe("ralph", () => {
       prompt: "Add a small feature",
       max_loops: 1,
       base_branch: "main",
+      git_worktree_dir: "",
     });
 
-    await mod.runRalphWorkflowFromCwd(ctx, requireRalphTempCwd());
+    await mod.default.run({ ...ctx, cwd: requireRalphTempCwd() });
 
     assertEveryRalphStageCwd(ctx, undefined);
   });
@@ -1337,9 +1338,10 @@ describe("ralph", () => {
       prompt: "Add a small feature",
       max_loops: 1,
       base_branch: "main",
+      git_worktree_dir: "",
     });
 
-    await mod.runRalphWorkflowFromCwd(ctx, requireRalphTempCwd());
+    await mod.default.run({ ...ctx, cwd: requireRalphTempCwd() });
 
     const prompt = ctx.calls.prompts["pull-request"]?.[0] ?? "";
     assert.match(prompt, /detached HEAD/);
@@ -1365,6 +1367,7 @@ describe("ralph", () => {
         prompt,
         max_loops: 2,
         base_branch: "main",
+        git_worktree_dir: "",
       },
       {
         task: (name) => {
@@ -1375,7 +1378,7 @@ describe("ralph", () => {
       },
     );
 
-    const result = await mod.runRalphWorkflowFromCwd(ctx, cwd);
+    const result = await mod.default.run({ ...ctx, cwd });
 
     assert.equal(result["plan_path"], expectedSpecPath);
     assert.equal(readFileSync(expectedSpecPath, "utf8"), "second revised spec\n");

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1329,7 +1329,7 @@ describe("ralph", () => {
     assert.match(description, /inside a Git repo/);
     assert.match(description, /absolute paths are used as-is/);
     assert.match(description, /relative paths resolve from the repo root/);
-    assert.match(description, /existing Git worktrees from the invoking repository are reused as-is/);
+    assert.match(description, /existing Git worktrees from the invoking repository are reused\/shared as-is/);
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
   });
 

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1362,6 +1362,8 @@ describe("ralph", () => {
     assert.match(prompt, /detached HEAD/);
     assert.match(prompt, /git checkout -b <branch>/);
     assert.ok(prompt.includes("git push origin HEAD:refs/heads/<branch>"));
+    assert.ok(prompt.includes("Worktree cleanup: safe-to-remove"));
+    assert.ok(prompt.includes("Worktree cleanup: preserve"));
   });
 });
 

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1330,7 +1330,6 @@ describe("ralph", () => {
     assert.match(description, /absolute paths are used as-is/);
     assert.match(description, /relative paths resolve from the repo root/);
     assert.match(description, /existing Git worktrees are reused as-is/);
-    assert.match(description, /active \.ralph\.lock files prevent concurrent use/);
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
   });
 
@@ -1363,8 +1362,6 @@ describe("ralph", () => {
     assert.match(prompt, /detached HEAD/);
     assert.match(prompt, /git checkout -b <branch>/);
     assert.ok(prompt.includes("git push origin HEAD:refs/heads/<branch>"));
-    assert.match(prompt, /`\.ralph\.lock` file while a git_worktree_dir run is active/);
-    assert.match(prompt, /do not stage, commit, or describe it as a meaningful change/);
     assert.match(prompt, /does not remove git_worktree_dir automatically/);
     assert.equal(prompt.includes("Worktree cleanup: safe-to-remove"), false);
     assert.equal(prompt.includes("Worktree cleanup: preserve"), false);

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1268,6 +1268,60 @@ describe("goal", () => {
 // ---------------------------------------------------------------------------
 
 describe("ralph", () => {
+  let previousCwd = process.cwd();
+  let tempRoot: string | undefined;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-test-"));
+    process.chdir(tempRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    if (tempRoot !== undefined) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = undefined;
+    }
+  });
+
+  function requireTempRoot(): string {
+    if (tempRoot === undefined) throw new Error("expected Ralph test temp root");
+    return tempRoot;
+  }
+
+  function initializeGitRepository(name = "repo"): string {
+    const repo = join(requireTempRoot(), name);
+    mkdirSync(repo, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "README.md"), "# test repo\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    return repo;
+  }
+
+  function assertEveryRalphStageCwd(
+    ctx: { readonly calls: MockCalls },
+    expectedCwd: string | undefined,
+  ): void {
+    for (const [taskName, entries] of Object.entries(ctx.calls.taskOptions)) {
+      for (const options of entries) {
+        assert.equal(options.cwd, expectedCwd, `unexpected cwd for ${taskName}`);
+      }
+    }
+    for (const options of ctx.calls.parallelOptions) {
+      assert.equal(options.cwd, expectedCwd, "unexpected cwd for parallel stage");
+    }
+  }
+
+  function assertWorktreeWasRemoved(repo: string, worktreePath: string): void {
+    assert.equal(existsSync(worktreePath), false, "expected Ralph-created worktree checkout to be removed");
+    const worktreeList = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"]).toString();
+    assert.equal(worktreeList.includes(worktreePath), false, "expected git worktree metadata to be removed");
+  }
+
   test("loads and has Ralph workflow shape", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     assertWorkflowDefinition(mod.default);
@@ -1293,98 +1347,172 @@ describe("ralph", () => {
       (mod.default.inputs["git_worktree_dir"] as { default?: string }).default,
       "",
     );
+    assert.match(
+      mod.default.inputs["git_worktree_dir"]?.description ?? "",
+      /host repository/,
+    );
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
+  });
+
+  test("leaves stage cwd unset when git_worktree_dir is not provided", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+    });
+
+    await d.run(ctx);
+
+    assertEveryRalphStageCwd(ctx, undefined);
   });
 
   test("creates a relative git_worktree_dir and runs stages from it", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-worktree-"));
-    const repo = join(tempRoot, "repo");
-    const expectedWorktree = join(tempRoot, "worktrees", "ralph");
-    const previousCwd = process.cwd();
-
-    try {
-      mkdirSync(repo, { recursive: true });
-      execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
-      writeFileSync(join(repo, "README.md"), "# test repo\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
-
-      process.chdir(repo);
-      const ctx = makeMockCtx({
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "worktrees", "ralph");
+    process.chdir(repo);
+    const ctx = makeMockCtx(
+      {
         prompt: "Add a small feature",
         max_loops: 1,
         base_branch: "main",
         git_worktree_dir: join("..", "worktrees", "ralph"),
-      });
+      },
+      {
+        task: (name, options) => {
+          if (name === "planner-1") {
+            assert.equal(options.cwd, expectedWorktree);
+            assert.ok(existsSync(join(expectedWorktree, ".git")), "expected git worktree checkout during stage execution");
+            assert.equal(
+              execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
+              execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
+            );
+          }
+          return undefined;
+        },
+      },
+    );
 
-      const result = await d.run(ctx);
+    const result = await d.run(ctx);
 
-      assert.ok(existsSync(join(expectedWorktree, ".git")), "expected git worktree checkout");
-      assert.equal(
-        execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
-        execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
-      );
-      assert.ok(String(result["plan_path"]).startsWith(expectedWorktree));
-      for (const [taskName, entries] of Object.entries(ctx.calls.taskOptions)) {
-        for (const options of entries) {
-          assert.equal(options.cwd, expectedWorktree, `expected ${taskName} to run in the worktree`);
-        }
-      }
-    } finally {
-      process.chdir(previousCwd);
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
+    assert.equal(String(result["plan_path"]).startsWith(expectedWorktree), false);
+    assertEveryRalphStageCwd(ctx, expectedWorktree);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
+  test("creates an absolute git_worktree_dir and runs stages from it", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "absolute-worktrees", "ralph");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+
+    await d.run(ctx);
+
+    assertEveryRalphStageCwd(ctx, expectedWorktree);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+  });
+
+  test("fails fast when requested git_worktree_dir cannot be created", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const occupiedWorktreePath = join(requireTempRoot(), "occupied-worktree");
+    mkdirSync(occupiedWorktreePath, { recursive: true });
+    writeFileSync(join(occupiedWorktreePath, "README.md"), "already here\n", "utf8");
+    process.chdir(repo);
+    const ctx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: occupiedWorktreePath,
+    });
+
+    await assert.rejects(
+      () => d.run(ctx),
+      /Failed to create git worktree at requested git_worktree_dir/,
+    );
+    assert.deepEqual(ctx.calls.task, []);
+  });
+
+  test("can re-run with the same git_worktree_dir", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const repo = initializeGitRepository();
+    const expectedWorktree = join(requireTempRoot(), "repeat-worktree");
+    process.chdir(repo);
+
+    const firstCtx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+    const secondCtx = makeMockCtx({
+      prompt: "Add a small feature",
+      max_loops: 1,
+      base_branch: "main",
+      git_worktree_dir: expectedWorktree,
+    });
+
+    await d.run(firstCtx);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
+    await d.run(secondCtx);
+
+    assertEveryRalphStageCwd(firstCtx, expectedWorktree);
+    assertEveryRalphStageCwd(secondCtx, expectedWorktree);
+    assertWorktreeWasRemoved(repo, expectedWorktree);
   });
 
   test("falls back to a default worktree path when git_worktree_dir is invalid", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-worktree-fallback-"));
-    const repo = join(tempRoot, "repo");
-    const previousCwd = process.cwd();
-
-    try {
-      mkdirSync(repo, { recursive: true });
-      execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
-      writeFileSync(join(repo, "README.md"), "# test repo\n", "utf8");
-      execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
-      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
-
-      process.chdir(repo);
-      const ctx = makeMockCtx({
+    const repo = initializeGitRepository();
+    process.chdir(repo);
+    let fallbackWorktree: string | undefined;
+    const ctx = makeMockCtx(
+      {
         prompt: "Add a small feature",
         max_loops: 1,
         base_branch: "main",
         git_worktree_dir: "invalid\0path",
-      });
+      },
+      {
+        task: (name, options) => {
+          if (name === "planner-1") {
+            const cwd = options.cwd;
+            if (cwd === undefined) throw new Error("expected planner cwd to use fallback worktree");
+            fallbackWorktree = cwd;
+            assert.ok(existsSync(join(cwd, ".git")), "expected fallback git worktree checkout during stage execution");
+            assert.equal(
+              execFileSync("git", ["-C", cwd, "rev-parse", "HEAD"]).toString().trim(),
+              execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
+            );
+          }
+          return undefined;
+        },
+      },
+    );
 
-      const result = await d.run(ctx);
-      const fallbackWorktree = ctx.calls.taskOptions["planner-1"]?.[0]?.cwd;
-      if (fallbackWorktree === undefined) throw new Error("expected planner cwd to use fallback worktree");
+    const result = await d.run(ctx);
+    if (fallbackWorktree === undefined) throw new Error("expected planner cwd to use fallback worktree");
 
-      assert.ok(isAbsolute(fallbackWorktree));
-      assert.ok(fallbackWorktree.startsWith(join(tmpdir(), "atomic-ralph-worktrees")));
-      assert.ok(existsSync(join(fallbackWorktree, ".git")), "expected fallback git worktree checkout");
-      assert.equal(
-        execFileSync("git", ["-C", fallbackWorktree, "rev-parse", "HEAD"]).toString().trim(),
-        execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
-      );
-      assert.ok(String(result["plan_path"]).startsWith(fallbackWorktree));
-      for (const [taskName, entries] of Object.entries(ctx.calls.taskOptions)) {
-        for (const options of entries) {
-          assert.equal(options.cwd, fallbackWorktree, `expected ${taskName} to run in the fallback worktree`);
-        }
-      }
-    } finally {
-      process.chdir(previousCwd);
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
+    assert.ok(isAbsolute(fallbackWorktree));
+    assert.ok(fallbackWorktree.startsWith(join(tmpdir(), "atomic-ralph-worktrees")));
+    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
+    assert.equal(String(result["plan_path"]).startsWith(fallbackWorktree), false);
+    assertEveryRalphStageCwd(ctx, fallbackWorktree);
+    assertWorktreeWasRemoved(repo, fallbackWorktree);
   });
 });
 

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1327,8 +1327,9 @@ describe("ralph", () => {
     );
     const description = mod.default.inputs["git_worktree_dir"]?.description ?? "";
     assert.match(description, /inside a Git repo/);
-    assert.match(description, /detached worktree/);
-    assert.match(description, /repo-root-relative path/);
+    assert.match(description, /absolute paths are used as-is/);
+    assert.match(description, /relative paths resolve from the repo root/);
+    assert.match(description, /existing Git worktrees are reused as-is/);
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
   });
 
@@ -1346,7 +1347,7 @@ describe("ralph", () => {
     assertEveryRalphStageCwd(ctx, undefined);
   });
 
-  test("pull-request stage documents detached HEAD branch handoff", async () => {
+  test("pull-request stage documents detached HEAD branch handoff without cleanup markers", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
     const ctx = makeMockCtx({
@@ -1361,8 +1362,9 @@ describe("ralph", () => {
     assert.match(prompt, /detached HEAD/);
     assert.match(prompt, /git checkout -b <branch>/);
     assert.ok(prompt.includes("git push origin HEAD:refs/heads/<branch>"));
-    assert.ok(prompt.includes("Worktree cleanup: safe-to-remove"));
-    assert.ok(prompt.includes("Worktree cleanup: preserve"));
+    assert.match(prompt, /does not remove git_worktree_dir automatically/);
+    assert.equal(prompt.includes("Worktree cleanup: safe-to-remove"), false);
+    assert.equal(prompt.includes("Worktree cleanup: preserve"), false);
   });
 });
 

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -1326,10 +1326,9 @@ describe("ralph", () => {
       "",
     );
     const description = mod.default.inputs["git_worktree_dir"]?.description ?? "";
-    assert.match(description, /inside a Git repository/);
-    assert.match(description, /detached-HEAD worktree/);
-    assert.match(description, /failed runs preserve it for recovery/);
-    assert.match(description, /concurrent runs/);
+    assert.match(description, /inside a Git repo/);
+    assert.match(description, /detached worktree/);
+    assert.match(description, /repo-root-relative path/);
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
   });
 

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -6,10 +6,9 @@
 
 import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, join } from "node:path";
 import type {
   WorkflowChainOptions,
   WorkflowDefinition,
@@ -1268,39 +1267,22 @@ describe("goal", () => {
 // ---------------------------------------------------------------------------
 
 describe("ralph", () => {
-  let previousCwd = process.cwd();
-  let tempRoot: string | undefined;
+  let previousCwd: string;
+  let tempCwd: string | undefined;
 
   beforeEach(() => {
     previousCwd = process.cwd();
-    tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-test-"));
-    process.chdir(tempRoot);
+    tempCwd = mkdtempSync(join(tmpdir(), "atomic-ralph-unit-"));
+    process.chdir(tempCwd);
   });
 
   afterEach(() => {
     process.chdir(previousCwd);
-    if (tempRoot !== undefined) {
-      rmSync(tempRoot, { recursive: true, force: true });
-      tempRoot = undefined;
+    if (tempCwd !== undefined) {
+      rmSync(tempCwd, { recursive: true, force: true });
+      tempCwd = undefined;
     }
   });
-
-  function requireTempRoot(): string {
-    if (tempRoot === undefined) throw new Error("expected Ralph test temp root");
-    return tempRoot;
-  }
-
-  function initializeGitRepository(name = "repo"): string {
-    const repo = join(requireTempRoot(), name);
-    mkdirSync(repo, { recursive: true });
-    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
-    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
-    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
-    writeFileSync(join(repo, "README.md"), "# test repo\n", "utf8");
-    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
-    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
-    return repo;
-  }
 
   function assertEveryRalphStageCwd(
     ctx: { readonly calls: MockCalls },
@@ -1314,12 +1296,6 @@ describe("ralph", () => {
     for (const options of ctx.calls.parallelOptions) {
       assert.equal(options.cwd, expectedCwd, "unexpected cwd for parallel stage");
     }
-  }
-
-  function assertWorktreeWasRemoved(repo: string, worktreePath: string): void {
-    assert.equal(existsSync(worktreePath), false, "expected Ralph-created worktree checkout to be removed");
-    const worktreeList = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"]).toString();
-    assert.equal(worktreeList.includes(worktreePath), false, "expected git worktree metadata to be removed");
   }
 
   test("loads and has Ralph workflow shape", async () => {
@@ -1347,10 +1323,11 @@ describe("ralph", () => {
       (mod.default.inputs["git_worktree_dir"] as { default?: string }).default,
       "",
     );
-    assert.match(
-      mod.default.inputs["git_worktree_dir"]?.description ?? "",
-      /host repository/,
-    );
+    const description = mod.default.inputs["git_worktree_dir"]?.description ?? "";
+    assert.match(description, /host repository/);
+    assert.match(description, /detached-HEAD worktree/);
+    assert.match(description, /failed runs preserve it for recovery/);
+    assert.match(description, /concurrent runs/);
     assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
   });
 
@@ -1368,151 +1345,21 @@ describe("ralph", () => {
     assertEveryRalphStageCwd(ctx, undefined);
   });
 
-  test("creates a relative git_worktree_dir and runs stages from it", async () => {
+  test("pull-request stage documents detached HEAD branch handoff", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "worktrees", "ralph");
-    process.chdir(repo);
-    const ctx = makeMockCtx(
-      {
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: join("..", "worktrees", "ralph"),
-      },
-      {
-        task: (name, options) => {
-          if (name === "planner-1") {
-            assert.equal(options.cwd, expectedWorktree);
-            assert.ok(existsSync(join(expectedWorktree, ".git")), "expected git worktree checkout during stage execution");
-            assert.equal(
-              execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
-              execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
-            );
-          }
-          return undefined;
-        },
-      },
-    );
-
-    const result = await d.run(ctx);
-
-    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
-    assert.equal(String(result["plan_path"]).startsWith(expectedWorktree), false);
-    assertEveryRalphStageCwd(ctx, expectedWorktree);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
-  });
-
-  test("creates an absolute git_worktree_dir and runs stages from it", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "absolute-worktrees", "ralph");
-    process.chdir(repo);
     const ctx = makeMockCtx({
       prompt: "Add a small feature",
       max_loops: 1,
       base_branch: "main",
-      git_worktree_dir: expectedWorktree,
     });
 
     await d.run(ctx);
 
-    assertEveryRalphStageCwd(ctx, expectedWorktree);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
-  });
-
-  test("fails fast when requested git_worktree_dir cannot be created", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const occupiedWorktreePath = join(requireTempRoot(), "occupied-worktree");
-    mkdirSync(occupiedWorktreePath, { recursive: true });
-    writeFileSync(join(occupiedWorktreePath, "README.md"), "already here\n", "utf8");
-    process.chdir(repo);
-    const ctx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: occupiedWorktreePath,
-    });
-
-    await assert.rejects(
-      () => d.run(ctx),
-      /Failed to create git worktree at requested git_worktree_dir/,
-    );
-    assert.deepEqual(ctx.calls.task, []);
-  });
-
-  test("can re-run with the same git_worktree_dir", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    const expectedWorktree = join(requireTempRoot(), "repeat-worktree");
-    process.chdir(repo);
-
-    const firstCtx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: expectedWorktree,
-    });
-    const secondCtx = makeMockCtx({
-      prompt: "Add a small feature",
-      max_loops: 1,
-      base_branch: "main",
-      git_worktree_dir: expectedWorktree,
-    });
-
-    await d.run(firstCtx);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
-    await d.run(secondCtx);
-
-    assertEveryRalphStageCwd(firstCtx, expectedWorktree);
-    assertEveryRalphStageCwd(secondCtx, expectedWorktree);
-    assertWorktreeWasRemoved(repo, expectedWorktree);
-  });
-
-  test("falls back to a default worktree path when git_worktree_dir is invalid", async () => {
-    const mod = await import("../../packages/workflows/builtin/ralph.js");
-    const d = mod.default as unknown as WorkflowDefinition;
-    const repo = initializeGitRepository();
-    process.chdir(repo);
-    let fallbackWorktree: string | undefined;
-    const ctx = makeMockCtx(
-      {
-        prompt: "Add a small feature",
-        max_loops: 1,
-        base_branch: "main",
-        git_worktree_dir: "invalid\0path",
-      },
-      {
-        task: (name, options) => {
-          if (name === "planner-1") {
-            const cwd = options.cwd;
-            if (cwd === undefined) throw new Error("expected planner cwd to use fallback worktree");
-            fallbackWorktree = cwd;
-            assert.ok(existsSync(join(cwd, ".git")), "expected fallback git worktree checkout during stage execution");
-            assert.equal(
-              execFileSync("git", ["-C", cwd, "rev-parse", "HEAD"]).toString().trim(),
-              execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
-            );
-          }
-          return undefined;
-        },
-      },
-    );
-
-    const result = await d.run(ctx);
-    if (fallbackWorktree === undefined) throw new Error("expected planner cwd to use fallback worktree");
-
-    assert.ok(isAbsolute(fallbackWorktree));
-    assert.ok(fallbackWorktree.startsWith(join(tmpdir(), "atomic-ralph-worktrees")));
-    assert.ok(String(result["plan_path"]).startsWith(join(repo, "specs")));
-    assert.equal(String(result["plan_path"]).startsWith(fallbackWorktree), false);
-    assertEveryRalphStageCwd(ctx, fallbackWorktree);
-    assertWorktreeWasRemoved(repo, fallbackWorktree);
+    const prompt = ctx.calls.prompts["pull-request"]?.[0] ?? "";
+    assert.match(prompt, /detached HEAD/);
+    assert.match(prompt, /git checkout -b <branch>/);
+    assert.ok(prompt.includes("git push origin HEAD:refs/heads/<branch>"));
   });
 });
 

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
@@ -1273,7 +1274,7 @@ describe("ralph", () => {
     assert.equal(mod.default.name, "ralph");
   });
 
-  test("declares prompt, max_loops, and base_branch inputs", async () => {
+  test("declares prompt, max_loops, base_branch, and git_worktree_dir inputs", async () => {
     const mod = await import("../../packages/workflows/builtin/ralph.js");
     assert.equal(mod.default.inputs["prompt"]?.type, "text");
     assert.equal(mod.default.inputs["prompt"]?.required, true);
@@ -1287,7 +1288,103 @@ describe("ralph", () => {
       (mod.default.inputs["base_branch"] as { default?: string }).default,
       "origin/main",
     );
-    assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "max_loops", "prompt"]);
+    assert.equal(mod.default.inputs["git_worktree_dir"]?.type, "string");
+    assert.equal(
+      (mod.default.inputs["git_worktree_dir"] as { default?: string }).default,
+      "",
+    );
+    assert.deepEqual(Object.keys(mod.default.inputs).sort(), ["base_branch", "git_worktree_dir", "max_loops", "prompt"]);
+  });
+
+  test("creates a relative git_worktree_dir and runs stages from it", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-worktree-"));
+    const repo = join(tempRoot, "repo");
+    const expectedWorktree = join(tempRoot, "worktrees", "ralph");
+    const previousCwd = process.cwd();
+
+    try {
+      mkdirSync(repo, { recursive: true });
+      execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+      writeFileSync(join(repo, "README.md"), "# test repo\n", "utf8");
+      execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+
+      process.chdir(repo);
+      const ctx = makeMockCtx({
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: join("..", "worktrees", "ralph"),
+      });
+
+      const result = await d.run(ctx);
+
+      assert.ok(existsSync(join(expectedWorktree, ".git")), "expected git worktree checkout");
+      assert.equal(
+        execFileSync("git", ["-C", expectedWorktree, "rev-parse", "HEAD"]).toString().trim(),
+        execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
+      );
+      assert.ok(String(result["plan_path"]).startsWith(expectedWorktree));
+      for (const [taskName, entries] of Object.entries(ctx.calls.taskOptions)) {
+        for (const options of entries) {
+          assert.equal(options.cwd, expectedWorktree, `expected ${taskName} to run in the worktree`);
+        }
+      }
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to a default worktree path when git_worktree_dir is invalid", async () => {
+    const mod = await import("../../packages/workflows/builtin/ralph.js");
+    const d = mod.default as unknown as WorkflowDefinition;
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-worktree-fallback-"));
+    const repo = join(tempRoot, "repo");
+    const previousCwd = process.cwd();
+
+    try {
+      mkdirSync(repo, { recursive: true });
+      execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+      writeFileSync(join(repo, "README.md"), "# test repo\n", "utf8");
+      execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+
+      process.chdir(repo);
+      const ctx = makeMockCtx({
+        prompt: "Add a small feature",
+        max_loops: 1,
+        base_branch: "main",
+        git_worktree_dir: "invalid\0path",
+      });
+
+      const result = await d.run(ctx);
+      const fallbackWorktree = ctx.calls.taskOptions["planner-1"]?.[0]?.cwd;
+      if (fallbackWorktree === undefined) throw new Error("expected planner cwd to use fallback worktree");
+
+      assert.ok(isAbsolute(fallbackWorktree));
+      assert.ok(fallbackWorktree.startsWith(join(tmpdir(), "atomic-ralph-worktrees")));
+      assert.ok(existsSync(join(fallbackWorktree, ".git")), "expected fallback git worktree checkout");
+      assert.equal(
+        execFileSync("git", ["-C", fallbackWorktree, "rev-parse", "HEAD"]).toString().trim(),
+        execFileSync("git", ["-C", repo, "rev-parse", "main"]).toString().trim(),
+      );
+      assert.ok(String(result["plan_path"]).startsWith(fallbackWorktree));
+      for (const [taskName, entries] of Object.entries(ctx.calls.taskOptions)) {
+        for (const options of entries) {
+          assert.equal(options.cwd, fallbackWorktree, `expected ${taskName} to run in the fallback worktree`);
+        }
+      }
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/unit/define-workflow.test.ts
+++ b/test/unit/define-workflow.test.ts
@@ -50,4 +50,18 @@ describe("defineWorkflow builder", () => {
     assert.deepEqual(Object.keys(def.inputs), ["a", "b"]);
     assert.deepEqual(def.inputs["b"], { type: "number", default: 4 });
   });
+
+  test("worktreeFromInputs stores workflow input bindings", () => {
+    const def = defineWorkflow("worktree-inputs")
+      .input("git_worktree_dir", { type: "string", default: "" })
+      .input("base_branch", { type: "string", default: "main" })
+      .worktreeFromInputs({ gitWorktreeDir: "git_worktree_dir", baseBranch: "base_branch" })
+      .run(async () => ({}))
+      .compile();
+
+    assert.deepEqual(def.inputBindings?.worktree, {
+      gitWorktreeDir: "git_worktree_dir",
+      baseBranch: "base_branch",
+    });
+  });
 });

--- a/test/unit/depth-enforcement.test.ts
+++ b/test/unit/depth-enforcement.test.ts
@@ -24,9 +24,14 @@ import type { WorkflowDefinition } from "../../packages/workflows/src/shared/typ
 
 function makeWf(name = "depth-test-wf"): WorkflowDefinition {
   return defineWorkflow(name)
-    .run(async (_ctx) => ({ ok: true }))
+    .run(async (ctx) => {
+      await ctx.task("depth-check", { prompt: "depth check" });
+      return { ok: true };
+    })
     .compile() as WorkflowDefinition;
 }
+
+const promptAdapter = { prompt: async () => "ok" };
 
 const configMaxDepth2: WorkflowRuntimeConfig = {
   maxDepth: 2,
@@ -69,6 +74,7 @@ describe("maxDepth enforcement — executor.run", () => {
   test("depth < maxDepth executes normally", async () => {
     const wf = makeWf("shallow-wf");
     const result = await run(wf, {}, {
+      adapters: { prompt: promptAdapter },
       store: createStore(),
       config: configMaxDepth2,
       depth: 1, // one below maxDepth → should run
@@ -81,6 +87,7 @@ describe("maxDepth enforcement — executor.run", () => {
   test("depth 0 (default) executes normally with maxDepth 2", async () => {
     const wf = makeWf("top-level-wf");
     const result = await run(wf, {}, {
+      adapters: { prompt: promptAdapter },
       store: createStore(),
       config: configMaxDepth2,
       // depth omitted → defaults to 0
@@ -131,7 +138,7 @@ describe("maxDepth enforcement — executor.run", () => {
     const wf = makeWf("md1-wf");
     const config: WorkflowRuntimeConfig = { ...configMaxDepth2, maxDepth: 1 };
 
-    const depthZero = await run(wf, {}, { store: createStore(), config, depth: 0 });
+    const depthZero = await run(wf, {}, { adapters: { prompt: promptAdapter }, store: createStore(), config, depth: 0 });
     assert.equal(depthZero.status, "completed");
 
     const depthOne = await run(wf, {}, { store: createStore(), config, depth: 1 });
@@ -143,7 +150,7 @@ describe("maxDepth enforcement — executor.run", () => {
     const config: WorkflowRuntimeConfig = { ...configMaxDepth2, maxDepth: 4 };
     const wf = makeWf("md4-wf");
 
-    const atBoundary = await run(wf, {}, { store: createStore(), config, depth: 3 });
+    const atBoundary = await run(wf, {}, { adapters: { prompt: promptAdapter }, store: createStore(), config, depth: 3 });
     assert.equal(atBoundary.status, "completed");
 
     const exceeded = await run(wf, {}, { store: createStore(), config, depth: 4 });

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -13,7 +13,7 @@
 
 import { afterAll, describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -694,21 +694,47 @@ describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
     assert.equal(registry.names().length, 0);
   });
 
-  test("workflow that completes without creating stages emits INVALID_DEFINITION", async () => {
-    const cwd = makeTempDir("invalid-no-stages");
+  test("workflow that completes without creating stages registers structurally", async () => {
+    const cwd = makeTempDir("structural-no-stages");
     const wfDir = join(cwd, ".atomic", "workflows");
     mkdirSync(wfDir, { recursive: true });
     writeNoStageWorkflowJs(wfDir, "no-stage.js");
 
-    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-invalid-no-stages"), includeBundled: false });
+    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-structural-no-stages"), includeBundled: false });
 
-    assert.equal(registry.has("no-stage-workflow"), false);
-    const inv = errors.filter((e) => e.code === "INVALID_DEFINITION");
-    assert.equal(inv.length, 1);
-    assert.match(inv[0]!.message, /run must create at least one workflow stage/);
+    assert.equal(registry.has("no-stage-workflow"), true);
+    assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
   });
 
-  test("workflow that reaches a stage through an aliased primitive registers", async () => {
+  test("discovery does not invoke workflow run bodies", async () => {
+    const cwd = makeTempDir("no-run-body-side-effects");
+    const wfDir = join(cwd, ".atomic", "workflows");
+    mkdirSync(wfDir, { recursive: true });
+    const sideEffectPath = join(cwd, "side-effect.txt");
+    writeFileSync(
+      join(wfDir, "side-effect.js"),
+      [
+        `import { writeFileSync } from "node:fs";`,
+        `export default {`,
+        `  __piWorkflow: true,`,
+        `  name: "Side Effect Workflow",`,
+        `  normalizedName: "side-effect-workflow",`,
+        `  description: "Would write during run if discovery invoked it",`,
+        `  inputs: {},`,
+        `  run: async () => { writeFileSync(${JSON.stringify(sideEffectPath)}, "ran"); return {}; },`,
+        `};`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-no-run-body-side-effects"), includeBundled: false });
+
+    assert.equal(registry.has("side-effect-workflow"), true);
+    assert.equal(errors.length, 0);
+    assert.equal(existsSync(sideEffectPath), false);
+  });
+
+  test("workflow that reaches a stage through an aliased primitive registers structurally", async () => {
     const cwd = makeTempDir("valid-aliased-stage-primitive");
     const wfDir = join(cwd, ".atomic", "workflows");
     mkdirSync(wfDir, { recursive: true });
@@ -731,65 +757,6 @@ describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
 
     assert.equal(registry.has("aliased-stage-workflow"), true);
     assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
-  });
-
-  test("workflow that throws during the startup probe registers with a warning", async () => {
-    const cwd = makeTempDir("valid-probe-warning");
-    const wfDir = join(cwd, ".atomic", "workflows");
-    mkdirSync(wfDir, { recursive: true });
-    writeFileSync(
-      join(wfDir, "throws-before-stage.js"),
-      [
-        `export default {`,
-        `  __piWorkflow: true,`,
-        `  name: "Throws Before Stage",`,
-        `  normalizedName: "throws-before-stage",`,
-        `  description: "Throws before creating a stage",`,
-        `  inputs: {},`,
-        `  run: async () => { throw new Error("probe boom"); },`,
-        `};`,
-      ].join("\n"),
-      "utf-8",
-    );
-
-    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-probe-warning"), includeBundled: false });
-
-    assert.equal(registry.has("throws-before-stage"), true);
-    assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
-    const warnings = errors.filter((e) => e.code === "VALIDATION_PROBE_FAILED");
-    assert.equal(warnings.length, 1);
-    assert.equal(warnings[0]!.level, "warn");
-    assert.match(warnings[0]!.message, /probe boom/);
-  });
-
-  test("required text inputs use non-empty probe values before stage validation", async () => {
-    const cwd = makeTempDir("valid-required-text-probe");
-    const wfDir = join(cwd, ".atomic", "workflows");
-    mkdirSync(wfDir, { recursive: true });
-    writeFileSync(
-      join(wfDir, "required-text.js"),
-      [
-        `export default {`,
-        `  __piWorkflow: true,`,
-        `  name: "Required Text Probe",`,
-        `  normalizedName: "required-text-probe",`,
-        `  description: "Validates text input before creating a stage",`,
-        `  inputs: { prompt: { type: "text", required: true } },`,
-        `  run: async (ctx) => {`,
-        `    if (!String(ctx.inputs.prompt ?? "").trim()) throw new Error("prompt is required");`,
-        `    await ctx.task("validation-smoke", { prompt: String(ctx.inputs.prompt) });`,
-        `    return {};`,
-        `  },`,
-        `};`,
-      ].join("\n"),
-      "utf-8",
-    );
-
-    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-required-text-probe"), includeBundled: false });
-
-    assert.equal(registry.has("required-text-probe"), true);
-    assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
-    assert.equal(errors.filter((e) => e.code === "VALIDATION_PROBE_FAILED").length, 0);
   });
 
   test("PATH_NOT_FOUND for configured path that does not exist", async () => {

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -762,6 +762,36 @@ describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
     assert.match(warnings[0]!.message, /probe boom/);
   });
 
+  test("required text inputs use non-empty probe values before stage validation", async () => {
+    const cwd = makeTempDir("valid-required-text-probe");
+    const wfDir = join(cwd, ".atomic", "workflows");
+    mkdirSync(wfDir, { recursive: true });
+    writeFileSync(
+      join(wfDir, "required-text.js"),
+      [
+        `export default {`,
+        `  __piWorkflow: true,`,
+        `  name: "Required Text Probe",`,
+        `  normalizedName: "required-text-probe",`,
+        `  description: "Validates text input before creating a stage",`,
+        `  inputs: { prompt: { type: "text", required: true } },`,
+        `  run: async (ctx) => {`,
+        `    if (!String(ctx.inputs.prompt ?? "").trim()) throw new Error("prompt is required");`,
+        `    await ctx.task("validation-smoke", { prompt: String(ctx.inputs.prompt) });`,
+        `    return {};`,
+        `  },`,
+        `};`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-required-text-probe"), includeBundled: false });
+
+    assert.equal(registry.has("required-text-probe"), true);
+    assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
+    assert.equal(errors.filter((e) => e.code === "VALIDATION_PROBE_FAILED").length, 0);
+  });
+
   test("PATH_NOT_FOUND for configured path that does not exist", async () => {
     const cwd = makeTempDir("path-not-found");
     const missingPath = join(makeTempDir("ghost-dir"), "ghost.js");

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -320,7 +320,7 @@ function writeNoStageWorkflowJs(dir: string, filename: string): string {
       `  __piWorkflow: true,`,
       `  name: "No Stage Workflow",`,
       `  normalizedName: "no-stage-workflow",`,
-      `  description: "Discovery accepts this structurally; runtime validates stage creation",`,
+      `  description: "Discovery rejects this because it creates no stages",`,
       `  inputs: {},`,
       `  run: async () => ({ ok: true }),`,
       `};`,
@@ -694,17 +694,43 @@ describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
     assert.equal(registry.names().length, 0);
   });
 
-  test("workflow with no source-visible stage primitive is registered by structural discovery", async () => {
-    const cwd = makeTempDir("valid-no-source-visible-stages");
+  test("workflow that completes without creating stages emits INVALID_DEFINITION", async () => {
+    const cwd = makeTempDir("invalid-no-stages");
     const wfDir = join(cwd, ".atomic", "workflows");
     mkdirSync(wfDir, { recursive: true });
     writeNoStageWorkflowJs(wfDir, "no-stage.js");
 
-    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-no-source-visible-stages"), includeBundled: false });
+    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-invalid-no-stages"), includeBundled: false });
 
-    assert.equal(registry.has("no-stage-workflow"), true);
+    assert.equal(registry.has("no-stage-workflow"), false);
     const inv = errors.filter((e) => e.code === "INVALID_DEFINITION");
-    assert.equal(inv.length, 0);
+    assert.equal(inv.length, 1);
+    assert.match(inv[0]!.message, /run must create at least one workflow stage/);
+  });
+
+  test("workflow that reaches a stage through an aliased primitive registers", async () => {
+    const cwd = makeTempDir("valid-aliased-stage-primitive");
+    const wfDir = join(cwd, ".atomic", "workflows");
+    mkdirSync(wfDir, { recursive: true });
+    writeFileSync(
+      join(wfDir, "aliased.js"),
+      [
+        `export default {`,
+        `  __piWorkflow: true,`,
+        `  name: "Aliased Stage Workflow",`,
+        `  normalizedName: "aliased-stage-workflow",`,
+        `  description: "Uses an aliased task primitive",`,
+        `  inputs: {},`,
+        `  run: async (ctx) => { const { task } = ctx; await task("validation-smoke", { prompt: "validation smoke" }); return {}; },`,
+        `};`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-aliased-stage-primitive"), includeBundled: false });
+
+    assert.equal(registry.has("aliased-stage-workflow"), true);
+    assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
   });
 
   test("PATH_NOT_FOUND for configured path that does not exist", async () => {

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -721,7 +721,7 @@ describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
         `  normalizedName: "side-effect-workflow",`,
         `  description: "Would write during run if discovery invoked it",`,
         `  inputs: {},`,
-        `  run: async () => { writeFileSync(${JSON.stringify(sideEffectPath)}, "ran"); return {}; },`,
+        `  run: async () => { writeFileSync(new URL("../../side-effect.txt", import.meta.url), "ran"); return {}; },`,
         `};`,
       ].join("\n"),
       "utf-8",

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -320,7 +320,7 @@ function writeNoStageWorkflowJs(dir: string, filename: string): string {
       `  __piWorkflow: true,`,
       `  name: "No Stage Workflow",`,
       `  normalizedName: "no-stage-workflow",`,
-      `  description: "Should be rejected because it has no workflow stages",`,
+      `  description: "Discovery accepts this structurally; runtime validates stage creation",`,
       `  inputs: {},`,
       `  run: async () => ({ ok: true }),`,
       `};`,
@@ -694,19 +694,17 @@ describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
     assert.equal(registry.names().length, 0);
   });
 
-  test("workflow with no stage-producing primitive is rejected and not registered", async () => {
-    const cwd = makeTempDir("invalid-no-stages");
+  test("workflow with no source-visible stage primitive is registered by structural discovery", async () => {
+    const cwd = makeTempDir("valid-no-source-visible-stages");
     const wfDir = join(cwd, ".atomic", "workflows");
     mkdirSync(wfDir, { recursive: true });
-    const fp = writeNoStageWorkflowJs(wfDir, "no-stage.js");
+    writeNoStageWorkflowJs(wfDir, "no-stage.js");
 
-    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-no-stages"), includeBundled: false });
+    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-no-source-visible-stages"), includeBundled: false });
 
-    assert.equal(registry.has("no-stage-workflow"), false);
+    assert.equal(registry.has("no-stage-workflow"), true);
     const inv = errors.filter((e) => e.code === "INVALID_DEFINITION");
-    assert.equal(inv.length, 1);
-    assert.equal(inv[0]!.source, fp);
-    assert.match(inv[0]!.message, /must create at least one workflow stage/i);
+    assert.equal(inv.length, 0);
   });
 
   test("PATH_NOT_FOUND for configured path that does not exist", async () => {

--- a/test/unit/discovery.test.ts
+++ b/test/unit/discovery.test.ts
@@ -733,6 +733,35 @@ describe("discoverWorkflows — INVALID_DEFINITION diagnostics", () => {
     assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
   });
 
+  test("workflow that throws during the startup probe registers with a warning", async () => {
+    const cwd = makeTempDir("valid-probe-warning");
+    const wfDir = join(cwd, ".atomic", "workflows");
+    mkdirSync(wfDir, { recursive: true });
+    writeFileSync(
+      join(wfDir, "throws-before-stage.js"),
+      [
+        `export default {`,
+        `  __piWorkflow: true,`,
+        `  name: "Throws Before Stage",`,
+        `  normalizedName: "throws-before-stage",`,
+        `  description: "Throws before creating a stage",`,
+        `  inputs: {},`,
+        `  run: async () => { throw new Error("probe boom"); },`,
+        `};`,
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { registry, errors } = await discoverWorkflows({ cwd, homeDir: makeTempDir("empty-probe-warning"), includeBundled: false });
+
+    assert.equal(registry.has("throws-before-stage"), true);
+    assert.equal(errors.filter((e) => e.code === "INVALID_DEFINITION").length, 0);
+    const warnings = errors.filter((e) => e.code === "VALIDATION_PROBE_FAILED");
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0]!.level, "warn");
+    assert.match(warnings[0]!.message, /probe boom/);
+  });
+
   test("PATH_NOT_FOUND for configured path that does not exist", async () => {
     const cwd = makeTempDir("path-not-found");
     const missingPath = join(makeTempDir("ghost-dir"), "ghost.js");

--- a/test/unit/executor-phase-c.test.ts
+++ b/test/unit/executor-phase-c.test.ts
@@ -216,6 +216,7 @@ describe("executor input resolution — Phase C", () => {
     const def = defineWorkflow("phaseC-defaults")
       .input("greeting", { type: "text", default: "hi" })
       .run(async (ctx) => {
+        await ctx.stage("read-default").prompt("x");
         return { greeting: ctx.inputs["greeting"] };
       })
       .compile() as WorkflowDefinition;
@@ -228,7 +229,10 @@ describe("executor input resolution — Phase C", () => {
   test("caller-provided value takes precedence over default", async () => {
     const def = defineWorkflow("phaseC-override")
       .input("name", { type: "text", default: "default-name" })
-      .run(async (ctx) => ({ name: ctx.inputs["name"] }))
+      .run(async (ctx) => {
+        await ctx.stage("read-override").prompt("x");
+        return { name: ctx.inputs["name"] };
+      })
       .compile() as WorkflowDefinition;
 
     const result = await run(def, { name: "custom" }, {

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -117,6 +117,18 @@ describe("executor.run", () => {
     assert.equal(wfResult.stages[0]?.status, "completed");
   });
 
+  test("fails completed workflows that create no stages", async () => {
+    const def = defineWorkflow("empty-graph-wf")
+      .run(async () => ({ ok: true }))
+      .compile();
+
+    const wfResult = await run(def, {}, { store: createStore() });
+
+    assert.equal(wfResult.status, "failed");
+    assert.equal(wfResult.stages.length, 0);
+    assert.match(wfResult.error ?? "", /completed without creating any workflow stages/);
+  });
+
   test("ctx.task creates a tracked stage and returns reusable previous output", async () => {
     const seenPrompts: string[] = [];
     const def = defineWorkflow("task-wf")
@@ -711,10 +723,14 @@ describe("executor.run", () => {
     try {
       const st = createStore();
       const def = defineWorkflow("prompt-node-ui-precedence-wf")
-        .run(async () => ({}))
+        .run(async (ctx) => {
+          await ctx.task("warning-smoke", { prompt: "go" });
+          return {};
+        })
         .compile();
 
       const result = await run(def, {}, {
+        adapters: { prompt: { prompt: async () => "ok" } },
         store: st,
         usePromptNodesForUi: true,
         ui: {
@@ -2106,11 +2122,16 @@ describe("executor.run — HIL adapter injection", () => {
     const def = defineWorkflow("hil-input-wf")
       .run(async (ctx) => {
         const value = await ctx.ui.input("What is your name?");
+        await ctx.task("after-input", { prompt: "record input" });
         return { value };
       })
       .compile();
 
-    const wfResult = await run(def, {}, { ui: uiAdapter, store: createStore() });
+    const wfResult = await run(def, {}, {
+      adapters: { prompt: { prompt: async () => "ok" } },
+      ui: uiAdapter,
+      store: createStore(),
+    });
 
     assert.equal(wfResult.status, "completed");
     assert.equal(wfResult.result?.["value"], "user-input");
@@ -2128,11 +2149,16 @@ describe("executor.run — HIL adapter injection", () => {
     const def = defineWorkflow("hil-confirm-wf")
       .run(async (ctx) => {
         const ok = await ctx.ui.confirm("Continue?");
+        await ctx.task("after-confirm", { prompt: "record confirm" });
         return { ok };
       })
       .compile();
 
-    const wfResult = await run(def, {}, { ui: uiAdapter, store: createStore() });
+    const wfResult = await run(def, {}, {
+      adapters: { prompt: { prompt: async () => "ok" } },
+      ui: uiAdapter,
+      store: createStore(),
+    });
 
     assert.equal(wfResult.status, "completed");
     assert.equal(wfResult.result?.["ok"], true);
@@ -2149,11 +2175,16 @@ describe("executor.run — HIL adapter injection", () => {
     const def = defineWorkflow("hil-select-wf")
       .run(async (ctx) => {
         const choice = await ctx.ui.select("Pick one", ["a", "b", "c"] as const);
+        await ctx.task("after-select", { prompt: "record select" });
         return { choice };
       })
       .compile();
 
-    const wfResult = await run(def, {}, { ui: uiAdapter, store: createStore() });
+    const wfResult = await run(def, {}, {
+      adapters: { prompt: { prompt: async () => "ok" } },
+      ui: uiAdapter,
+      store: createStore(),
+    });
 
     assert.equal(wfResult.status, "completed");
     assert.equal(wfResult.result?.["choice"], "b");
@@ -2170,11 +2201,16 @@ describe("executor.run — HIL adapter injection", () => {
     const def = defineWorkflow("hil-editor-wf")
       .run(async (ctx) => {
         const content = await ctx.ui.editor("draft");
+        await ctx.task("after-editor", { prompt: "record editor" });
         return { content };
       })
       .compile();
 
-    const wfResult = await run(def, {}, { ui: uiAdapter, store: createStore() });
+    const wfResult = await run(def, {}, {
+      adapters: { prompt: { prompt: async () => "ok" } },
+      ui: uiAdapter,
+      store: createStore(),
+    });
 
     assert.equal(wfResult.status, "completed");
     assert.equal(wfResult.result?.["content"], "edited: draft");
@@ -2302,10 +2338,14 @@ describe("executor.run — lifecycle persistence", () => {
     const { persistence, calls } = makePersistence();
 
     const def = defineWorkflow("payload-wf")
-      .run(async (_ctx) => ({}))
+      .run(async (ctx) => {
+        await ctx.task("payload-smoke", { prompt: "go" });
+        return {};
+      })
       .compile();
 
     const wfResult = await run(def, { x: 1 }, {
+      adapters: { prompt: { prompt: async () => "ok" } },
       store: createStore(),
       persistence,
     });
@@ -2365,14 +2405,41 @@ describe("executor.run — lifecycle persistence", () => {
     const { persistence, calls } = makePersistence();
 
     const def = defineWorkflow("run-end-wf")
-      .run(async (_ctx) => ({ x: 1 }))
+      .run(async (ctx) => {
+        await ctx.task("run-end-smoke", { prompt: "go" });
+        return { x: 1 };
+      })
       .compile();
 
-    await run(def, {}, { store: createStore(), persistence });
+    await run(def, {}, {
+      adapters: { prompt: { prompt: async () => "ok" } },
+      store: createStore(),
+      persistence,
+    });
 
     const runEnd = calls.find((c) => c.type === "workflow.run.end");
     assert.equal(runEnd?.payload["status"], "completed");
     assert.equal(typeof runEnd?.payload["ts"], "number");
+  });
+
+  test("empty graph validation appends failed run.end without stage entries", async () => {
+    const { persistence, calls } = makePersistence();
+
+    const def = defineWorkflow("empty-persist-wf")
+      .run(async () => ({ ok: true }))
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      store: createStore(),
+      persistence,
+    });
+
+    assert.equal(wfResult.status, "failed");
+    assert.match(wfResult.error ?? "", /completed without creating any workflow stages/);
+    assert.deepEqual(calls.map((c) => c.type), ["workflow.run.start", "workflow.run.end"]);
+    const runEnd = calls.find((c) => c.type === "workflow.run.end");
+    assert.equal(runEnd?.payload["status"], "failed");
+    assert.match(String(runEnd?.payload["error"] ?? ""), /completed without creating any workflow stages/);
   });
 
   test("failed stage: stage.end status=failed, run.end status=failed", async () => {
@@ -2502,10 +2569,14 @@ describe("executor.run — lifecycle persistence", () => {
     };
 
     const def = defineWorkflow("guard-wf")
-      .run(async (_ctx) => ({}))
+      .run(async (ctx) => {
+        await ctx.task("guard-smoke", { prompt: "go" });
+        return {};
+      })
       .compile();
 
     await run(def, {}, {
+      adapters: { prompt: { prompt: async () => "ok" } },
       store: guardedStore as import("../../packages/workflows/src/shared/store.js").Store,
       persistence,
     });

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -1,6 +1,7 @@
-import { describe, test } from "bun:test";
+import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { run, runChain, runParallel, runTask, resolveInputs } from "../../packages/workflows/src/runs/foreground/executor.js";
@@ -41,6 +42,25 @@ function callThroughStack<T>(depth: number, fn: () => Promise<T>): Promise<T> {
   if (depth <= 0) return fn();
   return callThroughStack(depth - 1, fn);
 }
+
+let savedGitEnv: Map<string, string | undefined> | undefined;
+
+beforeEach(() => {
+  savedGitEnv = new Map<string, string | undefined>();
+  for (const key of Object.keys(process.env).filter((candidate) => candidate.startsWith("GIT_"))) {
+    savedGitEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  if (savedGitEnv === undefined) return;
+  for (const [key, value] of savedGitEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  savedGitEnv = undefined;
+});
 
 // ---------------------------------------------------------------------------
 // resolveInputs
@@ -249,6 +269,290 @@ describe("executor.run", () => {
     assert.equal(wfResult.status, "completed");
     assert.deepEqual(seenPrompts.sort(), ["audit UI", "audit UI"]);
     assert.equal(wfResult.result?.["count"], 2);
+  });
+
+  test("ctx.stage defaults cwd to gitWorktreeDir while preserving the workflow relative cwd", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const repo = join(tempRoot, "repo");
+    mkdirSync(repo, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    mkdirSync(join(repo, "nested"), { recursive: true });
+    writeFileSync(join(repo, "nested", "fixture.txt"), "fixture\n", "utf8");
+    execFileSync("git", ["add", "nested/fixture.txt"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const workflowCwd = join(repo, "nested");
+    const worktreeRoot = join(repo, "worktrees", "sdk");
+    const expectedStageCwd = join(worktreeRoot, "nested");
+    const calls: CreateAgentSessionOptions[] = [];
+    const def = defineWorkflow("stage-git-worktree-wf")
+      .run(async (ctx) => {
+        await ctx.stage("worker", {
+          gitWorktreeDir: join("worktrees", "sdk"),
+          baseBranch: "main",
+        }).prompt("inspect");
+        return { ok: true };
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      cwd: workflowCwd,
+      adapters: {
+        agentSession: {
+          async create(options) {
+            calls.push(options);
+            return mockSession();
+          },
+        },
+      },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.equal(calls[0]?.cwd, expectedStageCwd);
+    assert.equal(existsSync(join(worktreeRoot, ".git")), true);
+  });
+
+  test("ctx.stage preserves explicit absolute cwd when gitWorktreeDir is set", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const repo = join(tempRoot, "repo");
+    mkdirSync(repo, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "README.md"), "# repo\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const explicitCwd = join(tempRoot, "explicit-cwd");
+    mkdirSync(explicitCwd, { recursive: true });
+    const calls: CreateAgentSessionOptions[] = [];
+    const def = defineWorkflow("stage-git-worktree-explicit-cwd-wf")
+      .run(async (ctx) => {
+        await ctx.stage("worker", {
+          gitWorktreeDir: join("worktrees", "sdk"),
+          baseBranch: "main",
+          cwd: explicitCwd,
+        }).prompt("inspect");
+        return { ok: true };
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      cwd: repo,
+      adapters: {
+        agentSession: {
+          async create(options) {
+            calls.push(options);
+            return mockSession();
+          },
+        },
+      },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.equal(calls[0]?.cwd, explicitCwd);
+    assert.equal(existsSync(join(repo, "worktrees", "sdk", ".git")), true);
+  });
+
+  test("ctx.stage preserves logical symlink repo cwd for gitWorktreeDir", async () => {
+    if (process.platform === "win32") return;
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const repo = join(tempRoot, "real-repo");
+    mkdirSync(join(repo, "nested"), { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "nested", "fixture.txt"), "fixture\n", "utf8");
+    execFileSync("git", ["add", "nested/fixture.txt"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const repoLink = join(tempRoot, "repo-link");
+    symlinkSync(repo, repoLink, "dir");
+    const calls: CreateAgentSessionOptions[] = [];
+    const def = defineWorkflow("stage-git-worktree-symlink-repo-wf")
+      .run(async (ctx) => {
+        await ctx.stage("worker", {
+          gitWorktreeDir: join("worktrees", "sdk"),
+          baseBranch: "main",
+        }).prompt("inspect");
+        return { ok: true };
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      cwd: join(repoLink, "nested"),
+      adapters: {
+        agentSession: {
+          async create(options) {
+            calls.push(options);
+            return mockSession();
+          },
+        },
+      },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.equal(calls[0]?.cwd, join(repoLink, "worktrees", "sdk", "nested"));
+  });
+
+  test("ctx.stage preserves logical symlink worktree parent for gitWorktreeDir", async () => {
+    if (process.platform === "win32") return;
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const repo = join(tempRoot, "repo");
+    mkdirSync(repo, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "README.md"), "# repo\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const realWorktrees = join(tempRoot, "real-worktrees");
+    mkdirSync(realWorktrees, { recursive: true });
+    const worktreesLink = join(tempRoot, "worktrees-link");
+    symlinkSync(realWorktrees, worktreesLink, "dir");
+    const calls: CreateAgentSessionOptions[] = [];
+    const def = defineWorkflow("stage-git-worktree-symlink-parent-wf")
+      .run(async (ctx) => {
+        await ctx.stage("worker", {
+          gitWorktreeDir: join(worktreesLink, "sdk"),
+          baseBranch: "main",
+        }).prompt("inspect");
+        return { ok: true };
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      cwd: repo,
+      adapters: {
+        agentSession: {
+          async create(options) {
+            calls.push(options);
+            return mockSession();
+          },
+        },
+      },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.equal(calls[0]?.cwd, join(worktreesLink, "sdk"));
+    assert.equal(existsSync(join(worktreesLink, "sdk", ".git")), true);
+  });
+
+  test("ctx.stage resolves explicit relative cwd against the gitWorktreeDir cwd", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const repo = join(tempRoot, "repo");
+    mkdirSync(join(repo, "nested", "deeper"), { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "nested", "deeper", "fixture.txt"), "fixture\n", "utf8");
+    execFileSync("git", ["add", "nested/deeper/fixture.txt"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const calls: CreateAgentSessionOptions[] = [];
+    const def = defineWorkflow("stage-git-worktree-relative-cwd-wf")
+      .run(async (ctx) => {
+        await ctx.stage("worker", {
+          gitWorktreeDir: join("worktrees", "sdk"),
+          baseBranch: "main",
+          cwd: "deeper",
+        }).prompt("inspect");
+        return { ok: true };
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      cwd: join(repo, "nested"),
+      adapters: {
+        agentSession: {
+          async create(options) {
+            calls.push(options);
+            return mockSession();
+          },
+        },
+      },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.equal(calls[0]?.cwd, join(repo, "worktrees", "sdk", "nested", "deeper"));
+  });
+
+  test("ctx.task, ctx.parallel, and ctx.chain inherit gitWorktreeDir cwd defaults", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const repo = join(tempRoot, "repo");
+    mkdirSync(join(repo, "nested"), { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "nested", "fixture.txt"), "fixture\n", "utf8");
+    execFileSync("git", ["add", "nested/fixture.txt"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const calls: CreateAgentSessionOptions[] = [];
+    const expectedCwd = join(repo, "worktrees", "sdk", "nested");
+    const def = defineWorkflow("task-parallel-chain-git-worktree-wf")
+      .run(async (ctx) => {
+        await ctx.task("task", { task: "inspect", gitWorktreeDir: join("worktrees", "sdk"), baseBranch: "main" });
+        await ctx.parallel([
+          { name: "parallel-a", task: "inspect a" },
+          { name: "parallel-b", task: "inspect b" },
+        ], { gitWorktreeDir: join("worktrees", "sdk"), baseBranch: "main" });
+        await ctx.chain([
+          { name: "chain-a", task: "inspect chain" },
+        ], { gitWorktreeDir: join("worktrees", "sdk"), baseBranch: "main" });
+        return { ok: true };
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      cwd: join(repo, "nested"),
+      adapters: {
+        agentSession: {
+          async create(options) {
+            calls.push(options);
+            return mockSession();
+          },
+        },
+      },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.equal(calls.length, 4);
+    assert.deepEqual(calls.map((call) => call.cwd), [expectedCwd, expectedCwd, expectedCwd, expectedCwd]);
+  });
+
+  test("worktree and gitWorktreeDir are mutually exclusive", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const repo = join(tempRoot, "repo");
+    mkdirSync(repo, { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "README.md"), "# repo\n", "utf8");
+    execFileSync("git", ["add", "README.md"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const def = defineWorkflow("mixed-worktree-mode-wf")
+      .run(async (ctx) => {
+        await ctx.task("worker", {
+          task: "inspect",
+          worktree: true,
+          gitWorktreeDir: join("worktrees", "sdk"),
+        });
+        return { ok: true };
+      })
+      .compile();
+
+    const wfResult = await run(def, {}, {
+      cwd: repo,
+      adapters: { agentSession: { async create() { return mockSession(); } } },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "failed");
+    assert.match(wfResult.error ?? "", /worktree and gitWorktreeDir are mutually exclusive/);
   });
 
   test("ctx.task forwards createAgentSession options to the SDK session", async () => {

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { run, runChain, runParallel, runTask, resolveInputs } from "../../packages/workflows/src/runs/foreground/executor.js";
@@ -272,7 +272,7 @@ describe("executor.run", () => {
   });
 
   test("ctx.stage defaults cwd to gitWorktreeDir while preserving the workflow relative cwd", async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "repo");
     mkdirSync(repo, { recursive: true });
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
@@ -315,7 +315,7 @@ describe("executor.run", () => {
   });
 
   test("ctx.stage preserves explicit absolute cwd when gitWorktreeDir is set", async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "repo");
     mkdirSync(repo, { recursive: true });
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
@@ -358,7 +358,7 @@ describe("executor.run", () => {
 
   test("ctx.stage preserves logical symlink repo cwd for gitWorktreeDir", async () => {
     if (process.platform === "win32") return;
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "real-repo");
     mkdirSync(join(repo, "nested"), { recursive: true });
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
@@ -399,7 +399,7 @@ describe("executor.run", () => {
 
   test("ctx.stage preserves logical symlink worktree parent for gitWorktreeDir", async () => {
     if (process.platform === "win32") return;
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "repo");
     mkdirSync(repo, { recursive: true });
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
@@ -442,7 +442,7 @@ describe("executor.run", () => {
   });
 
   test("ctx.stage resolves explicit relative cwd against the gitWorktreeDir cwd", async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "repo");
     mkdirSync(join(repo, "nested", "deeper"), { recursive: true });
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
@@ -481,7 +481,7 @@ describe("executor.run", () => {
   });
 
   test("ctx.task, ctx.parallel, and ctx.chain inherit gitWorktreeDir cwd defaults", async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "repo");
     mkdirSync(join(repo, "nested"), { recursive: true });
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
@@ -525,7 +525,7 @@ describe("executor.run", () => {
   });
 
   test("worktree and gitWorktreeDir are mutually exclusive", async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-"));
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "repo");
     mkdirSync(repo, { recursive: true });
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -24,9 +24,10 @@ test("session_start warns when discovered workflows fail validation", async () =
       workflowPath,
       [
         "export default {",
+        "  __piWorkflow: true,",
         "  name: 'Invalid Workflow',",
         "  normalizedName: 'invalid-workflow',",
-        "  description: 'invalid because it is missing the workflow sentinel',",
+        "  description: 'invalid because it creates no stages',",
         "  inputs: {},",
         "  run: async () => ({ ok: true }),",
         "};",
@@ -64,7 +65,7 @@ test("session_start warns when discovered workflows fail validation", async () =
     assert.notEqual(warning, undefined);
     assert.equal(warning?.type, "warning");
     assert.match(warning!.message, /empty-graph\.js/);
-    assert.match(warning!.message, /missing or incorrect __piWorkflow sentinel/);
+    assert.match(warning!.message, /run must create at least one workflow stage/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -19,15 +19,14 @@ test("session_start warns when discovered workflows fail validation", async () =
   try {
     const workflowDir = join(root, "workflows");
     mkdirSync(workflowDir, { recursive: true });
-    const workflowPath = join(workflowDir, "empty-graph.js");
+    const workflowPath = join(workflowDir, "invalid-shape.js");
     writeFileSync(
       workflowPath,
       [
         "export default {",
-        "  __piWorkflow: true,",
         "  name: 'Invalid Workflow',",
         "  normalizedName: 'invalid-workflow',",
-        "  description: 'invalid because it creates no stages',",
+        "  description: 'invalid because it is missing the workflow sentinel',",
         "  inputs: {},",
         "  run: async () => ({ ok: true }),",
         "};",
@@ -64,8 +63,8 @@ test("session_start warns when discovered workflows fail validation", async () =
     const warning = notifications.find((entry) => entry.message.includes("Workflow discovery diagnostics"));
     assert.notEqual(warning, undefined);
     assert.equal(warning?.type, "warning");
-    assert.match(warning!.message, /empty-graph\.js/);
-    assert.match(warning!.message, /run must create at least one workflow stage/);
+    assert.match(warning!.message, /invalid-shape\.js/);
+    assert.match(warning!.message, /missing or incorrect __piWorkflow sentinel/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -24,10 +24,9 @@ test("session_start warns when discovered workflows fail validation", async () =
       workflowPath,
       [
         "export default {",
-        "  __piWorkflow: true,",
-        "  name: 'Empty Graph',",
-        "  normalizedName: 'empty-graph',",
-        "  description: 'invalid because no stage is created',",
+        "  name: 'Invalid Workflow',",
+        "  normalizedName: 'invalid-workflow',",
+        "  description: 'invalid because it is missing the workflow sentinel',",
         "  inputs: {},",
         "  run: async () => ({ ok: true }),",
         "};",
@@ -65,7 +64,7 @@ test("session_start warns when discovered workflows fail validation", async () =
     assert.notEqual(warning, undefined);
     assert.equal(warning?.type, "warning");
     assert.match(warning!.message, /empty-graph\.js/);
-    assert.match(warning!.message, /must create at least one workflow stage/i);
+    assert.match(warning!.message, /missing or incorrect __piWorkflow sentinel/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/mcp-oauth-startup.test.ts
+++ b/test/unit/mcp-oauth-startup.test.ts
@@ -13,7 +13,6 @@ type SessionStartContext = { readonly cwd: string; readonly hasUI: false; readon
 type SessionStartHandler = (event: SessionStartEvent, ctx: SessionStartContext) => Promise<void> | void;
 
 const originalArgv = [...process.argv];
-const originalCwd = process.cwd();
 const originalAtomicAgentDir = process.env.ATOMIC_CODING_AGENT_DIR;
 const originalMcpDirectTools = process.env.MCP_DIRECT_TOOLS;
 
@@ -23,7 +22,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   process.argv = [...originalArgv];
-  process.chdir(originalCwd);
   if (originalAtomicAgentDir === undefined) {
     delete process.env.ATOMIC_CODING_AGENT_DIR;
   } else {
@@ -42,7 +40,6 @@ test("MCP session startup leaves OAuth callback handling lazy", async () => {
   const configPath = join(tempDir, "mcp.json");
   const remoteServer = { url: "https://example.invalid/mcp" } satisfies ServerEntry;
   writeFileSync(configPath, JSON.stringify({ mcpServers: { remote: remoteServer } }));
-  process.chdir(tempDir);
   process.env.ATOMIC_CODING_AGENT_DIR = join(tempDir, "agent");
   process.env.MCP_DIRECT_TOOLS = "__none__";
   process.argv = [...originalArgv, "--mcp-config", configPath];

--- a/test/unit/workflow-runner.test.ts
+++ b/test/unit/workflow-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CreateAgentSessionOptions } from "@bastani/atomic";
@@ -177,22 +177,32 @@ describe("programmatic workflow runner", () => {
   test("runs a named workflow from an explicit definition object", async () => {
     const prompts: string[] = [];
     const dir = mkdtempSync(join(tmpdir(), "workflow-runner-deep-research-"));
-    const result = await runWorkflow(
-      {
-        mode: "workflow",
-        workflow: "deep-research-codebase",
-        inputs: {
-          prompt: "map workflow sdk",
-          max_partitions: 1,
+    try {
+      const result = await runWorkflow(
+        {
+          mode: "workflow",
+          workflow: "deep-research-codebase",
+          inputs: {
+            prompt: "map workflow sdk",
+            max_partitions: 1,
+          },
         },
-      },
-      { cwd: dir, adapterOptions: { createAgentSession: makeSessionFactory(prompts) } },
-    );
+        { cwd: dir, adapterOptions: { createAgentSession: makeSessionFactory(prompts) } },
+      );
 
-    assert.equal(result.mode, "named");
-    assert.equal(result.status, "completed");
-    assert.equal(result.output?.["specialist_count"], 4);
-    assert.ok(prompts.some((prompt) => prompt.includes("Research question: map workflow sdk")));
+      assert.equal(result.mode, "named");
+      assert.equal(result.status, "completed");
+      assert.equal(result.output?.["specialist_count"], 4);
+      assert.ok(prompts.some((prompt) => prompt.includes("Research question: map workflow sdk")));
+      const researchDocPath = result.output?.["research_doc_path"];
+      const artifactDir = result.output?.["artifact_dir"];
+      assert.equal(typeof researchDocPath, "string");
+      assert.equal(typeof artifactDir, "string");
+      assert.equal(existsSync(join(dir, researchDocPath as string)), true);
+      assert.equal(existsSync(join(dir, artifactDir as string)), true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("validates named workflow inputs before starting a session", async () => {

--- a/test/unit/workflow-runner.test.ts
+++ b/test/unit/workflow-runner.test.ts
@@ -177,24 +177,17 @@ describe("programmatic workflow runner", () => {
   test("runs a named workflow from an explicit definition object", async () => {
     const prompts: string[] = [];
     const dir = mkdtempSync(join(tmpdir(), "workflow-runner-deep-research-"));
-    const previousCwd = process.cwd();
-    let result: Awaited<ReturnType<typeof runWorkflow>>;
-    try {
-      process.chdir(dir);
-      result = await runWorkflow(
-        {
-          mode: "workflow",
-          workflow: "deep-research-codebase",
-          inputs: {
-            prompt: "map workflow sdk",
-            max_partitions: 1,
-          },
+    const result = await runWorkflow(
+      {
+        mode: "workflow",
+        workflow: "deep-research-codebase",
+        inputs: {
+          prompt: "map workflow sdk",
+          max_partitions: 1,
         },
-        { adapterOptions: { createAgentSession: makeSessionFactory(prompts) } },
-      );
-    } finally {
-      process.chdir(previousCwd);
-    }
+      },
+      { cwd: dir, adapterOptions: { createAgentSession: makeSessionFactory(prompts) } },
+    );
 
     assert.equal(result.mode, "named");
     assert.equal(result.status, "completed");


### PR DESCRIPTION
## Summary

Adds an optional \`git_worktree_dir\` input to the Ralph workflow so stages can run from a detached Git worktree instead of the caller's checkout. Pairs with side-effect-free workflow discovery, runtime empty-graph validation, and \`ctx.cwd\` exposure to replace the previous static source-inspection approach.

## Key Changes

### Ralph Workflow (\`packages/workflows/builtin/ralph.ts\`)

- **New \`git_worktree_dir\` input** (\`string\`, default \`""\`) — empty string preserves existing no-worktree behavior.
- **Git repository requirement** — when set, Ralph fails fast unless invoked from inside a Git repository.
- **Path resolution** — absolute paths used as-is; relative paths resolve from repository root.
- **Worktree creation** — missing paths created with \`git worktree add --detach <path> <base_branch>\`.
- **Worktree reuse** — existing same-repository Git worktrees are reused as-is, including uncommitted state, enabling retry semantics without manual cleanup.
- **No automatic cleanup** — Ralph leaves \`git_worktree_dir\` intact after success or failure; callers handle cleanup.
- **Fail-fast guards** — rejects null-byte paths, missing \`base_branch\` for new worktrees, non-Git directories, and foreign-repository checkouts.
- **Stable spec files** — planner iterations revise one stable spec file rather than creating suffixed collision files.

### Worktree Bindings (\`packages/workflows/src/runs/shared/worktree.ts\`)

- Adds \`setupGitWorktree\` / \`GitWorktreeSetupOptions\` / \`GitWorktreeSetupResult\` — the low-level primitive that resolves, creates, or reuses a git worktree and returns an effective \`cwd\`.
- Git env sanitization — scrubs Git-local env vars and disables hooks/fsmonitor before internal bookkeeping commands to avoid inheriting nested-Git state.
- Symlink-preserving path canonicalization — logical paths through symlinks are preserved when a grandparent is a symlink, avoiding broken paths inside Docker/container mounts.
- \`worktree\` and \`gitWorktreeDir\` are now mutually exclusive; combining them throws a clear error.

### Executor (\`packages/workflows/src/runs/foreground/executor.ts\`)

- **\`ctx.cwd\`** is now exposed on \`WorkflowRunContext\`, explicitly set from the named-workflow runner's invocation directory.
- **Input runtime defaults** — \`gitWorktreeDir\`/\`baseBranch\` from workflow \`inputBindings.worktree\` propagate automatically to all stages as defaults.
- **\`stageOptionsWithGitWorktree\`** — resolves \`gitWorktreeDir\` into a concrete \`cwd\` at stage dispatch time, transparent to workflow authors.
- **Runtime empty-graph validation** — workflows that complete without creating any stages are recorded as failed with a clear error message (\`assertWorkflowCreatedStage\`).

### Workflow Discovery (\`packages/workflows/src/extension/discovery.ts\`)

- Removes \`Function.prototype.toString()\` regex check for \`.stage()\` / \`.task()\` / \`.chain()\` / \`.parallel()\` — discovery is now fully side-effect-free (shape-only validation via \`validateDefinitionShape\`).
- \`applyBatch\` is now \`async\`; bundled startup seeding retains a synchronous \`applyBatchShapeOnly\` path.
- Runtime empty-graph validation in the executor is the authoritative guard replacing the removed static check.

### Shared Prompts (\`packages/workflows/builtin/shared-prompts.ts\`)

- Adds \`WORKER_PREFLIGHT_CONTRACT\` instructing workers to infer project setup from repository evidence (manifests, lockfiles, CI configs) and run setup commands before implementation work.
- Injected into both Goal and Ralph worker prompts as a \`<project_initialization_preflight>\` block.

### Deep-Research Workflow (\`packages/workflows/builtin/deep-research-codebase.ts\`)

- Artifact root and \`countCodebaseLines\` are now \`cwd\`-relative, enabling correct artifact placement when the workflow runs from a worktree.
- \`displayPathFrom\` helper renders paths relative to the invocation cwd for cleaner output.

### Tests

- **\`test/integration/ralph-worktree.test.ts\`** *(new, 12 tests)* — real Git fixture coverage: relative/absolute paths, fail-fast outside Git, missing \`base_branch\`, non-Git directories, foreign checkouts/worktrees, same-repository worktree reuse, retry semantics, multi-iteration cwd propagation, and failure preservation.
- **\`test/unit/builtin-workflows.test.ts\`** — \`git_worktree_dir\` input contract, no-worktree cwd behavior, PR-stage guidance, removed cleanup markers.
- **\`test/unit/discovery.test.ts\` / \`test/unit/executor.test.ts\`** — side-effect-free structural discovery, non-execution of workflow bodies during discovery, runtime empty-graph validation.
- Parallelizable cwd-sensitive tests — Ralph and deep-research tests now pass explicit \`cwd\` seams instead of mutating \`process.cwd()\`.

## Breaking Changes

None — \`git_worktree_dir\` defaults to \`""\` preserving existing behavior. The workflow SDK authoring API and compiled \`WorkflowDefinition\` shape are unchanged.