### PR TITLE
fix(workflows): trust provider-qualified model fallback ids

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed builtin (and any) workflows falling back to the user's currently selected model instead of the stage's defined model. A fully-qualified `provider/model` id that the live model catalog did not list was treated as a hard "not available" failure; because candidate validation throws on any failure and the catalog resolver catches that throw and collapses the whole ordered candidate list down to the user's `currentModel`, a single absent cross-provider fallback discarded the defined primary plus every fallback. Provider-qualified ids are now trusted (passed through with the reasoning suffix split off the last colon), mirroring the subagent resolver, so the defined primary is used and only genuinely failing candidates fall through at runtime. Regressed when bundled workflow model lists were refreshed onto newer multi-provider ids alongside suffix-first reasoning levels ([#1199](https://github.com/bastani-inc/atomic/issues/1199)).
+
 ## [0.8.24-alpha.1] - 2026-06-02
 
 ### Breaking Changes

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -112,7 +112,17 @@ function resolveStringModel(
   }
 
   if (baseModel.includes("/")) {
-    return { input, reason: "not available" };
+    // Trust an explicit provider/model id even when the live catalog does not
+    // list it, mirroring the subagent resolver (resolveModelCandidate's
+    // `if (model.includes("/")) return model;`). The workflow catalog
+    // (ctx.modelRegistry.getAvailable()) can legitimately be a partial view
+    // (auth/provider gating, freshly added models), so treating an absent
+    // fully-qualified id as a hard failure made buildModelCandidates throw and
+    // collapse the whole ordered candidate list down to just the user's
+    // currentModel — discarding the workflow's defined primary and fallbacks.
+    // Pass it through with the reasoning suffix split off; the runtime fallback
+    // loop skips it only if the SDK genuinely cannot create a session for it.
+    return makeCandidate(baseModel, baseModel, level);
   }
 
   const byBareId = models.filter((model) => model.id === baseModel);

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -3773,12 +3773,15 @@ describe("executor.run", () => {
 
     test("invalid dynamic stage model fails before SDK session creation", async () => {
         let creates = 0;
+        // A bare id that cannot be resolved against the catalog is still a hard
+        // configuration error (it is neither provider-qualified nor uniquely
+        // matched), so the run must fail before any SDK session is created.
         const def = defineWorkflow("invalid-stage-model")
             .output("ok", Type.Boolean())
             .run(async (ctx) => {
                 await ctx.task("scout", {
                     prompt: "inspect",
-                    model: "missing/model",
+                    model: "missing-model",
                 });
                 return { ok: true };
             })
@@ -3810,9 +3813,55 @@ describe("executor.run", () => {
         );
 
         assert.equal(result.status, "failed");
-        assert.match(result.error ?? "", /missing\/model \(not available\)/);
+        assert.match(result.error ?? "", /missing-model \(not available\)/);
         assert.equal(creates, 0);
         assert.equal(result.stages[0]?.status, "failed");
+    });
+
+    test("provider-qualified stage model absent from the catalog is trusted and creates a session", async () => {
+        // Regression: a fully-qualified provider/model id that the catalog does
+        // not list must be trusted (passed through), not collapsed to the user's
+        // current model or rejected up front, so the workflow's defined model is
+        // what actually drives the stage session.
+        let createdModel: unknown;
+        let creates = 0;
+        const def = defineWorkflow("trusted-stage-model")
+            .output("ok", Type.Boolean())
+            .run(async (ctx) => {
+                await ctx.task("scout", {
+                    prompt: "inspect",
+                    model: "some-provider/brand-new:high",
+                });
+                return { ok: true };
+            })
+            .compile();
+
+        const result = await run(
+            def,
+            {},
+            {
+                models: {
+                    listModels: async () => [
+                        { provider: "openai", id: "fallback", fullId: "openai/fallback" },
+                    ],
+                },
+                adapters: {
+                    agentSession: {
+                        async create(options: CreateAgentSessionOptions) {
+                            creates += 1;
+                            createdModel = options.model;
+                            return mockSession();
+                        },
+                    },
+                },
+                store: createStore(),
+            },
+        );
+
+        assert.equal(result.status, "completed");
+        assert.equal(creates, 1);
+        assert.equal(createdModel, "some-provider/brand-new");
+        assert.equal(result.stages[0]?.status, "completed");
     });
 
     test("stage snapshot records failed status when stage throws", async () => {
@@ -4195,7 +4244,7 @@ describe("direct SDK helpers", () => {
             {
                 name: "scout",
                 prompt: "inspect repo",
-                model: "missing/model",
+                model: "missing-model",
                 output,
             },
             {},
@@ -4222,7 +4271,7 @@ describe("direct SDK helpers", () => {
         );
 
         assert.equal(details.status, "failed");
-        assert.match(details.error ?? "", /missing\/model \(not available\)/);
+        assert.match(details.error ?? "", /missing-model \(not available\)/);
         assert.equal(creates, 0);
         assert.throws(() => readFileSync(output, "utf8"));
     });

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildModelCandidates,
   buildModelCandidateIds,
+  buildModelCandidatesFromCatalog,
   splitReasoningSuffix,
   isRetryableModelFailure,
   validateWorkflowModels,
@@ -187,21 +188,95 @@ describe("model fallback helpers", () => {
     );
   });
 
-  test("validateWorkflowModels reports all unavailable and ambiguous models", async () => {
+  test("buildModelCandidates trusts a provider-qualified id absent from the catalog instead of failing", () => {
+    // Regression: a fully-qualified provider/id that the live catalog does not
+    // list must be trusted (passed through), mirroring the subagent resolver.
+    // Previously it returned a "not available" failure, which made
+    // buildModelCandidates throw and (via buildModelCandidatesFromCatalog)
+    // collapse the whole ordered list to just the user's currentModel.
+    assert.deepEqual(
+      buildModelCandidates({
+        primaryModel: "openai/gpt-5-mini:high",
+        fallbackModels: ["some-provider/brand-new-model:medium"],
+        currentModel: "anthropic/claude-sonnet-4",
+        availableModels: models,
+        preferredProvider: "anthropic",
+      }).map((candidate) => ({ id: candidate.id, reasoningLevel: candidate.reasoningLevel })),
+      [
+        { id: "openai/gpt-5-mini", reasoningLevel: "high" },
+        { id: "some-provider/brand-new-model", reasoningLevel: "medium" },
+        { id: "anthropic/claude-sonnet-4", reasoningLevel: undefined },
+      ],
+    );
+  });
+
+  test("buildModelCandidatesFromCatalog keeps the defined primary when a fallback provider is absent (regression)", async () => {
+    // The builtin workflows list cross-provider fallbacks. On a partial catalog
+    // (the user only has anthropic configured) the defined primary + fallbacks
+    // must survive ordered, not collapse down to the user's selected model.
+    const recorded: string[] = [];
+    const candidates = await buildModelCandidatesFromCatalog({
+      primaryModel: "openai/gpt-5.5:medium",
+      fallbackModels: [
+        "openai-codex/gpt-5.5:medium",
+        "github-copilot/gpt-5.5:medium",
+        "anthropic/claude-sonnet-4:xhigh",
+      ],
+      catalog: {
+        currentModel: "anthropic/claude-opus-4",
+        preferredProvider: "anthropic",
+        recordWarning: (warning: string) => recorded.push(warning),
+        listModels: async () => [
+          { provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+          { provider: "anthropic", id: "claude-opus-4", fullId: "anthropic/claude-opus-4" },
+        ],
+      },
+    });
+
+    assert.equal(candidates[0]?.id, "openai/gpt-5.5");
+    assert.equal(candidates[0]?.reasoningLevel, "medium");
+    assert.deepEqual(
+      candidates.map((candidate) => candidate.id),
+      [
+        "openai/gpt-5.5",
+        "openai-codex/gpt-5.5",
+        "github-copilot/gpt-5.5",
+        "anthropic/claude-sonnet-4",
+        "anthropic/claude-opus-4",
+      ],
+    );
+    // No catalog-unavailable warning: the catalog resolved fine, the absent
+    // provider-qualified fallbacks were simply trusted rather than collapsed.
+    assert.deepEqual(recorded, []);
+  });
+
+  test("validateWorkflowModels reports unavailable bare ids and ambiguous models", async () => {
     await assert.rejects(
       validateWorkflowModels({
         catalog: { listModels: async () => models },
         requests: [
-          { model: "claude-sonnet-4", fallbackModels: ["openai/missing-model"] },
+          { model: "claude-sonnet-4", fallbackModels: ["missing-model"] },
         ],
       }),
       (err: Error) => {
         assert.ok(err instanceof WorkflowModelValidationError);
         assert.match(err.message, /claude-sonnet-4 \(ambiguous:/);
-        assert.match(err.message, /openai\/missing-model \(not available\)/);
+        assert.match(err.message, /missing-model \(not available\)/);
         return true;
       },
     );
+  });
+
+  test("validateWorkflowModels trusts provider-qualified ids that are absent from the catalog", async () => {
+    // A fully-qualified id is no longer an authoring error just because the
+    // current catalog does not list it (provider/auth gating, new models).
+    const warnings = await validateWorkflowModels({
+      catalog: { listModels: async () => models },
+      requests: [
+        { model: "anthropic/claude-sonnet-4", fallbackModels: ["openai/gpt-7-preview:high"] },
+      ],
+    });
+    assert.deepEqual(warnings, []);
   });
 
   test("validateWorkflowModels warns and falls back to current model when catalog is unavailable", async () => {

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -267,12 +267,14 @@ describe("runtime.runDirect — workflow intercom", () => {
             task: {
                 name: "solo",
                 task: "inspect solo",
-                model: "missing/model",
+                // Bare unresolvable id (no provider prefix) is still a hard config
+                // error; provider-qualified ids are now trusted/passed through.
+                model: "missing-model",
             },
         });
 
         assert.equal(result.status, "failed");
-        assert.match(result.error ?? "", /missing\/model \(not available\)/);
+        assert.match(result.error ?? "", /missing-model \(not available\)/);
         assert.equal(activeStore.runs().length, 0);
     });
 

--- a/test/unit/subagents-reasoning-suffix.test.ts
+++ b/test/unit/subagents-reasoning-suffix.test.ts
@@ -1,9 +1,10 @@
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { buildModelCandidates } from "../../packages/subagents/src/runs/shared/model-fallback.js";
+import { buildModelCandidates, resolveModelCandidate } from "../../packages/subagents/src/runs/shared/model-fallback.js";
 import { applyThinkingSuffix } from "../../packages/subagents/src/runs/shared/pi-args.js";
 import { resolveEffectiveThinking, splitKnownThinkingSuffix } from "../../packages/subagents/src/shared/model-info.js";
 import type { AvailableModelInfo } from "../../packages/subagents/src/runs/shared/model-fallback.js";
+import { parseFrontmatter } from "../../packages/subagents/src/agents/frontmatter.js";
 
 const models: AvailableModelInfo[] = [
   { provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
@@ -42,6 +43,43 @@ describe("subagent suffix-first reasoning helpers", () => {
       ),
       ["anthropic/claude-sonnet-4:high", "anthropic/claude-sonnet-4:medium", "openai/gpt-5:low"],
     );
+  });
+
+  test("provider-qualified config models with ':' separators survive frontmatter parsing and resolution", () => {
+    // The user-facing principle: a subagent config `model:`/`fallbackModels:`
+    // entry may carry a reasoning suffix (and the provider/model id may itself
+    // contain a colon). Frontmatter parsing must keep the full value, and the
+    // resolver must split the reasoning level off the LAST colon while trusting
+    // a fully-qualified id even when it is absent from the live catalog.
+    const { frontmatter } = parseFrontmatter(
+      [
+        "---",
+        "name: custom",
+        "description: custom agent",
+        "model: provider:with-colon/model:off",
+        "fallbackModels: openai/gpt-7-preview:high, anthropic/claude-sonnet-4:medium",
+        "---",
+        "body",
+      ].join("\n"),
+    );
+    // The first ':' splits key from value; every later colon stays in the value.
+    assert.equal(frontmatter.model, "provider:with-colon/model:off");
+    assert.equal(frontmatter.fallbackModels, "openai/gpt-7-preview:high, anthropic/claude-sonnet-4:medium");
+
+    const fallbackModels = frontmatter.fallbackModels.split(",").map((entry) => entry.trim());
+    // openai/gpt-7-preview is absent from `models` but is trusted (pass-through),
+    // not dropped/collapsed; the catalog only disambiguates and rewrites matches.
+    assert.deepEqual(
+      buildModelCandidates(frontmatter.model, fallbackModels, models, "anthropic", "anthropic/claude-sonnet-4:medium"),
+      [
+        "provider:with-colon/model:off",
+        "openai/gpt-7-preview:high",
+        "anthropic/claude-sonnet-4:medium",
+      ],
+    );
+    // A fully-qualified id absent from the catalog resolves to itself.
+    assert.equal(resolveModelCandidate("openai/gpt-7-preview:high", models, "anthropic"), "openai/gpt-7-preview:high");
+    assert.deepEqual(splitKnownThinkingSuffix(frontmatter.model), { baseModel: "provider:with-colon/model", thinkingSuffix: ":off" });
   });
 
   test("fallbackThinkingLevels applies positionally only when fallback has no suffix", () => {


### PR DESCRIPTION
## Summary

Builtin (and any) workflows silently fell back to the user's currently selected model instead of the stage's defined model whenever a `provider/model` id was absent from the live model catalog.

## Root Cause

A fully-qualified `provider/model` id not listed in the live catalog was treated as a hard `"not available"` failure. Candidate validation throws on any failure, and the catalog resolver catches that throw, collapsing the **entire** ordered candidate list down to the user's `currentModel` — so a single absent cross-provider fallback discarded both the defined primary **and every fallback**. This regressed when bundled workflow model lists were refreshed onto newer multi-provider ids alongside suffix-first reasoning levels.

## Changes

- **`packages/workflows/src/runs/shared/model-fallback.ts`**: `resolveStringModel` now trusts an explicit `provider/model` id even when the live catalog does not list it — passes it through with the reasoning suffix split off the last colon, mirroring the subagent resolver (`resolveModelCandidate`'s `if (model.includes("/")) return model`). Bare unresolvable ids (no provider prefix) remain a hard configuration error.
- **Tests** (`executor`, `model-fallback`, `runtime`, `subagents-reasoning-suffix`): regression coverage verifying that:
  - A provider-qualified id absent from the catalog is trusted and drives the stage session
  - The defined primary + fallbacks survive ordered on a partial catalog
  - Bare unresolvable ids still fail before SDK session creation

## Breaking Changes

None.

Refs [#1199](https://github.com/bastani-inc/atomic/issues/1199)