### PR TITLE
feat(subagents): sync upstream acceptance fanout patches

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Synced upstream dynamic fanout and acceptance-gate support for subagent chains, including `.chain.json` discovery, named chain outputs, structured subagent output capture, workflow graph status rendering, and explicit acceptance contracts.
+
+### Fixed
+
+- Synced the upstream final-output fix so multi-part assistant responses use the last non-empty text part as the subagent's final output.
+
 ## [0.8.24-alpha.2] - 2026-06-03
 
 ### Changed

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -250,7 +250,7 @@ Skip this section until you want exact syntax.
 | `/run <agent> [task]` | Run one agent; omit the task for self-contained agents |
 | `/chain agent1 "task1" -> agent2 "task2"` | Run agents in sequence |
 | `/parallel agent1 "task1" -> agent2 "task2"` | Run agents in parallel |
-| `/run-chain <chainName> -- <task>` | Launch a saved `.chain.md` workflow |
+| `/run-chain <chainName> -- <task>` | Launch a saved `.chain.md` or `.chain.json` workflow |
 | `/subagents-doctor` | Show read-only setup diagnostics |
 
 Commands validate agent names locally, support tab completion, and send results back into the conversation.
@@ -494,14 +494,14 @@ When `extensions` is present, it takes precedence over extension paths implied b
 
 ## Chain files
 
-Chains are reusable `.chain.md` workflows stored separately from agent files.
+Chains are reusable workflows stored separately from agent files. Use `.chain.md` for simple sequential saved chains. Use `.chain.json` when a chain needs dynamic fanout.
 
 | Scope | Path |
 |-------|------|
-| User | `~/.atomic/agent/chains/**/*.chain.md` |
-| Project | `.atomic/chains/**/*.chain.md` |
+| User | `~/.atomic/agent/chains/**/*.chain.md`, `~/.atomic/agent/chains/**/*.chain.json` |
+| Project | `.atomic/chains/**/*.chain.md`, `.atomic/chains/**/*.chain.json` |
 
-Nested subdirectories are discovered recursively. If user and project scopes define the same parsed runtime chain name, the project chain wins. Chains support the same optional `package` frontmatter as agents; `name: review-flow` plus `package: code-analysis` runs as `code-analysis.review-flow`.
+Nested subdirectories are discovered recursively. If both `.chain.md` and `.chain.json` define the same parsed runtime chain name in the same scope, `.chain.json` wins. If user and project scopes define the same parsed runtime chain name, the project chain wins. Chains support the same optional `package` frontmatter as agents; `name: review-flow` plus `package: code-analysis` runs as `code-analysis.review-flow`.
 
 Example:
 
@@ -512,23 +512,67 @@ description: Gather context then plan implementation
 ---
 
 ## scout
+phase: Context
+label: Map auth flow
+as: context
 output: context.md
 
 Analyze the codebase for {task}
 
 ## planner
+phase: Planning
+label: Implementation plan
 reads: context.md
 model: anthropic/claude-sonnet-4-5:high
 progress: true
 
-Create an implementation plan based on {previous}
+Create an implementation plan based on {outputs.context}
 ```
 
-Each `## agent-name` section is a step. Config lines such as `output`, `outputMode`, `reads`, `model`, `skills`, and `progress` go immediately after the header. A blank line separates config from task text.
+Each `.chain.md` `## agent-name` section is a step. Config lines such as `phase`, `label`, `as`, `outputSchema`, `output`, `outputMode`, `reads`, `model`, `skills`, and `progress` go immediately after the header. A blank line separates config from task text. In saved `.chain.md` files, `outputSchema` is a path to a JSON Schema file; direct tool calls and `.chain.json` files can pass the schema object inline.
 
 For `output`, `reads`, `skills`, and `progress`, chain behavior is three-state: omitted inherits from the agent, a value overrides, and `false` disables.
 
-Create chains by writing `.chain.md` files directly or with the `subagent({ action: "create", config: ... })` management action. Run them with natural language or:
+Use `phase` to group related work in status output, `label` for a readable step name, and `as` to store a successful step or parallel task result for later `{outputs.name}` references. Duplicate `as` names, invalid identifiers, and unknown output references fail before child execution.
+
+Dynamic fanout is available only through direct `subagent({ chain: [...] })` JSON or saved `.chain.json` files. It expands an array from a prior structured named output, runs one child template per item, and stores the ordered collection under `collect.as`. The source must be structured output; prose is never parsed. `expand.maxItems` is required, over-limit arrays fail, nested fanout and arbitrary expressions are not supported, and `.chain.md` has no dynamic syntax in this release.
+
+```json
+{
+  "name": "dynamic-review",
+  "description": "Find review targets, fan out reviewers, then synthesize.",
+  "chain": [
+    {
+      "agent": "scout",
+      "task": "Return {\"items\":[{\"path\":\"...\",\"reason\":\"...\"}]} via structured_output.",
+      "as": "targets",
+      "outputSchema": { "type": "object" }
+    },
+    {
+      "expand": {
+        "from": { "output": "targets", "path": "/items" },
+        "item": "target",
+        "key": "/path",
+        "maxItems": 12
+      },
+      "parallel": {
+        "agent": "reviewer",
+        "label": "Review {target.path}",
+        "task": "Review {target.path}. Reason: {target.reason}",
+        "outputSchema": { "type": "object" }
+      },
+      "collect": { "as": "reviews" },
+      "concurrency": 4
+    },
+    {
+      "agent": "worker",
+      "task": "Synthesize fixes from {outputs.reviews}"
+    }
+  ]
+}
+```
+
+Create simple `.chain.md` chains by writing files directly or with the `subagent({ action: "create", config: ... })` management action. Create dynamic `.chain.json` chains by writing the JSON file directly. Run saved chains with natural language or:
 
 ```text
 /run-chain scout-planner -- refactor authentication
@@ -543,6 +587,7 @@ Task templates support:
 | `{task}` | Original task from the first step. |
 | `{previous}` | Output from the prior step, or aggregated output from a parallel step. |
 | `{chain_dir}` | Path to the chain artifact directory. |
+| `{outputs.name}` | Text value from a prior step or completed parallel task with `as: "name"`. |
 
 Parallel outputs are aggregated with clear separators before being passed to the next step:
 
@@ -638,13 +683,48 @@ These are the parameters the LLM passes when it calls the `subagent` tool. Most 
 
 // Chain with fan-out/fan-in
 { chain: [
-  { agent: "scout", task: "Gather context" },
+  { agent: "scout", task: "Gather context", phase: "Context", label: "Map code", as: "context" },
   { parallel: [
-    { agent: "worker", task: "Implement feature A from {previous}" },
-    { agent: "worker", task: "Implement feature B from {previous}" }
+    { agent: "worker", task: "Implement feature A from {outputs.context}", label: "Feature A", as: "featureA" },
+    { agent: "worker", task: "Implement feature B from {outputs.context}", label: "Feature B", as: "featureB" }
   ], concurrency: 2, failFast: true },
-  { agent: "reviewer", task: "Review all changes from {previous}" }
+  { agent: "reviewer", task: "Review {outputs.featureA} and {outputs.featureB}" }
 ]}
+
+// Dynamic fanout from structured output
+{ chain: [
+  {
+    agent: "scout",
+    task: "Return review targets as structured_output: { items: [{ path, reason }] }",
+    as: "targets",
+    outputSchema: { type: "object" }
+  },
+  {
+    expand: { from: { output: "targets", path: "/items" }, item: "target", key: "/path", maxItems: 12 },
+    parallel: { agent: "reviewer", task: "Review {target.path}. Reason: {target.reason}", outputSchema: { type: "object" } },
+    collect: { as: "reviews" },
+    concurrency: 4
+  },
+  { agent: "worker", task: "Synthesize fixes from {outputs.reviews}" }
+] }
+
+// Strict structured output for reliable handoff data
+{ chain: [
+  {
+    agent: "scout",
+    task: "Return the key files and risks for {task}",
+    as: "scan",
+    outputSchema: {
+      type: "object",
+      required: ["files", "risks"],
+      properties: {
+        files: { type: "array", items: { type: "string" } },
+        risks: { type: "array", items: { type: "string" } }
+      }
+    }
+  },
+  { agent: "planner", task: "Plan from this scan: {outputs.scan}" }
+] }
 
 // Worktree isolation
 { tasks: [
@@ -715,10 +795,10 @@ Agent definitions are not loaded into context by default. Management actions let
 | `outputMode` | `"inline" \| "file-only"` | `inline` | Return saved output inline or as a concise saved-file reference. `file-only` requires an `output` path. |
 | `skill` | `string \| string[] \| false` | agent default | Override skills or disable all. |
 | `model` | string | agent default | Override model. |
-| `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `reads`, `progress`, `skill`, and `model`. |
+| `tasks` | array | - | Top-level parallel tasks. Supports `agent`, `task`, `cwd`, `count`, `output`, `outputMode`, `reads`, `progress`, `skill`, `model`, and `acceptance`. |
 | `concurrency` | number | config or `4` | Top-level parallel concurrency. |
 | `worktree` | boolean | false | Create isolated git worktrees for parallel tasks. |
-| `chain` | array | - | Sequential and parallel chain steps. |
+| `chain` | array | - | Sequential, static parallel, and dynamic fanout chain steps. Steps and chain parallel tasks support `phase`, `label`, `as`, `outputSchema`, and `acceptance` in addition to the usual execution fields. Dynamic fanout uses `expand`, one child `parallel` template, and `collect`. |
 | `context` | `fresh \| fork` | agent default or `fresh` | `fork` creates real branched sessions from the parent leaf. Packaged `planner`, `worker`, and `oracle` default to `fork`. |
 | `chainDir` | string | temp chain dir | Persistent directory for chain artifacts. |
 | `clarify` | boolean | true for chains | Show TUI preview/edit flow. |
@@ -730,12 +810,13 @@ Agent definitions are not loaded into context by default. Management actions let
 | `includeProgress` | boolean | false | Include full progress in result. |
 | `share` | boolean | false | Upload session export to GitHub Gist. |
 | `sessionDir` | string | derived | Override session log directory. |
+| `acceptance` | string/object/false | inferred | Override the run's inferred acceptance gates. Use `"auto"`, `"attested"`, `"checked"`, `"verified"`, `"reviewed"`, or `{ level: "none", reason: "..." }`. |
 
 `context: "fork"` fails fast when the parent session is not persisted, the current leaf is missing, or the branched child session cannot be created. It never silently downgrades to `fresh`. In multi-agent runs, if any requested agent has `defaultContext: fork` and the launch omits `context`, the whole invocation uses forked context; pass `context: "fresh"` when you intentionally want a fresh run.
 
 Use `outputMode: "file-only"` when a saved output may be large and the parent only needs a pointer. The returned text is a compact reference like `Output saved to: /abs/report.md (48.2 KB, 2847 lines). Read this file if needed.` Failed runs and save errors still return normal inline output for debugging. In chains, later `{previous}` steps receive the same compact reference when the prior step used file-only mode.
 
-Sequential and parallel chain tasks accept `agent`, `task`, `cwd`, `output`, `outputMode`, `reads`, `progress`, `skill`, and `model`. Parallel tasks also accept `count`. Parallel step groups accept `parallel`, `concurrency`, `failFast`, and `worktree`.
+Sequential and parallel chain tasks accept `agent`, `task`, `phase`, `label`, `as`, `outputSchema`, `cwd`, `output`, `outputMode`, `reads`, `progress`, `skill`, and `model`. Parallel tasks also accept `count`. Parallel step groups accept `parallel`, `concurrency`, `failFast`, and `worktree`. If `outputSchema` is present, the child must call `structured_output` with schema-valid JSON; prose-only completion or invalid JSON fails the step. Validated structured values are preserved on the step result, and `as` also exposes a compact text representation through `{outputs.name}`.
 
 Status and control actions:
 
@@ -905,13 +986,43 @@ Async runs write:
 
 `status.json` powers the widget and `subagent({ action: "status" })` output. `events.jsonl` contains wrapper events plus child Pi JSON events annotated with run and step metadata. `output-<n>.log` is a live human-readable tail. Fallback information is persisted so background runs are debuggable after completion.
 
+## Acceptance Gates
+
+Every run resolves an effective acceptance policy. Callers may omit `acceptance` for the inferred default, or set it on single runs, top-level parallel task items, chain steps, static parallel tasks, and dynamic fanout templates.
+
+```ts
+{
+  agent: "worker",
+  task: "Implement the fix",
+  acceptance: {
+    level: "verified",
+    criteria: ["Patch the bug without widening scope"],
+    evidence: ["changed-files", "tests-added", "commands-run", "residual-risks", "no-staged-files"],
+    verify: [{ id: "focused", command: "npm test", timeoutMs: 120000 }]
+  }
+}
+```
+
+Accepted levels are `auto`, `none`, `attested`, `checked`, `verified`, and `reviewed`. `acceptance: "auto"` is the default. Read-only reviewer/scout tasks infer lightweight attestation, normal writer tasks infer checked evidence, and async/risky/dynamic writer contexts infer a reviewed gate. To disable gates, prefer `{ level: "none", reason: "..." }`.
+
+Acceptance provenance is stored separately from child prose:
+
+- `claimed`: child finished but did not provide structured evidence.
+- `attested`: child returned a structured acceptance report.
+- `checked`: runtime structural checks passed, such as required evidence and no staged files.
+- `verified`: configured runtime verification commands passed. Child-reported command success does not count.
+- `reviewed`: an independent reviewer result is present.
+- `rejected`: attestation, structural checks, verification, or review failed.
+
+For `attested` or stricter levels, the child prompt includes a standardized acceptance section and asks for a fenced `acceptance-report` JSON block. Explicit failed gates fail the run. Inferred gates are persisted for observability without breaking older calls that omit `acceptance`.
+
 ## Live progress
 
-Foreground runs show compact live progress for single, chain, and parallel modes: current tool, recent output, token counts, duration, activity freshness, and current-tool duration.
+Foreground runs show compact live progress for single, chain, and parallel modes: current tool, recent output, token counts, duration, activity freshness, current-tool duration, and chain graph metadata when available.
 
 Press `CTRL+O` to expand the full streaming view with complete output per step.
 
-Sequential chains show a flow line like `done scout → running planner`. Chains with parallel steps show per-step cards instead.
+Sequential chains show a flow line like `done scout → running planner`. Chains with parallel steps show per-step cards instead. Chain status uses `label` and `phase` metadata when present, while falling back to agent names for older chains.
 
 ## Session sharing
 
@@ -936,12 +1047,12 @@ Configure the limit with:
 3. `maxSubagentDepth` in agent frontmatter, which can only tighten the inherited limit
 
 ```bash
-export PI_SUBAGENT_MAX_DEPTH=3
-export PI_SUBAGENT_MAX_DEPTH=1
-export PI_SUBAGENT_MAX_DEPTH=0
+export ATOMIC_SUBAGENT_MAX_DEPTH=3
+export ATOMIC_SUBAGENT_MAX_DEPTH=1
+export ATOMIC_SUBAGENT_MAX_DEPTH=0
 ```
 
-`PI_SUBAGENT_DEPTH` is internal and propagated automatically. Do not set it manually.
+`ATOMIC_SUBAGENT_DEPTH` is internal and propagated automatically. Do not set it manually. Legacy `PI_SUBAGENT_MAX_DEPTH` and `PI_SUBAGENT_DEPTH` are still read for compatibility.
 
 ## Events
 

--- a/packages/subagents/prompts/parallel-context-build.md
+++ b/packages/subagents/prompts/parallel-context-build.md
@@ -4,14 +4,16 @@ description: Parallel codebase specialists building handoff context for planning
 
 Launch fresh-context codebase specialists in parallel to build grounded handoff context for planning or implementation.
 
-Use the `subagent` tool in chain mode with a single parallel step, not top-level parallel tasks, so relative output files live under the temporary chain directory. Use `context: "fresh"` unless I explicitly ask for forked context. Give every parallel task a distinct `output` path, for example:
+Use the `subagent` tool in chain mode with a single parallel step, not top-level parallel tasks, so relative output files live under the temporary chain directory. Use `context: "fresh"` unless I explicitly ask for forked context. Give every parallel task a distinct `output` path, `label`, and `as` name, for example:
 
 - `context-build/where-it-lives.md`
 - `context-build/how-it-works.md`
 - `context-build/existing-patterns.md`
 - `context-build/prior-research.md`
 
-Do not write these artifacts into the repository unless I explicitly ask for persistent files.
+Use one phase such as `phase: "Context build"` for the parallel tasks so async status is readable. A later synthesis step can reference specific outputs with `{outputs.requestScope}`, `{outputs.codebasePatterns}`, and `{outputs.validationRisks}` instead of relying only on `{previous}`.
+
+Do not write these context artifacts into the repository unless I explicitly ask for persistent files.
 
 Treat the slash command arguments as the primary request, target, or focus:
 

--- a/packages/subagents/prompts/parallel-handoff-plan.md
+++ b/packages/subagents/prompts/parallel-handoff-plan.md
@@ -20,13 +20,15 @@ Parallel discovery step. Choose the specialists that apply:
 - `codebase-pattern-finder` — add when transferable conventions or analogous implementations would shape the plan.
 - `codebase-research-locator` and `codebase-research-analyzer` — add when prior `research/` or `specs/` docs likely apply. Run them sequentially (locator first, then analyzer) or pair them inside the parallel step with distinct output paths.
 
-Use distinct output paths under the chain directory. Example outputs:
+Use distinct output paths, `label` values, and `as` names under the chain directory. Example outputs:
 
 - `handoff/external-reference.md`
 - `handoff/local-files.md`
 - `handoff/local-flow.md`
 - `handoff/local-patterns.md`
 - `handoff/prior-research.md`
+
+Use phases such as `Research`, `Local context`, and `Synthesis` so async status is readable. Prefer `{outputs.externalReference}`, `{outputs.localContext}`, and `{outputs.implementationStrategy}` in the synthesis task when those specific inputs are available; keep `{previous}` only when the whole parallel fan-in summary is the desired input.
 
 Do not write these artifacts into the repository unless I explicitly ask for persistent files.
 

--- a/packages/subagents/skills/subagent/SKILL.md
+++ b/packages/subagents/skills/subagent/SKILL.md
@@ -35,7 +35,7 @@ Humans often use the slash-command layer instead:
 - `/run` — launch a single agent
 - `/chain` — launch a chain of steps
 - `/parallel` — launch top-level parallel tasks
-- `/run-chain` — launch a saved `.chain.md` workflow
+- `/run-chain` — launch a saved `.chain.md` or `.chain.json` workflow
 - `/subagents-doctor` — diagnose setup, discovery, async paths, and intercom bridge state
 
 Prefer the tool when you are writing agent logic. Prefer the slash commands when you are guiding a human through an interactive flow.
@@ -112,7 +112,40 @@ Use this at the start of non-trivial work. Launch `codebase-locator` and `codeba
 
 ### Parallel cleanup technique
 
-Use this after implementation when the user wants cleanup review or when a final pass would reduce AI-slop. Launch two fresh-context `codebase-analyzer` scouts with `output: false` and `progress: false`: one deslop pass and one verbosity pass. If the `deslop` or `verbosity-cleaner` skills are available, pass the relevant skill to that scout; otherwise inline the criteria. Both scouts are read-only and should flag concrete issues with severity, file/line references, and smallest safe fixes. The parent decides what to apply and asks before making changes unless cleanup was already authorized. When the user opts to autofix, the parent launches one async `code-simplifier` writer with the synthesized fixes as its explicit scope.
+Use this after implementation when the user wants cleanup review or when a final pass would reduce AI-slop. Launch two fresh-context `codebase-analyzer` scouts with `output: false` and `progress: false`: one deslop pass and one verbosity pass. If the `deslop` or `verbosity-cleaner` skills are available, pass the relevant skill to that scout; otherwise inline the criteria. Both scouts are read-only and should flag concrete issues with severity, file/line references, and smallest safe fixes. Phrase the constraint as “Do not modify project/source files; returning findings through the configured output artifact is allowed” when you use `output` or `outputMode: "file-only"`. The parent decides what to apply and asks before making changes unless cleanup was already authorized. When the user opts to autofix, the parent launches one async `code-simplifier` writer with the synthesized fixes as its explicit scope.
+
+### Staged fix orchestration technique
+
+Use this when a broad diff has known reviewer findings across several items and the user wants the parent to coordinate a safe multi-stage fix. Keep the active worktree safe with a three-stage chain:
+
+1. A parallel read-only planning fanout, one specialist per issue cluster. Use `codebase-analyzer`, `debugger` in inspect-only mode, or `codebase-pattern-finder` based on the angle. Each child inspects the real diff and returns exact files, line refs, proposed fixes, and focused validation. They must not edit.
+2. One writer worker (`debugger` for correctness fixes or `code-simplifier` for cleanup fixes). It receives the planner summaries through `{previous}` or named `{outputs.name}` values, the parent’s accepted scope, stop rules, and verification contract. It is the only child allowed to edit the active worktree.
+3. A parallel read-only validation fanout. Validators inspect the worker diff from fresh context with distinct angles, report pass/fail, remaining blockers, and missing verification.
+
+Prefer `async: true`, `context: "fresh"` for planners/validators, `outputMode: "file-only"` for large summaries, and per-stage output names that will not collide. Add `phase` and `label` to make async status readable, and use `as` plus `{outputs.name}` when a later step needs a specific earlier result instead of the whole `{previous}` blob. Use this pattern instead of launching several writer workers into a dirty worktree. Include non-blocking suggestions in the writer prompt only when they are small, safe, and do not expand product scope; otherwise record them as deferred.
+
+When the first step can return a structured target list, prefer dynamic fanout instead of hand-authoring a static parallel group. Use `outputSchema` and `as` on the producer, then an `expand` step with `from: { output, path }`, an explicit `maxItems`, one `parallel` child template, and `collect.as`. Item templates may use `{item}` or a named item such as `{target.path}`. Do not use dynamic fanout for prose outputs, nested fanout, dynamic agent selection, reducers, `when` conditions, or arbitrary expressions; `.chain.md` does not support this syntax, so use direct JSON or a saved `.chain.json`.
+
+Example shape:
+
+```typescript
+subagent({
+  async: true,
+  context: "fresh",
+  chain: [
+    { parallel: [
+      { agent: "codebase-analyzer", phase: "Planning", label: "Deploy docs", as: "deployPlan", task: "Plan fixes for deploy docs/workflow. Inspect the current diff. Do not modify project/source files; returning findings via the configured output artifact is allowed.", output: "plans/deploy.md", outputMode: "file-only" },
+      { agent: "debugger", phase: "Planning", label: "Scheduler contract", as: "schedulerPlan", task: "Inspect-only plan for scheduler contract fixes. Do not edit. Return exact fixes and focused validation.", output: "plans/scheduler.md", outputMode: "file-only" },
+      { agent: "codebase-pattern-finder", phase: "Planning", label: "Sandbox patterns", as: "sandboxPlan", task: "Find existing patterns relevant to sandbox/security fixes. Do not edit.", output: "plans/sandbox.md", outputMode: "file-only" }
+    ], concurrency: 3 },
+    { agent: "debugger", phase: "Implementation", label: "Apply accepted fixes", as: "workerResult", task: "Apply only the accepted fixes from these planning summaries. You are the sole writer for the active worktree. Run focused validation and report changed files, commands, failures, and remaining issues.\n\nDeploy plan:\n{outputs.deployPlan}\n\nScheduler plan:\n{outputs.schedulerPlan}\n\nSandbox plan:\n{outputs.sandboxPlan}", output: "worker/fixes.md", outputMode: "file-only", progress: true },
+    { parallel: [
+      { agent: "codebase-analyzer", phase: "Validation", label: "Deploy/scheduler validation", task: "Validate the post-worker diff for deploy and scheduler fixes. Start from the worker result: {outputs.workerResult}. Do not modify project/source files; returning findings via the configured output artifact is allowed.", output: "validation/deploy-scheduler.md", outputMode: "file-only" },
+      { agent: "debugger", phase: "Validation", label: "Failure-mode validation", task: "Inspect-only failure-mode hunt on the post-worker diff. Start from the worker result: {outputs.workerResult}. Do not edit.", output: "validation/failure-modes.md", outputMode: "file-only" }
+    ], concurrency: 2 }
+  ]
+})
+```
 
 ## Builtin Agents
 
@@ -189,11 +222,10 @@ Agent files can live in:
 - legacy `.agents/**/*.md` and `.pi/agents/**/*.md` — still read for compatibility, but `.atomic/agents/` wins on conflicts
 
 Chains live in:
+- `~/.atomic/agent/chains/**/*.chain.md` and `~/.atomic/agent/chains/**/*.chain.json` — user scope
+- `.atomic/chains/**/*.chain.md` and `.atomic/chains/**/*.chain.json` — project scope
 
-- `~/.atomic/agent/chains/**/*.chain.md` — user scope
-- `.atomic/chains/**/*.chain.md` — project scope
-
-Discovery is recursive. `.chain.md` files do not define agents. Agents and chains can set optional frontmatter `package: code-analysis`; `name: codebase-analyzer` plus `package: code-analysis` registers as runtime name `code-analysis.codebase-analyzer` while serialization keeps `name` and `package` separate.
+Discovery is recursive. `.chain.md` files do not define agents. Use `.chain.md` for simple saved chains and `.chain.json` for dynamic fanout or inline schema objects. Agents and chains can set optional frontmatter/package metadata; `name: codebase-analyzer` plus `package: code-analysis` registers as runtime name `code-analysis.codebase-analyzer` while serialization keeps `name` and `package` separate.
 
 Precedence is by parsed runtime name:
 
@@ -264,7 +296,7 @@ subagent({
 })
 ```
 
-Chain steps can use templated variables such as `{task}`, `{previous}`, and `{chain_dir}`. This is the main way to pass structured summaries between steps without forcing each step to rediscover everything.
+Chain steps can use templated variables such as `{task}`, `{previous}`, `{chain_dir}`, and `{outputs.name}`. Use `as: "name"` on a successful step or parallel task to make that output available to later steps. Prefer named outputs when a later step needs one specific result; keep `{previous}` for simple linear handoffs or full fan-in summaries. Use `phase` and `label` for status readability. Use `outputSchema` when later steps need reliable structured data; the child must call `structured_output` with schema-valid JSON, or the step fails.
 
 ### Async/background
 
@@ -599,7 +631,9 @@ For feature work, use this sequence as scaffolding for parent-agent behavior:
 clarify → validation contract → parallel discovery → async writer (debugger or code-simplifier) → parallel async fresh-context specialist reviewers → async fix writer → follow-up review when warranted → parent review
 ```
 
-The validation contract defines what done means before code is written: expected behavior, acceptance checks, commands or user flows to exercise, and evidence the writer should return. Keep it lightweight for small tasks, but make it explicit enough that reviewers are checking the intended outcome rather than the writer's own assumptions.
+The validation contract defines acceptance before code is written: expected behavior, acceptance checks, commands or user flows to exercise, and evidence the writer should return. Keep it lightweight for small tasks, but make it explicit enough that reviewers and validators are checking the intended outcome rather than the writer’s own assumptions.
+
+Use the structured `acceptance` field when the run should carry an explicit acceptance contract. If omitted, subagents infer an effective acceptance policy from role, mode, and risk. Use `level: "checked"` for ordinary writer evidence gates, `level: "verified"` when the runtime should run explicit validation commands, and `level: "reviewed"` only when an independent reviewer result is expected. Do not call a run reviewed just because the writer says it is done; reviewed means a reviewer gate returned a result. Child-reported command success is evidence, not runtime verification.
 
 The first writer implements the approved change. The parent continues with independent inspection or validation prep while it runs, not parallel edits to the same worktree. When the async writer completes, treat its handoff as the transition into review, not as final completion, unless the user explicitly asked for writer-only work, review-only output, or to stop after implementation. Parallel specialist reviewers inspect the resulting diff from fresh context. The final fix writer applies synthesized review fixes, then the parent looks over the final diff before completing. The parent may launch these steps as an initial async chain when the workflow is already clear, or as follow-up subagent runs after each async completion. Initial chains should pass `async: true` so the main chat is unblocked; avoid `clarify: true` unless the user asked for foreground clarification. Do not stop after parallel review unless the user explicitly asked for review-only output or the review surfaced a decision that needs approval first.
 
@@ -609,8 +643,8 @@ For very large work, split into serial milestones instead of launching a swarm o
 
 Keep orchestration authority in the parent session. Child subagents should not launch more subagents, read this skill, or run their own orchestration loops unless the parent intentionally selected an explicit fanout agent whose resolved builtin `tools` includes `subagent` for that assigned fanout. Spawned non-fanout subagents do not receive the `subagent` skill, parent-only status/control/slash messages, prior parent `subagent` tool-call/tool-result artifacts, or the `subagent` extension tool. Child context filtering also strips old hidden orchestration-instruction messages when they appear in inherited history. Every child also receives a boundary instruction that says the parent owns orchestration, the child must not propose or run subagents unless explicitly authorized for fanout, and writer children must call real edit/write tools instead of printing pseudo tool calls. Pass children concrete role-specific work instead.
 
-1. Clarify first. Gather code context with `codebase-locator`, `codebase-analyzer`, `codebase-pattern-finder`, and prior research specialists; add `codebase-online-researcher` only when external evidence matters; then ask the user clarifying questions with `interview` until scope, acceptance criteria, constraints, and non-goals are clear.
-2. Define the validation contract. State what done means before implementation: expected behavior, checks to run, user flows to exercise, and evidence required in the writer handoff. For UI, CLI, integration, or workflow changes, include at least one validator angle that uses the product the way a user would rather than only reading code.
+1. Clarify first. This is mandatory. Gather code context with `codebase-locator`, `codebase-analyzer`, `codebase-pattern-finder`, and prior research specialists; add `codebase-online-researcher` only when external evidence matters; then ask the user clarifying questions with `interview` until scope, acceptance criteria, constraints, and non-goals are clear.
+2. Define the validation contract. State acceptance before implementation: expected behavior, checks to run, user flows to exercise, and evidence required in the writer handoff. For UI, CLI, integration, or workflow changes, include at least one validator angle that uses the product the way a user would rather than only reading code.
 3. Plan when useful. For complex work, write a plan doc yourself and get approval before implementation. For simple work, confirm shared understanding and explicitly note why planning is skipped.
 4. Implement with one writer. After approval, launch `debugger` (for correctness-shaped work) or `code-simplifier` (for refinement-shaped work) asynchronously with a proper meta prompt that includes clarified requirements, relevant context, plan path or summary, the validation contract, and output expectations. While it runs, prepare validation or inspect adjacent code instead of editing the same worktree.
 5. Require a useful writer handoff. Ask the writer to report changed files, what was implemented, what was left undone, commands run with exit codes, validation evidence, surprises or new risks, decisions made inside approved scope, and decisions needing parent approval.
@@ -625,6 +659,10 @@ Example writer handoff after clarification and optional planning:
 subagent({
   agent: "debugger",
   task: "Implement the approved fix.\n\nClarified requirements:\n- ...\n\nPlan: see ~/Documents/docs/...-plan.md\n\nValidation contract:\n- ...\n\nReturn a handoff with changed files, what was implemented, what was left undone, commands run with exit codes, validation evidence, surprises/new risks, and decisions needing parent approval.",
+  acceptance: {
+    level: "checked",
+    evidence: ["changed-files", "tests-added", "commands-run", "residual-risks", "no-staged-files"]
+  },
   async: true
 })
 ```
