### PR TITLE
chore(release): bump release to 0.8.24

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.24-alpha.4",
+      "version": "0.8.24",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.24-alpha.4",
+      "version": "0.8.24",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.24-alpha.4",
+      "version": "0.8.24",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.24-alpha.4",
+      "version": "0.8.24",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.24-alpha.4",
+      "version": "0.8.24",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.24-alpha.4",
+      "version": "0.8.24",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.24 prerelease package version to a stable release.
+
 ## [0.8.24-alpha.4] - 2026-06-04
 
 ### Fixed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.24-alpha.4",
+  "version": "0.8.24",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.24 prerelease package version to a stable release.
+
 ## [0.8.24-alpha.4] - 2026-06-04
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.24-alpha.4",
+  "version": "0.8.24",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.24 prerelease package version to a stable release.
+
 ## [0.8.24-alpha.4] - 2026-06-04
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.24-alpha.4",
+  "version": "0.8.24",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.24 prerelease package version to a stable release.
+
 ## [0.8.24-alpha.4] - 2026-06-04
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.24-alpha.4",
+  "version": "0.8.24",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.24 prerelease package version to a stable release.
+
 ## [0.8.24-alpha.4] - 2026-06-04
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.24-alpha.4",
+  "version": "0.8.24",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.24 prerelease package version to a stable release.
+
 ## [0.8.24-alpha.4] - 2026-06-04
 
 ### Changed

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.24-alpha.4",
+  "version": "0.8.24",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the \`0.8.24-alpha.4\` prerelease to the stable \`0.8.24\` release. Bumps all six workspace package versions and adds \`[0.8.24]\` changelog entries across every package.

## Changes

- Bump all workspace package versions \`0.8.24-alpha.4\` → \`0.8.24\` in \`package.json\` and \`bun.lock\`
- Add \`[0.8.24]\` stable-release changelog sections to all 6 packages

## What's included in 0.8.24

This stable release bundles all changes shipped across \`0.8.24-alpha.1\` through \`0.8.24-alpha.4\`:

**alpha.4**
- Fixed TUI flicker and scrollback wipes during active streaming in short terminals ([#1222](https://github.com/bastani-inc/atomic/issues/1222))

**alpha.3**
- Added `/exit` as a built-in interactive slash command alias for graceful shutdown

**alpha.2**
- Shipped externally-resolvable TypeScript types for the \`@bastani/workflows\` SDK via \`@bastani/atomic\` package exports — consumers get \`import { defineWorkflow, Type } from "@bastani/workflows"\` type-checking with no hand-authored \`.d.ts\` or \`paths\` alias ([#1208](https://github.com/bastani-inc/atomic/issues/1208))
- Added \`verify:workflow-types\` script for repeatable external-consumer type-check fixture ([#1208](https://github.com/bastani-inc/atomic/issues/1208))

**alpha.1** ⚠️ Breaking
- Removed imperative \`runWorkflow\` object-form API; workflow packages must export branded \`defineWorkflow(...).compile()\` definitions
- Adopted \`-alpha.N\` prerelease version convention (replacing legacy \`-N\` suffix) and dropped the leading \`v\` from release git tags and branch names
- Fixed workflow node rendering of parallel tool calls by pairing concurrent same-named calls by \`toolCallId\` ([#1198](https://github.com/bastani-inc/atomic/issues/1198))

## Release

After merge, tag \`0.8.24\` will be pushed to trigger the Publish workflow (npm dist-tag \`latest\`).