### PR TITLE
docs: add workflow import migration note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ See [Providers & Models](./packages/coding-agent/README.md#providers--models) fo
 
 > ⚠️ Workflows run with agent permission checks **disabled** so pipelines don't block on prompts. Run autonomous workflows inside a devcontainer, VM, or remote dev machine — not your host machine.
 
+> ⚠️ **Temporary workflow migration note:** Recent workflow authoring changes may require updates to custom workflows, especially workflows that import other workflows by registered name or path object. Workflow imports now use normal TypeScript module imports and pass compiled workflow definitions to `.import(workflow, { as? })`. If an existing workflow no longer loads, ask Atomic or your coding agent to update it using the [workflow import guidance](./packages/workflows/README.md#example-4--compose-workflows-with-imports).
+
 <details>
 <summary><b>Prerequisites, devcontainer</b></summary>
 


### PR DESCRIPTION
## Summary

Adds a temporary warning to the root README alerting users to a breaking change in workflow authoring that may require updates to custom workflows using the old import API.

## Key Changes

- Added a `⚠️` callout block in the README's workflow section noting that custom workflows importing other workflows by registered name or path object need to be migrated
- Points users to the workflow import guidance in `packages/workflows/README.md` for migration instructions

## Migration Context

This note accompanies the breaking change introduced in [#1181](https://github.com/bastani-inc/atomic/pull/1181) (`feat(workflows)!: TypeBox-native input/output schemas`). Workflow imports now use standard TypeScript module imports and pass compiled workflow definitions to `.import(workflow, { as? })` rather than importing by registered name or path object.