### PR TITLE
docs: update Ralph and worktree guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Clarified bundled workflow docs and `/atomic` onboarding copy for using `goal` on smaller scoped changes with explicit outcomes, testing instructions, and done criteria, while positioning `ralph` for larger migrations, broad refactors, and PR-prep workflows.
+- Updated the docs changelog and impacted workflow, subagent, and SDK docs for the latest Ralph goal-runner releases, worktree isolation behavior, and `excludedTools` SDK guidance.
 
 ## [0.8.17] - 2026-05-26
 

--- a/packages/coding-agent/docs/changelog.mdx
+++ b/packages/coding-agent/docs/changelog.mdx
@@ -3,6 +3,25 @@ title: "Changelog"
 description: "What's new in Atomic"
 ---
 
+<Update label="May 26, 2026" tags={["v0.8.17", "v0.8.16", "v0.8.15"]}>
+
+## Latest releases
+
+- **0.8.17 is the latest stable release.** It promotes the Ralph simplification from the prerelease while keeping `objective`, `max_turns`, and optional `base_branch` as the workflow inputs. Reviewer quorum and repeated-blocker thresholds now use fixed controller defaults. See [Workflows](/workflows).
+- **Ralph now runs as a deterministic Goal Runner.** The workflow keeps a goal ledger, records worker receipts, gates completion through parallel structured reviewers, reports `complete`, `blocked`, or `needs_human`, and keeps the full objective intact across turns.
+- **Workflow human-input prompts are visible graph nodes.** `ctx.ui.input`, `confirm`, `select`, and `editor` prompts render as `awaiting_input` stages with `StageSnapshot.promptAnswerState` metadata, and prompt answers replay only from live in-memory state.
+- **Workflow inspection and control expanded.** The workflow tool supports stage introspection and control actions such as `stages`, `stage`, `transcript`, `send`, `pause`, and `reload`.
+- **Direct workflow and subagent runs can isolate parallel writers with worktrees.** Use `worktree: true` for parallel tasks or chain parallel groups when concurrent agents may edit files; Atomic captures per-worktree diff summaries and patch artifacts.
+- **SDK tool exclusions are documented.** Provider/session integrations that support `excludedTools` can deny specific tools, and headless Copilot workflow stages merge the caller's exclusions with Atomic's required `ask_user` exclusion instead of replacing them. See [SDK](/sdk) and [Workflows](/workflows).
+
+## Fixes
+
+- Workflow prompt-node handling now returns cleanly to the graph orchestrator after answers or skips.
+- MCP OAuth callback handling no longer starts eagerly during session startup.
+- Bundled subagent fixes cover nested fanout state, child allowlists, async runner config permissions, fallback models, read-only guard overrides, Windows child process spawning, stable running glyphs, and recovered intermediate child errors.
+
+</Update>
+
 <Update label="May 25, 2026" tags={["v0.8.14"]}>
 
 ## Stable release

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -74,7 +74,7 @@ Atomic ships with four workflows you can run immediately. Use `/workflow list` t
 |---|---|---|
 | `deep-research-codebase` | Broad, cross-cutting research before you decide what to change. Scout → research-history → parallel specialist waves → aggregator. | `/workflow deep-research-codebase prompt="How do payment retries work end to end?"` |
 | `goal` | Small-to-medium scope changes when you can identify the work surface, state the exact outcome, and name the validation that proves it is done — for example tests, lint/typecheck, docs builds, or observable behavior. Keeps the run bounded with a goal ledger, reviewer gates, and final status `complete`, `blocked`, or `needs_human`. | `/workflow goal objective="Implement specs/2026-03-rate-limit.md, run the focused tests, and finish when burst traffic returns 429"` |
-| `ralph` | Larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report. | `/workflow ralph prompt="Plan the database migration, implement it, review it, and prepare a PR"` |
+| `ralph` | Larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to preserve a full objective, delegate implementation through sub-agents, review deterministically, and prepare a pull-request report. | `/workflow ralph objective="Plan the database migration, implement it, review it, and prepare a PR"` |
 | `open-claude-design` | UI and design-system work with generation, critique, and refinement loops; renders a live `preview.html` you can iterate against. | `/workflow open-claude-design prompt="Refresh the settings page hierarchy" output_type=page` |
 
 <p align="center"><img src="images/workflow-list.png" alt="Workflow List" width="600" /></p>
