### PR TITLE
docs(guide): clarify goal vs ralph scope, examples, and onboarding copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,18 @@ Turn research into an implementation-ready plan:
 
 If you are not sure what you want yet, brainstorm with Atomic first: explore trade-offs, compare approaches, then ask it to save the selected direction as a spec. Either way, the output is a repo-native artifact under `specs/` that an engineer can review before implementation starts.
 
-### 3. Implement with a built-in workflow
+### 3. Implement with `goal` or `ralph`
 
-Pass the spec to the workflow that matches the amount of structure you want:
+Pass the spec or a direct objective to the workflow that matches the scope:
 
 ```text
-/workflow goal objective="Implement specs/2026-03-rate-limit.md and validate the behavior"
+/workflow goal objective="Implement specs/2026-03-rate-limit.md, run the focused rate-limit tests, and finish when burst traffic returns 429 with Retry-After"
 /workflow ralph prompt="Plan, implement, review, and prepare a PR for specs/2026-03-rate-limit.md"
 ```
 
-`goal` is the focused Goal Runner loop: it persists the objective, renders continuation context, runs bounded worker turns, captures receipts, gates completion through parallel reviewers, and lets a TypeScript reducer decide `complete`, `blocked`, or `needs_human`.
+Use `goal` for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human`.
 
-`ralph` is the heavier spec-to-PR workflow: it writes an RFC-style plan, delegates implementation through sub-agents, runs simplification and infrastructure discovery, reviews the patch, iterates until approved or the loop limit is reached, then prepares a pull-request report.
+Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report.
 
 ---
 
@@ -232,8 +232,8 @@ Workflows define the outer loop: inputs, steps, branches, parallelism, retries, 
 
 | Workflow                 | What it does                                                                                                                                                                                                                                                                           | Example input                                                                                                                                                                                 |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `goal`                   | Focused Goal Runner loop with a persisted ledger, bounded worker turns, worker receipts, parallel reviewer gate, reviewer quorum, repeated-blocker detection, and final status report. Use it when you have a clear objective or spec and want autonomous implementation with auditable stop decisions. | `/workflow goal objective="Implement specs/2026-03-rate-limit.md and validate the behavior"`                                                                                                  |
-| `ralph`                  | Heavier plan → orchestrate → simplify → discover → review loop that writes RFC-style specs, delegates implementation through sub-agents, repeats until reviewers approve or the loop limit is reached, and prepares a PR report. Use it for larger spec-to-PR work.                  | `/workflow ralph prompt="Plan, implement, review, and prepare a PR for specs/2026-03-rate-limit.md"`                                                                                          |
+| `goal`                   | Focused workflow for small-to-medium changes when you can name the scope, exact desired outcome, and validation in the objective. It runs bounded worker turns, stores receipts in a goal ledger, requires reviewer quorum before completion, and stops as `complete`, `blocked`, or `needs_human`. | `/workflow goal objective="Update the CLI docs for --json, include one example, run the docs build, and finish when it passes"`                                                                |
+| `ralph`                  | Heavier plan → orchestrate → simplify → discover → review loop for larger migrations, broad refactors, multi-package changes, and spec-to-PR work. It writes RFC-style specs, delegates implementation through sub-agents, iterates on reviewer feedback, and prepares a PR report. | `/workflow ralph prompt="Plan, implement, review, and prepare a PR for specs/2026-03-rate-limit.md"`                                                                                          |
 | `deep-research-codebase` | Repo-wide research for broad, cross-cutting questions. It scouts the codebase, runs parallel specialist waves, aggregates findings, and writes durable research artifacts under `research/`. Prefer `/skill:research-codebase` for a focused subsystem or question.                    | `/workflow deep-research-codebase prompt="How do payment retries work end to end?"`                                                                                                           |
 | `open-claude-design`     | End-to-end design generation: discovers your design system, generates from a prompt, refines with feedback, and exports a handoff directory.                                                                                                                                           | `/workflow open-claude-design prompt="Team activity feed" reference=./mocks/feed.png output_type=prototype`                                                                                   |
 | _author your own_        | Anything outside the built-ins: issue-to-PR, review-to-merge, migration, triage, release, compliance, or team-specific review pipelines. Describe the process in natural language and Atomic can scaffold a `defineWorkflow()` file with typed CLI flags.                              | _"Create a reusable workflow that takes an issue, writes a plan, creates a branch, runs implementation and review stages, runs tests and lint, then stops for approval before final output."_ |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified bundled workflow docs and `/atomic` onboarding copy for using `goal` on smaller scoped changes with explicit outcomes, testing instructions, and done criteria, while positioning `ralph` for larger migrations, broad refactors, and PR-prep workflows.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -73,8 +73,8 @@ Atomic ships with four workflows you can run immediately. Use `/workflow list` t
 | Workflow | When to use | Example |
 |---|---|---|
 | `deep-research-codebase` | Broad, cross-cutting research before you decide what to change. Scout → research-history → parallel specialist waves → aggregator. | `/workflow deep-research-codebase prompt="How do payment retries work end to end?"` |
-| `goal` | Focused implementation against a clear objective or spec. Persists a goal ledger, captures worker receipts, gates completion through reviewer quorum, and stops as complete, blocked, or needing human follow-up. | `/workflow goal objective="Implement specs/2026-03-rate-limit.md and validate the behavior"` |
-| `ralph` | Heavier spec-to-PR work. Writes an RFC-style plan, delegates implementation through sub-agents, simplifies, discovers review infrastructure, runs reviewers, iterates, and prepares a PR report. | `/workflow ralph prompt="Plan, implement, review, and prepare a PR for specs/2026-03-rate-limit.md"` |
+| `goal` | Small-to-medium scope changes when you can identify the work surface, state the exact outcome, and name the validation that proves it is done — for example tests, lint/typecheck, docs builds, or observable behavior. Keeps the run bounded with a goal ledger, reviewer gates, and final status `complete`, `blocked`, or `needs_human`. | `/workflow goal objective="Implement specs/2026-03-rate-limit.md, run the focused tests, and finish when burst traffic returns 429"` |
+| `ralph` | Larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report. | `/workflow ralph prompt="Plan the database migration, implement it, review it, and prepare a PR"` |
 | `open-claude-design` | UI and design-system work with generation, critique, and refinement loops; renders a live `preview.html` you can iterate against. | `/workflow open-claude-design prompt="Refresh the settings page hierarchy" output_type=page` |
 
 <p align="center"><img src="images/workflow-list.png" alt="Workflow List" width="600" /></p>
@@ -87,7 +87,15 @@ You can also launch workflows with **natural language** — just describe the ta
 Run a deep codebase research workflow on how the rate limiter behaves under burst traffic.
 ```
 
