### PR TITLE
chore(release): prepare v0.8.18-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.17-0",
+      "version": "0.8.18-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.17-0",
+      "version": "0.8.18-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.17-0",
+      "version": "0.8.18-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.2.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.17-0",
+      "version": "0.8.18-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.17-0",
+      "version": "0.8.18-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.16.0",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.17-0",
+      "version": "0.8.18-0",
       "dependencies": {
         "jiti": "^2.7.0",
       },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.18-0] - 2026-05-27
+
 ### Added
 
 - Added SDK `excludeTools` support for omitting named built-in, extension, and custom tools from `createAgentSession()` sessions while preserving existing `tools` and `noTools` behavior ([#1070](https://github.com/flora131/atomic/issues/1070)).

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.17",
+  "version": "0.8.18-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.17",
+  "version": "0.8.18-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.17",
+  "version": "0.8.18-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.17",
+  "version": "0.8.18-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.17",
+  "version": "0.8.18-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.18-0] - 2026-05-27
+
 ### Added
 
 - Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing/sharing existing worktrees from the invoking repository as-is and leaving worktrees in place for retries.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.17",
+  "version": "0.8.18-0",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the v0.8.18-0 prerelease: stamps changelog sections with the release date, bumps all workspace package versions from 0.8.17 to 0.8.18-0, and refreshes `bun.lock`.

## Changes

### `@bastani/atomic` (coding-agent)
- Added SDK `excludeTools` blocklist to `createAgentSession()` for omitting named built-in, extension, and custom tools while preserving existing `tools`/`noTools` behavior ([#1070](https://github.com/flora131/atomic/issues/1070))
- Clarified bundled workflow docs and `/atomic` onboarding copy: `goal` for smaller scoped changes with explicit outcomes; `ralph` for larger migrations, broad refactors, and PR-prep workflows

### `@bastani/workflows`
- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing/sharing existing worktrees and leaving them in place for retries
- Replaced regex-based workflow discovery stage validation with runtime empty-graph validation (keeps discovery side-effect-free)
- Threaded named workflow invocation `cwd` into run contexts so workflow-owned artifacts use the explicit runner cwd
- Split worker project-initialization preflight guidance from Goal receipt/reporting instructions
- Fixed: `ctx.cwd` now defaults to the reusable worktree cwd when `worktreeFromInputs` resolves a `gitWorktreeDir`
- Fixed: blank deep-research display paths when displayed artifact path equals the workflow invocation directory
- Fixed: Ralph same-repository worktree classification and canonicalization failures vs. non-Git `git_worktree_dir` paths
- Fixed: Ralph now revises a stable original spec file across planner iterations; clarified `git_worktree_dir` null-byte diagnostics

### Version bumps
All workspace packages bumped `0.8.17` → `0.8.18-0`: `@bastani/atomic`, `@bastani/workflows`, `@bastani/intercom`, `@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`

## Validation

- `bun run typecheck`
- Pre-commit hooks: lint, test:unit