### PR TITLE
chore(release): bump prerelease to v0.8.23-0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.22",
+      "version": "0.8.23-0",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.22",
+      "version": "0.8.23-0",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.22",
+      "version": "0.8.23-0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.22",
+      "version": "0.8.23-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.22",
+      "version": "0.8.23-0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.22",
+      "version": "0.8.23-0",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.23-0] - 2026-06-02
+
 ### Changed
 
 - Documented workflow artifact-path handoffs and `Read the file at <path>...` downstream prompts as the preferred alternative to injecting large `previous` payloads, review histories, or session tails.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.22",
+  "version": "0.8.23-0",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.23-0] - 2026-06-02
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.23 prerelease.
+
 ## [0.8.18] - 2026-05-27
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.22",
+  "version": "0.8.23-0",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.23-0] - 2026-06-02
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.23 prerelease.
+
 ## [0.8.20] - 2026-05-29
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.22",
+  "version": "0.8.23-0",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.23-0] - 2026-06-02
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.23 prerelease.
+
 ## [0.8.22] - 2026-06-01
 
 ### Fixed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.22",
+  "version": "0.8.23-0",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.23-0] - 2026-06-02
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.23 prerelease.
+
 ## [0.8.20] - 2026-05-29
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.22",
+  "version": "0.8.23-0",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.23-0] - 2026-06-02
+
 ### Added
 
 - Added a workflow node chat Ctrl+D hint that shares the bottom footer line with model/cwd metadata and appears in the bottom-right corner of stage-local ctx.ui widgets.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.22",
+  "version": "0.8.23-0",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prerelease version bump to v0.8.23-0 across all workspace packages, promoting unreleased workflow and TUI improvements into this prerelease.

## Key Changes

### Workflows (`@bastani/workflows`)
- **Added** workflow node chat Ctrl+D hint in the bottom-right footer corner of stage-local `ctx.ui` widgets
- **Changed** Goal and Ralph workflows to save reviewer feedback as JSON artifacts and hand off only artifact paths downstream instead of injecting full review histories
- **Changed** Ralph workflow simplified by removing separate `infra-locate-*`, `infra-analyze-*`, and `infra-patterns-*` discovery stages — reviewers now inspect infrastructure directly
- **Changed** Workflow tool description updated to steer agents toward file/artifact handoffs for large stage-to-stage context
- **Fixed** paused workflow stage chats so Ctrl+D returns to the orchestrator graph instead of closing back to main chat

### Coding Agent (`@bastani/atomic`)
- **Changed** Documented workflow artifact-path handoffs and `Read the file at <path>...` downstream prompts as the preferred alternative to injecting large `previous` payloads, review histories, or session tails
- **Changed** Updated Ralph workflow docs to reflect the simplified plan/orchestrate/simplify/review loop
- **Changed** Updated default workflow system-prompt guidance to prefer file/artifact handoffs with explicit downstream read instructions
- **Fixed** Severe flickering in the `ask_user_question` dialog on short terminals — the animated working loader is now suspended while the blocking question UI is open

### Other Packages (`@bastani/subagents`, `@bastani/mcp`, `@bastani/intercom`, `@bastani/web-access`)
- Version bumped to 0.8.23-0 for the coordinated prerelease

## Validation
- `bun run typecheck`
- Pre-commit hooks: `bun run lint`, `bun run test:unit`