-Atomic picks the workflow, fills in inputs from the request, and confirms before launch. `goal` persists receipts in a goal ledger and stops only when reviewer quorum proves completion, the same blocker repeats enough times, or the turn limit requires human follow-up. `ralph` adds a planning/spec stage, sub-agent implementation orchestration, simplification, review-infrastructure discovery, and PR handoff.
+```text
+Use the goal workflow to update the CLI docs for --json, include one example, run the docs build, and finish when the build passes.
+```
+
+Atomic picks the workflow, fills in inputs from the request, and confirms before launch.
+
+Use `goal` for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human`.
+
+Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report.
 
 ### Monitor and steer a run
 
@@ -116,7 +124,7 @@ Skills are reusable expert instructions. Trigger one with `/skill:<name>` follow
 | `tdd` | Test-first feature or bug work. | `/skill:tdd` |
 | `impeccable` | Critique or refine frontend and product UI. | `/skill:impeccable` |
 
-Use `/skill:research-codebase` for a focused area and `/workflow deep-research-codebase` when the answer spans the whole repo. A typical focused flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal` to implement and validate; use `/workflow ralph` when you also want an RFC-style plan, sub-agent orchestration, iterative review, and PR handoff.
+Use `/skill:research-codebase` for a focused area and `/workflow deep-research-codebase` when the answer spans the whole repo. A typical focused flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal` with an objective that identifies the work surface, states the exact outcome, and names the validation that proves it is done. Keep using `/workflow ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan, delegate through sub-agents, simplify, review, iterate, and prepare a pull-request report.
 
 ### Create your own workflow in natural language
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -17,11 +17,12 @@ Use a workflow when a task should be repeatable, inspectable, resumable, or spli
 - **Package distribution** - Ship workflows through Atomic packages, settings, or conventional directories
 
 **Example use cases:**
+- Small, outcome-driven code or docs changes with explicit done criteria
 - Codebase research with parallel local and external research stages
 - Review/fix loops with independent reviewers and a synthesis stage
 - Release planning with human approval gates
 - Documentation audits that save findings as artifacts
