### PR TITLE
fix(tui): skip full clears for off-viewport mutations during streaming

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -416,6 +416,17 @@ jobs:
               working-directory: ${{ env.PACKAGE_DIR }}
               run: bun pm pack --dry-run
 
+            # Gate publishing on the temporary #1222 bundled pi-tui closure: pack the tarball,
+            # confirm it ships the patched pi-tui plus its full runtime dependency closure, and
+            # install/import it from an isolated consumer. A broken closure must fail here rather
+            # than silently ship. SKIP_BUILD=1 reuses the dist built earlier in this job.
+            - name: Verify bundled pi-tui closure ships in tarball
+              if: steps.registry.outputs.exists != 'true'
+              working-directory: ${{ env.PACKAGE_DIR }}
+              env:
+                  SKIP_BUILD: "1"
+              run: bun run verify:bundled-pi-tui
+
             - name: Publish to npm
               if: steps.registry.outputs.exists != 'true'
               working-directory: ${{ env.PACKAGE_DIR }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,14 @@ jobs:
             - name: Build @bastani/atomic package
               working-directory: packages/coding-agent
               run: bun run build
+            # Gate the temporary #1222 bundled pi-tui closure on a single Linux matrix entry: a
+            # broken dependency closure is OS-independent, so running it once avoids multiplying the
+            # pack/install fixture across every OS. SKIP_BUILD=1 reuses the dist built just above.
+            - name: Verify bundled pi-tui closure
+              if: runner.os == 'Linux'
+              env:
+                  SKIP_BUILD: "1"
+              run: bun run --cwd packages/coding-agent verify:bundled-pi-tui
             - name: Unit tests
               run: bun run test:unit
             - name: Integration tests

--- a/bun.lock
+++ b/bun.lock
@@ -153,6 +153,9 @@
       ],
     },
   },
