### PR TITLE
perf(tui): cache chat transcript blocks with windowed viewport rendering

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/chat-session-host.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-session-host.ts
@@ -113,6 +113,7 @@ export type ChatSessionHostEntry<TExtraEntry extends ChatTranscriptEntryLike = n
   | ChatMessageEntry
   | TExtraEntry;
 type AgentSnapshotMessage = AgentSession["messages"][number];
+type CacheKeyPart = string | number | boolean | null;
 
 export class ChatSessionHost<TExtraEntry extends ChatTranscriptEntryLike = never>
   implements Component, Focusable
@@ -152,6 +153,10 @@ export class ChatSessionHost<TExtraEntry extends ChatTranscriptEntryLike = never
   private animationTimer: ReturnType<typeof setInterval> | undefined;
   private renderThrottleTimer: ReturnType<typeof setTimeout> | undefined;
   private bodyViewport = new ScrollableComponentViewport();
+  private transcriptComponent: ChatTranscriptComponent<ChatSessionHostEntry<TExtraEntry>>;
+  private transcriptRenderSettingsKey = "";
+  private renderIdentityIds = new WeakMap<object, number>();
+  private nextRenderIdentityId = 1;
   private liveChat: LiveChatEntriesController;
   private editor: EditorComponent | undefined;
   private optimisticUserSignatureCounts = new Map<string, number>();
@@ -176,6 +181,11 @@ export class ChatSessionHost<TExtraEntry extends ChatTranscriptEntryLike = never
     this.renderExtraEntry = opts.renderExtraEntry;
     this.tui = opts.tui;
     this.liveChat = new LiveChatEntriesController(this.transcript);
+    this.transcriptComponent = new ChatTranscriptComponent(
+      this.transcript,
+      (entry) => this.renderEntry(entry),
+      (entry, index) => this.transcriptCacheKey(entry, index),
+    );
     this.editor = this.createEditor(
       opts.tui,
       opts.keybindings,
@@ -334,16 +344,17 @@ export class ChatSessionHost<TExtraEntry extends ChatTranscriptEntryLike = never
     return this.renderBody(width, 1);
   }
 