-- Multi-stage migrations with validation and rollback checks
+- Multi-stage migrations, broad refactors, and validation/rollback plans
 - Reusable team workflows distributed through npm, git, or project settings
 
 ## Table of Contents
@@ -139,9 +140,13 @@ Atomic bundles four workflows that cover the most common multi-stage jobs. They 
 | Workflow | What it does | When to use |
 |---|---|---|
 | `deep-research-codebase` | Scout + research-history chain → parallel specialist waves → aggregator. Indexes the whole repo and synthesizes findings. | Broad or cross-cutting research before you decide what to change. Prefer `/skill:research-codebase` for one subsystem. |
-| `goal` | Persisted goal ledger → bounded worker turns → receipts → three-reviewer gate → deterministic reducer → final report. | Focused implementation against a clear objective or spec where you want auditable progress, reviewer-quorum completion, repeated-blocker detection, and explicit stop decisions. |
-| `ralph` | RFC planning → sub-agent orchestration → simplification → infrastructure discovery → parallel review → PR handoff. | Larger spec-to-PR jobs where you want a generated technical plan, delegated implementation, iterative review, and pull-request preparation. |
+| `goal` | Persisted goal ledger → bounded worker turns → receipts → three-reviewer gate → deterministic reducer → final report. | Small-to-medium scope changes when you can identify the work surface, state the exact outcome, and name the validation that proves it is done — for example tests, lint/typecheck, docs builds, or observable behavior. |
+| `ralph` | RFC planning → sub-agent orchestration → simplification → infrastructure discovery → parallel review → PR handoff. | Larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report. |
 | `open-claude-design` | Design-system onboarding → reference import → HTML generation → impeccable-driven refinement → quality gate → rich HTML handoff. Renders a live `preview.html` you can iterate against (opens through `playwright-cli` when available). | UI, page, component, theme, or design-token work that benefits from generation + critique loops. |
+
+Use `goal` for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human`.
+
+Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report.
 
 ### `deep-research-codebase`
 
@@ -192,7 +197,7 @@ Inputs:
 
 | Input | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `objective` | text | yes | — | Goal-runner objective. |
+| `objective` | text | yes | — | Goal-runner objective. Include the desired end state, expected outcome, testing/validation instructions, and any explicit done criteria. |
 | `max_turns` | number | no | `10` | Maximum worker/review turns before human follow-up is needed. |
 | `base_branch` | string | no | `origin/main` | Branch reviewers compare the current code delta against. |
 
@@ -201,12 +206,14 @@ Inputs:
 Run examples:
 
 ```text
-/workflow goal objective="Implement specs/2026-03-rate-limit.md and validate the changed behavior"
-/workflow goal objective="Migrate the database layer to Drizzle" base_branch=develop
-/workflow goal objective="Finish the docs refresh" max_turns=2
+/workflow goal objective="Implement specs/2026-03-rate-limit.md, add the requested regression tests, run bun test packages/api/rate-limit.test.ts, and finish only when burst traffic returns 429 with Retry-After"
+/workflow goal objective="Update the CLI docs to describe the new --json flag, include one usage example, and verify the docs build still passes" max_turns=3
+/workflow goal objective="Fix the settings form validation bug; add/adjust the focused test and consider it done when invalid emails show the inline error without submitting"
 ```
 
 `goal` creates an OS-temp `goal-ledger.json` artifact, renders goal-continuation context for each worker turn, writes each worker receipt to `work-turn-N.md`, and appends receipts, reviewer decisions, blockers, reducer decisions, and lifecycle events to the ledger. The objective is treated as user-provided data, not higher-priority instructions.
+
+Write the `objective` like a compact acceptance spec. Say what should exist when the run is done, how you want testing handled, which command(s) or manual checks matter, and what outcome proves completion. The workflow is intentionally lean: it does not first generate an RFC or migration plan, so the developer-supplied objective is where scope, validation, and completion criteria belong.
 
 The worker may claim readiness, but it cannot finalize completion. Three reviewers independently inspect the ledger, worker receipt, repository state, and diff against `base_branch`; each returns structured JSON with findings, evidence, verification still remaining, and an optional blocker. A TypeScript reducer marks the goal complete only when reviewer quorum approves, marks blocked only when the same dependency/tool blocker repeats for the blocker threshold, continues when evidence is missing, and returns `needs_human` when `max_turns` is exhausted or worker execution fails.
 
@@ -226,7 +233,7 @@ Result fields:
 | `remaining_work` | Remaining gaps/blockers when incomplete, or `none`. |
 | `review_report` | Markdown report containing the last structured reviewer decision payloads used by the reducer. |
 
-Use `goal` when you already have a clear objective or reviewed spec and want the leanest auditable implementation loop.
+Use `goal` when you already have a clear objective or reviewed spec and want the leanest auditable implementation loop. It is the default choice for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human`.
 
 ### `ralph`
 