@@ -679,7 +717,7 @@ subagent({
 /run-chain review-chain -- review this branch
 ```
 
-Use saved `.chain.md` workflows when the user wants a repeatable multi-agent flow without rewriting the chain each time.
+Use saved `.chain.md` or `.chain.json` workflows when the user wants a repeatable multi-agent flow without rewriting the chain each time. Prefer `.chain.json` for dynamic fanout or inline `outputSchema` objects; `.chain.md` remains the simple sequential/static authoring format.
 
 ## Error Handling
 

--- a/packages/subagents/src/agents/agent-management.ts
+++ b/packages/subagents/src/agents/agent-management.ts
@@ -17,7 +17,7 @@ import {
 	parsePackageName,
 } from "./agents.ts";
 import { serializeAgent } from "./agent-serializer.ts";
-import { serializeChain } from "./chain-serializer.ts";
+import { serializeChain, serializeJsonChain } from "./chain-serializer.ts";
 import { discoverAvailableSkills } from "./skills.ts";
 import type { SubagentToolResult } from "../shared/types.ts";
 
@@ -116,10 +116,31 @@ function nameExistsInScope(cwd: string, scope: ManagementScope, name: string, ex
 	return false;
 }
 
+function chainStepAgentNames(step: ChainStepConfig): string[] {
+	const names: string[] = [];
+	if (typeof step.agent === "string") names.push(step.agent);
+	const parallel = step.parallel;
+	if (Array.isArray(parallel)) {
+		for (const item of parallel) {
+			if (item && typeof item === "object") {
+				const agent = (item as { agent?: unknown }).agent;
+				if (typeof agent === "string") names.push(agent);
+			}
+		}
+	} else if (parallel && typeof parallel === "object") {
+		const agent = (parallel as { agent?: unknown }).agent;
+		if (typeof agent === "string") names.push(agent);
+	}
+	return names;
+}
+
 function unknownChainAgents(cwd: string, steps: ChainStepConfig[]): string[] {
 	const d = discoverAgentsAll(cwd);
 	const known = new Set(allAgents(d).map((a) => a.name));
-	return [...new Set(steps.map((s) => s.agent).filter((a) => !known.has(a)))].sort((a, b) => a.localeCompare(b));
+	const unknown = steps
+		.flatMap((step) => chainStepAgentNames(step))
+		.filter((agent) => !known.has(agent));
+	return [...new Set(unknown)].sort((a, b) => a.localeCompare(b));
 }
 
 function chainStepWarnings(ctx: ManagementContext, steps: ChainStepConfig[]): string[] {
@@ -169,6 +190,22 @@ function parseStepList(raw: unknown): { steps?: ChainStepConfig[]; error?: strin
 		const s = item as Record<string, unknown>;
 		if (typeof s.agent !== "string" || !s.agent.trim()) return { error: `config.steps[${i}].agent must be a non-empty string.` };
 		const step: ChainStepConfig = { agent: s.agent.trim(), task: typeof s.task === "string" ? s.task : "" };
+		if (hasKey(s, "phase")) {
+			if (typeof s.phase === "string") step.phase = s.phase;
+			else return { error: `config.steps[${i}].phase must be a string.` };
+		}
+		if (hasKey(s, "label")) {
+			if (typeof s.label === "string") step.label = s.label;
+			else return { error: `config.steps[${i}].label must be a string.` };
+		}
+		if (hasKey(s, "as")) {
+			if (typeof s.as === "string") step.as = s.as;
+			else return { error: `config.steps[${i}].as must be a string.` };
+		}
+		if (hasKey(s, "outputSchema")) {
+			if (typeof s.outputSchema === "string") step.outputSchema = s.outputSchema;
+			else return { error: `config.steps[${i}].outputSchema must be a schema file path string for saved chains.` };
+		}
 		if (hasKey(s, "output")) {
 			if (s.output === false) step.output = false;
 			else if (typeof s.output === "string") step.output = s.output;
@@ -345,7 +382,7 @@ function renamePath(
 	cwd: string,
 ): { filePath?: string; error?: string } {
 	if (nameExistsInScope(cwd, scope, newName, currentPath)) return { error: `Name '${newName}' already exists in ${scope} scope.` };
-	const ext = kind === "agent" ? ".md" : ".chain.md";
+	const ext = kind === "agent" ? ".md" : currentPath.endsWith(".chain.json") ? ".chain.json" : ".chain.md";
 	const filePath = path.join(path.dirname(currentPath), `${newName}${ext}`);
 	if (fs.existsSync(filePath) && filePath !== currentPath) {
 		return { error: `File already exists at ${filePath} but is not a valid ${kind} definition. Remove or rename it first.` };
@@ -381,6 +418,41 @@ function formatAgentDetail(agent: AgentConfig): string {
 	return lines.join("\n");
 }
 
+function formatChainStepDetail(step: ChainStepConfig, index: number): string[] {
+	const lines: string[] = [];
+	if (step.expand || step.collect) {
+		const parallel = step.parallel && !Array.isArray(step.parallel) && typeof step.parallel === "object" ? step.parallel as { agent?: unknown; task?: unknown; label?: unknown; outputSchema?: unknown } : undefined;
+		const expand = step.expand && typeof step.expand === "object" ? step.expand as { from?: { output?: unknown; path?: unknown }; item?: unknown; key?: unknown; maxItems?: unknown; onEmpty?: unknown } : undefined;
+		const collect = step.collect && typeof step.collect === "object" ? step.collect as { as?: unknown; outputSchema?: unknown } : undefined;
+		lines.push(`${index + 1}. Dynamic fanout${typeof collect?.as === "string" ? ` -> ${collect.as}` : ""}`);
+		if (expand?.from) lines.push(`   Expand: ${String(expand.from.output ?? "?")}${String(expand.from.path ?? "")}`);
+		if (typeof expand?.item === "string") lines.push(`   Item variable: ${expand.item}`);
+		if (typeof expand?.key === "string") lines.push(`   Key: ${expand.key}`);
+		if (typeof expand?.maxItems === "number") lines.push(`   Max items: ${expand.maxItems}`);
+		if (typeof expand?.onEmpty === "string") lines.push(`   On empty: ${expand.onEmpty}`);
+		if (parallel?.agent) lines.push(`   Agent: ${String(parallel.agent)}`);
+		if (typeof parallel?.label === "string") lines.push(`   Label: ${parallel.label}`);
+		if (typeof parallel?.task === "string" && parallel.task.trim()) lines.push(`   Task: ${parallel.task}`);
+		if (parallel?.outputSchema) lines.push("   Structured output: true");
+		if (collect?.outputSchema) lines.push("   Collect schema: true");
+		if (step.concurrency !== undefined) lines.push(`   Concurrency: ${step.concurrency}`);
+		if (step.failFast !== undefined) lines.push(`   Fail fast: ${step.failFast ? "true" : "false"}`);
+		return lines;
+	}
+	lines.push(`${index + 1}. ${step.agent}`);
+	if (step.task?.trim()) lines.push(`   Task: ${step.task}`);
+	if (step.output === false) lines.push("   Output: false");
+	else if (step.output) lines.push(`   Output: ${step.output}`);
+	if (step.outputMode) lines.push(`   Output mode: ${step.outputMode}`);
+	if (step.reads === false) lines.push("   Reads: false");
+	else if (Array.isArray(step.reads) && step.reads.length > 0) lines.push(`   Reads: ${step.reads.join(", ")}`);
+	if (step.model) lines.push(`   Model: ${step.model}`);
+	if (step.skills === false) lines.push("   Skills: false");
+	else if (Array.isArray(step.skills) && step.skills.length > 0) lines.push(`   Skills: ${step.skills.join(", ")}`);
+	if (step.progress !== undefined) lines.push(`   Progress: ${step.progress ? "true" : "false"}`);
+	return lines;
+}
+
 function formatChainDetail(chain: ChainConfig): string {
 	const lines: string[] = [`Chain: ${chain.name} (${chain.source})`, `Path: ${chain.filePath}`, `Description: ${chain.description}`];
 	if (chain.packageName) {
@@ -389,18 +461,7 @@ function formatChainDetail(chain: ChainConfig): string {
 	}
 	lines.push("", "Steps:");
 	for (let i = 0; i < chain.steps.length; i++) {
-		const s = chain.steps[i]!;
-		lines.push(`${i + 1}. ${s.agent}`);
-		if (s.task.trim()) lines.push(`   Task: ${s.task}`);
-		if (s.output === false) lines.push("   Output: false");
-		else if (s.output) lines.push(`   Output: ${s.output}`);
-		if (s.outputMode) lines.push(`   Output mode: ${s.outputMode}`);
-		if (s.reads === false) lines.push("   Reads: false");
-		else if (Array.isArray(s.reads) && s.reads.length > 0) lines.push(`   Reads: ${s.reads.join(", ")}`);
-		if (s.model) lines.push(`   Model: ${s.model}`);
-		if (s.skills === false) lines.push("   Skills: false");
-		else if (Array.isArray(s.skills) && s.skills.length > 0) lines.push(`   Skills: ${s.skills.join(", ")}`);
-		if (s.progress !== undefined) lines.push(`   Progress: ${s.progress ? "true" : "false"}`);
+		lines.push(...formatChainStepDetail(chain.steps[i]!, i));
 	}
 	return lines.join("\n");
 }
@@ -411,6 +472,7 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Su
 	const scopedAgents = allAgents(d).filter((a) => scope === "both" || a.source === "builtin" || a.source === scope).sort((a, b) => a.name.localeCompare(b.name));
 	const agents = scopedAgents.filter((a) => !a.disabled);
 	const chains = d.chains.filter((c) => scope === "both" || c.source === scope).sort((a, b) => a.name.localeCompare(b.name));
+	const diagnostics = d.chainDiagnostics.filter((entry) => scope === "both" || entry.source === scope);
 	const lines = [
 		"Executable agents:",
 		...(agents.length
@@ -419,6 +481,7 @@ export function handleList(params: ManagementParams, ctx: ManagementContext): Su
 		"",
 		"Chains:",
 		...(chains.length ? chains.map((c) => `- ${c.name} (${c.source}): ${c.description}`) : ["- (none)"]),
+		...(diagnostics.length ? ["", "Chain diagnostics:", ...diagnostics.map((entry) => `- ${entry.filePath}: ${entry.error}`)] : []),
 	];
 	return result(lines.join("\n"));
 }
@@ -614,7 +677,7 @@ export function handleUpdate(params: ManagementParams, ctx: ManagementContext): 
 		if (renamed.error) return result(renamed.error, true);
 		updated.filePath = renamed.filePath!;
 	}
-	fs.writeFileSync(updated.filePath, serializeChain(updated), "utf-8");
+	fs.writeFileSync(updated.filePath, updated.filePath.endsWith(".chain.json") ? serializeJsonChain(updated) : serializeChain(updated), "utf-8");
 	const headline = updated.name === oldName
 		? `Updated chain '${updated.name}' at ${updated.filePath}.`
 		: `Updated chain '${oldName}' to '${updated.name}' at ${updated.filePath}.`;

--- a/packages/subagents/src/agents/agents.ts
+++ b/packages/subagents/src/agents/agents.ts
@@ -7,9 +7,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { CONFIG_DIR_NAME, getAgentConfigPaths, getEnvValue, getProjectConfigDirs } from "@bastani/atomic";
-import type { OutputMode } from "../shared/types.ts";
+import type { AcceptanceInput, OutputMode } from "../shared/types.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
-import { parseChain } from "./chain-serializer.ts";
+import { parseChain, parseJsonChain } from "./chain-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
 import { parseFrontmatter } from "./frontmatter.ts";
 import { buildRuntimeName, parsePackageName } from "./identity.ts";
@@ -111,14 +111,25 @@ interface SubagentSettings {
 const EMPTY_SUBAGENT_SETTINGS: SubagentSettings = { overrides: {} };
 
 export interface ChainStepConfig {
-	agent: string;
-	task: string;
+	agent?: string;
+	task?: string;
+	phase?: string;
+	label?: string;
+	as?: string;
+	outputSchema?: string | Record<string, unknown>;
 	output?: string | false;
 	outputMode?: OutputMode;
 	reads?: string[] | false;
 	model?: string;
 	skills?: string[] | false;
 	progress?: boolean;
+	parallel?: unknown;
+	expand?: unknown;
+	collect?: unknown;
+	concurrency?: number;
+	failFast?: boolean;
+	worktree?: boolean;
+	acceptance?: AcceptanceInput;
 }
 
 export interface ChainConfig {
@@ -130,6 +141,12 @@ export interface ChainConfig {
 	filePath: string;
 	steps: ChainStepConfig[];
 	extraFields?: Record<string, string>;
+}
+
+export interface ChainDiscoveryDiagnostic {
+	source: "user" | "project";
+	filePath: string;
+	error: string;
 }
 
 interface AgentDiscoveryResult {
@@ -582,7 +599,7 @@ export function removeBuiltinAgentOverride(cwd: string, name: string, scope: "us
 	return filePath;
 }
 
-function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) => boolean): string[] {
+function listFilesRecursive(dir: string, predicate: (fileName: string) => boolean): string[] {
 	const files: string[] = [];
 	if (!fs.existsSync(dir)) return files;
 
@@ -596,7 +613,7 @@ function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) =
 	for (const entry of entries) {
 		const filePath = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
-			files.push(...listMarkdownFilesRecursive(filePath, predicate));
+			files.push(...listFilesRecursive(filePath, predicate));
 			continue;
 		}
 		if (!entry.isFile() && !entry.isSymbolicLink()) continue;
@@ -609,7 +626,7 @@ function listMarkdownFilesRecursive(dir: string, predicate: (fileName: string) =
 function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
-	for (const filePath of listMarkdownFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
+	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
 		let content: string;
 		try {
 			content = fs.readFileSync(filePath, "utf-8");
@@ -741,10 +758,11 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
 	return agents;
 }
 
-function loadChainsFromDir(dir: string, source: "user" | "project"): ChainConfig[] {
-	const chains: ChainConfig[] = [];
+function loadChainsFromDir(dir: string, source: "user" | "project"): { chains: ChainConfig[]; diagnostics: ChainDiscoveryDiagnostic[] } {
+	const chains = new Map<string, ChainConfig>();
+	const diagnostics: ChainDiscoveryDiagnostic[] = [];
 
-	for (const filePath of listMarkdownFilesRecursive(dir, (fileName) => fileName.endsWith(".chain.md"))) {
+	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".chain.md") || fileName.endsWith(".chain.json"))) {
 		let content: string;
 		try {
 			content = fs.readFileSync(filePath, "utf-8");
@@ -753,13 +771,17 @@ function loadChainsFromDir(dir: string, source: "user" | "project"): ChainConfig
 		}
 
 		try {
-			chains.push(parseChain(content, source, filePath));
-		} catch {
+			const chain = filePath.endsWith(".chain.json") ? parseJsonChain(content, source, filePath) : parseChain(content, source, filePath);
+			const existing = chains.get(chain.name);
+			if (existing && existing.filePath.endsWith(".chain.json") && filePath.endsWith(".chain.md")) continue;
+			chains.set(chain.name, chain);
+		} catch (error) {
+			diagnostics.push({ source, filePath, error: error instanceof Error ? error.message : String(error) });
 			continue;
 		}
 	}
 
-	return chains;
+	return { chains: Array.from(chains.values()), diagnostics };
 }
 
 function isDirectory(p: string): boolean {
@@ -836,6 +858,7 @@ export function discoverAgentsAll(cwd: string): {
 	user: AgentConfig[];
 	project: AgentConfig[];
 	chains: ChainConfig[];
+	chainDiagnostics: ChainDiscoveryDiagnostic[];
 	userDir: string;
 	projectDir: string | null;
 	userChainDir: string;
@@ -875,19 +898,27 @@ export function discoverAgentsAll(cwd: string): {
 	const project = Array.from(projectMap.values());
 
 	const chainMap = new Map<string, ChainConfig>();
+	const projectChainDiagnostics: ChainDiscoveryDiagnostic[] = [];
 	for (const dir of projectChainDirs) {
-		for (const chain of loadChainsFromDir(dir, "project")) {
+		const loaded = loadChainsFromDir(dir, "project");
+		projectChainDiagnostics.push(...loaded.diagnostics);
+		for (const chain of loaded.chains) {
 			chainMap.set(chain.name, chain);
 		}
 	}
+	const userChainLoads = getUserChainDirs().map((dir) => loadChainsFromDir(dir, "user"));
 	const chains = [
-		...getUserChainDirs().flatMap((dir) => loadChainsFromDir(dir, "user")),
+		...userChainLoads.flatMap((loaded) => loaded.chains),
 		...Array.from(chainMap.values()),
+	];
+	const chainDiagnostics = [
+		...userChainLoads.flatMap((loaded) => loaded.diagnostics),
+		...projectChainDiagnostics,
 	];
 
 	const legacyUserAgentDir = userDirOld[0]!;
 	// ATOMIC_CODING_AGENT_DIR is already applied by getUserAgentDirs(); prefer that resolved path over ~/.agents.
 	const userDir = getEnvValue("ATOMIC_CODING_AGENT_DIR") ? legacyUserAgentDir : fs.existsSync(userDirNew) ? userDirNew : legacyUserAgentDir;
 
-	return { builtin, user, project, chains, userDir, projectDir, userChainDir, projectChainDir, userSettingsPath, projectSettingsPath };
+	return { builtin, user, project, chains, chainDiagnostics, userDir, projectDir, userChainDir, projectChainDir, userSettingsPath, projectSettingsPath };
 }

--- a/packages/subagents/src/agents/chain-serializer.ts
+++ b/packages/subagents/src/agents/chain-serializer.ts
@@ -1,6 +1,9 @@
 import type { ChainConfig, ChainStepConfig } from "./agents.ts";
 import { buildRuntimeName, frontmatterNameForConfig, parsePackageName } from "./identity.ts";
 import { parseFrontmatter } from "./frontmatter.ts";
+import { ChainOutputValidationError, validateChainOutputBindings } from "../runs/shared/chain-outputs.ts";
+import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
+import type { ChainStep } from "../shared/settings.ts";
 
 function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 	const lines = sectionBody.split("\n");
@@ -18,6 +21,25 @@ function parseStepBody(agent: string, sectionBody: string): ChainStepConfig {
 		if (key === "output") {
 			if (rawValue === "false") step.output = false;
 			else if (rawValue) step.output = rawValue;
+			continue;
+		}
+		if (key === "phase") {
+			if (rawValue) step.phase = rawValue;
+			continue;
+		}
+		if (key === "label") {
+			if (rawValue) step.label = rawValue;
+			continue;
+		}
+		if (key === "as") {
+			if (rawValue) step.as = rawValue;
+			continue;
+		}
+		if (key === "outputschema") {
+			if (rawValue.startsWith("{") || rawValue.startsWith("[")) {
+				throw new Error("Inline outputSchema values are not supported in .chain.md files; use a schema file path.");
+			}
+			if (rawValue) step.outputSchema = rawValue;
 			continue;
 		}
 		if (key === "outputmode") {
@@ -102,6 +124,94 @@ export function parseChain(content: string, source: "user" | "project", filePath
 	};
 }
 
+export function parseJsonChain(content: string, source: "user" | "project", filePath: string): ChainConfig {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(content);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON chain '${filePath}': ${message}`);
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`JSON chain '${filePath}' must contain an object root.`);
+	}
+	const input = parsed as Record<string, unknown>;
+	if (typeof input.name !== "string" || !input.name.trim()) {
+		throw new Error(`JSON chain '${filePath}' must include string name.`);
+	}
+	if (typeof input.description !== "string" || !input.description.trim()) {
+		throw new Error(`JSON chain '${filePath}' must include string description.`);
+	}
+	if (!Array.isArray(input.chain)) {
+		throw new Error(`JSON chain '${filePath}' must include array chain.`);
+	}
+	for (let i = 0; i < input.chain.length; i++) {
+		const step = input.chain[i];
+		if (!step || typeof step !== "object" || Array.isArray(step)) {
+			throw new Error(`JSON chain '${filePath}' step ${i + 1} must be an object.`);
+		}
+		const stepRecord = step as Record<string, unknown>;
+		const acceptanceErrors = validateAcceptanceInput(stepRecord.acceptance, `step ${i + 1} acceptance`);
+		if (acceptanceErrors.length > 0) {
+			throw new Error(`Invalid JSON chain '${filePath}': ${acceptanceErrors.join(" ")}`);
+		}
+		const parallel = stepRecord.parallel;
+		if (Array.isArray(parallel)) {
+			for (let taskIndex = 0; taskIndex < parallel.length; taskIndex++) {
+				const task = parallel[taskIndex];
+				if (!task || typeof task !== "object" || Array.isArray(task)) continue;
+				const taskErrors = validateAcceptanceInput((task as Record<string, unknown>).acceptance, `step ${i + 1} parallel task ${taskIndex + 1} acceptance`);
+				if (taskErrors.length > 0) {
+					throw new Error(`Invalid JSON chain '${filePath}': ${taskErrors.join(" ")}`);
+				}
+			}
+		} else if (parallel && typeof parallel === "object") {
+			const templateErrors = validateAcceptanceInput((parallel as Record<string, unknown>).acceptance, `step ${i + 1} dynamic template acceptance`);
+			if (templateErrors.length > 0) {
+				throw new Error(`Invalid JSON chain '${filePath}': ${templateErrors.join(" ")}`);
+			}
+		}
+	}
+	try {
+		validateChainOutputBindings(input.chain as ChainStep[], { maxItems: Number.MAX_SAFE_INTEGER });
+	} catch (error) {
+		if (error instanceof ChainOutputValidationError) throw new Error(`Invalid JSON chain '${filePath}': ${error.message}`);
+		throw error;
+	}
+	const parsedPackage = parsePackageName(typeof input.package === "string" ? input.package : undefined, `Chain '${input.name}' package`);
+	if (parsedPackage.error) throw new Error(parsedPackage.error);
+	const extraFields: Record<string, string> = {};
+	for (const [key, value] of Object.entries(input)) {
+		if (key === "name" || key === "package" || key === "description" || key === "chain") continue;
+		if (typeof value === "string") extraFields[key] = value;
+	}
+	return {
+		name: buildRuntimeName(input.name.trim(), parsedPackage.packageName),
+		localName: input.name.trim(),
+		packageName: parsedPackage.packageName,
+		description: input.description.trim(),
+		source,
+		filePath,
+		steps: input.chain as ChainStepConfig[],
+		extraFields: Object.keys(extraFields).length > 0 ? extraFields : undefined,
+	};
+}
+
+export function serializeJsonChain(config: ChainConfig): string {
+	const root: Record<string, unknown> = {
+		name: frontmatterNameForConfig(config),
+		description: config.description,
+		chain: config.steps,
+	};
+	if (config.packageName) root.package = config.packageName;
+	if (config.extraFields) {
+		for (const [key, value] of Object.entries(config.extraFields)) {
+			if (key !== "name" && key !== "description" && key !== "package" && key !== "chain") root[key] = value;
+		}
+	}
+	return `${JSON.stringify(root, null, 2)}\n`;
+}
+
 export function serializeChain(config: ChainConfig): string {
 	const lines: string[] = [];
 	lines.push("---");
@@ -121,6 +231,10 @@ export function serializeChain(config: ChainConfig): string {
 		lines.push(`## ${step.agent}`);
 		if (step.output === false) lines.push("output: false");
 		else if (step.output) lines.push(`output: ${step.output}`);
+		if (step.phase) lines.push(`phase: ${step.phase}`);
+		if (step.label) lines.push(`label: ${step.label}`);
+		if (step.as) lines.push(`as: ${step.as}`);
+		if (step.outputSchema) lines.push(`outputSchema: ${step.outputSchema}`);
 		if (step.outputMode) lines.push(`outputMode: ${step.outputMode}`);
 		if (step.reads === false) lines.push("reads: false");
 		else if (Array.isArray(step.reads) && step.reads.length > 0) lines.push(`reads: ${step.reads.join(", ")}`);

--- a/packages/subagents/src/extension/schemas.ts
+++ b/packages/subagents/src/extension/schemas.ts
@@ -35,6 +35,82 @@ const ReadsOverride = Type.Unsafe({
 	description: "Files to read before running (array of filenames), or false to disable",
 });
 
+const JsonSchemaObject = Type.Unsafe({
+	type: "object",
+	additionalProperties: true,
+	description: "JSON Schema object for strict structured output. Non-object roots are rejected.",
+});
+
+const AcceptanceEvidenceKind = Type.String({
+	enum: [
+		"changed-files",
+		"tests-added",
+		"commands-run",
+		"validation-output",
+		"residual-risks",
+		"no-staged-files",
+		"diff-summary",
+		"review-findings",
+		"manual-notes",
+	],
+});
+
+const AcceptanceGateSchema = Type.Object({
+	id: Type.String(),
+	must: Type.String(),
+	evidence: Type.Optional(Type.Array(AcceptanceEvidenceKind)),
+	severity: Type.Optional(Type.String({ enum: ["required", "recommended"] })),
+}, { additionalProperties: false });
+
+const AcceptanceVerifyCommandSchema = Type.Object({
+	id: Type.String(),
+	command: Type.String(),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+	cwd: Type.Optional(Type.String()),
+	env: Type.Optional(Type.Unsafe({ type: "object", additionalProperties: { type: "string" } })),
+	allowFailure: Type.Optional(Type.Boolean()),
+}, { additionalProperties: false });
+
+const AcceptanceReviewGateSchema = Type.Object({
+	agent: Type.Optional(Type.String()),
+	focus: Type.Optional(Type.String()),
+	required: Type.Optional(Type.Boolean()),
+}, { additionalProperties: false });
+
+const AcceptanceOverride = Type.Unsafe({
+	anyOf: [
+		{ type: "string", enum: ["auto", "none", "attested", "checked", "verified", "reviewed"] },
+		{ const: false },
+		{
+			type: "object",
+			properties: {
+				level: { type: "string", enum: ["auto", "none", "attested", "checked", "verified", "reviewed"] },
+				criteria: {
+					type: "array",
+					items: {
+						anyOf: [
+							{ type: "string" },
+							AcceptanceGateSchema,
+						],
+					},
+				},
+				evidence: { type: "array", items: AcceptanceEvidenceKind },
+				verify: { type: "array", items: AcceptanceVerifyCommandSchema },
+				review: {
+					anyOf: [
+						{ const: false },
+						AcceptanceReviewGateSchema,
+					],
+				},
+				stopRules: { type: "array", items: { type: "string" } },
+				reason: { type: "string" },
+			},
+			additionalProperties: false,
+		},
+	],
+	description: "Optional acceptance policy. Omitted means auto-inferred; verified requires configured runtime commands.",
+});
+
 const TaskItem = Type.Object({
 	agent: Type.String(), 
 	task: Type.String(), 
@@ -46,12 +122,17 @@ const TaskItem = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking for this task" })),
 	model: Type.Optional(Type.String({ description: "Override model for this task (e.g. 'google/gemini-3-pro')" })),
 	skill: Type.Optional(SkillOverride),
+	acceptance: Type.Optional(AcceptanceOverride),
 });
 
 // Parallel task item (within a parallel step)
 const ParallelTaskSchema = Type.Object({
 	agent: Type.String(),
 	task: Type.Optional(Type.String({ description: "Task template with {task}, {previous}, {chain_dir} variables. Defaults to {previous}." })),
+	phase: Type.Optional(Type.String({ description: "Optional phase/group label for status and graph rendering." })),
+	label: Type.Optional(Type.String({ description: "Optional user-facing label for this parallel task." })),
+	as: Type.Optional(Type.String({ description: "Optional safe identifier used as {outputs.name} in later chain steps." })),
+	outputSchema: Type.Optional(JsonSchemaObject),
 	cwd: Type.Optional(Type.String()),
 	count: Type.Optional(Type.Integer({ minimum: 1, description: "Repeat this parallel task N times with the same settings." })),
 	output: Type.Optional(OutputOverride),
@@ -60,14 +141,51 @@ const ParallelTaskSchema = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this task" })),
+	acceptance: Type.Optional(AcceptanceOverride),
 });
+
+const DynamicExpandSchema = Type.Object({
+	from: Type.Object({
+		output: Type.String({ description: "Prior named structured output to expand from." }),
+		path: Type.String({ description: "JSON Pointer into the structured output, e.g. /items." }),
+	}, { additionalProperties: false }),
+	item: Type.Optional(Type.String({ description: "Template variable name for each item. Defaults to item." })),
+	key: Type.Optional(Type.String({ description: "JSON Pointer relative to each item for stable child ids." })),
+	maxItems: Type.Optional(Type.Integer({ minimum: 0, description: "Required fanout bound unless configured globally." })),
+	onEmpty: Type.Optional(Type.String({ enum: ["skip", "fail"], description: "Empty input behavior. Defaults to skip." })),
+}, { additionalProperties: false });
+
+const DynamicParallelTemplateSchema = Type.Object({
+	agent: Type.String(),
+	task: Type.Optional(Type.String({ description: "Task template with {item}, {item.path}, {task}, {previous}, {chain_dir}, and {outputs.name} variables." })),
+	phase: Type.Optional(Type.String({ description: "Optional phase/group label for status and graph rendering." })),
+	label: Type.Optional(Type.String({ description: "Optional user-facing label; item templates are supported." })),
+	outputSchema: Type.Optional(JsonSchemaObject),
+	cwd: Type.Optional(Type.String()),
+	output: Type.Optional(OutputOverride),
+	outputMode: Type.Optional(OutputModeOverride),
+	reads: Type.Optional(ReadsOverride),
+	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
+	skill: Type.Optional(SkillOverride),
+	model: Type.Optional(Type.String({ description: "Override model for this task" })),
+	acceptance: Type.Optional(AcceptanceOverride),
+}, { additionalProperties: false });
+
+const DynamicCollectSchema = Type.Object({
+	as: Type.String({ description: "Safe output name for the ordered collected result array." }),
+	outputSchema: Type.Optional(JsonSchemaObject),
+}, { additionalProperties: false });
 
 // Flattened so chain steps do not need an object-shape anyOf/oneOf union.
 const ChainItem = Type.Object({
 	agent: Type.Optional(Type.String({ description: "Sequential step agent name" })),
 	task: Type.Optional(Type.String({
-		description: "Task template with variables: {task}=original request, {previous}=prior step's text response, {chain_dir}=shared folder. Required for first step, defaults to '{previous}' for subsequent steps."
+		description: "Task template with variables: {task}=original request, {previous}=prior step's text response, {chain_dir}=shared folder, {outputs.name}=prior named output. Required for first step, defaults to '{previous}' for subsequent steps."
 	})),
+	phase: Type.Optional(Type.String({ description: "Optional phase/group label for status and graph rendering." })),
+	label: Type.Optional(Type.String({ description: "Optional user-facing label for this chain step." })),
+	as: Type.Optional(Type.String({ description: "Optional safe identifier used as {outputs.name} in later chain steps." })),
+	outputSchema: Type.Optional(JsonSchemaObject),
 	cwd: Type.Optional(Type.String()),
 	output: Type.Optional(OutputOverride),
 	outputMode: Type.Optional(OutputModeOverride),
@@ -75,13 +193,30 @@ const ChainItem = Type.Object({
 	progress: Type.Optional(Type.Boolean({ description: "Enable progress.md tracking in {chain_dir}" })),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for this step" })),
-	parallel: Type.Optional(Type.Array(ParallelTaskSchema, { minItems: 1, description: "Tasks to run in parallel" })),
+	acceptance: Type.Optional(AcceptanceOverride),
+	parallel: Type.Optional(Type.Unsafe({
+		anyOf: [
+			Type.Array(ParallelTaskSchema, { minItems: 1, description: "Tasks to run in parallel" }),
+			DynamicParallelTemplateSchema,
+		],
+		description: "Static parallel tasks array, or a single dynamic fanout child template when expand/collect are present.",
+	})),
+	expand: Type.Optional(DynamicExpandSchema),
+	collect: Type.Optional(DynamicCollectSchema),
 	concurrency: Type.Optional(Type.Number({ description: "Max concurrent tasks (default: 4)" })),
 	failFast: Type.Optional(Type.Boolean({ description: "Stop on first failure (default: false)" })),
 	worktree: Type.Optional(Type.Boolean({
 		description: "Create isolated git worktrees for each parallel task."
 	})),
-}, { description: "Chain step: use {agent, task?, ...} for sequential or {parallel: [...]} for concurrent execution" });
+}, {
+	description: "Chain step: use {agent, task?, ...} for sequential, {parallel: [...]} for static concurrent execution, or {expand, parallel: {...}, collect} for dynamic fanout.",
+	additionalProperties: false,
+	allOf: [
+		{ if: { required: ["expand"] }, then: { required: ["parallel", "collect"], properties: { parallel: { type: "object" } } } },
+		{ if: { required: ["collect"] }, then: { required: ["expand", "parallel"], properties: { parallel: { type: "object" } } } },
+		{ not: { required: ["expand"], properties: { parallel: { type: "array", items: {} } } } },
+	],
+});
 
 const ControlOverrides = Type.Object({
 	enabled: Type.Optional(Type.Boolean({ description: "Enable/disable subagent control attention tracking for this run" })),
@@ -165,4 +300,5 @@ export const SubagentParams = Type.Object({
 	outputMode: Type.Optional(OutputModeOverride),
 	skill: Type.Optional(SkillOverride),
 	model: Type.Optional(Type.String({ description: "Override model for single agent (e.g. 'anthropic/claude-sonnet-4')" })),
+	acceptance: Type.Optional(AcceptanceOverride),
 });

--- a/packages/subagents/src/runs/background/async-execution.ts
+++ b/packages/subagents/src/runs/background/async-execution.ts
@@ -11,7 +11,7 @@ import { APP_NAME, getEnvValue, type ExtensionAPI } from "@bastani/atomic";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { applyThinkingSuffix, SUBAGENT_INTERCOM_SESSION_NAME_ENV } from "../shared/pi-args.ts";
 import { injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
-import { buildChainInstructions, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
+import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../../agents/skills.ts";
@@ -24,7 +24,12 @@ import {
 	resolveSubagentModelFastModeMetadata,
 } from "../../shared/fast-mode.ts";
 import { resolveExpectedWorktreeAgentCwd } from "../shared/worktree.ts";
+import { buildWorkflowGraphSnapshot } from "../shared/workflow-graph.ts";
+import { ChainOutputValidationError, validateChainOutputBindings } from "../shared/chain-outputs.ts";
+import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
+import { resolveEffectiveAcceptance } from "../shared/acceptance.ts";
 import {
+	type AcceptanceInput,
 	type ArtifactConfig,
 	type Details,
 	type MaxOutputConfig,
@@ -112,6 +117,7 @@ interface AsyncChainParams {
 	sessionRoot?: string;
 	chainSkills?: string[];
 	sessionFilesByFlatIndex?: (string | undefined)[];
+	dynamicFanoutMaxItems?: number;
 	maxSubagentDepth: number;
 	workflowStageSubagentGuard?: boolean;
 	worktreeSetupHook?: string;
@@ -120,6 +126,7 @@ interface AsyncChainParams {
 	controlIntercomTarget?: string;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
 	nestedRoute?: NestedRouteInfo;
+	acceptance?: AcceptanceInput;
 }
 
 interface AsyncSingleParams {
@@ -147,6 +154,7 @@ interface AsyncSingleParams {
 	controlIntercomTarget?: string;
 	childIntercomTarget?: (agent: string, index: number) => string | undefined;
 	nestedRoute?: NestedRouteInfo;
+	acceptance?: AcceptanceInput;
 }
 
 interface AsyncExecutionResult {
@@ -262,12 +270,25 @@ export function executeAsyncChain(
 	const runnerCwd = resolveChildCwd(ctx.cwd, cwd);
 	const firstStep = chain[0];
 	const originalTask = params.task ?? (firstStep
-		? (isParallelStep(firstStep) ? firstStep.parallel[0]?.task : (firstStep as SequentialStep).task)
+		? (isParallelStep(firstStep)
+			? firstStep.parallel[0]?.task
+			: isDynamicParallelStep(firstStep)
+				? firstStep.parallel.task
+				: (firstStep as SequentialStep).task)
 		: undefined);
+	try {
+		validateChainOutputBindings(chain, { maxItems: params.dynamicFanoutMaxItems });
+	} catch (error) {
+		if (error instanceof ChainOutputValidationError) return formatAsyncStartError(resultMode, error.message);
+		throw error;
+	}
+	const workflowGraph = buildWorkflowGraphSnapshot({ runId: id, mode: resultMode, steps: chain });
 
 	for (const s of chain) {
 		const stepAgents = isParallelStep(s)
 			? s.parallel.map((t) => t.agent)
+			: isDynamicParallelStep(s)
+				? [s.parallel.agent]
 			: [(s as SequentialStep).agent];
 		for (const agentName of stepAgents) {
 			if (!agents.find((x) => x.name === agentName)) {
@@ -330,7 +351,10 @@ export function executeAsyncChain(
 		const outputPath = resolveSingleOutputPath(behavior.output, ctx.cwd, instructionCwd);
 		const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Async step (${s.agent})`);
 		if (validationError) throw new AsyncStartValidationError(validationError);
-		const task = injectSingleOutputInstruction(`${readInstructions.prefix}${s.task ?? "{previous}"}${progressInstructions.suffix}`, outputPath);
+		let taskTemplate = s.task ?? "{previous}";
+		taskTemplate = taskTemplate.replace(/\{task\}/g, originalTask ?? "");
+		taskTemplate = taskTemplate.replace(/\{chain_dir\}/g, runnerCwd);
+		const task = injectSingleOutputInstruction(`${readInstructions.prefix}${taskTemplate}${progressInstructions.suffix}`, outputPath);
 
 		const primaryModel = resolveModelCandidate(behavior.model ?? a.model, availableModels, ctx.currentModelProvider);
 		const model = applyThinkingSuffix(primaryModel, a.thinking);
@@ -341,6 +365,10 @@ export function executeAsyncChain(
 		return {
 			agent: s.agent,
 			task,
+			phase: s.phase,
+			label: s.label,
+			outputName: s.as,
+			structured: Boolean(s.outputSchema),
 			cwd: stepCwd,
 			model,
 			thinking: resolveEffectiveThinking(model, a.thinking),
@@ -362,6 +390,16 @@ export function executeAsyncChain(
 			sessionFile,
 			maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, a.maxSubagentDepth),
 			workflowStageSubagentGuard,
+			effectiveAcceptance: resolveEffectiveAcceptance({
+				explicit: s.acceptance,
+				agentName: s.agent,
+				task: s.task,
+				mode: resultMode,
+				async: true,
+				dynamic: false,
+			}),
+			...(s.outputSchema ? { structuredOutputSchema: s.outputSchema } : {}),
+			...(s.outputSchema ? { structuredOutput: createStructuredOutputRuntime(s.outputSchema, path.join(asyncDir, "structured-output")) } : {}),
 		};
 	};
 
@@ -402,6 +440,32 @@ export function executeAsyncChain(
 					worktree: s.worktree,
 				};
 			}
+			if (isDynamicParallelStep(s)) {
+				const agent = agents.find((candidate) => candidate.name === s.parallel.agent)!;
+				const behavior = suppressProgressForReadOnlyTask(resolveStepBehavior(agent, buildStepOverrides(s.parallel), chainSkills), s.parallel.task, originalTask);
+				const progressPrecreated = behavior.progress;
+				if (progressPrecreated) {
+					writeInitialProgressFile(runnerCwd);
+					progressInstructionCreated = true;
+				}
+				return {
+					expand: s.expand,
+					parallel: buildSeqStep(s.parallel as SequentialStep, undefined, undefined, progressPrecreated, behavior),
+					collect: s.collect,
+					concurrency: s.concurrency,
+					failFast: s.failFast,
+					phase: s.phase,
+					label: s.label,
+					effectiveAcceptance: resolveEffectiveAcceptance({
+						explicit: s.acceptance,
+						agentName: s.parallel.agent,
+						task: s.parallel.task,
+						mode: resultMode,
+						async: true,
+						dynamicGroup: true,
+					}),
+				};
+			}
 			return buildSeqStep(s as SequentialStep, nextSessionFile());
 		});
 	} catch (error) {
@@ -411,6 +475,10 @@ export function executeAsyncChain(
 	let childTargetIndex = 0;
 	const childIntercomTargets = childIntercomTarget ? steps.flatMap((step) => {
 		if ("parallel" in step) {
+			if (!Array.isArray(step.parallel)) {
+				childTargetIndex++;
+				return [undefined];
+			}
 			return step.parallel.map((task) => childIntercomTarget(task.agent, childTargetIndex++));
 		}
 		return [childIntercomTarget(step.agent, childTargetIndex++)];
@@ -440,6 +508,8 @@ export function executeAsyncChain(
 				controlIntercomTarget,
 				childIntercomTargets,
 				resultMode,
+				dynamicFanoutMaxItems: params.dynamicFanoutMaxItems,
+				workflowGraph,
 				nestedRoute: nestedRoute ?? inheritedNestedRoute,
 				workflowStageSubagentGuard,
 				nestedSelf: inheritedNestedRoute && nestedAddress ? {
@@ -465,6 +535,8 @@ export function executeAsyncChain(
 		const firstStep = chain[0];
 		const firstAgents = isParallelStep(firstStep)
 			? firstStep.parallel.map((t) => t.agent)
+			: isDynamicParallelStep(firstStep)
+				? [firstStep.parallel.agent]
 			: [(firstStep as SequentialStep).agent];
 		const parallelGroups: Array<{ start: number; count: number; stepIndex: number }> = [];
 		const flatAgents: string[] = [];
@@ -475,6 +547,10 @@ export function executeAsyncChain(
 				parallelGroups.push({ start: flatStepStart, count: step.parallel.length, stepIndex });
 				flatAgents.push(...step.parallel.map((task) => task.agent));
 				flatStepStart += step.parallel.length;
+			} else if (isDynamicParallelStep(step)) {
+				parallelGroups.push({ start: flatStepStart, count: 1, stepIndex });
+				flatAgents.push(step.parallel.agent);
+				flatStepStart++;
 			} else {
 				flatAgents.push((step as SequentialStep).agent);
 				flatStepStart++;
@@ -523,12 +599,15 @@ export function executeAsyncChain(
 			agents: flatAgents,
 			task: isParallelStep(firstStep)
 				? firstStep.parallel[0]?.task?.slice(0, 50)
+				: isDynamicParallelStep(firstStep)
+					? firstStep.parallel.task?.slice(0, 50)
 				: (firstStep as SequentialStep).task?.slice(0, 50),
 			chain: chain.map((s) =>
-				isParallelStep(s) ? `[${s.parallel.map((t) => t.agent).join("+")}]` : (s as SequentialStep).agent,
+				isParallelStep(s) ? `[${s.parallel.map((t) => t.agent).join("+")}]` : isDynamicParallelStep(s) ? `expand:${s.parallel.agent}` : (s as SequentialStep).agent,
 			),
 			chainStepCount: chain.length,
 			parallelGroups,
+			workflowGraph,
 			cwd: runnerCwd,
 			asyncDir,
 			nestedRoute,
@@ -537,13 +616,13 @@ export function executeAsyncChain(
 
 	const chainDesc = chain
 		.map((s) =>
-			isParallelStep(s) ? `[${s.parallel.map((t) => t.agent).join("+")}]` : (s as SequentialStep).agent,
+			isParallelStep(s) ? `[${s.parallel.map((t) => t.agent).join("+")}]` : isDynamicParallelStep(s) ? `expand:${s.parallel.agent}` : (s as SequentialStep).agent,
 		)
 		.join(" -> ");
 
 	return {
 		content: [{ type: "text", text: formatAsyncStartedMessage(`Async ${resultMode}: ${chainDesc} [${id}]`) }],
-		details: { mode: resultMode, runId: id, results: [], asyncId: id, asyncDir },
+		details: { mode: resultMode, runId: id, results: [], asyncId: id, asyncDir, workflowGraph },
 	};
 }
 
@@ -647,6 +726,13 @@ export function executeAsyncSingle(
 						sessionFile,
 						maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, agentConfig.maxSubagentDepth),
 						workflowStageSubagentGuard,
+						effectiveAcceptance: resolveEffectiveAcceptance({
+							explicit: params.acceptance,
+							agentName: agent,
+							task,
+							mode: "single",
+							async: true,
+						}),
 					},
 				],
 				resultPath: inheritedNestedRoute ? nestedResultsPath(inheritedNestedRoute.rootRunId, id) : path.join(RESULTS_DIR, `${id}.json`),

--- a/packages/subagents/src/runs/background/async-status.ts
+++ b/packages/subagents/src/runs/background/async-status.ts
@@ -12,6 +12,10 @@ import { reconcileAsyncRun, reconcileNestedAsyncDescendants } from "./stale-run-
 interface AsyncRunStepSummary {
 	index: number;
 	agent: string;
+	label?: string;
+	phase?: string;
+	outputName?: string;
+	structured?: boolean;
 	status: AsyncJobStep["status"];
 	activityState?: ActivityState;
 	lastActivityAt?: number;
@@ -140,6 +144,10 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		return {
 			index,
 			agent: step.agent,
+			...(step.label ? { label: step.label } : {}),
+			...(step.phase ? { phase: step.phase } : {}),
+			...(step.outputName ? { outputName: step.outputName } : {}),
+			...(step.structured ? { structured: step.structured } : {}),
 			status: step.status,
 			...(stepActivityState ? { activityState: stepActivityState } : {}),
 			...(stepLastActivityAt ? { lastActivityAt: stepLastActivityAt } : {}),
@@ -261,7 +269,9 @@ function formatActivityFacts(input: { activityState?: ActivityState; lastActivit
 }
 
 function formatStepLine(step: AsyncRunStepSummary): string {
-	const parts = [`${step.index + 1}. ${step.agent}`, step.status];
+	const display = step.label ? `${step.label} (${step.agent})` : step.agent;
+	const phase = step.phase ? `[${step.phase}] ` : "";
+	const parts = [`${step.index + 1}. ${phase}${display}`, step.status];
 	const activity = formatActivityFacts(step);
 	if (activity) parts.push(activity);
 	const modelThinking = formatModelThinking(step.model, step.thinking, step.fastMode);

--- a/packages/subagents/src/runs/background/run-status.ts
+++ b/packages/subagents/src/runs/background/run-status.ts
@@ -216,7 +216,10 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				const modelThinking = formatModelThinking(step.model, step.thinking, step.fastMode);
 				const modelText = modelThinking ? ` (${modelThinking})` : "";
 				const errorText = step.error ? `, error: ${step.error}` : "";
-				lines.push(`${stepLineLabel(status, index)}: ${step.agent} ${step.status}${modelText}${stepActivityText ? `, ${stepActivityText}` : ""}${errorText}`);
+				const acceptanceText = step.acceptance?.status ? `, acceptance: ${step.acceptance.status}` : "";
+				const display = step.label ? `${step.label} (${step.agent})` : step.agent;
+				const phase = step.phase ? `[${step.phase}] ` : "";
+				lines.push(`${stepLineLabel(status, index)}: ${phase}${display} ${step.status}${modelText}${stepActivityText ? `, ${stepActivityText}` : ""}${acceptanceText}${errorText}`);
 				lines.push(...formatNestedRunStatusLines(step.children, { indent: "  ", commandHints: true, maxLines: 20 }));
 				const stepOutputPath = path.join(asyncDir, `output-${index}.log`);
 				if (stepOutputPath !== outputPath && fs.existsSync(stepOutputPath)) lines.push(`  Output: ${stepOutputPath}`);

--- a/packages/subagents/src/runs/background/subagent-runner.ts
+++ b/packages/subagents/src/runs/background/subagent-runner.ts
@@ -13,11 +13,13 @@ import {
 	type ArtifactPaths,
 	type AsyncParallelGroupStatus,
 	type AsyncStatus,
+	type ChainOutputMap,
 	type ModelAttempt,
 	type NestedRouteInfo,
 	type ResolvedControlConfig,
 	type SubagentRunMode,
 	type Usage,
+	type WorkflowGraphSnapshot,
 	DEFAULT_MAX_OUTPUT,
 	type MaxOutputConfig,
 	truncateOutput,
@@ -34,6 +36,7 @@ import {
 import {
 	type RunnerSubagentStep as SubagentStep,
 	type RunnerStep,
+	isDynamicRunnerGroup,
 	isParallelGroup,
 	flattenSteps,
 	mapConcurrent,
@@ -41,6 +44,9 @@ import {
 	MAX_PARALLEL_CONCURRENCY,
 } from "../shared/parallel-utils.ts";
 import { buildPiArgs, cleanupTempDir } from "../shared/pi-args.ts";
+import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/chain-outputs.ts";
+import { createStructuredOutputRuntime, readStructuredOutput } from "../shared/structured-output.ts";
+import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
 import { nestedSummaryFromAsyncStatus, writeNestedEvent } from "../shared/nested-events.ts";
 import { formatModelAttemptNote, isRetryableModelFailure } from "../shared/model-fallback.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
@@ -70,6 +76,8 @@ import {
 } from "../shared/worktree.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { writeInitialProgressFile } from "../../shared/settings.ts";
+import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
+import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, formatAcceptancePrompt, stripAcceptanceReport } from "../shared/acceptance.ts";
 
 interface SubagentRunConfig {
 	id: string;
@@ -94,6 +102,8 @@ interface SubagentRunConfig {
 	controlIntercomTarget?: string;
 	childIntercomTargets?: Array<string | undefined>;
 	resultMode?: SubagentRunMode;
+	dynamicFanoutMaxItems?: number;
+	workflowGraph?: WorkflowGraphSnapshot;
 	nestedRoute?: NestedRouteInfo;
 	workflowStageSubagentGuard?: boolean;
 	nestedSelf?: { parentRunId: string; parentStepIndex?: number; depth: number; path?: Array<{ runId: string; stepIndex?: number; agent?: string }> };
@@ -104,6 +114,7 @@ interface StepResult {
 	output: string;
 	error?: string;
 	success: boolean;
+	exitCode?: number | null;
 	skipped?: boolean;
 	sessionFile?: string;
 	intercomTarget?: string;
@@ -113,6 +124,10 @@ interface StepResult {
 	modelAttempts?: ModelAttempt[];
 	artifactPaths?: ArtifactPaths;
 	truncated?: boolean;
+	structuredOutput?: unknown;
+	structuredOutputPath?: string;
+	structuredOutputSchemaPath?: string;
+	acceptance?: import("../../shared/types.ts").AcceptanceLedger;
 }
 
 const ASYNC_INTERRUPT_SIGNAL: NodeJS.Signals = process.platform === "win32" ? "SIGBREAK" : "SIGUSR2";
@@ -558,6 +573,7 @@ function writeRunLog(
 /** Context for running a single step */
 interface SingleStepContext {
 	previousOutput: string;
+	outputs?: ChainOutputMap;
 	placeholder: string;
 	cwd: string;
 	sessionEnabled: boolean;
@@ -597,9 +613,22 @@ async function runSingleStep(
 	sessionFile?: string;
 	intercomTarget?: string;
 	completionGuardTriggered?: boolean;
+	structuredOutput?: unknown;
+	structuredOutputPath?: string;
+	structuredOutputSchemaPath?: string;
+	acceptance?: import("../../shared/types.ts").AcceptanceLedger;
 }> {
+	const effectiveStructuredOutput = step.structuredOutput ?? (step.structuredOutputSchema
+		? createStructuredOutputRuntime(step.structuredOutputSchema, path.join(path.dirname(ctx.outputFile), "structured-output"))
+		: undefined);
 	const placeholderRegex = new RegExp(ctx.placeholder.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
-	const task = step.task.replace(placeholderRegex, () => ctx.previousOutput);
+	let task = step.task.replace(placeholderRegex, () => ctx.previousOutput);
+	task = resolveOutputReferences(task, ctx.outputs ?? {});
+	const taskForCompletionGuard = task;
+	if (step.effectiveAcceptance) {
+		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance);
+		if (acceptancePrompt) task = `${task}\n${acceptancePrompt}`;
+	}
 	const sessionEnabled = Boolean(step.sessionFile) || ctx.sessionEnabled;
 	const sessionDir = step.sessionFile ? undefined : ctx.sessionDir;
 
@@ -632,6 +661,13 @@ async function runSingleStep(
 		const attemptFastMode = fastModeForStepAttempt(step, candidate);
 		ctx.onAttemptStart?.({ model: candidate, thinking: resolveEffectiveThinking(candidate, step.thinking), fastMode: attemptFastMode ? true : undefined });
 		const outputSnapshot = captureSingleOutputSnapshot(step.outputPath);
+		if (effectiveStructuredOutput) {
+			try {
+				if (fs.existsSync(effectiveStructuredOutput.outputPath)) fs.unlinkSync(effectiveStructuredOutput.outputPath);
+			} catch {
+				// Missing/stale structured-output files are handled after the child exits.
+			}
+		}
 		const { args, env, tempDir } = buildPiArgs({
 			baseArgs: ["--mode", "json", "-p"],
 			task,
@@ -659,6 +695,7 @@ async function runSingleStep(
 			parentCapabilityToken: ctx.nestedRoute?.capabilityToken,
 			codexFastModeSettings: step.codexFastModeSettings,
 			codexFastModeScope: step.codexFastModeScope,
+			structuredOutput: effectiveStructuredOutput,
 		});
 		const run = await runPiStreaming(
 			args,
@@ -676,10 +713,21 @@ async function runSingleStep(
 		cleanupTempDir(tempDir);
 
 		const hiddenError = run.exitCode === 0 && !run.error ? detectSubagentError(run.messages) : null;
+		let structuredOutput: unknown;
+		let structuredError: string | undefined;
+		if (effectiveStructuredOutput && run.exitCode === 0 && !run.error && !hiddenError?.hasError) {
+			const structured = readStructuredOutput({
+				schema: effectiveStructuredOutput.schema,
+				schemaPath: effectiveStructuredOutput.schemaPath,
+				outputPath: effectiveStructuredOutput.outputPath,
+			});
+			if (structured.error) structuredError = structured.error;
+			else structuredOutput = structured.value;
+		}
 		const completionGuard = run.exitCode === 0 && !run.error && !hiddenError?.hasError && step.completionGuard !== false
 			? evaluateCompletionMutationGuard({
 				agent: step.agent,
-				task,
+				task: taskForCompletionGuard,
 				messages: run.messages,
 				tools: step.tools,
 				mcpDirectTools: step.mcpDirectTools,
@@ -691,12 +739,15 @@ async function runSingleStep(
 			: undefined;
 		const effectiveExitCode = completionGuardTriggered
 			? 1
-			: hiddenError?.hasError
+			: structuredError
+				? 1
+				: hiddenError?.hasError
 				? (hiddenError.exitCode ?? 1)
 				: run.error && run.exitCode === 0
 					? 1
 					: run.exitCode;
 		const error = completionGuardError
+			?? structuredError
 			?? (hiddenError?.hasError
 				? hiddenError.details
 					? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
@@ -716,24 +767,26 @@ async function runSingleStep(
 		completionGuardTriggeredFinal = completionGuardTriggered;
 		finalFastMode = attemptFastMode;
 		finalOutputSnapshot = outputSnapshot;
-		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error };
+		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput } as RunPiStreamingResult & { structuredOutput?: unknown };
 		if (attempt.success || completionGuardTriggered) break;
 		if (!isRetryableModelFailure(error) || index === candidates.length - 1) break;
 		attemptNotes.push(formatModelAttemptNote(attempt, candidates[index + 1]));
 	}
 
 	const rawOutput = finalResult?.finalOutput ?? "";
+	const outputForPersistence = stripAcceptanceReport(rawOutput);
 	const resolvedOutput = step.outputPath && finalResult?.exitCode === 0
-		? resolveSingleOutput(step.outputPath, rawOutput, finalOutputSnapshot)
-		: { fullOutput: rawOutput };
+		? resolveSingleOutput(step.outputPath, outputForPersistence, finalOutputSnapshot)
+		: { fullOutput: outputForPersistence };
 	const output = resolvedOutput.fullOutput;
 	const outputReference = resolvedOutput.savedPath ? formatSavedOutputReference(resolvedOutput.savedPath, output) : undefined;
 	let outputForSummary = output;
-	if (attemptNotes.length > 0) {
-		outputForSummary = `${attemptNotes.join("\n")}\n\n${outputForSummary}`.trim();
-	}
-	const finalizedOutput = finalizeSingleOutput({
-		fullOutput: outputForSummary,
+		if (attemptNotes.length > 0) {
+			outputForSummary = `${attemptNotes.join("\n")}\n\n${outputForSummary}`.trim();
+		}
+	const outputForAcceptance = rawOutput;
+		const finalizedOutput = finalizeSingleOutput({
+			fullOutput: outputForSummary,
 		outputPath: step.outputPath,
 		outputMode: step.outputMode,
 		exitCode: finalResult?.exitCode ?? 1,
@@ -742,6 +795,19 @@ async function runSingleStep(
 		saveError: resolvedOutput.saveError,
 	});
 	outputForSummary = finalizedOutput.displayOutput;
+	const acceptance = step.effectiveAcceptance
+			? await evaluateAcceptance({
+				acceptance: step.effectiveAcceptance,
+				output: outputForAcceptance,
+				cwd: step.cwd ?? ctx.cwd,
+			})
+		: undefined;
+	const acceptanceFailure = acceptance ? acceptanceFailureMessage(acceptance) : undefined;
+	const acceptanceCanFailRun = acceptanceFailure && acceptance?.explicit && (finalResult?.exitCode ?? 1) === 0 && !finalResult?.interrupted;
+	const effectiveFinalExitCode = acceptanceCanFailRun ? 1 : finalResult?.exitCode ?? 1;
+	const effectiveFinalError = acceptanceCanFailRun
+		? (finalResult?.error ? `${finalResult.error}\n${acceptanceFailure}` : acceptanceFailure)
+		: finalResult?.error;
 
 	if (artifactPaths && ctx.artifactConfig?.enabled !== false) {
 		if (ctx.artifactConfig?.includeOutput !== false) {
@@ -754,7 +820,7 @@ async function runSingleStep(
 					runId: ctx.id,
 					agent: step.agent,
 					task,
-					exitCode: finalResult?.exitCode,
+					exitCode: effectiveFinalExitCode,
 					model: finalResult?.model,
 					...(finalFastMode ? { fastMode: true } : {}),
 					attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
@@ -770,8 +836,8 @@ async function runSingleStep(
 	return {
 		agent: step.agent,
 		output: outputForSummary,
-		exitCode: finalResult?.exitCode ?? 1,
-		error: finalResult?.error,
+		exitCode: effectiveFinalExitCode,
+		error: effectiveFinalError,
 		sessionFile: step.sessionFile,
 		intercomTarget: ctx.childIntercomTarget,
 		model: finalResult?.model,
@@ -781,6 +847,10 @@ async function runSingleStep(
 		artifactPaths,
 		interrupted: finalResult?.interrupted,
 		completionGuardTriggered: completionGuardTriggeredFinal,
+		structuredOutput: (finalResult as (RunPiStreamingResult & { structuredOutput?: unknown }) | undefined)?.structuredOutput,
+		structuredOutputPath: effectiveStructuredOutput?.outputPath,
+		structuredOutputSchemaPath: effectiveStructuredOutput?.schemaPath,
+		acceptance,
 	};
 }
 
@@ -823,7 +893,7 @@ function markParallelGroupSetupFailure(input: {
 		input.statusPayload.steps[flatTaskIndex].endedAt = input.failedAt;
 		input.statusPayload.steps[flatTaskIndex].durationMs = 0;
 		input.statusPayload.steps[flatTaskIndex].exitCode = 1;
-		input.results.push({ agent: input.group.parallel[taskIndex].agent, output: input.setupError, success: false, sessionFile: input.group.parallel[taskIndex].sessionFile });
+		input.results.push({ agent: input.group.parallel[taskIndex].agent, output: input.setupError, success: false, exitCode: 1, sessionFile: input.group.parallel[taskIndex].sessionFile });
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
@@ -913,6 +983,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	const { id, steps, resultPath, cwd, placeholder, taskIndex, totalTasks, maxOutput, artifactsDir, artifactConfig } =
 		config;
 	let previousOutput = "";
+	const outputs: ChainOutputMap = {};
 	const results: StepResult[] = [];
 	const overallStartTime = Date.now();
 	const shareEnabled = config.share === true;
@@ -929,13 +1000,61 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	let latestSessionFile: string | undefined;
 
 	const parallelGroups: Array<{ start: number; count: number; stepIndex: number }> = [];
+	const initialStatusSteps: RunnerStatusStep[] = [];
 	let flatStepCount = 0;
 	for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
 		const step = steps[stepIndex]!;
 		if (isParallelGroup(step)) {
 			parallelGroups.push({ start: flatStepCount, count: step.parallel.length, stepIndex });
+			for (const task of step.parallel) {
+				initialStatusSteps.push({
+					agent: task.agent,
+					phase: task.phase,
+					label: task.label,
+					outputName: task.outputName,
+					structured: task.structured,
+					status: "pending",
+					...(task.sessionFile ? { sessionFile: task.sessionFile } : {}),
+					skills: task.skills,
+					model: task.model,
+					thinking: task.thinking,
+					...(task.fastMode ? { fastMode: true } : {}),
+					attemptedModels: task.modelCandidates && task.modelCandidates.length > 0 ? task.modelCandidates : task.model ? [task.model] : undefined,
+					recentTools: [],
+					recentOutput: [],
+				});
+			}
 			flatStepCount += step.parallel.length;
+		} else if (isDynamicRunnerGroup(step)) {
+			parallelGroups.push({ start: flatStepCount, count: 1, stepIndex });
+			initialStatusSteps.push({
+				agent: `expand:${step.parallel.agent}`,
+				phase: step.phase ?? step.parallel.phase,
+				label: step.label ?? step.parallel.label ?? `Dynamic fanout (${step.collect.as})`,
+				outputName: step.collect.as,
+				structured: Boolean(step.collect.outputSchema),
+				status: "pending",
+				recentTools: [],
+				recentOutput: [],
+			});
+			flatStepCount++;
 		} else {
+			initialStatusSteps.push({
+				agent: step.agent,
+				phase: step.phase,
+				label: step.label,
+				outputName: step.outputName,
+				structured: step.structured,
+				status: "pending",
+				...(step.sessionFile ? { sessionFile: step.sessionFile } : {}),
+				skills: step.skills,
+				model: step.model,
+				thinking: step.thinking,
+				...(step.fastMode ? { fastMode: true } : {}),
+				attemptedModels: step.modelCandidates && step.modelCandidates.length > 0 ? step.modelCandidates : step.model ? [step.model] : undefined,
+				recentTools: [],
+				recentOutput: [],
+			});
 			flatStepCount++;
 		}
 	}
@@ -956,18 +1075,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		currentStep: 0,
 		chainStepCount: steps.length,
 		parallelGroups,
-		steps: flatSteps.map((step) => ({
-			agent: step.agent,
-			status: "pending",
-			...(step.sessionFile ? { sessionFile: step.sessionFile } : {}),
-			skills: step.skills,
-			model: step.model,
-			thinking: step.thinking,
-			...(step.fastMode ? { fastMode: true } : {}),
-			attemptedModels: step.modelCandidates && step.modelCandidates.length > 0 ? step.modelCandidates : step.model ? [step.model] : undefined,
-			recentTools: [],
-			recentOutput: [],
-		})),
+		workflowGraph: config.workflowGraph,
+		steps: initialStatusSteps,
 		artifactsDir,
 		sessionDir: config.sessionDir,
 		outputFile: path.join(asyncDir, "output-0.log"),
@@ -997,9 +1106,47 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			console.error("Failed to emit nested async status event:", error);
 		}
 	};
+	const refreshWorkflowGraph = (): void => {
+		if (!config.workflowGraph) return;
+		const graph = structuredClone(statusPayload.workflowGraph ?? config.workflowGraph);
+		const normalize = (status: RunnerStatusStep["status"]): "pending" | "running" | "completed" | "failed" | "paused" | "detached" => {
+			if (status === "complete" || status === "completed") return "completed";
+			if (status === "running" || status === "failed" || status === "paused" || status === "pending") return status;
+			return "pending";
+		};
+		const updateNode = (node: NonNullable<typeof graph.nodes>[number]): void => {
+			if (node.flatIndex !== undefined) {
+				const step = statusPayload.steps[node.flatIndex];
+				if (step) {
+					node.status = normalize(step.status);
+					node.error = step.error;
+					node.acceptanceStatus = step.acceptance?.status;
+				}
+				if (statusPayload.currentStep === node.flatIndex) graph.currentNodeId = node.id;
+			}
+			for (const child of node.children ?? []) updateNode(child);
+			if (node.children?.length) {
+				if (node.children.every((child) => child.status === "completed")) node.status = "completed";
+				else if (node.children.some((child) => child.status === "running")) node.status = "running";
+				else if (node.children.some((child) => child.status === "failed")) node.status = "failed";
+				else if (node.children.some((child) => child.status === "paused")) node.status = "paused";
+			}
+			if (node.error) node.status = "failed";
+		};
+		for (const node of graph.nodes) updateNode(node);
+		statusPayload.workflowGraph = graph;
+	};
 	const writeStatusPayload = (): void => {
+		refreshWorkflowGraph();
 		writeAtomicJson(statusPath, statusPayload);
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
+	};
+	const markDynamicGraphGroup = (stepIndex: number, status: "completed" | "failed" | "running", error?: string, acceptance?: import("../../shared/types.ts").AcceptanceLedger): void => {
+		const groupNode = statusPayload.workflowGraph?.nodes.find((node) => node.id === `step-${stepIndex}`);
+		if (!groupNode) return;
+		groupNode.status = status;
+		groupNode.error = error;
+		groupNode.acceptanceStatus = acceptance?.status ?? groupNode.acceptanceStatus;
 	};
 
 	const stepOutputActivityAt = (index: number): number => {
@@ -1017,8 +1164,8 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	};
 	const emittedControlEventKeys = new Set<string>();
 	const activeLongRunningSteps = new Set<number>();
-	const mutatingFailureStates = flatSteps.map(() => createMutatingFailureState());
-	const pendingToolResults: Array<{ tool: string; path?: string; mutates: boolean; startedAt?: number } | undefined> = [];
+	const mutatingFailureStates = initialStatusSteps.map(() => createMutatingFailureState());
+	const pendingToolResults: Array<{ tool: string; path?: string; mutates: boolean; startedAt?: number } | undefined> = initialStatusSteps.map(() => undefined);
 	const mutatingFailureWindowMs = 5 * 60_000;
 	const appendControlEvent = (event: ReturnType<typeof buildControlEvent>) => {
 		if (!controlConfig.enabled) return;
@@ -1160,7 +1307,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				resetMutatingFailureState(mutatingFailureStates[flatIndex]!);
 			}
 		} else if (event.type === "message_end" && event.message?.role === "assistant") {
-			appendRecentStepOutput(step, extractTextFromContent(event.message.content).split("\n").slice(-10));
+			appendRecentStepOutput(step, stripAcceptanceReport(extractTextFromContent(event.message.content)).split("\n").slice(-10));
 			step.turnCount = (step.turnCount ?? 0) + 1;
 			const usage = event.message.usage;
 			if (usage) {
@@ -1291,6 +1438,313 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 		if (interrupted) break;
 		const step = steps[stepIndex];
 
+		if (isDynamicRunnerGroup(step)) {
+			const groupStartFlatIndex = flatIndex;
+			let materialized: ReturnType<typeof materializeDynamicParallelStep>;
+			try {
+				materialized = materializeDynamicParallelStep(step as Parameters<typeof materializeDynamicParallelStep>[0], outputs, stepIndex, { maxItems: config.dynamicFanoutMaxItems, allowRunnerFields: true });
+				if (materialized.collectedOnEmpty) validateDynamicCollection(step.collect.outputSchema, materialized.collectedOnEmpty);
+			} catch (error) {
+				const now = Date.now();
+				const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
+				statusPayload.state = "failed";
+				statusPayload.error = message;
+				statusPayload.currentStep = flatIndex;
+				const placeholder = statusPayload.steps[groupStartFlatIndex];
+				if (placeholder) {
+					placeholder.status = "failed";
+					placeholder.error = message;
+					placeholder.startedAt = now;
+					placeholder.endedAt = now;
+					placeholder.durationMs = 0;
+					placeholder.exitCode = 1;
+				}
+				statusPayload.lastUpdate = now;
+				markDynamicGraphGroup(stepIndex, "failed", message);
+				writeStatusPayload();
+				results.push({ agent: step.parallel.agent, output: message, error: message, success: false, exitCode: 1 });
+				break;
+			}
+
+			if (materialized.parallel.length === 0) {
+				const now = Date.now();
+				const collection = materialized.collectedOnEmpty ?? [];
+				outputs[step.collect.as] = {
+					text: JSON.stringify(collection),
+					structured: collection,
+					agent: step.parallel.agent,
+					stepIndex,
+				};
+				statusPayload.outputs = outputs;
+				const placeholder = statusPayload.steps[groupStartFlatIndex];
+				if (placeholder) {
+					placeholder.status = "complete";
+					placeholder.startedAt = now;
+					placeholder.endedAt = now;
+					placeholder.durationMs = 0;
+				}
+				previousOutput = "Dynamic fanout produced 0 results.";
+				const groupAcceptance = step.effectiveAcceptance?.explicit
+					? await evaluateAcceptance({
+						acceptance: step.effectiveAcceptance,
+						output: "",
+						report: aggregateAcceptanceReport({
+							results: [],
+							notes: "Dynamic fanout produced 0 results.",
+						}),
+						cwd,
+					})
+					: undefined;
+				if (placeholder && groupAcceptance) placeholder.acceptance = groupAcceptance;
+				const groupAcceptanceFailure = groupAcceptance ? acceptanceFailureMessage(groupAcceptance) : undefined;
+				if (groupAcceptanceFailure) {
+					statusPayload.state = "failed";
+					statusPayload.error = groupAcceptanceFailure;
+					if (placeholder) {
+						placeholder.status = "failed";
+						placeholder.error = groupAcceptanceFailure;
+						placeholder.exitCode = 1;
+					}
+					markDynamicGraphGroup(stepIndex, "failed", groupAcceptanceFailure, groupAcceptance);
+					statusPayload.lastUpdate = now;
+					writeStatusPayload();
+					results.push({ agent: step.parallel.agent, output: groupAcceptanceFailure, error: groupAcceptanceFailure, success: false, exitCode: 1, acceptance: groupAcceptance });
+					break;
+				}
+				flatIndex++;
+				statusPayload.lastUpdate = now;
+				markDynamicGraphGroup(stepIndex, "completed", undefined, groupAcceptance);
+				writeStatusPayload();
+				continue;
+			}
+
+			const dynamicSteps = materialized.parallel.map((task, itemIndex) => ({
+				...step.parallel,
+				task: task.task ?? step.parallel.task,
+				label: task.label ?? step.parallel.label,
+				structuredOutput: undefined,
+				structuredOutputSchema: step.parallel.structuredOutputSchema ?? step.parallel.structuredOutput?.schema,
+			}));
+			const dynamicStatusSteps: RunnerStatusStep[] = dynamicSteps.map((task) => ({
+					agent: task.agent,
+					phase: task.phase ?? step.phase,
+					label: task.label,
+					outputName: undefined,
+					structured: Boolean(task.structuredOutputSchema),
+					status: "pending",
+					...(task.sessionFile ? { sessionFile: task.sessionFile } : {}),
+					skills: task.skills,
+					model: task.model,
+					thinking: task.thinking,
+					attemptedModels: task.modelCandidates && task.modelCandidates.length > 0 ? task.modelCandidates : task.model ? [task.model] : undefined,
+					recentTools: [],
+					recentOutput: [],
+				}));
+			statusPayload.steps.splice(groupStartFlatIndex, 1, ...dynamicStatusSteps);
+			if (config.childIntercomTargets) {
+				config.childIntercomTargets = statusPayload.steps.map((statusStep, index) => resolveSubagentIntercomTarget(id, statusStep.agent, index));
+			}
+			mutatingFailureStates.splice(groupStartFlatIndex, 1, ...dynamicStatusSteps.map(() => createMutatingFailureState()));
+			pendingToolResults.splice(groupStartFlatIndex, 1, ...dynamicStatusSteps.map(() => undefined));
+			const materializedDelta = dynamicStatusSteps.length - 1;
+			for (const group of statusPayload.parallelGroups) {
+				if (group.stepIndex === stepIndex) {
+					group.start = groupStartFlatIndex;
+					group.count = dynamicStatusSteps.length;
+				} else if (group.start > groupStartFlatIndex) {
+					group.start += materializedDelta;
+				}
+			}
+			if (statusPayload.workflowGraph) {
+				const shiftFlatIndexes = (nodes: NonNullable<typeof statusPayload.workflowGraph>["nodes"]): void => {
+					for (const node of nodes) {
+						if (node.stepIndex !== undefined && node.stepIndex > stepIndex && node.flatIndex !== undefined && node.flatIndex >= groupStartFlatIndex) {
+							node.flatIndex += dynamicStatusSteps.length;
+						}
+						if (node.children) shiftFlatIndexes(node.children);
+					}
+				};
+				shiftFlatIndexes(statusPayload.workflowGraph.nodes);
+				const groupNode = statusPayload.workflowGraph.nodes.find((node) => node.id === `step-${stepIndex}`);
+				if (groupNode) {
+					groupNode.children = materialized.items.map((item, itemIndex) => ({
+						id: `step-${stepIndex}-item-${item.idKey}`,
+						kind: "agent",
+						agent: step.parallel.agent,
+						phase: dynamicSteps[itemIndex]?.phase ?? step.phase,
+						label: dynamicSteps[itemIndex]?.label?.trim() || `${step.parallel.agent} ${item.key}`,
+						status: "pending",
+						flatIndex: groupStartFlatIndex + itemIndex,
+						stepIndex,
+						itemKey: item.key,
+						structured: Boolean(dynamicSteps[itemIndex]?.structuredOutputSchema),
+					}));
+				}
+			}
+			writeStatusPayload();
+
+			const concurrency = step.concurrency ?? MAX_PARALLEL_CONCURRENCY;
+			const failFast = step.failFast ?? false;
+			let aborted = false;
+			const parallelResults = await mapConcurrent(dynamicSteps, concurrency, async (task, taskIdx) => {
+				const fi = groupStartFlatIndex + taskIdx;
+				if (aborted && failFast) {
+					const skippedAt = Date.now();
+					statusPayload.steps[fi].status = "failed";
+					statusPayload.steps[fi].error = "Skipped due to fail-fast";
+					statusPayload.steps[fi].startedAt = skippedAt;
+					statusPayload.steps[fi].endedAt = skippedAt;
+					statusPayload.steps[fi].durationMs = 0;
+					statusPayload.steps[fi].exitCode = -1;
+					statusPayload.lastUpdate = skippedAt;
+					writeStatusPayload();
+					return { agent: task.agent, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true };
+				}
+				const taskStartTime = Date.now();
+				statusPayload.currentStep = fi;
+				statusPayload.steps[fi].status = "running";
+				statusPayload.steps[fi].error = undefined;
+				statusPayload.steps[fi].activityState = undefined;
+				resetStepLiveDetail(statusPayload.steps[fi]);
+				statusPayload.steps[fi].startedAt = taskStartTime;
+				statusPayload.steps[fi].lastActivityAt = taskStartTime;
+				statusPayload.outputFile = path.join(asyncDir, `output-${fi}.log`);
+				statusPayload.lastActivityAt = taskStartTime;
+				statusPayload.lastUpdate = taskStartTime;
+				writeStatusPayload();
+				appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.started", ts: taskStartTime, runId: id, stepIndex: fi, agent: task.agent }));
+				const singleResult = await runSingleStep(task, {
+					previousOutput, placeholder, cwd, sessionEnabled,
+					outputs,
+					sessionDir: config.sessionDir ? path.join(config.sessionDir, `dynamic-${stepIndex}-${taskIdx}`) : undefined,
+					artifactsDir, artifactConfig, id,
+					flatIndex: fi, flatStepCount: Math.max(statusPayload.steps.length, 1),
+					outputFile: path.join(asyncDir, `output-${fi}.log`),
+					piPackageRoot: config.piPackageRoot,
+					piArgv1: config.piArgv1,
+					childIntercomTarget: config.childIntercomTargets?.[fi],
+					orchestratorIntercomTarget: config.controlIntercomTarget,
+					nestedRoute: config.nestedRoute,
+					registerInterrupt: (interrupt) => {
+						activeChildInterrupt = interrupt;
+					},
+					onAttemptStart: (attempt) => updateStepModel(fi, attempt.model, attempt.thinking),
+					onChildEvent: (event) => updateStepFromChildEvent(fi, event),
+				});
+				const taskEndTime = Date.now();
+				statusPayload.steps[fi].status = singleResult.exitCode === 0 ? "complete" : "failed";
+				statusPayload.steps[fi].endedAt = taskEndTime;
+				statusPayload.steps[fi].durationMs = taskEndTime - taskStartTime;
+				statusPayload.steps[fi].exitCode = singleResult.exitCode;
+				statusPayload.steps[fi].model = singleResult.model;
+				statusPayload.steps[fi].thinking = resolveEffectiveThinking(singleResult.model, statusPayload.steps[fi].thinking);
+				statusPayload.steps[fi].attemptedModels = singleResult.attemptedModels;
+				statusPayload.steps[fi].modelAttempts = singleResult.modelAttempts;
+				statusPayload.steps[fi].error = singleResult.error;
+				statusPayload.steps[fi].structuredOutput = singleResult.structuredOutput;
+				statusPayload.steps[fi].structuredOutputPath = singleResult.structuredOutputPath;
+				statusPayload.steps[fi].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
+				statusPayload.steps[fi].acceptance = singleResult.acceptance;
+				statusPayload.lastUpdate = taskEndTime;
+				writeStatusPayload();
+				appendJsonl(eventsPath, JSON.stringify({
+					type: singleResult.exitCode === 0 ? "subagent.step.completed" : "subagent.step.failed",
+					ts: taskEndTime, runId: id, stepIndex: fi, agent: task.agent,
+					exitCode: singleResult.exitCode, durationMs: taskEndTime - taskStartTime,
+				}));
+				if (singleResult.exitCode !== 0 && failFast) aborted = true;
+				return { ...singleResult, skipped: false };
+			});
+
+			flatIndex += dynamicSteps.length;
+			for (const pr of parallelResults) {
+				results.push({
+					agent: pr.agent,
+					output: pr.output,
+					error: pr.error,
+					success: pr.exitCode === 0,
+					exitCode: pr.exitCode,
+					skipped: pr.skipped,
+					sessionFile: pr.sessionFile,
+					intercomTarget: pr.intercomTarget,
+					model: pr.model,
+					attemptedModels: pr.attemptedModels,
+					modelAttempts: pr.modelAttempts,
+					artifactPaths: pr.artifactPaths,
+					structuredOutput: pr.structuredOutput,
+					structuredOutputPath: pr.structuredOutputPath,
+					structuredOutputSchemaPath: pr.structuredOutputSchemaPath,
+					acceptance: pr.acceptance,
+				});
+			}
+			const collection = collectDynamicResults(step as Parameters<typeof collectDynamicResults>[0], materialized.items, parallelResults);
+			const failures = parallelResults.filter((result) => result.exitCode !== 0 && result.exitCode !== -1);
+			if (failures.length === 0) {
+				try {
+					validateDynamicCollection(step.collect.outputSchema, collection);
+					outputs[step.collect.as] = {
+						text: JSON.stringify(collection),
+						structured: collection,
+						agent: step.parallel.agent,
+						stepIndex,
+					};
+					statusPayload.outputs = outputs;
+					const groupAcceptance = step.effectiveAcceptance
+						? await evaluateAcceptance({
+							acceptance: step.effectiveAcceptance,
+							output: "",
+							report: aggregateAcceptanceReport({
+								results: parallelResults,
+								notes: `Dynamic fanout collected ${collection.length} result(s) into ${step.collect.as}.`,
+							}),
+							cwd,
+						})
+						: undefined;
+					const groupAcceptanceFailure = groupAcceptance ? acceptanceFailureMessage(groupAcceptance) : undefined;
+					markDynamicGraphGroup(stepIndex, groupAcceptanceFailure ? "failed" : "completed", groupAcceptanceFailure, groupAcceptance);
+					if (groupAcceptanceFailure) {
+						results.push({
+							agent: step.parallel.agent,
+							output: groupAcceptanceFailure,
+							error: groupAcceptanceFailure,
+							success: false,
+							exitCode: 1,
+							structuredOutput: collection,
+							acceptance: groupAcceptance,
+						});
+						statusPayload.error = groupAcceptanceFailure;
+					}
+				} catch (error) {
+					const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
+					results.push({ agent: step.parallel.agent, output: message, error: message, success: false, exitCode: 1, structuredOutput: collection });
+					statusPayload.error = message;
+					markDynamicGraphGroup(stepIndex, "failed", message);
+				}
+			}
+			previousOutput = aggregateParallelOutputs(
+				parallelResults.map((r, i) => ({
+					agent: r.agent,
+					taskIndex: i,
+					output: r.output,
+					exitCode: r.exitCode,
+					error: r.error,
+				})),
+				(i, agent) => `=== Dynamic Item ${i + 1} (${agent}, key ${materialized.items[i]?.key ?? i}) ===`,
+			);
+			appendJsonl(eventsPath, JSON.stringify({
+				type: "subagent.dynamic.completed",
+				ts: Date.now(),
+				runId: id,
+				stepIndex,
+				success: failures.length === 0,
+			}));
+			if (failures.length > 0) markDynamicGraphGroup(stepIndex, "failed", failures[0]?.error ?? "Dynamic fanout child failed.");
+			statusPayload.lastUpdate = Date.now();
+			writeStatusPayload();
+			if (failures.length > 0 || statusPayload.error) break;
+			continue;
+		}
+
 		if (isParallelGroup(step)) {
 			const group = step;
 			const concurrency = group.concurrency ?? MAX_PARALLEL_CONCURRENCY;
@@ -1408,6 +1862,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 
 						const singleResult = await runSingleStep(taskForRun, {
 							previousOutput, placeholder, cwd: taskCwd, sessionEnabled,
+							outputs,
 							sessionDir: taskSessionDir,
 							artifactsDir, artifactConfig, id,
 							flatIndex: fi, flatStepCount: flatSteps.length,
@@ -1441,6 +1896,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						statusPayload.steps[fi].attemptedModels = singleResult.attemptedModels;
 						statusPayload.steps[fi].modelAttempts = singleResult.modelAttempts;
 						statusPayload.steps[fi].error = singleResult.error;
+						statusPayload.steps[fi].structuredOutput = singleResult.structuredOutput;
+						statusPayload.steps[fi].structuredOutputPath = singleResult.structuredOutputPath;
+						statusPayload.steps[fi].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
+						statusPayload.steps[fi].acceptance = singleResult.acceptance;
 						statusPayload.lastUpdate = taskEndTime;
 						writeStatusPayload();
 
@@ -1494,6 +1953,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						output: pr.output,
 						error: pr.error,
 						success: pr.exitCode === 0,
+						exitCode: pr.exitCode,
 						skipped: pr.skipped,
 						sessionFile: pr.sessionFile,
 						intercomTarget: pr.intercomTarget,
@@ -1502,8 +1962,21 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 						attemptedModels: pr.attemptedModels,
 						modelAttempts: pr.modelAttempts,
 						artifactPaths: pr.artifactPaths,
-					});
+							structuredOutput: pr.structuredOutput,
+							structuredOutputPath: pr.structuredOutputPath,
+							structuredOutputSchemaPath: pr.structuredOutputSchemaPath,
+							acceptance: pr.acceptance,
+						});
+					}
+				for (let t = 0; t < group.parallel.length; t++) {
+					const outputName = group.parallel[t]?.outputName;
+					if (outputName) outputs[outputName] = outputEntryFromAsyncResult({
+						agent: parallelResults[t]!.agent,
+						output: parallelResults[t]!.output,
+						structuredOutput: parallelResults[t]!.structuredOutput,
+					}, stepIndex);
 				}
+				statusPayload.outputs = outputs;
 
 				previousOutput = aggregateParallelOutputs(
 					parallelResults.map((r) => ({
@@ -1558,6 +2031,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 
 			const singleResult = await runSingleStep(seqStep, {
 				previousOutput, placeholder, cwd, sessionEnabled,
+				outputs,
 				sessionDir: config.sessionDir,
 				artifactsDir, artifactConfig, id,
 				flatIndex, flatStepCount: flatSteps.length,
@@ -1584,6 +2058,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				output: singleResult.output,
 				error: singleResult.error,
 				success: singleResult.exitCode === 0,
+				exitCode: singleResult.exitCode,
 				sessionFile: singleResult.sessionFile,
 				intercomTarget: singleResult.intercomTarget,
 				model: singleResult.model,
@@ -1591,7 +2066,19 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				attemptedModels: singleResult.attemptedModels,
 				modelAttempts: singleResult.modelAttempts,
 				artifactPaths: singleResult.artifactPaths,
+				structuredOutput: singleResult.structuredOutput,
+				structuredOutputPath: singleResult.structuredOutputPath,
+				structuredOutputSchemaPath: singleResult.structuredOutputSchemaPath,
+				acceptance: singleResult.acceptance,
 			});
+			if (seqStep.outputName) {
+				outputs[seqStep.outputName] = outputEntryFromAsyncResult({
+					agent: singleResult.agent,
+					output: singleResult.output,
+					structuredOutput: singleResult.structuredOutput,
+				}, stepIndex);
+			}
+			statusPayload.outputs = outputs;
 
 			const cumulativeTokens = config.sessionDir ? parseSessionTokens(config.sessionDir) : null;
 			let stepTokens: TokenUsage | null = cumulativeTokens
@@ -1625,6 +2112,10 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 			statusPayload.steps[flatIndex].attemptedModels = singleResult.attemptedModels;
 			statusPayload.steps[flatIndex].modelAttempts = singleResult.modelAttempts;
 			statusPayload.steps[flatIndex].error = singleResult.error;
+			statusPayload.steps[flatIndex].structuredOutput = singleResult.structuredOutput;
+			statusPayload.steps[flatIndex].structuredOutputPath = singleResult.structuredOutputPath;
+			statusPayload.steps[flatIndex].structuredOutputSchemaPath = singleResult.structuredOutputSchemaPath;
+			statusPayload.steps[flatIndex].acceptance = singleResult.acceptance;
 			if (stepTokens) {
 				statusPayload.steps[flatIndex].tokens = stepTokens;
 				statusPayload.totalTokens = { ...previousCumulativeTokens };
@@ -1726,7 +2217,7 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 	statusPayload.shareUrl = shareUrl;
 	statusPayload.gistUrl = gistUrl;
 	statusPayload.shareError = shareError;
-	if (statusPayload.state === "failed") {
+	if (statusPayload.state === "failed" && !statusPayload.error) {
 		const failedStep = statusPayload.steps.find((s) => s.status === "failed");
 		if (failedStep?.agent) {
 			statusPayload.error = `Step failed: ${failedStep.agent}`;
@@ -1784,7 +2275,13 @@ async function runSubagent(config: SubagentRunConfig): Promise<void> {
 				modelAttempts: r.modelAttempts,
 				artifactPaths: r.artifactPaths,
 				truncated: r.truncated,
+				structuredOutput: r.structuredOutput,
+				structuredOutputPath: r.structuredOutputPath,
+				structuredOutputSchemaPath: r.structuredOutputSchemaPath,
+				acceptance: r.acceptance,
 			})),
+			outputs,
+			workflowGraph: statusPayload.workflowGraph,
 			exitCode: interrupted || results.every((r) => r.success) ? 0 : 1,
 			timestamp: runEndedAt,
 			durationMs: runEndedAt - overallStartTime,

--- a/packages/subagents/src/runs/foreground/chain-execution.ts
+++ b/packages/subagents/src/runs/foreground/chain-execution.ts
@@ -20,9 +20,11 @@ import {
 	createParallelDirs,
 	suppressProgressForReadOnlyTask,
 	aggregateParallelOutputs,
+	isDynamicParallelStep,
 	isParallelStep,
 	type StepOverrides,
 	type ChainStep,
+	type ParallelStep,
 	type SequentialStep,
 	type ParallelTaskResult,
 	type ResolvedStepBehavior,
@@ -60,6 +62,12 @@ import {
 } from "../../shared/types.ts";
 import { resolveModelCandidate } from "../shared/model-fallback.ts";
 import { validateFileOnlyOutputMode } from "../shared/single-output.ts";
+import { buildWorkflowGraphSnapshot } from "../shared/workflow-graph.ts";
+import { ChainOutputValidationError, outputEntryFromResult, resolveOutputReferences, validateChainOutputBindings } from "../shared/chain-outputs.ts";
+import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
+import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection, type DynamicCollectedResult } from "../shared/dynamic-fanout.ts";
+import { acceptanceFailureMessage, aggregateAcceptanceReport, evaluateAcceptance, resolveEffectiveAcceptance } from "../shared/acceptance.ts";
+import type { ChainOutputMap } from "../../shared/types.ts";
 
 type RunSyncDependency = typeof runSync;
 
@@ -85,12 +93,18 @@ interface ChainExecutionDetailsInput {
 	allArtifactPaths: ArtifactPaths[];
 	artifactsDir: string;
 	chainAgents: string[];
+	chainSteps: ChainStep[];
 	totalSteps: number;
 	currentStepIndex?: number;
+	runId: string;
+	outputs?: ChainOutputMap;
+	currentFlatIndex?: number;
+	dynamicChildren?: Record<number, Array<{ agent: string; label?: string; flatIndex: number; itemKey: string; outputName?: string; structured?: boolean; error?: string }>>;
+	dynamicGroupStatuses?: Record<number, { status: "pending" | "running" | "completed" | "failed" | "paused" | "detached"; error?: string; acceptance?: SingleResult["acceptance"] }>;
 }
 
 interface ParallelChainRunInput {
-	step: Exclude<ChainStep, SequentialStep>;
+	step: ParallelStep;
 	parallelTemplates: string[];
 	parallelBehaviors: ResolvedStepBehavior[];
 	agents: AgentConfig[];
@@ -118,8 +132,12 @@ interface ParallelChainRunInput {
 	foregroundControl?: ChainForegroundControl;
 	results: SingleResult[];
 	allProgress: AgentProgress[];
+	outputs: ChainOutputMap;
 	chainAgents: string[];
+	chainSteps: ChainStep[];
 	totalSteps: number;
+	dynamicChildren?: ChainExecutionDetailsInput["dynamicChildren"];
+	dynamicGroupStatuses?: ChainExecutionDetailsInput["dynamicGroupStatuses"];
 	worktreeSetup?: WorktreeSetup;
 	maxSubagentDepth: number;
 	workflowStageSubagentGuard?: boolean;
@@ -136,6 +154,17 @@ function buildChainExecutionDetails(input: ChainExecutionDetailsInput): Details 
 		chainAgents: input.chainAgents,
 		totalSteps: input.totalSteps,
 		currentStepIndex: input.currentStepIndex,
+		outputs: input.outputs,
+	workflowGraph: buildWorkflowGraphSnapshot({
+			runId: input.runId,
+			mode: "chain",
+			steps: input.chainSteps,
+			results: input.results,
+			currentStepIndex: input.currentStepIndex,
+			currentFlatIndex: input.currentFlatIndex,
+			dynamicChildren: input.dynamicChildren,
+			dynamicGroupStatuses: input.dynamicGroupStatuses,
+		}),
 	});
 }
 
@@ -202,7 +231,7 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				templateHasPrevious ? undefined : input.prev,
 			);
 
-			let taskStr = taskTemplate;
+			let taskStr = resolveOutputReferences(taskTemplate, input.outputs);
 			taskStr = taskStr.replace(/\{task\}/g, input.originalTask);
 			taskStr = taskStr.replace(/\{previous\}/g, input.prev);
 			taskStr = taskStr.replace(/\{chain_dir\}/g, input.chainDir);
@@ -237,6 +266,9 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				};
 			}
 
+			const structuredRuntime = task.outputSchema
+				? createStructuredOutputRuntime(task.outputSchema, path.join(input.chainDir, "structured-output"))
+				: undefined;
 			const result = await input.runSync(input.ctx.cwd, input.agents, task.agent, taskStr, {
 				cwd: taskCwd,
 				signal: input.signal,
@@ -264,6 +296,9 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 				currentModel: currentModelFullId(input.ctx.model),
 				preferredModelProvider: input.ctx.model?.provider,
 				skills: behavior.skills === false ? [] : behavior.skills,
+				structuredOutput: structuredRuntime,
+				acceptance: task.acceptance,
+				acceptanceContext: { mode: "chain" },
 				onUpdate: input.onUpdate
 					? (progressUpdate) => {
 						const stepResults = progressUpdate.details?.results || [];
@@ -292,6 +327,17 @@ async function runParallelChainTasks(input: ParallelChainRunInput): Promise<Sing
 								chainAgents: input.chainAgents,
 								totalSteps: input.totalSteps,
 								currentStepIndex: input.stepIndex,
+								outputs: input.outputs,
+								workflowGraph: buildWorkflowGraphSnapshot({
+									runId: input.runId,
+									mode: "chain",
+									steps: input.chainSteps,
+									results: input.results.concat(stepResults),
+									currentStepIndex: input.stepIndex,
+									currentFlatIndex: input.globalTaskIndex + taskIndex,
+									dynamicChildren: input.dynamicChildren,
+									dynamicGroupStatuses: input.dynamicGroupStatuses,
+								}),
 							},
 						});
 					}
@@ -337,6 +383,7 @@ interface ChainExecutionParams {
 	foregroundControl?: ChainForegroundControl;
 	chainSkills?: string[];
 	chainDir?: string;
+	dynamicFanoutMaxItems?: number;
 	maxSubagentDepth: number;
 	workflowStageSubagentGuard?: boolean;
 	nestedRoute?: NestedRouteInfo;
@@ -387,22 +434,60 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 	} = params;
 	const chainSkills = chainSkillsParam ?? [];
 
+	const results: SingleResult[] = [];
+	const outputs: ChainOutputMap = {};
+	const dynamicChildren: ChainExecutionDetailsInput["dynamicChildren"] = {};
+	const dynamicGroupStatuses: ChainExecutionDetailsInput["dynamicGroupStatuses"] = {};
 	const allProgress: AgentProgress[] = [];
 	const allArtifactPaths: ArtifactPaths[] = [];
 
 	const chainAgents: string[] = chainSteps.map((step) =>
 		isParallelStep(step)
 			? `[${step.parallel.map((t) => t.agent).join("+")}]`
+			: isDynamicParallelStep(step)
+				? `expand:${step.parallel.agent}`
 			: (step as SequentialStep).agent,
 	);
 	const totalSteps = chainSteps.length;
 
+	const makeDetailsInput = (overrides: Pick<Partial<ChainExecutionDetailsInput>, "currentStepIndex" | "currentFlatIndex"> = {}): ChainExecutionDetailsInput => ({
+		results,
+		...(includeProgress !== undefined ? { includeProgress } : {}),
+		allProgress,
+		allArtifactPaths,
+		artifactsDir,
+		chainAgents,
+		chainSteps,
+		totalSteps,
+		runId,
+		outputs,
+		dynamicChildren,
+		dynamicGroupStatuses,
+		...overrides,
+	});
+
 	const firstStep = chainSteps[0]!;
 	const originalTask = params.task
-		?? (isParallelStep(firstStep) ? firstStep.parallel[0]!.task! : (firstStep as SequentialStep).task!);
+		?? (isParallelStep(firstStep)
+			? firstStep.parallel[0]!.task!
+			: isDynamicParallelStep(firstStep)
+				? firstStep.parallel.task!
+				: (firstStep as SequentialStep).task!);
+	try {
+		validateChainOutputBindings(chainSteps, { maxItems: params.dynamicFanoutMaxItems });
+	} catch (error) {
+		if (error instanceof ChainOutputValidationError) {
+			return {
+				content: [{ type: "text", text: error.message }],
+				isError: true,
+				details: buildChainExecutionDetails(makeDetailsInput()),
+			};
+		}
+		throw error;
+	}
 
 	const chainDir = createChainDir(runId, chainDirBase);
-	const hasParallelSteps = chainSteps.some(isParallelStep);
+	const hasParallelSteps = chainSteps.some((step) => isParallelStep(step) || isDynamicParallelStep(step));
 	let templates: ResolvedTemplates = resolveChainTemplates(chainSteps);
 	const shouldClarify = clarify !== false && ctx.hasUI && !hasParallelSteps;
 	let tuiBehaviorOverrides: (BehaviorOverride | undefined)[] | undefined;
@@ -419,7 +504,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				return {
 					content: [{ type: "text", text: `Unknown agent: ${step.agent}` }],
 					isError: true,
-					details: { mode: "chain" as const, results: [] },
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: seqSteps.indexOf(step) })),
 				};
 			}
 			agentConfigs.push(config);
@@ -464,7 +549,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			removeChainDir(chainDir);
 			return {
 				content: [{ type: "text", text: "Chain cancelled" }],
-				details: { mode: "chain", results: [] },
+				details: buildChainExecutionDetails(makeDetailsInput()),
 			};
 		}
 
@@ -486,7 +571,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			});
 			return {
 				content: [{ type: "text", text: "Launching in background..." }],
-				details: { mode: "chain", results: [] },
+				details: buildChainExecutionDetails(makeDetailsInput()),
 				requestedAsync: { chain: updatedChain, chainSkills },
 			};
 		}
@@ -495,7 +580,6 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 		tuiBehaviorOverrides = result.behaviorOverrides;
 	}
 
-	const results: SingleResult[] = [];
 	let prev = "";
 	let globalTaskIndex = 0;
 	let progressCreated = false;
@@ -513,16 +597,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				if (worktreeTaskCwdConflict) {
 					return buildChainExecutionErrorResult(
 						`parallel chain step ${stepIndex + 1}: ${formatWorktreeTaskCwdConflict(worktreeTaskCwdConflict, parallelCwd)}`,
-						{
-							results,
-							includeProgress,
-							allProgress,
-							allArtifactPaths,
-							artifactsDir,
-							chainAgents,
-							totalSteps,
-							currentStepIndex: stepIndex,
-						},
+						makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }),
 					);
 				}
 				try {
@@ -534,16 +609,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					});
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);
-					return buildChainExecutionErrorResult(message, {
-						results,
-						includeProgress,
-						allProgress,
-						allArtifactPaths,
-						artifactsDir,
-						chainAgents,
-						totalSteps,
-						currentStepIndex: stepIndex,
-					});
+					return buildChainExecutionErrorResult(message, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
 				}
 			}
 
@@ -557,16 +623,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 						? (path.isAbsolute(behavior.output) ? behavior.output : path.join(chainDir, behavior.output))
 						: undefined;
 					const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Parallel chain step ${stepIndex + 1} task ${taskIndex + 1} (${step.parallel[taskIndex]!.agent})`);
-					if (validationError) return buildChainExecutionErrorResult(validationError, {
-						results,
-						includeProgress,
-						allProgress,
-						allArtifactPaths,
-						artifactsDir,
-						chainAgents,
-						totalSteps,
-						currentStepIndex: stepIndex,
-					});
+					if (validationError) return buildChainExecutionErrorResult(validationError, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex + taskIndex }));
 				}
 				progressCreated = ensureParallelProgressFile(chainDir, progressCreated, parallelBehaviors);
 				createParallelDirs(chainDir, stepIndex, step.parallel.length, agentNames);
@@ -595,8 +652,12 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					onUpdate,
 					results,
 					allProgress,
+					outputs,
 					chainAgents,
+					chainSteps,
 					totalSteps,
+					dynamicChildren,
+					dynamicGroupStatuses,
 					controlConfig,
 					onControlEvent,
 					childIntercomTarget,
@@ -615,21 +676,15 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					if (result.progress) allProgress.push(result.progress);
 					if (result.artifactPaths) allArtifactPaths.push(result.artifactPaths);
 				}
-
-				const interrupted = parallelResults.find((result) => result.interrupted);
+				const interruptedIndexInStep = parallelResults.findIndex((result) => result.interrupted);
+				const interrupted = interruptedIndexInStep >= 0 ? parallelResults[interruptedIndexInStep] : undefined;
 				if (interrupted) {
 					return {
 						content: [{ type: "text", text: `Chain paused after interrupt at step ${stepIndex + 1} (${interrupted.agent}). Waiting for explicit next action.` }],
-						details: buildChainExecutionDetails({
-							results,
-							includeProgress,
-							allProgress,
-							allArtifactPaths,
-							artifactsDir,
-							chainAgents,
-							totalSteps,
+						details: buildChainExecutionDetails(makeDetailsInput({
 							currentStepIndex: stepIndex,
-						}),
+							currentFlatIndex: globalTaskIndex - step.parallel.length + interruptedIndexInStep,
+						})),
 					};
 				}
 				const detachedIndexInStep = parallelResults.findIndex((result) => result.detached);
@@ -637,16 +692,10 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				if (detached) {
 					return {
 						content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${detached.agent}). Reply to the supervisor request first. After the child exits, start a fresh follow-up if needed.` }],
-						details: buildChainExecutionDetails({
-							results,
-							includeProgress,
-							allProgress,
-							allArtifactPaths,
-							artifactsDir,
-							chainAgents,
-							totalSteps,
+						details: buildChainExecutionDetails(makeDetailsInput({
 							currentStepIndex: stepIndex,
-						}),
+							currentFlatIndex: globalTaskIndex - step.parallel.length + detachedIndexInStep,
+						})),
 					};
 				}
 
@@ -665,17 +714,16 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 					return {
 						content: [{ type: "text", text: summary }],
 						isError: true,
-						details: buildChainExecutionDetails({
-							results,
-							includeProgress,
-							allProgress,
-							allArtifactPaths,
-							artifactsDir,
-							chainAgents,
-							totalSteps,
+						details: buildChainExecutionDetails(makeDetailsInput({
 							currentStepIndex: stepIndex,
-						}),
+							currentFlatIndex: globalTaskIndex - step.parallel.length + failures[0]!.originalIndex,
+						})),
 					};
+				}
+
+				for (let taskIndex = 0; taskIndex < parallelResults.length; taskIndex++) {
+					const outputName = step.parallel[taskIndex]?.as;
+					if (outputName) outputs[outputName] = outputEntryFromResult(parallelResults[taskIndex]!, stepIndex);
 				}
 
 				const taskResults: ParallelTaskResult[] = parallelResults.map((result, i) => {
@@ -703,6 +751,227 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			} finally {
 				if (worktreeSetup) cleanupWorktrees(worktreeSetup);
 			}
+		} else if (isDynamicParallelStep(step)) {
+			let materialized: ReturnType<typeof materializeDynamicParallelStep>;
+			try {
+				materialized = materializeDynamicParallelStep(step, outputs, stepIndex, { maxItems: params.dynamicFanoutMaxItems });
+			} catch (error) {
+				const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
+				dynamicGroupStatuses[stepIndex] = { status: "failed", error: message };
+				return buildChainExecutionErrorResult(message, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
+			}
+
+			dynamicChildren[stepIndex] = materialized.items.map((item, itemIndex) => ({
+				agent: step.parallel.agent,
+				label: materialized.parallel[itemIndex]?.label,
+				flatIndex: globalTaskIndex + itemIndex,
+				itemKey: item.key,
+				structured: Boolean(step.parallel.outputSchema),
+			}));
+
+			if (materialized.parallel.length === 0) {
+				const collection: DynamicCollectedResult[] = [];
+				try {
+					validateDynamicCollection(step.collect.outputSchema, collection);
+				} catch (error) {
+					const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
+					dynamicGroupStatuses[stepIndex] = { status: "failed", error: message };
+					return buildChainExecutionErrorResult(message, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
+				}
+				outputs[step.collect.as] = {
+					text: JSON.stringify(collection),
+					structured: collection,
+					agent: step.parallel.agent,
+					stepIndex,
+				};
+				dynamicGroupStatuses[stepIndex] = { status: "completed" };
+				if (step.acceptance !== undefined) {
+					const effectiveGroupAcceptance = resolveEffectiveAcceptance({
+						explicit: step.acceptance,
+						agentName: step.parallel.agent,
+						task: step.parallel.task ?? originalTask,
+						mode: "chain",
+						dynamicGroup: true,
+					});
+					const groupAcceptance = await evaluateAcceptance({
+						acceptance: effectiveGroupAcceptance,
+						output: "",
+						report: aggregateAcceptanceReport({
+							results: [],
+							notes: "Dynamic fanout produced 0 results.",
+						}),
+						cwd: cwd ?? ctx.cwd,
+					});
+					dynamicGroupStatuses[stepIndex].acceptance = groupAcceptance;
+					const groupAcceptanceFailure = acceptanceFailureMessage(groupAcceptance);
+					if (groupAcceptanceFailure) {
+						dynamicGroupStatuses[stepIndex] = { status: "failed", error: groupAcceptanceFailure, acceptance: groupAcceptance };
+						return buildChainExecutionErrorResult(groupAcceptanceFailure, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
+					}
+				}
+				prev = "Dynamic fanout produced 0 results.";
+				continue;
+			}
+
+			const dynamicParallelStep: ParallelStep = {
+				parallel: materialized.parallel,
+				concurrency: step.concurrency,
+				failFast: step.failFast,
+			};
+			const parallelTemplates = materialized.parallel.map((task) => task.task ?? "{previous}");
+			const parallelBehaviors = resolveParallelBehaviors(dynamicParallelStep.parallel, agents, stepIndex, chainSkills)
+				.map((behavior, taskIndex) => suppressProgressForReadOnlyTask(behavior, parallelTemplates[taskIndex] ?? dynamicParallelStep.parallel[taskIndex]?.task, originalTask));
+
+			for (let taskIndex = 0; taskIndex < dynamicParallelStep.parallel.length; taskIndex++) {
+				const behavior = parallelBehaviors[taskIndex]!;
+				const outputPath = typeof behavior.output === "string"
+					? (path.isAbsolute(behavior.output) ? behavior.output : path.join(chainDir, behavior.output))
+					: undefined;
+				const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Dynamic chain step ${stepIndex + 1} item ${taskIndex + 1} (${dynamicParallelStep.parallel[taskIndex]!.agent})`);
+				if (validationError) {
+					dynamicGroupStatuses[stepIndex] = { status: "failed", error: validationError };
+					return buildChainExecutionErrorResult(validationError, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex + taskIndex }));
+				}
+			}
+
+			progressCreated = ensureParallelProgressFile(chainDir, progressCreated, parallelBehaviors);
+			createParallelDirs(chainDir, stepIndex, dynamicParallelStep.parallel.length, dynamicParallelStep.parallel.map((task) => task.agent));
+			const parallelResults = await runParallelChainTasks({
+				step: dynamicParallelStep,
+				parallelTemplates,
+				parallelBehaviors,
+				agents,
+				stepIndex,
+				availableModels,
+				chainDir,
+				prev,
+				originalTask,
+				ctx,
+				intercomEvents,
+				cwd,
+				runId,
+				globalTaskIndex,
+				sessionDirForIndex,
+				sessionFileForIndex,
+				shareEnabled,
+				artifactConfig,
+				artifactsDir,
+				signal,
+				onUpdate,
+				results,
+				allProgress,
+				outputs,
+				chainAgents,
+				chainSteps,
+				totalSteps,
+				dynamicChildren,
+				dynamicGroupStatuses,
+				controlConfig,
+				onControlEvent,
+				childIntercomTarget,
+				orchestratorIntercomTarget,
+				foregroundControl,
+				nestedRoute: params.nestedRoute,
+				maxSubagentDepth: params.maxSubagentDepth,
+				workflowStageSubagentGuard: params.workflowStageSubagentGuard,
+				runSync: executeRunSync,
+			});
+			globalTaskIndex += dynamicParallelStep.parallel.length;
+
+			for (const result of parallelResults) {
+				results.push(result);
+				if (result.progress) allProgress.push(result.progress);
+				if (result.artifactPaths) allArtifactPaths.push(result.artifactPaths);
+			}
+			const collected = collectDynamicResults(step, materialized.items, parallelResults);
+			const interruptedIndexInStep = parallelResults.findIndex((result) => result.interrupted);
+			const interrupted = interruptedIndexInStep >= 0 ? parallelResults[interruptedIndexInStep] : undefined;
+			if (interrupted) {
+				return {
+					content: [{ type: "text", text: `Chain paused after interrupt at step ${stepIndex + 1} (${interrupted.agent}). Waiting for explicit next action.` }],
+					details: buildChainExecutionDetails(makeDetailsInput({
+						currentStepIndex: stepIndex,
+						currentFlatIndex: globalTaskIndex - dynamicParallelStep.parallel.length + interruptedIndexInStep,
+					})),
+				};
+			}
+			const detachedIndexInStep = parallelResults.findIndex((result) => result.detached);
+			const detached = detachedIndexInStep >= 0 ? parallelResults[detachedIndexInStep] : undefined;
+			if (detached) {
+				return {
+					content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${detached.agent}). Reply to the supervisor request first. After the child exits, start a fresh follow-up if needed.` }],
+					details: buildChainExecutionDetails(makeDetailsInput({
+						currentStepIndex: stepIndex,
+						currentFlatIndex: globalTaskIndex - dynamicParallelStep.parallel.length + detachedIndexInStep,
+					})),
+				};
+			}
+			const failures = parallelResults
+				.map((result, originalIndex) => ({ ...result, originalIndex }))
+				.filter((result) => result.exitCode !== 0 && result.exitCode !== -1);
+			if (failures.length > 0) {
+				const failureSummary = failures
+					.map((failure) => `- Item ${failure.originalIndex + 1} (${failure.agent}, key ${materialized.items[failure.originalIndex]?.key ?? failure.originalIndex}): ${failure.error || "failed"}`)
+					.join("\n");
+				const errorMsg = `Dynamic step ${stepIndex + 1} failed:\n${failureSummary}`;
+				dynamicGroupStatuses[stepIndex] = { status: "failed", error: errorMsg };
+				const summary = buildChainSummary(chainSteps, results, chainDir, "failed", {
+					index: stepIndex,
+					error: errorMsg,
+				});
+				return {
+					content: [{ type: "text", text: summary }],
+					isError: true,
+					details: buildChainExecutionDetails(makeDetailsInput({
+						currentStepIndex: stepIndex,
+						currentFlatIndex: globalTaskIndex - dynamicParallelStep.parallel.length + failures[0]!.originalIndex,
+					})),
+				};
+			}
+			try {
+				validateDynamicCollection(step.collect.outputSchema, collected);
+			} catch (error) {
+				const message = error instanceof DynamicFanoutError ? error.message : error instanceof Error ? error.message : String(error);
+				dynamicGroupStatuses[stepIndex] = { status: "failed", error: message };
+				return buildChainExecutionErrorResult(message, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - dynamicParallelStep.parallel.length }));
+			}
+			outputs[step.collect.as] = {
+				text: JSON.stringify(collected),
+				structured: collected,
+				agent: step.parallel.agent,
+				stepIndex,
+			};
+			dynamicGroupStatuses[stepIndex] = { status: "completed" };
+			const effectiveGroupAcceptance = resolveEffectiveAcceptance({
+				explicit: step.acceptance,
+				agentName: step.parallel.agent,
+				task: step.parallel.task ?? originalTask,
+				mode: "chain",
+				dynamicGroup: true,
+			});
+			const groupAcceptance = await evaluateAcceptance({
+				acceptance: effectiveGroupAcceptance,
+				output: "",
+				report: aggregateAcceptanceReport({
+					results: parallelResults,
+					notes: `Dynamic fanout collected ${collected.length} result(s) into ${step.collect.as}.`,
+				}),
+				cwd: cwd ?? ctx.cwd,
+			});
+			dynamicGroupStatuses[stepIndex].acceptance = groupAcceptance;
+			const groupAcceptanceFailure = acceptanceFailureMessage(groupAcceptance);
+			if (groupAcceptanceFailure) {
+				dynamicGroupStatuses[stepIndex] = { status: "failed", error: groupAcceptanceFailure, acceptance: groupAcceptance };
+				return buildChainExecutionErrorResult(groupAcceptanceFailure, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - dynamicParallelStep.parallel.length }));
+			}
+			const taskResults: ParallelTaskResult[] = parallelResults.map((result, i) => ({
+				agent: result.agent,
+				taskIndex: i,
+				output: getSingleResultOutput(result),
+				exitCode: result.exitCode,
+				error: result.error,
+			}));
+			prev = aggregateParallelOutputs(taskResults, (i, agent) => `=== Dynamic Item ${i + 1} (${agent}, key ${materialized.items[i]?.key ?? i}) ===`);
 		} else {
 			const seqStep = step as SequentialStep;
 			const stepTemplate = stepTemplates as string;
@@ -713,7 +982,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				return {
 					content: [{ type: "text", text: `Unknown agent: ${seqStep.agent}` }],
 					isError: true,
-					details: { mode: "chain" as const, results: [] },
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex })),
 				};
 			}
 
@@ -743,7 +1012,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				templateHasPrevious ? undefined : prev,
 			);
 
-			let stepTask = stepTemplate;
+			let stepTask = resolveOutputReferences(stepTemplate, outputs);
 			stepTask = stepTask.replace(/\{task\}/g, originalTask);
 			stepTask = stepTask.replace(/\{previous\}/g, prev);
 			stepTask = stepTask.replace(/\{chain_dir\}/g, chainDir);
@@ -760,16 +1029,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				: undefined;
 			const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Chain step ${stepIndex + 1} (${seqStep.agent})`);
 			if (validationError) {
-				return buildChainExecutionErrorResult(validationError, {
-					results,
-					includeProgress,
-					allProgress,
-					allArtifactPaths,
-					artifactsDir,
-					chainAgents,
-					totalSteps,
-					currentStepIndex: stepIndex,
-				});
+				return buildChainExecutionErrorResult(validationError, makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex }));
 			}
 			const maxSubagentDepth = resolveChildMaxSubagentDepth(params.maxSubagentDepth, agentConfig.maxSubagentDepth);
 			const interruptController = new AbortController();
@@ -787,6 +1047,9 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				};
 			}
 
+			const structuredRuntime = seqStep.outputSchema
+				? createStructuredOutputRuntime(seqStep.outputSchema, path.join(chainDir, "structured-output"))
+				: undefined;
 			const r = await executeRunSync(ctx.cwd, agents, seqStep.agent, stepTask, {
 				cwd: resolveChildCwd(cwd ?? ctx.cwd, seqStep.cwd),
 				signal,
@@ -814,6 +1077,9 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				currentModel: currentModelFullId(ctx.model),
 				preferredModelProvider: ctx.model?.provider,
 				skills: behavior.skills === false ? [] : behavior.skills,
+				structuredOutput: structuredRuntime,
+				acceptance: seqStep.acceptance,
+				acceptanceContext: { mode: "chain" },
 				onUpdate: onUpdate
 					? (p) => {
 						const stepResults = p.details?.results || [];
@@ -842,6 +1108,17 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 								chainAgents,
 								totalSteps,
 								currentStepIndex: stepIndex,
+								outputs,
+								workflowGraph: buildWorkflowGraphSnapshot({
+									runId,
+									mode: "chain",
+									steps: chainSteps,
+									results: results.concat(stepResults),
+									currentStepIndex: stepIndex,
+									currentFlatIndex: globalTaskIndex,
+									dynamicChildren,
+									dynamicGroupStatuses,
+								}),
 							},
 						});
 					}
@@ -861,31 +1138,13 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 			if (r.interrupted) {
 				return {
 					content: [{ type: "text", text: `Chain paused after interrupt at step ${stepIndex + 1} (${r.agent}). Waiting for explicit next action.` }],
-					details: buildChainExecutionDetails({
-						results,
-						includeProgress,
-						allProgress,
-						allArtifactPaths,
-						artifactsDir,
-						chainAgents,
-						totalSteps,
-						currentStepIndex: stepIndex,
-					}),
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - 1 })),
 				};
 			}
 			if (r.detached) {
 				return {
 					content: [{ type: "text", text: `Chain detached for intercom coordination at step ${stepIndex + 1} (${r.agent}). Reply to the supervisor request first. After the child exits, start a fresh follow-up if needed.` }],
-					details: buildChainExecutionDetails({
-						results,
-						includeProgress,
-						allProgress,
-						allArtifactPaths,
-						artifactsDir,
-						chainAgents,
-						totalSteps,
-						currentStepIndex: stepIndex,
-					}),
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - 1 })),
 				};
 			}
 
