### PR TITLE
docs(workflows): fix stale docs and type errors in examples

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -41,7 +41,7 @@ Use a workflow when a task should be repeatable, inspectable, resumable, or spli
 - [Monitor and Control Runs](#monitor-and-control-runs)
 - [Lifecycle Notices and Human Input](#lifecycle-notices-and-human-input)
 - [Direct One-Off Runs](#direct-one-off-runs)
-- [Codex Fast Mode for Workflow Stages](#codex-fast-mode-for-workflow-stages)
+- [Fast Inference for Workflow Stages](#fast-inference-for-workflow-stages)
 - [Writing a Workflow](#writing-a-workflow)
 - [Workflow Primitives](#workflow-primitives)
 - [Task and Stage Options](#task-and-stage-options)
@@ -930,7 +930,11 @@ Direct mode supports top-level/default options and per-task options such as `con
 
 For large fan-outs, prefer `outputMode: "file-only"` so the parent result contains compact file references instead of full output. Treat intercom payloads from async direct runs as user-visible workflow output.
 
-## Codex Fast Mode for Workflow Stages
+## Fast Inference for Workflow Stages
+
+Workflow stages can opt into faster, higher-priority inference on supported providers so multi-stage runs finish sooner. This is currently delivered through Codex fast mode.
+
+### Codex fast mode
 
 Use `/fast` to manage Codex fast mode separately for normal chat and workflow-stage sessions. The settings are `codexFastMode.chat` and `codexFastMode.workflow`; workflow stages use the workflow scope, not the chat scope.
 
@@ -1007,7 +1011,7 @@ Builder basics:
 - `.description(text)` sets the listing text.
 - `.input(key, schema)` declares typed user inputs.
 - `.worktreeFromInputs({ gitWorktreeDir, baseBranch })` optionally maps input names to workflow-wide reusable Git worktree defaults.
-- `.output(key, schema?)` declares typed outputs that parent workflows receive from `ctx.workflow(childWorkflow, ...)`.
+- `.output(key, schema)` declares typed outputs that parent workflows receive from `ctx.workflow(childWorkflow, ...)`.
 - `.run(async (ctx) => { ... })` defines the workflow body.
 - `.compile()` returns the workflow definition for discovery.
 
@@ -1035,7 +1039,7 @@ In TypeScript workflow files, `.input(...)` also narrows `ctx.inputs` for better
 
 ### Outputs
 
-Workflow outputs are runtime contracts for completed workflow runs and for parent workflows that call a child with `ctx.workflow(childWorkflow, ...)`. A workflow returns a JSON-serializable object from `.run()`, and `.output(key, schema?)` documents, validates, and exposes keys from that returned object. Primitives, arrays, `null`, functions, symbols, `undefined` properties, `NaN`, and infinite numbers fail validation.
+Workflow outputs are runtime contracts for completed workflow runs and for parent workflows that call a child with `ctx.workflow(childWorkflow, ...)`. A workflow returns a JSON-serializable object from `.run()`, and `.output(key, schema)` documents, validates, and exposes keys from that returned object. Primitives, arrays, `null`, functions, symbols, `undefined` properties, `NaN`, and infinite numbers fail validation.
 
 **Return convention:** outputs are return-object keys. Atomic never infers child workflow outputs from stage names, stage order, or the final assistant message. If a parent should read `child.outputs.foo`, the child workflow's `.run()` must both declare `.output("foo", schema)` and return `{ foo: value }`. `result` is not special and is never added for you: to expose `result`, declare `.output("result", schema)` and return `{ result }` exactly like any other output. Returning a key that is not declared with `.output(...)` fails the run with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it with .output("<key>", Type....) or remove it from the .run() return`.
 
@@ -1065,7 +1069,7 @@ export default defineWorkflow("review-with-summary")
   .compile();
 ```
 
-There is no automatic `result` output. A workflow exposes exactly the keys it declares with `.output(...)` and returns from `.run()` — nothing more. To expose `result`, declare `.output("result", schema)` and return `{ result }` like any other output. If `.run()` returns a key that was never declared with `.output(...)`, the run fails with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it with .output("<key>", Type....) or remove it from the .run() return` (the child-call variant reports `... child "<alias>" returned undeclared output "<key>" from "<childName>"`).
+There is no automatic `result` output. A workflow exposes exactly the keys it declares with `.output(...)` and returns from `.run()` — nothing more. To expose `result`, declare `.output("result", schema)` and return `{ result }` like any other output. If `.run()` returns a key that was never declared with `.output(...)`, the run fails with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it with .output("<key>", Type....) or remove it from the .run() return` (for a child workflow call, `<name>` is the child's own name, and the parent surfaces the failure through the child-failure wrapper `atomic-workflows: child workflow "<childName>" (<displayName>) failed with status failed: ...`).
 
 Outputs are declared with TypeBox `Type.*` schemas passed to `.output(key, schema)`. **Prefer precise schemas.** A precise schema gives a precise `Static<>` type for the `.run()` return and for any parent reading `child.outputs`, and it makes runtime validation enforce the real shape instead of waving values through. Reach for `Type.Unknown()`, `Type.Any()`, `Type.Array(Type.Unknown())`, or `Type.Object({}, { additionalProperties: true })` only for genuinely dynamic data whose shape you cannot know ahead of time.
 
@@ -1109,16 +1113,16 @@ The same rule applies to inputs: `.input("counts", Type.Array(Type.Number()))` m
 
 #### `Type.Unsafe<T>()` escape hatch for deeply-nested values
 
-When you already have a precise TypeScript interface for a deeply-nested serializable value and don't want to hand-write the equivalent TypeBox schema, wrap a permissive runtime schema with `Type.Unsafe<MyInterface>(...)`. The **static** type becomes exactly `MyInterface` (so `ctx.inputs`, the `.run()` return, and `child.outputs` stay precise), while the **runtime** check stays as lenient as the wrapped schema:
+When you already have a precise TypeScript type for a deeply-nested serializable value and don't want to hand-write the equivalent TypeBox schema, wrap a permissive runtime schema with `Type.Unsafe<MyType>(...)`. The **static** type becomes exactly `MyType` (so `ctx.inputs`, the `.run()` return, and `child.outputs` stay precise), while the **runtime** check stays as lenient as the wrapped schema. Use a `type` alias rather than an `interface` for the wrapped type — an `interface` has no implicit index signature, so it does not satisfy the serializable-output constraint:
 
 ```ts
 import { defineWorkflow, Type } from "@bastani/workflows";
 
-interface ResearchPacket {
+type ResearchPacket = {
   readonly topic: string;
   readonly score: number;
   readonly sections: readonly { readonly heading: string; readonly body: string }[];
-}
+};
 
 export default defineWorkflow("research-packet")
   .input("topic", Type.String())
@@ -1233,7 +1237,7 @@ export default defineWorkflow("research-then-implement")
       description: "Use goal for bounded changes or Ralph for broad spec-to-PR work.",
     }),
   )
-  .output("research_doc_path", Type.String({ description: "Path to the deep-research document used for implementation." }))
+  .output("research_doc_path", Type.Optional(Type.String({ description: "Path to the deep-research document used for implementation." })))
   .output("runner", Type.String({ description: "Which nested runner executed: \"goal\" or \"ralph\"." }))
   // Genuinely dynamic: the nested runner (goal vs ralph) is chosen at runtime and
   // each exposes a different declared output shape, so a loose object is appropriate here.
@@ -1304,7 +1308,7 @@ child.outputs.summary; // declared by sharedResearch.output("summary", ...)
 child.outputs.sources; // declared by sharedResearch.output("sources", ...)
 ```
 
-A child exposes exactly its declared outputs — the keys it declared with `.output(...)` and returned from `.run()`. There are no implicit outputs and no raw return-object passthrough. If `.run()` returns a key that was not declared with `.output(...)`, the child call fails with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it with .output("<key>", Type....) or remove it from the .run() return` (surfaced through the parent as `... child "<alias>" returned undeclared output "<key>" from "<childName>"`). A child with no declared outputs therefore exposes no outputs. Missing required outputs, schema type mismatches, and non-JSON-serializable returned values fail the child workflow call before the parent continues.
+A child exposes exactly its declared outputs — the keys it declared with `.output(...)` and returned from `.run()`. There are no implicit outputs and no raw return-object passthrough. If `.run()` returns a key that was not declared with `.output(...)`, the child run fails with `atomic-workflows: workflow "<childName>" returned undeclared output "<key>"; declare it with .output("<key>", Type....) or remove it from the .run() return`, and the parent surfaces that failure through the wrapper `atomic-workflows: child workflow "<childName>" (<displayName>) failed with status failed: ...`. A child with no declared outputs therefore exposes no outputs. Missing required outputs, schema type mismatches, and non-JSON-serializable returned values fail the child workflow call before the parent continues.
 
 Only compiled workflow definitions can be passed to `ctx.workflow(...)`. Import reusable workflows with TypeScript `import` statements first; use `/workflow` names such as `goal` only for launching named runs, not as `ctx.workflow(...)` arguments. If a module is missing or does not export a compiled workflow definition, workflow discovery fails when loading that module. Nested child workflows count against `maxDepth` (default `4` total workflow levels).
 

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -273,9 +273,9 @@ export default defineWorkflow("fallback-review")
   .description("Review with a model fallback chain.")
   .input("topic", Type.String())
   .output("review", Type.String({ description: "Reviewer output text." }))
-  .output("model", Type.String({ description: "Model that produced the review." }))
-  .output("attemptedModels", Type.Array(Type.String(), { description: "Models tried, in fallback order." }))
-  .output("modelAttempts", Type.Array(Type.Unknown(), { description: "Per-attempt model fallback details." }))
+  .output("model", Type.Optional(Type.String({ description: "Model that produced the review." })))
+  .output("attemptedModels", Type.Optional(Type.Array(Type.String(), { description: "Models tried, in fallback order." })))
+  .output("modelAttempts", Type.Optional(Type.Array(Type.Unknown(), { description: "Per-attempt model fallback details." })))
   .run(async (ctx) => {
     const review = await ctx.task("reviewer", {
       prompt: `Review this topic: ${String(ctx.inputs.topic)}`,
@@ -286,8 +286,8 @@ export default defineWorkflow("fallback-review")
     return {
       review: review.text,
       model: review.model,
-      attemptedModels: review.attemptedModels,
-      modelAttempts: review.modelAttempts,
+      attemptedModels: review.attemptedModels ? [...review.attemptedModels] : undefined,
+      modelAttempts: review.modelAttempts ? [...review.modelAttempts] : undefined,
     };
   })
   .compile();
@@ -362,7 +362,7 @@ A required input is any schema that is neither `Type.Optional(...)` nor carries 
 
 ### Output types
 
-Declare outputs with `.output(key, schema?)` when a workflow result should be part of its runtime contract, especially when another workflow will call it as a child. Lead with the most precise schema you can express — the loose rows at the bottom are last resorts for genuinely dynamic data.
+Declare outputs with `.output(key, schema)` when a workflow result should be part of its runtime contract, especially when another workflow will call it as a child. Lead with the most precise schema you can express — the loose rows at the bottom are last resorts for genuinely dynamic data.
 
 | Schema                                              | Runtime value accepted                              |
 | --------------------------------------------------- | --------------------------------------------------- |
@@ -399,16 +399,16 @@ A loose schema types the value as `unknown`/`Record<string, unknown>` everywhere
 
 #### `Type.Unsafe<T>()` escape hatch
 
-When you already have a precise TypeScript interface for a deeply-nested serializable value and don't want to hand-write the full TypeBox schema, wrap a permissive runtime schema with `Type.Unsafe<MyInterface>(...)`. The **static** type becomes exactly `MyInterface` (so `ctx.inputs`, the `.run()` return, and `child.outputs` stay precise), while the **runtime** stays as lenient as the wrapped schema:
+When you already have a precise TypeScript type for a deeply-nested serializable value and don't want to hand-write the full TypeBox schema, wrap a permissive runtime schema with `Type.Unsafe<MyType>(...)`. The **static** type becomes exactly `MyType` (so `ctx.inputs`, the `.run()` return, and `child.outputs` stay precise), while the **runtime** stays as lenient as the wrapped schema. Use a `type` alias rather than an `interface` for the wrapped type — an `interface` has no implicit index signature, so it does not satisfy the serializable-output constraint:
 
 ```typescript
 import { defineWorkflow, Type } from "@bastani/workflows";
 
-interface ResearchPacket {
+type ResearchPacket = {
   readonly topic: string;
   readonly score: number;
   readonly sections: readonly { readonly heading: string; readonly body: string }[];
-}
+};
 
 export default defineWorkflow("research-packet")
   .input("topic", Type.String())
@@ -460,7 +460,7 @@ Input overrides are bare `key=value` tokens (no leading `--`). Values are JSON-p
 
 Workflows always run as **background tasks** in interactive sessions — the chat editor stays free while a run executes. Press **F2** (or `/workflow connect <run-id>`) to attach to the live graph viewer; HIL prompts (`ctx.ui.input/confirm/select/editor`) appear as awaiting-input graph nodes. Press Enter on the node to answer locally, never as a modal dialog over the chat. Human input is detected when those runtime `ctx.ui.*` calls execute; workflows no longer have a declaration-time HIL flag.
 
-Nested `ctx.workflow(...)` calls are displayed as an expanded graph within the top-level run. `/workflow status` and run pickers list only top-level user-launched workflows, not implementation-owned child runs. `/workflow stages`, `/workflow stage`, `/workflow transcript`, `send`, `pause`, `interrupt`, and `resume` can still target visible child stage ids, prefixes, or names from the expanded graph; Atomic routes the control action to the owning nested run internally.
+Nested `ctx.workflow(...)` calls are displayed as an expanded graph within the top-level run. `/workflow status` and run pickers list only top-level user-launched workflows, not implementation-owned child runs. The `workflow` tool's `stages`, `stage`, `transcript`, `send`, `pause`, `interrupt`, and `resume` actions can still target visible child stage ids, prefixes, or names from the expanded graph; Atomic routes the control action to the owning nested run internally. (`stages`, `stage`, `transcript`, and `send` are `workflow` tool actions, not `/workflow` slash subcommands; the slash command exposes `connect`, `attach`, `pause`, `list`, `status`, `interrupt`, `kill`, `resume`, `reload`, and `inputs`.)
 
 Prompt answer replay is live-memory only. `StageSnapshot.promptAnswerState` reports whether continuation can replay a prompt answer (`available`), must ask again because the private ledger entry is gone (`unavailable`), or must ask again because multiple matching prompt nodes are ambiguous (`ambiguous`). Raw answers stay in a private `PromptAnswerRecord` ledger, are never serialized to snapshots or persistence, and remain resident in memory until the answer is cleared, the run is removed, or the store is cleared. Replay keys include prompt kind, message text, select choices, input/editor initial value, and hashed author callsite, so changing any of those inputs may intentionally re-ask on continuation. Empty `ctx.ui.select(..., [])` calls throw before creating a prompt node.
 
@@ -490,7 +490,16 @@ Prompt answer replay is live-memory only. `StageSnapshot.promptAnswerState` repo
     "promptId": "optional pending prompt identifier for send/answer",
     "reason": "optional human-readable reload reason",
     "all": "optional boolean for pause/interrupt/kill all; cannot be combined with stageId",
-    "task/tasks/chain": "optional direct workflow-native orchestration modes"
+    "task": "optional direct task object (name + prompt/task) or root task string for direct chain/parallel runs",
+    "tasks": "optional array of direct task objects (parallel direct run)",
+    "chain": "optional array of direct task objects and/or { parallel: [...] } groups (sequential direct run)",
+    "chainName": "optional label for a direct chain run",
+    "concurrency": "optional parallelism limit for direct tasks/chain",
+    "failFast": "optional fail-fast toggle for direct parallel work",
+    "async": "optional boolean to dispatch a run in the background",
+    "intercom": "optional intercom coordination options",
+    "chainDir": "optional directory for direct chain artifacts",
+    "session/task options": "per-stage overrides also accepted at the top level and on direct task items — model, thinkingLevel, fallbackModels, tools, noTools, customTools, mcp, context, cwd, output, outputMode, reads, worktree, gitWorktreeDir, baseBranch, maxOutput, artifacts, and more"
   }
 }
 ```
@@ -574,7 +583,7 @@ Goal Runner workflow: initialize a persisted goal ledger with a per-run goal id 
 
 `goal` defaults to 10 worker/review turns. Reviewer quorum is fixed internally at 2 reviewer `complete` votes. The repeated-blocker threshold defaults to 3 consecutive same-blocker turns and is clamped to `max_turns` when you run fewer than 3 turns.
 
-Child workflow outputs: `result`, `status`, `approved`, `goal_id`, `objective`, `ledger_path`, `turns_completed`, `iterations_completed`, `receipts`, `remaining_work`, and `review_report`.
+Child workflow outputs: `result`, `status`, `approved`, `goal_id`, `objective`, `ledger_path`, `turns_completed`, `iterations_completed`, `receipts`, `remaining_work`, `review_report`, and `review_report_path`.
 
 ### `ralph`
 


### PR DESCRIPTION
## Summary

Refreshes stale workflow documentation in `packages/coding-agent/docs/workflows.md` and `packages/workflows/README.md`, correcting prose inaccuracies and fixing 4 genuine type errors found in complete code examples by compiling them against the shipped `@bastani/workflows` type surface.

## Changes

### Content fixes
- Rename **"Codex Fast Mode for Workflow Stages" → "Fast Inference for Workflow Stages"** with Codex as a nested subheading; update TOC anchor accordingly.
- Correct `.output(key, schema?)` → `.output(key, schema)` throughout — the schema argument is required.
- Replace the nonexistent child undeclared-output error variant (`child "<alias>" returned undeclared output … from "<childName>"`) with the real child-failure wrapper the executor emits: `atomic-workflows: child workflow "<childName>" (<displayName>) failed with status failed: …`.
- Add the missing **`review_report_path`** output to the `goal` builtin description.
- Clarify that `stages` / `stage` / `transcript` / `send` are **`workflow` tool actions, not `/workflow` slash subcommands**, and expand the tool's parameter table (direct-mode fields + session/task per-stage overrides).

### Type-check fixes (validated against dist authoring surface via `@bastani/atomic/workflows/ambient`)
- **`Type.Unsafe<T>()` research-packet example**: use a `type` alias instead of an `interface` — interfaces have no implicit index signature and do not satisfy the serializable-output constraint; document the gotcha.
- **fallback-review example**: declare the optional `model`/`attemptedModels`/`modelAttempts` outputs with `Type.Optional(...)` and spread the `readonly` arrays in the return.
- **research-then-implement example**: declare `research_doc_path` as `Type.Optional(...)` to match the optional child output.

## Notes

- Verification: extracted all fenced TypeScript blocks from both docs and compiled the **21 complete `defineWorkflow(...).compile()` examples** against the shipped SDK types via a throwaway harness (`moduleResolution: NodeNext` + `types: ["@bastani/atomic/workflows/ambient"]`). First pass found 4 genuine consumer-facing type errors; all now pass. The harness was removed and is not part of this PR.
- Docs-only change — no source or runtime behavior is modified.
- prek hooks (lint + unit tests) passed locally on commit.