### PR TITLE
chore(release): bump release to 0.8.25

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.25] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.25 prerelease package version to a stable release.
+
 ## [0.8.25-alpha.1] - 2026-06-04
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.25-alpha.1",
+  "version": "0.8.25",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.25] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.25 prerelease package version to a stable release.
+
 ## [0.8.25-alpha.1] - 2026-06-04
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.25-alpha.1",
+  "version": "0.8.25",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.25] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.25 prerelease package version to a stable release.
+
 ## [0.8.25-alpha.1] - 2026-06-04
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.25-alpha.1",
+  "version": "0.8.25",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.25] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.25 prerelease package version to a stable release.
+
 ## [0.8.25-alpha.1] - 2026-06-04
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.25-alpha.1",
+  "version": "0.8.25",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.25] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.25 prerelease package version to a stable release.
+
 ## [0.8.25-alpha.1] - 2026-06-04
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.25-alpha.1",
+  "version": "0.8.25",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.25] - 2026-06-04
+
+### Changed
+
+- Promoted the 0.8.25 prerelease package version to a stable release.
+
 ## [0.8.25-alpha.1] - 2026-06-04
 
 ### Fixed

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.25-alpha.1",
+  "version": "0.8.25",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes **0.8.25-alpha.1** to the stable **0.8.25** release across all workspace packages.

## Changes

- Bumps all workspace package versions `0.8.25-alpha.1` → `0.8.25`:
  - `@bastani/atomic` (`packages/coding-agent`)
  - `@bastani/workflows` (`packages/workflows`)
  - `@bastani/subagents` (`packages/subagents`)
  - `@bastani/mcp` (`packages/mcp`)
  - `@bastani/web-access` (`packages/web-access`)
  - `@bastani/intercom` (`packages/intercom`)
- Adds `[0.8.25] - 2026-06-04` stable section to each package `CHANGELOG.md`

## Release Notes

After this merges to `main`, push the `0.8.25` tag to trigger the publish workflow:

```sh
git tag 0.8.25
git push origin 0.8.25
```

This will publish `@bastani/atomic@0.8.25` to npm (`latest` tag) with OIDC provenance and attach cross-compiled binaries to the GitHub Release.