### PR TITLE
perf(startup): lazy-load bundled extensions for faster cold start

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved Windows cold startup by lazily loading heavy bundled web-access/intercom/MCP implementation modules, moving fd/rg readiness checks after the first interactive frame, and adding detailed startup timing spans ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
 ## [0.8.25] - 2026-06-04
 
 ### Changed

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -10,6 +10,7 @@ import { DefaultResourceLoader, type DefaultResourceLoaderOptions, type Resource
 import { type CreateAgentSessionOptions, type CreateAgentSessionResult, createAgentSession } from "./sdk.ts";
 import type { SessionManager } from "./session-manager.ts";
 import { SettingsManager } from "./settings-manager.ts";
+import { endTimingSpan, startTimingSpan } from "./timings.ts";
 
 /**
  * Non-fatal issues collected while creating services or sessions.
@@ -133,18 +134,27 @@ export async function createAgentSessionServices(
 ): Promise<AgentSessionServices> {
 	const cwd = resolvePath(options.cwd);
 	const agentDir = options.agentDir ? resolvePath(options.agentDir) : getAgentDir();
+	const authStorageSpan = startTimingSpan("createAgentSessionServices.authStorage");
 	const authStorage = options.authStorage ?? AuthStorage.create(join(agentDir, "auth.json"));
+	endTimingSpan(authStorageSpan);
+	const settingsSpan = startTimingSpan("createAgentSessionServices.settingsManager");
 	const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+	endTimingSpan(settingsSpan);
+	const modelRegistrySpan = startTimingSpan("createAgentSessionServices.modelRegistry");
 	const modelRegistry = options.modelRegistry ?? ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+	endTimingSpan(modelRegistrySpan);
 	const resourceLoader = new DefaultResourceLoader({
 		...(options.resourceLoaderOptions ?? {}),
 		cwd,
 		agentDir,
 		settingsManager,
 	});
+	const reloadSpan = startTimingSpan("createAgentSessionServices.resourceLoader.reload");
 	await resourceLoader.reload();
+	endTimingSpan(reloadSpan);
 
 	const diagnostics: AgentSessionRuntimeDiagnostic[] = [];
+	const providerSpan = startTimingSpan("createAgentSessionServices.providerRegistrations");
 	const extensionsResult = resourceLoader.getExtensions();
 	for (const { name, config, extensionPath } of extensionsResult.runtime.pendingProviderRegistrations) {
 		try {
@@ -158,7 +168,10 @@ export async function createAgentSessionServices(
 		}
 	}
 	extensionsResult.runtime.pendingProviderRegistrations = [];
+	endTimingSpan(providerSpan);
+	const flagSpan = startTimingSpan("createAgentSessionServices.extensionFlagValidation");
 	diagnostics.push(...applyExtensionFlagValues(resourceLoader, options.extensionFlagValues));
+	endTimingSpan(flagSpan);
 
 	return {
 		cwd,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -35,6 +35,7 @@ import type { ExecOptions } from "../exec.ts";
 import type { ResolvedResource } from "../package-manager.ts";
 import { execCommand } from "../exec.ts";
 import { createSyntheticSourceInfo } from "../source-info.ts";
+import { endTimingSpan, startTimingSpan } from "../timings.ts";
 import type {
   Extension,
   ExtensionAPI,
@@ -464,7 +465,9 @@ async function loadExtension(
   const resolvedPath = resolvePath(extensionPath, cwd, { normalizeUnicodeSpaces: true });
 
   try {
+    const moduleSpan = startTimingSpan(`loadExtensions.${extensionPath}.module`);
     const factory = await loadExtensionModule(resolvedPath);
+    endTimingSpan(moduleSpan);
     if (!factory) {
       return {
         extension: null,
@@ -480,7 +483,9 @@ async function loadExtension(
       eventBus,
       workflowResourceProvider,
     );
+    const factorySpan = startTimingSpan(`loadExtensions.${extensionPath}.factory`);
     await factory(api);
+    endTimingSpan(factorySpan);
 
     return { extension, error: null };
   } catch (err) {
@@ -529,6 +534,7 @@ export async function loadExtensions(
   const runtime = createExtensionRuntime();
 
   for (const extPath of paths) {
+    const extensionSpan = startTimingSpan(`loadExtensions.${extPath}.total`);
     const { extension, error } = await loadExtension(
       extPath,
       resolvedCwd,
@@ -536,6 +542,7 @@ export async function loadExtensions(
       runtime,
       workflowResourceProvider,
     );
+    endTimingSpan(extensionSpan);
 
     if (error) {
       errors.push({ path: extPath, error });

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -23,6 +23,7 @@ import { SettingsManager } from "./settings-manager.ts";
 import type { Skill } from "./skills.ts";
 import { loadSkills } from "./skills.ts";
 import { createSourceInfo, type SourceInfo } from "./source-info.ts";
+import { endTimingSpan, startTimingSpan } from "./timings.ts";
 
 export interface ResourceExtensionPaths {
 	skillPaths?: Array<{ path: string; metadata: PathMetadata }>;
@@ -349,7 +350,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 	}
 
 	async reload(): Promise<void> {
+		const resolveSpan = startTimingSpan("DefaultResourceLoader.reload.resolvePackageResourcePaths");
 		const { resolvedPaths, cliExtensionPaths, builtinPackagePaths } = await this.resolvePackageResourcePaths();
+		endTimingSpan(resolveSpan);
 		const metadataByPath = new Map<string, PathMetadata>();
 
 		this.extensionSkillSourceInfos = new Map();
@@ -436,8 +439,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 			? cliEnabledExtensions
 			: this.mergePaths(cliEnabledExtensions, [...enabledExtensions, ...builtinEnabledExtensions]);
 
+		const loadExtensionsSpan = startTimingSpan("DefaultResourceLoader.reload.loadExtensions");
 		const extensionsResult = await loadExtensions(extensionPaths, this.cwd, this.eventBus, workflowResourceProvider);
+		endTimingSpan(loadExtensionsSpan);
+		const inlineExtensionsSpan = startTimingSpan("DefaultResourceLoader.reload.loadInlineExtensionFactories");
 		const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime, workflowResourceProvider);
+		endTimingSpan(inlineExtensionsSpan);
 		extensionsResult.extensions.push(...inlineExtensions.extensions);
 		extensionsResult.errors.push(...inlineExtensions.errors);
 
@@ -467,7 +474,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 				);
 
 		this.lastSkillPaths = skillPaths;
+		const skillsSpan = startTimingSpan("DefaultResourceLoader.reload.updateSkillsFromPaths");
 		this.updateSkillsFromPaths(skillPaths, metadataByPath);
+		endTimingSpan(skillsSpan);
 		for (const p of this.additionalSkillPaths) {
 			if (isLocalPath(p)) {
 				const resolved = this.resolveResourcePath(p);
@@ -485,7 +494,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 				);
 
 		this.lastPromptPaths = promptPaths;
+		const promptsSpan = startTimingSpan("DefaultResourceLoader.reload.updatePromptsFromPaths");
 		this.updatePromptsFromPaths(promptPaths, metadataByPath);
+		endTimingSpan(promptsSpan);
 		for (const p of this.additionalPromptTemplatePaths) {
 			if (isLocalPath(p)) {
 				const resolved = this.resolveResourcePath(p);
@@ -507,7 +518,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 				);
 
 		this.lastThemePaths = themePaths;
+		const themesSpan = startTimingSpan("DefaultResourceLoader.reload.updateThemesFromPaths");
 		this.updateThemesFromPaths(themePaths, metadataByPath);
+		endTimingSpan(themesSpan);
 		for (const p of this.additionalThemePaths) {
 			const resolved = this.resolveResourcePath(p);
 			if (!existsSync(resolved) && !this.themeDiagnostics.some((d) => d.path === resolved)) {
@@ -515,12 +528,15 @@ export class DefaultResourceLoader implements ResourceLoader {
 			}
 		}
 
+		const contextFilesSpan = startTimingSpan("DefaultResourceLoader.reload.loadProjectContextFiles");
 		const agentsFiles = {
 			agentsFiles: this.noContextFiles ? [] : loadProjectContextFiles({ cwd: this.cwd, agentDir: this.agentDir }),
 		};
+		endTimingSpan(contextFilesSpan);
 		const resolvedAgentsFiles = this.agentsFilesOverride ? this.agentsFilesOverride(agentsFiles) : agentsFiles;
 		this.agentsFiles = resolvedAgentsFiles.agentsFiles;
 
+		const promptFilesSpan = startTimingSpan("DefaultResourceLoader.reload.resolvePromptFiles");
 		const baseSystemPrompt = resolvePromptInput(
 			this.systemPromptSource ?? this.discoverSystemPromptFile(),
 			"system prompt",
@@ -536,6 +552,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.appendSystemPrompt = this.appendSystemPromptOverride
 			? this.appendSystemPromptOverride(baseAppend)
 			: baseAppend;
+		endTimingSpan(promptFilesSpan);
 	}
 
 	private emptyResolvedPaths(): ResolvedPaths {

--- a/packages/coding-agent/src/core/timings.ts
+++ b/packages/coding-agent/src/core/timings.ts
@@ -8,11 +8,22 @@ import { ENV_TIMING, getEnvValue } from "../config.ts";
 const ENABLED = getEnvValue(ENV_TIMING) === "1";
 const timings: Array<{ label: string; ms: number }> = [];
 let lastTime = Date.now();
+let resetTime = lastTime;
+
+export interface TimingSpan {
+	label: string;
+	start: number;
+}
+
+export function isTimingEnabled(): boolean {
+	return ENABLED;
+}
 
 export function resetTimings(): void {
 	if (!ENABLED) return;
 	timings.length = 0;
 	lastTime = Date.now();
+	resetTime = lastTime;
 }
 
 export function time(label: string): void {
@@ -22,12 +33,34 @@ export function time(label: string): void {
 	lastTime = now;
 }
 
+export function startTimingSpan(label: string): TimingSpan | null {
+	if (!ENABLED) return null;
+	return { label, start: Date.now() };
+}
+
+export function endTimingSpan(span: TimingSpan | null): void {
+	if (!ENABLED || !span) return;
+	const now = Date.now();
+	timings.push({ label: span.label, ms: now - span.start });
+	lastTime = now;
+}
+
+export function recordTiming(label: string, ms: number): void {
+	if (!ENABLED) return;
+	timings.push({ label, ms });
+}
+
+export function recordTimeSinceReset(label: string): void {
+	if (!ENABLED) return;
+	timings.push({ label, ms: Date.now() - resetTime });
+}
+
 export function printTimings(): void {
 	if (!ENABLED || timings.length === 0) return;
 	console.error("\n--- Startup Timings ---");
 	for (const t of timings) {
 		console.error(`  ${t.label}: ${t.ms}ms`);
 	}
-	console.error(`  TOTAL: ${timings.reduce((a, b) => a + b.ms, 0)}ms`);
+	console.error(`  TOTAL initialization time: ${Date.now() - resetTime}ms`);
 	console.error("------------------------\n");
 }

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -50,7 +50,7 @@ import {
 } from "./core/session-cwd.ts";
 import { SessionManager } from "./core/session-manager.ts";
 import { SettingsManager } from "./core/settings-manager.ts";
-import { printTimings, resetTimings, time } from "./core/timings.ts";
+import { endTimingSpan, printTimings, resetTimings, startTimingSpan, time } from "./core/timings.ts";
 import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
 import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.ts";
 import { ExtensionSelectorComponent } from "./modes/interactive/components/extension-selector.ts";
@@ -635,12 +635,14 @@ export async function main(args: string[], options?: MainOptions) {
 			diagnostics,
 		};
 	};
-	time("createRuntime");
+	time("createRuntimeFactory");
+	const runtimeCreationSpan = startTimingSpan("createAgentSessionRuntime");
 	const runtime = await createAgentSessionRuntime(createRuntime, {
 		cwd: sessionManager.getCwd(),
 		agentDir,
 		sessionManager,
 	});
+	endTimingSpan(runtimeCreationSpan);
 	const { services, session, modelFallbackMessage } = runtime;
 	const { settingsManager, modelRegistry, resourceLoader } = services;
 	configureHttpDispatcher(settingsManager.getHttpIdleTimeoutMs());

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -133,6 +133,7 @@ import { parseGitUrl } from "../../utils/git.ts";
 import { getCwdRelativePath } from "../../utils/paths.ts";
 import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
 import { killTrackedDetachedChildren } from "../../utils/shell.ts";
+import { recordTimeSinceReset } from "../../core/timings.ts";
 import { ensureTool } from "../../utils/tools-manager.ts";
 import { checkForNewPiVersion } from "../../utils/version-check.ts";
 import { ArminComponent } from "./components/armin.ts";
@@ -748,11 +749,6 @@ export class InteractiveMode {
     // Load changelog (only show new entries, skip for resumed sessions)
     this.changelogMarkdown = this.getChangelogForDisplay();
 
-    // Ensure fd and rg are available (downloads if missing, adds to PATH via getBinDir)
-    // Both are needed: fd for autocomplete, rg for grep tool and bash commands
-    const [fdPath] = await Promise.all([ensureTool("fd"), ensureTool("rg")]);
-    this.fdPath = fdPath;
-
     // Add header container as first child
     this.ui.addChild(this.headerContainer);
 
@@ -799,9 +795,22 @@ export class InteractiveMode {
     this.setupKeyHandlers();
     this.setupEditorSubmitHandler();
 
-    // Start the UI before initializing extensions so session_start handlers can use interactive dialogs
+    // Start the UI before initializing extensions so session_start handlers can use interactive dialogs.
+    // fd/rg readiness is intentionally checked after first paint because ensureTool may spawn
+    // or download tools on cold machines.
     this.ui.start();
+    recordTimeSinceReset("time-to-first-frame");
     this.isInitialized = true;
+
+    void Promise.all([ensureTool("fd"), ensureTool("rg")])
+      .then(([fdPath]) => {
+        this.fdPath = fdPath;
+        this.setupAutocompleteProvider();
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Tool readiness check failed: ${message}`);
+      });
 
     // Initialize extensions first so resources are shown before messages
     await this.rebindCurrentSession();
@@ -821,8 +830,11 @@ export class InteractiveMode {
       this.ui.requestRender();
     });
 
-    // Initialize available provider count for footer display
-    await this.updateAvailableProviderCount();
+    // Initialize available provider count for footer display without delaying first-frame startup.
+    void this.updateAvailableProviderCount().catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Failed to update provider count: ${message}`);
+    });
   }
 
   /**

--- a/packages/coding-agent/test/suite/regressions/1223-startup-lazy-builtins.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1223-startup-lazy-builtins.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = resolve(__dirname, "../../../../..");
+
+function readRepoFile(path: string): string {
+	return readFileSync(resolve(repoRoot, path), "utf-8");
+}
+
+function staticImportSpecifiers(source: string): string[] {
+	return [...source.matchAll(/^import\s+(?:type\s+)?(?:[\s\S]*?)\s+from\s+["']([^"']+)["'];/gm)]
+		.filter((match) => !match[0].startsWith("import type"))
+		.map((match) => match[1]);
+}
+
+function textBeforeLoadHeavy(source: string): string {
+	const loadHeavyIndex = source.indexOf("async function loadHeavy");
+	expect(loadHeavyIndex).toBeGreaterThan(-1);
+	return source.slice(0, loadHeavyIndex);
+}
+
+function dynamicHeavyImportCount(source: string): number {
+	return [...source.matchAll(/import\(["']\.\/index-heavy\.js["']\)/g)].length;
+}
+
+function assertColdRegistrationDoesNotImportHeavy(packagePath: string): void {
+	const tempDir = mkdtempSync(join(tmpdir(), "atomic-lazy-builtins-"));
+	const sentinelPath = join(tempDir, "heavy-imports.txt");
+	try {
+		const extensionPath = resolve(repoRoot, packagePath);
+		const loaderUrl = pathToFileURL(resolve(repoRoot, "packages/coding-agent/src/core/extensions/loader.ts")).href;
+		const script = `
+const { loadExtensions } = await import(${JSON.stringify(loaderUrl)});
+const result = await loadExtensions([${JSON.stringify(extensionPath)}], ${JSON.stringify(repoRoot)});
+if (result.errors.length > 0) throw new Error(JSON.stringify(result.errors));
+await new Promise((resolve) => setTimeout(resolve, 250));
+`;
+		const result = spawnSync("bun", ["--eval", script], {
+			cwd: repoRoot,
+			env: {
+				...process.env,
+				ATOMIC_TEST_LAZY_IMPORT_SENTINEL_FILE: sentinelPath,
+			},
+			encoding: "utf-8",
+		});
+
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+		expect(existsSync(sentinelPath)).toBe(false);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+function assertMcpColdStartupTools(options: { withCache: boolean; expectedTools: string[] }): void {
+	const tempDir = mkdtempSync(join(tmpdir(), "atomic-mcp-startup-"));
+	const agentDir = join(tempDir, "agent");
+	try {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(join(agentDir, "mcp.json"), JSON.stringify({
+			settings: { disableProxyTool: true },
+			mcpServers: {
+				demo: {
+					command: "bun",
+					args: ["--version"],
+					directTools: true,
+				},
+			},
+		}, null, 2));
+
+		const mcpUrl = pathToFileURL(resolve(repoRoot, "packages/mcp/index.ts")).href;
+		const metadataUrl = pathToFileURL(resolve(repoRoot, "packages/mcp/metadata-cache.ts")).href;
+		const script = `
+const { default: mcpAdapter } = await import(${JSON.stringify(mcpUrl)});
+const { computeServerHash } = await import(${JSON.stringify(metadataUrl)});
+const { writeFileSync } = await import("node:fs");
+const { join } = await import("node:path");
+const agentDir = process.env.ATOMIC_CODING_AGENT_DIR;
+const server = { command: "bun", args: ["--version"], directTools: true };
+if (${JSON.stringify(options.withCache)}) {
+  writeFileSync(join(agentDir, "mcp-cache.json"), JSON.stringify({
+    version: 1,
+    servers: {
+      demo: {
+        configHash: computeServerHash(server),
+        tools: [{ name: "echo", description: "Echo", inputSchema: { type: "object", properties: {} } }],
+        resources: [],
+        cachedAt: Date.now()
+      }
+    }
+  }, null, 2));
+}
+const handlers = [];
+const tools = [];
+const pi = {
+  registerFlag() {},
+  registerCommand() {},
+  registerShortcut() {},
+  registerMessageRenderer() {},
+  registerTool(tool) { tools.push(tool.name); },
+  getAllTools() { return []; },
+  refreshTools() {},
+  on(event, handler) { if (event === "session_start") handlers.push(handler); },
+  events: { on() { return () => {}; }, emit() {} }
+};
+mcpAdapter(pi);
+for (const handler of handlers) {
+  await handler({ type: "session_start", reason: "new" }, { cwd: ${JSON.stringify(repoRoot)} });
+}
+console.log(JSON.stringify(tools));
+process.exit(0);
+`;
+		// The agent/subagent runtime exports MCP_DIRECT_TOOLS=__none__ for child processes,
+		// which suppresses cached direct-tool registration and would make this cold-start
+		// assertion environment-dependent (registering the proxy ['mcp'] instead of the cached
+		// direct tool). Neutralize it so the test deterministically exercises the
+		// config/cache-driven registration path regardless of the ambient environment.
+		const childEnv = {
+			...process.env,
+			ATOMIC_CODING_AGENT_DIR: agentDir,
+			PI_CODING_AGENT_DIR: "",
+		};
+		delete childEnv.MCP_DIRECT_TOOLS;
+		const result = spawnSync("bun", ["--eval", script], {
+			cwd: repoRoot,
+			env: childEnv,
+			encoding: "utf-8",
+		});
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+		expect(JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "[]")).toEqual(options.expectedTools);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+describe("regression #1223 lazy built-in startup imports", () => {
+	it("does not statically import heavy web-access provider modules from the registration surface", () => {
+		const source = readRepoFile("packages/web-access/index.ts");
+		const imports = staticImportSpecifiers(source);
+
+		expect(imports).not.toContain("@mariozechner/pi-ai");
+		expect(imports).not.toContain("./extract.js");
+		expect(imports).not.toContain("./github-extract.js");
+		expect(imports).not.toContain("./gemini-search.js");
+		expect(imports).not.toContain("./code-search.js");
+		expect(imports).not.toContain("./curator-server.js");
+		expect(imports).not.toContain("./summary-review.js");
+		expect(imports).not.toContain("./perplexity.js");
+		expect(imports).not.toContain("./exa.js");
+		expect(imports).not.toContain("./gemini-api.js");
+		expect(imports).not.toContain("./gemini-web.js");
+		expect(source).toContain('import("./index-heavy.js")');
+		expect(source).toContain('pi.on("session_start"');
+		expect(source).toContain('pi.on("session_tree"');
+		expect(source).toContain('pi.on("session_shutdown"');
+		expect(source).toContain('prop === "registerShortcut"');
+		expect(source).toContain('pi.registerShortcut(shortcut');
+		expect(source).toContain('renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "web_search", args)');
+		expect(source).not.toContain('prop === "registerShortcut" || prop === "on" || prop === "registerMessageRenderer"');
+	});
+
+	it("does not statically import heavy intercom broker or overlay modules from the registration surface", () => {
+		const source = readRepoFile("packages/intercom/index.ts");
+		const imports = staticImportSpecifiers(source);
+
+		expect(imports).not.toContain("./broker/client.ts");
+		expect(imports).not.toContain("./broker/spawn.ts");
+		expect(imports).not.toContain("./ui/session-list.ts");
+		expect(imports).not.toContain("./ui/compose.ts");
+		expect(imports).not.toContain("./ui/inline-message.ts");
+		expect(source).toContain('import("./index-heavy.js")');
+		expect(source).toContain('"session_shutdown"');
+		expect(source).toContain('"tool_execution_start"');
+		expect(source).toContain('"model_select"');
+		expect(source).toContain('prop === "registerShortcut"');
+		expect(source).toContain('pi.registerShortcut("alt+m"');
+		expect(source).toContain('SUBAGENT_CONTROL_INTERCOM_EVENT');
+		expect(source).toContain('dispatchEventHandlers(heavy, eventName, payload)');
+		expect(source).toContain('renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "intercom", args)');
+		expect(source).not.toContain('return () => undefined');
+	});
+
+	it("executes cold registration without importing heavy provider modules", () => {
+		const webSource = readRepoFile("packages/web-access/index.ts");
+		const intercomSource = readRepoFile("packages/intercom/index.ts");
+
+		expect(dynamicHeavyImportCount(webSource)).toBe(1);
+		expect(dynamicHeavyImportCount(intercomSource)).toBe(1);
+		expect(textBeforeLoadHeavy(webSource)).not.toContain('import("./index-heavy.js")');
+		expect(textBeforeLoadHeavy(intercomSource)).not.toContain('import("./index-heavy.js")');
+		expect(webSource).not.toMatch(/void\s+loadHeavy\(/);
+		expect(intercomSource).not.toMatch(/void\s+import\(["']\.\/index-heavy\.js["']\)/);
+		expect(webSource).toContain('handler: async (ctx) => {\n\t\t\t\tconst heavy = await loadHeavy();');
+		expect(intercomSource).toContain('handler: async (ctx) => {\n\t\t\tconst heavy = await loadHeavy(ctx);');
+
+		assertColdRegistrationDoesNotImportHeavy("packages/web-access/index.ts");
+		assertColdRegistrationDoesNotImportHeavy("packages/intercom/index.ts");
+	});
+
+	it("keeps the MCP proxy fallback until cached direct tools are available", () => {
+		assertMcpColdStartupTools({ withCache: false, expectedTools: ["mcp"] });
+		assertMcpColdStartupTools({ withCache: true, expectedTools: ["demo_echo"] });
+	});
+});

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Changed
+
+- Deferred broker client/spawn and overlay UI modules until intercom connects or the overlay opens, reducing default CLI startup cost ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
 ## [0.8.25] - 2026-06-04
 
 ### Changed

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -1,0 +1,1754 @@
+import type { ExtensionAPI, ExtensionContext } from "@bastani/atomic";
+import { randomUUID } from "crypto";
+import { appendFileSync } from "node:fs";
+import { Type } from "typebox";
+import { Text } from "@mariozechner/pi-tui";
+import { renderContactSupervisorResult, renderIntercomResult } from "./result-renderers.js";
+import { APP_NAME, getEnvValue } from "@bastani/atomic";
+import { IntercomClient } from "./broker/client.ts";
+import { spawnBrokerIfNeeded } from "./broker/spawn.ts";
+import { SessionListOverlay } from "./ui/session-list.ts";
+import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
+import { InlineMessageComponent } from "./ui/inline-message.ts";
+import { loadConfig, type IntercomConfig } from "./config.ts";
+import type { SessionInfo, Message, Attachment } from "./types.ts";
+import { ReplyTracker } from "./reply-tracker.ts";
+
+if (process.env.ATOMIC_TEST_LAZY_IMPORT_SENTINEL === "1") {
+  process.env.ATOMIC_INTERCOM_HEAVY_IMPORTED = "1";
+}
+
+if (process.env.ATOMIC_TEST_LAZY_IMPORT_SENTINEL_FILE) {
+  appendFileSync(process.env.ATOMIC_TEST_LAZY_IMPORT_SENTINEL_FILE, "intercom\n");
+}
+
+const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
+const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
+const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
+const INBOUND_FLUSH_DELAY_MS = 200;
+const INBOUND_IDLE_RETRY_MS = 500;
+const DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX = "subagent-chat";
+const ENV_PREFIX = APP_NAME.toUpperCase();
+const SUBAGENT_ORCHESTRATOR_TARGET_ENV = `${ENV_PREFIX}_SUBAGENT_ORCHESTRATOR_TARGET`;
+const SUBAGENT_RUN_ID_ENV = `${ENV_PREFIX}_SUBAGENT_RUN_ID`;
+const SUBAGENT_CHILD_AGENT_ENV = `${ENV_PREFIX}_SUBAGENT_CHILD_AGENT`;
+const SUBAGENT_CHILD_INDEX_ENV = `${ENV_PREFIX}_SUBAGENT_CHILD_INDEX`;
+const SUBAGENT_INTERCOM_SESSION_NAME_ENV = `${ENV_PREFIX}_SUBAGENT_INTERCOM_SESSION_NAME`;
+
+interface ChildOrchestratorMetadata {
+  orchestratorTarget: string;
+  runId: string;
+  agent: string;
+  index: string;
+  sessionName?: string;
+}
+
+interface InboundMessageEntry {
+  from: SessionInfo;
+  message: Message;
+  replyCommand?: string;
+  bodyText: string;
+}
+
+type ContactSupervisorReason = "need_decision" | "progress_update" | "interview_request";
+
+interface SupervisorInterviewQuestion extends Record<string, unknown> {
+  id: string;
+  type: "single" | "multi" | "text" | "image" | "info";
+  question: string;
+  options?: unknown[];
+}
+
+interface SupervisorInterviewRequest extends Record<string, unknown> {
+  title?: string;
+  description?: string;
+  questions: SupervisorInterviewQuestion[];
+}
+
+interface SupervisorInterviewReply {
+  responses: Array<{ id: string; value: unknown }>;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function formatAttachments(attachments: Attachment[]): string {
+  let text = "";
+  for (const att of attachments) {
+    if (att.language) {
+      text += `\n\n---\n📎 ${att.name}\n~~~${att.language}\n${att.content}\n~~~`;
+    } else {
+      text += `\n\n---\n📎 ${att.name}\n${att.content}`;
+    }
+  }
+  return text;
+}
+function readChildOrchestratorMetadata(): ChildOrchestratorMetadata | null {
+  const orchestratorTarget = getEnvValue(SUBAGENT_ORCHESTRATOR_TARGET_ENV)?.trim();
+  const runId = getEnvValue(SUBAGENT_RUN_ID_ENV)?.trim();
+  const agent = getEnvValue(SUBAGENT_CHILD_AGENT_ENV)?.trim();
+  const index = getEnvValue(SUBAGENT_CHILD_INDEX_ENV)?.trim();
+  if (!orchestratorTarget || !runId || !agent || !index) {
+    return null;
+  }
+  const sessionName = getEnvValue(SUBAGENT_INTERCOM_SESSION_NAME_ENV)?.trim();
+  return {
+    orchestratorTarget,
+    runId,
+    agent,
+    index,
+    ...(sessionName ? { sessionName } : {}),
+  };
+}
+function formatChildOrchestratorMessage(kind: "ask" | "update" | "interview", metadata: ChildOrchestratorMetadata, message: string): string {
+  const heading = kind === "ask"
+    ? "Subagent needs a supervisor decision."
+    : kind === "interview"
+      ? "Subagent requests a structured supervisor interview."
+      : "Subagent progress update.";
+  return [
+    heading,
+    `Run: ${metadata.runId}`,
+    `Agent: ${metadata.agent}`,
+    `Child index: ${metadata.index}`,
+    metadata.sessionName ? `Child intercom target: ${metadata.sessionName}` : undefined,
+    "",
+    message,
+  ].filter((line): line is string => line !== undefined).join("\n");
+}
+
+function validateSupervisorInterviewRequest(input: unknown): { ok: true; interview: SupervisorInterviewRequest } | { ok: false; error: string } {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, error: "interview must be an object with a questions array" };
+  }
+
+  const raw = input as Record<string, unknown>;
+  if (raw.title !== undefined && typeof raw.title !== "string") {
+    return { ok: false, error: "interview.title must be a string when provided" };
+  }
+  if (raw.description !== undefined && typeof raw.description !== "string") {
+    return { ok: false, error: "interview.description must be a string when provided" };
+  }
+  if (!Array.isArray(raw.questions) || raw.questions.length === 0) {
+    return { ok: false, error: "interview.questions must be a non-empty array" };
+  }
+
+  const validTypes = new Set(["single", "multi", "text", "image", "info"]);
+  const ids = new Set<string>();
+  const questions: SupervisorInterviewQuestion[] = [];
+
+  for (let index = 0; index < raw.questions.length; index++) {
+    const questionInput = raw.questions[index];
+    if (!questionInput || typeof questionInput !== "object" || Array.isArray(questionInput)) {
+      return { ok: false, error: `interview.questions[${index}] must be an object` };
+    }
+    const question = questionInput as Record<string, unknown>;
+    if (typeof question.id !== "string" || question.id.trim() === "") {
+      return { ok: false, error: `interview.questions[${index}].id must be a non-empty string` };
+    }
+    const id = question.id.trim();
+    if (ids.has(id)) {
+      return { ok: false, error: `interview question id must be unique: ${id}` };
+    }
+    ids.add(id);
+
+    if (typeof question.type !== "string" || !validTypes.has(question.type)) {
+      return { ok: false, error: `interview.questions[${index}].type must be one of: single, multi, text, image, info` };
+    }
+    if (typeof question.question !== "string" || question.question.trim() === "") {
+      return { ok: false, error: `interview.questions[${index}].question must be a non-empty string` };
+    }
+    if (question.context !== undefined && typeof question.context !== "string") {
+      return { ok: false, error: `interview.questions[${index}].context must be a string when provided` };
+    }
+    let options: unknown[] | undefined;
+    if (question.options !== undefined) {
+      if (!Array.isArray(question.options)) {
+        return { ok: false, error: `interview.questions[${index}].options must be an array when provided` };
+      }
+      options = [];
+      for (let optionIndex = 0; optionIndex < question.options.length; optionIndex++) {
+        const option = question.options[optionIndex];
+        if (typeof option === "string") {
+          const label = option.trim();
+          if (!label) {
+            return { ok: false, error: `interview.questions[${index}].options[${optionIndex}] must not be empty` };
+          }
+          options.push(label);
+        } else if (!option || typeof option !== "object" || Array.isArray(option) || typeof (option as { label?: unknown }).label !== "string" || (option as { label: string }).label.trim() === "") {
+          return { ok: false, error: `interview.questions[${index}].options[${optionIndex}] must be a non-empty string or an object with a non-empty label` };
+        } else {
+          options.push({ ...option, label: (option as { label: string }).label.trim() });
+        }
+      }
+    }
+    if ((question.type === "single" || question.type === "multi") && (!options || options.length === 0)) {
+      return { ok: false, error: `interview.questions[${index}].options must be a non-empty array for ${question.type} questions` };
+    }
+    if (question.type !== "single" && question.type !== "multi" && options) {
+      return { ok: false, error: `interview.questions[${index}].options is only valid for single and multi questions` };
+    }
+
+    questions.push({
+      ...question,
+      id,
+      type: question.type as SupervisorInterviewQuestion["type"],
+      question: question.question.trim(),
+      ...(options ? { options } : {}),
+    });
+  }
+
+  return {
+    ok: true,
+    interview: {
+      ...raw,
+      ...(typeof raw.title === "string" ? { title: raw.title.trim() } : {}),
+      ...(typeof raw.description === "string" ? { description: raw.description.trim() } : {}),
+      questions,
+    },
+  };
+}
+
+function interviewOptionLabel(option: unknown): string {
+  return typeof option === "string" ? option : (option as { label: string }).label;
+}
+
+function interviewExampleValue(question: SupervisorInterviewQuestion): unknown {
+  if (question.type === "multi") {
+    return question.options?.slice(0, 2).map(interviewOptionLabel) ?? [];
+  }
+  if (question.type === "single") {
+    return question.options?.[0] !== undefined ? interviewOptionLabel(question.options[0]) : "option label";
+  }
+  if (question.type === "image") {
+    return "image/file reference or description";
+  }
+  return "answer text";
+}
+
+function formatSupervisorInterviewRequest(interview: SupervisorInterviewRequest, message?: string): string {
+  const lines: string[] = [];
+  const title = interview.title?.trim();
+  if (title) lines.push(`Interview: ${title}`);
+  const description = interview.description?.trim();
+  if (description) lines.push(description);
+  const note = message?.trim();
+  if (note) lines.push(`Child note: ${note}`);
+  if (lines.length > 0) lines.push("");
+
+  lines.push("Questions:");
+  interview.questions.forEach((question, index) => {
+    lines.push(`${index + 1}. [${question.id}] (${question.type}) ${question.question}`);
+    if (typeof question.context === "string" && question.context.trim()) {
+      lines.push(`   Context: ${question.context.trim()}`);
+    }
+    if (question.options?.length) {
+      lines.push("   Options:");
+      for (const option of question.options) {
+        lines.push(`   - ${interviewOptionLabel(option)}`);
+      }
+    }
+  });
+
+  const responseExample = {
+    responses: interview.questions
+      .filter((question) => question.type !== "info")
+      .map((question) => ({
+        id: question.id,
+        value: interviewExampleValue(question),
+      })),
+  };
+
+  lines.push(
+    "",
+    "Supervisor reply instructions:",
+    "Reply with plain JSON or a fenced ```json block using this stable shape. Use the question ids exactly. Info questions are context-only and do not need responses. For single questions, value is one option label. For multi questions, value is an array of option labels. For text/image questions, value is a string unless the question asks otherwise.",
+    "",
+    "```json",
+    JSON.stringify(responseExample, null, 2),
+    "```",
+  );
+
+  return lines.join("\n");
+}
+
+function validateSupervisorInterviewReply(value: unknown, interview: SupervisorInterviewRequest): SupervisorInterviewReply {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("reply JSON must be an object with a responses array");
+  }
+
+  const responsesInput = (value as Record<string, unknown>).responses;
+  if (!Array.isArray(responsesInput)) {
+    throw new Error("reply JSON must include a responses array");
+  }
+
+  const questionById = new Map(interview.questions
+    .filter((question) => question.type !== "info")
+    .map((question) => [question.id, question]));
+  const seenIds = new Set<string>();
+  const responses: SupervisorInterviewReply["responses"] = [];
+
+  for (let index = 0; index < responsesInput.length; index++) {
+    const response = responsesInput[index];
+    if (!response || typeof response !== "object" || Array.isArray(response)) {
+      throw new Error(`responses[${index}] must be an object`);
+    }
+
+    const raw = response as Record<string, unknown>;
+    if (typeof raw.id !== "string" || raw.id.trim() === "") {
+      throw new Error(`responses[${index}].id must be a non-empty string`);
+    }
+    const id = raw.id.trim();
+    const question = questionById.get(id);
+    if (!question) {
+      throw new Error(`responses[${index}].id must match a non-info interview question id`);
+    }
+    if (seenIds.has(id)) {
+      throw new Error(`responses[${index}].id is duplicated: ${id}`);
+    }
+    seenIds.add(id);
+    if (!Object.hasOwn(raw, "value")) {
+      throw new Error(`responses[${index}].value is required`);
+    }
+
+    const value = raw.value;
+    if (question.type === "single") {
+      if (typeof value !== "string") throw new Error(`responses[${index}].value must be a string for single questions`);
+      const optionLabels = new Set(question.options?.map(interviewOptionLabel));
+      if (!optionLabels.has(value.trim())) throw new Error(`responses[${index}].value must match one of the question options`);
+      responses.push({ id, value: value.trim() });
+      continue;
+    }
+
+    if (question.type === "multi") {
+      if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+        throw new Error(`responses[${index}].value must be an array of strings for multi questions`);
+      }
+      const optionLabels = new Set(question.options?.map(interviewOptionLabel));
+      const selected = value.map((item) => item.trim());
+      const invalid = selected.find((item) => !optionLabels.has(item));
+      if (invalid) throw new Error(`responses[${index}].value contains an option that is not in the question options: ${invalid}`);
+      responses.push({ id, value: selected });
+      continue;
+    }
+
+    if (typeof value !== "string") {
+      throw new Error(`responses[${index}].value must be a string for ${question.type} questions`);
+    }
+    responses.push({ id, value });
+  }
+
+  return { responses };
+}
+
+function parseStructuredSupervisorReply(text: string, interview: SupervisorInterviewRequest): { value?: SupervisorInterviewReply; error?: string } | undefined {
+  const fencedMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = (fencedMatch?.[1] ?? text).trim();
+  if (!candidate.startsWith("{") && !candidate.startsWith("[")) {
+    return undefined;
+  }
+  try {
+    return { value: validateSupervisorInterviewReply(JSON.parse(candidate), interview) };
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+}
+function duplicateSessionNames(sessions: SessionInfo[]): Set<string> {
+  return new Set(
+    sessions
+      .map(s => s.name?.toLowerCase())
+      .filter((name): name is string => Boolean(name))
+      .filter((name, index, names) => names.indexOf(name) !== index)
+  );
+}
+function shortSessionId(sessionId: string): string {
+  return sessionId.slice(0, 8);
+}
+function parseSubagentIntercomPayload(payload: unknown): { to: string; message: string; requestId?: string } | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  if (typeof record.to !== "string" || typeof record.message !== "string") {
+    return null;
+  }
+  const requestId = typeof record.requestId === "string" ? record.requestId : undefined;
+  return { to: record.to, message: record.message, ...(requestId ? { requestId } : {}) };
+}
+function resolveIntercomPresenceName(sessionName: string | undefined, sessionId: string): string {
+  const trimmedName = sessionName?.trim();
+  if (trimmedName) {
+    return trimmedName;
+  }
+  const normalizedSessionId = sessionId.startsWith("session-") ? sessionId.slice("session-".length) : sessionId;
+  return `${DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX}-${normalizedSessionId.slice(0, 8)}`;
+}
+function buildPresenceIdentity(pi: ExtensionAPI, sessionId: string): { name: string } {
+  return {
+    name: resolveIntercomPresenceName(pi.getSessionName(), sessionId),
+  };
+}
+function formatSessionLabel(session: SessionInfo, duplicates: Set<string>): string {
+  if (!session.name) {
+    return session.id;
+  }
+  return duplicates.has(session.name.toLowerCase())
+    ? `${session.name} (${shortSessionId(session.id)})`
+    : session.name;
+}
+function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: boolean): string {
+  const name = session.name || "Unnamed session";
+  const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status]
+    .filter((tag): tag is string => Boolean(tag));
+  const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
+  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model})${suffix}`;
+}
+function previewText(value: unknown, maxLength = 72): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 1)}…` : normalized;
+}
+export default function piIntercomExtension(pi: ExtensionAPI) {
+  let client: IntercomClient | null = null;
+  const config: IntercomConfig = loadConfig();
+  let runtimeContext: ExtensionContext | null = null;
+  let currentSessionId: string | null = null;
+  let currentModel = "unknown";
+  let sessionStartedAt: number | null = null;
+  let reconnectTimer: NodeJS.Timeout | null = null;
+  let reconnectPromise: Promise<IntercomClient> | null = null;
+  let reconnectPromiseGeneration: number | null = null;
+  let startupConnectTimer: NodeJS.Timeout | null = null;
+  let reconnectAttempt = 0;
+  let shuttingDown = false;
+  let disposed = true;
+  let runtimeStarted = false;
+  let runtimeGeneration = 0;
+  let agentRunning = false;
+  const activeTools = new Map<string, string>();
+  const replyTracker = new ReplyTracker();
+  const pendingIdleMessages: InboundMessageEntry[] = [];
+  let inboundFlushTimer: NodeJS.Timeout | null = null;
+  let replyWaiter: {
+    from: string;
+    replyTo: string;
+    resolve: (message: Message) => void;
+    reject: (error: Error) => void;
+  } | null = null;
+  function waitForReply(from: string, replyTo: string, signal?: AbortSignal): Promise<Message> {
+    if (replyWaiter) {
+      return Promise.reject(new Error("Already waiting for a reply"));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(new Error("Cancelled"));
+    }
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        rejectReplyWaiter(new Error(`No reply from "${from}" within 10 minutes`));
+      }, 10 * 60 * 1000);
+      const cleanup = () => {
+        clearTimeout(timeout);
+        signal?.removeEventListener("abort", onAbort);
+        if (replyWaiter?.replyTo === replyTo) {
+          replyWaiter = null;
+        }
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(new Error("Cancelled"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      replyWaiter = {
+        from,
+        replyTo,
+        resolve: (message) => {
+          cleanup();
+          resolve(message);
+        },
+        reject: (error) => {
+          cleanup();
+          reject(error);
+        },
+      };
+    });
+  }
+  function rejectReplyWaiter(error: Error): void {
+    replyWaiter?.reject(error);
+  }
+  function clearReconnectTimer(): void {
+    if (!reconnectTimer) {
+      return;
+    }
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  function clearStartupConnectTimer(): void {
+    if (!startupConnectTimer) {
+      return;
+    }
+    clearTimeout(startupConnectTimer);
+    startupConnectTimer = null;
+  }
+  function clearInboundFlushTimer(): void {
+    if (!inboundFlushTimer) {
+      return;
+    }
+    clearTimeout(inboundFlushTimer);
+    inboundFlushTimer = null;
+  }
+  function getLiveContext(ctx: ExtensionContext | null = runtimeContext, generation = runtimeGeneration): ExtensionContext | null {
+    if (disposed || shuttingDown || generation !== runtimeGeneration || !ctx) {
+      return null;
+    }
+    try {
+      if (currentSessionId && ctx.sessionManager.getSessionId() !== currentSessionId) {
+        return null;
+      }
+      void ctx.hasUI;
+      return ctx;
+    } catch {
+      // A context that throws while reading session/UI state is no longer usable.
+      return null;
+    }
+  }
+  function notifyIfLive(ctx: ExtensionContext, message: string, level: "info" | "warning" | "error", generation = runtimeGeneration): void {
+    const liveContext = getLiveContext(ctx, generation);
+    if (!liveContext?.hasUI) {
+      return;
+    }
+    try {
+      liveContext.ui.notify(message, level);
+    } catch {
+      // The UI can disappear during session shutdown/reload while async overlay work is settling.
+    }
+  }
+  function getReconnectDelayMs(): number {
+    const backoffMs = [1000, 2000, 5000, 10000, 30000];
+    return backoffMs[Math.min(reconnectAttempt, backoffMs.length - 1)]!;
+  }
+  function currentStatus(): string {
+    const activeToolName = activeTools.values().next().value;
+    const lifecycleStatus = activeToolName ? `tool:${activeToolName}` : agentRunning ? "thinking" : "idle";
+    return config.status ? `${lifecycleStatus} · ${config.status}` : lifecycleStatus;
+  }
+  function buildRegistration(): Omit<SessionInfo, "id"> {
+    const liveContext = getLiveContext();
+    if (!liveContext || !currentSessionId || sessionStartedAt === null) {
+      throw new Error("Intercom runtime not initialized");
+    }
+
+    const identity = buildPresenceIdentity(pi, currentSessionId);
+    return {
+      name: identity.name,
+      cwd: liveContext.cwd ?? process.cwd(),
+      model: currentModel,
+      pid: process.pid,
+      startedAt: sessionStartedAt,
+      lastActivity: Date.now(),
+      status: currentStatus(),
+    };
+  }
+  function syncPresenceIdentity(sessionId: string): void {
+    if (!client || !getLiveContext()) {
+      return;
+    }
+    client.updatePresence({ ...buildPresenceIdentity(pi, sessionId), status: currentStatus() });
+  }
+  function syncPresenceStatus(): void {
+    if (!client || !currentSessionId || !getLiveContext()) {
+      return;
+    }
+    client.updatePresence({ status: currentStatus() });
+  }
+  function currentSessionTargetMatches(to: string, resolvedTo?: string | null, activeClient?: IntercomClient): boolean {
+    const targets = new Set<string>();
+    const addTarget = (target: string | undefined | null) => {
+      const trimmed = target?.trim();
+      if (trimmed) targets.add(trimmed.toLowerCase());
+    };
+    addTarget(currentSessionId);
+    addTarget(activeClient?.sessionId);
+    addTarget(pi.getSessionName());
+    if (currentSessionId) addTarget(buildPresenceIdentity(pi, currentSessionId).name);
+    return Boolean(resolvedTo && activeClient?.sessionId && resolvedTo === activeClient.sessionId)
+      || targets.has(to.trim().toLowerCase());
+  }
+  function sendIncomingMessage(entry: InboundMessageEntry, delivery: "trigger" | "followUp", generation = runtimeGeneration): void {
+    if (runtimeStarted && !getLiveContext(runtimeContext, generation)) {
+      return;
+    }
+    if (delivery !== "followUp") {
+      replyTracker.queueTurnContext({ from: entry.from, message: entry.message, receivedAt: Date.now() });
+    }
+    const senderDisplay = entry.from.name || entry.from.id.slice(0, 8);
+    const replyInstruction = entry.replyCommand ? `\n\nTo reply, use the intercom tool: ${entry.replyCommand}` : "";
+    pi.sendMessage(
+      {
+        customType: "intercom_message",
+        content: `**📨 From ${senderDisplay}** (${entry.from.cwd})${replyInstruction}\n\n${entry.bodyText}`,
+        display: true,
+        details: entry,
+      },
+      delivery === "trigger"
+        ? { triggerTurn: true }
+        : { deliverAs: "followUp" }
+    );
+  }
+  function scheduleInboundFlush(delayMs = INBOUND_FLUSH_DELAY_MS): void {
+    if (!getLiveContext()) {
+      return;
+    }
+    const scheduledGeneration = runtimeGeneration;
+    clearInboundFlushTimer();
+    inboundFlushTimer = setTimeout(() => {
+      inboundFlushTimer = null;
+      flushIdleMessages(scheduledGeneration);
+    }, delayMs);
+  }
+  function flushIdleMessages(generation = runtimeGeneration): void {
+    if (pendingIdleMessages.length === 0) {
+      return;
+    }
+    const ctx = getLiveContext(runtimeContext, generation);
+    if (!ctx) {
+      return;
+    }
+
+    let isIdle: boolean;
+    try {
+      isIdle = ctx.isIdle();
+    } catch {
+      // Stale contexts are cleaned up by shutdown/reload; do not deliver queued messages through them.
+      return;
+    }
+    if (!isIdle) {
+      scheduleInboundFlush(INBOUND_IDLE_RETRY_MS);
+      return;
+    }
+
+    const entries = pendingIdleMessages.splice(0, pendingIdleMessages.length);
+    entries.forEach((entry, index) => {
+      sendIncomingMessage(entry, index === 0 ? "trigger" : "followUp");
+    });
+  }
+  function queueIdleMessage(entry: InboundMessageEntry): void {
+    pendingIdleMessages.push(entry);
+    scheduleInboundFlush();
+  }
+  function handleIncomingMessage(ctx: ExtensionContext, from: SessionInfo, message: Message): void {
+    const messageGeneration = runtimeGeneration;
+    const liveContext = getLiveContext(ctx, messageGeneration);
+    if (!liveContext) {
+      return;
+    }
+    if (replyWaiter) {
+      const senderTarget = from.name || from.id;
+      const fromMatches = senderTarget.toLowerCase() === replyWaiter.from.toLowerCase()
+        || from.id === replyWaiter.from;
+      const replyMatches = message.replyTo === replyWaiter.replyTo;
+      if (fromMatches && replyMatches) {
+        replyWaiter.resolve(message);
+        return;
+      }
+    }
+    const attachmentText = message.content.attachments?.length
+      ? formatAttachments(message.content.attachments)
+      : "";
+    const bodyText = `${message.content.text}${attachmentText}`;
+    const replyCommand = config.replyHint && message.expectsReply
+      ? `intercom({ action: "reply", message: "..." })`
+      : undefined;
+    replyTracker.recordIncomingMessage(from, message);
+    const entry = { from, message, replyCommand, bodyText };
+    void (async () => {
+      const activeContext = getLiveContext(liveContext, messageGeneration);
+      if (!activeContext) {
+        return;
+      }
+      if (!activeContext.isIdle()) {
+        if (!activeContext.hasUI) {
+          const activeClient = client;
+          if (!message.replyTo && activeClient?.isConnected()) {
+            try {
+              const result = await activeClient.send(from.id, {
+                text: "This agent is running in non-interactive mode and cannot respond to intercom messages while it is working. It will continue its current task and exit when done.",
+                replyTo: message.id,
+              });
+              if (result.delivered && getLiveContext(liveContext, messageGeneration)) {
+                replyTracker.markReplied(message.id);
+              }
+            } catch {
+              // Best-effort reply; keep the busy non-interactive session running either way.
+            }
+          }
+          return;
+        }
+        queueIdleMessage(entry);
+        return;
+      }
+      if (getLiveContext(liveContext, messageGeneration)) {
+        sendIncomingMessage(entry, "trigger", messageGeneration);
+      }
+    })();
+  }
+  function attachClientHandlers(nextClient: IntercomClient): void {
+    nextClient.on("message", (from, message) => {
+      const liveContext = getLiveContext();
+      if (client !== nextClient || !liveContext) {
+        return;
+      }
+      handleIncomingMessage(liveContext, from, message);
+    });
+    nextClient.on("disconnected", (error: Error) => {
+      if (client !== nextClient) {
+        return;
+      }
+      rejectReplyWaiter(new Error(`Disconnected while waiting for reply: ${error.message}`, { cause: error }));
+      client = null;
+      if (!shuttingDown && !disposed) {
+        clearReconnectTimer();
+        scheduleReconnect();
+      }
+    });
+    nextClient.on("error", () => {
+      // Keep broker/socket noise out of the TUI. Reconnect logic runs from the disconnect path.
+    });
+  }
+  function scheduleReconnect(): void {
+    if (disposed || shuttingDown || reconnectTimer || reconnectPromise || !getLiveContext()) {
+      return;
+    }
+    const scheduledGeneration = runtimeGeneration;
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      if (scheduledGeneration !== runtimeGeneration || !getLiveContext()) {
+        return;
+      }
+      reconnectAttempt += 1;
+      void ensureConnected("background").catch(() => {
+        // ensureConnected("background") already queued the next retry.
+      });
+    }, getReconnectDelayMs());
+  }
+  async function ensureConnected(reason: "startup" | "background" | "tool" | "overlay"): Promise<IntercomClient> {
+    if (!config.enabled) {
+      throw new Error("Intercom disabled");
+    }
+    if (disposed || shuttingDown) {
+      throw new Error("Intercom shutting down");
+    }
+    if (client && client.isConnected()) {
+      return client;
+    }
+    const contextAtStart = getLiveContext();
+    const generationAtStart = runtimeGeneration;
+    if (!contextAtStart || !currentSessionId || sessionStartedAt === null) {
+      throw new Error("Intercom runtime not initialized");
+    }
+    clearReconnectTimer();
+    if (reconnectPromise && reconnectPromiseGeneration === generationAtStart) {
+      return reconnectPromise;
+    }
+    const nextReconnectPromise = (async () => {
+      const nextClient = new IntercomClient();
+      client = nextClient;
+      attachClientHandlers(nextClient);
+      try {
+        await spawnBrokerIfNeeded(config.brokerCommand, config.brokerArgs);
+        await nextClient.connect(buildRegistration());
+        if (!getLiveContext(contextAtStart, generationAtStart)) {
+          await nextClient.disconnect();
+          throw new Error("Intercom runtime no longer active");
+        }
+        client = nextClient;
+        reconnectAttempt = 0;
+        return nextClient;
+      } catch (error) {
+        if (client === nextClient) {
+          client = null;
+        }
+        if (reason === "background" && getLiveContext(contextAtStart, generationAtStart)) {
+          scheduleReconnect();
+        }
+        throw toError(error);
+      } finally {
+        if (reconnectPromise === nextReconnectPromise) {
+          reconnectPromise = null;
+          reconnectPromiseGeneration = null;
+        }
+      }
+    })();
+    reconnectPromise = nextReconnectPromise;
+    reconnectPromiseGeneration = generationAtStart;
+    return nextReconnectPromise;
+  }
+  async function resolveSessionTarget(activeClient: IntercomClient, nameOrId: string): Promise<string | null> {
+    const sessions = await activeClient.listSessions();
+    const byId = sessions.find(s => s.id === nameOrId);
+    if (byId) {
+      return byId.id;
+    }
+    const lowerName = nameOrId.toLowerCase();
+    const byName = sessions.filter(s => s.name?.toLowerCase() === lowerName);
+    if (byName.length > 1) {
+      throw new Error(`Multiple sessions named "${nameOrId}" are connected. Use the session ID instead.`);
+    }
+    return byName[0]?.id ?? null;
+  }
+  function deliverLocalSubagentRelayMessage(sender: "subagent-control" | "subagent-result", status: string, messageText: string): void {
+    const now = Date.now();
+    sendIncomingMessage({
+      from: {
+        id: sender,
+        name: sender,
+        cwd: runtimeContext?.cwd ?? process.cwd(),
+        model: sender,
+        pid: process.pid,
+        startedAt: now,
+        lastActivity: now,
+        status,
+      },
+      message: {
+        id: randomUUID(),
+        timestamp: now,
+        content: { text: messageText },
+      },
+      bodyText: messageText,
+    }, "trigger");
+  }
+  function recordSubagentDeliveryError(entryType: string, to: string, message: string, error: unknown): void {
+    pi.appendEntry(entryType, {
+      to,
+      message,
+      error: getErrorMessage(error),
+      timestamp: Date.now(),
+    });
+  }
+  function emitResultDelivery(requestId: string | undefined, delivered: boolean, error?: unknown): void {
+    if (!requestId) return;
+    pi.events.emit(SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT, {
+      requestId,
+      delivered,
+      ...(error ? { error: getErrorMessage(error) } : {}),
+    });
+  }
+  function relaySubagentIntercomPayload(payload: unknown, options: {
+    sender: "subagent-control" | "subagent-result";
+    status: string;
+    errorEntryType: string;
+    acknowledge?: boolean;
+  }): void {
+    const parsed = parseSubagentIntercomPayload(payload);
+    if (!parsed) return;
+
+    const relayGeneration = runtimeGeneration;
+    void (async () => {
+      const relayStillLive = () => !runtimeStarted || Boolean(getLiveContext(runtimeContext, relayGeneration));
+      if (!relayStillLive()) {
+        return;
+      }
+      if (currentSessionTargetMatches(parsed.to)) {
+        deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
+        if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
+        return;
+      }
+
+      let activeClient: IntercomClient;
+      let target: string;
+      try {
+        activeClient = await ensureConnected("background");
+        target = await resolveSessionTarget(activeClient, parsed.to) ?? parsed.to;
+      } catch (error) {
+        if (!relayStillLive()) return;
+        recordSubagentDeliveryError(options.errorEntryType, parsed.to, parsed.message, error);
+        if (options.acknowledge) emitResultDelivery(parsed.requestId, false, error);
+        return;
+      }
+
+      if (!relayStillLive()) {
+        return;
+      }
+      if (currentSessionTargetMatches(parsed.to, target, activeClient)) {
+        deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
+        if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
+        return;
+      }
+
+      try {
+        const result = await activeClient.send(target, { text: parsed.message });
+        if (!relayStillLive()) return;
+        if (!result.delivered) {
+          const error = new Error(result.reason ?? "Session may not exist or has disconnected.");
+          recordSubagentDeliveryError(options.errorEntryType, parsed.to, parsed.message, error);
+          if (options.acknowledge) emitResultDelivery(parsed.requestId, false, error);
+          return;
+        }
+        if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
+      } catch (error) {
+        if (!relayStillLive()) return;
+        recordSubagentDeliveryError(options.errorEntryType, parsed.to, parsed.message, error);
+        if (options.acknowledge) emitResultDelivery(parsed.requestId, false, error);
+      }
+    })();
+  }
+  pi.events.on(SUBAGENT_CONTROL_INTERCOM_EVENT, (payload) => {
+    relaySubagentIntercomPayload(payload, {
+      sender: "subagent-control",
+      status: "needs_attention",
+      errorEntryType: "intercom_control_error",
+    });
+  });
+  pi.events.on(SUBAGENT_RESULT_INTERCOM_EVENT, (payload) => {
+    relaySubagentIntercomPayload(payload, {
+      sender: "subagent-result",
+      status: "result",
+      errorEntryType: "intercom_result_error",
+      acknowledge: true,
+    });
+  });
+  pi.on("session_start", (_event, ctx) => {
+    if (!config.enabled) {
+      return;
+    }
+    shuttingDown = false;
+    disposed = false;
+    runtimeStarted = true;
+    runtimeGeneration += 1;
+    reconnectAttempt = 0;
+    clearReconnectTimer();
+    clearStartupConnectTimer();
+    runtimeContext = ctx;
+    currentSessionId = ctx.sessionManager.getSessionId();
+    currentModel = ctx.model?.id ?? "unknown";
+    sessionStartedAt = Date.now();
+    agentRunning = false;
+    activeTools.clear();
+    const startupGeneration = runtimeGeneration;
+    startupConnectTimer = setTimeout(() => {
+      startupConnectTimer = null;
+      if (!getLiveContext(ctx, startupGeneration)) {
+        return;
+      }
+      void ensureConnected("startup").catch(() => {
+        if (!getLiveContext(ctx, startupGeneration)) {
+          return;
+        }
+        client = null;
+        scheduleReconnect();
+      });
+    }, 0);
+  });
+
+  pi.on("session_shutdown", async () => {
+    shuttingDown = true;
+    disposed = true;
+    runtimeGeneration += 1;
+    clearStartupConnectTimer();
+    clearReconnectTimer();
+    rejectReplyWaiter(new Error("Session shutting down"));
+    replyTracker.reset();
+    pendingIdleMessages.length = 0;
+    clearInboundFlushTimer();
+    agentRunning = false;
+    activeTools.clear();
+    if (client) {
+      await client.disconnect();
+      client = null;
+    }
+    runtimeContext = null;
+    currentSessionId = null;
+    sessionStartedAt = null;
+  });
+  pi.on("turn_end", () => {
+    if (!getLiveContext()) {
+      return;
+    }
+    replyTracker.endTurn();
+    scheduleInboundFlush(0);
+  });
+  pi.on("agent_start", () => {
+    if (!getLiveContext()) {
+      return;
+    }
+    agentRunning = true;
+    activeTools.clear();
+    syncPresenceStatus();
+  });
+  pi.on("tool_execution_start", (event) => {
+    if (!getLiveContext()) {
+      return;
+    }
+    activeTools.set(event.toolCallId, event.toolName);
+    syncPresenceStatus();
+  });
+  pi.on("tool_execution_end", (event) => {
+    if (!getLiveContext()) {
+      return;
+    }
+    activeTools.delete(event.toolCallId);
+    syncPresenceStatus();
+  });
+  pi.on("agent_end", () => {
+    if (!getLiveContext()) {
+      return;
+    }
+    agentRunning = false;
+    activeTools.clear();
+    syncPresenceStatus();
+    scheduleInboundFlush(0);
+  });
+  pi.on("turn_start", (_event, ctx) => {
+    if (!getLiveContext(ctx)) {
+      return;
+    }
+    currentSessionId = ctx.sessionManager.getSessionId();
+    syncPresenceIdentity(ctx.sessionManager.getSessionId());
+    replyTracker.beginTurn();
+  });
+  pi.on("model_select", (event, ctx) => {
+    if (!getLiveContext(ctx)) {
+      return;
+    }
+    currentModel = event.model.id;
+    if (client) {
+      client.updatePresence({
+        ...buildPresenceIdentity(pi, ctx.sessionManager.getSessionId()),
+        model: event.model.id,
+        status: currentStatus(),
+      });
+    }
+  });
+
+  pi.registerMessageRenderer("intercom_message", (message, _options, theme) => {
+    const details = message.details as { from: SessionInfo; message: Message; replyCommand?: string; bodyText?: string } | undefined;
+    if (!details) return undefined;
+    return new InlineMessageComponent(details.from, details.message, theme, details.replyCommand, details.bodyText);
+  });
+
+  const childOrchestratorMetadata = readChildOrchestratorMetadata();
+  if (childOrchestratorMetadata) {
+    pi.registerTool({
+      name: "contact_supervisor",
+      label: "Contact Supervisor",
+      description: "Subagent-only tool for contacting the supervisor agent that delegated this task. Use need_decision when blocked, uncertain, needing approval, or facing a product/API/scope decision before continuing; this waits for the supervisor's reply. Use interview_request when multiple structured questions need supervisor answers; this also waits for a reply. Use progress_update only for meaningful progress or unexpected discoveries that change the plan; this does not wait for a reply. Do not use for routine completion handoffs.",
+      promptSnippet: "Subagent-only: contact the supervisor for decisions, structured interviews, or meaningful plan-changing updates. Do not use for routine completion handoffs.",
+      promptGuidelines: [
+        "Use contact_supervisor with reason='need_decision' when a subagent is blocked, uncertain, needs approval, or faces a product/API/scope decision before continuing.",
+        "Use contact_supervisor with reason='interview_request' when the child needs multiple structured answers from the supervisor in one blocking exchange.",
+        "Use contact_supervisor with reason='progress_update' only for meaningful progress or unexpected discoveries that change the plan.",
+        "Do not use contact_supervisor for routine completion handoffs; return the final subagent result normally.",
+      ],
+      parameters: Type.Object({
+        reason: Type.String({
+          enum: ["need_decision", "progress_update", "interview_request"],
+          description: "Contact reason: 'need_decision' waits for a reply; 'interview_request' sends structured questions and waits for a reply; 'progress_update' sends a non-blocking update",
+        }),
+        message: Type.Optional(Type.String({
+          description: "Decision request, optional interview note, or meaningful progress update for the supervisor",
+        })),
+        interview: Type.Optional(Type.Object({
+          title: Type.Optional(Type.String()),
+          description: Type.Optional(Type.String()),
+          questions: Type.Array(Type.Object({
+            id: Type.String(),
+            type: Type.String({ description: "Question type: single, multi, text, image, or info" }),
+            question: Type.String(),
+            options: Type.Optional(Type.Array(Type.Unknown())),
+            context: Type.Optional(Type.String()),
+          })),
+        }, { description: "Structured interview request for reason='interview_request'" })),
+      }),
+      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+        const reason = params.reason as ContactSupervisorReason;
+        if (reason !== "need_decision" && reason !== "progress_update" && reason !== "interview_request") {
+          return {
+            content: [{ type: "text", text: "Invalid reason. Use 'need_decision', 'interview_request', or 'progress_update'." }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+        if ((reason === "need_decision" || reason === "progress_update") && typeof params.message !== "string") {
+          return {
+            content: [{ type: "text", text: `Missing 'message' parameter for reason '${reason}'.` }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+        const interviewValidation = reason === "interview_request"
+          ? validateSupervisorInterviewRequest(params.interview)
+          : undefined;
+        if (interviewValidation?.ok === false) {
+          return {
+            content: [{ type: "text", text: `Invalid interview request: ${interviewValidation.error}` }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+        const supervisorInterview = interviewValidation?.ok === true ? interviewValidation.interview : undefined;
+
+        let connectedClient: IntercomClient;
+        try {
+          connectedClient = await ensureConnected("tool");
+        } catch (error) {
+          return {
+            content: [{ type: "text", text: `Intercom not connected: ${getErrorMessage(error)}` }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+
+        syncPresenceIdentity(ctx.sessionManager.getSessionId());
+
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled" }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+
+        const metadata = childOrchestratorMetadata;
+        let sendTo: string;
+        try {
+          sendTo = await resolveSessionTarget(connectedClient, metadata.orchestratorTarget) ?? metadata.orchestratorTarget;
+        } catch (error) {
+          return {
+            content: [{ type: "text", text: `Failed to resolve supervisor target: ${getErrorMessage(error)}` }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+        if (signal?.aborted) {
+          return {
+            content: [{ type: "text", text: "Cancelled" }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+        if (sendTo === connectedClient.sessionId) {
+          return {
+            content: [{ type: "text", text: "Cannot message the current session" }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+
+        if (reason === "progress_update") {
+          const message = params.message as string;
+          try {
+            const result = await connectedClient.send(sendTo, {
+              text: formatChildOrchestratorMessage("update", metadata, message),
+            });
+            if (!result.delivered) {
+              const errorText = result.reason ?? "Session may not exist or has disconnected.";
+              return {
+                content: [{ type: "text", text: `Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}` }],
+                isError: true,
+                details: { messageId: result.id, delivered: false, reason: result.reason },
+              };
+            }
+            pi.appendEntry("intercom_sent", {
+              to: metadata.orchestratorTarget,
+              message: { text: message, reason },
+              messageId: result.id,
+              timestamp: Date.now(),
+              subagent: { runId: metadata.runId, agent: metadata.agent, index: metadata.index },
+            });
+            return {
+              content: [{ type: "text", text: `Progress update sent to supervisor ${metadata.orchestratorTarget}` }],
+              isError: false,
+              details: { messageId: result.id, delivered: true },
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to send progress update: ${getErrorMessage(error)}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+        }
+
+        if (replyWaiter) {
+          return {
+            content: [{ type: "text", text: "Already waiting for a reply" }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+
+        let replyPromise: Promise<Message> | null = null;
+        try {
+          const questionId = randomUUID();
+          replyPromise = waitForReply(sendTo, questionId, signal);
+          replyPromise.catch(() => undefined);
+          if (signal?.aborted) {
+            rejectReplyWaiter(new Error("Cancelled"));
+            try {
+              await replyPromise;
+            } catch {
+              // The waiter was intentionally rejected above; the tool result reports cancellation.
+            }
+            return {
+              content: [{ type: "text", text: "Cancelled" }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+          const requestText = reason === "interview_request"
+            ? formatChildOrchestratorMessage("interview", metadata, formatSupervisorInterviewRequest(supervisorInterview!, typeof params.message === "string" ? params.message : undefined))
+            : formatChildOrchestratorMessage("ask", metadata, params.message as string);
+          const sendResult = await connectedClient.send(sendTo, {
+            messageId: questionId,
+            text: requestText,
+            expectsReply: true,
+          });
+          if (!sendResult.delivered) {
+            const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
+            rejectReplyWaiter(new Error(`Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}`));
+            if (replyPromise) {
+              try {
+                await replyPromise;
+              } catch {
+                // The waiter was already rejected above. Keep the delivery failure as the only error here.
+              }
+            }
+            return {
+              content: [{ type: "text", text: `Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+          pi.appendEntry("intercom_sent", {
+            to: metadata.orchestratorTarget,
+            message: {
+              text: reason === "interview_request" ? requestText : params.message,
+              reason,
+              ...(reason === "interview_request" ? { interview: supervisorInterview } : {}),
+            },
+            messageId: sendResult.id,
+            timestamp: Date.now(),
+            subagent: { runId: metadata.runId, agent: metadata.agent, index: metadata.index },
+          });
+          const replyMessage = await replyPromise;
+          const replyText = replyMessage.content.text;
+          const replyAttachments = replyMessage.content.attachments?.length
+            ? formatAttachments(replyMessage.content.attachments)
+            : "";
+          const structuredReply = reason === "interview_request" ? parseStructuredSupervisorReply(replyText, supervisorInterview!) : undefined;
+          pi.appendEntry("intercom_received", {
+            from: metadata.orchestratorTarget,
+            message: { text: replyText, attachments: replyMessage.content.attachments },
+            messageId: replyMessage.id,
+            timestamp: replyMessage.timestamp,
+            subagent: { runId: metadata.runId, agent: metadata.agent, index: metadata.index },
+          });
+          return {
+            content: [{ type: "text", text: `**Reply from supervisor:**\n${replyText}${replyAttachments}` }],
+            isError: false,
+            ...(structuredReply
+              ? { details: structuredReply.value !== undefined ? { structuredReply: structuredReply.value } : { structuredReplyParseError: structuredReply.error } }
+              : {}),
+          };
+        } catch (error) {
+          rejectReplyWaiter(toError(error));
+          if (replyPromise) {
+            try {
+              await replyPromise;
+            } catch {
+              // The waiter is cleanup-only on this path. The real failure is the one from the outer catch.
+            }
+          }
+          return {
+            content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
+            isError: true,
+            details: { error: true },
+          };
+        }
+      },
+      renderCall(args, theme) {
+        const reason = typeof args.reason === "string" ? args.reason : "contact";
+        const messagePreview = previewText(args.message, 96);
+        const interview = args.interview && typeof args.interview === "object" ? args.interview as { title?: unknown } : undefined;
+        let text = theme.fg("toolTitle", theme.bold("contact_supervisor "));
+        text += theme.fg(reason === "need_decision" ? "warning" : reason === "progress_update" ? "muted" : "accent", reason);
+        if (typeof interview?.title === "string" && interview.title.trim()) {
+          text += " " + theme.fg("accent", interview.title.trim());
+        }
+        if (messagePreview) {
+          text += "\n  " + theme.fg("dim", messagePreview);
+        }
+        return new Text(text, 0, 0);
+      },
+      renderResult: renderContactSupervisorResult,
+    });
+  }
+
+  pi.registerTool({
+    name: "intercom",
+    label: "Intercom",
+    description: `Send a message to another pi session running on this machine.
+Use this to communicate findings, request help, or coordinate work with other sessions.
+
+Usage:
+  intercom({ action: "list" })                    → List active sessions
+  intercom({ action: "send", to: "session-name", message: "..." })  → Send message
+  intercom({ action: "ask", to: "session-name", message: "..." })   → Ask and wait for reply
+  intercom({ action: "reply", message: "..." })                      → Reply to the active/single pending ask
+  intercom({ action: "pending" })                                      → List unresolved inbound asks
+  intercom({ action: "status" })                  → Show connection status`,
+    promptSnippet:
+      "Use to coordinate with other local pi sessions: list peers, send updates, ask for help, or check intercom connectivity.",
+
+    parameters: Type.Object({
+      action: Type.String({
+        description: "Action: 'list', 'send', 'ask', 'reply', 'pending', or 'status'",
+      }),
+      to: Type.Optional(Type.String({
+        description: "Target session name or ID (for 'send', 'ask', or disambiguating 'reply')",
+      })),
+      message: Type.Optional(Type.String({
+        description: "Message to send (for 'send', 'ask', or 'reply' action)",
+      })),
+      attachments: Type.Optional(Type.Array(Type.Object({
+        type: Type.Union([Type.Literal("file"), Type.Literal("snippet"), Type.Literal("context")]),
+        name: Type.String(),
+        content: Type.String(),
+        language: Type.Optional(Type.String()),
+      }))),
+      replyTo: Type.Optional(Type.String({
+        description: "Message ID to reply to (for threading or responding to an 'ask')",
+      })),
+    }),
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      let connectedClient: IntercomClient;
+      try {
+        connectedClient = await ensureConnected("tool");
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Intercom not connected: ${getErrorMessage(error)}` }],
+          isError: true,
+          details: { error: true },
+        };
+      }
+
+      syncPresenceIdentity(ctx.sessionManager.getSessionId());
+
+      const { action, to, message, attachments, replyTo } = params;
+
+      switch (action) {
+        case "list": {
+          try {
+            const mySessionId = connectedClient.sessionId;
+            const sessions = await connectedClient.listSessions();
+            const currentSession = sessions.find(s => s.id === mySessionId);
+            const otherSessions = sessions.filter(s => s.id !== mySessionId);
+
+            if (!currentSession) {
+              return {
+                content: [{ type: "text", text: "Current session is missing from intercom session list." }],
+                isError: true,
+                details: { error: true },
+              };
+            }
+
+            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
+            const otherSection = otherSessions.length === 0
+              ? "**Other sessions:**\nNo other sessions connected."
+              : `**Other sessions:**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
+
+            return {
+              content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],
+              isError: false,
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to list sessions: ${getErrorMessage(error)}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+        }
+
+        case "send": {
+          if (!to || !message) {
+            return {
+              content: [{ type: "text", text: "Missing 'to' or 'message' parameter" }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+          try {
+            const sendTo = await resolveSessionTarget(connectedClient, to) ?? to;
+            if (sendTo === connectedClient.sessionId) {
+              return {
+                content: [{ type: "text", text: "Cannot message the current session" }],
+                isError: true,
+                details: { error: true },
+              };
+            }
+            if (!replyTo && config.confirmSend && ctx.hasUI) {
+              const attachmentText = attachments?.length ? formatAttachments(attachments) : "";
+              const confirmed = await ctx.ui.confirm(
+                "Send Message",
+                `Send to "${to}":\n\n${message}${attachmentText}`,
+              );
+              if (!confirmed) {
+                return {
+                  content: [{ type: "text", text: "Message cancelled by user" }],
+                  isError: false,
+                };
+              }
+            }
+            const result = await connectedClient.send(sendTo, {
+              text: message,
+              attachments,
+              replyTo,
+            });
+            if (!result.delivered) {
+              const errorText = result.reason ?? "Session may not exist or has disconnected.";
+              return {
+                content: [{ type: "text", text: `Message to "${to}" was not delivered: ${errorText}` }],
+                isError: true,
+                details: { messageId: result.id, delivered: false, reason: result.reason },
+              };
+            }
+            pi.appendEntry("intercom_sent", {
+              to,
+              message: { text: message, attachments, replyTo },
+              messageId: result.id,
+              timestamp: Date.now(),
+            });
+            if (replyTo) {
+              replyTracker.markReplied(replyTo);
+            }
+            return {
+              content: [{ type: "text", text: `Message sent to ${to}` }],
+              isError: false,
+              details: { messageId: result.id, delivered: true },
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to send: ${getErrorMessage(error)}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+        }
+
+        case "ask": {
+          if (!to || !message) {
+            return {
+              content: [{ type: "text", text: "Missing 'to' or 'message' parameter" }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+
+          if (replyWaiter) {
+            return {
+              content: [{ type: "text", text: "Already waiting for a reply" }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+
+          if (_signal?.aborted) {
+            return {
+              content: [{ type: "text", text: "Cancelled" }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+          let replyPromise: Promise<Message> | null = null;
+
+          try {
+            const sendTo = await resolveSessionTarget(connectedClient, to) ?? to;
+            if (_signal?.aborted) {
+              return {
+                content: [{ type: "text", text: "Cancelled" }],
+                isError: true,
+                details: { error: true },
+              };
+            }
+            if (sendTo === connectedClient.sessionId) {
+              return {
+                content: [{ type: "text", text: "Cannot message the current session" }],
+                isError: true,
+                details: { error: true },
+              };
+            }
+            const questionId = randomUUID();
+            replyPromise = waitForReply(sendTo, questionId, _signal);
+            const sendResult = await connectedClient.send(sendTo, {
+              messageId: questionId,
+              text: message,
+              attachments,
+              replyTo,
+              expectsReply: true,
+            });
+
+            if (!sendResult.delivered) {
+              const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
+              rejectReplyWaiter(new Error(`Message to "${to}" was not delivered: ${errorText}`));
+              if (replyPromise) {
+                try {
+                  await replyPromise;
+                } catch {
+                  // The waiter was already rejected above. Keep the delivery failure as the only error here.
+                }
+              }
+              return {
+                content: [{ type: "text", text: `Message to "${to}" was not delivered: ${errorText}` }],
+                isError: true,
+                details: { error: true },
+              };
+            }
+            pi.appendEntry("intercom_sent", {
+              to,
+              message: { text: message, attachments, replyTo },
+              messageId: sendResult.id,
+              timestamp: Date.now(),
+            });
+            const replyMessage = await replyPromise;
+            const replyText = replyMessage.content.text;
+            const replyAttachments = replyMessage.content.attachments?.length
+              ? formatAttachments(replyMessage.content.attachments)
+              : "";
+            pi.appendEntry("intercom_received", {
+              from: to,
+              message: { text: replyText, attachments: replyMessage.content.attachments },
+              messageId: replyMessage.id,
+              timestamp: replyMessage.timestamp,
+            });
+            return {
+              content: [{ type: "text", text: `**Reply from ${to}:**\n${replyText}${replyAttachments}` }],
+              isError: false,
+            };
+          } catch (error) {
+            rejectReplyWaiter(toError(error));
+            if (replyPromise) {
+              try {
+                await replyPromise;
+              } catch {
+                // The waiter is cleanup-only on this path. The real failure is the one from the outer catch.
+              }
+            }
+            return {
+              content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+        }
+
+        case "reply": {
+          if (!message) {
+            return {
+              content: [{ type: "text", text: "Missing 'message' parameter" }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+
+          try {
+            const target = replyTracker.resolveReplyTarget({ to });
+            if (target.from.id === connectedClient.sessionId) {
+              return {
+                content: [{ type: "text", text: "Cannot message the current session" }],
+                isError: true,
+                details: { error: true },
+              };
+            }
+            const result = await connectedClient.send(target.from.id, {
+              text: message,
+              replyTo: target.message.id,
+            });
+            if (!result.delivered) {
+              const errorText = result.reason ?? "Session may not exist or has disconnected.";
+              return {
+                content: [{ type: "text", text: `Reply to "${target.from.name || target.from.id}" was not delivered: ${errorText}` }],
+                isError: true,
+                details: { messageId: result.id, delivered: false, reason: result.reason },
+              };
+            }
+            replyTracker.markReplied(target.message.id);
+            pi.appendEntry("intercom_sent", {
+              to: target.from.name || target.from.id,
+              message: { text: message, replyTo: target.message.id },
+              messageId: result.id,
+              timestamp: Date.now(),
+            });
+            return {
+              content: [{ type: "text", text: `Reply sent to ${target.from.name || target.from.id}` }],
+              isError: false,
+              details: { messageId: result.id, delivered: true, replyTo: target.message.id },
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to reply: ${getErrorMessage(error)}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+        }
+
+        case "pending": {
+          const pendingAsks = replyTracker.listPending();
+          if (pendingAsks.length === 0) {
+            return {
+              content: [{ type: "text", text: "No unresolved inbound asks." }],
+              isError: false,
+            };
+          }
+
+          const now = Date.now();
+          const lines = pendingAsks.map(({ from, message, receivedAt }) => {
+            const preview = message.content.text.replace(/\s+/g, " ").slice(0, 80);
+            const elapsedSeconds = Math.max(0, Math.floor((now - receivedAt) / 1000));
+            return `- ${from.name || from.id} · ${message.id} · ${elapsedSeconds}s ago · ${preview}`;
+          });
+          return {
+            content: [{ type: "text", text: `**Pending asks:**\n${lines.join("\n")}` }],
+            isError: false,
+          };
+        }
+
+        case "status": {
+          try {
+            const mySessionId = connectedClient.sessionId;
+            const sessions = await connectedClient.listSessions();
+            return {
+              content: [{
+                type: "text",
+                text: `**Intercom Status:**\nConnected: Yes\nSession ID: ${mySessionId}\nActive sessions: ${sessions.length}`,
+              }],
+              isError: false,
+            };
+          } catch (error) {
+            return {
+              content: [{ type: "text", text: `Failed to get status: ${getErrorMessage(error)}` }],
+              isError: true,
+              details: { error: true },
+            };
+          }
+        }
+
+        default:
+          return {
+            content: [{ type: "text", text: `Unknown action: ${action}` }],
+            isError: true,
+            details: { error: true },
+          };
+      }
+    },
+    renderCall(args, theme) {
+      const action = typeof args.action === "string" ? args.action : "intercom";
+      const target = typeof args.to === "string" && args.to.trim() ? args.to.trim() : undefined;
+      const messagePreview = previewText(args.message, 96);
+      const attachmentCount = Array.isArray(args.attachments) ? args.attachments.length : 0;
+      let text = theme.fg("toolTitle", theme.bold("intercom "));
+      text += theme.fg(action === "ask" ? "warning" : action === "reply" ? "success" : "accent", action);
+      if (target) {
+        text += " " + theme.fg("muted", "→") + " " + theme.fg("accent", target);
+      }
+      if (attachmentCount > 0) {
+        text += " " + theme.fg("dim", `(${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"})`);
+      }
+      if (messagePreview) {
+        text += "\n  " + theme.fg("dim", messagePreview);
+      }
+      return new Text(text, 0, 0);
+    },
+    renderResult: renderIntercomResult,
+  });
+
+  async function openIntercomOverlay(ctx: ExtensionContext): Promise<void> {
+    const overlayGeneration = runtimeGeneration;
+    const liveContext = getLiveContext(ctx, overlayGeneration);
+    if (!liveContext?.hasUI) return;
+
+    let overlayClient: IntercomClient;
+    try {
+      overlayClient = await ensureConnected("overlay");
+    } catch (error) {
+      notifyIfLive(ctx, `Intercom unavailable: ${getErrorMessage(error)}`, "error", overlayGeneration);
+      return;
+    }
+    if (!getLiveContext(ctx, overlayGeneration)) return;
+
+    syncPresenceIdentity(ctx.sessionManager.getSessionId());
+
+    let currentSession: SessionInfo;
+    let sessions: SessionInfo[];
+    let duplicates: Set<string>;
+    try {
+      const mySessionId = overlayClient.sessionId;
+      const allSessions = await overlayClient.listSessions();
+      if (!getLiveContext(ctx, overlayGeneration)) return;
+      const foundCurrentSession = allSessions.find(s => s.id === mySessionId);
+      if (!foundCurrentSession) {
+        notifyIfLive(ctx, "Current session is missing from intercom session list", "error", overlayGeneration);
+        return;
+      }
+      currentSession = foundCurrentSession;
+      duplicates = duplicateSessionNames(allSessions);
+      sessions = allSessions.filter(s => s.id !== mySessionId);
+    } catch (error) {
+      notifyIfLive(ctx, `Failed to list sessions: ${getErrorMessage(error)}`, "error", overlayGeneration);
+      return;
+    }
+
+    const selectedSession = await ctx.ui.custom<SessionInfo | undefined>(
+      (_tui, theme, keybindings, done) => new SessionListOverlay(theme, keybindings, currentSession, sessions, done),
+      { overlay: true }
+    ).catch(() => undefined);
+
+    if (!selectedSession || !getLiveContext(ctx, overlayGeneration)) return;
+
+    try {
+      overlayClient = await ensureConnected("overlay");
+    } catch (error) {
+      notifyIfLive(ctx, `Intercom unavailable: ${getErrorMessage(error)}`, "error", overlayGeneration);
+      return;
+    }
+    if (!getLiveContext(ctx, overlayGeneration)) return;
+
+    const targetLabel = formatSessionLabel(selectedSession, duplicates);
+
+    const result = await ctx.ui.custom<ComposeResult>(
+      (tui, theme, keybindings, done) => new ComposeOverlay(tui, theme, keybindings, selectedSession, targetLabel, overlayClient, done),
+      { overlay: true }
+    ).catch(() => undefined);
+
+    if (result?.sent && result.messageId && result.text && getLiveContext(ctx, overlayGeneration)) {
+      pi.appendEntry("intercom_sent", {
+        to: selectedSession.name || selectedSession.id,
+        message: { text: result.text },
+        messageId: result.messageId,
+        timestamp: Date.now(),
+      });
+      notifyIfLive(ctx, `Message sent to ${targetLabel}`, "info", overlayGeneration);
+    }
+  }
+
+  pi.registerCommand("intercom", {
+    description: "Open session intercom overlay",
+    handler: async (_args, ctx) => openIntercomOverlay(ctx),
+  });
+
+  pi.registerShortcut("alt+m", {
+    description: "Open session intercom",
+    handler: async (ctx) => openIntercomOverlay(ctx),
+  });
+}

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -1,1313 +1,328 @@
-import type { ExtensionAPI, ExtensionContext } from "@bastani/atomic";
-import { randomUUID } from "crypto";
-import { Type } from "typebox";
+import type { ExtensionAPI, ExtensionContext, HandlerFn, MessageRenderer, RegisteredCommand, ToolDefinition } from "@bastani/atomic";
 import { Text } from "@mariozechner/pi-tui";
-import { APP_NAME, getEnvValue } from "@bastani/atomic";
-import { IntercomClient } from "./broker/client.ts";
-import { spawnBrokerIfNeeded } from "./broker/spawn.ts";
-import { SessionListOverlay } from "./ui/session-list.ts";
-import { ComposeOverlay, type ComposeResult } from "./ui/compose.ts";
-import { InlineMessageComponent } from "./ui/inline-message.ts";
-import { loadConfig, type IntercomConfig } from "./config.ts";
-import type { SessionInfo, Message, Attachment } from "./types.ts";
-import { ReplyTracker } from "./reply-tracker.ts";
+import { Type } from "typebox";
+import { renderIntercomToolResult } from "./result-renderers.js";
 
+type CapturedCommand = Omit<RegisteredCommand, "name" | "sourceInfo">;
+type CapturedShortcut = Parameters<ExtensionAPI["registerShortcut"]>[1];
+type EventHandler = Parameters<ExtensionAPI["events"]["on"]>[1];
+type ToolRenderResultArgs = Parameters<NonNullable<ToolDefinition["renderResult"]>>;
+type CapturedHeavy = {
+	tools: Map<string, ToolDefinition>;
+	commands: Map<string, CapturedCommand>;
+	handlers: Map<string, HandlerFn[]>;
+	shortcuts: Map<string, CapturedShortcut>;
+	eventHandlers: Map<string, EventHandler[]>;
+};
+type LifecycleSnapshot = {
+	event: unknown;
+	ctx: ExtensionContext;
+};
+
+type SessionSnapshot = LifecycleSnapshot & {
+	generation: number;
+};
+
+type ActiveLifecycleState = {
+	turnStart: LifecycleSnapshot | null;
+	agentStart: LifecycleSnapshot | null;
+	activeTools: Map<string, LifecycleSnapshot>;
+	modelSelect: LifecycleSnapshot | null;
+};
+
+type LazyLifecycleEvent =
+	| "session_start"
+	| "session_shutdown"
+	| "turn_start"
+	| "turn_end"
+	| "agent_start"
+	| "agent_end"
+	| "tool_execution_start"
+	| "tool_execution_end"
+	| "model_select";
+
+const FORWARDED_EVENTS: readonly LazyLifecycleEvent[] = [
+	"session_start",
+	"session_shutdown",
+	"turn_start",
+	"turn_end",
+	"agent_start",
+	"agent_end",
+	"tool_execution_start",
+	"tool_execution_end",
+	"model_select",
+];
 const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
-const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
-const INBOUND_FLUSH_DELAY_MS = 200;
-const INBOUND_IDLE_RETRY_MS = 500;
-const DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX = "subagent-chat";
-const ENV_PREFIX = APP_NAME.toUpperCase();
-const SUBAGENT_ORCHESTRATOR_TARGET_ENV = `${ENV_PREFIX}_SUBAGENT_ORCHESTRATOR_TARGET`;
-const SUBAGENT_RUN_ID_ENV = `${ENV_PREFIX}_SUBAGENT_RUN_ID`;
-const SUBAGENT_CHILD_AGENT_ENV = `${ENV_PREFIX}_SUBAGENT_CHILD_AGENT`;
-const SUBAGENT_CHILD_INDEX_ENV = `${ENV_PREFIX}_SUBAGENT_CHILD_INDEX`;
-const SUBAGENT_INTERCOM_SESSION_NAME_ENV = `${ENV_PREFIX}_SUBAGENT_INTERCOM_SESSION_NAME`;
 
-interface ChildOrchestratorMetadata {
-  orchestratorTarget: string;
-  runId: string;
-  agent: string;
-  index: string;
-  sessionName?: string;
+function hasSubagentIntercomEnv(): boolean {
+	return Object.keys(process.env).some((key) => key.endsWith("_SUBAGENT_ORCHESTRATOR_TARGET"));
 }
 
-interface InboundMessageEntry {
-  from: SessionInfo;
-  message: Message;
-  replyCommand?: string;
-  bodyText: string;
+function getToolCallId(event: unknown): string | null {
+	if (typeof event !== "object" || event === null || !("toolCallId" in event)) return null;
+	const toolCallId = event.toolCallId;
+	return typeof toolCallId === "string" ? toolCallId : null;
 }
 
-type ContactSupervisorReason = "need_decision" | "progress_update" | "interview_request";
-
-interface SupervisorInterviewQuestion extends Record<string, unknown> {
-  id: string;
-  type: "single" | "multi" | "text" | "image" | "info";
-  question: string;
-  options?: unknown[];
+function addHandler(captured: CapturedHeavy, event: string, handler: HandlerFn): void {
+	const handlers = captured.handlers.get(event) ?? [];
+	handlers.push(handler);
+	captured.handlers.set(event, handlers);
 }
 
-interface SupervisorInterviewRequest extends Record<string, unknown> {
-  title?: string;
-  description?: string;
-  questions: SupervisorInterviewQuestion[];
+function addEventHandler(captured: CapturedHeavy, event: string, handler: EventHandler): void {
+	const handlers = captured.eventHandlers.get(event) ?? [];
+	handlers.push(handler);
+	captured.eventHandlers.set(event, handlers);
 }
 
-interface SupervisorInterviewReply {
-  responses: Array<{ id: string; value: unknown }>;
+async function dispatchHandlers(captured: CapturedHeavy, eventName: string, event: unknown, ctx: ExtensionContext): Promise<void> {
+	for (const handler of captured.handlers.get(eventName) ?? []) {
+		await handler(event, ctx);
+	}
 }
 
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+async function dispatchEventHandlers(captured: CapturedHeavy, eventName: string, payload: unknown): Promise<void> {
+	for (const handler of captured.eventHandlers.get(eventName) ?? []) {
+		await handler(payload);
+	}
 }
 
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
+function createHeavyProxy(pi: ExtensionAPI, captured: CapturedHeavy): ExtensionAPI {
+	return new Proxy(pi, {
+		get(target, prop, receiver) {
+			if (prop === "registerTool") {
+				return (tool: ToolDefinition) => captured.tools.set(tool.name, tool);
+			}
+			if (prop === "registerCommand") {
+				return (name: string, options: CapturedCommand) => captured.commands.set(name, options);
+			}
+			if (prop === "on") {
+				return (event: string, handler: HandlerFn) => {
+					addHandler(captured, event, handler);
+				};
+			}
+			if (prop === "registerShortcut") {
+				return (shortcut: string, options: CapturedShortcut) => {
+					captured.shortcuts.set(shortcut, options);
+				};
+			}
+			if (prop === "registerMessageRenderer") {
+				return (customType: string, renderer: MessageRenderer) => pi.registerMessageRenderer(customType, renderer);
+			}
+			if (prop === "events") {
+				return new Proxy(pi.events, {
+					get(eventTarget, eventProp, eventReceiver) {
+						if (eventProp === "on") {
+							return (event: string, handler: EventHandler) => {
+								addEventHandler(captured, event, handler);
+								return () => {
+									const handlers = captured.eventHandlers.get(event) ?? [];
+									captured.eventHandlers.set(event, handlers.filter((candidate) => candidate !== handler));
+								};
+							};
+						}
+						return Reflect.get(eventTarget, eventProp, eventReceiver);
+					},
+				});
+			}
+			return Reflect.get(target, prop, receiver);
+		},
+	}) as ExtensionAPI;
 }
 
-function formatAttachments(attachments: Attachment[]): string {
-  let text = "";
-  for (const att of attachments) {
-    if (att.language) {
-      text += `\n\n---\n📎 ${att.name}\n~~~${att.language}\n${att.content}\n~~~`;
-    } else {
-      text += `\n\n---\n📎 ${att.name}\n${att.content}`;
-    }
-  }
-  return text;
-}
-function readChildOrchestratorMetadata(): ChildOrchestratorMetadata | null {
-  const orchestratorTarget = getEnvValue(SUBAGENT_ORCHESTRATOR_TARGET_ENV)?.trim();
-  const runId = getEnvValue(SUBAGENT_RUN_ID_ENV)?.trim();
-  const agent = getEnvValue(SUBAGENT_CHILD_AGENT_ENV)?.trim();
-  const index = getEnvValue(SUBAGENT_CHILD_INDEX_ENV)?.trim();
-  if (!orchestratorTarget || !runId || !agent || !index) {
-    return null;
-  }
-  const sessionName = getEnvValue(SUBAGENT_INTERCOM_SESSION_NAME_ENV)?.trim();
-  return {
-    orchestratorTarget,
-    runId,
-    agent,
-    index,
-    ...(sessionName ? { sessionName } : {}),
-  };
-}
-function formatChildOrchestratorMessage(kind: "ask" | "update" | "interview", metadata: ChildOrchestratorMetadata, message: string): string {
-  const heading = kind === "ask"
-    ? "Subagent needs a supervisor decision."
-    : kind === "interview"
-      ? "Subagent requests a structured supervisor interview."
-      : "Subagent progress update.";
-  return [
-    heading,
-    `Run: ${metadata.runId}`,
-    `Agent: ${metadata.agent}`,
-    `Child index: ${metadata.index}`,
-    metadata.sessionName ? `Child intercom target: ${metadata.sessionName}` : undefined,
-    "",
-    message,
-  ].filter((line): line is string => line !== undefined).join("\n");
+async function executeHeavyTool(
+	loadHeavy: (ctx?: ExtensionContext) => Promise<CapturedHeavy>,
+	name: string,
+	args: Parameters<NonNullable<ToolDefinition["execute"]>>,
+): Promise<ReturnType<NonNullable<ToolDefinition["execute"]>>> {
+	const ctx = args[4];
+	const heavy = await loadHeavy(ctx);
+	const tool = heavy.tools.get(name);
+	if (!tool?.execute) throw new Error(`Intercom tool implementation not found: ${name}`);
+	return tool.execute(...args) as ReturnType<NonNullable<ToolDefinition["execute"]>>;
 }
 
-function validateSupervisorInterviewRequest(input: unknown): { ok: true; interview: SupervisorInterviewRequest } | { ok: false; error: string } {
-  if (!input || typeof input !== "object" || Array.isArray(input)) {
-    return { ok: false, error: "interview must be an object with a questions array" };
-  }
-
-  const raw = input as Record<string, unknown>;
-  if (raw.title !== undefined && typeof raw.title !== "string") {
-    return { ok: false, error: "interview.title must be a string when provided" };
-  }
-  if (raw.description !== undefined && typeof raw.description !== "string") {
-    return { ok: false, error: "interview.description must be a string when provided" };
-  }
-  if (!Array.isArray(raw.questions) || raw.questions.length === 0) {
-    return { ok: false, error: "interview.questions must be a non-empty array" };
-  }
-
-  const validTypes = new Set(["single", "multi", "text", "image", "info"]);
-  const ids = new Set<string>();
-  const questions: SupervisorInterviewQuestion[] = [];
-
-  for (let index = 0; index < raw.questions.length; index++) {
-    const questionInput = raw.questions[index];
-    if (!questionInput || typeof questionInput !== "object" || Array.isArray(questionInput)) {
-      return { ok: false, error: `interview.questions[${index}] must be an object` };
-    }
-    const question = questionInput as Record<string, unknown>;
-    if (typeof question.id !== "string" || question.id.trim() === "") {
-      return { ok: false, error: `interview.questions[${index}].id must be a non-empty string` };
-    }
-    const id = question.id.trim();
-    if (ids.has(id)) {
-      return { ok: false, error: `interview question id must be unique: ${id}` };
-    }
-    ids.add(id);
-
-    if (typeof question.type !== "string" || !validTypes.has(question.type)) {
-      return { ok: false, error: `interview.questions[${index}].type must be one of: single, multi, text, image, info` };
-    }
-    if (typeof question.question !== "string" || question.question.trim() === "") {
-      return { ok: false, error: `interview.questions[${index}].question must be a non-empty string` };
-    }
-    if (question.context !== undefined && typeof question.context !== "string") {
-      return { ok: false, error: `interview.questions[${index}].context must be a string when provided` };
-    }
-    let options: unknown[] | undefined;
-    if (question.options !== undefined) {
-      if (!Array.isArray(question.options)) {
-        return { ok: false, error: `interview.questions[${index}].options must be an array when provided` };
-      }
-      options = [];
-      for (let optionIndex = 0; optionIndex < question.options.length; optionIndex++) {
-        const option = question.options[optionIndex];
-        if (typeof option === "string") {
-          const label = option.trim();
-          if (!label) {
-            return { ok: false, error: `interview.questions[${index}].options[${optionIndex}] must not be empty` };
-          }
-          options.push(label);
-        } else if (!option || typeof option !== "object" || Array.isArray(option) || typeof (option as { label?: unknown }).label !== "string" || (option as { label: string }).label.trim() === "") {
-          return { ok: false, error: `interview.questions[${index}].options[${optionIndex}] must be a non-empty string or an object with a non-empty label` };
-        } else {
-          options.push({ ...option, label: (option as { label: string }).label.trim() });
-        }
-      }
-    }
-    if ((question.type === "single" || question.type === "multi") && (!options || options.length === 0)) {
-      return { ok: false, error: `interview.questions[${index}].options must be a non-empty array for ${question.type} questions` };
-    }
-    if (question.type !== "single" && question.type !== "multi" && options) {
-      return { ok: false, error: `interview.questions[${index}].options is only valid for single and multi questions` };
-    }
-
-    questions.push({
-      ...question,
-      id,
-      type: question.type as SupervisorInterviewQuestion["type"],
-      question: question.question.trim(),
-      ...(options ? { options } : {}),
-    });
-  }
-
-  return {
-    ok: true,
-    interview: {
-      ...raw,
-      ...(typeof raw.title === "string" ? { title: raw.title.trim() } : {}),
-      ...(typeof raw.description === "string" ? { description: raw.description.trim() } : {}),
-      questions,
-    },
-  };
+async function runHeavyCommand(loadHeavy: (ctx?: ExtensionContext) => Promise<CapturedHeavy>, args: string | undefined, ctx: ExtensionContext): Promise<void> {
+	const heavy = await loadHeavy(ctx);
+	const command = heavy.commands.get("intercom");
+	if (!command) throw new Error("Intercom command implementation not found");
+	await command.handler(args, ctx);
 }
 
-function interviewOptionLabel(option: unknown): string {
-  return typeof option === "string" ? option : (option as { label: string }).label;
+function renderHeavyToolResult(loadedHeavy: CapturedHeavy | null, name: string, args: ToolRenderResultArgs): ReturnType<NonNullable<ToolDefinition["renderResult"]>> {
+	const renderer = loadedHeavy?.tools.get(name)?.renderResult;
+	if (renderer) return renderer(...args);
+	return renderIntercomToolResult(name, args);
 }
 
-function interviewExampleValue(question: SupervisorInterviewQuestion): unknown {
-  if (question.type === "multi") {
-    return question.options?.slice(0, 2).map(interviewOptionLabel) ?? [];
-  }
-  if (question.type === "single") {
-    return question.options?.[0] !== undefined ? interviewOptionLabel(question.options[0]) : "option label";
-  }
-  if (question.type === "image") {
-    return "image/file reference or description";
-  }
-  return "answer text";
-}
+export default function intercom(pi: ExtensionAPI) {
+	let heavyPromise: Promise<CapturedHeavy> | null = null;
+	let loadedHeavy: CapturedHeavy | null = null;
+	let sessionSnapshot: SessionSnapshot | null = null;
+	let lifecycleGeneration = 0;
+	let replayedGeneration = 0;
+	const activeLifecycle: ActiveLifecycleState = {
+		turnStart: null,
+		agentStart: null,
+		activeTools: new Map(),
+		modelSelect: null,
+	};
 
-function formatSupervisorInterviewRequest(interview: SupervisorInterviewRequest, message?: string): string {
-  const lines: string[] = [];
-  const title = interview.title?.trim();
-  if (title) lines.push(`Interview: ${title}`);
-  const description = interview.description?.trim();
-  if (description) lines.push(description);
-  const note = message?.trim();
-  if (note) lines.push(`Child note: ${note}`);
-  if (lines.length > 0) lines.push("");
+	async function replaySessionStart(heavy: CapturedHeavy): Promise<void> {
+		if (!sessionSnapshot || replayedGeneration === sessionSnapshot.generation) return;
+		replayedGeneration = sessionSnapshot.generation;
+		await dispatchHandlers(heavy, "session_start", sessionSnapshot.event, sessionSnapshot.ctx);
+		if (activeLifecycle.turnStart) {
+			await dispatchHandlers(heavy, "turn_start", activeLifecycle.turnStart.event, activeLifecycle.turnStart.ctx);
+		}
+		if (activeLifecycle.modelSelect) {
+			await dispatchHandlers(heavy, "model_select", activeLifecycle.modelSelect.event, activeLifecycle.modelSelect.ctx);
+		}
+		if (activeLifecycle.agentStart) {
+			await dispatchHandlers(heavy, "agent_start", activeLifecycle.agentStart.event, activeLifecycle.agentStart.ctx);
+		}
+		for (const activeTool of activeLifecycle.activeTools.values()) {
+			await dispatchHandlers(heavy, "tool_execution_start", activeTool.event, activeTool.ctx);
+		}
+	}
 
-  lines.push("Questions:");
-  interview.questions.forEach((question, index) => {
-    lines.push(`${index + 1}. [${question.id}] (${question.type}) ${question.question}`);
-    if (typeof question.context === "string" && question.context.trim()) {
-      lines.push(`   Context: ${question.context.trim()}`);
-    }
-    if (question.options?.length) {
-      lines.push("   Options:");
-      for (const option of question.options) {
-        lines.push(`   - ${interviewOptionLabel(option)}`);
-      }
-    }
-  });
+	async function loadHeavy(ctx?: ExtensionContext): Promise<CapturedHeavy> {
+		if (!heavyPromise) {
+			heavyPromise = (async () => {
+				const captured: CapturedHeavy = {
+					tools: new Map(),
+					commands: new Map(),
+					handlers: new Map(),
+					shortcuts: new Map(),
+					eventHandlers: new Map(),
+				};
+				const mod = await import("./index-heavy.js");
+				await mod.default(createHeavyProxy(pi, captured));
+				loadedHeavy = captured;
+				if (!sessionSnapshot && ctx) {
+					sessionSnapshot = { event: {}, ctx, generation: ++lifecycleGeneration };
+				}
+				await replaySessionStart(captured);
+				return captured;
+			})();
+		}
+		const heavy = await heavyPromise;
+		if (!sessionSnapshot && ctx) {
+			sessionSnapshot = { event: {}, ctx, generation: ++lifecycleGeneration };
+			await replaySessionStart(heavy);
+		}
+		return heavy;
+	}
 
-  const responseExample = {
-    responses: interview.questions
-      .filter((question) => question.type !== "info")
-      .map((question) => ({
-        id: question.id,
-        value: interviewExampleValue(question),
-      })),
-  };
+	for (const eventName of FORWARDED_EVENTS) {
+		switch (eventName) {
+			case "session_start":
+				pi.on("session_start", async (event, ctx) => {
+					const generation = ++lifecycleGeneration;
+					sessionSnapshot = { event, ctx, generation };
+					if (loadedHeavy) {
+						replayedGeneration = generation;
+						await dispatchHandlers(loadedHeavy, "session_start", event, ctx);
+					}
+				});
+				break;
+			case "session_shutdown":
+				pi.on("session_shutdown", async (event, ctx) => {
+					++lifecycleGeneration;
+					activeLifecycle.turnStart = null;
+					activeLifecycle.agentStart = null;
+					activeLifecycle.activeTools.clear();
+					activeLifecycle.modelSelect = null;
+					if (loadedHeavy) {
+						await dispatchHandlers(loadedHeavy, "session_shutdown", event, ctx);
+					}
+					sessionSnapshot = null;
+					replayedGeneration = lifecycleGeneration;
+				});
+				break;
+			case "turn_start":
+				pi.on("turn_start", async (event, ctx) => {
+					activeLifecycle.turnStart = { event, ctx };
+					if (loadedHeavy) await dispatchHandlers(loadedHeavy, "turn_start", event, ctx);
+				});
+				break;
+			case "turn_end":
+				pi.on("turn_end", async (event, ctx) => {
+					activeLifecycle.turnStart = null;
+					activeLifecycle.agentStart = null;
+					activeLifecycle.activeTools.clear();
+					if (loadedHeavy) await dispatchHandlers(loadedHeavy, "turn_end", event, ctx);
+				});
+				break;
+			case "agent_start":
+				pi.on("agent_start", async (event, ctx) => {
+					activeLifecycle.agentStart = { event, ctx };
+					activeLifecycle.activeTools.clear();
+					if (loadedHeavy) await dispatchHandlers(loadedHeavy, "agent_start", event, ctx);
+				});
+				break;
+			case "agent_end":
+				pi.on("agent_end", async (event, ctx) => {
+					activeLifecycle.agentStart = null;
+					activeLifecycle.activeTools.clear();
+					if (loadedHeavy) await dispatchHandlers(loadedHeavy, "agent_end", event, ctx);
+				});
+				break;
+			case "tool_execution_start":
+				pi.on("tool_execution_start", async (event, ctx) => {
+					const toolCallId = getToolCallId(event);
+					if (toolCallId) activeLifecycle.activeTools.set(toolCallId, { event, ctx });
+					if (loadedHeavy) await dispatchHandlers(loadedHeavy, "tool_execution_start", event, ctx);
+				});
+				break;
+			case "tool_execution_end":
+				pi.on("tool_execution_end", async (event, ctx) => {
+					const toolCallId = getToolCallId(event);
+					if (toolCallId) activeLifecycle.activeTools.delete(toolCallId);
+					if (loadedHeavy) await dispatchHandlers(loadedHeavy, "tool_execution_end", event, ctx);
+				});
+				break;
+			case "model_select":
+				pi.on("model_select", async (event, ctx) => {
+					activeLifecycle.modelSelect = { event, ctx };
+					if (loadedHeavy) await dispatchHandlers(loadedHeavy, "model_select", event, ctx);
+				});
+				break;
+		}
+	}
 
-  lines.push(
-    "",
-    "Supervisor reply instructions:",
-    "Reply with plain JSON or a fenced ```json block using this stable shape. Use the question ids exactly. Info questions are context-only and do not need responses. For single questions, value is one option label. For multi questions, value is an array of option labels. For text/image questions, value is a string unless the question asks otherwise.",
-    "",
-    "```json",
-    JSON.stringify(responseExample, null, 2),
-    "```",
-  );
+	pi.registerShortcut("alt+m", {
+		description: "Open session intercom overlay",
+		handler: async (ctx) => {
+			const heavy = await loadHeavy(ctx);
+			const handler = heavy.shortcuts.get("alt+m")?.handler;
+			if (!handler) throw new Error("Intercom shortcut implementation not found: alt+m");
+			await handler(ctx);
+		},
+	});
 
-  return lines.join("\n");
-}
+	for (const eventName of [SUBAGENT_CONTROL_INTERCOM_EVENT, SUBAGENT_RESULT_INTERCOM_EVENT] as const) {
+		pi.events.on(eventName, (payload) => {
+			void loadHeavy().then((heavy) => dispatchEventHandlers(heavy, eventName, payload)).catch((error) => {
+				console.error(`Intercom event relay failed (${eventName}):`, error);
+			});
+		});
+	}
 
-function validateSupervisorInterviewReply(value: unknown, interview: SupervisorInterviewRequest): SupervisorInterviewReply {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("reply JSON must be an object with a responses array");
-  }
+	if (hasSubagentIntercomEnv()) {
+		pi.on("session_start", (_event, ctx) => {
+			void loadHeavy(ctx).catch((error) => {
+				console.error("Intercom initialization failed:", error);
+			});
+		});
+	}
 
-  const responsesInput = (value as Record<string, unknown>).responses;
-  if (!Array.isArray(responsesInput)) {
-    throw new Error("reply JSON must include a responses array");
-  }
-
-  const questionById = new Map(interview.questions
-    .filter((question) => question.type !== "info")
-    .map((question) => [question.id, question]));
-  const seenIds = new Set<string>();
-  const responses: SupervisorInterviewReply["responses"] = [];
-
-  for (let index = 0; index < responsesInput.length; index++) {
-    const response = responsesInput[index];
-    if (!response || typeof response !== "object" || Array.isArray(response)) {
-      throw new Error(`responses[${index}] must be an object`);
-    }
-
-    const raw = response as Record<string, unknown>;
-    if (typeof raw.id !== "string" || raw.id.trim() === "") {
-      throw new Error(`responses[${index}].id must be a non-empty string`);
-    }
-    const id = raw.id.trim();
-    const question = questionById.get(id);
-    if (!question) {
-      throw new Error(`responses[${index}].id must match a non-info interview question id`);
-    }
-    if (seenIds.has(id)) {
-      throw new Error(`responses[${index}].id is duplicated: ${id}`);
-    }
-    seenIds.add(id);
-    if (!Object.hasOwn(raw, "value")) {
-      throw new Error(`responses[${index}].value is required`);
-    }
-
-    const value = raw.value;
-    if (question.type === "single") {
-      if (typeof value !== "string") throw new Error(`responses[${index}].value must be a string for single questions`);
-      const optionLabels = new Set(question.options?.map(interviewOptionLabel));
-      if (!optionLabels.has(value.trim())) throw new Error(`responses[${index}].value must match one of the question options`);
-      responses.push({ id, value: value.trim() });
-      continue;
-    }
-
-    if (question.type === "multi") {
-      if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
-        throw new Error(`responses[${index}].value must be an array of strings for multi questions`);
-      }
-      const optionLabels = new Set(question.options?.map(interviewOptionLabel));
-      const selected = value.map((item) => item.trim());
-      const invalid = selected.find((item) => !optionLabels.has(item));
-      if (invalid) throw new Error(`responses[${index}].value contains an option that is not in the question options: ${invalid}`);
-      responses.push({ id, value: selected });
-      continue;
-    }
-
-    if (typeof value !== "string") {
-      throw new Error(`responses[${index}].value must be a string for ${question.type} questions`);
-    }
-    responses.push({ id, value });
-  }
-
-  return { responses };
-}
-
-function parseStructuredSupervisorReply(text: string, interview: SupervisorInterviewRequest): { value?: SupervisorInterviewReply; error?: string } | undefined {
-  const fencedMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const candidate = (fencedMatch?.[1] ?? text).trim();
-  if (!candidate.startsWith("{") && !candidate.startsWith("[")) {
-    return undefined;
-  }
-  try {
-    return { value: validateSupervisorInterviewReply(JSON.parse(candidate), interview) };
-  } catch (error) {
-    return { error: getErrorMessage(error) };
-  }
-}
-function duplicateSessionNames(sessions: SessionInfo[]): Set<string> {
-  return new Set(
-    sessions
-      .map(s => s.name?.toLowerCase())
-      .filter((name): name is string => Boolean(name))
-      .filter((name, index, names) => names.indexOf(name) !== index)
-  );
-}
-function shortSessionId(sessionId: string): string {
-  return sessionId.slice(0, 8);
-}
-function parseSubagentIntercomPayload(payload: unknown): { to: string; message: string; requestId?: string } | null {
-  if (typeof payload !== "object" || payload === null) {
-    return null;
-  }
-  const record = payload as Record<string, unknown>;
-  if (typeof record.to !== "string" || typeof record.message !== "string") {
-    return null;
-  }
-  const requestId = typeof record.requestId === "string" ? record.requestId : undefined;
-  return { to: record.to, message: record.message, ...(requestId ? { requestId } : {}) };
-}
-function resolveIntercomPresenceName(sessionName: string | undefined, sessionId: string): string {
-  const trimmedName = sessionName?.trim();
-  if (trimmedName) {
-    return trimmedName;
-  }
-  const normalizedSessionId = sessionId.startsWith("session-") ? sessionId.slice("session-".length) : sessionId;
-  return `${DEFAULT_UNNAMED_SESSION_ALIAS_PREFIX}-${normalizedSessionId.slice(0, 8)}`;
-}
-function buildPresenceIdentity(pi: ExtensionAPI, sessionId: string): { name: string } {
-  return {
-    name: resolveIntercomPresenceName(pi.getSessionName(), sessionId),
-  };
-}
-function formatSessionLabel(session: SessionInfo, duplicates: Set<string>): string {
-  if (!session.name) {
-    return session.id;
-  }
-  return duplicates.has(session.name.toLowerCase())
-    ? `${session.name} (${shortSessionId(session.id)})`
-    : session.name;
-}
-function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: boolean): string {
-  const name = session.name || "Unnamed session";
-  const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status]
-    .filter((tag): tag is string => Boolean(tag));
-  const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `• ${name} (${shortSessionId(session.id)}) — ${session.cwd} (${session.model})${suffix}`;
-}
-function previewText(value: unknown, maxLength = 72): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (!normalized) {
-    return undefined;
-  }
-  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 1)}…` : normalized;
-}
-function firstTextContent(result: { content?: Array<{ type: string; text?: string }> }): string {
-  return result.content?.find((item) => item.type === "text" && typeof item.text === "string")?.text?.replace(/\*\*/g, "") ?? "";
-}
-export default function piIntercomExtension(pi: ExtensionAPI) {
-  let client: IntercomClient | null = null;
-  const config: IntercomConfig = loadConfig();
-  let runtimeContext: ExtensionContext | null = null;
-  let currentSessionId: string | null = null;
-  let currentModel = "unknown";
-  let sessionStartedAt: number | null = null;
-  let reconnectTimer: NodeJS.Timeout | null = null;
-  let reconnectPromise: Promise<IntercomClient> | null = null;
-  let reconnectPromiseGeneration: number | null = null;
-  let startupConnectTimer: NodeJS.Timeout | null = null;
-  let reconnectAttempt = 0;
-  let shuttingDown = false;
-  let disposed = true;
-  let runtimeStarted = false;
-  let runtimeGeneration = 0;
-  let agentRunning = false;
-  const activeTools = new Map<string, string>();
-  const replyTracker = new ReplyTracker();
-  const pendingIdleMessages: InboundMessageEntry[] = [];
-  let inboundFlushTimer: NodeJS.Timeout | null = null;
-  let replyWaiter: {
-    from: string;
-    replyTo: string;
-    resolve: (message: Message) => void;
-    reject: (error: Error) => void;
-  } | null = null;
-  function waitForReply(from: string, replyTo: string, signal?: AbortSignal): Promise<Message> {
-    if (replyWaiter) {
-      return Promise.reject(new Error("Already waiting for a reply"));
-    }
-    if (signal?.aborted) {
-      return Promise.reject(new Error("Cancelled"));
-    }
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        rejectReplyWaiter(new Error(`No reply from "${from}" within 10 minutes`));
-      }, 10 * 60 * 1000);
-      const cleanup = () => {
-        clearTimeout(timeout);
-        signal?.removeEventListener("abort", onAbort);
-        if (replyWaiter?.replyTo === replyTo) {
-          replyWaiter = null;
-        }
-      };
-      const onAbort = () => {
-        cleanup();
-        reject(new Error("Cancelled"));
-      };
-      signal?.addEventListener("abort", onAbort, { once: true });
-      replyWaiter = {
-        from,
-        replyTo,
-        resolve: (message) => {
-          cleanup();
-          resolve(message);
-        },
-        reject: (error) => {
-          cleanup();
-          reject(error);
-        },
-      };
-    });
-  }
-  function rejectReplyWaiter(error: Error): void {
-    replyWaiter?.reject(error);
-  }
-  function clearReconnectTimer(): void {
-    if (!reconnectTimer) {
-      return;
-    }
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-  }
-  function clearStartupConnectTimer(): void {
-    if (!startupConnectTimer) {
-      return;
-    }
-    clearTimeout(startupConnectTimer);
-    startupConnectTimer = null;
-  }
-  function clearInboundFlushTimer(): void {
-    if (!inboundFlushTimer) {
-      return;
-    }
-    clearTimeout(inboundFlushTimer);
-    inboundFlushTimer = null;
-  }
-  function getLiveContext(ctx: ExtensionContext | null = runtimeContext, generation = runtimeGeneration): ExtensionContext | null {
-    if (disposed || shuttingDown || generation !== runtimeGeneration || !ctx) {
-      return null;
-    }
-    try {
-      if (currentSessionId && ctx.sessionManager.getSessionId() !== currentSessionId) {
-        return null;
-      }
-      void ctx.hasUI;
-      return ctx;
-    } catch {
-      // A context that throws while reading session/UI state is no longer usable.
-      return null;
-    }
-  }
-  function notifyIfLive(ctx: ExtensionContext, message: string, level: "info" | "warning" | "error", generation = runtimeGeneration): void {
-    const liveContext = getLiveContext(ctx, generation);
-    if (!liveContext?.hasUI) {
-      return;
-    }
-    try {
-      liveContext.ui.notify(message, level);
-    } catch {
-      // The UI can disappear during session shutdown/reload while async overlay work is settling.
-    }
-  }
-  function getReconnectDelayMs(): number {
-    const backoffMs = [1000, 2000, 5000, 10000, 30000];
-    return backoffMs[Math.min(reconnectAttempt, backoffMs.length - 1)]!;
-  }
-  function currentStatus(): string {
-    const activeToolName = activeTools.values().next().value;
-    const lifecycleStatus = activeToolName ? `tool:${activeToolName}` : agentRunning ? "thinking" : "idle";
-    return config.status ? `${lifecycleStatus} · ${config.status}` : lifecycleStatus;
-  }
-  function buildRegistration(): Omit<SessionInfo, "id"> {
-    const liveContext = getLiveContext();
-    if (!liveContext || !currentSessionId || sessionStartedAt === null) {
-      throw new Error("Intercom runtime not initialized");
-    }
-
-    const identity = buildPresenceIdentity(pi, currentSessionId);
-    return {
-      name: identity.name,
-      cwd: liveContext.cwd ?? process.cwd(),
-      model: currentModel,
-      pid: process.pid,
-      startedAt: sessionStartedAt,
-      lastActivity: Date.now(),
-      status: currentStatus(),
-    };
-  }
-  function syncPresenceIdentity(sessionId: string): void {
-    if (!client || !getLiveContext()) {
-      return;
-    }
-    client.updatePresence({ ...buildPresenceIdentity(pi, sessionId), status: currentStatus() });
-  }
-  function syncPresenceStatus(): void {
-    if (!client || !currentSessionId || !getLiveContext()) {
-      return;
-    }
-    client.updatePresence({ status: currentStatus() });
-  }
-  function currentSessionTargetMatches(to: string, resolvedTo?: string | null, activeClient?: IntercomClient): boolean {
-    const targets = new Set<string>();
-    const addTarget = (target: string | undefined | null) => {
-      const trimmed = target?.trim();
-      if (trimmed) targets.add(trimmed.toLowerCase());
-    };
-    addTarget(currentSessionId);
-    addTarget(activeClient?.sessionId);
-    addTarget(pi.getSessionName());
-    if (currentSessionId) addTarget(buildPresenceIdentity(pi, currentSessionId).name);
-    return Boolean(resolvedTo && activeClient?.sessionId && resolvedTo === activeClient.sessionId)
-      || targets.has(to.trim().toLowerCase());
-  }
-  function sendIncomingMessage(entry: InboundMessageEntry, delivery: "trigger" | "followUp", generation = runtimeGeneration): void {
-    if (runtimeStarted && !getLiveContext(runtimeContext, generation)) {
-      return;
-    }
-    if (delivery !== "followUp") {
-      replyTracker.queueTurnContext({ from: entry.from, message: entry.message, receivedAt: Date.now() });
-    }
-    const senderDisplay = entry.from.name || entry.from.id.slice(0, 8);
-    const replyInstruction = entry.replyCommand ? `\n\nTo reply, use the intercom tool: ${entry.replyCommand}` : "";
-    pi.sendMessage(
-      {
-        customType: "intercom_message",
-        content: `**📨 From ${senderDisplay}** (${entry.from.cwd})${replyInstruction}\n\n${entry.bodyText}`,
-        display: true,
-        details: entry,
-      },
-      delivery === "trigger"
-        ? { triggerTurn: true }
-        : { deliverAs: "followUp" }
-    );
-  }
-  function scheduleInboundFlush(delayMs = INBOUND_FLUSH_DELAY_MS): void {
-    if (!getLiveContext()) {
-      return;
-    }
-    const scheduledGeneration = runtimeGeneration;
-    clearInboundFlushTimer();
-    inboundFlushTimer = setTimeout(() => {
-      inboundFlushTimer = null;
-      flushIdleMessages(scheduledGeneration);
-    }, delayMs);
-  }
-  function flushIdleMessages(generation = runtimeGeneration): void {
-    if (pendingIdleMessages.length === 0) {
-      return;
-    }
-    const ctx = getLiveContext(runtimeContext, generation);
-    if (!ctx) {
-      return;
-    }
-
-    let isIdle: boolean;
-    try {
-      isIdle = ctx.isIdle();
-    } catch {
-      // Stale contexts are cleaned up by shutdown/reload; do not deliver queued messages through them.
-      return;
-    }
-    if (!isIdle) {
-      scheduleInboundFlush(INBOUND_IDLE_RETRY_MS);
-      return;
-    }
-
-    const entries = pendingIdleMessages.splice(0, pendingIdleMessages.length);
-    entries.forEach((entry, index) => {
-      sendIncomingMessage(entry, index === 0 ? "trigger" : "followUp");
-    });
-  }
-  function queueIdleMessage(entry: InboundMessageEntry): void {
-    pendingIdleMessages.push(entry);
-    scheduleInboundFlush();
-  }
-  function handleIncomingMessage(ctx: ExtensionContext, from: SessionInfo, message: Message): void {
-    const messageGeneration = runtimeGeneration;
-    const liveContext = getLiveContext(ctx, messageGeneration);
-    if (!liveContext) {
-      return;
-    }
-    if (replyWaiter) {
-      const senderTarget = from.name || from.id;
-      const fromMatches = senderTarget.toLowerCase() === replyWaiter.from.toLowerCase()
-        || from.id === replyWaiter.from;
-      const replyMatches = message.replyTo === replyWaiter.replyTo;
-      if (fromMatches && replyMatches) {
-        replyWaiter.resolve(message);
-        return;
-      }
-    }
-    const attachmentText = message.content.attachments?.length
-      ? formatAttachments(message.content.attachments)
-      : "";
-    const bodyText = `${message.content.text}${attachmentText}`;
-    const replyCommand = config.replyHint && message.expectsReply
-      ? `intercom({ action: "reply", message: "..." })`
-      : undefined;
-    replyTracker.recordIncomingMessage(from, message);
-    const entry = { from, message, replyCommand, bodyText };
-    void (async () => {
-      const activeContext = getLiveContext(liveContext, messageGeneration);
-      if (!activeContext) {
-        return;
-      }
-      if (!activeContext.isIdle()) {
-        if (!activeContext.hasUI) {
-          const activeClient = client;
-          if (!message.replyTo && activeClient?.isConnected()) {
-            try {
-              const result = await activeClient.send(from.id, {
-                text: "This agent is running in non-interactive mode and cannot respond to intercom messages while it is working. It will continue its current task and exit when done.",
-                replyTo: message.id,
-              });
-              if (result.delivered && getLiveContext(liveContext, messageGeneration)) {
-                replyTracker.markReplied(message.id);
-              }
-            } catch {
-              // Best-effort reply; keep the busy non-interactive session running either way.
-            }
-          }
-          return;
-        }
-        queueIdleMessage(entry);
-        return;
-      }
-      if (getLiveContext(liveContext, messageGeneration)) {
-        sendIncomingMessage(entry, "trigger", messageGeneration);
-      }
-    })();
-  }
-  function attachClientHandlers(nextClient: IntercomClient): void {
-    nextClient.on("message", (from, message) => {
-      const liveContext = getLiveContext();
-      if (client !== nextClient || !liveContext) {
-        return;
-      }
-      handleIncomingMessage(liveContext, from, message);
-    });
-    nextClient.on("disconnected", (error: Error) => {
-      if (client !== nextClient) {
-        return;
-      }
-      rejectReplyWaiter(new Error(`Disconnected while waiting for reply: ${error.message}`, { cause: error }));
-      client = null;
-      if (!shuttingDown && !disposed) {
-        clearReconnectTimer();
-        scheduleReconnect();
-      }
-    });
-    nextClient.on("error", () => {
-      // Keep broker/socket noise out of the TUI. Reconnect logic runs from the disconnect path.
-    });
-  }
-  function scheduleReconnect(): void {
-    if (disposed || shuttingDown || reconnectTimer || reconnectPromise || !getLiveContext()) {
-      return;
-    }
-    const scheduledGeneration = runtimeGeneration;
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      if (scheduledGeneration !== runtimeGeneration || !getLiveContext()) {
-        return;
-      }
-      reconnectAttempt += 1;
-      void ensureConnected("background").catch(() => {
-        // ensureConnected("background") already queued the next retry.
-      });
-    }, getReconnectDelayMs());
-  }
-  async function ensureConnected(reason: "startup" | "background" | "tool" | "overlay"): Promise<IntercomClient> {
-    if (!config.enabled) {
-      throw new Error("Intercom disabled");
-    }
-    if (disposed || shuttingDown) {
-      throw new Error("Intercom shutting down");
-    }
-    if (client && client.isConnected()) {
-      return client;
-    }
-    const contextAtStart = getLiveContext();
-    const generationAtStart = runtimeGeneration;
-    if (!contextAtStart || !currentSessionId || sessionStartedAt === null) {
-      throw new Error("Intercom runtime not initialized");
-    }
-    clearReconnectTimer();
-    if (reconnectPromise && reconnectPromiseGeneration === generationAtStart) {
-      return reconnectPromise;
-    }
-    const nextReconnectPromise = (async () => {
-      const nextClient = new IntercomClient();
-      client = nextClient;
-      attachClientHandlers(nextClient);
-      try {
-        await spawnBrokerIfNeeded(config.brokerCommand, config.brokerArgs);
-        await nextClient.connect(buildRegistration());
-        if (!getLiveContext(contextAtStart, generationAtStart)) {
-          await nextClient.disconnect();
-          throw new Error("Intercom runtime no longer active");
-        }
-        client = nextClient;
-        reconnectAttempt = 0;
-        return nextClient;
-      } catch (error) {
-        if (client === nextClient) {
-          client = null;
-        }
-        if (reason === "background" && getLiveContext(contextAtStart, generationAtStart)) {
-          scheduleReconnect();
-        }
-        throw toError(error);
-      } finally {
-        if (reconnectPromise === nextReconnectPromise) {
-          reconnectPromise = null;
-          reconnectPromiseGeneration = null;
-        }
-      }
-    })();
-    reconnectPromise = nextReconnectPromise;
-    reconnectPromiseGeneration = generationAtStart;
-    return nextReconnectPromise;
-  }
-  async function resolveSessionTarget(activeClient: IntercomClient, nameOrId: string): Promise<string | null> {
-    const sessions = await activeClient.listSessions();
-    const byId = sessions.find(s => s.id === nameOrId);
-    if (byId) {
-      return byId.id;
-    }
-    const lowerName = nameOrId.toLowerCase();
-    const byName = sessions.filter(s => s.name?.toLowerCase() === lowerName);
-    if (byName.length > 1) {
-      throw new Error(`Multiple sessions named "${nameOrId}" are connected. Use the session ID instead.`);
-    }
-    return byName[0]?.id ?? null;
-  }
-  function deliverLocalSubagentRelayMessage(sender: "subagent-control" | "subagent-result", status: string, messageText: string): void {
-    const now = Date.now();
-    sendIncomingMessage({
-      from: {
-        id: sender,
-        name: sender,
-        cwd: runtimeContext?.cwd ?? process.cwd(),
-        model: sender,
-        pid: process.pid,
-        startedAt: now,
-        lastActivity: now,
-        status,
-      },
-      message: {
-        id: randomUUID(),
-        timestamp: now,
-        content: { text: messageText },
-      },
-      bodyText: messageText,
-    }, "trigger");
-  }
-  function recordSubagentDeliveryError(entryType: string, to: string, message: string, error: unknown): void {
-    pi.appendEntry(entryType, {
-      to,
-      message,
-      error: getErrorMessage(error),
-      timestamp: Date.now(),
-    });
-  }
-  function emitResultDelivery(requestId: string | undefined, delivered: boolean, error?: unknown): void {
-    if (!requestId) return;
-    pi.events.emit(SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT, {
-      requestId,
-      delivered,
-      ...(error ? { error: getErrorMessage(error) } : {}),
-    });
-  }
-  function relaySubagentIntercomPayload(payload: unknown, options: {
-    sender: "subagent-control" | "subagent-result";
-    status: string;
-    errorEntryType: string;
-    acknowledge?: boolean;
-  }): void {
-    const parsed = parseSubagentIntercomPayload(payload);
-    if (!parsed) return;
-
-    const relayGeneration = runtimeGeneration;
-    void (async () => {
-      const relayStillLive = () => !runtimeStarted || Boolean(getLiveContext(runtimeContext, relayGeneration));
-      if (!relayStillLive()) {
-        return;
-      }
-      if (currentSessionTargetMatches(parsed.to)) {
-        deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
-        if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
-        return;
-      }
-
-      let activeClient: IntercomClient;
-      let target: string;
-      try {
-        activeClient = await ensureConnected("background");
-        target = await resolveSessionTarget(activeClient, parsed.to) ?? parsed.to;
-      } catch (error) {
-        if (!relayStillLive()) return;
-        recordSubagentDeliveryError(options.errorEntryType, parsed.to, parsed.message, error);
-        if (options.acknowledge) emitResultDelivery(parsed.requestId, false, error);
-        return;
-      }
-
-      if (!relayStillLive()) {
-        return;
-      }
-      if (currentSessionTargetMatches(parsed.to, target, activeClient)) {
-        deliverLocalSubagentRelayMessage(options.sender, options.status, parsed.message);
-        if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
-        return;
-      }
-
-      try {
-        const result = await activeClient.send(target, { text: parsed.message });
-        if (!relayStillLive()) return;
-        if (!result.delivered) {
-          const error = new Error(result.reason ?? "Session may not exist or has disconnected.");
-          recordSubagentDeliveryError(options.errorEntryType, parsed.to, parsed.message, error);
-          if (options.acknowledge) emitResultDelivery(parsed.requestId, false, error);
-          return;
-        }
-        if (options.acknowledge) emitResultDelivery(parsed.requestId, true);
-      } catch (error) {
-        if (!relayStillLive()) return;
-        recordSubagentDeliveryError(options.errorEntryType, parsed.to, parsed.message, error);
-        if (options.acknowledge) emitResultDelivery(parsed.requestId, false, error);
-      }
-    })();
-  }
-  pi.events.on(SUBAGENT_CONTROL_INTERCOM_EVENT, (payload) => {
-    relaySubagentIntercomPayload(payload, {
-      sender: "subagent-control",
-      status: "needs_attention",
-      errorEntryType: "intercom_control_error",
-    });
-  });
-  pi.events.on(SUBAGENT_RESULT_INTERCOM_EVENT, (payload) => {
-    relaySubagentIntercomPayload(payload, {
-      sender: "subagent-result",
-      status: "result",
-      errorEntryType: "intercom_result_error",
-      acknowledge: true,
-    });
-  });
-  pi.on("session_start", (_event, ctx) => {
-    if (!config.enabled) {
-      return;
-    }
-    shuttingDown = false;
-    disposed = false;
-    runtimeStarted = true;
-    runtimeGeneration += 1;
-    reconnectAttempt = 0;
-    clearReconnectTimer();
-    clearStartupConnectTimer();
-    runtimeContext = ctx;
-    currentSessionId = ctx.sessionManager.getSessionId();
-    currentModel = ctx.model?.id ?? "unknown";
-    sessionStartedAt = Date.now();
-    agentRunning = false;
-    activeTools.clear();
-    const startupGeneration = runtimeGeneration;
-    startupConnectTimer = setTimeout(() => {
-      startupConnectTimer = null;
-      if (!getLiveContext(ctx, startupGeneration)) {
-        return;
-      }
-      void ensureConnected("startup").catch(() => {
-        if (!getLiveContext(ctx, startupGeneration)) {
-          return;
-        }
-        client = null;
-        scheduleReconnect();
-      });
-    }, 0);
-  });
-
-  pi.on("session_shutdown", async () => {
-    shuttingDown = true;
-    disposed = true;
-    runtimeGeneration += 1;
-    clearStartupConnectTimer();
-    clearReconnectTimer();
-    rejectReplyWaiter(new Error("Session shutting down"));
-    replyTracker.reset();
-    pendingIdleMessages.length = 0;
-    clearInboundFlushTimer();
-    agentRunning = false;
-    activeTools.clear();
-    if (client) {
-      await client.disconnect();
-      client = null;
-    }
-    runtimeContext = null;
-    currentSessionId = null;
-    sessionStartedAt = null;
-  });
-  pi.on("turn_end", () => {
-    if (!getLiveContext()) {
-      return;
-    }
-    replyTracker.endTurn();
-    scheduleInboundFlush(0);
-  });
-  pi.on("agent_start", () => {
-    if (!getLiveContext()) {
-      return;
-    }
-    agentRunning = true;
-    activeTools.clear();
-    syncPresenceStatus();
-  });
-  pi.on("tool_execution_start", (event) => {
-    if (!getLiveContext()) {
-      return;
-    }
-    activeTools.set(event.toolCallId, event.toolName);
-    syncPresenceStatus();
-  });
-  pi.on("tool_execution_end", (event) => {
-    if (!getLiveContext()) {
-      return;
-    }
-    activeTools.delete(event.toolCallId);
-    syncPresenceStatus();
-  });
-  pi.on("agent_end", () => {
-    if (!getLiveContext()) {
-      return;
-    }
-    agentRunning = false;
-    activeTools.clear();
-    syncPresenceStatus();
-    scheduleInboundFlush(0);
-  });
-  pi.on("turn_start", (_event, ctx) => {
-    if (!getLiveContext(ctx)) {
-      return;
-    }
-    currentSessionId = ctx.sessionManager.getSessionId();
-    syncPresenceIdentity(ctx.sessionManager.getSessionId());
-    replyTracker.beginTurn();
-  });
-  pi.on("model_select", (event, ctx) => {
-    if (!getLiveContext(ctx)) {
-      return;
-    }
-    currentModel = event.model.id;
-    if (client) {
-      client.updatePresence({
-        ...buildPresenceIdentity(pi, ctx.sessionManager.getSessionId()),
-        model: event.model.id,
-        status: currentStatus(),
-      });
-    }
-  });
-
-  pi.registerMessageRenderer("intercom_message", (message, _options, theme) => {
-    const details = message.details as { from: SessionInfo; message: Message; replyCommand?: string; bodyText?: string } | undefined;
-    if (!details) return undefined;
-    return new InlineMessageComponent(details.from, details.message, theme, details.replyCommand, details.bodyText);
-  });
-
-  const childOrchestratorMetadata = readChildOrchestratorMetadata();
-  if (childOrchestratorMetadata) {
-    pi.registerTool({
-      name: "contact_supervisor",
-      label: "Contact Supervisor",
-      description: "Subagent-only tool for contacting the supervisor agent that delegated this task. Use need_decision when blocked, uncertain, needing approval, or facing a product/API/scope decision before continuing; this waits for the supervisor's reply. Use interview_request when multiple structured questions need supervisor answers; this also waits for a reply. Use progress_update only for meaningful progress or unexpected discoveries that change the plan; this does not wait for a reply. Do not use for routine completion handoffs.",
-      promptSnippet: "Subagent-only: contact the supervisor for decisions, structured interviews, or meaningful plan-changing updates. Do not use for routine completion handoffs.",
-      promptGuidelines: [
-        "Use contact_supervisor with reason='need_decision' when a subagent is blocked, uncertain, needs approval, or faces a product/API/scope decision before continuing.",
-        "Use contact_supervisor with reason='interview_request' when the child needs multiple structured answers from the supervisor in one blocking exchange.",
-        "Use contact_supervisor with reason='progress_update' only for meaningful progress or unexpected discoveries that change the plan.",
-        "Do not use contact_supervisor for routine completion handoffs; return the final subagent result normally.",
-      ],
-      parameters: Type.Object({
-        reason: Type.String({
-          enum: ["need_decision", "progress_update", "interview_request"],
-          description: "Contact reason: 'need_decision' waits for a reply; 'interview_request' sends structured questions and waits for a reply; 'progress_update' sends a non-blocking update",
-        }),
-        message: Type.Optional(Type.String({
-          description: "Decision request, optional interview note, or meaningful progress update for the supervisor",
-        })),
-        interview: Type.Optional(Type.Object({
-          title: Type.Optional(Type.String()),
-          description: Type.Optional(Type.String()),
-          questions: Type.Array(Type.Object({
-            id: Type.String(),
-            type: Type.String({ description: "Question type: single, multi, text, image, or info" }),
-            question: Type.String(),
-            options: Type.Optional(Type.Array(Type.Unknown())),
-            context: Type.Optional(Type.String()),
-          })),
-        }, { description: "Structured interview request for reason='interview_request'" })),
-      }),
-      async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-        const reason = params.reason as ContactSupervisorReason;
-        if (reason !== "need_decision" && reason !== "progress_update" && reason !== "interview_request") {
-          return {
-            content: [{ type: "text", text: "Invalid reason. Use 'need_decision', 'interview_request', or 'progress_update'." }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-        if ((reason === "need_decision" || reason === "progress_update") && typeof params.message !== "string") {
-          return {
-            content: [{ type: "text", text: `Missing 'message' parameter for reason '${reason}'.` }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-        const interviewValidation = reason === "interview_request"
-          ? validateSupervisorInterviewRequest(params.interview)
-          : undefined;
-        if (interviewValidation?.ok === false) {
-          return {
-            content: [{ type: "text", text: `Invalid interview request: ${interviewValidation.error}` }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-        const supervisorInterview = interviewValidation?.ok === true ? interviewValidation.interview : undefined;
-
-        let connectedClient: IntercomClient;
-        try {
-          connectedClient = await ensureConnected("tool");
-        } catch (error) {
-          return {
-            content: [{ type: "text", text: `Intercom not connected: ${getErrorMessage(error)}` }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-
-        syncPresenceIdentity(ctx.sessionManager.getSessionId());
-
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled" }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-
-        const metadata = childOrchestratorMetadata;
-        let sendTo: string;
-        try {
-          sendTo = await resolveSessionTarget(connectedClient, metadata.orchestratorTarget) ?? metadata.orchestratorTarget;
-        } catch (error) {
-          return {
-            content: [{ type: "text", text: `Failed to resolve supervisor target: ${getErrorMessage(error)}` }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-        if (signal?.aborted) {
-          return {
-            content: [{ type: "text", text: "Cancelled" }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-        if (sendTo === connectedClient.sessionId) {
-          return {
-            content: [{ type: "text", text: "Cannot message the current session" }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-
-        if (reason === "progress_update") {
-          const message = params.message as string;
-          try {
-            const result = await connectedClient.send(sendTo, {
-              text: formatChildOrchestratorMessage("update", metadata, message),
-            });
-            if (!result.delivered) {
-              const errorText = result.reason ?? "Session may not exist or has disconnected.";
-              return {
-                content: [{ type: "text", text: `Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}` }],
-                isError: true,
-                details: { messageId: result.id, delivered: false, reason: result.reason },
-              };
-            }
-            pi.appendEntry("intercom_sent", {
-              to: metadata.orchestratorTarget,
-              message: { text: message, reason },
-              messageId: result.id,
-              timestamp: Date.now(),
-              subagent: { runId: metadata.runId, agent: metadata.agent, index: metadata.index },
-            });
-            return {
-              content: [{ type: "text", text: `Progress update sent to supervisor ${metadata.orchestratorTarget}` }],
-              isError: false,
-              details: { messageId: result.id, delivered: true },
-            };
-          } catch (error) {
-            return {
-              content: [{ type: "text", text: `Failed to send progress update: ${getErrorMessage(error)}` }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-        }
-
-        if (replyWaiter) {
-          return {
-            content: [{ type: "text", text: "Already waiting for a reply" }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-
-        let replyPromise: Promise<Message> | null = null;
-        try {
-          const questionId = randomUUID();
-          replyPromise = waitForReply(sendTo, questionId, signal);
-          replyPromise.catch(() => undefined);
-          if (signal?.aborted) {
-            rejectReplyWaiter(new Error("Cancelled"));
-            try {
-              await replyPromise;
-            } catch {
-              // The waiter was intentionally rejected above; the tool result reports cancellation.
-            }
-            return {
-              content: [{ type: "text", text: "Cancelled" }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-          const requestText = reason === "interview_request"
-            ? formatChildOrchestratorMessage("interview", metadata, formatSupervisorInterviewRequest(supervisorInterview!, typeof params.message === "string" ? params.message : undefined))
-            : formatChildOrchestratorMessage("ask", metadata, params.message as string);
-          const sendResult = await connectedClient.send(sendTo, {
-            messageId: questionId,
-            text: requestText,
-            expectsReply: true,
-          });
-          if (!sendResult.delivered) {
-            const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
-            rejectReplyWaiter(new Error(`Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}`));
-            if (replyPromise) {
-              try {
-                await replyPromise;
-              } catch {
-                // The waiter was already rejected above. Keep the delivery failure as the only error here.
-              }
-            }
-            return {
-              content: [{ type: "text", text: `Message to "${metadata.orchestratorTarget}" was not delivered: ${errorText}` }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-          pi.appendEntry("intercom_sent", {
-            to: metadata.orchestratorTarget,
-            message: {
-              text: reason === "interview_request" ? requestText : params.message,
-              reason,
-              ...(reason === "interview_request" ? { interview: supervisorInterview } : {}),
-            },
-            messageId: sendResult.id,
-            timestamp: Date.now(),
-            subagent: { runId: metadata.runId, agent: metadata.agent, index: metadata.index },
-          });
-          const replyMessage = await replyPromise;
-          const replyText = replyMessage.content.text;
-          const replyAttachments = replyMessage.content.attachments?.length
-            ? formatAttachments(replyMessage.content.attachments)
-            : "";
-          const structuredReply = reason === "interview_request" ? parseStructuredSupervisorReply(replyText, supervisorInterview!) : undefined;
-          pi.appendEntry("intercom_received", {
-            from: metadata.orchestratorTarget,
-            message: { text: replyText, attachments: replyMessage.content.attachments },
-            messageId: replyMessage.id,
-            timestamp: replyMessage.timestamp,
-            subagent: { runId: metadata.runId, agent: metadata.agent, index: metadata.index },
-          });
-          return {
-            content: [{ type: "text", text: `**Reply from supervisor:**\n${replyText}${replyAttachments}` }],
-            isError: false,
-            ...(structuredReply
-              ? { details: structuredReply.value !== undefined ? { structuredReply: structuredReply.value } : { structuredReplyParseError: structuredReply.error } }
-              : {}),
-          };
-        } catch (error) {
-          rejectReplyWaiter(toError(error));
-          if (replyPromise) {
-            try {
-              await replyPromise;
-            } catch {
-              // The waiter is cleanup-only on this path. The real failure is the one from the outer catch.
-            }
-          }
-          return {
-            content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
-            isError: true,
-            details: { error: true },
-          };
-        }
-      },
-      renderCall(args, theme) {
-        const reason = typeof args.reason === "string" ? args.reason : "contact";
-        const messagePreview = previewText(args.message, 96);
-        const interview = args.interview && typeof args.interview === "object" ? args.interview as { title?: unknown } : undefined;
-        let text = theme.fg("toolTitle", theme.bold("contact_supervisor "));
-        text += theme.fg(reason === "need_decision" ? "warning" : reason === "progress_update" ? "muted" : "accent", reason);
-        if (typeof interview?.title === "string" && interview.title.trim()) {
-          text += " " + theme.fg("accent", interview.title.trim());
-        }
-        if (messagePreview) {
-          text += "\n  " + theme.fg("dim", messagePreview);
-        }
-        return new Text(text, 0, 0);
-      },
-      renderResult(result, { isPartial }, theme, context) {
-        if (isPartial) {
-          return new Text(theme.fg("warning", "Waiting for supervisor..."), 0, 0);
-        }
-        const details = result.details as { delivered?: boolean; error?: boolean; messageId?: string; reason?: string; structuredReplyParseError?: string } | undefined;
-        const textContent = firstTextContent(result);
-        const failed = Boolean(context.isError || details?.error === true || details?.delivered === false);
-        const parseWarning = typeof details?.structuredReplyParseError === "string";
-        let text = failed
-          ? theme.fg("error", "✗ ")
-          : parseWarning
-            ? theme.fg("warning", "⚠ ")
-            : theme.fg("success", "✓ ");
-        text += theme.fg(failed ? "error" : "text", textContent);
-        if (parseWarning) {
-          text += "\n" + theme.fg("warning", `Structured reply parse issue: ${details.structuredReplyParseError}`);
-        }
-        return new Text(text, 0, 0);
-      },
-    });
-  }
-
-  pi.registerTool({
-    name: "intercom",
-    label: "Intercom",
-    description: `Send a message to another pi session running on this machine.
+	pi.registerTool({
+		name: "intercom",
+		label: "Intercom",
+		description: `Send a message to another pi session running on this machine.
 Use this to communicate findings, request help, or coordinate work with other sessions.
 
 Usage:
@@ -1317,464 +332,77 @@ Usage:
   intercom({ action: "reply", message: "..." })                      → Reply to the active/single pending ask
   intercom({ action: "pending" })                                      → List unresolved inbound asks
   intercom({ action: "status" })                  → Show connection status`,
-    promptSnippet:
-      "Use to coordinate with other local pi sessions: list peers, send updates, ask for help, or check intercom connectivity.",
+		promptSnippet: "Use to coordinate with other local pi sessions: list peers, send updates, ask for help, or check intercom connectivity.",
+		parameters: Type.Object({
+			action: Type.String({ description: "Action: 'list', 'send', 'ask', 'reply', 'pending', or 'status'" }),
+			to: Type.Optional(Type.String({ description: "Target session name or ID (for 'send', 'ask', or disambiguating 'reply')" })),
+			message: Type.Optional(Type.String({ description: "Message to send (for 'send', 'ask', or 'reply' action)" })),
+			attachments: Type.Optional(Type.Array(Type.Object({
+				type: Type.Union([Type.Literal("file"), Type.Literal("snippet"), Type.Literal("context")]),
+				name: Type.String(),
+				content: Type.String(),
+				language: Type.Optional(Type.String()),
+			}))),
+			replyTo: Type.Optional(Type.String({ description: "Message ID to reply to (for threading or responding to an 'ask')" })),
+		}),
+		execute: (...args) => executeHeavyTool(loadHeavy, "intercom", args),
+		renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "intercom", args),
+		renderCall(args, theme) {
+			const input = args as { action?: string; to?: string; message?: string };
+			const target = input.to ? ` ${input.to}` : "";
+			return new Text(theme.fg("toolTitle", theme.bold(`intercom ${input.action ?? ""}`)) + theme.fg("accent", target), 0, 0);
+		},
+	});
 
-    parameters: Type.Object({
-      action: Type.String({
-        description: "Action: 'list', 'send', 'ask', 'reply', 'pending', or 'status'",
-      }),
-      to: Type.Optional(Type.String({
-        description: "Target session name or ID (for 'send', 'ask', or disambiguating 'reply')",
-      })),
-      message: Type.Optional(Type.String({
-        description: "Message to send (for 'send', 'ask', or 'reply' action)",
-      })),
-      attachments: Type.Optional(Type.Array(Type.Object({
-        type: Type.Union([Type.Literal("file"), Type.Literal("snippet"), Type.Literal("context")]),
-        name: Type.String(),
-        content: Type.String(),
-        language: Type.Optional(Type.String()),
-      }))),
-      replyTo: Type.Optional(Type.String({
-        description: "Message ID to reply to (for threading or responding to an 'ask')",
-      })),
-    }),
+	if (hasSubagentIntercomEnv()) {
+		pi.registerTool({
+			name: "contact_supervisor",
+			label: "Contact Supervisor",
+			description: "Subagent-only tool for contacting the supervisor agent that delegated this task. Use need_decision when blocked, uncertain, needing approval, or facing a product/API/scope decision before continuing; this waits for the supervisor's reply. Use interview_request when multiple structured questions need supervisor answers; this also waits for a reply. Use progress_update only for meaningful progress or unexpected discoveries that change the plan; this does not wait for a reply. Do not use for routine completion handoffs.",
+			promptSnippet: "Subagent-only: contact the supervisor for decisions, structured interviews, or meaningful plan-changing updates. Do not use for routine completion handoffs.",
+			promptGuidelines: [
+				"Use contact_supervisor with reason='need_decision' when a subagent is blocked, uncertain, needs approval, or faces a product/API/scope decision before continuing.",
+				"Use contact_supervisor with reason='interview_request' when the child needs multiple structured answers from the supervisor in one blocking exchange.",
+				"Use contact_supervisor with reason='progress_update' only for meaningful progress or unexpected discoveries that change the plan.",
+				"Do not use contact_supervisor for routine completion handoffs; return the final subagent result normally.",
+			],
+			parameters: Type.Object({
+				reason: Type.String({
+					enum: ["need_decision", "progress_update", "interview_request"],
+					description: "Contact reason: 'need_decision' waits for a reply; 'interview_request' sends structured questions and waits for a reply; 'progress_update' sends a non-blocking update",
+				}),
+				message: Type.Optional(Type.String({
+					description: "Decision request, optional interview note, or meaningful progress update for the supervisor",
+				})),
+				interview: Type.Optional(Type.Object({
+					title: Type.Optional(Type.String()),
+					description: Type.Optional(Type.String()),
+					questions: Type.Array(Type.Object({
+						id: Type.String(),
+						type: Type.String({ description: "Question type: single, multi, text, image, or info" }),
+						question: Type.String(),
+						options: Type.Optional(Type.Array(Type.Unknown())),
+						context: Type.Optional(Type.String()),
+					})),
+				}, { description: "Structured interview request for reason='interview_request'" })),
+			}),
+			execute: (...args) => executeHeavyTool(loadHeavy, "contact_supervisor", args),
+			renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "contact_supervisor", args),
+			renderCall(args, theme) {
+				const input = args as { reason?: string; message?: string; interview?: { title?: string } };
+				const reason = input.reason ?? "contact";
+				const title = input.interview?.title?.trim();
+				const preview = input.message?.trim();
+				let text = theme.fg("toolTitle", theme.bold("contact_supervisor ")) + theme.fg(reason === "need_decision" ? "warning" : reason === "progress_update" ? "muted" : "accent", reason);
+				if (title) text += " " + theme.fg("accent", title);
+				if (preview) text += "\n  " + theme.fg("dim", preview.length > 96 ? `${preview.slice(0, 93)}...` : preview);
+				return new Text(text, 0, 0);
+			},
+		});
+	}
 
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      let connectedClient: IntercomClient;
-      try {
-        connectedClient = await ensureConnected("tool");
-      } catch (error) {
-        return {
-          content: [{ type: "text", text: `Intercom not connected: ${getErrorMessage(error)}` }],
-          isError: true,
-          details: { error: true },
-        };
-      }
-
-      syncPresenceIdentity(ctx.sessionManager.getSessionId());
-
-      const { action, to, message, attachments, replyTo } = params;
-
-      switch (action) {
-        case "list": {
-          try {
-            const mySessionId = connectedClient.sessionId;
-            const sessions = await connectedClient.listSessions();
-            const currentSession = sessions.find(s => s.id === mySessionId);
-            const otherSessions = sessions.filter(s => s.id !== mySessionId);
-
-            if (!currentSession) {
-              return {
-                content: [{ type: "text", text: "Current session is missing from intercom session list." }],
-                isError: true,
-                details: { error: true },
-              };
-            }
-
-            const currentSection = `**Current session:**\n${formatSessionListRow(currentSession, currentSession.cwd, true)}`;
-            const otherSection = otherSessions.length === 0
-              ? "**Other sessions:**\nNo other sessions connected."
-              : `**Other sessions:**\n${otherSessions.map(s => formatSessionListRow(s, currentSession.cwd, false)).join("\n")}`;
-
-            return {
-              content: [{ type: "text", text: `${currentSection}\n\n${otherSection}` }],
-              isError: false,
-            };
-          } catch (error) {
-            return {
-              content: [{ type: "text", text: `Failed to list sessions: ${getErrorMessage(error)}` }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-        }
-
-        case "send": {
-          if (!to || !message) {
-            return {
-              content: [{ type: "text", text: "Missing 'to' or 'message' parameter" }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-          try {
-            const sendTo = await resolveSessionTarget(connectedClient, to) ?? to;
-            if (sendTo === connectedClient.sessionId) {
-              return {
-                content: [{ type: "text", text: "Cannot message the current session" }],
-                isError: true,
-                details: { error: true },
-              };
-            }
-            if (!replyTo && config.confirmSend && ctx.hasUI) {
-              const attachmentText = attachments?.length ? formatAttachments(attachments) : "";
-              const confirmed = await ctx.ui.confirm(
-                "Send Message",
-                `Send to "${to}":\n\n${message}${attachmentText}`,
-              );
-              if (!confirmed) {
-                return {
-                  content: [{ type: "text", text: "Message cancelled by user" }],
-                  isError: false,
-                };
-              }
-            }
-            const result = await connectedClient.send(sendTo, {
-              text: message,
-              attachments,
-              replyTo,
-            });
-            if (!result.delivered) {
-              const errorText = result.reason ?? "Session may not exist or has disconnected.";
-              return {
-                content: [{ type: "text", text: `Message to "${to}" was not delivered: ${errorText}` }],
-                isError: true,
-                details: { messageId: result.id, delivered: false, reason: result.reason },
-              };
-            }
-            pi.appendEntry("intercom_sent", {
-              to,
-              message: { text: message, attachments, replyTo },
-              messageId: result.id,
-              timestamp: Date.now(),
-            });
-            if (replyTo) {
-              replyTracker.markReplied(replyTo);
-            }
-            return {
-              content: [{ type: "text", text: `Message sent to ${to}` }],
-              isError: false,
-              details: { messageId: result.id, delivered: true },
-            };
-          } catch (error) {
-            return {
-              content: [{ type: "text", text: `Failed to send: ${getErrorMessage(error)}` }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-        }
-
-        case "ask": {
-          if (!to || !message) {
-            return {
-              content: [{ type: "text", text: "Missing 'to' or 'message' parameter" }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-
-          if (replyWaiter) {
-            return {
-              content: [{ type: "text", text: "Already waiting for a reply" }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-
-          if (_signal?.aborted) {
-            return {
-              content: [{ type: "text", text: "Cancelled" }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-          let replyPromise: Promise<Message> | null = null;
-
-          try {
-            const sendTo = await resolveSessionTarget(connectedClient, to) ?? to;
-            if (_signal?.aborted) {
-              return {
-                content: [{ type: "text", text: "Cancelled" }],
-                isError: true,
-                details: { error: true },
-              };
-            }
-            if (sendTo === connectedClient.sessionId) {
-              return {
-                content: [{ type: "text", text: "Cannot message the current session" }],
-                isError: true,
-                details: { error: true },
-              };
-            }
-            const questionId = randomUUID();
-            replyPromise = waitForReply(sendTo, questionId, _signal);
-            const sendResult = await connectedClient.send(sendTo, {
-              messageId: questionId,
-              text: message,
-              attachments,
-              replyTo,
-              expectsReply: true,
-            });
-
-            if (!sendResult.delivered) {
-              const errorText = sendResult.reason ?? "Session may not exist or has disconnected.";
-              rejectReplyWaiter(new Error(`Message to "${to}" was not delivered: ${errorText}`));
-              if (replyPromise) {
-                try {
-                  await replyPromise;
-                } catch {
-                  // The waiter was already rejected above. Keep the delivery failure as the only error here.
-                }
-              }
-              return {
-                content: [{ type: "text", text: `Message to "${to}" was not delivered: ${errorText}` }],
-                isError: true,
-                details: { error: true },
-              };
-            }
-            pi.appendEntry("intercom_sent", {
-              to,
-              message: { text: message, attachments, replyTo },
-              messageId: sendResult.id,
-              timestamp: Date.now(),
-            });
-            const replyMessage = await replyPromise;
-            const replyText = replyMessage.content.text;
-            const replyAttachments = replyMessage.content.attachments?.length
-              ? formatAttachments(replyMessage.content.attachments)
-              : "";
-            pi.appendEntry("intercom_received", {
-              from: to,
-              message: { text: replyText, attachments: replyMessage.content.attachments },
-              messageId: replyMessage.id,
-              timestamp: replyMessage.timestamp,
-            });
-            return {
-              content: [{ type: "text", text: `**Reply from ${to}:**\n${replyText}${replyAttachments}` }],
-              isError: false,
-            };
-          } catch (error) {
-            rejectReplyWaiter(toError(error));
-            if (replyPromise) {
-              try {
-                await replyPromise;
-              } catch {
-                // The waiter is cleanup-only on this path. The real failure is the one from the outer catch.
-              }
-            }
-            return {
-              content: [{ type: "text", text: `Failed: ${getErrorMessage(error)}` }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-        }
-
-        case "reply": {
-          if (!message) {
-            return {
-              content: [{ type: "text", text: "Missing 'message' parameter" }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-
-          try {
-            const target = replyTracker.resolveReplyTarget({ to });
-            if (target.from.id === connectedClient.sessionId) {
-              return {
-                content: [{ type: "text", text: "Cannot message the current session" }],
-                isError: true,
-                details: { error: true },
-              };
-            }
-            const result = await connectedClient.send(target.from.id, {
-              text: message,
-              replyTo: target.message.id,
-            });
-            if (!result.delivered) {
-              const errorText = result.reason ?? "Session may not exist or has disconnected.";
-              return {
-                content: [{ type: "text", text: `Reply to "${target.from.name || target.from.id}" was not delivered: ${errorText}` }],
-                isError: true,
-                details: { messageId: result.id, delivered: false, reason: result.reason },
-              };
-            }
-            replyTracker.markReplied(target.message.id);
-            pi.appendEntry("intercom_sent", {
-              to: target.from.name || target.from.id,
-              message: { text: message, replyTo: target.message.id },
-              messageId: result.id,
-              timestamp: Date.now(),
-            });
-            return {
-              content: [{ type: "text", text: `Reply sent to ${target.from.name || target.from.id}` }],
-              isError: false,
-              details: { messageId: result.id, delivered: true, replyTo: target.message.id },
-            };
-          } catch (error) {
-            return {
-              content: [{ type: "text", text: `Failed to reply: ${getErrorMessage(error)}` }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-        }
-
-        case "pending": {
-          const pendingAsks = replyTracker.listPending();
-          if (pendingAsks.length === 0) {
-            return {
-              content: [{ type: "text", text: "No unresolved inbound asks." }],
-              isError: false,
-            };
-          }
-
-          const now = Date.now();
-          const lines = pendingAsks.map(({ from, message, receivedAt }) => {
-            const preview = message.content.text.replace(/\s+/g, " ").slice(0, 80);
-            const elapsedSeconds = Math.max(0, Math.floor((now - receivedAt) / 1000));
-            return `- ${from.name || from.id} · ${message.id} · ${elapsedSeconds}s ago · ${preview}`;
-          });
-          return {
-            content: [{ type: "text", text: `**Pending asks:**\n${lines.join("\n")}` }],
-            isError: false,
-          };
-        }
-
-        case "status": {
-          try {
-            const mySessionId = connectedClient.sessionId;
-            const sessions = await connectedClient.listSessions();
-            return {
-              content: [{
-                type: "text",
-                text: `**Intercom Status:**\nConnected: Yes\nSession ID: ${mySessionId}\nActive sessions: ${sessions.length}`,
-              }],
-              isError: false,
-            };
-          } catch (error) {
-            return {
-              content: [{ type: "text", text: `Failed to get status: ${getErrorMessage(error)}` }],
-              isError: true,
-              details: { error: true },
-            };
-          }
-        }
-
-        default:
-          return {
-            content: [{ type: "text", text: `Unknown action: ${action}` }],
-            isError: true,
-            details: { error: true },
-          };
-      }
-    },
-    renderCall(args, theme) {
-      const action = typeof args.action === "string" ? args.action : "intercom";
-      const target = typeof args.to === "string" && args.to.trim() ? args.to.trim() : undefined;
-      const messagePreview = previewText(args.message, 96);
-      const attachmentCount = Array.isArray(args.attachments) ? args.attachments.length : 0;
-      let text = theme.fg("toolTitle", theme.bold("intercom "));
-      text += theme.fg(action === "ask" ? "warning" : action === "reply" ? "success" : "accent", action);
-      if (target) {
-        text += " " + theme.fg("muted", "→") + " " + theme.fg("accent", target);
-      }
-      if (attachmentCount > 0) {
-        text += " " + theme.fg("dim", `(${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"})`);
-      }
-      if (messagePreview) {
-        text += "\n  " + theme.fg("dim", messagePreview);
-      }
-      return new Text(text, 0, 0);
-    },
-    renderResult(result, { isPartial }, theme, context) {
-      if (isPartial) {
-        return new Text(theme.fg("warning", "Intercom working..."), 0, 0);
-      }
-      const details = result.details as { delivered?: boolean; error?: boolean; messageId?: string; reason?: string } | undefined;
-      const failed = Boolean(context.isError || details?.error === true || details?.delivered === false);
-      let text = failed ? theme.fg("error", "✗ ") : theme.fg("success", "✓ ");
-      text += theme.fg(failed ? "error" : "text", firstTextContent(result));
-      if (details?.messageId && !context.expanded) {
-        text += theme.fg("dim", ` (${details.messageId.slice(0, 8)})`);
-      }
-      if (details?.reason && context.expanded) {
-        text += "\n" + theme.fg("dim", `Reason: ${details.reason}`);
-      }
-      return new Text(text, 0, 0);
-    },
-  });
-
-  async function openIntercomOverlay(ctx: ExtensionContext): Promise<void> {
-    const overlayGeneration = runtimeGeneration;
-    const liveContext = getLiveContext(ctx, overlayGeneration);
-    if (!liveContext?.hasUI) return;
-
-    let overlayClient: IntercomClient;
-    try {
-      overlayClient = await ensureConnected("overlay");
-    } catch (error) {
-      notifyIfLive(ctx, `Intercom unavailable: ${getErrorMessage(error)}`, "error", overlayGeneration);
-      return;
-    }
-    if (!getLiveContext(ctx, overlayGeneration)) return;
-
-    syncPresenceIdentity(ctx.sessionManager.getSessionId());
-
-    let currentSession: SessionInfo;
-    let sessions: SessionInfo[];
-    let duplicates: Set<string>;
-    try {
-      const mySessionId = overlayClient.sessionId;
-      const allSessions = await overlayClient.listSessions();
-      if (!getLiveContext(ctx, overlayGeneration)) return;
-      const foundCurrentSession = allSessions.find(s => s.id === mySessionId);
-      if (!foundCurrentSession) {
-        notifyIfLive(ctx, "Current session is missing from intercom session list", "error", overlayGeneration);
-        return;
-      }
-      currentSession = foundCurrentSession;
-      duplicates = duplicateSessionNames(allSessions);
-      sessions = allSessions.filter(s => s.id !== mySessionId);
-    } catch (error) {
-      notifyIfLive(ctx, `Failed to list sessions: ${getErrorMessage(error)}`, "error", overlayGeneration);
-      return;
-    }
-
-    const selectedSession = await ctx.ui.custom<SessionInfo | undefined>(
-      (_tui, theme, keybindings, done) => new SessionListOverlay(theme, keybindings, currentSession, sessions, done),
-      { overlay: true }
-    ).catch(() => undefined);
-
-    if (!selectedSession || !getLiveContext(ctx, overlayGeneration)) return;
-
-    try {
-      overlayClient = await ensureConnected("overlay");
-    } catch (error) {
-      notifyIfLive(ctx, `Intercom unavailable: ${getErrorMessage(error)}`, "error", overlayGeneration);
-      return;
-    }
-    if (!getLiveContext(ctx, overlayGeneration)) return;
-
-    const targetLabel = formatSessionLabel(selectedSession, duplicates);
-
-    const result = await ctx.ui.custom<ComposeResult>(
-      (tui, theme, keybindings, done) => new ComposeOverlay(tui, theme, keybindings, selectedSession, targetLabel, overlayClient, done),
-      { overlay: true }
-    ).catch(() => undefined);
-
-    if (result?.sent && result.messageId && result.text && getLiveContext(ctx, overlayGeneration)) {
-      pi.appendEntry("intercom_sent", {
-        to: selectedSession.name || selectedSession.id,
-        message: { text: result.text },
-        messageId: result.messageId,
-        timestamp: Date.now(),
-      });
-      notifyIfLive(ctx, `Message sent to ${targetLabel}`, "info", overlayGeneration);
-    }
-  }
-
-  pi.registerCommand("intercom", {
-    description: "Open session intercom overlay",
-    handler: async (_args, ctx) => openIntercomOverlay(ctx),
-  });
-
-  pi.registerShortcut("alt+m", {
-    description: "Open session intercom",
-    handler: async (ctx) => openIntercomOverlay(ctx),
-  });
+	pi.registerCommand("intercom", {
+		description: "Open session intercom overlay",
+		handler: (args, ctx) => runHeavyCommand(loadHeavy, args, ctx),
+	});
 }

--- a/packages/intercom/result-renderers.ts
+++ b/packages/intercom/result-renderers.ts
@@ -1,0 +1,77 @@
+import type { ToolDefinition } from "@bastani/atomic";
+import { Text } from "@mariozechner/pi-tui";
+
+type ToolResultRenderer = NonNullable<ToolDefinition["renderResult"]>;
+type ToolRenderResultArgs = Parameters<ToolResultRenderer>;
+type ToolRenderResult = ReturnType<ToolResultRenderer>;
+type RenderedResult = ToolRenderResultArgs[0];
+type TextContentBlock = Extract<RenderedResult["content"][number], { type: "text" }>;
+
+type IntercomResultDetails = {
+	delivered?: boolean;
+	error?: boolean;
+	messageId?: string;
+	reason?: string;
+};
+
+type ContactSupervisorResultDetails = IntercomResultDetails & {
+	structuredReplyParseError?: string;
+};
+
+function isTextContentBlock(block: RenderedResult["content"][number]): block is TextContentBlock {
+	return block.type === "text";
+}
+
+function firstTextContent(result: RenderedResult): string {
+	return result.content.find(isTextContentBlock)?.text.replace(/\*\*/g, "") ?? "";
+}
+
+export const renderContactSupervisorResult: ToolResultRenderer = (result, { isPartial }, theme, context) => {
+	if (isPartial) {
+		return new Text(theme.fg("warning", "Waiting for supervisor..."), 0, 0);
+	}
+	const details = result.details as ContactSupervisorResultDetails | undefined;
+	const textContent = firstTextContent(result);
+	const failed = Boolean(context.isError || details?.error === true || details?.delivered === false);
+	const parseWarning = typeof details?.structuredReplyParseError === "string";
+	let text = failed
+		? theme.fg("error", "✗ ")
+		: parseWarning
+			? theme.fg("warning", "⚠ ")
+			: theme.fg("success", "✓ ");
+	text += theme.fg(failed ? "error" : "text", textContent);
+	if (parseWarning) {
+		text += "\n" + theme.fg("warning", `Structured reply parse issue: ${details.structuredReplyParseError}`);
+	}
+	return new Text(text, 0, 0);
+};
+
+export const renderIntercomResult: ToolResultRenderer = (result, { isPartial }, theme, context) => {
+	if (isPartial) {
+		return new Text(theme.fg("warning", "Intercom working..."), 0, 0);
+	}
+	const details = result.details as IntercomResultDetails | undefined;
+	const failed = Boolean(context.isError || details?.error === true || details?.delivered === false);
+	let text = failed ? theme.fg("error", "✗ ") : theme.fg("success", "✓ ");
+	text += theme.fg(failed ? "error" : "text", firstTextContent(result));
+	if (details?.messageId && !context.expanded) {
+		text += theme.fg("dim", ` (${details.messageId.slice(0, 8)})`);
+	}
+	if (details?.reason && context.expanded) {
+		text += "\n" + theme.fg("dim", `Reason: ${details.reason}`);
+	}
+	return new Text(text, 0, 0);
+};
+
+export function renderIntercomToolResult(name: string, args: ToolRenderResultArgs): ToolRenderResult {
+	switch (name) {
+		case "intercom":
+			return renderIntercomResult(...args);
+		case "contact_supervisor":
+			return renderContactSupervisorResult(...args);
+		default: {
+			const theme = args[2];
+			return new Text(theme.fg("error", `Result renderer not found: ${name}`), 0, 0);
+		}
+	}
+}

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Kept MCP startup registration cheap by lazily importing the heavy MCP command, initialization, proxy-mode, and OAuth/auth-flow modules (and deferring config/cache-backed direct-tool discovery) instead of loading them on the cold extension factory path, while keeping the result renderer synchronous so restored MCP tool results still render ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
 ## [0.8.25] - 2026-06-04
 
 ### Changed

--- a/packages/mcp/index.ts
+++ b/packages/mcp/index.ts
@@ -1,20 +1,67 @@
 import type { AgentToolUpdateCallback, ExtensionAPI, ExtensionContext, ToolInfo } from "@bastani/atomic";
 import type { McpExtensionState } from "./state.ts";
+import type { McpConfig } from "./types.ts";
+import type { MetadataCache } from "./metadata-cache.ts";
 import { Type } from "typebox";
-import { showStatus, showTools, reconnectServers, authenticateServer, logoutServer, openMcpAuthPanel, openMcpPanel, openMcpSetup } from "./commands.ts";
 import { loadMcpConfig } from "./config.ts";
-import { buildProxyDescription, createDirectToolExecutor, getMissingConfiguredDirectToolServers, resolveDirectTools } from "./direct-tools.ts";
-import { flushMetadataCache, initializeMcp, updateStatusBar } from "./init.ts";
-import { loadMetadataCache } from "./metadata-cache.ts";
-import { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } from "./proxy-modes.ts";
-import { getConfigPathFromArgv, truncateAtWord } from "./utils.ts";
-import { shutdownOAuth } from "./mcp-auth-flow.ts";
+import { getConfigPathFromArgv } from "./utils.ts";
 import { renderMcpToolResult } from "./tool-result-renderer.ts";
 
 export default function mcpAdapter(pi: ExtensionAPI) {
   let state: McpExtensionState | null = null;
   let initPromise: Promise<McpExtensionState> | null = null;
   let lifecycleGeneration = 0;
+  let registeredDirectToolNames = new Set<string>();
+  let registeredProxyTool = false;
+
+  async function registerDirectToolsFromConfig(
+    config: McpConfig,
+    cache: MetadataCache | null,
+  ): Promise<{ directToolCount: number; missingConfiguredDirectToolServers: string[] }> {
+    const [{ resolveDirectTools, createDirectToolExecutor, getMissingConfiguredDirectToolServers }, { truncateAtWord }] = await Promise.all([
+      import("./direct-tools.ts"),
+      import("./utils.ts"),
+    ]);
+    const prefix = config.settings?.toolPrefix ?? "server";
+    const envRaw = process.env.MCP_DIRECT_TOOLS;
+    const directSpecs = envRaw === "__none__"
+      ? []
+      : resolveDirectTools(
+          config,
+          cache,
+          prefix,
+          envRaw?.split(",").map(s => s.trim()).filter(Boolean),
+        );
+    for (const spec of directSpecs) {
+      if (registeredDirectToolNames.has(spec.prefixedName)) continue;
+      registeredDirectToolNames.add(spec.prefixedName);
+      (pi.registerTool as (tool: unknown) => unknown)({
+        name: spec.prefixedName,
+        label: `MCP: ${spec.originalName}`,
+        description: spec.description || "(no description)",
+        promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
+        parameters: Type.Unsafe((spec.inputSchema || { type: "object", properties: {} }) as never),
+        execute: createDirectToolExecutor(() => state, () => initPromise, spec),
+        renderResult: renderMcpToolResult,
+      });
+    }
+    const refreshTools = (pi as { refreshTools?: () => void }).refreshTools;
+    refreshTools?.();
+    return {
+      directToolCount: directSpecs.length,
+      missingConfiguredDirectToolServers: getMissingConfiguredDirectToolServers(config, cache),
+    };
+  }
+
+  async function registerDirectTools(nextState: McpExtensionState): Promise<{ directToolCount: number; missingConfiguredDirectToolServers: string[] }> {
+    const { loadMetadataCache } = await import("./metadata-cache.ts");
+    return registerDirectToolsFromConfig(nextState.config, loadMetadataCache());
+  }
+
+  async function shutdownOAuthFlow(): Promise<void> {
+    const { shutdownOAuth } = await import("./mcp-auth-flow.ts");
+    await shutdownOAuth();
+  }
 
   async function shutdownState(currentState: McpExtensionState | null, reason: string): Promise<void> {
     if (!currentState) return;
@@ -26,6 +73,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
 
     let flushError: unknown;
     try {
+      const { flushMetadataCache } = await import("./init.ts");
       flushMetadataCache(currentState);
     } catch (error) {
       flushError = error;
@@ -47,36 +95,6 @@ export default function mcpAdapter(pi: ExtensionAPI) {
   }
 
   const earlyConfigPath = getConfigPathFromArgv();
-  const earlyConfig = loadMcpConfig(earlyConfigPath);
-  const earlyCache = loadMetadataCache();
-  const prefix = earlyConfig.settings?.toolPrefix ?? "server";
-
-  const envRaw = process.env.MCP_DIRECT_TOOLS;
-  const directSpecs = envRaw === "__none__"
-    ? []
-    : resolveDirectTools(
-        earlyConfig,
-        earlyCache,
-        prefix,
-        envRaw?.split(",").map(s => s.trim()).filter(Boolean),
-      );
-  const missingConfiguredDirectToolServers = getMissingConfiguredDirectToolServers(earlyConfig, earlyCache);
-  const shouldRegisterProxyTool =
-    earlyConfig.settings?.disableProxyTool !== true
-    || directSpecs.length === 0
-    || missingConfiguredDirectToolServers.length > 0;
-
-  for (const spec of directSpecs) {
-    (pi.registerTool as (tool: unknown) => unknown)({
-      name: spec.prefixedName,
-      label: `MCP: ${spec.originalName}`,
-      description: spec.description || "(no description)",
-      promptSnippet: truncateAtWord(spec.description, 100) || `MCP tool from ${spec.serverName}`,
-      parameters: Type.Unsafe((spec.inputSchema || { type: "object", properties: {} }) as never),
-      execute: createDirectToolExecutor(() => state, () => initPromise, spec),
-      renderResult: renderMcpToolResult,
-    });
-  }
 
   const getPiTools = (): ToolInfo[] => pi.getAllTools();
 
@@ -90,45 +108,85 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     const previousState = state;
     state = null;
     initPromise = null;
+    registeredDirectToolNames = new Set<string>();
 
     try {
-      await Promise.all([
-        shutdownState(previousState, "session_restart"),
-        shutdownOAuth(),
-      ]);
+      const config = loadMcpConfig(earlyConfigPath, ctx.cwd);
+      const { loadMetadataCache } = await import("./metadata-cache.ts");
+      const directToolState = await registerDirectToolsFromConfig(config, loadMetadataCache());
+      if (
+        config.settings?.disableProxyTool !== true
+        || directToolState.directToolCount === 0
+        || directToolState.missingConfiguredDirectToolServers.length > 0
+      ) {
+        registerProxyTool();
+      }
     } catch (error) {
-      console.error("MCP: failed to shut down previous session state", error);
+      console.error("MCP: failed to register cached startup tools; enabling MCP proxy fallback", error);
+      registerProxyTool();
     }
 
-    if (generation !== lifecycleGeneration) {
-      return;
-    }
+    const promiseRef: { current: Promise<McpExtensionState> | null } = { current: null };
+    const promise = (async () => {
+      try {
+        await Promise.all([
+          shutdownState(previousState, "session_restart"),
+          shutdownOAuthFlow(),
+        ]);
+      } catch (error) {
+        console.error("MCP: failed to shut down previous session state", error);
+      }
 
-    const promise = initializeMcp(pi, ctx);
-    initPromise = promise;
+      if (generation !== lifecycleGeneration) {
+        throw new Error("Stale MCP session initialization cancelled before startup");
+      }
 
-    promise.then(async (nextState) => {
-      if (generation !== lifecycleGeneration || initPromise !== promise) {
+      const { initializeMcp, updateStatusBar } = await import("./init.ts");
+      if (generation !== lifecycleGeneration) {
+        throw new Error("Stale MCP session initialization cancelled before startup");
+      }
+
+      const nextState = await initializeMcp(pi, ctx);
+      if (generation !== lifecycleGeneration || initPromise !== promiseRef.current) {
         try {
           await shutdownState(nextState, "stale_session_start");
         } catch (error) {
           console.error("MCP: failed to clean stale session state", error);
         }
-        return;
+        throw new Error("Stale MCP session initialization cancelled after startup");
       }
 
       state = nextState;
       updateStatusBar(nextState);
-      initPromise = null;
-    }).catch(err => {
+      const directToolState = await registerDirectTools(nextState);
+      if (
+        nextState.config.settings?.disableProxyTool !== true
+        || directToolState.directToolCount === 0
+        || directToolState.missingConfiguredDirectToolServers.length > 0
+      ) {
+        registerProxyTool();
+      }
+      if (initPromise === promiseRef.current) {
+        initPromise = null;
+      }
+      return nextState;
+    })();
+    promiseRef.current = promise;
+    initPromise = promise;
+    promise.catch((err) => {
       if (generation !== lifecycleGeneration) {
         return;
       }
       if (initPromise !== promise && initPromise !== null) {
         return;
       }
-      console.error("MCP initialization failed:", err);
-      initPromise = null;
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.startsWith("Stale MCP session initialization cancelled")) {
+        console.error("MCP initialization failed:", err);
+      }
+      if (initPromise === promise) {
+        initPromise = null;
+      }
     });
   });
 
@@ -137,11 +195,12 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     const currentState = state;
     state = null;
     initPromise = null;
+    registeredDirectToolNames = new Set<string>();
 
     try {
       await Promise.all([
         shutdownState(currentState, "session_shutdown"),
-        shutdownOAuth(),
+        shutdownOAuthFlow(),
       ]);
     } catch (error) {
       console.error("MCP: session shutdown cleanup failed", error);
@@ -165,6 +224,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         return;
       }
 
+      const { showStatus, showTools, reconnectServers, logoutServer, openMcpPanel, openMcpSetup } = await import("./commands.ts");
       const parts = args?.trim()?.split(/\s+/) ?? [];
       const subcommand = parts[0] ?? "";
       const targetServer = parts[1];
@@ -233,6 +293,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
         return;
       }
 
+      const { authenticateServer, openMcpAuthPanel } = await import("./commands.ts");
       if (!serverName) {
         await openMcpAuthPanel(state, pi, ctx, earlyConfigPath);
         return;
@@ -242,11 +303,13 @@ export default function mcpAdapter(pi: ExtensionAPI) {
     },
   });
 
-  if (shouldRegisterProxyTool) {
+  function registerProxyTool(): void {
+    if (registeredProxyTool) return;
+    registeredProxyTool = true;
     (pi.registerTool as (tool: unknown) => unknown)({
       name: "mcp",
       label: "MCP",
-      description: buildProxyDescription(earlyConfig, earlyCache, directSpecs),
+      description: "MCP gateway for connecting to configured MCP servers, searching tools, describing schemas, and calling tools lazily after MCP initialization.",
       promptSnippet: "MCP gateway - connect to MCP servers and call their tools",
       parameters: Type.Object({
         tool: Type.Optional(Type.String({ description: "Tool name to call (e.g., 'xcodebuild_list_sims')" })),
@@ -305,6 +368,7 @@ export default function mcpAdapter(pi: ExtensionAPI) {
           };
         }
 
+        const { executeCall, executeConnect, executeDescribe, executeList, executeSearch, executeStatus, executeUiMessages } = await import("./proxy-modes.ts");
         if (params.action === "ui-messages") {
           return executeUiMessages(state);
         }

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Deferred heavy search, fetch, curator, summary, provider-probing, and code-search modules until the relevant web-access tool or command is invoked, reducing default CLI startup cost ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
 ## [0.8.25] - 2026-06-04
 
 ### Changed

--- a/packages/web-access/index-heavy.ts
+++ b/packages/web-access/index-heavy.ts
@@ -1,0 +1,2060 @@
+import type { ExtensionAPI, ExtensionContext } from "@bastani/atomic";
+import { Text, truncateToWidth } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+import {
+	renderCodeSearchResult,
+	renderFetchContentResult,
+	renderGetSearchContentResult,
+	renderWebSearchResult,
+} from "./result-renderers.js";
+import { StringEnum, complete, getModel, type Model } from "@mariozechner/pi-ai";
+import { fetchAllContent, type ExtractedContent } from "./extract.js";
+import { clearCloneCache } from "./github-extract.js";
+import { search, type SearchProvider, type ResolvedSearchProvider } from "./gemini-search.js";
+import { executeCodeSearch } from "./code-search.js";
+import type { SearchResult } from "./perplexity.js";
+import {
+	clearResults,
+	deleteResult,
+	generateId,
+	getAllResults,
+	getResult,
+	restoreFromSession,
+	storeResult,
+	type QueryResultData,
+	type StoredSearchData,
+} from "./storage.js";
+import { activityMonitor, type ActivityEntry } from "./activity.js";
+import { startCuratorServer, type CuratorServerHandle } from "./curator-server.js";
+import {
+	buildDeterministicSummary,
+	generateSummaryDraft,
+	type SummaryGenerationContext,
+	type SummaryMeta,
+} from "./summary-review.js";
+import { randomUUID } from "node:crypto";
+import { appendFileSync } from "node:fs";
+
+if (process.env.ATOMIC_TEST_LAZY_IMPORT_SENTINEL_FILE) {
+	appendFileSync(process.env.ATOMIC_TEST_LAZY_IMPORT_SENTINEL_FILE, "web-access\n");
+}
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { platform, homedir } from "node:os";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG_DIR_NAME, getUserConfigPaths } from "@bastani/atomic";
+import { findReadableConfigPath } from "./config-paths.ts";
+import { isPerplexityAvailable } from "./perplexity.js";
+import { isExaAvailable } from "./exa.js";
+import { isGeminiApiAvailable } from "./gemini-api.js";
+
+if (process.env.ATOMIC_TEST_LAZY_IMPORT_SENTINEL === "1") {
+	process.env.ATOMIC_WEB_ACCESS_HEAVY_IMPORTED = "1";
+}
+import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.js";
+import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
+
+const WEB_SEARCH_CONFIG_PATH = getUserConfigPaths("web-search.json")[0] ?? join(homedir(), CONFIG_DIR_NAME, "web-search.json");
+const WEB_SEARCH_CONFIG_READ_PATH = findReadableConfigPath();
+
+interface WebSearchConfig {
+	provider?: string;
+	workflow?: string;
+	curatorTimeoutSeconds?: unknown;
+	summaryModel?: string;
+	shortcuts?: {
+		curate?: string;
+		activity?: string;
+	};
+}
+
+interface ProviderAvailability {
+	perplexity: boolean;
+	exa: boolean;
+	gemini: boolean;
+}
+
+type WebSearchWorkflow = "none" | "summary-review";
+type CuratorWorkflow = "summary-review";
+
+interface CuratorBootstrap {
+	availableProviders: ProviderAvailability;
+	defaultProvider: ResolvedSearchProvider;
+	timeoutSeconds: number;
+}
+
+function loadConfig(): WebSearchConfig {
+	if (!existsSync(WEB_SEARCH_CONFIG_READ_PATH)) return {};
+	const raw = readFileSync(WEB_SEARCH_CONFIG_READ_PATH, "utf-8");
+	try {
+		return JSON.parse(raw) as WebSearchConfig;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to parse ${WEB_SEARCH_CONFIG_READ_PATH}: ${message}`);
+	}
+}
+
+function saveConfig(updates: Partial<WebSearchConfig>): void {
+	let config: Record<string, unknown> = {};
+	const existingConfigPath = findReadableConfigPath();
+	if (existsSync(existingConfigPath)) {
+		const raw = readFileSync(existingConfigPath, "utf-8");
+		try {
+			config = JSON.parse(raw) as Record<string, unknown>;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new Error(`Failed to parse ${existingConfigPath}: ${message}`);
+		}
+	}
+
+	Object.assign(config, updates);
+	const dir = join(homedir(), CONFIG_DIR_NAME);
+	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+	writeFileSync(WEB_SEARCH_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+}
+
+const DEFAULT_SHORTCUTS = { curate: "ctrl+shift+s", activity: "ctrl+shift+w" };
+const DEFAULT_CURATOR_TIMEOUT_SECONDS = 20;
+const MAX_CURATOR_TIMEOUT_SECONDS = 600;
+
+function loadConfigForExtensionInit(): WebSearchConfig {
+	try {
+		return loadConfig();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.error(`[pi-web-access] ${message}`);
+		return {};
+	}
+}
+
+function normalizeProviderInput(value: unknown): SearchProvider | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string") return "auto";
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "auto" || normalized === "exa" || normalized === "perplexity" || normalized === "gemini") {
+		return normalized;
+	}
+	return "auto";
+}
+
+function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+	const normalized = Math.floor(value);
+	if (normalized < 1) return undefined;
+	return Math.min(normalized, MAX_CURATOR_TIMEOUT_SECONDS);
+}
+
+function resolveWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
+	if (!hasUI) return "none";
+	if (typeof input === "string" && input.trim().toLowerCase() === "none") return "none";
+	return "summary-review";
+}
+
+function normalizeQueryList(queryList: unknown[]): string[] {
+	const normalized: string[] = [];
+	for (const query of queryList) {
+		if (typeof query !== "string") continue;
+		const trimmed = query.trim();
+		if (trimmed.length > 0) normalized.push(trimmed);
+	}
+	return normalized;
+}
+
+function getCuratorTimeoutSeconds(): number {
+	const source = loadConfig();
+	return normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds) ?? DEFAULT_CURATOR_TIMEOUT_SECONDS;
+}
+
+async function getProviderAvailability(): Promise<ProviderAvailability> {
+	const geminiWebAvail = await isGeminiWebAvailable();
+	return {
+		perplexity: isPerplexityAvailable(),
+		exa: isExaAvailable(),
+		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
+	};
+}
+
+async function loadCuratorBootstrap(requestedProvider: unknown): Promise<CuratorBootstrap> {
+	const availableProviders = await getProviderAvailability();
+	return {
+		availableProviders,
+		defaultProvider: resolveProvider(requestedProvider, availableProviders),
+		timeoutSeconds: getCuratorTimeoutSeconds(),
+	};
+}
+
+function resolveProvider(
+	requested: unknown,
+	available: ProviderAvailability,
+): ResolvedSearchProvider {
+	const provider = normalizeProviderInput(requested ?? loadConfig().provider ?? "auto") ?? "auto";
+
+	if (provider === "auto") {
+		if (available.exa) return "exa";
+		if (available.perplexity) return "perplexity";
+		if (available.gemini) return "gemini";
+		return "exa";
+	}
+	if (provider === "exa" && !available.exa) {
+		if (available.perplexity) return "perplexity";
+		return available.gemini ? "gemini" : "exa";
+	}
+	if (provider === "perplexity" && !available.perplexity) {
+		if (available.exa) return "exa";
+		return available.gemini ? "gemini" : "perplexity";
+	}
+	if (provider === "gemini" && !available.gemini) {
+		if (available.exa) return "exa";
+		return available.perplexity ? "perplexity" : "gemini";
+	}
+	return provider;
+}
+
+const pendingFetches = new Map<string, AbortController>();
+let sessionActive = false;
+let widgetVisible = false;
+let widgetUnsubscribe: (() => void) | null = null;
+let activeCurator: CuratorServerHandle | null = null;
+let glimpseWin: GlimpseWindow | null = null;
+
+interface PendingCurate {
+	phase: "searching" | "curating";
+	workflow: CuratorWorkflow;
+	summaryContext: SummaryGenerationContext;
+	searchResults: Map<number, QueryResultData>;
+	allInlineContent: ExtractedContent[];
+	queryList: string[];
+	includeContent: boolean;
+	numResults?: number;
+	recencyFilter?: "day" | "week" | "month" | "year";
+	domainFilter?: string[];
+	availableProviders: ProviderAvailability;
+	defaultProvider: ResolvedSearchProvider;
+	summaryModels: Array<{ value: string; label: string }>;
+	defaultSummaryModel: string | null;
+	timeoutSeconds: number;
+	onUpdate: ((update: { content: Array<{ type: string; text: string }>; details?: Record<string, unknown> }) => void) | undefined;
+	signal: AbortSignal | undefined;
+	abortSearches: () => void;
+	finish: (value: unknown) => void;
+	cancel: (reason?: "user" | "stale") => void;
+	browserPromise?: Promise<void>;
+}
+
+let pendingCurate: PendingCurate | null = null;
+
+function cancelPendingCurate(reason: "user" | "stale" = "stale"): void {
+	pendingCurate?.cancel(reason);
+}
+
+const MAX_INLINE_CONTENT = 30000; // Content returned directly to agent
+
+function stripThumbnails(results: ExtractedContent[]): ExtractedContent[] {
+	return results.map(({ thumbnail, frames, ...rest }) => rest);
+}
+
+function formatSearchSummary(results: SearchResult[], answer: string): string {
+	let output = answer ? `${answer}\n\n---\n\n**Sources:**\n` : "";
+	output += results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}`).join("\n\n");
+	return output;
+}
+
+function duplicateQuerySet(results: QueryResultData[]): Set<string> {
+	const counts = new Map<string, number>();
+	for (const result of results) {
+		counts.set(result.query, (counts.get(result.query) ?? 0) + 1);
+	}
+	const duplicates = new Set<string>();
+	for (const [query, count] of counts) {
+		if (count > 1) duplicates.add(query);
+	}
+	return duplicates;
+}
+
+function formatQueryHeader(query: string, provider: string | undefined, duplicateQueries: Set<string>): string {
+	const suffix = duplicateQueries.has(query) && provider ? ` (${provider})` : "";
+	return `## Query: "${query}"${suffix}\n\n`;
+}
+
+function hasFullInlineCoverage(urls: string[], inlineContent: ExtractedContent[] | undefined): boolean {
+	if (!inlineContent || inlineContent.length === 0) return false;
+	const coveredUrls = new Set(inlineContent.map(c => c.url));
+	return urls.every(url => coveredUrls.has(url));
+}
+
+function formatFullResults(queryData: QueryResultData): string {
+	let output = `## Results for: "${queryData.query}"\n\n`;
+	if (queryData.answer) {
+		output += `${queryData.answer}\n\n---\n\n`;
+	}
+	for (const r of queryData.results) {
+		output += `### ${r.title}\n${r.url}\n\n`;
+	}
+	return output;
+}
+
+function abortPendingFetches(): void {
+	for (const controller of pendingFetches.values()) {
+		controller.abort();
+	}
+	pendingFetches.clear();
+}
+
+function closeCurator(): void {
+	const win = glimpseWin;
+	glimpseWin = null;
+	try { win?.close(); } catch {}
+	cancelPendingCurate();
+	if (activeCurator) {
+		activeCurator.close();
+		activeCurator = null;
+	}
+}
+
+async function openInBrowser(pi: ExtensionAPI, url: string): Promise<void> {
+	const plat = platform();
+	const result = plat === "darwin"
+		? await pi.exec("open", [url])
+		: plat === "win32"
+			? await pi.exec("cmd", ["/c", "start", "", url])
+			: await pi.exec("xdg-open", [url]);
+	if (result.code !== 0) {
+		throw new Error(result.stderr || `Failed to open browser (exit code ${result.code})`);
+	}
+}
+
+interface GlimpseWindow {
+	on(event: "closed", handler: () => void): void;
+	on(event: "message", handler: (data: unknown) => void): void;
+	on(event: "ready", handler: (info: { screen?: { visibleHeight?: number } }) => void): void;
+	close(): void;
+	_write(obj: Record<string, unknown>): void;
+}
+
+let glimpseOpen: ((html: string, opts: Record<string, unknown>) => GlimpseWindow) | null | undefined;
+
+function findGlimpseMjs(): string | null {
+	try {
+		const req = createRequire(import.meta.url);
+		return req.resolve("glimpseui");
+	} catch {
+		// Optional dependency.
+	}
+	try {
+		const globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf-8" }).trim();
+		const entry = join(globalRoot, "glimpseui", "src", "glimpse.mjs");
+		if (existsSync(entry)) return entry;
+	} catch {
+		// npm may be unavailable.
+	}
+	return null;
+}
+
+async function getGlimpseOpen() {
+	if (glimpseOpen !== undefined) return glimpseOpen;
+	const resolved = findGlimpseMjs();
+	if (resolved) {
+		try {
+			glimpseOpen = (await import(resolved)).open;
+			return glimpseOpen;
+		} catch {}
+	}
+	glimpseOpen = null;
+	return glimpseOpen;
+}
+
+function openInGlimpse(
+	open: (html: string, opts: Record<string, unknown>) => GlimpseWindow,
+	url: string,
+	title: string,
+): GlimpseWindow {
+	const shellHTML = `<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>${title}</title></head>
+<body style="margin:0; background:#1a1a2e;">
+  <script>window.location.replace(${JSON.stringify(url)});</script>
+</body>
+</html>`;
+	const win = open(shellHTML, {
+		width: 800,
+		height: 900,
+		title,
+	});
+
+	let maxHeight = 1200;
+	win.on("ready", (info) => {
+		const visibleHeight = info?.screen?.visibleHeight;
+		if (typeof visibleHeight === "number" && visibleHeight > 0) {
+			maxHeight = Math.floor(visibleHeight * 0.85);
+		}
+	});
+	win.on("message", (data) => {
+		if (!data || typeof data !== "object") return;
+		const msg = data as Record<string, unknown>;
+		if (msg.type !== "resize" || typeof msg.height !== "number") return;
+		const clamped = Math.max(400, Math.min(Math.round(msg.height), maxHeight));
+		win._write({ type: "resize", width: 800, height: clamped });
+	});
+
+	return win;
+}
+
+function extractDomain(url: string): string {
+	try { return new URL(url).hostname; }
+	catch { return url; }
+}
+
+function updateWidget(ctx: ExtensionContext): void {
+	const theme = ctx.ui.theme;
+	const entries = activityMonitor.getEntries();
+	const lines: string[] = [];
+
+	lines.push(theme.fg("accent", "─── Web Search Activity " + "─".repeat(36)));
+
+	if (entries.length === 0) {
+		lines.push(theme.fg("muted", "  No activity yet"));
+	} else {
+		for (const e of entries) {
+			lines.push("  " + formatEntryLine(e, theme));
+		}
+	}
+
+	lines.push(theme.fg("accent", "─".repeat(60)));
+
+	const rateInfo = activityMonitor.getRateLimitInfo();
+	const resetMs = rateInfo.oldestTimestamp ? Math.max(0, rateInfo.oldestTimestamp + rateInfo.windowMs - Date.now()) : 0;
+	const resetSec = Math.ceil(resetMs / 1000);
+	lines.push(
+		theme.fg("muted", `Rate: ${rateInfo.used}/${rateInfo.max}`) +
+			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : ""),
+	);
+
+	ctx.ui.setWidget("web-activity", new Text(lines.join("\n"), 0, 0));
+}
+
+function formatEntryLine(
+	entry: ActivityEntry,
+	theme: { fg: (color: string, text: string) => string },
+): string {
+	const typeStr = entry.type === "api" ? "API" : "GET";
+	const target =
+		entry.type === "api"
+			? `"${truncateToWidth(entry.query || "", 28, "")}"`
+			: truncateToWidth(entry.url?.replace(/^https?:\/\//, "") || "", 30, "");
+
+	const duration = entry.endTime
+		? `${((entry.endTime - entry.startTime) / 1000).toFixed(1)}s`
+		: `${((Date.now() - entry.startTime) / 1000).toFixed(1)}s`;
+
+	let statusStr: string;
+	let indicator: string;
+	if (entry.error) {
+		statusStr = "err";
+		indicator = theme.fg("error", "✗");
+	} else if (entry.status === null) {
+		statusStr = "...";
+		indicator = theme.fg("warning", "⋯");
+	} else if (entry.status === 0) {
+		statusStr = "abort";
+		indicator = theme.fg("muted", "○");
+	} else {
+		statusStr = String(entry.status);
+		indicator = entry.status >= 200 && entry.status < 300 ? theme.fg("success", "✓") : theme.fg("error", "✗");
+	}
+
+	return `${typeStr.padEnd(4)} ${target.padEnd(32)} ${statusStr.padStart(5)} ${duration.padStart(5)} ${indicator}`;
+}
+
+function handleSessionChange(ctx: ExtensionContext): void {
+	abortPendingFetches();
+	closeCurator();
+	clearCloneCache();
+	sessionActive = true;
+	restoreFromSession(ctx);
+	// Unsubscribe before clear() to avoid callback with stale ctx
+	widgetUnsubscribe?.();
+	widgetUnsubscribe = null;
+	activityMonitor.clear();
+	if (widgetVisible) {
+		// Re-subscribe with new ctx
+		widgetUnsubscribe = activityMonitor.onUpdate(() => updateWidget(ctx));
+		updateWidget(ctx);
+	}
+}
+
+export default function (pi: ExtensionAPI) {
+	const initConfig = loadConfigForExtensionInit();
+	const curateKey = initConfig.shortcuts?.curate || DEFAULT_SHORTCUTS.curate;
+	const activityKey = initConfig.shortcuts?.activity || DEFAULT_SHORTCUTS.activity;
+
+	function startBackgroundFetch(urls: string[]): string | null {
+		if (urls.length === 0) return null;
+		const fetchId = generateId();
+		const controller = new AbortController();
+		pendingFetches.set(fetchId, controller);
+		fetchAllContent(urls, controller.signal)
+			.then((fetched) => {
+				if (!sessionActive || !pendingFetches.has(fetchId)) return;
+				const data: StoredSearchData = {
+					id: fetchId,
+					type: "fetch",
+					timestamp: Date.now(),
+					urls: stripThumbnails(fetched),
+				};
+				storeResult(fetchId, data);
+				pi.appendEntry("web-search-results", data);
+				const ok = fetched.filter(f => !f.error).length;
+				pi.sendMessage(
+					{
+						customType: "web-search-content-ready",
+						content: `Content fetched for ${ok}/${fetched.length} URLs [${fetchId}]. Full page content now available.`,
+						display: true,
+					},
+					{ triggerTurn: true },
+				);
+			})
+			.catch((err) => {
+				if (!sessionActive || !pendingFetches.has(fetchId)) return;
+				const message = err instanceof Error ? err.message : String(err);
+				const isAbort = (err instanceof Error && err.name === "AbortError") || message.toLowerCase().includes("abort");
+				if (!isAbort) {
+					pi.sendMessage(
+						{
+							customType: "web-search-error",
+							content: `Content fetch failed [${fetchId}]: ${message}`,
+							display: true,
+						},
+						{ triggerTurn: false },
+					);
+				}
+			})
+			.finally(() => { pendingFetches.delete(fetchId); });
+		return fetchId;
+	}
+
+	function storeAndPublishSearch(results: QueryResultData[]): string {
+		const id = generateId();
+		const data: StoredSearchData = {
+			id, type: "search", timestamp: Date.now(), queries: results,
+		};
+		storeResult(id, data);
+		pi.appendEntry("web-search-results", data);
+		return id;
+	}
+
+	interface SearchReturnOptions {
+		queryList: string[];
+		results: QueryResultData[];
+		urls: string[];
+		includeContent: boolean;
+		inlineContent?: ExtractedContent[];
+		curated?: boolean;
+		curatedFrom?: number;
+		workflow?: CuratorWorkflow;
+		approvedSummary?: string;
+		summaryMeta?: SummaryMeta;
+	}
+
+	function normalizeSummaryMeta(meta: SummaryMeta | undefined, summaryText: string): SummaryMeta {
+		const normalizedText = summaryText.trim();
+		if (!meta) {
+			return {
+				model: null,
+				durationMs: 0,
+				tokenEstimate: normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0,
+				fallbackUsed: false,
+				edited: false,
+			};
+		}
+
+		return {
+			model: meta.model,
+			durationMs: Number.isFinite(meta.durationMs) && meta.durationMs >= 0 ? meta.durationMs : 0,
+			tokenEstimate: Number.isFinite(meta.tokenEstimate) && meta.tokenEstimate >= 0
+				? meta.tokenEstimate
+				: (normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0),
+			fallbackUsed: meta.fallbackUsed === true,
+			fallbackReason: meta.fallbackReason,
+			edited: meta.edited === true,
+		};
+	}
+
+	function buildCurationCancelledReturn(reason: "user" | "stale") {
+		const message = `Search curation cancelled (${reason}).`;
+		return {
+			content: [{ type: "text", text: message }],
+			details: {
+				error: message,
+				cancelled: true,
+				cancelReason: reason,
+			},
+		};
+	}
+
+	async function resolveFirstAvailableModel(
+		ctx: SummaryGenerationContext,
+		candidates: Array<{ provider: string; id: string }>,
+	): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
+		for (const { provider, id } of candidates) {
+			const model = getModel(provider, id);
+			if (!model) continue;
+			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+			if (auth.ok && auth.apiKey) return { model, apiKey: auth.apiKey, headers: auth.headers };
+		}
+		throw new Error(`No model available: ${candidates.map(c => `${c.provider}/${c.id}`).join(", ")}`);
+	}
+
+	async function rewriteSearchQuery(query: string, ctx: SummaryGenerationContext, signal: AbortSignal): Promise<string> {
+		const { model, apiKey, headers } = await resolveFirstAvailableModel(ctx, [
+			{ provider: "anthropic", id: "claude-haiku-4-5" },
+			{ provider: "google", id: "gemini-2.5-flash" },
+			{ provider: "openai", id: "gpt-4.1-mini" },
+		]);
+		const response = await complete(
+			model,
+			{
+				messages: [{
+					role: "user",
+					content: [{ type: "text", text: `Rewrite this web search query to get better, more specific results. Add relevant year qualifiers, precise technical terms, and specificity. Return ONLY the improved query text, nothing else.\n\nQuery: ${query}` }],
+					timestamp: Date.now(),
+				}],
+			},
+			{ apiKey, headers, signal },
+		);
+		if (response.stopReason === "aborted") throw new Error("Aborted");
+		const contentParts = Array.isArray(response.content) ? response.content : [];
+		const text = contentParts
+			.map(p => {
+				if (!p || typeof p !== "object") return "";
+				const part = p as Record<string, unknown>;
+				return typeof part.text === "string" ? part.text : "";
+			})
+			.join("")
+			.trim();
+		if (!text) throw new Error("Rewrite returned empty response");
+		return text;
+	}
+
+	async function generateSummaryForSelectedIndices(
+		selectedQueryIndices: number[],
+		resultsByIndex: Map<number, QueryResultData>,
+		summaryContext: SummaryGenerationContext,
+		signal?: AbortSignal,
+		modelOverride?: string,
+		feedback?: string,
+	): Promise<{ summary: string; meta: SummaryMeta }> {
+		const selectedResults: QueryResultData[] = [];
+		for (const qi of selectedQueryIndices) {
+			const result = resultsByIndex.get(qi);
+			if (result) selectedResults.push(result);
+		}
+		if (selectedResults.length === 0) {
+			throw new Error("No selected results available for summary generation");
+		}
+		try {
+			return await generateSummaryDraft(selectedResults, summaryContext, signal, modelOverride, feedback);
+		} catch (err) {
+			const isEmptyResponse = err instanceof Error && err.message.includes("Summary model returned empty response");
+			if (!isEmptyResponse) throw err;
+			const deterministic = buildDeterministicSummary(selectedResults);
+			return {
+				summary: deterministic.summary,
+				meta: {
+					...deterministic.meta,
+					fallbackReason: "summary-model-empty-response",
+				},
+			};
+		}
+	}
+
+	async function loadSummaryModelChoices(
+		summaryContext: SummaryGenerationContext,
+	): Promise<{ summaryModels: Array<{ value: string; label: string }>; defaultSummaryModel: string | null }> {
+		const summaryModels: Array<{ value: string; label: string }> = [];
+		const seen = new Set<string>();
+		const availableValues = new Set<string>();
+
+		const addModel = (provider: string, id: string) => {
+			const value = `${provider}/${id}`;
+			if (seen.has(value)) return;
+			seen.add(value);
+			summaryModels.push({ value, label: value });
+		};
+
+		try {
+			const availableModels = summaryContext.modelRegistry.getAvailable();
+			for (const model of availableModels) {
+				const value = `${model.provider}/${model.id}`;
+				availableValues.add(value);
+				addModel(model.provider, model.id);
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.error(`Failed to load summary models: ${message}`);
+		}
+
+		const currentModelValue = summaryContext.model
+			? `${summaryContext.model.provider}/${summaryContext.model.id}`
+			: null;
+		if (summaryContext.model && currentModelValue && !seen.has(currentModelValue)) {
+			addModel(summaryContext.model.provider, summaryContext.model.id);
+		}
+
+		const config = loadConfig();
+		const configuredSummaryModel = typeof config.summaryModel === "string" ? config.summaryModel.trim() : "";
+		const preferredDefaults = [
+			"anthropic/claude-haiku-4-5",
+			"openai-codex/gpt-5.3-codex-spark",
+		];
+
+		let defaultSummaryModel: string | null = null;
+		if (configuredSummaryModel.length > 0 && availableValues.has(configuredSummaryModel)) {
+			defaultSummaryModel = configuredSummaryModel;
+		}
+		if (!defaultSummaryModel) {
+			for (const preferred of preferredDefaults) {
+				if (availableValues.has(preferred)) {
+					defaultSummaryModel = preferred;
+					break;
+				}
+			}
+		}
+		if (!defaultSummaryModel && summaryModels.length > 0) {
+			defaultSummaryModel = summaryModels[0].value;
+		}
+
+		return { summaryModels, defaultSummaryModel };
+	}
+
+	function resolveSummaryForSubmit(
+		payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta },
+		resultsByIndex: Map<number, QueryResultData>,
+	): { approvedSummary: string; summaryMeta: SummaryMeta } {
+		const submittedSummary = typeof payload.summary === "string" ? payload.summary.trim() : "";
+		if (submittedSummary.length > 0) {
+			return {
+				approvedSummary: submittedSummary,
+				summaryMeta: normalizeSummaryMeta(payload.summaryMeta, submittedSummary),
+			};
+		}
+
+		const selected = filterByQueryIndices(payload.selectedQueryIndices, resultsByIndex).results;
+		const fallbackResults = selected.length > 0 ? selected : [...resultsByIndex.values()];
+		const deterministic = buildDeterministicSummary(fallbackResults);
+		return {
+			approvedSummary: deterministic.summary,
+			summaryMeta: deterministic.meta,
+		};
+	}
+
+	function buildSearchReturn(opts: SearchReturnOptions) {
+		const sc = opts.results.filter(r => !r.error).length;
+		const tr = opts.results.reduce((sum, r) => sum + r.results.length, 0);
+
+		const hasApprovedSummary = typeof opts.approvedSummary === "string" && opts.approvedSummary.trim().length > 0;
+		let output = "";
+		if (hasApprovedSummary) {
+			output = opts.approvedSummary!.trim();
+		} else {
+			if (opts.curated) {
+				output += "[These results were manually curated by the user in the browser. Use them as-is — do not re-search or discard.]\n\n";
+			}
+			const duplicateQueries = opts.curated ? duplicateQuerySet(opts.results) : new Set<string>();
+			for (const { query, answer, results, error, provider } of opts.results) {
+				if (opts.queryList.length > 1) {
+					output += opts.curated
+						? formatQueryHeader(query, provider, duplicateQueries)
+						: `## Query: "${query}"\n\n`;
+				}
+				if (error) output += `Error: ${error}\n\n`;
+				else if (results.length === 0) output += "No results found.\n\n";
+				else output += formatSearchSummary(results, answer) + "\n\n";
+			}
+		}
+
+		const hasInlineReady = hasFullInlineCoverage(opts.urls, opts.inlineContent);
+		let fetchId: string | null = null;
+		if (hasInlineReady && opts.inlineContent) {
+			fetchId = generateId();
+			const data: StoredSearchData = {
+				id: fetchId,
+				type: "fetch",
+				timestamp: Date.now(),
+				urls: opts.inlineContent,
+			};
+			storeResult(fetchId, data);
+			pi.appendEntry("web-search-results", data);
+			if (!hasApprovedSummary) {
+				output += `---\nFull content for ${opts.inlineContent.length} sources available [${fetchId}].`;
+			}
+		} else if (opts.includeContent) {
+			fetchId = startBackgroundFetch(opts.urls);
+			if (fetchId && !hasApprovedSummary) {
+				output += `---\nContent fetching in background [${fetchId}]. Will notify when ready.`;
+			}
+		}
+
+		const searchId = storeAndPublishSearch(opts.results);
+		const isBackgroundFetch = fetchId !== null && !hasInlineReady;
+
+		return {
+			content: [{ type: "text", text: output.trim() }],
+			details: {
+				queries: opts.queryList,
+				queryCount: opts.queryList.length,
+				successfulQueries: sc,
+				totalResults: tr,
+				includeContent: opts.includeContent,
+				fetchId,
+				fetchUrls: isBackgroundFetch ? opts.urls : undefined,
+				searchId,
+				...(opts.curated ? {
+					curated: true,
+					curatedFrom: opts.curatedFrom,
+					curatedQueries: opts.results.map(r => ({
+						query: r.query,
+						provider: r.provider || null,
+						answer: r.answer || null,
+						sources: r.results.map(s => ({ title: s.title, url: s.url })),
+						error: r.error,
+					})),
+				} : {}),
+				...((opts.workflow && hasApprovedSummary)
+					? {
+						summary: {
+							text: opts.approvedSummary!.trim(),
+							workflow: opts.workflow,
+							model: opts.summaryMeta?.model ?? null,
+							durationMs: opts.summaryMeta?.durationMs ?? 0,
+							tokenEstimate: opts.summaryMeta?.tokenEstimate ?? 0,
+							fallbackUsed: opts.summaryMeta?.fallbackUsed === true,
+							fallbackReason: opts.summaryMeta?.fallbackReason,
+							edited: opts.summaryMeta?.edited === true,
+						},
+					}
+					: {}),
+			},
+		};
+	}
+
+	function filterByQueryIndices(selectedQueryIndices: number[], results: Map<number, QueryResultData>) {
+		const filteredResults: QueryResultData[] = [];
+		const filteredUrls: string[] = [];
+		for (const qi of selectedQueryIndices) {
+			const r = results.get(qi);
+			if (r) {
+				filteredResults.push(r);
+				for (const res of r.results) {
+					if (!filteredUrls.includes(res.url)) filteredUrls.push(res.url);
+				}
+			}
+		}
+		return { results: filteredResults, urls: filteredUrls };
+	}
+
+	function collectAllResultsAndUrls(resultsByIndex: Map<number, QueryResultData>) {
+		const results = [...resultsByIndex.values()];
+		const urls: string[] = [];
+		for (const result of results) {
+			for (const source of result.results) {
+				if (!urls.includes(source.url)) urls.push(source.url);
+			}
+		}
+		return { results, urls };
+	}
+
+	async function openCuratorBrowser(pc: PendingCurate, searchesComplete = true): Promise<void> {
+		let handle: CuratorServerHandle | null = null;
+		try {
+			pc.phase = "curating";
+
+			const searchAbort = new AbortController();
+			const addSearchSignal = pc.signal
+				? AbortSignal.any([pc.signal, searchAbort.signal])
+				: searchAbort.signal;
+
+			const sessionToken = randomUUID();
+			handle = await startCuratorServer(
+				{
+					queries: pc.queryList,
+					sessionToken,
+					timeout: pc.timeoutSeconds,
+					availableProviders: pc.availableProviders,
+					defaultProvider: pc.defaultProvider,
+					summaryModels: pc.summaryModels,
+					defaultSummaryModel: pc.defaultSummaryModel,
+				},
+				{
+					async onSummarize(selectedQueryIndices, summarizeSignal, model, feedback) {
+						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						pc.onUpdate?.({
+							content: [{ type: "text", text: "Generating summary draft..." }],
+							details: { phase: "generating-summary", progress: 0.9 },
+						});
+						const draft = await generateSummaryForSelectedIndices(
+							selectedQueryIndices,
+							pc.searchResults,
+							pc.summaryContext,
+							summarizeSignal,
+							model,
+							feedback,
+						);
+						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						pc.onUpdate?.({
+							content: [{ type: "text", text: "Summary draft ready — waiting for approval..." }],
+							details: { phase: "waiting-for-approval", progress: 1 },
+						});
+						return draft;
+					},
+					onSubmit(payload) {
+						if (pendingCurate !== pc) return;
+						searchAbort.abort();
+						const filtered = payload.selectedQueryIndices.length > 0
+							? filterByQueryIndices(payload.selectedQueryIndices, pc.searchResults)
+							: collectAllResultsAndUrls(pc.searchResults);
+						const filteredInline = pc.allInlineContent.filter(c => filtered.urls.includes(c.url));
+						const base: SearchReturnOptions = {
+							queryList: filtered.results.map(r => r.query),
+							results: filtered.results,
+							urls: filtered.urls,
+							includeContent: pc.includeContent,
+							inlineContent: filteredInline.length > 0 ? filteredInline : undefined,
+							curated: true,
+							curatedFrom: pc.searchResults.size,
+						};
+						if (!payload.rawResults) {
+							const resolvedSummary = resolveSummaryForSubmit(payload, pc.searchResults);
+							base.workflow = pc.workflow;
+							base.approvedSummary = resolvedSummary.approvedSummary;
+							base.summaryMeta = resolvedSummary.summaryMeta;
+						}
+						pc.finish(buildSearchReturn(base));
+						closeCurator();
+					},
+					onCancel(reason) {
+						if (pendingCurate !== pc) return;
+						searchAbort.abort();
+						if (reason === "timeout") {
+							const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, pc.searchResults);
+							const all = collectAllResultsAndUrls(pc.searchResults);
+							const filteredInline = pc.allInlineContent.filter(c => all.urls.includes(c.url));
+							pc.finish(buildSearchReturn({
+								queryList: all.results.map(r => r.query),
+								results: all.results,
+								urls: all.urls,
+								includeContent: pc.includeContent,
+								inlineContent: filteredInline.length > 0 ? filteredInline : undefined,
+								curated: true,
+								curatedFrom: pc.searchResults.size,
+								workflow: pc.workflow,
+								approvedSummary: resolvedSummary.approvedSummary,
+								summaryMeta: resolvedSummary.summaryMeta,
+							}));
+						} else {
+							pc.finish(buildCurationCancelledReturn(reason));
+						}
+						closeCurator();
+					},
+					onProviderChange(provider) {
+						if (pendingCurate !== pc) return;
+						const normalized = normalizeProviderInput(provider);
+						if (!normalized || normalized === "auto") return;
+						pc.defaultProvider = normalized;
+						try {
+							saveConfig({ provider: normalized });
+						} catch (err) {
+							const message = err instanceof Error ? err.message : String(err);
+							console.error(`Failed to persist default provider: ${message}`);
+						}
+					},
+					async onAddSearch(query, queryIndex, provider) {
+						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						const normalizedProvider = normalizeProviderInput(provider);
+						const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
+							? pc.defaultProvider
+							: normalizedProvider;
+						try {
+							const { answer, results, inlineContent, provider: actualProvider } = await search(query, {
+								provider: requestedProvider,
+								numResults: pc.numResults,
+								recencyFilter: pc.recencyFilter,
+								domainFilter: pc.domainFilter,
+								includeContent: pc.includeContent,
+								signal: addSearchSignal,
+							});
+							if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+							pc.searchResults.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
+							if (inlineContent) pc.allInlineContent.push(...inlineContent);
+							return {
+								answer,
+								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+								provider: actualProvider,
+							};
+						} catch (err) {
+							const message = err instanceof Error ? err.message : String(err);
+							if (pendingCurate === pc) {
+								pc.searchResults.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
+							}
+							throw err;
+						}
+					},
+					async onRewriteQuery(query, rewriteSignal) {
+						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
+						return rewriteSearchQuery(query, pc.summaryContext, rewriteSignal);
+					},
+				},
+			);
+
+			if (pendingCurate !== pc) {
+				handle.close();
+				return;
+			}
+
+			activeCurator = handle;
+
+			for (const [qi, data] of pc.searchResults) {
+				if (data.error) {
+					handle.pushError(qi, data.error, data.provider);
+				} else {
+					handle.pushResult(qi, {
+						answer: data.answer,
+						results: data.results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+						provider: data.provider || pc.defaultProvider,
+					});
+				}
+			}
+			if (searchesComplete) handle.searchesDone();
+
+			pc.onUpdate?.({
+				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
+				details: { phase: "curating", progress: searchesComplete ? 1 : 0.5 },
+			});
+
+			const open = platform() === "darwin" ? await getGlimpseOpen() : null;
+			if (open) {
+				try {
+					const win = openInGlimpse(open, handle.url, "Search Curator");
+					glimpseWin = win;
+					win.on("closed", () => {
+						if (glimpseWin === win) {
+							glimpseWin = null;
+							closeCurator();
+						}
+					});
+					return;
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					console.error(`Failed to open Glimpse curator window: ${message}`);
+					glimpseWin = null;
+				}
+			}
+			await openInBrowser(pi, handle.url);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.error(`Failed to open curator UI: ${message}`);
+			if (pendingCurate === pc || (handle && activeCurator === handle)) {
+				closeCurator();
+			}
+		}
+	}
+
+	pi.registerShortcut(curateKey, {
+		description: "Review search results",
+		handler: async (ctx) => {
+			if (!pendingCurate) return;
+
+			if (pendingCurate.phase === "searching") {
+				pendingCurate.browserPromise = openCuratorBrowser(pendingCurate, false);
+				ctx.ui.notify("Opening curator — remaining searches will stream in", "info");
+				return;
+			}
+		},
+	});
+
+	pi.registerShortcut(activityKey, {
+		description: "Toggle web search activity",
+		handler: async (ctx) => {
+			widgetVisible = !widgetVisible;
+			if (widgetVisible) {
+				widgetUnsubscribe = activityMonitor.onUpdate(() => updateWidget(ctx));
+				updateWidget(ctx);
+			} else {
+				widgetUnsubscribe?.();
+				widgetUnsubscribe = null;
+				ctx.ui.setWidget("web-activity", null);
+			}
+		},
+	});
+
+	pi.on("session_start", async (_event, ctx) => handleSessionChange(ctx));
+	pi.on("session_tree", async (_event, ctx) => handleSessionChange(ctx));
+
+	pi.on("session_shutdown", () => {
+		sessionActive = false;
+		abortPendingFetches();
+		closeCurator();
+		clearCloneCache();
+		clearResults();
+		// Unsubscribe before clear() to avoid callback with stale ctx
+		widgetUnsubscribe?.();
+		widgetUnsubscribe = null;
+		activityMonitor.clear();
+		widgetVisible = false;
+	});
+
+	pi.registerTool({
+		name: "web_search",
+		label: "Web Search",
+		description:
+			`Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
+		promptSnippet:
+			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
+		parameters: Type.Object({
+			query: Type.Optional(Type.String({ description: "Single search query. For research tasks, prefer 'queries' with multiple varied angles instead." })),
+			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results)." })),
+			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)" })),
+			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content (async)" })),
+			recencyFilter: Type.Optional(
+				StringEnum(["day", "week", "month", "year"], { description: "Filter by recency" }),
+			),
+			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
+			provider: Type.Optional(
+				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)" }),
+			),
+			workflow: Type.Optional(
+				StringEnum(["none", "summary-review"], {
+					description: "Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)",
+				}),
+			),
+		}),
+
+		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const rawQueryList: unknown[] = Array.isArray(params.queries)
+				? params.queries
+				: (params.query !== undefined ? [params.query] : []);
+			const queryList = normalizeQueryList(rawQueryList);
+			const configWorkflow = loadConfigForExtensionInit().workflow;
+			const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
+			const shouldCurate = workflow !== "none";
+
+			if (queryList.length === 0) {
+				return {
+					content: [{ type: "text", text: "Error: No query provided. Use 'query' or 'queries' parameter." }],
+					details: { error: "No query provided" },
+				};
+			}
+
+			if (shouldCurate && !ctx) {
+				return {
+					content: [{ type: "text", text: "Error: Curation requires an active extension context." }],
+					details: { error: "Missing extension context" },
+				};
+			}
+
+			if (shouldCurate) {
+				closeCurator();
+
+				let resolvePromise: (value: unknown) => void = () => {};
+				const promise = new Promise<unknown>((resolve) => {
+					resolvePromise = resolve;
+				});
+				const includeContent = params.includeContent ?? false;
+				const searchResults = new Map<number, QueryResultData>();
+				const allInlineContent: ExtractedContent[] = [];
+				const searchAbort = new AbortController();
+				const searchSignal = signal
+					? AbortSignal.any([signal, searchAbort.signal])
+					: searchAbort.signal;
+				let cancelled = false;
+
+				const bootstrap = await loadCuratorBootstrap(params.provider);
+				const availableProviders = bootstrap.availableProviders;
+				const defaultProvider = bootstrap.defaultProvider;
+				const curatorTimeoutSeconds = bootstrap.timeoutSeconds;
+				const curatorWorkflow: CuratorWorkflow = "summary-review";
+
+				const summaryContext: SummaryGenerationContext = {
+					model: ctx.model,
+					modelRegistry: ctx.modelRegistry,
+				};
+				const summaryModelChoices = await loadSummaryModelChoices(summaryContext);
+
+				const pc: PendingCurate = {
+					phase: "searching",
+					workflow: curatorWorkflow,
+					summaryContext,
+					searchResults,
+					allInlineContent,
+					queryList,
+					includeContent,
+					numResults: params.numResults,
+					recencyFilter: params.recencyFilter,
+					domainFilter: params.domainFilter,
+					availableProviders,
+					defaultProvider,
+					summaryModels: summaryModelChoices.summaryModels,
+					defaultSummaryModel: summaryModelChoices.defaultSummaryModel,
+					timeoutSeconds: curatorTimeoutSeconds,
+					onUpdate: onUpdate as PendingCurate["onUpdate"],
+					signal,
+					abortSearches: () => {
+						if (!searchAbort.signal.aborted) searchAbort.abort();
+					},
+					finish: () => {},
+					cancel: () => {},
+				};
+
+				const finish = (value: unknown) => {
+					if (cancelled) return;
+					cancelled = true;
+					pc.abortSearches();
+					signal?.removeEventListener("abort", onAbort);
+					pendingCurate = null;
+					resolvePromise(value);
+				};
+
+				const cancel = (reason: "user" | "stale" = "stale") => {
+					if (cancelled) return;
+					finish(buildCurationCancelledReturn(reason));
+				};
+
+				pc.finish = finish;
+				pc.cancel = cancel;
+
+				const onAbort = () => closeCurator();
+				pendingCurate = pc;
+				signal?.addEventListener("abort", onAbort, { once: true });
+				pc.browserPromise = openCuratorBrowser(pc, false);
+
+				for (let qi = 0; qi < queryList.length; qi++) {
+					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
+					onUpdate?.({
+						content: [{ type: "text", text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...` }],
+						details: { phase: "searching", progress: qi / queryList.length, currentQuery: queryList[qi] },
+					});
+					const requestedProvider = pc.defaultProvider;
+					try {
+						const { answer, results, inlineContent, provider } = await search(queryList[qi], {
+							provider: requestedProvider,
+							numResults: params.numResults,
+							recencyFilter: params.recencyFilter,
+							domainFilter: params.domainFilter,
+							includeContent: params.includeContent,
+							signal: searchSignal,
+						});
+						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
+						searchResults.set(qi, { query: queryList[qi], answer, results, error: null, provider });
+						if (inlineContent) allInlineContent.push(...inlineContent);
+						if (activeCurator) {
+							activeCurator.pushResult(qi, {
+								answer,
+								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+								provider,
+							});
+						}
+					} catch (err) {
+						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
+						const message = err instanceof Error ? err.message : String(err);
+						searchResults.set(qi, { query: queryList[qi], answer: "", results: [], error: message, provider: requestedProvider });
+						if (activeCurator) {
+							activeCurator.pushError(qi, message, requestedProvider);
+						}
+					}
+				}
+
+				if (signal?.aborted || cancelled || searchAbort.signal.aborted) {
+					cancel();
+					return promise;
+				}
+
+				await pc.browserPromise;
+				if (activeCurator) {
+					activeCurator.searchesDone();
+					pc.onUpdate?.({
+						content: [{ type: "text", text: "All searches complete — waiting for summary approval in browser..." }],
+						details: { phase: "curating", progress: 1 },
+					});
+				}
+
+				return promise;
+			}
+
+			const searchResults: QueryResultData[] = [];
+			const allUrls: string[] = [];
+			const allInlineContent: ExtractedContent[] = [];
+			const resolvedProvider = normalizeProviderInput(params.provider ?? loadConfig().provider);
+
+			for (let i = 0; i < queryList.length; i++) {
+				const query = queryList[i];
+
+				onUpdate?.({
+					content: [{ type: "text", text: `Searching ${i + 1}/${queryList.length}: "${query}"...` }],
+					details: { phase: "search", progress: i / queryList.length, currentQuery: query },
+				});
+
+				try {
+					const { answer, results, inlineContent, provider } = await search(query, {
+						provider: resolvedProvider,
+						numResults: params.numResults,
+						recencyFilter: params.recencyFilter,
+						domainFilter: params.domainFilter,
+						includeContent: params.includeContent,
+						signal,
+					});
+
+					searchResults.push({ query, answer, results, error: null, provider });
+					for (const r of results) {
+						if (!allUrls.includes(r.url)) {
+							allUrls.push(r.url);
+						}
+					}
+					if (inlineContent) allInlineContent.push(...inlineContent);
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					const requestedProvider = typeof resolvedProvider === "string" && resolvedProvider !== "auto"
+						? resolvedProvider
+						: undefined;
+					searchResults.push({ query, answer: "", results: [], error: message, provider: requestedProvider });
+				}
+			}
+
+			return buildSearchReturn({
+				queryList,
+				results: searchResults,
+				urls: allUrls,
+				includeContent: params.includeContent ?? false,
+				inlineContent: allInlineContent.length > 0 ? allInlineContent : undefined,
+			});
+		},
+
+		renderCall(args, theme) {
+			const input = args as { query?: unknown; queries?: unknown };
+			const rawQueryList: unknown[] = Array.isArray(input.queries)
+				? input.queries
+				: (input.query !== undefined ? [input.query] : []);
+			const queryList = normalizeQueryList(rawQueryList);
+			if (queryList.length === 0) {
+				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("error", "(no query)"), 0, 0);
+			}
+			if (queryList.length === 1) {
+				const q = queryList[0];
+				const display = q.length > 60 ? q.slice(0, 57) + "..." : q;
+				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `"${display}"`), 0, 0);
+			}
+			const lines = [theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `${queryList.length} queries`)];
+			for (const q of queryList.slice(0, 5)) {
+				const display = q.length > 50 ? q.slice(0, 47) + "..." : q;
+				lines.push(theme.fg("muted", `  "${display}"`));
+			}
+			if (queryList.length > 5) {
+				lines.push(theme.fg("muted", `  ... and ${queryList.length - 5} more`));
+			}
+			return new Text(lines.join("\n"), 0, 0);
+		},
+
+		renderResult: renderWebSearchResult,
+	});
+
+	pi.registerTool({
+		name: "code_search",
+		label: "Code Search",
+		description: "Search for code examples, documentation, and API references. Returns relevant code snippets and docs from GitHub, Stack Overflow, and official documentation. Use for any programming question — API usage, library examples, debugging help.",
+		promptSnippet:
+			"Use for programming/API/library questions to retrieve concrete examples and docs before implementing or debugging code.",
+		parameters: Type.Object({
+			query: Type.String({ description: "Programming question, API, library, or debugging topic to search for" }),
+			maxTokens: Type.Optional(Type.Integer({
+				minimum: 1000,
+				maximum: 50000,
+				description: "Maximum tokens of code/documentation context to return (default: 5000)",
+			})),
+		}),
+
+		async execute(toolCallId, params, signal) {
+			return executeCodeSearch(toolCallId, params, signal);
+		},
+
+		renderCall(args, theme) {
+			const { query } = args as { query?: string };
+			const display = !query
+				? "(no query)"
+				: query.length > 70 ? query.slice(0, 67) + "..." : query;
+			return new Text(theme.fg("toolTitle", theme.bold("code_search ")) + theme.fg("accent", display), 0, 0);
+		},
+
+		renderResult: renderCodeSearchResult,
+	});
+
+	pi.registerTool({
+		name: "fetch_content",
+		label: "Fetch Content",
+		description: "Fetch URL(s) and extract readable content as markdown. Supports YouTube video transcripts (with thumbnail), GitHub repository contents, and local video files (with frame thumbnail). Video frames can be extracted via timestamp/range or sampled across the entire video with frames alone. Falls back to Gemini for pages that block bots or fail Readability extraction. For YouTube and video files: ALWAYS pass the user's specific question via the prompt parameter — this directs the AI to focus on that aspect of the video, producing much better results than a generic extraction. Content is always stored and can be retrieved with get_search_content.",
+		promptSnippet:
+			"Use to extract readable content from URL(s), YouTube, GitHub repos, or local videos. For video questions, pass the user's exact question in prompt.",
+		parameters: Type.Object({
+			url: Type.Optional(Type.String({ description: "Single URL to fetch" })),
+			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (parallel)" })),
+			forceClone: Type.Optional(Type.Boolean({
+				description: "Force cloning large GitHub repositories that exceed the size threshold",
+			})),
+			prompt: Type.Optional(Type.String({
+				description: "Question or instruction for video analysis (YouTube and video files). Pass the user's specific question here — e.g. 'describe the book shown at the advice for beginners section'. Without this, a generic transcript extraction is used which may miss what the user is asking about.",
+			})),
+			timestamp: Type.Optional(Type.String({
+				description: "Extract video frame(s) at a timestamp or time range. Single: '1:23:45', '23:45', or '85' (seconds). Range: '23:41-25:00' extracts evenly-spaced frames across that span (default 6). Use frames with ranges to control density; single+frames uses a fixed 5s interval. YouTube requires yt-dlp + ffmpeg; local videos require ffmpeg. Use a range when you know the approximate area but not the exact moment — you'll get a contact sheet to visually identify the right frame.",
+			})),
+			frames: Type.Optional(Type.Integer({
+				minimum: 1,
+				maximum: 12,
+				description: "Number of frames to extract. Use with timestamp range for custom density, with single timestamp to get N frames at 5s intervals, or alone to sample across the entire video. Requires yt-dlp + ffmpeg for YouTube, ffmpeg for local video.",
+			})),
+			model: Type.Optional(Type.String({
+				description: "Override the Gemini model for video/YouTube analysis (e.g. 'gemini-2.5-flash', 'gemini-3-flash-preview'). Defaults to config or gemini-3-flash-preview.",
+			})),
+		}),
+
+		async execute(_toolCallId, params, signal, onUpdate) {
+			const urlList = params.urls ?? (params.url ? [params.url] : []);
+			if (urlList.length === 0) {
+				return {
+					content: [{ type: "text", text: "Error: No URL provided." }],
+					details: { error: "No URL provided" },
+				};
+			}
+
+			onUpdate?.({
+				content: [{ type: "text", text: `Fetching ${urlList.length} URL(s)...` }],
+				details: { phase: "fetch", progress: 0 },
+			});
+
+			const fetchResults = await fetchAllContent(urlList, signal, {
+				forceClone: params.forceClone,
+				prompt: params.prompt,
+				timestamp: params.timestamp,
+				frames: params.frames,
+				model: params.model,
+			});
+			const successful = fetchResults.filter((r) => !r.error).length;
+			const totalChars = fetchResults.reduce((sum, r) => sum + r.content.length, 0);
+
+			// ALWAYS store results (even for single URL)
+			const responseId = generateId();
+			const data: StoredSearchData = {
+				id: responseId,
+				type: "fetch",
+				timestamp: Date.now(),
+				urls: stripThumbnails(fetchResults),
+			};
+			storeResult(responseId, data);
+			pi.appendEntry("web-search-results", data);
+
+			// Single URL: return content directly (possibly truncated) with responseId
+			if (urlList.length === 1) {
+				const result = fetchResults[0];
+				if (result.error) {
+					return {
+						content: [{ type: "text", text: `Error: ${result.error}` }],
+						details: { urls: urlList, urlCount: 1, successful: 0, error: result.error, responseId, prompt: params.prompt, timestamp: params.timestamp, frames: params.frames },
+					};
+				}
+
+				const fullLength = result.content.length;
+				const truncated = fullLength > MAX_INLINE_CONTENT;
+				let output = truncated
+					? result.content.slice(0, MAX_INLINE_CONTENT) + "\n\n[Content truncated...]"
+					: result.content;
+
+				if (truncated) {
+					output += `\n\n---\nShowing ${MAX_INLINE_CONTENT} of ${fullLength} chars. ` +
+						`Use get_search_content({ responseId: "${responseId}", urlIndex: 0 }) for full content.`;
+				}
+
+				const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [];
+				if (result.frames?.length) {
+					for (const frame of result.frames) {
+						content.push({ type: "image", data: frame.data, mimeType: frame.mimeType });
+						content.push({ type: "text", text: `Frame at ${frame.timestamp}` });
+					}
+				} else if (result.thumbnail) {
+					content.push({ type: "image", data: result.thumbnail.data, mimeType: result.thumbnail.mimeType });
+				}
+				content.push({ type: "text", text: output });
+
+				const imageCount = (result.frames?.length ?? 0) + (result.thumbnail ? 1 : 0);
+				return {
+					content,
+					details: {
+						urls: urlList,
+						urlCount: 1,
+						successful: 1,
+						totalChars: fullLength,
+						title: result.title,
+						responseId,
+						truncated,
+						hasImage: imageCount > 0,
+						imageCount,
+						prompt: params.prompt,
+						timestamp: params.timestamp,
+						frames: params.frames,
+						duration: result.duration,
+					},
+				};
+			}
+
+			// Multi-URL: existing behavior (summary + responseId)
+			let output = "## Fetched URLs\n\n";
+			for (const { url, title, content, error } of fetchResults) {
+				if (error) {
+					output += `- ${url}: Error - ${error}\n`;
+				} else {
+					output += `- ${title || url} (${content.length} chars)\n`;
+				}
+			}
+			output += `\n---\nUse get_search_content({ responseId: "${responseId}", urlIndex: 0 }) to retrieve full content.`;
+
+			return {
+				content: [{ type: "text", text: output }],
+				details: { urls: urlList, urlCount: urlList.length, successful, totalChars, responseId },
+			};
+		},
+
+		renderCall(args, theme) {
+			const { url, urls, prompt, timestamp, frames, model } = args as { url?: string; urls?: string[]; prompt?: string; timestamp?: string; frames?: number; model?: string };
+			const urlList = urls ?? (url ? [url] : []);
+			if (urlList.length === 0) {
+				return new Text(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("error", "(no URL)"), 0, 0);
+			}
+			const lines: string[] = [];
+			if (urlList.length === 1) {
+				const display = urlList[0].length > 60 ? urlList[0].slice(0, 57) + "..." : urlList[0];
+				lines.push(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", display));
+			} else {
+				lines.push(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", `${urlList.length} URLs`));
+				for (const u of urlList.slice(0, 5)) {
+					const display = u.length > 60 ? u.slice(0, 57) + "..." : u;
+					lines.push(theme.fg("muted", "  " + display));
+				}
+				if (urlList.length > 5) {
+					lines.push(theme.fg("muted", `  ... and ${urlList.length - 5} more`));
+				}
+			}
+			if (timestamp) {
+				lines.push(theme.fg("dim", "  timestamp: ") + theme.fg("warning", timestamp));
+			}
+			if (typeof frames === "number") {
+				lines.push(theme.fg("dim", "  frames: ") + theme.fg("warning", String(frames)));
+			}
+			if (prompt) {
+				const display = prompt.length > 250 ? prompt.slice(0, 247) + "..." : prompt;
+				lines.push(theme.fg("dim", "  prompt: ") + theme.fg("muted", `"${display}"`));
+			}
+			if (model) {
+				lines.push(theme.fg("dim", "  model: ") + theme.fg("warning", model));
+			}
+			return new Text(lines.join("\n"), 0, 0);
+		},
+
+		renderResult: renderFetchContentResult,
+	});
+
+	pi.registerTool({
+		name: "get_search_content",
+		label: "Get Search Content",
+		description: "Retrieve full content from a previous web_search or fetch_content call.",
+		promptSnippet:
+			"Use after web_search/fetch_content when full stored content is needed via responseId plus query/url selectors.",
+		parameters: Type.Object({
+			responseId: Type.String({ description: "The responseId from web_search or fetch_content" }),
+			query: Type.Optional(Type.String({ description: "Get content for this query (web_search)" })),
+			queryIndex: Type.Optional(Type.Number({ description: "Get content for query at index" })),
+			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
+			urlIndex: Type.Optional(Type.Number({ description: "Get content for URL at index" })),
+		}),
+
+		async execute(_toolCallId, params) {
+			const data = getResult(params.responseId);
+			if (!data) {
+				return {
+					content: [{ type: "text", text: `Error: No stored results for "${params.responseId}"` }],
+					details: { error: "Not found", responseId: params.responseId },
+				};
+			}
+
+			if (data.type === "search" && data.queries) {
+				let queryData: QueryResultData | undefined;
+
+				if (params.query !== undefined) {
+					queryData = data.queries.find((q) => q.query === params.query);
+					if (!queryData) {
+						const available = data.queries.map((q) => `"${q.query}"`).join(", ");
+						return {
+							content: [{ type: "text", text: `Query "${params.query}" not found. Available: ${available}` }],
+							details: { error: "Query not found" },
+						};
+					}
+				} else if (params.queryIndex !== undefined) {
+					queryData = data.queries[params.queryIndex];
+					if (!queryData) {
+						return {
+							content: [{ type: "text", text: `Index ${params.queryIndex} out of range (0-${data.queries.length - 1})` }],
+							details: { error: "Index out of range" },
+						};
+					}
+				} else {
+					const available = data.queries.map((q, i) => `${i}: "${q.query}"`).join(", ");
+					return {
+						content: [{ type: "text", text: `Specify query or queryIndex. Available: ${available}` }],
+						details: { error: "No query specified" },
+					};
+				}
+
+				if (queryData.error) {
+					return {
+						content: [{ type: "text", text: `Error for "${queryData.query}": ${queryData.error}` }],
+						details: { error: queryData.error, query: queryData.query },
+					};
+				}
+
+				return {
+					content: [{ type: "text", text: formatFullResults(queryData) }],
+					details: { query: queryData.query, resultCount: queryData.results.length },
+				};
+			}
+
+			if (data.type === "fetch" && data.urls) {
+				let urlData: ExtractedContent | undefined;
+
+				if (params.url !== undefined) {
+					urlData = data.urls.find((u) => u.url === params.url);
+					if (!urlData) {
+						const available = data.urls.map((u) => u.url).join("\n  ");
+						return {
+							content: [{ type: "text", text: `URL not found. Available:\n  ${available}` }],
+							details: { error: "URL not found" },
+						};
+					}
+				} else if (params.urlIndex !== undefined) {
+					urlData = data.urls[params.urlIndex];
+					if (!urlData) {
+						return {
+							content: [{ type: "text", text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})` }],
+							details: { error: "Index out of range" },
+						};
+					}
+				} else {
+					const available = data.urls.map((u, i) => `${i}: ${u.url}`).join("\n  ");
+					return {
+						content: [{ type: "text", text: `Specify url or urlIndex. Available:\n  ${available}` }],
+						details: { error: "No URL specified" },
+					};
+				}
+
+				if (urlData.error) {
+					return {
+						content: [{ type: "text", text: `Error for ${urlData.url}: ${urlData.error}` }],
+						details: { error: urlData.error, url: urlData.url },
+					};
+				}
+
+				return {
+					content: [{ type: "text", text: `# ${urlData.title}\n\n${urlData.content}` }],
+					details: { url: urlData.url, title: urlData.title, contentLength: urlData.content.length },
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: "Invalid stored data format" }],
+				details: { error: "Invalid data" },
+			};
+		},
+
+		renderCall(args, theme) {
+			const { responseId, query, queryIndex, url, urlIndex } = args as {
+				responseId: string;
+				query?: string;
+				queryIndex?: number;
+				url?: string;
+				urlIndex?: number;
+			};
+			let target = "";
+			if (query) target = `query="${query}"`;
+			else if (queryIndex !== undefined) target = `queryIndex=${queryIndex}`;
+			else if (url) target = url.length > 30 ? url.slice(0, 27) + "..." : url;
+			else if (urlIndex !== undefined) target = `urlIndex=${urlIndex}`;
+			return new Text(theme.fg("toolTitle", theme.bold("get_content ")) + theme.fg("accent", target || responseId.slice(0, 8)), 0, 0);
+		},
+
+		renderResult: renderGetSearchContentResult,
+	});
+
+	pi.registerCommand("websearch", {
+		description: "Open web search curator",
+		handler: async (args, ctx) => {
+			closeCurator();
+			const sessionToken = randomUUID();
+
+			const raw = args.trim();
+			const queries = raw.length > 0
+				? normalizeQueryList(raw.split(","))
+				: [];
+
+			let bootstrap: CuratorBootstrap;
+			try {
+				bootstrap = await loadCuratorBootstrap(undefined);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				ctx.ui.notify(`Failed to load web search config: ${message}`, "error");
+				return;
+			}
+			const availableProviders = bootstrap.availableProviders;
+			const initialProvider = bootstrap.defaultProvider;
+			const curatorTimeoutSeconds = bootstrap.timeoutSeconds;
+			let currentProvider = initialProvider;
+			const summaryContext: SummaryGenerationContext = {
+				model: ctx.model,
+				modelRegistry: ctx.modelRegistry,
+			};
+			const summaryModelChoices = await loadSummaryModelChoices(summaryContext);
+
+			ctx.ui.notify("Opening web search curator...", "info");
+
+			const collected = new Map<number, QueryResultData>();
+			const searchAbort = new AbortController();
+			let aborted = false;
+			let commandHandle: CuratorServerHandle | null = null;
+
+			function sendFollowUpFromReturn(payload: ReturnType<typeof buildSearchReturn>) {
+				pi.sendMessage({
+					customType: "web-search-results",
+					content: payload.content,
+					display: "tool",
+					details: payload.details,
+				}, { triggerTurn: true, deliverAs: "followUp" });
+			}
+
+			try {
+				const handle = await startCuratorServer(
+					{
+						queries,
+						sessionToken,
+						timeout: curatorTimeoutSeconds,
+						availableProviders,
+						defaultProvider: initialProvider,
+						summaryModels: summaryModelChoices.summaryModels,
+						defaultSummaryModel: summaryModelChoices.defaultSummaryModel,
+					},
+					{
+						async onSummarize(selectedQueryIndices, summarizeSignal, model, feedback) {
+							if (commandHandle && activeCurator !== commandHandle) {
+								throw new Error("Curator session is no longer active.");
+							}
+							return generateSummaryForSelectedIndices(
+								selectedQueryIndices,
+								collected,
+								summaryContext,
+								summarizeSignal,
+								model,
+								feedback,
+							);
+						},
+						onSubmit(payload) {
+							if (commandHandle && activeCurator !== commandHandle) return;
+							aborted = true;
+							searchAbort.abort();
+							const filtered = payload.selectedQueryIndices.length > 0
+								? filterByQueryIndices(payload.selectedQueryIndices, collected)
+								: collectAllResultsAndUrls(collected);
+							const base: SearchReturnOptions = {
+								queryList: filtered.results.map(r => r.query),
+								results: filtered.results,
+								urls: filtered.urls,
+								includeContent: false,
+								curated: true,
+								curatedFrom: collected.size,
+							};
+							if (!payload.rawResults) {
+								const resolvedSummary = resolveSummaryForSubmit(payload, collected);
+								base.workflow = "summary-review";
+								base.approvedSummary = resolvedSummary.approvedSummary;
+								base.summaryMeta = resolvedSummary.summaryMeta;
+							}
+							sendFollowUpFromReturn(buildSearchReturn(base));
+							closeCurator();
+						},
+						onCancel(reason) {
+							if (commandHandle && activeCurator !== commandHandle) return;
+							aborted = true;
+							searchAbort.abort();
+							if (reason === "timeout") {
+								const all = collectAllResultsAndUrls(collected);
+								const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, collected);
+								sendFollowUpFromReturn(buildSearchReturn({
+									queryList: all.results.map(r => r.query),
+									results: all.results,
+									urls: all.urls,
+									includeContent: false,
+									curated: true,
+									curatedFrom: collected.size,
+									workflow: "summary-review",
+									approvedSummary: resolvedSummary.approvedSummary,
+									summaryMeta: resolvedSummary.summaryMeta,
+								}));
+							}
+							closeCurator();
+						},
+						onProviderChange(provider) {
+							if (commandHandle && activeCurator !== commandHandle) return;
+							const normalized = normalizeProviderInput(provider);
+							if (!normalized || normalized === "auto") return;
+							currentProvider = normalized;
+							try {
+								saveConfig({ provider: normalized });
+							} catch (err) {
+								const message = err instanceof Error ? err.message : String(err);
+								console.error(`Failed to persist default provider: ${message}`);
+							}
+						},
+						async onAddSearch(query, queryIndex, provider) {
+							if (commandHandle && activeCurator !== commandHandle) {
+								throw new Error("Curator session is no longer active.");
+							}
+							const normalizedProvider = normalizeProviderInput(provider);
+							const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
+								? currentProvider
+								: normalizedProvider;
+							try {
+								const { answer, results, provider: actualProvider } = await search(query, {
+									provider: requestedProvider,
+									signal: searchAbort.signal,
+								});
+								if (commandHandle && activeCurator !== commandHandle) {
+									throw new Error("Curator session is no longer active.");
+								}
+								collected.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
+								return {
+									answer,
+									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+									provider: actualProvider,
+								};
+							} catch (err) {
+								const message = err instanceof Error ? err.message : String(err);
+								if (!commandHandle || activeCurator === commandHandle) {
+									collected.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
+								}
+								throw err;
+							}
+						},
+						async onRewriteQuery(query, rewriteSignal) {
+							if (commandHandle && activeCurator !== commandHandle) {
+								throw new Error("Curator session is no longer active.");
+							}
+							return rewriteSearchQuery(query, summaryContext, rewriteSignal);
+						},
+					},
+				);
+
+				commandHandle = handle;
+				activeCurator = handle;
+				const open = platform() === "darwin" ? await getGlimpseOpen() : null;
+				if (open) {
+					try {
+						const win = openInGlimpse(open, handle.url, "Search Curator");
+						glimpseWin = win;
+						win.on("closed", () => {
+							if (glimpseWin === win) {
+								glimpseWin = null;
+								closeCurator();
+							}
+						});
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						console.error(`Failed to open Glimpse curator window: ${message}`);
+						glimpseWin = null;
+						await openInBrowser(pi, handle.url);
+					}
+				} else {
+					await openInBrowser(pi, handle.url);
+				}
+
+				if (queries.length > 0) {
+					(async () => {
+						for (let qi = 0; qi < queries.length; qi++) {
+							if (aborted || activeCurator !== handle) break;
+							const requestedProvider = currentProvider;
+							try {
+								const { answer, results, provider } = await search(queries[qi], {
+									provider: requestedProvider,
+									signal: searchAbort.signal,
+								});
+								if (aborted || activeCurator !== handle) break;
+								handle.pushResult(qi, {
+									answer,
+									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
+									provider,
+								});
+								collected.set(qi, { query: queries[qi], answer, results, error: null, provider });
+							} catch (err) {
+								if (aborted || activeCurator !== handle) break;
+								const message = err instanceof Error ? err.message : String(err);
+								handle.pushError(qi, message, requestedProvider);
+								collected.set(qi, { query: queries[qi], answer: "", results: [], error: message, provider: requestedProvider });
+							}
+						}
+						if (!aborted && activeCurator === handle) handle.searchesDone();
+					})();
+				} else {
+					if (activeCurator === handle) handle.searchesDone();
+				}
+			} catch (err) {
+				closeCurator();
+				const message = err instanceof Error ? err.message : String(err);
+				ctx.ui.notify(`Failed to open curator: ${message}`, "error");
+			}
+		},
+	});
+
+	pi.registerCommand("curator", {
+		description: "Toggle or configure the search curator workflow",
+		handler: async (args, ctx) => {
+			const arg = args.trim().toLowerCase();
+
+			let newWorkflow: WebSearchWorkflow;
+			if (arg.length === 0) {
+				const current = resolveWorkflow(loadConfigForExtensionInit().workflow, true);
+				newWorkflow = current === "none" ? "summary-review" : "none";
+			} else if (arg === "on") {
+				newWorkflow = "summary-review";
+			} else if (arg === "off") {
+				newWorkflow = "none";
+			} else if (arg === "none" || arg === "summary-review") {
+				newWorkflow = arg;
+			} else {
+				ctx.ui.notify(`Unknown option: ${arg}. Use on, off, or summary-review.`, "error");
+				return;
+			}
+
+			try {
+				saveConfig({ workflow: newWorkflow });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				ctx.ui.notify(`Failed to save config: ${message}`, "error");
+				return;
+			}
+
+			const label = newWorkflow === "none"
+				? "Curator disabled — web_search will return raw results"
+				: "Curator enabled — web_search will open curator and auto-generate a summary draft";
+			pi.sendMessage({
+				customType: "curator-config",
+				content: [{ type: "text", text: label }],
+				display: "tool",
+				details: { workflow: newWorkflow },
+			}, { triggerTurn: false, deliverAs: "followUp" });
+		},
+	});
+
+	pi.registerCommand("google-account", {
+		description: "Show the active Google account for Gemini Web",
+		handler: async () => {
+			if (!isBrowserCookieAccessAllowed()) {
+				pi.sendMessage({
+					customType: "google-account",
+					content: [{ type: "text", text: `Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ~/${CONFIG_DIR_NAME}/web-search.json to enable it.` }],
+					display: "tool",
+					details: { available: false, cookieAccessAllowed: false },
+				}, { triggerTurn: true, deliverAs: "followUp" });
+				return;
+			}
+
+			const cookies = await isGeminiWebAvailable();
+			if (!cookies) {
+				pi.sendMessage({
+					customType: "google-account",
+					content: [{ type: "text", text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser." }],
+					display: "tool",
+					details: { available: false, cookieAccessAllowed: true },
+				}, { triggerTurn: true, deliverAs: "followUp" });
+				return;
+			}
+
+			const email = await getActiveGoogleEmail(cookies);
+			const text = email
+				? `Active Google account: ${email}`
+				: "Gemini Web is available, but the active Google account could not be determined.";
+
+			pi.sendMessage({
+				customType: "google-account",
+				content: [{ type: "text", text }],
+				display: "tool",
+				details: { available: true, email: email ?? null },
+			}, { triggerTurn: true, deliverAs: "followUp" });
+		},
+	});
+
+	pi.registerCommand("search", {
+		description: "Browse stored web search results",
+		handler: async (_args, ctx) => {
+			const results = getAllResults();
+
+			if (results.length === 0) {
+				ctx.ui.notify("No stored search results", "info");
+				return;
+			}
+
+			const options = results.map((r) => {
+				const age = Math.floor((Date.now() - r.timestamp) / 60000);
+				const ageStr = age < 60 ? `${age}m ago` : `${Math.floor(age / 60)}h ago`;
+				if (r.type === "search" && r.queries) {
+					const query = r.queries[0]?.query || "unknown";
+					return `[${r.id.slice(0, 6)}] "${query}" (${r.queries.length} queries) - ${ageStr}`;
+				}
+				if (r.type === "fetch" && r.urls) {
+					return `[${r.id.slice(0, 6)}] ${r.urls.length} URLs fetched - ${ageStr}`;
+				}
+				return `[${r.id.slice(0, 6)}] ${r.type} - ${ageStr}`;
+			});
+
+			const choice = await ctx.ui.select("Stored Search Results", options);
+			if (!choice) return;
+
+			const match = choice.match(/^\[([a-z0-9]+)\]/);
+			if (!match) return;
+
+			const selected = results.find((r) => r.id.startsWith(match[1]));
+			if (!selected) return;
+
+			const actions = ["View details", "Delete"];
+			const action = await ctx.ui.select(`Result ${selected.id.slice(0, 6)}`, actions);
+
+			if (action === "Delete") {
+				deleteResult(selected.id);
+				ctx.ui.notify(`Deleted ${selected.id.slice(0, 6)}`, "info");
+			} else if (action === "View details") {
+				let info = `ID: ${selected.id}\nType: ${selected.type}\nAge: ${Math.floor((Date.now() - selected.timestamp) / 60000)}m\n\n`;
+				if (selected.type === "search" && selected.queries) {
+					info += "Queries:\n";
+					const queries = selected.queries.slice(0, 10);
+					for (const q of queries) {
+						info += `- "${q.query}" (${q.results.length} results)\n`;
+					}
+					if (selected.queries.length > 10) {
+						info += `... and ${selected.queries.length - 10} more\n`;
+					}
+				}
+				if (selected.type === "fetch" && selected.urls) {
+					info += "URLs:\n";
+					const urls = selected.urls.slice(0, 10);
+					for (const u of urls) {
+						const urlDisplay = u.url.length > 50 ? u.url.slice(0, 47) + "..." : u.url;
+						info += `- ${urlDisplay} (${u.error || `${u.content.length} chars`})\n`;
+					}
+					if (selected.urls.length > 10) {
+						info += `... and ${selected.urls.length - 10} more\n`;
+					}
+				}
+				ctx.ui.notify(info, "info");
+			}
+		},
+	});
+}

--- a/packages/web-access/index.ts
+++ b/packages/web-access/index.ts
@@ -1,1534 +1,199 @@
-import type { ExtensionAPI, ExtensionContext } from "@bastani/atomic";
-import { Box, Text, truncateToWidth } from "@mariozechner/pi-tui";
-import { Type } from "typebox";
-import { StringEnum, complete, getModel, type Model } from "@mariozechner/pi-ai";
-import { fetchAllContent, type ExtractedContent } from "./extract.js";
-import { clearCloneCache } from "./github-extract.js";
-import { search, type SearchProvider, type ResolvedSearchProvider } from "./gemini-search.js";
-import { executeCodeSearch } from "./code-search.js";
-import type { SearchResult } from "./perplexity.js";
-import { formatSeconds } from "./utils.js";
-import {
-	clearResults,
-	deleteResult,
-	generateId,
-	getAllResults,
-	getResult,
-	restoreFromSession,
-	storeResult,
-	type QueryResultData,
-	type StoredSearchData,
-} from "./storage.js";
-import { activityMonitor, type ActivityEntry } from "./activity.js";
-import { startCuratorServer, type CuratorServerHandle } from "./curator-server.js";
-import {
-	buildDeterministicSummary,
-	generateSummaryDraft,
-	type SummaryGenerationContext,
-	type SummaryMeta,
-} from "./summary-review.js";
-import { randomUUID } from "node:crypto";
-import { execFileSync } from "node:child_process";
-import { createRequire } from "node:module";
-import { platform, homedir } from "node:os";
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import type { ExtensionAPI, ExtensionContext, HandlerFn, MessageRenderer, RegisteredCommand, ToolDefinition } from "@bastani/atomic";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import { CONFIG_DIR_NAME, getUserConfigPaths } from "@bastani/atomic";
-import { findReadableConfigPath } from "./config-paths.ts";
-import { isPerplexityAvailable } from "./perplexity.js";
-import { isExaAvailable } from "./exa.js";
-import { isGeminiApiAvailable } from "./gemini-api.js";
-import { getActiveGoogleEmail, isGeminiWebAvailable } from "./gemini-web.js";
-import { isBrowserCookieAccessAllowed } from "./gemini-web-config.ts";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+import { renderWebAccessToolResult } from "./result-renderers.js";
 
-const WEB_SEARCH_CONFIG_PATH = getUserConfigPaths("web-search.json")[0] ?? join(homedir(), CONFIG_DIR_NAME, "web-search.json");
-const WEB_SEARCH_CONFIG_READ_PATH = findReadableConfigPath();
+type CapturedCommand = Omit<RegisteredCommand, "name" | "sourceInfo">;
+type CapturedShortcut = Parameters<ExtensionAPI["registerShortcut"]>[1];
+type ToolRenderResultArgs = Parameters<NonNullable<ToolDefinition["renderResult"]>>;
+type CapturedHeavy = {
+	tools: Map<string, ToolDefinition>;
+	commands: Map<string, CapturedCommand>;
+	handlers: Map<string, HandlerFn[]>;
+	shortcuts: Map<string, CapturedShortcut>;
+};
+type SessionSnapshot = {
+	eventName: "session_start" | "session_tree";
+	event: unknown;
+	ctx: ExtensionContext;
+	generation: number;
+};
 
-interface WebSearchConfig {
-	provider?: string;
-	workflow?: string;
-	curatorTimeoutSeconds?: unknown;
-	summaryModel?: string;
-	shortcuts?: {
-		curate?: string;
-		activity?: string;
-	};
+function addHandler(captured: CapturedHeavy, event: string, handler: HandlerFn): void {
+	const handlers = captured.handlers.get(event) ?? [];
+	handlers.push(handler);
+	captured.handlers.set(event, handlers);
 }
 
-interface ProviderAvailability {
-	perplexity: boolean;
-	exa: boolean;
-	gemini: boolean;
-}
-
-type WebSearchWorkflow = "none" | "summary-review";
-type CuratorWorkflow = "summary-review";
-
-interface CuratorBootstrap {
-	availableProviders: ProviderAvailability;
-	defaultProvider: ResolvedSearchProvider;
-	timeoutSeconds: number;
-}
-
-function loadConfig(): WebSearchConfig {
-	if (!existsSync(WEB_SEARCH_CONFIG_READ_PATH)) return {};
-	const raw = readFileSync(WEB_SEARCH_CONFIG_READ_PATH, "utf-8");
-	try {
-		return JSON.parse(raw) as WebSearchConfig;
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		throw new Error(`Failed to parse ${WEB_SEARCH_CONFIG_READ_PATH}: ${message}`);
+async function dispatchHandlers(captured: CapturedHeavy, eventName: string, event: unknown, ctx: ExtensionContext): Promise<void> {
+	for (const handler of captured.handlers.get(eventName) ?? []) {
+		await handler(event, ctx);
 	}
 }
 
-function saveConfig(updates: Partial<WebSearchConfig>): void {
-	let config: Record<string, unknown> = {};
-	const existingConfigPath = findReadableConfigPath();
-	if (existsSync(existingConfigPath)) {
-		const raw = readFileSync(existingConfigPath, "utf-8");
-		try {
-			config = JSON.parse(raw) as Record<string, unknown>;
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			throw new Error(`Failed to parse ${existingConfigPath}: ${message}`);
-		}
-	}
-
-	Object.assign(config, updates);
-	const dir = join(homedir(), CONFIG_DIR_NAME);
-	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-	writeFileSync(WEB_SEARCH_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
-}
-
-const DEFAULT_SHORTCUTS = { curate: "ctrl+shift+s", activity: "ctrl+shift+w" };
-const DEFAULT_CURATOR_TIMEOUT_SECONDS = 20;
-const MAX_CURATOR_TIMEOUT_SECONDS = 600;
-
-function loadConfigForExtensionInit(): WebSearchConfig {
-	try {
-		return loadConfig();
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		console.error(`[pi-web-access] ${message}`);
-		return {};
-	}
-}
-
-function normalizeProviderInput(value: unknown): SearchProvider | undefined {
-	if (value === undefined) return undefined;
-	if (typeof value !== "string") return "auto";
-	const normalized = value.trim().toLowerCase();
-	if (normalized === "auto" || normalized === "exa" || normalized === "perplexity" || normalized === "gemini") {
-		return normalized;
-	}
-	return "auto";
-}
-
-function normalizeCuratorTimeoutSeconds(value: unknown): number | undefined {
-	if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-	const normalized = Math.floor(value);
-	if (normalized < 1) return undefined;
-	return Math.min(normalized, MAX_CURATOR_TIMEOUT_SECONDS);
-}
-
-function resolveWorkflow(input: unknown, hasUI: boolean): WebSearchWorkflow {
-	if (!hasUI) return "none";
-	if (typeof input === "string" && input.trim().toLowerCase() === "none") return "none";
-	return "summary-review";
-}
-
-function normalizeQueryList(queryList: unknown[]): string[] {
-	const normalized: string[] = [];
-	for (const query of queryList) {
-		if (typeof query !== "string") continue;
-		const trimmed = query.trim();
-		if (trimmed.length > 0) normalized.push(trimmed);
-	}
-	return normalized;
-}
-
-function getCuratorTimeoutSeconds(): number {
-	const source = loadConfig();
-	return normalizeCuratorTimeoutSeconds(source.curatorTimeoutSeconds) ?? DEFAULT_CURATOR_TIMEOUT_SECONDS;
-}
-
-async function getProviderAvailability(): Promise<ProviderAvailability> {
-	const geminiWebAvail = await isGeminiWebAvailable();
-	return {
-		perplexity: isPerplexityAvailable(),
-		exa: isExaAvailable(),
-		gemini: isGeminiApiAvailable() || !!geminiWebAvail,
-	};
-}
-
-async function loadCuratorBootstrap(requestedProvider: unknown): Promise<CuratorBootstrap> {
-	const availableProviders = await getProviderAvailability();
-	return {
-		availableProviders,
-		defaultProvider: resolveProvider(requestedProvider, availableProviders),
-		timeoutSeconds: getCuratorTimeoutSeconds(),
-	};
-}
-
-function resolveProvider(
-	requested: unknown,
-	available: ProviderAvailability,
-): ResolvedSearchProvider {
-	const provider = normalizeProviderInput(requested ?? loadConfig().provider ?? "auto") ?? "auto";
-
-	if (provider === "auto") {
-		if (available.exa) return "exa";
-		if (available.perplexity) return "perplexity";
-		if (available.gemini) return "gemini";
-		return "exa";
-	}
-	if (provider === "exa" && !available.exa) {
-		if (available.perplexity) return "perplexity";
-		return available.gemini ? "gemini" : "exa";
-	}
-	if (provider === "perplexity" && !available.perplexity) {
-		if (available.exa) return "exa";
-		return available.gemini ? "gemini" : "perplexity";
-	}
-	if (provider === "gemini" && !available.gemini) {
-		if (available.exa) return "exa";
-		return available.perplexity ? "perplexity" : "gemini";
-	}
-	return provider;
-}
-
-const pendingFetches = new Map<string, AbortController>();
-let sessionActive = false;
-let widgetVisible = false;
-let widgetUnsubscribe: (() => void) | null = null;
-let activeCurator: CuratorServerHandle | null = null;
-let glimpseWin: GlimpseWindow | null = null;
-
-interface PendingCurate {
-	phase: "searching" | "curating";
-	workflow: CuratorWorkflow;
-	summaryContext: SummaryGenerationContext;
-	searchResults: Map<number, QueryResultData>;
-	allInlineContent: ExtractedContent[];
-	queryList: string[];
-	includeContent: boolean;
-	numResults?: number;
-	recencyFilter?: "day" | "week" | "month" | "year";
-	domainFilter?: string[];
-	availableProviders: ProviderAvailability;
-	defaultProvider: ResolvedSearchProvider;
-	summaryModels: Array<{ value: string; label: string }>;
-	defaultSummaryModel: string | null;
-	timeoutSeconds: number;
-	onUpdate: ((update: { content: Array<{ type: string; text: string }>; details?: Record<string, unknown> }) => void) | undefined;
-	signal: AbortSignal | undefined;
-	abortSearches: () => void;
-	finish: (value: unknown) => void;
-	cancel: (reason?: "user" | "stale") => void;
-	browserPromise?: Promise<void>;
-}
-
-let pendingCurate: PendingCurate | null = null;
-
-function cancelPendingCurate(reason: "user" | "stale" = "stale"): void {
-	pendingCurate?.cancel(reason);
-}
-
-const MAX_INLINE_CONTENT = 30000; // Content returned directly to agent
-
-function stripThumbnails(results: ExtractedContent[]): ExtractedContent[] {
-	return results.map(({ thumbnail, frames, ...rest }) => rest);
-}
-
-function formatSearchSummary(results: SearchResult[], answer: string): string {
-	let output = answer ? `${answer}\n\n---\n\n**Sources:**\n` : "";
-	output += results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}`).join("\n\n");
-	return output;
-}
-
-function duplicateQuerySet(results: QueryResultData[]): Set<string> {
-	const counts = new Map<string, number>();
-	for (const result of results) {
-		counts.set(result.query, (counts.get(result.query) ?? 0) + 1);
-	}
-	const duplicates = new Set<string>();
-	for (const [query, count] of counts) {
-		if (count > 1) duplicates.add(query);
-	}
-	return duplicates;
-}
-
-function formatQueryHeader(query: string, provider: string | undefined, duplicateQueries: Set<string>): string {
-	const suffix = duplicateQueries.has(query) && provider ? ` (${provider})` : "";
-	return `## Query: "${query}"${suffix}\n\n`;
-}
-
-function hasFullInlineCoverage(urls: string[], inlineContent: ExtractedContent[] | undefined): boolean {
-	if (!inlineContent || inlineContent.length === 0) return false;
-	const coveredUrls = new Set(inlineContent.map(c => c.url));
-	return urls.every(url => coveredUrls.has(url));
-}
-
-function formatFullResults(queryData: QueryResultData): string {
-	let output = `## Results for: "${queryData.query}"\n\n`;
-	if (queryData.answer) {
-		output += `${queryData.answer}\n\n---\n\n`;
-	}
-	for (const r of queryData.results) {
-		output += `### ${r.title}\n${r.url}\n\n`;
-	}
-	return output;
-}
-
-function abortPendingFetches(): void {
-	for (const controller of pendingFetches.values()) {
-		controller.abort();
-	}
-	pendingFetches.clear();
-}
-
-function closeCurator(): void {
-	const win = glimpseWin;
-	glimpseWin = null;
-	try { win?.close(); } catch {}
-	cancelPendingCurate();
-	if (activeCurator) {
-		activeCurator.close();
-		activeCurator = null;
-	}
-}
-
-async function openInBrowser(pi: ExtensionAPI, url: string): Promise<void> {
-	const plat = platform();
-	const result = plat === "darwin"
-		? await pi.exec("open", [url])
-		: plat === "win32"
-			? await pi.exec("cmd", ["/c", "start", "", url])
-			: await pi.exec("xdg-open", [url]);
-	if (result.code !== 0) {
-		throw new Error(result.stderr || `Failed to open browser (exit code ${result.code})`);
-	}
-}
-
-interface GlimpseWindow {
-	on(event: "closed", handler: () => void): void;
-	on(event: "message", handler: (data: unknown) => void): void;
-	on(event: "ready", handler: (info: { screen?: { visibleHeight?: number } }) => void): void;
-	close(): void;
-	_write(obj: Record<string, unknown>): void;
-}
-
-let glimpseOpen: ((html: string, opts: Record<string, unknown>) => GlimpseWindow) | null | undefined;
-
-function findGlimpseMjs(): string | null {
-	try {
-		const req = createRequire(import.meta.url);
-		return req.resolve("glimpseui");
-	} catch {
-		// Optional dependency.
-	}
-	try {
-		const globalRoot = execFileSync("npm", ["root", "-g"], { encoding: "utf-8" }).trim();
-		const entry = join(globalRoot, "glimpseui", "src", "glimpse.mjs");
-		if (existsSync(entry)) return entry;
-	} catch {
-		// npm may be unavailable.
-	}
-	return null;
-}
-
-async function getGlimpseOpen() {
-	if (glimpseOpen !== undefined) return glimpseOpen;
-	const resolved = findGlimpseMjs();
-	if (resolved) {
-		try {
-			glimpseOpen = (await import(resolved)).open;
-			return glimpseOpen;
-		} catch {}
-	}
-	glimpseOpen = null;
-	return glimpseOpen;
-}
-
-function openInGlimpse(
-	open: (html: string, opts: Record<string, unknown>) => GlimpseWindow,
-	url: string,
-	title: string,
-): GlimpseWindow {
-	const shellHTML = `<!DOCTYPE html>
-<html>
-<head><meta charset="UTF-8"><title>${title}</title></head>
-<body style="margin:0; background:#1a1a2e;">
-  <script>window.location.replace(${JSON.stringify(url)});</script>
-</body>
-</html>`;
-	const win = open(shellHTML, {
-		width: 800,
-		height: 900,
-		title,
-	});
-
-	let maxHeight = 1200;
-	win.on("ready", (info) => {
-		const visibleHeight = info?.screen?.visibleHeight;
-		if (typeof visibleHeight === "number" && visibleHeight > 0) {
-			maxHeight = Math.floor(visibleHeight * 0.85);
-		}
-	});
-	win.on("message", (data) => {
-		if (!data || typeof data !== "object") return;
-		const msg = data as Record<string, unknown>;
-		if (msg.type !== "resize" || typeof msg.height !== "number") return;
-		const clamped = Math.max(400, Math.min(Math.round(msg.height), maxHeight));
-		win._write({ type: "resize", width: 800, height: clamped });
-	});
-
-	return win;
-}
-
-function extractDomain(url: string): string {
-	try { return new URL(url).hostname; }
-	catch { return url; }
-}
-
-function updateWidget(ctx: ExtensionContext): void {
-	const theme = ctx.ui.theme;
-	const entries = activityMonitor.getEntries();
-	const lines: string[] = [];
-
-	lines.push(theme.fg("accent", "─── Web Search Activity " + "─".repeat(36)));
-
-	if (entries.length === 0) {
-		lines.push(theme.fg("muted", "  No activity yet"));
-	} else {
-		for (const e of entries) {
-			lines.push("  " + formatEntryLine(e, theme));
-		}
-	}
-
-	lines.push(theme.fg("accent", "─".repeat(60)));
-
-	const rateInfo = activityMonitor.getRateLimitInfo();
-	const resetMs = rateInfo.oldestTimestamp ? Math.max(0, rateInfo.oldestTimestamp + rateInfo.windowMs - Date.now()) : 0;
-	const resetSec = Math.ceil(resetMs / 1000);
-	lines.push(
-		theme.fg("muted", `Rate: ${rateInfo.used}/${rateInfo.max}`) +
-			(resetMs > 0 ? theme.fg("dim", ` (resets in ${resetSec}s)`) : ""),
-	);
-
-	ctx.ui.setWidget("web-activity", new Text(lines.join("\n"), 0, 0));
-}
-
-function formatEntryLine(
-	entry: ActivityEntry,
-	theme: { fg: (color: string, text: string) => string },
-): string {
-	const typeStr = entry.type === "api" ? "API" : "GET";
-	const target =
-		entry.type === "api"
-			? `"${truncateToWidth(entry.query || "", 28, "")}"`
-			: truncateToWidth(entry.url?.replace(/^https?:\/\//, "") || "", 30, "");
-
-	const duration = entry.endTime
-		? `${((entry.endTime - entry.startTime) / 1000).toFixed(1)}s`
-		: `${((Date.now() - entry.startTime) / 1000).toFixed(1)}s`;
-
-	let statusStr: string;
-	let indicator: string;
-	if (entry.error) {
-		statusStr = "err";
-		indicator = theme.fg("error", "✗");
-	} else if (entry.status === null) {
-		statusStr = "...";
-		indicator = theme.fg("warning", "⋯");
-	} else if (entry.status === 0) {
-		statusStr = "abort";
-		indicator = theme.fg("muted", "○");
-	} else {
-		statusStr = String(entry.status);
-		indicator = entry.status >= 200 && entry.status < 300 ? theme.fg("success", "✓") : theme.fg("error", "✗");
-	}
-
-	return `${typeStr.padEnd(4)} ${target.padEnd(32)} ${statusStr.padStart(5)} ${duration.padStart(5)} ${indicator}`;
-}
-
-function handleSessionChange(ctx: ExtensionContext): void {
-	abortPendingFetches();
-	closeCurator();
-	clearCloneCache();
-	sessionActive = true;
-	restoreFromSession(ctx);
-	// Unsubscribe before clear() to avoid callback with stale ctx
-	widgetUnsubscribe?.();
-	widgetUnsubscribe = null;
-	activityMonitor.clear();
-	if (widgetVisible) {
-		// Re-subscribe with new ctx
-		widgetUnsubscribe = activityMonitor.onUpdate(() => updateWidget(ctx));
-		updateWidget(ctx);
-	}
-}
-
-export default function (pi: ExtensionAPI) {
-	const initConfig = loadConfigForExtensionInit();
-	const curateKey = initConfig.shortcuts?.curate || DEFAULT_SHORTCUTS.curate;
-	const activityKey = initConfig.shortcuts?.activity || DEFAULT_SHORTCUTS.activity;
-
-	function startBackgroundFetch(urls: string[]): string | null {
-		if (urls.length === 0) return null;
-		const fetchId = generateId();
-		const controller = new AbortController();
-		pendingFetches.set(fetchId, controller);
-		fetchAllContent(urls, controller.signal)
-			.then((fetched) => {
-				if (!sessionActive || !pendingFetches.has(fetchId)) return;
-				const data: StoredSearchData = {
-					id: fetchId,
-					type: "fetch",
-					timestamp: Date.now(),
-					urls: stripThumbnails(fetched),
+function createHeavyProxy(pi: ExtensionAPI, captured: CapturedHeavy): ExtensionAPI {
+	return new Proxy(pi, {
+		get(target, prop, receiver) {
+			if (prop === "registerTool") {
+				return (tool: ToolDefinition) => {
+					captured.tools.set(tool.name, tool);
 				};
-				storeResult(fetchId, data);
-				pi.appendEntry("web-search-results", data);
-				const ok = fetched.filter(f => !f.error).length;
-				pi.sendMessage(
-					{
-						customType: "web-search-content-ready",
-						content: `Content fetched for ${ok}/${fetched.length} URLs [${fetchId}]. Full page content now available.`,
-						display: true,
-					},
-					{ triggerTurn: true },
-				);
-			})
-			.catch((err) => {
-				if (!sessionActive || !pendingFetches.has(fetchId)) return;
-				const message = err instanceof Error ? err.message : String(err);
-				const isAbort = (err instanceof Error && err.name === "AbortError") || message.toLowerCase().includes("abort");
-				if (!isAbort) {
-					pi.sendMessage(
-						{
-							customType: "web-search-error",
-							content: `Content fetch failed [${fetchId}]: ${message}`,
-							display: true,
-						},
-						{ triggerTurn: false },
-					);
-				}
-			})
-			.finally(() => { pendingFetches.delete(fetchId); });
-		return fetchId;
-	}
-
-	function storeAndPublishSearch(results: QueryResultData[]): string {
-		const id = generateId();
-		const data: StoredSearchData = {
-			id, type: "search", timestamp: Date.now(), queries: results,
-		};
-		storeResult(id, data);
-		pi.appendEntry("web-search-results", data);
-		return id;
-	}
-
-	interface SearchReturnOptions {
-		queryList: string[];
-		results: QueryResultData[];
-		urls: string[];
-		includeContent: boolean;
-		inlineContent?: ExtractedContent[];
-		curated?: boolean;
-		curatedFrom?: number;
-		workflow?: CuratorWorkflow;
-		approvedSummary?: string;
-		summaryMeta?: SummaryMeta;
-	}
-
-	function normalizeSummaryMeta(meta: SummaryMeta | undefined, summaryText: string): SummaryMeta {
-		const normalizedText = summaryText.trim();
-		if (!meta) {
-			return {
-				model: null,
-				durationMs: 0,
-				tokenEstimate: normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0,
-				fallbackUsed: false,
-				edited: false,
-			};
-		}
-
-		return {
-			model: meta.model,
-			durationMs: Number.isFinite(meta.durationMs) && meta.durationMs >= 0 ? meta.durationMs : 0,
-			tokenEstimate: Number.isFinite(meta.tokenEstimate) && meta.tokenEstimate >= 0
-				? meta.tokenEstimate
-				: (normalizedText.length > 0 ? Math.max(1, Math.ceil(normalizedText.length / 4)) : 0),
-			fallbackUsed: meta.fallbackUsed === true,
-			fallbackReason: meta.fallbackReason,
-			edited: meta.edited === true,
-		};
-	}
-
-	function buildCurationCancelledReturn(reason: "user" | "stale") {
-		const message = `Search curation cancelled (${reason}).`;
-		return {
-			content: [{ type: "text", text: message }],
-			details: {
-				error: message,
-				cancelled: true,
-				cancelReason: reason,
-			},
-		};
-	}
-
-	async function resolveFirstAvailableModel(
-		ctx: SummaryGenerationContext,
-		candidates: Array<{ provider: string; id: string }>,
-	): Promise<{ model: Model; apiKey: string; headers?: Record<string, string> }> {
-		for (const { provider, id } of candidates) {
-			const model = getModel(provider, id);
-			if (!model) continue;
-			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-			if (auth.ok && auth.apiKey) return { model, apiKey: auth.apiKey, headers: auth.headers };
-		}
-		throw new Error(`No model available: ${candidates.map(c => `${c.provider}/${c.id}`).join(", ")}`);
-	}
-
-	async function rewriteSearchQuery(query: string, ctx: SummaryGenerationContext, signal: AbortSignal): Promise<string> {
-		const { model, apiKey, headers } = await resolveFirstAvailableModel(ctx, [
-			{ provider: "anthropic", id: "claude-haiku-4-5" },
-			{ provider: "google", id: "gemini-2.5-flash" },
-			{ provider: "openai", id: "gpt-4.1-mini" },
-		]);
-		const response = await complete(
-			model,
-			{
-				messages: [{
-					role: "user",
-					content: [{ type: "text", text: `Rewrite this web search query to get better, more specific results. Add relevant year qualifiers, precise technical terms, and specificity. Return ONLY the improved query text, nothing else.\n\nQuery: ${query}` }],
-					timestamp: Date.now(),
-				}],
-			},
-			{ apiKey, headers, signal },
-		);
-		if (response.stopReason === "aborted") throw new Error("Aborted");
-		const contentParts = Array.isArray(response.content) ? response.content : [];
-		const text = contentParts
-			.map(p => {
-				if (!p || typeof p !== "object") return "";
-				const part = p as Record<string, unknown>;
-				return typeof part.text === "string" ? part.text : "";
-			})
-			.join("")
-			.trim();
-		if (!text) throw new Error("Rewrite returned empty response");
-		return text;
-	}
-
-	async function generateSummaryForSelectedIndices(
-		selectedQueryIndices: number[],
-		resultsByIndex: Map<number, QueryResultData>,
-		summaryContext: SummaryGenerationContext,
-		signal?: AbortSignal,
-		modelOverride?: string,
-		feedback?: string,
-	): Promise<{ summary: string; meta: SummaryMeta }> {
-		const selectedResults: QueryResultData[] = [];
-		for (const qi of selectedQueryIndices) {
-			const result = resultsByIndex.get(qi);
-			if (result) selectedResults.push(result);
-		}
-		if (selectedResults.length === 0) {
-			throw new Error("No selected results available for summary generation");
-		}
-		try {
-			return await generateSummaryDraft(selectedResults, summaryContext, signal, modelOverride, feedback);
-		} catch (err) {
-			const isEmptyResponse = err instanceof Error && err.message.includes("Summary model returned empty response");
-			if (!isEmptyResponse) throw err;
-			const deterministic = buildDeterministicSummary(selectedResults);
-			return {
-				summary: deterministic.summary,
-				meta: {
-					...deterministic.meta,
-					fallbackReason: "summary-model-empty-response",
-				},
-			};
-		}
-	}
-
-	async function loadSummaryModelChoices(
-		summaryContext: SummaryGenerationContext,
-	): Promise<{ summaryModels: Array<{ value: string; label: string }>; defaultSummaryModel: string | null }> {
-		const summaryModels: Array<{ value: string; label: string }> = [];
-		const seen = new Set<string>();
-		const availableValues = new Set<string>();
-
-		const addModel = (provider: string, id: string) => {
-			const value = `${provider}/${id}`;
-			if (seen.has(value)) return;
-			seen.add(value);
-			summaryModels.push({ value, label: value });
-		};
-
-		try {
-			const availableModels = summaryContext.modelRegistry.getAvailable();
-			for (const model of availableModels) {
-				const value = `${model.provider}/${model.id}`;
-				availableValues.add(value);
-				addModel(model.provider, model.id);
 			}
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			console.error(`Failed to load summary models: ${message}`);
-		}
-
-		const currentModelValue = summaryContext.model
-			? `${summaryContext.model.provider}/${summaryContext.model.id}`
-			: null;
-		if (summaryContext.model && currentModelValue && !seen.has(currentModelValue)) {
-			addModel(summaryContext.model.provider, summaryContext.model.id);
-		}
-
-		const config = loadConfig();
-		const configuredSummaryModel = typeof config.summaryModel === "string" ? config.summaryModel.trim() : "";
-		const preferredDefaults = [
-			"anthropic/claude-haiku-4-5",
-			"openai-codex/gpt-5.3-codex-spark",
-		];
-
-		let defaultSummaryModel: string | null = null;
-		if (configuredSummaryModel.length > 0 && availableValues.has(configuredSummaryModel)) {
-			defaultSummaryModel = configuredSummaryModel;
-		}
-		if (!defaultSummaryModel) {
-			for (const preferred of preferredDefaults) {
-				if (availableValues.has(preferred)) {
-					defaultSummaryModel = preferred;
-					break;
-				}
+			if (prop === "registerCommand") {
+				return (name: string, options: CapturedCommand) => {
+					captured.commands.set(name, options);
+				};
 			}
-		}
-		if (!defaultSummaryModel && summaryModels.length > 0) {
-			defaultSummaryModel = summaryModels[0].value;
-		}
-
-		return { summaryModels, defaultSummaryModel };
-	}
-
-	function resolveSummaryForSubmit(
-		payload: { selectedQueryIndices: number[]; summary?: string; summaryMeta?: SummaryMeta },
-		resultsByIndex: Map<number, QueryResultData>,
-	): { approvedSummary: string; summaryMeta: SummaryMeta } {
-		const submittedSummary = typeof payload.summary === "string" ? payload.summary.trim() : "";
-		if (submittedSummary.length > 0) {
-			return {
-				approvedSummary: submittedSummary,
-				summaryMeta: normalizeSummaryMeta(payload.summaryMeta, submittedSummary),
-			};
-		}
-
-		const selected = filterByQueryIndices(payload.selectedQueryIndices, resultsByIndex).results;
-		const fallbackResults = selected.length > 0 ? selected : [...resultsByIndex.values()];
-		const deterministic = buildDeterministicSummary(fallbackResults);
-		return {
-			approvedSummary: deterministic.summary,
-			summaryMeta: deterministic.meta,
-		};
-	}
-
-	function buildSearchReturn(opts: SearchReturnOptions) {
-		const sc = opts.results.filter(r => !r.error).length;
-		const tr = opts.results.reduce((sum, r) => sum + r.results.length, 0);
-
-		const hasApprovedSummary = typeof opts.approvedSummary === "string" && opts.approvedSummary.trim().length > 0;
-		let output = "";
-		if (hasApprovedSummary) {
-			output = opts.approvedSummary!.trim();
-		} else {
-			if (opts.curated) {
-				output += "[These results were manually curated by the user in the browser. Use them as-is — do not re-search or discard.]\n\n";
+			if (prop === "on") {
+				return (event: string, handler: HandlerFn) => {
+					addHandler(captured, event, handler);
+				};
 			}
-			const duplicateQueries = opts.curated ? duplicateQuerySet(opts.results) : new Set<string>();
-			for (const { query, answer, results, error, provider } of opts.results) {
-				if (opts.queryList.length > 1) {
-					output += opts.curated
-						? formatQueryHeader(query, provider, duplicateQueries)
-						: `## Query: "${query}"\n\n`;
-				}
-				if (error) output += `Error: ${error}\n\n`;
-				else if (results.length === 0) output += "No results found.\n\n";
-				else output += formatSearchSummary(results, answer) + "\n\n";
+			if (prop === "registerShortcut") {
+				return (shortcut: string, options: CapturedShortcut) => {
+					captured.shortcuts.set(shortcut, options);
+				};
 			}
-		}
-
-		const hasInlineReady = hasFullInlineCoverage(opts.urls, opts.inlineContent);
-		let fetchId: string | null = null;
-		if (hasInlineReady && opts.inlineContent) {
-			fetchId = generateId();
-			const data: StoredSearchData = {
-				id: fetchId,
-				type: "fetch",
-				timestamp: Date.now(),
-				urls: opts.inlineContent,
-			};
-			storeResult(fetchId, data);
-			pi.appendEntry("web-search-results", data);
-			if (!hasApprovedSummary) {
-				output += `---\nFull content for ${opts.inlineContent.length} sources available [${fetchId}].`;
+			if (prop === "registerMessageRenderer") {
+				return (customType: string, renderer: MessageRenderer) => pi.registerMessageRenderer(customType, renderer);
 			}
-		} else if (opts.includeContent) {
-			fetchId = startBackgroundFetch(opts.urls);
-			if (fetchId && !hasApprovedSummary) {
-				output += `---\nContent fetching in background [${fetchId}]. Will notify when ready.`;
-			}
-		}
-
-		const searchId = storeAndPublishSearch(opts.results);
-		const isBackgroundFetch = fetchId !== null && !hasInlineReady;
-
-		return {
-			content: [{ type: "text", text: output.trim() }],
-			details: {
-				queries: opts.queryList,
-				queryCount: opts.queryList.length,
-				successfulQueries: sc,
-				totalResults: tr,
-				includeContent: opts.includeContent,
-				fetchId,
-				fetchUrls: isBackgroundFetch ? opts.urls : undefined,
-				searchId,
-				...(opts.curated ? {
-					curated: true,
-					curatedFrom: opts.curatedFrom,
-					curatedQueries: opts.results.map(r => ({
-						query: r.query,
-						provider: r.provider || null,
-						answer: r.answer || null,
-						sources: r.results.map(s => ({ title: s.title, url: s.url })),
-						error: r.error,
-					})),
-				} : {}),
-				...((opts.workflow && hasApprovedSummary)
-					? {
-						summary: {
-							text: opts.approvedSummary!.trim(),
-							workflow: opts.workflow,
-							model: opts.summaryMeta?.model ?? null,
-							durationMs: opts.summaryMeta?.durationMs ?? 0,
-							tokenEstimate: opts.summaryMeta?.tokenEstimate ?? 0,
-							fallbackUsed: opts.summaryMeta?.fallbackUsed === true,
-							fallbackReason: opts.summaryMeta?.fallbackReason,
-							edited: opts.summaryMeta?.edited === true,
-						},
-					}
-					: {}),
-			},
-		};
-	}
-
-	function filterByQueryIndices(selectedQueryIndices: number[], results: Map<number, QueryResultData>) {
-		const filteredResults: QueryResultData[] = [];
-		const filteredUrls: string[] = [];
-		for (const qi of selectedQueryIndices) {
-			const r = results.get(qi);
-			if (r) {
-				filteredResults.push(r);
-				for (const res of r.results) {
-					if (!filteredUrls.includes(res.url)) filteredUrls.push(res.url);
-				}
-			}
-		}
-		return { results: filteredResults, urls: filteredUrls };
-	}
-
-	function collectAllResultsAndUrls(resultsByIndex: Map<number, QueryResultData>) {
-		const results = [...resultsByIndex.values()];
-		const urls: string[] = [];
-		for (const result of results) {
-			for (const source of result.results) {
-				if (!urls.includes(source.url)) urls.push(source.url);
-			}
-		}
-		return { results, urls };
-	}
-
-	async function openCuratorBrowser(pc: PendingCurate, searchesComplete = true): Promise<void> {
-		let handle: CuratorServerHandle | null = null;
-		try {
-			pc.phase = "curating";
-
-			const searchAbort = new AbortController();
-			const addSearchSignal = pc.signal
-				? AbortSignal.any([pc.signal, searchAbort.signal])
-				: searchAbort.signal;
-
-			const sessionToken = randomUUID();
-			handle = await startCuratorServer(
-				{
-					queries: pc.queryList,
-					sessionToken,
-					timeout: pc.timeoutSeconds,
-					availableProviders: pc.availableProviders,
-					defaultProvider: pc.defaultProvider,
-					summaryModels: pc.summaryModels,
-					defaultSummaryModel: pc.defaultSummaryModel,
-				},
-				{
-					async onSummarize(selectedQueryIndices, summarizeSignal, model, feedback) {
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
-						pc.onUpdate?.({
-							content: [{ type: "text", text: "Generating summary draft..." }],
-							details: { phase: "generating-summary", progress: 0.9 },
-						});
-						const draft = await generateSummaryForSelectedIndices(
-							selectedQueryIndices,
-							pc.searchResults,
-							pc.summaryContext,
-							summarizeSignal,
-							model,
-							feedback,
-						);
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
-						pc.onUpdate?.({
-							content: [{ type: "text", text: "Summary draft ready — waiting for approval..." }],
-							details: { phase: "waiting-for-approval", progress: 1 },
-						});
-						return draft;
-					},
-					onSubmit(payload) {
-						if (pendingCurate !== pc) return;
-						searchAbort.abort();
-						const filtered = payload.selectedQueryIndices.length > 0
-							? filterByQueryIndices(payload.selectedQueryIndices, pc.searchResults)
-							: collectAllResultsAndUrls(pc.searchResults);
-						const filteredInline = pc.allInlineContent.filter(c => filtered.urls.includes(c.url));
-						const base: SearchReturnOptions = {
-							queryList: filtered.results.map(r => r.query),
-							results: filtered.results,
-							urls: filtered.urls,
-							includeContent: pc.includeContent,
-							inlineContent: filteredInline.length > 0 ? filteredInline : undefined,
-							curated: true,
-							curatedFrom: pc.searchResults.size,
-						};
-						if (!payload.rawResults) {
-							const resolvedSummary = resolveSummaryForSubmit(payload, pc.searchResults);
-							base.workflow = pc.workflow;
-							base.approvedSummary = resolvedSummary.approvedSummary;
-							base.summaryMeta = resolvedSummary.summaryMeta;
-						}
-						pc.finish(buildSearchReturn(base));
-						closeCurator();
-					},
-					onCancel(reason) {
-						if (pendingCurate !== pc) return;
-						searchAbort.abort();
-						if (reason === "timeout") {
-							const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, pc.searchResults);
-							const all = collectAllResultsAndUrls(pc.searchResults);
-							const filteredInline = pc.allInlineContent.filter(c => all.urls.includes(c.url));
-							pc.finish(buildSearchReturn({
-								queryList: all.results.map(r => r.query),
-								results: all.results,
-								urls: all.urls,
-								includeContent: pc.includeContent,
-								inlineContent: filteredInline.length > 0 ? filteredInline : undefined,
-								curated: true,
-								curatedFrom: pc.searchResults.size,
-								workflow: pc.workflow,
-								approvedSummary: resolvedSummary.approvedSummary,
-								summaryMeta: resolvedSummary.summaryMeta,
-							}));
-						} else {
-							pc.finish(buildCurationCancelledReturn(reason));
-						}
-						closeCurator();
-					},
-					onProviderChange(provider) {
-						if (pendingCurate !== pc) return;
-						const normalized = normalizeProviderInput(provider);
-						if (!normalized || normalized === "auto") return;
-						pc.defaultProvider = normalized;
-						try {
-							saveConfig({ provider: normalized });
-						} catch (err) {
-							const message = err instanceof Error ? err.message : String(err);
-							console.error(`Failed to persist default provider: ${message}`);
-						}
-					},
-					async onAddSearch(query, queryIndex, provider) {
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
-						const normalizedProvider = normalizeProviderInput(provider);
-						const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
-							? pc.defaultProvider
-							: normalizedProvider;
-						try {
-							const { answer, results, inlineContent, provider: actualProvider } = await search(query, {
-								provider: requestedProvider,
-								numResults: pc.numResults,
-								recencyFilter: pc.recencyFilter,
-								domainFilter: pc.domainFilter,
-								includeContent: pc.includeContent,
-								signal: addSearchSignal,
-							});
-							if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
-							pc.searchResults.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
-							if (inlineContent) pc.allInlineContent.push(...inlineContent);
-							return {
-								answer,
-								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
-								provider: actualProvider,
-							};
-						} catch (err) {
-							const message = err instanceof Error ? err.message : String(err);
-							if (pendingCurate === pc) {
-								pc.searchResults.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
-							}
-							throw err;
-						}
-					},
-					async onRewriteQuery(query, rewriteSignal) {
-						if (pendingCurate !== pc) throw new Error("Curator session is no longer active.");
-						return rewriteSearchQuery(query, pc.summaryContext, rewriteSignal);
-					},
-				},
-			);
-
-			if (pendingCurate !== pc) {
-				handle.close();
-				return;
-			}
-
-			activeCurator = handle;
-
-			for (const [qi, data] of pc.searchResults) {
-				if (data.error) {
-					handle.pushError(qi, data.error, data.provider);
-				} else {
-					handle.pushResult(qi, {
-						answer: data.answer,
-						results: data.results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
-						provider: data.provider || pc.defaultProvider,
-					});
-				}
-			}
-			if (searchesComplete) handle.searchesDone();
-
-			pc.onUpdate?.({
-				content: [{ type: "text", text: searchesComplete ? "Waiting for summary approval in browser..." : "Searches streaming to browser..." }],
-				details: { phase: "curating", progress: searchesComplete ? 1 : 0.5 },
-			});
-
-			const open = platform() === "darwin" ? await getGlimpseOpen() : null;
-			if (open) {
-				try {
-					const win = openInGlimpse(open, handle.url, "Search Curator");
-					glimpseWin = win;
-					win.on("closed", () => {
-						if (glimpseWin === win) {
-							glimpseWin = null;
-							closeCurator();
-						}
-					});
-					return;
-				} catch (err) {
-					const message = err instanceof Error ? err.message : String(err);
-					console.error(`Failed to open Glimpse curator window: ${message}`);
-					glimpseWin = null;
-				}
-			}
-			await openInBrowser(pi, handle.url);
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			console.error(`Failed to open curator UI: ${message}`);
-			if (pendingCurate === pc || (handle && activeCurator === handle)) {
-				closeCurator();
-			}
-		}
-	}
-
-	pi.registerShortcut(curateKey, {
-		description: "Review search results",
-		handler: async (ctx) => {
-			if (!pendingCurate) return;
-
-			if (pendingCurate.phase === "searching") {
-				pendingCurate.browserPromise = openCuratorBrowser(pendingCurate, false);
-				ctx.ui.notify("Opening curator — remaining searches will stream in", "info");
-				return;
-			}
+			return Reflect.get(target, prop, receiver);
 		},
+	}) as ExtensionAPI;
+}
+
+async function executeHeavyTool(
+	loadHeavy: () => Promise<CapturedHeavy>,
+	name: string,
+	args: Parameters<NonNullable<ToolDefinition["execute"]>>,
+): Promise<ReturnType<NonNullable<ToolDefinition["execute"]>>> {
+	const heavy = await loadHeavy();
+	const tool = heavy.tools.get(name);
+	if (!tool?.execute) throw new Error(`Web access tool implementation not found: ${name}`);
+	return tool.execute(...args) as ReturnType<NonNullable<ToolDefinition["execute"]>>;
+}
+
+async function runHeavyCommand(loadHeavy: () => Promise<CapturedHeavy>, name: string, args: string | undefined, ctx: ExtensionContext): Promise<void> {
+	const heavy = await loadHeavy();
+	const command = heavy.commands.get(name);
+	if (!command) throw new Error(`Web access command implementation not found: ${name}`);
+	await command.handler(args, ctx);
+}
+
+function renderHeavyToolResult(loadedHeavy: CapturedHeavy | null, name: string, args: ToolRenderResultArgs): ReturnType<NonNullable<ToolDefinition["renderResult"]>> {
+	const renderer = loadedHeavy?.tools.get(name)?.renderResult;
+	if (renderer) return renderer(...args);
+	return renderWebAccessToolResult(name, args);
+}
+
+function getInitialShortcutConfig(): { curate: string; activity: string } {
+	const defaults = { curate: "ctrl+shift+s", activity: "ctrl+shift+w" };
+	for (const configPath of [join(homedir(), ".atomic", "web-search.json"), join(homedir(), ".pi", "web-search.json")]) {
+		try {
+			if (!existsSync(configPath)) continue;
+			const parsed = JSON.parse(readFileSync(configPath, "utf8")) as { shortcuts?: { curate?: string; activity?: string } };
+			return {
+				curate: parsed.shortcuts?.curate?.trim() || defaults.curate,
+				activity: parsed.shortcuts?.activity?.trim() || defaults.activity,
+			};
+		} catch (error) {
+			console.error(`[pi-web-access] Failed to inspect shortcuts in ${configPath}:`, error);
+		}
+	}
+	return defaults;
+}
+
+export default function webAccess(pi: ExtensionAPI) {
+	let heavyPromise: Promise<CapturedHeavy> | null = null;
+	let loadedHeavy: CapturedHeavy | null = null;
+	let sessionSnapshot: SessionSnapshot | null = null;
+	let lifecycleGeneration = 0;
+	let replayedGeneration = 0;
+
+	async function replayCurrentSession(heavy: CapturedHeavy): Promise<void> {
+		if (!sessionSnapshot || replayedGeneration === sessionSnapshot.generation) return;
+		replayedGeneration = sessionSnapshot.generation;
+		await dispatchHandlers(heavy, sessionSnapshot.eventName, sessionSnapshot.event, sessionSnapshot.ctx);
+	}
+
+	async function loadHeavy(): Promise<CapturedHeavy> {
+		if (!heavyPromise) {
+			heavyPromise = (async () => {
+				const captured: CapturedHeavy = { tools: new Map(), commands: new Map(), handlers: new Map(), shortcuts: new Map() };
+				const mod = await import("./index-heavy.js");
+				await mod.default(createHeavyProxy(pi, captured));
+				loadedHeavy = captured;
+				await replayCurrentSession(captured);
+				return captured;
+			})();
+		}
+		return heavyPromise;
+	}
+
+	pi.on("session_start", async (event, ctx) => {
+		const generation = ++lifecycleGeneration;
+		sessionSnapshot = { eventName: "session_start", event, ctx, generation };
+		if (loadedHeavy) {
+			replayedGeneration = generation;
+			await dispatchHandlers(loadedHeavy, "session_start", event, ctx);
+		}
 	});
 
-	pi.registerShortcut(activityKey, {
-		description: "Toggle web search activity",
-		handler: async (ctx) => {
-			widgetVisible = !widgetVisible;
-			if (widgetVisible) {
-				widgetUnsubscribe = activityMonitor.onUpdate(() => updateWidget(ctx));
-				updateWidget(ctx);
-			} else {
-				widgetUnsubscribe?.();
-				widgetUnsubscribe = null;
-				ctx.ui.setWidget("web-activity", null);
-			}
-		},
+	pi.on("session_tree", async (event, ctx) => {
+		const generation = ++lifecycleGeneration;
+		sessionSnapshot = { eventName: "session_tree", event, ctx, generation };
+		if (loadedHeavy) {
+			replayedGeneration = generation;
+			await dispatchHandlers(loadedHeavy, "session_tree", event, ctx);
+		}
 	});
 
-	pi.on("session_start", async (_event, ctx) => handleSessionChange(ctx));
-	pi.on("session_tree", async (_event, ctx) => handleSessionChange(ctx));
-
-	pi.on("session_shutdown", () => {
-		sessionActive = false;
-		abortPendingFetches();
-		closeCurator();
-		clearCloneCache();
-		clearResults();
-		// Unsubscribe before clear() to avoid callback with stale ctx
-		widgetUnsubscribe?.();
-		widgetUnsubscribe = null;
-		activityMonitor.clear();
-		widgetVisible = false;
+	pi.on("session_shutdown", async (event, ctx) => {
+		++lifecycleGeneration;
+		if (loadedHeavy) {
+			await dispatchHandlers(loadedHeavy, "session_shutdown", event, ctx);
+		}
+		sessionSnapshot = null;
+		replayedGeneration = lifecycleGeneration;
 	});
+
+	const shortcuts = getInitialShortcutConfig();
+	for (const [shortcut, name] of [[shortcuts.curate, "curate"], [shortcuts.activity, "activity"]] as const) {
+		pi.registerShortcut(shortcut, {
+			description: name === "curate" ? "Open web search curator" : "Show web search activity",
+			handler: async (ctx) => {
+				const heavy = await loadHeavy();
+				const handler = heavy.shortcuts.get(shortcut)?.handler;
+				if (!handler) throw new Error(`Web access shortcut implementation not found: ${shortcut}`);
+				await handler(ctx);
+			},
+		});
+	}
 
 	pi.registerTool({
 		name: "web_search",
 		label: "Web Search",
-		description:
-			`Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to "none" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).`,
-		promptSnippet:
-			"Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
+		description: "Search the web using Perplexity AI, Exa, or Gemini. Returns an AI-synthesized answer with source citations. For comprehensive research, prefer queries (plural) with 2-4 varied angles over a single query — each query gets its own synthesized answer, so varying phrasing and scope gives much broader coverage. When includeContent is true, full page content is fetched in the background. Searches auto-open the interactive browser curator and stream results live; set workflow to \"none\" to skip curation. Provider auto-selects: Exa (direct API with key, MCP fallback without), else Perplexity (needs key), else Gemini API (needs key), else Gemini Web (needs a supported Chromium-based browser login).",
+		promptSnippet: "Use for web research questions. Prefer {queries:[...]} with 2-4 varied angles over a single query for broader coverage.",
 		parameters: Type.Object({
 			query: Type.Optional(Type.String({ description: "Single search query. For research tasks, prefer 'queries' with multiple varied angles instead." })),
-			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage. Good: ['React vs Vue performance benchmarks 2026', 'React vs Vue developer experience comparison', 'React ecosystem size vs Vue ecosystem']. Bad: ['React vs Vue', 'React vs Vue comparison', 'React vs Vue review'] (too similar, redundant results)." })),
+			queries: Type.Optional(Type.Array(Type.String(), { description: "Multiple queries searched in sequence, each returning its own synthesized answer. Prefer this for research — vary phrasing, scope, and angle across 2-4 queries to maximize coverage." })),
 			numResults: Type.Optional(Type.Number({ description: "Results per query (default: 5, max: 20)" })),
 			includeContent: Type.Optional(Type.Boolean({ description: "Fetch full page content (async)" })),
-			recencyFilter: Type.Optional(
-				StringEnum(["day", "week", "month", "year"], { description: "Filter by recency" }),
-			),
+			recencyFilter: Type.Optional(Type.String({ enum: ["day", "week", "month", "year"], description: "Filter by recency" })),
 			domainFilter: Type.Optional(Type.Array(Type.String(), { description: "Limit to domains (prefix with - to exclude)" })),
-			provider: Type.Optional(
-				StringEnum(["auto", "perplexity", "gemini", "exa"], { description: "Search provider (default: auto)" }),
-			),
-			workflow: Type.Optional(
-				StringEnum(["none", "summary-review"], {
-					description: "Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)",
-				}),
-			),
+			provider: Type.Optional(Type.String({ enum: ["auto", "perplexity", "gemini", "exa"], description: "Search provider (default: auto)" })),
+			workflow: Type.Optional(Type.String({ enum: ["none", "summary-review"], description: "Search workflow mode: none = no curator, summary-review = open curator with auto summary draft (default)" })),
 		}),
-
-		async execute(_toolCallId, params, signal, onUpdate, ctx) {
-			const rawQueryList: unknown[] = Array.isArray(params.queries)
-				? params.queries
-				: (params.query !== undefined ? [params.query] : []);
-			const queryList = normalizeQueryList(rawQueryList);
-			const configWorkflow = loadConfigForExtensionInit().workflow;
-			const workflow = resolveWorkflow(params.workflow ?? configWorkflow, ctx?.hasUI !== false);
-			const shouldCurate = workflow !== "none";
-
-			if (queryList.length === 0) {
-				return {
-					content: [{ type: "text", text: "Error: No query provided. Use 'query' or 'queries' parameter." }],
-					details: { error: "No query provided" },
-				};
-			}
-
-			if (shouldCurate && !ctx) {
-				return {
-					content: [{ type: "text", text: "Error: Curation requires an active extension context." }],
-					details: { error: "Missing extension context" },
-				};
-			}
-
-			if (shouldCurate) {
-				closeCurator();
-
-				let resolvePromise: (value: unknown) => void = () => {};
-				const promise = new Promise<unknown>((resolve) => {
-					resolvePromise = resolve;
-				});
-				const includeContent = params.includeContent ?? false;
-				const searchResults = new Map<number, QueryResultData>();
-				const allInlineContent: ExtractedContent[] = [];
-				const searchAbort = new AbortController();
-				const searchSignal = signal
-					? AbortSignal.any([signal, searchAbort.signal])
-					: searchAbort.signal;
-				let cancelled = false;
-
-				const bootstrap = await loadCuratorBootstrap(params.provider);
-				const availableProviders = bootstrap.availableProviders;
-				const defaultProvider = bootstrap.defaultProvider;
-				const curatorTimeoutSeconds = bootstrap.timeoutSeconds;
-				const curatorWorkflow: CuratorWorkflow = "summary-review";
-
-				const summaryContext: SummaryGenerationContext = {
-					model: ctx.model,
-					modelRegistry: ctx.modelRegistry,
-				};
-				const summaryModelChoices = await loadSummaryModelChoices(summaryContext);
-
-				const pc: PendingCurate = {
-					phase: "searching",
-					workflow: curatorWorkflow,
-					summaryContext,
-					searchResults,
-					allInlineContent,
-					queryList,
-					includeContent,
-					numResults: params.numResults,
-					recencyFilter: params.recencyFilter,
-					domainFilter: params.domainFilter,
-					availableProviders,
-					defaultProvider,
-					summaryModels: summaryModelChoices.summaryModels,
-					defaultSummaryModel: summaryModelChoices.defaultSummaryModel,
-					timeoutSeconds: curatorTimeoutSeconds,
-					onUpdate: onUpdate as PendingCurate["onUpdate"],
-					signal,
-					abortSearches: () => {
-						if (!searchAbort.signal.aborted) searchAbort.abort();
-					},
-					finish: () => {},
-					cancel: () => {},
-				};
-
-				const finish = (value: unknown) => {
-					if (cancelled) return;
-					cancelled = true;
-					pc.abortSearches();
-					signal?.removeEventListener("abort", onAbort);
-					pendingCurate = null;
-					resolvePromise(value);
-				};
-
-				const cancel = (reason: "user" | "stale" = "stale") => {
-					if (cancelled) return;
-					finish(buildCurationCancelledReturn(reason));
-				};
-
-				pc.finish = finish;
-				pc.cancel = cancel;
-
-				const onAbort = () => closeCurator();
-				pendingCurate = pc;
-				signal?.addEventListener("abort", onAbort, { once: true });
-				pc.browserPromise = openCuratorBrowser(pc, false);
-
-				for (let qi = 0; qi < queryList.length; qi++) {
-					if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
-					onUpdate?.({
-						content: [{ type: "text", text: `Searching ${qi + 1}/${queryList.length}: "${queryList[qi]}"...` }],
-						details: { phase: "searching", progress: qi / queryList.length, currentQuery: queryList[qi] },
-					});
-					const requestedProvider = pc.defaultProvider;
-					try {
-						const { answer, results, inlineContent, provider } = await search(queryList[qi], {
-							provider: requestedProvider,
-							numResults: params.numResults,
-							recencyFilter: params.recencyFilter,
-							domainFilter: params.domainFilter,
-							includeContent: params.includeContent,
-							signal: searchSignal,
-						});
-						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
-						searchResults.set(qi, { query: queryList[qi], answer, results, error: null, provider });
-						if (inlineContent) allInlineContent.push(...inlineContent);
-						if (activeCurator) {
-							activeCurator.pushResult(qi, {
-								answer,
-								results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
-								provider,
-							});
-						}
-					} catch (err) {
-						if (signal?.aborted || cancelled || searchAbort.signal.aborted) break;
-						const message = err instanceof Error ? err.message : String(err);
-						searchResults.set(qi, { query: queryList[qi], answer: "", results: [], error: message, provider: requestedProvider });
-						if (activeCurator) {
-							activeCurator.pushError(qi, message, requestedProvider);
-						}
-					}
-				}
-
-				if (signal?.aborted || cancelled || searchAbort.signal.aborted) {
-					cancel();
-					return promise;
-				}
-
-				await pc.browserPromise;
-				if (activeCurator && !cancelled) {
-					activeCurator.searchesDone();
-					pc.onUpdate?.({
-						content: [{ type: "text", text: "All searches complete — waiting for summary approval in browser..." }],
-						details: { phase: "curating", progress: 1 },
-					});
-				}
-
-				return promise;
-			}
-
-			const searchResults: QueryResultData[] = [];
-			const allUrls: string[] = [];
-			const allInlineContent: ExtractedContent[] = [];
-			const resolvedProvider = normalizeProviderInput(params.provider ?? loadConfig().provider);
-
-			for (let i = 0; i < queryList.length; i++) {
-				const query = queryList[i];
-
-				onUpdate?.({
-					content: [{ type: "text", text: `Searching ${i + 1}/${queryList.length}: "${query}"...` }],
-					details: { phase: "search", progress: i / queryList.length, currentQuery: query },
-				});
-
-				try {
-					const { answer, results, inlineContent, provider } = await search(query, {
-						provider: resolvedProvider,
-						numResults: params.numResults,
-						recencyFilter: params.recencyFilter,
-						domainFilter: params.domainFilter,
-						includeContent: params.includeContent,
-						signal,
-					});
-
-					searchResults.push({ query, answer, results, error: null, provider });
-					for (const r of results) {
-						if (!allUrls.includes(r.url)) {
-							allUrls.push(r.url);
-						}
-					}
-					if (inlineContent) allInlineContent.push(...inlineContent);
-				} catch (err) {
-					const message = err instanceof Error ? err.message : String(err);
-					const requestedProvider = typeof resolvedProvider === "string" && resolvedProvider !== "auto"
-						? resolvedProvider
-						: undefined;
-					searchResults.push({ query, answer: "", results: [], error: message, provider: requestedProvider });
-				}
-			}
-
-			return buildSearchReturn({
-				queryList,
-				results: searchResults,
-				urls: allUrls,
-				includeContent: params.includeContent ?? false,
-				inlineContent: allInlineContent.length > 0 ? allInlineContent : undefined,
-			});
-		},
-
+		execute: (...args) => executeHeavyTool(loadHeavy, "web_search", args),
+		renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "web_search", args),
 		renderCall(args, theme) {
-			const input = args as { query?: unknown; queries?: unknown };
-			const rawQueryList: unknown[] = Array.isArray(input.queries)
-				? input.queries
-				: (input.query !== undefined ? [input.query] : []);
-			const queryList = normalizeQueryList(rawQueryList);
-			if (queryList.length === 0) {
-				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("error", "(no query)"), 0, 0);
-			}
-			if (queryList.length === 1) {
-				const q = queryList[0];
-				const display = q.length > 60 ? q.slice(0, 57) + "..." : q;
-				return new Text(theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `"${display}"`), 0, 0);
-			}
-			const lines = [theme.fg("toolTitle", theme.bold("search ")) + theme.fg("accent", `${queryList.length} queries`)];
-			for (const q of queryList.slice(0, 5)) {
-				const display = q.length > 50 ? q.slice(0, 47) + "..." : q;
-				lines.push(theme.fg("muted", `  "${display}"`));
-			}
-			if (queryList.length > 5) {
-				lines.push(theme.fg("muted", `  ... and ${queryList.length - 5} more`));
-			}
-			return new Text(lines.join("\n"), 0, 0);
-		},
-
-		renderResult(result, { expanded, isPartial }, theme) {
-			type QueryDetail = {
-				query: string;
-				provider: string | null;
-				answer: string | null;
-				sources: Array<{ title: string; url: string }>;
-				error: string | null;
-			};
-			const details = result.details as {
-				queryCount?: number;
-				successfulQueries?: number;
-				totalResults?: number;
-				error?: string;
-				fetchId?: string;
-				fetchUrls?: string[];
-				phase?: string;
-				progress?: number;
-				currentQuery?: string;
-				curated?: boolean;
-				curatedFrom?: number;
-				curatedQueries?: QueryDetail[];
-				cancelled?: boolean;
-				cancelReason?: string;
-				summary?: {
-					text: string;
-					workflow: CuratorWorkflow;
-					model: string | null;
-					durationMs: number;
-					tokenEstimate: number;
-					fallbackUsed: boolean;
-					fallbackReason?: string;
-					edited?: boolean;
-				};
-			};
-
-			if (isPartial) {
-				if (details?.phase === "curating") {
-					return new Text(theme.fg("accent", "waiting for summary approval..."), 0, 0);
-				}
-				if (details?.phase === "searching") {
-					const progress = details?.progress ?? 0;
-					const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
-					const query = details?.currentQuery || "";
-					const display = query.length > 40 ? query.slice(0, 37) + "..." : query;
-					return new Text(theme.fg("accent", `[${bar}] ${display}`), 0, 0);
-				}
-				const progress = details?.progress ?? 0;
-				const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
-				return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "searching"}`), 0, 0);
-			}
-
-			if (details?.error) {
-				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
-			}
-
-			let statusLine: string;
-			const queryInfo = details?.queryCount === 1 ? "" : `${details?.successfulQueries}/${details?.queryCount} queries, `;
-			statusLine = theme.fg("success", `${queryInfo}${details?.totalResults ?? 0} sources`);
-			if (details?.curated && details?.curatedFrom) {
-				statusLine += theme.fg("muted", ` (${details.queryCount}/${details.curatedFrom} queries curated)`);
-			}
-			if (details?.fetchId && details?.fetchUrls) {
-				statusLine += theme.fg("muted", ` (fetching ${details.fetchUrls.length} URLs)`);
-			} else if (details?.fetchId) {
-				statusLine += theme.fg("muted", " (content ready)");
-			}
-
-			// Build expanded lines first so collapsed view can reference total count
-			const lines = [statusLine];
-			if (details?.summary?.text) {
-				lines.push("");
-				lines.push(theme.fg("accent", `── Summary (${details.summary.workflow}) ` + "─".repeat(32)));
-				lines.push("");
-				for (const line of details.summary.text.split("\n")) {
-					lines.push(`  ${line}`);
-				}
-				lines.push("");
-				const metaParts = [
-					details.summary.model ? `model=${details.summary.model}` : "model=deterministic",
-					`duration=${details.summary.durationMs}ms`,
-					`tokens~${details.summary.tokenEstimate}`,
-					details.summary.fallbackUsed ? "fallback=true" : "fallback=false",
-					details.summary.edited ? "edited=true" : "edited=false",
-				];
-				if (details.summary.fallbackReason) {
-					metaParts.push(`reason=${details.summary.fallbackReason}`);
-				}
-				lines.push(theme.fg("dim", "  " + metaParts.join(" · ")));
-			}
-
-			const queryDetails = details?.curatedQueries;
-			if (queryDetails?.length) {
-				const kept = queryDetails.length;
-				const from = details?.curatedFrom ?? kept;
-				lines.push("");
-				lines.push(theme.fg("accent", `\u2500\u2500 Curated Results (${kept} of ${from} queries kept) ` + "\u2500".repeat(24)));
-
-				for (const cq of queryDetails) {
-					lines.push("");
-					const dq = cq.query.length > 65 ? cq.query.slice(0, 62) + "..." : cq.query;
-					const providerLabel = cq.provider ? ` (${cq.provider})` : "";
-					lines.push(theme.fg("accent", `  "${dq}"${providerLabel}`));
-
-					if (cq.error) {
-						lines.push(theme.fg("error", `  ${cq.error}`));
-					} else if (cq.answer) {
-						lines.push("");
-						for (const line of cq.answer.split("\n")) {
-							lines.push(`  ${line}`);
-						}
-					}
-
-					if (cq.sources.length > 0) {
-						lines.push("");
-						for (const s of cq.sources) {
-							const domain = s.url.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
-							const title = s.title.length > 50 ? s.title.slice(0, 47) + "..." : s.title;
-							lines.push(theme.fg("muted", `  \u25b8 ${title}`) + theme.fg("dim", ` \u00b7 ${domain}`));
-						}
-					}
-				}
-				lines.push("");
-			} else {
-				const textContent = result.content.find((c) => c.type === "text")?.text || "";
-				const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
-				for (const line of preview.split("\n")) {
-					lines.push(theme.fg("dim", line));
-				}
-			}
-
-			if (details?.fetchUrls && details.fetchUrls.length > 0) {
-				if (details.curated) {
-					lines.push(theme.fg("muted", `Fetching ${details.fetchUrls.length} URLs in background`));
-				} else {
-					lines.push(theme.fg("muted", "Fetching:"));
-					for (const u of details.fetchUrls.slice(0, 5)) {
-						const display = u.length > 60 ? u.slice(0, 57) + "..." : u;
-						lines.push(theme.fg("dim", "  " + display));
-					}
-					if (details.fetchUrls.length > 5) {
-						lines.push(theme.fg("dim", `  ... and ${details.fetchUrls.length - 5} more`));
-					}
-				}
-			}
-
-			const totalLines = lines.length;
-
-			if (!expanded) {
-				const box = new Box(1, 0, (t) => theme.bg("toolSuccessBg", t));
-				box.addChild(new Text(statusLine, 0, 0));
-
-				let collapsedLines = 1; // statusLine
-				const summaryPreview = details?.summary?.text?.trim() || "";
-				if (summaryPreview) {
-					const preview = summaryPreview.length > 120 ? summaryPreview.slice(0, 117) + "..." : summaryPreview;
-					box.addChild(new Text(theme.fg("dim", preview), 0, 0));
-					collapsedLines++;
-				} else if (details?.curatedQueries?.length) {
-					for (const cq of details.curatedQueries.slice(0, 3)) {
-						const dq = cq.query.length > 55 ? cq.query.slice(0, 52) + "..." : cq.query;
-						const srcCount = cq.sources?.length ?? 0;
-						const suffix = cq.error ? theme.fg("error", " (error)") : theme.fg("dim", ` · ${srcCount} sources`);
-						box.addChild(new Text(theme.fg("accent", `  "${dq}"`) + suffix, 0, 0));
-						collapsedLines++;
-					}
-					if (details.curatedQueries.length > 3) {
-						box.addChild(new Text(theme.fg("dim", `  ... and ${details.curatedQueries.length - 3} more`), 0, 0));
-						collapsedLines++;
-					}
-				} else {
-					const textContent = result.content.find((c) => c.type === "text")?.text || "";
-					const firstContentLine = textContent.split("\n").find(l => {
-						const t = l.trim();
-						return t && !t.startsWith("[") && !t.startsWith("#") && !t.startsWith("---");
-					});
-					const fallbackLine = (firstContentLine?.trim() || "").replace(/\*\*/g, "");
-					if (fallbackLine) {
-						const preview = fallbackLine.length > 120 ? fallbackLine.slice(0, 117) + "..." : fallbackLine;
-						box.addChild(new Text(theme.fg("dim", preview), 0, 0));
-						collapsedLines++;
-					}
-				}
-				const moreLines = Math.max(0, totalLines - collapsedLines);
-				if (moreLines > 0) {
-					box.addChild(new Text(theme.fg("muted", `\n... (${moreLines} more lines, ${totalLines} total, CTRL+O Expand)`), 0, 0));
-				}
-				return box;
-			}
-
-			return new Text(lines.join("\n"), 0, 0);
+			const input = args as { query?: string; queries?: string[] };
+			const label = input.queries?.length ? `${input.queries.length} queries` : input.query ?? "(no query)";
+			return new Text(theme.fg("toolTitle", theme.bold("web_search ")) + theme.fg("accent", label), 0, 0);
 		},
 	});
 
@@ -1536,296 +201,38 @@ export default function (pi: ExtensionAPI) {
 		name: "code_search",
 		label: "Code Search",
 		description: "Search for code examples, documentation, and API references. Returns relevant code snippets and docs from GitHub, Stack Overflow, and official documentation. Use for any programming question — API usage, library examples, debugging help.",
-		promptSnippet:
-			"Use for programming/API/library questions to retrieve concrete examples and docs before implementing or debugging code.",
+		promptSnippet: "Use for programming/API/library questions to retrieve concrete examples and docs before implementing or debugging code.",
 		parameters: Type.Object({
 			query: Type.String({ description: "Programming question, API, library, or debugging topic to search for" }),
-			maxTokens: Type.Optional(Type.Integer({
-				minimum: 1000,
-				maximum: 50000,
-				description: "Maximum tokens of code/documentation context to return (default: 5000)",
-			})),
+			maxTokens: Type.Optional(Type.Integer({ minimum: 1000, maximum: 50000, description: "Maximum tokens of code/documentation context to return (default: 5000)" })),
 		}),
-
-		async execute(toolCallId, params, signal) {
-			return executeCodeSearch(toolCallId, params, signal);
-		},
-
-		renderCall(args, theme) {
-			const { query } = args as { query?: string };
-			const display = !query
-				? "(no query)"
-				: query.length > 70 ? query.slice(0, 67) + "..." : query;
-			return new Text(theme.fg("toolTitle", theme.bold("code_search ")) + theme.fg("accent", display), 0, 0);
-		},
-
-		renderResult(result, { expanded }, theme) {
-			const details = result.details as { query?: string; maxTokens?: number; error?: string };
-			if (details?.error) {
-				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
-			}
-
-			const summary = theme.fg("success", "code context returned") +
-				theme.fg("muted", ` (${details?.maxTokens ?? 5000} tokens max)`);
-			if (!expanded) return new Text(summary, 0, 0);
-
-			const textContent = result.content.find((c) => c.type === "text")?.text || "";
-			const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
-			return new Text(summary + "\n" + theme.fg("dim", preview), 0, 0);
-		},
+		execute: (...args) => executeHeavyTool(loadHeavy, "code_search", args),
+		renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "code_search", args),
 	});
 
 	pi.registerTool({
 		name: "fetch_content",
 		label: "Fetch Content",
 		description: "Fetch URL(s) and extract readable content as markdown. Supports YouTube video transcripts (with thumbnail), GitHub repository contents, and local video files (with frame thumbnail). Video frames can be extracted via timestamp/range or sampled across the entire video with frames alone. Falls back to Gemini for pages that block bots or fail Readability extraction. For YouTube and video files: ALWAYS pass the user's specific question via the prompt parameter — this directs the AI to focus on that aspect of the video, producing much better results than a generic extraction. Content is always stored and can be retrieved with get_search_content.",
-		promptSnippet:
-			"Use to extract readable content from URL(s), YouTube, GitHub repos, or local videos. For video questions, pass the user's exact question in prompt.",
+		promptSnippet: "Use to extract readable content from URL(s), YouTube, GitHub repos, or local videos. For video questions, pass the user's exact question in prompt.",
 		parameters: Type.Object({
 			url: Type.Optional(Type.String({ description: "Single URL to fetch" })),
 			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (parallel)" })),
-			forceClone: Type.Optional(Type.Boolean({
-				description: "Force cloning large GitHub repositories that exceed the size threshold",
-			})),
-			prompt: Type.Optional(Type.String({
-				description: "Question or instruction for video analysis (YouTube and video files). Pass the user's specific question here — e.g. 'describe the book shown at the advice for beginners section'. Without this, a generic transcript extraction is used which may miss what the user is asking about.",
-			})),
-			timestamp: Type.Optional(Type.String({
-				description: "Extract video frame(s) at a timestamp or time range. Single: '1:23:45', '23:45', or '85' (seconds). Range: '23:41-25:00' extracts evenly-spaced frames across that span (default 6). Use frames with ranges to control density; single+frames uses a fixed 5s interval. YouTube requires yt-dlp + ffmpeg; local videos require ffmpeg. Use a range when you know the approximate area but not the exact moment — you'll get a contact sheet to visually identify the right frame.",
-			})),
-			frames: Type.Optional(Type.Integer({
-				minimum: 1,
-				maximum: 12,
-				description: "Number of frames to extract. Use with timestamp range for custom density, with single timestamp to get N frames at 5s intervals, or alone to sample across the entire video. Requires yt-dlp + ffmpeg for YouTube, ffmpeg for local video.",
-			})),
-			model: Type.Optional(Type.String({
-				description: "Override the Gemini model for video/YouTube analysis (e.g. 'gemini-2.5-flash', 'gemini-3-flash-preview'). Defaults to config or gemini-3-flash-preview.",
-			})),
+			forceClone: Type.Optional(Type.Boolean({ description: "Force cloning large GitHub repositories that exceed the size threshold" })),
+			prompt: Type.Optional(Type.String({ description: "Question or instruction for video analysis (YouTube and video files)." })),
+			timestamp: Type.Optional(Type.String({ description: "Extract video frame(s) at a timestamp or time range." })),
+			frames: Type.Optional(Type.Integer({ minimum: 1, maximum: 12, description: "Number of frames to extract." })),
+			model: Type.Optional(Type.String({ description: "Override the Gemini model for video/YouTube analysis." })),
 		}),
-
-		async execute(_toolCallId, params, signal, onUpdate) {
-			const urlList = params.urls ?? (params.url ? [params.url] : []);
-			if (urlList.length === 0) {
-				return {
-					content: [{ type: "text", text: "Error: No URL provided." }],
-					details: { error: "No URL provided" },
-				};
-			}
-
-			onUpdate?.({
-				content: [{ type: "text", text: `Fetching ${urlList.length} URL(s)...` }],
-				details: { phase: "fetch", progress: 0 },
-			});
-
-			const fetchResults = await fetchAllContent(urlList, signal, {
-				forceClone: params.forceClone,
-				prompt: params.prompt,
-				timestamp: params.timestamp,
-				frames: params.frames,
-				model: params.model,
-			});
-			const successful = fetchResults.filter((r) => !r.error).length;
-			const totalChars = fetchResults.reduce((sum, r) => sum + r.content.length, 0);
-
-			// ALWAYS store results (even for single URL)
-			const responseId = generateId();
-			const data: StoredSearchData = {
-				id: responseId,
-				type: "fetch",
-				timestamp: Date.now(),
-				urls: stripThumbnails(fetchResults),
-			};
-			storeResult(responseId, data);
-			pi.appendEntry("web-search-results", data);
-
-			// Single URL: return content directly (possibly truncated) with responseId
-			if (urlList.length === 1) {
-				const result = fetchResults[0];
-				if (result.error) {
-					return {
-						content: [{ type: "text", text: `Error: ${result.error}` }],
-						details: { urls: urlList, urlCount: 1, successful: 0, error: result.error, responseId, prompt: params.prompt, timestamp: params.timestamp, frames: params.frames },
-					};
-				}
-
-				const fullLength = result.content.length;
-				const truncated = fullLength > MAX_INLINE_CONTENT;
-				let output = truncated
-					? result.content.slice(0, MAX_INLINE_CONTENT) + "\n\n[Content truncated...]"
-					: result.content;
-
-				if (truncated) {
-					output += `\n\n---\nShowing ${MAX_INLINE_CONTENT} of ${fullLength} chars. ` +
-						`Use get_search_content({ responseId: "${responseId}", urlIndex: 0 }) for full content.`;
-				}
-
-				const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [];
-				if (result.frames?.length) {
-					for (const frame of result.frames) {
-						content.push({ type: "image", data: frame.data, mimeType: frame.mimeType });
-						content.push({ type: "text", text: `Frame at ${frame.timestamp}` });
-					}
-				} else if (result.thumbnail) {
-					content.push({ type: "image", data: result.thumbnail.data, mimeType: result.thumbnail.mimeType });
-				}
-				content.push({ type: "text", text: output });
-
-				const imageCount = (result.frames?.length ?? 0) + (result.thumbnail ? 1 : 0);
-				return {
-					content,
-					details: {
-						urls: urlList,
-						urlCount: 1,
-						successful: 1,
-						totalChars: fullLength,
-						title: result.title,
-						responseId,
-						truncated,
-						hasImage: imageCount > 0,
-						imageCount,
-						prompt: params.prompt,
-						timestamp: params.timestamp,
-						frames: params.frames,
-						duration: result.duration,
-					},
-				};
-			}
-
-			// Multi-URL: existing behavior (summary + responseId)
-			let output = "## Fetched URLs\n\n";
-			for (const { url, title, content, error } of fetchResults) {
-				if (error) {
-					output += `- ${url}: Error - ${error}\n`;
-				} else {
-					output += `- ${title || url} (${content.length} chars)\n`;
-				}
-			}
-			output += `\n---\nUse get_search_content({ responseId: "${responseId}", urlIndex: 0 }) to retrieve full content.`;
-
-			return {
-				content: [{ type: "text", text: output }],
-				details: { urls: urlList, urlCount: urlList.length, successful, totalChars, responseId },
-			};
-		},
-
-		renderCall(args, theme) {
-			const { url, urls, prompt, timestamp, frames, model } = args as { url?: string; urls?: string[]; prompt?: string; timestamp?: string; frames?: number; model?: string };
-			const urlList = urls ?? (url ? [url] : []);
-			if (urlList.length === 0) {
-				return new Text(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("error", "(no URL)"), 0, 0);
-			}
-			const lines: string[] = [];
-			if (urlList.length === 1) {
-				const display = urlList[0].length > 60 ? urlList[0].slice(0, 57) + "..." : urlList[0];
-				lines.push(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", display));
-			} else {
-				lines.push(theme.fg("toolTitle", theme.bold("fetch ")) + theme.fg("accent", `${urlList.length} URLs`));
-				for (const u of urlList.slice(0, 5)) {
-					const display = u.length > 60 ? u.slice(0, 57) + "..." : u;
-					lines.push(theme.fg("muted", "  " + display));
-				}
-				if (urlList.length > 5) {
-					lines.push(theme.fg("muted", `  ... and ${urlList.length - 5} more`));
-				}
-			}
-			if (timestamp) {
-				lines.push(theme.fg("dim", "  timestamp: ") + theme.fg("warning", timestamp));
-			}
-			if (typeof frames === "number") {
-				lines.push(theme.fg("dim", "  frames: ") + theme.fg("warning", String(frames)));
-			}
-			if (prompt) {
-				const display = prompt.length > 250 ? prompt.slice(0, 247) + "..." : prompt;
-				lines.push(theme.fg("dim", "  prompt: ") + theme.fg("muted", `"${display}"`));
-			}
-			if (model) {
-				lines.push(theme.fg("dim", "  model: ") + theme.fg("warning", model));
-			}
-			return new Text(lines.join("\n"), 0, 0);
-		},
-
-		renderResult(result, { expanded, isPartial }, theme) {
-			const details = result.details as {
-				urlCount?: number;
-				successful?: number;
-				totalChars?: number;
-				error?: string;
-				title?: string;
-				truncated?: boolean;
-				responseId?: string;
-				phase?: string;
-				progress?: number;
-				hasImage?: boolean;
-				imageCount?: number;
-				prompt?: string;
-				timestamp?: string;
-				frames?: number;
-				duration?: number;
-			};
-
-			if (isPartial) {
-				const progress = details?.progress ?? 0;
-				const bar = "\u2588".repeat(Math.floor(progress * 10)) + "\u2591".repeat(10 - Math.floor(progress * 10));
-				return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "fetching"}`), 0, 0);
-			}
-
-			if (details?.error) {
-				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
-			}
-
-			if (details?.urlCount === 1) {
-				const title = details?.title || "Untitled";
-				const imgCount = details?.imageCount ?? (details?.hasImage ? 1 : 0);
-				const imageBadge = imgCount > 1
-					? theme.fg("accent", ` [${imgCount} images]`)
-					: imgCount === 1
-						? theme.fg("accent", " [image]")
-						: "";
-				let statusLine = theme.fg("success", title) + theme.fg("muted", ` (${details?.totalChars ?? 0} chars)`) + imageBadge;
-				if (details?.truncated) {
-					statusLine += theme.fg("warning", " [truncated]");
-				}
-				if (typeof details?.duration === "number") {
-					statusLine += theme.fg("muted", ` | ${formatSeconds(Math.floor(details.duration))} total`);
-				}
-				const textContent = result.content.find((c) => c.type === "text")?.text || "";
-				if (!expanded) {
-					const brief = textContent.length > 200 ? textContent.slice(0, 200) + "..." : textContent;
-					return new Text(statusLine + "\n" + theme.fg("dim", brief), 0, 0);
-				}
-				const lines = [statusLine];
-				if (details?.prompt) {
-					const display = details.prompt.length > 250 ? details.prompt.slice(0, 247) + "..." : details.prompt;
-					lines.push(theme.fg("dim", `  prompt: "${display}"`));
-				}
-				if (details?.timestamp) {
-					lines.push(theme.fg("dim", `  timestamp: ${details.timestamp}`));
-				}
-				if (typeof details?.frames === "number") {
-					lines.push(theme.fg("dim", `  frames: ${details.frames}`));
-				}
-				const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
-				lines.push(theme.fg("dim", preview));
-				return new Text(lines.join("\n"), 0, 0);
-			}
-
-			const countColor = (details?.successful ?? 0) > 0 ? "success" : "error";
-			const statusLine = theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) + theme.fg("muted", " (content stored)");
-			if (!expanded) {
-				return new Text(statusLine, 0, 0);
-			}
-			const textContent = result.content.find((c) => c.type === "text")?.text || "";
-			const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
-			return new Text(statusLine + "\n" + theme.fg("dim", preview), 0, 0);
-		},
+		execute: (...args) => executeHeavyTool(loadHeavy, "fetch_content", args),
+		renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "fetch_content", args),
 	});
 
 	pi.registerTool({
 		name: "get_search_content",
 		label: "Get Search Content",
 		description: "Retrieve full content from a previous web_search or fetch_content call.",
-		promptSnippet:
-			"Use after web_search/fetch_content when full stored content is needed via responseId plus query/url selectors.",
+		promptSnippet: "Use after web_search/fetch_content when full stored content is needed via responseId plus query/url selectors.",
 		parameters: Type.Object({
 			responseId: Type.String({ description: "The responseId from web_search or fetch_content" }),
 			query: Type.Optional(Type.String({ description: "Get content for this query (web_search)" })),
@@ -1833,518 +240,19 @@ export default function (pi: ExtensionAPI) {
 			url: Type.Optional(Type.String({ description: "Get content for this URL" })),
 			urlIndex: Type.Optional(Type.Number({ description: "Get content for URL at index" })),
 		}),
-
-		async execute(_toolCallId, params) {
-			const data = getResult(params.responseId);
-			if (!data) {
-				return {
-					content: [{ type: "text", text: `Error: No stored results for "${params.responseId}"` }],
-					details: { error: "Not found", responseId: params.responseId },
-				};
-			}
-
-			if (data.type === "search" && data.queries) {
-				let queryData: QueryResultData | undefined;
-
-				if (params.query !== undefined) {
-					queryData = data.queries.find((q) => q.query === params.query);
-					if (!queryData) {
-						const available = data.queries.map((q) => `"${q.query}"`).join(", ");
-						return {
-							content: [{ type: "text", text: `Query "${params.query}" not found. Available: ${available}` }],
-							details: { error: "Query not found" },
-						};
-					}
-				} else if (params.queryIndex !== undefined) {
-					queryData = data.queries[params.queryIndex];
-					if (!queryData) {
-						return {
-							content: [{ type: "text", text: `Index ${params.queryIndex} out of range (0-${data.queries.length - 1})` }],
-							details: { error: "Index out of range" },
-						};
-					}
-				} else {
-					const available = data.queries.map((q, i) => `${i}: "${q.query}"`).join(", ");
-					return {
-						content: [{ type: "text", text: `Specify query or queryIndex. Available: ${available}` }],
-						details: { error: "No query specified" },
-					};
-				}
-
-				if (queryData.error) {
-					return {
-						content: [{ type: "text", text: `Error for "${queryData.query}": ${queryData.error}` }],
-						details: { error: queryData.error, query: queryData.query },
-					};
-				}
-
-				return {
-					content: [{ type: "text", text: formatFullResults(queryData) }],
-					details: { query: queryData.query, resultCount: queryData.results.length },
-				};
-			}
-
-			if (data.type === "fetch" && data.urls) {
-				let urlData: ExtractedContent | undefined;
-
-				if (params.url !== undefined) {
-					urlData = data.urls.find((u) => u.url === params.url);
-					if (!urlData) {
-						const available = data.urls.map((u) => u.url).join("\n  ");
-						return {
-							content: [{ type: "text", text: `URL not found. Available:\n  ${available}` }],
-							details: { error: "URL not found" },
-						};
-					}
-				} else if (params.urlIndex !== undefined) {
-					urlData = data.urls[params.urlIndex];
-					if (!urlData) {
-						return {
-							content: [{ type: "text", text: `Index ${params.urlIndex} out of range (0-${data.urls.length - 1})` }],
-							details: { error: "Index out of range" },
-						};
-					}
-				} else {
-					const available = data.urls.map((u, i) => `${i}: ${u.url}`).join("\n  ");
-					return {
-						content: [{ type: "text", text: `Specify url or urlIndex. Available:\n  ${available}` }],
-						details: { error: "No URL specified" },
-					};
-				}
-
-				if (urlData.error) {
-					return {
-						content: [{ type: "text", text: `Error for ${urlData.url}: ${urlData.error}` }],
-						details: { error: urlData.error, url: urlData.url },
-					};
-				}
-
-				return {
-					content: [{ type: "text", text: `# ${urlData.title}\n\n${urlData.content}` }],
-					details: { url: urlData.url, title: urlData.title, contentLength: urlData.content.length },
-				};
-			}
-
-			return {
-				content: [{ type: "text", text: "Invalid stored data format" }],
-				details: { error: "Invalid data" },
-			};
-		},
-
-		renderCall(args, theme) {
-			const { responseId, query, queryIndex, url, urlIndex } = args as {
-				responseId: string;
-				query?: string;
-				queryIndex?: number;
-				url?: string;
-				urlIndex?: number;
-			};
-			let target = "";
-			if (query) target = `query="${query}"`;
-			else if (queryIndex !== undefined) target = `queryIndex=${queryIndex}`;
-			else if (url) target = url.length > 30 ? url.slice(0, 27) + "..." : url;
-			else if (urlIndex !== undefined) target = `urlIndex=${urlIndex}`;
-			return new Text(theme.fg("toolTitle", theme.bold("get_content ")) + theme.fg("accent", target || responseId.slice(0, 8)), 0, 0);
-		},
-
-		renderResult(result, { expanded }, theme) {
-			const details = result.details as {
-				error?: string;
-				query?: string;
-				url?: string;
-				title?: string;
-				resultCount?: number;
-				contentLength?: number;
-			};
-
-			if (details?.error) {
-				return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
-			}
-
-			let statusLine: string;
-			if (details?.query) {
-				statusLine = theme.fg("success", `"${details.query}"`) + theme.fg("muted", ` (${details.resultCount} results)`);
-			} else {
-				statusLine = theme.fg("success", details?.title || "Content") + theme.fg("muted", ` (${details?.contentLength ?? 0} chars)`);
-			}
-
-			if (!expanded) {
-				return new Text(statusLine, 0, 0);
-			}
-
-			const textContent = result.content.find((c) => c.type === "text")?.text || "";
-			const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
-			return new Text(statusLine + "\n" + theme.fg("dim", preview), 0, 0);
-		},
+		execute: (...args) => executeHeavyTool(loadHeavy, "get_search_content", args),
+		renderResult: (...args) => renderHeavyToolResult(loadedHeavy, "get_search_content", args),
 	});
 
-	pi.registerCommand("websearch", {
-		description: "Open web search curator",
-		handler: async (args, ctx) => {
-			closeCurator();
-			const sessionToken = randomUUID();
-
-			const raw = args.trim();
-			const queries = raw.length > 0
-				? normalizeQueryList(raw.split(","))
-				: [];
-
-			let bootstrap: CuratorBootstrap;
-			try {
-				bootstrap = await loadCuratorBootstrap(undefined);
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to load web search config: ${message}`, "error");
-				return;
-			}
-			const availableProviders = bootstrap.availableProviders;
-			const initialProvider = bootstrap.defaultProvider;
-			const curatorTimeoutSeconds = bootstrap.timeoutSeconds;
-			let currentProvider = initialProvider;
-			const summaryContext: SummaryGenerationContext = {
-				model: ctx.model,
-				modelRegistry: ctx.modelRegistry,
-			};
-			const summaryModelChoices = await loadSummaryModelChoices(summaryContext);
-
-			ctx.ui.notify("Opening web search curator...", "info");
-
-			const collected = new Map<number, QueryResultData>();
-			const searchAbort = new AbortController();
-			let aborted = false;
-			let commandHandle: CuratorServerHandle | null = null;
-
-			function sendFollowUpFromReturn(payload: ReturnType<typeof buildSearchReturn>) {
-				pi.sendMessage({
-					customType: "web-search-results",
-					content: payload.content,
-					display: "tool",
-					details: payload.details,
-				}, { triggerTurn: true, deliverAs: "followUp" });
-			}
-
-			try {
-				const handle = await startCuratorServer(
-					{
-						queries,
-						sessionToken,
-						timeout: curatorTimeoutSeconds,
-						availableProviders,
-						defaultProvider: initialProvider,
-						summaryModels: summaryModelChoices.summaryModels,
-						defaultSummaryModel: summaryModelChoices.defaultSummaryModel,
-					},
-					{
-						async onSummarize(selectedQueryIndices, summarizeSignal, model, feedback) {
-							if (commandHandle && activeCurator !== commandHandle) {
-								throw new Error("Curator session is no longer active.");
-							}
-							return generateSummaryForSelectedIndices(
-								selectedQueryIndices,
-								collected,
-								summaryContext,
-								summarizeSignal,
-								model,
-								feedback,
-							);
-						},
-						onSubmit(payload) {
-							if (commandHandle && activeCurator !== commandHandle) return;
-							aborted = true;
-							searchAbort.abort();
-							const filtered = payload.selectedQueryIndices.length > 0
-								? filterByQueryIndices(payload.selectedQueryIndices, collected)
-								: collectAllResultsAndUrls(collected);
-							const base: SearchReturnOptions = {
-								queryList: filtered.results.map(r => r.query),
-								results: filtered.results,
-								urls: filtered.urls,
-								includeContent: false,
-								curated: true,
-								curatedFrom: collected.size,
-							};
-							if (!payload.rawResults) {
-								const resolvedSummary = resolveSummaryForSubmit(payload, collected);
-								base.workflow = "summary-review";
-								base.approvedSummary = resolvedSummary.approvedSummary;
-								base.summaryMeta = resolvedSummary.summaryMeta;
-							}
-							sendFollowUpFromReturn(buildSearchReturn(base));
-							closeCurator();
-						},
-						onCancel(reason) {
-							if (commandHandle && activeCurator !== commandHandle) return;
-							aborted = true;
-							searchAbort.abort();
-							if (reason === "timeout") {
-								const all = collectAllResultsAndUrls(collected);
-								const resolvedSummary = resolveSummaryForSubmit({ selectedQueryIndices: [], summary: undefined, summaryMeta: undefined }, collected);
-								sendFollowUpFromReturn(buildSearchReturn({
-									queryList: all.results.map(r => r.query),
-									results: all.results,
-									urls: all.urls,
-									includeContent: false,
-									curated: true,
-									curatedFrom: collected.size,
-									workflow: "summary-review",
-									approvedSummary: resolvedSummary.approvedSummary,
-									summaryMeta: resolvedSummary.summaryMeta,
-								}));
-							}
-							closeCurator();
-						},
-						onProviderChange(provider) {
-							if (commandHandle && activeCurator !== commandHandle) return;
-							const normalized = normalizeProviderInput(provider);
-							if (!normalized || normalized === "auto") return;
-							currentProvider = normalized;
-							try {
-								saveConfig({ provider: normalized });
-							} catch (err) {
-								const message = err instanceof Error ? err.message : String(err);
-								console.error(`Failed to persist default provider: ${message}`);
-							}
-						},
-						async onAddSearch(query, queryIndex, provider) {
-							if (commandHandle && activeCurator !== commandHandle) {
-								throw new Error("Curator session is no longer active.");
-							}
-							const normalizedProvider = normalizeProviderInput(provider);
-							const requestedProvider = !normalizedProvider || normalizedProvider === "auto"
-								? currentProvider
-								: normalizedProvider;
-							try {
-								const { answer, results, provider: actualProvider } = await search(query, {
-									provider: requestedProvider,
-									signal: searchAbort.signal,
-								});
-								if (commandHandle && activeCurator !== commandHandle) {
-									throw new Error("Curator session is no longer active.");
-								}
-								collected.set(queryIndex, { query, answer, results, error: null, provider: actualProvider });
-								return {
-									answer,
-									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
-									provider: actualProvider,
-								};
-							} catch (err) {
-								const message = err instanceof Error ? err.message : String(err);
-								if (!commandHandle || activeCurator === commandHandle) {
-									collected.set(queryIndex, { query, answer: "", results: [], error: message, provider: requestedProvider });
-								}
-								throw err;
-							}
-						},
-						async onRewriteQuery(query, rewriteSignal) {
-							if (commandHandle && activeCurator !== commandHandle) {
-								throw new Error("Curator session is no longer active.");
-							}
-							return rewriteSearchQuery(query, summaryContext, rewriteSignal);
-						},
-					},
-				);
-
-				commandHandle = handle;
-				activeCurator = handle;
-				const open = platform() === "darwin" ? await getGlimpseOpen() : null;
-				if (open) {
-					try {
-						const win = openInGlimpse(open, handle.url, "Search Curator");
-						glimpseWin = win;
-						win.on("closed", () => {
-							if (glimpseWin === win) {
-								glimpseWin = null;
-								closeCurator();
-							}
-						});
-					} catch (err) {
-						const message = err instanceof Error ? err.message : String(err);
-						console.error(`Failed to open Glimpse curator window: ${message}`);
-						glimpseWin = null;
-						await openInBrowser(pi, handle.url);
-					}
-				} else {
-					await openInBrowser(pi, handle.url);
-				}
-
-				if (queries.length > 0) {
-					(async () => {
-						for (let qi = 0; qi < queries.length; qi++) {
-							if (aborted || activeCurator !== handle) break;
-							const requestedProvider = currentProvider;
-							try {
-								const { answer, results, provider } = await search(queries[qi], {
-									provider: requestedProvider,
-									signal: searchAbort.signal,
-								});
-								if (aborted || activeCurator !== handle) break;
-								handle.pushResult(qi, {
-									answer,
-									results: results.map(r => ({ title: r.title, url: r.url, domain: extractDomain(r.url) })),
-									provider,
-								});
-								collected.set(qi, { query: queries[qi], answer, results, error: null, provider });
-							} catch (err) {
-								if (aborted || activeCurator !== handle) break;
-								const message = err instanceof Error ? err.message : String(err);
-								handle.pushError(qi, message, requestedProvider);
-								collected.set(qi, { query: queries[qi], answer: "", results: [], error: message, provider: requestedProvider });
-							}
-						}
-						if (!aborted && activeCurator === handle) handle.searchesDone();
-					})();
-				} else {
-					if (activeCurator === handle) handle.searchesDone();
-				}
-			} catch (err) {
-				closeCurator();
-				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to open curator: ${message}`, "error");
-			}
-		},
-	});
-
-	pi.registerCommand("curator", {
-		description: "Toggle or configure the search curator workflow",
-		handler: async (args, ctx) => {
-			const arg = args.trim().toLowerCase();
-
-			let newWorkflow: WebSearchWorkflow;
-			if (arg.length === 0) {
-				const current = resolveWorkflow(loadConfigForExtensionInit().workflow, true);
-				newWorkflow = current === "none" ? "summary-review" : "none";
-			} else if (arg === "on") {
-				newWorkflow = "summary-review";
-			} else if (arg === "off") {
-				newWorkflow = "none";
-			} else if (arg === "none" || arg === "summary-review") {
-				newWorkflow = arg;
-			} else {
-				ctx.ui.notify(`Unknown option: ${arg}. Use on, off, or summary-review.`, "error");
-				return;
-			}
-
-			try {
-				saveConfig({ workflow: newWorkflow });
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				ctx.ui.notify(`Failed to save config: ${message}`, "error");
-				return;
-			}
-
-			const label = newWorkflow === "none"
-				? "Curator disabled — web_search will return raw results"
-				: "Curator enabled — web_search will open curator and auto-generate a summary draft";
-			pi.sendMessage({
-				customType: "curator-config",
-				content: [{ type: "text", text: label }],
-				display: "tool",
-				details: { workflow: newWorkflow },
-			}, { triggerTurn: false, deliverAs: "followUp" });
-		},
-	});
-
-	pi.registerCommand("google-account", {
-		description: "Show the active Google account for Gemini Web",
-		handler: async () => {
-			if (!isBrowserCookieAccessAllowed()) {
-				pi.sendMessage({
-					customType: "google-account",
-					content: [{ type: "text", text: `Gemini Web browser cookie access is disabled. Set allowBrowserCookies: true in ~/${CONFIG_DIR_NAME}/web-search.json to enable it.` }],
-					display: "tool",
-					details: { available: false, cookieAccessAllowed: false },
-				}, { triggerTurn: true, deliverAs: "followUp" });
-				return;
-			}
-
-			const cookies = await isGeminiWebAvailable();
-			if (!cookies) {
-				pi.sendMessage({
-					customType: "google-account",
-					content: [{ type: "text", text: "Gemini Web is unavailable. Sign into gemini.google.com in a supported Chromium-based browser." }],
-					display: "tool",
-					details: { available: false, cookieAccessAllowed: true },
-				}, { triggerTurn: true, deliverAs: "followUp" });
-				return;
-			}
-
-			const email = await getActiveGoogleEmail(cookies);
-			const text = email
-				? `Active Google account: ${email}`
-				: "Gemini Web is available, but the active Google account could not be determined.";
-
-			pi.sendMessage({
-				customType: "google-account",
-				content: [{ type: "text", text }],
-				display: "tool",
-				details: { available: true, email: email ?? null },
-			}, { triggerTurn: true, deliverAs: "followUp" });
-		},
-	});
-
-	pi.registerCommand("search", {
-		description: "Browse stored web search results",
-		handler: async (_args, ctx) => {
-			const results = getAllResults();
-
-			if (results.length === 0) {
-				ctx.ui.notify("No stored search results", "info");
-				return;
-			}
-
-			const options = results.map((r) => {
-				const age = Math.floor((Date.now() - r.timestamp) / 60000);
-				const ageStr = age < 60 ? `${age}m ago` : `${Math.floor(age / 60)}h ago`;
-				if (r.type === "search" && r.queries) {
-					const query = r.queries[0]?.query || "unknown";
-					return `[${r.id.slice(0, 6)}] "${query}" (${r.queries.length} queries) - ${ageStr}`;
-				}
-				if (r.type === "fetch" && r.urls) {
-					return `[${r.id.slice(0, 6)}] ${r.urls.length} URLs fetched - ${ageStr}`;
-				}
-				return `[${r.id.slice(0, 6)}] ${r.type} - ${ageStr}`;
-			});
-
-			const choice = await ctx.ui.select("Stored Search Results", options);
-			if (!choice) return;
-
-			const match = choice.match(/^\[([a-z0-9]+)\]/);
-			if (!match) return;
-
-			const selected = results.find((r) => r.id.startsWith(match[1]));
-			if (!selected) return;
-
-			const actions = ["View details", "Delete"];
-			const action = await ctx.ui.select(`Result ${selected.id.slice(0, 6)}`, actions);
-
-			if (action === "Delete") {
-				deleteResult(selected.id);
-				ctx.ui.notify(`Deleted ${selected.id.slice(0, 6)}`, "info");
-			} else if (action === "View details") {
-				let info = `ID: ${selected.id}\nType: ${selected.type}\nAge: ${Math.floor((Date.now() - selected.timestamp) / 60000)}m\n\n`;
-				if (selected.type === "search" && selected.queries) {
-					info += "Queries:\n";
-					const queries = selected.queries.slice(0, 10);
-					for (const q of queries) {
-						info += `- "${q.query}" (${q.results.length} results)\n`;
-					}
-					if (selected.queries.length > 10) {
-						info += `... and ${selected.queries.length - 10} more\n`;
-					}
-				}
-				if (selected.type === "fetch" && selected.urls) {
-					info += "URLs:\n";
-					const urls = selected.urls.slice(0, 10);
-					for (const u of urls) {
-						const urlDisplay = u.url.length > 50 ? u.url.slice(0, 47) + "..." : u.url;
-						info += `- ${urlDisplay} (${u.error || `${u.content.length} chars`})\n`;
-					}
-					if (selected.urls.length > 10) {
-						info += `... and ${selected.urls.length - 10} more\n`;
-					}
-				}
-				ctx.ui.notify(info, "info");
-			}
-		},
-	});
+	for (const [name, description] of [
+		["websearch", "Configure web search"],
+		["curator", "Configure web search curator"],
+		["google-account", "Show the active Google account for Gemini Web"],
+		["search", "Browse stored web search results"],
+	] as const) {
+		pi.registerCommand(name, {
+			description,
+			handler: (args, ctx) => runHeavyCommand(loadHeavy, name, args, ctx),
+		});
+	}
 }

--- a/packages/web-access/result-renderers.ts
+++ b/packages/web-access/result-renderers.ts
@@ -1,0 +1,364 @@
+import type { ToolDefinition } from "@bastani/atomic";
+import { Box, Text } from "@mariozechner/pi-tui";
+import { formatSeconds } from "./utils.js";
+
+type ToolResultRenderer = NonNullable<ToolDefinition["renderResult"]>;
+type ToolRenderResultArgs = Parameters<ToolResultRenderer>;
+type ToolRenderResult = ReturnType<ToolResultRenderer>;
+type RenderedResult = ToolRenderResultArgs[0];
+type TextContentBlock = Extract<RenderedResult["content"][number], { type: "text" }>;
+
+type QueryDetail = {
+	query: string;
+	provider: string | null;
+	answer: string | null;
+	sources: Array<{ title: string; url: string }>;
+	error: string | null;
+};
+
+type WebSearchResultDetails = {
+	queryCount?: number;
+	successfulQueries?: number;
+	totalResults?: number;
+	error?: string;
+	fetchId?: string;
+	fetchUrls?: string[];
+	phase?: string;
+	progress?: number;
+	currentQuery?: string;
+	curated?: boolean;
+	curatedFrom?: number;
+	curatedQueries?: QueryDetail[];
+	cancelled?: boolean;
+	cancelReason?: string;
+	summary?: {
+		text: string;
+		workflow: "summary-review";
+		model: string | null;
+		durationMs: number;
+		tokenEstimate: number;
+		fallbackUsed: boolean;
+		fallbackReason?: string;
+		edited?: boolean;
+	};
+};
+
+type CodeSearchResultDetails = {
+	query?: string;
+	maxTokens?: number;
+	error?: string;
+};
+
+type FetchContentResultDetails = {
+	urlCount?: number;
+	successful?: number;
+	totalChars?: number;
+	error?: string;
+	title?: string;
+	truncated?: boolean;
+	responseId?: string;
+	phase?: string;
+	progress?: number;
+	hasImage?: boolean;
+	imageCount?: number;
+	prompt?: string;
+	timestamp?: string;
+	frames?: number;
+	duration?: number;
+};
+
+type GetSearchContentResultDetails = {
+	error?: string;
+	query?: string;
+	url?: string;
+	title?: string;
+	resultCount?: number;
+	contentLength?: number;
+};
+
+function isTextContentBlock(block: RenderedResult["content"][number]): block is TextContentBlock {
+	return block.type === "text";
+}
+
+function firstTextContent(result: RenderedResult): string {
+	return result.content.find(isTextContentBlock)?.text ?? "";
+}
+
+function progressBar(progress: number): string {
+	const filled = Math.floor(progress * 10);
+	return "\u2588".repeat(filled) + "\u2591".repeat(10 - filled);
+}
+
+export const renderWebSearchResult: ToolResultRenderer = (result, { expanded, isPartial }, theme) => {
+	const details = result.details as WebSearchResultDetails | undefined;
+
+	if (isPartial) {
+		if (details?.phase === "curating") {
+			return new Text(theme.fg("accent", "waiting for summary approval..."), 0, 0);
+		}
+		if (details?.phase === "searching") {
+			const progress = details?.progress ?? 0;
+			const bar = progressBar(progress);
+			const query = details?.currentQuery || "";
+			const display = query.length > 40 ? query.slice(0, 37) + "..." : query;
+			return new Text(theme.fg("accent", `[${bar}] ${display}`), 0, 0);
+		}
+		const progress = details?.progress ?? 0;
+		const bar = progressBar(progress);
+		return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "searching"}`), 0, 0);
+	}
+
+	if (details?.error) {
+		return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
+	}
+
+	let statusLine: string;
+	const queryInfo = details?.queryCount === 1 ? "" : `${details?.successfulQueries}/${details?.queryCount} queries, `;
+	statusLine = theme.fg("success", `${queryInfo}${details?.totalResults ?? 0} sources`);
+	if (details?.curated && details?.curatedFrom) {
+		statusLine += theme.fg("muted", ` (${details.queryCount}/${details.curatedFrom} queries curated)`);
+	}
+	if (details?.fetchId && details?.fetchUrls) {
+		statusLine += theme.fg("muted", ` (fetching ${details.fetchUrls.length} URLs)`);
+	} else if (details?.fetchId) {
+		statusLine += theme.fg("muted", " (content ready)");
+	}
+
+	// Build expanded lines first so collapsed view can reference total count
+	const lines = [statusLine];
+	if (details?.summary?.text) {
+		lines.push("");
+		lines.push(theme.fg("accent", `── Summary (${details.summary.workflow}) ` + "─".repeat(32)));
+		lines.push("");
+		for (const line of details.summary.text.split("\n")) {
+			lines.push(`  ${line}`);
+		}
+		lines.push("");
+		const metaParts = [
+			details.summary.model ? `model=${details.summary.model}` : "model=deterministic",
+			`duration=${details.summary.durationMs}ms`,
+			`tokens~${details.summary.tokenEstimate}`,
+			details.summary.fallbackUsed ? "fallback=true" : "fallback=false",
+			details.summary.edited ? "edited=true" : "edited=false",
+		];
+		if (details.summary.fallbackReason) {
+			metaParts.push(`reason=${details.summary.fallbackReason}`);
+		}
+		lines.push(theme.fg("dim", "  " + metaParts.join(" · ")));
+	}
+
+	const queryDetails = details?.curatedQueries;
+	if (queryDetails?.length) {
+		const kept = queryDetails.length;
+		const from = details?.curatedFrom ?? kept;
+		lines.push("");
+		lines.push(theme.fg("accent", `\u2500\u2500 Curated Results (${kept} of ${from} queries kept) ` + "\u2500".repeat(24)));
+
+		for (const cq of queryDetails) {
+			lines.push("");
+			const dq = cq.query.length > 65 ? cq.query.slice(0, 62) + "..." : cq.query;
+			const providerLabel = cq.provider ? ` (${cq.provider})` : "";
+			lines.push(theme.fg("accent", `  "${dq}"${providerLabel}`));
+
+			if (cq.error) {
+				lines.push(theme.fg("error", `  ${cq.error}`));
+			} else if (cq.answer) {
+				lines.push("");
+				for (const line of cq.answer.split("\n")) {
+					lines.push(`  ${line}`);
+				}
+			}
+
+			if (cq.sources.length > 0) {
+				lines.push("");
+				for (const s of cq.sources) {
+					const domain = s.url.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+					const title = s.title.length > 50 ? s.title.slice(0, 47) + "..." : s.title;
+					lines.push(theme.fg("muted", `  \u25b8 ${title}`) + theme.fg("dim", ` \u00b7 ${domain}`));
+				}
+			}
+		}
+		lines.push("");
+	} else {
+		const textContent = firstTextContent(result);
+		const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+		for (const line of preview.split("\n")) {
+			lines.push(theme.fg("dim", line));
+		}
+	}
+
+	if (details?.fetchUrls && details.fetchUrls.length > 0) {
+		if (details.curated) {
+			lines.push(theme.fg("muted", `Fetching ${details.fetchUrls.length} URLs in background`));
+		} else {
+			lines.push(theme.fg("muted", "Fetching:"));
+			for (const u of details.fetchUrls.slice(0, 5)) {
+				const display = u.length > 60 ? u.slice(0, 57) + "..." : u;
+				lines.push(theme.fg("dim", "  " + display));
+			}
+			if (details.fetchUrls.length > 5) {
+				lines.push(theme.fg("dim", `  ... and ${details.fetchUrls.length - 5} more`));
+			}
+		}
+	}
+
+	const totalLines = lines.length;
+
+	if (!expanded) {
+		const box = new Box(1, 0, (t) => theme.bg("toolSuccessBg", t));
+		box.addChild(new Text(statusLine, 0, 0));
+
+		let collapsedLines = 1; // statusLine
+		const summaryPreview = details?.summary?.text?.trim() || "";
+		if (summaryPreview) {
+			const preview = summaryPreview.length > 120 ? summaryPreview.slice(0, 117) + "..." : summaryPreview;
+			box.addChild(new Text(theme.fg("dim", preview), 0, 0));
+			collapsedLines++;
+		} else if (details?.curatedQueries?.length) {
+			for (const cq of details.curatedQueries.slice(0, 3)) {
+				const dq = cq.query.length > 55 ? cq.query.slice(0, 52) + "..." : cq.query;
+				const srcCount = cq.sources?.length ?? 0;
+				const suffix = cq.error ? theme.fg("error", " (error)") : theme.fg("dim", ` · ${srcCount} sources`);
+				box.addChild(new Text(theme.fg("accent", `  "${dq}"`) + suffix, 0, 0));
+				collapsedLines++;
+			}
+			if (details.curatedQueries.length > 3) {
+				box.addChild(new Text(theme.fg("dim", `  ... and ${details.curatedQueries.length - 3} more`), 0, 0));
+				collapsedLines++;
+			}
+		} else {
+			const textContent = firstTextContent(result);
+			const firstContentLine = textContent.split("\n").find(l => {
+				const t = l.trim();
+				return t && !t.startsWith("[") && !t.startsWith("#") && !t.startsWith("---");
+			});
+			const fallbackLine = (firstContentLine?.trim() || "").replace(/\*\*/g, "");
+			if (fallbackLine) {
+				const preview = fallbackLine.length > 120 ? fallbackLine.slice(0, 117) + "..." : fallbackLine;
+				box.addChild(new Text(theme.fg("dim", preview), 0, 0));
+				collapsedLines++;
+			}
+		}
+		const moreLines = Math.max(0, totalLines - collapsedLines);
+		if (moreLines > 0) {
+			box.addChild(new Text(theme.fg("muted", `\n... (${moreLines} more lines, ${totalLines} total, CTRL+O Expand)`), 0, 0));
+		}
+		return box;
+	}
+
+	return new Text(lines.join("\n"), 0, 0);
+};
+
+export const renderCodeSearchResult: ToolResultRenderer = (result, { expanded }, theme) => {
+	const details = result.details as CodeSearchResultDetails | undefined;
+	if (details?.error) {
+		return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
+	}
+
+	const summary = theme.fg("success", "code context returned") +
+		theme.fg("muted", ` (${details?.maxTokens ?? 5000} tokens max)`);
+	if (!expanded) return new Text(summary, 0, 0);
+
+	const textContent = firstTextContent(result);
+	const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+	return new Text(summary + "\n" + theme.fg("dim", preview), 0, 0);
+};
+
+export const renderFetchContentResult: ToolResultRenderer = (result, { expanded, isPartial }, theme) => {
+	const details = result.details as FetchContentResultDetails | undefined;
+
+	if (isPartial) {
+		const progress = details?.progress ?? 0;
+		const bar = progressBar(progress);
+		return new Text(theme.fg("accent", `[${bar}] ${details?.phase || "fetching"}`), 0, 0);
+	}
+
+	if (details?.error) {
+		return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
+	}
+
+	if (details?.urlCount === 1) {
+		const title = details?.title || "Untitled";
+		const imgCount = details?.imageCount ?? (details?.hasImage ? 1 : 0);
+		const imageBadge = imgCount > 1
+			? theme.fg("accent", ` [${imgCount} images]`)
+			: imgCount === 1
+				? theme.fg("accent", " [image]")
+				: "";
+		let statusLine = theme.fg("success", title) + theme.fg("muted", ` (${details?.totalChars ?? 0} chars)`) + imageBadge;
+		if (details?.truncated) {
+			statusLine += theme.fg("warning", " [truncated]");
+		}
+		if (typeof details?.duration === "number") {
+			statusLine += theme.fg("muted", ` | ${formatSeconds(Math.floor(details.duration))} total`);
+		}
+		const textContent = firstTextContent(result);
+		if (!expanded) {
+			const brief = textContent.length > 200 ? textContent.slice(0, 200) + "..." : textContent;
+			return new Text(statusLine + "\n" + theme.fg("dim", brief), 0, 0);
+		}
+		const lines = [statusLine];
+		if (details?.prompt) {
+			const display = details.prompt.length > 250 ? details.prompt.slice(0, 247) + "..." : details.prompt;
+			lines.push(theme.fg("dim", `  prompt: "${display}"`));
+		}
+		if (details?.timestamp) {
+			lines.push(theme.fg("dim", `  timestamp: ${details.timestamp}`));
+		}
+		if (typeof details?.frames === "number") {
+			lines.push(theme.fg("dim", `  frames: ${details.frames}`));
+		}
+		const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+		lines.push(theme.fg("dim", preview));
+		return new Text(lines.join("\n"), 0, 0);
+	}
+
+	const countColor = (details?.successful ?? 0) > 0 ? "success" : "error";
+	const statusLine = theme.fg(countColor, `${details?.successful}/${details?.urlCount} URLs`) + theme.fg("muted", " (content stored)");
+	if (!expanded) {
+		return new Text(statusLine, 0, 0);
+	}
+	const textContent = firstTextContent(result);
+	const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+	return new Text(statusLine + "\n" + theme.fg("dim", preview), 0, 0);
+};
+
+export const renderGetSearchContentResult: ToolResultRenderer = (result, { expanded }, theme) => {
+	const details = result.details as GetSearchContentResultDetails | undefined;
+
+	if (details?.error) {
+		return new Text(theme.fg("error", `Error: ${details.error}`), 0, 0);
+	}
+
+	let statusLine: string;
+	if (details?.query) {
+		statusLine = theme.fg("success", `"${details.query}"`) + theme.fg("muted", ` (${details.resultCount} results)`);
+	} else {
+		statusLine = theme.fg("success", details?.title || "Content") + theme.fg("muted", ` (${details?.contentLength ?? 0} chars)`);
+	}
+
+	if (!expanded) {
+		return new Text(statusLine, 0, 0);
+	}
+
+	const textContent = firstTextContent(result);
+	const preview = textContent.length > 500 ? textContent.slice(0, 500) + "..." : textContent;
+	return new Text(statusLine + "\n" + theme.fg("dim", preview), 0, 0);
+};
+
+export function renderWebAccessToolResult(name: string, args: ToolRenderResultArgs): ToolRenderResult {
+	switch (name) {
+		case "web_search":
+			return renderWebSearchResult(...args);
+		case "code_search":
+			return renderCodeSearchResult(...args);
+		case "fetch_content":
+			return renderFetchContentResult(...args);
+		case "get_search_content":
+			return renderGetSearchContentResult(...args);
+		default: {
+			const theme = args[2];
+			return new Text(theme.fg("error", `Result renderer not found: ${name}`), 0, 0);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Cold startup was dominated by eagerly importing the bundled `web-access` (~1.6s), `intercom` (~1.0s), and `mcp` (~2.5s cold) extension module graphs on every launch. This PR makes those heavy graphs load lazily on first use, adds accurate startup instrumentation, and moves first-paint-blocking work off the critical path.

**Warm startup: ~2.6s → ~0.45s** (per-extension cold load: web-access ~1.6s→~42ms, intercom ~1.0s→~23ms, mcp ~200ms→~10ms).

## Changes

### Lazy bundled extensions
- Split `web-access`, `intercom`, and `mcp` into a lightweight registration surface + a heavy `index-heavy.ts` loaded via dynamic `import()` on first tool/command/lifecycle use
- Extracted `result-renderers.ts` for `web-access` and `intercom` so restored/persisted tool results still render their cards without pulling in the heavy module graph
- `mcp`: lazy-imports `commands`/`init`/`proxy-modes`/`mcp-auth-flow` inside handlers; keeps `config`/`utils`/`tool-result-renderer` static so the result renderer stays synchronous and the proxy/direct-tool fallback registers cheaply

### First-paint improvements
- Moved `ensureTool("fd"/"rg")` off the pre-`ui.start()` blocking path — runs in the background and refreshes autocomplete when ready
- Records a `time-to-first-frame` metric immediately after `ui.start()`
- Made the footer provider-count refresh non-blocking (fire-and-forget with error logging)

### Instrumentation
- Added `TimingSpan` / `startTimingSpan` / `endTimingSpan` for accurate wall-clock sub-spans
- Added `recordTiming` and `recordTimeSinceReset` helpers
- Wrapped `createAgentSessionRuntime` await in its own span (previously mislabeled as `readPipedStdin`)
- Per-stage spans throughout `DefaultResourceLoader.reload()`, `loadExtensions`, and `createAgentSessionServices`
- Total initialization time now reported as wall-clock from reset, not the sum of individual spans

### Regression test
- `1223-startup-lazy-builtins.test.ts`: deterministically asserts heavy modules are absent from the cold path (loader sentinel) and verifies the MCP proxy/direct-tool fallback, hardened against the ambient `MCP_DIRECT_TOOLS=__none__` the agent runtime exports to child processes

## Notes

- **Scope:** implements the high-impact, bounded-risk slice of #1223 (lazy loading + instrumentation + first-paint deferral + regression test). The deeper architecture rewrite to paint a first TUI frame *before* `createAgentSessionRuntime` was intentionally left out of scope.
- **Windows test suite:** `cd packages/coding-agent && bun run test` surfaces ~9–13 pre-existing, Windows-specific failures (path separators, `EACCES`/chmod, `SIGTSTP`/`SIGCONT`, fswatch, path globs, flaky stdout timeout) in files this PR does not touch — unrelated to these changes and expected to pass on Linux CI. `typecheck`, `lint`, `test:unit`, and the new regression all pass.

Refs #1223