### PR TITLE
fix(subagents): hydrate async widget from active runs

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Hydrate active async subagent runs from durable status files into the below-editor widget so background work visible via `subagent({ action: "status" })` also appears in the TUI after launch/session rebinding ([#1146](https://github.com/flora131/atomic/issues/1146)).
+
 ## [0.8.20] - 2026-05-29
 
 ### Changed

--- a/packages/subagents/src/extension/index.ts
+++ b/packages/subagents/src/extension/index.ts
@@ -23,7 +23,7 @@ import { discoverAgents } from "../agents/agents.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
-import { renderWidget, renderSubagentResult, stopResultAnimations, stopWidgetAnimation, syncResultAnimation } from "../tui/render.ts";
+import { renderSubagentResult, stopResultAnimations, stopWidgetAnimation, syncResultAnimation } from "../tui/render.ts";
 import { SubagentParams } from "./schemas.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { createAsyncJobTracker } from "../runs/background/async-job-tracker.ts";
@@ -281,7 +281,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	};
 	globalStore[runtimeCleanupStoreKey] = runtimeCleanup;
 
-	const { ensurePoller, handleStarted, handleComplete, resetJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR);
+	const { ensurePoller, handleStarted, handleComplete, resetJobs, hydrateActiveJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR);
 	const executor = createSubagentExecutor({
 		pi,
 		state,
@@ -337,7 +337,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	});
 
 	const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {
-		if (ctx.hasUI) ctx.ui.setToolsExpanded(false);
+		if (ctx.hasUI) {
+			state.lastUiContext = ctx;
+			ctx.ui.setToolsExpanded(false);
+		}
 		return executor.execute(id, params, signal, onUpdate, ctx);
 	};
 
@@ -513,11 +516,8 @@ DIAGNOSTICS:
 		if (event.toolName !== "subagent") return;
 		if (!ctx.hasUI) return;
 		state.lastUiContext = ctx;
-		if (state.asyncJobs.size > 0) {
-			renderWidget(ctx, Array.from(state.asyncJobs.values()));
-			ctx.ui.requestRender?.();
-			ensurePoller();
-		}
+		hydrateActiveJobs(ctx);
+		if (state.asyncJobs.size > 0) ensurePoller();
 	});
 
 	const cleanupSessionArtifacts = (ctx: ExtensionContext) => {
@@ -538,6 +538,7 @@ DIAGNOSTICS:
 		cleanupSessionArtifacts(ctx);
 		clearPendingForegroundControlNotices(state);
 		resetJobs(ctx);
+		hydrateActiveJobs(ctx);
 		restoreSlashFinalSnapshots(ctx.sessionManager.getEntries());
 		primeExistingResults();
 	};

--- a/packages/subagents/src/runs/background/async-job-tracker.ts
+++ b/packages/subagents/src/runs/background/async-job-tracker.ts
@@ -14,6 +14,7 @@ import {
 	SUBAGENT_CONTROL_INTERCOM_EVENT,
 } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
+import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
 import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-reconciler.ts";
 import { hasLiveNestedDescendants, updateAsyncJobNestedProjection } from "../shared/nested-events.ts";
@@ -26,18 +27,82 @@ interface AsyncJobTrackerOptions {
 	now?: () => number;
 }
 