@@ -95,7 +95,7 @@ Atomic picks the workflow, fills in inputs from the request, and confirms before
 
 Use `goal` for small-to-medium scope changes when you can identify the work surface, state the exact outcome you want, and name the validation that proves it is done — for example specific tests, lint/typecheck commands, docs builds, or observable behavior. It keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human`.
 
-Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report.
+Keep using `ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to keep the full objective in a ledger, delegate implementation through sub-agents, review with deterministic gates, and prepare a pull-request report.
 
 ### Monitor and steer a run
 
@@ -124,7 +124,7 @@ Skills are reusable expert instructions. Trigger one with `/skill:<name>` follow
 | `tdd` | Test-first feature or bug work. | `/skill:tdd` |
 | `impeccable` | Critique or refine frontend and product UI. | `/skill:impeccable` |
 
-Use `/skill:research-codebase` for a focused area and `/workflow deep-research-codebase` when the answer spans the whole repo. A typical focused flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal` with an objective that identifies the work surface, states the exact outcome, and names the validation that proves it is done. Keep using `/workflow ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan, delegate through sub-agents, simplify, review, iterate, and prepare a pull-request report.
+Use `/skill:research-codebase` for a focused area and `/workflow deep-research-codebase` when the answer spans the whole repo. A typical focused flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal` with an objective that identifies the work surface, states the exact outcome, and names the validation that proves it is done. Keep using `/workflow ralph objective="..."` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to keep the full objective in a ledger, delegate through sub-agents, review with deterministic gates, and prepare a pull-request report.
 
 ### Create your own workflow in natural language
 

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -501,6 +501,20 @@ const { session } = await createAgentSession({
 });
 ```
 
+#### Provider session `excludedTools`
+
+Use `tools` for an Atomic session allowlist. Provider-backed workflow SDK integrations that expose provider session options may also support `excludedTools`, a denylist that keeps the provider's normal tool set except for the named tools.
+
+For Copilot-backed headless workflow stages, Atomic merges your `excludedTools` with its required `ask_user` exclusion instead of replacing your list. That keeps native tmux-pane human input as the interaction surface while preserving your own exclusions.
+
+```typescript
+// Provider session options in workflow/agent SDK integrations that support Copilot
+const sessionOptions = {
+  excludedTools: ["dangerous_tool"],
+};
+// Headless Copilot stages run with ["dangerous_tool", "ask_user"].
+```
+
 #### Tools with Custom cwd
 
 When you pass a custom `cwd`, `createAgentSession()` builds selected built-in tools for that cwd.

--- a/packages/coding-agent/docs/subagents.md
+++ b/packages/coding-agent/docs/subagents.md
@@ -104,7 +104,32 @@ Subagents can run with fresh or forked context:
 
 For adversarial review or research, prefer fresh context so the specialist inspects the repository directly. Use forked context when a writer needs the parent conversation history in a separate branch.
 
-For parallel implementation work, `worktree: true` can give each child an isolated git worktree so concurrent edits do not clobber each other.
+For parallel implementation work, use `worktree: true` when multiple writer children might edit at the same time. Each child gets an isolated git worktree so concurrent edits do not clobber each other.
+
+## Worktree isolation
+
+`worktree: true` applies to top-level parallel `tasks`, chain steps with `{ parallel: [...] }`, and async/background chains. Use it for intentionally parallel writer workflows; keep normal work single-writer when possible.
+
+```ts
+subagent({
+  tasks: [
+    { agent: "debugger", task: "Fix package A" },
+    { agent: "code-simplifier", task: "Clean up package B" },
+  ],
+  worktree: true,
+})
+```
+
+Requirements and behavior:
+
+- The run must start inside a git repository with a clean working tree.
+- Each parallel child gets a temporary worktree branched from `HEAD`.
+- Task-level `cwd` overrides must be omitted or match the shared cwd.
+- `node_modules/` is symlinked into each worktree when present.
+- Results include per-child diff stats, and full patch files are written with artifacts.
+- Temporary worktrees and branches are cleaned up after diff capture.
+
+If a project needs generated files, virtualenvs, copied local config, or other setup inside each temporary worktree, configure the subagents extension `worktreeSetupHook` so those helper paths can be created and excluded from captured patches.
 
 ## Nested and fanout boundaries
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -141,7 +141,7 @@ Atomic bundles four workflows that cover the most common multi-stage jobs. They 
 |---|---|---|
 | `deep-research-codebase` | Scout + research-history chain → parallel specialist waves → aggregator. Indexes the whole repo and synthesizes findings. | Broad or cross-cutting research before you decide what to change. Prefer `/skill:research-codebase` for one subsystem. |
 | `goal` | Persisted goal ledger → bounded worker turns → receipts → three-reviewer gate → deterministic reducer → final report. | Small-to-medium scope changes when you can identify the work surface, state the exact outcome, and name the validation that proves it is done — for example tests, lint/typecheck, docs builds, or observable behavior. |