-  invalidate(): void {}
+  invalidate(): void {
+    this.transcriptComponent.invalidate();
+    this.bodyViewport.invalidate();
+    this.editor?.invalidate();
+  }
 
   renderBody(width: number, budget: number): string[] {
     const components: Component[] = [];
+    this.transcriptRenderSettingsKey = this.chatRenderSettingsCacheKey();
     if (this.transcript.length > 0) {
-      components.push(
-        new ChatTranscriptComponent(this.transcript, (entry) =>
-          this.renderEntry(entry),
-        ),
-      );
+      components.push(this.transcriptComponent);
     }
     if (this.statusMessage) {
       components.push(new Spacer(1));
@@ -809,6 +820,80 @@ export class ChatSessionHost<TExtraEntry extends ChatTranscriptEntryLike = never
     return { requestRender: () => this.requestRender?.() };
   }
 
+  private chatRenderSettingsCacheKey(): string {
+    const inherited = this.getChatRenderSettings?.();
+    return cacheKey([
+      "settings",
+      inherited?.hideThinkingBlock === true,
+      inherited?.hiddenThinkingLabel ?? "",
+      inherited?.toolOutputExpanded === true,
+      inherited?.showImages !== false,
+      inherited?.imageWidthCells ?? null,
+      this.getCwd?.() ?? this.getAgentSession?.()?.sessionManager.getCwd() ?? process.cwd(),
+      this.bodyViewport.getScrollFromBottom() === 0,
+      this.isStreaming(),
+    ]);
+  }
+
+  private transcriptCacheKey(
+    entry: ChatSessionHostEntry<TExtraEntry>,
+    index: number,
+  ): string {
+    return cacheKey([
+      this.transcriptRenderSettingsKey,
+      index,
+      entry.role,
+      this.renderIdentityKey(entry),
+      this.entryContentCacheKey(entry),
+    ]);
+  }
+
+  private entryContentCacheKey(entry: ChatSessionHostEntry<TExtraEntry>): string {
+    if (!isChatMessageEntry(entry)) return cacheKey(["extra"]);
+    switch (entry.kind) {
+      case "assistant":
+        return cacheKey(["assistant", this.renderIdentityKey(entry.message)]);
+      case "tool":
+        return cacheKey([
+          "tool",
+          entry.toolCallId,
+          entry.toolName,
+          entry.isPartial === true,
+          entry.result === undefined ? null : this.renderIdentityKey(entry.result),
+        ]);
+      case "bashExecution":
+        return cacheKey([
+          "bashExecution",
+          entry.isPartial === true,
+          entry.message.command,
+          entry.message.output,
+          entry.message.exitCode ?? null,
+          entry.message.cancelled,
+          entry.message.truncated,
+          entry.message.fullOutputPath ?? null,
+        ]);
+      case "user":
+        return cacheKey(["user", entry.text]);
+      case "custom":
+        return cacheKey(["custom", this.renderIdentityKey(entry.message)]);
+      case "branchSummary":
+        return cacheKey(["branchSummary", this.renderIdentityKey(entry.message)]);
+      case "compactionSummary":
+        return cacheKey(["compactionSummary", this.renderIdentityKey(entry.message)]);
+      case "system":
+        return cacheKey(["system", entry.text]);
+    }
+  }
+
+  private renderIdentityKey(value: object): string {
+    const existing = this.renderIdentityIds.get(value);
+    if (existing !== undefined) return String(existing);
+    const id = this.nextRenderIdentityId;
+    this.nextRenderIdentityId += 1;
+    this.renderIdentityIds.set(value, id);
+    return String(id);
+  }
+
   private pendingMessageLine(
     width: number,
     label: "Steering" | "Follow-up" | "Queued",
@@ -1083,6 +1168,10 @@ function isSharedLiveChatEvent(type: string): boolean {
     type === "tool_execution_update" ||
     type === "tool_execution_end"
   );
+}
+
+function cacheKey(parts: readonly CacheKeyPart[]): string {
+  return JSON.stringify(parts);
 }
 
 function isChatMessageEntry<TExtraEntry extends ChatTranscriptEntryLike>(

--- a/packages/coding-agent/src/modes/interactive/components/chat-transcript.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-transcript.ts
@@ -30,6 +30,38 @@ export type ChatTranscriptRenderer<TEntry extends ChatTranscriptEntryLike> = (
   entry: TEntry,
 ) => Component;
 
+export type ChatTranscriptCacheKey<TEntry extends ChatTranscriptEntryLike> = (
+  entry: TEntry,
+  index: number,
+) => string;
+
+interface CachedChatTranscriptBlock<TEntry extends ChatTranscriptEntryLike> {
+  readonly entry: TEntry;
+  readonly key: string;
+  readonly width: number;
+  readonly lines: readonly string[];
+}
+
+interface RowWindowComponent extends Component {
+  readonly supportsRowWindow: true;
+  rowCount(width: number): number;
+  renderRows(width: number, startRow: number, endRow: number): string[];
+}
+
+interface WindowedComponentRows {
+  readonly kind: "windowed";
+  readonly component: RowWindowComponent;
+  readonly rowCount: number;
+}
+
+interface StaticComponentRows {
+  readonly kind: "static";
+  readonly lines: readonly string[];
+  readonly rowCount: number;
+}
+
+type ComponentRows = WindowedComponentRows | StaticComponentRows;
+
 export function addChatTranscriptEntry(
   container: Container,
   component: Component,
@@ -62,26 +94,109 @@ function needsLeadingSpacer(role: ChatTranscriptRole): boolean {
 export class ChatTranscriptComponent<TEntry extends ChatTranscriptEntryLike>
   implements Component
 {
-  declare private readonly entries: readonly TEntry[];
-  declare private readonly renderEntry: ChatTranscriptRenderer<TEntry>;
+  private readonly entries: readonly TEntry[];
+  private readonly renderEntry: ChatTranscriptRenderer<TEntry>;
+  readonly supportsRowWindow: boolean;
+
+  private readonly cacheKey: ChatTranscriptCacheKey<TEntry> | undefined;
+  private blockCache: Array<CachedChatTranscriptBlock<TEntry> | undefined> = [];
 
   constructor(
     entries: readonly TEntry[],
     renderEntry: ChatTranscriptRenderer<TEntry>,
+    cacheKey?: ChatTranscriptCacheKey<TEntry>,
   ) {
     this.entries = entries;
     this.renderEntry = renderEntry;
-	}
-
-  render(width: number): string[] {
-    const container = new Container();
-    for (const entry of this.entries) {
-      addChatTranscriptEntry(container, this.renderEntry(entry), entry.role);
-    }
-    return container.render(width);
+    this.cacheKey = cacheKey;
+    this.supportsRowWindow = cacheKey !== undefined;
   }
 
-  invalidate(): void {}
+  render(width: number): string[] {
+    if (!this.supportsRowWindow) return this.renderAllRows(width);
+    return this.renderRows(width, 0, this.rowCount(width));
+  }
+
+  rowCount(width: number): number {
+    if (!this.supportsRowWindow) return this.renderAllRows(width).length;
+    this.ensureBlockCache(width);
+    let count = 0;
+    for (const block of this.blockCache) {
+      if (block !== undefined) count += block.lines.length;
+    }
+    return count;
+  }
+
+  renderRows(width: number, startRow: number, endRow: number): string[] {
+    const start = Math.max(0, Math.floor(startRow));
+    const end = Math.max(start, Math.floor(endRow));
+    if (end <= start) return [];
+    if (!this.supportsRowWindow) return this.renderAllRows(width).slice(start, end);
+
+    this.ensureBlockCache(width);
+    const lines: string[] = [];
+    let cursor = 0;
+    for (let index = 0; index < this.entries.length; index += 1) {
+      const block = this.blockCache[index];
+      if (block === undefined) continue;
+      const blockStart = cursor;
+      const blockEnd = blockStart + block.lines.length;
+      if (blockEnd > start && blockStart < end) {
+        const localStart = Math.max(0, start - blockStart);
+        const localEnd = Math.min(block.lines.length, end - blockStart);
+        lines.push(...block.lines.slice(localStart, localEnd));
+      }
+      cursor = blockEnd;
+      if (cursor >= end) break;
+    }
+    return lines;
+  }
+
+  invalidate(): void {
+    this.blockCache = [];
+  }
+
+  private ensureBlockCache(width: number): void {
+    if (this.blockCache.length > this.entries.length) {
+      this.blockCache.length = this.entries.length;
+    }
+    for (let index = 0; index < this.entries.length; index += 1) {
+      const entry = this.entries[index];
+      if (entry === undefined) continue;
+      const key = this.cacheKey?.(entry, index) ?? `${index}:${entry.role}`;
+      const cached = this.blockCache[index];
+      if (
+        cached !== undefined &&
+        cached.entry === entry &&
+        cached.key === key &&
+        cached.width === width
+      ) {
+        continue;
+      }
+      this.blockCache[index] = {
+        entry,
+        key,
+        width,
+        lines: this.renderEntryBlock(entry, index, width),
+      };
+    }
+  }
+
+  private renderAllRows(width: number): string[] {
+    const lines: string[] = [];
+    for (let index = 0; index < this.entries.length; index += 1) {
+      const entry = this.entries[index];
+      if (entry !== undefined) lines.push(...this.renderEntryBlock(entry, index, width));
+    }
+    return lines;
+  }
+
+  private renderEntryBlock(entry: TEntry, index: number, width: number): string[] {
+    const lines: string[] = [];
+    if (index > 0 && needsLeadingSpacer(entry.role)) lines.push("");
+    lines.push(...this.renderEntry(entry).render(width));
+    return lines;
+  }
 }
 
 const DEFAULT_SCROLL_STEP_ROWS = 4;
@@ -161,24 +276,74 @@ export class ScrollableComponentViewport implements Component {
   }
 
   render(width: number): string[] {
-    const allLines = this.components.flatMap((component) => component.render(width));
-    const maxScroll = Math.max(0, allLines.length - this.visibleRows);
-    if (this.scrollFromBottom > 0 && this.lastWidth === width && allLines.length > this.lastLineCount) {
-      this.scrollFromBottom += allLines.length - this.lastLineCount;
+    const componentRows = this.measureComponentRows(width);
+    const lineCount = componentRows.reduce((sum, rows) => sum + rows.rowCount, 0);
+    const maxScroll = Math.max(0, lineCount - this.visibleRows);
+    if (this.scrollFromBottom > 0 && this.lastWidth === width && lineCount > this.lastLineCount) {
+      this.scrollFromBottom += lineCount - this.lastLineCount;
     }
-    this.lastLineCount = allLines.length;
+    this.lastLineCount = lineCount;
     this.lastWidth = width;
     this.maxScroll = maxScroll;
     this.clampScroll();
 
     const start = Math.max(0, maxScroll - this.scrollFromBottom);
-    const visible = allLines.slice(start, start + this.visibleRows);
+    const visible = this.renderVisibleRows(
+      componentRows,
+      width,
+      start,
+      start + this.visibleRows,
+    );
     while (visible.length < this.visibleRows) visible.push(" ".repeat(width));
     return visible;
   }
 
   invalidate(): void {
     for (const component of this.components) component.invalidate();
+  }
+
+  private measureComponentRows(width: number): ComponentRows[] {
+    return this.components.map((component) => {
+      if (isRowWindowComponent(component)) {
+        return {
+          kind: "windowed",
+          component,
+          rowCount: component.rowCount(width),
+        };
+      }
+      const lines = component.render(width);
+      return {
+        kind: "static",
+        lines,
+        rowCount: lines.length,
+      };
+    });
+  }
+
+  private renderVisibleRows(
+    componentRows: readonly ComponentRows[],
+    width: number,
+    startRow: number,
+    endRow: number,
+  ): string[] {
+    const lines: string[] = [];
+    let cursor = 0;
+    for (const rows of componentRows) {
+      const componentStart = cursor;
+      const componentEnd = componentStart + rows.rowCount;
+      if (componentEnd > startRow && componentStart < endRow) {
+        const localStart = Math.max(0, startRow - componentStart);
+        const localEnd = Math.min(rows.rowCount, endRow - componentStart);
+        if (rows.kind === "windowed") {
+          lines.push(...rows.component.renderRows(width, localStart, localEnd));
+        } else {
+          lines.push(...rows.lines.slice(localStart, localEnd));
+        }
+      }
+      cursor = componentEnd;
+      if (cursor >= endRow) break;
+    }
+    return lines;
   }
 
   private pageSize(): number {
@@ -188,6 +353,13 @@ export class ScrollableComponentViewport implements Component {
   private clampScroll(): void {
     this.scrollFromBottom = Math.max(0, Math.min(this.maxScroll, this.scrollFromBottom));
   }
+}
+
+function isRowWindowComponent(component: Component): component is RowWindowComponent {
+  const candidate = component as Partial<RowWindowComponent>;
+  return candidate.supportsRowWindow === true &&
+    typeof candidate.rowCount === "function" &&
+    typeof candidate.renderRows === "function";
 }
 
 export class ScrollableChatTranscriptComponent<TEntry extends ChatTranscriptEntryLike>

--- a/packages/coding-agent/src/modes/interactive/components/index.ts
+++ b/packages/coding-agent/src/modes/interactive/components/index.ts
@@ -23,6 +23,7 @@ export {
   ChatTranscriptComponent,
   ScrollableChatTranscriptComponent,
   ScrollableComponentViewport,
+  type ChatTranscriptCacheKey,
   type ChatTranscriptEntryLike,
   type ChatTranscriptRenderer,
   type ChatTranscriptRole,

--- a/packages/workflows/src/tui/stage-chat-view.ts
+++ b/packages/workflows/src/tui/stage-chat-view.ts
@@ -706,7 +706,9 @@ export class StageChatView implements Component, Focusable {
     if (blocked) this.chatHost.scrollToBottom();
 
     let bodyLines: string[];
-    if (promptActive) {
+    if (bodyBudget <= 0) {
+      bodyLines = [];
+    } else if (promptActive) {
       bodyLines = this._renderPromptBody(w, bodyBudget);
     } else if (blocked) {
       bodyLines = this._renderBlockedBody(w, bodyBudget, stage);
@@ -1408,6 +1410,7 @@ export class StageChatView implements Component, Focusable {
   }
 
   invalidate(): void {
+    this.chatHost.invalidate();
     this._syncPromptState(this._currentStage()?.pendingPrompt);
   }
 

--- a/test/unit/chat-message-renderer.test.ts
+++ b/test/unit/chat-message-renderer.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import {
+  ChatTranscriptComponent,
   chatEntriesFromAgentMessages,
   LiveChatEntriesController,
   ScrollableComponentViewport,
@@ -99,5 +100,69 @@ describe("chat message renderer utilities", () => {
     assert.deepEqual(viewport.render(20), ["line-0", "line-1", "line-2"]);
     assert.equal(viewport.handleInput("\x1b[6~"), true);
     assert.deepEqual(viewport.render(20), ["line-2", "line-3", "line-4"]);
+  });
+
+  test("scrollable viewport renders only visible rows for windowed components", () => {
+    const viewport = new ScrollableComponentViewport();
+    const renderedWindows: Array<readonly [number, number]> = [];
+    viewport.setVisibleRows(2);
+    const windowedComponent = {
+      supportsRowWindow: true as const,
+      rowCount: () => 5,
+      renderRows: (_width: number, startRow: number, endRow: number) => {
+        renderedWindows.push([startRow, endRow]);
+        return ["line-0", "line-1", "line-2", "line-3", "line-4"].slice(startRow, endRow);
+      },
+      render: () => {
+        throw new Error("windowed component should not render all rows");
+      },
+      invalidate: () => {},
+    };
+    viewport.setComponents([windowedComponent]);
+
+    assert.deepEqual(viewport.render(20), ["line-3", "line-4"]);
+    assert.deepEqual(renderedWindows, [[3, 5]]);
+  });
+
+  test("chat transcript without cache key reflects in-place entry mutations", () => {
+    const entries: Array<{ role: "user"; text: string }> = [
+      { role: "user", text: "first" },
+    ];
+    const transcript = new ChatTranscriptComponent(entries, (entry) => ({
+      render: () => [entry.text],
+      invalidate: () => {},
+    }));
+
+    assert.deepEqual(transcript.render(20), ["first"]);
+    entries[0]!.text = "updated";
+    assert.deepEqual(transcript.render(20), ["updated"]);
+  });
+
+  test("chat transcript reuses cached entry blocks across small viewport renders", () => {
+    const entries = [
+      { role: "user" as const, text: "first" },
+      { role: "assistant" as const, text: "second" },
+      { role: "user" as const, text: "third" },
+    ];
+    let renderCount = 0;
+    const transcript = new ChatTranscriptComponent(
+      entries,
+      (entry) => {
+        renderCount += 1;
+        return {
+          render: () => [entry.text],
+          invalidate: () => {},
+        };
+      },
+      (entry) => entry.text,
+    );
+    const viewport = new ScrollableComponentViewport();
+    viewport.setVisibleRows(1);
+    viewport.setComponents([transcript]);
+
+    assert.deepEqual(viewport.render(20), ["third"]);
+    assert.equal(renderCount, 3);
+    assert.deepEqual(viewport.render(20), ["third"]);
+    assert.equal(renderCount, 3);
   });
 });

--- a/test/unit/chat-session-host.test.ts
+++ b/test/unit/chat-session-host.test.ts
@@ -186,6 +186,42 @@ test("ChatSessionHost parses ! and !! bash commands without prompting", async ()
   host.dispose();
 });
 
+test("ChatSessionHost reuses transcript render cache with fresh render settings", () => {
+  interface CountEntry {
+    role: "custom";
+    text: string;
+  }
+
+  let renderCount = 0;
+  const host = new ChatSessionHost<CountEntry>({
+    style: plainStyle,
+    editorTheme,
+    getChatRenderSettings: () => ({ showImages: true }),
+    renderExtraEntry: (entry) => ({
+      render: () => {
+        renderCount += 1;
+        return [entry.text];
+      },
+      invalidate: () => {},
+    }),
+  });
+
+  host.appendExtraEntry({ role: "custom", text: "first" });
+  host.appendExtraEntry({ role: "custom", text: "second" });
+  host.appendExtraEntry({ role: "custom", text: "third" });
+
+  assert.deepEqual(host.renderBody(80, 1), ["third"]);
+  assert.equal(renderCount, 3);
+  assert.deepEqual(host.renderBody(80, 1), ["third"]);
+  assert.equal(renderCount, 3);
+
+  host.invalidate();
+
+  assert.deepEqual(host.renderBody(80, 1), ["third"]);
+  assert.equal(renderCount, 6);
+  host.dispose();
+});
+
 test("ChatSessionHost preserves bare bang input as a normal prompt", async () => {
   const prompts: string[] = [];
   const host = makeHost({


### PR DESCRIPTION
## Summary

Eliminates redundant chat transcript rendering in the TUI by introducing per-entry block caching and windowed (visible-rows-only) rendering support. Fixes lag in workflow node chat sessions caused by re-rendering all transcript entries on every frame. Refs #1187.

## Changes

- **Block-level transcript cache** — `ChatTranscriptComponent` now accepts an optional `ChatTranscriptCacheKey` function. When provided, each entry is rendered once and the result is stored; subsequent frames skip re-rendering if the key, width, and entry reference are unchanged.
- **Windowed rendering** — `ChatTranscriptComponent` implements `rowCount`/`renderRows` (the `RowWindowComponent` protocol), allowing `ScrollableComponentViewport` to request only the visible row slice instead of rendering the entire transcript and slicing the result.
- **Persistent transcript instance** — `ChatSessionHost` now holds a single `ChatTranscriptComponent` across renders (previously re-created on every `renderBody` call), enabling the cache to survive between frames.
- **Cache key infrastructure** — `ChatSessionHost` derives a stable cache key per entry from render settings, entry kind, content identity, and streaming state via `transcriptCacheKey` / `chatRenderSettingsCacheKey` / `entryContentCacheKey`.
- **Proper `invalidate()` propagation** — `ChatSessionHost.invalidate()` now forwards to the transcript component, body viewport, and editor; `StageChatView.invalidate()` now forwards to `chatHost`.
- **Zero-budget guard** — `StageChatView` skips body rendering when `bodyBudget <= 0`, preventing unnecessary work.
- **Tests** — unit coverage for windowed viewport rendering, uncached transcript mutation reflection, cache reuse across consecutive renders, and `ChatSessionHost` transcript cache with settings-driven keys.

## Breaking Changes

None. The `cacheKey` parameter to `ChatTranscriptComponent` is optional; existing callers without it continue to work as before.