### PR TITLE
chore(release): drop leading "v" from release tags and branch names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,11 @@ name: Publish
 on:
     push:
         tags:
-            - "v*"
+            - "[0-9]*.[0-9]*.[0-9]*"
     workflow_dispatch:
         inputs:
             tag:
-                description: "Tag to publish (e.g., v0.8.0)"
+                description: "Tag to publish (e.g., 0.8.0 or 0.8.0-alpha.1)"
                 required: true
                 type: string
 
@@ -188,8 +188,8 @@ jobs:
                     ref="${GITHUB_REF#refs/tags/}"
                   fi
                   release_version_re='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-alpha\.[1-9][0-9]*)?'
-                  if [[ ! "$ref" =~ ^v$release_version_re$ ]]; then
-                    echo "Unexpected tag format: $ref (expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-alpha.REVISION, e.g. v0.8.0 or v0.8.0-alpha.1)" >&2
+                  if [[ ! "$ref" =~ ^$release_version_re$ ]]; then
+                    echo "Unexpected tag format: $ref (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-alpha.REVISION, e.g. 0.8.0 or 0.8.0-alpha.1)" >&2
                     exit 1
                   fi
                   echo "ref=$ref" >> "$GITHUB_OUTPUT"
@@ -241,7 +241,7 @@ jobs:
 
                   name=$(bun --eval 'import pkg from "./package.json" with { type: "json" }; console.log(pkg.name);')
                   version=$(bun --eval 'import pkg from "./package.json" with { type: "json" }; console.log(pkg.version);')
-                  expected_tag="v$version"
+                  expected_tag="$version"
 
                   if [ "$name" != "$PACKAGE_NAME" ]; then
                     echo "Only $PACKAGE_NAME may be published by this workflow; found $name in $PACKAGE_DIR/package.json." >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ atomic:
 
 ## Releasing
 
-Atomic mirrors pi's tag-driven release flow: bump versions locally, commit, push a `v<version>` git tag, and CI publishes to npm with OIDC provenance and creates the GitHub Release with cross-compiled binaries attached.
+Atomic mirrors pi's tag-driven release flow: bump versions locally, commit, push a `<version>` git tag (no leading `v`, for example `0.8.24` or `0.8.24-alpha.1`), and CI publishes to npm with OIDC provenance and creates the GitHub Release with cross-compiled binaries attached.
 
 ### Agent publishing requests
 
@@ -126,7 +126,7 @@ If a user asks you to publish the package or create a release/prerelease:
 
 1. Ask the user with the `ask_user_question`/ask-question tool what version to publish if they have not supplied a version.
 2. Ask whether they want a release or prerelease if that cannot be inferred from the supplied version, or if the version is in an incorrect format. Valid formats are `MAJOR.MINOR.PATCH` for releases and `MAJOR.MINOR.PATCH-alpha.REVISION` (revision starts at 1) for prereleases.
-3. Create a branch using the naming convention: `[prerelease | release]/v<version>` where `[prerelease | release]` changes depending on whether the version if a release or prerelease version.
+3. Create a branch using the naming convention: `[prerelease | release]/<version>` (no leading `v`) where `[prerelease | release]` changes depending on whether the version if a release or prerelease version.
 4. Follow the guidance in the "Changelog" section to update the `CHANGELOG.md` files.
 5. Follow the "Bumping Versions" guidance to correctly bump the package version.
 6. Commit all unstaged changes in the current branch.
@@ -134,7 +134,7 @@ If a user asks you to publish the package or create a release/prerelease:
 8. Wait to make sure all of the CI checks pass using the `gh` tool.
 9. Auto-merge when all CI checks pass. If the checks don't pass, ask the user what they want to do using the `ask_user_question` tool.
 10. If/when the branch is merged to main, switch back to main, and pull the latest changes from `origin/main`.
-11. A branch push or PR merge alone does not publish, so if all the steps above succeed, create the new release by creating a git tag with: `git tag v<version>` and push it with `git push origin v<version>`.
+11. A branch push or PR merge alone does not publish, so if all the steps above succeed, create the new release by creating a git tag with: `git tag <version>` and push it with `git push origin <version>`.
 12. Wait for the release to finish and monitor the status of the publish action. If the publish checks don't pass, ask the user what they want to do using the `ask_user_question` tool. Otherwise, provide a summary to the user.
 
 ## Changelog

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -240,19 +240,19 @@ Examples import the workspace package `@bastani/workflows`.
 
 ## Releasing
 
-Atomic uses a tag-driven release flow: push a `v<version>` git tag and CI cross-compiles binaries, publishes to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
+Atomic uses a tag-driven release flow: push a `<version>` git tag (no leading `v`, for example `0.8.24` or `0.8.24-alpha.1`) and CI cross-compiles binaries, publishes to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
 
 ### Workflow
 
 1. Run `bun run scripts/bump-version.ts <version>` (e.g. `0.8.0` or `0.8.0-alpha.1`), then `bun install`.
 2. Move the `[Unreleased]` section in `packages/coding-agent/CHANGELOG.md` to a new `## [<version>] - <YYYY-MM-DD>` section. CI extracts release notes from this section.
 3. Run `bun run typecheck`, `cd packages/coding-agent && bun run build`, and `bun run test:all`.
