### PR TITLE
fix(workflows): allow headless workflow runs to exit

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed headless workflow shutdown so completed stage chat handles are disposed on CLI quit, allowing successful non-interactive `/workflow` runs to return to the shell prompt ([#1167](https://github.com/bastani-inc/atomic/issues/1167)).
 - Fixed bundled workflow modules so they import the leaf `defineWorkflow` authoring API instead of the public package entrypoint, avoiding an ESM initialization cycle during builtin workflow discovery.
 - Fixed workflow HIL prompts so awaiting-input and answered-prompt notices no longer wake the main chat agent, answer notices stay out of LLM context and explicitly forbid auto-answering later HIL prompts, and stale Enter input from graph/connect focus transitions is quarantined when prompts appear after the attach pane is already open, covering input, confirm, select, and editor prompts ([#1163](https://github.com/bastani-inc/atomic/issues/1163)).
 - Fixed workflow run widgets so store changes and elapsed-time ticks repaint through a long-lived reactive widget instead of waiting for unrelated chat input or remounting the widget ([#1150](https://github.com/bastani-inc/atomic/issues/1150)).

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -3840,6 +3840,7 @@ function factory(pi: ExtensionAPI): void {
           cancellation: cancellationRegistry,
           persistence: persistenceRef.current,
         });
+        stageControlRegistry.clear();
       }
       storeWidgetUnsubscribe?.();
       storeWidgetUnsubscribe = null;

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import factory, { type ExtensionAPI } from "../../packages/workflows/src/extension/index.js";
+import { stageControlRegistry } from "../../packages/workflows/src/runs/foreground/stage-control-registry.js";
 import { store } from "../../packages/workflows/src/shared/store.js";
 import type { RunSnapshot } from "../../packages/workflows/src/shared/store-types.js";
 
@@ -74,6 +75,7 @@ function getSessionBeforeSwitchHandler(): SessionBeforeSwitchHandler {
 }
 
 beforeEach(() => {
+  stageControlRegistry.clear();
   store.clear();
 });
 
@@ -291,6 +293,42 @@ test("session_start warns when discovered workflows fail validation", async () =
 // Non-interactive (-p) mode: the `workflow` tool remains available so
 // deterministic non-HiL workflows can run through the tool or `/workflow`.
 // ---------------------------------------------------------------------------
+
+test("session_shutdown quit disposes retained completed stage handles", async () => {
+  let disposed = 0;
+  stageControlRegistry.register({
+    runId: "run-1",
+    stageId: "stage-1",
+    stageName: "completed-stage",
+    status: "completed",
+    sessionId: "session-1",
+    sessionFile: undefined,
+    isStreaming: false,
+    messages: [],
+    async ensureAttached() {},
+    async prompt() {},
+    async steer() {},
+    async followUp() {},
+    async pause() {},
+    async resume() {},
+    subscribe() {
+      return () => {};
+    },
+    dispose() {
+      disposed += 1;
+    },
+  });
+  stageControlRegistry.detachControl("run-1", "stage-1");
+
+  const handlers = captureHandlers();
+  const sessionShutdown = handlers.get("session_shutdown");
+  assert.notEqual(sessionShutdown, undefined);
+
+  await sessionShutdown?.({ reason: "quit" });
+
+  assert.equal(disposed, 1);
+  assert.equal(stageControlRegistry.get("run-1", "stage-1"), undefined);
+});
 
 test("session_start removes ask_user_question but keeps workflow in non-interactive sessions", async () => {
   const { handlers, setCalls } = captureHandlersWithActiveTools([


### PR DESCRIPTION
## Summary

Fixes a bug ([#1167](https://github.com/bastani-inc/atomic/issues/1167)) where non-interactive `/workflow` prompt runs would hang at the shell instead of returning after completion. The root cause was retained completed stage chat handles in `stageControlRegistry` that were never disposed on CLI quit, keeping the process alive.

## Changes

- **Fix:** Call `stageControlRegistry.clear()` during `session_shutdown` when the reason is `quit`, disposing all retained completed stage handles after in-flight workflow shutdown handling completes.
- **Test:** Add regression test (`session_shutdown quit disposes retained completed stage handles`) that registers a completed stage handle, detaches it, fires a `quit` shutdown, and asserts the handle is disposed and removed from the registry.
- **Changelog:** Add `[Unreleased]` entry in `packages/workflows/CHANGELOG.md` for this fix.

## Validation

```sh
bun test test/unit/extension.test.ts
bun run typecheck
bun run lint
bun run test:unit
```

## Notes

The fix is scoped to `quit` shutdowns only — active workflow processing is unaffected. Retained handles are cleared after in-flight workflow shutdown logic runs, so no work is interrupted.