### PR TITLE
ci: run npm provenance publish on GitHub-hosted runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,7 +164,8 @@ jobs:
 
     publish:
         name: Publish @bastani/atomic
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        # npm provenance only supports GitHub-hosted runners.
+        runs-on: ubuntu-latest
         needs:
             - linux-binary-smoke
             - windows-binary-smoke
@@ -193,7 +194,7 @@ jobs:
                   fi
                   echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
-            - uses: useblacksmith/checkout@v1
+            - uses: actions/checkout@v6.0.2
               with:
                   ref: ${{ steps.checkout_ref.outputs.ref }}
                   fetch-depth: 0

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -149,6 +149,7 @@ git push origin v0.8.0
 Publish @bastani/atomic
   · resolve and validate the tag name
   · checkout the tag
+  · run on a GitHub-hosted Ubuntu runner (required for npm provenance)
   · setup Bun and Node (Node 24 for npm provenance publish)
   · bun install --frozen-lockfile
   · bun run typecheck && bun run test:all
@@ -178,6 +179,8 @@ Create GitHub Release with softprops/action-gh-release@v3
 ### Why npm Publish Before GitHub Release?
 
 npm versions are immutable. The workflow publishes to npm first so the GitHub Release is only created after the npm package is available.
+
+npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test jobs can use Blacksmith runners.
 
 ### GitHub Release Creation
 
@@ -243,7 +246,7 @@ The meaningful pre-publish checks are:
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, validate docs links, build `@bastani/atomic`, unit/integration tests, build native Linux/Windows binaries, and run `atomic --version` archive smoke tests                                 |
-| `publish.yml`        | `v*` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel, validate docs links before publish metadata checks, build binaries, publish `@bastani/atomic` to npm with OIDC provenance, create GitHub Release with binaries |
+| `publish.yml`        | `v*` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel, validate docs links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic`, create GitHub Release with binaries |
 | `code-review.yml`    | PR opened/synchronized                        | Claude-powered code review                                                                                                                                                                                    |
 | `pr-description.yml` | PR opened/synchronized                        | Claude-powered PR description generation, skipped for Dependabot                                                                                                                                              |
 | `claude.yml`         | Issue/PR comments, issues, PR reviews         | Interactive Claude assistant gated on `@claude` mentions                                                                                                                                                      |


### PR DESCRIPTION
## Summary

Moves the `Publish @bastani/atomic` job to a GitHub-hosted runner (`ubuntu-latest`), which is required for npm's OIDC-signed provenance bundles. Binary smoke-test jobs continue using Blacksmith runners for performance.

## Changes

- Switches the publish job runner from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-latest` with an inline comment explaining the requirement
- Replaces `useblacksmith/checkout@v1` with `actions/checkout@v6.0.2` (Blacksmith's checkout action is incompatible with GitHub-hosted runners)
- Documents the GitHub-hosted runner requirement in `docs/ci.md` — both in the publish flow steps and in the "Why npm Publish Before GitHub Release?" rationale section

## Why

npm provenance uses GitHub's OIDC token exchange to cryptographically bind a package to its source commit and workflow. This mechanism is only supported on GitHub-hosted runners; third-party runners (Blacksmith) cannot obtain the required OIDC tokens from GitHub Actions.

## Breaking Changes

None. The change is limited to the publish job's runner environment; the binary build and smoke-test jobs are unaffected.

## Validation

- Pre-commit hook: YAML validation
- Pre-commit hook: `bun run lint`
- Pre-commit hook: `bun run test:unit`