### PR TITLE
chore(release): adopt -alpha.N prerelease version convention

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,9 +187,9 @@ jobs:
                   else
                     ref="${GITHUB_REF#refs/tags/}"
                   fi
-                  release_version_re='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*))?'
+                  release_version_re='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-alpha\.[1-9][0-9]*)?'
                   if [[ ! "$ref" =~ ^v$release_version_re$ ]]; then
-                    echo "Unexpected tag format: $ref (expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-NUMBER, e.g. v0.8.0 or v0.8.0-0)" >&2
+                    echo "Unexpected tag format: $ref (expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-alpha.REVISION, e.g. v0.8.0 or v0.8.0-alpha.1)" >&2
                     exit 1
                   fi
                   echo "ref=$ref" >> "$GITHUB_OUTPUT"
@@ -229,7 +229,7 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  release_version_re='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*))?'
+                  release_version_re='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-alpha\.[1-9][0-9]*)?'
 
                   root_name=$(bun --eval 'import pkg from "./package.json" with { type: "json" }; console.log(pkg.name);')
                   if [ "$root_name" != "atomic-monorepo" ]; then
@@ -249,7 +249,7 @@ jobs:
                   fi
 
                   if [[ ! "$version" =~ ^$release_version_re$ ]]; then
-                    echo "$PACKAGE_DIR/package.json version $version is invalid (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-NUMBER, e.g. 0.8.0 or 0.8.0-0)." >&2
+                    echo "$PACKAGE_DIR/package.json version $version is invalid (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-alpha.REVISION, e.g. 0.8.0 or 0.8.0-alpha.1)." >&2
                     exit 1
                   fi
 
@@ -262,7 +262,7 @@ jobs:
 
                   while IFS=$'\t' read -r manifest_path manifest_name manifest_version manifest_private; do
                     if [[ ! "$manifest_version" =~ ^$release_version_re$ ]]; then
-                      echo "$manifest_path version $manifest_version is invalid (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-NUMBER)." >&2
+                      echo "$manifest_path version $manifest_version is invalid (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-alpha.REVISION)." >&2
                       exit 1
                     fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Atomic mirrors pi's tag-driven release flow: bump versions locally, commit, push
 If a user asks you to publish the package or create a release/prerelease:
 
 1. Ask the user with the `ask_user_question`/ask-question tool what version to publish if they have not supplied a version.
-2. Ask whether they want a release or prerelease if that cannot be inferred from the supplied version, or if the version is in an incorrect format. Valid formats are `MAJOR.MINOR.PATCH` for releases and `MAJOR.MINOR.PATCH-NUMBER` for prereleases.
+2. Ask whether they want a release or prerelease if that cannot be inferred from the supplied version, or if the version is in an incorrect format. Valid formats are `MAJOR.MINOR.PATCH` for releases and `MAJOR.MINOR.PATCH-alpha.REVISION` (revision starts at 1) for prereleases.
 3. Create a branch using the naming convention: `[prerelease | release]/v<version>` where `[prerelease | release]` changes depending on whether the version if a release or prerelease version.
 4. Follow the guidance in the "Changelog" section to update the `CHANGELOG.md` files.
 5. Follow the "Bumping Versions" guidance to correctly bump the package version.
@@ -171,7 +171,7 @@ Use the top-level `scripts/bump-version.ts` script to update every `packages/*/p
 ```sh
 # Explicit version
 bun run scripts/bump-version.ts 0.1.0
-bun run scripts/bump-version.ts 0.1.0-0
+bun run scripts/bump-version.ts 0.1.0-alpha.1
 ```
 
 Run `bun install` afterward to refresh `bun.lock`.

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -244,7 +244,7 @@ Atomic uses a tag-driven release flow: push a `v<version>` git tag and CI cross-
 
 ### Workflow
 
-1. Run `bun run scripts/bump-version.ts <version>` (e.g. `0.8.0` or `0.8.0-0`), then `bun install`.
+1. Run `bun run scripts/bump-version.ts <version>` (e.g. `0.8.0` or `0.8.0-alpha.1`), then `bun install`.
 2. Move the `[Unreleased]` section in `packages/coding-agent/CHANGELOG.md` to a new `## [<version>] - <YYYY-MM-DD>` section. CI extracts release notes from this section.
 3. Run `bun run typecheck`, `cd packages/coding-agent && bun run build`, and `bun run test:all`.
 4. Commit `packages/*/package.json`, `packages/*/README.md`, `packages/coding-agent/CHANGELOG.md`, and `bun.lock` with `chore(release): bump to v<version>`.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -113,7 +113,7 @@ The publish pipeline (`publish.yml`) runs when:
 | Tag                                                       | npm tag  | GitHub Release                |
 | --------------------------------------------------------- | -------- | ----------------------------- |
 | `v<major>.<minor>.<patch>` (e.g. `v0.8.0`)                | `latest` | normal release, marked latest |