+  "patchedDependencies": {
+    "@earendil-works/pi-tui@0.78.0": "patches/@earendil-works%2Fpi-tui@0.78.0.patch",
+  },
   "packages": {
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "@j178/prek": "0.4.3",
     "@types/bun": "^1.3.14",
     "typescript": "^6.0.3"
+  },
+  "patchedDependencies": {
+    "@earendil-works/pi-tui@0.78.0": "patches/@earendil-works%2Fpi-tui@0.78.0.patch"
   }
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed TUI flicker and scrollback wipes while scrolling during active streaming in short terminals by avoiding full clears for same-shape off-viewport renderer diffs ([#1222](https://github.com/bastani-inc/atomic/issues/1222)).
+- Fixed TUI flicker and scrollback wipes while scrolling during active streaming in short terminals by adding a strict no-write off-viewport renderer skip and preserving scrollback for content-driven full redraws ([#1222](https://github.com/bastani-inc/atomic/issues/1222)).
 
 ## [0.8.24-alpha.3] - 2026-06-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed TUI flicker and scrollback wipes while scrolling during active streaming in short terminals by avoiding full clears for same-shape off-viewport renderer diffs ([#1222](https://github.com/bastani-inc/atomic/issues/1222)).
+
 ## [0.8.24-alpha.3] - 2026-06-03
 
 ### Added

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -63,7 +63,10 @@
     "copy-builtin-workflows": "bun run copy-builtin-packages",
     "docs:check": "bun run scripts/validate-docs-links.ts",
     "verify:workflow-types": "bun run scripts/verify-workflow-sdk-types.ts",
+    "verify:bundled-pi-tui": "bun run scripts/verify-bundled-pi-tui-install.ts",
     "test": "vitest --run",
+    "prepack": "bun run scripts/materialize-bundled-pi-tui.ts",
+    "postpack": "bun run scripts/materialize-bundled-pi-tui.ts --clean",
     "prepublishOnly": "bun run clean && bun run build"
   },
   "dependencies": {
@@ -94,6 +97,11 @@
     "yaml": "^2.9.0",
     "zod": "^3.25.0 || ^4.0.0"
   },
+  "bundleDependencies": [
+    "@earendil-works/pi-tui",
+    "get-east-asian-width",
+    "marked"
+  ],
   "overrides": {
     "rimraf": "6.1.2",
     "gaxios": {

--- a/packages/coding-agent/scripts/bundled-pi-tui-config.ts
+++ b/packages/coding-agent/scripts/bundled-pi-tui-config.ts
@@ -4,6 +4,9 @@ export const bundledPiTuiExpectedRuntimePackages = [
 	"get-east-asian-width",
 	"marked",
 ] as const;
+// Sentinel string lifted from the TEMPORARY #1222 renderer patch: its presence in dist/tui.js is how
+// we prove the patched pi-tui (not a stock copy) got bundled. Delete this once an upstream pi-tui
+// release ships the fix and the bundling mechanism is removed.
 export const bundledPiTuiPatchedRendererMarker = "Strict off-viewport same-count changes are state-only";
 
 export function bundledPackageJsonTarPath(packageName: string): string {

--- a/packages/coding-agent/scripts/bundled-pi-tui-config.ts
+++ b/packages/coding-agent/scripts/bundled-pi-tui-config.ts
@@ -1,0 +1,15 @@
+export const bundledPiTuiRootPackageName = "@earendil-works/pi-tui";
+export const bundledPiTuiExpectedRuntimePackages = [
+	bundledPiTuiRootPackageName,
+	"get-east-asian-width",
+	"marked",
+] as const;
+export const bundledPiTuiPatchedRendererMarker = "Same-shape text changes above the previous viewport";
+
+export function bundledPackageJsonTarPath(packageName: string): string {
+	return `package/node_modules/${packageName}/package.json`;
+}
+
+export function bundledPackageTarPath(packageName: string, relativePackagePath: string): string {
+	return `package/node_modules/${packageName}/${relativePackagePath}`;
+}

--- a/packages/coding-agent/scripts/bundled-pi-tui-config.ts
+++ b/packages/coding-agent/scripts/bundled-pi-tui-config.ts
@@ -4,7 +4,7 @@ export const bundledPiTuiExpectedRuntimePackages = [
 	"get-east-asian-width",
 	"marked",
 ] as const;
-export const bundledPiTuiPatchedRendererMarker = "Same-shape text changes above the previous viewport";
+export const bundledPiTuiPatchedRendererMarker = "Strict off-viewport same-count changes are state-only";
 
 export function bundledPackageJsonTarPath(packageName: string): string {
 	return `package/node_modules/${packageName}/package.json`;

--- a/packages/coding-agent/scripts/materialize-bundled-pi-tui.ts
+++ b/packages/coding-agent/scripts/materialize-bundled-pi-tui.ts
@@ -319,6 +319,9 @@ function cleanBundledDependency(): void {
 	}
 }
 
+// Intentional sharp edge of this TEMPORARY #1222 bundling mechanism: we refuse to clobber any
+// pre-existing package-local copy rather than guessing whether it is safe to overwrite. Remove this
+// helper (and the rest of the bundling) once an upstream pi-tui release ships the renderer fix.
 function assertNoDestinationConflicts(closure: readonly ClosurePackage[]): void {
 	for (const entry of closure) {
 		if (!existsSync(entry.destinationDir)) continue;

--- a/packages/coding-agent/scripts/materialize-bundled-pi-tui.ts
+++ b/packages/coding-agent/scripts/materialize-bundled-pi-tui.ts
@@ -1,0 +1,381 @@
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+	bundledPiTuiExpectedRuntimePackages,
+	bundledPiTuiPatchedRendererMarker,
+	bundledPiTuiRootPackageName,
+} from "./bundled-pi-tui-config.js";
+
+const rootPackageName = bundledPiTuiRootPackageName;
+const expectedRuntimePackages = bundledPiTuiExpectedRuntimePackages;
+const patchedRendererMarker = bundledPiTuiPatchedRendererMarker;
+const packageRoot = resolve(import.meta.dir, "..");
+const repositoryRoot = resolve(packageRoot, "..", "..");
+const rootNodeModulesDir = resolve(repositoryRoot, "node_modules");
+const packageNodeModulesDir = resolve(packageRoot, "node_modules");
+const materializationManifestPath = join(packageNodeModulesDir, ".atomic-bundled-pi-tui-manifest.json");
+const legacyMarkerPath = join(packageNodeModulesDir, "@earendil-works", ".atomic-bundled-pi-tui");
+
+interface PackageJson {
+	readonly name?: string;
+	readonly version?: string;
+	readonly dependencies?: Readonly<Record<string, string>>;
+	readonly bundleDependencies?: readonly string[];
+	readonly bundledDependencies?: readonly string[];
+}
+
+interface InstalledPackageJson extends PackageJson {
+	readonly name: string;
+	readonly version: string;
+}
+
+interface ClosurePackage {
+	readonly name: string;
+	readonly version: string;
+	readonly sourceDir: string;
+	readonly destinationDir: string;
+	readonly relativeDestination: string;
+}
+
+interface DependencyRequirement {
+	readonly dependentName: string;
+	readonly dependencyName: string;
+	readonly specifier: string;
+}
+
+interface MaterializedPackageEntry {
+	readonly name: string;
+	readonly path: string;
+}
+
+interface MaterializationManifest {
+	readonly version: 1;
+	readonly issue: "1222";
+	readonly rootPackage: string;
+	readonly packages: readonly MaterializedPackageEntry[];
+}
+
+function packageSegments(packageName: string): string[] {
+	const segments = packageName.split("/");
+	if (packageName.startsWith("@")) {
+		if (segments.length !== 2 || segments.some((segment) => segment.length === 0)) {
+			throw new Error(`Invalid scoped package name in bundled pi-tui closure: ${packageName}`);
+		}
+		return segments;
+	}
+	if (segments.length !== 1 || segments[0].length === 0) {
+		throw new Error(`Invalid package name in bundled pi-tui closure: ${packageName}`);
+	}
+	return segments;
+}
+
+function packageRelativeDestination(packageName: string): string {
+	return ["node_modules", ...packageSegments(packageName)].join("/");
+}
+
+function packageSourceDir(packageName: string): string {
+	return resolve(rootNodeModulesDir, ...packageSegments(packageName));
+}
+
+function packageDestinationDir(packageName: string): string {
+	return resolve(packageNodeModulesDir, ...packageSegments(packageName));
+}
+
+function readPackageJson(packageDir: string, expectedName: string): InstalledPackageJson {
+	const packageJsonPath = join(packageDir, "package.json");
+	if (!existsSync(packageDir)) {
+		throw new Error(`${expectedName} source directory is missing at ${packageDir}`);
+	}
+	if (!existsSync(packageJsonPath)) {
+		throw new Error(`${expectedName} is missing package.json at ${packageJsonPath}`);
+	}
+
+	const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8")) as PackageJson;
+	if (manifest.name !== expectedName) {
+		throw new Error(
+			`Expected package.json at ${packageJsonPath} to declare name ${expectedName}, found ${manifest.name ?? "<missing>"}`,
+		);
+	}
+	if (!manifest.version) {
+		throw new Error(`${expectedName} is missing a version in ${packageJsonPath}`);
+	}
+	return manifest as InstalledPackageJson;
+}
+
+function isExactSemverLiteral(specifier: string): boolean {
+	return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u.test(specifier);
+}
+
+function verifyDependencyRequirements(closure: readonly ClosurePackage[], requirements: readonly DependencyRequirement[]): void {
+	const closureVersions = new Map(closure.map((entry) => [entry.name, entry.version] as const));
+	for (const requirement of requirements) {
+		const installedVersion = closureVersions.get(requirement.dependencyName);
+		if (!installedVersion) {
+			throw new Error(
+				`${requirement.dependentName} depends on ${requirement.dependencyName}@${requirement.specifier}, but that package was not included in the materialized runtime closure`,
+			);
+		}
+		if (isExactSemverLiteral(requirement.specifier) && installedVersion !== requirement.specifier) {
+			throw new Error(
+				`${requirement.dependentName} depends on ${requirement.dependencyName}@${requirement.specifier}, but root node_modules has ${requirement.dependencyName}@${installedVersion}`,
+			);
+		}
+	}
+}
+
+function buildRuntimeClosure(): ClosurePackage[] {
+	const visited = new Set<string>();
+	const queue: string[] = [rootPackageName];
+	const closure: ClosurePackage[] = [];
+	const requirements: DependencyRequirement[] = [];
+
+	for (let index = 0; index < queue.length; index += 1) {
+		const packageName = queue[index];
+		if (packageName === undefined) {
+			throw new Error(`Internal error while traversing ${rootPackageName} runtime closure at index ${index}`);
+		}
+		if (visited.has(packageName)) continue;
+		visited.add(packageName);
+
+		const sourceDir = packageSourceDir(packageName);
+		const manifest = readPackageJson(sourceDir, packageName);
+		const dependencyEntries = Object.entries(manifest.dependencies ?? {}).sort(([leftName], [rightName]) =>
+			leftName.localeCompare(rightName),
+		);
+		const dependencyNames = dependencyEntries.map(([dependencyName]) => dependencyName);
+		requirements.push(
+			...dependencyEntries.map(([dependencyName, specifier]) => ({
+				dependentName: packageName,
+				dependencyName,
+				specifier,
+			})),
+		);
+		closure.push({
+			name: packageName,
+			version: manifest.version,
+			sourceDir,
+			destinationDir: packageDestinationDir(packageName),
+			relativeDestination: packageRelativeDestination(packageName),
+		});
+		queue.push(...dependencyNames);
+	}
+
+	const closureNames = new Set(closure.map((entry) => entry.name));
+	const missingExpectedPackages = expectedRuntimePackages.filter((packageName) => !closureNames.has(packageName));
+	if (missingExpectedPackages.length > 0) {
+		throw new Error(
+			`${rootPackageName} runtime dependency closure is missing expected #1222 fallback package(s): ${missingExpectedPackages.join(
+				", ",
+			)}`,
+		);
+	}
+	verifyDependencyRequirements(closure, requirements);
+
+	return closure;
+}
+
+function sorted(values: Iterable<string>): string[] {
+	return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function assertSamePackageSet(actual: readonly string[], expected: readonly string[], label: string): void {
+	const actualSorted = sorted(actual);
+	const expectedSorted = sorted(expected);
+	const actualSet = new Set(actualSorted);
+	const expectedSet = new Set(expectedSorted);
+	const missing = expectedSorted.filter((packageName) => !actualSet.has(packageName));
+	const extra = actualSorted.filter((packageName) => !expectedSet.has(packageName));
+	if (missing.length === 0 && extra.length === 0) return;
+
+	throw new Error(
+		`${label} must match the materialized ${rootPackageName} runtime closure. Missing: ${
+			missing.length > 0 ? missing.join(", ") : "<none>"
+		}; extra: ${extra.length > 0 ? extra.join(", ") : "<none>"}; expected exactly: ${expectedSorted.join(", ")}`,
+	);
+}
+
+function verifyPackageBundleDependencies(closure: readonly ClosurePackage[]): void {
+	const packageManifest = readPackageJson(packageRoot, "@bastani/atomic");
+	const bundleDependencies = packageManifest.bundleDependencies ?? packageManifest.bundledDependencies;
+	if (!bundleDependencies) {
+		throw new Error(
+			`packages/coding-agent/package.json must declare bundleDependencies for the materialized ${rootPackageName} runtime closure`,
+		);
+	}
+	assertSamePackageSet(bundleDependencies, closure.map((entry) => entry.name), "bundleDependencies");
+}
+
+function verifyPatchedRenderer(directory: string): void {
+	const tuiPath = join(directory, "dist", "tui.js");
+	if (!existsSync(tuiPath)) {
+		throw new Error(`${rootPackageName} is missing dist/tui.js at ${tuiPath}`);
+	}
+
+	const tuiSource = readFileSync(tuiPath, "utf8");
+	if (!tuiSource.includes(patchedRendererMarker)) {
+		throw new Error(
+			`${rootPackageName} at ${directory} does not contain the temporary #1222 patched renderer marker; run bun install so the root patchedDependencies entry materializes the patch before packing.`,
+		);
+	}
+}
+
+function manifestForClosure(closure: readonly ClosurePackage[]): MaterializationManifest {
+	return {
+		version: 1,
+		issue: "1222",
+		rootPackage: rootPackageName,
+		packages: closure.map((entry) => ({ name: entry.name, path: entry.relativeDestination })),
+	};
+}
+
+function writeMaterializationManifest(closure: readonly ClosurePackage[]): void {
+	mkdirSync(packageNodeModulesDir, { recursive: true });
+	const temporaryManifestPath = `${materializationManifestPath}.tmp`;
+	writeFileSync(temporaryManifestPath, `${JSON.stringify(manifestForClosure(closure), null, 2)}\n`, "utf8");
+	rmSync(materializationManifestPath, { force: true });
+	renameSync(temporaryManifestPath, materializationManifestPath);
+}
+
+function readMaterializationManifest(): MaterializationManifest {
+	const manifest = JSON.parse(readFileSync(materializationManifestPath, "utf8")) as Partial<MaterializationManifest>;
+	if (manifest.version !== 1 || manifest.issue !== "1222" || manifest.rootPackage !== rootPackageName) {
+		throw new Error(`Unrecognized bundled pi-tui materialization manifest at ${materializationManifestPath}`);
+	}
+	if (!Array.isArray(manifest.packages)) {
+		throw new Error(`Bundled pi-tui materialization manifest at ${materializationManifestPath} is missing packages`);
+	}
+	for (const entry of manifest.packages) {
+		if (typeof entry.name !== "string" || typeof entry.path !== "string") {
+			throw new Error(`Bundled pi-tui materialization manifest at ${materializationManifestPath} has an invalid package entry`);
+		}
+	}
+	return manifest as MaterializationManifest;
+}
+
+function resolveMaterializedPath(relativePath: string): string {
+	const absolutePath = resolve(packageRoot, ...relativePath.split("/"));
+	const relativeFromPackageRoot = relative(packageRoot, absolutePath);
+	if (
+		isAbsolute(relativeFromPackageRoot) ||
+		relativeFromPackageRoot.startsWith("..") ||
+		absolutePath === packageNodeModulesDir ||
+		!absolutePath.startsWith(`${packageNodeModulesDir}${sep}`)
+	) {
+		throw new Error(`Refusing to clean path outside package-local node_modules from manifest: ${relativePath}`);
+	}
+	return absolutePath;
+}
+
+function removeEmptyScopeDirForPackage(packageName: string): void {
+	if (!packageName.startsWith("@")) return;
+	const [scope] = packageSegments(packageName);
+	const scopeDir = join(packageNodeModulesDir, scope);
+	if (existsSync(scopeDir) && readdirSync(scopeDir).length === 0) {
+		rmdirSync(scopeDir);
+	}
+}
+
+function cleanLegacyMaterialization(): boolean {
+	if (!existsSync(legacyMarkerPath)) return false;
+
+	const legacyDestinationDir = packageDestinationDir(rootPackageName);
+	rmSync(legacyDestinationDir, { recursive: true, force: true });
+	rmSync(legacyMarkerPath, { force: true });
+	removeEmptyScopeDirForPackage(rootPackageName);
+	return true;
+}
+
+function cleanBundledDependency(): void {
+	let removedPackageCount = 0;
+	if (existsSync(materializationManifestPath)) {
+		const manifest = readMaterializationManifest();
+		for (const entry of manifest.packages) {
+			rmSync(resolveMaterializedPath(entry.path), { recursive: true, force: true });
+			removedPackageCount += 1;
+		}
+		rmSync(materializationManifestPath, { force: true });
+		for (const entry of manifest.packages) {
+			removeEmptyScopeDirForPackage(entry.name);
+		}
+	}
+
+	const removedLegacyPackage = cleanLegacyMaterialization();
+	if (removedPackageCount > 0 || removedLegacyPackage) {
+		console.log(
+			`Removed materialized bundled ${rootPackageName} fallback (${removedPackageCount}${
+				removedLegacyPackage ? " plus legacy marker" : ""
+			} package path${removedPackageCount === 1 ? "" : "s"})`,
+		);
+	}
+}
+
+function assertNoDestinationConflicts(closure: readonly ClosurePackage[]): void {
+	for (const entry of closure) {
+		if (!existsSync(entry.destinationDir)) continue;
+		throw new Error(
+			`Refusing to overwrite existing package-local ${entry.name} at ${entry.destinationDir}; run the postpack cleanup or remove the unrelated package-local copy before packing.`,
+		);
+	}
+}
+
+function verifyCopiedClosure(closure: readonly ClosurePackage[]): void {
+	for (const entry of closure) {
+		readPackageJson(entry.destinationDir, entry.name);
+	}
+	verifyPatchedRenderer(packageDestinationDir(rootPackageName));
+}
+
+function cleanAfterMaterializeFailure(): void {
+	try {
+		cleanBundledDependency();
+	} catch (cleanupError) {
+		console.error(`Bundled ${rootPackageName} cleanup also failed: ${String(cleanupError)}`);
+	}
+}
+
+function materializeBundledDependency(): void {
+	try {
+		const closure = buildRuntimeClosure();
+		verifyPackageBundleDependencies(closure);
+		verifyPatchedRenderer(packageSourceDir(rootPackageName));
+
+		cleanBundledDependency();
+		assertNoDestinationConflicts(closure);
+		writeMaterializationManifest(closure);
+
+		for (const entry of closure) {
+			mkdirSync(dirname(entry.destinationDir), { recursive: true });
+			cpSync(entry.sourceDir, entry.destinationDir, {
+				recursive: true,
+				dereference: true,
+				preserveTimestamps: true,
+			});
+		}
+
+		verifyCopiedClosure(closure);
+		console.log(
+			`Materialized bundled ${rootPackageName} runtime closure: ${closure
+				.map((entry) => `${entry.name}@${entry.version}`)
+				.join(", ")}`,
+		);
+	} catch (error) {
+		cleanAfterMaterializeFailure();
+		throw error;
+	}
+}
+
+if (process.argv.includes("--clean")) {
+	cleanBundledDependency();
+} else {
+	materializeBundledDependency();
+}

--- a/packages/coding-agent/scripts/verify-bundled-pi-tui-install.ts
+++ b/packages/coding-agent/scripts/verify-bundled-pi-tui-install.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env bun
+/*
+ * Issue #1222 package acceptance test: prove that the temporary bundled pi-tui
+ * fallback is self-contained in the packed @bastani/atomic tarball. The test
+ * packs the package, inspects the .tgz for the patched pi-tui package and its
+ * runtime dependency closure, installs the tarball into an external Bun
+ * consumer, and imports @bastani/atomic without access to the monorepo's
+ * hoisted node_modules.
+ *
+ * Usage:
+ *   bun run scripts/verify-bundled-pi-tui-install.ts
+ *   SKIP_BUILD=1 bun run scripts/verify-bundled-pi-tui-install.ts
+ *   KEEP_FIXTURE=1 bun run scripts/verify-bundled-pi-tui-install.ts
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+	bundledPackageJsonTarPath,
+	bundledPackageTarPath,
+	bundledPiTuiExpectedRuntimePackages,
+	bundledPiTuiPatchedRendererMarker,
+	bundledPiTuiRootPackageName,
+} from "./bundled-pi-tui-config.js";
+
+const codingAgentRoot = resolve(import.meta.dir, "..");
+const distIndexPath = join(codingAgentRoot, "dist", "index.js");
+const skipBuild = process.env["SKIP_BUILD"] === "1";
+const keepFixture = process.env["KEEP_FIXTURE"] === "1";
+
+const REQUIRED_PACKAGE_JSON_PATHS = bundledPiTuiExpectedRuntimePackages.map((packageName) =>
+	bundledPackageJsonTarPath(packageName),
+);
+const PATCHED_TUI_PATH = bundledPackageTarPath(bundledPiTuiRootPackageName, "dist/tui.js");
+
+interface CommandResult {
+	readonly status: number;
+	readonly output: string;
+}
+
+interface TarEntry {
+	readonly name: string;
+	readonly body: Buffer;
+}
+
+function run(command: string, args: readonly string[], cwd: string): CommandResult {
+	const result = spawnSync(command, [...args], { cwd, encoding: "utf8", env: process.env });
+	return {
+		status: result.status ?? 1,
+		output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+	};
+}
+
+function fail(message: string): never {
+	console.error(`\n❌ ${message}`);
+	process.exit(1);
+}
+
+function readNullTerminated(buffer: Buffer, start: number, length: number): string {
+	const slice = buffer.subarray(start, start + length);
+	const nullIndex = slice.indexOf(0);
+	const end = nullIndex >= 0 ? nullIndex : slice.length;
+	return slice.subarray(0, end).toString("utf8");
+}
+
+function readOctal(buffer: Buffer, start: number, length: number): number {
+	const raw = readNullTerminated(buffer, start, length).trim();
+	return raw.length === 0 ? 0 : Number.parseInt(raw, 8);
+}
+
+function stripTrailingNulls(value: string): string {
+	return value.replace(/\0.*$/u, "");
+}
+
+function parseTarGz(tarballPath: string): TarEntry[] {
+	const tar = gunzipSync(readFileSync(tarballPath));
+	const entries: TarEntry[] = [];
+	let offset = 0;
+	let pendingLongName: string | undefined;
+
+	while (offset + 512 <= tar.length) {
+		const header = tar.subarray(offset, offset + 512);
+		if (header.every((byte) => byte === 0)) break;
+
+		const name = readNullTerminated(header, 0, 100);
+		const size = readOctal(header, 124, 12);
+		const typeflag = readNullTerminated(header, 156, 1);
+		const prefix = readNullTerminated(header, 345, 155);
+		const bodyStart = offset + 512;
+		const bodyEnd = bodyStart + size;
+		const body = Buffer.from(tar.subarray(bodyStart, bodyEnd));
+		offset = bodyStart + Math.ceil(size / 512) * 512;
+
+		if (typeflag === "L") {
+			pendingLongName = stripTrailingNulls(body.toString("utf8"));
+			continue;
+		}
+
+		const tarName = pendingLongName ?? (prefix.length > 0 ? `${prefix}/${name}` : name);
+		pendingLongName = undefined;
+		entries.push({ name: tarName, body });
+	}
+
+	return entries;
+}
+
+function requireTarEntry(entries: readonly TarEntry[], path: string): TarEntry {
+	const entry = entries.find((candidate) => candidate.name === path);
+	if (!entry) fail(`Packed tarball is missing required entry: ${path}`);
+	return entry;
+}
+
+function requirePatchedRendererMarker(source: string, label: string): void {
+	if (!source.includes(bundledPiTuiPatchedRendererMarker)) {
+		fail(`${label} does not contain the temporary #1222 patched renderer marker.`);
+	}
+}
+
+function verifyTarballContents(tarballPath: string): void {
+	const entries = parseTarGz(tarballPath);
+	for (const packageJsonPath of REQUIRED_PACKAGE_JSON_PATHS) {
+		requireTarEntry(entries, packageJsonPath);
+	}
+
+	const tuiEntry = requireTarEntry(entries, PATCHED_TUI_PATH);
+	requirePatchedRendererMarker(tuiEntry.body.toString("utf8"), `Packed ${PATCHED_TUI_PATH}`);
+
+	console.log("• Tarball contains patched pi-tui plus bundled runtime deps.");
+}
+
+function installedPackagePath(atomicRoot: string, tarEntryPath: string): string {
+	return join(atomicRoot, ...tarEntryPath.replace(/^package\//u, "").split("/"));
+}
+
+function verifyInstalledBundledFiles(consumerDir: string): void {
+	const atomicRoot = join(consumerDir, "node_modules", "@bastani", "atomic");
+	for (const packageJsonPath of REQUIRED_PACKAGE_JSON_PATHS) {
+		const installedPath = installedPackagePath(atomicRoot, packageJsonPath);
+		if (!existsSync(installedPath)) {
+			fail(`Installed consumer is missing bundled dependency entry: ${installedPath}`);
+		}
+	}
+
+	const installedTuiPath = installedPackagePath(atomicRoot, PATCHED_TUI_PATH);
+	requirePatchedRendererMarker(readFileSync(installedTuiPath, "utf8"), `Installed consumer ${installedTuiPath}`);
+}
+
+const packageVersion = (JSON.parse(readFileSync(join(codingAgentRoot, "package.json"), "utf8")) as { version?: string }).version;
+console.log(`Verifying bundled pi-tui fallback for @bastani/atomic@${packageVersion ?? "?"}\n`);
+
+const workRoot = mkdtempSync(join(tmpdir(), "atomic-bundled-pi-tui-"));
+console.log(`• Fixture root: ${workRoot}`);
+
+try {
+	if (!skipBuild) {
+		console.log("• Building @bastani/atomic (set SKIP_BUILD=1 to reuse current dist)...");
+		const build = run("bun", ["run", "build"], codingAgentRoot);
+		if (build.status !== 0) {
+			console.error(build.output);
+			fail("Build failed.");
+		}
+	} else {
+		console.log("• SKIP_BUILD=1 — reusing current dist.");
+	}
+
+	if (!existsSync(distIndexPath)) {
+		fail(`Missing ${distIndexPath}; run bun run --cwd packages/coding-agent build first or omit SKIP_BUILD=1.`);
+	}
+
+	console.log("• Packing @bastani/atomic with bun pm pack...");
+	const pack = run("bun", ["pm", "pack", "--destination", workRoot], codingAgentRoot);
+	const explicitCleanup = run("bun", ["run", "scripts/materialize-bundled-pi-tui.ts", "--clean"], codingAgentRoot);
+	if (explicitCleanup.status !== 0) {
+		console.error(explicitCleanup.output);
+		fail("Bundled pi-tui cleanup failed after pack attempt.");
+	}
+	if (pack.status !== 0) {
+		console.error(pack.output);
+		fail("bun pm pack failed.");
+	}
+
+	const tarball = readdirSync(workRoot).find((fileName) => fileName.endsWith(".tgz"));
+	if (!tarball) fail("No .tgz produced by bun pm pack.");
+	const tarballPath = join(workRoot, tarball);
+	console.log(`• Tarball: ${tarballPath}`);
+	verifyTarballContents(tarballPath);
+
+	const consumerDir = join(workRoot, "consumer");
+	rmSync(consumerDir, { recursive: true, force: true });
+	mkdirSync(consumerDir, { recursive: true });
+	writeFileSync(
+		join(consumerDir, "package.json"),
+		JSON.stringify(
+			{
+				name: "atomic-bundled-pi-tui-consumer",
+				private: true,
+				type: "module",
+				dependencies: { "@bastani/atomic": `file:${tarballPath}` },
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+
+	console.log("• Installing tarball into isolated Bun consumer...");
+	const install = run("bun", ["install", "--no-progress"], consumerDir);
+	if (install.status !== 0) {
+		console.error(install.output);
+		fail("Isolated consumer bun install failed.");
+	}
+	verifyInstalledBundledFiles(consumerDir);
+
+	console.log("• Importing @bastani/atomic from isolated consumer...");
+	const importCheck = run("bun", ["-e", "await import('@bastani/atomic'); console.log('import ok')"], consumerDir);
+	if (importCheck.status !== 0) {
+		console.error(importCheck.output);
+		fail("Isolated consumer import failed.");
+	}
+	console.log(importCheck.output.trim());
+	console.log("\n✓ Bundled pi-tui fallback tarball installed and imported successfully.");
+} finally {
+	if (!keepFixture) {
+		rmSync(workRoot, { recursive: true, force: true });
+	} else {
+		console.log(`• KEEP_FIXTURE=1 — left fixtures at ${workRoot}`);
+	}
+}

--- a/packages/coding-agent/scripts/verify-bundled-pi-tui-install.ts
+++ b/packages/coding-agent/scripts/verify-bundled-pi-tui-install.ts
@@ -170,6 +170,11 @@ try {
 		fail(`Missing ${distIndexPath}; run bun run --cwd packages/coding-agent build first or omit SKIP_BUILD=1.`);
 	}
 
+	// `bun pm pack` is what materializes the bundled pi-tui closure: it fires the package's
+	// `prepack` (materialize) and `postpack` (--clean) lifecycle hooks, so we deliberately do not
+	// run the non-clean materialize ourselves here — only the explicit `--clean` below as a belt-and-
+	// suspenders cleanup. A Bun version that changes pack lifecycle behavior would break both this
+	// verifier and `npm publish` (which relies on the same prepack/postpack hooks).
 	console.log("• Packing @bastani/atomic with bun pm pack...");
 	const pack = run("bun", ["pm", "pack", "--destination", workRoot], codingAgentRoot);
 	const explicitCleanup = run("bun", ["run", "scripts/materialize-bundled-pi-tui.ts", "--clean"], codingAgentRoot);

--- a/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
@@ -60,11 +60,15 @@ class MutableLines implements Component {
 	setLine(index: number, value: string): void {
 		this.lines[index] = value;
 	}
+
+	replaceLines(lines: string[]): void {
+		this.lines.splice(0, this.lines.length, ...lines);
+	}
 }
 
 type RenderBaseline = {
 	fullRedraws: number;
-	writeStart: number;
+	writeCount: number;
 };
 
 const activeTuis: TUI[] = [];
@@ -100,12 +104,12 @@ async function startTui(component: Component, terminal = new FakeTerminal()): Pr
 function captureRenderBaseline(tui: TUI, terminal: FakeTerminal): RenderBaseline {
 	return {
 		fullRedraws: tui.fullRedraws,
-		writeStart: terminal.writes.length,
+		writeCount: terminal.writes.length,
 	};
 }
 
-function writesAfter(terminal: FakeTerminal, baseline: RenderBaseline): string {
-	return terminal.writes.slice(baseline.writeStart).join("");
+function outputAfter(terminal: FakeTerminal, baseline: RenderBaseline): string {
+	return terminal.writes.slice(baseline.writeCount).join("");
 }
 
 describe("pi-tui off-viewport redraw behavior", () => {
@@ -117,11 +121,12 @@ describe("pi-tui off-viewport redraw behavior", () => {
 		component.setLine(55, OFFSCREEN_UPDATE);
 		await requestRenderAndWait(tui);
 
-		const mutationWrites = writesAfter(terminal, baseline);
+		const renderOutput = outputAfter(terminal, baseline);
 		expect(tui.fullRedraws).toBe(baseline.fullRedraws);
-		expect(mutationWrites).toBe("");
-		expect(mutationWrites).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
-		expect(mutationWrites).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
+		expect(terminal.writes).toHaveLength(baseline.writeCount);
+		expect(renderOutput).toBe("");
+		expect(renderOutput).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(renderOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
 	});
 
 	it("preserves scrollback for content-driven full redraws", async () => {
@@ -133,11 +138,11 @@ describe("pi-tui off-viewport redraw behavior", () => {
 		component.setLine(75, VISIBLE_UPDATE);
 		await requestRenderAndWait(tui);
 
-		const mutationWrites = writesAfter(terminal, baseline);
+		const renderOutput = outputAfter(terminal, baseline);
 		expect(tui.fullRedraws).toBe(baseline.fullRedraws + 1);
-		expect(mutationWrites).toContain(VIEWPORT_CLEAR_SEQUENCE);
-		expect(mutationWrites).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
-		expect(mutationWrites).toContain(VISIBLE_UPDATE);
+		expect(renderOutput).toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(renderOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
+		expect(renderOutput).toContain(VISIBLE_UPDATE);
 	});
 
 	it("wipes scrollback for terminal width changes", async () => {
@@ -148,9 +153,9 @@ describe("pi-tui off-viewport redraw behavior", () => {
 		terminal.columns = 100;
 		await requestRenderAndWait(tui);
 
-		const mutationWrites = writesAfter(terminal, baseline);
+		const renderOutput = outputAfter(terminal, baseline);
 		expect(tui.fullRedraws).toBe(baseline.fullRedraws + 1);
-		expect(mutationWrites).toContain(VIEWPORT_AND_SCROLLBACK_CLEAR_SEQUENCE);
+		expect(renderOutput).toContain(VIEWPORT_AND_SCROLLBACK_CLEAR_SEQUENCE);
 	});
 
 	it("keeps pure visible changes on the differential path", async () => {
@@ -161,10 +166,33 @@ describe("pi-tui off-viewport redraw behavior", () => {
 		component.setLine(75, VISIBLE_UPDATE);
 		await requestRenderAndWait(tui);
 
-		const mutationWrites = writesAfter(terminal, baseline);
+		const renderOutput = outputAfter(terminal, baseline);
 		expect(tui.fullRedraws).toBe(baseline.fullRedraws);
-		expect(mutationWrites).toContain(VISIBLE_UPDATE);
-		expect(mutationWrites).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
-		expect(mutationWrites).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
+		expect(renderOutput).toContain(VISIBLE_UPDATE);
+		expect(renderOutput).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(renderOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
+	});
+
+	it("does not repeatedly clear after clearOnShrink handles a shorter render", async () => {
+		const component = new MutableLines(createLines(20));
+		const { terminal, tui } = await startTui(component);
+		tui.setClearOnShrink(true);
+		const shrinkBaseline = captureRenderBaseline(tui, terminal);
+
+		component.replaceLines(createLines(5));
+		await requestRenderAndWait(tui);
+
+		const shrinkOutput = outputAfter(terminal, shrinkBaseline);
+		expect(tui.fullRedraws).toBe(shrinkBaseline.fullRedraws + 1);
+		expect(shrinkOutput).toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(shrinkOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
+
+		const noopBaseline = captureRenderBaseline(tui, terminal);
+		await requestRenderAndWait(tui);
+
+		const noopOutput = outputAfter(terminal, noopBaseline);
+		expect(tui.fullRedraws).toBe(noopBaseline.fullRedraws);
+		expect(noopOutput).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(noopOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { type Component, type Terminal, TUI } from "@earendil-works/pi-tui";
+
+const FULL_CLEAR_SEQUENCE = "\x1b[2J\x1b[H\x1b[3J";
+const OFFSCREEN_UPDATE = "line 55 offscreen update";
+const VISIBLE_UPDATE = "line 75 visible update";
+const REPEATED_SEPARATOR_ROW = "------------------------------";
+const RENDER_SETTLE_MS = 35;
+
+class FakeTerminal implements Terminal {
+	columns = 80;
+	rows = 10;
+	kittyProtocolActive = true;
+	writes: string[] = [];
+
+	start(): void {}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(data: string): void {
+		this.writes.push(data);
+	}
+	moveBy(_lines: number): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(_title: string): void {}
+	setProgress(_active: boolean): void {}
+
+	get fullClearCount(): number {
+		return this.writes.filter((write) => write.includes(FULL_CLEAR_SEQUENCE)).length;
+	}
+}
+
+class MutableLines implements Component {
+	constructor(private readonly lines: string[]) {}
+
+	render(_width: number): string[] {
+		return [...this.lines];
+	}
+
+	invalidate(): void {}
+
+	setLine(index: number, value: string): void {
+		this.lines[index] = value;
+	}
+
+	appendLine(value: string): void {
+		this.lines.push(value);
+	}
+
+	insertLine(index: number, value: string): void {
+		this.lines.splice(index, 0, value);
+	}
+
+	removeLine(index: number): void {
+		this.lines.splice(index, 1);
+	}
+}
+
+type RenderBaseline = {
+	fullRedraws: number;
+	fullClearCount: number;
+	writeStart: number;
+};
+
+const activeTuis: TUI[] = [];
+
+afterEach(() => {
+	for (const tui of activeTuis.splice(0)) {
+		tui.stop();
+	}
+});
+
+async function waitForRender(): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, RENDER_SETTLE_MS));
+}
+
+async function requestRenderAndWait(tui: TUI): Promise<void> {
+	tui.requestRender();
+	await waitForRender();
+}
+
+function createLines(count: number): string[] {
+	return Array.from({ length: count }, (_, index) => `line ${index.toString().padStart(2, "0")}`);
+}
+
+function createLinesWithRepeatedTail(repeatedTailStart: number, repeatedRow: string): string[] {
+	const lines = createLines(80);
+	for (let index = repeatedTailStart; index < lines.length; index += 1) {
+		lines[index] = repeatedRow;
+	}
+	return lines;
+}
+
+async function startTui(component: Component, terminal = new FakeTerminal()): Promise<{ terminal: FakeTerminal; tui: TUI }> {
+	const tui = new TUI(terminal);
+	activeTuis.push(tui);
+	tui.addChild(component);
+	tui.start();
+	await waitForRender();
+	return { terminal, tui };
+}
+
+function captureRenderBaseline(tui: TUI, terminal: FakeTerminal): RenderBaseline {
+	return {
+		fullRedraws: tui.fullRedraws,
+		fullClearCount: terminal.fullClearCount,
+		writeStart: terminal.writes.length,
+	};
+}
+
+function expectNoFullRedrawOrClear(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): void {
+	expect(tui.fullRedraws).toBe(baseline.fullRedraws);
+	expect(terminal.fullClearCount).toBe(baseline.fullClearCount);
+}
+
+function expectOneFullRedrawAndClear(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): void {
+	expect(tui.fullRedraws).toBe(baseline.fullRedraws + 1);
+	expect(terminal.fullClearCount).toBe(baseline.fullClearCount + 1);
+}
+
+function writesAfter(terminal: FakeTerminal, baseline: RenderBaseline): string {
+	return terminal.writes.slice(baseline.writeStart).join("");
+}
+
+function expectDifferentialWrites(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): string {
+	const mutationWrites = writesAfter(terminal, baseline);
+	expectNoFullRedrawOrClear(tui, terminal, baseline);
+	expect(mutationWrites).not.toContain(FULL_CLEAR_SEQUENCE);
+	return mutationWrites;
+}
+
+function expectFullClearWrites(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): string {
+	const mutationWrites = writesAfter(terminal, baseline);
+	expectOneFullRedrawAndClear(tui, terminal, baseline);
+	expect(mutationWrites).toContain(FULL_CLEAR_SEQUENCE);
+	return mutationWrites;
+}
+
+describe("pi-tui off-viewport redraw behavior", () => {
+	it("does not full-clear scrollback for an off-viewport same-shape text mutation", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(55, "line 55 updated");
+		await requestRenderAndWait(tui);
+
+		expectNoFullRedrawOrClear(tui, terminal, baseline);
+	});
+
+	it("renders append-only tail growth without full-clearing off-viewport text mutations", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(55, OFFSCREEN_UPDATE);
+		component.appendLine("line 80 appended");
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).toContain("line 80 appended");
+		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
+	});
+
+	it("renders duplicate previous-tail append-only rows without full-clearing off-viewport text mutations", async () => {
+		const lines = createLines(80);
+		const duplicatedTail = lines[lines.length - 1];
+		const component = new MutableLines(lines);
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(55, OFFSCREEN_UPDATE);
+		component.appendLine(duplicatedTail);
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).toContain(duplicatedTail);
+		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
+	});
+
+	it("renders pure append-only separator growth without full-clearing a repeated tail", async () => {
+		const component = new MutableLines(createLinesWithRepeatedTail(55, REPEATED_SEPARATOR_ROW));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.appendLine(REPEATED_SEPARATOR_ROW);
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).toContain(REPEATED_SEPARATOR_ROW);
+	});
+
+	it("renders repeated-tail append after an off-viewport mutation when a unique same-index anchor proves append-only alignment", async () => {
+		const component = new MutableLines(createLinesWithRepeatedTail(57, REPEATED_SEPARATOR_ROW));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(55, OFFSCREEN_UPDATE);
+		component.appendLine(REPEATED_SEPARATOR_ROW);
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).toContain(REPEATED_SEPARATOR_ROW);
+		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
+	});
+
+	it("full-clears ambiguous repeated-tail growth after an off-viewport mutation", async () => {
+		const component = new MutableLines(createLinesWithRepeatedTail(55, REPEATED_SEPARATOR_ROW));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		// Rendered text has no row identity here: this mutation plus append is
+		// indistinguishable from a structural insertion into the repeated tail.
+		component.setLine(60, "line 60 repeated-block update");
+		component.appendLine(REPEATED_SEPARATOR_ROW);
+		await requestRenderAndWait(tui);
+
+		expectFullClearWrites(tui, terminal, baseline);
+	});
+
+	it("renders visible pre-existing mutations and append-only tail growth without full-clearing off-viewport text mutations", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(55, OFFSCREEN_UPDATE);
+		component.setLine(75, VISIBLE_UPDATE);
+		component.appendLine("line 80 appended");
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
+		expect(mutationWrites).toContain(VISIBLE_UPDATE);
+		expect(mutationWrites).toContain("line 80 appended");
+	});
+
+	it("renders append-only growth after a boundary offscreen mutation when no shifted structural evidence exists", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		const boundaryUpdate = "line 69 offscreen boundary update";
+		const appendedLine = "line 80 appended";
+		component.setLine(69, boundaryUpdate);
+		component.setLine(75, VISIBLE_UPDATE);
+		component.appendLine(appendedLine);
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).not.toContain(boundaryUpdate);
+		expect(mutationWrites).toContain(VISIBLE_UPDATE);
+		expect(mutationWrites).toContain(appendedLine);
+	});
+
+	it("full-clears structural insertion above the viewport even when visible mutations manufacture a same-index anchor", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.insertLine(69, "inserted structural row");
+		component.setLine(79, "line 79");
+		component.setLine(80, "changed shifted tail");
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectFullClearWrites(tui, terminal, baseline);
+		expect(mutationWrites).toContain("inserted structural row");
+	});
+
+	it("preserves full clear behavior for a later structural insertion after an off-viewport mutation", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(55, OFFSCREEN_UPDATE);
+		component.insertLine(65, "inserted structural row");
+		await requestRenderAndWait(tui);
+
+		expectFullClearWrites(tui, terminal, baseline);
+	});
+
+	it("preserves full clear behavior for repeated-row structural insertion above the viewport", async () => {
+		const lines = createLines(80);
+		lines[59] = "repeated row";
+		lines[60] = "repeated row";
+		const component = new MutableLines(lines);
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.insertLine(55, "inserted structural row");
+		await requestRenderAndWait(tui);
+
+		expectFullClearWrites(tui, terminal, baseline);
+	});
+
+	it("preserves full clear behavior for structural insertion into a fully repeated tail above the viewport", async () => {
+		const component = new MutableLines(createLinesWithRepeatedTail(55, REPEATED_SEPARATOR_ROW));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.insertLine(65, "inserted structural row");
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectFullClearWrites(tui, terminal, baseline);
+		expect(mutationWrites).toContain("inserted structural row");
+	});
+
+	it("preserves full clear behavior for off-viewport shrink/deletion", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.removeLine(55);
+		await requestRenderAndWait(tui);
+
+		expectOneFullRedrawAndClear(tui, terminal, baseline);
+	});
+
+	it("clamps mixed off-viewport and visible mutations to the visible viewport", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(55, OFFSCREEN_UPDATE);
+		component.setLine(75, VISIBLE_UPDATE);
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
+		expect(mutationWrites).toContain(VISIBLE_UPDATE);
+	});
+
+	it("repaints visible mutations differentially", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(75, VISIBLE_UPDATE);
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
+		expect(mutationWrites).toContain(VISIBLE_UPDATE);
+	});
+
+	it("preserves full clear behavior for terminal width changes", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		terminal.columns = 100;
+		await requestRenderAndWait(tui);
+
+		expectOneFullRedrawAndClear(tui, terminal, baseline);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
@@ -1,36 +1,51 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { type Component, type Terminal, TUI } from "@earendil-works/pi-tui";
 
-const FULL_CLEAR_SEQUENCE = "\x1b[2J\x1b[H\x1b[3J";
+const VIEWPORT_CLEAR_SEQUENCE = "\x1b[2J\x1b[H";
+const SCROLLBACK_CLEAR_SEQUENCE = "\x1b[3J";
+const VIEWPORT_AND_SCROLLBACK_CLEAR_SEQUENCE = `${VIEWPORT_CLEAR_SEQUENCE}${SCROLLBACK_CLEAR_SEQUENCE}`;
 const OFFSCREEN_UPDATE = "line 55 offscreen update";
 const VISIBLE_UPDATE = "line 75 visible update";
-const REPEATED_SEPARATOR_ROW = "------------------------------";
 const RENDER_SETTLE_MS = 35;
 
 class FakeTerminal implements Terminal {
 	columns = 80;
 	rows = 10;
 	kittyProtocolActive = true;
-	writes: string[] = [];
+	readonly writes: string[] = [];
 
-	start(): void {}
+	start(_onInput: (data: string) => void, _onResize: () => void): void {}
 	stop(): void {}
-	async drainInput(): Promise<void> {}
+	async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {}
 	write(data: string): void {
 		this.writes.push(data);
 	}
-	moveBy(_lines: number): void {}
-	hideCursor(): void {}
-	showCursor(): void {}
-	clearLine(): void {}
-	clearFromCursor(): void {}
-	clearScreen(): void {}
-	setTitle(_title: string): void {}
-	setProgress(_active: boolean): void {}
-
-	get fullClearCount(): number {
-		return this.writes.filter((write) => write.includes(FULL_CLEAR_SEQUENCE)).length;
+	moveBy(lines: number): void {
+		if (lines > 0) {
+			this.write(`\x1b[${lines}B`);
+		} else if (lines < 0) {
+			this.write(`\x1b[${-lines}A`);
+		}
 	}
+	hideCursor(): void {
+		this.write("\x1b[?25l");
+	}
+	showCursor(): void {
+		this.write("\x1b[?25h");
+	}
+	clearLine(): void {
+		this.write("\r\x1b[2K");
+	}
+	clearFromCursor(): void {
+		this.write("\x1b[J");
+	}
+	clearScreen(): void {
+		this.write(VIEWPORT_CLEAR_SEQUENCE);
+	}
+	setTitle(title: string): void {
+		this.write(`\x1b]0;${title}\x07`);
+	}
+	setProgress(_active: boolean): void {}
 }
 
 class MutableLines implements Component {
@@ -45,23 +60,10 @@ class MutableLines implements Component {
 	setLine(index: number, value: string): void {
 		this.lines[index] = value;
 	}
-
-	appendLine(value: string): void {
-		this.lines.push(value);
-	}
-
-	insertLine(index: number, value: string): void {
-		this.lines.splice(index, 0, value);
-	}
-
-	removeLine(index: number): void {
-		this.lines.splice(index, 1);
-	}
 }
 
 type RenderBaseline = {
 	fullRedraws: number;
-	fullClearCount: number;
 	writeStart: number;
 };
 
@@ -86,14 +88,6 @@ function createLines(count: number): string[] {
 	return Array.from({ length: count }, (_, index) => `line ${index.toString().padStart(2, "0")}`);
 }
 
-function createLinesWithRepeatedTail(repeatedTailStart: number, repeatedRow: string): string[] {
-	const lines = createLines(80);
-	for (let index = repeatedTailStart; index < lines.length; index += 1) {
-		lines[index] = repeatedRow;
-	}
-	return lines;
-}
-
 async function startTui(component: Component, terminal = new FakeTerminal()): Promise<{ terminal: FakeTerminal; tui: TUI }> {
 	const tui = new TUI(terminal);
 	activeTuis.push(tui);
@@ -106,219 +100,31 @@ async function startTui(component: Component, terminal = new FakeTerminal()): Pr
 function captureRenderBaseline(tui: TUI, terminal: FakeTerminal): RenderBaseline {
 	return {
 		fullRedraws: tui.fullRedraws,
-		fullClearCount: terminal.fullClearCount,
 		writeStart: terminal.writes.length,
 	};
-}
-
-function expectNoFullRedrawOrClear(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): void {
-	expect(tui.fullRedraws).toBe(baseline.fullRedraws);
-	expect(terminal.fullClearCount).toBe(baseline.fullClearCount);
-}
-
-function expectOneFullRedrawAndClear(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): void {
-	expect(tui.fullRedraws).toBe(baseline.fullRedraws + 1);
-	expect(terminal.fullClearCount).toBe(baseline.fullClearCount + 1);
 }
 
 function writesAfter(terminal: FakeTerminal, baseline: RenderBaseline): string {
 	return terminal.writes.slice(baseline.writeStart).join("");
 }
 
-function expectDifferentialWrites(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): string {
-	const mutationWrites = writesAfter(terminal, baseline);
-	expectNoFullRedrawOrClear(tui, terminal, baseline);
-	expect(mutationWrites).not.toContain(FULL_CLEAR_SEQUENCE);
-	return mutationWrites;
-}
-
-function expectFullClearWrites(tui: TUI, terminal: FakeTerminal, baseline: RenderBaseline): string {
-	const mutationWrites = writesAfter(terminal, baseline);
-	expectOneFullRedrawAndClear(tui, terminal, baseline);
-	expect(mutationWrites).toContain(FULL_CLEAR_SEQUENCE);
-	return mutationWrites;
-}
-
 describe("pi-tui off-viewport redraw behavior", () => {
-	it("does not full-clear scrollback for an off-viewport same-shape text mutation", async () => {
-		const component = new MutableLines(createLines(80));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.setLine(55, "line 55 updated");
-		await requestRenderAndWait(tui);
-
-		expectNoFullRedrawOrClear(tui, terminal, baseline);
-	});
-
-	it("renders append-only tail growth without full-clearing off-viewport text mutations", async () => {
+	it("writes zero bytes for strict off-viewport same-count changes", async () => {
 		const component = new MutableLines(createLines(80));
 		const { terminal, tui } = await startTui(component);
 		const baseline = captureRenderBaseline(tui, terminal);
 
 		component.setLine(55, OFFSCREEN_UPDATE);
-		component.appendLine("line 80 appended");
 		await requestRenderAndWait(tui);
 
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).toContain("line 80 appended");
-		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
+		const mutationWrites = writesAfter(terminal, baseline);
+		expect(tui.fullRedraws).toBe(baseline.fullRedraws);
+		expect(mutationWrites).toBe("");
+		expect(mutationWrites).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(mutationWrites).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
 	});
 
-	it("renders duplicate previous-tail append-only rows without full-clearing off-viewport text mutations", async () => {
-		const lines = createLines(80);
-		const duplicatedTail = lines[lines.length - 1];
-		const component = new MutableLines(lines);
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.setLine(55, OFFSCREEN_UPDATE);
-		component.appendLine(duplicatedTail);
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).toContain(duplicatedTail);
-		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
-	});
-
-	it("renders pure append-only separator growth without full-clearing a repeated tail", async () => {
-		const component = new MutableLines(createLinesWithRepeatedTail(55, REPEATED_SEPARATOR_ROW));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.appendLine(REPEATED_SEPARATOR_ROW);
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).toContain(REPEATED_SEPARATOR_ROW);
-	});
-
-	it("renders repeated-tail append after an off-viewport mutation when a unique same-index anchor proves append-only alignment", async () => {
-		const component = new MutableLines(createLinesWithRepeatedTail(57, REPEATED_SEPARATOR_ROW));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.setLine(55, OFFSCREEN_UPDATE);
-		component.appendLine(REPEATED_SEPARATOR_ROW);
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).toContain(REPEATED_SEPARATOR_ROW);
-		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
-	});
-
-	it("full-clears ambiguous repeated-tail growth after an off-viewport mutation", async () => {
-		const component = new MutableLines(createLinesWithRepeatedTail(55, REPEATED_SEPARATOR_ROW));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		// Rendered text has no row identity here: this mutation plus append is
-		// indistinguishable from a structural insertion into the repeated tail.
-		component.setLine(60, "line 60 repeated-block update");
-		component.appendLine(REPEATED_SEPARATOR_ROW);
-		await requestRenderAndWait(tui);
-
-		expectFullClearWrites(tui, terminal, baseline);
-	});
-
-	it("renders visible pre-existing mutations and append-only tail growth without full-clearing off-viewport text mutations", async () => {
-		const component = new MutableLines(createLines(80));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.setLine(55, OFFSCREEN_UPDATE);
-		component.setLine(75, VISIBLE_UPDATE);
-		component.appendLine("line 80 appended");
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
-		expect(mutationWrites).toContain(VISIBLE_UPDATE);
-		expect(mutationWrites).toContain("line 80 appended");
-	});
-
-	it("renders append-only growth after a boundary offscreen mutation when no shifted structural evidence exists", async () => {
-		const component = new MutableLines(createLines(80));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		const boundaryUpdate = "line 69 offscreen boundary update";
-		const appendedLine = "line 80 appended";
-		component.setLine(69, boundaryUpdate);
-		component.setLine(75, VISIBLE_UPDATE);
-		component.appendLine(appendedLine);
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).not.toContain(boundaryUpdate);
-		expect(mutationWrites).toContain(VISIBLE_UPDATE);
-		expect(mutationWrites).toContain(appendedLine);
-	});
-
-	it("full-clears structural insertion above the viewport even when visible mutations manufacture a same-index anchor", async () => {
-		const component = new MutableLines(createLines(80));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.insertLine(69, "inserted structural row");
-		component.setLine(79, "line 79");
-		component.setLine(80, "changed shifted tail");
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectFullClearWrites(tui, terminal, baseline);
-		expect(mutationWrites).toContain("inserted structural row");
-	});
-
-	it("preserves full clear behavior for a later structural insertion after an off-viewport mutation", async () => {
-		const component = new MutableLines(createLines(80));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.setLine(55, OFFSCREEN_UPDATE);
-		component.insertLine(65, "inserted structural row");
-		await requestRenderAndWait(tui);
-
-		expectFullClearWrites(tui, terminal, baseline);
-	});
-
-	it("preserves full clear behavior for repeated-row structural insertion above the viewport", async () => {
-		const lines = createLines(80);
-		lines[59] = "repeated row";
-		lines[60] = "repeated row";
-		const component = new MutableLines(lines);
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.insertLine(55, "inserted structural row");
-		await requestRenderAndWait(tui);
-
-		expectFullClearWrites(tui, terminal, baseline);
-	});
-
-	it("preserves full clear behavior for structural insertion into a fully repeated tail above the viewport", async () => {
-		const component = new MutableLines(createLinesWithRepeatedTail(55, REPEATED_SEPARATOR_ROW));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.insertLine(65, "inserted structural row");
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectFullClearWrites(tui, terminal, baseline);
-		expect(mutationWrites).toContain("inserted structural row");
-	});
-
-	it("preserves full clear behavior for off-viewport shrink/deletion", async () => {
-		const component = new MutableLines(createLines(80));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.removeLine(55);
-		await requestRenderAndWait(tui);
-
-		expectOneFullRedrawAndClear(tui, terminal, baseline);
-	});
-
-	it("clamps mixed off-viewport and visible mutations to the visible viewport", async () => {
+	it("preserves scrollback for content-driven full redraws", async () => {
 		const component = new MutableLines(createLines(80));
 		const { terminal, tui } = await startTui(component);
 		const baseline = captureRenderBaseline(tui, terminal);
@@ -327,24 +133,14 @@ describe("pi-tui off-viewport redraw behavior", () => {
 		component.setLine(75, VISIBLE_UPDATE);
 		await requestRenderAndWait(tui);
 
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).not.toContain(OFFSCREEN_UPDATE);
+		const mutationWrites = writesAfter(terminal, baseline);
+		expect(tui.fullRedraws).toBe(baseline.fullRedraws + 1);
+		expect(mutationWrites).toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(mutationWrites).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
 		expect(mutationWrites).toContain(VISIBLE_UPDATE);
 	});
 
-	it("repaints visible mutations differentially", async () => {
-		const component = new MutableLines(createLines(80));
-		const { terminal, tui } = await startTui(component);
-		const baseline = captureRenderBaseline(tui, terminal);
-
-		component.setLine(75, VISIBLE_UPDATE);
-		await requestRenderAndWait(tui);
-
-		const mutationWrites = expectDifferentialWrites(tui, terminal, baseline);
-		expect(mutationWrites).toContain(VISIBLE_UPDATE);
-	});
-
-	it("preserves full clear behavior for terminal width changes", async () => {
+	it("wipes scrollback for terminal width changes", async () => {
 		const component = new MutableLines(createLines(80));
 		const { terminal, tui } = await startTui(component);
 		const baseline = captureRenderBaseline(tui, terminal);
@@ -352,6 +148,23 @@ describe("pi-tui off-viewport redraw behavior", () => {
 		terminal.columns = 100;
 		await requestRenderAndWait(tui);
 
-		expectOneFullRedrawAndClear(tui, terminal, baseline);
+		const mutationWrites = writesAfter(terminal, baseline);
+		expect(tui.fullRedraws).toBe(baseline.fullRedraws + 1);
+		expect(mutationWrites).toContain(VIEWPORT_AND_SCROLLBACK_CLEAR_SEQUENCE);
+	});
+
+	it("keeps pure visible changes on the differential path", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		component.setLine(75, VISIBLE_UPDATE);
+		await requestRenderAndWait(tui);
+
+		const mutationWrites = writesAfter(terminal, baseline);
+		expect(tui.fullRedraws).toBe(baseline.fullRedraws);
+		expect(mutationWrites).toContain(VISIBLE_UPDATE);
+		expect(mutationWrites).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(mutationWrites).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1222-tui-offviewport-redraw.test.ts
@@ -6,6 +6,12 @@ const SCROLLBACK_CLEAR_SEQUENCE = "\x1b[3J";
 const VIEWPORT_AND_SCROLLBACK_CLEAR_SEQUENCE = `${VIEWPORT_CLEAR_SEQUENCE}${SCROLLBACK_CLEAR_SEQUENCE}`;
 const OFFSCREEN_UPDATE = "line 55 offscreen update";
 const VISIBLE_UPDATE = "line 75 visible update";
+const ABOVE_VIEWPORT_INSERT = "line 69 inserted above viewport";
+// Renders are throttled to TUI.MIN_RENDER_INTERVAL_MS (16ms): requestRender() defers through
+// process.nextTick + setTimeout(max(0, 16 - elapsedSinceLastRender)), so a single non-force render
+// can land up to ~16ms late. 35ms comfortably clears that throttle so one fixed wait reliably
+// observes the throttled frame. (The sibling edit-tool-no-full-redraw test can use setTimeout(0)
+// only because it polls render output inside a retry loop rather than waiting once.)
 const RENDER_SETTLE_MS = 35;
 
 class FakeTerminal implements Terminal {
@@ -194,5 +200,61 @@ describe("pi-tui off-viewport redraw behavior", () => {
 		expect(tui.fullRedraws).toBe(noopBaseline.fullRedraws);
 		expect(noopOutput).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
 		expect(noopOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
+	});
+
+	it("render following a skipped off-viewport frame lands on the correct row", async () => {
+		// 80-line buffer in a 10-row terminal => viewport is rows 70-79 (prevViewportTop = 70),
+		// and the hardware cursor is parked on the bottom visible row (index 79) after baseline.
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+
+		// Frame 1: a strictly off-viewport, same-line-count mutation hits the no-write skip.
+		// commitState() advances cursorRow but intentionally does not move the hardware cursor.
+		const skipBaseline = captureRenderBaseline(tui, terminal);
+		component.setLine(55, OFFSCREEN_UPDATE);
+		await requestRenderAndWait(tui);
+
+		const skipOutput = outputAfter(terminal, skipBaseline);
+		expect(tui.fullRedraws).toBe(skipBaseline.fullRedraws);
+		expect(terminal.writes).toHaveLength(skipBaseline.writeCount);
+		expect(skipOutput).toBe("");
+
+		// Frame 2: a visible mutation immediately after the skipped frame must still land on the
+		// correct row using the bookkeeping commitState() left behind. The bottom visible row is
+		// index 79 (screen row 9); index 75 is screen row 5, so the differential repaint must move
+		// the cursor up exactly 4 rows. A stale cursor would emit the wrong move count here.
+		const followUpBaseline = captureRenderBaseline(tui, terminal);
+		component.setLine(75, VISIBLE_UPDATE);
+		await requestRenderAndWait(tui);
+
+		const followUpOutput = outputAfter(terminal, followUpBaseline);
+		expect(tui.fullRedraws).toBe(followUpBaseline.fullRedraws);
+		expect(followUpOutput).toContain(VISIBLE_UPDATE);
+		expect(followUpOutput).toContain("\x1b[4A"); // cursor up 4 rows: bottom row 79 -> visible row 75
+		expect(followUpOutput).toContain("\x1b[2K"); // clear + repaint the targeted visible row
+		expect(followUpOutput).not.toContain(VIEWPORT_CLEAR_SEQUENCE);
+		expect(followUpOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE);
+	});
+
+	it("insert immediately above the viewport plus a visible mutation conservatively repaints the viewport without wiping scrollback", async () => {
+		const component = new MutableLines(createLines(80));
+		const { terminal, tui } = await startTui(component);
+		const baseline = captureRenderBaseline(tui, terminal);
+
+		// Insert a line immediately above the viewport (index 69, prevViewportTop is 70) AND mutate a
+		// now-visible row. firstChanged (69) is above the viewport and the line count grows (80 -> 81),
+		// so this is NOT the strict same-count off-viewport skip. Ambiguous above-viewport growth must
+		// fall through to the conservative fullRender(true): clear the viewport but preserve scrollback.
+		const grown = createLines(80);
+		grown.splice(69, 0, ABOVE_VIEWPORT_INSERT);
+		grown[76] = VISIBLE_UPDATE; // within the new viewport (rows 71-80)
+		component.replaceLines(grown);
+		await requestRenderAndWait(tui);
+
+		const renderOutput = outputAfter(terminal, baseline);
+		expect(tui.fullRedraws).toBe(baseline.fullRedraws + 1);
+		expect(renderOutput).toContain(VIEWPORT_CLEAR_SEQUENCE); // viewport cleared
+		expect(renderOutput).not.toContain(SCROLLBACK_CLEAR_SEQUENCE); // scrollback preserved (no ESC[3J)
+		expect(renderOutput).toContain(VISIBLE_UPDATE);
 	});
 });

--- a/patches/@earendil-works%2Fpi-tui@0.78.0.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.78.0.patch
@@ -48,8 +48,8 @@ index b521ceb3..145e6fac 100644
              this.hardwareCursorRow = this.cursorRow;
 -            // Reset max lines when clearing, otherwise track growth
 -            if (clear) {
-+            // Reset max lines only when scrollback is wiped; otherwise track growth.
-+            if (clear === "scrollback") {
++            // Reset max lines after any viewport clear; otherwise track growth.
++            if (clear === true || clear === "scrollback") {
                  this.maxLinesRendered = newLines.length;
              }
              else {

--- a/patches/@earendil-works%2Fpi-tui@0.78.0.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.78.0.patch
@@ -1,171 +1,80 @@
 diff --git a/dist/tui.js b/dist/tui.js
-index b521ceb3..ff14b87 100644
+index b521ceb3..145e6fac 100644
 --- a/dist/tui.js
 +++ b/dist/tui.js
-@@ -837,17 +837,33 @@ export class TUI extends Container {
-                 lastChanged = i;
-             }
-         }
--        const appendedLines = newLines.length > this.previousLines.length;
-+        const previousLineCount = this.previousLines.length;
-+        const newLineCount = newLines.length;
-+        const appendedLines = newLineCount > previousLineCount;
-         if (appendedLines) {
-             if (firstChanged === -1) {
--                firstChanged = this.previousLines.length;
-+                firstChanged = previousLineCount;
-             }
--            lastChanged = newLines.length - 1;
-+            lastChanged = newLineCount - 1;
-         }
-+        const rawLastChanged = lastChanged;
-         if (firstChanged !== -1) {
-             lastChanged = this.expandLastChangedForKittyImages(firstChanged, lastChanged);
-         }
--        const appendStart = appendedLines && firstChanged === this.previousLines.length && firstChanged > 0;
-+        let appendStart = appendedLines && firstChanged === previousLineCount && firstChanged > 0;
-+        const lineHasImage = (line) => isImageLine(line) || extractKittyImageIds(line).length > 0;
-+        const changedRangeHasImage = (start, end) => {
-+            const clampedStart = Math.max(0, start);
-+            const clampedEnd = Math.max(clampedStart, end);
-+            for (let i = clampedStart; i <= clampedEnd; i++) {
-+                const oldLine = this.previousLines[i] ?? "";
-+                const newLine = newLines[i] ?? "";
-+                if (oldLine !== newLine && (lineHasImage(oldLine) || lineHasImage(newLine))) {
-+                    return true;
-+                }
-+            }
-+            return false;
+@@ -755,16 +755,35 @@
+         // Extract cursor position before applying line resets (marker must be found first)
+         const cursorPos = this.extractCursorPosition(newLines, height);
+         newLines = this.applyLineResets(newLines);
+-        // Helper to clear scrollback and viewport and render all new lines
++        // Sync renderer state for strict no-write skips. This intentionally avoids
++        // cursor movement or visibility calls so off-viewport-only frames emit zero bytes.
++        const commitState = () => {
++            this.cursorRow = Math.max(0, newLines.length - 1);
++            this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
++            this.previousViewportTop = prevViewportTop;
++            this.previousLines = newLines;
++            this.previousKittyImageIds = this.collectKittyImageIds(newLines);
++            this.previousWidth = width;
++            this.previousHeight = height;
 +        };
-         // No changes - but still need to update hardware cursor position if it moved
-         if (firstChanged === -1) {
-             this.positionHardwareCursor(cursorPos, newLines.length);
-@@ -904,18 +920,123 @@ export class TUI extends Container {
++        // Helper to clear viewport (and optionally scrollback) and render new lines.
++        // `clear === true` preserves scrollback; `clear === "scrollback"` wipes it.
+         const fullRender = (clear) => {
+             this.fullRedrawCount += 1;
+             let buffer = "\x1b[?2026h"; // Begin synchronized output
+-            if (clear) {
++            if (clear === "scrollback") {
+                 buffer += this.deleteKittyImages(this.previousKittyImageIds);
+                 buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
+             }
+-            for (let i = 0; i < newLines.length; i++) {
+-                if (i > 0)
++            else if (clear === true) {
++                buffer += this.deleteKittyImages(this.previousKittyImageIds);
++                buffer += "\x1b[2J\x1b[H"; // Clear screen + home, preserve scrollback
++            }
++            // For viewport-only clears, write only visible rows so preserved scrollback
++            // is not duplicated by replaying the full logical buffer.
++            const startLine = clear === true ? Math.max(0, newLines.length - height) : 0;
++            for (let i = startLine; i < newLines.length; i++) {
++                if (i > startLine)
+                     buffer += "\r\n";
+                 buffer += newLines[i];
+             }
+@@ -772,8 +791,8 @@
+             this.terminal.write(buffer);
+             this.cursorRow = Math.max(0, newLines.length - 1);
+             this.hardwareCursorRow = this.cursorRow;
+-            // Reset max lines when clearing, otherwise track growth
+-            if (clear) {
++            // Reset max lines only when scrollback is wiped; otherwise track growth.
++            if (clear === "scrollback") {
+                 this.maxLinesRendered = newLines.length;
+             }
+             else {
+@@ -802,9 +821,10 @@
+             return;
+         }
+         // Width changes always need a full re-render because wrapping changes.
++        // Existing scrollback was wrapped at the old width, so wipe it only here.
+         if (widthChanged) {
+             logRedraw(`terminal width changed (${this.previousWidth} -> ${width})`);
+-            fullRender(true);
++            fullRender("scrollback");
+             return;
+         }
+         // Height changes normally need a full re-render to keep the visible viewport aligned,
+@@ -904,6 +924,12 @@
              this.previousViewportTop = prevViewportTop;
              return;
          }
-+        const prevViewportBottom = prevViewportTop + height - 1;
++        // Strict off-viewport same-count changes are state-only: visible pixels and
++        // bottom anchoring are unchanged, so writing would only disturb scrollback.
++        if (lastChanged < prevViewportTop && newLines.length === this.previousLines.length) {
++            commitState();
++            return;
++        }
          // Differential rendering can only touch what was actually visible.
--        // If the first changed line is above the previous viewport, we need a full redraw.
-+        // Same-shape text changes above the previous viewport are safe to record
-+        // without writing to the terminal; the offscreen scrollback may stay stale,
-+        // but we avoid clearing and replaying all scrollback while users read it.
+         // If the first changed line is above the previous viewport, we need a full redraw.
          if (firstChanged < prevViewportTop) {
--            logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
--            fullRender(true);
--            return;
-+            const offscreenEnd = Math.min(rawLastChanged, prevViewportTop - 1, previousLineCount - 1);
-+            if (changedRangeHasImage(firstChanged, offscreenEnd)) {
-+                logRedraw(`image change above viewport (${firstChanged} < ${prevViewportTop})`);
-+                fullRender(true);
-+                return;
-+            }
-+            if (newLineCount < previousLineCount) {
-+                logRedraw(`structural shrink above viewport (${firstChanged} < ${prevViewportTop})`);
-+                fullRender(true);
-+                return;
-+            }
-+            if (newLineCount > previousLineCount) {
-+                let visiblePreExistingChanged = false;
-+                for (let i = prevViewportTop; i < previousLineCount; i++) {
-+                    if ((this.previousLines[i] ?? "") !== (newLines[i] ?? "")) {
-+                        visiblePreExistingChanged = true;
-+                        break;
-+                    }
-+                }
-+                const growth = newLineCount - previousLineCount;
-+                let hasOffscreenPreExistingMismatch = false;
-+                let pendingOffscreenMismatch = false;
-+                let offscreenAlignmentProvenAfterLastOffscreenMismatch = false;
-+                let hasPossibleStructuralShift = false;
-+                const minShiftedRunLength = Math.max(3, growth + 1);
-+                let shiftedMismatchRunLength = 0;
-+                let shiftedMismatchRunStart = -1;
-+                let maxShiftedMismatchRunLength = 0;
-+                let hasShiftedStructuralInsert = false;
-+                for (let i = firstChanged; i < previousLineCount; i++) {
-+                    const oldLine = this.previousLines[i] ?? "";
-+                    const newSameIndexLine = newLines[i] ?? "";
-+                    const newShiftedLine = newLines[i + growth] ?? "";
-+                    const sameIndexStable = oldLine === newSameIndexLine;
-+                    const shiftedMatch = oldLine === newShiftedLine;
-+                    const sameIndexMismatch = !sameIndexStable;
-+                    const isOffscreen = i < prevViewportTop;
-+                    const isBoundary = i === prevViewportTop;
-+                    if (isOffscreen && sameIndexMismatch) {
-+                        hasOffscreenPreExistingMismatch = true;
-+                        pendingOffscreenMismatch = true;
-+                        offscreenAlignmentProvenAfterLastOffscreenMismatch = false;
-+                    }
-+                    if (isOffscreen && pendingOffscreenMismatch && sameIndexStable && !shiftedMatch) {
-+                        offscreenAlignmentProvenAfterLastOffscreenMismatch = true;
-+                        pendingOffscreenMismatch = false;
-+                    }
-+                    if (sameIndexMismatch && shiftedMatch) {
-+                        if (shiftedMismatchRunLength === 0) {
-+                            shiftedMismatchRunStart = i;
-+                        }
-+                        shiftedMismatchRunLength++;
-+                        maxShiftedMismatchRunLength = Math.max(maxShiftedMismatchRunLength, shiftedMismatchRunLength);
-+                        if (!offscreenAlignmentProvenAfterLastOffscreenMismatch &&
-+                            hasOffscreenPreExistingMismatch &&
-+                            (isOffscreen || isBoundary || shiftedMismatchRunStart <= prevViewportTop)) {
-+                            hasPossibleStructuralShift = true;
-+                        }
-+                        if (shiftedMismatchRunStart <= prevViewportTop && shiftedMismatchRunLength >= minShiftedRunLength) {
-+                            hasShiftedStructuralInsert = true;
-+                            break;
-+                        }
-+                    }
-+                    else if (!shiftedMatch) {
-+                        shiftedMismatchRunLength = 0;
-+                        shiftedMismatchRunStart = -1;
-+                    }
-+                }
-+                if (hasShiftedStructuralInsert) {
-+                    logRedraw(`shifted structural insert above viewport (${firstChanged} < ${prevViewportTop}, growth=${growth}, shiftedRun=${maxShiftedMismatchRunLength})`);
-+                    fullRender(true);
-+                    return;
-+                }
-+                if (hasOffscreenPreExistingMismatch &&
-+                    !offscreenAlignmentProvenAfterLastOffscreenMismatch &&
-+                    hasPossibleStructuralShift) {
-+                    logRedraw(`structural/ambiguous growth above viewport (${firstChanged} < ${prevViewportTop}, growth=${growth}, offscreenProof=${offscreenAlignmentProvenAfterLastOffscreenMismatch}, structuralShift=${hasPossibleStructuralShift}, shiftedRun=${maxShiftedMismatchRunLength})`);
-+                    fullRender(true);
-+                    return;
-+                }
-+                if (visiblePreExistingChanged) {
-+                    firstChanged = prevViewportTop;
-+                    lastChanged = Math.max(lastChanged, newLineCount - 1, firstChanged);
-+                    appendStart = false;
-+                }
-+                else {
-+                    firstChanged = previousLineCount;
-+                    lastChanged = Math.max(newLineCount - 1, firstChanged);
-+                    appendStart = firstChanged > 0;
-+                }
-+            }
-+            else {
-+                if (rawLastChanged < prevViewportTop) {
-+                    this.positionHardwareCursor(cursorPos, newLines.length);
-+                    this.cursorRow = Math.max(0, newLines.length - 1);
-+                    this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
-+                    this.previousViewportTop = prevViewportTop;
-+                    this.previousLines = newLines;
-+                    this.previousKittyImageIds = this.collectKittyImageIds(newLines);
-+                    this.previousWidth = width;
-+                    this.previousHeight = height;
-+                    return;
-+                }
-+                firstChanged = prevViewportTop;
-+                lastChanged = Math.max(lastChanged, firstChanged);
-+            }
-         }
-         // Render from first changed line to end
-         // Build buffer with all updates wrapped in synchronized output
-         let buffer = "\x1b[?2026h"; // Begin synchronized output
-         buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
--        const prevViewportBottom = prevViewportTop + height - 1;
-         const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
-         if (moveTargetRow > prevViewportBottom) {
-             const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));

--- a/patches/@earendil-works%2Fpi-tui@0.78.0.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.78.0.patch
@@ -2,7 +2,7 @@ diff --git a/dist/tui.js b/dist/tui.js
 index b521ceb3..145e6fac 100644
 --- a/dist/tui.js
 +++ b/dist/tui.js
-@@ -755,16 +755,35 @@
+@@ -755,16 +755,38 @@
          // Extract cursor position before applying line resets (marker must be found first)
          const cursorPos = this.extractCursorPosition(newLines, height);
          newLines = this.applyLineResets(newLines);
@@ -23,37 +23,40 @@ index b521ceb3..145e6fac 100644
          const fullRender = (clear) => {
              this.fullRedrawCount += 1;
              let buffer = "\x1b[?2026h"; // Begin synchronized output
++            const wipesScrollback = clear === "scrollback";
++            const viewportOnlyClear = clear === true;
++            const clearsViewport = viewportOnlyClear || wipesScrollback;
 -            if (clear) {
-+            if (clear === "scrollback") {
++            if (wipesScrollback) {
                  buffer += this.deleteKittyImages(this.previousKittyImageIds);
                  buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
              }
 -            for (let i = 0; i < newLines.length; i++) {
 -                if (i > 0)
-+            else if (clear === true) {
++            else if (viewportOnlyClear) {
 +                buffer += this.deleteKittyImages(this.previousKittyImageIds);
 +                buffer += "\x1b[2J\x1b[H"; // Clear screen + home, preserve scrollback
 +            }
 +            // For viewport-only clears, write only visible rows so preserved scrollback
 +            // is not duplicated by replaying the full logical buffer.
-+            const startLine = clear === true ? Math.max(0, newLines.length - height) : 0;
++            const startLine = viewportOnlyClear ? Math.max(0, newLines.length - height) : 0;
 +            for (let i = startLine; i < newLines.length; i++) {
 +                if (i > startLine)
                      buffer += "\r\n";
                  buffer += newLines[i];
              }
-@@ -772,8 +791,8 @@
+@@ -772,8 +794,8 @@
              this.terminal.write(buffer);
              this.cursorRow = Math.max(0, newLines.length - 1);
              this.hardwareCursorRow = this.cursorRow;
 -            // Reset max lines when clearing, otherwise track growth
 -            if (clear) {
 +            // Reset max lines after any viewport clear; otherwise track growth.
-+            if (clear === true || clear === "scrollback") {
++            if (clearsViewport) {
                  this.maxLinesRendered = newLines.length;
              }
              else {
-@@ -802,9 +821,10 @@
+@@ -802,9 +824,10 @@
              return;
          }
          // Width changes always need a full re-render because wrapping changes.
@@ -65,7 +68,7 @@ index b521ceb3..145e6fac 100644
              return;
          }
          // Height changes normally need a full re-render to keep the visible viewport aligned,
-@@ -904,6 +924,12 @@
+@@ -904,6 +927,12 @@
              this.previousViewportTop = prevViewportTop;
              return;
          }

--- a/patches/@earendil-works%2Fpi-tui@0.78.0.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.78.0.patch
@@ -1,0 +1,171 @@
+diff --git a/dist/tui.js b/dist/tui.js
+index b521ceb3..ff14b87 100644
+--- a/dist/tui.js
++++ b/dist/tui.js
+@@ -837,17 +837,33 @@ export class TUI extends Container {
+                 lastChanged = i;
+             }
+         }
+-        const appendedLines = newLines.length > this.previousLines.length;
++        const previousLineCount = this.previousLines.length;
++        const newLineCount = newLines.length;
++        const appendedLines = newLineCount > previousLineCount;
+         if (appendedLines) {
+             if (firstChanged === -1) {
+-                firstChanged = this.previousLines.length;
++                firstChanged = previousLineCount;
+             }
+-            lastChanged = newLines.length - 1;
++            lastChanged = newLineCount - 1;
+         }
++        const rawLastChanged = lastChanged;
+         if (firstChanged !== -1) {
+             lastChanged = this.expandLastChangedForKittyImages(firstChanged, lastChanged);
+         }
+-        const appendStart = appendedLines && firstChanged === this.previousLines.length && firstChanged > 0;
++        let appendStart = appendedLines && firstChanged === previousLineCount && firstChanged > 0;
++        const lineHasImage = (line) => isImageLine(line) || extractKittyImageIds(line).length > 0;
++        const changedRangeHasImage = (start, end) => {
++            const clampedStart = Math.max(0, start);
++            const clampedEnd = Math.max(clampedStart, end);
++            for (let i = clampedStart; i <= clampedEnd; i++) {
++                const oldLine = this.previousLines[i] ?? "";
++                const newLine = newLines[i] ?? "";
++                if (oldLine !== newLine && (lineHasImage(oldLine) || lineHasImage(newLine))) {
++                    return true;
++                }
++            }
++            return false;
++        };
+         // No changes - but still need to update hardware cursor position if it moved
+         if (firstChanged === -1) {
+             this.positionHardwareCursor(cursorPos, newLines.length);
+@@ -904,18 +920,123 @@ export class TUI extends Container {
+             this.previousViewportTop = prevViewportTop;
+             return;
+         }
++        const prevViewportBottom = prevViewportTop + height - 1;
+         // Differential rendering can only touch what was actually visible.
+-        // If the first changed line is above the previous viewport, we need a full redraw.
++        // Same-shape text changes above the previous viewport are safe to record
++        // without writing to the terminal; the offscreen scrollback may stay stale,
++        // but we avoid clearing and replaying all scrollback while users read it.
+         if (firstChanged < prevViewportTop) {
+-            logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+-            fullRender(true);
+-            return;
++            const offscreenEnd = Math.min(rawLastChanged, prevViewportTop - 1, previousLineCount - 1);
++            if (changedRangeHasImage(firstChanged, offscreenEnd)) {
++                logRedraw(`image change above viewport (${firstChanged} < ${prevViewportTop})`);
++                fullRender(true);
++                return;
++            }
++            if (newLineCount < previousLineCount) {
++                logRedraw(`structural shrink above viewport (${firstChanged} < ${prevViewportTop})`);
++                fullRender(true);
++                return;
++            }
++            if (newLineCount > previousLineCount) {
++                let visiblePreExistingChanged = false;
++                for (let i = prevViewportTop; i < previousLineCount; i++) {
++                    if ((this.previousLines[i] ?? "") !== (newLines[i] ?? "")) {
++                        visiblePreExistingChanged = true;
++                        break;
++                    }
++                }
++                const growth = newLineCount - previousLineCount;
++                let hasOffscreenPreExistingMismatch = false;
++                let pendingOffscreenMismatch = false;
++                let offscreenAlignmentProvenAfterLastOffscreenMismatch = false;
++                let hasPossibleStructuralShift = false;
++                const minShiftedRunLength = Math.max(3, growth + 1);
++                let shiftedMismatchRunLength = 0;
++                let shiftedMismatchRunStart = -1;
++                let maxShiftedMismatchRunLength = 0;
++                let hasShiftedStructuralInsert = false;
++                for (let i = firstChanged; i < previousLineCount; i++) {
++                    const oldLine = this.previousLines[i] ?? "";
++                    const newSameIndexLine = newLines[i] ?? "";
++                    const newShiftedLine = newLines[i + growth] ?? "";
++                    const sameIndexStable = oldLine === newSameIndexLine;
++                    const shiftedMatch = oldLine === newShiftedLine;
++                    const sameIndexMismatch = !sameIndexStable;
++                    const isOffscreen = i < prevViewportTop;
++                    const isBoundary = i === prevViewportTop;
++                    if (isOffscreen && sameIndexMismatch) {
++                        hasOffscreenPreExistingMismatch = true;
++                        pendingOffscreenMismatch = true;
++                        offscreenAlignmentProvenAfterLastOffscreenMismatch = false;
++                    }
++                    if (isOffscreen && pendingOffscreenMismatch && sameIndexStable && !shiftedMatch) {
++                        offscreenAlignmentProvenAfterLastOffscreenMismatch = true;
++                        pendingOffscreenMismatch = false;
++                    }
++                    if (sameIndexMismatch && shiftedMatch) {
++                        if (shiftedMismatchRunLength === 0) {
++                            shiftedMismatchRunStart = i;
++                        }
++                        shiftedMismatchRunLength++;
++                        maxShiftedMismatchRunLength = Math.max(maxShiftedMismatchRunLength, shiftedMismatchRunLength);
++                        if (!offscreenAlignmentProvenAfterLastOffscreenMismatch &&
++                            hasOffscreenPreExistingMismatch &&
++                            (isOffscreen || isBoundary || shiftedMismatchRunStart <= prevViewportTop)) {
++                            hasPossibleStructuralShift = true;
++                        }
++                        if (shiftedMismatchRunStart <= prevViewportTop && shiftedMismatchRunLength >= minShiftedRunLength) {
++                            hasShiftedStructuralInsert = true;
++                            break;
++                        }
++                    }
++                    else if (!shiftedMatch) {
++                        shiftedMismatchRunLength = 0;
++                        shiftedMismatchRunStart = -1;
++                    }
++                }
++                if (hasShiftedStructuralInsert) {
++                    logRedraw(`shifted structural insert above viewport (${firstChanged} < ${prevViewportTop}, growth=${growth}, shiftedRun=${maxShiftedMismatchRunLength})`);
++                    fullRender(true);
++                    return;
++                }
++                if (hasOffscreenPreExistingMismatch &&
++                    !offscreenAlignmentProvenAfterLastOffscreenMismatch &&
++                    hasPossibleStructuralShift) {
++                    logRedraw(`structural/ambiguous growth above viewport (${firstChanged} < ${prevViewportTop}, growth=${growth}, offscreenProof=${offscreenAlignmentProvenAfterLastOffscreenMismatch}, structuralShift=${hasPossibleStructuralShift}, shiftedRun=${maxShiftedMismatchRunLength})`);
++                    fullRender(true);
++                    return;
++                }
++                if (visiblePreExistingChanged) {
++                    firstChanged = prevViewportTop;
++                    lastChanged = Math.max(lastChanged, newLineCount - 1, firstChanged);
++                    appendStart = false;
++                }
++                else {
++                    firstChanged = previousLineCount;
++                    lastChanged = Math.max(newLineCount - 1, firstChanged);
++                    appendStart = firstChanged > 0;
++                }
++            }
++            else {
++                if (rawLastChanged < prevViewportTop) {
++                    this.positionHardwareCursor(cursorPos, newLines.length);
++                    this.cursorRow = Math.max(0, newLines.length - 1);
++                    this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);
++                    this.previousViewportTop = prevViewportTop;
++                    this.previousLines = newLines;
++                    this.previousKittyImageIds = this.collectKittyImageIds(newLines);
++                    this.previousWidth = width;
++                    this.previousHeight = height;
++                    return;
++                }
++                firstChanged = prevViewportTop;
++                lastChanged = Math.max(lastChanged, firstChanged);
++            }
+         }
+         // Render from first changed line to end
+         // Build buffer with all updates wrapped in synchronized output
+         let buffer = "\x1b[?2026h"; // Begin synchronized output
+         buffer += this.deleteChangedKittyImages(firstChanged, lastChanged);
+-        const prevViewportBottom = prevViewportTop + height - 1;
+         const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
+         if (moveTargetRow > prevViewportBottom) {
+             const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));


### PR DESCRIPTION
## Summary

Fixes TUI flicker and scrollback wipes when Atomic streams output in a short (non-fullscreen) terminal and the user has manually scrolled. Root cause: `@earendil-works/pi-tui@0.78.0`'s `TUI.doRender()` unconditionally fell back to a destructive full clear + scrollback wipe (`CSI 2J` / `CSI H` / `CSI 3J`) whenever a changed logical line sat above the bottom-anchored viewport — a condition that fires constantly during live streaming in short terminals.

`0.78.0` is the latest published `@earendil-works/pi-tui`, and upstream has **not** fixed this (the matching issues — #4785, #4044, #4260, #4506, #3756 — were closed without a merged fix; the bug is still present on `pi` `main`). So there is nothing to bump to, and the fix is carried as a patched, bundled dependency.

Closes #1222

## The fix — correct by construction, no heuristics

The renderer change adds exactly **one** safe no-write skip plus a scrollback-preserving clear split. It does **not** try to classify off-viewport diffs (no append-vs-insert / shifted-run guessing).

**Patch (`patches/@earendil-works%2Fpi-tui@0.78.0.patch`):**

1. **`commitState()`** — advances renderer bookkeeping (`previousLines`, `previousViewportTop`, `maxLinesRendered`, cursor row, etc.) and writes **zero bytes**.
2. **Strict off-viewport no-write skip** — inserted before the destructive branch:
   ```js
   if (lastChanged < prevViewportTop && newLines.length === this.previousLines.length) {
     commitState(); return;   // visible pixels already correct → write nothing
   }
   ```
   When the entire change is strictly above the viewport **and** the line count is unchanged, the visible viewport is already correct, so the renderer emits nothing and the user's scroll position is preserved exactly. This is provably safe — no classification.
3. **`fullRender(clear)` split** into `false | true | "scrollback"`:
   - `true` → `CSI 2J CSI H` (viewport clear, **scrollback preserved**); writes only the last `height` rows so preserved scrollback isn't duplicated.
   - `"scrollback"` → `CSI 2J CSI H CSI 3J` (full wipe), used **only** on terminal width change (existing scrollback was wrapped at the old width).
4. **Everything else** (e.g. an insert above the viewport, or a change that also touches visible rows / changes line count) falls through to the existing `fullRender(true)` — now scrollback-preserving. This is the conservative path: a viewport repaint that never wipes scrollback. There is intentionally no attempt to be cleverer than that.

> Terminal codes are kept as raw escapes inside the synchronized-output buffer (`CSI ?2026h … CSI ?2026l`), matching pi-tui's own render-core convention. pi-tui's `Terminal.clearScreen()`/`moveBy()` methods emit identical bytes (no platform branching) and write straight to stdout, which would break the atomic synchronized write and reintroduce flicker — so they are deliberately not used here.

## Delivery (bundled patched dependency)

Since `@bastani/atomic` is an npm package, a root-only Bun patch wouldn't reach consumers. The patched `@earendil-works/pi-tui` plus its runtime closure (`marked`, `get-east-asian-width`) is materialized into `node_modules` at pack time (`prepack`/`postpack`) and declared in `bundleDependencies`, with an isolated pack-install-import verifier (`verify:bundled-pi-tui`). This is a **temporary mechanism** to be removed once an upstream pi-tui release ships the fix.

## Tests (`test/suite/regressions/1222-tui-offviewport-redraw.test.ts`)

`FakeTerminal` + `MutableLines` regressions over the patched build (imported via `patchedDependencies`):
- Strictly off-viewport, same-count mutation → **zero bytes written**, `fullRedraws` unchanged.
- A render **following** a skipped frame still lands on the correct row (asserts the exact `CSI 4A` cursor move) — validates `commitState()` cursor bookkeeping.
- Insert immediately above the viewport + a visible mutation → conservative `fullRender(true)`: writes `CSI 2J CSI H`, **never** `CSI 3J` (scrollback preserved).
- Terminal width change → `fullRender("scrollback")` (`CSI 3J`).
- Pure visible change → differential path, no clear.
- `clearOnShrink` full clear does not repeat on the next no-op render.

## CI

- **`publish.yml`** — `verify:bundled-pi-tui` runs as a gate **before** `npm publish`, so a broken bundle closure cannot silently ship.
- **`test.yml`** — `verify:bundled-pi-tui` runs on the Linux matrix entry for early PR feedback.

## Validation

- `bun run typecheck` ✅ · `bun run lint` ✅
- `bun run --cwd packages/coding-agent test -- test/suite/regressions/1222-tui-offviewport-redraw.test.ts` ✅ (7)
- `bun run --cwd packages/coding-agent test -- test/edit-tool-no-full-redraw.test.ts` ✅ (3)
- `SKIP_BUILD=1 bun run --cwd packages/coding-agent verify:bundled-pi-tui` ✅
- Patch applies cleanly to a pristine `0.78.0` install (+ reverse dry-run).

## Out of scope / follow-up

A *perfect* cure for the rarer "streaming markdown reflow rewraps a line that already scrolled above the fold" case needs a **stable-prefix / freeze-above-the-fold** discipline in `AssistantMessageComponent.updateContent()` (which clears+rebuilds the full `Markdown` each token). That's a larger, separate change and is intentionally not attempted here; this PR makes the renderer scrollback-safe and eliminates the destructive wipe + off-viewport repaints.
