### PR TITLE
fix(ask-user-question): stop dialog flicker on short terminals

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed severe flickering in the `ask_user_question` dialog on short terminals by suspending the animated working loader while the blocking question UI is open; the inline dialog no longer pushes the ticking loader above the viewport, which had forced a full-screen clear+replay on every spinner frame.
+
 ## [0.8.22] - 2026-06-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts
@@ -81,18 +81,37 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 
 			const itemsByTab: WrappingSelectItem[][] = typed.questions.map((q) => buildItemsForQuestion(q));
 
-			const result = await ctx.ui.custom<QuestionnaireResult>((tui, theme, _kb, done) => {
-				const session = new QuestionnaireSession({
-					tui,
-					theme,
-					params: typed,
-					itemsByTab,
-					done,
-				});
-				return session.component;
-			}, { signal });
+			// Suspend the animated working loader for the lifetime of the blocking dialog.
+			//
+			// The questionnaire mounts inline, directly below the status/working-loader row.
+			// That loader ticks every ~80ms and calls `requestRender()` on each frame. On a
+			// short terminal the (tall) side-by-side dialog pushes the loader line above the
+			// viewport top, so pi-tui's differential renderer sees `firstChanged < viewportTop`
+			// and falls back to a full clear+replay (`\x1b[2J\x1b[H\x1b[3J`) on every tick. The
+			// transcript is replayed before the dialog each time, which is the flicker. The
+			// loader conveys nothing while we're blocked on human input, so hide it for the
+			// duration and restore it once the dialog closes (on every path).
+			//
+			// Guarded: some hosts (e.g. the workflow stage-UI broker) pass a minimal UI
+			// context that only implements `custom`, so treat a missing loader control as a
+			// no-op rather than throwing.
+			ctx.ui.setWorkingVisible?.(false);
+			try {
+				const result = await ctx.ui.custom<QuestionnaireResult>((tui, theme, _kb, done) => {
+					const session = new QuestionnaireSession({
+						tui,
+						theme,
+						params: typed,
+						itemsByTab,
+						done,
+					});
+					return session.component;
+				}, { signal });
 
-			return buildQuestionnaireResponse(result, typed);
+				return buildQuestionnaireResponse(result, typed);
+			} finally {
+				ctx.ui.setWorkingVisible?.(true);
+			}
 		},
 	};
 }

