### PR TITLE
fix(workflows): correct parallel same-name tool call rendering in node chat

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Removed the bundled workflows package's imperative `runWorkflow` object-form API; workflow packages must export branded `defineWorkflow(...).compile()` definitions while direct `workflow` tool task/tasks/chain modes remain available.
 
+### Fixed
+
+- Fixed workflow node chat rendering a bare tool-name marker (e.g. `read …`) instead of tool output for parallel tool calls; `LiveChatEntriesController` now pairs concurrent same-named tool calls strictly by `toolCallId` ([#1198](https://github.com/bastani-inc/atomic/issues/1198)).
+
 ## [0.8.23] - 2026-06-02
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive/components/chat-message-renderer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-message-renderer.ts
@@ -359,11 +359,26 @@ export class LiveChatEntriesController {
     return true;
   }
 
+  private isSyntheticToolCallId(toolCallId: string): boolean {
+    return toolCallId.startsWith("live-");
+  }
+
   private findToolEntryIndex(toolCallId: string, toolName?: string): number {
     for (let i = this.entries.length - 1; i >= 0; i--) {
       const entry = this.entries[i];
       if (!this.isToolEntry(entry)) continue;
-      if (entry.toolCallId === toolCallId || (toolName && entry.toolName === toolName && entry.isPartial !== false)) return i;
+      if (entry.toolCallId === toolCallId) return i;
+      // Legacy reconciliation ONLY: a synthetic `live-<name>` id may pair with a
+      // row for the same in-flight tool name (or vice versa). Never collapse two
+      // distinct concrete toolCallIds — that merges parallel tool calls (#1198).
+      if (
+        toolName &&
+        entry.toolName === toolName &&
+        entry.isPartial !== false &&
+        (this.isSyntheticToolCallId(toolCallId) || this.isSyntheticToolCallId(entry.toolCallId))
+      ) {
+        return i;
+      }
     }
     return -1;
   }

--- a/test/integration/workflow-package-typing.test.ts
+++ b/test/integration/workflow-package-typing.test.ts
@@ -404,5 +404,5 @@ export default workflow;
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 });

--- a/test/unit/chat-message-renderer.test.ts
+++ b/test/unit/chat-message-renderer.test.ts
@@ -85,6 +85,58 @@ describe("chat message renderer utilities", () => {
     assert.deepEqual(live.pendingToolIds(), []);
   });
 
+  test("renders distinct rows and output for parallel same-name tool calls (live events)", () => {
+    const entries = [] as ReturnType<typeof chatEntriesFromAgentMessages>;
+    const live = new LiveChatEntriesController(entries);
+
+    // A single assistant snapshot announcing TWO parallel `read` tool calls.
+    live.applyEvent({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "A", name: "read", arguments: { path: "a.ts" } },
+          { type: "toolCall", id: "B", name: "read", arguments: { path: "b.ts" } },
+        ],
+      },
+    });
+
+    live.applyEvent({ type: "tool_execution_start", toolCallId: "A", toolName: "read", args: { path: "a.ts" } });
+    live.applyEvent({ type: "tool_execution_start", toolCallId: "B", toolName: "read", args: { path: "b.ts" } });
+    live.applyEvent({
+      type: "tool_execution_end",
+      toolCallId: "A",
+      toolName: "read",
+      result: { content: [{ type: "text", text: "OUTPUT_A" }] },
+      isError: false,
+    });
+    live.applyEvent({
+      type: "tool_execution_end",
+      toolCallId: "B",
+      toolName: "read",
+      result: { content: [{ type: "text", text: "OUTPUT_B" }] },
+      isError: false,
+    });
+
+    // Two distinct concrete toolCallIds must keep two distinct transcript rows.
+    const tools = entries.filter((e) => e.kind === "tool");
+    assert.equal(tools.length, 2);
+    assert.deepEqual(tools.map((tool) => tool.toolCallId), ["A", "B"]);
+
+    // Neither row may be left as a bare result-less tool marker (the #1198 bug).
+    for (const tool of tools) {
+      assert.notEqual(tool.result, undefined);
+      assert.equal(tool.isPartial, false);
+    }
+
+    const aBlock = tools[0]?.result?.content[0];
+    assert.equal(aBlock?.type === "text" ? aBlock.text : undefined, "OUTPUT_A");
+    const bBlock = tools[1]?.result?.content[0];
+    assert.equal(bBlock?.type === "text" ? bBlock.text : undefined, "OUTPUT_B");
+
+    assert.deepEqual(live.pendingToolIds(), []);
+  });
+
   test("scrollable viewport defaults to sticky bottom and handles PageUp/PageDown", () => {
     const viewport = new ScrollableComponentViewport();
     viewport.setVisibleRows(3);


### PR DESCRIPTION
## Summary

Parallel tool calls sharing the same tool name (e.g. two concurrent `read` calls) in the **workflow node (stage) chat** rendered as bare `read …` markers with no output. Sequential tool calls and the main interactive chat were unaffected. Fixes #1198.

## Root Cause

`LiveChatEntriesController.findToolEntryIndex` in `chat-message-renderer.ts` had a name-based fallback that matched any in-flight pending row by tool name:

```ts
if (entry.toolCallId === toolCallId || (toolName && entry.toolName === toolName && entry.isPartial !== false)) return i;
```

When two concurrent tool calls share a name, the second call matched the first's still-pending row by name, aliasing two distinct `toolCallId`s onto one transcript slot. Results were routed to the wrong/merged row, leaving the other parallel call stuck as a bare marker.

The main chat keys pending tools strictly by `toolCallId`, so it never collided. Session replay (`chatEntriesFromAgentMessages`) is id-keyed too. Only the live workflow path was affected.

## Key Changes

- **`chat-message-renderer.ts`**: Narrowed the name fallback in `findToolEntryIndex` so it only reconciles synthetic `live-<name>` ids (at least one side of the pair must be a `live-*` id). Two distinct concrete `toolCallId`s no longer collapse — bringing the live workflow path to parity with the main chat's strict-id semantics.
- **`isSyntheticToolCallId` helper**: Encapsulates the `live-` prefix check, keeping the guard readable.
- **`test/unit/chat-message-renderer.test.ts`**: Regression test drives two parallel same-name `read` calls through the live controller and asserts two distinct rows each carry their own resolved output (`OUTPUT_A` / `OUTPUT_B`). Verified to **FAIL** without the fix and **PASS** with it.
- **`test/integration/workflow-package-typing.test.ts`**: Raised standalone typing test timeout to 60 s for slow Windows CI runs.
- **`CHANGELOG.md`**: Added `### Fixed` entry under `[Unreleased]` referencing #1198.

## Validation

- `bun run typecheck` ✅
- `bun run lint` ✅
- `chat-message-renderer` / `chat-session-host` / `stage-chat-view` bun:test suites: 110 pass / 0 fail ✅
- Pre-commit + pre-push hooks (incl. `test:unit`) passed ✅