@@ -896,16 +1155,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				});
 				return {
 					content: [{ type: "text", text: summary }],
-					details: buildChainExecutionDetails({
-						results,
-						includeProgress,
-						allProgress,
-						allArtifactPaths,
-						artifactsDir,
-						chainAgents,
-						totalSteps,
-						currentStepIndex: stepIndex,
-					}),
+					details: buildChainExecutionDetails(makeDetailsInput({ currentStepIndex: stepIndex, currentFlatIndex: globalTaskIndex - 1 })),
 					isError: true,
 				};
 			}
@@ -928,6 +1178,7 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 				}
 			}
 
+			if (seqStep.as) outputs[seqStep.as] = outputEntryFromResult(r, stepIndex);
 			prev = getSingleResultOutput(r);
 		}
 	}
@@ -936,14 +1187,6 @@ export async function executeChain(params: ChainExecutionParams): Promise<ChainE
 
 	return {
 		content: [{ type: "text", text: summary }],
-		details: buildChainExecutionDetails({
-			results,
-			includeProgress,
-			allProgress,
-			allArtifactPaths,
-			artifactsDir,
-			chainAgents,
-			totalSteps,
-		}),
+		details: buildChainExecutionDetails(makeDetailsInput()),
 	};
 }

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -3,7 +3,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, unlinkSync } from "node:fs";
 import type { Message } from "@earendil-works/pi-ai";
 import type { CodexFastModeResolvedSettings, CodexFastModeScope } from "@bastani/atomic";
 import type { AgentConfig } from "../../agents/agents.ts";