+interface RenderRequestingContext extends ExtensionContext {
+	ui: ExtensionContext["ui"] & { requestRender?: () => void };
+}
+
+const ACTIVE_HYDRATION_STATES: Array<AsyncRunSummary["state"]> = ["queued", "running"];
+
+function cwdMatches(summaryCwd: string | undefined, currentCwd: string | undefined): boolean {
+	return Boolean(summaryCwd && currentCwd && path.resolve(summaryCwd) === path.resolve(currentCwd));
+}
+
+function shouldHydrateRunForCurrentUi(summary: AsyncRunSummary, currentSessionId: string | null, currentCwd: string | undefined): boolean {
+	if (summary.sessionId && currentSessionId) return summary.sessionId === currentSessionId;
+	return cwdMatches(summary.cwd, currentCwd);
+}
+
+function asyncRunSummaryToJobState(summary: AsyncRunSummary, existing?: AsyncJobState): AsyncJobState {
+	const chainStepCount = summary.chainStepCount ?? summary.steps.length;
+	const groups = normalizeParallelGroups(summary.parallelGroups, summary.steps.length, chainStepCount);
+	const activeGroup = summary.currentStep !== undefined
+		? groups.find((group) => summary.currentStep! >= group.start && summary.currentStep! < group.start + group.count)
+		: undefined;
+	const steps = activeGroup
+		? summary.steps.slice(activeGroup.start, activeGroup.start + activeGroup.count).map((step, index) => ({ ...step, index: activeGroup.start + index }))
+		: summary.steps.map((step, index) => ({ ...step, index: step.index ?? index }));
+	const agents = steps.map((step) => step.agent);
+	const stepsTotal = steps.length > 0 ? steps.length : existing?.stepsTotal ?? (agents.length > 0 ? agents.length : undefined);
+	const completedSteps = summary.state === "complete"
+		? steps.length
+		: steps.filter((step) => step.status === "complete" || step.status === "completed").length;
+	return {
+		...existing,
+		asyncId: summary.id,
+		asyncDir: summary.asyncDir,
+		status: summary.state,
+		sessionId: summary.sessionId ?? existing?.sessionId,
+		activityState: summary.activityState,
+		lastActivityAt: summary.lastActivityAt,
+		currentTool: summary.currentTool,
+		currentToolStartedAt: summary.currentToolStartedAt,
+		currentPath: summary.currentPath,
+		turnCount: summary.turnCount,
+		toolCount: summary.toolCount,
+		mode: summary.mode,
+		agents: agents.length > 0 ? agents : existing?.agents,
+		currentStep: summary.currentStep,
+		chainStepCount: summary.chainStepCount ?? existing?.chainStepCount,
+		parallelGroups: groups,
+		steps: steps.length > 0 ? steps : existing?.steps,
+		stepsTotal,
+		runningSteps: steps.filter((step) => step.status === "running").length,
+		completedSteps,
+		hasParallelGroups: groups.length > 0,
+		activeParallelGroup: Boolean(activeGroup),
+		startedAt: summary.startedAt,
+		updatedAt: summary.lastUpdate ?? summary.startedAt,
+		sessionDir: summary.sessionDir ?? existing?.sessionDir,
+		outputFile: summary.outputFile ?? existing?.outputFile,
+		totalTokens: summary.totalTokens,
+		sessionFile: summary.sessionFile ?? existing?.sessionFile,
+		nestedChildren: summary.nestedChildren,
+	};
+}
+
 export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: SubagentState, asyncDirRoot: string, options: AsyncJobTrackerOptions = {}): {
 	ensurePoller: () => void;
 	handleStarted: (data: unknown) => void;
 	handleComplete: (data: unknown) => void;
 	resetJobs: (ctx?: ExtensionContext) => void;
+	hydrateActiveJobs: (ctx?: ExtensionContext) => void;
 } {
 	const completionRetentionMs = options.completionRetentionMs ?? 10000;
 	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
 	const resultsDir = options.resultsDir ?? RESULTS_DIR;
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
 		renderWidget(ctx, jobs);
-		ctx.ui.requestRender?.();
+		(ctx as RenderRequestingContext).ui.requestRender?.();
 	};
 	const cancelCleanup = (asyncId: string) => {
 		const existingTimer = state.cleanupTimers.get(asyncId);
@@ -233,12 +298,47 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		state.poller.unref?.();
 	};
 
+	const hydrateActiveJobs = (ctx?: ExtensionContext) => {
+		if (ctx?.hasUI) state.lastUiContext = ctx;
+		const renderCtx = state.lastUiContext?.hasUI ? state.lastUiContext : undefined;
+		const currentCwd = (ctx?.cwd ?? state.lastUiContext?.cwd ?? state.baseCwd) || undefined;
+		let summaries: AsyncRunSummary[];
+		try {
+			summaries = listAsyncRuns(asyncDirRoot, {
+				states: ACTIVE_HYDRATION_STATES,
+				resultsDir,
+				kill: options.kill,
+				now: options.now,
+			});
+		} catch (error) {
+			console.error(`Failed to hydrate active async jobs from '${asyncDirRoot}':`, error);
+			if (renderCtx) rerenderWidget(renderCtx);
+			return;
+		}
+
+		for (const summary of summaries) {
+			if (!shouldHydrateRunForCurrentUi(summary, state.currentSessionId, currentCwd)) continue;
+			cancelCleanup(summary.id);
+			state.asyncJobs.set(summary.id, asyncRunSummaryToJobState(summary, state.asyncJobs.get(summary.id)));
+		}
+
+		if (state.asyncJobs.size > 0) ensurePoller();
+		if (renderCtx) rerenderWidget(renderCtx);
+	};
+
 	const handleStarted = (data: unknown) => {
 		const info = data as AsyncStartedEvent;
 		if (!info.id) return;
 		const now = Date.now();
 		const asyncDir = info.asyncDir ?? path.join(asyncDirRoot, info.id);
-		const rawAgents = info.agents?.length ? info.agents : info.chain && info.chain.length > 0 ? info.chain : info.agent ? [info.agent] : undefined;
+		let rawAgents: string[] | undefined;
+		if (info.agents?.length) {
+			rawAgents = info.agents;
+		} else if (info.chain && info.chain.length > 0) {
+			rawAgents = info.chain;
+		} else if (info.agent) {
+			rawAgents = [info.agent];
+		}
 		const validParallelGroups = normalizeParallelGroups(info.parallelGroups, Number.MAX_SAFE_INTEGER, info.chainStepCount ?? Number.MAX_SAFE_INTEGER);
 		const firstGroup = validParallelGroups.find((group) => group.start === 0);
 		const firstGroupCount = firstGroup?.count;
@@ -306,5 +406,5 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		}
 	};
 
