### PR TITLE
fix(subagents): inject executor runtime dependencies

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Hardened workflow-stage subagent guard propagation tests with an internal executor runtime DI seam ([#1088](https://github.com/flora131/atomic/issues/1088)).
 - Capped subagent fanout spawned from workflow stages to a single child level with a workflow-specific nested-subagent error.
 
 ## [0.24.3] - 2026-05-14

--- a/packages/subagents/src/agents/agent-management.ts
+++ b/packages/subagents/src/agents/agent-management.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { CONFIG_DIR_NAME } from "@bastani/atomic";
 import type { ExtensionContext } from "@bastani/atomic";
 import {
@@ -20,7 +19,7 @@ import {
 import { serializeAgent } from "./agent-serializer.ts";
 import { serializeChain } from "./chain-serializer.ts";
 import { discoverAvailableSkills } from "./skills.ts";
-import type { Details } from "../shared/types.ts";
+import type { SubagentToolResult } from "../shared/types.ts";
 
 type ManagementAction = "list" | "get" | "create" | "update" | "delete";
 type ManagementScope = "user" | "project";
@@ -34,7 +33,7 @@ interface ManagementParams {
 	config?: unknown;
 }
 
-function result(text: string, isError = false): AgentToolResult<Details> {
+function result(text: string, isError = false): SubagentToolResult {
 	return { content: [{ type: "text", text }], isError, details: { mode: "management", results: [] } };
 }
 
@@ -305,14 +304,20 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 	return undefined;
 }
 
+type MutableDefinition<T extends { source: AgentSource }> = T & { source: ManagementScope };
+
+function isMutableDefinition<T extends { source: AgentSource }>(value: T): value is MutableDefinition<T> {
+	return value.source === "user" || value.source === "project";
+}
+
 function resolveTarget<T extends { source: AgentSource; filePath: string }>(
 	kind: "agent" | "chain",
 	name: string,
 	matches: T[],
 	cwd: string,
 	scopeHint?: string,
-): T | AgentToolResult<Details> {
-	const mutable = matches.filter((m) => m.source !== "builtin");
+): MutableDefinition<T> | SubagentToolResult {
+	const mutable = matches.filter(isMutableDefinition);
 	if (mutable.length === 0) {
 		if (matches.length > 0) {
 			return result(`${kind === "agent" ? "Agent" : "Chain"} '${name}' is builtin and cannot be modified. Create a same-named ${kind} in user or project scope to override it.`, true);
@@ -400,7 +405,7 @@ function formatChainDetail(chain: ChainConfig): string {
 	return lines.join("\n");
 }
 
-export function handleList(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
+export function handleList(params: ManagementParams, ctx: ManagementContext): SubagentToolResult {
 	const scope = normalizeListScope(params.agentScope) ?? "both";
 	const d = discoverAgentsAll(ctx.cwd);
 	const scopedAgents = allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === scope).sort((a, b) => a.name.localeCompare(b.name));
@@ -418,7 +423,7 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Ag
 	return result(lines.join("\n"));
 }
 
-function handleGet(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
+function handleGet(params: ManagementParams, ctx: ManagementContext): SubagentToolResult {
 	if (!params.agent && !params.chainName) return result("Specify 'agent' or 'chainName' for get.", true);
 	const hasBoth = Boolean(params.agent && params.chainName);
 	const blocks: string[] = [];
@@ -448,7 +453,7 @@ function handleGet(params: ManagementParams, ctx: ManagementContext): AgentToolR
 	return result(blocks.join("\n\n"), !anyFound);
 }
 
-export function handleCreate(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
+export function handleCreate(params: ManagementParams, ctx: ManagementContext): SubagentToolResult {
 	const parsedConfig = configObject(params.config);
 	if (parsedConfig.error) return result(parsedConfig.error, true);
 	const cfg = parsedConfig.value;
@@ -508,7 +513,7 @@ export function handleCreate(params: ManagementParams, ctx: ManagementContext): 
 	return result([`Created agent '${runtimeName}' at ${targetPath}.`, ...warnings].join("\n"));
 }
 
-export function handleUpdate(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
+export function handleUpdate(params: ManagementParams, ctx: ManagementContext): SubagentToolResult {
 	if (!params.agent && !params.chainName) return result("Specify 'agent' or 'chainName' for update.", true);
 	if (params.agent && params.chainName) return result("Specify either 'agent' or 'chainName', not both.", true);
 	const parsedConfig = configObject(params.config);
@@ -616,7 +621,7 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 	return result([headline, ...warnings].join("\n"));
 }
 
-function handleDelete(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
+function handleDelete(params: ManagementParams, ctx: ManagementContext): SubagentToolResult {
 	if (!params.agent && !params.chainName) return result("Specify 'agent' or 'chainName' for delete.", true);
 	if (params.agent && params.chainName) return result("Specify either 'agent' or 'chainName', not both.", true);
 	const scopeHint = asDisambiguationScope(params.agentScope);
@@ -637,7 +642,7 @@ function handleDelete(params: ManagementParams, ctx: ManagementContext): AgentTo
 	return result(`Deleted chain '${target.name}' at ${target.filePath}.`);
 }
 
-export function handleManagementAction(action: string, params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
+export function handleManagementAction(action: string, params: ManagementParams, ctx: ManagementContext): SubagentToolResult {
 	switch (action as ManagementAction) {
 		case "list": return handleList(params, ctx);
 		case "get": return handleGet(params, ctx);

--- a/packages/subagents/src/runs/background/run-status.ts
+++ b/packages/subagents/src/runs/background/run-status.ts
@@ -1,11 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { formatAsyncRunList, formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns } from "./async-status.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
-import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type Details, type NestedRunSummary, type SubagentState } from "../../shared/types.ts";
+import { ASYNC_DIR, RESULTS_DIR, type AsyncStatus, type NestedRunSummary, type SubagentState, type SubagentToolResult } from "../../shared/types.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
 import { resolveAsyncRunLocation } from "./async-resume.ts";
 import { resolveSubagentRunId } from "./run-id-resolver.ts";
@@ -98,7 +97,7 @@ function formatNestedExactStatus(rootRunId: string, run: NestedRunSummary): stri
 	return lines.join("\n");
 }
 
-export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDeps = {}): AgentToolResult<Details> {
+export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDeps = {}): SubagentToolResult {
 	const asyncDirRoot = deps.asyncDirRoot ?? ASYNC_DIR;
 	const resultsDir = deps.resultsDir ?? RESULTS_DIR;
 	if (!params.id && !params.runId && !params.dir) {

--- a/packages/subagents/src/runs/foreground/chain-clarify.ts
+++ b/packages/subagents/src/runs/foreground/chain-clarify.ts
@@ -775,7 +775,7 @@ export class ChainClarifyComponent implements Component {
 
 	private handleEditInput(data: string): void {
 		const textWidth = this.width - 4; // Must match render: innerW - 2 = (width - 2) - 2
-		if (matchesKey(data, "shift+up") || matchesKey(data, "pageup")) {
+		if (matchesKey(data, "shift+up") || matchesKey(data, "pageUp")) {
 			const { lines: wrapped, starts } = wrapText(this.editState.buffer, textWidth);
 			const cursorPos = getCursorDisplayPos(this.editState.cursor, starts);
 			const targetLine = Math.max(0, cursorPos.line - this.EDIT_VIEWPORT_HEIGHT);
@@ -785,7 +785,7 @@ export class ChainClarifyComponent implements Component {
 			return;
 		}
 
-		if (matchesKey(data, "shift+down") || matchesKey(data, "pagedown")) {
+		if (matchesKey(data, "shift+down") || matchesKey(data, "pageDown")) {
 			const { lines: wrapped, starts } = wrapText(this.editState.buffer, textWidth);
 			const cursorPos = getCursorDisplayPos(this.editState.cursor, starts);
 			const targetLine = Math.min(wrapped.length - 1, cursorPos.line + this.EDIT_VIEWPORT_HEIGHT);

--- a/packages/subagents/src/runs/foreground/chain-execution.ts
+++ b/packages/subagents/src/runs/foreground/chain-execution.ts
@@ -61,6 +61,23 @@ import {
 import { resolveModelCandidate } from "../shared/model-fallback.ts";
 import { validateFileOnlyOutputMode } from "../shared/single-output.ts";
 
+type RunSyncDependency = typeof runSync;
+
+type ChainForegroundControl = {
+	updatedAt: number;
+	currentAgent?: string;
+	currentIndex?: number;
+	currentActivityState?: ActivityState;
+	lastActivityAt?: number;
+	currentTool?: string;
+	currentToolStartedAt?: number;
+	currentPath?: string;
+	turnCount?: number;
+	tokens?: number;
+	toolCount?: number;
+	interrupt?: () => boolean;
+};
+
 interface ChainExecutionDetailsInput {
 	results: SingleResult[];
 	includeProgress?: boolean;
@@ -98,16 +115,7 @@ interface ParallelChainRunInput {
 	controlConfig: ResolvedControlConfig;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
 	orchestratorIntercomTarget?: string;
-	foregroundControl?: {
-		updatedAt: number;
-		currentAgent?: string;
-		currentIndex?: number;
-		currentActivityState?: ActivityState;
-		lastActivityAt?: number;
-		currentTool?: string;
-		currentToolStartedAt?: number;
-		interrupt?: () => boolean;
-	};
+	foregroundControl?: ChainForegroundControl;
 	results: SingleResult[];
 	allProgress: AgentProgress[];
 	chainAgents: string[];
@@ -116,6 +124,7 @@ interface ParallelChainRunInput {
 	maxSubagentDepth: number;
 	workflowStageSubagentGuard?: boolean;
 	nestedRoute?: NestedRouteInfo;
+	runSync: RunSyncDependency;
 }
 
 function buildChainExecutionDetails(input: ChainExecutionDetailsInput): Details {
@@ -228,7 +237,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				};
 			}
 
-			const result = await runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
+			const result = await input.runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				cwd: taskCwd,
 				signal: input.signal,
 				interruptSignal: interruptController.signal,
@@ -325,16 +334,7 @@ interface ChainExecutionParams {
 	controlConfig: ResolvedControlConfig;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
 	orchestratorIntercomTarget?: string;
-	foregroundControl?: {
-		updatedAt: number;
-		currentAgent?: string;
-		currentIndex?: number;
-		currentActivityState?: ActivityState;
-		lastActivityAt?: number;
-		currentTool?: string;
-		currentToolStartedAt?: number;
-		interrupt?: () => boolean;
-	};
+	foregroundControl?: ChainForegroundControl;
 	chainSkills?: string[];
 	chainDir?: string;
 	maxSubagentDepth: number;
@@ -342,6 +342,7 @@ interface ChainExecutionParams {
 	nestedRoute?: NestedRouteInfo;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
+	runSync?: RunSyncDependency;
 }
 
 interface ChainExecutionResult {
@@ -359,6 +360,7 @@ interface ChainExecutionResult {
  * Execute a chain of subagent steps
  */
 export async function executeChain(params: ChainExecutionParams): Promise<ChainExecutionResult> {
+	const executeRunSync = params.runSync ?? runSync;
 	const {
 		chain: chainSteps,
 		agents,
@@ -604,6 +606,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					worktreeSetup,
 					maxSubagentDepth: params.maxSubagentDepth,
 					workflowStageSubagentGuard: params.workflowStageSubagentGuard,
+					runSync: executeRunSync,
 				});
 				globalTaskIndex += step.parallel.length;
 
@@ -784,7 +787,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				};
 			}
 
-			const r = await runSync(ctx.cwd, agents, seqStep.agent, stepTask, {
+			const r = await executeRunSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				cwd: resolveChildCwd(cwd ?? ctx.cwd, seqStep.cwd),
 				signal,
 				interruptSignal: interruptController.signal,

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -140,6 +140,28 @@ export interface SubagentParamsLike {
 	chainDir?: string;
 }
 
+export interface SubagentExecutorRuntimeDeps {
+	runSync: typeof runSync;
+	executeAsyncChain: typeof executeAsyncChain;
+	executeAsyncSingle: typeof executeAsyncSingle;
+	isAsyncAvailable: typeof isAsyncAvailable;
+	formatAsyncStartedMessage: typeof formatAsyncStartedMessage;
+}
+
+const defaultSubagentExecutorRuntimeDeps: SubagentExecutorRuntimeDeps = {
+	runSync,
+	executeAsyncChain,
+	executeAsyncSingle,
+	isAsyncAvailable,
+	formatAsyncStartedMessage,
+};
+
+function resolveSubagentExecutorRuntimeDeps(
+	overrides?: Partial<SubagentExecutorRuntimeDeps>,
+): SubagentExecutorRuntimeDeps {
+	return { ...defaultSubagentExecutorRuntimeDeps, ...overrides };
+}
+
 interface ExecutorDeps {
 	pi: ExtensionAPI;
 	state: SubagentState;
@@ -150,6 +172,11 @@ interface ExecutorDeps {
 	expandTilde: (p: string) => string;
 	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[] };
 	allowMutatingManagementActions?: boolean;
+	runtime?: Partial<SubagentExecutorRuntimeDeps>;
+}
+
+interface ResolvedExecutorDeps extends Omit<ExecutorDeps, "runtime"> {
+	runtime: SubagentExecutorRuntimeDeps;
 }
 
 interface ExecutionContextData {
@@ -209,7 +236,7 @@ function formatForegroundActivity(control: SubagentState["foregroundControls"] e
 	return [`active ${seconds}s ago`, ...facts].join(" | ");
 }
 
-function nestedResolutionScopeForExecutor(deps: ExecutorDeps): NestedRunResolutionScope | undefined {
+function nestedResolutionScopeForExecutor(deps: ResolvedExecutorDeps): NestedRunResolutionScope | undefined {
 	if (deps.allowMutatingManagementActions !== false) return undefined;
 	const route = resolveInheritedNestedRouteFromEnv();
 	const address = route ? resolveNestedParentAddressFromEnv() : undefined;
@@ -551,7 +578,7 @@ async function resumeAsyncRun(input: {
 	params: SubagentParamsLike;
 	requestCwd: string;
 	ctx: ExtensionContext;
-	deps: ExecutorDeps;
+	deps: ResolvedExecutorDeps;
 }): Promise<AgentToolResult<Details>> {
 	const followUp = (input.params.message ?? input.params.task ?? "").trim();
 	if (!followUp) {
@@ -647,7 +674,7 @@ async function resumeAsyncRun(input: {
 	const runId = randomUUID().slice(0, 8);
 	const artifactConfig: ArtifactConfig = { ...DEFAULT_ARTIFACT_CONFIG, enabled: input.params.artifacts !== false };
 	const availableModels = input.ctx.modelRegistry.getAvailable().map(toModelInfo);
-	const result = executeAsyncSingle(runId, {
+	const result = input.deps.runtime.executeAsyncSingle(runId, {
 		agent: target.agent,
 		task: buildRevivedAsyncTask(target, followUp),
 		agentConfig,
@@ -688,7 +715,7 @@ async function resumeAsyncRun(input: {
 		revivedTarget ? `Intercom target: ${revivedTarget} (if registered)` : undefined,
 		`Status if needed: subagent({ action: "status", id: "${revivedId}" })`,
 	].filter((line): line is string => Boolean(line));
-	return { content: [{ type: "text", text: formatAsyncStartedMessage(lines.join("\n")) }], details: result.details };
+	return { content: [{ type: "text", text: input.deps.runtime.formatAsyncStartedMessage(lines.join("\n")) }], details: result.details };
 }
 
 function resultSummaryForIntercom(result: SingleResult): string {
@@ -1016,7 +1043,7 @@ function wrapChainTasksForFork(chain: ChainStep[], context: SubagentParamsLike["
 	});
 }
 
-function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentToolResult<Details> | null {
+function runAsyncPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): AgentToolResult<Details> | null {
 	const {
 		params,
 		effectiveCwd,
@@ -1059,7 +1086,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		}
 	}
 
-	if (!isAsyncAvailable()) {
+	if (!deps.runtime.isAsyncAvailable()) {
 		return {
 			content: [{ type: "text", text: `Async mode requires upstream jiti for TypeScript execution but it could not be found. Ensure the ${APP_NAME}-subagents package dependencies are installed.` }],
 			isError: true,
@@ -1099,7 +1126,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 			...(task.reads !== undefined && task.reads !== true ? { reads: task.reads } : {}),
 			...(task.progress !== undefined ? { progress: task.progress } : {}),
 		}));
-		return executeAsyncChain(id, {
+		return deps.runtime.executeAsyncChain(id, {
 			chain: [{
 				parallel: parallelTasks,
 				concurrency: resolveTopLevelParallelConcurrency(params.concurrency, deps.config.parallel?.concurrency),
@@ -1132,7 +1159,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const normalized = normalizeSkillInput(params.skill);
 		const chainSkills = normalized === false ? [] : (normalized ?? []);
 		const chain = wrapChainTasksForFork(params.chain as ChainStep[], params.context);
-		return executeAsyncChain(id, {
+		return deps.runtime.executeAsyncChain(id, {
 			chain,
 			task: params.task,
 			agents,
@@ -1173,7 +1200,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 		const skills = normalizedSkills === false ? [] : normalizedSkills;
 		const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, a.maxSubagentDepth);
 		const modelOverride = resolveModelCandidate((params.model as string | undefined) ?? a.model, availableModels, currentProvider);
-		return executeAsyncSingle(id, {
+		return deps.runtime.executeAsyncSingle(id, {
 			agent: params.agent!,
 			task: params.context === "fork" ? wrapForkTask(params.task ?? "") : (params.task ?? ""),
 			agentConfig: a,
@@ -1204,7 +1231,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): AgentTool
 	return null;
 }
 
-async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
+async function runChainPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<AgentToolResult<Details>> {
 	const {
 		params,
 		effectiveCwd,
@@ -1259,10 +1286,11 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		workflowStageSubagentGuard,
 		worktreeSetupHook: deps.config.worktreeSetupHook,
 		worktreeSetupHookTimeoutMs: deps.config.worktreeSetupHookTimeoutMs,
+		runSync: deps.runtime.runSync,
 	});
 
 	if (chainResult.requestedAsync) {
-		if (!isAsyncAvailable()) {
+		if (!deps.runtime.isAsyncAvailable()) {
 			return {
 				content: [{ type: "text", text: `Background mode requires upstream jiti for TypeScript execution but it could not be found. Ensure the ${APP_NAME}-subagents package dependencies are installed.` }],
 				isError: true,
@@ -1278,7 +1306,7 @@ async function runChainPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			currentModel: currentModelFullId(ctx.model),
 		};
 		const asyncChain = wrapChainTasksForFork(chainResult.requestedAsync.chain, params.context);
-		return executeAsyncChain(id, {
+		return deps.runtime.executeAsyncChain(id, {
 			chain: asyncChain,
 			task: params.task,
 			agents,
@@ -1358,6 +1386,7 @@ interface ForegroundParallelRunInput {
 	liveProgress: (AgentProgress | undefined)[];
 	onUpdate?: (r: AgentToolResult<Details>) => void;
 	worktreeSetup?: WorktreeSetup;
+	runtime: Pick<SubagentExecutorRuntimeDeps, "runSync">;
 }
 
 function buildParallelModeError(message: string): AgentToolResult<Details> {
@@ -1490,7 +1519,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			};
 		}
 		const agentConfig = input.agents.find((agent) => agent.name === task.agent);
-		return runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
+		return input.runtime.runSync(input.ctx.cwd, input.agents, task.agent, taskText, {
 			cwd: taskCwd,
 			signal: input.signal,
 			interruptSignal: interruptController.signal,
@@ -1561,7 +1590,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 	});
 }
 
-async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
+async function runParallelPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<AgentToolResult<Details>> {
 	const {
 		params,
 		effectiveCwd,
@@ -1682,7 +1711,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 		}
 
 		if (result.runInBackground) {
-			if (!isAsyncAvailable()) {
+			if (!deps.runtime.isAsyncAvailable()) {
 				return {
 					content: [{ type: "text", text: `Background mode requires upstream jiti for TypeScript execution but it could not be found. Ensure the ${APP_NAME}-subagents package dependencies are installed.` }],
 					isError: true,
@@ -1712,7 +1741,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 					...(progress !== undefined ? { progress } : {}),
 				};
 			});
-			return executeAsyncChain(id, {
+			return deps.runtime.executeAsyncChain(id, {
 				chain: [{ parallel: parallelTasks, concurrency: parallelConcurrency, worktree: params.worktree }],
 				resultMode: "parallel",
 				agents,
@@ -1808,6 +1837,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 			liveProgress,
 			onUpdate,
 			worktreeSetup,
+			runtime: deps.runtime,
 		});
 		for (let i = 0; i < results.length; i++) {
 			const run = results[i]!;
@@ -1886,7 +1916,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ExecutorDeps): 
 	}
 }
 
-async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
+async function runSinglePath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<AgentToolResult<Details>> {
 	const {
 		params,
 		effectiveCwd,
@@ -1966,7 +1996,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		if (override?.skills !== undefined) skillOverride = override.skills;
 
 		if (result.runInBackground) {
-			if (!isAsyncAvailable()) {
+			if (!deps.runtime.isAsyncAvailable()) {
 				return {
 					content: [{ type: "text", text: `Background mode requires upstream jiti for TypeScript execution but it could not be found. Ensure the ${APP_NAME}-subagents package dependencies are installed.` }],
 					isError: true,
@@ -1981,7 +2011,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				currentModelProvider: ctx.model?.provider,
 				currentModel: currentModelFullId(ctx.model),
 			};
-			return executeAsyncSingle(id, {
+			return deps.runtime.executeAsyncSingle(id, {
 				agent: params.agent!,
 				task: params.context === "fork" ? wrapForkTask(task) : task,
 				agentConfig,
@@ -2062,7 +2092,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		}
 		: undefined;
 
-	const r = await runSync(ctx.cwd, agents, params.agent!, task, {
+	const r = await deps.runtime.runSync(ctx.cwd, agents, params.agent!, task, {
 		cwd: effectiveCwd,
 		signal,
 		interruptSignal: interruptController.signal,
@@ -2175,7 +2205,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	};
 }
 
-export function createSubagentExecutor(deps: ExecutorDeps): {
+export function createSubagentExecutor(rawDeps: ExecutorDeps): {
 	execute: (
 		id: string,
 		params: SubagentParamsLike,
@@ -2184,6 +2214,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		ctx: ExtensionContext,
 	) => Promise<AgentToolResult<Details>>;
 } {
+	const deps: ResolvedExecutorDeps = { ...rawDeps, runtime: resolveSubagentExecutorRuntimeDeps(rawDeps.runtime) };
 	const execute = async (
 		_id: string,
 		params: SubagentParamsLike,

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { APP_NAME, getEnvValue, type ExtensionAPI, type ExtensionContext } from "@bastani/atomic";
 import { type AgentConfig, type AgentScope } from "../../agents/agents.ts";
 import { getArtifactsDir } from "../../shared/artifacts.ts";
@@ -78,6 +77,7 @@ import {
 	type SingleResult,
 	type SubagentRunMode,
 	type SubagentState,
+	type SubagentToolResult,
 	DEFAULT_ARTIFACT_CONFIG,
 	SUBAGENT_ACTIONS,
 	SUBAGENT_CONTROL_EVENT,
@@ -110,7 +110,7 @@ interface TaskParam {
 }
 
 export interface SubagentParamsLike {
-	action?: string;
+	action?: (typeof SUBAGENT_ACTIONS)[number];
 	id?: string;
 	runId?: string;
 	dir?: string;
@@ -118,6 +118,8 @@ export interface SubagentParamsLike {
 	agent?: string;
 	task?: string;
 	message?: string;
+	chainName?: string;
+	config?: unknown;
 	chain?: ChainStep[];
 	tasks?: TaskParam[];
 	concurrency?: number;
@@ -136,7 +138,7 @@ export interface SubagentParamsLike {
 	skill?: string | string[] | boolean;
 	output?: string | boolean;
 	outputMode?: "inline" | "file-only";
-	agentScope?: unknown;
+	agentScope?: string;
 	chainDir?: string;
 }
 
@@ -184,7 +186,7 @@ interface ExecutionContextData {
 	effectiveCwd: string;
 	ctx: ExtensionContext;
 	signal: AbortSignal;
-	onUpdate?: (r: AgentToolResult<Details>) => void;
+	onUpdate?: (r: SubagentToolResult) => void;
 	agents: AgentConfig[];
 	runId: string;
 	shareEnabled: boolean;
@@ -246,7 +248,7 @@ function nestedResolutionScopeForExecutor(deps: ResolvedExecutorDeps): NestedRun
 	};
 }
 
-function foregroundStatusResult(control: SubagentState["foregroundControls"] extends Map<string, infer T> ? T : never): AgentToolResult<Details> {
+function foregroundStatusResult(control: SubagentState["foregroundControls"] extends Map<string, infer T> ? T : never): SubagentToolResult {
 	let nestedWarning: string | undefined;
 	try {
 		updateForegroundNestedProjection(control);
@@ -429,7 +431,7 @@ function emitControlNotification(input: {
 	}
 }
 
-function interruptAsyncRun(state: SubagentState, runId: string | undefined): AgentToolResult<Details> | null {
+function interruptAsyncRun(state: SubagentState, runId: string | undefined): SubagentToolResult | null {
 	const target = getAsyncInterruptTarget(state, runId);
 	if (!target) return null;
 	const status = readStatus(target.asyncDir);
@@ -539,7 +541,7 @@ async function sendNestedControlRequest(target: ResolvedSubagentRunId & { kind: 
 	return waitForNestedControlResult(target, requestId);
 }
 
-function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nested" }): AgentToolResult<Details> | undefined {
+function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nested" }): SubagentToolResult | undefined {
 	const run = target.match.run;
 	const asyncDir = resolveNestedAsyncDir(target.match.rootRunId, run);
 	if (!asyncDir) return undefined;
@@ -555,7 +557,7 @@ function directNestedAsyncInterrupt(target: ResolvedSubagentRunId & { kind: "nes
 	}
 }
 
-async function interruptNestedRun(target: ResolvedSubagentRunId & { kind: "nested" }): Promise<AgentToolResult<Details>> {
+async function interruptNestedRun(target: ResolvedSubagentRunId & { kind: "nested" }): Promise<SubagentToolResult> {
 	const run = target.match.run;
 	if (run.state === "complete") return { content: [{ type: "text", text: `Nested run ${run.id} is already complete and cannot be interrupted.` }], isError: true, details: { mode: "management", results: [] } };
 	if (run.state === "failed") return { content: [{ type: "text", text: `Nested run ${run.id} has failed and cannot be interrupted.` }], isError: true, details: { mode: "management", results: [] } };
@@ -567,7 +569,7 @@ async function interruptNestedRun(target: ResolvedSubagentRunId & { kind: "neste
 	return { content: [{ type: "text", text: `Nested run ${run.id} owner is not reachable and no safe direct async interrupt fallback is available.` }], isError: true, details: { mode: "management", results: [] } };
 }
 
-async function resumeLiveNestedRun(input: { target: ResolvedSubagentRunId & { kind: "nested" }; message: string }): Promise<AgentToolResult<Details>> {
+async function resumeLiveNestedRun(input: { target: ResolvedSubagentRunId & { kind: "nested" }; message: string }): Promise<SubagentToolResult> {
 	const run = input.target.match.run;
 	const result = await sendNestedControlRequest(input.target, "resume", input.message);
 	if (result) return { content: [{ type: "text", text: result.message }], isError: result.ok ? undefined : true, details: { mode: "management", results: [] } };
@@ -579,7 +581,7 @@ async function resumeAsyncRun(input: {
 	requestCwd: string;
 	ctx: ExtensionContext;
 	deps: ResolvedExecutorDeps;
-}): Promise<AgentToolResult<Details>> {
+}): Promise<SubagentToolResult> {
 	const followUp = (input.params.message ?? input.params.task ?? "").trim();
 	if (!followUp) {
 		return {
@@ -803,7 +805,7 @@ function validateExecutionInput(
 	hasTasks: boolean,
 	hasSingle: boolean,
 	allowClarifyTaskPrompt: boolean,
-): AgentToolResult<Details> | null {
+): SubagentToolResult | null {
 	if (Number(hasChain) + Number(hasTasks) + Number(hasSingle) !== 1) {
 		return {
 			content: [
@@ -907,7 +909,7 @@ function applyAgentDefaultContext(params: SubagentParamsLike, agents: AgentConfi
 		: params;
 }
 
-function buildRequestedModeError(params: SubagentParamsLike, message: string): AgentToolResult<Details> {
+function buildRequestedModeError(params: SubagentParamsLike, message: string): SubagentToolResult {
 	return withForkContext(
 		{
 			content: [{ type: "text", text: message }],
@@ -959,7 +961,7 @@ function expandChainParallelCounts(chain: ChainStep[]): { chain?: ChainStep[]; e
 	return { chain: expandedChain };
 }
 
-function normalizeRepeatedParallelCounts(params: SubagentParamsLike): { params?: SubagentParamsLike; error?: AgentToolResult<Details> } {
+function normalizeRepeatedParallelCounts(params: SubagentParamsLike): { params?: SubagentParamsLike; error?: SubagentToolResult } {
 	if (params.tasks) {
 		const expandedTasks = expandTopLevelTaskCounts(params.tasks);
 		if (expandedTasks.error) {
@@ -978,9 +980,9 @@ function normalizeRepeatedParallelCounts(params: SubagentParamsLike): { params?:
 }
 
 function withForkContext(
-	result: AgentToolResult<Details>,
+	result: SubagentToolResult,
 	context: SubagentParamsLike["context"],
-): AgentToolResult<Details> {
+): SubagentToolResult {
 	if (context !== "fork" || !result.details) return result;
 	return {
 		...result,
@@ -991,7 +993,7 @@ function withForkContext(
 	};
 }
 
-function toExecutionErrorResult(params: SubagentParamsLike, error: unknown): AgentToolResult<Details> {
+function toExecutionErrorResult(params: SubagentParamsLike, error: unknown): SubagentToolResult {
 	const message = error instanceof Error ? error.message : String(error);
 	return withForkContext(
 		{
@@ -1043,7 +1045,7 @@ function wrapChainTasksForFork(chain: ChainStep[], context: SubagentParamsLike["
 	});
 }
 
-function runAsyncPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): AgentToolResult<Details> | null {
+function runAsyncPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): SubagentToolResult | null {
 	const {
 		params,
 		effectiveCwd,
@@ -1231,7 +1233,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): A
 	return null;
 }
 
-async function runChainPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<AgentToolResult<Details>> {
+async function runChainPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<SubagentToolResult> {
 	const {
 		params,
 		effectiveCwd,
@@ -1384,12 +1386,12 @@ interface ForegroundParallelRunInput {
 	concurrencyLimit: number;
 	liveResults: (SingleResult | undefined)[];
 	liveProgress: (AgentProgress | undefined)[];
-	onUpdate?: (r: AgentToolResult<Details>) => void;
+	onUpdate?: (r: SubagentToolResult) => void;
 	worktreeSetup?: WorktreeSetup;
 	runtime: Pick<SubagentExecutorRuntimeDeps, "runSync">;
 }
 
-function buildParallelModeError(message: string): AgentToolResult<Details> {
+function buildParallelModeError(message: string): SubagentToolResult {
 	return {
 		content: [{ type: "text", text: message }],
 		isError: true,
@@ -1404,7 +1406,7 @@ function createParallelWorktreeSetup(
 	tasks: TaskParam[],
 	setupHook: ExtensionConfig["worktreeSetupHook"],
 	setupHookTimeoutMs: ExtensionConfig["worktreeSetupHookTimeoutMs"],
-): { setup?: WorktreeSetup; errorResult?: AgentToolResult<Details> } {
+): { setup?: WorktreeSetup; errorResult?: SubagentToolResult } {
 	if (!enabled) return {};
 	try {
 		return {
@@ -1590,7 +1592,7 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 	});
 }
 
-async function runParallelPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<AgentToolResult<Details>> {
+async function runParallelPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<SubagentToolResult> {
 	const {
 		params,
 		effectiveCwd,
@@ -1916,7 +1918,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ResolvedExecuto
 	}
 }
 
-async function runSinglePath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<AgentToolResult<Details>> {
+async function runSinglePath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<SubagentToolResult> {
 	const {
 		params,
 		effectiveCwd,
@@ -2073,7 +2075,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ResolvedExecutorD
 	}
 
 	const forwardSingleUpdate = onUpdate
-		? (update: AgentToolResult<Details>) => {
+		? (update: SubagentToolResult) => {
 			if (foregroundControl) {
 				const firstProgress = update.details?.progress?.[0];
 				foregroundControl.currentAgent = params.agent;
@@ -2210,18 +2212,18 @@ export function createSubagentExecutor(rawDeps: ExecutorDeps): {
 		id: string,
 		params: SubagentParamsLike,
 		signal: AbortSignal,
-		onUpdate: ((r: AgentToolResult<Details>) => void) | undefined,
+		onUpdate: ((r: SubagentToolResult) => void) | undefined,
 		ctx: ExtensionContext,
-	) => Promise<AgentToolResult<Details>>;
+	) => Promise<SubagentToolResult>;
 } {
 	const deps: ResolvedExecutorDeps = { ...rawDeps, runtime: resolveSubagentExecutorRuntimeDeps(rawDeps.runtime) };
 	const execute = async (
 		_id: string,
 		params: SubagentParamsLike,
 		signal: AbortSignal,
-		onUpdate: ((r: AgentToolResult<Details>) => void) | undefined,
+		onUpdate: ((r: SubagentToolResult) => void) | undefined,
 		ctx: ExtensionContext,
-	): Promise<AgentToolResult<Details>> => {
+	): Promise<SubagentToolResult> => {
 		deps.state.baseCwd = ctx.cwd;
 		deps.state.foregroundRuns ??= new Map();
 		deps.state.foregroundControls ??= new Map();
@@ -2280,7 +2282,12 @@ export function createSubagentExecutor(rawDeps: ExecutorDeps): {
 					const foreground = getForegroundControl(deps.state, undefined);
 					if (foreground) return foregroundStatusResult(foreground);
 				}
-				return inspectSubagentStatus(paramsWithResolvedCwd, { state: deps.state, nested: nestedResolutionScopeForExecutor(deps) });
+				return inspectSubagentStatus({
+					action: "status",
+					id: paramsWithResolvedCwd.id,
+					runId: paramsWithResolvedCwd.runId,
+					dir: paramsWithResolvedCwd.dir,
+				}, { state: deps.state, nested: nestedResolutionScopeForExecutor(deps) });
 			}
 			if (params.action === "resume") {
 				return resumeAsyncRun({ params: paramsWithResolvedCwd, requestCwd, ctx, deps });
@@ -2445,7 +2452,7 @@ export function createSubagentExecutor(rawDeps: ExecutorDeps): {
 			sessionFileForIndex(idx) ?? path.join(sessionDirForIndex(idx), "session.jsonl");
 
 		const onUpdateWithContext = onUpdate
-			? (r: AgentToolResult<Details>) => onUpdate(withForkContext(r, effectiveParams.context))
+			? (r: SubagentToolResult) => onUpdate(withForkContext(r, effectiveParams.context))
 			: undefined;
 
 		const execData: ExecutionContextData = {
@@ -2488,7 +2495,7 @@ export function createSubagentExecutor(rawDeps: ExecutorDeps): {
 			deps.state.lastForegroundControlId = runId;
 		}
 
-		const writeNestedForegroundEvent = (type: "subagent.nested.started" | "subagent.nested.completed", result?: AgentToolResult<Details>): void => {
+		const writeNestedForegroundEvent = (type: "subagent.nested.started" | "subagent.nested.completed", result?: SubagentToolResult): void => {
 			if (!inheritedNestedRoute || !nestedParentAddress) return;
 			const now = Date.now();
 			const details = result?.details;

--- a/packages/subagents/src/runs/shared/run-history.ts
+++ b/packages/subagents/src/runs/shared/run-history.ts
@@ -54,6 +54,6 @@ export function loadRunsForAgent(agent: string): RunEntry[] {
 
 	return lines
 		.map((line) => { try { return JSON.parse(line) as RunEntry; } catch { return undefined; } })
-		.filter((entry): entry is RunEntry => Boolean(entry) && entry.agent === agent)
+		.filter((entry): entry is RunEntry => entry !== undefined && entry.agent === agent)
 		.reverse();
 }

--- a/packages/subagents/src/shared/settings.ts
+++ b/packages/subagents/src/shared/settings.ts
@@ -70,6 +70,7 @@ interface ParallelTaskItem {
 /** Parallel step: multiple agents running concurrently */
 interface ParallelStep {
 	parallel: ParallelTaskItem[];
+	cwd?: string;
 	concurrency?: number;
 	failFast?: boolean;
 	worktree?: boolean;

--- a/packages/subagents/src/shared/types.ts
+++ b/packages/subagents/src/shared/types.ts
@@ -256,6 +256,7 @@ export interface Details {
 	currentStepIndex?: number;   // 0-indexed current step (for running chains)
 }
 
+// Upstream AgentToolResult omits the runtime isError flag that subagent tool results still emit/read.
 export type SubagentToolResult = AgentToolResult<Details> & { isError?: boolean };
 
 // ============================================================================

--- a/packages/subagents/src/shared/types.ts
+++ b/packages/subagents/src/shared/types.ts
@@ -5,6 +5,7 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { FSWatcher } from "node:fs";
 import type { ExtensionContext } from "@bastani/atomic";
 import { APP_NAME, getEnvValue, WORKFLOW_STAGE_SUBAGENT_GUARD_ENV } from "@bastani/atomic";
@@ -254,6 +255,8 @@ export interface Details {
 	totalSteps?: number;         // Total steps in chain
 	currentStepIndex?: number;   // 0-indexed current step (for running chains)
 }
+
+export type SubagentToolResult = AgentToolResult<Details> & { isError?: boolean };
 
 // ============================================================================
 // Artifacts

--- a/specs/2026-05-28-implement-github-issue-https-github-com-flora131-atomic-issues-1088-in-this-repo.md
+++ b/specs/2026-05-28-implement-github-issue-https-github-com-flora131-atomic-issues-1088-in-this-repo.md
@@ -1,0 +1,312 @@
+# Atomic Subagents Technical Design Document / RFC
+
+| Document Metadata      | Details |
+| ---------------------- | ------- |
+| Author(s)              | Norin Lavaee |
+| Status                 | Draft (WIP) |
+| Team / Owner           | Atomic Subagents maintainers / `@bastani/subagents` |
+| Created / Last Updated | 2026-05-28 / 2026-05-28 |
+
+## 1. Executive Summary
+
+Implement GitHub issue [#1088](https://github.com/flora131/atomic/issues/1088) by refactoring `test/unit/subagents-foreground-guard-propagation.test.ts` away from `spyOn` against ESM namespace imports. The issue is a follow-up from PR #1081 review: Bun currently allows this pattern, but it is fragile if imported ESM module bindings become read-only or if module-load ordering changes.
+
+The proposed fix is to add a narrow, internal dependency-injection seam to `createSubagentExecutor()` in `packages/subagents/src/runs/foreground/subagent-executor.ts`. Production callers continue using the real foreground/background execution functions by default, while tests can inject typed fakes for `runSync`, `executeAsyncChain`, `executeAsyncSingle`, and async availability checks. The existing guard-propagation tests will then assert behavior through injected collaborators instead of monkey-patching module exports.
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+Issue #1088 states that `test/unit/subagents-foreground-guard-propagation.test.ts` uses `spyOn` against ESM namespace imports and recommends DI seams in `createSubagentExecutor`.
+
+Current evidence:
+
+- `test/unit/subagents-foreground-guard-propagation.test.ts:1` imports `spyOn` from `bun:test`.
+- The test imports real modules:
+  - `../../packages/subagents/src/runs/background/async-execution.ts`
+  - `../../packages/subagents/src/runs/foreground/execution.ts`
+- The test patches module exports with `spyOn(...).mockImplementation(...)` for:
+  - `foregroundExecution.runSync`
+  - `asyncExecution.executeAsyncChain`
+  - `asyncExecution.executeAsyncSingle`
+  - `asyncExecution.formatAsyncStartedMessage`
+  - `asyncExecution.isAsyncAvailable`
+- The test dynamically imports `subagent-executor.ts` only after spies are installed, creating a module-load-order dependency.
+- `packages/subagents/src/runs/foreground/subagent-executor.ts` directly imports these collaborators at module scope:
+  - `runSync` from `./execution.ts`
+  - `executeAsyncChain`, `executeAsyncSingle`, `formatAsyncStartedMessage`, and `isAsyncAvailable` from `../background/async-execution.ts`
+- Direct call sites include:
+  - `executeAsyncSingle(...)` in async resume and single async paths.
+  - `executeAsyncChain(...)` in async chain/parallel and clarify-to-background paths.
+  - `isAsyncAvailable()` before async launches.
+  - `runSync(...)` in foreground parallel and single paths.
+
+The current `createSubagentExecutor(deps)` entry point is defined in `packages/subagents/src/runs/foreground/subagent-executor.ts`, and its `ExecutorDeps` already centralizes runtime dependencies such as `pi`, `state`, config, cwd expansion, and agent discovery.
+
+Prior-art DI exists elsewhere in this package, for example `packages/subagents/src/runs/shared/pi-spawn.ts`, where `getPiSpawnCommand(args, deps = {})` accepts optional collaborators for filesystem/platform/package resolution.
+
+### 2.2 The Problem
+
+The guard-propagation test verifies important behavior: workflow-stage subagent calls must pass `maxSubagentDepth: 1` and `workflowStageSubagentGuard: true` through foreground and async execution paths. However, the current test achieves this by mutating ESM namespace imports.
+
+Risks:
+
+- If Bun or another runner treats ESM namespace exports as read-only, the test can fail even though production behavior is correct.
+- Dynamic import ordering makes the test harder to reason about.
+- Module-level spies are broader than the behavior under test.
+- Future tests cannot easily create multiple executor instances with different fake execution collaborators in the same file.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+1. Add an internal DI seam to `createSubagentExecutor()` for execution collaborators currently patched by the test.
+2. Keep production behavior unchanged when no collaborators are injected.
+3. Refactor `test/unit/subagents-foreground-guard-propagation.test.ts` to use injected fakes instead of `spyOn`/dynamic import ordering.
+4. Preserve all existing assertions for workflow-stage guard propagation through:
+   - sequential/parallel chain children,
+   - foreground parallel children,
+   - parallel clarify-to-background async handoff,
+   - single clarify-to-background async handoff.
+5. Use Bun-first TDD and validation commands.
+6. Add a concise `packages/subagents/CHANGELOG.md` entry if maintainers consider the test hardening/change noteworthy.
+
+### 3.2 Non-Goals (Out of Scope)
+
+- No change to the public `subagent` tool schema or CLI behavior.
+- No change to workflow-stage recursion policy.
+- No change to background runner semantics.
+- No broad refactor of `chain-execution.ts`, `async-execution.ts`, or `execution.ts`.
+- No cleanup of unrelated duplicate `[Unreleased]` changelog sections unless explicitly requested.
+- No new public SDK for third-party executor customization.
+
+## 4. Proposed Solution (High-Level Design)
+
+Add a typed optional runtime-collaborator object to `ExecutorDeps` in `packages/subagents/src/runs/foreground/subagent-executor.ts`. `createSubagentExecutor()` resolves real defaults and uses injected replacements only when supplied by tests.
+
+### 4.1 System Architecture Diagram
+
+```mermaid
+flowchart TD
+    Test["test/unit/subagents-foreground-guard-propagation.test.ts"]
+    Extension["packages/subagents/src/extension/index.ts"]
+    Executor["createSubagentExecutor()\npackages/subagents/src/runs/foreground/subagent-executor.ts"]
+    Runtime["SubagentExecutorRuntimeDeps\noptional injected collaborators"]
+    RealForeground["runSync()\npackages/subagents/src/runs/foreground/execution.ts"]
+    RealAsync["executeAsyncChain()/executeAsyncSingle()/isAsyncAvailable()\npackages/subagents/src/runs/background/async-execution.ts"]
+    FakeForeground["test fake runSync\ncaptures options"]
+    FakeAsync["test fake async functions\ncapture params"]
+    Assertions["guard propagation assertions\nmaxSubagentDepth=1\nworkflowStageSubagentGuard=true"]
+
+    Extension -->|production deps without runtime override| Executor
+    Test -->|test deps with runtime override| Executor
+    Executor --> Runtime
+    Runtime -->|default| RealForeground
+    Runtime -->|default| RealAsync
+    Runtime -->|test override| FakeForeground
+    Runtime -->|test override| FakeAsync
+    FakeForeground --> Assertions
+    FakeAsync --> Assertions
+```
+
+### 4.2 Architectural Pattern
+
+Use dependency injection through a small internal Facade/Strategy object:
+
+- Facade: `SubagentExecutorRuntimeDeps` groups execution-side effects behind one object.
+- Strategy: tests provide alternate implementations for selected collaborators.
+- Default strategy: production uses the existing imported functions.
+
+This keeps the seam explicit and local to `createSubagentExecutor()` instead of spreading module mocks across tests.
+
+### 4.3 Key Components
+
+| Component | Responsibility | Technology Stack | Justification |
+| --------- | -------------- | ---------------- | ------------- |
+| `packages/subagents/src/runs/foreground/subagent-executor.ts` | Owns `createSubagentExecutor()`, validates params, selects single/parallel/chain/async paths, and forwards guard policy into child execution. | TypeScript, Bun runtime | Primary component under issue #1088; direct imports are what force current test monkey-patching. |
+| `SubagentExecutorRuntimeDeps` | Typed internal seam for `runSync`, `executeAsyncChain`, `executeAsyncSingle`, `isAsyncAvailable`, and optionally `formatAsyncStartedMessage`. | TypeScript structural typing | Allows tests to inject fakes without changing user-facing behavior. |
+| `test/unit/subagents-foreground-guard-propagation.test.ts` | Regression test for workflow-stage subagent guard propagation. | `bun:test`, `node:assert/strict` | The exact test called out by the GitHub issue. |
+| `packages/subagents/src/runs/foreground/execution.ts` | Real foreground child process execution via `runSync`. | TypeScript, child process spawn | Production default collaborator; should remain behaviorally unchanged. |
+| `packages/subagents/src/runs/background/async-execution.ts` | Real async launch/status formatting helpers. | TypeScript, filesystem async run state | Production default collaborator; current test fakes async launch behavior. |
+| `packages/subagents/CHANGELOG.md` | Records user/developer-visible package changes under `[Unreleased]`. | Markdown | Project instructions require changelog updates when appropriate. |
+
+## 5. Detailed Design
+
+### 5.1 API Interfaces
+
+No user-facing API changes.
+
+Internal interface to add in `packages/subagents/src/runs/foreground/subagent-executor.ts`:
+
+```ts
+export interface SubagentExecutorRuntimeDeps {
+  runSync: typeof runSync;
+  executeAsyncChain: typeof executeAsyncChain;
+  executeAsyncSingle: typeof executeAsyncSingle;
+  isAsyncAvailable: typeof isAsyncAvailable;
+  formatAsyncStartedMessage: typeof formatAsyncStartedMessage;
+}
+
+const defaultSubagentExecutorRuntimeDeps: SubagentExecutorRuntimeDeps = {
+  runSync,
+  executeAsyncChain,
+  executeAsyncSingle,
+  isAsyncAvailable,
+  formatAsyncStartedMessage,
+};
+```
+
+Extend existing `ExecutorDeps` with:
+
+```ts
+runtime?: Partial<SubagentExecutorRuntimeDeps>;
+```
+
+Resolve defaults once per executor or via a helper:
+
+```ts
+function resolveSubagentExecutorRuntimeDeps(
+  overrides?: Partial<SubagentExecutorRuntimeDeps>,
+): SubagentExecutorRuntimeDeps {
+  return { ...defaultSubagentExecutorRuntimeDeps, ...overrides };
+}
+```
+
+Recommended call-site changes:
+
+- Replace direct `runSync(...)` calls with `runtime.runSync(...)`.
+- Replace direct `executeAsyncChain(...)` calls with `runtime.executeAsyncChain(...)`.
+- Replace direct `executeAsyncSingle(...)` calls with `runtime.executeAsyncSingle(...)`.
+- Replace direct `isAsyncAvailable()` calls with `runtime.isAsyncAvailable()`.
+- Replace direct `formatAsyncStartedMessage(...)` in async resume formatting with `runtime.formatAsyncStartedMessage(...)`.
+
+`runForegroundParallelTasks()` currently does not receive `deps`; add a narrow field to its input object, e.g.:
+
+```ts
+runtime: Pick<SubagentExecutorRuntimeDeps, "runSync">;
+```
+
+### 5.2 Data Model / Schema
+
+No persistent data model changes.
+
+No changes to:
+
+- `SubagentParamsLike`
+- `Details`
+- `RunSyncOptions`
+- async run status files
+- workflow-stage orchestration context
+- environment variable names such as `ATOMIC_WORKFLOW_STAGE_SUBAGENT_GUARD`
+
+The only new structure is an in-memory TypeScript dependency object used at executor construction time.
+
+### 5.3 Algorithms and State Management
+
+Runtime resolution algorithm:
+
+1. `createSubagentExecutor(deps)` is called by production extension code or tests.
+2. Resolve:
+   - real default collaborators from imported modules,
+   - test overrides from `deps.runtime`.
+3. Execution path functions use the resolved runtime object instead of module-level functions.
+4. Guard propagation logic remains unchanged:
+   - `resolveSubagentDepthPolicy(ctx, deps.config.maxSubagentDepth)` still determines `maxSubagentDepth` and `workflowStageSubagentGuard`.
+   - Child launch params/options continue to receive those values.
+5. Tests capture collaborator call arguments through injected fake functions.
+
+Test refactor algorithm:
+
+1. Remove ESM namespace imports for `foregroundExecution` and `asyncExecution`.
+2. Remove all `spyOn(...)` setup and `mockRestore()` teardown.
+3. Statically import `createSubagentExecutor` using repo convention `.js` specifier.
+4. Pass `runtime` fakes from `makeExecutor()`.
+5. Keep captured arrays:
+   - `runSyncCalls`
+   - `asyncChainCalls`
+   - `asyncSingleCalls`
+6. Assert captured params/options as before.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Reason for Rejection |
+| ------ | ---- | ---- | -------------------- |
+| Keep current `spyOn` pattern | Minimal code change; tests pass today in Bun. | Fragile under read-only ESM bindings; depends on dynamic import ordering; called out directly by issue #1088. | Rejected because the issue explicitly requests moving away from this pattern. |
+| Use `mock.module()` for execution modules | Avoids `spyOn` on namespace exports. | PR #1081 history showed broad module mocks can leak or omit exports such as `writeAsyncRunnerConfig`; higher cross-test pollution risk. | Rejected due prior failure mode and broader blast radius. |
+| Add optional runtime collaborators to `createSubagentExecutor()` | Narrow seam; type-safe; production defaults unchanged; tests become direct and deterministic. | Requires mechanical replacements at several call sites; small internal API expansion. | Selected because it addresses the issue with minimal production impact. |
+| Extract all subagent execution orchestration into separate classes | Could improve long-term modularity. | Much larger refactor; unrelated to issue #1088; increases risk. | Rejected as over-scoped for a test-hardening issue. |
+| Inject collaborators through process globals/env vars | No signature changes. | Hidden coupling; unsafe in concurrent tests; not type-safe. | Rejected because it worsens test isolation. |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Security and Privacy
+
+No new user input, network access, credentials, or persisted data are introduced.
+
+The DI seam must remain internal and should not be wired to user configuration. Test fakes should only be passed by in-repo tests. Production behavior continues to call the real child process execution functions.
+
+### 7.2 Observability Strategy
+
+No runtime observability changes are required.
+
+Testing observability improves because the test captures exact call arguments through injected fakes instead of relying on patched module exports. Existing assertions on `maxSubagentDepth` and `workflowStageSubagentGuard` remain the primary observability mechanism for this regression.
+
+### 7.3 Scalability and Capacity Planning
+
+No capacity impact.
+
+Runtime overhead is negligible: resolving a small dependency object once per executor or reading from it at call sites is constant-time and not on a hot path compared to spawning foreground/background subagents.
+
+## 8. Migration, Rollout, and Testing
+
+### 8.1 Deployment Strategy
+
+This is an internal code/test refactor in `@bastani/subagents`.
+
+Recommended rollout steps:
+
+1. Add failing/red test refactor first: remove spies and inject fakes via `createSubagentExecutor()` deps.
+2. Implement `SubagentExecutorRuntimeDeps` and use it at call sites.
+3. Confirm the refactored test passes.
+4. Add one `packages/subagents/CHANGELOG.md` `[Unreleased]` entry if maintainers want developer-facing test hardening recorded.
+
+### 8.2 Data Migration Plan
+
+No data migration is required.
+
+No files under async run directories, session directories, artifacts, config, or package manifests need migration.
+
+### 8.3 Test Plan
+
+TDD sequence:
+
+1. Red:
+   - Refactor `test/unit/subagents-foreground-guard-propagation.test.ts` to inject fakes through `runtime`.
+   - Before implementation, the fake call arrays should remain empty or real execution should be attempted, causing the test to fail.
+2. Green:
+   - Implement the DI seam and route all relevant calls through it.
+3. Refactor:
+   - Remove unused `spyOn`, namespace imports, dynamic import machinery, and `afterAll` mock restoration.
+   - Prefer `.js` import specifiers in the test.
+
+Targeted validation:
+
+```sh
+AGENT=1 bun test test/unit/subagents-foreground-guard-propagation.test.ts
+AGENT=1 bun test test/unit/subagents-depth-guard.test.ts test/unit/subagents-async-config.test.ts
+bun run typecheck
+git diff --check
+```
+
+Broader validation if time permits:
+
+```sh
+AGENT=1 bun run test:unit
+```
+
+## 9. Open Questions / Unresolved Issues
+
+1. `[OWNER: subagents maintainers]` Should `formatAsyncStartedMessage` be part of the seam even though the current foreground guard propagation tests do not directly need it? Recommendation: include it because the current test patches it today and async resume uses it in the same executor module.
+2. `[OWNER: subagents maintainers]` Should `SubagentExecutorRuntimeDeps` be exported from `subagent-executor.ts` for test typing, or kept module-private with structural test objects? Recommendation: export the type from the source file only; do not re-export it from the package root.
+3. `[OWNER: release maintainer]` Should this test-hardening/internal-seam change receive a changelog entry? Recommendation: add a single concise `Fixed` entry under the topmost `packages/subagents/CHANGELOG.md` `[Unreleased]` section if issue #1088 is expected to be tracked in release notes.
+4. `[OWNER: subagents maintainers]` Should `executeChain` also be injectable? Recommendation: not in iteration 1; current issue only requires replacing collaborators patched by the foreground guard propagation test.

--- a/test/unit/subagents-foreground-guard-propagation.test.ts
+++ b/test/unit/subagents-foreground-guard-propagation.test.ts
@@ -199,7 +199,6 @@ function makeExecutor(cwd: string, agents: MinimalAgentConfig[]) {
 			runSync: runSyncMock,
 			executeAsyncChain: executeAsyncChainMock,
 			executeAsyncSingle: executeAsyncSingleMock,
-			formatAsyncStartedMessage: (message: string) => `Started ${message}`,
 			isAsyncAvailable: () => true,
 		},
 	} satisfies ExecutorDepsForTest;
@@ -222,7 +221,7 @@ function resetCapturedCalls(): void {
 }
 
 function assertNoErrorFlag(result: ExecutorResultForTest): void {
-	assert.equal("isError" in result ? result.isError : undefined, undefined);
+	assert.equal(result.isError, undefined);
 }
 
 function assertGuardedRunSyncCalls(expectedAgentNames: string[]): void {

--- a/test/unit/subagents-foreground-guard-propagation.test.ts
+++ b/test/unit/subagents-foreground-guard-propagation.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, mock, test } from "bun:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { createSubagentExecutor } from "../../packages/subagents/src/runs/foreground/subagent-executor.js";
 import { WORKFLOW_STAGE_SUBAGENT_GUARD_ENV } from "../../packages/subagents/src/shared/types.js";
 
 interface MinimalRunSyncOptions {
@@ -48,20 +49,10 @@ interface MinimalAgentConfig {
 	maxSubagentDepth?: number;
 }
 
-interface MinimalExecutorModule {
-	createSubagentExecutor: (deps: Record<string, unknown>) => {
-		execute: (
-			id: string,
-			params: Record<string, unknown>,
-			signal: AbortSignal,
-			onUpdate: undefined,
-			ctx: Record<string, unknown>,
-		) => Promise<{ isError?: boolean }>;
-	};
-}
-
-const executorModulePath = "../../packages/subagents/src/runs/foreground/subagent-executor.ts";
-const { createSubagentExecutor } = await import(executorModulePath) as MinimalExecutorModule;
+type ExecutorForTest = ReturnType<typeof createSubagentExecutor>;
+type ExecutorDepsForTest = Parameters<typeof createSubagentExecutor>[0];
+type ExecutorContextForTest = Parameters<ExecutorForTest["execute"]>[4];
+type ExecutorResultForTest = Awaited<ReturnType<ExecutorForTest["execute"]>>;
 
 const runSyncCalls: CapturedRunSyncCall[] = [];
 const asyncChainCalls: CapturedAsyncChainCall[] = [];
@@ -138,22 +129,32 @@ function makeState() {
 	};
 }
 
-function makeWorkflowStageContext(cwd: string, uiResult?: unknown): Record<string, unknown> {
+function makeUiContext(uiResult?: unknown): ExecutorContextForTest["ui"] {
+	const ui: Pick<ExecutorContextForTest["ui"], "custom"> = {
+		custom: async <T>() => uiResult as T,
+	};
+	return ui as ExecutorContextForTest["ui"];
+}
+
+function makeModelRegistry(): ExecutorContextForTest["modelRegistry"] {
+	const modelRegistry: Pick<ExecutorContextForTest["modelRegistry"], "getAvailable"> = {
+		getAvailable: () => [],
+	};
+	return modelRegistry as ExecutorContextForTest["modelRegistry"];
+}
+
+function makeWorkflowStageContext(cwd: string, uiResult?: unknown): ExecutorContextForTest {
 	return {
 		cwd,
 		hasUI: uiResult !== undefined,
-		ui: {
-			custom: mock(async () => uiResult),
-		},
+		ui: makeUiContext(uiResult),
 		model: undefined,
-		modelRegistry: {
-			getAvailable: () => [],
-		},
+		modelRegistry: makeModelRegistry(),
 		sessionManager: {
 			getSessionFile: () => undefined,
 			getSessionId: () => "parent-session",
 			getLeafId: () => null,
-		},
+		} as ExecutorContextForTest["sessionManager"],
 		orchestrationContext: {
 			kind: "workflow-stage",
 			workflowRunId: "workflow-run-1",
@@ -161,19 +162,32 @@ function makeWorkflowStageContext(cwd: string, uiResult?: unknown): Record<strin
 			workflowStageName: "Stage 1",
 			constraints: { disableWorkflowTool: true, maxSubagentDepth: 1 },
 		},
+		isIdle: () => true,
+		signal: undefined,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	} satisfies ExecutorContextForTest;
+}
+
+function makePi(): ExecutorDepsForTest["pi"] {
+	const pi: Pick<ExecutorDepsForTest["pi"], "events" | "getSessionName"> = {
+		events: {
+			on: (_channel: string, _handler: (data: unknown) => void) => () => {},
+			emit: (_channel: string, _data: unknown) => {},
+		},
+		getSessionName: () => "parent-session-name",
 	};
+	return pi as ExecutorDepsForTest["pi"];
 }
 
 function makeExecutor(cwd: string, agents: MinimalAgentConfig[]) {
 	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-subagent-guard-"));
-	return createSubagentExecutor({
-		pi: {
-			events: {
-				on: () => () => {},
-				emit: () => {},
-			},
-			getSessionName: () => "parent-session-name",
-		},
+	const deps = {
+		pi: makePi(),
 		state: makeState(),
 		config: { maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 8 } },
 		asyncByDefault: false,
@@ -188,7 +202,8 @@ function makeExecutor(cwd: string, agents: MinimalAgentConfig[]) {
 			formatAsyncStartedMessage: (message: string) => `Started ${message}`,
 			isAsyncAvailable: () => true,
 		},
-	});
+	} satisfies ExecutorDepsForTest;
+	return createSubagentExecutor(deps);
 }
 
 function clearSubagentGuardEnv(): void {
@@ -206,6 +221,10 @@ function resetCapturedCalls(): void {
 	executeAsyncSingleMock.mockClear();
 }
 
+function assertNoErrorFlag(result: ExecutorResultForTest): void {
+	assert.equal("isError" in result ? result.isError : undefined, undefined);
+}
+
 function assertGuardedRunSyncCalls(expectedAgentNames: string[]): void {
 	assert.deepEqual(runSyncCalls.map((call) => call.agentName), expectedAgentNames);
 	for (const call of runSyncCalls) {
@@ -219,6 +238,7 @@ beforeEach(() => {
 	clearSubagentGuardEnv();
 });
 
+afterAll(clearSubagentGuardEnv);
 
 describe("foreground workflow-stage subagent guard propagation", () => {
 	test("passes workflow-stage guard to sequential and parallel chain children", async () => {
@@ -240,7 +260,7 @@ describe("foreground workflow-stage subagent guard propagation", () => {
 			makeWorkflowStageContext(cwd),
 		);
 
-		assert.equal(result.isError, undefined);
+		assertNoErrorFlag(result);
 		assertGuardedRunSyncCalls(["alpha", "beta", "gamma"]);
 	});
 
@@ -260,7 +280,7 @@ describe("foreground workflow-stage subagent guard propagation", () => {
 			makeWorkflowStageContext(cwd),
 		);
 
-		assert.equal(result.isError, undefined);
+		assertNoErrorFlag(result);
 		assertGuardedRunSyncCalls(["alpha", "beta"]);
 	});
 
@@ -286,7 +306,7 @@ describe("foreground workflow-stage subagent guard propagation", () => {
 			makeWorkflowStageContext(cwd, uiResult),
 		);
 
-		assert.equal(result.isError, undefined);
+		assertNoErrorFlag(result);
 		assert.equal(runSyncCalls.length, 0);
 		assert.equal(asyncChainCalls.length, 1);
 		assert.equal(asyncChainCalls[0]!.params.maxSubagentDepth, 1);
@@ -316,7 +336,7 @@ describe("foreground workflow-stage subagent guard propagation", () => {
 			makeWorkflowStageContext(cwd, uiResult),
 		);
 
-		assert.equal(result.isError, undefined);
+		assertNoErrorFlag(result);
 		assert.equal(runSyncCalls.length, 0);
 		assert.equal(asyncSingleCalls.length, 1);
 		assert.equal(asyncSingleCalls[0]!.params.maxSubagentDepth, 1);

--- a/test/unit/subagents-foreground-guard-propagation.test.ts
+++ b/test/unit/subagents-foreground-guard-propagation.test.ts
@@ -1,10 +1,8 @@
-import { afterAll, beforeEach, describe, mock, spyOn, test } from "bun:test";
+import { beforeEach, describe, mock, test } from "bun:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import * as asyncExecution from "../../packages/subagents/src/runs/background/async-execution.ts";
-import * as foregroundExecution from "../../packages/subagents/src/runs/foreground/execution.ts";
 import { WORKFLOW_STAGE_SUBAGENT_GUARD_ENV } from "../../packages/subagents/src/shared/types.js";
 
 interface MinimalRunSyncOptions {
@@ -51,7 +49,7 @@ interface MinimalAgentConfig {
 }
 
 interface MinimalExecutorModule {
-	createSubagentExecutor: (deps: unknown) => {
+	createSubagentExecutor: (deps: Record<string, unknown>) => {
 		execute: (
 			id: string,
 			params: Record<string, unknown>,
@@ -62,14 +60,22 @@ interface MinimalExecutorModule {
 	};
 }
 
+const executorModulePath = "../../packages/subagents/src/runs/foreground/subagent-executor.ts";
+const { createSubagentExecutor } = await import(executorModulePath) as MinimalExecutorModule;
+
 const runSyncCalls: CapturedRunSyncCall[] = [];
 const asyncChainCalls: CapturedAsyncChainCall[] = [];
 const asyncSingleCalls: CapturedAsyncSingleCall[] = [];
 
 const emptyUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
 
-const runSyncMock = mock(async (...args: [string, MinimalAgentConfig[], string, string, MinimalRunSyncOptions]) => {
-	const [, , agentName, task, options] = args;
+const runSyncMock = mock(async (
+	_cwd: string,
+	_agents: MinimalAgentConfig[],
+	agentName: string,
+	task: string,
+	options: MinimalRunSyncOptions,
+) => {
 	runSyncCalls.push({ agentName, options });
 	return {
 		agent: agentName,
@@ -81,8 +87,7 @@ const runSyncMock = mock(async (...args: [string, MinimalAgentConfig[], string, 
 	};
 });
 
-const executeAsyncChainMock = mock((...args: [string, MinimalAsyncChainParams]) => {
-	const [id, params] = args;
+const executeAsyncChainMock = mock((id: string, params: MinimalAsyncChainParams) => {
 	asyncChainCalls.push({ id, params });
 	return {
 		content: [{ type: "text" as const, text: "Launching in background..." }],
@@ -90,31 +95,13 @@ const executeAsyncChainMock = mock((...args: [string, MinimalAsyncChainParams]) 
 	};
 });
 
-const executeAsyncSingleMock = mock((...args: [string, MinimalAsyncSingleParams]) => {
-	const [id, params] = args;
+const executeAsyncSingleMock = mock((id: string, params: MinimalAsyncSingleParams) => {
 	asyncSingleCalls.push({ id, params });
 	return {
 		content: [{ type: "text" as const, text: "Launching in background..." }],
 		details: { mode: "single" as const, results: [] },
 	};
 });
-
-const runSyncSpy = spyOn(foregroundExecution, "runSync").mockImplementation(
-	runSyncMock as typeof foregroundExecution.runSync,
-);
-const executeAsyncChainSpy = spyOn(asyncExecution, "executeAsyncChain").mockImplementation(
-	executeAsyncChainMock as typeof asyncExecution.executeAsyncChain,
-);
-const executeAsyncSingleSpy = spyOn(asyncExecution, "executeAsyncSingle").mockImplementation(
-	executeAsyncSingleMock as typeof asyncExecution.executeAsyncSingle,
-);
-const formatAsyncStartedMessageSpy = spyOn(asyncExecution, "formatAsyncStartedMessage").mockImplementation(
-	(id: string) => `Started ${id}`,
-);
-const isAsyncAvailableSpy = spyOn(asyncExecution, "isAsyncAvailable").mockImplementation(() => true);
-
-const executorModulePath = "../../packages/subagents/src/runs/foreground/subagent-executor.ts";
-const { createSubagentExecutor } = await import(executorModulePath) as MinimalExecutorModule;
 
 function makeAgent(name: string, maxSubagentDepth?: number): MinimalAgentConfig {
 	return {
@@ -194,6 +181,13 @@ function makeExecutor(cwd: string, agents: MinimalAgentConfig[]) {
 		getSubagentSessionRoot: () => path.join(tempRoot, "sessions"),
 		expandTilde: (p: string) => p,
 		discoverAgents: () => ({ agents }),
+		runtime: {
+			runSync: runSyncMock,
+			executeAsyncChain: executeAsyncChainMock,
+			executeAsyncSingle: executeAsyncSingleMock,
+			formatAsyncStartedMessage: (message: string) => `Started ${message}`,
+			isAsyncAvailable: () => true,
+		},
 	});
 }
 
@@ -225,14 +219,6 @@ beforeEach(() => {
 	clearSubagentGuardEnv();
 });
 
-afterAll(() => {
-	runSyncSpy.mockRestore();
-	executeAsyncChainSpy.mockRestore();
-	executeAsyncSingleSpy.mockRestore();
-	formatAsyncStartedMessageSpy.mockRestore();
-	isAsyncAvailableSpy.mockRestore();
-	clearSubagentGuardEnv();
-});
 
 describe("foreground workflow-stage subagent guard propagation", () => {
 	test("passes workflow-stage guard to sequential and parallel chain children", async () => {


### PR DESCRIPTION
## Summary

Introduces a \`SubagentExecutorRuntimeDeps\` dependency-injection seam into the foreground subagent executor so that \`runSync\`, \`executeAsyncChain\`, \`executeAsyncSingle\`, \`isAsyncAvailable\`, and \`formatAsyncStartedMessage\` can be overridden per-executor instance. Fixes unreliable \`spyOn\` usage against ESM module namespaces in tests; production defaults are unchanged.

## Changes

### Core DI seam (\`subagent-executor.ts\`)
- Exports \`SubagentExecutorRuntimeDeps\` interface with all five overridable functions
- Adds internal \`ResolvedExecutorDeps\` type that narrows the optional \`runtime\` field to fully-resolved after construction
- All execution paths (\`runAsyncPath\`, \`runChainPath\`, \`runParallelPath\`, \`runSinglePath\`, \`resumeAsyncRun\`) route through \`deps.runtime.*\` instead of module-level imports
- Tightens \`SubagentParamsLike\`: \`action\` constrained to \`SUBAGENT_ACTIONS\`, \`agentScope\` typed as \`string\`; adds missing \`chainName\` and \`config\` fields
- Fixes \`inspectSubagentStatus\` call to pass a narrowed params object instead of the full \`SubagentParamsLike\`

### Chain execution (\`chain-execution.ts\`)
- Extracts \`ChainForegroundControl\` type (was duplicated inline across two interfaces)
- Adds \`RunSyncDependency\` type alias
- Threads injected \`runSync\` through \`ChainExecutionParams\` and \`ParallelChainRunInput\` so sequential and parallel chain children use the overridden function

### Type consolidation (\`types.ts\`)
- Adds \`SubagentToolResult = AgentToolResult<Details> & { isError?: boolean }\` alias — consolidates the result type used throughout and removes scattered re-imports of \`AgentToolResult\` from \`pi-agent-core\`

### Supporting fixes
- **\`agent-management.ts\`**: Migrates all handler return types to \`SubagentToolResult\`; adds \`MutableDefinition\` narrowing type guard for \`resolveTarget\`
- **\`run-status.ts\`**: Migrates \`inspectSubagentStatus\` return type to \`SubagentToolResult\`
- **\`settings.ts\`**: Adds \`cwd?: string\` to \`ParallelStep\` interface
- **\`run-history.ts\`**: Replaces \`Boolean(entry)\` with \`entry !== undefined\` for correct TypeScript narrowing in the filter predicate
- **\`chain-clarify.ts\`**: Fixes key casing \`pageup\`/\`pagedown\` → \`pageUp\`/\`pageDown\` to match upstream key-matching convention

### Tests (\`subagents-foreground-guard-propagation.test.ts\`)
- Replaces all \`spyOn\` calls against ESM module namespaces with typed mock functions passed via \`runtime\`
- Removes the \`afterAll\` spy-restore block (no longer needed)
- Derives test types directly from exported signatures (\`ExecutorForTest\`, \`ExecutorDepsForTest\`, etc.)
- Tightens mock signatures from rest-arg destructuring to explicit typed parameters
- Adds \`assertNoErrorFlag\` helper and \`makeUiContext\`/\`makeModelRegistry\` helpers for typed test contexts

## Why

\`spyOn\` against ESM namespace exports is unreliable — module bindings are live and not always reassignable. Dependency injection at the executor level is the idiomatic fix: tests pass fakes through the public API instead of mutating module state.

## Validation

\`\`\`sh
AGENT=1 bun test test/unit/subagents-foreground-guard-propagation.test.ts
bun run lint
bun run test:unit
\`\`\`

Refs #1088