### PR TITLE
fix(workflows): freeze elapsed-time in tool-result status cards (fixes whole-screen flicker)

### DIFF
--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -2284,14 +2284,23 @@ function factory(pi: ExtensionAPI): void {
       },
       renderCall: (args, _theme, _context) =>
         dynamicTextRenderComponent((width) => renderCall(args, { width })),
-      renderResult: (result, opts, _theme, context) =>
-        dynamicTextRenderComponent((width) =>
+      renderResult: (result, opts, _theme, context) => {
+        // Capture wall-clock ONCE per chat entry. The lambda below is
+        // invoked on every TUI re-render; without a captured `now`, every
+        // tick would recompute elapsed/running durations and trigger
+        // pi-tui's full-redraw path for any entry above the viewport —
+        // visible as whole-screen flicker on terminals without
+        // synchronized output support (e.g. mosh).
+        const capturedNow = Date.now();
+        return dynamicTextRenderComponent((width) =>
           renderResult(result.details, {
             ...opts,
             width,
+            now: capturedNow,
             runInputs: (context as { args?: WorkflowToolArgs }).args?.inputs,
           }),
-        ),
+        );
+      },
     });
   }
 

--- a/packages/workflows/src/extension/render-result.ts
+++ b/packages/workflows/src/extension/render-result.ts
@@ -161,6 +161,15 @@ export interface RenderResultOpts {
    * When false/undefined the canonical Catppuccin chrome is rendered.
    */
   plain?: boolean;
+  /**
+   * Stable wall-clock used for elapsed-time labels in scrollback. Capture
+   * once when the chat entry is created so subsequent host re-renders do
+   * not silently tick `elapsed` / `running` durations — every off-viewport
+   * tick forces pi-tui's full-redraw path (CSI 2J + CSI H + CSI 3J) and
+   * is visible as whole-screen flicker under terminal emulators that do
+   * not implement synchronized output (e.g. mosh).
+   */
+  now?: number;
 }
 
 /**
@@ -227,6 +236,7 @@ export function renderResult(result: WorkflowToolResult, opts?: RenderResultOpts
       return renderStatusList(r.snapshots, {
         theme: themed ? deriveGraphTheme({}) : undefined,
         width: opts?.width,
+        now: opts?.now,
       });
     }
 
@@ -239,6 +249,7 @@ export function renderResult(result: WorkflowToolResult, opts?: RenderResultOpts
       return renderRunDetail(r.detail, {
         theme: themed ? deriveGraphTheme({}) : undefined,
         width: opts?.width,
+        now: opts?.now,
       });
     }
 

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -486,6 +486,31 @@ describe("renderResult — run variant", () => {
     assert.ok(out.includes("wf"));
     assert.match(out, /running/);
   });
+
+  test("renderResult honours opts.now so scrollback entries don't tick on host re-renders", () => {
+    const snapshot = {
+      id: "run-1-uuid",
+      name: "wf-tick-test",
+      inputs: {},
+      status: "running" as const,
+      stages: [],
+      startedAt: 0,
+    };
+    const first = renderResult({ action: "status", snapshots: [snapshot] }, { now: 60_000, plain: true });
+    const second = renderResult({ action: "status", snapshots: [snapshot] }, { now: 120_000, plain: true });
+    assert.notEqual(
+      first,
+      second,
+      "sanity: differing opts.now must produce differing output (proves elapsed is sensitive to the param)",
+    );
+    const stableFirst = renderResult({ action: "status", snapshots: [snapshot] }, { now: 60_000, plain: true });
+    const stableSecond = renderResult({ action: "status", snapshots: [snapshot] }, { now: 60_000, plain: true });
+    assert.equal(
+      stableFirst,
+      stableSecond,
+      "workflow tool result must be stable when opts.now is captured once per chat entry",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix intermittent whole-screen flicker / scroll-back-and-forth in the TUI during long sessions, especially under terminals that don't support synchronized output (notably mosh).

Fixes #1121.

## Root cause

When the agent invokes the `workflow` tool with `action: "status"` or `"statusDetail"`, the resulting card is rendered into chat scrollback via:

```ts
// packages/workflows/src/extension/index.ts:2289 (before)
renderResult: (result, opts, _theme, context) =>
  dynamicTextRenderComponent((width) =>
    renderResult(result.details, {
      ...opts,
      width,
      runInputs: (context as { args?: WorkflowToolArgs }).args?.inputs,
    }),
  ),
```

The lambda passed to `dynamicTextRenderComponent` runs **on every TUI render**. `renderResult` (in `extension/render-result.ts`) called `renderStatusList` / `renderRunDetail` without a captured `now`, so those helpers fell through to `Date.now()` in `elapsedRunMs` / `elapsedStageMs`. The card's `elapsed` / stage-`running` lines therefore mutated every render.

Because those lines sit above the viewport in long sessions, pi-tui's `TUI.doRender()` diff takes the full-redraw branch (`CSI 2J` + `CSI H` + `CSI 3J` + replay-all-lines). Mosh doesn't implement `?2026` synchronized output, so the replay is visible as a screen-wide flicker every ~80 ms.

## Fix

Capture wall-clock **once** when the chat entry is created, thread it through `RenderResultOpts.now`, and pass it down to the inner renderers. Three small edits:

1. **`packages/workflows/src/extension/render-result.ts`** — add optional `now?: number` to `RenderResultOpts`; pass `opts.now` to `renderStatusList` and `renderRunDetail`.
2. **`packages/workflows/src/extension/index.ts`** — capture `const capturedNow = Date.now()` outside the per-render lambda and pass it as `opts.now`. The lambda re-runs every render but now sees a stable timestamp.
3. **`test/unit/runtime.test.ts`** — regression test: two `renderResult(..., { now: 60_000 })` invocations produce byte-identical output; two invocations with differing `now` produce differing output (sanity).

The slash-command path (`packages/workflows/src/tui/chat-surface-message.ts`) was already covered by a prior `capturedAt` mechanism and is unchanged here. This PR fixes the parallel tool-result path.

## Verification

- **Negative control:** the new regression test fails on `main`, passes with the fix.
- **End-to-end:** captured `PI_DEBUG_REDRAW=1` before the fix → `fullRender: firstChanged < viewportTop (527 < N)` firing every ~80 ms with `firstChanged` always 527 or 530. After the fix → zero such firings during streaming/typing in the same mosh+tmux session.
- **Test suite:** `bun run test:unit` → 1695/1695 pass. `bun run typecheck` → clean. `bun run lint` → clean.

## Notes for reviewers

- I did not touch pi-tui. The fix is in the application layer.
- Worth flagging as separate follow-ups (not in this PR):
  - Any other extension that registers a `renderResult` slot using `dynamicTextRenderComponent` and reads wall-clock time directly is susceptible to the same pattern.
  - Upstream pi-tui: `TUI.doRender()` triggering a full screen clear on any off-viewport diff is hostile to terminals without `?2026`. A viewport-windowed diff or a capability-probed unconditional `?2026` emit would help.
