### PR TITLE
fix(workflows): render nested workflows as a single flattened top-level view

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added TypeScript module-style workflow composition: parent workflows can pass compiled child workflow definitions directly to `ctx.workflow(compiledWorkflow, options)`. The bundled `deep-research-codebase`, `goal`, `ralph`, and `open-claude-design` workflows are reusable from `@bastani/workflows/builtin` or individual builtin module paths.
-- Added first-class workflow composition: child workflows can declare `.output()` contracts, and `ctx.workflow()` runs compiled child workflow definitions as nested runs with input validation, schema-validated declared outputs, and a visible parent boundary stage ([#1071](https://github.com/bastani-inc/atomic/issues/1071)).
+- Added first-class workflow composition: child workflows can declare `.output()` contracts, and `ctx.workflow()` runs compiled child workflow definitions as nested runs with input validation, schema-validated declared outputs, and the nested workflow's stages flattened inline into the parent graph ([#1071](https://github.com/bastani-inc/atomic/issues/1071)).
 
 ### Changed
 
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Declared explicit output contracts for the bundled `deep-research-codebase`, `goal`, `ralph`, and `open-claude-design` workflows so parent workflows receive schema-validated child outputs.
 - Renamed workflow runtime error prefixes from `pi-workflows:` to `atomic-workflows:`.
 - Render workflow stage notices, lifecycle notices, and HiL answer notices as compact emoji-free TUI cards instead of plain wrapped rows, matching the debugger warning card treatment.
+- Flatten imported workflows in the expanded run graph so a `ctx.workflow()` import reads as a single flat layout: the child run's stages stand in for the import instead of rendering an extra boundary "information" node above them. The boundary's incoming dependencies become the child roots' dependencies and downstream stages rewire to the child's terminal stages, so a depth-1 composition of single-stage leaves now shows one node per import instead of two. A boundary whose child run produced no stages of its own is still kept as a single node so the import stays visible. Affects the graph overlay, session list, `status` stage counts/details, and attach resolution alike.
 - Updated the registered `workflow` tool description so agent-facing metadata covers named and direct runs, discovery, inspection, prompt answering/steering, run control, and reload ([#1151](https://github.com/bastani-inc/atomic/issues/1151)).
 
 ### Fixed
@@ -37,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fixed workflow run widgets so store changes and elapsed-time ticks repaint through a long-lived reactive widget instead of waiting for unrelated chat input or remounting the widget ([#1150](https://github.com/bastani-inc/atomic/issues/1150)).
 - Fixed `/workflow reload` and `workflow({ action: "reload" })` so newly added package-manifest workflow entries are rediscovered in-process without requiring top-level `/reload` or restart ([#1155](https://github.com/bastani-inc/atomic/issues/1155)).
 - Fixed completed child workflow boundary stages rendering as empty graph nodes by showing the child workflow name, child run id prefix, and output count in the node card.
+- Fixed the background workflow widget (`BACKGROUND` panel) listing nested `ctx.workflow()` child runs as separate top-level entries, so a two-level composition no longer shows the root, parent, and child runs as three separate items with an inflated `N runs` count. The widget now applies the same top-level visibility rule (`run.parentRunId === undefined`) already used by `statusRuns`, the `status` action, and the `/workflow connect` session picker. The "needs attention" (awaiting HiL input) badge still fires for a hidden nested descendant by attributing its awaiting state to the visible top-level ancestor via `rootRunId`, so a HiL prompt waiting inside an imported child workflow stays discoverable.
 - Fixed the bundled deep-research workflow line-count heuristic hanging Windows CI by replacing its POSIX `wc` subprocess with portable in-process line counting.
 - Kept workflow stage model metadata as the raw model id while surfacing Codex fast mode as a separate visible `fast` marker on workflow node cards, including stages that use the default Atomic SDK adapter settings manager.
 - Show workflow Codex fast-mode metadata on running workflow nodes as soon as the stage session starts, including explicit-model stages, catalog-resolved bare model aliases, and custom resource-loader stages whose settings manager is created by the Atomic SDK.

--- a/packages/workflows/src/shared/expanded-workflow-graph.ts
+++ b/packages/workflows/src/shared/expanded-workflow-graph.ts
@@ -53,6 +53,16 @@ function localTerminalStageIds(stages: readonly StageSnapshot[]): readonly strin
  * runs it references. Child stages are cloned with virtual ids so their local
  * parent ids do not collide with parent-run stage ids; each virtual node keeps
  * a target mapping back to the actual `{ runId, stageId }` for attach/control.
+ *
+ * Imported workflows are flattened: a boundary stage that wraps a child run
+ * with its own stages is NOT emitted as its own node. Instead the child's
+ * stages stand in for it, so a nested workflow reads as a flat layout with no
+ * extra "information" node marking the import boundary. The boundary's incoming
+ * parents become the child roots' parents, and stages downstream of the
+ * boundary rewire to the child's terminal stages. A boundary whose child run
+ * produced no stages of its own is kept as a single node so the import stays
+ * visible. Boundary stages are non-attachable, so dropping them loses no
+ * interactive capability.
  */
 export function expandWorkflowGraph(
   snapshot: StoreSnapshot,
@@ -84,11 +94,31 @@ export function expandWorkflowGraph(
 
     for (const stage of run.stages) {
       const id = virtualStageId(run.id, stage.id, isRootRun);
-      const parentIds = stage.parentIds.length === 0
+      const resolvedParentIds = stage.parentIds.length === 0
         ? [...incomingParentIds]
         : stage.parentIds.flatMap((parentId) =>
             replacementTerminals.get(parentId) ?? [virtualStageId(run.id, parentId, isRootRun)],
           );
+
+      const childRunId = childRunIdFor(stage);
+      const childRun = childRunId === undefined ? undefined : runById.get(childRunId);
+
+      // Flatten the imported workflow in place: when the boundary wraps a child
+      // run that has its own stages, splice those stages in instead of emitting
+      // the boundary node. Child roots inherit the boundary's incoming parents,
+      // and downstream stages rewire to the child's terminals below.
+      if (childRun !== undefined && childRun.stages.length > 0) {
+        const childExpanded = expandRun(childRun, depth + 1, resolvedParentIds);
+        expandedStages.push(...childExpanded.stages);
+        replacementTerminals.set(
+          stage.id,
+          childExpanded.terminalIds.length > 0 ? childExpanded.terminalIds : resolvedParentIds,
+        );
+        continue;
+      }
+
+      // Regular stage, or a boundary whose child produced no stages of its own:
+      // emit it so the import still appears as exactly one node.
       const target: ExpandedWorkflowStageTarget = {
         runId: run.id,
         stageId: stage.id,
@@ -99,20 +129,9 @@ export function expandWorkflowGraph(
       expandedStages.push({
         ...stage,
         id,
-        parentIds: Object.freeze(parentIds),
+        parentIds: Object.freeze(resolvedParentIds),
         workflowGraphTarget: target,
       });
-
-      const childRunId = childRunIdFor(stage);
-      if (childRunId === undefined) continue;
-      const childRun = runById.get(childRunId);
-      if (childRun === undefined) continue;
-      const childExpanded = expandRun(childRun, depth + 1, [id]);
-      expandedStages.push(...childExpanded.stages);
-      replacementTerminals.set(
-        stage.id,
-        childExpanded.terminalIds.length > 0 ? childExpanded.terminalIds : [id],
-      );
     }
 
     const terminalIds = localTerminalStageIds(run.stages).flatMap((stageId) =>

--- a/packages/workflows/src/tui/widget.ts
+++ b/packages/workflows/src/tui/widget.ts
@@ -27,6 +27,7 @@ import type {
   RunSnapshot,
 } from "../shared/store-types.js";
 import { elapsedRunMs } from "../shared/timing.js";
+import { topLevelWorkflowRuns } from "../shared/run-visibility.js";
 import type { PiTheme } from "./store-widget-installer.js";
 import { renderRoundedBoxLines } from "./chat-surface.js";
 import type { FlatBandBadge } from "./chat-surface.js";
@@ -82,17 +83,36 @@ interface RunCounts {
   awaiting: number;
 }
 
-function countRuns(runs: readonly RunSnapshot[]): RunCounts {
+function runAwaitsInput(run: RunSnapshot): boolean {
+  return (
+    run.endedAt === undefined &&
+    (run.pendingPrompt !== undefined || run.stages.some((s) => s.status === "awaiting_input"))
+  );
+}
+
+/**
+ * A top-level run "needs attention" when it OR any of its nested
+ * `ctx.workflow()` descendants is awaiting human input. Nested child runs are
+ * hidden from the widget, but each carries `rootRunId` pointing at the ultimate
+ * top-level run, so a hidden child's awaiting (HiL) state surfaces on the
+ * visible ancestor instead of vanishing with it.
+ */
+function subtreeAwaitsInput(root: RunSnapshot, allRuns: readonly RunSnapshot[]): boolean {
+  if (runAwaitsInput(root)) return true;
+  return allRuns.some((run) => run.rootRunId === root.id && runAwaitsInput(run));
+}
+
+function countRuns(
+  runs: readonly RunSnapshot[],
+  allRuns: readonly RunSnapshot[] = runs,
+): RunCounts {
   const counts: RunCounts = { active: 0, paused: 0, done: 0, failed: 0, awaiting: 0 };
   for (const r of runs) {
     if (r.endedAt === undefined && r.status === "paused") counts.paused++;
     else if (r.endedAt === undefined) counts.active++;
     else if (r.status === "completed") counts.done++;
     else if (r.status === "failed" || r.status === "killed") counts.failed++;
-    if (
-      r.endedAt === undefined &&
-      (r.pendingPrompt !== undefined || r.stages.some((s) => s.status === "awaiting_input"))
-    ) {
+    if (r.endedAt === undefined && subtreeAwaitsInput(r, allRuns)) {
       counts.awaiting++;
     }
   }
@@ -121,7 +141,12 @@ export function nextWidgetRefreshDelayMs(
 }
 
 function selectDisplayRuns(snap: StoreSnapshot, now: number): RunSnapshot[] {
-  const all = snap.runs as readonly RunSnapshot[];
+  // Only surface top-level workflows. Nested `ctx.workflow()` child runs carry
+  // a `parentRunId`, and they are already represented inline as flattened
+  // stages of their parent's graph, so listing them here would show the same
+  // composition three times (root + parent + child). Matches the visibility
+  // rule `statusRuns`/the `status` action already apply.
+  const all = topLevelWorkflowRuns(snap.runs);
   const active = all.filter((r) => isActive(r));
   const recent = all.filter((r) => recentlyEnded(r, now));
   // Most recently started first within each bucket; active runs precede recent.
@@ -333,7 +358,7 @@ export function buildThemedWidgetLines(
   const display = selectDisplayRuns(snap, now);
   if (display.length === 0) return [];
 
-  const counts = countRuns(snap.runs as readonly RunSnapshot[]);
+  const counts = countRuns(topLevelWorkflowRuns(snap.runs), snap.runs);
   // Active + recently-ended dominate the badge counts so a finished run
   // visually persists for a beat before dropping off.
   const visibleCounts: RunCounts = {

--- a/test/unit/background-status.test.ts
+++ b/test/unit/background-status.test.ts
@@ -90,7 +90,7 @@ describe("statusRuns", () => {
         assert.equal(typeof entry.stageCount, "number");
     });
 
-    test("hides nested child workflow runs and counts expanded stages on the parent", () => {
+    test("hides nested child workflow runs and counts flattened child stages on the parent", () => {
         const st = createStore();
         st.recordRunStart(makeRun({
             id: "parent-run",
@@ -118,7 +118,9 @@ describe("statusRuns", () => {
         const result = statusRuns({ store: st });
 
         assert.deepEqual(result.map((entry) => entry.runId), ["parent-run"]);
-        assert.equal(result[0]?.stageCount, 3);
+        // The imported workflow is flattened: the boundary node is dropped and
+        // only the child's two inlined stages are counted on the parent.
+        assert.equal(result[0]?.stageCount, 2);
     });
 });
 

--- a/test/unit/overlay-graph.test.ts
+++ b/test/unit/overlay-graph.test.ts
@@ -420,6 +420,86 @@ describe("expanded workflow graph", () => {
 
     assert.deepEqual(after?.parentIds, ["child-run:child-second"]);
   });
+
+  it("flattens the imported workflow: drops the boundary node and inlines child stages", () => {
+    const rootBoundary: StageSnapshot = {
+      ...makeStage("workflow:child"),
+      status: "completed",
+      workflowChild: {
+        alias: "child",
+        workflow: "child-workflow",
+        runId: "child-run",
+        status: "completed",
+        outputs: { result: "ok" },
+      },
+    };
+    const rootAfter = makeStage("parent-after", ["workflow:child"]);
+    const childFirst = makeStage("child-first");
+    const childSecond = makeStage("child-second", ["child-first"]);
+    const snap: StoreSnapshot = {
+      runs: [
+        makeRun([rootBoundary, rootAfter]),
+        {
+          id: "child-run",
+          name: "child-workflow",
+          inputs: {},
+          status: "completed",
+          stages: [childFirst, childSecond],
+          startedAt: Date.now(),
+          endedAt: Date.now(),
+        },
+      ],
+      notices: [],
+      version: 1,
+    };
+
+    const graph = expandWorkflowGraph(snap, "run-1");
+
+    // The boundary "information" node is gone; the nested workflow reads flat.
+    assert.equal(graph.stages.some((stage) => stage.name === "workflow:child"), false);
+    // Child root inherits the boundary's (empty) incoming parents.
+    const first = graph.stages.find((stage) => stage.name === "child-first");
+    assert.deepEqual(first?.parentIds, []);
+    // Exactly the two inlined child stages + the downstream parent stage remain.
+    assert.deepEqual(
+      graph.stages.map((stage) => stage.name).sort(),
+      ["child-first", "child-second", "parent-after"],
+    );
+  });
+
+  it("keeps the boundary node when the imported workflow has no stages of its own", () => {
+    const rootBoundary: StageSnapshot = {
+      ...makeStage("workflow:child"),
+      status: "completed",
+      workflowChild: {
+        alias: "child",
+        workflow: "child-workflow",
+        runId: "child-run",
+        status: "completed",
+        outputs: { result: "ok" },
+      },
+    };
+    const snap: StoreSnapshot = {
+      runs: [
+        makeRun([rootBoundary]),
+        {
+          id: "child-run",
+          name: "child-workflow",
+          inputs: {},
+          status: "completed",
+          stages: [],
+          startedAt: Date.now(),
+          endedAt: Date.now(),
+        },
+      ],
+      notices: [],
+      version: 1,
+    };
+
+    const graph = expandWorkflowGraph(snap, "run-1");
+
+    assert.deepEqual(graph.stages.map((stage) => stage.name), ["workflow:child"]);
+  });
 });
 
 describe("GraphView keyboard navigation", () => {
@@ -472,7 +552,8 @@ describe("GraphView keyboard navigation", () => {
     });
 
     const text = visibleText(view.render(120));
-    assert.match(text, /workflow:child/);
+    // Flattened: the boundary "information" node is not rendered.
+    assert.doesNotMatch(text, /workflow:child/);
     assert.match(text, /child-first/);
     assert.match(text, /child-second/);
     view.dispose();

--- a/test/unit/widget-rendering.test.ts
+++ b/test/unit/widget-rendering.test.ts
@@ -166,6 +166,59 @@ describe("renderWidgetLines — standard form", () => {
     assert.ok(wfTwoIdx < wfOneIdx, "most recently started run renders first");
   });
 
+  test("hides nested child workflow runs, showing only the top-level run", () => {
+    const t = Date.now();
+    const root = makeRun("root1111", "contract-hil-nested-root", "running", [], t - 3000);
+    const parent: RunSnapshot = {
+      ...makeRun("parent22", "contract-hil-nested-parent", "running", [], t - 2000),
+      parentRunId: "root1111",
+      parentStageId: "hil-parent:imported-composition",
+      rootRunId: "root1111",
+    };
+    const child: RunSnapshot = {
+      ...makeRun("child333", "contract-hil-nested-child", "running", [], t - 1000),
+      parentRunId: "parent22",
+      parentStageId: "hil-child:imported",
+      rootRunId: "root1111",
+    };
+    const lines = renderWidgetLines(makeSnap([child, parent, root]), 120).map(stripAnsi);
+    const joined = lines.join("\n");
+    // Only the top-level root is listed; the count reflects one run, not three.
+    assert.ok(lines[0]!.includes("1 run"), `expected "1 run" subtitle, got: ${lines[0]}`);
+    assert.ok(joined.includes("contract-hil-nested-root"));
+    assert.ok(!joined.includes("contract-hil-nested-parent"), "nested parent run must be hidden");
+    assert.ok(!joined.includes("contract-hil-nested-child"), "nested child run must be hidden");
+  });
+
+  test("surfaces a hidden nested child's awaiting-input (HiL) state on the top-level run", () => {
+    const t = Date.now();
+    // Root is running and blocked on its imported composition; the actual HiL
+    // prompt is awaiting in the nested child run, which the widget hides.
+    const root = makeRun("root1111", "contract-hil-nested-root", "running", [], t - 3000);
+    const parent: RunSnapshot = {
+      ...makeRun("parent22", "contract-hil-nested-parent", "running", [], t - 2000),
+      parentRunId: "root1111",
+      rootRunId: "root1111",
+    };
+    const child: RunSnapshot = {
+      ...makeRun("child333", "contract-hil-nested-child", "running", [
+        makeStage("s1", "ask", "awaiting_input"),
+      ], t - 1000),
+      parentRunId: "parent22",
+      rootRunId: "root1111",
+    };
+    const lines = renderWidgetLines(makeSnap([child, parent, root]), 120).map(stripAnsi);
+    const header = lines[0]!;
+    // Only the root is listed, but its hidden descendant's awaiting state still
+    // raises the "needs attention" badge so the HiL prompt is discoverable.
+    assert.ok(header.includes("1 run"), `expected "1 run" subtitle, got: ${header}`);
+    assert.ok(
+      header.includes("↵ 1 needs attention (attach to workflow with `/workflow connect`)"),
+      `expected nested HiL to surface a needs-attention badge, got: ${header}`,
+    );
+    assert.ok(!lines.join("\n").includes("contract-hil-nested-child"), "nested child stays hidden");
+  });
+
   test("count badges include stage-local awaiting input", () => {
     const awaiting = makeRun("r1xxxxxx", "wf-await", "running", [
       makeStage("s1", "ask", "awaiting_input"),


### PR DESCRIPTION
## Summary

`ctx.workflow()` child runs were surfacing twice in the workflow UI: once as an extra boundary "information" node in the expanded run graph, and again as separate top-level entries in the background widget. This PR makes nested/imported workflows read as a single flat top-level view in both surfaces, while preserving the human-in-the-loop "needs attention" signal.

## Changes

### Graph overlay — flatten imported workflows (`expanded-workflow-graph.ts`)
- A boundary stage that wraps a child run with its own stages is no longer emitted as its own node; the child's stages are inlined in its place
- Child root stages inherit the boundary's incoming parent IDs; stages downstream of the boundary rewire to the child's terminal stages
- A boundary whose child run produced no stages is kept as a single node so the import stays visible
- A depth-1 composition of single-stage leaves now renders **one** node per import instead of two

### Background widget — hide nested child runs (`widget.ts`)
- The `BACKGROUND` panel now applies the same top-level visibility rule (`run.parentRunId === undefined`) already used by `statusRuns`, the `status` action, and the `/workflow connect` session picker
- A two-level composition no longer lists root + parent + child as three separate entries with an inflated `N runs` count

### Background widget — preserve HiL "needs attention" badge (`widget.ts`)
- Awaiting-input detection is now subtree-aware via a new `subtreeAwaitsInput` helper
- A hidden nested descendant's awaiting (HiL) state is attributed to its visible top-level ancestor via `rootRunId`
- HiL prompts waiting inside imported child workflows remain discoverable via `↵ N needs attention (attach to workflow with \`/workflow connect\`)`

## Testing

- Updated `overlay-graph.test.ts`: boundary node now absent from graph; added flattening + no-stage-fallback cases
- Updated `background-status.test.ts`: flattened stage count 3 → 2
- Added `widget-rendering.test.ts`: nested-run hiding and subtree HiL badge propagation cases
- Full unit suite (1949 tests) + `lint`/`typecheck` pass; pre-commit hooks ran clean

## Notes

- View/derivation only — no workflow execution or output-contract behavior changes
- Affects: graph overlay, session list, `status` stage counts/details, attach resolution, and background widget
- The composition feature is still unreleased; CHANGELOG `Added` note reworded (previously promised "a visible parent boundary stage") alongside new `Changed`/`Fixed` entries
- A long-running Atomic process must be restarted to pick up extension-module changes; `/workflow reload` only reloads workflow *definitions*