### PR TITLE
fix(workflows): warn before session switch stops in-flight runs

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Warn before starting a new session when workflows are still running, allowing users to cancel before those runs are killed and current-session workflow history is cleared ([#1082](https://github.com/flora131/atomic/issues/1082)).
+
 ## [0.8.18] - 2026-05-27
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Warn before starting a new session when workflows are still running, allowing users to cancel before those runs are killed and current-session workflow history is cleared ([#1082](https://github.com/flora131/atomic/issues/1082)).
+- Warn before starting or resuming another session when workflows are still in flight, allowing users to cancel before those runs are killed and current-session workflow history is cleared ([#1082](https://github.com/flora131/atomic/issues/1082)).
 
 ## [0.8.18] - 2026-05-27
 

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -3260,22 +3260,25 @@ function factory(pi: ExtensionAPI): void {
       const reason = typeof event === "object" && event !== null && "reason" in event
         ? (event as { readonly reason?: string }).reason
         : undefined;
-      if (reason !== "new") return undefined;
+      if (reason !== "new" && reason !== "resume") return undefined;
 
-      const runningWorkflowCount = store.runs().filter((run) => run.endedAt === undefined).length;
-      if (runningWorkflowCount === 0) return undefined;
+      const inFlightWorkflowCount = inFlightRunCount();
+      if (inFlightWorkflowCount === 0) return undefined;
 
-      const confirmNewSession = ctx?.ui?.confirm;
-      if (typeof confirmNewSession !== "function") return undefined;
+      const confirmSessionSwitch = ctx?.ui?.confirm;
+      // Headless/non-interactive callers intentionally fail open so automation cannot wedge.
+      if (typeof confirmSessionSwitch !== "function") return undefined;
 
-      const workflowPlural = runningWorkflowCount === 1 ? "" : "s";
-      const promptTitle = `Start a new session and stop ${runningWorkflowCount} running workflow${workflowPlural}?`;
+      const workflowPlural = inFlightWorkflowCount === 1 ? "" : "s";
+      const actionLabel = reason === "new" ? "Start a new session" : "Resume another session";
+      const promptTitle = `${actionLabel} and stop ${inFlightWorkflowCount} in-flight workflow${workflowPlural}?`;
       const promptMessage =
-        "Starting a new session will stop/kill running workflows and clear workflow history tied to the current session.";
-      const shouldStartNewSession = await confirmNewSession(promptTitle, promptMessage);
-      if (shouldStartNewSession) return undefined;
+        `${actionLabel} will stop/kill in-flight workflows and clear workflow history tied to the current session.`;
+      const shouldSwitchSession = await confirmSessionSwitch(promptTitle, promptMessage);
+      if (shouldSwitchSession) return undefined;
 
-      ctx?.ui?.notify?.("New session cancelled; running workflows were left unchanged.", "info");
+      const cancelledLabel = reason === "new" ? "New session" : "Resume";
+      ctx?.ui?.notify?.(`${cancelledLabel} cancelled; in-flight workflows were left unchanged.`, "info");
       return { cancel: true };
     });
 

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -3256,6 +3256,29 @@ function factory(pi: ExtensionAPI): void {
   // 4. Persistence: session_start restore + session_before_compact hook (§5.6, Phase D)
   // -------------------------------------------------------------------------
   if (typeof pi.on === "function") {
+    pi.on("session_before_switch", async (event, ctx) => {
+      const reason = typeof event === "object" && event !== null && "reason" in event
+        ? (event as { readonly reason?: string }).reason
+        : undefined;
+      if (reason !== "new") return undefined;
+
+      const runningWorkflowCount = store.runs().filter((run) => run.endedAt === undefined).length;
+      if (runningWorkflowCount === 0) return undefined;
+
+      const confirmNewSession = ctx?.ui?.confirm;
+      if (typeof confirmNewSession !== "function") return undefined;
+
+      const workflowPlural = runningWorkflowCount === 1 ? "" : "s";
+      const promptTitle = `Start a new session and stop ${runningWorkflowCount} running workflow${workflowPlural}?`;
+      const promptMessage =
+        "Starting a new session will stop/kill running workflows and clear workflow history tied to the current session.";
+      const shouldStartNewSession = await confirmNewSession(promptTitle, promptMessage);
+      if (shouldStartNewSession) return undefined;
+
+      ctx?.ui?.notify?.("New session cancelled; running workflows were left unchanged.", "info");
+      return { cancel: true };
+    });
+
     pi.on("session_start", async (_event, ctx) => {
       // Workflow lifecycle is scoped to the originating chat session.
       // A new session inherits a clean store; any leftover runs from a

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -3262,6 +3262,8 @@ function factory(pi: ExtensionAPI): void {
         : undefined;
       if (reason !== "new" && reason !== "resume") return undefined;
 
+      // "In-flight" intentionally includes paused runs: session_start kills any run
+      // without endedAt, so warn for the same set that would be stopped by the switch.
       const inFlightWorkflowCount = inFlightRunCount();
       if (inFlightWorkflowCount === 0) return undefined;
 
@@ -3269,12 +3271,19 @@ function factory(pi: ExtensionAPI): void {
       // Headless/non-interactive callers intentionally fail open so automation cannot wedge.
       if (typeof confirmSessionSwitch !== "function") return undefined;
 
-      const workflowPlural = inFlightWorkflowCount === 1 ? "" : "s";
+      const workflowNoun = inFlightWorkflowCount === 1 ? "workflow" : "workflows";
       const actionLabel = reason === "new" ? "Start a new session" : "Resume another session";
-      const promptTitle = `${actionLabel} and stop ${inFlightWorkflowCount} in-flight workflow${workflowPlural}?`;
+      const messageLabel = reason === "new" ? "Starting a new session" : "Resuming another session";
+      const promptTitle = `${actionLabel} and stop ${inFlightWorkflowCount} in-flight ${workflowNoun}?`;
       const promptMessage =
-        `${actionLabel} will stop/kill in-flight workflows and clear workflow history tied to the current session.`;
-      const shouldSwitchSession = await confirmSessionSwitch(promptTitle, promptMessage);
+        `${messageLabel} will stop/kill ${inFlightWorkflowCount} in-flight ${workflowNoun} and clear workflow history tied to the current session.`;
+      let shouldSwitchSession: boolean | undefined;
+      try {
+        shouldSwitchSession = await confirmSessionSwitch(promptTitle, promptMessage);
+      } catch {
+        // Keep headless/failed UI behavior fail-open so session automation cannot wedge.
+        return undefined;
+      }
       if (shouldSwitchSession) return undefined;
 
       const cancelledLabel = reason === "new" ? "New session" : "Resume";

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -4,6 +4,47 @@ import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import factory, { type ExtensionAPI } from "../../packages/workflows/src/extension/index.js";
+import { store } from "../../packages/workflows/src/shared/store.js";
+import type { RunSnapshot } from "../../packages/workflows/src/shared/store-types.js";
+
+type SessionBeforeSwitchHandler = (event?: unknown, ctx?: unknown) => unknown;
+
+function workflowRun(overrides: Partial<RunSnapshot> = {}): RunSnapshot {
+  return {
+    id: "run-1",
+    name: "Test workflow",
+    inputs: {},
+    status: "running",
+    stages: [],
+    startedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function captureHandlers(): Map<string, SessionBeforeSwitchHandler> {
+  const handlers = new Map<string, SessionBeforeSwitchHandler>();
+  const pi: ExtensionAPI = {
+    registerTool: () => undefined,
+    registerCommand: () => undefined,
+    registerMessageRenderer: () => undefined,
+    registerFlag: () => undefined,
+    registerShortcut: () => undefined,
+    on: (event, handler) => {
+      handlers.set(event, handler as SessionBeforeSwitchHandler);
+    },
+    disableAsyncDiscovery: true,
+  };
+  factory(pi);
+  return handlers;
+}
+
+function getSessionBeforeSwitchHandler(): SessionBeforeSwitchHandler {
+  const handler = captureHandlers().get("session_before_switch");
+  if (handler === undefined) {
+    assert.fail("session_before_switch handler was not registered");
+  }
+  return handler;
+}
 
 test("extension factory is a function", () => {
   assert.equal(typeof factory, "function");
@@ -12,6 +53,88 @@ test("extension factory is a function", () => {
 test("extension factory runs without error (no-op)", () => {
   // Phase A: factory accepts any API object and does nothing.
   assert.doesNotThrow(() => factory({}));
+});
+
+test("session_before_switch prompts for /new when workflows are in flight", async () => {
+  store.clear();
+  try {
+    store.recordRunStart(workflowRun());
+    const handler = getSessionBeforeSwitchHandler();
+
+    const prompts: Array<{ title: string; message?: string }> = [];
+    const result = await handler({ reason: "new" }, {
+      ui: {
+        confirm: async (title: string, message?: string) => {
+          prompts.push({ title, message });
+          return true;
+        },
+      },
+    });
+
+    assert.equal(result, undefined);
+    assert.equal(prompts.length, 1);
+    const promptText = `${prompts[0]?.title}\n${prompts[0]?.message}`;
+    assert.match(promptText, /new session/i);
+    assert.match(promptText, /stop|kill/i);
+    assert.match(promptText, /running workflows/i);
+    assert.match(promptText, /clear workflow history tied to (the )?current session/i);
+    assert.equal(store.runs().length, 1);
+    assert.equal(store.runs()[0]?.endedAt, undefined);
+  } finally {
+    store.clear();
+  }
+});
+
+test("session_before_switch cancels /new when warning is declined", async () => {
+  store.clear();
+  try {
+    store.recordRunStart(workflowRun());
+    const handler = getSessionBeforeSwitchHandler();
+    const notifications: Array<{ message: string; type?: string }> = [];
+
+    const result = await handler({ reason: "new" }, {
+      ui: {
+        confirm: async () => false,
+        notify: (message: string, type?: string) => notifications.push({ message, type }),
+      },
+    });
+
+    assert.deepEqual(result, { cancel: true });
+    assert.equal(store.runs().length, 1);
+    assert.equal(store.runs()[0]?.endedAt, undefined);
+    assert.equal(notifications.at(-1)?.type, "info");
+  } finally {
+    store.clear();
+  }
+});
+
+test("session_before_switch does not prompt without in-flight workflows or confirm UI", async () => {
+  store.clear();
+  try {
+    store.recordRunStart(workflowRun({ id: "done", status: "running" }));
+    store.recordRunEnd("done", "completed", {});
+    const handler = getSessionBeforeSwitchHandler();
+    let confirmCalls = 0;
+    const declineNewSession = async () => {
+      confirmCalls += 1;
+      return false;
+    };
+
+    assert.equal(
+      await handler({ reason: "new" }, { ui: { confirm: declineNewSession } }),
+      undefined,
+    );
+    assert.equal(
+      await handler({ reason: "resume" }, { ui: { confirm: declineNewSession } }),
+      undefined,
+    );
+    store.recordRunStart(workflowRun({ id: "running" }));
+    assert.equal(await handler({ reason: "new" }, { ui: {} }), undefined);
+    assert.equal(confirmCalls, 0);
+    assert.equal(store.runs().length, 2);
+  } finally {
+    store.clear();
+  }
 });
 
 test("session_start warns when discovered workflows fail validation", async () => {

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -55,83 +55,107 @@ test("extension factory runs without error (no-op)", () => {
   assert.doesNotThrow(() => factory({}));
 });
 
-test("session_before_switch prompts for /new when workflows are in flight", async () => {
-  store.clear();
-  try {
-    store.recordRunStart(workflowRun());
-    const handler = getSessionBeforeSwitchHandler();
+test("session_before_switch prompts for /new and /resume when workflows are in flight", async () => {
+  for (const reason of ["new", "resume"] as const) {
+    store.clear();
+    try {
+      store.recordRunStart(workflowRun());
+      const handler = getSessionBeforeSwitchHandler();
 
-    const prompts: Array<{ title: string; message?: string }> = [];
-    const result = await handler({ reason: "new" }, {
-      ui: {
-        confirm: async (title: string, message?: string) => {
-          prompts.push({ title, message });
-          return true;
+      const prompts: Array<{ title: string; message?: string }> = [];
+      const result = await handler({ reason }, {
+        ui: {
+          confirm: async (title: string, message?: string) => {
+            prompts.push({ title, message });
+            return true;
+          },
         },
-      },
-    });
+      });
 
-    assert.equal(result, undefined);
-    assert.equal(prompts.length, 1);
-    const promptText = `${prompts[0]?.title}\n${prompts[0]?.message}`;
-    assert.match(promptText, /new session/i);
-    assert.match(promptText, /stop|kill/i);
-    assert.match(promptText, /running workflows/i);
-    assert.match(promptText, /clear workflow history tied to (the )?current session/i);
-    assert.equal(store.runs().length, 1);
-    assert.equal(store.runs()[0]?.endedAt, undefined);
-  } finally {
-    store.clear();
+      assert.equal(result, undefined);
+      assert.equal(prompts.length, 1);
+      const promptText = `${prompts[0]?.title}\n${prompts[0]?.message}`;
+      assert.match(promptText, reason === "new" ? /new session/i : /resume another session/i);
+      assert.match(promptText, /stop|kill/i);
+      assert.match(promptText, /in-flight workflows/i);
+      assert.match(promptText, /clear workflow history tied to (the )?current session/i);
+      assert.equal(store.runs().length, 1);
+      assert.equal(store.runs()[0]?.endedAt, undefined);
+    } finally {
+      store.clear();
+    }
   }
 });
 
-test("session_before_switch cancels /new when warning is declined", async () => {
-  store.clear();
-  try {
-    store.recordRunStart(workflowRun());
-    const handler = getSessionBeforeSwitchHandler();
-    const notifications: Array<{ message: string; type?: string }> = [];
-
-    const result = await handler({ reason: "new" }, {
-      ui: {
-        confirm: async () => false,
-        notify: (message: string, type?: string) => notifications.push({ message, type }),
-      },
-    });
-
-    assert.deepEqual(result, { cancel: true });
-    assert.equal(store.runs().length, 1);
-    assert.equal(store.runs()[0]?.endedAt, undefined);
-    assert.equal(notifications.at(-1)?.type, "info");
-  } finally {
+test("session_before_switch cancels /new and /resume when warning is declined", async () => {
+  for (const reason of ["new", "resume"] as const) {
     store.clear();
+    try {
+      store.recordRunStart(workflowRun());
+      const handler = getSessionBeforeSwitchHandler();
+      const notifications: Array<{ message: string; type?: string }> = [];
+
+      const result = await handler({ reason }, {
+        ui: {
+          confirm: async () => false,
+          notify: (message: string, type?: string) => notifications.push({ message, type }),
+        },
+      });
+
+      assert.deepEqual(result, { cancel: true });
+      assert.equal(store.runs().length, 1);
+      assert.equal(store.runs()[0]?.endedAt, undefined);
+      assert.equal(notifications.at(-1)?.type, "info");
+      assert.match(notifications.at(-1)?.message ?? "", reason === "new" ? /New session cancelled/i : /Resume cancelled/i);
+    } finally {
+      store.clear();
+    }
   }
 });
 
-test("session_before_switch does not prompt without in-flight workflows or confirm UI", async () => {
+test("session_before_switch does not prompt without in-flight workflows", async () => {
   store.clear();
   try {
     store.recordRunStart(workflowRun({ id: "done", status: "running" }));
     store.recordRunEnd("done", "completed", {});
     const handler = getSessionBeforeSwitchHandler();
     let confirmCalls = 0;
-    const declineNewSession = async () => {
-      confirmCalls += 1;
-      return false;
-    };
 
     assert.equal(
-      await handler({ reason: "new" }, { ui: { confirm: declineNewSession } }),
+      await handler({ reason: "new" }, { ui: { confirm: async () => { confirmCalls += 1; return false; } } }),
       undefined,
     );
-    assert.equal(
-      await handler({ reason: "resume" }, { ui: { confirm: declineNewSession } }),
-      undefined,
-    );
-    store.recordRunStart(workflowRun({ id: "running" }));
-    assert.equal(await handler({ reason: "new" }, { ui: {} }), undefined);
     assert.equal(confirmCalls, 0);
-    assert.equal(store.runs().length, 2);
+  } finally {
+    store.clear();
+  }
+});
+
+test("session_before_switch does not prompt for unrelated switch reasons", async () => {
+  store.clear();
+  try {
+    store.recordRunStart(workflowRun());
+    const handler = getSessionBeforeSwitchHandler();
+    let confirmCalls = 0;
+
+    assert.equal(
+      await handler({ reason: "fork" }, { ui: { confirm: async () => { confirmCalls += 1; return false; } } }),
+      undefined,
+    );
+    assert.equal(confirmCalls, 0);
+  } finally {
+    store.clear();
+  }
+});
+
+test("session_before_switch does not prompt without confirm UI", async () => {
+  store.clear();
+  try {
+    store.recordRunStart(workflowRun());
+    const handler = getSessionBeforeSwitchHandler();
+
+    assert.equal(await handler({ reason: "new" }, { ui: {} }), undefined);
+    assert.equal(store.runs().length, 1);
   } finally {
     store.clear();
   }

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -1,4 +1,4 @@
-import { test } from "bun:test";
+import { beforeEach, test } from "bun:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -46,6 +46,10 @@ function getSessionBeforeSwitchHandler(): SessionBeforeSwitchHandler {
   return handler;
 }
 
+beforeEach(() => {
+  store.clear();
+});
+
 test("extension factory is a function", () => {
   assert.equal(typeof factory, "function");
 });
@@ -77,7 +81,8 @@ test("session_before_switch prompts for /new and /resume when workflows are in f
       const promptText = `${prompts[0]?.title}\n${prompts[0]?.message}`;
       assert.match(promptText, reason === "new" ? /new session/i : /resume another session/i);
       assert.match(promptText, /stop|kill/i);
-      assert.match(promptText, /in-flight workflows/i);
+      assert.match(promptText, /1 in-flight workflow/i);
+      assert.doesNotMatch(promptText, /1 in-flight workflows/i);
       assert.match(promptText, /clear workflow history tied to (the )?current session/i);
       assert.equal(store.runs().length, 1);
       assert.equal(store.runs()[0]?.endedAt, undefined);
@@ -85,6 +90,44 @@ test("session_before_switch prompts for /new and /resume when workflows are in f
       store.clear();
     }
   }
+});
+
+test("session_before_switch renders plural in-flight workflow counts", async () => {
+  store.recordRunStart(workflowRun({ id: "run-1" }));
+  store.recordRunStart(workflowRun({ id: "run-2" }));
+  const handler = getSessionBeforeSwitchHandler();
+
+  const prompts: Array<{ title: string; message?: string }> = [];
+  const result = await handler({ reason: "new" }, {
+    ui: {
+      confirm: async (title: string, message?: string) => {
+        prompts.push({ title, message });
+        return true;
+      },
+    },
+  });
+
+  assert.equal(result, undefined);
+  assert.equal(prompts.length, 1);
+  assert.match(prompts[0]?.title ?? "", /2 in-flight workflows/i);
+  assert.match(prompts[0]?.message ?? "", /2 in-flight workflows/i);
+});
+
+test("session_before_switch fails open when confirm throws", async () => {
+  store.recordRunStart(workflowRun());
+  const handler = getSessionBeforeSwitchHandler();
+
+  const result = await handler({ reason: "new" }, {
+    ui: {
+      confirm: async () => {
+        throw new Error("confirm unavailable");
+      },
+    },
+  });
+
+  assert.equal(result, undefined);
+  assert.equal(store.runs().length, 1);
+  assert.equal(store.runs()[0]?.endedAt, undefined);
 });
 
 test("session_before_switch cancels /new and /resume when warning is declined", async () => {


### PR DESCRIPTION
## Summary

Adds a `session_before_switch` guard that intercepts `/new` and `/resume` session transitions when workflows are still in flight, prompting the user to confirm before proceeding. Without this, switching sessions silently killed active runs and cleared session-scoped workflow history with no opportunity to cancel.

## Changes

- **`session_before_switch` handler** registered in the extension factory; fires only for `reason: "new"` and `reason: "resume"` — other transitions (e.g. `"fork"`) pass through silently.
- **In-flight detection** counts runs without `endedAt` from the store, matching the same set that `session_start` would stop on switch.
- **Confirmation dialog** displays a titled prompt describing both consequences (stops in-flight runs, clears session-scoped history); action and message labels are tailored to the transition reason.
- **`{ cancel: true }` return** when the user declines, accompanied by an info toast; `undefined` return when the user confirms so the switch proceeds normally.
- **Fail-open semantics**: skips the prompt when there are no in-flight runs, when `ctx.ui.confirm` is absent, or when the confirm call throws — ensuring headless/automation callers are never wedged.
- **Tests** (`test/unit/extension.test.ts`): 7 new unit tests covering confirm path, cancel path, plural noun rendering, confirm-throws fail-open, no in-flight runs, unrelated switch reason, and missing confirm UI.
- **Changelog** updated under `[Unreleased] > Fixed` in `packages/workflows/CHANGELOG.md`.

## Breaking Changes

None.

## Test Plan

```sh
bun test test/unit/extension.test.ts
bun run typecheck
bun run lint
bun run test:unit
```

Closes #1082