### PR TITLE
fix(workflows): disable workflows in non-interactive (-p) mode

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Disabled workflows in non-interactive (`-p` / `--print` / `--mode json`) sessions, which bind a no-op UI surface and cannot drive workflow prompts, pickers, or the graph overlay: the `workflow` tool is removed from the model's active tool set at session start, and the `/workflow` command (reachable via `atomic -p "/workflow …"`) is refused — preventing headless runs from stalling on work that can never complete ([#1096](https://github.com/flora131/atomic/issues/1096)).
 - Escaped workflow lifecycle notice text and structured response hints, isolated lifecycle send failures from store subscribers, and rejected empty lifecycle notification event lists ([#1085](https://github.com/flora131/atomic/issues/1085)).
 - Fixed stage awaiting-input lifecycle notice dedupe so promptless pauses after resolved prompts are not suppressed by historical prompt metadata ([#1085](https://github.com/flora131/atomic/issues/1085)).
 - Reset workflow lifecycle-notification dedupe state at chat session boundaries so reused workflow run IDs in later sessions still emit completion/failure/input notices ([#1085](https://github.com/flora131/atomic/issues/1085)).

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -317,7 +317,7 @@ Press **F2** while a workflow is running to open the DAG overlay for the active 
 
 `@bastani/workflows` follows pi's package/extension model: pi loads `src/extension/index.ts` from the package `pi.extensions` manifest, then the extension registers the `workflow` tool, `/workflow` slash command, renderers, widget, and lifecycle hooks in-process.
 
-For interactive use, run workflows through `/workflow <name> [key=value ...]` or let the LLM call the `workflow` tool. For library or scripted use, call the explicit programmatic runner:
+For interactive use, run workflows through `/workflow <name> [key=value ...]` or let the LLM call the `workflow` tool. Both the `/workflow` command and the `workflow` tool are disabled in non-interactive (`-p` / `--print` / `--mode json`) sessions, which bind a no-op UI surface and therefore cannot drive workflow pickers, the graph overlay, or human-in-the-loop prompts. For library or scripted use, call the explicit programmatic runner instead:
 
 ```ts
 import { runWorkflow, type WorkflowOptions } from "@bastani/workflows";

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -195,6 +195,11 @@ export interface PiCommandContext extends PiModelContext {
   ui: {
     notify: (message: string, type?: "info" | "warning" | "error") => void;
   } & PiUISurface;
+  /**
+   * False when the host bound a no-op UI surface (print/JSON `-p` modes).
+   * Absent on older hosts and unit-test stubs; treat absence as interactive.
+   */
+  hasUI?: boolean;
 }
 
 /** CLI flag registration options. Mirrors the inline options on `ExtensionAPI.registerFlag`. */
@@ -322,6 +327,17 @@ export interface ExtensionAPI {
       handler: (ctx?: PiCommandContext) => void | Promise<void>;
     },
   ) => void;
+  /**
+   * Read the model's currently-active tool names. Present on pi's ExtensionAPI;
+   * absent on older runtimes.
+   */
+  getActiveTools?: () => string[];
+  /**
+   * Replace the model's active tool set by name. Used to drop the `workflow`
+   * tool in non-interactive sessions. Present on pi's ExtensionAPI; absent on
+   * older runtimes.
+   */
+  setActiveTools?: (toolNames: string[]) => void;
   /**
    * Sets the current session name. Present on pi's ExtensionAPI.
    */
@@ -963,6 +979,41 @@ function hasWorkflowStageSubagentGuardEnv(): boolean {
 
 function isWorkflowStageToolContext(ctx: PiExecuteContext): boolean {
   return hasWorkflowStageSubagentGuardEnv() || ctx.orchestrationContext?.kind === "workflow-stage";
+}
+
+/** Tool name registered for workflow execution; shared by the de-advertise guard. */
+const WORKFLOW_TOOL_NAME = "workflow";
+
+/**
+ * User-facing message shown when the `/workflow` command is invoked in a
+ * non-interactive (`-p` / `--print` / `--mode json`) session. Such sessions
+ * bind a no-op UI surface (`ctx.hasUI === false`) and cannot drive workflow
+ * pickers, the graph overlay, or human-in-the-loop prompts.
+ *
+ * The `workflow` tool is removed from the model's tool set in these sessions
+ * (see `deAdvertiseWorkflowToolWhenHeadless`). The slash command has no
+ * advertise layer and is still reachable via `atomic -p "/workflow …"` (print
+ * mode dispatches leading-slash commands through `session.prompt`), so it is
+ * refused here instead.
+ */
+export const WORKFLOW_NON_INTERACTIVE_MESSAGE =
+  "Workflows are disabled in non-interactive (-p) mode; run Atomic interactively to use workflows.";
+
+/**
+ * Remove the `workflow` tool from the model's active tool set in non-interactive
+ * (`-p` / `--mode json`) sessions, which bind a no-op UI (`ctx.hasUI === false`)
+ * and cannot drive workflow prompts or the graph overlay. Invoked from
+ * `session_start`, which the host awaits before the first prompt, so the tool is
+ * gone before the model's first turn. Interactive and RPC modes bind a real UI
+ * context (`hasUI: true`) and keep the tool. No-ops on hosts that predate the
+ * `getActiveTools`/`setActiveTools` extension API.
+ */
+function deAdvertiseWorkflowToolWhenHeadless(pi: ExtensionAPI, hasUI: boolean | undefined): void {
+  if (hasUI !== false) return;
+  if (typeof pi.getActiveTools !== "function" || typeof pi.setActiveTools !== "function") return;
+  const active = pi.getActiveTools();
+  if (!active.includes(WORKFLOW_TOOL_NAME)) return;
+  pi.setActiveTools(active.filter((name) => name !== WORKFLOW_TOOL_NAME));
 }
 
 // ---------------------------------------------------------------------------
@@ -2740,6 +2791,13 @@ function factory(pi: ExtensionAPI): void {
       description:
         "Run or inspect pi workflows. Usage: /workflow <name> [key=value…] | /workflow [list|status|connect|attach|interrupt|kill|pause|resume|inputs|reload] [args]",
       handler: async (args: string, ctx: PiCommandContext) => {
+        // Print/JSON (`-p`) sessions cannot drive workflow pickers, the graph
+        // overlay, or human-in-the-loop prompts. Refuse before parsing so the
+        // command surface matches the disabled `workflow` tool.
+        if (ctx.hasUI === false) {
+          ctx.ui.notify(WORKFLOW_NON_INTERACTIVE_MESSAGE, "warning");
+          return;
+        }
         const print = (msg: string): void => ctx.ui.notify(msg, "info");
         // Quote-aware split so `prompt="map the codebase"` stays a single
         // token. Plain `.split(/\s+/)` would mangle quoted multi-word values
@@ -3366,6 +3424,12 @@ function factory(pi: ExtensionAPI): void {
     });
 
     pi.on("session_start", async (_event, ctx) => {
+      // Non-interactive (`-p` / `--mode json`) sessions cannot drive workflow
+      // prompts or the graph overlay; drop the `workflow` tool from the model's
+      // tool set before the first turn. The host awaits this handler during
+      // bindExtensions, ahead of the initial prompt.
+      deAdvertiseWorkflowToolWhenHeadless(pi, ctx?.hasUI);
+
       // Workflow lifecycle is scoped to the originating chat session.
       // A new session inherits a clean store; any leftover live runs from a
       // previous session in the same pi process are killed (subprocess

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -38,6 +38,33 @@ function captureHandlers(): Map<string, SessionBeforeSwitchHandler> {
   return handlers;
 }
 
+function captureHandlersWithActiveTools(activeTools: readonly string[]): {
+  handlers: Map<string, SessionBeforeSwitchHandler>;
+  setCalls: string[][];
+} {
+  const handlers = new Map<string, SessionBeforeSwitchHandler>();
+  const setCalls: string[][] = [];
+  let current = [...activeTools];
+  const pi: ExtensionAPI = {
+    registerTool: () => undefined,
+    registerCommand: () => undefined,
+    registerMessageRenderer: () => undefined,
+    registerFlag: () => undefined,
+    registerShortcut: () => undefined,
+    getActiveTools: () => [...current],
+    setActiveTools: (names: string[]) => {
+      current = [...names];
+      setCalls.push([...names]);
+    },
+    on: (event, handler) => {
+      handlers.set(event, handler as SessionBeforeSwitchHandler);
+    },
+    disableAsyncDiscovery: true,
+  };
+  factory(pi);
+  return { handlers, setCalls };
+}
+
 function getSessionBeforeSwitchHandler(): SessionBeforeSwitchHandler {
   const handler = captureHandlers().get("session_before_switch");
   if (handler === undefined) {
@@ -258,4 +285,47 @@ test("session_start warns when discovered workflows fail validation", async () =
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Non-interactive (-p) mode: the `workflow` tool is removed from the model's
+// active tool set in session_start (ctx.hasUI === false). The host awaits
+// session_start during bindExtensions, before the first prompt, so the tool is
+// gone before the model's first turn.
+// ---------------------------------------------------------------------------
+
+test("session_start de-advertises the workflow tool in non-interactive sessions", async () => {
+  const { handlers, setCalls } = captureHandlersWithActiveTools(["read", "bash", "workflow", "todos"]);
+  const sessionStart = handlers.get("session_start");
+  assert.notEqual(sessionStart, undefined);
+
+  await sessionStart?.({ reason: "startup" }, { hasUI: false });
+
+  assert.deepEqual(setCalls, [["read", "bash", "todos"]]);
+});
+
+test("session_start keeps the workflow tool when a UI is available", async () => {
+  const { handlers, setCalls } = captureHandlersWithActiveTools(["read", "workflow"]);
+  const sessionStart = handlers.get("session_start");
+
+  await sessionStart?.({ reason: "startup" }, { hasUI: true });
+
+  assert.deepEqual(setCalls, []);
+});
+
+test("session_start leaves the active tool set untouched when workflow is already absent", async () => {
+  const { handlers, setCalls } = captureHandlersWithActiveTools(["read", "bash"]);
+  const sessionStart = handlers.get("session_start");
+
+  await sessionStart?.({ reason: "startup" }, { hasUI: false });
+
+  assert.deepEqual(setCalls, []);
+});
+
+test("session_start does not throw on hosts without the active-tools API", async () => {
+  const handlers = captureHandlers();
+  const sessionStart = handlers.get("session_start");
+  assert.notEqual(sessionStart, undefined);
+
+  await assert.doesNotReject(Promise.resolve(sessionStart?.({ reason: "startup" }, { hasUI: false })));
 });

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -19,6 +19,7 @@ import {
   parseWorkflowArgs,
   tokenizeWorkflowArgs,
   makeExecuteWorkflowTool,
+  WORKFLOW_NON_INTERACTIVE_MESSAGE,
 } from "../../packages/workflows/src/extension/index.js";
 import { renderResult } from "../../packages/workflows/src/extension/render-result.js";
 import type { WorkflowToolResult } from "../../packages/workflows/src/extension/render-result.js";
@@ -2234,5 +2235,70 @@ describe("tool run-control actions", () => {
     assert.equal(r.status, "noop");
     assert.equal(r.runId, runId);
     assert.match(r.message, /workflow_not_found/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-interactive (-p) mode: /workflow command is disabled (hasUI === false).
+// Mirrors the workflow-tool guard so print/JSON sessions cannot drive workflows
+// that have no UI to answer human-in-the-loop prompts.
+// ---------------------------------------------------------------------------
+
+describe("/workflow command disabled in non-interactive (-p) mode", () => {
+  async function registerWorkflowCommand(): Promise<{
+    handler: NonNullable<PiCommandOptions["handler"]>;
+    sent: SentMessage[];
+  }> {
+    const { pi, commands, sent } = buildMockPi();
+    await runFactory(pi);
+    const cmd = commands.find((c) => c.name === "workflow");
+    assert.ok(cmd, "expected /workflow command registration");
+    return { handler: cmd.options.handler, sent };
+  }
+
+  function commandCtx(hasUI: boolean | undefined): { ctx: PiCommandContext; messages: string[] } {
+    const messages: string[] = [];
+    const ctx: PiCommandContext = {
+      ...(hasUI === undefined ? {} : { hasUI }),
+      ui: {
+        notify: (msg: string) => {
+          messages.push(msg);
+        },
+      },
+    };
+    return { ctx, messages };
+  }
+
+  test("/workflow notifies and short-circuits when no UI is available", async () => {
+    const { handler, sent } = await registerWorkflowCommand();
+    const { ctx, messages } = commandCtx(false);
+
+    await handler("list", ctx);
+
+    assert.equal(sent.length, 0);
+    assert.ok(
+      messages.some((m) => m === WORKFLOW_NON_INTERACTIVE_MESSAGE),
+      `expected non-interactive notice, got: ${JSON.stringify(messages)}`,
+    );
+  });
+
+  test("/workflow proceeds when a UI is available", async () => {
+    const { handler, sent } = await registerWorkflowCommand();
+    const { ctx, messages } = commandCtx(true);
+
+    await handler("list", ctx);
+
+    assert.equal(messages.some((m) => m === WORKFLOW_NON_INTERACTIVE_MESSAGE), false);
+    assert.ok(sent.length > 0, "expected /workflow list to emit a chat surface");
+  });
+
+  test("/workflow proceeds when hasUI is unset (degraded runtimes)", async () => {
+    const { handler, sent } = await registerWorkflowCommand();
+    const { ctx, messages } = commandCtx(undefined);
+
+    await handler("list", ctx);
+
+    assert.equal(messages.some((m) => m === WORKFLOW_NON_INTERACTIVE_MESSAGE), false);
+    assert.ok(sent.length > 0, "expected /workflow list to emit a chat surface");
   });
 });


### PR DESCRIPTION
## Summary

Prevents headless sessions from stalling by proactively removing the `workflow` tool from the model's active tool set at session start, and refusing `/workflow` command invocations in non-interactive (`-p` / `--print` / `--mode json`) sessions. These sessions bind a no-op UI surface with no way to drive workflow human-in-the-loop prompts, pickers, or the graph overlay.

Closes #1096.

## Key Changes

- **`PiCommandContext.hasUI`** — new optional `boolean` field; `false` when the host binds a no-op UI surface (print/JSON modes), absent on older hosts and unit-test stubs (treated as interactive)
- **`ExtensionAPI.getActiveTools` / `setActiveTools`** — new optional methods on the `ExtensionAPI` interface used to mutate the model's active tool set from the `session_start` handler
- **`WORKFLOW_NON_INTERACTIVE_MESSAGE`** — exported constant for the user-facing refusal message, surfaced via `ctx.ui.notify()` with `"warning"` type on the command path
- **`deAdvertiseWorkflowToolWhenHeadless()`** — called from `session_start`, removes the `workflow` tool from the model's active tool set before the first prompt when `hasUI === false`; no-ops on hosts that predate `getActiveTools`/`setActiveTools`
- **`/workflow` command handler** — short-circuits with a warning before parsing args when `ctx.hasUI === false`, keeping the command surface consistent with the de-advertised tool
- **Docs** — README updated to document the non-interactive restriction and direct users to the programmatic runner
- **Tests** — 7 new unit tests covering: tool de-advertising at `session_start` in headless sessions, tool retention when UI is available, no-op when workflow tool is already absent, graceful fallback on hosts without the active-tools API, and the parallel `/workflow` command cases

## Breaking Changes

None. `hasUI` is optional; `getActiveTools`/`setActiveTools` are optional on `ExtensionAPI`. Handlers on older hosts or unit-test stubs that omit these fields continue to operate as if interactive.