### PR TITLE
chore(release): prepare v0.8.22-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.21",
+      "version": "0.8.22-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.21",
+      "version": "0.8.22-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.21",
+      "version": "0.8.22-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.21",
+      "version": "0.8.22-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.21",
+      "version": "0.8.22-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.21",
+      "version": "0.8.22-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.22-0] - 2026-06-01
+
 ### Added
 
 - Added `ExtensionUIContext.requestRender()` and a shared reactive widget installer for extensions to mount widgets once, repaint via coalesced render requests, and own timer-based refreshes without remount flicker ([#1150](https://github.com/bastani-inc/atomic/issues/1150)).

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.21",
+  "version": "0.8.22-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.21",
+  "version": "0.8.22-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.21",
+  "version": "0.8.22-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.22-0] - 2026-06-01
+
 ### Fixed
 - Show Codex fast-mode launch metadata in foreground subagent result badges, async subagent widgets, and async status output when eligible OpenAI/OpenAI Codex child runs start with `/fast` enabled ([#1153](https://github.com/bastani-inc/atomic/issues/1153)).
 - Scope subagent Codex fast-mode launches to the parent chat surface, so main-chat subagents follow `codexFastMode.chat` while workflow-node subagents follow `codexFastMode.workflow` ([#1153](https://github.com/bastani-inc/atomic/issues/1153)).

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.21",
+  "version": "0.8.22-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.21",
+  "version": "0.8.22-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.22-0] - 2026-06-01
+
 ### Breaking Changes
 
 - Migrated workflow input/output declarations to a TypeBox-native schema system, replacing the legacy `{ type, required, default, choices }` descriptor. Authors now declare inputs/outputs with TypeBox schemas (`.input("prompt", Type.String({ description }))`, `.input("count", Type.Number({ default: 2 }))`, `.input("flavor", Type.Union([Type.Literal("a"), Type.Literal("b")]))`, `.output("packet", Type.Object({ topic: Type.String(), score: Type.Number() }))`). `ctx.inputs`, the `.run()` return, and `ctx.workflow(child).outputs` are precisely typed via `Static<>`, and the runtime validates inputs and outputs with TypeBox `Value`. `Type` is re-exported from `@bastani/workflows` (with types `Static` and `TSchema`) so workflow authors single-import. An optional field is declared with `Type.Optional(...)`; a `default` keeps the key required at the type level. This is a clean break with no legacy descriptor support.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.21",
+  "version": "0.8.22-0",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the Atomic workspace for the **v0.8.22-0** prerelease. Bumps all workspace package manifests and `bun.lock` from `0.8.21` to `0.8.22-0`, and cuts the unreleased changelog entries into versioned `[0.8.22-0]` sections across `coding-agent`, `subagents`, and `workflows`.

---

## Changes by Package

### @bastani/atomic (coding-agent)

**Added**
- `ExtensionUIContext.requestRender()` and a shared reactive widget installer so extensions mount once, repaint via coalesced render requests, and own timer refreshes without remount flicker ([#1150](https://github.com/bastani-inc/atomic/issues/1150))
- `/fast` Codex fast-mode toggles for chat and workflow-stage sessions — applies OpenAI priority service tier to `openai/*` and `openai-codex/*` models with a visible `fast` indicator ([#1134](https://github.com/bastani-inc/atomic/issues/1134))
- Extension custom-message `deliverAs: "interrupt"` delivery so extensions can abort a stale streaming turn and start an immediate custom-message turn ([#1137](https://github.com/bastani-inc/atomic/issues/1137))
- `interruptAbortMessage` option for interrupt-delivered extension messages so meaningful external events replace generic `Operation aborted` tool output ([#1137](https://github.com/bastani-inc/atomic/issues/1137))

**Changed**
- Expanded workflow authoring docs for direct `ctx.workflow()` composition, TypeScript module-style calls, builtin workflow modules, and child output contracts
- Refined `/fast` selector into a conventional toggle UI with on/off states, clearer scope descriptions, and space/enter toggle support ([#1134](https://github.com/bastani-inc/atomic/issues/1134))
- Updated workflow tool guidance and workflow-creation prompts for first-time authors

**Fixed**
- Workflow-resource refresh path so reloads re-read package manifests without a full Atomic reload ([#1155](https://github.com/bastani-inc/atomic/issues/1155))
- `/fast` changes now update the banner/footer and current session immediately; inherited chat fast-mode state reaches subagent children without a restart ([#1134](https://github.com/bastani-inc/atomic/issues/1134))
- `/fast` persistence: project-level overrides update alongside global settings without clobbering untouched scopes ([#1134](https://github.com/bastani-inc/atomic/issues/1134))
- Attached workflow-stage chat footers now resolve the `fast` indicator against workflow fast-mode settings instead of chat settings ([#1134](https://github.com/bastani-inc/atomic/issues/1134))
- Print-mode non-zero extension-error exits scoped to command-originated failures only ([#1123](https://github.com/bastani-inc/atomic/issues/1123))
- `ask_user_question` abort handling so interrupt-delivered workflow HiL answer notices are not stuck behind a blocking question modal ([#1137](https://github.com/bastani-inc/atomic/issues/1137))
- Print-mode slash-command output for headless `/workflow` automation ([#1156](https://github.com/bastani-inc/atomic/issues/1156))

---

### @bastani/subagents

**Fixed**
- Show Codex fast-mode launch metadata in foreground result badges, async subagent widgets, and async status output when eligible child runs start with `/fast` enabled ([#1153](https://github.com/bastani-inc/atomic/issues/1153))
- Scope subagent Codex fast-mode launches to the parent chat surface (`codexFastMode.chat` for main-chat, `codexFastMode.workflow` for workflow-node subagents) ([#1153](https://github.com/bastani-inc/atomic/issues/1153))
- Keep the async subagent widget mounted across visible status updates; animate foreground chatbox spinners with spinner-only ticks to keep elapsed/activity text stable ([#1150](https://github.com/bastani-inc/atomic/issues/1150))
- Harden global npm skill discovery by suppressing noisy probe output and caching failures for constrained environments
- Hydrate active async subagent runs from durable status files into the below-editor widget after launch/session rebinding ([#1146](https://github.com/bastani-inc/atomic/issues/1146))

---

### @bastani/workflows

> **Contains breaking changes** — see migration notes below.

**Breaking Changes**
- Migrated workflow input/output declarations to TypeBox-native schemas, replacing the legacy `{ type, required, default, choices }` descriptor. Use `.input("name", Type.String())` / `.output("name", Type.Object(...))`. `ctx.inputs`, `.run()` return, and `ctx.workflow(child).outputs` are precisely typed via `Static<>` and runtime-validated with TypeBox `Value`. `Type`, `Static`, and `TSchema` are re-exported from `@bastani/workflows`. **No legacy descriptor support.**
- Removed the unshipped `.import(...)` API and string-alias child workflow calls. Pass compiled TypeScript workflow definitions directly to `ctx.workflow(workflowDefinition, options)`.
- Removed parent-side child output selection/renaming from `ctx.workflow(...)`. Parents receive the child's declared `.output()` contract as `child.outputs`.
- Workflow outputs are now fully explicit — a `.run()` returning an undeclared key fails with `atomic-workflows: ... returned undeclared output "<key>"`. The implicit `result` output and `child.rawOutput` escape hatch are removed; declare `.output("result", schema)` explicitly.
- Changed default transcript inspection from inlining ~50 recent entries to a reference-first 5-entry preview with `sessionFile`/`transcriptPath`; pass explicit `tail` or `limit` to override.
- Removed the `.humanInTheLoop(...)` builder API; use runtime `ctx.ui.*` calls directly.

**Added**
- TypeBox as the workflow schema engine; `Type`, `Static`, `TSchema` re-exported from the public entry point
- TypeScript module-style workflow composition via `ctx.workflow(compiledWorkflow, options)`
- First-class workflow composition: child workflows declare `.output()` contracts, inputs are validated, and child stages flatten inline into the parent graph ([#1071](https://github.com/bastani-inc/atomic/issues/1071))

**Removed**
- `zod` dependency from `@bastani/workflows`; validation now runs on TypeBox `Value`

**Changed**
- `deep-research-codebase` default `max_concurrency` raised from 4 to 100 for parallel stage fan-out
- Bundled workflows (`deep-research-codebase`, `goal`, `ralph`, `open-claude-design`) now declare explicit output contracts
- Workflow runtime error prefixes renamed from `pi-workflows:` to `atomic-workflows:`
- Workflow stage/lifecycle/HiL notices render as compact TUI cards instead of plain wrapped rows
- Imported workflows flatten into the parent run graph (single-stage leaf imports show one node instead of two)

**Fixed**
- `runWorkflow` now resolves declared input defaults before validating ([#1071](https://github.com/bastani-inc/atomic/issues/1071))
- Slow workflow discovery outside the compiled binary: `@bastani/workflows` SDK always resolves to in-memory virtual modules in the jiti loader
- Headless workflow shutdown: completed stage chat handles are disposed on CLI quit ([#1167](https://github.com/bastani-inc/atomic/issues/1167))
- Workflow HIL prompts: stale Enter input quarantined, answer notices stay out of LLM context ([#1163](https://github.com/bastani-inc/atomic/issues/1163))
- Workflow run widgets repaint through a long-lived reactive widget instead of waiting for unrelated chat input ([#1150](https://github.com/bastani-inc/atomic/issues/1150))
- `/workflow reload` rediscovers newly added package-manifest entries in-process ([#1155](https://github.com/bastani-inc/atomic/issues/1155))
- Background workflow widget no longer lists nested `ctx.workflow()` child runs as separate top-level entries
- `deep-research-codebase` line-count heuristic replaced with portable in-process counting (fixes Windows CI hang)

---

## Validation

- `AGENT=1 bun run typecheck`
- Pre-commit hook: `bun run lint`
- Pre-commit hook: `bun run test:unit`