### PR TITLE
docs: update quickstart prerequisites

### DIFF
--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -6,8 +6,7 @@ This page gets you from install to a useful first Atomic session.
 
 - **Node.js 24 LTS or newer** — Atomic requires the latest Node LTS runtime. Check with `node --version`.
 - **A package manager** — use npm (included with Node), pnpm, Yarn, or Bun. Use Bun 1.3.14+ for Bun installs or workflow-authoring examples.
-- **Model-provider access** — bring an API key or sign in with `/login` after startup.
-- **A compatible terminal** — for the best TUI experience, use a terminal with Kitty keyboard protocol support. See [Terminal setup](/terminal-setup). On Windows, use Git Bash or WSL.
+- **Model-provider access** — Use `/login` after startup. Supports provider subscriptions and APIs.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Simplifies the quickstart prerequisites section by streamlining model-provider guidance and removing the terminal compatibility requirement.

## Changes

- **Model-provider access**: Replaced the dual-path description ("bring an API key or sign in with `/login`") with a single, cleaner directive — "Use `/login` after startup. Supports provider subscriptions and APIs." This reduces ambiguity for new users.
- **Terminal compatibility**: Removed the separate prerequisite line about Kitty keyboard protocol support and platform-specific terminal recommendations (Git Bash / WSL). This reduces onboarding friction for users on non-standard terminals.

## Notes

- No functional or API changes — documentation only.
- Pre-commit hooks passed, including `bun run lint` and `bun run test:unit`.