@@ -47,6 +47,7 @@ import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir } from "../shared/pi-args.ts";
+import { readStructuredOutput } from "../shared/structured-output.ts";
 import { captureSingleOutputSnapshot, formatSavedOutputReference, resolveSingleOutput, validateFileOnlyOutputMode, type SingleOutputSnapshot } from "../shared/single-output.ts";
 import {
 	buildModelCandidates,
@@ -70,8 +71,10 @@ import {
 	resolveSubagentModelFastMode,
 } from "../../shared/fast-mode.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
+import { acceptanceFailureMessage, evaluateAcceptance, formatAcceptancePrompt, resolveEffectiveAcceptance, stripAcceptanceReport } from "../shared/acceptance.ts";
 
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
+const acceptanceOutputByResult = new WeakMap<SingleResult, string>();
 
 function emptyUsage(): Usage {
 	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
@@ -91,6 +94,17 @@ function appendRecentOutput(progress: AgentProgress, lines: string[]): void {
 	progress.recentOutput.push(...lines.filter((line) => line.trim()));
 	if (progress.recentOutput.length > 50) {
 		progress.recentOutput.splice(0, progress.recentOutput.length - 50);
+	}
+}
+
+function stripAcceptanceReportsFromMessages(messages: Message[] | undefined): void {
+	for (const message of messages ?? []) {
+		if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
+		for (const part of message.content) {
+			if (part.type === "text" && "text" in part && typeof part.text === "string") {
+				part.text = stripAcceptanceReport(part.text);
+			}
+		}
 	}
 }
 
@@ -142,6 +156,7 @@ async function runSingleAttempt(
 		outputSnapshot?: SingleOutputSnapshot;
 		fastModeSettings: CodexFastModeResolvedSettings;
 		fastModeScope: CodexFastModeScope;
+		originalTask?: string;
 	},
 ): Promise<SingleResult> {
 	const modelArg = applyThinkingSuffix(model, agent.thinking);
@@ -180,11 +195,12 @@ async function runSingleAttempt(
 		parentCapabilityToken: options.nestedRoute?.capabilityToken,
 		codexFastModeSettings: shared.fastModeSettings,
 		codexFastModeScope: shared.fastModeScope,
+		structuredOutput: options.structuredOutput,
 	});
 
 	const result: SingleResult = {
 		agent: agent.name,
-		task,
+		task: shared.originalTask ?? task,
 		exitCode: 0,
 		messages: [],
 		usage: emptyUsage(),
@@ -195,6 +211,13 @@ async function runSingleAttempt(
 		skillsWarning: shared.skillsWarning,
 	};
 	const startTime = Date.now();
+	if (options.structuredOutput) {
+		try {
+			if (existsSync(options.structuredOutput.outputPath)) unlinkSync(options.structuredOutput.outputPath);
+		} catch {
+			// Missing/stale structured-output files are handled after the child exits.
+		}
+	}
 	const controlConfig = options.controlConfig ?? DEFAULT_CONTROL_CONFIG;
 	let interruptedByControl = false;
 	const allControlEvents: ControlEvent[] = [];
@@ -680,6 +703,21 @@ async function runSingleAttempt(
 				: `${errInfo.errorType} failed with exit code ${errInfo.exitCode}`;
 		}
 	}
+	if (options.structuredOutput && result.exitCode === 0 && !result.error) {
+		const structured = readStructuredOutput({
+			schema: options.structuredOutput.schema,
+			schemaPath: options.structuredOutput.schemaPath,
+			outputPath: options.structuredOutput.outputPath,
+		});
+		result.structuredOutputSchemaPath = options.structuredOutput.schemaPath;
+		result.structuredOutputPath = options.structuredOutput.outputPath;
+		if (structured.error) {
+			result.exitCode = 1;
+			result.error = structured.error;
+		} else {
+			result.structuredOutput = structured.value;
+		}
+	}
 
 	progress.status = result.exitCode === 0 ? "completed" : "failed";
 	progress.durationMs = Date.now() - startTime;
@@ -696,11 +734,12 @@ async function runSingleAttempt(
 		durationMs: progress.durationMs,
 	};
 
-	let fullOutput = getFinalOutput(result.messages ?? []);
+	const acceptanceOutput = getFinalOutput(result.messages ?? []);
+	let fullOutput = stripAcceptanceReport(acceptanceOutput);
 	const completionGuard = result.exitCode === 0 && !result.error && agent.completionGuard !== false
 		? evaluateCompletionMutationGuard({
 			agent: agent.name,
-			task,
+			task: shared.originalTask ?? task,
 			messages: result.messages ?? [],
 			tools: agent.tools,
 			mcpDirectTools: agent.mcpDirectTools,
@@ -724,7 +763,7 @@ async function runSingleAttempt(
 	}
 	if (options.outputPath && result.exitCode === 0) {
 		const resolvedOutput = resolveSingleOutput(options.outputPath, fullOutput, shared.outputSnapshot);
-		fullOutput = resolvedOutput.fullOutput;
+		fullOutput = stripAcceptanceReport(resolvedOutput.fullOutput);
 		result.savedOutputPath = resolvedOutput.savedPath;
 		result.outputSaveError = resolvedOutput.saveError;
 		if (resolvedOutput.savedPath) {
@@ -732,6 +771,7 @@ async function runSingleAttempt(
 		}
 	}
 	artifactOutputByResult.set(result, fullOutput);
+	acceptanceOutputByResult.set(result, acceptanceOutput);
 	result.outputMode = options.outputMode ?? "inline";
 	result.finalOutput = options.outputMode === "file-only" && result.savedOutputPath && result.outputReference
 		? result.outputReference.message
@@ -789,6 +829,17 @@ export async function runSync(
 	}
 
 	const shareEnabled = options.share === true;
+	const effectiveAcceptance = resolveEffectiveAcceptance({
+		explicit: options.acceptance,
+		agentName,
+		task,
+		mode: options.acceptanceContext?.mode ?? "single",
+		async: options.acceptanceContext?.async,
+		dynamic: options.acceptanceContext?.dynamic,
+		dynamicGroup: options.acceptanceContext?.dynamicGroup,
+	});
+	const acceptancePrompt = formatAcceptancePrompt(effectiveAcceptance);
+	const taskWithAcceptance = acceptancePrompt ? `${task}\n${acceptancePrompt}` : task;
 	const sessionEnabled = Boolean(options.sessionFile || options.sessionDir) || shareEnabled;
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const skillCwd = options.cwd ?? runtimeCwd;
@@ -833,7 +884,7 @@ export async function runSync(
 		artifactPathsResult = getArtifactPaths(options.artifactsDir, options.runId, agentName, options.index);
 		ensureArtifactsDir(options.artifactsDir);
 		if (options.artifactConfig?.includeInput !== false) {
-			writeArtifact(artifactPathsResult.inputPath, `# Task for ${agentName}\n\n${task}`);
+				writeArtifact(artifactPathsResult.inputPath, `# Task for ${agentName}\n\n${taskWithAcceptance}`);
 		}
 		if (options.artifactConfig?.includeJsonl !== false) {
 			jsonlPath = artifactPathsResult.jsonlPath;
@@ -846,7 +897,7 @@ export async function runSync(
 		const candidate = modelsToTry[i];
 		if (candidate) attemptedModels.push(candidate);
 		const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-		const result = await runSingleAttempt(runtimeCwd, agent, task, candidate, options, {
+		const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, options, {
 			sessionEnabled,
 			systemPrompt,
 			resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
@@ -857,6 +908,7 @@ export async function runSync(
 			outputSnapshot,
 			fastModeSettings,
 			fastModeScope,
+			originalTask: task,
 		});
 		lastResult = result;
 		sumUsage(aggregateUsage, result.usage);
@@ -947,6 +999,22 @@ export async function runSync(
 	} else if (shareEnabled && options.sessionDir) {
 		const sessionFile = findLatestSessionFile(options.sessionDir);
 		if (sessionFile) result.sessionFile = sessionFile;
+	}
+
+		result.acceptance = await evaluateAcceptance({
+			acceptance: effectiveAcceptance,
+			output: acceptanceOutputByResult.get(result) ?? result.finalOutput ?? "",
+			cwd: options.cwd ?? runtimeCwd,
+		});
+		const acceptanceFailure = acceptanceFailureMessage(result.acceptance);
+		stripAcceptanceReportsFromMessages(result.messages);
+		if (acceptanceFailure && result.acceptance.explicit && result.exitCode === 0 && !result.detached && !result.interrupted) {
+		result.exitCode = 1;
+		result.error = result.error ? `${result.error}\n${acceptanceFailure}` : acceptanceFailure;
+		if (result.progress) {
+			result.progress.status = "failed";
+			result.progress.error = result.error;
+		}
 	}
 
 	return result;

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -21,6 +21,7 @@ import {
 	writeInitialProgressFile,
 	getStepAgents,
 	isParallelStep,
+	isDynamicParallelStep,
 	resolveStepBehavior,
 	suppressProgressForReadOnlyTask,
 	taskDisallowsFileUpdates,
@@ -63,6 +64,7 @@ import {
 } from "../shared/worktree.ts";
 import {
 	type AgentProgress,
+	type AcceptanceInput,
 	type ArtifactConfig,
 	type ArtifactPaths,
 	type ControlConfig,
@@ -107,6 +109,7 @@ interface TaskParam {
 	progress?: boolean;
 	model?: string;
 	skill?: string | string[] | boolean;
+	acceptance?: AcceptanceInput;
 }
 
 export interface SubagentParamsLike {
@@ -140,6 +143,7 @@ export interface SubagentParamsLike {
 	outputMode?: "inline" | "file-only";
 	agentScope?: string;
 	chainDir?: string;
+	acceptance?: AcceptanceInput;
 }
 
 export interface SubagentExecutorRuntimeDeps {
@@ -858,6 +862,12 @@ function validateExecutionInput(
 					details: { mode: "chain" as const, results: [] },
 				};
 			}
+		} else if (isDynamicParallelStep(firstStep)) {
+			return {
+				content: [{ type: "text", text: "First step in chain cannot be dynamic fanout; expand.from requires a prior structured named output" }],
+				isError: true,
+				details: { mode: "chain" as const, results: [] },
+			};
 		} else if (!(firstStep as SequentialStep).task && !params.task && !allowClarifyTaskPrompt) {
 			return {
 				content: [{ type: "text", text: "First step in chain must have a task" }],
@@ -1019,6 +1029,10 @@ function collectChainSessionFiles(
 			}
 			continue;
 		}
+		if (isDynamicParallelStep(step)) {
+			sessionFiles.push(undefined);
+			continue;
+		}
 		sessionFiles.push(sessionFileForIndex(flatIndex));
 		flatIndex++;
 	}
@@ -1035,6 +1049,15 @@ function wrapChainTasksForFork(chain: ChainStep[], context: SubagentParamsLike["
 					...task,
 					task: wrapForkTask(task.task ?? "{previous}"),
 				})),
+			};
+		}
+		if (isDynamicParallelStep(step)) {
+			return {
+				...step,
+				parallel: {
+					...step.parallel,
+					task: wrapForkTask(step.parallel.task ?? "{previous}"),
+				},
 			};
 		}
 		const sequential = step as SequentialStep;
@@ -1127,6 +1150,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): S
 			...(task.outputMode !== undefined ? { outputMode: task.outputMode } : {}),
 			...(task.reads !== undefined && task.reads !== true ? { reads: task.reads } : {}),
 			...(task.progress !== undefined ? { progress: task.progress } : {}),
+			...(task.acceptance !== undefined ? { acceptance: task.acceptance } : {}),
 		}));
 		return deps.runtime.executeAsyncChain(id, {
 			chain: [{
@@ -1175,6 +1199,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): S
 			sessionRoot,
 			chainSkills,
 			sessionFilesByFlatIndex: collectChainSessionFiles(chain, sessionFileForIndex),
+			dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: currentMaxSubagentDepth,
 			workflowStageSubagentGuard,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
@@ -1227,6 +1252,7 @@ function runAsyncPath(data: ExecutionContextData, deps: ResolvedExecutorDeps): S
 			controlIntercomTarget,
 			childIntercomTarget: childIntercomTarget ? (agent, index) => childIntercomTarget(agent, index) : undefined,
 			nestedRoute,
+			acceptance: params.acceptance,
 		});
 	}
 
@@ -1284,6 +1310,7 @@ async function runChainPath(data: ExecutionContextData, deps: ResolvedExecutorDe
 		nestedRoute: foregroundControl?.nestedRoute,
 		chainSkills,
 		chainDir: params.chainDir,
+		dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 		maxSubagentDepth: currentMaxSubagentDepth,
 		workflowStageSubagentGuard,
 		worktreeSetupHook: deps.config.worktreeSetupHook,
@@ -1322,6 +1349,7 @@ async function runChainPath(data: ExecutionContextData, deps: ResolvedExecutorDe
 			sessionRoot,
 			chainSkills: chainResult.requestedAsync.chainSkills,
 			sessionFilesByFlatIndex: collectChainSessionFiles(asyncChain, sessionFileForIndex),
+			dynamicFanoutMaxItems: deps.config.chain?.dynamicFanout?.maxItems,
 			maxSubagentDepth: currentMaxSubagentDepth,
 			workflowStageSubagentGuard,
 			worktreeSetupHook: deps.config.worktreeSetupHook,
@@ -1549,6 +1577,8 @@ async function runForegroundParallelTasks(input: ForegroundParallelRunInput): Pr
 			preferredModelProvider: input.ctx.model?.provider,
 			currentModel: currentModelFullId(input.ctx.model),
 			skills: effectiveSkills === false ? [] : effectiveSkills,
+			acceptance: task.acceptance,
+			acceptanceContext: { mode: "parallel" },
 			onUpdate: input.onUpdate
 				? (progressUpdate) => {
 					const stepResults = progressUpdate.details?.results || [];
@@ -1741,6 +1771,7 @@ async function runParallelPath(data: ExecutionContextData, deps: ResolvedExecuto
 					...(behaviorOverrides[i]?.outputMode !== undefined ? { outputMode: behaviorOverrides[i]!.outputMode } : {}),
 					...(behaviorOverrides[i]?.reads !== undefined ? { reads: behaviorOverrides[i]!.reads } : {}),
 					...(progress !== undefined ? { progress } : {}),
+					...(t.acceptance !== undefined ? { acceptance: t.acceptance } : {}),
 				};
 			});
 			return deps.runtime.executeAsyncChain(id, {
@@ -2123,6 +2154,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ResolvedExecutorD
 		preferredModelProvider: currentProvider,
 		currentModel: currentModelFullId(ctx.model),
 		skills: effectiveSkills,
+		acceptance: params.acceptance,
+		acceptanceContext: { mode: "single" },
 	});
 	if (foregroundControl?.currentIndex === 0) {
 		foregroundControl.interrupt = undefined;

--- a/packages/subagents/src/runs/shared/acceptance.ts
+++ b/packages/subagents/src/runs/shared/acceptance.ts
@@ -1,0 +1,611 @@
+import { spawn } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+import type {
+	AcceptanceConfig,
+	AcceptanceEvidenceKind,
+	AcceptanceInput,
+	AcceptanceLedger,
+	AcceptanceLevel,
+	AcceptanceReport,
+	AcceptanceRuntimeCheck,
+	AcceptanceReviewResult,
+	AcceptanceVerifyCommand,
+	AcceptanceVerifyResult,
+	ResolvedAcceptanceConfig,
+	ResolvedAcceptanceGate,
+	SingleResult,
+	SubagentRunMode,
+} from "../../shared/types.ts";
+
+const LEVEL_RANK: Record<Exclude<AcceptanceLevel, "auto">, number> = {
+	none: 0,
+	attested: 1,
+	checked: 2,
+	verified: 3,
+	reviewed: 4,
+};
+
+const VALID_LEVELS = new Set<AcceptanceLevel>(["auto", "none", "attested", "checked", "verified", "reviewed"]);
+const VALID_EVIDENCE = new Set<AcceptanceEvidenceKind>([
+	"changed-files",
+	"tests-added",
+	"commands-run",
+	"validation-output",
+	"residual-risks",
+	"no-staged-files",
+	"diff-summary",
+	"review-findings",
+	"manual-notes",
+]);
+
+function normalizeLevel(level: AcceptanceLevel | undefined): Exclude<AcceptanceLevel, "auto"> | "auto" {
+	return level ?? "auto";
+}
+
+function unique<T>(items: T[]): T[] {
+	return [...new Set(items)];
+}
+
+function requiredEvidenceForLevel(level: Exclude<AcceptanceLevel, "auto">): AcceptanceEvidenceKind[] {
+	switch (level) {
+		case "none":
+			return [];
+		case "attested":
+			return ["manual-notes", "residual-risks"];
+		case "checked":
+			return ["changed-files", "tests-added", "commands-run", "residual-risks", "no-staged-files"];
+		case "verified":
+		case "reviewed":
+			return ["changed-files", "tests-added", "commands-run", "validation-output", "residual-risks", "no-staged-files"];
+	}
+}
+
+function inferLevel(input: {
+	agentName: string;
+	task?: string;
+	mode?: SubagentRunMode;
+	async?: boolean;
+	dynamic?: boolean;
+	dynamicGroup?: boolean;
+}): { level: Exclude<AcceptanceLevel, "auto">; reasons: string[]; criteria: string[]; evidence: AcceptanceEvidenceKind[]; review?: { agent?: string; required?: boolean } } {
+	const agent = input.agentName.toLowerCase();
+	const task = input.task?.toLowerCase() ?? "";
+	const reasons: string[] = [];
+	const readOnlyAgent = [
+		"codebase-locator",
+		"codebase-analyzer",
+		"codebase-pattern-finder",
+		"codebase-research-locator",
+		"codebase-research-analyzer",
+		"codebase-online-researcher",
+	].includes(agent) || /\b(?:reviewer|scout|context-builder|researcher|analyst)\b/.test(agent);
+	const readOnlyTask = /\b(?:read[- ]only|review[- ]only|do not edit|don't edit|no edits|without edits|inspect|summari[sz]e)\b/.test(task);
+	const writeTask = /\b(?:fix|implement|update|write|edit|modify|migrate|release|security|delete|remove|refactor|commit)\b/.test(task)
+		|| /\bworker\b/.test(agent);
+	const risky = Boolean(input.async && writeTask)
+		|| Boolean(input.dynamic)
+		|| Boolean(input.dynamicGroup)
+		|| /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/.test(task);
+
+	if (risky) {
+		reasons.push(input.async ? "async write-capable or risky run" : "risky write-capable run");
+		if (input.dynamic || input.dynamicGroup) reasons.push("dynamic fanout context");
+		return {
+			level: "reviewed",
+			reasons,
+			criteria: ["Implement the requested change without widening scope", "Return evidence sufficient for an independent acceptance review"],
+			evidence: requiredEvidenceForLevel("reviewed"),
+			review: { agent: "codebase-analyzer", required: true },
+		};
+	}
+	if (writeTask && !readOnlyTask) {
+		reasons.push("write-capable worker/task");
+		return {
+			level: "checked",
+			reasons,
+			criteria: ["Implement the requested change without widening scope"],
+			evidence: requiredEvidenceForLevel("checked"),
+		};
+	}
+	if (readOnlyAgent || readOnlyTask) {
+		reasons.push(readOnlyAgent ? "read-only/reviewer-style agent" : "read-only task wording");
+		return {
+			level: "attested",
+			reasons,
+			criteria: ["Return concrete findings with file paths and severity when applicable"],
+			evidence: ["review-findings", "residual-risks"],
+		};
+	}
+	reasons.push("default lightweight attestation");
+	return {
+		level: "attested",
+		reasons,
+		criteria: ["Return a concise result and residual risks when applicable"],
+		evidence: ["manual-notes", "residual-risks"],
+	};
+}
+
+export function normalizeAcceptanceInput(input: AcceptanceInput | undefined): AcceptanceConfig {
+	if (input === undefined || input === "auto") return { level: "auto" };
+	if (input === false) return { level: "none", reason: "disabled by deprecated false shorthand" };
+	if (typeof input === "string") return { level: input };
+	return { ...input };
+}
+
+function explicitAcceptanceCanDisable(explicit: AcceptanceConfig): boolean {
+	return explicit.level === "none" && typeof explicit.reason === "string" && explicit.reason.trim().length > 0;
+}
+
+export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"): string[] {
+	const errors: string[] = [];
+	if (input === undefined) return errors;
+	if (input === false) return errors;
+	if (typeof input === "string") {
+		if (!VALID_LEVELS.has(input as AcceptanceLevel)) errors.push(`${pathLabel} has invalid level '${input}'.`);
+		return errors;
+	}
+	if (!input || typeof input !== "object" || Array.isArray(input)) {
+		errors.push(`${pathLabel} must be a string level, false, or an object.`);
+		return errors;
+	}
+	const value = input as Record<string, unknown>;
+	if (value.level !== undefined && (typeof value.level !== "string" || !VALID_LEVELS.has(value.level as AcceptanceLevel))) {
+		errors.push(`${pathLabel}.level must be one of auto, none, attested, checked, verified, reviewed.`);
+	}
+	if (value.level === "none" && (typeof value.reason !== "string" || !value.reason.trim())) {
+		errors.push(`${pathLabel}.reason is required when level is none.`);
+	}
+	if (value.criteria !== undefined && !Array.isArray(value.criteria)) errors.push(`${pathLabel}.criteria must be an array.`);
+	if (Array.isArray(value.evidence)) {
+		for (const [index, item] of value.evidence.entries()) {
+			if (typeof item !== "string" || !VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)) {
+				errors.push(`${pathLabel}.evidence[${index}] is not a supported evidence kind.`);
+			}
+		}
+	} else if (value.evidence !== undefined) {
+		errors.push(`${pathLabel}.evidence must be an array.`);
+	}
+	if (value.verify !== undefined && !Array.isArray(value.verify)) errors.push(`${pathLabel}.verify must be an array.`);
+	if (Array.isArray(value.verify)) {
+		for (const [index, command] of value.verify.entries()) {
+			if (!command || typeof command !== "object" || Array.isArray(command)) {
+				errors.push(`${pathLabel}.verify[${index}] must be an object.`);
+				continue;
+			}
+			const cmd = command as Record<string, unknown>;
+			if (typeof cmd.id !== "string" || !cmd.id.trim()) errors.push(`${pathLabel}.verify[${index}].id is required.`);
+			if (typeof cmd.command !== "string" || !cmd.command.trim()) errors.push(`${pathLabel}.verify[${index}].command is required.`);
+			if (cmd.timeoutMs !== undefined && (typeof cmd.timeoutMs !== "number" || cmd.timeoutMs <= 0)) {
+				errors.push(`${pathLabel}.verify[${index}].timeoutMs must be a positive number.`);
+			}
+		}
+	}
+	return errors;
+}
+
+function normalizeCriteria(criteria: Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }> | undefined, evidence: AcceptanceEvidenceKind[]): ResolvedAcceptanceGate[] {
+	return (criteria ?? []).map<ResolvedAcceptanceGate>((criterion, index) => {
+		if (typeof criterion === "string") {
+			return { id: `criterion-${index + 1}`, must: criterion, evidence, severity: "required" };
+		}
+		return {
+			id: criterion.id?.trim() || `criterion-${index + 1}`,
+			must: criterion.must ?? "",
+			evidence: criterion.evidence?.filter((item) => VALID_EVIDENCE.has(item)) ?? evidence,
+			severity: criterion.severity ?? "required",
+		};
+	}).filter((criterion) => criterion.must.trim().length > 0);
+}
+
+export function resolveEffectiveAcceptance(input: {
+	explicit?: AcceptanceInput;
+	agentName: string;
+	task?: string;
+	mode?: SubagentRunMode;
+	async?: boolean;
+	dynamic?: boolean;
+	dynamicGroup?: boolean;
+}): ResolvedAcceptanceConfig {
+	const explicit = normalizeAcceptanceInput(input.explicit);
+	const inferred = inferLevel(input);
+	const explicitLevel = normalizeLevel(explicit.level);
+	const level = explicitAcceptanceCanDisable(explicit)
+		? "none"
+		: explicitLevel === "auto"
+			? inferred.level
+			: (LEVEL_RANK[explicitLevel] >= LEVEL_RANK[inferred.level] ? explicitLevel : inferred.level);
+	const evidence = unique([...(level === inferred.level ? inferred.evidence : requiredEvidenceForLevel(level)), ...(explicit.evidence ?? [])]);
+	const criteria = normalizeCriteria(
+		(explicit.criteria?.length ? explicit.criteria : inferred.criteria) as Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }>,
+		evidence,
+	);
+	let review = explicit.review !== undefined ? explicit.review : inferred.review;
+	if (level === "reviewed" && explicitLevel !== "auto" && explicitLevel !== "reviewed" && explicit.review === undefined && review) {
+		review = { ...review, required: false };
+	}
+	return {
+		level,
+		explicit: input.explicit !== undefined,
+		inferredReason: inferred.reasons,
+		criteria,
+		evidence,
+		verify: explicit.verify ?? [],
+		review,
+		stopRules: explicit.stopRules ?? [],
+		reason: explicit.reason,
+	};
+}
+
+export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig): string {
+	if (acceptance.level === "none") return "";
+	const lines = [
+		"",
+		"## Acceptance Contract",
+		`Acceptance level: ${acceptance.level}`,
+		"Completion is not accepted from prose alone. End with a structured acceptance report.",
+		"",
+		"Criteria:",
+		...(acceptance.criteria.length ? acceptance.criteria.map((criterion) => `- ${criterion.id}: ${criterion.must}`) : ["- Return the requested result."]),
+		"",
+		`Required evidence: ${acceptance.evidence.join(", ") || "none"}`,
+	];
+	if (acceptance.verify.length > 0) {
+		lines.push("", "Runtime verification commands configured by parent:");
+		for (const command of acceptance.verify) lines.push(`- ${command.id}: ${command.command}`);
+	}
+	if (acceptance.review) {
+		lines.push("", `Review gate: ${acceptance.review.required === false ? "optional" : "required"}${acceptance.review.agent ? ` by ${acceptance.review.agent}` : ""}.`);
+		if (acceptance.review.focus) lines.push(`Review focus: ${acceptance.review.focus}`);
+	}
+	if (acceptance.stopRules.length > 0) {
+		lines.push("", "Stop rules:", ...acceptance.stopRules.map((rule) => `- ${rule}`));
+	}
+	lines.push(
+		"",
+		"Finish with a fenced JSON block tagged `acceptance-report` in this shape:",
+		"```acceptance-report",
+		JSON.stringify({
+			criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "specific proof" }],
+			changedFiles: [],
+			testsAddedOrUpdated: [],
+			commandsRun: [{ command: "command", result: "passed", summary: "short result" }],
+			validationOutput: [],
+			residualRisks: [],
+			noStagedFiles: true,
+			notes: "anything else the parent should know",
+		}, null, 2),
+		"```",
+	);
+	return lines.join("\n");
+}
+
+function extractBalancedJson(text: string, start: number): string | undefined {
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let i = start; i < text.length; i++) {
+		const char = text[i]!;
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (char === "\\") escaped = true;
+			else if (char === "\"") inString = false;
+			continue;
+		}
+		if (char === "\"") {
+			inString = true;
+			continue;
+		}
+		if (char === "{") depth++;
+		if (char === "}") {
+			depth--;
+			if (depth === 0) return text.slice(start, i + 1);
+		}
+	}
+	return undefined;
+}
+
+export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
+	const fenced = [...output.matchAll(/```acceptance-report\s*\n([\s\S]*?)```/gi)]
+		.map((match) => match[1]?.trim())
+		.filter((value): value is string => Boolean(value));
+	const parseErrors: string[] = [];
+	for (const body of fenced) {
+		try {
+			const parsed = JSON.parse(body) as unknown;
+			const report = (parsed && typeof parsed === "object" && "acceptance" in parsed)
+				? (parsed as { acceptance?: unknown }).acceptance
+				: parsed;
+			if (isAcceptanceReport(report)) return { report };
+			parseErrors.push("acceptance-report block does not contain a valid acceptance report");
+		} catch (error) {
+			parseErrors.push(error instanceof Error ? error.message : String(error));
+		}
+	}
+	if (parseErrors.length > 0) return { error: `Failed to parse acceptance-report: ${parseErrors.join("; ")}` };
+	const markerIndex = output.search(/ACCEPTANCE_REPORT\s*:/i);
+	if (markerIndex !== -1) {
+		const jsonStart = output.indexOf("{", markerIndex);
+		if (jsonStart !== -1) {
+			const json = extractBalancedJson(output, jsonStart);
+			if (json) {
+				try {
+					const parsed = JSON.parse(json) as unknown;
+					if (isAcceptanceReport(parsed)) return { report: parsed };
+				} catch (error) {
+					return { error: error instanceof Error ? error.message : String(error) };
+				}
+			}
+		}
+	}
+	return { error: "Structured acceptance report not found." };
+}
+
+export function stripAcceptanceReport(output: string): string {
+	return output
+		.replace(/\n?```acceptance-report\s*\n[\s\S]*?```\s*$/i, "")
+		.replace(/\n?ACCEPTANCE_REPORT\s*:\s*\{[\s\S]*\}\s*$/i, "")
+		.trimEnd();
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isAcceptanceReport(value: unknown): value is AcceptanceReport {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const report = value as AcceptanceReport;
+	if (report.criteriaSatisfied !== undefined) {
+		if (!Array.isArray(report.criteriaSatisfied)) return false;
+		for (const item of report.criteriaSatisfied) {
+			if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+			const criterion = item as { id?: unknown; status?: unknown; evidence?: unknown };
+			if (criterion.id !== undefined && typeof criterion.id !== "string") return false;
+			if (criterion.status !== "satisfied" && criterion.status !== "not-satisfied" && criterion.status !== "not-applicable") return false;
+			if (typeof criterion.evidence !== "string" || !criterion.evidence.trim()) return false;
+		}
+	}
+	return report.criteriaSatisfied !== undefined
+		|| report.changedFiles !== undefined
+		|| report.testsAddedOrUpdated !== undefined
+		|| report.commandsRun !== undefined
+		|| report.residualRisks !== undefined
+		|| report.manualNotes !== undefined
+		|| report.reviewFindings !== undefined;
+}
+
+function checkCriteriaSatisfied(criteria: ResolvedAcceptanceGate[], report: AcceptanceReport): AcceptanceRuntimeCheck[] {
+	const reports = new Map((report.criteriaSatisfied ?? []).filter((item) => item.id).map((item) => [item.id!, item]));
+	return criteria.filter((criterion) => criterion.severity !== "recommended").map((criterion) => {
+		const item = reports.get(criterion.id);
+		if (!item) return { id: `criterion:${criterion.id}`, status: "failed", message: `Required criterion '${criterion.id}' was not reported.` };
+		if (item.status !== "satisfied") return { id: `criterion:${criterion.id}`, status: "failed", message: `Required criterion '${criterion.id}' was reported as ${item.status}.` };
+		return { id: `criterion:${criterion.id}`, status: "passed", message: `Required criterion '${criterion.id}' satisfied.` };
+	});
+}
+
+function reportEvidencePresent(report: AcceptanceReport, kind: AcceptanceEvidenceKind): boolean {
+	switch (kind) {
+		case "changed-files": return isStringArray(report.changedFiles) && report.changedFiles.length > 0;
+		case "tests-added": return isStringArray(report.testsAddedOrUpdated) && report.testsAddedOrUpdated.length > 0;
+		case "commands-run": return Array.isArray(report.commandsRun) && report.commandsRun.length > 0;
+		case "validation-output": return isStringArray(report.validationOutput) && report.validationOutput.length > 0;
+		case "residual-risks": return isStringArray(report.residualRisks);
+		case "no-staged-files": return report.noStagedFiles === true;
+		case "diff-summary": return typeof report.diffSummary === "string" && report.diffSummary.trim().length > 0;
+		case "review-findings": return isStringArray(report.reviewFindings);
+		case "manual-notes": return Boolean((report.manualNotes ?? report.notes)?.trim());
+	}
+}
+
+function checkNoStagedFiles(cwd: string): AcceptanceRuntimeCheck {
+	const result = spawnSync("git", ["status", "--short"], { cwd, encoding: "utf-8" });
+	if (result.status !== 0) {
+		return { id: "no-staged-files", status: "not-applicable", message: "git status unavailable; no staged-files check skipped" };
+	}
+	const staged = result.stdout.split(/\r?\n/).filter((line) => line.length >= 2 && line[0] !== " " && line[0] !== "?");
+	return staged.length === 0
+		? { id: "no-staged-files", status: "passed", message: "No staged files detected." }
+		: { id: "no-staged-files", status: "failed", message: `Staged files present: ${staged.join(", ")}` };
+}
+
+function runStructuralChecks(acceptance: ResolvedAcceptanceConfig, report: AcceptanceReport, cwd: string): AcceptanceRuntimeCheck[] {
+	const checks: AcceptanceRuntimeCheck[] = [];
+	for (const kind of acceptance.evidence) {
+		const present = reportEvidencePresent(report, kind);
+		checks.push({
+			id: `evidence:${kind}`,
+			status: present ? "passed" : "failed",
+			message: present ? `${kind} evidence present.` : `${kind} evidence missing from child report.`,
+		});
+	}
+	if (acceptance.evidence.includes("no-staged-files")) checks.push(checkNoStagedFiles(cwd));
+	return checks;
+}
+
+function trimOutput(value: string): string | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	return trimmed.length > 12_000 ? `${trimmed.slice(0, 12_000)}\n...[truncated]` : trimmed;
+}
+
+function uniqueStrings(items: Array<string | undefined>): string[] {
+	return unique(items.map((item) => item?.trim()).filter((item): item is string => Boolean(item)));
+}
+
+export function aggregateAcceptanceReport(input: {
+	results: Array<Pick<SingleResult, "agent" | "acceptance" | "error" | "exitCode">>;
+	notes?: string;
+}): AcceptanceReport {
+	const childReports = input.results.map((result) => result.acceptance?.childReport).filter((report): report is AcceptanceReport => Boolean(report));
+	const blockers = input.results.filter((result) => result.exitCode !== 0 || result.acceptance?.status === "rejected");
+	const successfulChildren = input.results.length > 0 && blockers.length === 0;
+	return {
+		criteriaSatisfied: [
+			{ id: "criterion-1", status: successfulChildren ? "satisfied" : "not-satisfied", evidence: successfulChildren ? `All ${input.results.length} dynamic child run(s) completed without child or acceptance blockers.` : "Dynamic fanout produced no accepted child evidence." },
+			{ id: "criterion-2", status: successfulChildren ? "satisfied" : "not-satisfied", evidence: successfulChildren ? "Collected child acceptance evidence for aggregate review." : "Dynamic fanout produced no aggregate review evidence." },
+			...input.results.map((result, index): NonNullable<AcceptanceReport["criteriaSatisfied"]>[number] => ({
+				id: `child-${index + 1}`,
+				status: result.exitCode === 0 && result.acceptance?.status !== "rejected" ? "satisfied" : "not-satisfied",
+				evidence: `${result.agent}: acceptance ${result.acceptance?.status ?? "unreported"}${result.error ? ` (${result.error})` : ""}`,
+			})),
+		],
+		changedFiles: uniqueStrings(childReports.flatMap((report) => report.changedFiles ?? [])),
+		testsAddedOrUpdated: uniqueStrings(childReports.flatMap((report) => report.testsAddedOrUpdated ?? [])),
+		commandsRun: childReports.flatMap((report) => report.commandsRun ?? []),
+		validationOutput: uniqueStrings(childReports.flatMap((report) => report.validationOutput ?? [])),
+		residualRisks: uniqueStrings([
+			...childReports.flatMap((report) => report.residualRisks ?? []),
+			...blockers.map((result) => `${result.agent}: ${result.error ?? "child or acceptance gate failed"}`),
+		]),
+		noStagedFiles: childReports.length > 0 && childReports.every((report) => report.noStagedFiles === true),
+		reviewFindings: uniqueStrings(childReports.flatMap((report) => report.reviewFindings ?? [])),
+		manualNotes: input.notes ?? `Aggregated acceptance evidence from ${input.results.length} dynamic fanout child run(s).`,
+		notes: input.notes,
+	};
+}
+
+function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string): Promise<AcceptanceVerifyResult> {
+	return new Promise((resolve) => {
+		const startedAt = Date.now();
+		const cwd = command.cwd ? path.resolve(defaultCwd, command.cwd) : defaultCwd;
+		let stdout = "";
+		let stderr = "";
+		let timedOut = false;
+		const child = spawn(command.command, {
+			cwd,
+			env: { ...process.env, ...(command.env ?? {}) },
+			shell: true,
+			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
+		});
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGTERM");
+			setTimeout(() => child.kill("SIGKILL"), 1000).unref?.();
+		}, command.timeoutMs ?? 120_000);
+		timeout.unref?.();
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		child.on("close", (exitCode) => {
+			clearTimeout(timeout);
+			const durationMs = Date.now() - startedAt;
+			const passed = exitCode === 0 && !timedOut;
+			resolve({
+				id: command.id,
+				command: command.command,
+				cwd,
+				exitCode,
+				status: timedOut ? "timed-out" : passed ? "passed" : command.allowFailure ? "allowed-failure" : "failed",
+				stdout: trimOutput(stdout),
+				stderr: trimOutput(stderr),
+				durationMs,
+			});
+		});
+		child.on("error", (error) => {
+			clearTimeout(timeout);
+			resolve({
+				id: command.id,
+				command: command.command,
+				cwd,
+				exitCode: 1,
+				status: command.allowFailure ? "allowed-failure" : "failed",
+				stderr: error instanceof Error ? error.message : String(error),
+				durationMs: Date.now() - startedAt,
+			});
+		});
+	});
+}
+
+export async function evaluateAcceptance(input: {
+	acceptance: ResolvedAcceptanceConfig;
+	output: string;
+	cwd: string;
+	report?: AcceptanceReport;
+	reviewResult?: AcceptanceReviewResult;
+}): Promise<AcceptanceLedger> {
+	const acceptance = input.acceptance;
+	const ledger: AcceptanceLedger = {
+		status: acceptance.level === "none" ? "not-required" : "claimed",
+		explicit: acceptance.explicit,
+		effectiveAcceptance: acceptance,
+		inferredReason: acceptance.inferredReason,
+		criteria: acceptance.criteria,
+		runtimeChecks: [],
+		verifyRuns: [],
+	};
+	if (acceptance.level === "none") return ledger;
+
+	const parsed = input.report ? { report: input.report } : parseAcceptanceReport(input.output);
+	if (parsed.report) {
+		ledger.childReport = parsed.report;
+		ledger.status = "attested";
+	} else {
+		ledger.childReportParseError = parsed.error;
+		ledger.runtimeChecks.push({ id: "attestation", status: "failed", message: parsed.error ?? "Structured acceptance report missing." });
+		ledger.status = "rejected";
+		return ledger;
+	}
+
+	if (LEVEL_RANK[acceptance.level] >= LEVEL_RANK.checked) {
+		ledger.runtimeChecks = [
+			...checkCriteriaSatisfied(acceptance.criteria, parsed.report),
+			...runStructuralChecks(acceptance, parsed.report, input.cwd),
+		];
+		if (ledger.runtimeChecks.some((check) => check.status === "failed")) {
+			ledger.status = "rejected";
+			return ledger;
+		}
+		ledger.status = "checked";
+	}
+
+	if (LEVEL_RANK[acceptance.level] >= LEVEL_RANK.verified && (acceptance.level === "verified" || acceptance.verify.length > 0)) {
+		if (acceptance.level === "verified" && acceptance.verify.length === 0) {
+			ledger.runtimeChecks.push({ id: "verification-config", status: "failed", message: "verified acceptance requires runtime verify commands." });
+			ledger.status = "rejected";
+			return ledger;
+		}
+		ledger.verifyRuns = [];
+		for (const command of acceptance.verify) ledger.verifyRuns.push(await runVerifyCommand(command, input.cwd));
+		if (ledger.verifyRuns.some((run) => run.status === "failed" || run.status === "timed-out")) {
+			ledger.status = "rejected";
+			return ledger;
+		}
+		ledger.status = "verified";
+	}
+
+	if (acceptance.level === "reviewed") {
+		if (input.reviewResult) {
+			ledger.reviewResult = input.reviewResult;
+			ledger.status = input.reviewResult.status === "no-blockers" ? "reviewed" : "rejected";
+		} else {
+			const optionalReview = Boolean(acceptance.review && acceptance.review.required === false);
+			ledger.reviewResult = {
+				status: "needs-parent-decision",
+				findings: [{
+					severity: acceptance.explicit && !optionalReview ? "blocker" : "non-blocking",
+					issue: "Reviewed acceptance requires an independent reviewer result.",
+					rationale: "The run cannot be marked reviewed from child evidence alone.",
+				}],
+			};
+			if (acceptance.review === false || (acceptance.explicit && !optionalReview)) ledger.status = "rejected";
+		}
+	}
+
+	return ledger;
+}
+
+export function acceptanceFailureMessage(ledger: AcceptanceLedger): string | undefined {
+	if (ledger.status !== "rejected") return undefined;
+	const failedCheck = ledger.runtimeChecks.find((check) => check.status === "failed");
+	if (failedCheck) return `Acceptance rejected: ${failedCheck.message}`;
+	const failedVerify = ledger.verifyRuns.find((run) => run.status === "failed" || run.status === "timed-out");
+	if (failedVerify) return `Acceptance verification '${failedVerify.id}' ${failedVerify.status}.`;
+	if (ledger.reviewResult?.status === "needs-parent-decision") return "Acceptance review required but no automatic reviewer result is available.";
+	if (ledger.reviewResult?.status === "blockers") return "Acceptance review found blockers.";
+	return "Acceptance rejected.";
+}