-| `ralph` | RFC planning → sub-agent orchestration → simplification → infrastructure discovery → parallel review → PR handoff. | Larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report. |
+| `ralph` | Goal ledger → bounded work turns → worktree-isolated implementation/review → structured reviewer gate → final status and PR handoff. | Larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to preserve the full objective, capture receipts, review deterministically, and prepare a pull-request report. |
 | `open-claude-design` | Design-system onboarding → reference import → HTML generation → impeccable-driven refinement → quality gate → rich HTML handoff. Renders a live `preview.html` you can iterate against (opens through `playwright-cli` when available). | UI, page, component, theme, or design-token work that benefits from generation + critique loops. |
 
 ### `deep-research-codebase`
@@ -235,33 +235,36 @@ Inputs:
 
 | Input | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `prompt` | text | yes | — | Task, feature request, issue summary, or spec path to plan, execute, refine, review, and prepare for PR. |
-| `max_loops` | number | no | `10` | Maximum plan/orchestrate/review iterations before the workflow proceeds to PR handoff without reviewer approval. |
+| `objective` | text | yes | — | Full task objective. Include the desired end state, constraints, validation instructions, and any spec, issue, or PR-prep context. |
+| `max_turns` | number | no | `10` | Maximum worker/review turns before the workflow stops for human follow-up. |
 | `base_branch` | string | no | `origin/main` | Branch reviewers and the PR-prep stage compare the current code delta against. |
+
+`ralph` no longer accepts the old `prompt`, `max_loops`, `review_quorum`, or `blocker_threshold` inputs. Reviewer quorum and repeated-blocker thresholds are fixed controller defaults so runs stay deterministic.
 
 Run examples:
 
 ```text
-/workflow ralph prompt="Plan and migrate the database layer to Drizzle" max_loops=3 base_branch=develop
-/workflow ralph prompt="Refactor authentication across the API, CLI, and web UI, then prepare the PR"
+/workflow ralph objective="Plan and migrate the database layer to Drizzle, run the focused validation, and prepare a PR" max_turns=3 base_branch=develop
+/workflow ralph objective="Refactor authentication across the API, CLI, and web UI; finish only when tests pass and the PR handoff is ready"
 ```
 
-Each `ralph` iteration writes an RFC-style technical design document under `specs/`, initializes an OS-temp implementation notes file, delegates implementation through sub-agents, runs a behavior-preserving code simplifier, discovers review infrastructure, and asks two reviewers to inspect the patch against `base_branch`. The loop stops when every reviewer approves or `max_loops` is reached, then runs a pull-request preparation stage.
+Ralph keeps the full objective in a persisted goal ledger, runs bounded worker turns, records receipts and validation evidence, and asks parallel structured reviewers to inspect the ledger, repository state, and diff against `base_branch`. Parallel implementation or review passes can use isolated git worktrees so concurrent writers do not clobber the main checkout; Atomic captures per-worktree diff stats and patch artifacts before cleaning up temporary worktrees and branches. The reducer marks the run `complete` only when the fixed reviewer quorum approves, `blocked` only when the same blocker repeats enough times, and `needs_human` when `max_turns` is exhausted or execution fails. When possible, the final phase prepares a pull-request report against `base_branch`.
 
 Result fields:
 
 | Field | Meaning |
 |---|---|