@@ -241,11 +248,11 @@ Inputs:
 Run examples:
 
 ```text
-/workflow ralph prompt="Implement specs/2026-03-rate-limit.md and prepare the PR"
 /workflow ralph prompt="Plan and migrate the database layer to Drizzle" max_loops=3 base_branch=develop
+/workflow ralph prompt="Refactor authentication across the API, CLI, and web UI, then prepare the PR"
 ```
 
-`ralph` is a heavier spec-to-PR workflow. Each iteration writes an RFC-style technical design document under `specs/`, initializes an OS-temp implementation notes file, delegates implementation through sub-agents, runs a behavior-preserving code simplifier, discovers review infrastructure, and asks two reviewers to inspect the patch against `base_branch`. The loop stops when every reviewer approves or `max_loops` is reached, then runs a pull-request preparation stage.
+Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report. Each iteration writes an RFC-style technical design document under `specs/`, initializes an OS-temp implementation notes file, delegates implementation through sub-agents, runs a behavior-preserving code simplifier, discovers review infrastructure, and asks two reviewers to inspect the patch against `base_branch`. The loop stops when every reviewer approves or `max_loops` is reached, then runs a pull-request preparation stage.
 
 Result fields:
 
@@ -260,7 +267,7 @@ Result fields:
 | `iterations_completed` | Number of plan/orchestrate/review loops completed. |
 | `review_report` | Markdown report containing the latest reviewer payloads. |
 
-A typical end-to-end flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal objective="Implement the researched rate-limit behavior and validate it"`. Use `/workflow ralph` instead when you want Atomic to generate the RFC, coordinate implementation sub-agents, iterate on review findings, and prepare a PR report in one workflow.
+A typical end-to-end flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal objective="Implement the researched rate-limit behavior, run the focused tests, and finish when the documented burst behavior is validated"` when you can identify the work surface, state the exact outcome, and name the validation that proves it is done. Keep using `/workflow ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan, delegate through sub-agents, simplify, review, iterate, and prepare a pull-request report.
 
 ### `open-claude-design`
 
@@ -291,11 +298,11 @@ Run a deep codebase research workflow on how the rate limiter behaves under burs
 ```
 
 ```text
-Use the goal workflow to implement specs/2026-03-rate-limit.md and cap it at 5 turns.
+Use the goal workflow to implement specs/2026-03-rate-limit.md, run the focused rate-limit tests, finish only when burst traffic returns 429 with Retry-After, and cap it at 5 turns.
 ```
 
 ```text
-Use the ralph workflow to plan, implement, review, and prepare a PR for specs/2026-03-rate-limit.md.
+Use the ralph workflow to plan a database-layer migration, implement it, review it, and prepare a PR.
 ```
 
 ```text
@@ -338,6 +345,8 @@ If the task is only deterministic TypeScript with no LLM/session stage, use a sc
 | User goal | Use |
 |-----------|-----|
 | Run, inspect, attach to, pause, interrupt, resume, or check status for an existing workflow | `/workflow ...` or `workflow({ action: ... })` |
+| Implement a small-to-medium scope change with an identifiable work surface, exact outcome, and named validation | `/workflow goal objective="..."` so Atomic keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human` |
+| Plan and execute a larger migration, broad refactor, multi-package change, or spec-to-PR effort | `/workflow ralph prompt="..."` so Atomic can plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report |
 | Create or edit reusable automation | a TypeScript workflow definition with `defineWorkflow(...).run(...).compile()` |
 | Track one-off work without saving a workflow file | direct `workflow({ task })`, `workflow({ tasks })`, or `workflow({ chain })` calls |
 | Make a workflow robust | design the stage graph, context handoffs, artifacts, validation gates, model fallbacks, and human approval points before coding |

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -144,10 +144,6 @@ Atomic bundles four workflows that cover the most common multi-stage jobs. They 
 | `ralph` | RFC planning → sub-agent orchestration → simplification → infrastructure discovery → parallel review → PR handoff. | Larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report. |
 | `open-claude-design` | Design-system onboarding → reference import → HTML generation → impeccable-driven refinement → quality gate → rich HTML handoff. Renders a live `preview.html` you can iterate against (opens through `playwright-cli` when available). | UI, page, component, theme, or design-token work that benefits from generation + critique loops. |
 
