### PR TITLE
fix(skills): allow frontmatter names to differ from directory names

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,14 +12,14 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.20-0",
+      "version": "0.8.20",
       "bin": {
         "atomic": "dist/cli.js",
       },
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.77.0",
-        "@earendil-works/pi-ai": "^0.77.0",
-        "@earendil-works/pi-tui": "^0.77.0",
+        "@earendil-works/pi-agent-core": "^0.78.0",
+        "@earendil-works/pi-ai": "^0.78.0",
+        "@earendil-works/pi-tui": "^0.78.0",
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@mozilla/readability": "^0.6.0",
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.20-0",
+      "version": "0.8.20",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.20-0",
+      "version": "0.8.20",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.20-0",
+      "version": "0.8.20",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.20-0",
+      "version": "0.8.20",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.20-0",
+      "version": "0.8.20",
       "dependencies": {
         "jiti": "^2.7.0",
       },
@@ -219,11 +219,11 @@
 
     "@bastani/workflows": ["@bastani/workflows@workspace:packages/workflows"],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.77.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.77.0", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-l/mYLJPjpgiPDmcfnFIGdOBqICkWaf8IawCdAbae5guBrPXg+Z0o84l9OuHyRJPOb8RfedeGg8DtSnq8t7grOg=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.78.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.78.0", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-xhWd59Qzd8yO88gYQw2S4dEQstJJEiUtxRP01//YzVJ61jCtUASMfcyAmYhgGYR4Onp7GmwEAbBBGOiV6Iwk9g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.77.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-H21BrQDPf3ydaeBmS5maNDHxUGFMiKBF/n3WnE+OTWloIZSayeL+/NVEgG3aKQw8fZL6HAMYAGpUIVJgFuKtnw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.78.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.77.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-QV/eYtcT3hM9pJjLCkjUFOUmgAm4GPzJ0K4kofVq9+BGU7wNJVzflTO4VY2tYpaI4VSo6A5Hsuw00wY/CDmY/Q=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.78.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the pi runtime packages (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui`) to 0.78.0 and aligned skill name validation with upstream pi so frontmatter names no longer need to match parent directory names ([#1124](https://github.com/flora131/atomic/issues/1124)).
+
 ## [0.8.20] - 2026-05-29
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -48,9 +48,9 @@
     "prepublishOnly": "bun run clean && bun run build"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.77.0",
-    "@earendil-works/pi-ai": "^0.77.0",
-    "@earendil-works/pi-tui": "^0.77.0",
+    "@earendil-works/pi-agent-core": "^0.78.0",
+    "@earendil-works/pi-ai": "^0.78.0",
+    "@earendil-works/pi-tui": "^0.78.0",
     "@modelcontextprotocol/ext-apps": "^1.7.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@mozilla/readability": "^0.6.0",

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -89,12 +89,8 @@ export interface LoadSkillsResult {
  * Validate skill name per Agent Skills spec.
  * Returns array of validation error messages (empty if valid).
  */
-function validateName(name: string, parentDirName: string): string[] {
+function validateName(name: string): string[] {
 	const errors: string[] = [];
-
-	if (name !== parentDirName) {
-		errors.push(`name "${name}" does not match parent directory "${parentDirName}"`);
-	}
 
 	if (name.length > MAX_NAME_LENGTH) {
 		errors.push(`name exceeds ${MAX_NAME_LENGTH} characters (${name.length})`);
@@ -300,7 +296,7 @@ function loadSkillFromFile(
 		const name = frontmatter.name || parentDirName;
 
 		// Validate name
-		const nameErrors = validateName(name, parentDirName);
+		const nameErrors = validateName(name);
 		for (const error of nameErrors) {
 			diagnostics.push({ type: "warning", message: error, path: filePath });
 		}

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -41,7 +41,7 @@ describe("skills", () => {
 			expect(diagnostics).toHaveLength(0);
 		});
 
-		it("should warn when name doesn't match parent directory", () => {
+		it("should allow skill names that differ from the parent directory", () => {
 			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: join(fixturesDir, "name-mismatch"),
 				source: "test",
@@ -51,7 +51,7 @@ describe("skills", () => {
 			expect(skills[0].name).toBe("different-name");
 			expect(
 				diagnostics.some((d: ResourceDiagnostic) => d.message.includes("does not match parent directory")),
-			).toBe(true);
+			).toBe(false);
 		});
 
 		it("should warn when name contains invalid characters", () => {

--- a/test/integration/overlay-entrypoints.test.ts
+++ b/test/integration/overlay-entrypoints.test.ts
@@ -1068,7 +1068,7 @@ describe("buildGraphOverlayAdapter — animation tick visibility gating", () => 
     // enough that a single wall-clock sleep observes only one interval turn.
     // Poll across scheduler turns instead of assuming 250ms means two ticks.
     try {
-      await waitForRenderCount(() => renderCalls, 2);
+      await waitForRenderCount(() => renderCalls, 2, 200, 25);
       assert.ok(
         renderCalls >= 2,
         `expected tui.requestRender to fire on the animation tick (got ${renderCalls})`,
@@ -1076,7 +1076,7 @@ describe("buildGraphOverlayAdapter — animation tick visibility gating", () => 
     } finally {
       component!.dispose?.();
     }
-  });
+  }, 15_000);
 
   test("requestRender suppresses tui.requestRender while overlay is hidden", async () => {
     const runId = `tick-hidden-${Date.now()}`;


### PR DESCRIPTION
## Summary

Removes the validation that required a skill's frontmatter \`name\` to match its parent directory name, aligning with upstream pi v0.78.0 behavior. Skills with scoped or bundled names (where the frontmatter name intentionally differs from the directory) now load without warnings.

Closes #1124

## Changes

### Core fix
- **`packages/coding-agent/src/core/skills.ts`**: Removed the \`name !== parentDirName\` equality check from \`validateName\`. The function no longer requires \`parentDirName\` as a parameter, simplifying the call site as well.

### Tests
- **`packages/coding-agent/test/skills.test.ts`**: Updated the \`name-mismatch\` regression test to assert the mismatch is *accepted* (no warning produced), inverting the previous expectation.
- **`test/integration/overlay-entrypoints.test.ts`**: Hardened animation tick timing in the overlay entrypoint integration test — added explicit poll interval/timeout parameters to \`waitForRenderCount\` and a 15 s test-level timeout to prevent flakiness on slow CI runners.

### Dependencies
- **`packages/coding-agent/package.json`**: Bumped \`@earendil-works/pi-agent-core\`, \`@earendil-works/pi-ai\`, and \`@earendil-works/pi-tui\` from \`^0.77.0\` to \`^0.78.0\`.
- **`bun.lock`**: Refreshed to resolve updated pi runtime packages and promote all workspace package versions from \`0.8.20-0\` to \`0.8.20\`.

### Changelog
- **\`packages/coding-agent/CHANGELOG.md\`**: Added \`[Unreleased] → Changed\` entry documenting the validation removal and pi 0.78.0 runtime upgrade.

## Validation

- \`bun --cwd packages/coding-agent test test/skills.test.ts\` — passes
- \`bun run typecheck\` — no errors
- \`bun run lint\` — clean
- \`bun run test:unit\` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)