-4. Commit `packages/*/package.json`, `packages/*/README.md`, `packages/coding-agent/CHANGELOG.md`, and `bun.lock` with `chore(release): bump to v<version>`.
+4. Commit `packages/*/package.json`, `packages/*/README.md`, `packages/coding-agent/CHANGELOG.md`, and `bun.lock` with `chore(release): bump to <version>`.
 5. Tag and push:
     ```sh
-    git tag v<version>
+    git tag <version>
     git push origin main
-    git push origin v<version>
+    git push origin <version>
     ```
 6. The tag push triggers `.github/workflows/publish.yml`, which publishes `@bastani/atomic` to npm with OIDC provenance and creates the GitHub Release with six binary archives attached (darwin/linux/windows × arm64/x64).
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -18,7 +18,7 @@ Pull request / push
   ├─ bun run test:integration
   └─ scripts/build-binaries.sh --platform <native-x64> + atomic --version smoke test
 
-v<version> tag pushed
+<version> tag pushed
   ├─ smoke test Linux x64 release archive in a dedicated job
   ├─ smoke test Windows x64 release archive in a dedicated job
   └─ publish after both smoke jobs pass
@@ -105,17 +105,17 @@ Responds to `@claude` mentions in issue comments, pull request review comments, 
 
 The publish pipeline (`publish.yml`) runs when:
 
