### PR TITLE
ci: use Blacksmith for GitHub Actions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout repository
-              uses: useblacksmith/checkout@v6
+              uses: useblacksmith/checkout@v1
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: useblacksmith/checkout@v6
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -11,7 +11,7 @@ jobs:
             pull-requests: write
             id-token: write
         steps:
-            - uses: useblacksmith/checkout@v6
+            - uses: useblacksmith/checkout@v1
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -11,7 +11,7 @@ jobs:
             pull-requests: write
             id-token: write
         steps:
-            - uses: actions/checkout@v6
+            - uses: useblacksmith/checkout@v6
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -14,7 +14,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout repository
-              uses: useblacksmith/checkout@v6
+              uses: useblacksmith/checkout@v1
               with:
                   fetch-depth: 0 # Full history for better diff analysis
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -14,7 +14,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: useblacksmith/checkout@v6
               with:
                   fetch-depth: 0 # Full history for better diff analysis
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         runs-on: blacksmith-4vcpu-ubuntu-2404
 
         steps:
-            - uses: useblacksmith/checkout@v6
+            - uses: useblacksmith/checkout@v1
               with:
                   ref: ${{ github.event.inputs.tag || github.ref_name }}
                   persist-credentials: false
@@ -40,7 +40,7 @@ jobs:
               with:
                   bun-version: latest
 
-            - uses: useblacksmith/setup-node@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 24
 
@@ -97,7 +97,7 @@ jobs:
         runs-on: blacksmith-4vcpu-windows-2025
 
         steps:
-            - uses: useblacksmith/checkout@v6
+            - uses: useblacksmith/checkout@v1
               with:
                   ref: ${{ github.event.inputs.tag || github.ref_name }}
                   persist-credentials: false
@@ -106,7 +106,7 @@ jobs:
               with:
                   bun-version: latest
 
-            - uses: useblacksmith/setup-node@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 24
 
@@ -193,7 +193,7 @@ jobs:
                   fi
                   echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
-            - uses: useblacksmith/checkout@v6
+            - uses: useblacksmith/checkout@v1
               with:
                   ref: ${{ steps.checkout_ref.outputs.ref }}
                   fetch-depth: 0
@@ -203,7 +203,7 @@ jobs:
               with:
                   bun-version: latest
 
-            - uses: useblacksmith/setup-node@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 24
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         runs-on: blacksmith-4vcpu-ubuntu-2404
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: useblacksmith/checkout@v6
               with:
                   ref: ${{ github.event.inputs.tag || github.ref_name }}
                   persist-credentials: false
@@ -40,7 +40,7 @@ jobs:
               with:
                   bun-version: latest
 
-            - uses: actions/setup-node@v6
+            - uses: useblacksmith/setup-node@v6
               with:
                   node-version: 24
 
@@ -97,7 +97,7 @@ jobs:
         runs-on: blacksmith-4vcpu-windows-2025
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: useblacksmith/checkout@v6
               with:
                   ref: ${{ github.event.inputs.tag || github.ref_name }}
                   persist-credentials: false
@@ -106,7 +106,7 @@ jobs:
               with:
                   bun-version: latest
 
-            - uses: actions/setup-node@v6
+            - uses: useblacksmith/setup-node@v6
               with:
                   node-version: 24
 
@@ -193,7 +193,7 @@ jobs:
                   fi
                   echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
-            - uses: actions/checkout@v6
+            - uses: useblacksmith/checkout@v6
               with:
                   ref: ${{ steps.checkout_ref.outputs.ref }}
                   fetch-depth: 0
@@ -203,7 +203,7 @@ jobs:
               with:
                   bun-version: latest
 
-            - uses: actions/setup-node@v6
+            - uses: useblacksmith/setup-node@v6
               with:
                   node-version: 24
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,14 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: ubuntu-latest
+                    - os: blacksmith-4vcpu-ubuntu-2404
                       binary_platform: linux-x64
                     - os: blacksmith-4vcpu-windows-2025
                       binary_platform: windows-x64
             fail-fast: false
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: useblacksmith/checkout@v6
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             fail-fast: false
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: useblacksmith/checkout@v6
+            - uses: useblacksmith/checkout@v1
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest


### PR DESCRIPTION
## Summary

Updates GitHub Actions workflows to consistently use Blacksmith runners and Blacksmith-provided action forks where available.

## Changes

- Replaces the remaining hosted Linux test runner with `blacksmith-4vcpu-ubuntu-2404`.
- Replaces `actions/checkout@v6` with `useblacksmith/checkout@v6` across workflows.
- Replaces `actions/setup-node@v6` with `useblacksmith/setup-node@v6` in the publish workflow.

## Validation

- Pre-commit hooks passed during commit and push, including YAML validation, `bun run lint`, and `bun run test:unit`.
- Verified no remaining hosted runner labels or standard checkout/setup-node actions in `.github/workflows`.