--- a/packages/subagents/src/runs/shared/chain-outputs.ts
+++ b/packages/subagents/src/runs/shared/chain-outputs.ts
@@ -1,0 +1,101 @@
+import { isDynamicParallelStep, isParallelStep, type ChainStep, type SequentialStep } from "../../shared/settings.ts";
+import type { ChainOutputMap, ChainOutputMapEntry, SingleResult } from "../../shared/types.ts";
+import { getSingleResultOutput } from "../../shared/utils.ts";
+import { DynamicFanoutError, hasDynamicFanoutFields, type DynamicFanoutConfig, validateDynamicStepShape } from "./dynamic-fanout.ts";
+
+const OUTPUT_REF_PATTERN = /\{outputs\.([^}]*)\}/g;
+const SAFE_OUTPUT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export class ChainOutputValidationError extends Error {}
+
+function outputNamesForStep(step: ChainStep): string[] {
+	if (isParallelStep(step)) return step.parallel.map((task) => task.as).filter((name): name is string => Boolean(name));
+	if (isDynamicParallelStep(step)) return [step.collect.as];
+	const name = (step as SequentialStep).as;
+	return name ? [name] : [];
+}
+
+function taskTemplatesForStep(step: ChainStep): string[] {
+	if (isParallelStep(step)) return step.parallel.map((task) => task.task ?? "{previous}");
+	if (isDynamicParallelStep(step)) return [step.parallel.task ?? "{previous}", step.parallel.label ?? ""].filter(Boolean);
+	return [(step as SequentialStep).task ?? "{previous}"];
+}
+
+export function validateChainOutputBindings(steps: ChainStep[], dynamicFanoutConfig: DynamicFanoutConfig = {}): void {
+	const available = new Set<string>();
+	const seen = new Set<string>();
+	for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
+		const step = steps[stepIndex]!;
+		if (hasDynamicFanoutFields(step)) {
+			if (!isDynamicParallelStep(step)) {
+				throw new ChainOutputValidationError(`Dynamic chain step ${stepIndex + 1} requires expand, a single parallel template object, and collect; dynamic expand/collect cannot be mixed with static parallel arrays.`);
+			}
+			try {
+				validateDynamicStepShape(step, stepIndex, dynamicFanoutConfig);
+			} catch (error) {
+				if (error instanceof DynamicFanoutError) throw new ChainOutputValidationError(error.message);
+				throw error;
+			}
+			if (!available.has(step.expand.from.output)) {
+				throw new ChainOutputValidationError(`Dynamic chain step ${stepIndex + 1} references unknown output '${step.expand.from.output}'. Named outputs are only available after producing step/group completes.`);
+			}
+		}
+		for (const name of outputNamesForStep(step)) {
+			if (!SAFE_OUTPUT_NAME_PATTERN.test(name)) {
+				throw new ChainOutputValidationError(`Invalid chain output name '${name}' at step ${stepIndex + 1}. Use /^[A-Za-z_][A-Za-z0-9_]*$/.`);
+			}
+			if (seen.has(name)) {
+				throw new ChainOutputValidationError(`Duplicate chain output name '${name}'. Each as name must be unique.`);
+			}
+			seen.add(name);
+		}
+		for (const template of taskTemplatesForStep(step)) {
+			for (const match of template.matchAll(OUTPUT_REF_PATTERN)) {
+				const rawReference = match[0];
+				const name = match[1]!;
+				if (!SAFE_OUTPUT_NAME_PATTERN.test(name)) {
+					throw new ChainOutputValidationError(`Invalid chain output reference '${rawReference}' at step ${stepIndex + 1}. Use {outputs.name} with /^[A-Za-z_][A-Za-z0-9_]*$/ names.`);
+				}
+				if (!available.has(name)) {
+					throw new ChainOutputValidationError(`Unknown chain output reference '${rawReference}' at step ${stepIndex + 1}. Named outputs are only available after producing step/group completes.`);
+				}
+			}
+		}
+		for (const name of outputNamesForStep(step)) {
+			available.add(name);
+		}
+	}
+}
+
+export function resolveOutputReferences(template: string, outputs: ChainOutputMap): string {
+	return template.replace(OUTPUT_REF_PATTERN, (rawReference, name: string) => {
+		if (!SAFE_OUTPUT_NAME_PATTERN.test(name)) {
+			throw new ChainOutputValidationError(`Invalid chain output reference '${rawReference}'. Use {outputs.name} with /^[A-Za-z_][A-Za-z0-9_]*$/ names.`);
+		}
+		const entry = outputs[name];
+		if (!entry) throw new ChainOutputValidationError(`Unknown chain output reference '${rawReference}'.`);
+		return entry.text;
+	});
+}
+
+function compactStructuredText(value: unknown): string {
+	return JSON.stringify(value);
+}
+
+export function outputEntryFromResult(result: SingleResult, stepIndex: number): ChainOutputMapEntry {
+	return {
+		text: result.structuredOutput !== undefined ? compactStructuredText(result.structuredOutput) : getSingleResultOutput(result),
+		...(result.structuredOutput !== undefined ? { structured: result.structuredOutput } : {}),
+		agent: result.agent,
+		stepIndex,
+	};
+}
+
+export function outputEntryFromAsyncResult(result: { agent: string; output: string; structuredOutput?: unknown }, stepIndex: number): ChainOutputMapEntry {
+	return {
+		text: result.structuredOutput !== undefined ? compactStructuredText(result.structuredOutput) : result.output,
+		...(result.structuredOutput !== undefined ? { structured: result.structuredOutput } : {}),
+		agent: result.agent,
+		stepIndex,
+	};
+}