-Use `goal` for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human`.
-
-Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report.
-
 ### `deep-research-codebase`
 
 Inputs:
@@ -233,8 +229,6 @@ Result fields:
 | `remaining_work` | Remaining gaps/blockers when incomplete, or `none`. |
 | `review_report` | Markdown report containing the last structured reviewer decision payloads used by the reducer. |
 
-Use `goal` when you already have a clear objective or reviewed spec and want the leanest auditable implementation loop. It is the default choice for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human`.
-
 ### `ralph`
 
 Inputs:
@@ -252,7 +246,7 @@ Run examples:
 /workflow ralph prompt="Refactor authentication across the API, CLI, and web UI, then prepare the PR"
 ```
 
-Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report. Each iteration writes an RFC-style technical design document under `specs/`, initializes an OS-temp implementation notes file, delegates implementation through sub-agents, runs a behavior-preserving code simplifier, discovers review infrastructure, and asks two reviewers to inspect the patch against `base_branch`. The loop stops when every reviewer approves or `max_loops` is reached, then runs a pull-request preparation stage.
+Each `ralph` iteration writes an RFC-style technical design document under `specs/`, initializes an OS-temp implementation notes file, delegates implementation through sub-agents, runs a behavior-preserving code simplifier, discovers review infrastructure, and asks two reviewers to inspect the patch against `base_branch`. The loop stops when every reviewer approves or `max_loops` is reached, then runs a pull-request preparation stage.
 
 Result fields:
 

--- a/packages/coding-agent/src/core/atomic-guide-command.ts
+++ b/packages/coding-agent/src/core/atomic-guide-command.ts
@@ -7,7 +7,7 @@ export const ATOMIC_GUIDE_COMMAND_DESCRIPTION = "Atomic onboarding and help guid
 
 const OVERVIEW = `# Atomic overview
 
