### PR TITLE
fix(workflows): retain terminal runs for inspection

### DIFF
--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -102,12 +102,12 @@ Keep using `ralph` for larger migrations, broad refactors, multi-package changes
 Named workflow runs execute in the background. After launch you get a run id; use it to inspect, attach, pause, or resume:
 
 ```text
-/workflow status                  # list in-flight runs (add --all for ended runs)
+/workflow status                  # list current-session active and retained terminal runs
 /workflow connect <run-id>        # open the graph viewer (F2 also opens the latest)
 /workflow attach <run-id> <stage> # chat with one stage
 /workflow interrupt <run-id>      # pause resumably
 /workflow resume <run-id> "go"    # send a steer message and resume
-/workflow kill <run-id>           # destructive abort
+/workflow kill <run-id>           # abort and retain for inspection
 ```
 
 Human-in-the-loop prompts (`ctx.ui.input`, `confirm`, `select`, `editor`) surface in the graph viewer, not as chat modals — connect to the run to answer them. See [Workflows](/workflows) for the full reference and authoring guide.

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -102,7 +102,7 @@ Keep using `ralph` for larger migrations, broad refactors, multi-package changes
 Named workflow runs execute in the background. After launch you get a run id; use it to inspect, attach, pause, or resume:
 
 ```text
-/workflow status                  # list current-session active and retained terminal runs
+/workflow status                  # list this session's active and terminal runs
 /workflow connect <run-id>        # open the graph viewer (F2 also opens the latest)
 /workflow attach <run-id> <stage> # chat with one stage
 /workflow interrupt <run-id>      # pause resumably

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -314,12 +314,12 @@ If required inputs are missing or ambiguous, Atomic will either ask or open the 
 Named runs go to the background. Common controls:
 
 ```text
-/workflow status                       # list in-flight runs (--all includes ended runs)
-/workflow connect <run-id>             # graph viewer (F2 also opens the latest)
+/workflow status                       # list retained active and terminal runs
+/workflow connect <run-id>             # graph viewer, including terminal runs
 /workflow attach <run-id> <stage>      # chat with a single stage
 /workflow interrupt <run-id>           # pause resumably
 /workflow resume <run-id> [stage] msg  # forward a steer message and resume
-/workflow kill <run-id>                # destructive abort
+/workflow kill <run-id>                # abort and retain for inspection
 ```
 
 Human-in-the-loop prompts from `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, and `ctx.ui.editor` appear as awaiting-input nodes in the workflow graph viewer, not as chat modals — use `/workflow connect <run-id>` (or F2), focus the node, and press Enter to answer them locally.
