### PR TITLE
chore(release): v0.8.23

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.23] - 2026-06-02
+
+### Changed
+
+- Promoted the 0.8.23 prerelease package version to a stable release.
+
 ## [0.8.23-0] - 2026-06-02
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.23-0",
+  "version": "0.8.23",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.23] - 2026-06-02
+
+### Changed
+
+- Promoted the 0.8.23 prerelease package version to a stable release.
+
 ## [0.8.23-0] - 2026-06-02
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.23-0",
+  "version": "0.8.23",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.23] - 2026-06-02
+
+### Changed
+
+- Promoted the 0.8.23 prerelease package version to a stable release.
+
 ## [0.8.23-0] - 2026-06-02
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.23-0",
+  "version": "0.8.23",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.23] - 2026-06-02
+
+### Changed
+
+- Promoted the 0.8.23 prerelease package version to a stable release.
+
 ## [0.8.23-0] - 2026-06-02
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.23-0",
+  "version": "0.8.23",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.23] - 2026-06-02
+
+### Changed
+
+- Promoted the 0.8.23 prerelease package version to a stable release.
+
 ## [0.8.23-0] - 2026-06-02
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.23-0",
+  "version": "0.8.23",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.23] - 2026-06-02
+
+### Changed
+
+- Promoted the 0.8.23 prerelease package version to a stable release.
+
 ## [0.8.23-0] - 2026-06-02
 
 ### Added

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.23-0",
+  "version": "0.8.23",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the v0.8.23-0 prerelease to a stable release. Bumps all workspace package versions from `0.8.23-0` → `0.8.23` and adds stable changelog sections across all packages.

## Changes in this release

### workflows
- Added workflow node chat Ctrl+D hint in the bottom-right corner of stage-local `ctx.ui` widgets
- Updated bundled Goal and Ralph workflows to save reviewer feedback as JSON artifacts and hand only the latest review artifact path to downstream agents (avoids injecting full review histories)
- Removed Ralph's separate `infra-locate-*`, `infra-analyze-*`, and `infra-patterns-*` discovery stages — reviewers now inspect repository infrastructure directly
- Documented artifact-path handoffs, `outputMode: "file-only"`, `reads`, and explicit downstream read prompts as the preferred pattern for large inter-stage context
- Fixed paused workflow stage chats so Ctrl+D returns to the orchestrator graph instead of closing to main chat

### coding-agent
- Fixed severe flickering in the `ask_user_question` dialog on short terminals — animated loader is now suspended while the blocking question UI is open
- Documented workflow artifact-path handoffs and `Read the file at <path>...` downstream prompts as the preferred alternative to injecting large `previous` payloads
- Updated Ralph workflow and default system-prompt guidance to reflect the simplified plan/orchestrate/simplify/review loop

## Validation
- `bun run typecheck`
- Pre-commit hooks: `bun run lint`, `bun run test:unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)