### PR TITLE
feat(subagents): propagate and display fast-mode across all subagent UI layers

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Show Codex fast-mode launch metadata in foreground subagent result badges, async subagent widgets, and async status output when eligible OpenAI/OpenAI Codex child runs start with `/fast` enabled ([#1153](https://github.com/flora131/atomic/issues/1153)).
 - Hydrate active async subagent runs from durable status files into the below-editor widget so background work visible via `subagent({ action: "status" })` also appears in the TUI after launch/session rebinding ([#1146](https://github.com/flora131/atomic/issues/1146)).
 
 ## [0.8.20] - 2026-05-29

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Show Codex fast-mode launch metadata in foreground subagent result badges, async subagent widgets, and async status output when eligible OpenAI/OpenAI Codex child runs start with `/fast` enabled ([#1153](https://github.com/flora131/atomic/issues/1153)).
+- Scope subagent Codex fast-mode launches to the parent chat surface, so main-chat subagents follow `codexFastMode.chat` while workflow-node subagents follow `codexFastMode.workflow` ([#1153](https://github.com/flora131/atomic/issues/1153)).
 - Hydrate active async subagent runs from durable status files into the below-editor widget so background work visible via `subagent({ action: "status" })` also appears in the TUI after launch/session rebinding ([#1146](https://github.com/flora131/atomic/issues/1146)).
 
 ## [0.8.20] - 2026-05-29

--- a/packages/subagents/src/runs/background/async-execution.ts
+++ b/packages/subagents/src/runs/background/async-execution.ts
@@ -19,6 +19,7 @@ import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } f
 import { resolveChildCwd } from "../../shared/utils.ts";
 import { buildModelCandidates, resolveModelCandidate, type AvailableModelInfo } from "../shared/model-fallback.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
+import { getSubagentCodexFastModeSettings, resolveSubagentModelFastModeMetadata } from "../../shared/fast-mode.ts";
 import { resolveExpectedWorktreeAgentCwd } from "../shared/worktree.ts";
 import {
 	type ArtifactConfig,
@@ -329,15 +330,18 @@ export function executeAsyncChain(
 
 		const primaryModel = resolveModelCandidate(behavior.model ?? a.model, availableModels, ctx.currentModelProvider);
 		const model = applyThinkingSuffix(primaryModel, a.thinking);
+		const modelCandidates = buildModelCandidates(behavior.model ?? a.model, a.fallbackModels, availableModels, ctx.currentModelProvider, ctx.currentModel)
+			.map((candidate) => applyThinkingSuffix(candidate, a.thinking))
+			.filter((candidate): candidate is string => typeof candidate === "string");
+		const fastModeSettings = getSubagentCodexFastModeSettings(stepCwd);
 		return {
 			agent: s.agent,
 			task,
 			cwd: stepCwd,
 			model,
 			thinking: resolveEffectiveThinking(model, a.thinking),
-			modelCandidates: buildModelCandidates(behavior.model ?? a.model, a.fallbackModels, availableModels, ctx.currentModelProvider, ctx.currentModel)
-				.map((candidate) => applyThinkingSuffix(candidate, a.thinking))
-				.filter((candidate): candidate is string => typeof candidate === "string"),
+			...resolveSubagentModelFastModeMetadata({ model, modelCandidates, cwd: stepCwd, settings: fastModeSettings }),
+			modelCandidates,
 			tools: a.tools,
 			extensions: a.extensions,
 			mcpDirectTools: a.mcpDirectTools,
@@ -602,6 +606,10 @@ export function executeAsyncSingle(
 		resolveModelCandidate(params.modelOverride ?? agentConfig.model, availableModels, ctx.currentModelProvider),
 		agentConfig.thinking,
 	);
+	const modelCandidates = buildModelCandidates(params.modelOverride ?? agentConfig.model, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, ctx.currentModel)
+		.map((candidate) => applyThinkingSuffix(candidate, agentConfig.thinking))
+		.filter((candidate): candidate is string => typeof candidate === "string");
+	const fastModeSettings = getSubagentCodexFastModeSettings(runnerCwd);
 	let spawnResult: { pid?: number; error?: string } = {};
 	try {
 		spawnResult = spawnRunner(
@@ -614,9 +622,8 @@ export function executeAsyncSingle(
 						cwd: runnerCwd,
 						model,
 						thinking: resolveEffectiveThinking(model, agentConfig.thinking),
-						modelCandidates: buildModelCandidates(params.modelOverride ?? agentConfig.model, agentConfig.fallbackModels, availableModels, ctx.currentModelProvider, ctx.currentModel)
-							.map((candidate) => applyThinkingSuffix(candidate, agentConfig.thinking))
-							.filter((candidate): candidate is string => typeof candidate === "string"),
+						...resolveSubagentModelFastModeMetadata({ model, modelCandidates, cwd: runnerCwd, settings: fastModeSettings }),
+						modelCandidates,
 						tools: agentConfig.tools,
 						extensions: agentConfig.extensions,
 						mcpDirectTools: agentConfig.mcpDirectTools,

--- a/packages/subagents/src/runs/background/async-execution.ts
+++ b/packages/subagents/src/runs/background/async-execution.ts
@@ -19,7 +19,11 @@ import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } f
 import { resolveChildCwd } from "../../shared/utils.ts";
 import { buildModelCandidates, resolveModelCandidate, type AvailableModelInfo } from "../shared/model-fallback.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
-import { getSubagentCodexFastModeSettings, resolveSubagentModelFastModeMetadata } from "../../shared/fast-mode.ts";
+import {
+	getSubagentCodexFastModeSettings,
+	resolveSubagentCodexFastModeScope,
+	resolveSubagentModelFastModeMetadata,
+} from "../../shared/fast-mode.ts";
 import { resolveExpectedWorktreeAgentCwd } from "../shared/worktree.ts";
 import {
 	type ArtifactConfig,
@@ -255,6 +259,7 @@ export function executeAsyncChain(
 	const resultMode = params.resultMode ?? "chain";
 	const chainSkills = params.chainSkills ?? [];
 	const availableModels = params.availableModels;
+	const fastModeScope = resolveSubagentCodexFastModeScope(workflowStageSubagentGuard);
 	const runnerCwd = resolveChildCwd(ctx.cwd, cwd);
 	const firstStep = chain[0];
 	const originalTask = params.task ?? (firstStep
@@ -340,8 +345,10 @@ export function executeAsyncChain(
 			cwd: stepCwd,
 			model,
 			thinking: resolveEffectiveThinking(model, a.thinking),
-			...resolveSubagentModelFastModeMetadata({ model, modelCandidates, cwd: stepCwd, settings: fastModeSettings }),
+			...resolveSubagentModelFastModeMetadata({ model, modelCandidates, cwd: stepCwd, settings: fastModeSettings, scope: fastModeScope }),
 			modelCandidates,
+			codexFastModeSettings: fastModeSettings,
+			codexFastModeScope: fastModeScope,
 			tools: a.tools,
 			extensions: a.extensions,
 			mcpDirectTools: a.mcpDirectTools,
@@ -610,6 +617,7 @@ export function executeAsyncSingle(
 		.map((candidate) => applyThinkingSuffix(candidate, agentConfig.thinking))
 		.filter((candidate): candidate is string => typeof candidate === "string");
 	const fastModeSettings = getSubagentCodexFastModeSettings(runnerCwd);
+	const fastModeScope = resolveSubagentCodexFastModeScope(workflowStageSubagentGuard);
 	let spawnResult: { pid?: number; error?: string } = {};
 	try {
 		spawnResult = spawnRunner(
@@ -622,8 +630,10 @@ export function executeAsyncSingle(
 						cwd: runnerCwd,
 						model,
 						thinking: resolveEffectiveThinking(model, agentConfig.thinking),
-						...resolveSubagentModelFastModeMetadata({ model, modelCandidates, cwd: runnerCwd, settings: fastModeSettings }),
+						...resolveSubagentModelFastModeMetadata({ model, modelCandidates, cwd: runnerCwd, settings: fastModeSettings, scope: fastModeScope }),
 						modelCandidates,
+						codexFastModeSettings: fastModeSettings,
+						codexFastModeScope: fastModeScope,
 						tools: agentConfig.tools,
 						extensions: agentConfig.extensions,
 						mcpDirectTools: agentConfig.mcpDirectTools,

--- a/packages/subagents/src/runs/background/async-status.ts
+++ b/packages/subagents/src/runs/background/async-status.ts
@@ -28,6 +28,7 @@ interface AsyncRunStepSummary {
 	skills?: string[];
 	model?: string;
 	thinking?: string;
+	fastMode?: boolean;
 	attemptedModels?: string[];
 	error?: string;
 	children?: NestedRunSummary[];
@@ -155,6 +156,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 			...(step.skills ? { skills: step.skills } : {}),
 			...(step.model ? { model: step.model } : {}),
 			...(step.thinking ? { thinking: step.thinking } : {}),
+			...(step.fastMode !== undefined ? { fastMode: step.fastMode } : {}),
 			...(step.attemptedModels ? { attemptedModels: step.attemptedModels } : {}),
 			...(step.error ? { error: step.error } : {}),
 			...(step.children?.length ? { children: step.children } : {}),
@@ -262,7 +264,7 @@ function formatStepLine(step: AsyncRunStepSummary): string {
 	const parts = [`${step.index + 1}. ${step.agent}`, step.status];
 	const activity = formatActivityFacts(step);
 	if (activity) parts.push(activity);
-	const modelThinking = formatModelThinking(step.model, step.thinking);
+	const modelThinking = formatModelThinking(step.model, step.thinking, step.fastMode);
 	if (modelThinking) parts.push(modelThinking);
 	if (step.durationMs !== undefined) parts.push(formatDuration(step.durationMs));
 	if (step.tokens) parts.push(`${formatTokens(step.tokens.total)} tok`);

--- a/packages/subagents/src/runs/background/run-status.ts
+++ b/packages/subagents/src/runs/background/run-status.ts
@@ -213,7 +213,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			].filter((line): line is string => Boolean(line));
 			for (const [index, step] of (status.steps ?? []).entries()) {
 				const stepActivityText = step.status === "running" ? formatActivityLabel(step.lastActivityAt, step.activityState) : undefined;
-				const modelThinking = formatModelThinking(step.model, step.thinking);
+				const modelThinking = formatModelThinking(step.model, step.thinking, step.fastMode);
 				const modelText = modelThinking ? ` (${modelThinking})` : "";
 				const errorText = step.error ? `, error: ${step.error}` : "";
 				lines.push(`${stepLineLabel(status, index)}: ${step.agent} ${step.status}${modelText}${stepActivityText ? `, ${stepActivityText}` : ""}${errorText}`);

--- a/packages/subagents/src/runs/background/stale-run-reconciler.ts
+++ b/packages/subagents/src/runs/background/stale-run-reconciler.ts
@@ -79,6 +79,7 @@ interface ResultChildOutcome {
 	error?: string;
 	sessionFile?: string;
 	model?: string;
+	fastMode?: boolean;
 	attemptedModels?: string[];
 	modelAttempts?: NonNullable<AsyncStatus["steps"]>[number]["modelAttempts"];
 }
@@ -123,6 +124,7 @@ function terminalStatusFromResult(status: AsyncStatus, resultPath: string, now: 
 			error: state === "failed" ? step.error ?? child?.error : step.error,
 			sessionFile: step.sessionFile ?? child?.sessionFile,
 			model: step.model ?? child?.model,
+			fastMode: step.fastMode ?? child?.fastMode,
 			attemptedModels: step.attemptedModels ?? child?.attemptedModels,
 			modelAttempts: step.modelAttempts ?? child?.modelAttempts,
 		};
@@ -205,6 +207,7 @@ function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, r
 				error: step.status === "complete" || step.status === "completed" ? undefined : step.error ?? message,
 				success: step.status === "complete" || step.status === "completed",
 				model: step.model,
+				fastMode: step.fastMode,
 				attemptedModels: step.attemptedModels,
 				modelAttempts: step.modelAttempts,
 				sessionFile: step.sessionFile,

--- a/packages/subagents/src/runs/background/subagent-runner.ts
+++ b/packages/subagents/src/runs/background/subagent-runner.ts
@@ -108,6 +108,7 @@ interface StepResult {
 	sessionFile?: string;
 	intercomTarget?: string;
 	model?: string;
+	fastMode?: boolean;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	artifactPaths?: ArtifactPaths;
@@ -164,6 +165,14 @@ function resetStepLiveDetail(step: RunnerStatusStep): void {
 	step.currentPath = undefined;
 	step.recentTools = [];
 	step.recentOutput = [];
+}
+
+function fastModeForStepAttempt(step: SubagentStep, model: string | undefined): boolean | undefined {
+	if (model && step.modelFastModes && Object.prototype.hasOwnProperty.call(step.modelFastModes, model)) {
+		return step.modelFastModes[model];
+	}
+	if (model === undefined || model === step.model) return step.fastMode;
+	return undefined;
 }
 
 interface ChildEventContext {
@@ -565,7 +574,7 @@ interface SingleStepContext {
 	childIntercomTarget?: string;
 	orchestratorIntercomTarget?: string;
 	nestedRoute?: NestedRouteInfo;
-	onAttemptStart?: (attempt: { model?: string; thinking?: string }) => void;
+	onAttemptStart?: (attempt: { model?: string; thinking?: string; fastMode?: boolean }) => void;
 	onChildEvent?: (event: ChildEvent) => void;
 	workflowStageSubagentGuard?: boolean;
 }
@@ -580,6 +589,7 @@ async function runSingleStep(
 	exitCode: number | null;
 	error?: string;
 	model?: string;
+	fastMode?: boolean;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	artifactPaths?: ArtifactPaths;
@@ -613,12 +623,14 @@ async function runSingleStep(
 	const attemptNotes: string[] = [];
 	const eventsPath = path.join(path.dirname(ctx.outputFile), "events.jsonl");
 	let finalResult: RunPiStreamingResult | undefined;
+	let finalFastMode: boolean | undefined;
 	let finalOutputSnapshot: SingleOutputSnapshot | undefined;
 	let completionGuardTriggeredFinal = false;
 
 	for (let index = 0; index < candidates.length; index++) {
 		const candidate = candidates[index];
-		ctx.onAttemptStart?.({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking) });
+		const attemptFastMode = fastModeForStepAttempt(step, candidate);
+		ctx.onAttemptStart?.({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking), fastMode: attemptFastMode ? true : undefined });
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
 		const { args, env, tempDir } = buildPiArgs({
 			baseArgs: ["--mode", "json", "-p"],
@@ -698,6 +710,7 @@ async function runSingleStep(
 		modelAttempts.push(attempt);
 		if (candidate) attemptedModels.push(candidate);
 		completionGuardTriggeredFinal = completionGuardTriggered;
+		finalFastMode = attemptFastMode;
 		finalOutputSnapshot = outputSnapshot;
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error };
 		if (attempt.success || completionGuardTriggered) break;
@@ -739,6 +752,7 @@ async function runSingleStep(
 					task,
 					exitCode: finalResult?.exitCode,
 					model: finalResult?.model,
+					...(finalFastMode ? { fastMode: true } : {}),
 					attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
 					modelAttempts,
 					skills: step.skills,
@@ -757,6 +771,7 @@ async function runSingleStep(
 		sessionFile: step.sessionFile,
 		intercomTarget: ctx.childIntercomTarget,
 		model: finalResult?.model,
+		...(finalFastMode ? { fastMode: true } : {}),
 		attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
 		modelAttempts,
 		artifactPaths,
@@ -944,6 +959,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			skills: step.skills,
 			model: step.model,
 			thinking: step.thinking,
+			...(step.fastMode ? { fastMode: true } : {}),
 			attemptedModels: step.modelCandidates && step.modelCandidates.length > 0 ? step.modelCandidates : step.model ? [step.model] : undefined,
 			recentTools: [],
 			recentOutput: [],
@@ -1065,11 +1081,12 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		appendControlEvent(event);
 		return true;
 	};
-	const updateStepModel = (flatIndex: number, model: string | undefined, thinking: string | undefined, now = Date.now()): void => {
+	const updateStepModel = (flatIndex: number, model: string | undefined, thinking: string | undefined, fastMode: boolean | undefined, now = Date.now()): void => {
 		const step = statusPayload.steps[flatIndex];
 		if (!step) return;
 		step.model = model;
 		step.thinking = thinking;
+		step.fastMode = fastMode ? true : undefined;
 		statusPayload.lastUpdate = now;
 		writeStatusPayload();
 	};
@@ -1399,7 +1416,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 							registerInterrupt: (interrupt) => {
 								activeChildInterrupt = interrupt;
 							},
-							onAttemptStart: (attempt) => updateStepModel(fi, attempt.model, attempt.thinking),
+							onAttemptStart: (attempt) => updateStepModel(fi, attempt.model, attempt.thinking, attempt.fastMode),
 							onChildEvent: (event) => updateStepFromChildEvent(fi, event),
 							workflowStageSubagentGuard: config.workflowStageSubagentGuard,
 						});
@@ -1416,6 +1433,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						statusPayload.steps[fi].exitCode = singleResult.exitCode;
 						statusPayload.steps[fi].model = singleResult.model;
 						statusPayload.steps[fi].thinking = resolveEffectiveThinking(singleResult.model, statusPayload.steps[fi].thinking);
+						statusPayload.steps[fi].fastMode = singleResult.fastMode ? true : undefined;
 						statusPayload.steps[fi].attemptedModels = singleResult.attemptedModels;
 						statusPayload.steps[fi].modelAttempts = singleResult.modelAttempts;
 						statusPayload.steps[fi].error = singleResult.error;
@@ -1476,6 +1494,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						sessionFile: pr.sessionFile,
 						intercomTarget: pr.intercomTarget,
 						model: pr.model,
+						fastMode: pr.fastMode,
 						attemptedModels: pr.attemptedModels,
 						modelAttempts: pr.modelAttempts,
 						artifactPaths: pr.artifactPaths,
@@ -1484,13 +1503,14 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 
 				previousOutput = aggregateParallelOutputs(
 					parallelResults.map((r) => ({
-					agent: r.agent,
-					output: r.output,
-					exitCode: r.exitCode,
-					error: r.error,
-					model: r.model,
-					attemptedModels: r.attemptedModels,
-				})),
+						agent: r.agent,
+						output: r.output,
+						exitCode: r.exitCode,
+						error: r.error,
+						model: r.model,
+						fastMode: r.fastMode,
+						attemptedModels: r.attemptedModels,
+					})),
 				);
 				previousOutput = appendParallelWorktreeSummary(previousOutput, worktreeSetup, asyncDir, stepIndex, group);
 
@@ -1546,7 +1566,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				registerInterrupt: (interrupt) => {
 					activeChildInterrupt = interrupt;
 				},
-				onAttemptStart: (attempt) => updateStepModel(flatIndex, attempt.model, attempt.thinking),
+				onAttemptStart: (attempt) => updateStepModel(flatIndex, attempt.model, attempt.thinking, attempt.fastMode),
 				onChildEvent: (event) => updateStepFromChildEvent(flatIndex, event),
 				workflowStageSubagentGuard: config.workflowStageSubagentGuard,
 			});
@@ -1563,6 +1583,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				sessionFile: singleResult.sessionFile,
 				intercomTarget: singleResult.intercomTarget,
 				model: singleResult.model,
+				fastMode: singleResult.fastMode,
 				attemptedModels: singleResult.attemptedModels,
 				modelAttempts: singleResult.modelAttempts,
 				artifactPaths: singleResult.artifactPaths,
@@ -1596,6 +1617,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			statusPayload.steps[flatIndex].exitCode = singleResult.exitCode;
 			statusPayload.steps[flatIndex].model = singleResult.model;
 			statusPayload.steps[flatIndex].thinking = resolveEffectiveThinking(singleResult.model, statusPayload.steps[flatIndex].thinking);
+			statusPayload.steps[flatIndex].fastMode = singleResult.fastMode ? true : undefined;
 			statusPayload.steps[flatIndex].attemptedModels = singleResult.attemptedModels;
 			statusPayload.steps[flatIndex].modelAttempts = singleResult.modelAttempts;
 			statusPayload.steps[flatIndex].error = singleResult.error;
@@ -1753,6 +1775,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				sessionFile: r.sessionFile,
 				intercomTarget: r.intercomTarget,
 				model: r.model,
+				fastMode: r.fastMode,
 				attemptedModels: r.attemptedModels,
 				modelAttempts: r.modelAttempts,
 				artifactPaths: r.artifactPaths,

--- a/packages/subagents/src/runs/background/subagent-runner.ts
+++ b/packages/subagents/src/runs/background/subagent-runner.ts
@@ -657,6 +657,8 @@ async function runSingleStep(
 			parentControlInbox: ctx.nestedRoute?.controlInbox,
 			parentRootRunId: ctx.nestedRoute?.rootRunId,
 			parentCapabilityToken: ctx.nestedRoute?.capabilityToken,
+			codexFastModeSettings: step.codexFastModeSettings,
+			codexFastModeScope: step.codexFastModeScope,
 		});
 		const run = await runPiStreaming(
 			args,

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -63,6 +63,7 @@ import {
 	shouldEscalateMutatingFailures,
 	summarizeRecentMutatingFailures,
 } from "../shared/long-running-guard.ts";
+import { resolveSubagentModelFastMode } from "../../shared/fast-mode.ts";
 
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
 
@@ -136,6 +137,8 @@ async function runSingleAttempt(
 	},
 ): Promise<SingleResult> {
 	const modelArg = applyThinkingSuffix(model, agent.thinking);
+	const runCwd = options.cwd ?? runtimeCwd;
+	const fastMode = resolveSubagentModelFastMode({ model: modelArg, cwd: runCwd });
 	const { args, env: sharedEnv, tempDir } = buildPiArgs({
 		baseArgs: ["--mode", "json", "-p"],
 		task,
@@ -151,7 +154,7 @@ async function runSingleAttempt(
 		extensions: agent.extensions,
 		systemPrompt: shared.systemPrompt,
 		mcpDirectTools: agent.mcpDirectTools,
-		cwd: options.cwd ?? runtimeCwd,
+		cwd: runCwd,
 		promptFileStem: agent.name,
 		intercomSessionName: options.intercomSessionName,
 		orchestratorIntercomTarget: options.orchestratorIntercomTarget,
@@ -171,6 +174,7 @@ async function runSingleAttempt(
 		messages: [],
 		usage: emptyUsage(),
 		model: modelArg,
+		...(fastMode ? { fastMode } : {}),
 		artifactPaths: shared.artifactPaths,
 		skills: shared.resolvedSkillNames,
 		skillsWarning: shared.skillsWarning,
@@ -215,7 +219,7 @@ async function runSingleAttempt(
 	const exitCode = await new Promise<number>((resolve) => {
 		const spawnSpec = getPiSpawnCommand(args);
 		const proc = spawn(spawnSpec.command, spawnSpec.args, {
-			cwd: options.cwd ?? runtimeCwd,
+			cwd: runCwd,
 			env: spawnEnv,
 			stdio: ["ignore", "pipe", "pipe"],
 			windowsHide: true,
@@ -892,6 +896,7 @@ export async function runSync(
 				exitCode: result.exitCode,
 				usage: result.usage,
 				model: result.model,
+				fastMode: result.fastMode,
 				attemptedModels: result.attemptedModels,
 				modelAttempts: result.modelAttempts,
 				durationMs: result.progressSummary?.durationMs,

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -5,6 +5,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import type { Message } from "@earendil-works/pi-ai";
+import type { CodexFastModeResolvedSettings, CodexFastModeScope } from "@bastani/atomic";
 import type { AgentConfig } from "../../agents/agents.ts";
 import {
 	ensureArtifactsDir,
@@ -63,7 +64,11 @@ import {
 	shouldEscalateMutatingFailures,
 	summarizeRecentMutatingFailures,
 } from "../shared/long-running-guard.ts";
-import { resolveSubagentModelFastMode } from "../../shared/fast-mode.ts";
+import {
+	getSubagentCodexFastModeSettings,
+	resolveSubagentCodexFastModeScope,
+	resolveSubagentModelFastMode,
+} from "../../shared/fast-mode.ts";
 
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
 
@@ -134,11 +139,18 @@ async function runSingleAttempt(
 		artifactPaths?: ArtifactPaths;
 		attemptNotes: string[];
 		outputSnapshot?: SingleOutputSnapshot;
+		fastModeSettings: CodexFastModeResolvedSettings;
+		fastModeScope: CodexFastModeScope;
 	},
 ): Promise<SingleResult> {
 	const modelArg = applyThinkingSuffix(model, agent.thinking);
 	const runCwd = options.cwd ?? runtimeCwd;
-	const fastMode = resolveSubagentModelFastMode({ model: modelArg, cwd: runCwd });
+	const fastMode = resolveSubagentModelFastMode({
+		model: modelArg,
+		cwd: runCwd,
+		settings: shared.fastModeSettings,
+		scope: shared.fastModeScope,
+	});
 	const { args, env: sharedEnv, tempDir } = buildPiArgs({
 		baseArgs: ["--mode", "json", "-p"],
 		task,
@@ -165,6 +177,8 @@ async function runSingleAttempt(
 		parentControlInbox: options.nestedRoute?.controlInbox,
 		parentRootRunId: options.nestedRoute?.rootRunId,
 		parentCapabilityToken: options.nestedRoute?.capabilityToken,
+		codexFastModeSettings: shared.fastModeSettings,
+		codexFastModeScope: shared.fastModeScope,
 	});
 
 	const result: SingleResult = {
@@ -801,6 +815,9 @@ export async function runSync(
 		options.preferredModelProvider,
 		options.currentModel,
 	);
+	const fastModeCwd = options.cwd ?? runtimeCwd;
+	const fastModeSettings = getSubagentCodexFastModeSettings(fastModeCwd);
+	const fastModeScope = resolveSubagentCodexFastModeScope(options.workflowStageSubagentGuard);
 	const attemptedModels: string[] = [];
 	const modelAttempts: ModelAttempt[] = [];
 	const aggregateUsage = emptyUsage();
@@ -836,6 +853,8 @@ export async function runSync(
 			artifactPaths: artifactPathsResult,
 			attemptNotes,
 			outputSnapshot,
+			fastModeSettings,
+			fastModeScope,
 		});
 		lastResult = result;
 		sumUsage(aggregateUsage, result.usage);

--- a/packages/subagents/src/runs/shared/parallel-utils.ts
+++ b/packages/subagents/src/runs/shared/parallel-utils.ts
@@ -4,6 +4,8 @@ export interface RunnerSubagentStep {
 	cwd?: string;
 	model?: string;
 	thinking?: string;
+	fastMode?: boolean;
+	modelFastModes?: Record<string, boolean>;
 	modelCandidates?: string[];
 	tools?: string[];
 	extensions?: string[];
@@ -75,6 +77,7 @@ export interface ParallelTaskResult {
 	exitCode: number | null;
 	error?: string;
 	model?: string;
+	fastMode?: boolean;
 	attemptedModels?: string[];
 	outputTargetPath?: string;
 	outputTargetExists?: boolean;

--- a/packages/subagents/src/runs/shared/parallel-utils.ts
+++ b/packages/subagents/src/runs/shared/parallel-utils.ts
@@ -1,3 +1,5 @@
+import type { CodexFastModeResolvedSettings, CodexFastModeScope } from "@bastani/atomic";
+
 export interface RunnerSubagentStep {
 	agent: string;
 	task: string;
@@ -7,6 +9,8 @@ export interface RunnerSubagentStep {
 	fastMode?: boolean;
 	modelFastModes?: Record<string, boolean>;
 	modelCandidates?: string[];
+	codexFastModeSettings?: CodexFastModeResolvedSettings;
+	codexFastModeScope?: CodexFastModeScope;
 	tools?: string[];
 	extensions?: string[];
 	mcpDirectTools?: string[];

--- a/packages/subagents/src/runs/shared/pi-args.ts
+++ b/packages/subagents/src/runs/shared/pi-args.ts
@@ -2,7 +2,13 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { APP_NAME, getEnvValue } from "@bastani/atomic";
+import {
+	APP_NAME,
+	ENV_CODEX_FAST_MODE,
+	getEnvValue,
+	type CodexFastModeResolvedSettings,
+	type CodexFastModeScope,
+} from "@bastani/atomic";
 import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from "./nested-path.ts";
 import { resolveMcpDirectToolNames } from "./mcp-direct-tool-allowlist.ts";
 
@@ -60,6 +66,8 @@ interface BuildPiArgsInput {
 	parentDepth?: number;
 	parentPath?: NestedPathEntry[];
 	parentCapabilityToken?: string;
+	codexFastModeSettings?: CodexFastModeResolvedSettings;
+	codexFastModeScope?: CodexFastModeScope;
 }
 
 interface BuildPiArgsResult {
@@ -73,6 +81,20 @@ export function applyThinkingSuffix(model: string | undefined, thinking: string 
 	const colonIdx = model.lastIndexOf(":");
 	if (colonIdx !== -1 && THINKING_LEVELS.includes(model.substring(colonIdx + 1))) return model;
 	return `${model}:${thinking}`;
+}
+
+function serializeChildCodexFastModeSettings(settings: CodexFastModeResolvedSettings): string {
+	return `chat=${settings.chat ? "1" : "0"};workflow=${settings.workflow ? "1" : "0"}`;
+}
+
+function mapChildCodexFastModeSettings(
+	settings: CodexFastModeResolvedSettings,
+	scope: CodexFastModeScope,
+): CodexFastModeResolvedSettings {
+	return {
+		chat: settings[scope],
+		workflow: settings.workflow,
+	};
 }
 
 export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
@@ -155,6 +177,11 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	const env: Record<string, string | undefined> = {};
 	env[SUBAGENT_CHILD_ENV] = "1";
 	env[SUBAGENT_FANOUT_CHILD_ENV] = fanoutAuthorized ? "1" : "0";
+	if (input.codexFastModeSettings) {
+		env[ENV_CODEX_FAST_MODE] = serializeChildCodexFastModeSettings(
+			mapChildCodexFastModeSettings(input.codexFastModeSettings, input.codexFastModeScope ?? "chat"),
+		);
+	}
 	const parentEventSinkEnv = getEnvValue(SUBAGENT_PARENT_EVENT_SINK_ENV);
 	const parentControlInboxEnv = getEnvValue(SUBAGENT_PARENT_CONTROL_INBOX_ENV);
 	const parentRootRunIdEnv = getEnvValue(SUBAGENT_PARENT_ROOT_RUN_ID_ENV);

--- a/packages/subagents/src/shared/fast-mode.ts
+++ b/packages/subagents/src/shared/fast-mode.ts
@@ -1,0 +1,72 @@
+import {
+	SettingsManager,
+	isCodexFastModeCandidateModelId,
+	shouldApplyCodexFastModeForScope,
+	type CodexFastModeResolvedSettings,
+} from "@bastani/atomic";
+import { splitKnownThinkingSuffix } from "./model-info.ts";
+
+export interface ResolveSubagentModelFastModeInput {
+	model?: string;
+	cwd: string;
+	settings?: CodexFastModeResolvedSettings;
+}
+
+export interface ResolveSubagentModelFastModeMapInput {
+	models: readonly (string | undefined)[];
+	cwd: string;
+	settings?: CodexFastModeResolvedSettings;
+}
+
+export interface ResolveSubagentModelFastModeMetadataInput {
+	model?: string;
+	modelCandidates: readonly (string | undefined)[];
+	cwd: string;
+	settings?: CodexFastModeResolvedSettings;
+}
+
+export interface SubagentModelFastModeMetadata {
+	fastMode?: true;
+	modelFastModes: Record<string, boolean>;
+}
+
+export function getSubagentCodexFastModeSettings(cwd: string): CodexFastModeResolvedSettings {
+	try {
+		return SettingsManager.create(cwd).getCodexFastModeSettings();
+	} catch {
+		return { chat: false, workflow: false };
+	}
+}
+
+function providerFromModelId(model: string | undefined): string | undefined {
+	if (!model) return undefined;
+	const { baseModel } = splitKnownThinkingSuffix(model);
+	if (!isCodexFastModeCandidateModelId(baseModel)) return undefined;
+	return baseModel.split("/", 1)[0];
+}
+
+export function resolveSubagentModelFastMode(input: ResolveSubagentModelFastModeInput): boolean {
+	const provider = providerFromModelId(input.model);
+	if (!provider) return false;
+	const settings = input.settings ?? getSubagentCodexFastModeSettings(input.cwd);
+	return shouldApplyCodexFastModeForScope({ provider }, settings, "chat");
+}
+
+export function resolveSubagentModelFastModeMap(input: ResolveSubagentModelFastModeMapInput): Record<string, boolean> {
+	const settings = input.settings ?? getSubagentCodexFastModeSettings(input.cwd);
+	const fastModes: Record<string, boolean> = {};
+	for (const model of input.models) {
+		if (!model || Object.prototype.hasOwnProperty.call(fastModes, model)) continue;
+		fastModes[model] = resolveSubagentModelFastMode({ model, cwd: input.cwd, settings });
+	}
+	return fastModes;
+}
+
+export function resolveSubagentModelFastModeMetadata(input: ResolveSubagentModelFastModeMetadataInput): SubagentModelFastModeMetadata {
+	const settings = input.settings ?? getSubagentCodexFastModeSettings(input.cwd);
+	const fastMode = resolveSubagentModelFastMode({ model: input.model, cwd: input.cwd, settings });
+	return {
+		...(fastMode ? { fastMode: true as const } : {}),
+		modelFastModes: resolveSubagentModelFastModeMap({ models: input.modelCandidates, cwd: input.cwd, settings }),
+	};
+}

--- a/packages/subagents/src/shared/fast-mode.ts
+++ b/packages/subagents/src/shared/fast-mode.ts
@@ -3,6 +3,7 @@ import {
 	isCodexFastModeCandidateModelId,
 	shouldApplyCodexFastModeForScope,
 	type CodexFastModeResolvedSettings,
+	type CodexFastModeScope,
 } from "@bastani/atomic";
 import { splitKnownThinkingSuffix } from "./model-info.ts";
 
@@ -10,12 +11,14 @@ export interface ResolveSubagentModelFastModeInput {
 	model?: string;
 	cwd: string;
 	settings?: CodexFastModeResolvedSettings;
+	scope?: CodexFastModeScope;
 }
 
 export interface ResolveSubagentModelFastModeMapInput {
 	models: readonly (string | undefined)[];
 	cwd: string;
 	settings?: CodexFastModeResolvedSettings;
+	scope?: CodexFastModeScope;
 }
 
 export interface ResolveSubagentModelFastModeMetadataInput {
@@ -23,6 +26,7 @@ export interface ResolveSubagentModelFastModeMetadataInput {
 	modelCandidates: readonly (string | undefined)[];
 	cwd: string;
 	settings?: CodexFastModeResolvedSettings;
+	scope?: CodexFastModeScope;
 }
 
 export interface SubagentModelFastModeMetadata {
@@ -45,11 +49,15 @@ function providerFromModelId(model: string | undefined): string | undefined {
 	return baseModel.split("/", 1)[0];
 }
 
+export function resolveSubagentCodexFastModeScope(workflowStageSubagentGuard: boolean | undefined): CodexFastModeScope {
+	return workflowStageSubagentGuard ? "workflow" : "chat";
+}
+
 export function resolveSubagentModelFastMode(input: ResolveSubagentModelFastModeInput): boolean {
 	const provider = providerFromModelId(input.model);
 	if (!provider) return false;
 	const settings = input.settings ?? getSubagentCodexFastModeSettings(input.cwd);
-	return shouldApplyCodexFastModeForScope({ provider }, settings, "chat");
+	return shouldApplyCodexFastModeForScope({ provider }, settings, input.scope ?? "chat");
 }
 
 export function resolveSubagentModelFastModeMap(input: ResolveSubagentModelFastModeMapInput): Record<string, boolean> {
@@ -57,16 +65,16 @@ export function resolveSubagentModelFastModeMap(input: ResolveSubagentModelFastM
 	const fastModes: Record<string, boolean> = {};
 	for (const model of input.models) {
 		if (!model || Object.prototype.hasOwnProperty.call(fastModes, model)) continue;
-		fastModes[model] = resolveSubagentModelFastMode({ model, cwd: input.cwd, settings });
+		fastModes[model] = resolveSubagentModelFastMode({ model, cwd: input.cwd, settings, scope: input.scope });
 	}
 	return fastModes;
 }
 
 export function resolveSubagentModelFastModeMetadata(input: ResolveSubagentModelFastModeMetadataInput): SubagentModelFastModeMetadata {
 	const settings = input.settings ?? getSubagentCodexFastModeSettings(input.cwd);
-	const fastMode = resolveSubagentModelFastMode({ model: input.model, cwd: input.cwd, settings });
+	const fastMode = resolveSubagentModelFastMode({ model: input.model, cwd: input.cwd, settings, scope: input.scope });
 	return {
 		...(fastMode ? { fastMode: true as const } : {}),
-		modelFastModes: resolveSubagentModelFastModeMap({ models: input.modelCandidates, cwd: input.cwd, settings }),
+		modelFastModes: resolveSubagentModelFastModeMap({ models: input.modelCandidates, cwd: input.cwd, settings, scope: input.scope }),
 	};
 }

--- a/packages/subagents/src/shared/formatters.ts
+++ b/packages/subagents/src/shared/formatters.ts
@@ -16,7 +16,7 @@ export function formatTokens(n: number): string {
 	return n < 1000 ? String(n) : n < 10000 ? `${(n / 1000).toFixed(1)}k` : `${Math.round(n / 1000)}k`;
 }
 
-export function formatModelThinking(model?: string, thinking?: string): string {
+export function formatModelThinking(model?: string, thinking?: string, fastMode?: boolean): string {
 	const parsed = model ? splitKnownThinkingSuffix(model) : undefined;
 	let displayModel = parsed?.baseModel ?? model;
 	const explicitThinking = THINKING_LEVELS.find((level) => level === thinking?.trim());
@@ -25,7 +25,9 @@ export function formatModelThinking(model?: string, thinking?: string): string {
 		const slashIdx = displayModel.lastIndexOf("/");
 		if (slashIdx !== -1) displayModel = displayModel.slice(slashIdx + 1);
 	}
-	return [displayModel, displayThinking ? `thinking ${displayThinking}` : undefined].filter(Boolean).join(" · ");
+	const parts = [displayModel, displayThinking ? `thinking ${displayThinking}` : undefined].filter(Boolean);
+	if (fastMode && parts.length > 0) parts.push("fast");
+	return parts.join(" · ");
 }
 
 /**

--- a/packages/subagents/src/shared/types.ts
+++ b/packages/subagents/src/shared/types.ts
@@ -211,6 +211,7 @@ export interface SingleResult {
 	messages?: Message[];
 	usage: Usage;
 	model?: string;
+	fastMode?: boolean;
 	attemptedModels?: string[];
 	modelAttempts?: ModelAttempt[];
 	controlEvents?: ControlEvent[];
@@ -416,6 +417,7 @@ export interface AsyncStatus {
 		skills?: string[];
 		model?: string;
 		thinking?: string;
+		fastMode?: boolean;
 		attemptedModels?: string[];
 		modelAttempts?: ModelAttempt[];
 		error?: string;

--- a/packages/subagents/src/tui/render.ts
+++ b/packages/subagents/src/tui/render.ts
@@ -502,7 +502,7 @@ function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded =
 		const marker = index === job.steps.length - 1 ? "└" : "├";
 		const activity = widgetStepActivity(step, job.updatedAt);
 		const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
-		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
+		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking, step.fastMode);
 		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index))} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 8 : 1)) lines.push(`    ${nestedLine}`);
 	}
@@ -723,8 +723,8 @@ function widgetStepStats(theme: Theme, step: NonNullable<AsyncJobState["steps"]>
 	]);
 }
 
-function modelThinkingBadge(theme: Theme, model?: string, thinking?: string): string {
-	const label = formatModelThinking(model, thinking);
+function modelThinkingBadge(theme: Theme, model?: string, thinking?: string, fastMode?: boolean): string {
+	const label = formatModelThinking(model, thinking, fastMode);
 	return label ? theme.fg("dim", ` (${label})`) : "";
 }
 
@@ -832,7 +832,7 @@ function foregroundStyleWidgetStepLines(
 ): string[] {
 	const status = widgetStepStatus(step.status, theme);
 	const stats = widgetStepStats(theme, step);
-	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
+	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking, step.fastMode);
 	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1))} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
 	const activity = widgetStepActivityLine(step, width, expanded, job.updatedAt);
 	if (activity) lines.push(`    ${theme.fg("dim", `⎿  ${activity}`)}`);
@@ -903,7 +903,7 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 		const activity = widgetStepActivityLine(step, width, false, job.updatedAt);
 		const stepStats = widgetStepStats(theme, step);
 		const activitySuffix = activity ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", activity)}` : "";
-		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
+		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking, step.fastMode);
 		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index))} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt)) lines.push(`    ${nestedLine}`);
 	}
@@ -1127,7 +1127,7 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 	]);
 	const c = new Container();
 	const width = getTermWidth() - 4;
-	const modelDisplay = modelThinkingBadge(theme, r.model);
+	const modelDisplay = modelThinkingBadge(theme, r.model, undefined, r.fastMode);
 	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
 
 	if (isRunning && r.progress) {
@@ -1459,7 +1459,7 @@ export function renderSubagentResult(
 					? theme.fg("warning", "warning")
 					: theme.fg("success", "done");
 		const stats = rProg ? ` | ${rProg.toolCount} tools, ${formatDuration(rProg.durationMs)}` : "";
-		const modelDisplay = modelThinkingBadge(theme, r.model);
+		const modelDisplay = modelThinkingBadge(theme, r.model, undefined, r.fastMode);
 		const stepLabel = resultRowLabel(d, multiLabel, i, stepNumber);
 		const stepHeader = rRunning
 			? `${statusIcon} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${modelDisplay}${stats}`

--- a/test/unit/subagents-async-status-fast-mode.test.ts
+++ b/test/unit/subagents-async-status-fast-mode.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { inspectSubagentStatus } from "../../packages/subagents/src/runs/background/run-status.js";
+import type { AsyncStatus } from "../../packages/subagents/src/shared/types.js";
+
+const tempRoots: string[] = [];
+
+function makeTempRoot(prefix: string): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempRoots.push(root);
+	return root;
+}
+
+function writeStatus(asyncRoot: string, runId: string, status: AsyncStatus): string {
+	const asyncDir = path.join(asyncRoot, runId);
+	fs.mkdirSync(asyncDir, { recursive: true });
+	fs.writeFileSync(path.join(asyncDir, "status.json"), `${JSON.stringify(status, null, 2)}\n`, "utf-8");
+	return asyncDir;
+}
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("subagent async status fast-mode labels (issue #1153)", () => {
+	test("active status list includes fast after thinking", () => {
+		const asyncRoot = makeTempRoot("atomic-subagent-status-fast-async-");
+		const resultsDir = makeTempRoot("atomic-subagent-status-fast-results-");
+		writeStatus(asyncRoot, "run-fast", {
+			runId: "run-fast",
+			mode: "single",
+			state: "running",
+			startedAt: 1_000,
+			lastUpdate: 2_000,
+			currentStep: 0,
+			steps: [{
+				agent: "worker",
+				status: "running",
+				model: "openai/gpt-5.1-codex",
+				thinking: "medium",
+				fastMode: true,
+			}],
+		});
+
+		const result = inspectSubagentStatus({ action: "status" }, { asyncDirRoot: asyncRoot, resultsDir });
+		const firstContent = result.content[0];
+		const text = firstContent?.type === "text" ? firstContent.text : "";
+
+		assert.match(text, /gpt-5\.1-codex · thinking medium · fast/);
+	});
+
+	test("exact status output includes fast after thinking", () => {
+		const asyncRoot = makeTempRoot("atomic-subagent-status-fast-async-");
+		const resultsDir = makeTempRoot("atomic-subagent-status-fast-results-");
+		const asyncDir = writeStatus(asyncRoot, "run-fast", {
+			runId: "run-fast",
+			mode: "single",
+			state: "running",
+			startedAt: 1_000,
+			lastUpdate: 2_000,
+			currentStep: 0,
+			steps: [{
+				agent: "worker",
+				status: "running",
+				model: "openai/gpt-5.1-codex",
+				thinking: "medium",
+				fastMode: true,
+			}],
+		});
+
+		const result = inspectSubagentStatus({ action: "status", dir: asyncDir }, { asyncDirRoot: asyncRoot, resultsDir });
+		const firstContent = result.content[0];
+		const text = firstContent?.type === "text" ? firstContent.text : "";
+
+		assert.match(text, /Step 1: worker running \(gpt-5\.1-codex · thinking medium · fast\)/);
+	});
+});

--- a/test/unit/subagents-fast-mode.test.ts
+++ b/test/unit/subagents-fast-mode.test.ts
@@ -1,0 +1,72 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+  resolveSubagentCodexFastModeScope,
+  resolveSubagentModelFastMode,
+  resolveSubagentModelFastModeMetadata,
+} from "../../packages/subagents/src/shared/fast-mode.js";
+
+const cwd = process.cwd();
+
+describe("subagent fast-mode scope", () => {
+  test("uses chat settings for main-chat subagents only", () => {
+    const settings = { chat: true, workflow: false };
+
+    assert.equal(
+      resolveSubagentModelFastMode({ model: "openai/gpt-5.1-codex", cwd, settings, scope: "chat" }),
+      true,
+    );
+    assert.equal(
+      resolveSubagentModelFastMode({ model: "openai/gpt-5.1-codex", cwd, settings, scope: "workflow" }),
+      false,
+    );
+  });
+
+  test("uses workflow settings for workflow-stage subagents only", () => {
+    const settings = { chat: false, workflow: true };
+
+    assert.equal(
+      resolveSubagentModelFastMode({ model: "openai/gpt-5.1-codex", cwd, settings, scope: "chat" }),
+      false,
+    );
+    assert.equal(
+      resolveSubagentModelFastMode({ model: "openai/gpt-5.1-codex", cwd, settings, scope: "workflow" }),
+      true,
+    );
+  });
+
+  test("supports openai-codex models with thinking suffixes", () => {
+    const settings = { chat: false, workflow: true };
+
+    assert.equal(
+      resolveSubagentModelFastMode({ model: "openai-codex/gpt-5.1-codex:medium", cwd, settings, scope: "workflow" }),
+      true,
+    );
+    assert.equal(
+      resolveSubagentModelFastMode({ model: "anthropic/claude-sonnet-4:medium", cwd, settings, scope: "workflow" }),
+      false,
+    );
+  });
+
+  test("builds scoped metadata for primary and fallback candidates", () => {
+    const metadata = resolveSubagentModelFastModeMetadata({
+      model: "openai/gpt-5.1-codex",
+      modelCandidates: ["openai/gpt-5.1-codex", "anthropic/claude-sonnet-4"],
+      cwd,
+      settings: { chat: false, workflow: true },
+      scope: "workflow",
+    });
+
+    assert.equal(metadata.fastMode, true);
+    assert.deepEqual(metadata.modelFastModes, {
+      "openai/gpt-5.1-codex": true,
+      "anthropic/claude-sonnet-4": false,
+    });
+  });
+
+  test("derives scope from workflow-stage guard", () => {
+    assert.equal(resolveSubagentCodexFastModeScope(false), "chat");
+    assert.equal(resolveSubagentCodexFastModeScope(undefined), "chat");
+    assert.equal(resolveSubagentCodexFastModeScope(true), "workflow");
+  });
+});

--- a/test/unit/subagents-formatters.test.ts
+++ b/test/unit/subagents-formatters.test.ts
@@ -1,6 +1,27 @@
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { formatDuration } from "../../packages/subagents/src/shared/formatters.js";
+import { formatDuration, formatModelThinking } from "../../packages/subagents/src/shared/formatters.js";
+
+describe("subagent formatModelThinking", () => {
+	test("appends fast after model and inferred thinking suffix", () => {
+		assert.equal(
+			formatModelThinking("openai/gpt-5.1-codex:medium", undefined, true),
+			"gpt-5.1-codex · thinking medium · fast",
+		);
+	});
+
+	test("omits fast when fast mode metadata is missing or disabled", () => {
+		assert.equal(formatModelThinking("openai/gpt-5.1-codex:medium"), "gpt-5.1-codex · thinking medium");
+		assert.equal(formatModelThinking("openai/gpt-5.1-codex:medium", undefined, false), "gpt-5.1-codex · thinking medium");
+	});
+
+	test("appends fast after explicit thinking metadata", () => {
+		assert.equal(
+			formatModelThinking("openai/gpt-5.1-codex", "high", true),
+			"gpt-5.1-codex · thinking high · fast",
+		);
+	});
+});
 
 describe("subagent formatDuration", () => {
 	test("uses whole seconds without fractional or millisecond labels", () => {

--- a/test/unit/subagents-pi-args.test.ts
+++ b/test/unit/subagents-pi-args.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
+import { ENV_CODEX_FAST_MODE } from "../../packages/coding-agent/src/config.js";
 import {
   buildPiArgs,
   FANOUT_CHILD_EXTENSION_PATH,
@@ -82,5 +83,39 @@ describe("subagent child CLI args", () => {
 
     assert.equal(disabled.env.MCP_DIRECT_TOOLS, "__none__");
     assert.equal(selected.env.MCP_DIRECT_TOOLS, "github/search_code");
+  });
+
+  test("maps scoped fast-mode settings onto child chat env", () => {
+    const chatScoped = buildPiArgs({
+      baseArgs: [],
+      task: "hello",
+      sessionEnabled: false,
+      inheritProjectContext: true,
+      inheritSkills: true,
+      codexFastModeSettings: { chat: true, workflow: false },
+      codexFastModeScope: "chat",
+    });
+    const workflowScoped = buildPiArgs({
+      baseArgs: [],
+      task: "hello",
+      sessionEnabled: false,
+      inheritProjectContext: true,
+      inheritSkills: true,
+      codexFastModeSettings: { chat: false, workflow: true },
+      codexFastModeScope: "workflow",
+    });
+    const workflowDisabled = buildPiArgs({
+      baseArgs: [],
+      task: "hello",
+      sessionEnabled: false,
+      inheritProjectContext: true,
+      inheritSkills: true,
+      codexFastModeSettings: { chat: true, workflow: false },
+      codexFastModeScope: "workflow",
+    });
+
+    assert.equal(chatScoped.env[ENV_CODEX_FAST_MODE], "chat=1;workflow=0");
+    assert.equal(workflowScoped.env[ENV_CODEX_FAST_MODE], "chat=1;workflow=1");
+    assert.equal(workflowDisabled.env[ENV_CODEX_FAST_MODE], "chat=0;workflow=0");
   });
 });

--- a/test/unit/subagents-render-stability.test.ts
+++ b/test/unit/subagents-render-stability.test.ts
@@ -73,6 +73,75 @@ function runningSingleResult(): AgentToolResult<Details> {
   };
 }
 
+describe("subagent fast-mode UI labels (issue #1153)", () => {
+  test("foreground compact result renders fast after thinking", () => {
+    const result: AgentToolResult<Details> = {
+      content: [{ type: "text", text: "done" }],
+      details: {
+        mode: "single",
+        results: [{
+          agent: "worker",
+          task: "do work",
+          exitCode: 0,
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+          model: "openai/gpt-5.1-codex:medium",
+          fastMode: true,
+          finalOutput: "done",
+        }],
+      },
+    };
+
+    const text = renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n");
+
+    assert.match(text, /gpt-5\.1-codex · thinking medium · fast/);
+  });
+
+  test("foreground result omits fast when metadata is missing", () => {
+    const result: AgentToolResult<Details> = {
+      content: [{ type: "text", text: "done" }],
+      details: {
+        mode: "single",
+        results: [{
+          agent: "worker",
+          task: "do work",
+          exitCode: 0,
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+          model: "openai/gpt-5.1-codex:medium",
+          finalOutput: "done",
+        }],
+      },
+    };
+
+    const text = renderSubagentResult(result, { expanded: false }, theme).render(120).join("\n");
+
+    assert.match(text, /gpt-5\.1-codex · thinking medium/);
+    assert.doesNotMatch(text, / · fast/);
+  });
+
+  test("async widget step renders fast after thinking", () => {
+    const job: AsyncJobState = {
+      asyncId: "fast-run",
+      asyncDir: "/tmp/fast-run",
+      status: "running",
+      mode: "single",
+      agents: ["worker"],
+      updatedAt: 10_000,
+      steps: [{
+        index: 0,
+        agent: "worker",
+        status: "running",
+        model: "openai/gpt-5.1-codex",
+        thinking: "medium",
+        fastMode: true,
+      }],
+    };
+
+    const text = withMockedNow(10_000, () => buildWidgetLines([job], theme, 120).join("\n"));
+
+    assert.match(text, /gpt-5\.1-codex · thinking medium · fast/);
+  });
+});
+
 describe("subagent running spinner animation (issue #1084)", () => {
   afterEach(() => {
     stopResultAnimations();


### PR DESCRIPTION
## Summary

Surfaces fast-mode status across all subagent UI layers and propagates fast-mode settings to child processes for Codex runs launched with `/fast` enabled. Fixes #1153.

## Key Changes

- **New `fast-mode.ts` module** (`packages/subagents/src/shared/fast-mode.ts`): Resolves Codex fast-mode settings via `SettingsManager` and exposes `resolveSubagentModelFastMode`, `resolveSubagentModelFastModeMap`, and `resolveSubagentModelFastModeMetadata` to compute per-model fast-mode metadata at launch time for both primary and candidate models
- **Child process propagation** (`pi-args.ts`): Serializes `codexFastModeSettings` into the `ENV_CODEX_FAST_MODE` env var passed to child subagent processes, scoping `chat` to the active scope before hand-off
- **Type extensions**: `fastMode?: boolean` and `modelFastModes?: Record<string, boolean>` added to `SingleResult`, `AsyncStatus` steps, `RunnerSubagentStep`, `ParallelTaskResult`, `ResultChildOutcome`, and related internal interfaces
- **Formatter** (`formatters.ts`): `formatModelThinking` updated to append ` · fast` when `fastMode` is true — e.g. `gpt-5.1-codex · thinking medium · fast`
- **TUI render** (`render.ts`): `modelThinkingBadge` and all widget render paths (`widgetParallelAgentDetails`, `foregroundStyleWidgetStepLines`, `compactSingleWidgetLines`, `renderSingleCompact`, `renderSubagentResult`) propagate `fastMode` to the badge
- **Async execution** (`async-execution.ts`): Resolves fast-mode metadata during step config construction for both chain and single runs; passes settings and scope through to child config
- **Background runner** (`subagent-runner.ts`): `fastModeForStepAttempt` helper resolves per-attempt fast-mode from `modelFastModes` map; `fastMode` persisted at step initialization, attempt start, and completion
- **Foreground execution** (`execution.ts`): Resolves fast mode per attempt via shared settings/scope computed once at run start; included in `SingleResult`
- **Status output** (`async-status.ts`, `run-status.ts`): `fastMode` forwarded through step summaries and inspection text to `formatModelThinking`
- **Stale run reconciler**: Preserves `fastMode` through terminal status and failed-repair resolution
- **Tests**: Four new test files covering `fast-mode.ts` resolution logic, `pi-args` serialization, `formatModelThinking` fast-mode variants, TUI render stability (foreground compact + async widget), and async status inspection output

## Validation

```sh
AGENT=1 bun test test/unit/subagents-formatters.test.ts test/unit/subagents-render-stability.test.ts test/unit/subagents-async-status-fast-mode.test.ts test/unit/subagents-fast-mode.test.ts test/unit/subagents-pi-args.test.ts
AGENT=1 bun run typecheck
# git commit hooks: bun run lint, bun run test:unit
```