### PR TITLE
chore(release): bump version to 0.8.20

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.20] - 2026-05-29
+
+### Changed
+
+- Promoted the 0.8.20 prerelease changes to a stable release.
+
 ## [0.8.20-0] - 2026-05-29
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.20-0",
+  "version": "0.8.20",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.20-0",
+  "version": "0.8.20",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.20] - 2026-05-29
+
+### Changed
+- Promoted the 0.8.20 prerelease changes to a stable release.
+
 ## [0.8.20-0] - 2026-05-29
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.20-0",
+  "version": "0.8.20",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.8.20] - 2026-05-29
+
+### Changed
+- Promoted the 0.8.20 prerelease changes to a stable release.
+
 ## [0.8.20-0] - 2026-05-29
 
 ### Fixed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.20-0",
+  "version": "0.8.20",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.20] - 2026-05-29
+
+### Changed
+- Promoted the 0.8.20 prerelease changes to a stable release.
+
 ## [0.8.20-0] - 2026-05-29
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.20-0",
+  "version": "0.8.20",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.20] - 2026-05-29
+
+### Changed
+
+- Promoted the 0.8.20 prerelease changes to a stable release.
+
 ## [0.8.20-0] - 2026-05-29
 
 ### Added

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.20-0",
+  "version": "0.8.20",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the \`0.8.20-0\` prerelease to the stable \`0.8.20\` release across all workspace packages. Bumps \`package.json\` versions and adds stable-release CHANGELOG entries following the established promotion pattern.

## Changes

- **Version bumps** (\`0.8.20-0\` → \`0.8.20\`) in all workspace \`package.json\` files:
  - \`@bastani/atomic\` (coding-agent)
  - \`@bastani/mcp\`
  - \`@bastani/subagents\`
  - \`@bastani/web-access\`
  - \`@bastani/workflows\`
  - \`@bastani/intercom\` (version-only bump; no unreleased changes)
- **CHANGELOG** — added \`## [0.8.20] - 2026-05-29\` stable-promotion section to: coding-agent, mcp, subagents, web-access, workflows (intercom omitted — empty \`[Unreleased]\`)

## Mechanics

- Versions bumped via \`bun run scripts/bump-version.ts 0.8.20\`
- \`bun.lock\` unchanged (consistent with prior stable-release commits)
- Tag \`v0.8.20\` will be pushed after merge to trigger the publish workflow and move npm \`latest\` → \`0.8.20\`

## Notes

No code changes — this is a pure version promotion from the prerelease published in #1114. Follows the same stable-promotion pattern as \`0.8.15\`–\`0.8.18\`.