### PR TITLE
chore(release): bump prerelease to 0.8.24-alpha.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.23-0",
+      "version": "0.8.24-alpha.1",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.23-0",
+      "version": "0.8.24-alpha.1",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.23-0",
+      "version": "0.8.24-alpha.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.23-0",
+      "version": "0.8.24-alpha.1",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.23-0",
+      "version": "0.8.24-alpha.1",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.23-0",
+      "version": "0.8.24-alpha.1",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.24-alpha.1] - 2026-06-02
+
 ### Breaking Changes
 
 - Removed the bundled workflows package's imperative `runWorkflow` object-form API; workflow packages must export branded `defineWorkflow(...).compile()` definitions while direct `workflow` tool task/tasks/chain modes remain available.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.23",
+  "version": "0.8.24-alpha.1",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.24-alpha.1] - 2026-06-02
+
 ### Changed
 
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.23",
+  "version": "0.8.24-alpha.1",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.24-alpha.1] - 2026-06-02
+
 ### Changed
 
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.23",
+  "version": "0.8.24-alpha.1",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.24-alpha.1] - 2026-06-02
+
 ### Added
 
 - Added suffix-first reasoning levels for subagent `model` and `fallbackModels` values plus `fallbackThinkingLevels` compatibility metadata and per-attempt `reasoningLevel` reporting ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.23",
+  "version": "0.8.24-alpha.1",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.24-alpha.1] - 2026-06-02
+
 ### Changed
 
 - Adopted the new `-alpha.N` prerelease version convention (revision starting at 1), replacing the legacy numeric `-N` prerelease suffix in the release tooling (bump script, CI publish validation, and changelog parsing).

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.23",
+  "version": "0.8.24-alpha.1",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.24-alpha.1] - 2026-06-02
+
 ### Breaking Changes
 
 - Removed the imperative `runWorkflow` object-form API from `@bastani/workflows`; workflow authors must export definitions produced by `defineWorkflow(...).compile()`, and forged `__piWorkflow: true` objects are rejected by discovery and composition.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.23",
+  "version": "0.8.24-alpha.1",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the `0.8.24-alpha.1` prerelease across all workspace packages by bumping versions, cutting changelog sections, and refreshing the lockfile.

## Changes

- Bumped all workspace package versions `0.8.23` → `0.8.24-alpha.1` (`@bastani/atomic`, `@bastani/intercom`, `@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`, `@bastani/workflows`)
- Cut `## [Unreleased]` entries into a `## [0.8.24-alpha.1] - 2026-06-02` section in each package CHANGELOG
- Refreshed `bun.lock` to reflect updated workspace versions

## Release highlights (0.8.24-alpha.1)

- **feat(subagents):** Suffix-first reasoning levels for subagent/workflow `model` + `fallbackModels` (e.g. `openai/gpt-5:high`), with `fallbackThinkingLevels` compatibility ([#1199](https://github.com/bastani-inc/atomic/issues/1199))
- **fix(workflows):** Fixed parallel same-name tool-call rendering in workflow node chat ([#1198](https://github.com/bastani-inc/atomic/issues/1198))
- **chore:** Adopted the `-alpha.N` prerelease convention and dropped the leading `v` from release tags and branch names ([#1206](https://github.com/bastani-inc/atomic/pull/1206))

## Breaking Changes

- **`@bastani/workflows`** — The imperative `runWorkflow` object-form API is removed. Workflow packages must export definitions produced by `defineWorkflow(...).compile()`; forged `__piWorkflow: true` objects are rejected at discovery and composition time.
- **`@bastani/atomic`** — The bundled workflows package reflects the same `runWorkflow` removal.

## Migration

Replace any direct `runWorkflow({...})` calls with a `defineWorkflow(...).compile()` export:

```ts
// Before
export const myWorkflow = { __piWorkflow: true, run: async () => { ... } }

// After
import { defineWorkflow } from "@bastani/workflows"
export const myWorkflow = defineWorkflow({ name: "my-workflow" }, async () => { ... }).compile()
```

## Next steps

After merge, push the bare tag to trigger the Publish workflow (npm `alpha` dist-tag + GitHub prerelease):

```sh
git tag 0.8.24-alpha.1 && git push origin 0.8.24-alpha.1
```