-| `result` | Final implementation report from the orchestrator stage. |
-| `plan` | Latest RFC-style plan text. |
-| `plan_path` | Path to the latest generated spec under `specs/`. |
-| `implementation_notes_path` | OS-temp notes file containing decisions, deviations, blockers, and validation notes. |
-| `pr_report` | Pull-request preparation report: diff review, PR status, commands, and follow-up steps. |
-| `approved` | Whether the reviewer loop approved before PR handoff. |
-| `iterations_completed` | Number of plan/orchestrate/review loops completed. |
-| `review_report` | Markdown report containing the latest reviewer payloads. |
+| `result` | Final report with objective, status, receipts, turns, and remaining work. |
+| `status` | Final reducer status: `complete`, `blocked`, or `needs_human` (or `active` if externally interrupted). |
+| `approved` | Whether the reducer reached `complete`. |
+| `objective` | Normalized objective used by the run. |
+| `ledger_path` | OS-temp goal-ledger path containing receipts, reviewer decisions, reducer decisions, blockers, and lifecycle events. |
+| `turns_completed` | Worker/review turns completed. |
+| `remaining_work` | Remaining gaps or blockers when incomplete, or `none`. |
+| `review_report` | Markdown report containing the latest structured reviewer decisions. |
+| `pr_report` | Pull-request preparation report when PR handoff runs. |
 
-A typical end-to-end flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal objective="Implement the researched rate-limit behavior, run the focused tests, and finish when the documented burst behavior is validated"` when you can identify the work surface, state the exact outcome, and name the validation that proves it is done. Keep using `/workflow ralph` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan, delegate through sub-agents, simplify, review, iterate, and prepare a pull-request report.
+A typical end-to-end flow is `/skill:research-codebase` → `/skill:create-spec` → `/workflow goal objective="Implement the researched rate-limit behavior, run the focused tests, and finish when the documented burst behavior is validated"` when you can identify the work surface, state the exact outcome, and name the validation that proves it is done. Keep using `/workflow ralph objective="..."` for larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to preserve a full objective, delegate implementation, review with deterministic gates, and prepare a pull-request report.
 
 ### `open-claude-design`
 
@@ -340,7 +343,7 @@ If the task is only deterministic TypeScript with no LLM/session stage, use a sc
 |-----------|-----|
 | Run, inspect, attach to, pause, interrupt, resume, or check status for an existing workflow | `/workflow ...` or `workflow({ action: ... })` |
 | Implement a small-to-medium scope change with an identifiable work surface, exact outcome, and named validation | `/workflow goal objective="..."` so Atomic keeps the run bounded, captures receipts in a goal ledger, gates completion through reviewers, and stops as `complete`, `blocked`, or `needs_human` |
-| Plan and execute a larger migration, broad refactor, multi-package change, or spec-to-PR effort | `/workflow ralph prompt="..."` so Atomic can plan the approach, delegate implementation through sub-agents, simplify, review, iterate, and prepare a pull-request report |
+| Plan and execute a larger migration, broad refactor, multi-package change, or spec-to-PR effort | `/workflow ralph objective="..."` so Atomic can preserve the full objective, delegate implementation, review with deterministic gates, and prepare a pull-request report |
 | Create or edit reusable automation | a TypeScript workflow definition with `defineWorkflow(...).run(...).compile()` |
 | Track one-off work without saving a workflow file | direct `workflow({ task })`, `workflow({ tasks })`, or `workflow({ chain })` calls |
 | Make a workflow robust | design the stage graph, context handoffs, artifacts, validation gates, model fallbacks, and human approval points before coding |
@@ -663,7 +666,9 @@ workflow({
 })
 ```
 
-Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `tools`, `noTools`, `customTools`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
+Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `tools`, `noTools`, `excludedTools`, `customTools`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
+
+For parallel writers, set `worktree: true` on top-level parallel runs or chain parallel groups. Atomic creates temporary git worktrees from `HEAD`, rejects conflicting task-level `cwd` overrides, appends per-task diff stats to the result, writes full patch artifacts when artifacts are enabled, and cleans up temp worktrees and branches afterward. Async/background chains support the same worktree isolation.
 
 For large fan-outs, prefer `outputMode: "file-only"` so the parent result contains compact file references instead of full output. Treat intercom payloads from async direct runs as user-visible workflow output.
 
@@ -772,11 +777,13 @@ Common task/stage options include:
 - `previous` for handoff context
 - `context: "fresh" | "fork"`, `forkFromSessionFile`
 - `model`, `fallbackModels`, `thinkingLevel`, `scopedModels`, `modelRegistry`
-- `tools`, `noTools`, `customTools`, `mcp: { allow?: string[], deny?: string[] }`
+- `tools`, `noTools`, `excludedTools`, `customTools`, `mcp: { allow?: string[], deny?: string[] }`
 - `output`, `outputMode`, `reads`, `worktree`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, `agentDir`
 - advanced host-supplied SDK seams: `authStorage`, `resourceLoader`, `sessionManager`, `settingsManager`, `sessionStartEvent`
 
 `fallbackModels` retries transient provider/model failures with the primary `model` first, then each fallback, then the current Atomic-selected model when available. It is for rate limits, quota/auth/provider outages, unavailable models, network timeouts, and 5xx errors — not workflow-code errors, tool failures, validation failures, or cancellations.
+
+`excludedTools` is a provider/session-level denylist for SDK integrations that support it. Use `tools` when you want an explicit allowlist and `excludedTools` when the provider should keep its normal tool set except for named tools. Headless Copilot workflow stages merge caller-supplied `excludedTools` with Atomic's required `ask_user` exclusion so native tmux-pane HIL remains the interaction surface without dropping your own exclusions.
 
 ## Programmatic Usage
 

