### PR TITLE
chore(release): bump prerelease to 0.8.25-alpha.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.24",
+      "version": "0.8.25-alpha.1",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.24",
+      "version": "0.8.25-alpha.1",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.24",
+      "version": "0.8.25-alpha.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.24",
+      "version": "0.8.25-alpha.1",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.24",
+      "version": "0.8.25-alpha.1",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.24",
+      "version": "0.8.25-alpha.1",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.25-alpha.1] - 2026-06-04
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.25-alpha.1 prerelease.
+
 ## [0.8.24] - 2026-06-04
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.24",
+  "version": "0.8.25-alpha.1",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.25-alpha.1] - 2026-06-04
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.25-alpha.1 prerelease.
+
 ## [0.8.24] - 2026-06-04
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.24",
+  "version": "0.8.25-alpha.1",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.25-alpha.1] - 2026-06-04
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.25-alpha.1 prerelease.
+
 ## [0.8.24] - 2026-06-04
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.24",
+  "version": "0.8.25-alpha.1",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.25-alpha.1] - 2026-06-04
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.25-alpha.1 prerelease.
+
 ## [0.8.24] - 2026-06-04
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.24",
+  "version": "0.8.25-alpha.1",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.25-alpha.1] - 2026-06-04
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.25-alpha.1 prerelease.
+
 ## [0.8.24] - 2026-06-04
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.24",
+  "version": "0.8.25-alpha.1",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.25-alpha.1] - 2026-06-04
+
 ### Fixed
 
 - Fixed the interactive workflow inputs selector so it hides the working loader while replacing the editor, keeping the picker pinned to the bottom like `ask_user_question` without wedged host chrome ([#1224](https://github.com/bastani-inc/atomic/issues/1224)).

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.24",
+  "version": "0.8.25-alpha.1",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepares the **0.8.25-alpha.1** prerelease across all workspace packages.

## Key Changes

- Bumps all workspace package versions `0.8.24` → `0.8.25-alpha.1` (`coding-agent`, `workflows`, `subagents`, `mcp`, `web-access`, `intercom`)
- Refreshes `bun.lock` to reflect updated versions
- Updates each package `CHANGELOG.md` with a `0.8.25-alpha.1` release section:
  - `@bastani/workflows`: promotes the unreleased interactive inputs-selector fix ([#1224](https://github.com/bastani-inc/atomic/issues/1224)) — hides the working loader while replacing the editor, keeping the picker pinned to the bottom like `ask_user_question`
  - All other packages: version-bump note under `### Changed`

## Release Notes

After this merges, push the `0.8.25-alpha.1` tag to trigger the publish workflow:

```sh
git tag 0.8.25-alpha.1
git push origin 0.8.25-alpha.1
```

No breaking changes. No migration required.