-Atomic turns one-off prompts into developer workflows: on-call debugging, repo research that turns into implementation, testing and review loops, and larger multi-stage automation. Start it in a project with \`atomic\`, then talk to it normally. Use \`@file\` to attach files, \`!command\` to run shell output through the model, and \`!!command\` to run shell output without adding it to context.
+Atomic turns one-off prompts into developer workflows: on-call debugging, repo research that turns into implementation, testing and review loops, and larger multi-stage automation. Use \`/workflow goal\` for small-to-medium changes with a clear work surface, exact outcome, and named validation; keep \`/workflow ralph\` for larger migrations, broad refactors, and spec-to-PR work. Start Atomic in a project with \`atomic\`, then talk to it normally. Use \`@file\` to attach files, \`!command\` to run shell output through the model, and \`!!command\` to run shell output without adding it to context.
 
 ## Core session commands
 
@@ -26,10 +26,32 @@ Atomic turns one-off prompts into developer workflows: on-call debugging, repo r
 | Goal | How to use |
 |---|---|
 | On-call / broken behavior | Run \`/run debugger "Reproduce the failure, patch the root cause, and validate it"\` for a focused fix loop, or ask Atomic in chat to build a reusable workflow that does the same |
-| Research → spec → implementation | Chain \`/skill:research-codebase\` → \`/skill:create-spec\` → direct implementation or \`/workflow ralph ...\`; ask Atomic in chat to turn the repeatable process into a reusable workflow using the workflow docs |
+| Research → spec → implementation | Chain \`/skill:research-codebase\` → \`/skill:create-spec\` → \`/workflow goal objective="..."\` for bounded scoped work with explicit validation; use \`/workflow ralph ...\` when the work needs planning, broad refactoring, or PR prep |
 | Testing / regression hardening | Run \`/skill:tdd\` for test-first work, then \`/parallel-review current diff\`, then land the change |
 | Large repo discovery | Run \`/parallel codebase-locator "map the area" -> codebase-analyzer "trace the current flow" -> codebase-pattern-finder "find patterns" --bg\`, or \`/workflow deep-research-codebase\` for whole-repo synthesis |
 | UI / product polish | Run \`/skill:impeccable\` for interface critique and refinement, or \`/workflow open-claude-design\` for generation + refinement loops |
+
+## Built-in workflows
+
+| Workflow | When to use | How to run |
+|---|---|---|
+| \`deep-research-codebase\` | broad repo or cross-cutting research before you decide what to change (for one area, use \`/skill:research-codebase\`; this indexes the whole repo) | \`/workflow deep-research-codebase prompt="How do payment retries work end to end?"\` |
+| \`goal\` | small-to-medium scoped changes when you can name the work surface, outcome, and validation; keeps receipts in a ledger and stops as \`complete\`, \`blocked\`, or \`needs_human\` | \`/workflow goal objective="Implement specs/<date>-<topic>.md, run focused tests, and validate the changed behavior"\` |
+| \`ralph\` | larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan, delegate, simplify, review, iterate, and prepare a PR report | \`/workflow ralph prompt="Plan and implement specs/<date>-<topic>.md, then prepare the PR"\` |
+| \`open-claude-design\` | UI and design-system work that benefits from generation and refinement loops | \`/workflow open-claude-design prompt="Refresh the settings page hierarchy"\` |
+
+Use \`/workflow list\` to see what is available and \`/workflow inputs <name>\` to inspect inputs in your environment.
+
+## Top skills
+
+| Skill | When to use | How to run |
+|---|---|---|
+| \`research-codebase\` | write a grounded research artifact for one subsystem or question | \`/skill:research-codebase how the rate limiter works in src/middleware/\` |
+| \`create-spec\` | turn research into an implementation-ready plan | \`/skill:create-spec from research/docs/<date>-<topic>.md\` |
+| \`tdd\` | do test-first feature or bug work | \`/skill:tdd\` |
+| \`prompt-engineer\` | tighten a vague prompt before a long run | \`/skill:prompt-engineer Draft a sharper implementation prompt for ...\` |
+| \`subagent\` | learn delegation patterns and exact \`/run\`, \`/parallel\`, and \`/chain\` usage | \`/skill:subagent\` |
+| \`impeccable\` | critique or refine frontend and product UI | \`/skill:impeccable\` |
 
 ## Subagents
 
@@ -46,27 +68,6 @@ How the direct commands map to repo work:
 - \`/run\` = one specialist on one job, for example \`/run codebase-locator "Map the webhook retry flow"\`
 - \`/parallel\` = several independent specialists at once, for example \`/parallel codebase-locator "map retry files" -> codebase-pattern-finder "find existing retry/backoff patterns" -> codebase-online-researcher "research current retry guidance" --bg\`
 - \`/chain\` = ordered handoffs, for example \`/chain codebase-locator "find the auth files" -> codebase-analyzer "trace the auth flow" -> debugger "patch the failing auth edge case"\`
-
-## Top skills
-
-| Skill | When to use | How to run |
-|---|---|---|
-| \`research-codebase\` | write a grounded research artifact for one subsystem or question | \`/skill:research-codebase how the rate limiter works in src/middleware/\` |
-| \`create-spec\` | turn research into an implementation-ready plan | \`/skill:create-spec from research/docs/<date>-<topic>.md\` |
-| \`tdd\` | do test-first feature or bug work | \`/skill:tdd\` |
-| \`prompt-engineer\` | tighten a vague prompt before a long run | \`/skill:prompt-engineer Draft a sharper implementation prompt for ...\` |
-| \`subagent\` | learn delegation patterns and exact \`/run\`, \`/parallel\`, and \`/chain\` usage | \`/skill:subagent\` |
-| \`impeccable\` | critique or refine frontend and product UI | \`/skill:impeccable\` |
-
-## Built-in workflows
-
-| Workflow | When to use | How to run |
-|---|---|---|
-| \`deep-research-codebase\` | broad repo or cross-cutting research before you decide what to change (for one area, use \`/skill:research-codebase\`; this indexes the whole repo) | \`/workflow deep-research-codebase prompt="How do payment retries work end to end?"\` |
-| \`ralph\` | larger implementation loops with a persisted goal ledger, reviewer quorum, and explicit stop decisions | \`/workflow ralph objective="Implement specs/<date>-<topic>.md and validate the changed behavior"\` |
-| \`open-claude-design\` | UI and design-system work that benefits from generation and refinement loops | \`/workflow open-claude-design prompt="Refresh the settings page hierarchy"\` |
-
-Use \`/workflow list\` to see what is available and \`/workflow inputs <name>\` to inspect inputs in your environment.
 
 ─────────────────────────────────────────────────────────────────
 
@@ -105,15 +106,21 @@ For ordinary work, ask Atomic directly and require validation:
 
 \`Implement the approved spec in specs/<date>-<topic>.md. Run focused tests and summarize validation.\`
 
-For larger work, use subagents or a workflow:
+For small-to-medium scoped changes where you can identify the work surface, exact outcome, and validation, use \`goal\`:
 
-\`/workflow ralph objective="Implement specs/<date>-<topic>.md and validate the changed behavior"\`
+\`/workflow goal objective="Implement specs/<date>-<topic>.md, run focused tests, and finish when the documented behavior is validated"\`
+
+For larger migrations, broad refactors, multi-package changes, or spec-to-PR work, use \`ralph\`:
+
+\`/workflow ralph prompt="Plan and implement specs/<date>-<topic>.md, then prepare the PR"\`
 
 ## 4. Decide and land
 
-If you used \`ralph\`, the workflow already persisted receipts and ran parallel reviewers. Use its final reducer status and review feedback to decide whether to ship or iterate again.
+If you used \`goal\`, the workflow already persisted receipts in a goal ledger and reviewer-gated completion. Use its final status — \`complete\`, \`blocked\`, or \`needs_human\` — plus the remaining-work report to decide whether to ship, unblock, or clarify.
 
-If you implemented directly instead of using \`ralph\`, you can still run:
+If you used \`ralph\`, the workflow planned the approach, delegated implementation through sub-agents, simplified, reviewed, iterated, and prepared a pull-request report. Use its review feedback and PR report to decide whether to ship or iterate again.
+
+If you implemented directly instead of using a workflow, you can still run:
 
 \`/parallel-review current diff\`
 
@@ -137,10 +144,15 @@ You do not have to write TypeScript to add one. Describe the workflow you want i
 | Workflow | When to use | How to run |
 |---|---|---|
 | \`deep-research-codebase\` | broad repo or cross-cutting research before you decide what to change (for one area, use \`/skill:research-codebase\`; this indexes the whole repo) | \`/workflow deep-research-codebase prompt="How do payment retries work end to end?"\` |
-| \`ralph\` | larger implementation and review loops with reviewer-gated completion | \`/workflow ralph objective="Implement specs/<date>-<topic>.md and validate the changed behavior"\` |
+| \`goal\` | small-to-medium scoped changes with a clear outcome and named validation | \`/workflow goal objective="Update the CLI docs, include one usage example, and verify the docs build passes"\` |
+| \`ralph\` | larger migrations, broad refactors, multi-package changes, and spec-to-PR work | \`/workflow ralph prompt="Plan a database-layer migration, implement it, review it, and prepare the PR"\` |
 | \`open-claude-design\` | frontend and product design work | \`/workflow open-claude-design prompt="Refresh the settings page hierarchy"\` |
 
 Use \`/workflow inputs <name>\` to inspect the exact inputs in your environment.
+
+Use \`goal\` for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as \`complete\`, \`blocked\`, or \`needs_human\`.
+
+Keep using \`ralph\` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report.
 
 Use \`/skill:research-codebase ...\` when you want research on one subsystem, directory, or focused question. Use \`/workflow deep-research-codebase ...\` when the answer needs end-to-end tracing across many parts of the repo.
 
@@ -179,9 +191,13 @@ Why this is good:
 
 \`/workflow list\`
 
+\`/workflow inputs goal\`
+
+\`/workflow goal objective="Fix the settings form validation bug, add the focused test, and finish when invalid emails show the inline error without submitting"\`
+
 \`/workflow inputs ralph\`
 
-\`/workflow ralph objective="Migrate the database layer to Drizzle"\`
+\`/workflow ralph prompt="Migrate the database layer to Drizzle and prepare the PR"\`
 
 \`/workflow status\`
 

--- a/packages/coding-agent/src/core/atomic-guide-command.ts
+++ b/packages/coding-agent/src/core/atomic-guide-command.ts
@@ -150,10 +150,6 @@ You do not have to write TypeScript to add one. Describe the workflow you want i
 
 Use \`/workflow inputs <name>\` to inspect the exact inputs in your environment.
 
-Use \`goal\` for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as \`complete\`, \`blocked\`, or \`needs_human\`.
-
-Keep using \`ralph\` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report.
-
 Use \`/skill:research-codebase ...\` when you want research on one subsystem, directory, or focused question. Use \`/workflow deep-research-codebase ...\` when the answer needs end-to-end tracing across many parts of the repo.
 
 If you are drafting research, reviewer, or synthesis prompts for a workflow, use \`/skill:prompt-engineer\` first. It is a good fit when a stage prompt feels vague, overloaded, or underspecified.

--- a/test/unit/atomic-guide-command.test.ts
+++ b/test/unit/atomic-guide-command.test.ts
@@ -39,6 +39,19 @@ describe("/atomic guide command", () => {
     assert.match(getAtomicGuideMessage(normalizeAtomicGuideMode("what's new"), cwd), /^# What's new/);
   });
 
+  test("explains goal versus ralph across onboarding sections", () => {
+    const cwd = "/repo";
+    const overview = getAtomicGuideMessage(normalizeAtomicGuideMode("overview"), cwd);
+    const example = getAtomicGuideMessage(normalizeAtomicGuideMode("example"), cwd);
+    const workflows = getAtomicGuideMessage(normalizeAtomicGuideMode("workflows"), cwd);
+
+    assert.match(overview, /`goal` \| small-to-medium scoped changes/);
+    assert.match(overview, /`ralph` \| larger migrations, broad refactors, multi-package changes, and spec-to-PR work/);
+    assert.match(example, /For small-to-medium scoped changes where you can identify the work surface, exact outcome, and validation, use `goal`/);
+    assert.match(workflows, /Use `goal` for small-to-medium scope changes/);
+    assert.match(workflows, /Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work/);
+  });
+
   test("treats adversarial punctuation arguments as unknown help requests", () => {
     assert.equal(normalizeAtomicGuideMode(`${"!".repeat(50_000)}a`), "help");
   });

--- a/test/unit/atomic-guide-command.test.ts
+++ b/test/unit/atomic-guide-command.test.ts
@@ -48,8 +48,8 @@ describe("/atomic guide command", () => {
     assert.match(overview, /`goal` \| small-to-medium scoped changes/);
     assert.match(overview, /`ralph` \| larger migrations, broad refactors, multi-package changes, and spec-to-PR work/);
     assert.match(example, /For small-to-medium scoped changes where you can identify the work surface, exact outcome, and validation, use `goal`/);
-    assert.match(workflows, /Use `goal` for small-to-medium scope changes/);
-    assert.match(workflows, /Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work/);
+    assert.match(workflows, /\| `goal` \| small-to-medium scoped changes with a clear outcome and named validation/);
+    assert.match(workflows, /\| `ralph` \| larger migrations, broad refactors, multi-package changes, and spec-to-PR work/);
   });
 
   test("treats adversarial punctuation arguments as unknown help requests", () => {


### PR DESCRIPTION
## Summary

Clarifies when to use `goal` versus `ralph` across all user-facing documentation and the `/atomic` onboarding guide, making the distinction between the two built-in workflows actionable rather than mechanical.

## Changes

- **`atomic-guide-command.ts`** — Adds `goal` to the built-in workflows table (it was absent before), reorders sections so workflows appear before subagents, and routes the "Research → spec → implementation" guidance through `goal` for bounded scoped changes.
- **`README.md`** — Renames "Implement with a built-in workflow" to "Implement with `goal` or `ralph`"; sharpens scope guidance with concrete validation examples in both the step description and the workflow reference table.
- **`docs/quickstart.md`** — Updates workflow table descriptions, adds a concrete `goal` example for bounded documentation work, and expands the post-launch copy to explain the two workflows independently.
- **`docs/workflows.md`** — Expands the `objective` field description to require done criteria; adds acceptance-spec guidance for writing objectives; refreshes natural-language launch examples with explicit validation; adds `goal` and `ralph` rows to the "When to Use Workflows" decision table.
- **`CHANGELOG.md`** — Records the clarification under `[Unreleased]`.
- **`test/unit/atomic-guide-command.test.ts`** — Adds a test asserting the new `goal` vs `ralph` copy appears correctly in the overview, example, and workflows guide sections.

The core distinction established throughout: use `goal` for small-to-medium scope changes when you can name the work surface, exact outcome, and validation that proves it is done (specific tests, lint/typecheck, docs builds, or observable behavior); use `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where planning, sub-agent delegation, and PR preparation are needed.

## Validation

- `cd packages/coding-agent && bun run docs:check`
- `bun test test/unit/atomic-guide-command.test.ts`
- Pre-commit/pre-push hooks: `bun run lint` and `bun run test:unit` passed