### PR TITLE
fix(workflows): break ESM init cycle in builtin workflow modules

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed bundled workflow modules so they import the leaf `defineWorkflow` authoring API instead of the public package entrypoint, avoiding an ESM initialization cycle during builtin workflow discovery.
 - Fixed workflow HIL prompts so awaiting-input and answered-prompt notices no longer wake the main chat agent, answer notices stay out of LLM context and explicitly forbid auto-answering later HIL prompts, and stale Enter input from graph/connect focus transitions is quarantined when prompts appear after the attach pane is already open, covering input, confirm, select, and editor prompts ([#1163](https://github.com/bastani-inc/atomic/issues/1163)).
 - Fixed workflow run widgets so store changes and elapsed-time ticks repaint through a long-lived reactive widget instead of waiting for unrelated chat input or remounting the widget ([#1150](https://github.com/bastani-inc/atomic/issues/1150)).
 - Fixed `/workflow reload` and `workflow({ action: "reload" })` so newly added package-manifest workflow entries are rediscovered in-process without requiring top-level `/reload` or restart ([#1155](https://github.com/bastani-inc/atomic/issues/1155)).

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -11,7 +11,7 @@
 import { readFileSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, relative } from "node:path";
-import { defineWorkflow } from "../src/index.js";
+import { defineWorkflow } from "../src/workflows/define-workflow.js";
 import type {
   WorkflowOutputMode,
   WorkflowRunContext,

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -10,7 +10,7 @@ import { randomUUID } from "node:crypto";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { defineWorkflow } from "../src/index.js";
+import { defineWorkflow } from "../src/workflows/define-workflow.js";
 import type { WorkflowTaskResult } from "../src/shared/types.js";
 import { WORKER_PREFLIGHT_CONTRACT } from "./shared-prompts.js";
 

--- a/packages/workflows/builtin/open-claude-design.ts
+++ b/packages/workflows/builtin/open-claude-design.ts
@@ -27,7 +27,7 @@
  * embeds the agreed-upon design alongside the implementation handoff.
  */
 
-import { defineWorkflow } from "../src/index.js";
+import { defineWorkflow } from "../src/workflows/define-workflow.js";
 import type {
   WorkflowTaskResult,
   WorkflowTaskStep,

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -10,7 +10,7 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { defineWorkflow } from "../src/index.js";
+import { defineWorkflow } from "../src/workflows/define-workflow.js";
 import type {
   WorkflowRunContext,
   WorkflowTaskResult,


### PR DESCRIPTION
## Summary

Removes an ESM initialization cycle that caused `ReferenceError: Cannot access ... before initialization` in the unit-test suite. Builtin workflow modules were importing `defineWorkflow` from the public package entrypoint (`src/index.js`), which transitively re-imported the module loader — creating a cycle at startup.

## Changes

- **`builtin/deep-research-codebase.ts`** — import `defineWorkflow` from `src/workflows/define-workflow.js` directly
- **`builtin/goal.ts`** — same targeted import fix
- **`builtin/open-claude-design.ts`** — same targeted import fix
- **`builtin/ralph.ts`** — same targeted import fix
- **`packages/workflows/CHANGELOG.md`** — added Unreleased entry describing the fix

## Root Cause

Each builtin workflow module was reaching for `../src/index.js` just to get `defineWorkflow`. The public entrypoint pulls in the workflow module loader, which in turn attempts to load the builtin modules — a classic circular ESM initializer dependency. The fix is to import the leaf authoring API (`define-workflow.ts`) directly, keeping builtins out of the entrypoint's initialization graph.

## Validation

- `bun test test/unit/builtin-workflows.test.ts`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:integration`
- `cd packages/coding-agent && bun run build`

Fixes CI failure from run [26743099718](https://github.com/bastani-inc/atomic/actions/runs/26743099718).