### PR TITLE
fix(workflows): refresh manifest workflows on reload

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Added a host workflow-resource refresh path so workflow reloads can re-read package manifests without a full Atomic reload ([#1155](https://github.com/flora131/atomic/issues/1155)).
 - Preserved custom registered provider streamers when Codex fast mode is enabled for native OpenAI response APIs ([#1134](https://github.com/flora131/atomic/issues/1134)).
 - Fixed `/fast` changes so the banner/footer and current session update immediately, and inherited chat fast-mode state now reaches subagent child sessions without waiting for a restart ([#1134](https://github.com/flora131/atomic/issues/1134)).
 - Fixed `/fast` persistence so existing project-level fast-mode overrides are updated alongside global settings for the changed scope without clobbering untouched global chat or workflow fast-mode preferences ([#1134](https://github.com/flora131/atomic/issues/1134)).

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -566,7 +566,7 @@ In the TUI, `/workflow <name>` opens an input picker when the workflow declares 
 /workflow reload
 ```
 
-Use `connect` for the workflow graph. Use `attach` when you want a chat pane for a specific stage. Use `interrupt`, `pause`, and `resume` for resumable live work; `resume` on a non-paused run reopens the saved snapshot or overlay. Use `kill` only when the run should be terminated; killed runs are retained in live history/status for read-only inspection. Use `/workflow reload` after adding, editing, installing, or removing workflow resources and you want Atomic to rediscover them in-process. `/workflow status` lists all retained active and terminal runs by default; `/workflow status --all` is retained as a compatibility alias.
+Use `connect` for the workflow graph. Use `attach` when you want a chat pane for a specific stage. Use `interrupt`, `pause`, and `resume` for resumable live work; `resume` on a non-paused run reopens the saved snapshot or overlay. Use `kill` only when the run should be terminated; killed runs are retained in live history/status for read-only inspection. Use `/workflow reload` after adding, editing, installing, or removing workflow resources or package manifest workflow entries and you want Atomic to rediscover them in-process. `/workflow status` lists all retained active and terminal runs by default; `/workflow status --all` is retained as a compatibility alias.
 
 <p align="center"><img src="images/workflow-graph.png" alt="Workflow Graph Viewer" width="600" /></p>
 

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -10,6 +10,7 @@ export {
 	loadExtensionFromFactory,
 	loadExtensions,
 } from "./loader.ts";
+export type { WorkflowResourceProvider, WorkflowResourceProviderInput } from "./loader.ts";
 export type {
 	ExtensionErrorListener,
 	ForkHandler,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -139,6 +139,25 @@ function getAliases(): Record<string, string> {
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 
+export interface WorkflowResourceProvider {
+  get(): ResolvedResource[];
+  refresh?(): Promise<ResolvedResource[]>;
+}
+
+export type WorkflowResourceProviderInput = WorkflowResourceProvider | ResolvedResource[];
+
+function createStaticWorkflowResourceProvider(workflowResources: ResolvedResource[]): WorkflowResourceProvider {
+  return {
+    get: () => workflowResources,
+  };
+}
+
+function normalizeWorkflowResourceProvider(input: WorkflowResourceProviderInput): WorkflowResourceProvider {
+  return Array.isArray(input) ? createStaticWorkflowResourceProvider(input) : input;
+}
+
+const emptyWorkflowResourceProvider = createStaticWorkflowResourceProvider([]);
+
 /**
  * Create a runtime with throwing stubs for action methods.
  * Runner.bindCore() replaces these with real implementations.
@@ -209,8 +228,9 @@ function createExtensionAPI(
   runtime: ExtensionRuntime,
   cwd: string,
   eventBus: EventBus,
-  workflowResources: ResolvedResource[] = [],
+  workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
 ): ExtensionAPI {
+  const workflowResources = normalizeWorkflowResourceProvider(workflowResourceProvider);
   const api = {
     // Registration methods - write to extension
     on(event: string, handler: HandlerFn): void {
@@ -294,7 +314,13 @@ function createExtensionAPI(
 
     getWorkflowResources(): ResolvedResource[] {
       runtime.assertActive();
-      return [...workflowResources];
+      return [...workflowResources.get()];
+    },
+
+    async refreshWorkflowResources(): Promise<ResolvedResource[]> {
+      runtime.assertActive();
+      const refreshed = await workflowResources.refresh?.();
+      return [...(refreshed ?? workflowResources.get())];
     },
 
     // Action methods - delegate to shared runtime
@@ -433,7 +459,7 @@ async function loadExtension(
   cwd: string,
   eventBus: EventBus,
   runtime: ExtensionRuntime,
-  workflowResources: ResolvedResource[] = [],
+  workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
 ): Promise<{ extension: Extension | null; error: string | null }> {
   const resolvedPath = resolvePath(extensionPath, cwd, { normalizeUnicodeSpaces: true });
 
@@ -452,7 +478,7 @@ async function loadExtension(
       runtime,
       cwd,
       eventBus,
-      workflowResources,
+      workflowResourceProvider,
     );
     await factory(api);
 
@@ -472,7 +498,7 @@ export async function loadExtensionFromFactory(
   eventBus: EventBus,
   runtime: ExtensionRuntime,
   extensionPath = "<inline>",
-  workflowResources: ResolvedResource[] = [],
+  workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
 ): Promise<Extension> {
   const extension = createExtension(extensionPath, extensionPath);
   const resolvedCwd = resolvePath(cwd);
@@ -481,7 +507,7 @@ export async function loadExtensionFromFactory(
     runtime,
     resolvedCwd,
     eventBus,
-    workflowResources,
+    workflowResourceProvider,
   );
   await factory(api);
   return extension;
@@ -494,7 +520,7 @@ export async function loadExtensions(
   paths: string[],
   cwd: string,
   eventBus?: EventBus,
-  workflowResources: ResolvedResource[] = [],
+  workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
 ): Promise<LoadExtensionsResult> {
   const extensions: Extension[] = [];
   const errors: Array<{ path: string; error: string }> = [];
@@ -508,7 +534,7 @@ export async function loadExtensions(
       resolvedCwd,
       resolvedEventBus,
       runtime,
-      workflowResources,
+      workflowResourceProvider,
     );
 
     if (error) {

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1223,6 +1223,12 @@ export interface ExtensionAPI {
 	/** Return package-provided workflow files discovered for this session. */
 	getWorkflowResources(): ResolvedResource[];
 
+	/**
+	 * Re-read package/settings workflow resources and return the updated snapshot when supported by the host.
+	 * Does not reload extensions, skills, prompts, themes, or context files.
+	 */
+	refreshWorkflowResources?: () => Promise<ResolvedResource[]>;
+
 	// =========================================================================
 	// Message Rendering
 	// =========================================================================

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -9,9 +9,14 @@ export type { ResourceCollision, ResourceDiagnostic } from "./diagnostics.ts";
 
 import { canonicalizePath, isLocalPath, resolvePath } from "../utils/paths.ts";
 import { createEventBus, type EventBus } from "./event-bus.ts";
-import { createExtensionRuntime, loadExtensionFromFactory, loadExtensions } from "./extensions/loader.ts";
+import {
+	createExtensionRuntime,
+	loadExtensionFromFactory,
+	loadExtensions,
+	type WorkflowResourceProvider,
+} from "./extensions/loader.ts";
 import type { Extension, ExtensionFactory, ExtensionRuntime, LoadExtensionsResult } from "./extensions/types.ts";
-import { DefaultPackageManager, type PathMetadata, type ResolvedResource } from "./package-manager.ts";
+import { DefaultPackageManager, type PathMetadata, type ResolvedPaths, type ResolvedResource } from "./package-manager.ts";
 import type { PromptTemplate } from "./prompt-templates.ts";
 import { loadPromptTemplates } from "./prompt-templates.ts";
 import { SettingsManager } from "./settings-manager.ts";
@@ -203,6 +208,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private agentsFiles: Array<{ path: string; content: string }>;
 	private systemPrompt?: string;
 	private appendSystemPrompt: string[];
+	private workflowResources: ResolvedResource[];
 	private lastSkillPaths: string[];
 	private extensionSkillSourceInfos: Map<string, SourceInfo>;
 	private extensionPromptSourceInfos: Map<string, SourceInfo>;
@@ -250,6 +256,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.themeDiagnostics = [];
 		this.agentsFiles = [];
 		this.appendSystemPrompt = [];
+		this.workflowResources = [];
 		this.lastSkillPaths = [];
 		this.extensionSkillSourceInfos = new Map();
 		this.extensionPromptSourceInfos = new Map();
@@ -284,6 +291,21 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	getAppendSystemPrompt(): string[] {
 		return this.appendSystemPrompt;
+	}
+
+	getWorkflowResources(): ResolvedResource[] {
+		return [...this.workflowResources];
+	}
+
+	async refreshWorkflowResources(): Promise<ResolvedResource[]> {
+		const { resolvedPaths, cliExtensionPaths, builtinPackagePaths } = await this.resolvePackageResourcePaths();
+		const workflowResources = this.collectWorkflowResources(
+			resolvedPaths,
+			cliExtensionPaths,
+			builtinPackagePaths,
+		);
+		this.workflowResources = workflowResources;
+		return [...this.workflowResources];
 	}
 
 	extendResources(paths: ResourceExtensionPaths): void {
@@ -327,15 +349,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	}
 
 	async reload(): Promise<void> {
-		await this.settingsManager.reload();
-		const resolvedPaths = await this.packageManager.resolve();
-		const cliExtensionPaths = await this.packageManager.resolveExtensionSources(this.additionalExtensionPaths, {
-			temporary: true,
-		});
-		const builtinPackagePaths =
-			this.builtinPackagePaths.length > 0
-				? await this.packageManager.resolveExtensionSources(this.builtinPackagePaths, { temporary: true })
-				: { extensions: [], skills: [], prompts: [], themes: [], workflows: [] };
+		const { resolvedPaths, cliExtensionPaths, builtinPackagePaths } = await this.resolvePackageResourcePaths();
 		const metadataByPath = new Map<string, PathMetadata>();
 
 		this.extensionSkillSourceInfos = new Map();
@@ -361,7 +375,6 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const enabledSkillResources = getEnabledResources(resolvedPaths.skills);
 		const enabledPrompts = getEnabledPaths(resolvedPaths.prompts);
 		const enabledThemes = getEnabledPaths(resolvedPaths.themes);
-		const enabledWorkflowResources = getEnabledResources(resolvedPaths.workflows);
 
 		const builtinEnabledExtensions = this.noExtensions
 			? []
@@ -369,7 +382,6 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const builtinEnabledSkillResources = this.noSkills ? [] : getEnabledResources(builtinPackagePaths.skills);
 		const builtinEnabledPrompts = this.noPromptTemplates ? [] : getEnabledPaths(builtinPackagePaths.prompts);
 		const builtinEnabledThemes = this.noThemes ? [] : getEnabledPaths(builtinPackagePaths.themes);
-		const builtinEnabledWorkflowResources = getEnabledResources(builtinPackagePaths.workflows);
 
 		const mapSkillPath = (resource: { path: string; metadata: PathMetadata }): string => {
 			if (resource.metadata.source !== "auto" && resource.metadata.origin !== "package") {
@@ -412,19 +424,20 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const cliEnabledSkills = getEnabledPaths(cliExtensionPaths.skills);
 		const cliEnabledPrompts = getEnabledPaths(cliExtensionPaths.prompts);
 		const cliEnabledThemes = getEnabledPaths(cliExtensionPaths.themes);
-		const cliEnabledWorkflowResources = getEnabledResources(cliExtensionPaths.workflows);
-		const workflowResources = [
-			...cliEnabledWorkflowResources,
-			...enabledWorkflowResources,
-			...builtinEnabledWorkflowResources,
-		].filter((resource) => resource.metadata.origin === "package");
+		const workflowResources = this.collectWorkflowResources(
+			resolvedPaths,
+			cliExtensionPaths,
+			builtinPackagePaths,
+		);
+		this.workflowResources = workflowResources;
+		const workflowResourceProvider = this.createWorkflowResourceProvider();
 
 		const extensionPaths = this.noExtensions
 			? cliEnabledExtensions
 			: this.mergePaths(cliEnabledExtensions, [...enabledExtensions, ...builtinEnabledExtensions]);
 
-		const extensionsResult = await loadExtensions(extensionPaths, this.cwd, this.eventBus, workflowResources);
-		const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime, workflowResources);
+		const extensionsResult = await loadExtensions(extensionPaths, this.cwd, this.eventBus, workflowResourceProvider);
+		const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime, workflowResourceProvider);
 		extensionsResult.extensions.push(...inlineExtensions.extensions);
 		extensionsResult.errors.push(...inlineExtensions.errors);
 
@@ -523,6 +536,50 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.appendSystemPrompt = this.appendSystemPromptOverride
 			? this.appendSystemPromptOverride(baseAppend)
 			: baseAppend;
+	}
+
+	private emptyResolvedPaths(): ResolvedPaths {
+		return { extensions: [], skills: [], prompts: [], themes: [], workflows: [] };
+	}
+
+	private async resolvePackageResourcePaths(): Promise<{
+		resolvedPaths: ResolvedPaths;
+		cliExtensionPaths: ResolvedPaths;
+		builtinPackagePaths: ResolvedPaths;
+	}> {
+		await this.settingsManager.reload();
+		const resolvedPaths = await this.packageManager.resolve();
+		const cliExtensionPaths = await this.packageManager.resolveExtensionSources(this.additionalExtensionPaths, {
+			temporary: true,
+		});
+		const builtinPackagePaths =
+			this.builtinPackagePaths.length > 0
+				? await this.packageManager.resolveExtensionSources(this.builtinPackagePaths, { temporary: true })
+				: this.emptyResolvedPaths();
+		return { resolvedPaths, cliExtensionPaths, builtinPackagePaths };
+	}
+
+	private enabledPackageWorkflowResources(resources: ResolvedResource[]): ResolvedResource[] {
+		return resources.filter((resource) => resource.enabled && resource.metadata.origin === "package");
+	}
+
+	private collectWorkflowResources(
+		resolvedPaths: ResolvedPaths,
+		cliExtensionPaths: ResolvedPaths,
+		builtinPackagePaths: ResolvedPaths,
+	): ResolvedResource[] {
+		return [
+			...this.enabledPackageWorkflowResources(cliExtensionPaths.workflows),
+			...this.enabledPackageWorkflowResources(resolvedPaths.workflows),
+			...this.enabledPackageWorkflowResources(builtinPackagePaths.workflows),
+		];
+	}
+
+	private createWorkflowResourceProvider(): WorkflowResourceProvider {
+		return {
+			get: () => this.workflowResources,
+			refresh: () => this.refreshWorkflowResources(),
+		};
 	}
 
 	private normalizeExtensionPaths(
@@ -816,7 +873,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		}
 	}
 
-	private async loadExtensionFactories(runtime: ExtensionRuntime, workflowResources: ResolvedResource[]): Promise<{
+	private async loadExtensionFactories(runtime: ExtensionRuntime, workflowResourceProvider: WorkflowResourceProvider): Promise<{
 		extensions: Extension[];
 		errors: Array<{ path: string; error: string }>;
 	}> {
@@ -826,7 +883,14 @@ export class DefaultResourceLoader implements ResourceLoader {
 		for (const [index, factory] of this.extensionFactories.entries()) {
 			const extensionPath = `<inline:${index + 1}>`;
 			try {
-				const extension = await loadExtensionFromFactory(factory, this.cwd, this.eventBus, runtime, extensionPath, workflowResources);
+				const extension = await loadExtensionFromFactory(
+					factory,
+					this.cwd,
+					this.eventBus,
+					runtime,
+					extensionPath,
+					workflowResourceProvider,
+				);
 				extensions.push(extension);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : "failed to load extension";

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -284,6 +284,49 @@ Content`,
 			// Should NOT find helper.ts (not declared in manifest)
 			expect(result.extensions.some((r) => pathEndsWith(r.path, "helper.ts"))).toBe(false);
 		});
+
+		it("should resolve package-declared workflows from atomic and legacy manifests", async () => {
+			const atomicPkg = join(tempDir, "atomic-workflows-pkg");
+			const piPkg = join(tempDir, "pi-workflows-pkg");
+			const singularPkg = join(tempDir, "pi-workflow-singular-pkg");
+
+			mkdirSync(join(atomicPkg, "workflows"), { recursive: true });
+			mkdirSync(join(piPkg, "workflows"), { recursive: true });
+			mkdirSync(join(singularPkg, "workflow"), { recursive: true });
+			writeFileSync(join(atomicPkg, "workflows", "atomic.ts"), "export default {}");
+			writeFileSync(join(piPkg, "workflows", "legacy.ts"), "export default {}");
+			writeFileSync(join(singularPkg, "workflow", "singular.ts"), "export default {}");
+			writeFileSync(
+				join(atomicPkg, "package.json"),
+				JSON.stringify({
+					name: "atomic-workflows-pkg",
+					atomic: { workflows: ["workflows/atomic.ts"] },
+				}),
+			);
+			writeFileSync(
+				join(piPkg, "package.json"),
+				JSON.stringify({
+					name: "pi-workflows-pkg",
+					pi: { workflows: ["workflows/legacy.ts"] },
+				}),
+			);
+			writeFileSync(
+				join(singularPkg, "package.json"),
+				JSON.stringify({
+					name: "pi-workflow-singular-pkg",
+					pi: { workflow: ["workflow/singular.ts"] },
+				}),
+			);
+
+			settingsManager.setPackages([atomicPkg, piPkg, singularPkg]);
+
+			const result = await packageManager.resolve();
+
+			expect(result.workflows.some((r) => isEnabled(r, join("workflows", "atomic.ts")))).toBe(true);
+			expect(result.workflows.some((r) => isEnabled(r, join("workflows", "legacy.ts")))).toBe(true);
+			expect(result.workflows.some((r) => isEnabled(r, join("workflow", "singular.ts")))).toBe(true);
+			expect(result.workflows.every((r) => r.metadata.origin === "package")).toBe(true);
+		});
 	});
 
 	describe("auto-discovered skill metadata", () => {

--- a/packages/coding-agent/test/resource-loader.test.ts
+++ b/packages/coding-agent/test/resource-loader.test.ts
@@ -1,11 +1,13 @@
 import { mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { ExtensionRunner } from "../src/core/extensions/runner.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
+import type { ExtensionAPI } from "../src/core/extensions/types.ts";
+import type { ResolvedResource } from "../src/core/package-manager.ts";
 import { DefaultResourceLoader } from "../src/core/resource-loader.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
@@ -37,6 +39,64 @@ describe("DefaultResourceLoader", () => {
 			expect(loader.getSkills().skills).toEqual([]);
 			expect(loader.getPrompts().prompts).toEqual([]);
 			expect(loader.getThemes().themes).toEqual([]);
+		});
+
+		it("should refresh package workflow resources without reloading extensions", async () => {
+			const settingsManager = SettingsManager.inMemory();
+			const pkgDir = join(tempDir, "workflow-package");
+			const workflowDir = join(pkgDir, "workflows");
+			const workflowA = join(workflowDir, "a.ts");
+			const workflowB = join(workflowDir, "b.ts");
+			const manifestPath = join(pkgDir, "package.json");
+			const writeManifest = (workflows: string[]): void => {
+				writeFileSync(
+					manifestPath,
+					JSON.stringify({
+						name: "workflow-package",
+						atomic: { workflows },
+					}),
+				);
+			};
+
+			mkdirSync(workflowDir, { recursive: true });
+			writeFileSync(workflowA, "export default {}");
+			writeFileSync(workflowB, "export default {}");
+			writeManifest(["workflows/a.ts"]);
+			settingsManager.setPackages([pkgDir]);
+
+			let factoryCalls = 0;
+			let apiGetWorkflowResources: (() => ResolvedResource[]) | undefined;
+			let apiRefreshWorkflowResources: (() => Promise<ResolvedResource[]>) | undefined;
+			const loader = new DefaultResourceLoader({
+				cwd,
+				agentDir,
+				settingsManager,
+				extensionFactories: [
+					(pi: ExtensionAPI) => {
+						factoryCalls += 1;
+						apiGetWorkflowResources = () => pi.getWorkflowResources();
+						apiRefreshWorkflowResources = () => pi.refreshWorkflowResources();
+					},
+				],
+			});
+
+			await loader.reload();
+
+			if (!apiGetWorkflowResources || !apiRefreshWorkflowResources) {
+				throw new Error("expected extension factory to capture workflow resource APIs");
+			}
+
+			expect(factoryCalls).toBe(1);
+			expect(apiGetWorkflowResources().map((resource) => resource.path)).toEqual([workflowA]);
+			expect(loader.getWorkflowResources().map((resource) => resource.path)).toEqual([workflowA]);
+
+			writeManifest(["workflows/a.ts", "workflows/b.ts"]);
+			const refreshed = await apiRefreshWorkflowResources();
+
+			expect(refreshed.map((resource) => resource.path)).toEqual([workflowA, workflowB]);
+			expect(apiGetWorkflowResources().map((resource) => resource.path)).toEqual([workflowA, workflowB]);
+			expect(loader.getWorkflowResources().map((resource) => resource.path)).toEqual([workflowA, workflowB]);
+			expect(factoryCalls).toBe(1);
 		});
 
 		it("should discover skills from agentDir", async () => {
@@ -130,9 +190,11 @@ description: project
 Project skill`,
 			);
 
-			const baseTheme = JSON.parse(
-				readFileSync(join(process.cwd(), "src", "modes", "interactive", "theme", "dark.json"), "utf-8"),
-			) as { name: string; vars?: Record<string, string> };
+			const baseThemePath = fileURLToPath(new URL("../src/modes/interactive/theme/dark.json", import.meta.url));
+			const baseTheme = JSON.parse(readFileSync(baseThemePath, "utf-8")) as {
+				name: string;
+				vars?: Record<string, string>;
+			};
 			baseTheme.name = "collision-theme";
 			const userThemePath = join(agentDir, "themes", "collision.json");
 			const projectThemePath = join(cwd, ".pi", "themes", "collision.json");

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed `/workflow reload` and `workflow({ action: "reload" })` so newly added package-manifest workflow entries are rediscovered in-process without requiring top-level `/reload` or restart ([#1155](https://github.com/flora131/atomic/issues/1155)).
 - Fixed completed imported workflow boundary stages rendering as empty graph nodes by showing the child workflow name, child run id prefix, and selected output count in the node card.
 - Fixed the bundled deep-research workflow line-count heuristic hanging Windows CI by replacing its POSIX `wc` subprocess with portable in-process line counting.
 - Kept workflow stage model metadata as the raw model id while surfacing Codex fast mode as a separate visible `fast` marker on workflow node cards, including stages that use the default Atomic SDK adapter settings manager.

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -314,7 +314,7 @@ registry.get("alpha"); // compiled workflow definition | undefined
 | `/workflow interrupt [run-id\|--all]` | Pause active/named/all active runs so they can resume    |
 | `/workflow kill [run-id\|--all]`      | Kill in-flight workflow runs; killed runs are retained for inspection |
 | `/workflow resume <run-id>`           | Resume paused work or re-open a run snapshot             |
-| `/workflow reload`                    | Reload discovered workflow resources in-process          |
+| `/workflow reload`                    | Reload discovered workflow resources and package-manifest entries in-process |
 | `/workflow inputs <name>`             | Print the input schema for a workflow                    |
 
 Input overrides are bare `key=value` tokens (no leading `--`). Values are JSON-parsed when possible, so numbers, booleans, and quoted strings work as expected (e.g. `count=3`, `flag=true`, `prompt="multi word value"`). A whole-object override can be passed as a single JSON token (e.g. `{"prompt":"...","count":3}`).

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -334,6 +334,8 @@ export interface ExtensionAPI {
   registerFlag?: (name: string, opts: PiFlagNamedOpts) => void;
   /** Return package-provided workflow files discovered by Atomic's package loader. */
   getWorkflowResources?: () => readonly WorkflowResourceInfo[];
+  /** Refresh package-provided workflow files before rediscovery, when supported by host. */
+  refreshWorkflowResources?: () => Promise<readonly WorkflowResourceInfo[]>;
   /**
    * Register a keyboard shortcut.
    * Present on pi >= 1.x; absent on older runtimes.
@@ -2427,6 +2429,16 @@ function factory(pi: ExtensionAPI): void {
     await reload;
   }
 
+  async function loadPackageWorkflowPaths(): Promise<string[]> {
+    const packageResources =
+      (await pi.refreshWorkflowResources?.()) ??
+      pi.getWorkflowResources?.() ??
+      [];
+    return packageResources
+      .filter((resource) => resource.enabled !== false)
+      .map((resource) => resource.path);
+  }
+
   async function reloadWorkflowResourcesNow(options?: { allowInFlight?: boolean }): Promise<void> {
     const activeRuns = inFlightRunCount();
     if (options?.allowInFlight !== true) {
@@ -2457,9 +2469,7 @@ function factory(pi: ExtensionAPI): void {
           )
         : undefined;
 
-    const packageWorkflowPaths = (pi.getWorkflowResources?.() ?? [])
-      .filter((resource) => resource.enabled !== false)
-      .map((resource) => resource.path);
+    const packageWorkflowPaths = await loadPackageWorkflowPaths();
     const result = await discoverWorkflows({ config: discoveryConfig, packageWorkflowPaths });
     discoveryRef.current = result;
 

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -75,13 +75,18 @@ afterEach(async () => {
 });
 
 async function writeWorkflowFixture(filePath: string, name: string): Promise<void> {
+  const encodedName = JSON.stringify(name);
   await writeFile(
     filePath,
-    `import { defineWorkflow } from "@bastani/workflows";
-
-export default defineWorkflow("${name}")
-  .run(async () => ({ ok: true }))
-  .compile();
+    `export default Object.freeze({
+  __piWorkflow: true,
+  name: ${encodedName},
+  normalizedName: ${encodedName},
+  interaction: Object.freeze({ humanInput: "none" }),
+  async run() {
+    return { ok: true };
+  },
+});
 `,
     "utf8",
   );

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -13,7 +13,7 @@
  *   - parseWorkflowArgs correctly parses key=value pairs and JSON objects.
  */
 
-import { afterEach, describe, test } from "bun:test";
+import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -62,12 +62,30 @@ import {
 import { stageUiBroker } from "../../packages/workflows/src/shared/stage-ui-broker.js";
 import { buildStagePromptAdapter } from "../../packages/workflows/src/shared/stage-prompt.js";
 
+beforeEach(() => {
+  delete process.env[WORKFLOW_STAGE_SUBAGENT_GUARD_ENV];
+});
+
 afterEach(async () => {
+  delete process.env[WORKFLOW_STAGE_SUBAGENT_GUARD_ENV];
   stageControlRegistry.clear();
   killAllRuns({ store, cancellation: cancellationRegistry });
   await Promise.all(jobTracker.runIds().map((runId) => jobTracker.get(runId)?.promise));
   store.clear();
 });
+
+async function writeWorkflowFixture(filePath: string, name: string): Promise<void> {
+  await writeFile(
+    filePath,
+    `import { defineWorkflow } from "@bastani/workflows";
+
+export default defineWorkflow("${name}")
+  .run(async () => ({ ok: true }))
+  .compile();
+`,
+    "utf8",
+  );
+}
 
 // ---------------------------------------------------------------------------
 // parseWorkflowArgs
@@ -1013,6 +1031,74 @@ describe("/workflow interrupt chat command", () => {
     await workflowCmd.options.handler("reload", ctx);
 
     assert.equal(messages.some((message) => message.includes("Reload failed: package loader unavailable")), true);
+  });
+
+  test("top-level /workflow reload refreshes package workflow resources before discovery", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "atomic-workflow-refresh-"));
+    try {
+      const existingWorkflow = join(dir, "existing.ts");
+      const addedWorkflow = join(dir, "added.ts");
+      await writeWorkflowFixture(existingWorkflow, "refresh-existing");
+      await writeWorkflowFixture(addedWorkflow, "refresh-added");
+
+      const { pi, commands } = buildMockPi();
+      addFactoryStubs(pi);
+      let refreshCalls = 0;
+      pi.getWorkflowResources = () => [{ path: existingWorkflow, enabled: true }];
+      pi.refreshWorkflowResources = async () => {
+        refreshCalls += 1;
+        return [
+          { path: existingWorkflow, enabled: true },
+          { path: addedWorkflow, enabled: true },
+        ];
+      };
+
+      const factoryModule = await import("../../packages/workflows/src/extension/index.js");
+      factoryModule.default(pi);
+
+      const workflowCmd = commands.find((c) => c.name === "workflow")!;
+      const { ctx, messages } = buildCtx();
+
+      await workflowCmd.options.handler("reload", ctx);
+
+      assert.equal(refreshCalls, 1);
+      assert.equal(messages.some((message) => message.includes("Reloaded workflow resources.")), true);
+      const completions = workflowCmd.options.getArgumentCompletions?.("refresh-added");
+      assert.equal(completions?.some((completion) => completion.label === "refresh-added"), true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("top-level /workflow reload falls back to getWorkflowResources when refresh is unavailable", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "atomic-workflow-refresh-fallback-"));
+    try {
+      const fallbackWorkflow = join(dir, "fallback.ts");
+      await writeWorkflowFixture(fallbackWorkflow, "refresh-fallback");
+
+      const { pi, commands } = buildMockPi();
+      addFactoryStubs(pi);
+      let getCalls = 0;
+      pi.getWorkflowResources = () => {
+        getCalls += 1;
+        return [{ path: fallbackWorkflow, enabled: true }];
+      };
+
+      const factoryModule = await import("../../packages/workflows/src/extension/index.js");
+      factoryModule.default(pi);
+
+      const workflowCmd = commands.find((c) => c.name === "workflow")!;
+      const { ctx, messages } = buildCtx();
+
+      await workflowCmd.options.handler("reload", ctx);
+
+      assert.equal(getCalls, 1);
+      assert.equal(messages.some((message) => message.includes("Reloaded workflow resources.")), true);
+      const completions = workflowCmd.options.getArgumentCompletions?.("refresh-fallback");
+      assert.equal(completions?.some((completion) => completion.label === "refresh-fallback"), true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -2184,6 +2270,51 @@ export default defineWorkflow("tool-headless-lifecycle")
     assert.match(reload.message, /Reloaded workflow resources/);
     assert.equal(reloads, 1);
     assert.deepEqual(sent, []);
+  });
+
+  test("registered workflow tool reload refreshes package workflow resources before discovery", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "atomic-workflow-tool-refresh-"));
+    try {
+      const addedWorkflow = join(dir, "tool-refresh-added.ts");
+      await writeWorkflowFixture(addedWorkflow, "tool-refresh-added");
+
+      const { pi, commands } = buildMockPi();
+      addFactoryStubs(pi);
+      let refreshCalls = 0;
+      pi.getWorkflowResources = () => [];
+      pi.refreshWorkflowResources = async () => {
+        refreshCalls += 1;
+        return [{ path: addedWorkflow, enabled: true }];
+      };
+      let registered: PiToolOpts<WorkflowToolArgs, WorkflowToolResult> | undefined;
+      pi.registerTool = (opts) => {
+        registered = opts as unknown as PiToolOpts<WorkflowToolArgs, WorkflowToolResult>;
+      };
+
+      const factoryModule = await import("../../packages/workflows/src/extension/index.js");
+      factoryModule.default(pi);
+      assert.ok(registered, "expected workflow tool registration");
+
+      const result = await registered.execute(
+        "tool-reload-refresh-call",
+        { action: "reload", reason: "manifest changed" },
+        undefined,
+        undefined,
+        {} as never,
+      );
+
+      assert.equal(refreshCalls, 1);
+      assert.equal(result.details.action, "reload");
+      const reload = result.details as Extract<WorkflowToolResult, { action: "reload" }>;
+      assert.equal(reload.status, "ok");
+      assert.match(reload.message, /Reloaded workflow resources/);
+      const workflowCmd = commands.find((command) => command.name === "workflow");
+      assert.ok(workflowCmd, "expected workflow command registration");
+      const completions = workflowCmd.options.getArgumentCompletions?.("tool-refresh-added") ?? [];
+      assert.equal(completions.some((completion) => completion.label === "tool-refresh-added"), true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   test("makeExecuteWorkflowTool treats explicit empty reload reason as omitted", async () => {


### PR DESCRIPTION
## Summary

Fixes `/workflow reload` and `workflow({ action: "reload" })` so package-manifest workflow entries are re-read from disk before workflow rediscovery — without requiring a full extension reload or agent restart.

Closes #1155

## Changes

### Host (`coding-agent`)
- Introduced `WorkflowResourceProvider` interface (`get()` + optional `refresh()`) in `extensions/loader.ts`; extensions now receive a live provider instead of a frozen snapshot so they can trigger an in-place manifest re-read
- `DefaultResourceLoader` caches the current workflow resource snapshot and exposes `getWorkflowResources()` / `refreshWorkflowResources()`, the latter of which re-reads package manifests independently of extension loading
- Extracted path-resolution logic into a shared `resolvePackageResourcePaths()` helper used by both `reload()` and `refreshWorkflowResources()`
- Added `collectWorkflowResources()` helper to consolidate the CLI/resolved/builtin workflow path merging in one place

### Extension API
- Added optional `refreshWorkflowResources?(): Promise<ResolvedResource[]>` to `ExtensionAPI` — absent on older host runtimes so extensions must handle `undefined`

### Workflows extension
- New `loadPackageWorkflowPaths()` calls `pi.refreshWorkflowResources?.()` with a transparent fallback to `pi.getWorkflowResources?.()` for older hosts that do not expose the refresh path
- `reloadWorkflowResourcesNow` is now async and awaits `loadPackageWorkflowPaths()`

### Tests
- Added regression coverage for `atomic` / `pi` / singular manifest variants (package-manager)
- Stale package workflow refresh (refresh-without-reload) with live provider validation
- `/workflow reload` with and without `refreshWorkflowResources` support
- Tool-based `workflow({ action: "reload" })` with refresh

### Docs
- Updated `coding-agent/docs/workflows.md` and `workflows/README.md` to document package-manifest reload support
- Updated both package changelogs under `[Unreleased]`

## Validation

```sh
bun test packages/coding-agent/test/package-manager.test.ts
bun test packages/coding-agent/test/resource-loader.test.ts
bun test test/unit/slash-dispatch.test.ts
bun test test/unit/discovery.test.ts
bun test packages/coding-agent/test/extensions-discovery.test.ts
bun run typecheck
bunx --bun --no-install tsgo -p packages/coding-agent/tsconfig.build.json --noEmit
bun run lint && bun run test:unit
```