### PR TITLE
feat(workflows)!: require module-style imports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
+- Documented TypeScript module-style workflow imports and reusable builtin workflow modules in the bundled workflow authoring guide.
 - Refined the `/fast` selector into a conventional toggle UI with on/off states, clearer scope descriptions, and space/enter toggle support ([#1134](https://github.com/flora131/atomic/issues/1134)).
 - Compressed the `/fast` selector copy, row layout, and per-change status message so the summary, toggles, scopes, and keyboard hints stay readable without duplicate off/standard-tier messaging ([#1134](https://github.com/flora131/atomic/issues/1134)).
 - Clarified workflow-creation guidance so Atomic asks clarifying questions and writes first-time workflows directly, reserving `/goal` for explicitly chosen long-running reviewer-gated implementation.

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -778,7 +778,7 @@ Builder basics:
 - `.description(text)` sets the listing text.
 - `.input(key, schema)` declares typed user inputs.
 - `.worktreeFromInputs({ gitWorktreeDir, baseBranch })` optionally maps input names to workflow-wide reusable Git worktree defaults.
-- `.import(alias, source, options?)` declares a reusable child workflow by registered workflow id or local module path. The optional `options.description` explains the import in generated metadata.
+- `.import(workflowDefinition, options?)` declares a reusable child workflow from a normal TypeScript module import and registers the child's normalized workflow name as the default `ctx.workflow(...)` alias. Pass `options.as` to use a parent-local alias. Registry-name and path-object import declarations are not supported.
 - `.output(key, schema?)` declares typed outputs that parent workflows can select from imports.
 - `.humanInTheLoop(reason?)` marks workflows that can require `ctx.ui.*` user input so non-interactive runs fail before starting.
 - `.run(async (ctx) => { ... })` defines the workflow body.
@@ -838,13 +838,13 @@ The marker is user-facing metadata and a safety gate: headless/non-interactive s
 
 ### Workflow Imports
 
-Use workflow imports when one workflow should call another reusable workflow and consume its outputs as a tracked boundary stage.
+Use workflow imports when one workflow should call another reusable workflow and consume its outputs as a tracked boundary stage. Prefer normal TypeScript imports: import the compiled child workflow definition, pass it to `.import(...)`, then call `ctx.workflow(childWorkflowName)`.
 
 ```ts
 // .atomic/workflows/shared-research.ts
 import { defineWorkflow } from "@bastani/workflows";
 
-export const sharedResearch = defineWorkflow("shared-research")
+export default defineWorkflow("shared-research")
   .input("topic", { type: "text", required: true })
   .output("summary", { type: "text", required: true, description: "Research summary markdown." })
   .output("sources", { type: "array", description: "Source URLs and file references." })
@@ -855,13 +855,16 @@ export const sharedResearch = defineWorkflow("shared-research")
   .compile();
 
 // .atomic/workflows/research-and-synthesize.ts
+import { defineWorkflow } from "@bastani/workflows";
+import { goal } from "@bastani/workflows/builtin";
+import sharedResearch from "./shared-research.js";
+
 export default defineWorkflow("research-and-synthesize")
   .input("topic", { type: "text", required: true })
-  .import("research", { workflow: "shared-research" }, { description: "Reusable topic research." })
-  // Local module imports are also supported:
-  // .import("research", { path: "./shared-research.ts", export: "sharedResearch" })
+  .import(sharedResearch, { description: "Reusable topic research." })
+  .import(goal, { as: "implementation-goal" })
   .run(async (ctx) => {
-    const child = await ctx.workflow("research", {
+    const child = await ctx.workflow("shared-research", {
       inputs: { topic: ctx.inputs.topic },
       outputs: { summary: "research_summary" },
       stageName: "run shared research",
@@ -875,7 +878,9 @@ export default defineWorkflow("research-and-synthesize")
   .compile();
 ```
 
-`ctx.workflow(alias)` starts a workflow declared with `.import(alias, source)` as a nested run and records a parent boundary stage named `import:<alias>` by default. The returned child result has:
+Direct definition imports register the imported workflow's normalized name as the default alias (`shared-research` above). Use `{ as: "alias" }` for a shorter parent-local alias. Builtin workflows are available from `@bastani/workflows/builtin` and individual module paths such as `@bastani/workflows/builtin/goal`, including `deepResearchCodebase`, `goal`, and `ralph`.
+
+`ctx.workflow(alias)` starts a workflow declared with `.import(...)` as a nested run and records a parent boundary stage named `import:<alias>` by default. The returned child result has:
 
 | Field | Meaning |
 |---|---|
@@ -896,9 +901,9 @@ export default defineWorkflow("research-and-synthesize")
 Output selection rules:
 
 ```ts
-await ctx.workflow("research"); // selects every key returned by the child
-await ctx.workflow("research", { outputs: ["summary", "sources"] });
-await ctx.workflow("research", { outputs: { summary: "research_summary" } });
+await ctx.workflow("shared-research"); // selects every key returned by the child
+await ctx.workflow("shared-research", { outputs: ["summary", "sources"] });
+await ctx.workflow("shared-research", { outputs: { summary: "research_summary" } });
 ```
 
 | `outputs` form | Behavior |
@@ -909,15 +914,7 @@ await ctx.workflow("research", { outputs: { summary: "research_summary" } });
 
 If the child declares outputs and the parent explicitly requests an undeclared key, the import fails. Required declared outputs are added implicitly even when the parent asks for a smaller subset. Missing selected outputs, duplicate parent output names, schema type mismatches, and non-serializable selected values fail the import before the parent continues.
 
-Import sources can reference either a registered workflow or a local module export:
-
-```ts
-.import("child", { workflow: "registered-name" })
-.import("child", { path: "./child.ts" })                // default export
-.import("child", { path: "./shared.ts", export: "x" }) // named export
-```
-
-Relative paths resolve from the importing workflow file when discovery has source metadata, then from the invocation cwd. Atomic validates imports during discovery/dispatch and fails fast for undeclared aliases, missing registered workflows, missing exports, invalid workflow exports, circular imports, and invalid declarations. Nested imports count against `maxDepth` (default `4` total workflow levels). Local path imports execute the imported file's top-level code during validation, so only reference trusted workflow modules.
+Only compiled workflow definitions can be passed to `.import(...)`. Import reusable workflows with TypeScript `import` statements first; if a module is missing or does not export a compiled workflow definition, workflow discovery fails when loading that module. Atomic validates circular or invalid compiled-definition import graphs during discovery/dispatch. Nested imports count against `maxDepth` (default `4` total workflow levels).
 
 The graph node for a completed import boundary shows the child workflow name, child run id prefix, and selected output count, rather than a blank zero-duration stage. Use `stageName` when the parent needs a more specific label, but keep it concise so the child summary remains readable in the graph.
 
@@ -932,7 +929,7 @@ Prefer high-level primitives because they create tracked graph nodes, provide co
 | One LLM/session task with workflow tracking | `ctx.task(name, options)` |
 | Dependent sequential tasks | `ctx.chain(steps, options?)` |
 | Independent concurrent branches | `ctx.parallel(steps, options?)` |
-| Reusable child workflow | Declare `.import(alias, source)` and call `ctx.workflow(alias, options?)` |
+| Reusable child workflow | Declare `.import(workflowDefinition)` and call `ctx.workflow(alias, options?)` |
 | Human input during a workflow run | `ctx.ui.input/confirm/select/editor` |
 | Pure deterministic computation, parsing, or file I/O | Plain TypeScript in `.run()` or helpers |
 | Fine-grained session control | `ctx.stage(name, options?)` |

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Removed legacy workflow import declarations by registered workflow name or path object. Workflows must now use normal TypeScript imports and pass compiled workflow definitions to `.import(workflow, { as? })`.
+
 ### Added
 
+- Added TypeScript module-style workflow imports: `.import(compiledWorkflow, { as? })` registers the imported workflow's name for `ctx.workflow(...)`, while the bundled `deep-research-codebase`, `goal`, and `ralph` workflows are reusable from `@bastani/workflows/builtin` or individual builtin module paths.
 - Added first-class workflow imports for composition: workflows can declare `.import()` dependencies, child workflows can declare `.output()` contracts, discovery validates unresolved/circular/invalid import graphs, and `ctx.workflow()` runs imported workflows as nested runs with input validation, output selection/mapping, and a visible parent boundary stage ([#1071](https://github.com/flora131/atomic/issues/1071)).
 - Added explicit workflow interaction metadata through `defineWorkflow(...).humanInTheLoop(reason?)` and a runtime execution policy that distinguishes interactive from non-interactive workflow runs ([#1123](https://github.com/flora131/atomic/issues/1123)).
 

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -125,27 +125,19 @@ export default defineWorkflow("review-and-merge")
 
 ### Example 4 — Compose workflows with imports
 
-Use `.import(alias, source)` to declare a child workflow, then execute it with `ctx.workflow(alias)`. The child runs as its own nested workflow run behind a parent boundary stage named `import:<alias>` by default. Inputs are validated against the child workflow before it starts, and selected outputs can be renamed for downstream parent stages.
+Prefer regular TypeScript module imports for reusable child workflows: import the compiled workflow definition, pass it to `.import(...)`, then execute it with `ctx.workflow(childWorkflowName)`. Direct definition imports register the child's normalized workflow name as the default alias; pass `{ as: "alias" }` when the parent wants a shorter local name.
 
 ```typescript
 import { defineWorkflow } from "@bastani/workflows";
-
-export const sharedResearch = defineWorkflow("shared-research")
-  .input("topic", { type: "text", required: true })
-  .output("summary", { type: "text", required: true })
-  .run(async (ctx) => {
-    const report = await ctx.task("research", {
-      prompt: `Research: ${String(ctx.inputs.topic)}`,
-    });
-    return { summary: report.text };
-  })
-  .compile();
+import goal from "@bastani/workflows/builtin/goal";
+import sharedResearch from "./shared-research.js";
 
 export default defineWorkflow("research-and-synthesize")
   .input("topic", { type: "text", required: true })
-  .import("research", { workflow: "shared-research" })
+  .import(sharedResearch) // registers ctx.workflow("shared-research")
+  .import(goal, { as: "implementation-goal" })
   .run(async (ctx) => {
-    const child = await ctx.workflow("research", {
+    const child = await ctx.workflow("shared-research", {
       inputs: { topic: ctx.inputs.topic },
       outputs: { summary: "research_summary" },
     });
@@ -158,16 +150,33 @@ export default defineWorkflow("research-and-synthesize")
   .compile();
 ```
 
-Imports can reference a registered workflow ID (`{ workflow: "shared-research" }`) or a local workflow module (`{ path: "./shared-research.ts" }`, optionally `{ path: "./shared.ts", export: "sharedResearch" }`):
+The child runs as its own nested workflow run behind a parent boundary stage named `import:<alias>` by default. Inputs are validated against the child workflow before it starts, and selected outputs can be renamed for downstream parent stages.
+
+A reusable child module can simply default-export a compiled workflow:
 
 ```typescript
-export default defineWorkflow("research-and-synthesize")
-  .import("research", { path: "./shared.ts", export: "sharedResearch" })
-  .run(async (ctx) => ctx.workflow("research", { inputs: { topic: "workflow imports" } }))
+import { defineWorkflow } from "@bastani/workflows";
+
+export default defineWorkflow("shared-research")
+  .input("topic", { type: "text", required: true })
+  .output("summary", { type: "text", required: true })
+  .run(async (ctx) => {
+    const report = await ctx.task("research", {
+      prompt: `Research: ${String(ctx.inputs.topic)}`,
+    });
+    return { summary: report.text };
+  })
   .compile();
 ```
 
-Local relative paths resolve from the importing workflow file when discovery knows its file path, otherwise from the workflow invocation cwd. Discovery reports unresolved, circular, or invalid imports before runs start. Local path imports execute the imported module's top-level TypeScript during validation/discovery (through the same loader used for workflow discovery), so only import trusted workflow files and expect missing or pathological modules to fail before the first dispatch.
+Builtin workflows are also importable as modules for reuse:
+
+```typescript
+import { deepResearchCodebase, goal, ralph } from "@bastani/workflows/builtin";
+import goalWorkflow from "@bastani/workflows/builtin/goal";
+```
+
+Only compiled workflow definitions can be passed to `.import(...)`; registry-name and path-object import declarations are intentionally not supported. Missing or invalid module imports fail when the workflow file itself is loaded, and Atomic validates circular or invalid compiled-definition import graphs before runs start.
 
 ### Reusable Git worktrees
 

--- a/packages/workflows/src/extension/dispatcher.ts
+++ b/packages/workflows/src/extension/dispatcher.ts
@@ -67,9 +67,9 @@ export interface DispatcherOpts {
   models?: WorkflowModelCatalogPort;
   /** Runtime-derived interaction policy for this dispatch. */
   policy?: WorkflowExecutionPolicy;
-  /** Invocation cwd used for local path workflow imports. */
+  /** Invocation cwd used for workflow execution. */
   cwd?: string;
-  /** Discovery source metadata used to resolve relative local path imports. */
+  /** Discovery source metadata for workflow resources. */
   workflowSources?: readonly WorkflowSourceReference[];
 }
 

--- a/packages/workflows/src/extension/runtime.ts
+++ b/packages/workflows/src/extension/runtime.ts
@@ -84,9 +84,9 @@ export interface ExtensionRuntimeOpts {
   models?: WorkflowModelCatalogPort;
   /** Job tracker forwarded to named detached runs. */
   jobs?: JobTracker;
-  /** Discovery source metadata used to resolve relative local path imports. */
+  /** Discovery source metadata for workflow resources. */
   workflowSources?: readonly WorkflowSourceReference[];
-  /** Invocation cwd used for local path workflow imports. Defaults to process.cwd(). */
+  /** Invocation cwd used for workflow execution. Defaults to process.cwd(). */
   cwd?: string;
 }
 

--- a/packages/workflows/src/extension/workflow-module-loader.ts
+++ b/packages/workflows/src/extension/workflow-module-loader.ts
@@ -11,6 +11,10 @@ import { createRequire } from "node:module";
 import { isBunBinary } from "@bastani/atomic";
 import { createJiti } from "jiti/static";
 import * as workflowsSdkSurface from "../sdk-surface.js";
+import deepResearchCodebase from "../../builtin/deep-research-codebase.js";
+import goal from "../../builtin/goal.js";
+import openClaudeDesign from "../../builtin/open-claude-design.js";
+import ralph from "../../builtin/ralph.js";
 
 type RunWorkflowFunction = typeof import("../runs/shared/workflow-runner.js").runWorkflow;
 
@@ -21,6 +25,7 @@ const runWorkflow: RunWorkflowFunction = async (...args) => {
 
 const require = createRequire(import.meta.url);
 const WORKFLOWS_MODULE_SPECIFIER = "@bastani/workflows";
+const WORKFLOWS_BUILTIN_MODULE_SPECIFIER = `${WORKFLOWS_MODULE_SPECIFIER}/builtin`;
 // Keep this in sync with index.ts through sdk-surface.ts. runWorkflow stays as
 // a lazy wrapper because the public re-export comes from workflow-runner.ts,
 // which imports discovery.ts and would otherwise reintroduce a cycle.
@@ -28,21 +33,32 @@ const WORKFLOWS_SDK_MODULE: Record<string, unknown> = {
   ...workflowsSdkSurface,
   runWorkflow,
 };
+const WORKFLOWS_BUILTIN_MODULE: Record<string, unknown> = {
+  deepResearchCodebase,
+  goal,
+  openClaudeDesign,
+  ralph,
+};
 const WORKFLOWS_VIRTUAL_MODULES: Record<string, unknown> = {
   [WORKFLOWS_MODULE_SPECIFIER]: WORKFLOWS_SDK_MODULE,
+  [WORKFLOWS_BUILTIN_MODULE_SPECIFIER]: WORKFLOWS_BUILTIN_MODULE,
+  [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/deep-research-codebase`]: { default: deepResearchCodebase },
+  [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/goal`]: { default: goal },
+  [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/open-claude-design`]: { default: openClaudeDesign },
+  [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/ralph`]: { default: ralph },
 };
 
-function resolveWorkflowsSdkAlias(): string {
-  // Resolve the package self-reference through package.json exports instead of
-  // pinning loader code to the current src/extension -> src/index.ts layout.
-  const sdkEntry = require.resolve(WORKFLOWS_MODULE_SPECIFIER);
-  if (!existsSync(sdkEntry)) {
+function resolveWorkflowPackageSpecifier(specifier: string): string {
+  // Resolve package self-references through package.json exports instead of
+  // pinning loader code to the current source layout.
+  const entry = require.resolve(specifier);
+  if (!existsSync(entry)) {
     throw new Error(
-      `Unable to resolve ${WORKFLOWS_MODULE_SPECIFIER} SDK entry at ${sdkEntry}. ` +
-        "Check the package exports map for the workflows SDK entry.",
+      `Unable to resolve ${specifier} entry at ${entry}. ` +
+        "Check the package exports map for the workflows package.",
     );
   }
-  return sdkEntry;
+  return entry;
 }
 
 const workflowModuleLoader = createJiti(import.meta.url, {
@@ -52,7 +68,16 @@ const workflowModuleLoader = createJiti(import.meta.url, {
   tryNative: false,
   ...(isBunBinary
     ? { virtualModules: WORKFLOWS_VIRTUAL_MODULES }
-    : { alias: { [WORKFLOWS_MODULE_SPECIFIER]: resolveWorkflowsSdkAlias() } }),
+    : {
+        alias: {
+          [WORKFLOWS_MODULE_SPECIFIER]: resolveWorkflowPackageSpecifier(WORKFLOWS_MODULE_SPECIFIER),
+          [WORKFLOWS_BUILTIN_MODULE_SPECIFIER]: resolveWorkflowPackageSpecifier(WORKFLOWS_BUILTIN_MODULE_SPECIFIER),
+          [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/deep-research-codebase`]: resolveWorkflowPackageSpecifier(`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/deep-research-codebase`),
+          [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/goal`]: resolveWorkflowPackageSpecifier(`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/goal`),
+          [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/open-claude-design`]: resolveWorkflowPackageSpecifier(`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/open-claude-design`),
+          [`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/ralph`]: resolveWorkflowPackageSpecifier(`${WORKFLOWS_BUILTIN_MODULE_SPECIFIER}/ralph`),
+        },
+      }),
 });
 
 function materializeModuleObject(mod: object): Record<string, unknown> {

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -146,7 +146,7 @@ export interface RunOpts {
   models?: WorkflowModelCatalogPort;
   /** Registry used to resolve declared workflow imports. */
   registry?: WorkflowRegistry;
-  /** Discovery source metadata used to resolve relative local path imports. */
+  /** Discovery source metadata for workflow resources. */
   workflowSources?: readonly WorkflowSourceReference[];
   /**
    * Current nesting depth of this workflow run. Starts at 0 for top-level runs.
@@ -3213,18 +3213,12 @@ export async function run<TInputs extends Record<string, unknown>>(
           deferWorkflowStart: _parentDeferWorkflowStart,
           ...childBaseOpts
         } = opts;
-        const childSources = resolved.resolved.filePath === undefined
-          ? opts.workflowSources
-          : [
-              { id: child.normalizedName, filePath: resolved.resolved.filePath },
-              ...(opts.workflowSources ?? []),
-            ];
         const childRun = await run(child, childInputs, {
           ...childBaseOpts,
           cwd: resolveWorkflowCwd(),
           depth: depth + 1,
           registry: importRegistry,
-          ...(childSources !== undefined ? { workflowSources: childSources } : {}),
+          ...(opts.workflowSources !== undefined ? { workflowSources: opts.workflowSources } : {}),
           signal: ownController.signal,
           deferWorkflowStart: false,
         });

--- a/packages/workflows/src/shared/types.ts
+++ b/packages/workflows/src/shared/types.ts
@@ -130,12 +130,14 @@ export interface WorkflowInteractionMetadata {
 // Workflow imports and outputs
 // ---------------------------------------------------------------------------
 
-export type WorkflowImportSource =
-  | { readonly workflow: string }
-  | { readonly path: string; readonly export?: string };
+export interface WorkflowImportOptions {
+  readonly description?: string;
+  /** Optional parent-local ctx.workflow(alias) name for an imported workflow definition. */
+  readonly as?: string;
+}
 
 export interface WorkflowImportDeclaration {
-  readonly source: WorkflowImportSource;
+  readonly definition: WorkflowDefinition;
   readonly description?: string;
 }
 
@@ -613,7 +615,7 @@ export interface WorkflowRunContext<TInputs extends Record<string, unknown> = Re
   chain(steps: readonly WorkflowTaskStep[], options?: WorkflowChainOptions): Promise<WorkflowTaskResult[]>;
   /** Run tasks in parallel. Missing step tasks use the first available task as a fallback. */
   parallel(steps: readonly WorkflowTaskStep[], options?: WorkflowParallelOptions): Promise<WorkflowTaskResult[]>;
-  /** Execute a workflow declared with defineWorkflow(...).import(alias, source). */
+  /** Execute a workflow declared with defineWorkflow(...).import(...). */
   workflow(alias: string, options?: WorkflowRunChildOptions): Promise<WorkflowChildResult>;
   /** HIL primitives for user interaction during a run. */
   readonly ui: WorkflowUIContext;

--- a/packages/workflows/src/workflows/define-workflow.ts
+++ b/packages/workflows/src/workflows/define-workflow.ts
@@ -11,7 +11,7 @@
 import type {
   WorkflowDefinition,
   WorkflowImportDeclaration,
-  WorkflowImportSource,
+  WorkflowImportOptions,
   WorkflowInputBindings,
   WorkflowInputSchema,
   WorkflowInteractionMetadata,
@@ -60,7 +60,7 @@ export interface WorkflowBuilder<TInputs extends Record<string, unknown> = Recor
     schema: WorkflowInputSchema,
   ): WorkflowBuilder<TInputs & Record<K, unknown>>;
   /** Declare a workflow import that can be executed with ctx.workflow(alias). */
-  import(alias: string, source: WorkflowImportSource, options?: { description?: string }): WorkflowBuilder<TInputs>;
+  import<TChildInputs extends Record<string, unknown>>(definition: WorkflowDefinition<TChildInputs>, options?: WorkflowImportOptions): WorkflowBuilder<TInputs>;
   /** Declare an output contract for parent workflows selecting child outputs. */
   output(key: string, schema?: WorkflowOutputSchema): WorkflowBuilder<TInputs>;
   /** Bind workflow inputs to reusable git worktree runtime defaults. */
@@ -81,7 +81,7 @@ export interface CompletedWorkflowBuilder<TInputs extends Record<string, unknown
     key: K,
     schema: WorkflowInputSchema,
   ): CompletedWorkflowBuilder<TInputs & Record<K, unknown>>;
-  import(alias: string, source: WorkflowImportSource, options?: { description?: string }): CompletedWorkflowBuilder<TInputs>;
+  import<TChildInputs extends Record<string, unknown>>(definition: WorkflowDefinition<TChildInputs>, options?: WorkflowImportOptions): CompletedWorkflowBuilder<TInputs>;
   output(key: string, schema?: WorkflowOutputSchema): CompletedWorkflowBuilder<TInputs>;
   worktreeFromInputs(binding: WorkflowWorktreeInputBinding): CompletedWorkflowBuilder<TInputs>;
   humanInTheLoop(reason?: string): CompletedWorkflowBuilder<TInputs>;
@@ -100,34 +100,54 @@ function requireNonEmptyString(value: string, label: string): void {
   }
 }
 
-function cloneImportSource(source: WorkflowImportSource): WorkflowImportSource {
-  if (source === null || typeof source !== "object") {
-    throw new TypeError("defineWorkflow: import source must be an object");
+function isWorkflowDefinition(value: unknown): value is WorkflowDefinition {
+  if (value === null || typeof value !== "object") return false;
+  const record = value as Partial<WorkflowDefinition>;
+  return record.__piWorkflow === true &&
+    typeof record.name === "string" &&
+    record.name.trim().length > 0 &&
+    typeof record.normalizedName === "string" &&
+    record.normalizedName.trim().length > 0 &&
+    typeof record.run === "function";
+}
+
+function cloneImportOptions(options: WorkflowImportOptions | undefined): WorkflowImportOptions {
+  if (options === undefined) return Object.freeze({});
+  if (options === null || typeof options !== "object") {
+    throw new TypeError("defineWorkflow: import options must be an object when provided");
   }
-  const record = source as Partial<Record<"workflow" | "path" | "export", unknown>>;
-  const hasWorkflow = "workflow" in record;
-  const hasPath = "path" in record;
-  if (hasWorkflow === hasPath) {
-    throw new TypeError("defineWorkflow: import source must be exactly one of { workflow } or { path }");
+  if (options.description !== undefined && typeof options.description !== "string") {
+    throw new TypeError("defineWorkflow: import options.description must be a string when provided");
   }
-  if (hasWorkflow) {
-    if (typeof record.workflow !== "string") {
-      throw new TypeError("defineWorkflow: import source.workflow must be a non-empty string");
+  if (options.as !== undefined) {
+    if (typeof options.as !== "string") {
+      throw new TypeError("defineWorkflow: import options.as must be a non-empty string when provided");
     }
-    requireNonEmptyString(record.workflow, "import source.workflow");
-    return Object.freeze({ workflow: record.workflow });
-  }
-  if (typeof record.path !== "string") {
-    throw new TypeError("defineWorkflow: import source.path must be a non-empty string");
-  }
-  requireNonEmptyString(record.path, "import source.path");
-  if (record.export !== undefined && typeof record.export !== "string") {
-    throw new TypeError("defineWorkflow: import source.export must be a string when provided");
+    requireNonEmptyString(options.as, "import options.as");
   }
   return Object.freeze({
-    path: record.path,
-    ...(record.export !== undefined ? { export: record.export } : {}),
+    ...(options.description !== undefined ? { description: options.description } : {}),
+    ...(options.as !== undefined ? { as: options.as } : {}),
   });
+}
+
+function normalizeImportArgs<TChildInputs extends Record<string, unknown>>(
+  definition: WorkflowDefinition<TChildInputs>,
+  optionsInput?: WorkflowImportOptions,
+): { alias: string; declaration: WorkflowImportDeclaration } {
+  if (!isWorkflowDefinition(definition)) {
+    throw new TypeError("defineWorkflow: import definition must be a compiled workflow definition");
+  }
+  const options = cloneImportOptions(optionsInput);
+  const alias = options.as ?? definition.normalizedName;
+  requireNonEmptyString(alias, "import alias");
+  return {
+    alias,
+    declaration: {
+      definition: definition as WorkflowDefinition,
+      ...(options.description !== undefined ? { description: options.description } : {}),
+    },
+  };
 }
 
 function freezeImports(
@@ -137,7 +157,7 @@ function freezeImports(
     Object.entries(imports).map(([alias, declaration]) => [
       alias,
       Object.freeze({
-        source: cloneImportSource(declaration.source),
+        definition: declaration.definition,
         ...(declaration.description !== undefined ? { description: declaration.description } : {}),
       }),
     ]),
@@ -167,12 +187,8 @@ function makeBuilder<TInputs extends Record<string, unknown>>(
       } as BuilderState<TInputs & Record<K, unknown>>);
     },
 
-    import(alias: string, source: WorkflowImportSource, options?: { description?: string }) {
-      requireNonEmptyString(alias, "import alias");
-      const declaration: WorkflowImportDeclaration = {
-        source: cloneImportSource(source),
-        ...(options?.description !== undefined ? { description: options.description } : {}),
-      };
+    import<TChildInputs extends Record<string, unknown>>(definition: WorkflowDefinition<TChildInputs>, options?: WorkflowImportOptions) {
+      const { alias, declaration } = normalizeImportArgs(definition, options);
       return makeBuilder<TInputs>({
         ...state,
         imports: { ...state.imports, [alias]: declaration },

--- a/packages/workflows/src/workflows/import-resolver.ts
+++ b/packages/workflows/src/workflows/import-resolver.ts
@@ -1,21 +1,17 @@
 /**
  * Workflow import resolution and import graph validation.
  *
- * Supports imports by registered workflow id and by local module path plus an
- * optional export key. Path imports use the shared workflow jiti loader so they
- * behave like discovery-loaded workflow files.
+ * Imports are regular TypeScript module imports: workflow authors import a
+ * compiled WorkflowDefinition and pass it to defineWorkflow(...).import(...).
+ * The builder stores direct child definitions, so resolution does not perform
+ * registry-name or path lookups.
  */
 
-import { dirname, isAbsolute, resolve } from "node:path";
 import type {
   WorkflowDefinition,
   WorkflowImportDeclaration,
-  WorkflowImportSource,
 } from "../shared/types.js";
-import {
-  loadWorkflowModule,
-  validateWorkflowDefinitionShape,
-} from "../extension/workflow-module-loader.js";
+import { validateWorkflowDefinitionShape } from "../extension/workflow-module-loader.js";
 import type { WorkflowRegistry } from "./registry.js";
 
 export type WorkflowImportDiagnosticCode = "IMPORT_UNRESOLVED" | "IMPORT_CIRCULAR" | "IMPORT_INVALID";
@@ -51,8 +47,6 @@ export interface ResolvedWorkflowImport {
   readonly definition: WorkflowDefinition;
   readonly identity: string;
   readonly label: string;
-  readonly filePath?: string;
-  readonly exportKey?: string;
 }
 
 export type WorkflowImportResolution =
@@ -68,18 +62,6 @@ interface StackNode {
   readonly label: string;
 }
 
-interface PathCacheEntry {
-  readonly filePath: string;
-  readonly exportKey: string;
-  readonly value?: unknown;
-  readonly loadError?: string;
-}
-
-function importSourceSummary(source: WorkflowImportSource): string {
-  if ("workflow" in source) return `workflow:${source.workflow}`;
-  return `path:${source.path}${source.export !== undefined ? `#${source.export}` : "#default"}`;
-}
-
 function hasOwnRecordKey(value: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
 }
@@ -88,16 +70,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function isValidImportSource(value: unknown): value is WorkflowImportSource {
-  if (!isRecord(value)) return false;
-  const hasWorkflow = hasOwnRecordKey(value, "workflow");
-  const hasPath = hasOwnRecordKey(value, "path");
-  if (hasWorkflow === hasPath) return false;
-  if (hasWorkflow) {
-    return typeof value["workflow"] === "string" && value["workflow"].trim().length > 0;
-  }
-  if (typeof value["path"] !== "string" || value["path"].trim().length === 0) return false;
-  return value["export"] === undefined || typeof value["export"] === "string";
+function isValidWorkflowDefinition(value: unknown): value is WorkflowDefinition {
+  return validateWorkflowDefinitionShape(value) === null;
 }
 
 function invalidDiagnostic(
@@ -132,57 +106,8 @@ function unresolvedDiagnostic(
   };
 }
 
-function sourceFileForWorkflow(
-  workflow: WorkflowDefinition,
-  sources: readonly WorkflowSourceReference[] | undefined,
-): string | undefined {
-  return sources?.find((source) => source.id === workflow.normalizedName)?.filePath;
-}
-
-function baseDirForWorkflow(
-  workflow: WorkflowDefinition,
-  options: WorkflowImportResolverOptions,
-  pathOrigins?: WeakMap<WorkflowDefinition, string>,
-): string {
-  const originFile = pathOrigins?.get(workflow);
-  if (originFile !== undefined) return dirname(originFile);
-  const sourceFile = sourceFileForWorkflow(workflow, options.sources);
-  if (sourceFile !== undefined) return dirname(sourceFile);
-  return options.cwd ?? process.cwd();
-}
-
-function resolveImportPath(
-  parent: WorkflowDefinition,
-  path: string,
-  options: WorkflowImportResolverOptions,
-  pathOrigins?: WeakMap<WorkflowDefinition, string>,
-): string {
-  return isAbsolute(path) ? path : resolve(baseDirForWorkflow(parent, options, pathOrigins), path);
-}
-
 function workflowIdentity(definition: WorkflowDefinition): string {
   return `workflow:${definition.normalizedName}`;
-}
-
-function pathIdentity(filePath: string, exportKey: string): string {
-  return `path:${filePath}#${exportKey}`;
-}
-
-function identityForResolvedPathDefinition(
-  definition: WorkflowDefinition,
-  filePath: string,
-  exportKey: string,
-  options: WorkflowImportResolverOptions,
-): string {
-  const sourceFile = sourceFileForWorkflow(definition, options.sources);
-  if (sourceFile !== undefined && sourceFile === filePath) {
-    return workflowIdentity(definition);
-  }
-  return pathIdentity(filePath, exportKey);
-}
-
-function resolutionLabel(definition: WorkflowDefinition, identity: string): string {
-  return identity.startsWith("workflow:") ? definition.normalizedName : identity.replace(/^path:/, "");
 }
 
 function declarationForAlias(
@@ -199,9 +124,9 @@ function declarationForAlias(
   if (!isRecord(declaration)) {
     return { ok: false, diagnostic: invalidDiagnostic(parent, alias, "declaration must be an object") };
   }
-  const source = declaration["source"];
-  if (!isValidImportSource(source)) {
-    return { ok: false, diagnostic: invalidDiagnostic(parent, alias, "source must be { workflow: string } or { path: string; export?: string }") };
+  const definition = declaration["definition"];
+  if (!isValidWorkflowDefinition(definition)) {
+    return { ok: false, diagnostic: invalidDiagnostic(parent, alias, "definition must be a compiled workflow definition") };
   }
   if (declaration["description"] !== undefined && typeof declaration["description"] !== "string") {
     return { ok: false, diagnostic: invalidDiagnostic(parent, alias, "description must be a string when provided") };
@@ -209,107 +134,26 @@ function declarationForAlias(
   return {
     ok: true,
     declaration: {
-      source,
+      definition,
       ...(typeof declaration["description"] === "string" ? { description: declaration["description"] } : {}),
     },
   };
 }
 
-function loadPathExport(
-  filePath: string,
-  exportKey: string,
-  pathCache: Map<string, PathCacheEntry>,
-): PathCacheEntry {
-  const cacheKey = `${filePath}#${exportKey}`;
-  const cached = pathCache.get(cacheKey);
-  if (cached !== undefined) return cached;
-
-  try {
-    const mod = loadWorkflowModule(filePath);
-    if (!hasOwnRecordKey(mod, exportKey) || mod[exportKey] === undefined) {
-      const entry: PathCacheEntry = {
-        filePath,
-        exportKey,
-        loadError: `export "${exportKey}" was not found`,
-      };
-      pathCache.set(cacheKey, entry);
-      return entry;
-    }
-    const entry: PathCacheEntry = { filePath, exportKey, value: mod[exportKey] };
-    pathCache.set(cacheKey, entry);
-    return entry;
-  } catch (err) {
-    const entry: PathCacheEntry = {
-      filePath,
-      exportKey,
-      loadError: err instanceof Error ? err.message : String(err),
-    };
-    pathCache.set(cacheKey, entry);
-    return entry;
-  }
-}
-
 function resolveDeclaredImport(
-  parent: WorkflowDefinition,
   alias: string,
   declaration: WorkflowImportDeclaration,
-  options: WorkflowImportResolverOptions,
-  pathCache: Map<string, PathCacheEntry>,
-  pathOrigins?: WeakMap<WorkflowDefinition, string>,
 ): WorkflowImportResolution {
-  const source = declaration.source;
-  if ("workflow" in source) {
-    const child = options.registry.get(source.workflow);
-    if (child === undefined) {
-      return {
-        ok: false,
-        diagnostic: unresolvedDiagnostic(parent, alias, `registered workflow "${source.workflow}" was not found`, source.workflow),
-      };
-    }
-    const identity = workflowIdentity(child);
-    return {
-      ok: true,
-      resolved: {
-        alias,
-        declaration,
-        definition: child,
-        identity,
-        label: resolutionLabel(child, identity),
-      },
-    };
-  }
-
-  const exportKey = source.export ?? "default";
-  const filePath = resolveImportPath(parent, source.path, options, pathOrigins);
-  const entry = loadPathExport(filePath, exportKey, pathCache);
-  if (entry.loadError !== undefined) {
-    return {
-      ok: false,
-      diagnostic: unresolvedDiagnostic(parent, alias, `${entry.loadError} (${filePath}#${exportKey})`, `${filePath}#${exportKey}`),
-    };
-  }
-
-  const reason = validateWorkflowDefinitionShape(entry.value);
-  if (reason !== null) {
-    return {
-      ok: false,
-      diagnostic: invalidDiagnostic(parent, alias, `path export "${exportKey}" rejected: ${reason}`, `${filePath}#${exportKey}`),
-    };
-  }
-
-  const definition = entry.value as WorkflowDefinition;
-  pathOrigins?.set(definition, filePath);
-  const identity = identityForResolvedPathDefinition(definition, filePath, exportKey, options);
+  const child = declaration.definition;
+  const identity = workflowIdentity(child);
   return {
     ok: true,
     resolved: {
       alias,
       declaration,
-      definition,
+      definition: child,
       identity,
-      label: resolutionLabel(definition, identity),
-      filePath,
-      exportKey,
+      label: child.normalizedName,
     },
   };
 }
@@ -357,11 +201,11 @@ function pushDiagnostic(
 export function resolveWorkflowImport(
   parent: WorkflowDefinition,
   alias: string,
-  options: WorkflowImportResolverOptions,
+  _options: WorkflowImportResolverOptions,
 ): WorkflowImportResolution {
   const declaration = declarationForAlias(parent, alias);
   if (!declaration.ok) return declaration;
-  return resolveDeclaredImport(parent, alias, declaration.declaration, options, new Map());
+  return resolveDeclaredImport(alias, declaration.declaration);
 }
 
 export function validateWorkflowImportGraph(
@@ -370,8 +214,6 @@ export function validateWorkflowImportGraph(
   const diagnostics: WorkflowImportDiagnostic[] = [];
   const seenDiagnostics = new Set<string>();
   const visited = new Set<string>();
-  const pathCache = new Map<string, PathCacheEntry>();
-  const pathOrigins = new WeakMap<WorkflowDefinition, string>();
   const roots = options.roots ?? options.registry.all();
 
   const visit = (definition: WorkflowDefinition, identity: string, label: string, stack: readonly StackNode[]): void => {
@@ -393,16 +235,20 @@ export function validateWorkflowImportGraph(
         pushDiagnostic(diagnostics, seenDiagnostics, invalidDiagnostic(definition, alias, "declaration must be an object"));
         continue;
       }
-      const source = rawDeclaration["source"];
-      if (!isValidImportSource(source)) {
-        pushDiagnostic(diagnostics, seenDiagnostics, invalidDiagnostic(definition, alias, "source must be { workflow: string } or { path: string; export?: string }"));
+      const childDefinition = rawDeclaration["definition"];
+      if (!isValidWorkflowDefinition(childDefinition)) {
+        pushDiagnostic(diagnostics, seenDiagnostics, invalidDiagnostic(definition, alias, "definition must be a compiled workflow definition"));
+        continue;
+      }
+      if (rawDeclaration["description"] !== undefined && typeof rawDeclaration["description"] !== "string") {
+        pushDiagnostic(diagnostics, seenDiagnostics, invalidDiagnostic(definition, alias, "description must be a string when provided"));
         continue;
       }
       const declaration: WorkflowImportDeclaration = {
-        source,
+        definition: childDefinition,
         ...(typeof rawDeclaration["description"] === "string" ? { description: rawDeclaration["description"] } : {}),
       };
-      const resolved = resolveDeclaredImport(definition, alias, declaration, options, pathCache, pathOrigins);
+      const resolved = resolveDeclaredImport(alias, declaration);
       if (!resolved.ok) {
         pushDiagnostic(diagnostics, seenDiagnostics, resolved.diagnostic);
         continue;
@@ -430,5 +276,5 @@ export function formatWorkflowImportDiagnostics(diagnostics: readonly WorkflowIm
 }
 
 export function workflowImportSourceSummary(declaration: WorkflowImportDeclaration): string {
-  return importSourceSummary(declaration.source);
+  return `definition:${declaration.definition.normalizedName}`;
 }

--- a/test/unit/define-workflow.test.ts
+++ b/test/unit/define-workflow.test.ts
@@ -87,20 +87,39 @@ describe("defineWorkflow builder", () => {
     assert.equal(Object.isFrozen(def.interaction), true);
   });
 
-  test("import() records immutable workflow import metadata", () => {
-    const base = defineWorkflow("parent");
-    const withImport = base.import("child", { workflow: "shared-child" }, { description: "Shared child" });
-    const def = withImport.run(async () => ({})).compile();
-    const baseDef = base.run(async () => ({})).compile();
+  test("import() can register a compiled workflow definition by workflow name", () => {
+    const child = defineWorkflow("Shared Child")
+      .run(async (ctx) => {
+        await ctx.task("child", { prompt: "child" });
+        return { ok: true };
+      })
+      .compile();
+    const def = defineWorkflow("parent")
+      .import(child, { description: "Static TS module import" })
+      .run(async () => ({}))
+      .compile();
 
-    assert.equal(baseDef.imports, undefined);
-    assert.deepEqual(def.imports?.["child"], {
-      source: { workflow: "shared-child" },
-      description: "Shared child",
-    });
+    assert.deepEqual(Object.keys(def.imports ?? {}), ["shared-child"]);
+    assert.equal(def.imports!["shared-child"]!.definition, child);
+    assert.equal(def.imports?.["shared-child"]?.description, "Static TS module import");
     assert.equal(Object.isFrozen(def.imports), true);
-    assert.equal(Object.isFrozen(def.imports?.["child"]), true);
-    assert.equal(Object.isFrozen(def.imports?.["child"]?.source), true);
+    assert.equal(Object.isFrozen(def.imports?.["shared-child"]), true);
+  });
+
+  test("import() can alias a compiled workflow definition", () => {
+    const child = defineWorkflow("shared-child")
+      .run(async (ctx) => {
+        await ctx.task("child", { prompt: "child" });
+        return { ok: true };
+      })
+      .compile();
+    const def = defineWorkflow("parent")
+      .import(child, { as: "research" })
+      .run(async () => ({}))
+      .compile();
+
+    assert.equal(def.imports!["research"]!.definition, child);
+    assert.equal(def.imports?.["shared-child"], undefined);
   });
 
   test("output() records immutable workflow output metadata", () => {

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -226,7 +226,7 @@ describe("executor.run", () => {
       .compile();
     const parent = defineWorkflow("research-parent")
       .input("topic", { type: "text", required: true })
-      .import("research", { workflow: "research-child" })
+      .import(child, { as: "research" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("research", {
           inputs: { topic: ctx.inputs.topic },
@@ -264,6 +264,42 @@ describe("executor.run", () => {
     assert.equal(st.runs().length, 2);
   });
 
+  test("ctx.workflow executes a statically imported child definition by workflow name", async () => {
+    const seenPrompts: string[] = [];
+    const child = defineWorkflow("static-child")
+      .output("summary", { type: "text", required: true })
+      .run(async (ctx) => {
+        const result = await ctx.task("child", { prompt: "static-child" });
+        return { summary: result.text };
+      })
+      .compile();
+    const parent = defineWorkflow("static-parent")
+      .import(child)
+      .run(async (ctx) => {
+        const childResult = await ctx.workflow("static-child", { outputs: ["summary"] });
+        const final = await ctx.task("final", { prompt: `final:${String(childResult.outputs.summary)}` });
+        return { final: final.text };
+      })
+      .compile();
+
+    const wfResult = await run(parent, {}, {
+      store: createStore(),
+      adapters: {
+        prompt: {
+          prompt: async (text) => {
+            seenPrompts.push(text);
+            return text === "static-child" ? "child-output" : "final-output";
+          },
+        },
+      },
+    });
+
+    assert.equal(wfResult.status, "completed");
+    assert.deepEqual(seenPrompts, ["static-child", "final:child-output"]);
+    assert.equal(wfResult.result?.["final"], "final-output");
+    assert.deepEqual(wfResult.stages.map((stage) => stage.name), ["import:static-child", "final"]);
+  });
+
   test("ctx.workflow completes when unselected child raw output is not cloneable", async () => {
     const child = defineWorkflow("uncloneable-raw-child")
       .output("summary", { type: "text", required: true })
@@ -273,7 +309,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("uncloneable-raw-parent")
-      .import("child", { workflow: "uncloneable-raw-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("child", { outputs: ["summary"] });
         const final = await ctx.stage("final").prompt(`final:${String(childResult.outputs.summary)}`);
@@ -304,7 +340,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("uncloneable-selected-parent")
-      .import("child", { workflow: "uncloneable-selected-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         await ctx.workflow("child", { outputs: ["bad"] });
         await ctx.stage("downstream").prompt("should-not-run");
@@ -343,7 +379,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("default-input-parent")
-      .import("child", { workflow: "default-input-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("child");
         return { summary: childResult.outputs.summary };
@@ -378,7 +414,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("implicit-output-parent")
-      .import("child", { workflow: "implicit-output-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("child");
         return { childOutputs: childResult.outputs, rawOutput: childResult.rawOutput };
@@ -406,7 +442,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("explicit-output-parent")
-      .import("child", { workflow: "explicit-output-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         await ctx.workflow("child", { outputs: ["extra"] });
         await ctx.task("downstream", { prompt: "should-not-run" });
@@ -444,7 +480,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("implicit-missing-output-parent")
-      .import("child", { workflow: "implicit-missing-output-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         await ctx.workflow("child");
         await ctx.task("downstream", { prompt: "should-not-run" });
@@ -483,7 +519,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("explicit-missing-required-output-parent")
-      .import("child", { workflow: "explicit-missing-required-output-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         await ctx.workflow("child", { outputs: ["optional"] });
         await ctx.task("downstream", { prompt: "should-not-run" });
@@ -522,7 +558,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("colliding-required-output-parent")
-      .import("child", { workflow: "colliding-required-output-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         await ctx.workflow("child", { outputs: { other: "summary" } });
         await ctx.task("downstream", { prompt: "should-not-run" });
@@ -561,7 +597,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("input-parent")
-      .import("child", { workflow: "input-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         await ctx.workflow("child", { inputs: { topic: 123 } });
         return {};
@@ -592,7 +628,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("output-parent")
-      .import("child", { workflow: "output-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         await ctx.workflow("child", { outputs: ["summary"] });
         await ctx.task("downstream", { prompt: "should-not-run" });
@@ -966,7 +1002,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("resume-import-parent")
-      .import("child", { workflow: "resume-import-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("child");
         const after = await ctx.stage("after").prompt(`after:${String(childResult.outputs["value"])}`);
@@ -1032,7 +1068,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("resume-import-clone-parent")
-      .import("child", { workflow: "resume-import-clone-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("child");
         const value = childResult.outputs["value"] as { nested: string };
@@ -1088,7 +1124,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("resume-uncloneable-raw-parent")
-      .import("child", { workflow: "resume-uncloneable-raw-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("child", { outputs: ["value"] });
         const after = await ctx.stage("after").prompt(`after:${String(childResult.outputs["value"])}`);
@@ -1141,13 +1177,16 @@ describe("executor.run", () => {
   });
 
   test("validates workflow imports when caller supplies a registry", async () => {
-    const parent = defineWorkflow("registry-validation-parent")
-      .import("ghost", { workflow: "registry-validation-missing" })
+    const baseParent = defineWorkflow("registry-validation-parent")
       .run(async (ctx) => {
         await ctx.stage("should-not-start").prompt("should not start");
         return {};
       })
       .compile();
+    const parent = {
+      ...baseParent,
+      imports: { ghost: { definition: { not: "a workflow" } } },
+    } as unknown as WorkflowDefinition;
     const registry = createRegistry([parent]);
     const promptCalls: string[] = [];
 
@@ -1164,8 +1203,8 @@ describe("executor.run", () => {
     });
 
     assert.equal(result.status, "failed");
-    assert.match(result.error ?? "", /IMPORT_UNRESOLVED/);
-    assert.match(result.error ?? "", /registry-validation-missing/);
+    assert.match(result.error ?? "", /IMPORT_INVALID/);
+    assert.match(result.error ?? "", /definition must be a compiled workflow definition/);
     assert.deepEqual(result.stages, []);
     assert.deepEqual(promptCalls, []);
   });
@@ -1179,7 +1218,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("resume-import-repeated-parent")
-      .import("child", { workflow: "resume-import-repeated-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const [first, second] = await Promise.all([
           ctx.workflow("child"),
@@ -1251,7 +1290,7 @@ describe("executor.run", () => {
       })
       .compile();
     const parent = defineWorkflow("resume-import-legacy-parent")
-      .import("child", { workflow: "resume-import-legacy-child" })
+      .import(child, { as: "child" })
       .run(async (ctx) => {
         const childResult = await ctx.workflow("child");
         const after = await ctx.stage("after").prompt(`after:${String(childResult.outputs["value"])}`);

--- a/test/unit/workflow-imports.test.ts
+++ b/test/unit/workflow-imports.test.ts
@@ -4,8 +4,9 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { discoverWorkflows } from "../../packages/workflows/src/extension/discovery.js";
+import type { WorkflowDefinition } from "../../packages/workflows/src/shared/types.js";
 import { defineWorkflow } from "../../packages/workflows/src/workflows/define-workflow.js";
-import { validateWorkflowImportGraph } from "../../packages/workflows/src/workflows/import-resolver.js";
+import { resolveWorkflowImport, validateWorkflowImportGraph } from "../../packages/workflows/src/workflows/import-resolver.js";
 import { createRegistry } from "../../packages/workflows/src/workflows/registry.js";
 
 let tmpRoot: string;
@@ -26,8 +27,20 @@ function workflowSource(name: string, body: string): string {
   ].join("\n");
 }
 
+function manualWorkflow(name: string, imports?: Record<string, unknown>): WorkflowDefinition {
+  return {
+    __piWorkflow: true,
+    name,
+    normalizedName: name,
+    description: "",
+    inputs: {},
+    ...(imports !== undefined ? { imports: imports as WorkflowDefinition["imports"] } : {}),
+    run: async () => ({}),
+  };
+}
+
 describe("workflow import resolver", () => {
-  test("resolves registered workflow id imports", () => {
+  test("resolves compiled workflow definition imports without registry registration", () => {
     const child = defineWorkflow("shared-child")
       .run(async (ctx) => {
         await ctx.task("child", { prompt: "child" });
@@ -35,120 +48,81 @@ describe("workflow import resolver", () => {
       })
       .compile();
     const parent = defineWorkflow("parent")
-      .import("child", { workflow: "shared-child" })
+      .import(child)
       .run(async () => ({}))
       .compile();
-    const registry = createRegistry([parent, child]);
+    const registry = createRegistry([parent]);
 
     const diagnostics = validateWorkflowImportGraph({ registry, roots: [parent] });
+    const resolved = resolveWorkflowImport(parent, "shared-child", { registry });
 
     assert.deepEqual(diagnostics, []);
+    assert.equal(resolved.ok, true);
+    if (resolved.ok) {
+      assert.equal(resolved.resolved.definition, child);
+      assert.equal(resolved.resolved.alias, "shared-child");
+    }
   });
 
-  test("resolves local path imports relative to the parent source file", async () => {
-    const childPath = join(tmpRoot, "child.ts");
-    const parentPath = join(tmpRoot, "parent.ts");
-    await writeFile(
-      childPath,
-      workflowSource(
-        "path-child",
-        `.output("answer", { type: "text", required: true })\n  .run(async (ctx) => { await ctx.task("child", { prompt: "child" }); return { answer: "ok" }; })\n  .compile();`,
-      ),
-      "utf8",
-    );
-    const parent = defineWorkflow("path-parent")
-      .import("child", { path: "./child.ts" })
+  test("resolves compiled workflow definition imports with local aliases", () => {
+    const child = defineWorkflow("shared-child")
+      .run(async (ctx) => {
+        await ctx.task("child", { prompt: "child" });
+        return { ok: true };
+      })
+      .compile();
+    const parent = defineWorkflow("parent")
+      .import(child, { as: "research" })
       .run(async () => ({}))
       .compile();
     const registry = createRegistry([parent]);
 
-    const diagnostics = validateWorkflowImportGraph({
-      registry,
-      cwd: join(tmpRoot, "elsewhere"),
-      sources: [{ id: parent.normalizedName, filePath: parentPath }],
-      roots: [parent],
-    });
+    const diagnostics = validateWorkflowImportGraph({ registry, roots: [parent] });
+    const resolved = resolveWorkflowImport(parent, "research", { registry });
 
     assert.deepEqual(diagnostics, []);
+    assert.equal(resolved.ok, true);
+    if (resolved.ok) {
+      assert.equal(resolved.resolved.definition, child);
+      assert.equal(resolved.resolved.alias, "research");
+    }
   });
 
-  test("keeps path identity for same-named workflows from different files", async () => {
-    const childPath = join(tmpRoot, "child.ts");
-    const parentPath = join(tmpRoot, "parent.ts");
-    await writeFile(
-      childPath,
-      workflowSource(
-        "same-name",
-        `.run(async (ctx) => { await ctx.task("child", { prompt: "child" }); return {}; })\n  .compile();`,
-      ),
-      "utf8",
-    );
-    const parent = defineWorkflow("same-name")
-      .import("child", { path: "./child.ts" })
-      .run(async () => ({}))
+  test("reports undeclared aliases", () => {
+    const parent = defineWorkflow("parent")
+      .run(async (ctx) => {
+        await ctx.task("parent", { prompt: "parent" });
+        return {};
+      })
       .compile();
-    const registry = createRegistry([parent]);
+    const resolved = resolveWorkflowImport(parent, "ghost", { registry: createRegistry([parent]) });
 
-    const diagnostics = validateWorkflowImportGraph({
-      registry,
-      cwd: join(tmpRoot, "elsewhere"),
-      sources: [{ id: parent.normalizedName, filePath: parentPath }],
-      roots: [parent],
+    assert.equal(resolved.ok, false);
+    if (!resolved.ok) {
+      assert.equal(resolved.diagnostic.code, "IMPORT_UNRESOLVED");
+      assert.match(resolved.diagnostic.message, /alias is not declared/);
+    }
+  });
+
+  test("reports invalid raw import declarations", () => {
+    const parent = manualWorkflow("invalid-parent", {
+      child: { definition: { not: "a workflow" } },
     });
-
-    assert.deepEqual(diagnostics, []);
-  });
-
-  test("uses workflow identity for path imports proven to be the same source file", async () => {
-    const parentPath = join(tmpRoot, "parent.ts");
-    await writeFile(
-      parentPath,
-      workflowSource(
-        "same-source-cycle",
-        `.run(async (ctx) => { await ctx.task("self", { prompt: "self" }); return {}; })\n  .compile();`,
-      ),
-      "utf8",
-    );
-    const parent = defineWorkflow("same-source-cycle")
-      .import("self", { path: "./parent.ts" })
-      .run(async () => ({}))
-      .compile();
-    const registry = createRegistry([parent]);
-
-    const diagnostics = validateWorkflowImportGraph({
-      registry,
-      cwd: join(tmpRoot, "elsewhere"),
-      sources: [{ id: parent.normalizedName, filePath: parentPath }],
-      roots: [parent],
-    });
-
-    assert.equal(diagnostics.length, 1);
-    assert.equal(diagnostics[0]?.code, "IMPORT_CIRCULAR");
-    assert.match(diagnostics[0]?.message ?? "", /same-source-cycle -> same-source-cycle/);
-  });
-
-  test("reports unresolved imports", () => {
-    const parent = defineWorkflow("parent-missing")
-      .import("ghost", { workflow: "ghost-workflow" })
-      .run(async () => ({}))
-      .compile();
     const diagnostics = validateWorkflowImportGraph({ registry: createRegistry([parent]), roots: [parent] });
 
     assert.equal(diagnostics.length, 1);
-    assert.equal(diagnostics[0]?.code, "IMPORT_UNRESOLVED");
-    assert.match(diagnostics[0]?.message ?? "", /ghost-workflow/);
+    assert.equal(diagnostics[0]?.code, "IMPORT_INVALID");
+    assert.match(diagnostics[0]?.message ?? "", /definition must be a compiled workflow definition/);
   });
 
   test("reports circular imports with chain text", () => {
-    const parent = defineWorkflow("cycle-parent")
-      .import("child", { workflow: "cycle-child" })
-      .run(async () => ({}))
-      .compile();
-    const child = defineWorkflow("cycle-child")
-      .import("parent", { workflow: "cycle-parent" })
-      .run(async () => ({}))
-      .compile();
-    const diagnostics = validateWorkflowImportGraph({ registry: createRegistry([parent, child]), roots: [parent] });
+    const parent = manualWorkflow("cycle-parent");
+    const child = manualWorkflow("cycle-child");
+    const parentWithImport = { ...parent, imports: { child: { definition: child } } } as WorkflowDefinition;
+    const childWithImport = { ...child, imports: { parent: { definition: parentWithImport } } } as WorkflowDefinition;
+    const cyclicParent = { ...parentWithImport, imports: { child: { definition: childWithImport } } } as WorkflowDefinition;
+
+    const diagnostics = validateWorkflowImportGraph({ registry: createRegistry([cyclicParent]), roots: [cyclicParent] });
 
     assert.equal(diagnostics.length, 1);
     assert.equal(diagnostics[0]?.code, "IMPORT_CIRCULAR");
@@ -165,11 +139,44 @@ describe("discoverWorkflows import diagnostics", () => {
     return filePath;
   }
 
-  test("emits IMPORT_UNRESOLVED while keeping the parent registered", async () => {
+  test("static TS module imports register local child workflow definitions", async () => {
+    await writeProjectWorkflow(
+      "child.ts",
+      workflowSource(
+        "discover-module-child",
+        `.output("answer", { type: "text", required: true })\n  .run(async (ctx) => { await ctx.task("child", { prompt: "child" }); return { answer: "ok" }; })\n  .compile();`,
+      ),
+    );
+    await writeProjectWorkflow(
+      "parent.ts",
+      [
+        `import { defineWorkflow } from "@bastani/workflows";`,
+        `import child from "./child.js";`,
+        ``,
+        `export default defineWorkflow("discover-module-parent")`,
+        `  .import(child)`,
+        `  .run(async (ctx) => { await ctx.workflow("discover-module-child", { outputs: ["answer"] }); return {}; })`,
+        `  .compile();`,
+      ].join("\n"),
+    );
+
+    const result = await discoverWorkflows({
+      cwd: join(tmpRoot, "cwd"),
+      homeDir: join(tmpRoot, "home"),
+      includeBundled: false,
+    });
+
+    const parent = result.registry.get("discover-module-parent");
+    assert.notEqual(parent, undefined);
+    assert.equal(parent?.imports?.["discover-module-child"] !== undefined, true);
+    assert.equal(result.errors.filter((error) => error.code.startsWith("IMPORT_")).length, 0);
+  });
+
+  test("legacy source syntax fails during module import", async () => {
     await writeProjectWorkflow(
       "parent.ts",
       workflowSource(
-        "discover-missing-parent",
+        "legacy-source-parent",
         `.import("ghost", { workflow: "missing-child" })\n  .run(async (ctx) => { await ctx.task("parent", { prompt: "parent" }); return {}; })\n  .compile();`,
       ),
     );
@@ -180,24 +187,27 @@ describe("discoverWorkflows import diagnostics", () => {
       includeBundled: false,
     });
 
-    assert.equal(result.registry.has("discover-missing-parent"), true);
-    assert.equal(result.errors.some((error) => error.code === "IMPORT_UNRESOLVED"), true);
+    assert.equal(result.registry.has("legacy-source-parent"), false);
+    const failure = result.errors.find((error) => error.code === "IMPORT_FAILED");
+    assert.notEqual(failure, undefined);
+    assert.match(failure?.message ?? "", /import definition must be a compiled workflow definition/);
   });
 
-  test("emits IMPORT_CIRCULAR for discovered workflow cycles", async () => {
+  test("static TS module imports can register builtin workflow definitions", async () => {
     await writeProjectWorkflow(
       "parent.ts",
-      workflowSource(
-        "discover-cycle-parent",
-        `.import("child", { workflow: "discover-cycle-child" })\n  .run(async (ctx) => { await ctx.task("parent", { prompt: "parent" }); return {}; })\n  .compile();`,
-      ),
-    );
-    await writeProjectWorkflow(
-      "child.ts",
-      workflowSource(
-        "discover-cycle-child",
-        `.import("parent", { workflow: "discover-cycle-parent" })\n  .run(async (ctx) => { await ctx.task("child", { prompt: "child" }); return {}; })\n  .compile();`,
-      ),
+      [
+        `import { defineWorkflow } from "@bastani/workflows";`,
+        `import deepResearchCodebase from "@bastani/workflows/builtin/deep-research-codebase";`,
+        `import { goal, ralph } from "@bastani/workflows/builtin";`,
+        ``,
+        `export default defineWorkflow("builtin-module-parent")`,
+        `  .import(deepResearchCodebase)`,
+        `  .import(goal)`,
+        `  .import(ralph, { as: "planner" })`,
+        `  .run(async (ctx) => { await ctx.task("parent", { prompt: "parent" }); return {}; })`,
+        `  .compile();`,
+      ].join("\n"),
     );
 
     const result = await discoverWorkflows({
@@ -206,36 +216,11 @@ describe("discoverWorkflows import diagnostics", () => {
       includeBundled: false,
     });
 
-    const circular = result.errors.find((error) => error.code === "IMPORT_CIRCULAR");
-    assert.notEqual(circular, undefined);
-    assert.match(circular?.message ?? "", /discover-cycle-parent/);
-    assert.match(circular?.message ?? "", /discover-cycle-child/);
-    assert.match(circular?.message ?? "", / -> /);
-  });
-
-  test("path imports use the parent workflow file as their base path", async () => {
-    await writeProjectWorkflow(
-      "child.ts",
-      workflowSource(
-        "discover-path-child",
-        `.output("answer", { type: "text", required: true })\n  .run(async (ctx) => { await ctx.task("child", { prompt: "child" }); return { answer: "ok" }; })\n  .compile();`,
-      ),
-    );
-    await writeProjectWorkflow(
-      "parent.ts",
-      workflowSource(
-        "discover-path-parent",
-        `.import("child", { path: "./child.ts" })\n  .run(async (ctx) => { await ctx.workflow("child", { outputs: ["answer"] }); return {}; })\n  .compile();`,
-      ),
-    );
-
-    const result = await discoverWorkflows({
-      cwd: join(tmpRoot, "cwd"),
-      homeDir: join(tmpRoot, "home"),
-      includeBundled: false,
-    });
-
-    assert.equal(result.registry.has("discover-path-parent"), true);
+    const parent = result.registry.get("builtin-module-parent");
+    assert.notEqual(parent, undefined);
+    assert.equal(parent?.imports?.["deep-research-codebase"] !== undefined, true);
+    assert.equal(parent?.imports?.["goal"] !== undefined, true);
+    assert.equal(parent?.imports?.["planner"] !== undefined, true);
     assert.equal(result.errors.filter((error) => error.code.startsWith("IMPORT_")).length, 0);
   });
 });

--- a/test/unit/workflow-runner.test.ts
+++ b/test/unit/workflow-runner.test.ts
@@ -250,14 +250,18 @@ describe("programmatic workflow runner", () => {
       writeFileSync(
         join(workflowDir, "parent.ts"),
         [
-          `import { defineWorkflow } from "@bastani/workflows";`,
-          `export default defineWorkflow("runner-import-parent")`,
-          `  .import("missing", { workflow: "runner-missing-child" })`,
-          `  .run(async (ctx) => {`,
+          `export default {`,
+          `  __piWorkflow: true,`,
+          `  name: "runner-import-parent",`,
+          `  normalizedName: "runner-import-parent",`,
+          `  description: "",`,
+          `  inputs: {},`,
+          `  imports: { missing: { definition: { not: "a workflow" } } },`,
+          `  run: async (ctx) => {`,
           `    await ctx.task("should-not-run", { prompt: "no" });`,
           `    return {};`,
-          `  })`,
-          `  .compile();`,
+          `  },`,
+          `};`,
         ].join("\n"),
         "utf8",
       );
@@ -268,7 +272,7 @@ describe("programmatic workflow runner", () => {
           { mode: "workflow", workflow: "runner-import-parent" },
           { cwd: dir, adapterOptions: { createAgentSession: makeSessionFactory(prompts) } },
         ),
-        /Invalid workflow imports[\s\S]*IMPORT_UNRESOLVED[\s\S]*runner-missing-child/,
+        /Invalid workflow imports[\s\S]*IMPORT_INVALID[\s\S]*definition must be a compiled workflow definition/,
       );
       assert.deepEqual(prompts, []);
     } finally {


### PR DESCRIPTION
## Summary

Replace the registry-name and path-object workflow import syntax with direct TypeScript module imports. Workflow authors now import compiled `WorkflowDefinition` objects and pass them to `.import(definition, { as? })`, making child workflow dependencies explicit at the type level and enabling builtin workflows to be reused as standard modules.

## Changes

- **API**: `.import(alias, { workflow | path })` replaced by `.import(compiledDefinition, { as?, description? })` — the child's normalized name becomes the default `ctx.workflow(...)` alias; `as` overrides it
- **Types**: `WorkflowImportSource` union removed; `WorkflowImportDeclaration.source` replaced with `.definition`; new `WorkflowImportOptions` interface added
- **Resolver**: stripped path-loading, registry-lookup, jiti loading, and path-cache logic — resolution is now a direct definition reference
- **Builtin modules**: `@bastani/workflows/builtin` virtual module exposes `deepResearchCodebase`, `goal`, `openClaudeDesign`, and `ralph`; individual paths (`@bastani/workflows/builtin/goal`, etc.) also work
- **Docs**: updated `packages/workflows/README.md` and `packages/coding-agent/docs/workflows.md` with new import pattern and builtin module usage examples
- **Tests**: updated `define-workflow`, `workflow-imports`, `executor`, and `workflow-runner` unit tests for the new API

## Breaking Changes

Workflows must now use normal TypeScript imports and pass compiled definitions to `.import(...)`:

```ts
import { defineWorkflow } from "@bastani/workflows";
import { goal } from "@bastani/workflows/builtin";
import sharedResearch from "./shared-research.js";

export default defineWorkflow("research-and-synthesize")
  .import(sharedResearch)                              // alias defaults to "shared-research"
  .import(goal, { as: "implementation-goal" })         // explicit alias override
  .run(async (ctx) => {
    await ctx.workflow("shared-research", { ... });
    await ctx.workflow("implementation-goal", { ... });
  })
  .compile();
```

The previous forms are no longer supported:

```ts
// ❌ removed
.import("child", { workflow: "registered-name" })
.import("child", { path: "./child.ts" })
.import("child", { path: "./child.ts", export: "namedExport" })
```

## Validation

```sh
AGENT=1 bun test test/unit/define-workflow.test.ts test/unit/workflow-imports.test.ts test/unit/executor.test.ts test/unit/workflow-runner.test.ts
AGENT=1 bun run test:unit
bun run typecheck
bun run lint
```