-| `v<major>.<minor>.<patch>-<prerelease>` (e.g. `v0.8.0-0`) | `next`   | prerelease, not marked latest |
+| `v<major>.<minor>.<patch>-<prerelease>` (e.g. `v0.8.0-alpha.1`) | `next`   | prerelease, not marked latest |
 
 The tag must match `packages/coding-agent/package.json` after removing the leading `v`. All `packages/*` package versions stay in sync via `scripts/bump-version.ts`.
 
@@ -123,7 +123,7 @@ Use the top-level script:
 
 ```sh
 bun run scripts/bump-version.ts 0.8.0
-bun run scripts/bump-version.ts 0.8.0-0
+bun run scripts/bump-version.ts 0.8.0-alpha.1
 bun install
 ```
 
@@ -295,4 +295,4 @@ The meaningful pre-publish checks are:
 
 5. Confirm `publish.yml` runs docs link validation, cross-compiles binaries, publishes `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
 
-For prereleases, substitute `0.8.0-0` and tag `v0.8.0-0`.
+For prereleases, substitute `0.8.0-alpha.1` and tag `v0.8.0-alpha.1`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Removed the bundled workflows package's imperative `runWorkflow` object-form API; workflow packages must export branded `defineWorkflow(...).compile()` definitions while direct `workflow` tool task/tasks/chain modes remain available.
 
+### Changed
+
+- Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+
 ### Fixed
 
 - Fixed workflow node chat rendering a bare tool-name marker (e.g. `read …`) instead of tool output for parallel tool calls; `LiveChatEntriesController` now pairs concurrent same-named tool calls strictly by `toolCallId` ([#1198](https://github.com/bastani-inc/atomic/issues/1198)).

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -717,7 +717,7 @@ export class InteractiveMode {
     this.chatContainer.addChild(new DynamicBorder());
     if (this.settingsManager.getCollapseChangelog()) {
       const versionMatch = this.changelogMarkdown.match(
-        /##\s+\[?((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*))?)\]?/,
+        /##\s+\[?((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:alpha\.)?(?:0|[1-9]\d*))?)\]?/,
       );
       const latestVersion = versionMatch ? versionMatch[1] : this.version;
       const condensedText = `Updated to v${latestVersion}. Use ${theme.bold("/changelog")} to view full changelog.`;

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -12,37 +12,46 @@ export interface ChangelogEntry extends VersionParts {
 	content: string;
 }
 
-const RELEASE_VERSION_RE = /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?$/;
-const CHANGELOG_VERSION_HEADER_RE = /^##\s+\[?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?\]?/;
+// The prerelease group accepts BOTH the legacy numeric form (`-N`) and the new
+// `-alpha.N` convention while capturing the numeric revision. The outer capture
+// group preserves the raw version substring so each entry's `version` round-trips
+// faithfully (a `0.8.1-0` header stays `0.8.1-0`; a `0.8.2-alpha.1` header stays
+// `0.8.2-alpha.1`).
+const RELEASE_VERSION_RE = /^(?:v)?((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:alpha\.)?(0|[1-9]\d*))?)$/;
+const CHANGELOG_VERSION_HEADER_RE =
+	/^##\s+\[?((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:alpha\.)?(0|[1-9]\d*))?)\]?/;
 
-function formatVersion(parts: VersionParts): string {
-	const base = `${parts.major}.${parts.minor}.${parts.patch}`;
-	return parts.prerelease === null ? base : `${base}-${parts.prerelease}`;
+interface ParsedVersion extends VersionParts {
+	version: string;
 }
 
-function partsFromMatch(match: RegExpMatchArray): VersionParts {
+function parsedVersionFromMatch(match: RegExpMatchArray): ParsedVersion {
 	return {
-		major: Number.parseInt(match[1] as string, 10),
-		minor: Number.parseInt(match[2] as string, 10),
-		patch: Number.parseInt(match[3] as string, 10),
-		prerelease: match[4] === undefined ? null : Number.parseInt(match[4], 10),
+		version: match[1] as string,
+		major: Number.parseInt(match[2] as string, 10),
+		minor: Number.parseInt(match[3] as string, 10),
+		patch: Number.parseInt(match[4] as string, 10),
+		prerelease: match[5] === undefined ? null : Number.parseInt(match[5], 10),
 	};
 }
 
 function parseVersion(version: string): VersionParts | null {
 	const match = version.trim().match(RELEASE_VERSION_RE);
-	return match ? partsFromMatch(match) : null;
+	return match ? parsedVersionFromMatch(match) : null;
 }
 
-function parseVersionHeader(line: string): VersionParts | null {
+function parseVersionHeader(line: string): ParsedVersion | null {
 	const match = line.match(CHANGELOG_VERSION_HEADER_RE);
-	return match ? partsFromMatch(match) : null;
+	return match ? parsedVersionFromMatch(match) : null;
 }
 
-function createChangelogEntry(version: VersionParts, lines: string[]): ChangelogEntry {
+function createChangelogEntry(version: ParsedVersion, lines: string[]): ChangelogEntry {
 	return {
-		...version,
-		version: formatVersion(version),
+		major: version.major,
+		minor: version.minor,
+		patch: version.patch,
+		prerelease: version.prerelease,
+		version: version.version,
 		content: lines.join("\n").trim(),
 	};
 }
@@ -62,7 +71,7 @@ export function parseChangelog(changelogPath: string): ChangelogEntry[] {
 		const entries: ChangelogEntry[] = [];
 
 		let currentLines: string[] = [];
-		let currentVersion: VersionParts | null = null;
+		let currentVersion: ParsedVersion | null = null;
 
 		for (const line of lines) {
 			// Check if this is a version header (## [x.y.z] ...)
@@ -116,7 +125,9 @@ export function compareVersions(v1: VersionParts, v2: VersionParts): number {
 /**
  * Get entries newer than lastVersion, optionally bounded by currentVersion.
  *
- * Atomic uses numeric prereleases (for example, 0.8.1-0) and started its own
+ * Atomic uses alpha prereleases (for example, 0.8.2-alpha.1, with the revision
+ * starting at 1) while legacy numeric prerelease entries (for example, 0.8.1-0)
+ * remain parseable, and started its own
  * version line above the upstream Pi changelog history. When currentVersion is
  * provided, changelog order wins over semantic version filtering so historical
  * upstream entries like 0.74.0 or an old 0.10.0 section are not treated as

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Changed
+
+- Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+
 ## [0.8.23] - 2026-06-02
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+
 ## [0.8.23] - 2026-06-02
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Migrated packaged subagents to encode their reasoning level directly in model and fallback model entries ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
 - Documented the `model_name:thinking_effort` suffix syntax and `thinking` migration guidance in the subagents docs, package README, and subagent skill ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
+- Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
 
 ### Deprecated
 

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+
 ## [0.8.23] - 2026-06-02
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Changed bundled workflows to encode their existing reasoning levels directly on model and fallback model strings ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
 - Documented the `model_name:thinking_effort` suffix syntax and `thinkingLevel` migration guidance in the workflows docs and package README ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
+- Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
 
 ### Deprecated
 

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -8,17 +8,17 @@
  *
  * Examples:
  *   bun run scripts/bump-version.ts 0.8.0
- *   bun run scripts/bump-version.ts 0.8.0-0
+ *   bun run scripts/bump-version.ts 0.8.0-alpha.1
  *   bun run scripts/bump-version.ts --from-branch   # extracts version from current branch name
  *
  * Accepted versions are strict release versions only:
- *   0.8.0   for stable releases
- *   0.8.0-0 for prereleases
+ *   0.8.0         for stable releases
+ *   0.8.0-alpha.1 for prereleases
  *
  * The --from-branch flag reads the current git branch and extracts the version
  * from branch names matching:
- *   release/v0.8.0      → 0.8.0
- *   prerelease/v0.8.0-0 → 0.8.0-0
+ *   release/v0.8.0            → 0.8.0
+ *   prerelease/v0.8.0-alpha.1 → 0.8.0-alpha.1
  */
 
 import { $ } from "bun";
@@ -74,9 +74,9 @@ function findRepoRoot(startDir: string): string {
   }
 }
 
-const STRICT_RELEASE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?$/;
+const STRICT_RELEASE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-alpha\.([1-9]\d*))?$/;
 const STABLE_RELEASE_BRANCH_RE = /^(?:release)\/v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$/;
-const NUMERIC_PRERELEASE_BRANCH_RE = /^(?:prerelease)\/v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-(?:0|[1-9]\d*))$/;
+const ALPHA_PRERELEASE_BRANCH_RE = /^(?:prerelease)\/v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-alpha\.[1-9]\d*)$/;
 
 const { rootOverride, positional } = parseArgv();
 
@@ -90,11 +90,11 @@ function parseVersionFromBranch(branch: string): string {
   const stableMatch = branch.match(STABLE_RELEASE_BRANCH_RE);
   if (stableMatch) return stableMatch[1] as string;
 
-  const prereleaseMatch = branch.match(NUMERIC_PRERELEASE_BRANCH_RE);
+  const prereleaseMatch = branch.match(ALPHA_PRERELEASE_BRANCH_RE);
   if (prereleaseMatch) return prereleaseMatch[1] as string;
 
   console.error(
-    `Error: branch "${branch}" does not match release/vMAJOR.MINOR.PATCH or prerelease/vMAJOR.MINOR.PATCH-NUMBER`,
+    `Error: branch "${branch}" does not match release/vMAJOR.MINOR.PATCH or prerelease/vMAJOR.MINOR.PATCH-alpha.REVISION`,
   );
   process.exit(1);
 }
@@ -102,7 +102,7 @@ function parseVersionFromBranch(branch: string): string {
 function validateVersion(version: string): void {
   if (!STRICT_RELEASE_VERSION_RE.test(version)) {
     console.error(
-      `Error: "${version}" is not a valid release version. Expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-NUMBER (for example, 0.8.0 or 0.8.0-0).`,
+      `Error: "${version}" is not a valid release version. Expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-alpha.REVISION (for example, 0.8.0 or 0.8.0-alpha.1).`,
     );
     process.exit(1);
   }

--- a/test/unit/bump-version-script.test.ts
+++ b/test/unit/bump-version-script.test.ts
@@ -70,30 +70,41 @@ describe("scripts/bump-version.ts", () => {
   test("updates every versioned package manifest and README badge", () => {
     const root = createFixtureRoot();
     try {
-      const result = runBump(root, "1.2.3-4");
+      const result = runBump(root, "1.2.3-alpha.1");
       assert.equal(result.exitCode, 0, result.stderr);
 
-      assert.equal(readJson(join(root, "package.json")).version, "1.2.3-4");
-      assert.equal(readJson(join(root, "packages", "alpha", "package.json")).version, "1.2.3-4");
-      assert.equal(readJson(join(root, "packages", "beta", "package.json")).version, "1.2.3-4");
+      assert.equal(readJson(join(root, "package.json")).version, "1.2.3-alpha.1");
+      assert.equal(readJson(join(root, "packages", "alpha", "package.json")).version, "1.2.3-alpha.1");
+      assert.equal(readJson(join(root, "packages", "beta", "package.json")).version, "1.2.3-alpha.1");
       assert.match(
         readFileSync(join(root, "packages", "alpha", "README.md"), "utf8"),
-        /version-1\.2\.3--4-blue" alt="Version 1\.2\.3-4"/,
+        /version-1\.2\.3--alpha\.1-blue" alt="Version 1\.2\.3-alpha\.1"/,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });
 
-  test("rejects v-prefixed and non-numeric prerelease versions", () => {
-    const invalidVersions = ["v1.2.3", "1.2.3-rc.1", "1.2.3-1.2", "01.2.3"];
+  test("rejects v-prefixed, legacy-numeric, and malformed alpha prerelease versions", () => {
+    // The prerelease convention is `-alpha.N` with the revision starting at 1.
+    // Legacy numeric prereleases (the old `-0`/`-4` style suffix) and any other
+    // suffix shape are rejected.
+    const invalidVersions = [
+      "v1.2.3",
+      "1.2.3-0",
+      "1.2.3-alpha.0",
+      "1.2.3-alpha",
+      "1.2.3-alpha.01",
+      "1.2.3-rc.1",
+      "01.2.3",
+    ];
 
     for (const version of invalidVersions) {
       const root = createFixtureRoot();
       try {
         const result = runBump(root, version);
         assert.notEqual(result.exitCode, 0, `${version} should be rejected`);
-        assert.match(result.stderr, /Expected MAJOR\.MINOR\.PATCH or MAJOR\.MINOR\.PATCH-NUMBER/);
+        assert.match(result.stderr, /Expected MAJOR\.MINOR\.PATCH or MAJOR\.MINOR\.PATCH-alpha\.REVISION/);
         assert.equal(readJson(join(root, "package.json")).version, "0.1.0");
         assert.equal(readJson(join(root, "packages", "alpha", "package.json")).version, "0.1.0");
       } finally {

--- a/test/unit/changelog.test.ts
+++ b/test/unit/changelog.test.ts
@@ -3,7 +3,12 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { getEntriesForVersion, getNewEntries, parseChangelog } from "../../packages/coding-agent/src/utils/changelog.js";
+import {
+  compareVersions,
+  getEntriesForVersion,
+  getNewEntries,
+  parseChangelog,
+} from "../../packages/coding-agent/src/utils/changelog.js";
 
 function writeChangelog(content: string): string {
   const root = mkdtempSync(join(tmpdir(), "atomic-changelog-"));
@@ -37,6 +42,53 @@ describe("changelog parsing", () => {
       );
       assert.equal(entries[0]?.prerelease, null);
       assert.equal(entries[1]?.prerelease, 0);
+    } finally {
+      rmSync(dirname(changelogPath), { recursive: true, force: true });
+    }
+  });
+
+  test("parses alpha prerelease versions, round-tripping the header and ordering by revision", () => {
+    const changelogPath = writeChangelog(`# Changelog
+
+## [0.8.24] - 2026-06-10
+
+### Fixed
+
+- Stable fix.
+
+## [0.8.24-alpha.2] - 2026-06-09
+
+### Fixed
+
+- Second prerelease fix.
+
+## [0.8.24-alpha.1] - 2026-06-08
+
+### Fixed
+
+- First prerelease fix.
+`);
+
+    try {
+      const entries = parseChangelog(changelogPath);
+      assert.deepEqual(
+        entries.map((entry) => entry.version),
+        ["0.8.24", "0.8.24-alpha.2", "0.8.24-alpha.1"],
+      );
+      assert.equal(entries[0]?.prerelease, null);
+      assert.equal(entries[1]?.prerelease, 2);
+      assert.equal(entries[2]?.prerelease, 1);
+
+      const [stable, alpha2, alpha1] = entries;
+      assert.ok(stable && alpha2 && alpha1);
+      // stable 0.8.24 is newer than 0.8.24-alpha.2, which is newer than 0.8.24-alpha.1.
+      assert.equal(compareVersions(stable, alpha2), 1);
+      assert.equal(compareVersions(alpha2, alpha1), 1);
+
+      assert.deepEqual(
+        getEntriesForVersion(entries, "0.8.24-alpha.1").map((entry) => entry.version),
+        ["0.8.24-alpha.1"],
+      );
     } finally {
       rmSync(dirname(changelogPath), { recursive: true, force: true });
     }

--- a/test/unit/package-metadata.test.ts
+++ b/test/unit/package-metadata.test.ts
@@ -10,7 +10,7 @@ import webAccessPackageJson from "../../packages/web-access/package.json" with {
 import workflowsPackageJson from "../../packages/workflows/package.json" with { type: "json" };
 
 const STRICT_RELEASE_VERSION_RE =
-    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?$/;
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-alpha\.([1-9]\d*))?$/;
 
 type DependencySectionName =
     | "dependencies"


### PR DESCRIPTION
## Summary

Replaces the legacy numeric `-N` prerelease suffix with `-alpha.N` (revision starts at 1) across all release tooling. Stable release naming (`MAJOR.MINOR.PATCH`) is unchanged.

## Changes

- **Bump script** (`scripts/bump-version.ts`): strict version regex now accepts only `-alpha.N` (N≥1); renamed `NUMERIC_PRERELEASE_BRANCH_RE` → `ALPHA_PRERELEASE_BRANCH_RE`; updated error messages and JSDoc examples.
- **CI** (`.github/workflows/publish.yml`): both `release_version_re` checks (tag-format gate and package-metadata validation) updated to the alpha form; error strings updated to match.
- **Changelog parser** (`packages/coding-agent/src/utils/changelog.ts`): accepts both `-alpha.N` (new) and legacy `-N` (old), capturing the numeric revision and round-tripping each header faithfully so existing immutable `-N` sections still render correctly. `interactive-mode.ts` changelog-version regex updated to match.
- **Tests**: `bump-version-script` (new valid/invalid cases including rejection of legacy `-0`, `-alpha.0`, `-alpha.01`), `package-metadata` (strict regex), and `changelog` (new alpha parse/round-trip/ordering test; legacy test retained).
- **Docs**: `CLAUDE.md`, `docs/ci.md`, `DEV_SETUP.md` examples updated.
- **Changelogs**: `### Changed` entry under `[Unreleased]` in all six packages.

## Compatibility

- Stable convention (`MAJOR.MINOR.PATCH`, `release/v<version>`, tag `v<version>`, npm `latest`) is **unchanged**.
- Backward compatible: existing `## [x.y.z-N]` changelog sections remain parseable; only forward-looking validators (bump script, CI, package-metadata test) require the new `-alpha.N` format.

## Validation

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test:unit` — 1986 pass / 0 fail
- Bash regex sanity: `v0.8.0`, `v0.8.0-alpha.1`, `v0.8.0-alpha.12` accepted; `v0.8.0-0`, `v0.8.0-alpha.0` rejected