### PR TITLE
chore(release): bump version to 0.8.21

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.21] - 2026-05-30
+
+### Changed
+
+- Promoted the 0.8.21 prerelease changes to a stable release.
+
 ## [0.8.21-0] - 2026-05-30
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.21-0",
+  "version": "0.8.21",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.21-0",
+  "version": "0.8.21",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.21-0",
+  "version": "0.8.21",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.21-0",
+  "version": "0.8.21",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.21-0",
+  "version": "0.8.21",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.21] - 2026-05-30
+
+### Changed
+
+- Promoted the 0.8.21 prerelease changes to a stable release.
+
 ## [0.8.21-0] - 2026-05-30
 
 ### Added

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.21-0",
+  "version": "0.8.21",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.21 prerelease to a stable release by bumping all workspace package versions from \`0.8.21-0\` to \`0.8.21\` and adding corresponding stable changelog entries.

## Changes

- **Version bumps** (`0.8.21-0` → `0.8.21`) across all workspace packages:
  - `@bastani/atomic` (`packages/coding-agent`)
  - `@bastani/workflows` (`packages/workflows`)
  - `@bastani/intercom` (`packages/intercom`)
  - `@bastani/mcp` (`packages/mcp`)
  - `@bastani/subagents` (`packages/subagents`)
  - `@bastani/web-access` (`packages/web-access`)
- **Changelog promotion** for packages with prerelease entries:
  - `packages/coding-agent/CHANGELOG.md` — added `[0.8.21]` stable release section
  - `packages/workflows/CHANGELOG.md` — added `[0.8.21]` stable release section

## Verification

- `bun run typecheck`
- pre-commit: `bun run lint`
- pre-commit: `bun run test:unit`