### PR TITLE
fix(workflows): pin inputs selector to bottom like ask_user_question

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the interactive workflow inputs selector so it hides the working loader while replacing the editor, keeping the picker pinned to the bottom like `ask_user_question` without wedged host chrome ([#1224](https://github.com/bastani-inc/atomic/issues/1224)).
+
 ## [0.8.24] - 2026-06-04
 
 ### Changed

--- a/packages/workflows/src/tui/inputs-overlay.ts
+++ b/packages/workflows/src/tui/inputs-overlay.ts
@@ -15,14 +15,17 @@
  *
  * Mount mode
  * ----------
- * Uses `{ overlay: false }`. pi's interactive
- * `ExtensionUiController.custom` REPLACES the editor with the mounted
- * component (`editorContainer.clear(); addChild(component)`), so the
- * picker renders **inline** at the editor's natural position in the
- * chat layout. This avoids the bottom-anchored overlay regression
- * captured in `ui/workflows/Screenshot 2026-05-13 at 1.09.32 AM.png`
- * (host `Working…` / widget rows wedged between command and picker)
- * without any overlay padding tricks — the host owns geometry.
+ * Uses the same bottom-pinned primitive as `ask_user_question`: hide the
+ * host working-loader row for the lifetime of the blocking picker and mount
+ * with `{ overlay: false }`. pi's interactive `ExtensionUiController.custom`
+ * then REPLACES the editor with the mounted component
+ * (`editorContainer.clear(); addChild(component)`), which puts the focused
+ * picker in the bottom editor slot instead of a floating overlay. Suppressing
+ * `Working…` while mounted keeps host chrome from being wedged between the
+ * `/workflow …` command and the picker, avoiding the prior bottom-anchored
+ * overlay regression captured in
+ * `ui/workflows/Screenshot 2026-05-13 at 1.09.32 AM.png` without overlay
+ * anchor/padding tricks — the host owns geometry.
  *
  * cross-ref:
  *   - src/tui/inputs-picker.ts (pure state + render)
@@ -48,6 +51,7 @@ import {
 
 export interface InputsUiSurface {
   custom?: PiCustomOverlayFunction;
+  setWorkingVisible?: (visible: boolean) => void;
 }
 
 export type InputsPickerResult =
@@ -68,7 +72,7 @@ export interface OpenInputsPickerOpts {
  * confirm, or `cancel` on esc / no UI surface.
  *
  * Behaviour matrix:
- *   - `pi.ui.custom` present: mounted as an overlay, settled by `done()`
+ *   - `pi.ui.custom` present: mounted in the editor slot, settled by `done()`
  *   - no `pi.ui.custom` at all: resolves `cancel` immediately so the slash
  *                               command can fall back to the "missing
  *                               required input" text path
@@ -79,11 +83,6 @@ export function openInputsPicker(
 ): Promise<InputsPickerResult> {
   return new Promise<InputsPickerResult>((resolve) => {
     const { workflowName, fields, prefilled, theme } = opts;
-    const custom = ui.custom;
-    if (typeof custom !== "function") {
-      resolve({ kind: "cancel" });
-      return;
-    }
     if (fields.length === 0) {
       // No inputs to collect — treat as immediate run with whatever the
       // caller already prefilled (likely empty).
@@ -91,10 +90,39 @@ export function openInputsPicker(
       return;
     }
 
+    let workingHidden = false;
+    const hideWorking = (): void => {
+      ui.setWorkingVisible?.(false);
+      workingHidden = true;
+    };
+    const restoreWorking = (): void => {
+      if (!workingHidden) return;
+      workingHidden = false;
+      ui.setWorkingVisible?.(true);
+    };
+
+    hideWorking();
+
+    const custom = ui.custom;
+    if (typeof custom !== "function") {
+      restoreWorking();
+      resolve({ kind: "cancel" });
+      return;
+    }
+
     const state = createInputsPickerState(fields, prefilled);
     let settled = false;
     let cursorOn = true;
     let cursorTimer: ReturnType<typeof setInterval> | null = null;
+
+    const settleWithoutDone = (result: InputsPickerResult): void => {
+      if (settled) return;
+      settled = true;
+      if (cursorTimer) clearInterval(cursorTimer);
+      cursorTimer = null;
+      restoreWorking();
+      resolve(result);
+    };
 
     const factory = (
       tui: PiCustomOverlayFactoryTui,
@@ -114,8 +142,12 @@ export function openInputsPicker(
         settled = true;
         if (cursorTimer) clearInterval(cursorTimer);
         cursorTimer = null;
-        done(undefined);
-        resolve(result);
+        try {
+          done(undefined);
+        } finally {
+          restoreWorking();
+          resolve(result);
+        }
       };
 
       return {
@@ -144,12 +176,7 @@ export function openInputsPicker(
         },
         invalidate: () => tui.requestRender?.(),
         dispose: () => {
-          if (cursorTimer) clearInterval(cursorTimer);
-          cursorTimer = null;
-          if (!settled) {
-            settled = true;
-            resolve({ kind: "cancel" });
-          }
+          settleWithoutDone({ kind: "cancel" });
         },
       };
     };
@@ -157,6 +184,12 @@ export function openInputsPicker(
     // overlay: false — picker replaces the editor in-place (see header
     // comment). The host owns geometry/focus; no overlayOptions are
     // forwarded by interactive pi today.
-    void custom(factory, { overlay: false });
+    try {
+      void Promise.resolve(custom(factory, { overlay: false })).catch(() => {
+        settleWithoutDone({ kind: "cancel" });
+      });
+    } catch {
+      settleWithoutDone({ kind: "cancel" });
+    }
   });
 }

--- a/test/unit/inputs-picker.test.ts
+++ b/test/unit/inputs-picker.test.ts
@@ -19,13 +19,62 @@ import {
   invalidForField,
   renderInputsPicker,
 } from "../../packages/workflows/src/tui/inputs-picker.ts";
+import { openInputsPicker, type InputsPickerResult } from "../../packages/workflows/src/tui/inputs-overlay.ts";
 import { renderInputsSchema } from "../../packages/workflows/src/shared/render-inputs-schema.ts";
 import { deriveGraphTheme } from "../../packages/workflows/src/tui/graph-theme.ts";
 import { wrapPlainText } from "../../packages/workflows/src/tui/text-helpers.ts";
 import type { WorkflowInputEntry } from "../../packages/workflows/src/extension/render-result.ts";
+import type {
+  PiCustomComponent,
+  PiCustomOverlayFactory,
+  PiCustomOverlayFunction,
+  PiCustomOverlayOptions,
+} from "../../packages/workflows/src/extension/wiring.ts";
 import { makeFakeKeybindings } from "../support/fake-keybindings.ts";
 
 const KB = makeFakeKeybindings();
+
+const OVERLAY_FIELDS: WorkflowInputEntry[] = [
+  { name: "prompt", type: "string", required: true },
+];
+
+interface MountedInputsPicker {
+  readonly component: PiCustomComponent;
+  readonly promise: Promise<InputsPickerResult>;
+  readonly workingCalls: boolean[];
+  readonly customOptions: PiCustomOverlayOptions[];
+}
+
+function mountInputsPicker(): MountedInputsPicker {
+  let component: PiCustomComponent | undefined;
+  const workingCalls: boolean[] = [];
+  const customOptions: PiCustomOverlayOptions[] = [];
+  const custom: PiCustomOverlayFunction = (
+    factory: PiCustomOverlayFactory,
+    options: PiCustomOverlayOptions,
+  ) => {
+    customOptions.push(options);
+    const mounted = factory({ requestRender: () => undefined }, undefined, KB, () => undefined);
+    if (mounted instanceof Promise) {
+      throw new Error("test seam expects synchronous picker factory");
+    }
+    component = mounted;
+  };
+  const promise = openInputsPicker(
+    {
+      custom,
+      setWorkingVisible: (visible) => workingCalls.push(visible),
+    },
+    {
+      workflowName: "ralph",
+      fields: OVERLAY_FIELDS,
+      prefilled: { prompt: "ready" },
+      theme: deriveGraphTheme({}),
+    },
+  );
+  assert.ok(component, "custom factory should mount synchronously in this test seam");
+  return { component, promise, workingCalls, customOptions };
+}
 
 const FIELDS: WorkflowInputEntry[] = [
   { name: "prompt", type: "text", required: true, description: "task to do" },
@@ -39,6 +88,57 @@ const FIELDS: WorkflowInputEntry[] = [
   },
   { name: "verbose", type: "boolean", required: false },
 ];
+
+// ── Overlay mount adapter ─────────────────────────────────────────────────
+
+test("openInputsPicker hides Working while mounted and restores it on submit", async () => {
+  const mounted = mountInputsPicker();
+  assert.deepEqual(mounted.customOptions, [{ overlay: false }]);
+  assert.deepEqual(mounted.workingCalls, [false]);
+
+  mounted.component.handleInput?.("\t"); // focus Submit
+  mounted.component.handleInput?.("\r");
+
+  assert.deepEqual(await mounted.promise, { kind: "run", values: { prompt: "ready" } });
+  assert.deepEqual(mounted.workingCalls, [false, true]);
+});
+
+test("openInputsPicker restores Working on cancel", async () => {
+  const mounted = mountInputsPicker();
+  assert.deepEqual(mounted.workingCalls, [false]);
+
+  mounted.component.handleInput?.("\x1b");
+
+  assert.deepEqual(await mounted.promise, { kind: "cancel" });
+  assert.deepEqual(mounted.workingCalls, [false, true]);
+});
+
+test("openInputsPicker restores Working on dispose", async () => {
+  const mounted = mountInputsPicker();
+  assert.deepEqual(mounted.workingCalls, [false]);
+
+  mounted.component.dispose?.();
+
+  assert.deepEqual(await mounted.promise, { kind: "cancel" });
+  assert.deepEqual(mounted.workingCalls, [false, true]);
+});
+
+test("openInputsPicker restores Working when custom UI is unavailable", async () => {
+  const workingCalls: boolean[] = [];
+
+  const result = await openInputsPicker(
+    { setWorkingVisible: (visible) => workingCalls.push(visible) },
+    {
+      workflowName: "ralph",
+      fields: OVERLAY_FIELDS,
+      prefilled: { prompt: "ready" },
+      theme: deriveGraphTheme({}),
+    },
+  );
+
+  assert.deepEqual(result, { kind: "cancel" });
+  assert.deepEqual(workingCalls, [false, true]);
+});
 
 // ── State construction ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Pins the interactive `/workflow <name>` inputs selector to the bottom of the viewport so it matches the placement and feel of the `ask_user_question` prompt UI. Both surfaces collect structured input and now behave consistently — the picker replaces the editor slot at the bottom instead of floating mid-screen with host chrome wedged in.

Closes #1224

## Changes

- **`packages/workflows/src/tui/inputs-overlay.ts`**
  - `openInputsPicker` now hides the host `Working…` loader for the picker's lifetime via `setWorkingVisible(false)`, matching the `ask_user_question` bottom-pinned primitive
  - Extended `InputsUiSurface` with optional `setWorkingVisible?`
  - Added `settleWithoutDone` helper to centralize settle logic (clear timer, restore loader, resolve)
  - Loader restore is idempotent (`workingHidden` flag) and fires on every settle path: submit, Esc/cancel, dispose, missing `pi.ui.custom`, and custom-mount throw/reject
  - `custom()` call is now wrapped in `try` + `Promise.catch` to handle sync and async mount failures gracefully
  - Updated header doc to describe the bottom-pinned rationale (replaces stale inline-position description)

- **`test/unit/inputs-picker.test.ts`**
  - 5 new lifecycle tests asserting `setWorkingVisible(false)` on mount and `(true)` restore on submit, cancel, dispose, and no-custom-UI
  - Asserts `{ overlay: false }` is preserved through the mount path

- **`packages/workflows/CHANGELOG.md`** — `### Fixed` entry under `[Unreleased]` referencing #1224

## Notes

- Scoped exactly to `openInputsPicker`. The inline sticky-card path (`openInlineInputsForm`) is intentionally untouched.
- Pure render/key-handling in `inputs-picker.ts` is unchanged — keyboard/focus behavior (field tab bar, ↑/↓, Tab, Enter, Esc) and all field types are preserved by existing coverage.
- `bun run typecheck`, `bun run test:unit` (2030 pass), and `bun run lint` all pass.