### PR TITLE
chore(release): prepare v0.8.22

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.22-0",
+      "version": "0.8.22",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.22-0",
+      "version": "0.8.22",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.22-0",
+      "version": "0.8.22",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.22-0",
+      "version": "0.8.22",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.22-0",
+      "version": "0.8.22",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.22-0",
+      "version": "0.8.22",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+## [0.8.22] - 2026-06-01
+
+### Breaking Changes
+
+- Migrated bundled workflow authoring to explicit TypeBox input/output schemas and explicit workflow outputs, so composed workflows now validate contracts with `Type`/`Static` and no longer support legacy descriptors, implicit `result`, `rawOutput`, `.import(...)`, or declaration-time `.humanInTheLoop(...)`.
+
+### Added
+
+- Added Codex `/fast` mode toggles for chat and workflow-stage sessions with visible `fast` model markers on eligible OpenAI/OpenAI Codex models.
+- Added reactive extension UI rendering via `ExtensionUIContext.requestRender()` so long-lived widgets can repaint without remount flicker.
+- Added interrupt-delivered extension custom messages with optional abort messages, letting workflow and other first-party extensions surface urgent events immediately.
+
+### Changed
+
+- Expanded bundled workflow authoring docs and agent guidance for direct `ctx.workflow(compiledWorkflow, options)` composition, reusable builtin workflow modules, explicit child outputs, and safer long-running workflow monitoring.
+- Refined the `/fast` selector copy, layout, toggle states, and keyboard support for clearer chat/workflow scoping.
+- Improved workflow graph/status rendering for nested child workflows, compact lifecycle/HIL cards, and reference-first transcript inspection.
+
+### Fixed
+
+- Fixed workflow reloads so package-manifest workflow entries refresh in-process without a full Atomic restart.
+- Fixed Codex fast-mode propagation, persistence, request payloads, workflow footer markers, subagent launch metadata, and fallback marker synchronization across chat, workflow, and subagent surfaces.
+- Fixed headless `/workflow` automation and print-mode output so successful commands emit displayable summaries, terminal failures surface correctly, completed stage handles dispose on exit, and command-originated extension errors are the only non-zero extension-error exits.
+- Hardened workflow human-in-the-loop prompts and answers so brokered prompts remain focusable/scrollable, avoid stale Enter submissions, stay out of model context where appropriate, and resolve duplicate or raced tool answers deterministically.
+- Stabilized long-lived workflow and subagent widgets with coalesced repaint paths, durable async-run hydration, and spinner ticks that avoid remount or scrollback flicker.
+
 ## [0.8.22-0] - 2026-06-01
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.22-0",
+  "version": "0.8.22",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.22-0",
+  "version": "0.8.22",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.22-0",
+  "version": "0.8.22",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.8.22] - 2026-06-01
+
+### Fixed
+- Surfaced Codex fast-mode state in foreground result badges, async widgets, and async status output, while scoping child fast-mode launches to the parent chat or workflow surface.
+- Stabilized async subagent widgets and foreground spinner animation so visible status updates no longer remount widgets or churn elapsed/activity text between semantic progress changes.
+- Hydrated durable active async runs into the below-editor widget and hardened global npm skill discovery with quieter probing, conservative timeouts, and cached failures.
+
 ## [0.8.22-0] - 2026-06-01
 
 ### Fixed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.22-0",
+  "version": "0.8.22",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.22-0",
+  "version": "0.8.22",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.22] - 2026-06-01
+
+### Breaking Changes
+
+- Migrated workflow contracts to TypeBox schemas and fully explicit outputs, removing legacy descriptor schemas, `.import(...)`, string-alias child workflow calls, parent-side output remapping, implicit `result`/`rawOutput`, and declaration-time `.humanInTheLoop(...)` metadata.
+
+### Added
+
+- Added TypeBox re-exports, TypeScript module-style child workflow composition, schema-validated child outputs, reusable builtin workflow modules, and flattened nested child workflow stages.
+
+### Changed
+
+- Raised the bundled deep-research workflow's default parallelism, renamed workflow runtime errors to `atomic-workflows:`, rendered workflow notices as compact TUI cards, flattened imported workflow graph boundaries, and expanded registered workflow-tool metadata.
+
+### Fixed
+
+- Fixed defaulted input validation, slow workflow discovery through the jiti loader, headless workflow shutdown and print-mode automation, builtin workflow initialization cycles, package-manifest workflow reloads, nested workflow widgets/graph cards, portable deep-research line counting, Codex fast-mode workflow markers, human-in-the-loop focus/answer behavior, background widget rendering, and deterministic headless command output.
+
 ## [0.8.22-0] - 2026-06-01
 
 ### Breaking Changes

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.22-0",
+  "version": "0.8.22",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the `0.8.22-0` prerelease to the stable `0.8.22` release across all workspace packages, with descriptive changelog entries documenting the full set of changes shipped in this version.

## Changes

- **Version bump**: Promotes all workspace package manifests (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/intercom`, `@bastani/mcp`, `@bastani/web-access`) from `0.8.22-0` → `0.8.22` and updates `bun.lock` accordingly.
- **Changelog — `@bastani/atomic`**: Documents breaking workflow authoring migration to explicit TypeBox schemas; new Codex `/fast` mode toggles, reactive extension UI rendering, and interrupt-delivered custom messages; improved workflow graph rendering and `/fast` selector UX; fixes for workflow reloads, Codex fast-mode propagation, headless `/workflow` automation, human-in-the-loop prompts, and long-lived widget stability.
- **Changelog — `@bastani/workflows`**: Documents breaking removal of legacy descriptor schemas, `.import()`, string-alias calls, and implicit outputs; new TypeBox re-exports and builtin workflow modules; raised deep-research parallelism and compact TUI cards; broad fixes for input validation, jiti loader speed, headless shutdown, nested widgets, and deterministic headless output.
- **Changelog — `@bastani/subagents`**: Documents fixes for Codex fast-mode state in result badges and async widgets, stabilized widget rendering, durable async-run hydration, and hardened npm skill discovery.

## Breaking Changes

> These were introduced in the `0.8.22-0` prerelease and are now stable.

- **Workflow authoring**: Workflow contracts now require explicit TypeBox `input`/`output` schemas and explicit child outputs. Legacy descriptor schemas, `.import(...)`, string-alias child workflow calls, parent-side output remapping, implicit `result`/`rawOutput`, and declaration-time `.humanInTheLoop(...)` metadata are no longer supported.

## Validation

- `bun install --frozen-lockfile`
- `AGENT=1 bun run typecheck`
- Pre-commit hook: `bun run lint`
- Pre-commit hook: `bun run test:unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)