### PR TITLE
test(workflows): add regression coverage for headless /workflow print-mode (#1156)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed attached workflow-stage chat footers to resolve the `fast` model indicator against workflow fast-mode settings instead of chat settings ([#1134](https://github.com/flora131/atomic/issues/1134)).
 - Scoped print-mode non-zero extension-error exits to command-originated failures so non-fatal lifecycle extension errors do not fail otherwise successful headless output ([#1123](https://github.com/flora131/atomic/issues/1123)).
 - Fixed `ask_user_question` custom UI abort handling so interrupt-delivered workflow HiL answer notices are not stuck behind a blocking question modal ([#1137](https://github.com/flora131/atomic/issues/1137)).
+- Fixed print-mode slash-command output for headless `/workflow` automation by printing final displayable custom messages and treating command-originated extension errors as non-zero while suppressing stale final output ([#1156](https://github.com/flora131/atomic/issues/1156)).
 
 ## [0.8.21] - 2026-05-30
 

--- a/packages/coding-agent/test/print-mode.test.ts
+++ b/packages/coding-agent/test/print-mode.test.ts
@@ -183,7 +183,7 @@ describe("runPrintMode", () => {
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
 	});
 
-	it("prints final displayable custom message content in text mode", async () => {
+	it("issue #1156: prints final displayable workflow custom message content in text mode", async () => {
 		const runtimeHost = createRuntimeHost(createCustomMessage({ content: "workflow completed\nresult: ok" }));
 		const stdoutChunks = captureStdout();
 
@@ -213,7 +213,7 @@ describe("runPrintMode", () => {
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
 	});
 
-	it("returns non-zero on extension command errors and still emits session_shutdown", async () => {
+	it("issue #1156: command-originated extension errors exit non-zero and suppress stale assistant output", async () => {
 		const runtimeHost = createRuntimeHost(createAssistantMessage({ text: "done" }));
 		const { session } = runtimeHost;
 		let bindings: ExtensionBindings | undefined;
@@ -233,7 +233,7 @@ describe("runPrintMode", () => {
 
 		expect(exitCode).toBe(1);
 		expect(errorSpy).toHaveBeenCalledWith(`Extension error (command:workflow): ${MISSING_INPUT_ERROR}`);
-		expect(stdoutChunks.join("")).not.toContain("done");
+		expect(stdoutChunks.join("")).toBe("");
 		expect(session.extensionRunner.emit).toHaveBeenCalledTimes(1);
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
 	});
@@ -293,7 +293,7 @@ describe("runPrintMode", () => {
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
 	});
 
-	it("suppresses final custom output after extension command errors", async () => {
+	it("issue #1156: command-originated extension errors suppress stale custom output", async () => {
 		const runtimeHost = createRuntimeHost(createCustomMessage({ content: "stale workflow result" }));
 		const { session } = runtimeHost;
 		let bindings: ExtensionBindings | undefined;
@@ -313,7 +313,7 @@ describe("runPrintMode", () => {
 
 		expect(exitCode).toBe(1);
 		expect(errorSpy).toHaveBeenCalledWith(`Extension error (command:workflow): ${RUN_MISSING_ERROR}`);
-		expect(stdoutChunks.join("")).not.toContain("stale workflow result");
+		expect(stdoutChunks.join("")).toBe("");
 		expect(session.extensionRunner.emit).toHaveBeenCalledWith({ type: "session_shutdown", reason: "quit" });
 	});
 });

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Cleared brokered stage HIL UI during terminal stage cleanup so a completed workflow does not leave an active `ask_user_question`/custom prompt card visible after detach ([#1141](https://github.com/flora131/atomic/issues/1141)).
 - Fixed workflow HIL select/editor prompts so navigation, scroll input, and ambiguous Escape-prefix input cannot advance prompts before an explicit configured confirm/Enter submit or Ctrl+C skip. Graph-mode prompt cards now honor custom select keybindings, and Enter submitted during connect/attach/detach transitions is time-boxed so key repeat cannot attach or answer the next prompt accidentally ([#1148](https://github.com/flora131/atomic/issues/1148)).
 - Preserved synthetic workflow HiL prompt nodes as `awaiting_input` when an unrelated main-chat `ask_user_question` result arrives, so choosing to leave a workflow prompt open no longer makes the orchestrator node look like it resumed while the prompt is still unanswered ([#1137](https://github.com/flora131/atomic/issues/1137)).
+- Fixed headless `/workflow <name>` print-mode automation so successful non-interactive runs wait for terminal snapshots and emit printable run-detail summaries, while terminal failures surface as command-visible errors instead of silent zero-output successes ([#1156](https://github.com/flora131/atomic/issues/1156)).
 
 ## [0.8.21] - 2026-05-30
 

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -2424,9 +2424,11 @@ export default defineWorkflow("tool-headless-lifecycle")
 // ---------------------------------------------------------------------------
 // Non-interactive (-p) mode: /workflow remains available, but UI pickers are
 // skipped and deterministic validation errors are surfaced instead.
+// Issue #1156 specifically guards against `atomic -p '/workflow <name>'`
+// silently exiting 0 with empty stdout/stderr after a terminal success/failure.
 // ---------------------------------------------------------------------------
 
-describe("/workflow command in non-interactive (-p) mode", () => {
+describe("/workflow command in non-interactive (-p) mode (#1156 regressions)", () => {
   async function registerWorkflowCommand(): Promise<{
     handler: NonNullable<PiCommandOptions["handler"]>;
     sent: SentMessage[];
@@ -2838,7 +2840,7 @@ export default defineWorkflow("approval-required")
     }
   });
 
-  test("/workflow rejects failed terminal results in headless mode", async () => {
+  test("issue #1156: headless terminal workflow failure throws a command-visible error", async () => {
     const resource = await registerWorkflowCommandWithResource(
       "terminal-failure.ts",
       `import { defineWorkflow } from "@bastani/workflows";
@@ -2862,7 +2864,7 @@ export default defineWorkflow("terminal-failure")
     }
   });
 
-  test("/workflow emits terminal detail instead of dispatch after headless success", async () => {
+  test("issue #1156: headless /workflow success emits a printable terminal detail summary", async () => {
     const resource = await registerWorkflowCommandWithResource(
       "headless-terminal-success.ts",
       `import { defineWorkflow } from "@bastani/workflows";
@@ -2880,19 +2882,18 @@ export default defineWorkflow("headless-terminal-success")
     try {
       await resource.handler("headless-terminal-success", headlessNoOpCtx());
 
-      const payloads = resource.sent
-        .map(chatSurfacePayload)
-        .filter((payload): payload is ChatSurfacePayload => payload !== undefined);
       assert.equal(
-        payloads.some((payload) => payload.kind === "dispatch"),
+        resource.sent.some((message) => chatSurfacePayload(message)?.kind === "dispatch"),
         false,
         "headless success must not emit an interactive dispatch surface",
       );
-      const detailPayload = payloads.find(
-        (payload): payload is Extract<ChatSurfacePayload, { kind: "detail" }> =>
-          payload.kind === "detail",
+
+      const detailMessage = resource.sent.find(
+        (message) => chatSurfacePayload(message)?.kind === "detail",
       );
-      assert.ok(detailPayload, "expected a terminal run detail chat surface");
+      assert.ok(detailMessage, "expected a terminal run detail chat surface");
+      const detailPayload = chatSurfacePayload(detailMessage);
+      assert.ok(detailPayload?.kind === "detail", "expected terminal run detail payload");
       assert.equal(detailPayload.detail.status, "completed");
       assert.deepEqual(detailPayload.detail.result, { ok: true, value: "terminal" });
       assert.ok(detailPayload.detail.stages.length > 0, "expected completed stage details");
@@ -2905,13 +2906,15 @@ export default defineWorkflow("headless-terminal-success")
         false,
         "headless slash completion should not emit a lifecycle steer notice before terminal detail",
       );
-      const detailMessage = resource.sent.find(
-        (message) => chatSurfacePayload(message)?.kind === "detail",
-      );
-      assert.equal(typeof detailMessage?.content, "string");
-      assert.match(detailMessage?.content ?? "", /headless-terminal-success/);
-      assert.match(detailMessage?.content ?? "", /completed/);
-      assert.match(detailMessage?.content ?? "", /"value":"terminal"/);
+      assert.equal(detailMessage.display, true, "terminal detail must be displayable for print mode");
+      assert.equal(typeof detailMessage.content, "string");
+
+      const printableDetail = detailMessage.content ?? "";
+      assert.match(printableDetail, /headless-terminal-success/);
+      assert.match(printableDetail, /completed/);
+      assert.match(printableDetail, /STAGES/);
+      assert.match(printableDetail, /terminal-stage/);
+      assert.match(printableDetail, /"value":"terminal"/);
     } finally {
       await resource.cleanup();
     }


### PR DESCRIPTION
## Summary

Adds explicit regression test coverage and changelog attribution for issue #1156, which addressed headless \`/workflow <name>\` automation silently exiting zero with empty stdout/stderr after terminal success or failure.

## Changes

- **Tests — `slash-dispatch.test.ts`**: Renamed non-interactive mode describe block to reference #1156; renamed two test cases to clearly identify them as regression guards; refactored headless-success assertions to check `display: true` on the detail message and match against `STAGES`/`terminal-stage` patterns for stronger print-mode validation.
- **Tests — `print-mode.test.ts`**: Renamed three test cases to reference #1156; tightened two stdout assertions from `.not.toContain(...)` to `.toBe("")` to enforce fully empty stdout on command-originated extension errors.
- **Changelogs**: Added `[Unreleased]` → `### Fixed` entries in both `packages/coding-agent/CHANGELOG.md` and `packages/workflows/CHANGELOG.md` attributing the behavior fix to #1156.

## Closes

Closes #1156

## Validation

- Commit hooks: `bun run lint`, `bun run test:unit`
- Targeted: `env -u ATOMIC_WORKFLOW_STAGE_SUBAGENT_GUARD bun test test/unit/slash-dispatch.test.ts -t "issue #1156"`
- Targeted: `bun run --cwd packages/coding-agent test -- print-mode.test.ts`
- Type check: `bun run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)