@@ -547,7 +547,7 @@ In the TUI, `/workflow <name>` opens an input picker when the workflow declares 
 /workflow reload
 ```
 
-Use `connect` for the workflow graph. Use `attach` when you want a chat pane for a specific stage. Use `interrupt`, `pause`, and `resume` for resumable live work; `resume` on a non-paused run reopens the saved snapshot or overlay. Use `kill` only when the run should be terminated and removed from live history/status. Use `/workflow reload` after adding, editing, installing, or removing workflow resources and you want Atomic to rediscover them in-process. `/workflow status` lists in-flight runs by default; `/workflow status --all` includes retained ended runs.
+Use `connect` for the workflow graph. Use `attach` when you want a chat pane for a specific stage. Use `interrupt`, `pause`, and `resume` for resumable live work; `resume` on a non-paused run reopens the saved snapshot or overlay. Use `kill` only when the run should be terminated; killed runs are retained in live history/status for read-only inspection. Use `/workflow reload` after adding, editing, installing, or removing workflow resources and you want Atomic to rediscover them in-process. `/workflow status` lists all retained active and terminal runs by default; `/workflow status --all` is retained as a compatibility alias.
 
 <p align="center"><img src="images/workflow-graph.png" alt="Workflow Graph Viewer" width="600" /></p>
 
@@ -595,7 +595,7 @@ Control behavior:
 - `interrupt` is resumable: it pauses live work when pausable stages exist and keeps the run in live history/status.
 - `pause` is useful for pausing a live run or a single live stage without treating it as a destructive abort.
 - `resume` can target a stage with `stageId`; the target may be a stage id, unique prefix, or stage name. `message` is forwarded to paused work.
-- `kill` is destructive: it aborts in-flight work and removes the run from live history/status.
+- `kill` aborts in-flight work, marks the run `killed`, and retains it in live history/status for inspection.
 - `reload` refreshes discovered workflow resources in-process; the optional `reason` is echoed in the result.
 
 Use slash commands for graph connect and stage attach because those are interactive TUI surfaces. When a run needs user input or attention, surface that to the user instead of polling silently.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Warn before starting or resuming another session when workflows are still in flight, allowing users to cancel before those runs are killed and current-session workflow history is cleared ([#1082](https://github.com/flora131/atomic/issues/1082)).
 - Prevented workflow stage sessions from exposing or executing the `workflow` tool while preserving stage-level subagent delegation.
+- Retained completed, failed, and killed workflow runs in user-facing status/connect surfaces and changed workflow kill controls to mark runs killed without removing them from live inspection history ([#1083](https://github.com/flora131/atomic/issues/1083)).
 
 ## [0.8.18] - 2026-05-27
 

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -248,7 +248,7 @@ registry.get("alpha"); // compiled workflow definition | undefined
 | `/workflow attach [run-id] [stage]`   | Open the attach/chat pane for a run or stage             |
 | `/workflow pause [run-id] [stage]`    | Pause a live run or stage                                |
 | `/workflow interrupt [run-id\|--all]` | Pause active/named/all active runs so they can resume    |
-| `/workflow kill [run-id\|--all]`      | Abort in-flight work, mark runs killed, and retain them for inspection |
+| `/workflow kill [run-id\|--all]`      | Kill in-flight workflow runs; killed runs are retained for inspection |
 | `/workflow resume <run-id>`           | Resume paused work or re-open a run snapshot             |
 | `/workflow reload`                    | Reload discovered workflow resources in-process          |
 | `/workflow inputs <name>`             | Print the input schema for a workflow                    |

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -243,12 +243,12 @@ registry.get("alpha"); // compiled workflow definition | undefined
 | `/workflow <name> [key=value ...]`    | Start a named workflow, passing optional input overrides |
 | `/workflow <name> --help`             | Print the workflow's input schema                        |
 | `/workflow list`                      | List all registered workflows with descriptions          |
-| `/workflow status [run-id]`           | Show active runs or details for one run                  |
+| `/workflow status [run-id]`           | Show active plus retained terminal/current-session runs, or details for one run |
 | `/workflow connect [run-id]`          | Attach to a workflow run overlay                         |
 | `/workflow attach [run-id] [stage]`   | Open the attach/chat pane for a run or stage             |
 | `/workflow pause [run-id] [stage]`    | Pause a live run or stage                                |
 | `/workflow interrupt [run-id\|--all]` | Pause active/named/all active runs so they can resume    |
-| `/workflow kill [run-id\|--all]`      | Kill and remove active/named/all active runs from status |
+| `/workflow kill [run-id\|--all]`      | Abort in-flight work, mark runs killed, and retain them for inspection |
 | `/workflow resume <run-id>`           | Resume paused work or re-open a run snapshot             |
 | `/workflow reload`                    | Reload discovered workflow resources in-process          |
 | `/workflow inputs <name>`             | Print the input schema for a workflow                    |

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -1383,6 +1383,7 @@ export function makeExecuteWorkflowTool(
           status: "noop",
           message: result.reason === "already_ended"
             ? formatAlreadyEndedRetainedMessage(target.runId)
+            // Defensive fallback: resolveRunTarget already found this run, and killRun no longer removes runs.
             : `Run not found: ${target.runId}`,
         };
       }
@@ -2398,7 +2399,7 @@ function factory(pi: ExtensionAPI): void {
         }
         if (!yes && ctx.ui && typeof ctx.ui.confirm === "function") {
           const ok = await ctx.ui.confirm(
-            `Kill and retain all ${inFlight.length} in-flight workflow runs?`,
+            `Kill ${inFlight.length} in-flight workflow runs? Killed runs are retained for inspection.`,
             `Aborts: ${inFlight.map((r) => `${r.name} (${r.id.slice(0, 8)})`).join(", ")}`,
           );
           if (!ok) {

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -2244,6 +2244,10 @@ function factory(pi: ExtensionAPI): void {
             print(`Run not found: ${result.runId}`);
             return true;
           }
+          if (run.endedAt !== undefined) {
+            print(formatAlreadyEndedRetainedMessage(result.runId));
+            return true;
+          }
           const confirmed = await openKillConfirm(ui, run, theme);
           if (!confirmed) {
             print(
@@ -2430,6 +2434,10 @@ function factory(pi: ExtensionAPI): void {
         return true;
       }
       const run = store.runs().find((r) => r.id === resolved.runId);
+      if (run?.endedAt !== undefined) {
+        print(formatAlreadyEndedRetainedMessage(resolved.runId));
+        return true;
+      }
       if (!yes && run && ctx.ui) {
         const confirmed = await openKillConfirm(ctx.ui, run, theme);
         if (!confirmed) {
@@ -3140,14 +3148,7 @@ function factory(pi: ExtensionAPI): void {
         }
 
         if (subcommand === "status") {
-          return completeToken(partial, [
-            {
-              value: "--all ",
-              label: "--all",
-              description: "Compatibility no-op; retained runs are shown by default",
-            },
-            ...runIdItems(),
-          ]);
+          return completeToken(partial, runIdItems());
         }
 
         if (subcommand === "connect") {

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -1944,7 +1944,6 @@ function factory(pi: ExtensionAPI): void {
           kind: "killed",
           run,
           previousStatus: result.previousStatus,
-          wasInFlight: true,
         });
       }
     },
@@ -2264,7 +2263,6 @@ function factory(pi: ExtensionAPI): void {
               kind: "killed",
               run,
               previousStatus: killed.previousStatus,
-              wasInFlight: true,
             });
           }
           print(
@@ -2457,7 +2455,6 @@ function factory(pi: ExtensionAPI): void {
             kind: "killed",
             run,
             previousStatus: result.previousStatus,
-            wasInFlight: true,
           });
         }
         print(

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -15,9 +15,8 @@ import { restoreOnSessionStart } from "../shared/persistence-restore.js";
 import type { SessionManager } from "../shared/persistence-restore.js";
 import { installCompactionHook } from "../shared/persistence-compaction-policy.js";
 import {
+  killRun,
   killAllRuns,
-  destroyRun,
-  destroyAllRuns,
   resumeRun,
   pauseRun,
   pauseAllRuns,
@@ -897,6 +896,10 @@ function snapshotTranscriptEntries(
   return sortTranscriptEntriesChronologically(entries);
 }
 
+function formatAlreadyEndedRetainedMessage(runId: string): string {
+  return `Run ${runId.slice(0, 8)} already ended; retained for inspection.`;
+}
+
 function stageFailureMessage(
   runId: string,
   resultReason: string,
@@ -1020,9 +1023,9 @@ export function makeExecuteWorkflowTool(
             error: `run not found: ${target}`,
           };
         }
-        // List mode — emit live snapshots; the renderer produces the
+        // List mode — emit all retained snapshots; the renderer produces the
         // canonical band + card surface.
-        const snapshots = store.runs().filter((r) => r.endedAt === undefined);
+        const snapshots = store.runs();
         return {
           action: "status",
           snapshots: snapshots.map((snapshot) => structuredClone(snapshot)),
@@ -1341,7 +1344,7 @@ export function makeExecuteWorkflowTool(
               message: allStageConflictMessage("kill"),
             };
           }
-          const results = destroyAllRuns({
+          const results = killAllRuns({
             cancellation: cancellationRegistry,
             persistence: getPersistence(),
           });
@@ -1352,7 +1355,7 @@ export function makeExecuteWorkflowTool(
             status: killed > 0 ? "killed" : "noop",
             message:
               killed > 0
-                ? `Killed and removed ${killed} run(s).`
+                ? `Killed and retained ${killed} run(s) for inspection.`
                 : "No in-flight runs to kill.",
           };
         }
@@ -1362,7 +1365,7 @@ export function makeExecuteWorkflowTool(
         if (target.kind === "not_found") {
           return { action, runId: target.target, status: "noop", message: target.message };
         }
-        const result = destroyRun(target.runId, {
+        const result = killRun(target.runId, {
           cancellation: cancellationRegistry,
           persistence: getPersistence(),
         });
@@ -1371,14 +1374,16 @@ export function makeExecuteWorkflowTool(
             action,
             runId: result.runId,
             status: "killed",
-            message: `Run ${result.runId} killed and removed (was ${result.previousStatus}).`,
+            message: `Run ${result.runId} killed and retained for inspection (was ${result.previousStatus}).`,
           };
         }
         return {
           action,
           runId: target.runId,
           status: "noop",
-          message: `Run not found: ${target.runId}`,
+          message: result.reason === "already_ended"
+            ? formatAlreadyEndedRetainedMessage(target.runId)
+            : `Run not found: ${target.runId}`,
         };
       }
 
@@ -1930,7 +1935,7 @@ function factory(pi: ExtensionAPI): void {
   const overlay: GraphOverlayPort = buildGraphOverlayAdapter(pi, store, {
     onKillRun: (runId) => {
       const run = store.runs().find((r) => r.id === runId);
-      const result = destroyRun(runId, {
+      const result = killRun(runId, {
         cancellation: cancellationRegistry,
         persistence: persistenceRef.current,
       });
@@ -1939,7 +1944,7 @@ function factory(pi: ExtensionAPI): void {
           kind: "killed",
           run,
           previousStatus: result.previousStatus,
-          wasInFlight: result.wasInFlight,
+          wasInFlight: true,
         });
       }
     },
@@ -2204,7 +2209,7 @@ function factory(pi: ExtensionAPI): void {
    *   connect [runId|prefix]              no arg → picker overlay; arg → attach to graph
    *   attach  [runId|prefix [stageId]]    open the in-place attach pane on a stage
    *   interrupt [runId|prefix|--all] [-y] confirmation overlay unless -y
-   *   kill      [runId|prefix|--all] [-y] kill and remove from history/status
+   *   kill      [runId|prefix|--all] [-y] kill and retain for inspection
    *   pause     [runId|prefix [stageId]]    pause a run or specific stage
    *   resume  [runId|prefix [stageId] …]  resume paused work or reopen snapshot
    */
@@ -2223,7 +2228,7 @@ function factory(pi: ExtensionAPI): void {
         const ui = ctx.ui;
         if (!ui || typeof ui.custom !== "function") {
           print(
-            `${renderSessionList(store.runs(), { theme, includeAll: false })}\n\nPicker requires a UI surface. Pass a runId: /workflow connect <id>`,
+            `${renderSessionList(store.runs(), { theme, includeAll: true })}\n\nPicker requires a UI surface. Pass a runId: /workflow connect <id>`,
           );
           return true;
         }
@@ -2246,7 +2251,7 @@ function factory(pi: ExtensionAPI): void {
             );
             return true;
           }
-          const killed = destroyRun(result.runId, {
+          const killed = killRun(result.runId, {
             cancellation: cancellationRegistry,
             persistence: persistenceRef.current,
           });
@@ -2255,13 +2260,15 @@ function factory(pi: ExtensionAPI): void {
               kind: "killed",
               run,
               previousStatus: killed.previousStatus,
-              wasInFlight: killed.wasInFlight,
+              wasInFlight: true,
             });
           }
           print(
             killed.ok
-              ? `Run ${killed.runId.slice(0, 8)} killed and removed.`
-              : `Run not found: ${result.runId.slice(0, 8)}.`,
+              ? `Run ${killed.runId.slice(0, 8)} killed and retained for inspection.`
+              : killed.reason === "already_ended"
+                ? formatAlreadyEndedRetainedMessage(killed.runId)
+                : `Run not found: ${result.runId.slice(0, 8)}.`,
           );
           return true;
         }
@@ -2389,7 +2396,7 @@ function factory(pi: ExtensionAPI): void {
         }
         if (!yes && ctx.ui && typeof ctx.ui.confirm === "function") {
           const ok = await ctx.ui.confirm(
-            `Kill and remove all ${inFlight.length} in-flight workflow runs?`,
+            `Kill and retain all ${inFlight.length} in-flight workflow runs?`,
             `Aborts: ${inFlight.map((r) => `${r.name} (${r.id.slice(0, 8)})`).join(", ")}`,
           );
           if (!ok) {
@@ -2397,14 +2404,14 @@ function factory(pi: ExtensionAPI): void {
             return true;
           }
         }
-        const results = destroyAllRuns({
+        const results = killAllRuns({
           cancellation: cancellationRegistry,
           persistence: persistenceRef.current,
         });
         const killed = results.filter((r) => r.ok).length;
         print(
           killed > 0
-            ? `Killed and removed ${killed} run(s).`
+            ? `Killed and retained ${killed} run(s) for inspection.`
             : "No in-flight runs to kill.",
         );
         return true;
@@ -2432,7 +2439,7 @@ function factory(pi: ExtensionAPI): void {
           return true;
         }
       }
-      const result = destroyRun(resolved.runId, {
+      const result = killRun(resolved.runId, {
         cancellation: cancellationRegistry,
         persistence: persistenceRef.current,
       });
@@ -2442,14 +2449,18 @@ function factory(pi: ExtensionAPI): void {
             kind: "killed",
             run,
             previousStatus: result.previousStatus,
-            wasInFlight: result.wasInFlight,
+            wasInFlight: true,
           });
         }
         print(
-          `Run ${result.runId.slice(0, 8)} killed and removed (was ${result.previousStatus}).`,
+          `Run ${result.runId.slice(0, 8)} killed and retained for inspection (was ${result.previousStatus}).`,
         );
       } else {
-        print(`Run not found: ${target}`);
+        print(
+          result.reason === "already_ended"
+            ? formatAlreadyEndedRetainedMessage(result.runId)
+            : `Run not found: ${target}`,
+        );
       }
       return true;
     }
@@ -2462,7 +2473,7 @@ function factory(pi: ExtensionAPI): void {
         const ui = ctx.ui;
         if (!ui || typeof ui.custom !== "function") {
           print(
-            `${renderSessionList(store.runs(), { theme, includeAll: false })}\n\nPicker requires a UI surface. Pass a runId: /workflow attach <id> [stageId]`,
+            `${renderSessionList(store.runs(), { theme, includeAll: true })}\n\nPicker requires a UI surface. Pass a runId: /workflow attach <id> [stageId]`,
           );
           return true;
         }
@@ -2724,9 +2735,8 @@ function factory(pi: ExtensionAPI): void {
 
         // -----------------------------------------------------------------------
         // status — band-header rich list, or per-run detail when an id is
-        // supplied. `/workflow status` lists everything in-flight (`--all`
-        // includes ended runs older than an hour); `/workflow status <id>`
-        // drills into a single run via the inspectRun detail block.
+        // supplied. `/workflow status` lists all retained snapshots; `/workflow
+        // status <id>` drills into a single run via the inspectRun detail block.
         // -----------------------------------------------------------------------
         if (subcommand === "status") {
           const target = parts[1];
@@ -2752,13 +2762,12 @@ function factory(pi: ExtensionAPI): void {
             emitChatSurface(pi, { kind: "detail", detail: inspected.detail });
             return;
           }
-          // Mirror renderSessionList's filter: keep `--all` semantics, then
-          // hand the already-filtered snapshot to the chat-surface renderer.
-          const includeAll = parts.includes("--all");
+          // Status lists all retained snapshots by default; --all remains
+          // accepted as a compatibility no-op.
           const rows = selectRunsForPicker(
             store.runs(),
             "",
-            includeAll,
+            true,
             Date.now(),
           );
           emitChatSurface(pi, { kind: "status", runs: rows.map((r) => r.run) });
@@ -2804,7 +2813,7 @@ function factory(pi: ExtensionAPI): void {
         }
 
         // -----------------------------------------------------------------------
-        // kill — destructive fast path: abort and remove from history/status.
+        // kill — abort in-flight work, mark killed, and retain for inspection.
         // -----------------------------------------------------------------------
         if (subcommand === "kill") {
           const killArgs = parts.slice(1);
@@ -3083,7 +3092,7 @@ function factory(pi: ExtensionAPI): void {
           {
             value: "status ",
             label: "status",
-            description: "List in-flight runs",
+            description: "List current-session active and retained terminal runs",
           },
           {
             value: "interrupt ",
@@ -3093,7 +3102,7 @@ function factory(pi: ExtensionAPI): void {
           {
             value: "kill ",
             label: "kill",
-            description: "Kill and remove a run",
+            description: "Kill and retain a run for inspection",
           },
           {
             value: "pause ",
@@ -3135,7 +3144,7 @@ function factory(pi: ExtensionAPI): void {
             {
               value: "--all ",
               label: "--all",
-              description: "Include recently ended runs",
+              description: "Compatibility no-op; retained runs are shown by default",
             },
             ...runIdItems(),
           ]);
@@ -3154,7 +3163,7 @@ function factory(pi: ExtensionAPI): void {
         }
 
         if (subcommand === "interrupt" || subcommand === "kill") {
-          const verb = subcommand === "kill" ? "Kill and remove" : "Interrupt";
+          const verb = subcommand === "kill" ? "Kill and retain" : "Interrupt";
           return completeToken(partial, [
             {
               value: "--all ",
@@ -3315,10 +3324,10 @@ function factory(pi: ExtensionAPI): void {
 
     pi.on("session_start", async (_event, ctx) => {
       // Workflow lifecycle is scoped to the originating chat session.
-      // A new session inherits a clean store; any leftover runs from a
+      // A new session inherits a clean store; any leftover live runs from a
       // previous session in the same pi process are killed (subprocess
-      // aborted) and dropped. `restoreOnSessionStart` below then loads
-      // *this* session's persisted runs from disk.
+      // aborted), then all stale snapshots are cleared. `restoreOnSessionStart`
+      // below loads *this* session's persisted runs from disk.
       killAllRuns({
         store,
         cancellation: cancellationRegistry,

--- a/packages/workflows/src/extension/render-call.ts
+++ b/packages/workflows/src/extension/render-call.ts
@@ -67,7 +67,7 @@ export function renderCall(args: WorkflowToolArgs, opts: RenderCallOpts = {}): s
       line = "workflow: list registered workflows";
       break;
     case "status":
-      line = "workflow: list in-flight runs";
+      line = "workflow: list retained runs";
       break;
     case "inputs":
       line = name === undefined

--- a/packages/workflows/src/runs/background/status.ts
+++ b/packages/workflows/src/runs/background/status.ts
@@ -34,10 +34,6 @@ export type KillResult =
   | { ok: true; runId: string; previousStatus: RunStatus }
   | { ok: false; runId: string; reason: "not_found" | "already_ended" };
 
-export type DestroyRunResult =
-  | { ok: true; runId: string; previousStatus: RunStatus; wasInFlight: boolean }
-  | { ok: false; runId: string; reason: "not_found" };
-
 export type ResumeResult =
   | {
       ok: true;
@@ -171,57 +167,6 @@ export function killAllRuns(opts?: {
   const inFlight = activeStore.runs().filter((r) => r.endedAt === undefined);
   return inFlight.map((r) =>
     killRun(r.id, { store: activeStore, cancellation: opts?.cancellation, persistence: opts?.persistence }),
-  );
-}
-
-// ---------------------------------------------------------------------------
-// destroyRun
-// ---------------------------------------------------------------------------
-
-/**
- * Destructively kills a workflow run and removes it from live history/status.
- *
- * In-flight runs are aborted and persisted with a terminal `killed` entry so
- * session restore will not resurrect them. Ended runs are simply removed from
- * the live store without appending a duplicate terminal event.
- */
-export function destroyRun(
-  runId: string,
-  opts?: { store?: Store; cancellation?: CancellationRegistry; persistence?: WorkflowPersistencePort },
-): DestroyRunResult {
-  const activeStore = opts?.store ?? defaultStore;
-  const run = activeStore.runs().find((r) => r.id === runId);
-
-  if (!run) {
-    return { ok: false, runId, reason: "not_found" };
-  }
-
-  const previousStatus = run.status;
-  const wasInFlight = run.endedAt === undefined;
-
-  if (wasInFlight) {
-    opts?.cancellation?.abort(runId, "workflow killed");
-    if (opts?.persistence) {
-      appendRunEnd(opts.persistence, { runId, status: "killed", ts: Date.now() });
-    }
-  }
-
-  activeStore.removeRun(runId);
-  return { ok: true, runId, previousStatus, wasInFlight };
-}
-
-/**
- * Destructively kills and removes all in-flight runs.
- */
-export function destroyAllRuns(opts?: {
-  store?: Store;
-  cancellation?: CancellationRegistry;
-  persistence?: WorkflowPersistencePort;
-}): DestroyRunResult[] {
-  const activeStore = opts?.store ?? defaultStore;
-  const inFlight = activeStore.runs().filter((r) => r.endedAt === undefined);
-  return inFlight.map((r) =>
-    destroyRun(r.id, { store: activeStore, cancellation: opts?.cancellation, persistence: opts?.persistence }),
   );
 }
 
@@ -403,7 +348,7 @@ export function pauseAllRuns(opts?: {
 
 /**
  * Interrupt a run in a resumable way by pausing live stage handles when
- * available. Unlike `destroyRun`, this never aborts the workflow controller and
+ * available. This never aborts the workflow controller and
  * never removes the run from status/history.
  */
 export function interruptRun(

--- a/packages/workflows/src/runs/background/status.ts
+++ b/packages/workflows/src/runs/background/status.ts
@@ -1,5 +1,5 @@
 /**
- * Status / kill / resume control helpers for in-flight workflow runs.
+ * Status / kill / resume helpers for retained workflow runs and live controls.
  *
  * These helpers operate against the singleton store and are consumed by:
  *   - The `workflow` tool execute handler (action: "status" | "kill" | "resume")
@@ -95,27 +95,22 @@ export type InspectRunResult =
 // ---------------------------------------------------------------------------
 
 /**
- * Returns a summary of all in-flight (not-yet-ended) runs in the store.
- * If `all` is true, returns completed/failed runs too.
+ * Returns a summary of all retained runs in the current store/session.
+ *
+ * Terminal snapshots are retained for inspection and are visible by default;
+ * the legacy `all` option is accepted as a compatibility no-op.
  */
 export function statusRuns(opts?: { all?: boolean; store?: Store }): RunStatusEntry[] {
   const activeStore = opts?.store ?? defaultStore;
-  const runs = activeStore.runs();
-  const result: RunStatusEntry[] = [];
 
-  for (const run of runs) {
-    if (!opts?.all && run.endedAt !== undefined) continue;
-    result.push({
-      runId: run.id,
-      name: run.name,
-      status: run.status,
-      startedAt: run.startedAt,
-      durationMs: run.durationMs,
-      stageCount: run.stages.length,
-    });
-  }
-
-  return result;
+  return activeStore.runs().map((run) => ({
+    runId: run.id,
+    name: run.name,
+    status: run.status,
+    startedAt: run.startedAt,
+    durationMs: run.durationMs,
+    stageCount: run.stages.length,
+  }));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/shared/persistence-restore.ts
+++ b/packages/workflows/src/shared/persistence-restore.ts
@@ -334,6 +334,7 @@ function restoreTerminalRuns(entries: readonly SessionEntry[], store: Store): vo
 
     const runMeta = findRunStartMetadata(entries, runId);
     const stages = _buildStageSnapshots(entries, runId);
+    if (status === "completed" && stages.some((stage) => stage.status !== "completed")) continue;
     store.recordRunStart({
       id: runId,
       name: start.name,

--- a/packages/workflows/src/shared/persistence-restore.ts
+++ b/packages/workflows/src/shared/persistence-restore.ts
@@ -163,7 +163,7 @@ export function restoreOnSessionStart(
 
   const entries = getEntries.call(sessionManager);
   const sessionEntries = entries as readonly SessionEntry[];
-  restoreEndedFailedRuns(sessionEntries, store);
+  restoreTerminalRuns(sessionEntries, store);
   const inFlight = scanInFlightRuns(sessionEntries);
   if (inFlight.length === 0) return;
 
@@ -300,7 +300,7 @@ function restoreStageStatus(status: unknown): StageStatus {
   }
 }
 
-function restoreEndedFailedRuns(entries: readonly SessionEntry[], store: Store): void {
+function restoreTerminalRuns(entries: readonly SessionEntry[], store: Store): void {
   const started = new Map<string, { readonly name: string; readonly inputs: Readonly<Record<string, unknown>>; readonly startTs: number }>();
   const ended = new Map<string, Record<string, unknown>>();
 
@@ -365,8 +365,9 @@ function restoreEndedFailedRuns(entries: readonly SessionEntry[], store: Store):
   }
 }
 
-function restoreTerminalRunStatus(status: unknown): "failed" | "killed" | undefined {
+function restoreTerminalRunStatus(status: unknown): "completed" | "failed" | "killed" | undefined {
   switch (status) {
+    case "completed":
     case "failed":
     case "killed":
       return status;

--- a/packages/workflows/src/tui/chat-surface-message.ts
+++ b/packages/workflows/src/tui/chat-surface-message.ts
@@ -84,7 +84,6 @@ export interface KilledPayload {
   kind: "killed";
   run: RunSnapshot;
   previousStatus: RunStatus;
-  wasInFlight: boolean;
 }
 
 export type ChatSurfacePayload =
@@ -234,7 +233,6 @@ function renderPayload(
         theme,
         run: payload.run,
         previousStatus: payload.previousStatus,
-        wasInFlight: payload.wasInFlight,
       }).join("\n");
   }
 }

--- a/packages/workflows/src/tui/chat-surface-message.ts
+++ b/packages/workflows/src/tui/chat-surface-message.ts
@@ -79,7 +79,7 @@ export interface DetailPayload {
   detail: RunDetail;
 }
 
-/** Inline notice after a workflow run is destructively killed and removed. */
+/** Inline notice after a workflow run is killed and retained for inspection. */
 export interface KilledPayload {
   kind: "killed";
   run: RunSnapshot;

--- a/packages/workflows/src/tui/overlay-adapter.ts
+++ b/packages/workflows/src/tui/overlay-adapter.ts
@@ -19,7 +19,7 @@ import type { Store } from "../shared/store.js";
 import type { ChatMessageRenderOptions, ReadonlyFooterDataProvider } from "@bastani/atomic";
 import { WorkflowAttachPane } from "./workflow-attach-pane.js";
 import { deriveGraphThemeFromPiTheme } from "./graph-theme.js";
-import { destroyRun } from "../runs/background/status.js";
+import { killRun as defaultKillRun } from "../runs/background/status.js";
 import { cancellationRegistry } from "../runs/background/cancellation-registry.js";
 import { stageControlRegistry as defaultStageControlRegistry } from "../runs/foreground/stage-control-registry.js";
 import type { StageControlRegistry } from "../runs/foreground/stage-control-registry.js";
@@ -109,9 +109,9 @@ export interface BuildGraphOverlayAdapterOpts {
   /** Broker used to route stage-local custom UI into attached stage chats. */
   stageUiBroker?: StageUiBroker;
   /**
-   * Destructive kill hook used by graph-mode `q`. The extension factory
-   * supplies this so persistence can record a terminal event before the run is
-   * removed from live history/status.
+   * Kill hook used by graph-mode `q`. The extension factory supplies this so
+   * persistence can record a terminal event while retaining the run for
+   * inspection.
    */
   onKillRun?: (runId: string) => void;
 }
@@ -124,7 +124,7 @@ export function buildGraphOverlayAdapter(
   const registry = buildOpts.stageControlRegistry ?? defaultStageControlRegistry;
   const stageUiBroker = buildOpts.stageUiBroker;
   const killRun = buildOpts.onKillRun ?? ((id: string): void => {
-    destroyRun(id, { store, cancellation: cancellationRegistry });
+    defaultKillRun(id, { store, cancellation: cancellationRegistry });
   });
   let currentView: WorkflowAttachPane | null = null;
   // pi-tui returns an OverlayHandle via `options.onHandle`. We hold onto

--- a/packages/workflows/src/tui/session-confirm.ts
+++ b/packages/workflows/src/tui/session-confirm.ts
@@ -284,7 +284,10 @@ export function renderWorkflowKilledNotice(
   ));
   lines.push(renderBlankRow(inner, theme));
 
-  lines.push(renderKilledTextRow(inner, theme, `      ${success}✓${RESET}${panelBg} ${muted}Active stage work was aborted.${RESET}`));
+  const action = runningStages > 0
+    ? "Active stage work was aborted."
+    : "Run was marked killed; no stages were actively running.";
+  lines.push(renderKilledTextRow(inner, theme, `      ${success}✓${RESET}${panelBg} ${muted}${action}${RESET}`));
   lines.push(renderKilledTextRow(
     inner,
     theme,

--- a/packages/workflows/src/tui/session-confirm.ts
+++ b/packages/workflows/src/tui/session-confirm.ts
@@ -154,12 +154,12 @@ export function renderKillConfirm(opts: KillConfirmRenderOpts): string[] {
   lines.push(renderTextRow(
     inner,
     theme,
-    `      ${muted}Aborts the active stage and discards partial work.${RESET}`,
+    `      ${muted}Aborts in-flight work and marks the run killed.${RESET}`,
   ));
   lines.push(renderTextRow(
     inner,
     theme,
-    `      ${muted}Removes the run from live history/status.${RESET}`,
+    `      ${muted}Retains it in history/status for inspection.${RESET}`,
   ));
   lines.push(renderBlankRow(inner, theme));
 
@@ -287,12 +287,12 @@ export function renderWorkflowKilledNotice(
 
   const action = wasInFlight
     ? "Active stage work was aborted."
-    : "The completed run was removed.";
+    : "Run had already ended; no live work was aborted.";
   lines.push(renderKilledTextRow(inner, theme, `      ${success}✓${RESET}${panelBg} ${muted}${action}${RESET}`));
   lines.push(renderKilledTextRow(
     inner,
     theme,
-    `      ${success}✓${RESET}${panelBg} ${muted}Run removed from live history and status.${RESET}`,
+    `      ${success}✓${RESET}${panelBg} ${muted}Run retained for read-only inspection.${RESET}`,
   ));
   lines.push(renderBlankRow(inner, theme));
   lines.push(renderKilledFooter(width, theme));

--- a/packages/workflows/src/tui/session-confirm.ts
+++ b/packages/workflows/src/tui/session-confirm.ts
@@ -219,7 +219,6 @@ export interface WorkflowKilledNoticeRenderOpts {
   theme: GraphTheme;
   run: RunSnapshot;
   previousStatus: RunStatus;
-  wasInFlight: boolean;
 }
 
 const KILLED_TITLE = "Workflow killed";
@@ -252,7 +251,7 @@ function renderKilledTextRow(
 export function renderWorkflowKilledNotice(
   opts: WorkflowKilledNoticeRenderOpts,
 ): string[] {
-  const { width, theme, run, previousStatus, wasInFlight } = opts;
+  const { width, theme, run, previousStatus } = opts;
   const inner = Math.max(4, width - 2);
   const idShort = run.id.slice(0, 8);
   const stageCount = run.stages.length;
@@ -285,10 +284,7 @@ export function renderWorkflowKilledNotice(
   ));
   lines.push(renderBlankRow(inner, theme));
 
-  const action = wasInFlight
-    ? "Active stage work was aborted."
-    : "Run had already ended; no live work was aborted.";
-  lines.push(renderKilledTextRow(inner, theme, `      ${success}✓${RESET}${panelBg} ${muted}${action}${RESET}`));
+  lines.push(renderKilledTextRow(inner, theme, `      ${success}✓${RESET}${panelBg} ${muted}Active stage work was aborted.${RESET}`));
   lines.push(renderKilledTextRow(
     inner,
     theme,

--- a/packages/workflows/src/tui/session-picker.ts
+++ b/packages/workflows/src/tui/session-picker.ts
@@ -51,13 +51,13 @@ export function createSessionPickerState(): SessionPickerState {
 /** A run plus a derived bucket — keeps the renderer monomorphic. */
 export interface PickerRow {
   readonly run: RunSnapshot;
-  readonly bucket: "active" | "recent";
+  readonly bucket: "active" | "terminal";
 }
 
 const RECENT_WINDOW_MS = 60 * 60 * 1000;
 
 /**
- * Slice runs into picker rows. Active = `endedAt === undefined`. Recent =
+ * Slice runs into picker rows. Active = `endedAt === undefined`. Terminal =
  * retained terminal runs. With `includeAll` false, terminal rows are limited
  * to the legacy recent-ended one-hour window.
  *
@@ -88,7 +88,7 @@ export function selectRunsForPicker(
     }
 
     if (includeAll || now - endedAt <= RECENT_WINDOW_MS) {
-      terminal.push({ run: r, bucket: "recent" });
+      terminal.push({ run: r, bucket: "terminal" });
     }
   }
   active.sort((a, b) => a.run.startedAt - b.run.startedAt);
@@ -312,7 +312,7 @@ export function renderSessionPicker(opts: SessionPickerRenderOpts): string[] {
   for (let i = 0; i < visible.length; i++) {
     const row = visible[i]!;
     if (row.bucket !== prevBucket) {
-      lines.push(renderSectionRow(row.bucket === "active" ? "ACTIVE" : "RECENT", inner, theme));
+      lines.push(renderSectionRow(row.bucket === "active" ? "ACTIVE" : "TERMINAL", inner, theme));
       prevBucket = row.bucket;
     }
     const absIndex = Math.max(0, start) + i;
@@ -402,7 +402,7 @@ export function handleSessionPickerInput(
   // `x` = kill. Avoids collision with vim's `k` = up.
   if (matchesKey(data, "x") || matchesKey(data, Key.shift("x"))) {
     const row = rows[state.selectedIndex];
-    if (!row) return { kind: "noop" };
+    if (!row || row.run.endedAt !== undefined) return { kind: "noop" };
     return { kind: "kill", runId: row.run.id };
   }
 

--- a/packages/workflows/src/tui/session-picker.ts
+++ b/packages/workflows/src/tui/session-picker.ts
@@ -38,14 +38,14 @@ export interface SessionPickerState {
   query: string;
   /** 0-based index into the filtered/visible list. */
   selectedIndex: number;
-  /** Toggle for "include long-ended runs". Default false. */
+  /** Toggle for terminal run visibility. Default true so retained terminal runs stay inspectable. */
   includeAll: boolean;
   /** True when the filter input has focus (typing routes to query). */
   filterFocused: boolean;
 }
 
 export function createSessionPickerState(): SessionPickerState {
-  return { query: "", selectedIndex: 0, includeAll: false, filterFocused: false };
+  return { query: "", selectedIndex: 0, includeAll: true, filterFocused: false };
 }
 
 /** A run plus a derived bucket — keeps the renderer monomorphic. */
@@ -58,10 +58,11 @@ const RECENT_WINDOW_MS = 60 * 60 * 1000;
 
 /**
  * Slice runs into picker rows. Active = `endedAt === undefined`. Recent =
- * ended within the last hour. With `includeAll`, the hour cutoff is dropped.
+ * retained terminal runs. With `includeAll` false, terminal rows are limited
+ * to the legacy recent-ended one-hour window.
  *
  * Sort: active first (newest start last in the list = bottom-of-pane),
- * then recent newest-end first.
+ * then terminal newest-end first.
  */
 export function selectRunsForPicker(
   runs: readonly RunSnapshot[],
@@ -76,20 +77,23 @@ export function selectRunsForPicker(
   };
 
   const active: PickerRow[] = [];
-  const recent: PickerRow[] = [];
+  const terminal: PickerRow[] = [];
   for (const r of runs) {
     if (!matches(r)) continue;
-    if (r.endedAt === undefined) {
+
+    const endedAt = r.endedAt;
+    if (endedAt === undefined) {
       active.push({ run: r, bucket: "active" });
       continue;
     }
-    if (includeAll || now - (r.endedAt ?? 0) <= RECENT_WINDOW_MS) {
-      recent.push({ run: r, bucket: "recent" });
+
+    if (includeAll || now - endedAt <= RECENT_WINDOW_MS) {
+      terminal.push({ run: r, bucket: "recent" });
     }
   }
   active.sort((a, b) => a.run.startedAt - b.run.startedAt);
-  recent.sort((a, b) => (b.run.endedAt ?? 0) - (a.run.endedAt ?? 0));
-  return [...active, ...recent];
+  terminal.sort((a, b) => (b.run.endedAt ?? 0) - (a.run.endedAt ?? 0));
+  return [...active, ...terminal];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/tui/status-list.ts
+++ b/packages/workflows/src/tui/status-list.ts
@@ -336,8 +336,8 @@ function shortId(id: string): string {
 }
 
 function emptyStateLine(theme?: GraphTheme): string {
-  if (!theme) return "  no in-flight runs";
-  return `  ${hexToAnsi(theme.dim)}no in-flight runs${RESET}`;
+  if (!theme) return "  no workflow runs in current session";
+  return `  ${hexToAnsi(theme.dim)}no workflow runs in current session${RESET}`;
 }
 
 function statusIconForRun(run: RunSnapshot): string {

--- a/test/integration/mock-extension-api.test.ts
+++ b/test/integration/mock-extension-api.test.ts
@@ -699,9 +699,7 @@ describe("MockExtensionAPI — slash command registration", () => {
     assert.ok(inputs?.some((c) => c.value === "inputs deep-research-codebase "));
 
     const status = cmd.options.getArgumentCompletions?.("status --");
-    const statusAll = status?.find((c) => c.value === "status --all ");
-    assert.ok(statusAll);
-    assert.match(statusAll.description ?? "", /Compatibility no-op/);
+    assert.equal(status?.some((c) => c.value === "status --all ") ?? false, false);
 
     const interrupt = cmd.options.getArgumentCompletions?.("interrupt -");
     assert.ok(interrupt?.some((c) => c.value === "interrupt -y "));

--- a/test/integration/mock-extension-api.test.ts
+++ b/test/integration/mock-extension-api.test.ts
@@ -128,6 +128,25 @@ async function runTool(
   return out.details;
 }
 
+function recordWorkflowRun(
+  id: string,
+  name: string,
+  status: "running" | "completed" | "failed" | "killed",
+  error?: string,
+): void {
+  defaultStore.recordRunStart({
+    id,
+    name,
+    inputs: {},
+    stages: [],
+    status: "running",
+    startedAt: Date.now(),
+  });
+  if (status !== "running") {
+    defaultStore.recordRunEnd(id, status, undefined, error);
+  }
+}
+
 function getCommand(commands: RegisteredCommand[], name: string): RegisteredCommand | undefined {
   return commands.find((c) => c.name === name);
 }
@@ -464,6 +483,26 @@ describe("MockExtensionAPI — tool registration", () => {
     );
   });
 
+  test("tool execute status includes retained terminal snapshots", async () => {
+    const execute = mock.tools[0]!.opts.execute;
+    const activeId = `status-active-${Date.now()}`;
+    const completedId = `status-completed-${Date.now()}`;
+    const failedId = `status-failed-${Date.now()}`;
+    const killedId = `status-killed-${Date.now()}`;
+    recordWorkflowRun(activeId, "active", "running");
+    recordWorkflowRun(completedId, "completed", "completed");
+    recordWorkflowRun(failedId, "failed", "failed", "boom");
+    recordWorkflowRun(killedId, "killed", "killed", "killed");
+
+    const result = await runTool(execute, { inputs: {}, action: "status" });
+    const snapshots = (result as { action: "status"; snapshots: Array<{ id: string; status: string }> }).snapshots;
+
+    assert.deepEqual(
+      [activeId, completedId, failedId, killedId].map((id) => snapshots.find((s) => s.id === id)?.status),
+      ["running", "completed", "failed", "killed"],
+    );
+  });
+
   test("tool execute returns inputs stub for action='inputs'", async () => {
     const execute = mock.tools[0]!.opts.execute;
     const result = await runTool(execute, { workflow: "wf", inputs: {}, action: "inputs" });
@@ -660,7 +699,9 @@ describe("MockExtensionAPI — slash command registration", () => {
     assert.ok(inputs?.some((c) => c.value === "inputs deep-research-codebase "));
 
     const status = cmd.options.getArgumentCompletions?.("status --");
-    assert.ok(status?.some((c) => c.value === "status --all "));
+    const statusAll = status?.find((c) => c.value === "status --all ");
+    assert.ok(statusAll);
+    assert.match(statusAll.description ?? "", /Compatibility no-op/);
 
     const interrupt = cmd.options.getArgumentCompletions?.("interrupt -");
     assert.ok(interrupt?.some((c) => c.value === "interrupt -y "));
@@ -766,7 +807,7 @@ describe("renderCall — all action branches", () => {
   });
 
   test("action='status' returns status string", () => {
-    assert.equal(renderCall({ action: "status" }), "workflow: list in-flight runs");
+    assert.equal(renderCall({ action: "status" }), "workflow: list retained runs");
   });
 
   test("action='inputs' includes workflow", () => {
@@ -920,7 +961,7 @@ describe("renderResult — all action branches", () => {
     const out = renderResult({ action: "status", snapshots: [] });
     assert.match(out, /BACKGROUND/);
     assert.match(out, /0 runs/);
-    assert.match(out, /no in-flight runs/);
+    assert.match(out, /no workflow runs in current session/);
   });
 
   test("action='status' with snapshots renders cards", () => {
@@ -1013,10 +1054,10 @@ describe("renderResult — all action branches", () => {
       action: "kill",
       runId: "r-kill",
       status: "killed",
-      message: "Killed and removed",
+      message: "Killed and retained for inspection",
     });
     assert.ok(out.includes("r-kill"));
-    assert.ok(out.includes("Killed and removed"));
+    assert.ok(out.includes("Killed and retained for inspection"));
   });
 
   test("action='resume' shows message", () => {

--- a/test/integration/overlay-entrypoints.test.ts
+++ b/test/integration/overlay-entrypoints.test.ts
@@ -19,7 +19,7 @@
  *     overlay.open(activeRunId).
  *   - /workflow resume + /workflow attach + /workflow pause routing.
  *   - Graph-mode Ctrl+D / `h` never kills the run.
- *   - `q` kills and removes the active run (regression gate).
+ *   - `q` kills and retains the active run for inspection (regression gate).
  */
 
 import { describe, test } from "bun:test";
@@ -962,7 +962,7 @@ describe("buildGraphOverlayAdapter — Ctrl+D / h non-destructive hide", () => {
     assert.equal(run!.endedAt, undefined);
   });
 
-  test("`q` on a real custom mount kills and removes the active run (regression gate)", () => {
+  test("`q` on a real custom mount kills and retains the active run (regression gate)", () => {
     const runId = `q-kill-${Date.now()}`;
     const store = createStore();
     store.recordRunStart({
@@ -993,7 +993,9 @@ describe("buildGraphOverlayAdapter — Ctrl+D / h non-destructive hide", () => {
     capturedComponent!.handleInput!("q");
 
     const run = store.runs().find((r) => r.id === runId);
-    assert.equal(run, undefined, "`q` must remove the run from live history/status");
+    assert.ok(run, "`q` must retain the run in live history/status for inspection");
+    assert.equal(run.status, "killed");
+    assert.notEqual(run.endedAt, undefined);
   });
 });
 

--- a/test/unit/background-runner.test.ts
+++ b/test/unit/background-runner.test.ts
@@ -213,7 +213,7 @@ describe("statusRuns — lists detached run during active stage", () => {
     if (job) await job.promise;
   });
 
-  test("completed run no longer listed in statusRuns (default: in-flight only)", async () => {
+  test("settled retained run remains listed in statusRuns by default", async () => {
     const store = createStore();
     const cancellation = createCancellationRegistry();
     const jobs = createJobTracker();
@@ -230,10 +230,12 @@ describe("statusRuns — lists detached run during active stage", () => {
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     const runs = statusRuns({ store });
-    assert.equal(runs.find((r) => r.runId === accepted.runId), undefined);
+    const found = runs.find((r) => r.runId === accepted.runId);
+    assert.notEqual(found, undefined);
+    assert.notEqual(store.runs().find((r) => r.id === accepted.runId)?.endedAt, undefined);
   });
 
-  test("statusRuns all:true includes completed run", async () => {
+  test("statusRuns all:true is equivalent to default retained-run status", async () => {
     const store = createStore();
     const cancellation = createCancellationRegistry();
     const jobs = createJobTracker();
@@ -246,8 +248,7 @@ describe("statusRuns — lists detached run during active stage", () => {
     if (job) await job.promise;
     await new Promise((resolve) => setTimeout(resolve, 5));
 
-    const runsAll = statusRuns({ all: true, store });
-    assert.notEqual(runsAll.find((r) => r.runId === accepted.runId), undefined);
+    assert.deepEqual(statusRuns({ all: true, store }), statusRuns({ store }));
   });
 });
 

--- a/test/unit/background-status.test.ts
+++ b/test/unit/background-status.test.ts
@@ -43,20 +43,24 @@ describe("statusRuns", () => {
     assert.equal(result[0]!.runId, "r1");
   });
 
-  test("excludes ended runs by default", () => {
+  test("includes retained ended runs by default", () => {
     const st = createStore();
     st.recordRunStart(makeRun({ id: "r1" }));
     st.recordRunEnd("r1", "completed");
-    assert.equal(statusRuns({ store: st }).length, 0);
-  });
-
-  test("includes ended runs when all=true", () => {
-    const st = createStore();
-    st.recordRunStart(makeRun({ id: "r1" }));
-    st.recordRunEnd("r1", "completed");
-    const result = statusRuns({ all: true, store: st });
+    const result = statusRuns({ store: st });
     assert.equal(result.length, 1);
     assert.equal(result[0]!.runId, "r1");
+    assert.equal(result[0]!.status, "completed");
+  });
+
+  test("treats all as a compatibility no-op", () => {
+    const st = createStore();
+    st.recordRunStart(makeRun({ id: "active" }));
+    st.recordRunStart(makeRun({ id: "ended" }));
+    st.recordRunEnd("ended", "failed");
+    const defaultResult = statusRuns({ store: st });
+    assert.deepEqual(statusRuns({ all: true, store: st }), defaultResult);
+    assert.deepEqual(statusRuns({ all: false, store: st }), defaultResult);
   });
 
   test("entry has correct shape", () => {

--- a/test/unit/background-status.test.ts
+++ b/test/unit/background-status.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { statusRuns, killRun, killAllRuns, destroyRun, destroyAllRuns, resumeRun, pauseRun, interruptRun } from "../../packages/workflows/src/runs/background/status.js";
+import { statusRuns, killRun, killAllRuns, resumeRun, pauseRun, interruptRun } from "../../packages/workflows/src/runs/background/status.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import type { RunSnapshot } from "../../packages/workflows/src/shared/store-types.js";
 
@@ -136,52 +136,6 @@ describe("killAllRuns", () => {
     const results = killAllRuns({ store: st });
     // No in-flight runs, so returns empty
     assert.equal(results.length, 0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// destroyRun / destroyAllRuns
-// ---------------------------------------------------------------------------
-
-describe("destroyRun", () => {
-  test("kills and removes an in-flight run from live status", () => {
-    const st = createStore();
-    st.recordRunStart(makeRun({ id: "r1" }));
-
-    const result = destroyRun("r1", { store: st });
-
-    assert.equal(result.ok, true);
-    assert.equal(st.runs().some((r) => r.id === "r1"), false);
-    assert.equal(statusRuns({ store: st, all: true }).some((r) => r.runId === "r1"), false);
-  });
-
-  test("removes an already-ended run from live history", () => {
-    const st = createStore();
-    st.recordRunStart(makeRun({ id: "r1" }));
-    st.recordRunEnd("r1", "completed");
-
-    const result = destroyRun("r1", { store: st });
-
-    assert.equal(result.ok, true);
-    assert.equal(st.runs().some((r) => r.id === "r1"), false);
-  });
-});
-
-describe("destroyAllRuns", () => {
-  test("kills and removes all in-flight runs only", () => {
-    const st = createStore();
-    st.recordRunStart(makeRun({ id: "r1" }));
-    st.recordRunStart(makeRun({ id: "r2", name: "wf2" }));
-    st.recordRunStart(makeRun({ id: "ended", name: "wf3" }));
-    st.recordRunEnd("ended", "completed");
-
-    const results = destroyAllRuns({ store: st });
-
-    assert.equal(results.length, 2);
-    assert.equal(results.every((r) => r.ok), true);
-    assert.equal(st.runs().some((r) => r.id === "r1"), false);
-    assert.equal(st.runs().some((r) => r.id === "r2"), false);
-    assert.equal(st.runs().some((r) => r.id === "ended"), true);
   });
 });
 

--- a/test/unit/chat-surface.test.ts
+++ b/test/unit/chat-surface.test.ts
@@ -192,7 +192,7 @@ describe("renderHintRows", () => {
     const out = renderHintRows(
       [
         { command: "/workflow connect 0391c9c1", hint: "attach & watch" },
-        { command: "/workflow status", hint: "list in-flight runs" },
+        { command: "/workflow status", hint: "list retained runs" },
       ],
       theme,
     );
@@ -275,7 +275,9 @@ describe("registerChatSurfaceRenderer", () => {
     const rendered = stripAnsi(component.render(72).join("\n"));
     assert.match(rendered, /Workflow killed/);
     assert.match(rendered, /demo-kill/);
-    assert.match(rendered, /removed from live history/);
+    assert.doesNotMatch(rendered, /removed from live history/);
+    assert.match(rendered, /retained/i);
+    assert.match(rendered, /read-only inspection/i);
     assert.doesNotMatch(rendered, /close/);
   });
 });

--- a/test/unit/chat-surface.test.ts
+++ b/test/unit/chat-surface.test.ts
@@ -269,7 +269,6 @@ describe("registerChatSurfaceRenderer", () => {
           startedAt: 1000,
         },
         previousStatus: "running",
-        wasInFlight: true,
       },
     }) as { render(width: number): string[] };
     const rendered = stripAnsi(component.render(72).join("\n"));

--- a/test/unit/persistence-restore.test.ts
+++ b/test/unit/persistence-restore.test.ts
@@ -301,6 +301,19 @@ describe("restoreOnSessionStart", () => {
     assert.equal(run.stages[0]!.status, "completed");
   });
 
+  test("skips completed terminal runs with incomplete stage end data", () => {
+    const st = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "r1", name: "wf", inputs: {}, ts: 1 } },
+      { id: "e2", type: "workflow.stage.start", payload: { runId: "r1", stageId: "s1", name: "fetch", parentIds: [], ts: 2 } },
+      { id: "e3", type: "workflow.run.end", payload: { runId: "r1", status: "completed", ts: 3 } },
+    ];
+
+    restoreOnSessionStart(makeSessionManager(entries), { resumeInFlight: "never", persistRuns: true }, st);
+
+    assert.deepEqual(st.runs(), []);
+  });
+
   test("ignores invalid run failureKind from run.end entries", () => {
     const st = createStore();
     const entries: SessionEntry[] = [

--- a/test/unit/persistence-restore.test.ts
+++ b/test/unit/persistence-restore.test.ts
@@ -133,7 +133,8 @@ describe("restoreOnSessionStart", () => {
       { onCrashed: (r) => crashed.push(r) },
     );
     assert.equal(crashed.length, 0);
-    assert.equal(st.runs().length, 0);
+    assert.equal(st.runs().length, 1);
+    assert.equal(st.runs()[0]?.status, "completed");
   });
 
   test("resumeInFlight=never: marks run as failed and calls onCrashed", () => {
@@ -282,6 +283,22 @@ describe("restoreOnSessionStart", () => {
     assert.equal(run.failureMessage, "429 too many requests");
     assert.equal(run.failedStageId, "s1");
     assert.equal(run.resumable, true);
+  });
+
+  test("restores completed terminal runs from run.end entries", () => {
+    const st = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "r1", name: "wf", inputs: {}, ts: 1 } },
+      { id: "e2", type: "workflow.stage.start", payload: { runId: "r1", stageId: "s1", name: "fetch", parentIds: [], ts: 2 } },
+      { id: "e3", type: "workflow.stage.end", payload: { runId: "r1", stageId: "s1", status: "completed", summary: "done" } },
+      { id: "e4", type: "workflow.run.end", payload: { runId: "r1", status: "completed", ts: 3 } },
+    ];
+
+    restoreOnSessionStart(makeSessionManager(entries), { resumeInFlight: "never", persistRuns: true }, st);
+    const run = st.runs()[0]!;
+    assert.equal(run.status, "completed");
+    assert.notEqual(run.endedAt, undefined);
+    assert.equal(run.stages[0]!.status, "completed");
   });
 
   test("ignores invalid run failureKind from run.end entries", () => {

--- a/test/unit/session-confirm-list.test.ts
+++ b/test/unit/session-confirm-list.test.ts
@@ -126,6 +126,24 @@ test("workflow killed notice renders transparent completion details", () => {
   }
 });
 
+test("workflow killed notice handles paused runs without active stages", () => {
+  const theme = deriveGraphTheme({});
+  const lines = renderWorkflowKilledNotice({
+    width: 72,
+    theme,
+    run: makeRun({
+      id: "abc12345-0000-0000-0000-000000000000",
+      name: "paused-workflow",
+      status: "paused",
+      stages: [{ id: "s1", name: "await-input", status: "paused", parentIds: [], toolEvents: [] }],
+    }),
+    previousStatus: "paused",
+  });
+  const joined = lines.join("\n");
+  assert.match(joined, /no stages were actively running/i);
+  assert.doesNotMatch(joined, /Active stage work was aborted/);
+});
+
 test("workflow killed notice stays within narrow panes", () => {
   const theme = deriveGraphTheme({});
   const width = 40;

--- a/test/unit/session-confirm-list.test.ts
+++ b/test/unit/session-confirm-list.test.ts
@@ -111,7 +111,6 @@ test("workflow killed notice renders transparent completion details", () => {
     theme,
     run,
     previousStatus: "running",
-    wasInFlight: true,
   });
   const joined = lines.join("\n");
   assert.match(joined, /Workflow killed/);
@@ -140,7 +139,6 @@ test("workflow killed notice stays within narrow panes", () => {
       stages: [{ id: "s1", name: "plan", status: "running", parentIds: [], toolEvents: [] }],
     }),
     previousStatus: "running",
-    wasInFlight: true,
   });
   for (const line of lines) {
     assert.ok(visibleWidth(line) <= width, `line exceeds ${width}: ${visibleWidth(line)} ${JSON.stringify(line)}`);

--- a/test/unit/session-confirm-list.test.ts
+++ b/test/unit/session-confirm-list.test.ts
@@ -71,6 +71,9 @@ test("kill confirm renders run identity and button row", () => {
   assert.match(joined, /Cancel/);
   assert.match(joined, /Kill run/);
   assert.match(joined, /1\/2 stages running/);
+  assert.match(joined, /marks the run killed/);
+  assert.match(joined, /Retains it in history\/status for inspection/);
+  assert.doesNotMatch(joined, /Removes the run from live history\/status/);
 });
 
 test("kill confirm clamps long and wide workflow names to the dialog width", () => {
@@ -114,7 +117,9 @@ test("workflow killed notice renders transparent completion details", () => {
   assert.match(joined, /Workflow killed/);
   assert.match(joined, /issue-973-validation/);
   assert.match(joined, /abc12345/);
-  assert.match(joined, /removed from live history/);
+  assert.doesNotMatch(joined, /removed from live history/);
+  assert.match(joined, /retained/i);
+  assert.match(joined, /read-only inspection/i);
   assert.match(joined, /Active stage work was aborted/);
   assert.doesNotMatch(joined, /close/);
   for (const line of lines) {
@@ -166,10 +171,30 @@ test("session list renders the band-header chrome with both runs and a detail hi
   assert.match(out, /\/workflow status \w+/);
 });
 
+test("session list includeAll:true includes old retained terminal runs", () => {
+  const theme = deriveGraphTheme({});
+  const now = 3 * 60 * 60 * 1000;
+  const oldTerminal = makeRun({
+    id: "33333333-0000-0000-0000-000000000000",
+    name: "old-retained-terminal",
+    status: "completed",
+    startedAt: now - 2 * 60 * 60 * 1000 - 10_000,
+    endedAt: now - 2 * 60 * 60 * 1000,
+    durationMs: 10_000,
+  });
+
+  const activeOnly = renderSessionList([oldTerminal], { theme, includeAll: false, now });
+  const includeAll = renderSessionList([oldTerminal], { theme, includeAll: true, now });
+
+  assert.doesNotMatch(activeOnly, /old-retained-terminal/);
+  assert.match(includeAll, /old-retained-terminal/);
+  assert.match(includeAll, /333333/);
+});
+
 test("session list emits the band-header chrome with a quiet empty state", () => {
   const theme = deriveGraphTheme({});
   const out = renderSessionList([], { theme, includeAll: false });
   assert.match(out, /BACKGROUND/);
   assert.match(out, /0 runs/);
-  assert.match(out, /no in-flight runs/);
+  assert.match(out, /no workflow runs in current session/);
 });

--- a/test/unit/session-picker.test.ts
+++ b/test/unit/session-picker.test.ts
@@ -39,7 +39,7 @@ test("selectRunsForPicker buckets active vs retained terminal by default", () =>
   ];
   const rows = selectRunsForPicker(runs, "", true, now);
   assert.deepEqual(rows.map((r) => r.run.id), ["a-active", "b-recent", "c-old"]);
-  assert.deepEqual(rows.map((r) => r.bucket), ["active", "recent", "recent"]);
+  assert.deepEqual(rows.map((r) => r.bucket), ["active", "terminal", "terminal"]);
 
   const legacyRecentOnly = selectRunsForPicker(runs, "", false, now);
   assert.deepEqual(legacyRecentOnly.map((r) => r.run.id), ["a-active", "b-recent"]);
@@ -66,7 +66,7 @@ test("handleSessionPickerInput: enter on selected row returns connect", () => {
   assert.deepEqual(action, { kind: "connect", runId: "id-1" });
 });
 
-test("handleSessionPickerInput: arrows navigate, x kills selected row", () => {
+test("handleSessionPickerInput: arrows navigate, x kills selected active row", () => {
   const state = createSessionPickerState();
   const rows = [
     { run: makeRun({ id: "id-1" }), bucket: "active" as const },
@@ -76,6 +76,15 @@ test("handleSessionPickerInput: arrows navigate, x kills selected row", () => {
   assert.equal(state.selectedIndex, 1);
   const kill = handleSessionPickerInput("x", state, rows);
   assert.deepEqual(kill, { kind: "kill", runId: "id-2" });
+});
+
+test("handleSessionPickerInput: x is a no-op on terminal rows", () => {
+  const state = createSessionPickerState();
+  const rows = [
+    { run: makeRun({ id: "id-1", status: "completed", endedAt: 2000 }), bucket: "terminal" as const },
+  ];
+  const action = handleSessionPickerInput("x", state, rows);
+  assert.deepEqual(action, { kind: "noop" });
 });
 
 test("handleSessionPickerInput: / enters filter mode and types into query", () => {
@@ -126,13 +135,13 @@ test("renderSessionPicker emits header, sections, and footer hints", () => {
   const state = createSessionPickerState();
   const rows = [
     { run: makeRun({ id: "aaaa1111-0000-0000-0000-000000000000", name: "ralph" }), bucket: "active" as const },
-    { run: makeRun({ id: "bbbb2222-0000-0000-0000-000000000000", name: "deep-research", status: "completed", endedAt: 2000 }), bucket: "recent" as const },
+    { run: makeRun({ id: "bbbb2222-0000-0000-0000-000000000000", name: "deep-research", status: "completed", endedAt: 2000 }), bucket: "terminal" as const },
   ];
   const lines = renderSessionPicker({ width: 80, theme, rows, state });
   const joined = lines.join("\n");
   assert.match(joined, /Connect to workflow run/);
   assert.match(joined, /ACTIVE/);
-  assert.match(joined, /RECENT/);
+  assert.match(joined, /TERMINAL/);
   assert.match(joined, /aaaa1111/);
   assert.match(joined, /ralph/);
   assert.match(joined, /Navigate/);

--- a/test/unit/session-picker.test.ts
+++ b/test/unit/session-picker.test.ts
@@ -29,7 +29,7 @@ function makeRun(over: Partial<RunSnapshot>): RunSnapshot {
   };
 }
 
-test("selectRunsForPicker buckets active vs recent, drops old by default", () => {
+test("selectRunsForPicker buckets active vs retained terminal by default", () => {
   const now = 10_000_000;
   const hourMs = 60 * 60 * 1000;
   const runs: RunSnapshot[] = [
@@ -37,12 +37,12 @@ test("selectRunsForPicker buckets active vs recent, drops old by default", () =>
     makeRun({ id: "b-recent", status: "completed", startedAt: now - 5000, endedAt: now - 1000, durationMs: 4000 }),
     makeRun({ id: "c-old", status: "completed", startedAt: now - hourMs * 4, endedAt: now - hourMs * 3, durationMs: hourMs }),
   ];
-  const rows = selectRunsForPicker(runs, "", false, now);
-  assert.deepEqual(rows.map((r) => r.run.id), ["a-active", "b-recent"]);
-  assert.deepEqual(rows.map((r) => r.bucket), ["active", "recent"]);
+  const rows = selectRunsForPicker(runs, "", true, now);
+  assert.deepEqual(rows.map((r) => r.run.id), ["a-active", "b-recent", "c-old"]);
+  assert.deepEqual(rows.map((r) => r.bucket), ["active", "recent", "recent"]);
 
-  const all = selectRunsForPicker(runs, "", true, now);
-  assert.equal(all.length, 3);
+  const legacyRecentOnly = selectRunsForPicker(runs, "", false, now);
+  assert.deepEqual(legacyRecentOnly.map((r) => r.run.id), ["a-active", "b-recent"]);
 });
 
 test("selectRunsForPicker filters by name and runId prefix", () => {
@@ -106,11 +106,11 @@ test("handleSessionPickerInput: double esc exits filter mode", () => {
 
 test("handleSessionPickerInput: a toggles includeAll", () => {
   const state = createSessionPickerState();
-  assert.equal(state.includeAll, false);
-  handleSessionPickerInput("a", state, []);
   assert.equal(state.includeAll, true);
   handleSessionPickerInput("a", state, []);
   assert.equal(state.includeAll, false);
+  handleSessionPickerInput("a", state, []);
+  assert.equal(state.includeAll, true);
 });
 
 test("handleSessionPickerInput: esc variants close", () => {

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -757,23 +757,28 @@ describe("/workflow interrupt chat command", () => {
 
     const { workflowCmd } = await registerWorkflowCommand();
     const msgs: string[] = [];
+    let confirmCalls = 0;
     const ctx: PiCommandContext = {
       ui: {
         notify: (message: string) => { msgs.push(message); },
-        confirm: async () => true,
+        confirm: async () => {
+          confirmCalls++;
+          return true;
+        },
       },
     };
 
     await workflowCmd.options.handler(`kill ${runId}`, ctx);
 
     const joined = msgs.join("\n");
+    assert.equal(confirmCalls, 0);
     assert.match(joined, /already ended/i);
     assert.match(joined, /retained/i);
     assert.doesNotMatch(joined, /Run not found/);
     assert.equal(store.runs().find((r) => r.id === runId)?.status, status);
   });
 
-  test("picker kill on a terminal row reports already-ended retained copy", async () => {
+  test("picker kill on a terminal row is a no-op", async () => {
     const runId = `picker-kill-ended-${Date.now()}`;
     recordTerminalRun(runId, "completed");
 
@@ -788,6 +793,7 @@ describe("/workflow interrupt chat command", () => {
       } else {
         (component as PiCustomComponent).render(80);
         (component as PiCustomComponent).handleInput?.("x");
+        (component as PiCustomComponent).handleInput?.("\x1b");
       }
       return undefined;
     };
@@ -800,10 +806,7 @@ describe("/workflow interrupt chat command", () => {
 
     await workflowCmd.options.handler("connect", ctx);
 
-    const joined = msgs.join("\n");
-    assert.match(joined, /already ended/i);
-    assert.match(joined, /retained/i);
-    assert.doesNotMatch(joined, /Run not found/);
+    assert.deepEqual(msgs, []);
   });
 
   test("/workflow connect no-custom-UI fallback includes older retained terminal runs", async () => {

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -710,8 +710,139 @@ function makeInflightRun(id: string) {
   };
 }
 
+async function registerWorkflowCommand() {
+  const { pi, commands, sent } = buildMockPi();
+  addFactoryStubs(pi);
+  const factoryModule = await import("../../packages/workflows/src/extension/index.js");
+  factoryModule.default(pi);
+  const workflowCmd = commands.find((c) => c.name === "workflow");
+  assert.notEqual(workflowCmd, undefined);
+  return { pi, commands, sent, workflowCmd: workflowCmd! };
+}
+
+function recordTerminalRun(
+  id: string,
+  status: "completed" | "failed" | "killed",
+  overrides: { name?: string; startedAt?: number; endedAt?: number } = {},
+): void {
+  store.recordRunStart({
+    ...makeInflightRun(id),
+    name: overrides.name ?? "terminal-wf",
+    startedAt: overrides.startedAt ?? Date.now() - 10_000,
+  });
+  const completed = status === "completed";
+  store.recordRunEnd(
+    id,
+    status,
+    completed ? { ok: true } : undefined,
+    completed ? undefined : status,
+  );
+  if (overrides.endedAt !== undefined) {
+    const run = store.runs().find((r) => r.id === id);
+    if (run) {
+      run.endedAt = overrides.endedAt;
+      run.durationMs = run.endedAt - run.startedAt;
+    }
+  }
+}
+
 describe("/workflow interrupt chat command", () => {
-  test("top-level /workflow kill <id> kills and removes from chat without requiring confirmation", async () => {
+  test.each([
+    ["completed"],
+    ["failed"],
+    ["killed"],
+  ] as const)("top-level /workflow kill <id> reports %s runs as already ended and retained", async (status) => {
+    const runId = `slash-kill-${status}-${Date.now()}`;
+    recordTerminalRun(runId, status);
+
+    const { workflowCmd } = await registerWorkflowCommand();
+    const msgs: string[] = [];
+    const ctx: PiCommandContext = {
+      ui: {
+        notify: (message: string) => { msgs.push(message); },
+        confirm: async () => true,
+      },
+    };
+
+    await workflowCmd.options.handler(`kill ${runId}`, ctx);
+
+    const joined = msgs.join("\n");
+    assert.match(joined, /already ended/i);
+    assert.match(joined, /retained/i);
+    assert.doesNotMatch(joined, /Run not found/);
+    assert.equal(store.runs().find((r) => r.id === runId)?.status, status);
+  });
+
+  test("picker kill on a terminal row reports already-ended retained copy", async () => {
+    const runId = `picker-kill-ended-${Date.now()}`;
+    recordTerminalRun(runId, "completed");
+
+    const { workflowCmd } = await registerWorkflowCommand();
+    const msgs: string[] = [];
+    const customFn: PiCustomOverlayFunction = (factoryArg, options) => {
+      const tui: PiCustomOverlayFactoryTui = { requestRender: () => undefined };
+      const component = factoryArg(tui, {}, {}, () => undefined);
+      if (component instanceof Promise) throw new Error("expected sync factory");
+      if (options.overlay) {
+        (component as PiCustomComponent).handleInput?.("y");
+      } else {
+        (component as PiCustomComponent).render(80);
+        (component as PiCustomComponent).handleInput?.("x");
+      }
+      return undefined;
+    };
+    const ctx: PiCommandContext = {
+      ui: {
+        notify: (message: string) => { msgs.push(message); },
+        custom: customFn,
+      },
+    };
+
+    await workflowCmd.options.handler("connect", ctx);
+
+    const joined = msgs.join("\n");
+    assert.match(joined, /already ended/i);
+    assert.match(joined, /retained/i);
+    assert.doesNotMatch(joined, /Run not found/);
+  });
+
+  test("/workflow connect no-custom-UI fallback includes older retained terminal runs", async () => {
+    const oldEndedAt = Date.now() - 2 * 60 * 60 * 1000;
+    recordTerminalRun("old-connect-terminal-run", "completed", {
+      name: "old-connect-terminal",
+      startedAt: oldEndedAt - 5_000,
+      endedAt: oldEndedAt,
+    });
+
+    const { workflowCmd } = await registerWorkflowCommand();
+    const { ctx, messages } = buildCtx();
+
+    await workflowCmd.options.handler("connect", ctx);
+
+    const joined = messages.join("\n");
+    assert.match(joined, /old-connect-terminal/);
+    assert.match(joined, /Picker requires a UI surface/);
+  });
+
+  test("/workflow attach no-custom-UI fallback includes older retained terminal runs", async () => {
+    const oldEndedAt = Date.now() - 2 * 60 * 60 * 1000;
+    recordTerminalRun("old-attach-terminal-run", "failed", {
+      name: "old-attach-terminal",
+      startedAt: oldEndedAt - 5_000,
+      endedAt: oldEndedAt,
+    });
+
+    const { workflowCmd } = await registerWorkflowCommand();
+    const { ctx, messages } = buildCtx();
+
+    await workflowCmd.options.handler("attach", ctx);
+
+    const joined = messages.join("\n");
+    assert.match(joined, /old-attach-terminal/);
+    assert.match(joined, /Picker requires a UI surface/);
+  });
+
+  test("top-level /workflow kill <id> kills and retains run without requiring confirmation", async () => {
     const runId = `kill-chat-${Date.now()}`;
     store.recordRunStart(makeInflightRun(runId));
 
@@ -738,8 +869,8 @@ describe("/workflow interrupt chat command", () => {
 
     const run = store.runs().find((r) => r.id === runId);
     assert.equal(confirmCalls, 0);
-    assert.equal(run, undefined);
-    assert.equal(msgs.some((m) => m.includes("killed and removed")), true);
+    assert.equal(run?.status, "killed");
+    assert.equal(msgs.some((m) => m.includes("killed and retained for inspection")), true);
     assert.equal(sent.some((m) => (m.details as { kind?: string } | undefined)?.kind === "killed"), true);
   });
 
@@ -1181,7 +1312,7 @@ describe("tool run-control actions", () => {
     const r = result as { action: string; status: string; runId: string };
     assert.equal(r.status, "killed");
     assert.equal(r.runId, runId);
-    assert.equal(store.runs().some((run) => run.id === runId), false);
+    assert.equal(store.runs().find((run) => run.id === runId)?.status, "killed");
   });
 
   test("makeExecuteWorkflowTool kill supports unique run id prefixes", async () => {
@@ -1195,7 +1326,7 @@ describe("tool run-control actions", () => {
     const r = result as { action: string; status: string; runId: string };
     assert.equal(r.status, "killed");
     assert.equal(r.runId, runId);
-    assert.equal(store.runs().some((run) => run.id === runId), false);
+    assert.equal(store.runs().find((run) => run.id === runId)?.status, "killed");
   });
 
   test("makeExecuteWorkflowTool kill supports all:true", async () => {
@@ -1213,9 +1344,9 @@ describe("tool run-control actions", () => {
     assert.equal(result.action, "kill");
     const r = result as { action: string; status: string };
     assert.equal(r.status, "killed");
-    assert.equal(store.runs().some((run) => run.id === r1), false);
-    assert.equal(store.runs().some((run) => run.id === r2), false);
-    assert.equal(store.runs().some((run) => run.id === ended), true);
+    assert.equal(store.runs().find((run) => run.id === r1)?.status, "killed");
+    assert.equal(store.runs().find((run) => run.id === r2)?.status, "killed");
+    assert.equal(store.runs().find((run) => run.id === ended)?.status, "completed");
   });
 
   test("makeExecuteWorkflowTool pause all reports noop when no runs are in flight", async () => {

--- a/test/unit/status-list-render.test.ts
+++ b/test/unit/status-list-render.test.ts
@@ -60,7 +60,7 @@ describe("renderStatusList — empty", () => {
     const plain = stripAnsi(out);
     assert.match(plain, /╭ BACKGROUND  0 runs /);
     assert.match(plain, /0 runs/);
-    assert.match(plain, /no in-flight runs/);
+    assert.match(plain, /no workflow runs in current session/);
   });
 });
 


### PR DESCRIPTION
## Summary

Workflow runs that complete, fail, or are killed are now retained in all user-facing surfaces (status, connect, attach, picker) instead of being destructively removed. Kill operations mark a run as \`killed\` and keep its snapshot in the store — no snapshot is ever deleted on kill.

## Key Changes

- **\`killRun\` / \`killAllRuns\` replace \`destroyRun\` / \`destroyAllRuns\`** — kill paths mark runs with status \`killed\` and keep their snapshots in the store; \`destroyRun\`/\`destroyAllRuns\` (which called \`store.removeRun\`) are removed entirely
- **\`statusRuns\` returns all retained runs** — the \`endedAt\` filter is removed; the legacy \`all\` option is accepted as a compatibility no-op
- **Status tool action and \`/workflow status\` emit all runs by default** — \`--all\` remains accepted as a no-op; \`--all\` is removed from tab-completion candidates
- **Session picker defaults to \`includeAll: true\`** — \`createSessionPickerState\` starts with \`includeAll: true\` so terminal runs are visible in the connect/attach pickers without any extra toggle
- **\`selectRunsForPicker\` bucket renamed** — internal \`recent\` bucket renamed to \`terminal\`; the legacy one-hour recency window is preserved only when \`includeAll\` is explicitly \`false\`
- **Persistence restore extended to completed runs** — \`restoreTerminalRuns\` (formerly \`restoreEndedFailedRuns\`) now restores completed runs in addition to failed and killed ones; \`restoreTerminalRunStatus\` adds \`"completed"\` as a valid terminal status
- **Already-ended kill paths** — attempting to kill an already-terminal run returns \`"already ended; retained for inspection"\` instead of \`"run not found"\`
- **\`wasInFlight\` field removed from \`KilledPayload\`** — the field was only used to switch between two removal messages; both messages are now replaced by a single retention message; the killed notice panel now derives active-stage state from \`runningStages\` count instead
- **TUI copy updated** — kill-confirm dialog now says "marks the run killed / retains it in history/status for inspection"; killed-notice panel says "retained for read-only inspection"; empty-state line updated to "no workflow runs in current session"; picker \`x\` key is a no-op on terminal rows
- **Docs** — \`workflows.md\`, \`quickstart.md\`, and \`README.md\` updated to reflect the new retention semantics
- **Tests** — regression coverage added in \`slash-dispatch.test.ts\`, \`session-confirm-list.test.ts\`, \`background-status.test.ts\`, and \`mock-extension-api.test.ts\` for all terminal-run states (completed, failed, killed); \`destroyRun\`/\`destroyAllRuns\` test suites removed

## Breaking Changes

None for end users. \`--all\` on \`/workflow status\` continues to work (now a no-op since all runs are shown by default).

**Internal:** \`destroyRun\` and \`destroyAllRuns\` are removed from \`packages/workflows/src/runs/background/status.ts\`. Any caller outside the extension must migrate to \`killRun\`/\`killAllRuns\`, which retain the snapshot instead of removing it.

Fixes #1083

## Validation

- \`bun run lint\` (via commit/push hooks)
- \`bun run test:unit\` (via commit/push hooks)
- \`bun run typecheck\`
- All 23 changed files verified in \`git diff --stat origin/main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)