--- a/packages/subagents/src/runs/shared/dynamic-fanout.ts
+++ b/packages/subagents/src/runs/shared/dynamic-fanout.ts
@@ -1,0 +1,293 @@
+import type { DynamicParallelStep, ParallelTaskItem } from "../../shared/settings.ts";
+import type { ArtifactPaths, ChainOutputMap, JsonSchemaObject, SingleResult } from "../../shared/types.ts";
+import { getSingleResultOutput } from "../../shared/utils.ts";
+import { validateStructuredOutputValue } from "./structured-output.ts";
+
+export class DynamicFanoutError extends Error {}
+
+export interface DynamicFanoutConfig {
+	maxItems?: number;
+	allowRunnerFields?: boolean;
+}
+
+export interface DynamicMaterializedItem {
+	index: number;
+	key: string;
+	idKey: string;
+	item: unknown;
+}
+
+export interface DynamicCollectedResult {
+	key: string;
+	index: number;
+	item: unknown;
+	agent: string;
+	exitCode: number | null;
+	text: string;
+	structured?: unknown;
+	error?: string;
+	outputPath?: string;
+	artifactPaths?: ArtifactPaths;
+}
+
+export interface DynamicMaterializedGroup {
+	items: DynamicMaterializedItem[];
+	parallel: ParallelTaskItem[];
+	collectedOnEmpty?: DynamicCollectedResult[];
+}
+
+const SAFE_OUTPUT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const ITEM_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const ITEM_REF_PATTERN = /\{([A-Za-z_][A-Za-z0-9_]*)(?:\.([^{}]+))?\}/g;
+const RESERVED_TEMPLATE_NAMES = new Set(["task", "previous", "chain_dir", "outputs"]);
+const DYNAMIC_STEP_KEYS = new Set(["expand", "parallel", "collect", "concurrency", "failFast", "phase", "label", "acceptance"]);
+const RUNNER_DYNAMIC_STEP_KEYS = new Set([...DYNAMIC_STEP_KEYS, "effectiveAcceptance"]);
+const DYNAMIC_EXPAND_KEYS = new Set(["from", "item", "key", "maxItems", "onEmpty"]);
+const DYNAMIC_EXPAND_FROM_KEYS = new Set(["output", "path"]);
+const DYNAMIC_PARALLEL_KEYS = new Set(["agent", "task", "phase", "label", "outputSchema", "cwd", "output", "outputMode", "reads", "progress", "skill", "model", "acceptance"]);
+const RUNNER_DYNAMIC_PARALLEL_KEYS = new Set([
+	...DYNAMIC_PARALLEL_KEYS,
+	"outputName", "structured", "inheritProjectContext", "inheritSkills", "skills", "outputPath", "maxSubagentDepth",
+	"structuredOutput", "structuredOutputSchema", "tools", "extensions", "mcpDirectTools", "completionGuard", "systemPrompt",
+	"systemPromptMode", "thinking", "modelCandidates", "sessionFile", "effectiveAcceptance",
+]);
+const DYNAMIC_COLLECT_KEYS = new Set(["as", "outputSchema"]);
+
+export function isSafeOutputName(name: string): boolean {
+	return SAFE_OUTPUT_NAME_PATTERN.test(name);
+}
+
+export function assertJsonPointer(pointer: string, label: string): void {
+	if (pointer === "") return;
+	if (!pointer.startsWith("/")) {
+		throw new DynamicFanoutError(`${label} must be a JSON Pointer starting with '/'.`);
+	}
+	for (const segment of pointer.slice(1).split("/")) {
+		if (/~(?![01])/.test(segment)) {
+			throw new DynamicFanoutError(`${label} contains invalid JSON Pointer escape.`);
+		}
+	}
+}
+
+function decodePointerSegment(segment: string): string {
+	return segment.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+export function resolveJsonPointer(value: unknown, pointer: string, label: string): unknown {
+	assertJsonPointer(pointer, label);
+	if (pointer === "") return value;
+	let current = value;
+	for (const rawSegment of pointer.slice(1).split("/")) {
+		const segment = decodePointerSegment(rawSegment);
+		if (Array.isArray(current)) {
+			if (!/^(0|[1-9][0-9]*)$/.test(segment)) {
+				throw new DynamicFanoutError(`${label} segment '${segment}' does not address an array index.`);
+			}
+			const index = Number(segment);
+			if (index >= current.length) throw new DynamicFanoutError(`${label} does not exist.`);
+			current = current[index];
+			continue;
+		}
+		if (!current || typeof current !== "object") {
+			throw new DynamicFanoutError(`${label} does not exist.`);
+		}
+		const record = current as Record<string, unknown>;
+		if (!Object.prototype.hasOwnProperty.call(record, segment)) {
+			throw new DynamicFanoutError(`${label} does not exist.`);
+		}
+		current = record[segment];
+	}
+	return current;
+}
+
+function scalarToKey(value: unknown, label: string): string {
+	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+		const key = String(value);
+		if (!key.trim()) throw new DynamicFanoutError(`${label} resolved to an empty key.`);
+		if (/[\u0000-\u001F\u007F]/.test(key)) throw new DynamicFanoutError(`${label} resolved to an unsafe key.`);
+		if (key.length > 200) throw new DynamicFanoutError(`${label} resolved to a key longer than 200 characters.`);
+		return key;
+	}
+	throw new DynamicFanoutError(`${label} must resolve to a string, number, or boolean.`);
+}
+
+export function normalizeItemKeyForId(key: string): string {
+	const normalized = key
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 80);
+	return normalized || "item";
+}
+
+function valueToTemplateText(value: unknown, reference: string): string {
+	if (value === undefined) throw new DynamicFanoutError(`Unresolved item reference '${reference}'.`);
+	if (typeof value === "string") return value;
+	if (typeof value === "number" || typeof value === "boolean" || value === null) return String(value);
+	return JSON.stringify(value);
+}
+
+function resolveItemPath(item: unknown, pathText: string | undefined, reference: string): unknown {
+	if (!pathText) return item;
+	const pointer = `/${pathText.split(".").map((segment) => segment.replace(/~/g, "~0").replace(/\//g, "~1")).join("/")}`;
+	return resolveJsonPointer(item, pointer, reference);
+}
+
+export function resolveItemTemplate(template: string, itemName: string, item: unknown): string {
+	return template.replace(ITEM_REF_PATTERN, (raw, name: string, pathText: string | undefined) => {
+		if (name !== itemName) return raw;
+		if (pathText !== undefined && (!pathText.trim() || pathText.includes(".."))) {
+			throw new DynamicFanoutError(`Invalid item reference '${raw}'.`);
+		}
+		return valueToTemplateText(resolveItemPath(item, pathText, raw), raw);
+	});
+}
+
+function assertOnlyKeys(value: unknown, allowed: Set<string>, label: string): void {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new DynamicFanoutError(`${label} must be an object.`);
+	for (const key of Object.keys(value)) {
+		if (!allowed.has(key)) throw new DynamicFanoutError(`${label} does not support field '${key}'.`);
+	}
+}
+
+export function assertNoUnresolvedItemReferences(template: string, itemName: string, label: string): void {
+	for (const match of template.matchAll(/\{([^{}]*)\}/g)) {
+		const raw = match[0]!;
+		const reference = match[1]!;
+		if (reference === itemName || reference.startsWith(`${itemName}.`)) {
+			if (!ITEM_REF_PATTERN.test(raw) || reference === `${itemName}.` || reference.includes("..")) {
+				throw new DynamicFanoutError(`Invalid item reference '${raw}' in ${label}.`);
+			}
+			ITEM_REF_PATTERN.lastIndex = 0;
+			continue;
+		}
+		ITEM_REF_PATTERN.lastIndex = 0;
+		const name = reference.match(/^[A-Za-z_][A-Za-z0-9_]*/)?.[0];
+		if (name === itemName) throw new DynamicFanoutError(`Invalid item reference '${raw}' in ${label}.`);
+		if (name && RESERVED_TEMPLATE_NAMES.has(name)) continue;
+		if (name) throw new DynamicFanoutError(`Unsupported template reference '${raw}' in ${label}.`);
+	}
+	ITEM_REF_PATTERN.lastIndex = 0;
+	if (template.includes(`{${itemName}.}`) || new RegExp(`\\{${itemName}(?:\\.|$)[^}]*$`).test(template)) {
+		throw new DynamicFanoutError(`Invalid item reference in ${label}.`);
+	}
+}
+
+export function hasDynamicFanoutFields(step: unknown): boolean {
+	return !!step && typeof step === "object" && !Array.isArray(step)
+		&& (Object.prototype.hasOwnProperty.call(step, "expand") || Object.prototype.hasOwnProperty.call(step, "collect"));
+}
+
+export function validateDynamicStepShape(step: DynamicParallelStep, stepIndex: number, config: DynamicFanoutConfig = {}): void {
+	const prefix = `Dynamic chain step ${stepIndex + 1}`;
+	assertOnlyKeys(step, config.allowRunnerFields ? RUNNER_DYNAMIC_STEP_KEYS : DYNAMIC_STEP_KEYS, prefix);
+	if (!step.expand || !step.expand.from) throw new DynamicFanoutError(`${prefix} requires expand.from.`);
+	assertOnlyKeys(step.expand, DYNAMIC_EXPAND_KEYS, `${prefix} expand`);
+	assertOnlyKeys(step.expand.from, DYNAMIC_EXPAND_FROM_KEYS, `${prefix} expand.from`);
+	if (!isSafeOutputName(step.expand.from.output)) throw new DynamicFanoutError(`${prefix} has invalid expand.from.output '${step.expand.from.output}'.`);
+	assertJsonPointer(step.expand.from.path, `${prefix} expand.from.path`);
+	if (step.expand.key !== undefined) assertJsonPointer(step.expand.key, `${prefix} expand.key`);
+	const itemName = step.expand.item ?? "item";
+	if (!ITEM_NAME_PATTERN.test(itemName)) throw new DynamicFanoutError(`${prefix} has invalid expand.item '${itemName}'.`);
+	if (step.expand.maxItems === undefined && config.maxItems === undefined) {
+		throw new DynamicFanoutError(`${prefix} requires expand.maxItems or config.chain.dynamicFanout.maxItems.`);
+	}
+	if (step.expand.maxItems !== undefined && (!Number.isInteger(step.expand.maxItems) || step.expand.maxItems < 0)) {
+		throw new DynamicFanoutError(`${prefix} expand.maxItems must be an integer >= 0.`);
+	}
+	if (config.maxItems !== undefined && (!Number.isInteger(config.maxItems) || config.maxItems < 0)) {
+		throw new DynamicFanoutError("config.chain.dynamicFanout.maxItems must be an integer >= 0.");
+	}
+	if (!step.parallel || Array.isArray(step.parallel)) throw new DynamicFanoutError(`${prefix} requires a single parallel template object and cannot mix dynamic expand/collect with static parallel arrays.`);
+	assertOnlyKeys(step.parallel, config.allowRunnerFields ? RUNNER_DYNAMIC_PARALLEL_KEYS : DYNAMIC_PARALLEL_KEYS, `${prefix} parallel`);
+	if ("expand" in (step.parallel as object)) throw new DynamicFanoutError(`${prefix} does not support nested dynamic fanout.`);
+	if (!step.parallel.agent) throw new DynamicFanoutError(`${prefix} parallel.agent is required.`);
+	if (!step.collect?.as || !isSafeOutputName(step.collect.as)) throw new DynamicFanoutError(`${prefix} requires collect.as with a safe output name.`);
+	assertOnlyKeys(step.collect, DYNAMIC_COLLECT_KEYS, `${prefix} collect`);
+	for (const [label, template] of [
+		["parallel.task", step.parallel.task],
+		["parallel.label", step.parallel.label],
+	] as const) {
+		if (template) assertNoUnresolvedItemReferences(template, itemName, `${prefix} ${label}`);
+	}
+}
+
+export function resolveDynamicFanoutItems(step: DynamicParallelStep, outputs: ChainOutputMap, stepIndex: number, config: DynamicFanoutConfig = {}): DynamicMaterializedItem[] {
+	validateDynamicStepShape(step, stepIndex, config);
+	const sourceName = step.expand.from.output;
+	const source = outputs[sourceName];
+	if (!source) throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} references unknown output '${sourceName}'.`);
+	if (source.structured === undefined) throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} requires structured output '${sourceName}'.`);
+	const value = resolveJsonPointer(source.structured, step.expand.from.path, `Dynamic chain step ${stepIndex + 1} expand.from.path`);
+	if (!Array.isArray(value)) throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} expand.from.path must resolve to an array.`);
+	const maxItems = step.expand.maxItems ?? config.maxItems;
+	if (maxItems === undefined) throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} requires an effective maxItems.`);
+	if (value.length > maxItems) throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} resolved ${value.length} items, exceeding maxItems ${maxItems}.`);
+	const seen = new Set<string>();
+	const seenIds = new Set<string>();
+	return value.map((item, index) => {
+		const key = step.expand.key === undefined
+			? String(index)
+			: scalarToKey(resolveJsonPointer(item, step.expand.key, `Dynamic chain step ${stepIndex + 1} expand.key`), `Dynamic chain step ${stepIndex + 1} expand.key`);
+		if (seen.has(key)) throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} produced duplicate item key '${key}'.`);
+		seen.add(key);
+		const idKey = normalizeItemKeyForId(key);
+		if (seenIds.has(idKey)) throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} produced colliding item id '${idKey}'.`);
+		seenIds.add(idKey);
+		return { index, key, idKey, item };
+	});
+}
+
+export function materializeDynamicParallelStep(step: DynamicParallelStep, outputs: ChainOutputMap, stepIndex: number, config: DynamicFanoutConfig = {}): DynamicMaterializedGroup {
+	const items = resolveDynamicFanoutItems(step, outputs, stepIndex, config);
+	if (items.length === 0) {
+		if ((step.expand.onEmpty ?? "skip") === "fail") {
+			throw new DynamicFanoutError(`Dynamic chain step ${stepIndex + 1} source array is empty.`);
+		}
+		return { items, parallel: [], collectedOnEmpty: [] };
+	}
+	const itemName = step.expand.item ?? "item";
+	const parallel = items.map((entry) => {
+		const task = resolveItemTemplate(step.parallel.task ?? "{previous}", itemName, entry.item);
+		const label = step.parallel.label ? resolveItemTemplate(step.parallel.label, itemName, entry.item) : undefined;
+		return {
+			...step.parallel,
+			task,
+			...(label !== undefined ? { label } : {}),
+		};
+	});
+	return { items, parallel };
+}
+
+export function collectDynamicResults(
+	step: DynamicParallelStep,
+	items: DynamicMaterializedItem[],
+	results: Array<Pick<SingleResult, "agent" | "exitCode" | "error" | "structuredOutput" | "artifactPaths" | "savedOutputPath"> & { output?: string; finalOutput?: string }>,
+): DynamicCollectedResult[] {
+	return items.map((entry, index) => {
+		const result = results[index];
+		const text = result
+			? ("output" in result && typeof result.output === "string" ? result.output : getSingleResultOutput(result as SingleResult))
+			: "";
+		return {
+			key: entry.key,
+			index: entry.index,
+			item: entry.item,
+			agent: result?.agent ?? step.parallel.agent,
+			exitCode: result?.exitCode ?? null,
+			text,
+			...(result?.structuredOutput !== undefined ? { structured: result.structuredOutput } : {}),
+			...(result?.error ? { error: result.error } : {}),
+			...(result?.savedOutputPath ? { outputPath: result.savedOutputPath } : {}),
+			...(result?.artifactPaths ? { artifactPaths: result.artifactPaths } : {}),
+		};
+	});
+}
+
+export function validateDynamicCollection(schema: JsonSchemaObject | undefined, value: DynamicCollectedResult[]): void {
+	if (!schema) return;
+	const validation = validateStructuredOutputValue(schema, value);
+	if (validation.status === "invalid") {
+		throw new DynamicFanoutError(`Collected output validation failed: ${validation.message}`);
+	}
+}

--- a/packages/subagents/src/runs/shared/parallel-utils.ts
+++ b/packages/subagents/src/runs/shared/parallel-utils.ts
@@ -3,6 +3,10 @@ import type { CodexFastModeResolvedSettings, CodexFastModeScope } from "@bastani
 export interface RunnerSubagentStep {
 	agent: string;
 	task: string;
+	phase?: string;
+	label?: string;
+	outputName?: string;
+	structured?: boolean;
 	cwd?: string;
 	model?: string;
 	thinking?: string;
@@ -25,6 +29,13 @@ export interface RunnerSubagentStep {
 	sessionFile?: string;
 	maxSubagentDepth?: number;
 	workflowStageSubagentGuard?: boolean;
+	structuredOutput?: {
+		schema: import("../../shared/types.ts").JsonSchemaObject;
+		schemaPath: string;
+		outputPath: string;
+	};
+	structuredOutputSchema?: import("../../shared/types.ts").JsonSchemaObject;
+	effectiveAcceptance?: import("../../shared/types.ts").ResolvedAcceptanceConfig;
 }
 
 export interface ParallelStepGroup {
@@ -34,10 +45,25 @@ export interface ParallelStepGroup {
 	worktree?: boolean;
 }
 
-export type RunnerStep = RunnerSubagentStep | ParallelStepGroup;
+export interface DynamicRunnerGroup {
+	expand: import("../../shared/settings.ts").DynamicExpandSpec;
+	parallel: RunnerSubagentStep;
+	collect: import("../../shared/settings.ts").DynamicCollectSpec;
+	concurrency?: number;
+	failFast?: boolean;
+	phase?: string;
+	label?: string;
+	effectiveAcceptance?: import("../../shared/types.ts").ResolvedAcceptanceConfig;
+}
+
+export type RunnerStep = RunnerSubagentStep | ParallelStepGroup | DynamicRunnerGroup;
 
 export function isParallelGroup(step: RunnerStep): step is ParallelStepGroup {
 	return "parallel" in step && Array.isArray(step.parallel);
+}
+
+export function isDynamicRunnerGroup(step: RunnerStep): step is DynamicRunnerGroup {
+	return "expand" in step && "collect" in step && "parallel" in step && !Array.isArray((step as { parallel?: unknown }).parallel);
 }
 
 export function flattenSteps(steps: RunnerStep[]): RunnerSubagentStep[] {
@@ -45,6 +71,8 @@ export function flattenSteps(steps: RunnerStep[]): RunnerSubagentStep[] {
 	for (const step of steps) {
 		if (isParallelGroup(step)) {
 			for (const task of step.parallel) flat.push(task);
+		} else if (isDynamicRunnerGroup(step)) {
+			continue;
 		} else {
 			flat.push(step);
 		}

--- a/packages/subagents/src/runs/shared/pi-args.ts
+++ b/packages/subagents/src/runs/shared/pi-args.ts
@@ -11,6 +11,8 @@ import {
 } from "@bastani/atomic";
 import { encodeNestedPathEnv, parseNestedPathEnv, type NestedPathEntry } from "./nested-path.ts";
 import { resolveMcpDirectToolNames } from "./mcp-direct-tool-allowlist.ts";
+import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
+import type { JsonSchemaObject } from "../../shared/types.ts";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 const TASK_ARG_LIMIT = 8000;
@@ -68,6 +70,11 @@ interface BuildPiArgsInput {
 	parentCapabilityToken?: string;
 	codexFastModeSettings?: CodexFastModeResolvedSettings;
 	codexFastModeScope?: CodexFastModeScope;
+	structuredOutput?: {
+		schema: JsonSchemaObject;
+		schemaPath: string;
+		outputPath: string;
+	};
 }
 
 interface BuildPiArgsResult {
@@ -246,6 +253,10 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		env.MCP_DIRECT_TOOLS = input.mcpDirectTools.join(",");
 	} else {
 		env.MCP_DIRECT_TOOLS = "__none__";
+	}
+	if (input.structuredOutput) {
+		env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
+		env[STRUCTURED_OUTPUT_SCHEMA_ENV] = input.structuredOutput.schemaPath;
 	}
 
 	return { args, env, tempDir };

--- a/packages/subagents/src/runs/shared/structured-output.ts
+++ b/packages/subagents/src/runs/shared/structured-output.ts
@@ -1,0 +1,79 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { APP_NAME } from "@bastani/atomic";
+import { Compile } from "typebox/compile";
+import type { JsonSchemaObject } from "../../shared/types.ts";
+
+const ENV_PREFIX = APP_NAME.toUpperCase();
+export const STRUCTURED_OUTPUT_SCHEMA_ENV = `${ENV_PREFIX}_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA`;
+export const STRUCTURED_OUTPUT_CAPTURE_ENV = `${ENV_PREFIX}_SUBAGENT_STRUCTURED_OUTPUT_CAPTURE`;
+
+export interface StructuredOutputRuntime {
+	schema: JsonSchemaObject;
+	schemaPath: string;
+	outputPath: string;
+}
+
+interface CompiledJsonSchema {
+	Check(value: unknown): boolean;
+	Errors(value: unknown): Iterable<{ instancePath?: string; message?: string }>;
+}
+
+export function assertJsonSchemaObject(schema: unknown, label = "outputSchema"): asserts schema is JsonSchemaObject {
+	if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+		throw new Error(`${label} must be a JSON Schema object.`);
+	}
+}
+
+export function createStructuredOutputRuntime(schema: JsonSchemaObject, baseDir?: string): StructuredOutputRuntime {
+	assertJsonSchemaObject(schema);
+	const rootDir = baseDir ?? os.tmpdir();
+	fs.mkdirSync(rootDir, { recursive: true });
+	const dir = fs.mkdtempSync(path.join(rootDir, "pi-subagent-structured-"));
+	const schemaPath = path.join(dir, "schema.json");
+	const outputPath = path.join(dir, "output.json");
+	fs.writeFileSync(schemaPath, JSON.stringify(schema), { mode: 0o600 });
+	return { schema, schemaPath, outputPath };
+}
+
+export function validateStructuredOutputValue(schema: JsonSchemaObject, value: unknown): { status: "valid" } | { status: "invalid"; message: string } {
+	let validator: CompiledJsonSchema;
+	try {
+		validator = (Compile as (schema: unknown) => CompiledJsonSchema)(schema);
+	} catch (error) {
+		return { status: "invalid", message: `invalid outputSchema: ${error instanceof Error ? error.message : String(error)}` };
+	}
+	if (validator.Check(value)) return { status: "valid" };
+	const errors = [...validator.Errors(value)]
+		.slice(0, 8)
+		.map((error) => {
+			const pathText = error.instancePath ? error.instancePath.replace(/^\//, "").replace(/\//g, ".") : "root";
+			return `${pathText}: ${error.message}`;
+		});
+	return { status: "invalid", message: errors.join("; ") || "schema validation failed" };
+}
+
+export function readStructuredOutput(runtime: StructuredOutputRuntime): { value?: unknown; error?: string } {
+	if (!fs.existsSync(runtime.outputPath)) {
+		return { error: "Missing structured_output call; this step has outputSchema and must finish by calling structured_output." };
+	}
+	let value: unknown;
+	try {
+		value = JSON.parse(fs.readFileSync(runtime.outputPath, "utf-8"));
+	} catch (error) {
+		return { error: `Failed to read structured output: ${error instanceof Error ? error.message : String(error)}` };
+	}
+	const validation = validateStructuredOutputValue(runtime.schema, value);
+	if (validation.status === "invalid") return { error: `Structured output validation failed: ${validation.message}` };
+	return { value };
+}
+
+export function cleanupStructuredOutputRuntime(runtime: StructuredOutputRuntime | undefined): void {
+	if (!runtime) return;
+	try {
+		fs.rmSync(path.dirname(runtime.schemaPath), { recursive: true, force: true });
+	} catch {
+		// Best-effort temp cleanup.
+	}
+}

--- a/packages/subagents/src/runs/shared/subagent-prompt-runtime.ts
+++ b/packages/subagents/src/runs/shared/subagent-prompt-runtime.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import type { ExtensionAPI } from "@bastani/atomic";
 import { getEnvValue } from "@bastani/atomic";
 import {
@@ -6,8 +8,16 @@ import {
 	SUBAGENT_INHERIT_SKILLS_ENV,
 	SUBAGENT_INTERCOM_SESSION_NAME_ENV,
 } from "./pi-args.ts";
+import { STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
+import type { JsonSchemaObject } from "../../shared/types.ts";
 
 export { SUBAGENT_INTERCOM_SESSION_NAME_ENV } from "./pi-args.ts";
+
+const STRUCTURED_OUTPUT_INSTRUCTIONS = [
+	"This subagent step has a strict structured output contract.",
+	"Your final action must be to call the `structured_output` tool with JSON matching the provided schema.",
+	"Do not rely on prose-only completion; if you do not call `structured_output`, the parent will fail this step.",
+].join("\n");
 
 export const CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS = [
 	"You are a child subagent, not the parent orchestrator.",
@@ -98,7 +108,8 @@ export function rewriteSubagentPrompt(
 	rewritten = stripSubagentOrchestrationSkill(rewritten);
 	rewritten = stripChildBoundaryInstructions(rewritten);
 	const boundary = options.fanoutChild ? CHILD_FANOUT_BOUNDARY_INSTRUCTIONS : CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS;
-	return `${boundary}\n\n${rewritten}`;
+	const structured = process.env[STRUCTURED_OUTPUT_CAPTURE_ENV] ? `\n\n${STRUCTURED_OUTPUT_INSTRUCTIONS}` : "";
+	return `${boundary}${structured}\n\n${rewritten}`;
 }
 
 function isParentOnlySubagentMessage(message: unknown): boolean {
@@ -147,7 +158,46 @@ export function stripParentOnlySubagentMessages(messages: unknown[]): unknown[] 
 }
 
 export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
-	pi.on("context", (event) => {
+	const structuredOutputPath = process.env[STRUCTURED_OUTPUT_CAPTURE_ENV];
+	const structuredSchemaPath = process.env[STRUCTURED_OUTPUT_SCHEMA_ENV];
+	if (structuredOutputPath && structuredSchemaPath) {
+		const schema = JSON.parse(fs.readFileSync(structuredSchemaPath, "utf-8")) as JsonSchemaObject;
+		const parameters = {
+			type: "object",
+			properties: { value: schema },
+			required: ["value"],
+			additionalProperties: false,
+		};
+		const registerTool = pi.registerTool as unknown as (tool: {
+			name: string;
+			label: string;
+			description: string;
+			parameters: unknown;
+			execute: (_id: string, params: { value: unknown }) => Promise<unknown>;
+		}) => void;
+		registerTool({
+			name: "structured_output",
+			label: "Structured Output",
+			description: "Submit the required final structured output for this subagent step. This terminates the step.",
+			parameters: parameters as never,
+			async execute(_id: string, params: { value: unknown }) {
+				const validation = validateStructuredOutputValue(schema, params.value);
+				if (validation.status === "invalid") {
+					throw new Error(`Structured output validation failed: ${validation.message}`);
+				}
+				fs.mkdirSync(path.dirname(structuredOutputPath), { recursive: true });
+				fs.writeFileSync(structuredOutputPath, JSON.stringify(params.value), { mode: 0o600 });
+				return {
+					content: [{ type: "text", text: "Structured output captured." }],
+					details: { path: structuredOutputPath },
+					terminate: true,
+				};
+			},
+		});
+	}
+
+	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown) => unknown) => void;
+	onRuntimeEvent("context", (event: { messages: unknown[] }) => {
 		const messages = stripParentOnlySubagentMessages(event.messages);
 		if (messages === event.messages) return undefined;
 		return { messages };

--- a/packages/subagents/src/runs/shared/workflow-graph.ts
+++ b/packages/subagents/src/runs/shared/workflow-graph.ts
@@ -1,0 +1,206 @@
+import { isDynamicParallelStep, isParallelStep, type ChainStep, type SequentialStep } from "../../shared/settings.ts";
+import type { SingleResult, SubagentRunMode, WorkflowGraphNode, WorkflowGraphSnapshot, WorkflowNodeStatus } from "../../shared/types.ts";
+
+export interface WorkflowGraphBuildInput {
+	runId: string;
+	mode?: SubagentRunMode;
+	steps: ChainStep[];
+	results?: Array<Pick<SingleResult, "exitCode" | "detached" | "interrupted" | "error" | "acceptance">>;
+	currentFlatIndex?: number;
+	currentStepIndex?: number;
+	stepStatuses?: Array<{ status?: string; error?: string }>;
+	dynamicChildren?: Record<number, Array<{ agent: string; label?: string; flatIndex: number; itemKey: string; outputName?: string; structured?: boolean; error?: string }>>;
+	dynamicGroupStatuses?: Record<number, { status: WorkflowNodeStatus; error?: string; acceptance?: SingleResult["acceptance"] }>;
+}
+
+function normalizeStatus(status: string | undefined): WorkflowNodeStatus | undefined {
+	switch (status) {
+		case "complete":
+		case "completed":
+			return "completed";
+		case "running":
+			return "running";
+		case "failed":
+			return "failed";
+		case "paused":
+			return "paused";
+		case "detached":
+			return "detached";
+		case "pending":
+			return "pending";
+		default:
+			return undefined;
+	}
+}
+
+function resultStatus(result: Pick<SingleResult, "exitCode" | "detached" | "interrupted"> | undefined): WorkflowNodeStatus | undefined {
+	if (!result) return undefined;
+	if (result.detached) return "detached";
+	if (result.interrupted) return "paused";
+	return result.exitCode === 0 ? "completed" : "failed";
+}
+
+function nodeStatus(input: WorkflowGraphBuildInput, flatIndex: number): WorkflowNodeStatus {
+	return normalizeStatus(input.stepStatuses?.[flatIndex]?.status)
+		?? resultStatus(input.results?.[flatIndex])
+		?? (input.currentFlatIndex === flatIndex ? "running" : "pending");
+}
+
+function pushPhase(phases: WorkflowGraphSnapshot["phases"], phase: string | undefined, nodeId: string): void {
+	if (!phase) return;
+	let group = phases.find((candidate) => candidate.title === phase);
+	if (!group) {
+		group = { title: phase, nodeIds: [] };
+		phases.push(group);
+	}
+	group.nodeIds.push(nodeId);
+}
+
+function seqLabel(step: SequentialStep, stepIndex: number): string {
+	return step.label?.trim() || step.agent || `Step ${stepIndex + 1}`;
+}
+
+function summarizeParallelStatuses(statuses: WorkflowNodeStatus[]): WorkflowNodeStatus {
+	if (statuses.some((status) => status === "running")) return "running";
+	if (statuses.some((status) => status === "failed")) return "failed";
+	if (statuses.some((status) => status === "paused")) return "paused";
+	if (statuses.some((status) => status === "detached")) return "detached";
+	if (statuses.length > 0 && statuses.every((status) => status === "completed")) return "completed";
+	if (statuses.some((status) => status === "completed")) return "running";
+	return "pending";
+}
+
+export function buildWorkflowGraphSnapshot(input: WorkflowGraphBuildInput): WorkflowGraphSnapshot {
+	const nodes: WorkflowGraphNode[] = [];
+	const phases: WorkflowGraphSnapshot["phases"] = [];
+	let flatIndex = 0;
+	let currentNodeId: string | undefined;
+
+	for (let stepIndex = 0; stepIndex < input.steps.length; stepIndex++) {
+		const step = input.steps[stepIndex]!;
+		if (isParallelStep(step)) {
+			const groupId = `step-${stepIndex}`;
+			const children: WorkflowGraphNode[] = [];
+			const childStatuses: WorkflowNodeStatus[] = [];
+			for (let taskIndex = 0; taskIndex < step.parallel.length; taskIndex++) {
+				const task = step.parallel[taskIndex]!;
+				const status = nodeStatus(input, flatIndex);
+				childStatuses.push(status);
+				const childId = `step-${stepIndex}-agent-${taskIndex}`;
+				const child: WorkflowGraphNode = {
+					id: childId,
+					kind: "agent",
+					agent: task.agent,
+					phase: task.phase,
+					label: task.label?.trim() || task.agent || `Agent ${taskIndex + 1}`,
+					status,
+					flatIndex,
+					stepIndex,
+					outputName: task.as,
+					structured: Boolean(task.outputSchema),
+					acceptanceStatus: input.results?.[flatIndex]?.acceptance?.status,
+					error: input.stepStatuses?.[flatIndex]?.error ?? input.results?.[flatIndex]?.error,
+				};
+				children.push(child);
+				pushPhase(phases, task.phase, childId);
+				if (status === "running" || input.currentFlatIndex === flatIndex) currentNodeId = childId;
+				flatIndex++;
+			}
+			const groupStatus = summarizeParallelStatuses(childStatuses);
+			if (input.currentStepIndex === stepIndex && !currentNodeId) currentNodeId = groupId;
+			nodes.push({
+				id: groupId,
+				kind: "parallel-group",
+				label: step.parallel.length === 1 ? "Parallel task" : `Parallel group (${step.parallel.length})`,
+				status: groupStatus,
+				stepIndex,
+				children,
+			});
+			continue;
+		}
+
+		if (isDynamicParallelStep(step)) {
+			const groupId = `step-${stepIndex}`;
+			const materialized = input.dynamicChildren?.[stepIndex] ?? [];
+			const groupOverride = input.dynamicGroupStatuses?.[stepIndex];
+			const children: WorkflowGraphNode[] = [];
+			const childStatuses: WorkflowNodeStatus[] = [];
+			for (let taskIndex = 0; taskIndex < materialized.length; taskIndex++) {
+				const task = materialized[taskIndex]!;
+				const status = nodeStatus(input, task.flatIndex);
+				childStatuses.push(status);
+				const childId = `step-${stepIndex}-item-${task.itemKey.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+				const child: WorkflowGraphNode = {
+					id: childId,
+					kind: "agent",
+					agent: task.agent,
+					phase: step.parallel.phase ?? step.phase,
+					label: task.label?.trim() || step.parallel.label?.trim() || `${task.agent} ${task.itemKey}`,
+					status,
+					flatIndex: task.flatIndex,
+					stepIndex,
+					itemKey: task.itemKey,
+					outputName: task.outputName,
+					structured: task.structured,
+					acceptanceStatus: input.results?.[task.flatIndex]?.acceptance?.status,
+					error: input.stepStatuses?.[task.flatIndex]?.error ?? input.results?.[task.flatIndex]?.error ?? task.error,
+				};
+				children.push(child);
+				pushPhase(phases, child.phase, childId);
+				if (status === "running" || input.currentFlatIndex === task.flatIndex) currentNodeId = childId;
+			}
+			const groupStatus = groupOverride?.status ?? (children.length > 0 ? summarizeParallelStatuses(childStatuses) : (input.currentStepIndex === stepIndex ? "running" : "pending"));
+			if (input.currentStepIndex === stepIndex && !currentNodeId) currentNodeId = groupId;
+			nodes.push({
+				id: groupId,
+				kind: "dynamic-parallel-group",
+				label: step.label?.trim() || step.parallel.label?.trim() || `Dynamic fanout (${step.collect.as})`,
+				status: groupStatus,
+				stepIndex,
+				outputName: step.collect.as,
+				structured: Boolean(step.collect.outputSchema),
+				acceptanceStatus: groupOverride?.acceptance?.status,
+				error: groupOverride?.error,
+				dynamic: {
+					sourceOutput: step.expand.from.output,
+					sourcePath: step.expand.from.path,
+					itemName: step.expand.item ?? "item",
+					maxItems: step.expand.maxItems,
+					collectAs: step.collect.as,
+				},
+				children,
+			});
+			if (materialized.length > 0) flatIndex = Math.max(flatIndex, ...materialized.map((child) => child.flatIndex + 1));
+			continue;
+		}
+
+		const seq = step as SequentialStep;
+		const status = nodeStatus(input, flatIndex);
+		const id = `step-${stepIndex}`;
+		nodes.push({
+			id,
+			kind: "step",
+			agent: seq.agent,
+			phase: seq.phase,
+			label: seqLabel(seq, stepIndex),
+			status,
+			flatIndex,
+			stepIndex,
+			outputName: seq.as,
+			structured: Boolean(seq.outputSchema),
+			acceptanceStatus: input.results?.[flatIndex]?.acceptance?.status,
+			error: input.stepStatuses?.[flatIndex]?.error ?? input.results?.[flatIndex]?.error,
+		});
+		pushPhase(phases, seq.phase, id);
+		if (status === "running" || input.currentFlatIndex === flatIndex || input.currentStepIndex === stepIndex) currentNodeId = id;
+		flatIndex++;
+	}
+
+	return {
+		runId: input.runId,
+		mode: input.mode ?? "chain",
+		phases,
+		nodes,
+		currentNodeId,
+	};
+}

