### PR TITLE
chore(release): prepare v0.8.18

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.18] - 2026-05-27
+
+### Changed
+
+- Promoted the 0.8.18 prerelease changes to a stable release.
+
 ## [0.8.18-0] - 2026-05-27
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.18-0",
+  "version": "0.8.18",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.18] - 2026-05-27
+
+### Changed
+- Promoted the 0.8.18 prerelease package version to a stable release.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.18-0",
+  "version": "0.8.18",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.18] - 2026-05-27
+
+### Changed
+- Promoted the 0.8.18 prerelease package version to a stable release.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.18-0",
+  "version": "0.8.18",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 ## [Unreleased]
 
+## [0.8.18] - 2026-05-27
+
+### Changed
+- Promoted the 0.8.18 prerelease package version to a stable release.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.18-0",
+  "version": "0.8.18",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.18] - 2026-05-27
+
+### Changed
+- Promoted the 0.8.18 prerelease package version to a stable release.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.18-0",
+  "version": "0.8.18",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.18] - 2026-05-27
+
+### Changed
+
+- Promoted the 0.8.18 prerelease changes to a stable release.
+
 ## [0.8.18-0] - 2026-05-27
 
 ### Added

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.18-0",
+  "version": "0.8.18",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.18-0 prerelease to a stable release across all workspace packages, bumping versions from `0.8.18-0` → `0.8.18` and adding stable changelog entries.

## Changes

**`@bastani/atomic` (coding-agent)**
- Added `excludeTools` SDK support for omitting named built-in, extension, and custom tools from `createAgentSession()` sessions while preserving existing `tools` and `noTools` behavior ([#1070](https://github.com/flora131/atomic/issues/1070))
- Clarified bundled workflow docs and `/atomic` onboarding copy distinguishing `goal` (smaller scoped changes) from `ralph` (larger migrations, broad refactors, PR-prep workflows)

**`@bastani/workflows`**
- Added Ralph `git_worktree_dir` support for running stages from an optional Git worktree, reusing/sharing existing worktrees and leaving them in place for retries
- Replaced regex-based workflow discovery stage validation with runtime empty-graph validation based on actual stage creation
- Threaded named workflow invocation `cwd` into workflow run contexts so workflow-owned artifacts use the explicit runner cwd
- Fixed `ctx.cwd` defaulting to reusable worktree cwd when `worktreeFromInputs` resolves a `gitWorktreeDir`
- Fixed blank deep-research display paths when a displayed artifact path equals the workflow invocation directory
- Fixed Ralph same-repository worktree classification and canonicalization failure handling
- Updated Ralph to revise a stable original spec file across planner iterations

**All packages** (`@bastani/intercom`, `@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`)
- Version promoted from `0.8.18-0` → `0.8.18`

## Validation

- `bun run typecheck`
- Pre-commit hooks: lint, `test:unit`