### PR TITLE
fix(subagents): animate running spinner smoothly without flicker

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the subagent running spinner freezing/stuttering and the surrounding TUI flickering while subagents run: the running glyph is now driven by wall-clock time with a steady re-render ticker (result cards, slash result cards, and the async-agents widget), so it animates smoothly and continuously instead of only advancing when progress data changes. Per-frame diffs stay limited to the spinner glyph cell, so the differential renderer keeps doing partial redraws (no full-screen clear / flicker), and the ticker is torn down on completion, reload, and session shutdown ([#1084](https://github.com/flora131/atomic/issues/1084)).
 - Hardened workflow-stage subagent guard propagation tests with an internal executor runtime DI seam ([#1088](https://github.com/flora131/atomic/issues/1088)).
 - Capped subagent fanout spawned from workflow stages to a single child level with a workflow-specific nested-subagent error.
 

--- a/packages/subagents/src/extension/index.ts
+++ b/packages/subagents/src/extension/index.ts
@@ -23,7 +23,7 @@ import { discoverAgents } from "../agents/agents.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
-import { clearLegacyResultAnimationTimer, renderWidget, renderSubagentResult } from "../tui/render.ts";
+import { renderWidget, renderSubagentResult, stopResultAnimations, stopWidgetAnimation, syncResultAnimation } from "../tui/render.ts";
 import { SubagentParams } from "./schemas.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
@@ -135,8 +135,10 @@ function createSlashResultComponent(
 	details: SlashMessageDetails,
 	options: { expanded: boolean },
 	theme: ExtensionContext["ui"]["theme"],
+	requestRender: () => void,
 ): Container {
 	const container = new Container();
+	const animationState: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> } = {};
 	let lastVersion = -1;
 	container.render = (width: number): string[] => {
 		const snapshot = getSlashRenderableSnapshot(details);
@@ -144,6 +146,9 @@ function createSlashResultComponent(
 			lastVersion = snapshot.version;
 			rebuildSlashResultContainer(container, snapshot.result, options, theme);
 		}
+		// Keep the live slash card's spinner animating by scheduling steady
+		// re-renders while it runs (and tearing the timer down once it settles).
+		syncResultAnimation(snapshot.result, { state: animationState, invalidate: requestRender });
 		return Container.prototype.render.call(container, width);
 	};
 	return container;
@@ -266,6 +271,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	const runtimeCleanup = () => {
 		stopResultWatcher();
+		stopWidgetAnimation();
+		stopResultAnimations();
 		clearPendingForegroundControlNotices(state);
 		if (state.poller) {
 			clearInterval(state.poller);
@@ -289,7 +296,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	pi.registerMessageRenderer<SlashMessageDetails>(SLASH_RESULT_TYPE, (message, options, theme) => {
 		const details = resolveSlashMessageDetails(message.details);
 		if (!details) return undefined;
-		return createSlashResultComponent(details, options, theme);
+		return createSlashResultComponent(details, options, theme, () => state.lastUiContext?.ui.requestRender?.());
 	});
 
 	pi.registerMessageRenderer<SubagentNotifyDetails>("subagent-notify", (message, options, theme) => {
@@ -458,7 +465,9 @@ DIAGNOSTICS:
 		},
 
 		renderResult(result, options, theme, context) {
-			clearLegacyResultAnimationTimer(context);
+			// Animate the live subagent spinner by scheduling steady re-renders
+			// while the result is running; the timer stops once it settles.
+			syncResultAnimation(result, context);
 			return renderSubagentResult(result, options, theme);
 		},
 
@@ -549,6 +558,8 @@ DIAGNOSTICS:
 			delete globalStore[eventUnsubscribeStoreKey];
 		}
 		stopResultWatcher();
+		stopWidgetAnimation();
+		stopResultAnimations();
 		if (state.poller) clearInterval(state.poller);
 		state.poller = null;
 		clearPendingForegroundControlNotices(state);

--- a/packages/subagents/src/tui/render.ts
+++ b/packages/subagents/src/tui/render.ts
@@ -90,7 +90,27 @@ function truncLine(text: string, maxWidth: number): string {
 const RUNNING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const STATIC_RUNNING_GLYPH = "●";
 
+/**
+ * Spinner cadence (ms per frame). The running glyph is derived from wall-clock
+ * time so every active spinner advances smoothly and in lockstep, independent
+ * of how often (or how irregularly) progress data updates arrive. The animation
+ * timers below only schedule re-renders; the displayed frame always comes from
+ * the clock. This fixes the frozen/stuttering spinner from issue #1084 while
+ * keeping per-frame diffs to a single glyph cell so the differential renderer
+ * never needs a full-clear (no flicker).
+ */
+export const RUNNING_ANIMATION_MS = 80;
+const STALE_EXTENSION_CONTEXT_MESSAGE = "This extension ctx is stale after session replacement or reload";
+
 type ProgressSeedSource = Partial<Pick<AgentProgress, "index" | "toolCount" | "tokens" | "durationMs" | "lastActivityAt" | "currentToolStartedAt" | "turnCount">>;
+
+/**
+ * Wall-clock-derived animation frame counter. Advances exactly one step every
+ * `RUNNING_ANIMATION_MS`. Exposed for tests so they can pin a deterministic now.
+ */
+export function currentRunningFrame(now: number = Date.now()): number {
+	return Math.floor(now / RUNNING_ANIMATION_MS);
+}
 
 function runningSeed(...values: Array<number | undefined>): number | undefined {
 	let seed: number | undefined;
@@ -102,8 +122,12 @@ function runningSeed(...values: Array<number | undefined>): number | undefined {
 }
 
 function runningGlyph(seed?: number): string {
-	if (seed === undefined) return STATIC_RUNNING_GLYPH;
-	return RUNNING_FRAMES[Math.abs(seed) % RUNNING_FRAMES.length]!;
+	// Fold the wall-clock frame into the (optional) progress seed so the glyph
+	// advances over time. The frame is always defined, so a running entity always
+	// animates; the seed only offsets its starting phase between concurrent agents.
+	const animatedSeed = runningSeed(seed, currentRunningFrame());
+	if (animatedSeed === undefined) return STATIC_RUNNING_GLYPH;
+	return RUNNING_FRAMES[Math.abs(animatedSeed) % RUNNING_FRAMES.length]!;
 }
 
 function progressRunningSeed(progress: ProgressSeedSource | undefined): number | undefined {
@@ -119,15 +143,73 @@ function progressRunningSeed(progress: ProgressSeedSource | undefined): number |
 	);
 }
 
+interface ResultAnimationContext {
+	state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
+	invalidate: () => void;
+}
+
 interface LegacyResultAnimationContext {
 	state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
 }
 
-export function clearLegacyResultAnimationTimer(context: LegacyResultAnimationContext): void {
+// Registry of every live result-animation timer so they can be torn down in one
+// shot on reload/shutdown even if their owning render context never re-renders.
+const resultAnimationTimers = new Map<ReturnType<typeof setInterval>, ResultAnimationContext["state"]>();
+
+function isStaleExtensionContextError(error: unknown): boolean {
+	return error instanceof Error && error.message.includes(STALE_EXTENSION_CONTEXT_MESSAGE);
+}
+
+function resultIsRunning(result: AgentToolResult<Details>): boolean {
+	return Boolean(
+		result.details?.progress?.some((entry) => entry.status === "running")
+		|| result.details?.results.some((entry) => entry.progress?.status === "running"),
+	);
+}
+
+function stopResultAnimation(context: LegacyResultAnimationContext): void {
 	const timer = context.state.subagentResultAnimationTimer;
 	if (!timer) return;
 	clearInterval(timer);
+	resultAnimationTimers.delete(timer);
 	context.state.subagentResultAnimationTimer = undefined;
+}
+
+export function clearLegacyResultAnimationTimer(context: LegacyResultAnimationContext): void {
+	stopResultAnimation(context);
+}
+
+/**
+ * Keep a running subagent result's spinner animating by scheduling a steady
+ * re-render while it is active, and tearing the timer down once it settles.
+ * The timer only calls `context.invalidate()`; the glyph value itself comes
+ * from {@link currentRunningFrame}, so each tick produces a single-glyph diff.
+ */
+export function syncResultAnimation(result: AgentToolResult<Details>, context: ResultAnimationContext): void {
+	if (!resultIsRunning(result)) {
+		stopResultAnimation(context);
+		return;
+	}
+	if (context.state.subagentResultAnimationTimer) return;
+	const timer = setInterval(() => {
+		try {
+			context.invalidate();
+		} catch (error) {
+			if (!isStaleExtensionContextError(error)) throw error;
+			stopResultAnimation(context);
+		}
+	}, RUNNING_ANIMATION_MS);
+	timer.unref?.();
+	context.state.subagentResultAnimationTimer = timer;
+	resultAnimationTimers.set(timer, context.state);
+}
+
+export function stopResultAnimations(): void {
+	for (const [timer, state] of resultAnimationTimers) {
+		clearInterval(timer);
+		state.subagentResultAnimationTimer = undefined;
+	}
+	resultAnimationTimers.clear();
 }
 
 function extractOutputTarget(task: string): string | undefined {
@@ -836,18 +918,82 @@ function fitWidgetLineBudget(lines: string[], theme: Theme, width: number, expan
 	return [...lines.slice(0, visibleLines), truncLine(theme.fg("dim", hint), width)];
 }
 
-function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: unknown, theme: Theme) => Component {
-	return (_tui, theme) => {
-		const width = getTermWidth();
+/**
+ * Live async-agents widget. Recomputes its lines on every render so the
+ * wall-clock-driven running glyph (and elapsed-time labels) stay current; the
+ * widget animation ticker below schedules those re-renders while jobs run.
+ */
+class LiveWidgetComponent implements Component {
+	private readonly container = new Container();
+
+	constructor(
+		private readonly jobs: AsyncJobState[],
+		private readonly theme: Theme,
+		private readonly getExpanded: () => boolean,
+	) {}
+
+	render(width: number): string[] {
+		const expanded = this.getExpanded();
 		const lines = expanded
-			? buildWidgetLines(jobs, theme, width, true)
-			: jobs.length === 1
-				? compactSingleWidgetLines(jobs[0]!, theme, width)
-				: buildWidgetLines(jobs, theme, width, false);
-		const container = new Container();
-		for (const line of fitWidgetLineBudget(lines, theme, width, expanded)) container.addChild(new Text(line, 1, 0));
-		return container;
-	};
+			? buildWidgetLines(this.jobs, this.theme, width, true)
+			: this.jobs.length === 1
+				? compactSingleWidgetLines(this.jobs[0]!, this.theme, width)
+				: buildWidgetLines(this.jobs, this.theme, width, false);
+		this.container.clear();
+		for (const line of fitWidgetLineBudget(lines, this.theme, width, expanded)) this.container.addChild(new Text(line, 1, 0));
+		return this.container.render(width);
+	}
+
+	invalidate(): void {
+		this.container.invalidate();
+	}
+}
+
+function buildWidgetComponent(jobs: AsyncJobState[], getExpanded: () => boolean): (_tui: unknown, theme: Theme) => Component {
+	return (_tui, theme) => new LiveWidgetComponent(jobs, theme, getExpanded);
+}
+
+interface RenderRequestingContext {
+	ui: ExtensionContext["ui"] & { requestRender?: () => void };
+}
+
+let latestWidgetCtx: ExtensionContext | undefined;
+let latestWidgetJobs: AsyncJobState[] = [];
+let widgetTimer: ReturnType<typeof setInterval> | undefined;
+
+function hasAnimatedWidgetJobs(jobs: AsyncJobState[]): boolean {
+	return jobs.some((job) => job.status === "running");
+}
+
+function refreshAnimatedWidget(): void {
+	if (!latestWidgetCtx?.hasUI) return;
+	try {
+		(latestWidgetCtx as RenderRequestingContext).ui.requestRender?.();
+	} catch (error) {
+		if (!isStaleExtensionContextError(error)) throw error;
+		stopWidgetAnimation();
+	}
+}
+
+function ensureWidgetAnimation(): void {
+	if (widgetTimer) return;
+	widgetTimer = setInterval(() => {
+		if (!hasAnimatedWidgetJobs(latestWidgetJobs)) {
+			stopWidgetAnimation();
+			return;
+		}
+		refreshAnimatedWidget();
+	}, RUNNING_ANIMATION_MS);
+	widgetTimer.unref?.();
+}
+
+export function stopWidgetAnimation(): void {
+	if (widgetTimer) {
+		clearInterval(widgetTimer);
+		widgetTimer = undefined;
+	}
+	latestWidgetCtx = undefined;
+	latestWidgetJobs = [];
 }
 
 export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = getTermWidth(), expanded = false): string[] {
@@ -925,11 +1071,19 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
  */
 export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void {
 	if (jobs.length === 0) {
+		stopWidgetAnimation();
 		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
 		return;
 	}
-	if (!ctx.hasUI) return;
-	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false));
+	if (!ctx.hasUI) {
+		stopWidgetAnimation();
+		return;
+	}
+	latestWidgetCtx = ctx;
+	latestWidgetJobs = [...jobs];
+	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, () => ctx.ui.getToolsExpanded?.() ?? false));
+	if (hasAnimatedWidgetJobs(jobs)) ensureWidgetAnimation();
+	else stopWidgetAnimation();
 }
 
 function renderSingleCompact(d: Details, r: Details["results"][number], theme: Theme): Component {

--- a/packages/subagents/src/tui/render.ts
+++ b/packages/subagents/src/tui/render.ts
@@ -99,7 +99,6 @@ const RUNNING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
  * never needs a full-clear (no flicker).
  */
 export const RUNNING_ANIMATION_MS = 80;
-const STALE_EXTENSION_CONTEXT_MESSAGE = "This extension ctx is stale after session replacement or reload";
 
 type ProgressSeedSource = Partial<Pick<AgentProgress, "index" | "toolCount" | "tokens" | "durationMs" | "lastActivityAt" | "currentToolStartedAt" | "turnCount">>;
 
@@ -141,29 +140,21 @@ function progressRunningSeed(progress: ProgressSeedSource | undefined): number |
 	);
 }
 
+type ResultAnimationState = { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
+
 interface ResultAnimationContext {
-	state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
+	state: ResultAnimationState;
 	invalidate: () => void;
 }
 
-interface LegacyResultAnimationContext {
-	state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
-}
-
-interface ResultAnimationEntry {
-	state: ResultAnimationContext["state"];
-	invalidate: () => void;
-}
+type LegacyResultAnimationContext = { state: ResultAnimationState };
+type ResultAnimationEntry = ResultAnimationContext;
 
 // Registry of every live result-animation timer so they can be torn down in one
 // shot on reload/shutdown even if their owning render context never re-renders.
 // Each tick reads the latest `invalidate` from here so a re-sync can refresh the
 // callback if the host ever swaps render contexts for the same renderable.
 const resultAnimationTimers = new Map<ReturnType<typeof setInterval>, ResultAnimationEntry>();
-
-function isStaleExtensionContextError(error: unknown): boolean {
-	return error instanceof Error && error.message.includes(STALE_EXTENSION_CONTEXT_MESSAGE);
-}
 
 function resultIsRunning(result: AgentToolResult<Details>): boolean {
 	return Boolean(
@@ -208,8 +199,10 @@ export function syncResultAnimation(result: AgentToolResult<Details>, context: R
 		if (!entry) return;
 		try {
 			entry.invalidate();
-		} catch (error) {
-			if (!isStaleExtensionContextError(error)) throw error;
+		} catch {
+			// A cosmetic spinner tick must never crash the host (e.g. a stale extension
+			// context after reload/session swap, or any other render glitch). Stop this
+			// timer; the next real render re-syncs and restarts it while still running.
 			stopResultAnimation(context);
 		}
 	}, RUNNING_ANIMATION_MS);
@@ -986,9 +979,12 @@ function hasAnimatedWidgetJobs(jobs: AsyncJobState[]): boolean {
 function refreshAnimatedWidget(): void {
 	if (!latestWidgetCtx?.hasUI) return;
 	try {
+		// The cast is required because narrowing on `hasUI` above collapses `ui` to
+		// the base ExtensionUIContext, which does not declare the optional
+		// requestRender that the running interactive host actually provides.
 		(latestWidgetCtx as RenderRequestingContext).ui.requestRender?.();
-	} catch (error) {
-		if (!isStaleExtensionContextError(error)) throw error;
+	} catch {
+		// Never let a cosmetic widget tick crash the host; stop on any error.
 		stopWidgetAnimation();
 	}
 }
@@ -1005,11 +1001,17 @@ function ensureWidgetAnimation(): void {
 	widgetTimer.unref?.();
 }
 
-export function stopWidgetAnimation(): void {
+// Stop only the ticker, keeping the last-rendered widget context/jobs intact.
+function stopWidgetTicker(): void {
 	if (widgetTimer) {
 		clearInterval(widgetTimer);
 		widgetTimer = undefined;
 	}
+}
+
+// Full teardown: stop the ticker and forget the driving context/jobs entirely.
+export function stopWidgetAnimation(): void {
+	stopWidgetTicker();
 	latestWidgetCtx = undefined;
 	latestWidgetJobs = [];
 }
@@ -1100,8 +1102,10 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 	latestWidgetCtx = ctx;
 	latestWidgetJobs = [...jobs];
 	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, () => ctx.ui.getToolsExpanded?.() ?? false));
+	// Keep the just-rendered ctx/jobs as the last-rendered state; only the ticker
+	// is conditional on whether anything is still animating.
 	if (hasAnimatedWidgetJobs(jobs)) ensureWidgetAnimation();
-	else stopWidgetAnimation();
+	else stopWidgetTicker();
 }
 
 function renderSingleCompact(d: Details, r: Details["results"][number], theme: Theme): Component {

--- a/packages/subagents/src/tui/render.ts
+++ b/packages/subagents/src/tui/render.ts
@@ -88,7 +88,6 @@ function truncLine(text: string, maxWidth: number): string {
 }
 
 const RUNNING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-const STATIC_RUNNING_GLYPH = "●";
 
 /**
  * Spinner cadence (ms per frame). The running glyph is derived from wall-clock
@@ -123,10 +122,9 @@ function runningSeed(...values: Array<number | undefined>): number | undefined {
 
 function runningGlyph(seed?: number): string {
 	// Fold the wall-clock frame into the (optional) progress seed so the glyph
-	// advances over time. The frame is always defined, so a running entity always
+	// advances over time. The frame is always finite, so a running entity always
 	// animates; the seed only offsets its starting phase between concurrent agents.
-	const animatedSeed = runningSeed(seed, currentRunningFrame());
-	if (animatedSeed === undefined) return STATIC_RUNNING_GLYPH;
+	const animatedSeed = runningSeed(seed, currentRunningFrame()) ?? 0;
 	return RUNNING_FRAMES[Math.abs(animatedSeed) % RUNNING_FRAMES.length]!;
 }
 
@@ -152,9 +150,16 @@ interface LegacyResultAnimationContext {
 	state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
 }
 
+interface ResultAnimationEntry {
+	state: ResultAnimationContext["state"];
+	invalidate: () => void;
+}
+
 // Registry of every live result-animation timer so they can be torn down in one
 // shot on reload/shutdown even if their owning render context never re-renders.
-const resultAnimationTimers = new Map<ReturnType<typeof setInterval>, ResultAnimationContext["state"]>();
+// Each tick reads the latest `invalidate` from here so a re-sync can refresh the
+// callback if the host ever swaps render contexts for the same renderable.
+const resultAnimationTimers = new Map<ReturnType<typeof setInterval>, ResultAnimationEntry>();
 
 function isStaleExtensionContextError(error: unknown): boolean {
 	return error instanceof Error && error.message.includes(STALE_EXTENSION_CONTEXT_MESSAGE);
@@ -190,10 +195,19 @@ export function syncResultAnimation(result: AgentToolResult<Details>, context: R
 		stopResultAnimation(context);
 		return;
 	}
-	if (context.state.subagentResultAnimationTimer) return;
+	const existing = context.state.subagentResultAnimationTimer;
+	if (existing) {
+		// Keep using the most recent invalidate in case the host handed us a fresh
+		// render context object on this re-sync.
+		const entry = resultAnimationTimers.get(existing);
+		if (entry) entry.invalidate = context.invalidate;
+		return;
+	}
 	const timer = setInterval(() => {
+		const entry = resultAnimationTimers.get(timer);
+		if (!entry) return;
 		try {
-			context.invalidate();
+			entry.invalidate();
 		} catch (error) {
 			if (!isStaleExtensionContextError(error)) throw error;
 			stopResultAnimation(context);
@@ -201,13 +215,13 @@ export function syncResultAnimation(result: AgentToolResult<Details>, context: R
 	}, RUNNING_ANIMATION_MS);
 	timer.unref?.();
 	context.state.subagentResultAnimationTimer = timer;
-	resultAnimationTimers.set(timer, context.state);
+	resultAnimationTimers.set(timer, { state: context.state, invalidate: context.invalidate });
 }
 
 export function stopResultAnimations(): void {
-	for (const [timer, state] of resultAnimationTimers) {
+	for (const [timer, entry] of resultAnimationTimers) {
 		clearInterval(timer);
-		state.subagentResultAnimationTimer = undefined;
+		entry.state.subagentResultAnimationTimer = undefined;
 	}
 	resultAnimationTimers.clear();
 }
@@ -957,12 +971,16 @@ interface RenderRequestingContext {
 	ui: ExtensionContext["ui"] & { requestRender?: () => void };
 }
 
+// There is only ever one async-agents widget per host process, so the widget
+// ticker keeps its driving context/jobs in module-level singletons.
 let latestWidgetCtx: ExtensionContext | undefined;
 let latestWidgetJobs: AsyncJobState[] = [];
 let widgetTimer: ReturnType<typeof setInterval> | undefined;
 
 function hasAnimatedWidgetJobs(jobs: AsyncJobState[]): boolean {
-	return jobs.some((job) => job.status === "running");
+	// Animate while any job — or any of its nested steps — is still running so the
+	// header/step spinners never freeze before the work actually settles.
+	return jobs.some((job) => job.status === "running" || job.steps?.some((step) => step.status === "running"));
 }
 
 function refreshAnimatedWidget(): void {

--- a/test/unit/subagents-render-stability.test.ts
+++ b/test/unit/subagents-render-stability.test.ts
@@ -81,6 +81,9 @@ describe("subagent running spinner animation (issue #1084)", () => {
     assert.notEqual(second, first, "running spinner should advance after one animation interval");
   });
 
+  // NOTE: this invariant assumes the render path only consults Date.now() for
+  // time (which the tests mock). If elapsed-time labels ever start reading
+  // performance.now()/process.uptime(), this assertion would start to drift.
   test("renders within the same animation frame are identical (deterministic, no churn)", () => {
     const result = runningSingleResult();
     const frameStart = 10_000;
@@ -200,6 +203,22 @@ describe("subagent result animation timer lifecycle", () => {
     assert.equal(context.state.subagentResultAnimationTimer, undefined, "completed result must stop the animation timer");
   });
 
+  test("re-sync refreshes the invalidate callback used by the ticker", async () => {
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const state = {} as { subagentResultAnimationTimer?: ReturnType<typeof setInterval> };
+    syncResultAnimation(runningSingleResult(), { state, invalidate: () => firstCalls++ });
+    const timer = state.subagentResultAnimationTimer;
+    // Re-sync with the same (stable) state object but a fresh invalidate closure,
+    // mirroring the host handing us a new render context for the same renderable.
+    syncResultAnimation(runningSingleResult(), { state, invalidate: () => secondCalls++ });
+    assert.equal(state.subagentResultAnimationTimer, timer, "timer should be reused across re-sync");
+    await new Promise((resolve) => setTimeout(resolve, RUNNING_ANIMATION_MS * 3 + 40));
+    stopResultAnimations();
+    assert.equal(firstCalls, 0, "stale invalidate must not be called after re-sync");
+    assert.ok(secondCalls >= 1, `refreshed invalidate should fire, saw ${secondCalls}`);
+  });
+
   test("invokes invalidate on each animation tick", async () => {
     let ticks = 0;
     const context = {
@@ -224,6 +243,10 @@ describe("subagent result animation timer lifecycle", () => {
 });
 
 describe("subagent render stability invariants", () => {
+  afterEach(() => {
+    stopResultAnimations();
+  });
+
   test("widget render key is stable when only wall clock changes", () => {
     const job: AsyncJobState = {
       asyncId: "abc123",

--- a/test/unit/subagents-render-stability.test.ts
+++ b/test/unit/subagents-render-stability.test.ts
@@ -6,11 +6,14 @@ import {
   clearLegacyResultAnimationTimer,
   currentRunningFrame,
   renderSubagentResult,
+  renderWidget,
   RUNNING_ANIMATION_MS,
   stopResultAnimations,
+  stopWidgetAnimation,
   syncResultAnimation,
   widgetRenderKey,
 } from "../../packages/subagents/src/tui/render.js";
+import type { ExtensionContext } from "@bastani/atomic";
 import type { AsyncJobState, Details } from "../../packages/subagents/src/shared/types.js";
 
 type RenderTheme = Parameters<typeof renderSubagentResult>[2];
@@ -37,6 +40,11 @@ function withMockedNow<T>(now: number, run: () => T): T {
 
 function stripSpinnerChars(line: string): string {
   return [...line].filter((char) => !SPINNER_CHARS.has(char)).join("");
+}
+
+function firstSpinnerChar(text: string): string | undefined {
+  for (const char of text) if (SPINNER_CHARS.has(char)) return char;
+  return undefined;
 }
 
 function runningSingleResult(): AgentToolResult<Details> {
@@ -116,16 +124,24 @@ describe("subagent running spinner animation (issue #1084)", () => {
     assert.ok(changedLines > 0, "expected at least one spinner line to animate");
   });
 
-  test("running glyph cycles through every frame over a full period", () => {
+  test("running glyph cycles through frames in order over a full period", () => {
     const result = runningSingleResult();
-    const seen = new Set<string>();
-    const base = 0;
-    for (let frame = 0; frame < RUNNING_FRAMES.length; frame++) {
-      const out = withMockedNow(base + frame * RUNNING_ANIMATION_MS, () =>
+    const sequence: string[] = [];
+    for (let frame = 0; frame <= RUNNING_FRAMES.length; frame++) {
+      const out = withMockedNow(frame * RUNNING_ANIMATION_MS, () =>
         renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
-      for (const char of out) if (SPINNER_CHARS.has(char)) seen.add(char);
+      const glyph = firstSpinnerChar(out);
+      assert.ok(glyph, `expected a spinner glyph at frame ${frame}`);
+      sequence.push(glyph!);
     }
-    assert.equal(seen.size, RUNNING_FRAMES.length, "spinner should visit every frame across one full period");
+    // Every distinct frame is visited...
+    assert.equal(new Set(sequence).size, RUNNING_FRAMES.length, "spinner should visit every frame");
+    // ...and each step advances to the cyclic successor in RUNNING_FRAMES order.
+    for (let i = 1; i < sequence.length; i++) {
+      const prev = RUNNING_FRAMES.indexOf(sequence[i - 1]!);
+      const cur = RUNNING_FRAMES.indexOf(sequence[i]!);
+      assert.equal(cur, (prev + 1) % RUNNING_FRAMES.length, `frame ${i} did not advance by exactly one step`);
+    }
   });
 
   test("async widget spinner advances with wall clock for running jobs", () => {
@@ -239,6 +255,67 @@ describe("subagent result animation timer lifecycle", () => {
     assert.ok(context.state.subagentResultAnimationTimer);
     stopResultAnimations();
     assert.equal(context.state.subagentResultAnimationTimer, undefined);
+  });
+
+  test("a throwing invalidate tears the ticker down instead of crashing", async () => {
+    const context = {
+      state: {} as { subagentResultAnimationTimer?: ReturnType<typeof setInterval> },
+      invalidate: () => {
+        throw new Error("This extension ctx is stale after session replacement or reload");
+      },
+    };
+    syncResultAnimation(runningSingleResult(), context);
+    assert.ok(context.state.subagentResultAnimationTimer);
+    await new Promise((resolve) => setTimeout(resolve, RUNNING_ANIMATION_MS * 2 + 40));
+    assert.equal(context.state.subagentResultAnimationTimer, undefined, "a throwing tick must stop and clear its own timer");
+  });
+});
+
+describe("async widget animation ticker lifecycle", () => {
+  afterEach(() => {
+    stopWidgetAnimation();
+  });
+
+  function mockWidgetCtx(): { ctx: ExtensionContext; renders: () => number } {
+    let renderCount = 0;
+    const ctx = {
+      hasUI: true,
+      ui: {
+        setWidget: () => {},
+        getToolsExpanded: () => false,
+        requestRender: () => {
+          renderCount++;
+        },
+      },
+    } as unknown as ExtensionContext;
+    return { ctx, renders: () => renderCount };
+  }
+
+  function runningJob(): AsyncJobState {
+    return {
+      asyncId: "job1",
+      asyncDir: "/tmp/job1",
+      status: "running",
+      mode: "single",
+      agents: ["worker"],
+      updatedAt: 10_000,
+      lastActivityAt: 10_000,
+      toolCount: 1,
+      turnCount: 1,
+    };
+  }
+
+  test("running jobs drive periodic re-renders; finished jobs stop them", async () => {
+    const { ctx, renders } = mockWidgetCtx();
+    renderWidget(ctx, [runningJob()]);
+    await new Promise((resolve) => setTimeout(resolve, RUNNING_ANIMATION_MS * 3 + 40));
+    const whileRunning = renders();
+    assert.ok(whileRunning >= 1, `expected periodic widget re-renders while running, saw ${whileRunning}`);
+
+    renderWidget(ctx, [{ ...runningJob(), status: "complete" }]);
+    const afterStop = renders();
+    await new Promise((resolve) => setTimeout(resolve, RUNNING_ANIMATION_MS * 3 + 40));
+    assert.equal(renders(), afterStop, "widget ticker must stop once no job is running");
   });
 });
 

--- a/test/unit/subagents-render-stability.test.ts
+++ b/test/unit/subagents-render-stability.test.ts
@@ -1,7 +1,16 @@
-import { describe, test } from "bun:test";
+import { afterEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { clearLegacyResultAnimationTimer, renderSubagentResult, widgetRenderKey } from "../../packages/subagents/src/tui/render.js";
+import {
+  buildWidgetLines,
+  clearLegacyResultAnimationTimer,
+  currentRunningFrame,
+  renderSubagentResult,
+  RUNNING_ANIMATION_MS,
+  stopResultAnimations,
+  syncResultAnimation,
+  widgetRenderKey,
+} from "../../packages/subagents/src/tui/render.js";
 import type { AsyncJobState, Details } from "../../packages/subagents/src/shared/types.js";
 
 type RenderTheme = Parameters<typeof renderSubagentResult>[2];
@@ -11,6 +20,10 @@ const theme = {
   bg: (_name: string, value: string) => value,
   bold: (value: string) => value,
 } as unknown as RenderTheme;
+
+// Braille spinner frames used by the running glyph. Kept in sync with render.ts.
+const RUNNING_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_CHARS = new Set(RUNNING_FRAMES);
 
 function withMockedNow<T>(now: number, run: () => T): T {
   const originalNow = Date.now;
@@ -22,10 +35,146 @@ function withMockedNow<T>(now: number, run: () => T): T {
   }
 }
 
-describe("subagent render stability", () => {
-  test("running result glyph is progress-driven, not wall-clock-driven", () => {
-    const result: AgentToolResult<Details> = {
-      content: [{ type: "text", text: "running" }],
+function stripSpinnerChars(line: string): string {
+  return [...line].filter((char) => !SPINNER_CHARS.has(char)).join("");
+}
+
+function runningSingleResult(): AgentToolResult<Details> {
+  return {
+    content: [{ type: "text", text: "running" }],
+    details: {
+      mode: "single",
+      results: [{
+        agent: "worker",
+        task: "do work",
+        exitCode: 0,
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+        progress: {
+          agent: "worker",
+          index: 0,
+          status: "running",
+          task: "do work",
+          durationMs: 2_000,
+          toolCount: 1,
+          tokens: 10,
+          recentTools: [],
+          recentOutput: [],
+        },
+      }],
+    },
+  };
+}
+
+describe("subagent running spinner animation (issue #1084)", () => {
+  afterEach(() => {
+    stopResultAnimations();
+  });
+
+  test("running glyph advances with wall clock (no longer frozen)", () => {
+    const result = runningSingleResult();
+
+    // Two renders exactly one animation frame apart must differ: the spinner
+    // is driven by wall-clock time, not by progress data changes.
+    const first = withMockedNow(10_000, () => renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
+    const second = withMockedNow(10_000 + RUNNING_ANIMATION_MS, () => renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
+
+    assert.notEqual(second, first, "running spinner should advance after one animation interval");
+  });
+
+  test("renders within the same animation frame are identical (deterministic, no churn)", () => {
+    const result = runningSingleResult();
+    const frameStart = 10_000;
+
+    const a = withMockedNow(frameStart, () => renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
+    const b = withMockedNow(frameStart + RUNNING_ANIMATION_MS - 1, () => renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
+
+    assert.equal(b, a, "renders inside the same animation frame must be byte-identical");
+  });
+
+  test("consecutive frames differ only in spinner glyph cells (minimal diff = no flicker)", () => {
+    const result = runningSingleResult();
+
+    const firstLines = withMockedNow(10_000, () => renderSubagentResult(result, { expanded: false }, theme).render(120));
+    const secondLines = withMockedNow(10_000 + RUNNING_ANIMATION_MS, () => renderSubagentResult(result, { expanded: false }, theme).render(120));
+
+    assert.equal(firstLines.length, secondLines.length, "line count must stay stable across animation frames");
+
+    let changedLines = 0;
+    for (let i = 0; i < firstLines.length; i++) {
+      if (firstLines[i] === secondLines[i]) continue;
+      changedLines++;
+      // The only thing that may change between frames is the spinner glyph.
+      assert.equal(
+        stripSpinnerChars(firstLines[i]!),
+        stripSpinnerChars(secondLines[i]!),
+        `line ${i} changed in non-spinner content between animation frames`,
+      );
+    }
+    assert.ok(changedLines > 0, "expected at least one spinner line to animate");
+  });
+
+  test("running glyph cycles through every frame over a full period", () => {
+    const result = runningSingleResult();
+    const seen = new Set<string>();
+    const base = 0;
+    for (let frame = 0; frame < RUNNING_FRAMES.length; frame++) {
+      const out = withMockedNow(base + frame * RUNNING_ANIMATION_MS, () =>
+        renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
+      for (const char of out) if (SPINNER_CHARS.has(char)) seen.add(char);
+    }
+    assert.equal(seen.size, RUNNING_FRAMES.length, "spinner should visit every frame across one full period");
+  });
+
+  test("async widget spinner advances with wall clock for running jobs", () => {
+    const job: AsyncJobState = {
+      asyncId: "abc123",
+      asyncDir: "/tmp/abc123",
+      status: "running",
+      mode: "single",
+      agents: ["worker"],
+      updatedAt: 10_000,
+      lastActivityAt: 10_000,
+      toolCount: 1,
+      turnCount: 2,
+    };
+    const first = withMockedNow(10_000, () => buildWidgetLines([job], theme, 120).join("\n"));
+    const second = withMockedNow(10_000 + RUNNING_ANIMATION_MS, () => buildWidgetLines([job], theme, 120).join("\n"));
+    assert.notEqual(second, first, "running async widget spinner should animate over wall-clock time");
+  });
+
+  test("currentRunningFrame advances one step per animation interval", () => {
+    const f0 = currentRunningFrame(1_000_000);
+    const f1 = currentRunningFrame(1_000_000 + RUNNING_ANIMATION_MS);
+    const fSame = currentRunningFrame(1_000_000 + RUNNING_ANIMATION_MS - 1);
+    assert.equal(f1 - f0, 1);
+    assert.equal(fSame, f0);
+  });
+});
+
+describe("subagent result animation timer lifecycle", () => {
+  afterEach(() => {
+    stopResultAnimations();
+  });
+
+  test("starts an invalidate ticker for running results and is idempotent", () => {
+    const context = { state: {} as { subagentResultAnimationTimer?: ReturnType<typeof setInterval> }, invalidate: () => {} };
+
+    syncResultAnimation(runningSingleResult(), context);
+    const timer = context.state.subagentResultAnimationTimer;
+    assert.ok(timer, "expected a running result to start an animation timer");
+
+    // Calling again with a still-running result must not spawn a second timer.
+    syncResultAnimation(runningSingleResult(), context);
+    assert.equal(context.state.subagentResultAnimationTimer, timer, "timer should be reused while still running");
+  });
+
+  test("stops the ticker when the result is no longer running", () => {
+    const context = { state: {} as { subagentResultAnimationTimer?: ReturnType<typeof setInterval> }, invalidate: () => {} };
+    syncResultAnimation(runningSingleResult(), context);
+    assert.ok(context.state.subagentResultAnimationTimer);
+
+    const finished: AgentToolResult<Details> = {
+      content: [{ type: "text", text: "done" }],
       details: {
         mode: "single",
         results: [{
@@ -36,7 +185,7 @@ describe("subagent render stability", () => {
           progress: {
             agent: "worker",
             index: 0,
-            status: "running",
+            status: "completed",
             task: "do work",
             durationMs: 2_000,
             toolCount: 1,
@@ -47,13 +196,34 @@ describe("subagent render stability", () => {
         }],
       },
     };
-
-    const first = withMockedNow(10_000, () => renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
-    const second = withMockedNow(10_080, () => renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n"));
-
-    assert.equal(second, first);
+    syncResultAnimation(finished, context);
+    assert.equal(context.state.subagentResultAnimationTimer, undefined, "completed result must stop the animation timer");
   });
 
+  test("invokes invalidate on each animation tick", async () => {
+    let ticks = 0;
+    const context = {
+      state: {} as { subagentResultAnimationTimer?: ReturnType<typeof setInterval> },
+      invalidate: () => {
+        ticks++;
+      },
+    };
+    syncResultAnimation(runningSingleResult(), context);
+    await new Promise((resolve) => setTimeout(resolve, RUNNING_ANIMATION_MS * 3 + 40));
+    stopResultAnimations();
+    assert.ok(ticks >= 1, `expected the animation ticker to fire at least once, saw ${ticks}`);
+  });
+
+  test("stopResultAnimations clears all timers", () => {
+    const context = { state: {} as { subagentResultAnimationTimer?: ReturnType<typeof setInterval> }, invalidate: () => {} };
+    syncResultAnimation(runningSingleResult(), context);
+    assert.ok(context.state.subagentResultAnimationTimer);
+    stopResultAnimations();
+    assert.equal(context.state.subagentResultAnimationTimer, undefined);
+  });
+});
+
+describe("subagent render stability invariants", () => {
   test("widget render key is stable when only wall clock changes", () => {
     const job: AsyncJobState = {
       asyncId: "abc123",


### PR DESCRIPTION
## Summary

Fixes the subagent running spinner freezing/stuttering and TUI flickering during subagent execution ([#1084](https://github.com/flora131/atomic/issues/1084)). The spinner glyph was driven solely by incoming progress data, so it only advanced when data arrived — a regression from the v0.25.0 upstream sync. This PR restores smooth, continuous animation by driving the glyph from wall-clock time rather than data arrival rate, while keeping per-frame diffs limited to the spinner glyph cell so the differential renderer never needs a full-screen clear.

## Root Cause

`runningGlyph` used a pure progress seed with no wall-clock component. If no new progress events arrived (e.g. during a long-running tool call), the seed stayed constant and the spinner froze. The fix folds `Math.floor(Date.now() / 80ms)` into the seed so every active spinner always advances, independent of data flow.

## Changes

### `packages/subagents/src/tui/render.ts`

- **`RUNNING_ANIMATION_MS = 80`** — exported cadence constant (ms per frame) shared by spinner derivation and all animation timers
- **`currentRunningFrame(now?)`** — new exported helper mapping wall-clock time to an animation frame index; exposed for deterministic test overrides
- **`runningGlyph`** — folds `currentRunningFrame()` into the progress seed so every running spinner always animates; the seed only phase-offsets concurrent agents from each other
- **`syncResultAnimation(result, context)`** — starts/maintains/stops a per-result `setInterval` that calls `context.invalidate()` while the result is running; timers are globally tracked in `resultAnimationTimers` for bulk teardown; all timers are `unref`'d; re-sync refreshes the `invalidate` callback without spawning a new timer; errors in `invalidate` are caught and tear down the timer instead of crashing the host
- **`stopResultAnimations()`** — bulk-clears every tracked result timer; called on `runtimeCleanup` and `session_shutdown`
- **`clearLegacyResultAnimationTimer`** — preserved as a thin shim over the internal `stopResultAnimation` for backward-compat call sites
- **`LiveWidgetComponent`** (new class) — replaces the static `buildWidgetComponent` factory for the async-agents widget; recomputes lines on every `render()` call so the wall-clock-driven glyph and elapsed-time labels stay live without caching stale output
- **`ensureWidgetAnimation` / `stopWidgetAnimation`** — module-level singleton ticker for the async-agents widget; auto-stops when no jobs are animating; `latestWidgetCtx`/`latestWidgetJobs` singletons let the ticker always target the most-recent render context
- **`renderWidget`** — wires up `LiveWidgetComponent` and the widget ticker; calls `stopWidgetAnimation` when the job list empties or the UI is unavailable

### `packages/subagents/src/extension/index.ts`

- **`createSlashResultComponent`** — accepts a new `requestRender` callback and calls `syncResultAnimation` inside its `render` method so slash-result-card spinners stay alive while the agent runs and stop once it settles
- **`renderResult` hook** — calls `syncResultAnimation` (replacing the previous `clearLegacyResultAnimationTimer` no-op path)
- **`runtimeCleanup` / `session_shutdown`** — both now call `stopWidgetAnimation()` and `stopResultAnimations()` to ensure all timers are torn down on extension unload or session replacement

### `test/unit/subagents-render-stability.test.ts`

New test groups covering the fixed behaviour:

- **"subagent running spinner animation (issue #1084)"**
  - Spinner advances after one animation interval (wall-clock driven)
  - Renders within the same animation frame are byte-identical (no churn)
  - Consecutive frames differ only in spinner glyph cells (minimal diff → no flicker)
  - Glyph cycles through all 10 Braille frames across one full period
  - Async-widget spinner also advances with wall clock for running jobs
  - `currentRunningFrame` advances exactly one step per `RUNNING_ANIMATION_MS`

- **"subagent result animation timer lifecycle"**
  - `syncResultAnimation` starts a ticker for running results and is idempotent
  - Timer is stopped when the result transitions to a completed state
  - Re-sync refreshes the `invalidate` callback without spawning a second timer
  - Ticker fires `invalidate` on each interval tick
  - A throwing `invalidate` tears down its own timer instead of crashing the host
  - `stopResultAnimations` clears all tracked timers at once

- **"async widget animation ticker lifecycle"**
  - Running jobs drive periodic re-renders; finished jobs stop the ticker

## No-Flicker Guarantee

Per-frame diffs stay limited to the spinner glyph cell, so the differential renderer always does partial redraws without needing a full-screen clear (`\x1b[2J`). Verified in a real TUI session (tmux, 100×28) with `PI_TUI_WRITE_LOG`/`PI_DEBUG_REDRAW` showing **0 full-screen clears** before and after.

## Test Results

- `bun run typecheck` ✓
- `bun run lint` ✓
- `bun run test:unit` ✓ (1675 tests)
- `bun run test:integration` ✓ (211 tests)

Closes #1084