--- a/packages/subagents/src/shared/formatters.ts
+++ b/packages/subagents/src/shared/formatters.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Usage, SingleResult } from "./types.ts";
 import type { ChainStep } from "./settings.ts";
-import { isParallelStep } from "./settings.ts";
+import { isDynamicParallelStep, isParallelStep } from "./settings.ts";
 import { splitKnownThinkingSuffix, THINKING_LEVELS } from "./model-info.ts";
 
 /**
@@ -70,7 +70,7 @@ export function buildChainSummary(
 	failedStep?: { index: number; error: string },
 ): string {
 	const stepNames = steps
-		.map((step) => (isParallelStep(step) ? `parallel[${step.parallel.length}]` : step.agent))
+		.map((step) => (isParallelStep(step) ? `parallel[${step.parallel.length}]` : isDynamicParallelStep(step) ? `expand:${step.parallel.agent}` : step.agent))
 		.join(" → ");
 
 	const totalDuration = results.reduce((sum, r) => sum + (r.progress?.durationMs || 0), 0);

--- a/packages/subagents/src/shared/settings.ts
+++ b/packages/subagents/src/shared/settings.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentConfig } from "../agents/agents.ts";
 import { normalizeSkillInput } from "../agents/skills.ts";
-import { CHAIN_RUNS_DIR, type OutputMode } from "./types.ts";
+import { CHAIN_RUNS_DIR, type AcceptanceInput, type JsonSchemaObject, type OutputMode } from "./types.ts";
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const INITIAL_PROGRESS_CONTENT = "# Progress\n\n## Status\nIn Progress\n\n## Tasks\n\n## Files Changed\n\n## Notes\n";
 
@@ -44,6 +44,10 @@ function normalizeOutputOverride(output: string | false | undefined): string | f
 export interface SequentialStep {
 	agent: string;
 	task?: string;
+	phase?: string;
+	label?: string;
+	as?: string;
+	outputSchema?: JsonSchemaObject;
 	cwd?: string;
 	output?: string | false;
 	outputMode?: OutputMode;
@@ -51,12 +55,17 @@ export interface SequentialStep {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	acceptance?: AcceptanceInput;
 }
 
 /** Parallel task item within a parallel step */
