### PR TITLE
fix(workflows): route paused stage Ctrl+D back to orchestrator graph

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a workflow node chat Ctrl+D hint that shares the bottom footer line with model/cwd metadata and appears in the bottom-right corner of stage-local ctx.ui widgets.
+
+### Fixed
+
+- Fixed paused workflow stage chats so Ctrl+D returns to the orchestrator graph instead of closing back to the main chat.
+
 ## [0.8.22] - 2026-06-01
 
 ### Breaking Changes

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -3009,12 +3009,9 @@ function factory(pi: ExtensionAPI): void {
       if (policy.allowInputPicker) {
         overlay.open(runId, overlaySurfaceFromContext(ctx), stageId);
       }
-      const attachedStage = stageId ? run?.stages.find((s) => s.id === stageId) : undefined;
       print(
         stageId
-          ? attachedStage?.status === "paused"
-            ? `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d close · esc close.`
-            : `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d return to graph · esc close.`
+          ? `Attached to ${runId.slice(0, 8)} stage ${stageId.slice(0, 8)}. ctrl+d return to graph · esc close.`
           : `Attached to ${runId.slice(0, 8)}. ↵ chat · ctrl+d detach.`,
       );
       return true;

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -22,7 +22,7 @@
  *  - **Escape** mirrors the main coding-agent chat interrupt path for active
  *    live stages: it requests a controlled pause/abort while keeping the
  *    composer active. While paused, Enter calls `handle.resume(text)`.
- *  - **Ctrl+D** detaches (back to graph), or closes the popup while paused;
+ *  - **Ctrl+D** detaches (back to graph), including while paused;
  *    **Escape** closes the popup when idle.
  *  - **Blocked** stage: keystrokes absorbed; BLOCKED banner names the
  *    upstream awaiter.
@@ -69,7 +69,7 @@ import type { StageControlHandle } from "../runs/foreground/stage-control-regist
 import { isKeybindingsLike, type KeybindingsLike } from "./keybindings-adapter.js";
 import { BOLD, RESET, hexBg, hexToAnsi, lerpColor } from "./color-utils.js";
 import { renderWorkflowNoticeCard, type WorkflowNoticeTone } from "./workflow-notice-card.js";
-import { Key, matchesKey, visibleWidth } from "./text-helpers.js";
+import { Key, matchesKey, truncateToWidth, visibleWidth } from "./text-helpers.js";
 import {
   fitStageChatFrame,
   planStageChatFrame,
@@ -105,7 +105,7 @@ export interface StageChatViewOpts {
    * inspect-only (settled stage with no live handle).
    */
   handle?: StageControlHandle;
-  /** Called when the user presses Ctrl+D outside a paused stage (back to graph). */
+  /** Called when the user presses Ctrl+D (back to graph). */
   onDetach: (reason?: StageChatDetachReason, metadata?: StageChatDetachMetadata) => void;
   /** Called when the user presses Escape (close the whole popup). */
   onClose: () => void;
@@ -678,7 +678,9 @@ export class StageChatView implements Component, Focusable {
     const workingLines = chatChromeHidden ? [] : this.chatHost.renderWorkingStatus(w);
     const usageLines = chatChromeHidden ? [] : this.chatHost.renderUsage(w);
     const editorLines = chatChromeHidden ? [] : this.chatHost.renderEditor(w);
-    const footerLines = chatChromeHidden ? [] : this.chatHost.renderFooter(w);
+    const footerLines = chatChromeHidden
+      ? []
+      : this._renderFooterWithOrchestratorReturnHint(w, this.chatHost.renderFooter(w));
 
     const totalRows = this._viewLineCount();
     const plan = planStageChatFrame({
@@ -776,6 +778,67 @@ export class StageChatView implements Component, Focusable {
 
   private _sepRule(width: number): string {
     return hexToAnsi(this.theme.borderDim) + "─".repeat(width) + RESET;
+  }
+
+  private _renderFooterWithOrchestratorReturnHint(
+    width: number,
+    footerLines: readonly string[],
+  ): string[] {
+    if (footerLines.length === 0) {
+      return [this._mergeOrchestratorReturnHintIntoLine("", width)];
+    }
+    const lines = [...footerLines];
+    const lastIndex = lines.length - 1;
+    lines[lastIndex] = this._mergeOrchestratorReturnHintIntoLine(
+      lines[lastIndex] ?? "",
+      width,
+    );
+    return lines;
+  }
+
+  private _embedOrchestratorReturnHintInWidget(
+    widgetLines: readonly string[],
+    width: number,
+  ): string[] {
+    if (widgetLines.length === 0) {
+      return [this._mergeOrchestratorReturnHintIntoLine("", width)];
+    }
+    const lines = [...widgetLines];
+    const targetIndex = widgetHintTargetLineIndex(lines);
+    lines[targetIndex] = this._mergeOrchestratorReturnHintIntoLine(
+      lines[targetIndex] ?? "",
+      width,
+      { preserveTrailingBorder: true, rightMargin: 2 },
+    );
+    return lines;
+  }
+
+  private _mergeOrchestratorReturnHintIntoLine(
+    line: string,
+    width: number,
+    options: { preserveTrailingBorder?: boolean; rightMargin?: number } = {},
+  ): string {
+    const plain = "ctrl+d returns to orchestrator panel";
+    const styled =
+      paint("ctrl+d", this.theme.text, { bold: true }) +
+      paint(" returns to orchestrator panel", this.theme.textMuted);
+    const trailingBorder = options.preserveTrailingBorder === true
+      ? trailingWidgetBorderChar(line)
+      : "";
+    const suffixWidth = visibleWidth(trailingBorder);
+    const hintWidth = visibleWidth(plain);
+    const requestedRightMargin = Math.max(
+      0,
+      Math.floor(options.rightMargin ?? 0),
+    );
+    const rightMargin = Math.min(
+      requestedRightMargin,
+      Math.max(0, width - suffixWidth - hintWidth),
+    );
+    const hintStart = Math.max(0, width - suffixWidth - rightMargin - hintWidth);
+    const prefix = truncateToWidth(line, hintStart, "", true);
+    const gap = Math.max(0, hintStart - visibleWidth(prefix));
+    return prefix + " ".repeat(gap) + styled + " ".repeat(rightMargin) + trailingBorder;
   }
 
   // -------------------------------------------------------------------------
@@ -913,7 +976,7 @@ export class StageChatView implements Component, Focusable {
         "warning",
         "❚❚",
         "PAUSED",
-        "enter resumes · ctrl+d close",
+        "enter resumes · ctrl+d graph",
       ),
     );
     callout.push(
@@ -981,12 +1044,18 @@ export class StageChatView implements Component, Focusable {
     const component = this.mountedCustomUi?.component;
     if (!component) return [];
     setComponentFocused(component, this.focused);
-    return component.render(width);
+    return this._embedOrchestratorReturnHintInWidget(component.render(width), width);
   }
 
   private _renderPromptBody(width: number, budget: number): string[] {
     const primitiveLines = this._renderPrimitivePromptBody(width);
-    if (primitiveLines) return this._fitPromptBodyLines(primitiveLines, width, budget);
+    if (primitiveLines) {
+      return this._fitPromptBodyLines(
+        this._embedOrchestratorReturnHintInWidget(primitiveLines, width),
+        width,
+        budget,
+      );
+    }
 
     const state = this.promptState;
     const lines = state
@@ -997,7 +1066,11 @@ export class StageChatView implements Component, Focusable {
         cursorOn: this.focused,
       })
       : [];
-    return this._fitPromptBodyLines(lines, width, budget);
+    return this._fitPromptBodyLines(
+      this._embedOrchestratorReturnHintInWidget(lines, width),
+      width,
+      budget,
+    );
   }
 
   private _renderPrimitivePromptBody(width: number): string[] | null {
@@ -1203,8 +1276,7 @@ export class StageChatView implements Component, Focusable {
         // stays pending (the stage remains awaiting_input) and is re-displayed
         // when the user re-attaches.
         this._releaseMountedCustomUi();
-        if (this._isPaused()) this.onClose();
-        else this.onDetach();
+        this.onDetach();
         return true;
       }
       if (matchesKey(data, Key.ctrl("c"))) {
@@ -1233,8 +1305,7 @@ export class StageChatView implements Component, Focusable {
     const readOnlyPromptArchive = readOnlyArchive && stage?.promptFootprint !== undefined;
     if (matchesKey(data, Key.ctrl("d"))) {
       if (!this.promptState && this.chatHost.hasInputText()) return this.chatHost.handleInput(data);
-      if (this._isPaused()) this.onClose();
-      else this.onDetach();
+      this.onDetach();
       return true;
     }
     if (this.promptState) {
@@ -1697,6 +1768,29 @@ function editorThemeFromGraphTheme(t: GraphTheme): EditorTheme {
 
 function takeRows(lines: readonly string[], rows: number): string[] {
   return lines.slice(0, rows);
+}
+
+function widgetHintTargetLineIndex(lines: readonly string[]): number {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (!isWidgetBottomBorderLine(lines[index] ?? "")) return index;
+  }
+  return Math.max(0, lines.length - 1);
+}
+
+function isWidgetBottomBorderLine(line: string): boolean {
+  const plain = stripAnsi(line).trim();
+  const chars = Array.from(plain);
+  if (chars.length < 2) return false;
+  const first = chars[0] ?? "";
+  const last = chars.at(-1) ?? "";
+  if (!"╰└+".includes(first) || !"╯┘+".includes(last)) return false;
+  return chars.slice(1, -1).every((char) => "─═- ".includes(char));
+}
+
+function trailingWidgetBorderChar(line: string): string {
+  const plain = stripAnsi(line).trimEnd();
+  const last = Array.from(plain).at(-1) ?? "";
+  return "╯┘┤┴│|+".includes(last) ? last : "";
 }
 
 interface PaintOpts {

--- a/packages/workflows/src/tui/workflow-attach-pane.ts
+++ b/packages/workflows/src/tui/workflow-attach-pane.ts
@@ -5,8 +5,8 @@
  * between the orchestrator `GraphView` and a stage-scoped
  * `StageChatView`. Pressing Enter on a graph node attaches the popup
  * to that node's chat; Ctrl+D in chat mode swaps back to graph mode
- * with the same node still focused (see ui/attach-mockup.html), except
- * paused stage chats close the pane to mirror shell EOF semantics.
+ * with the same node still focused (see ui/attach-mockup.html), including
+ * paused stage chats.
  *
  * The shell never remounts the overlay — it only flips a `mode`
  * field and re-renders, so the popup stays in pi-tui's overlay layer

--- a/test/unit/stage-chat-view.test.ts
+++ b/test/unit/stage-chat-view.test.ts
@@ -214,6 +214,22 @@ const CTRL_D_VARIANTS = [
     "\x1b[27;5;100~",
 ];
 
+const RETURN_HINT_TEXT = "ctrl+d returns to orchestrator panel";
+
+function expectRightAlignedReturnHint(
+    lines: readonly string[],
+    width: number,
+    rightInset = 0,
+): number {
+    const index = lines.findIndex((line) => line.includes(RETURN_HINT_TEXT));
+    assert.ok(index >= 0, "expected Ctrl+D orchestrator hint");
+    assert.equal(
+        lines[index]!.indexOf(RETURN_HINT_TEXT),
+        width - RETURN_HINT_TEXT.length - rightInset,
+    );
+    return index;
+}
+
 function makePendingPrompt(
     overrides: Partial<PendingPrompt> = {},
 ): PendingPrompt {
@@ -1273,7 +1289,15 @@ describe("StageChatView", () => {
             "run-1",
             "stage-a",
             (_tui, _theme, _kb, done) => ({
-                render: () => ["Proceed with the plan?"],
+                render: (width: number) => {
+                    const inner = Math.max(2, width - 2);
+                    const question = "Proceed with the plan?";
+                    return [
+                        `╭${"─".repeat(inner)}╮`,
+                        `│${question}${" ".repeat(Math.max(0, inner - question.length))}│`,
+                        `╰${"─".repeat(inner)}╯`,
+                    ];
+                },
                 handleInput: (data: string) => {
                     questionInputs.push(data);
                     if (data === "y") done("Yes");
@@ -1283,10 +1307,20 @@ describe("StageChatView", () => {
         );
         await flush();
 
-        // Both the prior transcript and the question render together.
-        const rendered = stripAnsi(view.render(80).join("\n"));
+        // Both the prior transcript and the question render together, with the
+        // return-to-orchestrator hint inside the custom UI's bottom-right corner.
+        const renderedLines = view.render(80).map(stripAnsi);
+        const rendered = renderedLines.join("\n");
         assert.match(rendered, /EARLIER-HISTORY-MARKER/);
         assert.match(rendered, /Proceed with the plan\?/);
+        const questionIndex = renderedLines.findIndex((line) =>
+            line.includes("Proceed with the plan?"),
+        );
+        const hintIndex = expectRightAlignedReturnHint(renderedLines, 80, 3);
+        assert.equal(hintIndex, questionIndex);
+        assert.match(renderedLines[hintIndex] ?? "", /^│/);
+        assert.match(renderedLines[hintIndex] ?? "", /  ctrl\+d returns to orchestrator panel  │$/);
+        assert.doesNotMatch(renderedLines[hintIndex] ?? "", /^╰/);
 
         // Scroll input (mouse wheel) is consumed by the transcript, not the
         // question component, so history stays scrollable while the gate is open.
@@ -1385,13 +1419,14 @@ describe("StageChatView", () => {
 
     test("ctrl+c closes and ctrl+d detaches without cancelling the pending custom UI", async () => {
         for (const variant of [
-            { key: "\x03", expect: "close" },
-            { key: "\x04", expect: "detach" },
+            { key: "\x03", expect: "close", status: "running" },
+            { key: "\x04", expect: "detach", status: "running" },
+            { key: "\x04", expect: "detach", status: "paused" },
         ] as const) {
             const store = createStore();
-            setupRun(store, "run-1", "stage-a");
+            setupRun(store, "run-1", "stage-a", variant.status);
             const broker = new StageUiBroker(store);
-            const { handle } = makeHandle();
+            const { handle } = makeHandle(undefined, [], variant.status);
             let closed = 0;
             let detached = 0;
             const view = new StageChatView({
@@ -1441,14 +1476,19 @@ describe("StageChatView", () => {
             // The local display is released (transcript renders again)...
             assert.doesNotMatch(stripAnsi(view.render(80).join("\n")), /Q/);
             // ...but the human-input request is NOT cancelled — it stays pending so a
-            // re-attach can re-display it.
+            // re-attach can re-display it. Paused stages keep their paused
+            // snapshot status because the store intentionally does not convert
+            // paused/blocked stages into awaiting_input.
             await flush();
             assert.equal(
                 settled,
                 false,
                 "detach/close must not settle the request",
             );
-            assert.equal(store.runs()[0]?.stages[0]?.status, "awaiting_input");
+            assert.equal(
+                store.runs()[0]?.stages[0]?.status,
+                variant.status === "paused" ? "paused" : "awaiting_input",
+            );
             view.dispose();
         }
     });
@@ -2288,11 +2328,17 @@ describe("StageChatView", () => {
             onClose: () => {},
         });
         const rendered = view.render(96).join("\n");
+        const visibleLines = rendered.split("\n").map(stripAnsi);
         assert.doesNotMatch(rendered, /Attached to/);
         assert.doesNotMatch(rendered, /This stage is idle/);
         assert.doesNotMatch(rendered, /type a message to start this stage/i);
         assert.match(rendered, /❯/);
         assert.match(rendered, /\x1b\[7m \x1b\[0m/);
+        const hintIndex = expectRightAlignedReturnHint(visibleLines, 96);
+        assert.ok(
+            hintIndex > visibleLines.findIndex((line) => line.includes("❯")),
+            "expected orchestrator hint below the chat box",
+        );
         view.dispose();
     });
 
@@ -2373,7 +2419,7 @@ describe("StageChatView", () => {
         view.dispose();
     });
 
-    test("attached live sessions render the usage ribbon above the chatbox and only the coding-agent footer below it", () => {
+    test("attached live sessions render the usage ribbon, orchestrator hint, and coding-agent footer", () => {
         const store = createStore();
         setupRun(store, "run-1", "stage-a", "running");
         const { handle } = makeHandle({
@@ -2416,6 +2462,7 @@ describe("StageChatView", () => {
         );
         const usageIndex = lines.findIndex((line) => line.includes("$0.123"));
         const promptIndex = lines.findIndex((line) => line.includes("❯"));
+        const hintIndex = expectRightAlignedReturnHint(lines, 120);
         const identityIndex = lines.findIndex((line) =>
             line.includes("esc to interrupt"),
         );
@@ -2431,13 +2478,53 @@ describe("StageChatView", () => {
             promptIndex > usageIndex,
             "expected composer below usage line",
         );
-        assert.equal(identityIndex, promptIndex + 2);
+        assert.ok(
+            hintIndex > promptIndex,
+            "expected orchestrator hint below the chat box",
+        );
+        assert.equal(identityIndex, hintIndex);
+        assert.notEqual(lines[hintIndex]?.trim(), RETURN_HINT_TEXT);
         assert.equal(commandsIndex, -1);
         assert.doesNotMatch(lines[identityIndex] ?? "", /steer|follow-up/);
         assert.doesNotMatch(
             rendered,
-            /pageup\/pagedown|ctrl\+d|follow-up|steer/,
+            /pageup\/pagedown|follow-up|steer/,
         );
+        view.dispose();
+    });
+
+    test("footer keeps model context and Ctrl+D orchestrator hint on one line", () => {
+        const store = createStore();
+        setupRun(store, "run-1", "stage-a", "running");
+        const { handle } = makeHandle();
+        const handleWithSession: StageControlHandle = {
+            ...handle,
+            agentSession: fakeFooterAgentSession(false),
+        };
+        const view = new StageChatView({
+            store,
+            graphTheme: deriveGraphTheme({}),
+            runId: "run-1",
+            stageId: "stage-a",
+            workflowName: "test-wf",
+            handle: handleWithSession,
+            footerData: {
+                getGitBranch: () => "main",
+                getExtensionStatuses: () => new Map(),
+                getAvailableProviderCount: () => 2,
+                onBranchChange: () => () => {},
+            },
+            onDetach: () => {},
+            onClose: () => {},
+        });
+
+        const lines = view.render(120).map(stripAnsi);
+        const hintIndex = expectRightAlignedReturnHint(lines, 120);
+        assert.match(
+            lines[hintIndex] ?? "",
+            /\(openai-codex\) gpt-5\.5 high .*Documents\/projects\/atomic/,
+        );
+        assert.notEqual(lines[hintIndex]?.trim(), RETURN_HINT_TEXT);
         view.dispose();
     });
 
@@ -2647,7 +2734,7 @@ describe("StageChatView", () => {
         }
     });
 
-    test("Ctrl+D variants close a paused structured pending prompt without answering", async () => {
+    test("Ctrl+D variants detach from a paused structured pending prompt without answering", async () => {
         for (const key of CTRL_D_VARIANTS) {
             const store = createStore();
             setupRun(store, "run-1", "stage-a", "paused");
@@ -2684,8 +2771,8 @@ describe("StageChatView", () => {
 
             assert.equal(view.handleInput(key), true);
             await flush();
-            assert.equal(closed, 1, JSON.stringify(key));
-            assert.equal(detached, 0, JSON.stringify(key));
+            assert.equal(detached, 1, JSON.stringify(key));
+            assert.equal(closed, 0, JSON.stringify(key));
             assert.equal(resolved, false, JSON.stringify(key));
             assert.equal(
                 store.runs()[0]?.stages[0]?.pendingPrompt?.id,
@@ -2695,7 +2782,7 @@ describe("StageChatView", () => {
         }
     });
 
-    test("Ctrl+D variants close a paused stage chat", () => {
+    test("Ctrl+D variants detach from a paused stage chat", () => {
         for (const key of CTRL_D_VARIANTS) {
             const store = createStore();
             setupRun(store, "run-1", "stage-a", "paused");
@@ -2717,8 +2804,8 @@ describe("StageChatView", () => {
                 },
             });
             view.handleInput(key);
-            assert.equal(closed, 1, JSON.stringify(key));
-            assert.equal(detached, 0, JSON.stringify(key));
+            assert.equal(detached, 1, JSON.stringify(key));
+            assert.equal(closed, 0, JSON.stringify(key));
             view.dispose();
         }
     });

--- a/test/unit/workflow-attach-pane.test.ts
+++ b/test/unit/workflow-attach-pane.test.ts
@@ -1318,7 +1318,7 @@ describe("WorkflowAttachPane", () => {
         pane.dispose();
     });
 
-    test("Ctrl+D in paused stage-chat mode closes the pane", () => {
+    test("Ctrl+D in paused stage-chat mode returns to graph", () => {
         const store = createStore();
         setupRun(store, "run-1", [
             { id: "stage-a", name: "A", status: "paused" },
@@ -1345,9 +1345,11 @@ describe("WorkflowAttachPane", () => {
         });
         assert.equal(pane._mode, "stage-chat");
         pane.handleInput(Key.ctrl("d"));
-        assert.equal(closed, 1);
+        assert.equal(closed, 0);
         assert.equal(hidden, 0);
-        assert.equal(pane._mode, "stage-chat");
+        assert.equal(pane._mode, "graph");
+        assert.equal(pane._hasChatView, false);
+        assert.equal(pane._lastAttachedStageId, "stage-a");
         pane.dispose();
     });
 


### PR DESCRIPTION
## Summary

Fixes inconsistent Ctrl+D behavior in workflow stage chats: paused stages previously exited back to the main chat (EOF semantics) rather than returning to the orchestrator graph. Now Ctrl+D consistently detaches to the graph regardless of stage state.

Also surfaces a \"ctrl+d returns to orchestrator panel\" hint in the stage chat UI — merged into the footer's model/cwd line and embedded inside the bottom-right corner of stage-local ctx.ui prompt widgets.

## Changes

- **Fix:** Route Ctrl+D in paused stage chats to `onDetach()` (back to graph) instead of `onClose()` — applies to both plain chat and structured pending prompts.
- **Fix:** Simplify attach message in `extension/index.ts` to always show \"ctrl+d return to graph\" (no more conditional branch for paused vs. running stages).
- **Feat:** Add `_renderFooterWithOrchestratorReturnHint()` — overlays the return hint right-aligned onto the last footer line, sharing space with model/cwd metadata.
- **Feat:** Add `_embedOrchestratorReturnHintInWidget()` — injects the hint into the last non-border line of stage-local custom UI widgets and primitive prompt boxes, preserving the box outline's trailing border character.
- **Feat:** Add helper functions `widgetHintTargetLineIndex()`, `isWidgetBottomBorderLine()`, and `trailingWidgetBorderChar()` for box-border detection.
- **Docs:** Update `workflow-attach-pane.ts` module comment and `stage-chat-view.ts` JSDoc to reflect that Ctrl+D always returns to graph.
- **Test:** Rename and flip assertions in paused-stage Ctrl+D tests (`closed → detached`); add `expectRightAlignedReturnHint()` helper and new coverage for footer hint placement, widget hint embedding, and paused custom UI detach.

## Validated with

- `AGENT=1 bun test test/unit/stage-chat-view.test.ts test/unit/workflow-attach-pane.test.ts`
- `AGENT=1 bun run typecheck`
- Pre-commit `bun run lint` and `bun run test:unit`