### PR TITLE
chore(release): bump version to 0.8.19

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.19] - 2026-05-27
+
+### Changed
+
+- Renamed the SDK tool exclusion option from `excludeTools` to `excludedTools` for consistency with internal system prompt terminology, while preserving backward-compatible handling for existing SDK callers.
+
 ## [0.8.19-0] - 2026-05-27
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.19-0",
+  "version": "0.8.19",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.19-0",
+  "version": "0.8.19",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.19-0",
+  "version": "0.8.19",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.19-0",
+  "version": "0.8.19",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.19-0",
+  "version": "0.8.19",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.19-0",
+  "version": "0.8.19",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary
Promotes the `0.8.19-0` prerelease to the stable `0.8.19` release across all workspace packages, and adds the corresponding changelog entry.

## Changes
- Bump all workspace package versions from `0.8.19-0` → `0.8.19`:
  - `packages/coding-agent`
  - `packages/intercom`
  - `packages/mcp`
  - `packages/subagents`
  - `packages/web-access`
  - `packages/workflows`
- Add `[0.8.19] - 2026-05-27` section to `packages/coding-agent/CHANGELOG.md`

## What's in 0.8.19
- **Changed:** Renamed the SDK tool exclusion option from `excludeTools` to `excludedTools` for consistency with internal system-prompt terminology, while preserving backward-compatible handling for existing SDK callers (#1077, #1078)

## Tests
- `bun run typecheck`
- `bun run lint` (pre-commit hook)
- `bun run test:unit` (pre-commit hook)