-interface ParallelTaskItem {
+export interface ParallelTaskItem {
 	agent: string;
 	task?: string;
+	phase?: string;
+	label?: string;
+	as?: string;
+	outputSchema?: JsonSchemaObject;
 	cwd?: string;
 	count?: number;
 	output?: string | false;
@@ -65,10 +74,40 @@ interface ParallelTaskItem {
 	progress?: boolean;
 	skill?: string | string[] | false;
 	model?: string;
+	acceptance?: AcceptanceInput;
+}
+
+export interface DynamicExpandSpec {
+	from: {
+		output: string;
+		path: string;
+	};
+	item?: string;
+	key?: string;
+	maxItems?: number;
+	onEmpty?: "skip" | "fail";
+}
+
+export type DynamicParallelTemplate = Omit<ParallelTaskItem, "as" | "count">;
+
+export interface DynamicCollectSpec {
+	as: string;
+	outputSchema?: JsonSchemaObject;
+}
+
+export interface DynamicParallelStep {
+	expand: DynamicExpandSpec;
+	parallel: DynamicParallelTemplate;
+	collect: DynamicCollectSpec;
+	concurrency?: number;
+	failFast?: boolean;
+	phase?: string;
+	label?: string;
+	acceptance?: AcceptanceInput;
 }
 
 /** Parallel step: multiple agents running concurrently */
-interface ParallelStep {
+export interface ParallelStep {
 	parallel: ParallelTaskItem[];
 	cwd?: string;
 	concurrency?: number;
@@ -77,7 +116,7 @@ interface ParallelStep {
 }
 
 /** Union type for chain steps */
-export type ChainStep = SequentialStep | ParallelStep;
+export type ChainStep = SequentialStep | ParallelStep | DynamicParallelStep;
 
 // =============================================================================
 // Type Guards
@@ -87,10 +126,17 @@ export function isParallelStep(step: ChainStep): step is ParallelStep {
 	return "parallel" in step && Array.isArray((step as ParallelStep).parallel);
 }
 
+export function isDynamicParallelStep(step: ChainStep): step is DynamicParallelStep {
+	return "expand" in step && "collect" in step && "parallel" in step && !Array.isArray((step as { parallel?: unknown }).parallel);
+}
+
 /** Get all agent names in a step (single for sequential, multiple for parallel) */
 export function getStepAgents(step: ChainStep): string[] {
 	if (isParallelStep(step)) {
 		return step.parallel.map((t) => t.agent);
+	}
+	if (isDynamicParallelStep(step)) {
+		return [step.parallel.agent];
 	}
 	return [step.agent];
 }
@@ -160,6 +206,9 @@ export function resolveChainTemplates(
 				// Default for parallel tasks is {previous}
 				return "{previous}";
 			});
+		}
+		if (isDynamicParallelStep(step)) {
+			return step.parallel.task ?? "{previous}";
 		}
 		// Sequential step: existing logic
 		const seq = step as SequentialStep;

--- a/packages/subagents/src/shared/types.ts
+++ b/packages/subagents/src/shared/types.ts
@@ -26,6 +26,51 @@ export interface MaxOutputConfig {
 
 export type OutputMode = "inline" | "file-only";
 
+export type JsonSchemaObject = Record<string, unknown>;
+
+export interface ChainOutputMapEntry {
+	text: string;
+	structured?: unknown;
+	agent: string;
+	stepIndex: number;
+}
+
+export type ChainOutputMap = Record<string, ChainOutputMapEntry>;
+
+export type WorkflowNodeStatus = "pending" | "running" | "completed" | "failed" | "paused" | "detached";
+
+export interface WorkflowGraphNode {
+	id: string;
+	kind: "step" | "parallel-group" | "dynamic-parallel-group" | "agent";
+	agent?: string;
+	phase?: string;
+	label: string;
+	status: WorkflowNodeStatus;
+	flatIndex?: number;
+	stepIndex?: number;
+	children?: WorkflowGraphNode[];
+	dynamic?: {
+		sourceOutput: string;
+		sourcePath: string;
+		itemName: string;
+		maxItems?: number;
+		collectAs?: string;
+	};
+	itemKey?: string;
+	outputName?: string;
+	structured?: boolean;
+	acceptanceStatus?: AcceptanceLedgerStatus;
+	error?: string;
+}
+
+export interface WorkflowGraphSnapshot {
+	runId: string;
+	mode: "chain" | "parallel" | "single";
+	phases: Array<{ title: string; nodeIds: string[] }>;
+	nodes: WorkflowGraphNode[];
+	currentNodeId?: string;
+}
+
 export interface SavedOutputReference {
 	path: string;
 	bytes: number;
@@ -202,6 +247,151 @@ export interface ModelAttempt {
 	usage?: Usage;
 }
 
+export type AcceptanceLevel = "auto" | "none" | "attested" | "checked" | "verified" | "reviewed";
+
+export type AcceptanceEvidenceKind =
+	| "changed-files"
+	| "tests-added"
+	| "commands-run"
+	| "validation-output"
+	| "residual-risks"
+	| "no-staged-files"
+	| "diff-summary"
+	| "review-findings"
+	| "manual-notes";
+
+export interface AcceptanceGate {
+	id: string;
+	must: string;
+	evidence?: AcceptanceEvidenceKind[];
+	severity?: "required" | "recommended";
+}
+
+export interface AcceptanceVerifyCommand {
+	id: string;
+	command: string;
+	timeoutMs?: number;
+	cwd?: string;
+	env?: Record<string, string>;
+	allowFailure?: boolean;
+}
+
+export interface AcceptanceReviewGate {
+	agent?: string;
+	focus?: string;
+	required?: boolean;
+}
+
+export interface AcceptanceConfig {
+	level?: AcceptanceLevel;
+	criteria?: Array<string | AcceptanceGate>;
+	evidence?: AcceptanceEvidenceKind[];
+	verify?: AcceptanceVerifyCommand[];
+	review?: AcceptanceReviewGate | false;
+	stopRules?: string[];
+	reason?: string;
+}
+
+export type AcceptanceInput = AcceptanceLevel | false | AcceptanceConfig;
+
+export interface ResolvedAcceptanceGate extends AcceptanceGate {
+	id: string;
+	must: string;
+	evidence: AcceptanceEvidenceKind[];
+	severity: "required" | "recommended";
+}
+
+export interface ResolvedAcceptanceConfig {
+	level: Exclude<AcceptanceLevel, "auto">;
+	explicit: boolean;
+	inferredReason: string[];
+	criteria: ResolvedAcceptanceGate[];
+	evidence: AcceptanceEvidenceKind[];
+	verify: AcceptanceVerifyCommand[];
+	review?: AcceptanceReviewGate | false;
+	stopRules: string[];
+	reason?: string;
+}
+
+export interface AcceptanceReport {
+	criteriaSatisfied?: Array<{
+		id?: string;
+		status: "satisfied" | "not-satisfied" | "not-applicable";
+		evidence: string;
+	}>;
+	changedFiles?: string[];
+	testsAddedOrUpdated?: string[];
+	commandsRun?: Array<{
+		command: string;
+		result: "passed" | "failed" | "not-run";
+		summary: string;
+	}>;
+	validationOutput?: string[];
+	residualRisks?: string[];
+	noStagedFiles?: boolean;
+	diffSummary?: string;
+	reviewFindings?: string[];
+	manualNotes?: string;
+	notes?: string;
+}
+
+export type AcceptanceRuntimeCheckStatus = "passed" | "failed" | "not-applicable";
+
+export interface AcceptanceRuntimeCheck {
+	id: string;
+	status: AcceptanceRuntimeCheckStatus;
+	message: string;
+}
+
+export interface AcceptanceVerifyResult {
+	id: string;
+	command: string;
+	cwd?: string;
+	exitCode: number | null;
+	status: "passed" | "failed" | "timed-out" | "allowed-failure";
+	stdout?: string;
+	stderr?: string;
+	durationMs: number;
+}
+
+export interface AcceptanceReviewResult {
+	status: "no-blockers" | "blockers" | "needs-parent-decision";
+	findings: Array<{
+		severity: "blocker" | "non-blocking";
+		file?: string;
+		issue: string;
+		rationale: string;
+	}>;
+}
+
+export type AcceptanceLedgerStatus =
+	| "not-required"
+	| "claimed"
+	| "attested"
+	| "checked"
+	| "verified"
+	| "reviewed"
+	| "accepted"
+	| "rejected";
+
+export interface AcceptanceLedger {
+	status: AcceptanceLedgerStatus;
+	explicit: boolean;
+	effectiveAcceptance: ResolvedAcceptanceConfig;
+	inferredReason: string[];
+	criteria: ResolvedAcceptanceGate[];
+	childReport?: AcceptanceReport;
+	childReportParseError?: string;
+	runtimeChecks: AcceptanceRuntimeCheck[];
+	verifyRuns: AcceptanceVerifyResult[];
+	reviewResult?: AcceptanceReviewResult;
+	parentDecision?: {
+		status: "accepted" | "rejected";
+		at: string;
+		reason?: string;
+	};
+}
+
 export interface SingleResult {
 	agent: string;
 	task: string;
@@ -230,6 +420,10 @@ export interface SingleResult {
 	savedOutputPath?: string;
 	outputReference?: SavedOutputReference;
 	outputSaveError?: string;
+	structuredOutput?: unknown;
+	structuredOutputPath?: string;
+	structuredOutputSchemaPath?: string;
+	acceptance?: AcceptanceLedger;
 }
 
 export interface Details {
@@ -256,6 +450,8 @@ export interface Details {
 	chainAgents?: string[];      // Agent names in order, e.g., ["scout", "planner"]
 	totalSteps?: number;         // Total steps in chain
 	currentStepIndex?: number;   // 0-indexed current step (for running chains)
+	workflowGraph?: WorkflowGraphSnapshot;
+	outputs?: ChainOutputMap;
 }
 
 // Upstream AgentToolResult omits the runtime isError flag that subagent tool results still emit/read.
@@ -372,6 +568,7 @@ export interface AsyncStartedEvent {
 	chain?: string[];
 	chainStepCount?: number;
 	parallelGroups?: AsyncParallelGroupStatus[];
+	workflowGraph?: WorkflowGraphSnapshot;
 	nestedRoute?: NestedRouteInfo;
 }
 
@@ -395,8 +592,13 @@ export interface AsyncStatus {
 	currentStep?: number;
 	chainStepCount?: number;
 	parallelGroups?: AsyncParallelGroupStatus[];
+	workflowGraph?: WorkflowGraphSnapshot;
 	steps?: Array<{
 		agent: string;
+		phase?: string;
+		label?: string;
+		outputName?: string;
+		structured?: boolean;
 		status: "pending" | "running" | "complete" | "completed" | "failed" | "paused";
 		children?: NestedRunSummary[];
 		sessionFile?: string;
@@ -422,11 +624,16 @@ export interface AsyncStatus {
 		attemptedModels?: string[];
 		modelAttempts?: ModelAttempt[];
 		error?: string;
+		structuredOutput?: unknown;
+		structuredOutputPath?: string;
+		structuredOutputSchemaPath?: string;
+		acceptance?: AcceptanceLedger;
 	}>;
 	sessionDir?: string;
 	outputFile?: string;
 	totalTokens?: TokenUsage;
 	sessionFile?: string;
+	outputs?: ChainOutputMap;
 }
 
 export type AsyncJobStep = NonNullable<AsyncStatus["steps"]>[number] & {
@@ -592,6 +799,18 @@ export interface RunSyncOptions {
 	currentModel?: string;
 	/** Skills to inject (overrides agent default if provided) */
 	skills?: string[];
+	structuredOutput?: {
+		schema: JsonSchemaObject;
+		schemaPath: string;
+		outputPath: string;
+	};
+	acceptance?: AcceptanceInput;
+	acceptanceContext?: {
+		mode?: SubagentRunMode;
+		async?: boolean;
+		dynamic?: boolean;
+		dynamicGroup?: boolean;
+	};
 }
 
 export type IntercomBridgeMode = "off" | "fork-only" | "always";
@@ -606,6 +825,12 @@ interface TopLevelParallelConfig {
 	concurrency?: number;
 }
 
+interface ExtensionChainConfig {
+	dynamicFanout?: {
+		maxItems?: number;
+	};
+}
+
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	forceTopLevelAsync?: boolean;
@@ -613,6 +838,7 @@ export interface ExtensionConfig {
 	maxSubagentDepth?: number;
 	control?: ControlConfig;
 	parallel?: TopLevelParallelConfig;
+	chain?: ExtensionChainConfig;
 	worktreeSetupHook?: string;
 	worktreeSetupHookTimeoutMs?: number;
 	intercomBridge?: IntercomBridgeConfig;

--- a/packages/subagents/src/shared/utils.ts
+++ b/packages/subagents/src/shared/utils.ts
@@ -132,7 +132,8 @@ export function getFinalOutput(messages: Message[]): string {
 			const hasAssistantError = ("errorMessage" in msg && typeof msg.errorMessage === "string" && msg.errorMessage.length > 0)
 				|| ("stopReason" in msg && msg.stopReason === "error");
 			if (hasAssistantError) continue;
-			for (const part of msg.content) {
+			for (let j = msg.content.length - 1; j >= 0; j--) {
+				const part = msg.content[j];
 				if (part.type === "text" && part.text.trim().length > 0) return part.text;
 			}
 		}

--- a/packages/subagents/src/slash/slash-commands.ts
+++ b/packages/subagents/src/slash/slash-commands.ts
@@ -5,7 +5,8 @@ import type { ExtensionAPI, ExtensionContext } from "@bastani/atomic";
 import { Key, matchesKey } from "@earendil-works/pi-tui";
 import { discoverAgents, discoverAgentsAll, type ChainConfig } from "../agents/agents.ts";
 import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
-import { isParallelStep, type ChainStep } from "../shared/settings.ts";
+import { isDynamicParallelStep, isParallelStep, type ChainStep } from "../shared/settings.ts";
+import { assertJsonSchemaObject } from "../runs/shared/structured-output.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
 import {
 	applySlashUpdate,
@@ -20,6 +21,7 @@ import {
 	SLASH_SUBAGENT_RESPONSE_EVENT,
 	SLASH_SUBAGENT_STARTED_EVENT,
 	SLASH_SUBAGENT_UPDATE_EVENT,
+	type JsonSchemaObject,
 	type SingleResult,
 	type SubagentState,
 } from "../shared/types.ts";
@@ -123,12 +125,48 @@ const makeChainCompletions = (state: SubagentState) => (prefix: string) => {
 		.map((chain) => ({ value: chain.name, label: chain.name }));
 };
 
+function loadSavedOutputSchema(chain: ChainConfig, stepAgent: string, outputSchema: unknown): JsonSchemaObject | undefined {
+	if (outputSchema === undefined) return undefined;
+	if (typeof outputSchema === "string") {
+		const schemaPath = path.isAbsolute(outputSchema)
+			? outputSchema
+			: path.join(path.dirname(chain.filePath), outputSchema);
+		const parsed = JSON.parse(fs.readFileSync(schemaPath, "utf-8")) as unknown;
+		assertJsonSchemaObject(parsed, `outputSchema for chain '${chain.name}' step '${stepAgent}' (${schemaPath})`);
+		return parsed;
+	}
+	assertJsonSchemaObject(outputSchema, `outputSchema for chain '${chain.name}' step '${stepAgent}'`);
+	return outputSchema;
+}
+
 const mapSavedChainSteps = (chain: ChainConfig, worktree = false): ChainStep[] => {
-	return (chain.steps as Array<ChainStep & { skills?: string[] | false }>).map((step) => {
-		if (isParallelStep(step)) return worktree ? { ...step, worktree: true } : { ...step };
+	return (chain.steps as unknown as Array<ChainStep & { skills?: string[] | false }>).map((step) => {
+		if (isParallelStep(step)) {
+			const parallel = step.parallel.map((task) => {
+				const { outputSchema: rawOutputSchema, ...rest } = task as typeof task & { outputSchema?: unknown };
+				const outputSchema = loadSavedOutputSchema(chain, task.agent, rawOutputSchema);
+				return { ...rest, ...(outputSchema ? { outputSchema } : {}) };
+			});
+			return { ...step, parallel, ...(worktree ? { worktree: true } : {}) };
+		}
+		if (isDynamicParallelStep(step)) {
+			const { outputSchema: rawOutputSchema, ...parallelRest } = step.parallel as typeof step.parallel & { outputSchema?: unknown };
+			const outputSchema = loadSavedOutputSchema(chain, step.parallel.agent, rawOutputSchema);
+			const collectSchema = loadSavedOutputSchema(chain, `${step.collect.as} collection`, step.collect.outputSchema);
+			return {
+				...step,
+				parallel: { ...parallelRest, ...(outputSchema ? { outputSchema } : {}) },
+				collect: { ...step.collect, ...(collectSchema ? { outputSchema: collectSchema } : {}) },
+			};
+		}
+		const outputSchema = loadSavedOutputSchema(chain, step.agent, (step as { outputSchema?: unknown }).outputSchema);
 		return {
 			agent: step.agent,
 			task: step.task || undefined,
+			...(step.phase ? { phase: step.phase } : {}),
+			...(step.label ? { label: step.label } : {}),
+			...(step.as ? { as: step.as } : {}),
+			...(outputSchema ? { outputSchema } : {}),
 			output: step.output,
 			outputMode: step.outputMode,
 			reads: step.reads,

--- a/packages/subagents/src/tui/render.ts
+++ b/packages/subagents/src/tui/render.ts
@@ -14,6 +14,7 @@ import {
 	type Details,
 	type NestedRunSummary,
 	type NestedStepSummary,
+	type WorkflowNodeStatus,
 	MAX_WIDGET_JOBS,
 	WIDGET_KEY,
 } from "../shared/types.ts";
@@ -305,6 +306,7 @@ function resultStatusLine(result: Details["results"][number], output: string): s
 	if (result.detached) return result.detachedReason ? `Detached: ${result.detachedReason}` : "Detached";
 	if (result.interrupted) return "Paused";
 	if (result.exitCode !== 0) return `Error: ${result.error ?? (firstOutputLine(output) || `exit ${result.exitCode}`)}`;
+	if (result.acceptance?.status && result.acceptance.status !== "not-required") return `Done · acceptance: ${result.acceptance.status}`;
 	if (hasEmptyTextOutputWithoutOutputTarget(result.task, output)) return "Done (no text output)";
 	return "Done";
 }
@@ -507,32 +509,56 @@ function parseParallelGroupAgentCount(label: string | undefined): number | undef
 	return inner.split("+").map((part) => part.trim()).filter(Boolean).length;
 }
 
-function isChainParallelGroupActive(details: Pick<Details, "mode" | "chainAgents" | "currentStepIndex">): boolean {
-	if (details.mode !== "chain") return false;
-	if (details.currentStepIndex === undefined) return false;
-	const currentLabel = details.chainAgents?.[details.currentStepIndex];
-	return parseParallelGroupAgentCount(currentLabel) !== undefined;
-}
-
 interface ChainStepSpan {
 	stepIndex: number;
 	start: number;
 	count: number;
 	isParallel: boolean;
+	status?: WorkflowNodeStatus;
+	label?: string;
+	error?: string;
 }
 
-function buildChainStepSpans(chainAgents: string[] | undefined): ChainStepSpan[] {
-	if (!chainAgents?.length) return [];
+function buildChainStepSpans(details: Pick<Details, "chainAgents" | "workflowGraph">): ChainStepSpan[] {
+	if (details.workflowGraph?.nodes?.length) {
+		const spans: ChainStepSpan[] = [];
+		let flatCursor = 0;
+		for (const node of details.workflowGraph.nodes) {
+			if (node.stepIndex === undefined) continue;
+			if (node.kind === "parallel-group" || node.kind === "dynamic-parallel-group") {
+				const childFlatIndexes = (node.children ?? [])
+					.map((child) => child.flatIndex)
+					.filter((value): value is number => typeof value === "number");
+				const start = childFlatIndexes.length ? Math.min(...childFlatIndexes) : flatCursor;
+				const count = node.children?.length ?? 0;
+				spans.push({ stepIndex: node.stepIndex, start, count, isParallel: true, status: node.status, label: node.label, error: node.error });
+				flatCursor = Math.max(flatCursor, start + count);
+				continue;
+			}
+			const start = node.flatIndex ?? flatCursor;
+			spans.push({ stepIndex: node.stepIndex, start, count: 1, isParallel: false, status: node.status, label: node.label, error: node.error });
+			flatCursor = Math.max(flatCursor, start + 1);
+		}
+		if (spans.length) return spans.sort((left, right) => left.stepIndex - right.stepIndex);
+	}
+
+	if (!details.chainAgents?.length) return [];
 	const spans: ChainStepSpan[] = [];
 	let start = 0;
-	for (let stepIndex = 0; stepIndex < chainAgents.length; stepIndex++) {
-		const label = chainAgents[stepIndex]!;
+	for (let stepIndex = 0; stepIndex < details.chainAgents.length; stepIndex++) {
+		const label = details.chainAgents[stepIndex]!;
 		const parsedCount = parseParallelGroupAgentCount(label);
 		const count = parsedCount ?? 1;
 		spans.push({ stepIndex, start, count, isParallel: parsedCount !== undefined });
 		start += count;
 	}
 	return spans;
+}
+
+function isChainParallelGroupActive(details: Pick<Details, "mode" | "chainAgents" | "currentStepIndex" | "workflowGraph">): boolean {
+	if (details.mode !== "chain") return false;
+	if (details.currentStepIndex === undefined) return false;
+	return buildChainStepSpans(details).some((span) => span.stepIndex === details.currentStepIndex && span.isParallel);
 }
 
 function buildAsyncChainStepSpans(total: number, stepCount: number, parallelGroups: AsyncParallelGroupStatus[] = []): ChainStepSpan[] {
@@ -559,6 +585,55 @@ function isDoneResult(result: Details["results"][number]): boolean {
 	return result.exitCode === 0;
 }
 
+function workflowGraphHasStatus(details: Pick<Details, "workflowGraph">, statuses: WorkflowNodeStatus[]): boolean {
+	return details.workflowGraph?.nodes.some((node) => statuses.includes(node.status)) ?? false;
+}
+
+interface ChainRenderResultEntry {
+	kind: "result";
+	resultIndex: number;
+	rowNumber: number;
+	agentName: string;
+}
+
+interface ChainRenderPlaceholderEntry {
+	kind: "placeholder";
+	rowNumber: number;
+	stepLabel: string;
+	agentName: string;
+	status: WorkflowNodeStatus;
+	error?: string;
+}
+
+type ChainRenderEntry = ChainRenderResultEntry | ChainRenderPlaceholderEntry;
+
+function buildChainRenderEntries(details: Details, label: MultiProgressLabel): ChainRenderEntry[] | undefined {
+	if (details.mode !== "chain" || !label.hasParallelInChain || label.showActiveGroupOnly) return undefined;
+	const entries: ChainRenderEntry[] = [];
+	for (const span of buildChainStepSpans(details)) {
+		if (span.isParallel && span.count === 0) {
+			entries.push({
+				kind: "placeholder",
+				rowNumber: span.stepIndex + 1,
+				stepLabel: `Step ${span.stepIndex + 1}`,
+				agentName: span.label ?? details.chainAgents?.[span.stepIndex] ?? `step-${span.stepIndex + 1}`,
+				status: span.status ?? "pending",
+				error: span.error,
+			});
+			continue;
+		}
+		for (let index = span.start; index < span.start + span.count; index++) {
+			entries.push({
+				kind: "result",
+				resultIndex: index,
+				rowNumber: index + 1,
+				agentName: details.results[index]?.agent ?? details.chainAgents?.[span.stepIndex] ?? `step-${span.stepIndex + 1}`,
+			});
+		}
+	}
+	return entries;
+}
+
 interface MultiProgressLabel {
 	headerLabel: string;
 	itemTitle: "Step" | "Agent";
@@ -570,8 +645,8 @@ interface MultiProgressLabel {
 	showActiveGroupOnly: boolean;
 }
 
-function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "progress" | "totalSteps" | "currentStepIndex" | "chainAgents">, hasRunning: boolean): MultiProgressLabel {
-	const stepSpans = buildChainStepSpans(details.chainAgents);
+function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "progress" | "totalSteps" | "currentStepIndex" | "chainAgents" | "workflowGraph">, hasRunning: boolean): MultiProgressLabel {
+	const stepSpans = buildChainStepSpans(details);
 	const hasParallelInChain = details.mode === "chain" && stepSpans.some((span) => span.isParallel);
 	const activeParallelGroup = isChainParallelGroupActive(details);
 	const itemTitle: "Step" | "Agent" = details.mode === "parallel" || activeParallelGroup ? "Agent" : "Step";
@@ -635,11 +710,13 @@ function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "pr
 	if (details.mode === "chain" && details.chainAgents?.length) {
 		const totalCount = details.totalSteps ?? details.chainAgents.length;
 		const doneLogical = stepSpans.filter((span) => {
+			if (span.status && span.status !== "completed") return false;
+			if (span.count === 0) return span.status === "completed";
 			for (let index = span.start; index < span.start + span.count; index++) {
 				const progressEntry = details.progress?.find((progress) => progress.index === index);
 				const resultEntry = details.results.find((result) => result.progress?.index === index) ?? details.results[index];
-				if (progressEntry?.status === "running" || progressEntry?.status === "pending") return false;
-				if (resultEntry && !isDoneResult(resultEntry)) return false;
+				if (progressEntry?.status === "running" || progressEntry?.status === "pending" || progressEntry?.status === "failed") return false;
+				if (!resultEntry || !isDoneResult(resultEntry)) return false;
 			}
 			return true;
 		}).length;
@@ -655,9 +732,9 @@ function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "pr
 	return { headerLabel, itemTitle, totalCount, hasParallelInChain, activeParallelGroup, groupStartIndex: 0, groupEndIndex: details.results.length, showActiveGroupOnly: false };
 }
 
-function resultRowLabel(details: Pick<Details, "mode" | "chainAgents">, label: MultiProgressLabel, resultIndex: number, stepNumber: number): string {
+function resultRowLabel(details: Pick<Details, "mode" | "chainAgents" | "workflowGraph">, label: MultiProgressLabel, resultIndex: number, stepNumber: number): string {
 	if (details.mode === "chain" && label.hasParallelInChain) {
-		const span = buildChainStepSpans(details.chainAgents).find((candidate) => resultIndex >= candidate.start && resultIndex < candidate.start + candidate.count);
+		const span = buildChainStepSpans(details).find((candidate) => resultIndex >= candidate.start && resultIndex < candidate.start + candidate.count);
 		if (span?.isParallel) return `Agent ${resultIndex - span.start + 1}/${span.count}`;
 		if (span) return `Step ${span.stepIndex + 1}`;
 	}
@@ -1216,9 +1293,12 @@ function renderSingleCompact(d: Details, r: Details["results"][number], theme: T
 
 function renderMultiCompact(d: Details, theme: Theme, now?: number, spinnerNow?: number): Component {
 	const hasRunning = d.progress?.some((p) => p.status === "running")
-		|| d.results.some((r) => r.progress?.status === "running");
-	const failed = d.results.some((r) => r.exitCode !== 0 && r.progress?.status !== "running");
-	const paused = d.results.some((r) => (r.interrupted || r.detached) && r.progress?.status !== "running");
+		|| d.results.some((r) => r.progress?.status === "running")
+		|| workflowGraphHasStatus(d, ["running"]);
+	const failed = d.results.some((r) => r.exitCode !== 0 && r.progress?.status !== "running")
+		|| workflowGraphHasStatus(d, ["failed"]);
+	const paused = d.results.some((r) => (r.interrupted || r.detached) && r.progress?.status !== "running")
+		|| workflowGraphHasStatus(d, ["paused", "detached"]);
 	let totalSummary = d.progressSummary;
 	if (!totalSummary) {
 		let sawProgress = false;
@@ -1251,13 +1331,29 @@ function renderMultiCompact(d: Details, theme: Theme, now?: number, spinnerNow?:
 	const useResultsDirectly = multiLabel.hasParallelInChain || !d.chainAgents?.length;
 	const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
 	const displayEnd = multiLabel.showActiveGroupOnly ? multiLabel.groupEndIndex : (useResultsDirectly ? d.results.length : d.chainAgents!.length);
-	for (let i = displayStart; i < displayEnd; i++) {
+	const chainEntries = buildChainRenderEntries(d, multiLabel);
+	const renderEntries = chainEntries ?? Array.from({ length: displayEnd - displayStart }, (_, offset): ChainRenderEntry => {
+		const i = displayStart + offset;
 		const r = d.results[i];
 		const fallbackLabel = itemTitle.toLowerCase();
 		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		const agentName = useResultsDirectly ? (r?.agent || `${fallbackLabel}-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `${fallbackLabel}-${rowNumber}`);
+		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? (r?.agent || `${fallbackLabel}-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `${fallbackLabel}-${rowNumber}`) };
+	});
+	for (const entry of renderEntries) {
+		if (entry.kind === "placeholder") {
+			const glyph = widgetStepGlyph(entry.status as AsyncJobStep["status"], theme);
+			const statusLabel = widgetStepStatus(entry.status as AsyncJobStep["status"], theme);
+			c.addChild(new Text(truncLine(`  ${glyph} ${entry.stepLabel}: ${themeBold(theme, entry.agentName)} ${theme.fg("dim", "·")} ${statusLabel}`, width), 0, 0));
+			if (entry.error) c.addChild(new Text(truncLine(theme.fg("error", `    ⎿  Error: ${entry.error}`), width), 0, 0));
+			continue;
+		}
+		const i = entry.resultIndex;
+		const r = d.results[i];
+		const rowNumber = entry.rowNumber;
+		const agentName = entry.agentName;
 		if (!r) {
-			c.addChild(new Text(truncLine(theme.fg("dim", `  ◦ ${itemTitle} ${rowNumber}: ${agentName} · pending`), width), 0, 0));
+			const pendingLabel = chainEntries ? resultRowLabel(d, multiLabel, i, rowNumber) : `${itemTitle} ${rowNumber}`;
+			c.addChild(new Text(truncLine(theme.fg("dim", `  ◦ ${pendingLabel}: ${agentName} · pending`), width), 0, 0));
 			continue;
 		}
 		const output = getSingleResultOutput(r);
@@ -1489,20 +1585,27 @@ export function renderSubagentResult(
 	if (!expanded) return renderMultiCompact(d, theme, options.now, options.spinnerNow);
 
 	const hasRunning = d.progress?.some((p) => p.status === "running")
-		|| d.results.some((r) => r.progress?.status === "running");
+		|| d.results.some((r) => r.progress?.status === "running")
+		|| workflowGraphHasStatus(d, ["running"]);
 	const ok = d.results.filter((r) => r.progress?.status === "completed" || (r.exitCode === 0 && r.progress?.status !== "running")).length;
 	const hasEmptyWithoutTarget = d.results.some((r) =>
 		r.exitCode === 0
 		&& r.progress?.status !== "running"
 		&& hasEmptyTextOutputWithoutOutputTarget(r.task, getSingleResultOutput(r)),
 	);
+	const hasWorkflowFailure = workflowGraphHasStatus(d, ["failed"]);
+	const hasWorkflowPause = workflowGraphHasStatus(d, ["paused", "detached"]);
 	const icon = hasRunning
 		? theme.fg("warning", "running")
 		: hasEmptyWithoutTarget
 			? theme.fg("warning", "warning")
-			: ok === d.results.length
-				? theme.fg("success", "ok")
-				: theme.fg("error", "failed");
+			: hasWorkflowFailure
+				? theme.fg("error", "failed")
+				: hasWorkflowPause
+					? theme.fg("warning", "paused")
+					: ok === d.results.length
+						? theme.fg("success", "ok")
+						: theme.fg("error", "failed");
 
 	const totalSummary =
 		d.progressSummary ||
@@ -1573,18 +1676,33 @@ export function renderSubagentResult(
 	const useResultsDirectly = multiLabel.hasParallelInChain || !d.chainAgents?.length;
 	const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
 	const displayEnd = multiLabel.showActiveGroupOnly ? multiLabel.groupEndIndex : (useResultsDirectly ? d.results.length : d.chainAgents!.length);
+	const chainEntries = buildChainRenderEntries(d, multiLabel);
+	const renderEntries = chainEntries ?? Array.from({ length: displayEnd - displayStart }, (_, offset): ChainRenderEntry => {
+		const i = displayStart + offset;
+		const r = d.results[i];
+		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
+		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? (r?.agent || `step-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `step-${rowNumber}`) };
+	});
 
 	c.addChild(new Spacer(1));
 
-	for (let i = displayStart; i < displayEnd; i++) {
+	for (const entry of renderEntries) {
+		if (entry.kind === "placeholder") {
+			const statusLabel = widgetStepStatus(entry.status as AsyncJobStep["status"], theme);
+			c.addChild(new Text(fit(`  ${statusLabel} ${entry.stepLabel}: ${theme.bold(entry.agentName)}`), 0, 0));
+			c.addChild(new Text(theme.fg(entry.status === "failed" ? "error" : "dim", `    status: ${entry.status}`), 0, 0));
+			if (entry.error) c.addChild(new Text(theme.fg("error", `    error: ${entry.error}`), 0, 0));
+			c.addChild(new Spacer(1));
+			continue;
+		}
+		const i = entry.resultIndex;
 		const r = d.results[i];
-		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		const agentName = useResultsDirectly
-			? (r?.agent || `step-${rowNumber}`)
-			: (d.chainAgents![i] || r?.agent || `step-${rowNumber}`);
+		const rowNumber = entry.rowNumber;
+		const agentName = entry.agentName;
 
 		if (!r) {
-			c.addChild(new Text(fit(theme.fg("dim", `  ${itemTitle} ${rowNumber}: ${agentName}`)), 0, 0));
+			const pendingLabel = chainEntries ? resultRowLabel(d, multiLabel, i, rowNumber) : `${itemTitle} ${rowNumber}`;
+			c.addChild(new Text(fit(theme.fg("dim", `  ${pendingLabel}: ${agentName}`)), 0, 0));
 			c.addChild(new Text(theme.fg("dim", `    status: pending`), 0, 0));
 			c.addChild(new Spacer(1));
 			continue;

--- a/test/unit/subagents-acceptance.test.ts
+++ b/test/unit/subagents-acceptance.test.ts
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, test } from "bun:test";
+import {
+	acceptanceFailureMessage,
+	aggregateAcceptanceReport,
+	evaluateAcceptance,
+	formatAcceptancePrompt,
+	parseAcceptanceReport,
+	resolveEffectiveAcceptance,
+	validateAcceptanceInput,
+} from "../../packages/subagents/src/runs/shared/acceptance.js";
+
+function report(overrides: Record<string, unknown> = {}): string {
+	return [
+		"done",
+		"```acceptance-report",
+		JSON.stringify({
+			criteriaSatisfied: [{ id: "criterion-1", status: "satisfied", evidence: "verified in test" }],
+			changedFiles: ["src/file.js"],
+			testsAddedOrUpdated: ["test/file.test.js"],
+			commandsRun: [{ command: "npm test", result: "passed", summary: "passed" }],
+			validationOutput: ["tests passed"],
+			residualRisks: [],
+			noStagedFiles: true,
+			notes: "complete",
+			...overrides,
+		}),
+		"```",
+	].join("\n");
+}
+
+function tempRepo(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-acceptance-"));
+	fs.writeFileSync(path.join(dir, "file.txt"), "hello\n", "utf-8");
+	return dir;
+}
+
+describe("acceptance gates", () => {
+	test("infers different policies for reviewer, writer, async writer, and dynamic contexts", () => {
+		assert.equal(resolveEffectiveAcceptance({ agentName: "reviewer", task: "Review-only. Do not edit.", mode: "single" }).level, "attested");
+		assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task: "Implement the fix", mode: "single" }).level, "checked");
+		assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task: "Implement the fix", mode: "single", async: true }).level, "reviewed");
+		assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task: "Fix each item", mode: "chain", dynamic: true }).level, "reviewed");
+	});
+
+	test("explicit acceptance can strengthen inferred policy", () => {
+		const resolved = resolveEffectiveAcceptance({
+			agentName: "reviewer",
+			task: "Review-only.",
+			explicit: { level: "verified", verify: [{ id: "ok", command: "node --version" }] },
+		});
+
+		assert.equal(resolved.level, "verified");
+		assert.equal(resolved.verify[0]?.id, "ok");
+	});
+
+	test("formats a standardized child prompt section", () => {
+		const resolved = resolveEffectiveAcceptance({
+			agentName: "worker",
+			task: "Implement a fix",
+			explicit: { level: "checked", criteria: ["Patch the bug"], stopRules: ["Do not stop after analysis"] },
+		});
+		const prompt = formatAcceptancePrompt(resolved);
+
+		assert.match(prompt, /## Acceptance Contract/);
+		assert.match(prompt, /Acceptance level: checked/);
+		assert.match(prompt, /Patch the bug/);
+		assert.match(prompt, /```acceptance-report/);
+	});
+
+	test("parses only explicit acceptance-report fences", () => {
+		const parsed = parseAcceptanceReport(report());
+
+		assert.ok(parsed.report);
+		assert.deepEqual(parsed.report.changedFiles, ["src/file.js"]);
+		assert.equal(parsed.error, undefined);
+
+		const genericJson = parseAcceptanceReport(`done\n\
+\
+\`\`\`json\n{\"notes\":\"not an acceptance report\"}\n\`\`\``);
+		assert.equal(genericJson.report, undefined);
+		assert.match(genericJson.error ?? "", /Structured acceptance report not found/);
+
+		const malformed = parseAcceptanceReport("```acceptance-report\n{bad-json\n```");
+		assert.equal(malformed.report, undefined);
+		assert.match(malformed.error ?? "", /Failed to parse acceptance-report/);
+	});
+
+	test("explicit none disables inferred gates when a reason is present", () => {
+		const acceptance = resolveEffectiveAcceptance({
+			agentName: "worker",
+			task: "Implement a fix",
+			explicit: { level: "none", reason: "parent is doing manual acceptance" },
+		});
+
+		assert.equal(acceptance.level, "none");
+		assert.deepEqual(acceptance.evidence, []);
+	});
+
+	test("checked mode rejects missing required evidence", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked" },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: report({ testsAddedOrUpdated: [] }),
+				cwd,
+			});
+
+			assert.equal(ledger.status, "rejected");
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /tests-added evidence missing/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("checked mode rejects not-satisfied required criteria", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked", criteria: [{ id: "regression", must: "Regression is covered" }] },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: report({ criteriaSatisfied: [{ id: "regression", status: "not-satisfied", evidence: "test missing" }] }),
+				cwd,
+			});
+
+			assert.equal(ledger.status, "rejected");
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /Required criterion 'regression' was reported as not-satisfied/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("verified mode records runtime command success and failure separately from child command claims", async () => {
+		const cwd = tempRepo();
+		try {
+			const passing = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "verified", verify: [{ id: "pass", command: "node -e \"process.exit(0)\"", timeoutMs: 10_000 }] },
+			});
+			const passLedger = await evaluateAcceptance({ acceptance: passing, output: report(), cwd });
+			assert.equal(passLedger.status, "verified");
+			assert.equal(passLedger.verifyRuns[0]?.status, "passed");
+
+			const failing = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "verified", verify: [{ id: "fail", command: "node -e \"process.exit(7)\"", timeoutMs: 10_000 }] },
+			});
+			const failLedger = await evaluateAcceptance({ acceptance: failing, output: report(), cwd });
+			assert.equal(failLedger.status, "rejected");
+			assert.equal(failLedger.childReport?.commandsRun?.[0]?.result, "passed");
+			assert.equal(failLedger.verifyRuns[0]?.status, "failed");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("reviewed mode records no-blocker and blocker reviewer outcomes", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a risky fix",
+				explicit: { level: "reviewed", review: { agent: "reviewer", required: true } },
+			});
+			const noBlockers = await evaluateAcceptance({
+				acceptance,
+				output: report(),
+				cwd,
+				reviewResult: { status: "no-blockers", findings: [] },
+			});
+			assert.equal(noBlockers.status, "reviewed");
+			assert.equal(noBlockers.reviewResult?.status, "no-blockers");
+
+			const blockers = await evaluateAcceptance({
+				acceptance,
+				output: report(),
+				cwd,
+				reviewResult: {
+					status: "blockers",
+					findings: [{ severity: "blocker", issue: "Missing test", rationale: "Acceptance requires test evidence." }],
+				},
+			});
+			assert.equal(blockers.status, "rejected");
+			assert.equal(blockers.reviewResult?.status, "blockers");
+
+			const unavailable = await evaluateAcceptance({ acceptance, output: report(), cwd });
+			assert.equal(unavailable.status, "rejected");
+			assert.equal(unavailable.reviewResult?.status, "needs-parent-decision");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("does not make explicit checked acceptance an explicit reviewed blocker when inference recommends review", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement each dynamic item",
+				dynamic: true,
+				explicit: { level: "checked" },
+			});
+
+			assert.equal(acceptance.level, "reviewed");
+			assert.equal(acceptance.review ? acceptance.review.required : undefined, false);
+			const ledger = await evaluateAcceptance({ acceptance, output: report({ criteriaSatisfied: [
+				{ id: "criterion-1", status: "satisfied", evidence: "implemented" },
+				{ id: "criterion-2", status: "satisfied", evidence: "evidence returned" },
+			] }), cwd });
+			assert.equal(ledger.status, "checked");
+			assert.equal(ledger.reviewResult?.status, "needs-parent-decision");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("does not mark reviewed without an independent reviewer result", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: {
+					level: "reviewed",
+					review: false,
+				},
+			});
+			assert.equal(acceptance.level, "reviewed");
+
+			const ledger = await evaluateAcceptance({ acceptance, output: report(), cwd });
+			assert.equal(ledger.status, "rejected");
+			assert.equal(ledger.reviewResult?.status, "needs-parent-decision");
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /review required/i);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("zero-child aggregate reports do not fabricate required evidence", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement dynamic fanout fixes",
+				explicit: { level: "checked" },
+			});
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: "",
+				report: aggregateAcceptanceReport({ results: [] }),
+				cwd,
+			});
+
+			assert.equal(ledger.status, "rejected");
+			assert.match(acceptanceFailureMessage(ledger) ?? "", /criterion|changed-files|tests-added|commands-run|validation-output|no-staged-files/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("validates invalid disable and verify shapes", () => {
+		assert.deepEqual(validateAcceptanceInput({ level: "none" }), ["acceptance.reason is required when level is none."]);
+		assert.deepEqual(validateAcceptanceInput({ verify: [{ id: "missing-command" }] }), ["acceptance.verify[0].command is required."]);
+	});
+});

--- a/test/unit/subagents-dynamic-fanout.test.ts
+++ b/test/unit/subagents-dynamic-fanout.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+import { ChainOutputValidationError, validateChainOutputBindings } from "../../packages/subagents/src/runs/shared/chain-outputs.js";
+import {
+	DynamicFanoutError,
+	collectDynamicResults,
+	materializeDynamicParallelStep,
+	resolveJsonPointer,
+	validateDynamicCollection,
+} from "../../packages/subagents/src/runs/shared/dynamic-fanout.js";
+import type { ChainStep } from "../../packages/subagents/src/shared/settings.js";
+import type { ChainOutputMap, SingleResult } from "../../packages/subagents/src/shared/types.js";
+
+const outputs: ChainOutputMap = {
+	targets: {
+		text: "{\"items\":[{\"path\":\"src/a.ts\"},{\"path\":\"src/b.ts\"}]}",
+		structured: { items: [{ path: "src/a.js" }, { path: "src/b.js" }] },
+		agent: "scout",
+		stepIndex: 0,
+	},
+};
+
+describe("dynamic fanout helpers", () => {
+	test("resolves JSON Pointers and materializes item templates", () => {
+		assert.deepEqual(resolveJsonPointer({ items: [1, 2] }, "/items/1", "path"), 2);
+		const step: ChainStep = {
+			expand: { from: { output: "targets", path: "/items" }, item: "target", key: "/path", maxItems: 4 },
+			parallel: { agent: "reviewer", task: "Review {target.path}", label: "Review {target.path}" },
+			collect: { as: "reviews" },
+		};
+		const materialized = materializeDynamicParallelStep(step, outputs, 1);
+		assert.deepEqual(materialized.items.map((item) => item.key), ["src/a.js", "src/b.js"]);
+		assert.deepEqual(materialized.parallel.map((task) => task.task), ["Review src/a.js", "Review src/b.js"]);
+		assert.deepEqual(materialized.parallel.map((task) => task.label), ["Review src/a.js", "Review src/b.js"]);
+	});
+
+	test("rejects missing structured sources, over-limit arrays, duplicate keys, colliding ids, and bad templates", () => {
+		const base: ChainStep = {
+			expand: { from: { output: "targets", path: "/items" }, item: "target", key: "/path", maxItems: 4 },
+			parallel: { agent: "reviewer", task: "Review {target.path}" },
+			collect: { as: "reviews" },
+		};
+		assert.throws(
+			() => materializeDynamicParallelStep({ ...base, expand: { ...base.expand, maxItems: 1 } }, outputs, 1),
+			/exceeding maxItems/,
+		);
+		assert.throws(
+			() => materializeDynamicParallelStep(base, { targets: { text: "plain", agent: "scout", stepIndex: 0 } }, 1),
+			/requires structured output/,
+		);
+		assert.throws(
+			() => materializeDynamicParallelStep(base, { targets: { ...outputs.targets, structured: { items: [{ path: "x" }, { path: "x" }] } } }, 1),
+			/duplicate item key/,
+		);
+		assert.throws(
+			() => materializeDynamicParallelStep(base, { targets: { ...outputs.targets, structured: { items: [{ path: "a/b" }, { path: "a-b" }] } } }, 1),
+			/colliding item id/,
+		);
+		assert.throws(
+			() => materializeDynamicParallelStep({ ...base, parallel: { agent: "reviewer", task: "Review {other.path}" } }, outputs, 1),
+			/Unsupported template reference/,
+		);
+		assert.throws(
+			() => materializeDynamicParallelStep({ ...base, parallel: { agent: "reviewer", task: "Review {target[path]}" } }, outputs, 1),
+			/Invalid item reference/,
+		);
+		assert.throws(
+			() => materializeDynamicParallelStep({ ...base, parallel: { agent: "reviewer", task: "Review {target.path" } }, outputs, 1),
+			/Invalid item reference/,
+		);
+	});
+
+	test("allows config maxItems defaults and handles empty arrays deterministically", () => {
+		const base: ChainStep = {
+			expand: { from: { output: "targets", path: "/items" }, item: "target", key: "/path" },
+			parallel: { agent: "reviewer", task: "Review {target.path}" },
+			collect: { as: "reviews" },
+		};
+		const materialized = materializeDynamicParallelStep(base, outputs, 1, { maxItems: 4 });
+		assert.equal(materialized.parallel.length, 2);
+		assert.doesNotThrow(() => validateChainOutputBindings([
+			{ agent: "scout", task: "Return targets", as: "targets", outputSchema: { type: "object" } },
+			base,
+		], { maxItems: 4 }));
+		const empty = materializeDynamicParallelStep(base, { targets: { ...outputs.targets, structured: { items: [] } } }, 1, { maxItems: 4 });
+		assert.equal(empty.parallel.length, 0);
+		assert.throws(
+			() => materializeDynamicParallelStep({ ...base, expand: { ...base.expand, onEmpty: "fail" } }, { targets: { ...outputs.targets, structured: { items: [] } } }, 1, { maxItems: 4 }),
+			/source array is empty/,
+		);
+	});
+
+	test("rejects malformed dynamic-like shapes before they can run as static parallel", () => {
+		const malformed = [
+			{
+				expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+				parallel: [{ agent: "reviewer", task: "Review" }],
+				collect: { as: "reviews" },
+			},
+			{
+				expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+				parallel: { agent: "reviewer", task: "Review {item.path}" },
+			},
+			{
+				expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+				parallel: { agent: "reviewer", task: "Review {item.path}" },
+				collect: { as: "reviews" },
+				when: "later",
+			},
+			{
+				expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+				parallel: { agent: "reviewer", task: "Review {item.path}", as: "child" },
+				collect: { as: "reviews" },
+			},
+		] as ChainStep[];
+
+		for (const step of malformed) {
+			assert.throws(
+				() => validateChainOutputBindings([{ agent: "scout", task: "Return targets", as: "targets", outputSchema: { type: "object" } }, step]),
+				ChainOutputValidationError,
+			);
+		}
+	});
+
+	test("validates source ordering and collect name collisions", () => {
+		const chain: ChainStep[] = [
+			{ agent: "scout", task: "Return targets", as: "targets", outputSchema: { type: "object" } },
+			{
+				expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+				parallel: { agent: "reviewer", task: "Review {item.path}" },
+				collect: { as: "targets" },
+			},
+		];
+		assert.throws(() => validateChainOutputBindings(chain), ChainOutputValidationError);
+		assert.throws(
+			() => validateChainOutputBindings([chain[1]!]),
+			/unknown output 'targets'/,
+		);
+	});
+
+	test("collects ordered child result records and validates aggregate schema", () => {
+		const step: ChainStep = {
+			expand: { from: { output: "targets", path: "/items" }, key: "/path", maxItems: 4 },
+			parallel: { agent: "reviewer", task: "Review {item.path}" },
+			collect: { as: "reviews" },
+		};
+		const materialized = materializeDynamicParallelStep(step, outputs, 1);
+		const result = (agent: string, structuredOutput: unknown): SingleResult => ({
+			agent,
+			task: "t",
+			exitCode: 0,
+			messages: [],
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 },
+			finalOutput: "ok",
+			structuredOutput,
+		});
+		const collected = collectDynamicResults(step, materialized.items, [result("reviewer", { ok: "a" }), result("reviewer", { ok: "b" })]);
+		assert.deepEqual(collected.map((item) => item.key), ["src/a.js", "src/b.js"]);
+		assert.deepEqual(collected.map((item) => item.structured), [{ ok: "a" }, { ok: "b" }]);
+		assert.doesNotThrow(() => validateDynamicCollection({ type: "array", minItems: 2 }, collected));
+		assert.throws(() => validateDynamicCollection({ type: "object" }, collected), DynamicFanoutError);
+	});
+});

--- a/test/unit/subagents-get-final-output.test.ts
+++ b/test/unit/subagents-get-final-output.test.ts
@@ -1,0 +1,76 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import type { Message } from "@earendil-works/pi-ai";
+import { getFinalOutput } from "../../packages/subagents/src/shared/utils.js";
+
+function assistantContent(content: unknown[]): Message {
+	return { role: "assistant", content } as unknown as Message;
+}
+
+describe("subagents getFinalOutput", () => {
+	test("uses the last non-empty text part in the latest assistant message", () => {
+		const messages = [assistantContent([
+			{ type: "text", text: "" },
+			{ type: "text", text: "Summary" },
+		])];
+
+		assert.equal(getFinalOutput(messages), "Summary");
+	});
+
+	test("prefers final text over progress text in a multi-part assistant message", () => {
+		const messages = [assistantContent([
+			{ type: "text", text: "Working on the fix..." },
+			{ type: "thinking", thinking: "Cursor shell: shell $ npm test" },
+			{ type: "text", text: "Implemented: patch applied." },
+		])];
+
+		assert.equal(getFinalOutput(messages), "Implemented: patch applied.");
+	});
+
+	test("falls back to an older assistant message when latest text is whitespace-only", () => {
+		const messages = [
+			assistantContent([{ type: "text", text: "Earlier" }]),
+			assistantContent([{ type: "text", text: " \n\t " }]),
+		];
+
+		assert.equal(getFinalOutput(messages), "Earlier");
+	});
+
+	test("falls back to an older assistant message when latest assistant message is tool-only", () => {
+		const messages = [
+			assistantContent([{ type: "text", text: "Earlier" }]),
+			assistantContent([{ type: "toolCall", name: "read", arguments: { path: "README.md" } }]),
+		];
+
+		assert.equal(getFinalOutput(messages), "Earlier");
+	});
+
+	test("returns empty output when all assistant text is empty or whitespace-only", () => {
+		const messages = [
+			assistantContent([{ type: "text", text: "" }]),
+			assistantContent([{ type: "text", text: "\n\t " }]),
+		];
+
+		assert.equal(getFinalOutput(messages), "");
+	});
+
+	test("does not use provider-error assistant text as fallback output", () => {
+		const messages = [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "temporary provider failure" }],
+				stopReason: "error",
+				errorMessage: "provider transport failed",
+			} as unknown as Message,
+			assistantContent([{ type: "text", text: "" }]),
+		];
+
+		assert.equal(getFinalOutput(messages), "");
+	});
+
+	test("preserves surrounding whitespace on the selected non-empty text", () => {
+		const messages = [assistantContent([{ type: "text", text: " \n Summary \n " }])];
+
+		assert.equal(getFinalOutput(messages), " \n Summary \n ");
+	});
+});

--- a/test/unit/subagents-workflow-graph.test.ts
+++ b/test/unit/subagents-workflow-graph.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+import { buildWorkflowGraphSnapshot } from "../../packages/subagents/src/runs/shared/workflow-graph.js";
+
+describe("workflow graph snapshots", () => {
+	test("maps sequential chains with phase, label, output name, and stable flat indexes", () => {
+		const graph = buildWorkflowGraphSnapshot({
+			runId: "run-1",
+			steps: [
+				{ agent: "scout", task: "Scan", phase: "Research", label: "Find context", as: "context" },
+				{ agent: "writer", task: "Use {outputs.context}", phase: "Synthesis", outputSchema: { type: "object" } },
+			],
+			results: [{ exitCode: 0 }, { exitCode: 1, error: "bad output" }],
+		});
+
+		assert.equal(graph.nodes[0]?.id, "step-0");
+		assert.equal(graph.nodes[0]?.label, "Find context");
+		assert.equal(graph.nodes[0]?.flatIndex, 0);
+		assert.equal(graph.nodes[0]?.outputName, "context");
+		assert.equal(graph.nodes[1]?.structured, true);
+		assert.equal(graph.nodes[1]?.status, "failed");
+		assert.deepEqual(graph.phases, [
+			{ title: "Research", nodeIds: ["step-0"] },
+			{ title: "Synthesis", nodeIds: ["step-1"] },
+		]);
+	});
+
+	test("maps parallel chain steps with stable group and child indexes", () => {
+		const graph = buildWorkflowGraphSnapshot({
+			runId: "run-2",
+			steps: [
+				{ agent: "setup", task: "Setup" },
+				{
+					parallel: [
+						{ agent: "reviewer", label: "Correctness", phase: "Review", as: "correctness" },
+						{ agent: "security", label: "Security", phase: "Review", as: "security" },
+					],
+				},
+			],
+			currentFlatIndex: 2,
+		});
+
+		const group = graph.nodes[1];
+		assert.equal(group?.kind, "parallel-group");
+		assert.equal(group?.children?.[0]?.id, "step-1-agent-0");
+		assert.equal(group?.children?.[0]?.flatIndex, 1);
+		assert.equal(group?.children?.[1]?.flatIndex, 2);
+		assert.equal(group?.children?.[1]?.status, "running");
+		assert.equal(graph.currentNodeId, "step-1-agent-1");
+		assert.deepEqual(graph.phases, [{ title: "Review", nodeIds: ["step-1-agent-0", "step-1-agent-1"] }]);
+	});
+
+	test("marks partially completed parallel groups as running", () => {
+		const graph = buildWorkflowGraphSnapshot({
+			runId: "run-3",
+			steps: [{ parallel: [{ agent: "first" }, { agent: "second" }] }],
+			results: [{ exitCode: 0 }],
+		});
+
+		assert.equal(graph.nodes[0]?.status, "running");
+		assert.equal(graph.nodes[0]?.children?.[0]?.status, "completed");
+		assert.equal(graph.nodes[0]?.children?.[1]?.status, "pending");
+	});
+
+	test("summarizes mixed terminal parallel group statuses with explicit precedence", () => {
+		const failedThenPaused = buildWorkflowGraphSnapshot({
+			runId: "run-4",
+			steps: [{ parallel: [{ agent: "first" }, { agent: "second" }] }],
+			results: [{ exitCode: 1 }, { exitCode: 1, interrupted: true }],
+		});
+		const pausedThenFailed = buildWorkflowGraphSnapshot({
+			runId: "run-5",
+			steps: [{ parallel: [{ agent: "first" }, { agent: "second" }] }],
+			results: [{ exitCode: 1, interrupted: true }, { exitCode: 1 }],
+		});
+
+		assert.equal(failedThenPaused.nodes[0]?.status, "failed");
+		assert.equal(pausedThenFailed.nodes[0]?.status, "failed");
+	});
+
+	test("uses dynamic group status overrides for empty or aggregate-failure fanout states", () => {
+		const steps = [{
+			expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+			parallel: { agent: "reviewer", task: "Review {item}" },
+			collect: { as: "reviews" },
+		}];
+
+		const emptySkip = buildWorkflowGraphSnapshot({
+			runId: "run-dynamic-empty",
+			steps,
+			dynamicGroupStatuses: { 0: { status: "completed" } },
+		});
+		assert.equal(emptySkip.nodes[0]?.kind, "dynamic-parallel-group");
+		assert.equal(emptySkip.nodes[0]?.status, "completed");
+		assert.deepEqual(emptySkip.nodes[0]?.children, []);
+
+		const collectFailure = buildWorkflowGraphSnapshot({
+			runId: "run-dynamic-collect-fail",
+			steps,
+			dynamicChildren: { 0: [{ agent: "reviewer", flatIndex: 0, itemKey: "a" }] },
+			results: [{ exitCode: 0 }],
+			dynamicGroupStatuses: { 0: { status: "failed", error: "Collected output validation failed" } },
+		});
+		assert.equal(collectFailure.nodes[0]?.status, "failed");
+		assert.match(collectFailure.nodes[0]?.error ?? "", /Collected output validation failed/);
+		assert.equal(collectFailure.nodes[0]?.children?.[0]?.status, "completed");
+	});
+});


### PR DESCRIPTION
## Summary

Syncs upstream `nicobailon/pi-subagents` patches starting at `9ea6c548`, porting dynamic chain fanout, acceptance contracts, structured output capture, workflow graph status, and final-output selection fixes into `@bastani/subagents`.

## Key Changes

### New Capabilities

- **Dynamic fanout** (`dynamic-fanout.ts`): `.chain.json` steps can now `expand` a named output into a runtime-materialized list of parallel tasks, collected back via a typed `collect` clause. Supports `onEmpty` handling, `maxItems` guard, and `{item.*}` template interpolation.
- **Acceptance contracts** (`acceptance.ts`): Subagent runs carry an explicit acceptance gate (`none` | `attested` | `checked` | `verified` | `reviewed`). Gates auto-infer from agent name/task risk or can be declared in `.chain.json`. Foreground and async execution paths both evaluate and surface gate results.
- **Structured output capture** (`structured-output.ts`): Chain steps can declare an `outputSchema` (JSON Schema); the subagent writes validated JSON to a temp file and the runner reads it back as a typed `ChainOutputMap` entry.
- **Named chain outputs** (`chain-outputs.ts`): Steps can declare `as: <name>` to bind their result to a named slot referenceable in later steps via `{outputs.<name>}` template interpolation. Binding validation is run up-front before execution.
- **Workflow graph snapshots** (`workflow-graph.ts`): A live DAG snapshot is computed after every step and surfaced in execution details, enabling richer TUI progress rendering for sequential, parallel, and dynamic-fanout chains.
- **Chain serializer** (`chain-serializer.ts`): `.chain.json` discovery, parsing, and validation against the extended schema including new `phase`, `label`, `as`, `outputSchema`, and `acceptance` fields.

### Bug Fixes

- **Final output selection**: Multi-part assistant responses now use the last non-empty text part as the canonical subagent output, fixing truncation when the model appends a trailing empty block.

### Tests

Four focused unit test suites added:
- `subagents-acceptance.test.ts` — gate inference, evaluation, and report aggregation
- `subagents-dynamic-fanout.test.ts` — materialization, template expansion, and collection
- `subagents-get-final-output.test.ts` — multi-part response final-output selection
- `subagents-workflow-graph.test.ts` — snapshot building for sequential, parallel, and dynamic steps

### Atomic-Specific Preservations

- `@bastani/atomic` import paths and `APP_NAME`-prefixed env vars kept throughout
- Atomic env/config prefix conventions applied to all new env keys (e.g., `ATOMIC_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA`)
- Codex fast-mode propagation and workflow-stage subagent guard forwarded into dynamic fanout runs
- Root-level Bun tests continue to pass (2022 tests, 0 failures)

## Validation

```
bun run typecheck   # 0 errors
bun run test:unit   # 2022 passed, 0 failed
git diff --cached --check
```