--- a/packages/coding-agent/test/ask-user-question-tool.test.ts
+++ b/packages/coding-agent/test/ask-user-question-tool.test.ts
@@ -31,6 +31,7 @@ describe("ask_user_question tool", () => {
 		let capturedSignal: AbortSignal | undefined;
 
 		const ui = {
+			setWorkingVisible: () => {},
 			custom: <T>(_factory: Parameters<ExtensionUIContext["custom"]>[0], options?: { signal?: AbortSignal }) => {
 				capturedSignal = options?.signal;
 				if (capturedSignal === undefined) {
@@ -44,7 +45,7 @@ describe("ask_user_question tool", () => {
 					);
 				});
 			},
-		} as Pick<ExtensionUIContext, "custom">;
+		} as Pick<ExtensionUIContext, "custom" | "setWorkingVisible">;
 
 		const execution = tool.execute(
 			"ask-1",
@@ -59,5 +60,82 @@ describe("ask_user_question tool", () => {
 
 		controller.abort(abortReason);
 		await expect(execution).rejects.toBe(abortReason);
+	});
+
+	it("suspends the working loader while the dialog is open and restores it afterward", async () => {
+		const tool = createAskUserQuestionToolDefinition();
+		const events: string[] = [];
+
+		const ui = {
+			setWorkingVisible: (visible: boolean) => {
+				events.push(visible ? "working:on" : "working:off");
+			},
+			custom: <T>() => {
+				events.push("custom");
+				return Promise.resolve({ answers: [], cancelled: true } as T);
+			},
+		} as Pick<ExtensionUIContext, "custom" | "setWorkingVisible">;
+
+		await tool.execute(
+			"ask-loader",
+			QUESTION_PARAMS,
+			new AbortController().signal,
+			() => undefined,
+			{ hasUI: true, ui } as Parameters<typeof tool.execute>[4],
+		);
+
+		// Loader is hidden before the dialog mounts and restored once it closes.
+		expect(events).toEqual(["working:off", "custom", "working:on"]);
+	});
+
+	it("restores the working loader even when the dialog rejects", async () => {
+		const tool = createAskUserQuestionToolDefinition();
+		const events: string[] = [];
+		const failure = new Error("dialog blew up");
+
+		const ui = {
+			setWorkingVisible: (visible: boolean) => {
+				events.push(visible ? "working:on" : "working:off");
+			},
+			custom: <T>() => Promise.reject<T>(failure),
+		} as Pick<ExtensionUIContext, "custom" | "setWorkingVisible">;
+
+		await expect(
+			tool.execute(
+				"ask-loader-reject",
+				QUESTION_PARAMS,
+				new AbortController().signal,
+				() => undefined,
+				{ hasUI: true, ui } as Parameters<typeof tool.execute>[4],
+			),
+		).rejects.toBe(failure);
+
+		// The `finally` restores the loader even on the failure/abort path.
+		expect(events).toEqual(["working:off", "working:on"]);
+	});
+
+	it("works when the host UI context does not implement setWorkingVisible", async () => {
+		// Some hosts (e.g. the workflow stage-UI broker) pass a minimal context that only
+		// implements `custom`. The loader control must degrade to a no-op, not throw.
+		const tool = createAskUserQuestionToolDefinition();
+		let customCalled = false;
+
+		const ui = {
+			custom: <T>() => {
+				customCalled = true;
+				return Promise.resolve({ answers: [], cancelled: true } as T);
+			},
+		} as Pick<ExtensionUIContext, "custom">;
+
+		const result = await tool.execute(
+			"ask-no-loader",
+			QUESTION_PARAMS,
+			new AbortController().signal,
+			() => undefined,
+			{ hasUI: true, ui } as Parameters<typeof tool.execute>[4],
+		);
+
+		expect(customCalled).toBe(true);
+		expect(result).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Summary

The `ask_user_question` clarification dialog flickered severely on short terminals — the dialog rapidly alternated with the underlying transcript on every spinner tick. This fix eliminates the root cause by suspending the animated working loader for the lifetime of the blocking dialog.

## Root Cause

The questionnaire mounts **inline**, directly below the animated working-loader row. That loader ticks ~every 80 ms and calls `requestRender()` on each frame. On a short terminal the tall side-by-side dialog (~33 rows) pushes the loader line **above the viewport top**, causing pi-tui's differential renderer to fall back to `fullRender(true)` — `\x1b[2J\x1b[H\x1b[3J` (clear screen + scrollback) followed by replaying every line top-to-bottom (transcript first, dialog last). The visible transcript → dialog replay on every spinner tick is the flicker. It only manifests on short terminals because taller terminals keep the loader inside the viewport, allowing pi-tui to diff just that one line.

## Changes

- **Suspend loader during dialog** — calls `ctx.ui.setWorkingVisible(false)` before mounting the dialog and restores it in a `finally` block, covering resolve, reject, and abort paths. The loader conveys nothing while blocked on human input, so hiding it eliminates the 80 ms render churn entirely.
- **Optional-chain guard** — uses `ctx.ui.setWorkingVisible?.(...)` so hosts that pass a minimal UI context (e.g., the workflow stage-UI broker, which only implements `custom`) degrade gracefully to a no-op instead of throwing.
- **Regression tests** — three new test cases:
  - Suspend/restore ordering on the happy path (resolve).
  - Loader restoration on the reject/abort path (via `finally`).
  - Graceful no-op when the host omits `setWorkingVisible`.
- **CHANGELOG** — entry added under `[Unreleased] ### Fixed` in `packages/coding-agent/CHANGELOG.md`.

## Notes

- Scope is intentionally minimal and low-risk: removes the flicker source rather than reworking the dialog layout.
- Potential deeper follow-ups (out of scope for this PR): render the dialog as an overlay, make the layout height-aware with internal scroll, or teach pi-tui to skip full redraws when only off-screen lines change.
- Verified: `bun run typecheck` (exit 0) and `bun run test:unit` (1949 pass, 0 fail), including the previously-failing `readiness-gate-decision` broker tests that exercise the real tool through a minimal UI context.