### PR TITLE
fix(workflows): default ctx.cwd to worktree path for worktreeFromInputs

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Defaulted workflow `ctx.cwd` to the reusable worktree cwd when `worktreeFromInputs` resolves a `gitWorktreeDir`, so workflow-owned artifacts such as Ralph specs are written inside the worktree unless explicitly overridden.
 - Avoided blank deep-research display paths when a displayed artifact path equals the workflow invocation directory.
 - Distinguished Ralph same-repository worktree classification and canonicalization failures from definitely non-Git existing `git_worktree_dir` paths.
 - Updated Ralph to revise a stable original spec file across planner iterations and clarified `git_worktree_dir` null-byte diagnostics.

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -107,7 +107,7 @@ export default defineWorkflow("review-and-merge")
 
 ### Reusable Git worktrees
 
-Use `gitWorktreeDir` when a workflow should run stages in a reusable Git worktree instead of the invoking checkout. The executor creates the worktree if it is missing, reuses it when it already exists as a same-repository worktree root, and defaults the stage/task `cwd` to the matching path inside that worktree.
+Use `gitWorktreeDir` when a workflow should run in a reusable Git worktree instead of the invoking checkout. The executor creates the worktree if it is missing, reuses it when it already exists as a same-repository worktree root, defaults workflow `ctx.cwd` to the matching path inside that worktree for `worktreeFromInputs`, and defaults stage/task `cwd` to that worktree path.
 
 ```typescript
 import { defineWorkflow } from "@bastani/workflows";
@@ -155,7 +155,7 @@ Worktree semantics:
 - `gitWorktreeDir` must be used from inside a Git repository. Relative paths resolve from the logical invoking repository root; absolute paths are used as-is.
 - If the requested path exists, it must be an actual Git worktree/checkout root belonging to the invoking repository. Existing subdirectories are rejected so writes do not silently land in the main checkout.
 - If the path is missing, the parent directory is created and Git runs `git worktree add --detach <path> <baseBranch>`. `baseBranch` defaults to `HEAD` when omitted.
-- The default execution cwd preserves the caller's repo-relative cwd inside the worktree. For example, invoking a workflow from `repo/packages/api` with `gitWorktreeDir=../repo-wt` runs stages from `../repo-wt/packages/api`.
+- The default execution cwd preserves the caller's repo-relative cwd inside the worktree. For example, invoking a workflow from `repo/packages/api` with `gitWorktreeDir=../repo-wt` uses `../repo-wt/packages/api` for workflow `ctx.cwd` and stage/task execution.
 - Symlinked repo/worktree paths preserve their logical spelling in the default cwd, matching Codex-style worktree behavior.
 - Explicit `cwd` still wins. Relative `cwd` values are resolved against the worktree default cwd; absolute `cwd` values are used as provided.
 

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -403,8 +403,9 @@ async function runRalphWorkflow(
   let finalPlanPath = "";
   let finalResult = "";
   let finalPrReport = "";
-  // Keep generated specs under the directory where Ralph was invoked, not in
-  // the worktree, so plan artifacts remain easy to find across retries.
+  // Keep generated specs under the workflow runtime cwd. When Ralph is invoked
+  // with git_worktree_dir, the executor defaults ctx.cwd to the matching
+  // worktree cwd so specs and stage writes land in the same checkout.
   const workflowSpecPath = resolve(workflowStartCwd, defaultSpecPath(prompt));
   const implementationNotesPath = await createImplementationNotesFile(prompt);
   let approved = false;

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -751,7 +751,7 @@ function stageOptionsWithInputDefaults<T extends StageOptions>(options: T | unde
   return { ...defaults, ...withoutUndefinedProperties(options ?? {}) } as T;
 }
 
-function stageOptionsWithGitWorktree<T extends StageOptions>(options: T | undefined, workflowCwd: string): T | undefined {
+function stageOptionsWithGitWorktree<T extends StageOptions>(options: T | undefined, workflowInvocationCwd: string): T | undefined {
   if (options === undefined) return undefined;
   if (typeof options.gitWorktreeDir !== "string" || options.gitWorktreeDir.trim().length === 0) {
     return options;
@@ -759,10 +759,21 @@ function stageOptionsWithGitWorktree<T extends StageOptions>(options: T | undefi
   const setup = setupGitWorktree({
     gitWorktreeDir: options.gitWorktreeDir,
     baseBranch: options.baseBranch,
-    cwd: workflowCwd,
+    cwd: workflowInvocationCwd,
   });
   const explicitCwd = resolveWorktreeCwdOverride(options.cwd, setup.cwd);
   return { ...options, gitWorktreeDir: undefined, baseBranch: undefined, cwd: explicitCwd ?? setup.cwd };
+}
+
+function workflowCwdWithInputWorktree(inputDefaults: Partial<StageOptions>, workflowInvocationCwd: string): string {
+  if (typeof inputDefaults.gitWorktreeDir !== "string" || inputDefaults.gitWorktreeDir.trim().length === 0) {
+    return workflowInvocationCwd;
+  }
+  return setupGitWorktree({
+    gitWorktreeDir: inputDefaults.gitWorktreeDir,
+    baseBranch: inputDefaults.baseBranch,
+    cwd: workflowInvocationCwd,
+  }).cwd;
 }
 
 function directWorktreeDiffsDir(options: WorkflowDirectOptions, setup: WorktreeSetup, runId: string, scope: string): string {
@@ -1553,6 +1564,12 @@ export async function run<TInputs extends Record<string, unknown>>(
   const tracker = new GraphFrontierTracker();
   const inputConcurrency = resolveInputConcurrency(def.inputs, resolvedInputs);
   const inputRuntimeDefaults = resolveInputRuntimeDefaults(def, resolvedInputs);
+  const workflowInvocationCwd = opts.cwd ?? process.cwd();
+  let workflowCwd: string | undefined;
+  const resolveWorkflowCwd = (): string => {
+    workflowCwd ??= workflowCwdWithInputWorktree(inputRuntimeDefaults, workflowInvocationCwd);
+    return workflowCwd;
+  };
   const limiter = createRunLimiter(inputConcurrency ?? opts.config?.defaultConcurrency);
   interface ReleaseBarrier {
     readonly promise: Promise<void>;
@@ -1885,16 +1902,15 @@ export async function run<TInputs extends Record<string, unknown>>(
   };
 
   // 5. Build WorkflowRunContext
-  const workflowCwd = opts.cwd ?? process.cwd();
   const ctx: WorkflowRunContext<TInputs> = {
     inputs: resolvedInputs as TInputs,
-    cwd: workflowCwd,
+    get cwd() { return resolveWorkflowCwd(); },
     // Prompt nodes and caller-provided UI adapters are mutually exclusive;
     // executor-owned prompt nodes intentionally take precedence when enabled.
     ui: opts.usePromptNodesForUi === true ? buildPromptNodeUiAdapter() : opts.ui ?? makeUnavailableUIContext(),
 
     stage(name: string, options?: StageOptions, stageFailFastScope?: ParallelFailFastScope) {
-      options = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(options, inputRuntimeDefaults), workflowCwd);
+      options = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(options, inputRuntimeDefaults), workflowInvocationCwd);
       // a. Generate stageId
       const stageId = crypto.randomUUID();
 
@@ -2440,7 +2456,7 @@ export async function run<TInputs extends Record<string, unknown>>(
 
     async task(name: string, options: WorkflowTaskOptions, stageFailFastScope?: ParallelFailFastScope): Promise<WorkflowTaskResult> {
       const runTaskOnce = async (taskOptions: WorkflowTaskOptions): Promise<WorkflowTaskResult> => {
-        const resolvedTaskOptions = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(taskOptions, inputRuntimeDefaults), workflowCwd) ?? taskOptions;
+        const resolvedTaskOptions = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(taskOptions, inputRuntimeDefaults), workflowInvocationCwd) ?? taskOptions;
         const stage = (ctx.stage as typeof ctx.stage & ((stageName: string, stageOptions?: StageOptions, scope?: ParallelFailFastScope) => StageContext))(
           name,
           taskStageOptions(resolvedTaskOptions),

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -149,7 +149,7 @@ describe("ralph git worktree integration", () => {
   let tempRoot: string | undefined;
 
   beforeEach(() => {
-    tempRoot = mkdtempSync(join(tmpdir(), "atomic-ralph-integration-"));
+    tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-ralph-integration-")));
   });
 
   afterEach(() => {

--- a/test/integration/ralph-worktree.test.ts
+++ b/test/integration/ralph-worktree.test.ts
@@ -66,11 +66,31 @@ function ralphWorktreeDefaults(
 
 function withRalphWorktreeDefaults<TOptions extends { readonly cwd?: string }>(
   inputs: Record<string, unknown>,
-  workflowCwd: string | undefined,
+  worktreeSetupCwd: string | undefined,
   options: TOptions,
 ): TOptions {
   if (options.cwd !== undefined) return options;
-  return { ...options, ...ralphWorktreeDefaults(inputs, workflowCwd) };
+  return { ...options, ...ralphWorktreeDefaults(inputs, worktreeSetupCwd) };
+}
+
+function workflowWorktreeSetupCwd(ctx: { readonly cwd?: string; readonly worktreeSetupCwd?: unknown }): string | undefined {
+  return typeof ctx.worktreeSetupCwd === "string" ? ctx.worktreeSetupCwd : ctx.cwd;
+}
+
+function ralphWorkflowCwd(inputs: Record<string, unknown>, cwd: string): string {
+  return ralphWorktreeDefaults(inputs, cwd).cwd ?? cwd;
+}
+
+async function runRalphModule(
+  mod: RalphTestModule,
+  ctx: WorkflowRunContext<Record<string, unknown>> & { readonly calls: MockCalls },
+  cwd: string,
+): Promise<Record<string, unknown>> {
+  return await mod.default.run({
+    ...ctx,
+    cwd: ralphWorkflowCwd(ctx.inputs, cwd),
+    worktreeSetupCwd: cwd,
+  } as WorkflowRunContext<Record<string, unknown>>);
 }
 
 function makeMockCtx<TInputs extends Record<string, unknown>>(
@@ -97,7 +117,7 @@ function makeMockCtx<TInputs extends Record<string, unknown>>(
       throw new Error(`ctx.stage should not be used by builtin workflow ${name}`);
     },
     async task(this: WorkflowRunContext<TInputs>, name: string, options: WorkflowTaskOptions): Promise<WorkflowTaskResult> {
-      const taskOptions = withRalphWorktreeDefaults(inputs, this.cwd, options);
+      const taskOptions = withRalphWorktreeDefaults(inputs, workflowWorktreeSetupCwd(this), options);
       calls.task.push(name);
       calls.taskOptions[name] = [...(calls.taskOptions[name] ?? []), taskOptions];
       const text = promptText(taskOptions);
@@ -112,9 +132,10 @@ function makeMockCtx<TInputs extends Record<string, unknown>>(
       return results;
     },
     async parallel(this: WorkflowRunContext<TInputs>, steps: readonly WorkflowTaskStep[], options: WorkflowParallelOptions = {}): Promise<WorkflowTaskResult[]> {
-      const parallelOptions = withRalphWorktreeDefaults(inputs, this.cwd, options);
+      const worktreeSetupCwd = workflowWorktreeSetupCwd(this);
+      const parallelOptions = withRalphWorktreeDefaults(inputs, worktreeSetupCwd, options);
       calls.parallelOptions.push(parallelOptions);
-      const preparedSteps = steps.map((step) => withRalphWorktreeDefaults(inputs, this.cwd, step));
+      const preparedSteps = steps.map((step) => withRalphWorktreeDefaults(inputs, worktreeSetupCwd, step));
       const override = await responders.parallel?.(preparedSteps, parallelOptions, calls);
       if (override !== undefined) return override;
       return Promise.all(preparedSteps.map((step) => this.task(step.name, step)));
@@ -249,11 +270,11 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    const result = await mod.default.run({ ...ctx, cwd: subdir });
+    const result = await runRalphModule(mod, ctx, subdir);
 
-    assertRalphResultShape(result, subdir);
+    assertRalphResultShape(result, expectedCwd);
     const planPath = String(result["plan_path"]);
-    assert.equal(planPath.startsWith(expectedWorktreeRoot), false);
+    assert.equal(planPath.startsWith(expectedCwd), true);
     const orchestratorReads = ctx.calls.taskOptions["orchestrator-1"]?.[0]?.reads;
     assert.ok(Array.isArray(orchestratorReads) && orchestratorReads.includes(planPath));
     assertEveryRalphStageCwd(ctx, expectedCwd);
@@ -271,7 +292,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: requireTempRoot() }),
+      () => runRalphModule(mod, ctx, requireTempRoot()),
       /git_worktree_dir requires Ralph to be invoked from inside a Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -289,7 +310,7 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await mod.default.run({ ...ctx, cwd: repo });
+    await runRalphModule(mod, ctx, repo);
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assertWorktreeRegistered(repo, expectedWorktree);
@@ -309,7 +330,7 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await mod.default.run({ ...ctx, cwd: repo });
+    await runRalphModule(mod, ctx, repo);
 
     assertEveryRalphStageCwd(ctx, expectedWorktree);
     assert.equal(existsSync(uncommittedPath), true);
@@ -329,7 +350,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       /git_worktree_dir already exists but is not a Git worktree root/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -350,7 +371,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       /git_worktree_dir already exists but is not a Git worktree root/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -370,7 +391,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       /git_worktree_dir already exists but does not belong to the invoking Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -388,7 +409,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       /git_worktree_dir already exists but does not belong to the invoking Git repository/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -412,9 +433,9 @@ describe("ralph git worktree integration", () => {
       git_worktree_dir: expectedWorktree,
     });
 
-    await mod.default.run({ ...firstCtx, cwd: repo });
+    await runRalphModule(mod, firstCtx, repo);
     assertWorktreeRegistered(repo, expectedWorktree);
-    await mod.default.run({ ...secondCtx, cwd: repo });
+    await runRalphModule(mod, secondCtx, repo);
 
     assertEveryRalphStageCwd(firstCtx, expectedWorktree);
     assertEveryRalphStageCwd(secondCtx, expectedWorktree);
@@ -433,7 +454,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       /Failed to create git worktree at requested git_worktree_dir/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -453,7 +474,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       (error: unknown) => {
         assert.ok(error instanceof Error);
         assert.match(error.message, /Failed to create parent directory for requested git_worktree_dir/);
@@ -478,7 +499,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       /git_worktree_dir already exists but is not a Git worktree/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -495,7 +516,7 @@ describe("ralph git worktree integration", () => {
     });
 
     await assert.rejects(
-      () => mod.default.run({ ...ctx, cwd: repo }),
+      () => runRalphModule(mod, ctx, repo),
       /git_worktree_dir contains an unusable null byte/,
     );
     assert.deepEqual(ctx.calls.task, []);
@@ -534,7 +555,7 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    await mod.default.run({ ...ctx, cwd: repo });
+    await runRalphModule(mod, ctx, repo);
 
     for (const name of ["planner-1", "orchestrator-1", "code-simplifier-1", "planner-2", "orchestrator-2", "code-simplifier-2"]) {
       assertSamePath(ctx.calls.taskOptions[name]?.[0]?.cwd, expectedWorktree, `unexpected cwd for ${name}`);
@@ -562,7 +583,7 @@ describe("ralph git worktree integration", () => {
       },
     );
 
-    await assert.rejects(() => mod.default.run({ ...ctx, cwd: repo }), /planner failed/);
+    await assert.rejects(() => runRalphModule(mod, ctx, repo), /planner failed/);
 
     assertWorktreeRegistered(repo, expectedWorktree);
   });

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -271,6 +271,60 @@ describe("executor.run", () => {
     assert.equal(wfResult.result?.["count"], 2);
   });
 
+  test("worktreeFromInputs defaults ctx.cwd and stages to the reusable worktree cwd", async () => {
+    const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-input-worktree-")));
+    const repo = join(tempRoot, "repo");
+    mkdirSync(join(repo, "nested"), { recursive: true });
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(join(repo, "nested", "fixture.txt"), "fixture\n", "utf8");
+    execFileSync("git", ["add", "nested/fixture.txt"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "initial"], { cwd: repo, stdio: "ignore" });
+    const invocationCwd = join(repo, "nested");
+    const worktreeRoot = join(repo, "worktrees", "input-bound");
+    const expectedCwd = join(worktreeRoot, "nested");
+    const expectedArtifact = join(expectedCwd, "specs", "artifact.md");
+    const calls: CreateAgentSessionOptions[] = [];
+    const def = defineWorkflow("input-worktree-cwd-wf")
+      .input("git_worktree_dir", { type: "string", default: "" })
+      .input("base_branch", { type: "string", default: "main" })
+      .worktreeFromInputs({ gitWorktreeDir: "git_worktree_dir", baseBranch: "base_branch" })
+      .run(async (ctx) => {
+        if (ctx.cwd === undefined) throw new Error("expected workflow cwd");
+        mkdirSync(join(ctx.cwd, "specs"), { recursive: true });
+        writeFileSync(join(ctx.cwd, "specs", "artifact.md"), "artifact\n", "utf8");
+        await ctx.task("worker", { task: "inspect" });
+        await ctx.task("relative-worker", { task: "inspect relative", cwd: "deeper" });
+        return { cwd: ctx.cwd, artifact: join(ctx.cwd, "specs", "artifact.md") };
+      })
+      .compile();
+
+    const wfResult = await run(def, {
+      git_worktree_dir: join("worktrees", "input-bound"),
+      base_branch: "main",
+    }, {
+      cwd: invocationCwd,
+      adapters: {
+        agentSession: {
+          async create(options) {
+            calls.push(options);
+            return mockSession();
+          },
+        },
+      },
+      store: createStore(),
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.equal(wfResult.result?.["cwd"], expectedCwd);
+    assert.equal(wfResult.result?.["artifact"], expectedArtifact);
+    assert.equal(calls[0]?.cwd, expectedCwd);
+    assert.equal(calls[1]?.cwd, join(expectedCwd, "deeper"));
+    assert.equal(existsSync(expectedArtifact), true);
+    assert.equal(existsSync(join(invocationCwd, "specs", "artifact.md")), false);
+  });
+
   test("ctx.stage defaults cwd to gitWorktreeDir while preserving the workflow relative cwd", async () => {
     const tempRoot = realpathSync.native(mkdtempSync(join(tmpdir(), "atomic-workflow-git-worktree-")));
     const repo = join(tempRoot, "repo");


### PR DESCRIPTION
## Summary

When a workflow uses `worktreeFromInputs` and `gitWorktreeDir` resolves to a valid worktree, `ctx.cwd` now defaults to the resolved worktree path instead of the original invocation directory. This ensures workflow-level artifact writes (e.g. Ralph spec files) land inside the worktree checkout, consistent with how stage/task `cwd` already behaved.

## Key Changes

- **`executor.ts`**: Added `workflowCwdWithInputWorktree` to derive `ctx.cwd` from the input-bound `gitWorktreeDir` at workflow startup. Renamed the invocation cwd variable to `workflowInvocationCwd` to distinguish it from the resolved workflow cwd. Changed `ctx.cwd` to a lazy getter so worktree setup is deferred until first access.
- **`executor.ts`**: Stage and task `cwd` resolution continues to use `workflowInvocationCwd` (the original invocation dir) for `git worktree add` — only `ctx.cwd` is affected.
- **`builtin/ralph.ts`**: Updated comment to reflect that `workflowStartCwd` (i.e. `ctx.cwd`) now resolves to the worktree path when `git_worktree_dir` is supplied, so Ralph specs land in the worktree automatically.
- **`test/unit/executor.test.ts`**: New test verifying `ctx.cwd` and all stage/task `cwd` values resolve to the worktree path when `worktreeFromInputs` is used with a `gitWorktreeDir` input, and that artifacts written to `ctx.cwd` land in the worktree (not the invocation dir).
- **`test/integration/ralph-worktree.test.ts`**: Introduced `runRalphModule` and `workflowWorktreeSetupCwd` helpers to thread worktree setup cwd through mock contexts separately from `ctx.cwd`. Updated spec-path assertions to expect plan files inside the worktree. Canonicalized temp roots with `realpathSync.native`.
- **`README.md`**: Documented that `worktreeFromInputs` defaults `ctx.cwd` to the worktree path, not just stage/task `cwd`.
- **`CHANGELOG.md`**: Added entry under `[Unreleased] > Fixed`.

## Behavior Before / After

| Scenario | Before | After |
|---|---|---|
| `worktreeFromInputs` + `git_worktree_dir` set | `ctx.cwd` = invocation dir | `ctx.cwd` = worktree path |
| Stage/task `cwd` default | worktree path ✓ | worktree path ✓ (unchanged) |
| Explicit `cwd` override | respected ✓ | respected ✓ (unchanged) |
| No `git_worktree_dir` input | `ctx.cwd` = invocation dir | `ctx.cwd` = invocation dir (unchanged) |

## Validation

```sh
AGENT=1 bun test test/unit/executor.test.ts test/integration/ralph-worktree.test.ts
AGENT=1 bun test test/unit/workflow-runner.test.ts test/unit/define-workflow.test.ts
bun run typecheck
bun run lint
```