--- a/packages/coding-agent/src/core/atomic-guide-command.ts
+++ b/packages/coding-agent/src/core/atomic-guide-command.ts
@@ -26,7 +26,7 @@ Atomic turns one-off prompts into developer workflows: on-call debugging, repo r
 | Goal | How to use |
 |---|---|
 | On-call / broken behavior | Run \`/run debugger "Reproduce the failure, patch the root cause, and validate it"\` for a focused fix loop, or ask Atomic in chat to build a reusable workflow that does the same |
-| Research → spec → implementation | Chain \`/skill:research-codebase\` → \`/skill:create-spec\` → \`/workflow goal objective="..."\` for bounded scoped work with explicit validation; use \`/workflow ralph ...\` when the work needs planning, broad refactoring, or PR prep |
+| Research → spec → implementation | Chain \`/skill:research-codebase\` → \`/skill:create-spec\` → \`/workflow goal objective="..."\` for bounded scoped work with explicit validation; use \`/workflow ralph objective="..."\` when the work needs planning, broad refactoring, or PR prep |
 | Testing / regression hardening | Run \`/skill:tdd\` for test-first work, then \`/parallel-review current diff\`, then land the change |
 | Large repo discovery | Run \`/parallel codebase-locator "map the area" -> codebase-analyzer "trace the current flow" -> codebase-pattern-finder "find patterns" --bg\`, or \`/workflow deep-research-codebase\` for whole-repo synthesis |
 | UI / product polish | Run \`/skill:impeccable\` for interface critique and refinement, or \`/workflow open-claude-design\` for generation + refinement loops |
@@ -37,7 +37,7 @@ Atomic turns one-off prompts into developer workflows: on-call debugging, repo r
 |---|---|---|
 | \`deep-research-codebase\` | broad repo or cross-cutting research before you decide what to change (for one area, use \`/skill:research-codebase\`; this indexes the whole repo) | \`/workflow deep-research-codebase prompt="How do payment retries work end to end?"\` |
 | \`goal\` | small-to-medium scoped changes when you can name the work surface, outcome, and validation; keeps receipts in a ledger and stops as \`complete\`, \`blocked\`, or \`needs_human\` | \`/workflow goal objective="Implement specs/<date>-<topic>.md, run focused tests, and validate the changed behavior"\` |
-| \`ralph\` | larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to plan, delegate, simplify, review, iterate, and prepare a PR report | \`/workflow ralph prompt="Plan and implement specs/<date>-<topic>.md, then prepare the PR"\` |
+| \`ralph\` | larger migrations, broad refactors, multi-package changes, and spec-to-PR work where you want Atomic to preserve a full objective, delegate, review deterministically, and prepare a PR report | \`/workflow ralph objective="Plan and implement specs/<date>-<topic>.md, then prepare the PR"\` |
 | \`open-claude-design\` | UI and design-system work that benefits from generation and refinement loops | \`/workflow open-claude-design prompt="Refresh the settings page hierarchy"\` |
 
 Use \`/workflow list\` to see what is available and \`/workflow inputs <name>\` to inspect inputs in your environment.
@@ -112,13 +112,13 @@ For small-to-medium scoped changes where you can identify the work surface, exac
 
 For larger migrations, broad refactors, multi-package changes, or spec-to-PR work, use \`ralph\`:
 
-\`/workflow ralph prompt="Plan and implement specs/<date>-<topic>.md, then prepare the PR"\`
+\`/workflow ralph objective="Plan and implement specs/<date>-<topic>.md, then prepare the PR"\`
 
 ## 4. Decide and land
 
 If you used \`goal\`, the workflow already persisted receipts in a goal ledger and reviewer-gated completion. Use its final status — \`complete\`, \`blocked\`, or \`needs_human\` — plus the remaining-work report to decide whether to ship, unblock, or clarify.
 
-If you used \`ralph\`, the workflow planned the approach, delegated implementation through sub-agents, simplified, reviewed, iterated, and prepared a pull-request report. Use its review feedback and PR report to decide whether to ship or iterate again.
+If you used \`ralph\`, the workflow preserved the full objective in a ledger, delegated implementation through sub-agents, reviewed with deterministic gates, and prepared a pull-request report. Use its final status, review feedback, and PR report to decide whether to ship, unblock, or iterate again.
 
 If you implemented directly instead of using a workflow, you can still run:
 
@@ -145,7 +145,7 @@ You do not have to write TypeScript to add one. Describe the workflow you want i
 |---|---|---|
 | \`deep-research-codebase\` | broad repo or cross-cutting research before you decide what to change (for one area, use \`/skill:research-codebase\`; this indexes the whole repo) | \`/workflow deep-research-codebase prompt="How do payment retries work end to end?"\` |
 | \`goal\` | small-to-medium scoped changes with a clear outcome and named validation | \`/workflow goal objective="Update the CLI docs, include one usage example, and verify the docs build passes"\` |
-| \`ralph\` | larger migrations, broad refactors, multi-package changes, and spec-to-PR work | \`/workflow ralph prompt="Plan a database-layer migration, implement it, review it, and prepare the PR"\` |
+| \`ralph\` | larger migrations, broad refactors, multi-package changes, and spec-to-PR work | \`/workflow ralph objective="Plan a database-layer migration, implement it, review it, and prepare the PR"\` |
 | \`open-claude-design\` | frontend and product design work | \`/workflow open-claude-design prompt="Refresh the settings page hierarchy"\` |
 
 Use \`/workflow inputs <name>\` to inspect the exact inputs in your environment.
@@ -193,7 +193,7 @@ Why this is good:
 
 \`/workflow inputs ralph\`
 
-\`/workflow ralph prompt="Migrate the database layer to Drizzle and prepare the PR"\`
+\`/workflow ralph objective="Migrate the database layer to Drizzle and prepare the PR"\`
 
 \`/workflow status\`
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Updated README guidance for Ralph's `objective`/`max_turns` inputs, worktree-isolated parallel execution, and SDK `excludedTools` session options.
+
 ## [0.8.17] - 2026-05-26
 
 ### Changed

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -280,7 +280,9 @@ await runWorkflow({
 });
 ```
 
