### PR TITLE
chore(release): prepare 0.8.24-alpha.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.24-alpha.2",
+      "version": "0.8.24-alpha.3",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.24-alpha.2",
+      "version": "0.8.24-alpha.3",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.24-alpha.2",
+      "version": "0.8.24-alpha.3",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.24-alpha.2",
+      "version": "0.8.24-alpha.3",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.24-alpha.2",
+      "version": "0.8.24-alpha.3",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.24-alpha.2",
+      "version": "0.8.24-alpha.3",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.24-alpha.3] - 2026-06-03
+
 ### Added
 
 - Added `/exit` as a built-in interactive slash command alias for graceful app shutdown from the main chat.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.24-alpha.2",
+  "version": "0.8.24-alpha.3",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.24-alpha.3] - 2026-06-03
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.24-alpha.3 prerelease.
+
 ## [0.8.24-alpha.2] - 2026-06-03
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.24-alpha.2",
+  "version": "0.8.24-alpha.3",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.24-alpha.3] - 2026-06-03
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.24-alpha.3 prerelease.
+
 ## [0.8.24-alpha.2] - 2026-06-03
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.24-alpha.2",
+  "version": "0.8.24-alpha.3",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.24-alpha.3] - 2026-06-03
+
 ### Added
 
 - Synced upstream dynamic fanout and acceptance-gate support for subagent chains, including `.chain.json` discovery, named chain outputs, structured subagent output capture, workflow graph status rendering, and explicit acceptance contracts.

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.24-alpha.2",
+  "version": "0.8.24-alpha.3",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.24-alpha.3] - 2026-06-03
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.24-alpha.3 prerelease.
+
 ## [0.8.24-alpha.2] - 2026-06-03
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.24-alpha.2",
+  "version": "0.8.24-alpha.3",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.24-alpha.3] - 2026-06-03
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.24-alpha.3 prerelease.
+
 ## [0.8.24-alpha.2] - 2026-06-03
 
 ### Added

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.24-alpha.2",
+  "version": "0.8.24-alpha.3",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the workspace for the `0.8.24-alpha.3` prerelease, bumping all package versions and cutting changelog sections across the monorepo.

## Changes

- Bumped all workspace package versions from `0.8.24-alpha.2` → `0.8.24-alpha.3` (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`)
- Cut `[0.8.24-alpha.3]` changelog sections for every package; notable entries:
  - **`@bastani/atomic`** — added `/exit` as a built-in interactive slash-command alias for graceful app shutdown
  - **`@bastani/subagents`** — synced upstream dynamic fanout and acceptance-gate support for subagent chains (`.chain.json` discovery, named chain outputs, structured output capture, workflow graph status rendering, explicit acceptance contracts)
- Refreshed `bun.lock` to reflect the new prerelease versions

## Validation

- `AGENT=1 bun run typecheck` — passed
- `AGENT=1 bun run test:unit` — 2026 tests passed