### PR TITLE
docs: remove terminal compatibility prerequisite from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@
 - **Node.js 24 LTS or newer** — Atomic requires the latest Node LTS runtime. Check with `node --version`.
 - **A package manager** — use npm (included with Node), pnpm, Yarn, or Bun. Use Bun 1.3.14+ for Bun installs or workflow-authoring examples.
 - **Model-provider access** — bring an API key or sign in with `/login` after startup.
-- **A compatible terminal** — for the best TUI experience, use a terminal with Kitty keyboard protocol support. See [Terminal setup](./packages/coding-agent/docs/terminal-setup.md). On Windows, use Git Bash or WSL.
 
 ### Install
 


### PR DESCRIPTION
## Summary

Removes the terminal compatibility requirement from the README prerequisites section, as it is no longer necessary to call out a compatible terminal as a prerequisite.

## Changes

- Removed the bullet point recommending a terminal with Kitty keyboard protocol support from the Prerequisites section in `README.md`