-	return { ensurePoller, handleStarted, handleComplete, resetJobs };
+	return { ensurePoller, handleStarted, handleComplete, resetJobs, hydrateActiveJobs };
 }

--- a/test/unit/coding-agent-builtin-workflows.test.ts
+++ b/test/unit/coding-agent-builtin-workflows.test.ts
@@ -157,7 +157,7 @@ describe("coding-agent builtin resources", () => {
     }
 
     assert.ok(labels.includes("package-command"), `expected package workflow completion in ${labels.join(", ")}`);
-  }, 20_000);
+  }, fullBuiltinPackageLoadTimeoutMs);
 
   test("loads builtin pi package resources", async () => {
     const cwd = tempDir("atomic-builtin-packages-cwd-");

--- a/test/unit/subagents-async-widget-visibility.test.ts
+++ b/test/unit/subagents-async-widget-visibility.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@bastani/atomic";
+import { createAsyncJobTracker } from "../../packages/subagents/src/runs/background/async-job-tracker.js";
+import { stopWidgetAnimation } from "../../packages/subagents/src/tui/render.js";
+import type { AsyncStatus, SubagentState } from "../../packages/subagents/src/shared/types.js";
+
+type SetWidgetArgs = Parameters<ExtensionContext["ui"]["setWidget"]>;
+type WidgetCall = {
+	key: string;
+	content: SetWidgetArgs[1];
+	options: SetWidgetArgs[2];
+};
+
+const states: SubagentState[] = [];
+const tempRoots: string[] = [];
+
+function makeTempRoot(prefix: string): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempRoots.push(root);
+	return root;
+}
+
+function makeState(cwd: string, currentSessionId: string | null = "session-current"): SubagentState {
+	const state: SubagentState = {
+		baseCwd: cwd,
+		currentSessionId,
+		asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: {
+			schedule: () => false,
+			clear: () => {},
+		},
+	};
+	states.push(state);
+	return state;
+}
+
+function makePi(): Pick<ExtensionAPI, "events"> {
+	return {
+		events: {
+			emit: () => {},
+			on: () => () => {},
+		},
+	} as Pick<ExtensionAPI, "events">;
+}
+
+function makeUiContext(cwd: string, sessionId = "session-current"): { ctx: ExtensionContext; widgetCalls: WidgetCall[]; renderCount: () => number } {
+	const widgetCalls: WidgetCall[] = [];
+	let renders = 0;
+	const ctx = {
+		hasUI: true,
+		cwd,
+		ui: {
+			setWidget: (key: string, content: SetWidgetArgs[1], options?: SetWidgetArgs[2]) => {
+				widgetCalls.push({ key, content, options });
+			},
+			getToolsExpanded: () => false,
+			setToolsExpanded: () => {},
+			requestRender: () => {
+				renders++;
+			},
+		},
+		sessionManager: {
+			getSessionFile: () => sessionId,
+			getSessionId: () => sessionId,
+			getEntries: () => [],
+		},
+		modelRegistry: {
+			getAvailable: () => [],
+		},
+		model: undefined,
+		isIdle: () => true,
+		signal: undefined,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	} as unknown as ExtensionContext;
+	return { ctx, widgetCalls, renderCount: () => renders };
+}
+
+function makeStatus(runId: string, cwd: string, overrides: Partial<AsyncStatus> = {}): AsyncStatus {
+	return {
+		runId,
+		mode: "single",
+		state: "running",
+		cwd,
+		startedAt: 1_000,
+		lastUpdate: 2_000,
+		currentStep: 0,
+		steps: [{ agent: "worker", status: "running", startedAt: 1_000 }],
+		...overrides,
+	};
+}
+
+function writeStatus(asyncRoot: string, runId: string, status: AsyncStatus): void {
+	const asyncDir = path.join(asyncRoot, runId);
+	fs.mkdirSync(asyncDir, { recursive: true });
+	fs.writeFileSync(path.join(asyncDir, "status.json"), `${JSON.stringify(status, null, 2)}\n`, "utf-8");
+}
+
+function makeTracker(state: SubagentState, asyncRoot: string, resultsDir: string) {
+	return createAsyncJobTracker(makePi(), state, asyncRoot, {
+		resultsDir,
+		pollIntervalMs: 60_000,
+	});
+}
+
+afterEach(() => {
+	stopWidgetAnimation();
+	for (const state of states.splice(0)) {
+		if (state.poller) clearInterval(state.poller);
+		state.poller = null;
+		for (const timer of state.cleanupTimers.values()) clearTimeout(timer);
+		state.cleanupTimers.clear();
+	}
+	for (const root of tempRoots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("subagent async widget hydration (issue #1146)", () => {
+	test("hydrates an active status-visible run and renders the widget belowEditor", () => {
+		const cwd = makeTempRoot("atomic-subagent-widget-cwd-");
+		const asyncRoot = makeTempRoot("atomic-subagent-widget-async-");
+		const resultsDir = makeTempRoot("atomic-subagent-widget-results-");
+		const state = makeState(cwd, "session-current");
+		writeStatus(asyncRoot, "run-visible", makeStatus("run-visible", cwd, {
+			sessionId: "session-current",
+			currentTool: "read",
+			currentToolStartedAt: 1_500,
+			toolCount: 2,
+		}));
+		const { ctx, widgetCalls, renderCount } = makeUiContext(cwd);
+
+		makeTracker(state, asyncRoot, resultsDir).hydrateActiveJobs(ctx);
+
+		const job = state.asyncJobs.get("run-visible");
+		assert.ok(job, "status-visible active run should be projected into widget state");
+		assert.equal(job.asyncDir, path.join(asyncRoot, "run-visible"));
+		assert.equal(job.status, "running");
+		assert.equal(job.sessionId, "session-current");
+		assert.equal(job.currentTool, "read");
+		assert.ok(widgetCalls.some((call) => call.options?.placement === "belowEditor"), "hydrated active run should mount belowEditor");
+		assert.equal(renderCount(), 1);
+	});
+
+	test("does not hydrate active runs from unrelated sessions or directories", () => {
+		const cwd = makeTempRoot("atomic-subagent-widget-current-");
+		const otherCwd = makeTempRoot("atomic-subagent-widget-other-");
+		const asyncRoot = makeTempRoot("atomic-subagent-widget-async-");
+		const resultsDir = makeTempRoot("atomic-subagent-widget-results-");
+		const state = makeState(cwd, "session-current");
+		writeStatus(asyncRoot, "run-other-session", makeStatus("run-other-session", cwd, { sessionId: "session-other" }));
+		writeStatus(asyncRoot, "run-other-cwd", makeStatus("run-other-cwd", otherCwd));
+		const { ctx, widgetCalls } = makeUiContext(cwd);
+
+		makeTracker(state, asyncRoot, resultsDir).hydrateActiveJobs(ctx);
+
+		assert.equal(state.asyncJobs.size, 0);
+		assert.ok(!widgetCalls.some((call) => call.options?.placement === "belowEditor"), "unrelated runs must not mount an active widget");
+	});
+
+	test("uses cwd fallback for active runs that do not have a session id", () => {
+		const cwd = makeTempRoot("atomic-subagent-widget-current-");
+		const otherCwd = makeTempRoot("atomic-subagent-widget-other-");
+		const asyncRoot = makeTempRoot("atomic-subagent-widget-async-");
+		const resultsDir = makeTempRoot("atomic-subagent-widget-results-");
+		const state = makeState(cwd, "session-current");
+		writeStatus(asyncRoot, "run-matching-cwd", makeStatus("run-matching-cwd", cwd));
+		writeStatus(asyncRoot, "run-different-cwd", makeStatus("run-different-cwd", otherCwd));
+		const { ctx, widgetCalls } = makeUiContext(cwd);
+
+		makeTracker(state, asyncRoot, resultsDir).hydrateActiveJobs(ctx);
+
+		assert.deepEqual([...state.asyncJobs.keys()], ["run-matching-cwd"]);
+		assert.ok(widgetCalls.some((call) => call.options?.placement === "belowEditor"));
+	});
+
+	test("hydrates only active queued/running statuses, not terminal history", () => {
+		const cwd = makeTempRoot("atomic-subagent-widget-cwd-");
+		const asyncRoot = makeTempRoot("atomic-subagent-widget-async-");
+		const resultsDir = makeTempRoot("atomic-subagent-widget-results-");
+		const state = makeState(cwd, "session-current");
+		writeStatus(asyncRoot, "run-queued", makeStatus("run-queued", cwd, {
+			sessionId: "session-current",
+			state: "queued",
+			steps: [{ agent: "worker", status: "pending", startedAt: 1_000 }],
+		}));
+		writeStatus(asyncRoot, "run-complete", makeStatus("run-complete", cwd, {
+			sessionId: "session-current",
+			state: "complete",
+			endedAt: 2_000,
+			steps: [{ agent: "worker", status: "complete", startedAt: 1_000, endedAt: 2_000 }],
+		}));
+		writeStatus(asyncRoot, "run-failed", makeStatus("run-failed", cwd, {
+			sessionId: "session-current",
+			state: "failed",
+			endedAt: 2_000,
+			steps: [{ agent: "worker", status: "failed", startedAt: 1_000, endedAt: 2_000 }],
+		}));
+		writeStatus(asyncRoot, "run-paused", makeStatus("run-paused", cwd, {
+			sessionId: "session-current",
+			state: "paused",
+			endedAt: 2_000,
+			steps: [{ agent: "worker", status: "paused", startedAt: 1_000, endedAt: 2_000 }],
+		}));
+		const { ctx, widgetCalls } = makeUiContext(cwd);
+
+		makeTracker(state, asyncRoot, resultsDir).hydrateActiveJobs(ctx);
+
+		assert.deepEqual([...state.asyncJobs.keys()], ["run-queued"]);
+		assert.equal(state.asyncJobs.get("run-queued")?.status, "queued");
+		assert.ok(!state.asyncJobs.has("run-complete"));
+		assert.ok(!state.asyncJobs.has("run-failed"));
+		assert.ok(!state.asyncJobs.has("run-paused"));
+		assert.ok(widgetCalls.some((call) => call.options?.placement === "belowEditor"), "active queued runs should render while terminal history stays out of the widget");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a gap where active async subagent runs — visible via `subagent({ action: "status" })` — were not reflected in the TUI below-editor widget after launch or session rebinding. The widget now hydrates from durable status files on startup and on each subagent tool result. Closes #1146.

## Changes

- **`async-job-tracker.ts`** — adds `hydrateActiveJobs(ctx?)`: reads `listAsyncRuns()` filtered to `queued`/`running` states, applies session-id matching with cwd fallback to avoid leaking unrelated runs, merges into `state.asyncJobs`, and re-renders the widget. Also exposes `hydrateActiveJobs` from the tracker's return value and narrows `requestRender` typing via `RenderRequestingContext`.
- **`extension/index.ts`** — captures `state.lastUiContext` before collapsed subagent execution so newly started async runs have a render target; replaces the inline render block in the `onToolResult` handler with `hydrateActiveJobs(ctx)`; calls `hydrateActiveJobs(ctx)` on session initialization (after `resetJobs`) to restore widget state on session rebind.
- **`test/unit/subagents-async-widget-visibility.test.ts`** — four regression tests covering: hydrated widget visibility with `belowEditor` placement, unrelated-session/directory filtering, cwd fallback for session-id-less runs, and terminal-state exclusion (`complete`/`failed`/`paused` must not appear in the widget).
- **`CHANGELOG.md`** — changelog entry under `[Unreleased] > Fixed`.

## How it works

`hydrateActiveJobs` resolves the right session context (passed `ctx` → `state.lastUiContext` → `state.baseCwd`) and calls `listAsyncRuns` to enumerate on-disk status files. For each active run it checks:

1. If the status file has a `sessionId`, it must match `state.currentSessionId`.
2. Otherwise it falls back to a `cwd` path comparison (resolved via `path.resolve`).

Matched runs are projected into `AsyncJobState` via `asyncRunSummaryToJobState` (preserving any existing in-memory fields), the poller is started if needed, and the widget is re-rendered.

## Testing

```sh
bun test test/unit/subagents-async-widget-visibility.test.ts
bun run typecheck
bun run test:unit
```