### PR TITLE
chore(release): bump version to 0.8.20-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.19",
+      "version": "0.8.20-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.19",
+      "version": "0.8.20-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.19",
+      "version": "0.8.20-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.19",
+      "version": "0.8.20-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.19",
+      "version": "0.8.20-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.19",
+      "version": "0.8.20-0",
       "dependencies": {
         "jiti": "^2.7.0",
       },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.20-0] - 2026-05-29
+
 ### Added
 
 - Added session-scoped `orchestrationContext` support to SDK agent sessions and extension contexts for workflow-stage policy enforcement.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.19",
+  "version": "0.8.20-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.19",
+  "version": "0.8.20-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.20-0] - 2026-05-29
+
 ### Changed
 - Bumped `@modelcontextprotocol/ext-apps` to 1.7.2 to align with the pi 0.77.0 upgrade.
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.19",
+  "version": "0.8.20-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [Unreleased]
 
+## [0.8.20-0] - 2026-05-29
+
 ### Fixed
 
 - Fixed the subagent running spinner freezing/stuttering and the surrounding TUI flickering while subagents run: the running glyph is now driven by wall-clock time with a steady re-render ticker (result cards, slash result cards, and the async-agents widget), so it animates smoothly and continuously instead of only advancing when progress data changes. Per-frame diffs stay limited to the spinner glyph cell, so the differential renderer keeps doing partial redraws (no full-screen clear / flicker), and the ticker is torn down on completion, reload, and session shutdown ([#1084](https://github.com/flora131/atomic/issues/1084)).
 - Moved the async-agents (background subagent) widget from above the editor to below it (`belowEditor`). The widget animates a running glyph and elapsed labels every tick; pi-tui full-clears the screen+scrollback whenever a changed line sits above the viewport fold, so an above-editor widget flickered once the bottom region grew tall and pushed it above the fold. Rendering below the editor keeps the live line within the bottom viewport (flicker-free) and matches the workflow companion widget's placement ([#1109](https://github.com/flora131/atomic/issues/1109)).
 - Hardened workflow-stage subagent guard propagation tests with an internal executor runtime DI seam ([#1088](https://github.com/flora131/atomic/issues/1088)).
 - Capped subagent fanout spawned from workflow stages to a single child level with a workflow-specific nested-subagent error.
+- Fixed builtin subagent skill resolution from project cwd ([#1087](https://github.com/flora131/atomic/issues/1087)).
 
 ## [0.24.3] - 2026-05-14
 
@@ -17,12 +20,6 @@
 
 ### Fixed
 - Let `async: true` chain tool calls run in the background when `clarify` is omitted, and avoid showing the async badge for explicit foreground clarify runs.
-
-## [Unreleased]
-
-### Fixed
-- Fixed builtin subagent skill resolution from project cwd ([#1087](https://github.com/flora131/atomic/issues/1087)).
-- Capped subagent fanout spawned from workflow stages to a single child level with a workflow-specific nested-subagent error.
 
 ## [0.8.18] - 2026-05-27
 

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.19",
+  "version": "0.8.20-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.20-0] - 2026-05-29
+
 ### Changed
 - Bumped `linkedom` to 0.18.12 to align with the pi 0.77.0 upgrade.
 

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.19",
+  "version": "0.8.20-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.20-0] - 2026-05-29
+
 ### Added
 
 - Added main-chat lifecycle steer notices for workflow completion, failure, and awaiting-input pauses with global notification config controls ([#1085](https://github.com/flora131/atomic/issues/1085)).

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.19",
+  "version": "0.8.20-0",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes all workspace packages from `0.8.19` to `0.8.20-0`, advances `[Unreleased]` CHANGELOG entries into versioned `[0.8.20-0] - 2026-05-29` sections, and refreshes `bun.lock`.

## Key Changes

- **Version bump**: all `packages/*/package.json` files updated from `0.8.19` → `0.8.20-0` via `bun run scripts/bump-version.ts 0.8.20-0`
- **CHANGELOG promotions**: each package's `[Unreleased]` block promoted to a new `## [0.8.20-0] - 2026-05-29` section
- **subagents CHANGELOG fix**: merged two malformed `[Unreleased]` blocks into a single `[0.8.20-0]` section (deduped the repeated fanout cap entry; `[0.24.3]` left in place)
- **bun.lock refresh**: lockfile updated to reflect new workspace versions

## Package CHANGELOG Highlights

### `@bastani/atomic` (coding-agent)
- Added session-scoped `orchestrationContext` SDK support for workflow-stage policy enforcement
- Added Claude Opus 4.8 model support
- Upgraded to pi 0.77.0 runtime
- Fixed footer/widget ordering

### `@bastani/mcp`
- Bumped `@modelcontextprotocol/ext-apps` to 1.7.2 to align with pi 0.77.0

### `@bastani/subagents`
- Fixed subagent running spinner freezing/stuttering and surrounding TUI flickering ([#1084](https://github.com/flora131/atomic/issues/1084))
- Moved async-agents widget below the editor to eliminate viewport-fold flicker ([#1109](https://github.com/flora131/atomic/issues/1109))
- Hardened workflow-stage subagent guard propagation tests ([#1088](https://github.com/flora131/atomic/issues/1088))
- Capped subagent fanout from workflow stages to a single child level
- Fixed builtin subagent skill resolution from project cwd ([#1087](https://github.com/flora131/atomic/issues/1087))

### `@bastani/web-access`
- Bumped `linkedom` to 0.18.12 to align with pi 0.77.0

### `@bastani/workflows`
- Added main-chat lifecycle steer notices for workflow completion, failure, and awaiting-input pauses ([#1085](https://github.com/flora131/atomic/issues/1085))
- Fixed companion-counter/notice flicker and narrow-terminal crash
- Added non-interactive mode disablement and terminal-run retention

### `@bastani/intercom`
- Version-only bump (no new changes in this cycle)

## Release Mechanics

1. Versions bumped via `bun run scripts/bump-version.ts 0.8.20-0`
2. `bun install` refreshed `bun.lock`
3. Tag `v0.8.20-0` will be pushed after merge to trigger the publish workflow