### PR TITLE
chore(workflows): raise reasoning levels and refresh model fallbacks

### DIFF
--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -412,12 +412,12 @@ export default defineWorkflow("deep-research-codebase")
     );
 
     const plannerModelConfig = {
-      model: "openai/gpt-5.5:high",
+      model: "openai/gpt-5.5:xhigh",
       fallbackModels: [
-        "openai-codex/gpt-5.5:high",
-        "github-copilot/gpt-5.5:high",
-        "anthropic/claude-opus-4-8:high",
-        "github-copilot/claude-opus-4.7:high",
+        "openai-codex/gpt-5.5:xhigh",
+        "github-copilot/gpt-5.5:xhigh",
+        "anthropic/claude-opus-4-8:xhigh",
+        "github-copilot/claude-opus-4.8:medium",
       ],
       excludedTools: ["ask_user_question"],
     };

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -1026,23 +1026,23 @@ export default defineWorkflow("goal")
     const { ledger, ledgerPath, artifactDir } = await createGoalLedger(objective);
 
     const workerModelConfig = {
-      model: "openai/gpt-5.5:low",
+      model: "openai/gpt-5.5:medium",
       fallbackModels: [
-        "openai-codex/gpt-5.5:low",
-        "github-copilot/gpt-5.5:low",
-        "anthropic/claude-sonnet-4-7:low",
-        "github-copilot/claude-sonnet-4.7:low",
+        "openai-codex/gpt-5.5:medium",
+        "github-copilot/gpt-5.5:medium",
+        "anthropic/claude-sonnet-4-8:medium",
+        "github-copilot/claude-sonnet-4.8:medium",
       ],
       tools: goalRunnerTools,
     };
 
     const reviewerModelConfig = {
-      model: "openai/gpt-5.5:high",
+      model: "openai/gpt-5.5:xhigh",
       fallbackModels: [
-        "openai-codex/gpt-5.5:high",
-        "github-copilot/gpt-5.5:high",
-        "anthropic/claude-sonnet-4-7:high",
-        "github-copilot/claude-sonnet-4.7:high",
+        "openai-codex/gpt-5.5:xhigh",
+        "github-copilot/gpt-5.5:xhigh",
+        "anthropic/claude-sonnet-4-8:xhigh",
+        "github-copilot/claude-sonnet-4.8:medium",
       ],
       tools: [...goalRunnerTools, reviewDecisionTool.name],
       customTools: [reviewDecisionTool],

--- a/packages/workflows/builtin/open-claude-design.ts
+++ b/packages/workflows/builtin/open-claude-design.ts
@@ -226,11 +226,11 @@ export default defineWorkflow("open-claude-design")
     const specFileUrl = `file://${specPath}`;
 
     const designModelConfig = {
-      model: "anthropic/claude-opus-4-8:high",
+      model: "anthropic/claude-opus-4-8:xhigh",
       fallbackModels: [
-        "github-copilot/claude-opus-4.7:high",
-        "anthropic/claude-sonnet-4-6:high",
-        "github-copilot/claude-sonnet-4.6:high",
+        "github-copilot/claude-opus-4.8:medium",
+        "anthropic/claude-sonnet-4-6:xhigh",
+        "github-copilot/claude-sonnet-4.6:medium",
       ],
     };
 

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -432,12 +432,12 @@ async function runRalphWorkflow(
   let iterationsCompleted = 0;
 
   const plannerModelConfig = {
-    model: "openai/gpt-5.5:high",
+    model: "openai/gpt-5.5:xhigh",
     fallbackModels: [
-      "openai-codex/gpt-5.5:high",
-      "github-copilot/gpt-5.5:high",
-      "anthropic/claude-opus-4-8:high",
-      "github-copilot/claude-opus-4.7:high",
+      "openai-codex/gpt-5.5:xhigh",
+      "github-copilot/gpt-5.5:xhigh",
+      "anthropic/claude-opus-4-8:xhigh",
+      "github-copilot/claude-opus-4.8:medium",
     ],
     excludedTools: ["ask_user_question"],
   };
@@ -465,12 +465,12 @@ async function runRalphWorkflow(
   };
 
   const reviewerModelConfig = {
-    model: "openai/gpt-5.5:high",
+    model: "openai/gpt-5.5:xhigh",
     fallbackModels: [
-      "openai-codex/gpt-5.5:high",
-      "github-copilot/gpt-5.5:high",
-      "anthropic/claude-opus-4-8:high",
-      "github-copilot/claude-opus-4.7:high",
+      "openai-codex/gpt-5.5:xhigh",
+      "github-copilot/gpt-5.5:xhigh",
+      "anthropic/claude-opus-4-8:xhigh",
+      "github-copilot/claude-opus-4.8:medium",
     ],
     excludedTools: ["ask_user_question"],
     customTools: [reviewDecisionTool],


### PR DESCRIPTION
## Summary

Bumps model configurations across all four builtin workflows to higher reasoning tiers and newer fallback model versions. No structural or API changes — only model IDs and reasoning-level suffixes were adjusted.

## Changes

| Workflow | Role | Before | After |
|---|---|---|---|
| `deep-research-codebase` | planner (primary + fallbacks) | `:high` | `:xhigh` |
| `deep-research-codebase` | copilot opus fallback | `4.7:high` | `4.8:medium` |
| `goal` | worker (primary + fallbacks) | `:low` / sonnet 4-7 | `:medium` / sonnet 4-8 |
| `goal` | reviewer (primary + fallbacks) | `:high` / sonnet 4-7 | `:xhigh` / sonnet 4-8 |
| `goal` | copilot opus/sonnet fallbacks | `4.7` | `4.8:medium` |
| `open-claude-design` | design primary | `opus-4-8:high` | `opus-4-8:xhigh` |
| `open-claude-design` | copilot opus fallback | `4.7:high` | `4.8:medium` |
| `open-claude-design` | sonnet fallbacks | `4-6:high` / `4.6:high` | `4-6:xhigh` / `4.6:medium` |
| `ralph` | planner + reviewer (primary + fallbacks) | `:high` | `:xhigh` |
| `ralph` | copilot opus fallback | `4.7:high` | `4.8:medium` |

## Notes

- Pure configuration change — no logic, API, or structural modifications.
- GitHub Copilot fallbacks cap at `:medium` reasoning (platform ceiling); native Anthropic/OpenAI providers promote to `:xhigh`.
- Pre-commit hooks (`bun run lint`, `bun run test:unit`) pass.