-- a `v<version>` tag is pushed (matches pi's `build-binaries.yml` trigger)
-- `workflow_dispatch` is run with an explicit tag input such as `v0.8.0`
+- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`)
+- `workflow_dispatch` is run with an explicit tag input such as `0.8.0`
 
 ### Tag Naming
 
 | Tag                                                       | npm tag  | GitHub Release                |
 | --------------------------------------------------------- | -------- | ----------------------------- |
-| `v<major>.<minor>.<patch>` (e.g. `v0.8.0`)                | `latest` | normal release, marked latest |
-| `v<major>.<minor>.<patch>-<prerelease>` (e.g. `v0.8.0-alpha.1`) | `next`   | prerelease, not marked latest |
+| `<major>.<minor>.<patch>` (e.g. `0.8.0`)                  | `latest` | normal release, marked latest |
+| `<major>.<minor>.<patch>-<prerelease>` (e.g. `0.8.0-alpha.1`) | `next`   | prerelease, not marked latest |
 
-The tag must match `packages/coding-agent/package.json` after removing the leading `v`. All `packages/*` package versions stay in sync via `scripts/bump-version.ts`.
+The tag must match `packages/coding-agent/package.json` exactly (no leading `v`). All `packages/*` package versions stay in sync via `scripts/bump-version.ts`.
 
 ### Version Bump
 
@@ -132,7 +132,7 @@ The script updates every `packages/*/package.json` version and any package READM
 ### Publish Flow
 
 ```text
-git push origin v0.8.0
+git push origin 0.8.0
        │
        ├─ Smoke Linux binary
        │    · build linux-x64
@@ -287,12 +287,12 @@ The meaningful pre-publish checks are:
     ```sh
     git add packages/*/package.json packages/coding-agent/CHANGELOG.md bun.lock
     git add packages/*/README.md # only if the version bump script changed README badges
-    git commit -m "chore(release): bump to v0.8.0"
-    git tag v0.8.0
+    git commit -m "chore(release): bump to 0.8.0"
+    git tag 0.8.0
     git push origin main
-    git push origin v0.8.0
+    git push origin 0.8.0
     ```
 
 5. Confirm `publish.yml` runs docs link validation, cross-compiles binaries, publishes `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
 
-For prereleases, substitute `0.8.0-alpha.1` and tag `v0.8.0-alpha.1`.
+For prereleases, substitute `0.8.0-alpha.1` and tag `0.8.0-alpha.1`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+- Dropped the leading `v` from release git tags and `release/`/`prerelease/` branch names; the Publish CI now triggers on and validates bare version tags such as `0.8.24` or `0.8.24-alpha.1`.
 
 ### Fixed
 

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 ### Changed
 
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+- Dropped the leading `v` from release git tags and `release/`/`prerelease/` branch names; the Publish CI now triggers on and validates bare version tags such as `0.8.24` or `0.8.24-alpha.1`.
 
 ## [0.8.23] - 2026-06-02
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+- Dropped the leading `v` from release git tags and `release/`/`prerelease/` branch names; the Publish CI now triggers on and validates bare version tags such as `0.8.24` or `0.8.24-alpha.1`.
 
 ## [0.8.23] - 2026-06-02
 

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Migrated packaged subagents to encode their reasoning level directly in model and fallback model entries ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
 - Documented the `model_name:thinking_effort` suffix syntax and `thinking` migration guidance in the subagents docs, package README, and subagent skill ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+- Dropped the leading `v` from release git tags and `release/`/`prerelease/` branch names; the Publish CI now triggers on and validates bare version tags such as `0.8.24` or `0.8.24-alpha.1`.
 
 ### Deprecated
 

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+- Dropped the leading `v` from release git tags and `release/`/`prerelease/` branch names; the Publish CI now triggers on and validates bare version tags such as `0.8.24` or `0.8.24-alpha.1`.
 
 ## [0.8.23] - 2026-06-02
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Changed bundled workflows to encode their existing reasoning levels directly on model and fallback model strings ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
 - Documented the `model_name:thinking_effort` suffix syntax and `thinkingLevel` migration guidance in the workflows docs and package README ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).
+- Dropped the leading `v` from release git tags and `release/`/`prerelease/` branch names; the Publish CI now triggers on and validates bare version tags such as `0.8.24` or `0.8.24-alpha.1`.
 
 ### Deprecated
 

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -17,8 +17,8 @@
  *
  * The --from-branch flag reads the current git branch and extracts the version
  * from branch names matching:
- *   release/v0.8.0            → 0.8.0
- *   prerelease/v0.8.0-alpha.1 → 0.8.0-alpha.1
+ *   release/0.8.0            → 0.8.0
+ *   prerelease/0.8.0-alpha.1 → 0.8.0-alpha.1
  */
 
 import { $ } from "bun";
@@ -75,8 +75,8 @@ function findRepoRoot(startDir: string): string {
 }
 
 const STRICT_RELEASE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-alpha\.([1-9]\d*))?$/;
-const STABLE_RELEASE_BRANCH_RE = /^(?:release)\/v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$/;
-const ALPHA_PRERELEASE_BRANCH_RE = /^(?:prerelease)\/v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-alpha\.[1-9]\d*)$/;
+const STABLE_RELEASE_BRANCH_RE = /^(?:release)\/((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))$/;
+const ALPHA_PRERELEASE_BRANCH_RE = /^(?:prerelease)\/((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-alpha\.[1-9]\d*)$/;
 
 const { rootOverride, positional } = parseArgv();
 
@@ -94,7 +94,7 @@ function parseVersionFromBranch(branch: string): string {
   if (prereleaseMatch) return prereleaseMatch[1] as string;
 
   console.error(
-    `Error: branch "${branch}" does not match release/vMAJOR.MINOR.PATCH or prerelease/vMAJOR.MINOR.PATCH-alpha.REVISION`,
+    `Error: branch "${branch}" does not match release/MAJOR.MINOR.PATCH or prerelease/MAJOR.MINOR.PATCH-alpha.REVISION`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Follow-up to #1205. Removes the leading \`v\` from release **git tags** and **release/prerelease branch names** so the version, tag, and branch all use the bare form — e.g. tag \`0.8.24\` / \`0.8.24-alpha.1\`, branch \`release/0.8.24\` / \`prerelease/0.8.24-alpha.1\`.

## Changes

### CI (`.github/workflows/publish.yml`)
- Tag trigger updated from \`"v*"\` → \`"[0-9]*.[0-9]*.[0-9]*"\` so only bare version tags start the pipeline
- Ref-format validation regex drops the \`v\` prefix requirement (\`^$release_version_re$\` instead of \`^v$release_version_re$\`)
- \`expected_tag\` comparison uses \`"$version"\` (was \`"v$version"\`)
- Error messages and \`workflow_dispatch\` input hint updated to the no-\`v\` format

### Bump script (`scripts/bump-version.ts`)
- \`--from-branch\` now parses \`release/<version>\` and \`prerelease/<version>-alpha.N\` (without \`v\` prefix)
- Branch-mismatch error message and JSDoc examples updated accordingly

### Docs (`CLAUDE.md`, `DEV_SETUP.md`, `docs/ci.md`)
- All tag and branch examples updated to bare version format (e.g. \`git tag 0.8.0\`, \`git push origin 0.8.0\`)

### Changelogs
- \`### Changed\` entry added under \`[Unreleased]\` in all six packages

## Behavior

- **New (no-\`v\`) format only.** Pushing a \`v\`-prefixed tag no longer triggers the publish pipeline. Existing historical \`v*\` GitHub releases and tags are untouched.
- Stable-vs-prerelease semantics, npm \`latest\`/\`next\` dist-tags, and the \`-alpha.N\` convention from #1205 are unchanged.

## Validation

- \`bun run typecheck\` — clean
- \`bun run test:unit\` — 1986 pass / 0 fail (also enforced by pre-commit hooks)
- Branch-regex check: accepts \`release/1.2.3\`, \`prerelease/1.2.3-alpha.1\`; rejects \`release/v1.2.3\`, \`prerelease/v1.2.3-alpha.1\`, \`prerelease/1.2.3-0\`, \`feature/foo\`
- Ref-format check: accepts \`0.8.0\`, \`0.8.0-alpha.1\`; rejects \`v0.8.0\`, \`0.8.0-0\`, \`0.8.0-alpha.0\`