-The programmatic definition object mirrors the workflow tool: named workflow runs, single-task runs, parallel `tasks`, and mixed `chain` runs accept the same direct options (`reads`, `output`, `outputMode`, `worktree`, `maxOutput`, `artifacts`, `concurrency`, `failFast`, and stage/session options such as `cwd`, `agentDir`, `model`, `tools`, `context`, and `sessionDir`). `chainDir` is chain-only: it provides the shared artifact directory for chain reads, outputs, and worktree diffs.
+The programmatic definition object mirrors the workflow tool: named workflow runs, single-task runs, parallel `tasks`, and mixed `chain` runs accept the same direct options (`reads`, `output`, `outputMode`, `worktree`, `maxOutput`, `artifacts`, `concurrency`, `failFast`, and stage/session options such as `cwd`, `agentDir`, `model`, `tools`, `excludedTools`, `context`, and `sessionDir`). `chainDir` is chain-only: it provides the shared artifact directory for chain reads, outputs, and worktree diffs.
+
+Use `worktree: true` for parallel writer stages that must not share one checkout. The runner creates temporary git worktrees from `HEAD`, captures per-worktree diff summaries and patch artifacts, then cleans up the temporary worktrees and branches. Provider/session integrations that support `excludedTools` can use it as a denylist; headless Copilot stages merge caller exclusions with Atomic's required `ask_user` exclusion.
 
 Workflow stage sessions follow Atomic SDK directory defaults: `DefaultResourceLoader` is initialized with the project `cwd` and the Atomic default `~/.atomic/agent` directory, while legacy `.pi` paths remain readable where the SDK supports multiple config directories. A stage-supplied `agentDir` is treated as an explicit user override; a stage-supplied `resourceLoader` owns discovery, with `cwd`/`agentDir` left for session naming and tool path resolution.
 
@@ -324,17 +326,19 @@ Goal Runner workflow: initialize a persisted goal ledger with a per-run goal id 
 
 ### `ralph`
 
-Plan → orchestrate → simplify → discover → review → PR-handoff workflow: write an RFC-style technical design document under `specs/`, delegate implementation through sub-agents, simplify recent changes, discover review infrastructure, run parallel reviewers, iterate until approval or the loop limit, then prepare a pull-request report.
+Goal-ledger workflow for larger migrations, broad refactors, multi-package changes, and spec-to-PR work: preserve the full objective, run bounded worker/review turns, capture receipts, review with a fixed structured reviewer gate, use worktree isolation for concurrent implementation/review passes, and prepare a pull-request report when possible.
 
 ```text
-/workflow ralph prompt="Plan and migrate the database layer to Drizzle ORM" max_loops=3 base_branch=develop
+/workflow ralph objective="Plan and migrate the database layer to Drizzle ORM, validate the migration, and prepare a PR" max_turns=3 base_branch=develop
 ```
 
 | Input         | Type     | Required | Default       | Description                                                   |
 | ------------- | -------- | -------- | ------------- | ------------------------------------------------------------- |
-| `prompt`      | `text`   | ✓        | —             | Task, feature request, issue summary, or spec path to plan, execute, refine, review, and prepare for PR. |
-| `max_loops`   | `number` | —        | `10`          | Maximum plan/orchestrate/review iterations before PR handoff. |
+| `objective`   | `text`   | ✓        | —             | Full task objective, including constraints, validation, and PR-prep context. |
+| `max_turns`   | `number` | —        | `10`          | Maximum worker/review turns before human follow-up is needed. |
 | `base_branch` | `string` | —        | `origin/main` | Branch reviewers and PR-prep compare the current delta with.  |
+
+The legacy `prompt`, `max_loops`, `review_quorum`, and `blocker_threshold` inputs were removed. Reviewer quorum and repeated-blocker thresholds are fixed controller defaults.
 
 ### `open-claude-design`
 


### PR DESCRIPTION
## Summary

Updates the Atomic and workflows docs for the latest Ralph goal-runner behavior, worktree-isolated parallel execution, and provider/session `excludedTools` guidance.

## Changes

- Documents Ralph's `objective`/`max_turns` inputs, deterministic review gates, final statuses, and updated examples.
- Adds worktree isolation guidance for subagents and direct workflow runs, including behavior and requirements.
- Adds SDK/provider `excludedTools` guidance and updates changelog entries for the docs refresh.

## Notes

Validation ran through git hooks during commit and push:
- `bun run lint`
- `bun run test:unit`
