### PR TITLE
fix(tui): guard custom-message renderer results to prevent /resume crash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an uncaught `TypeError: child.render is not a function` that crashed the TUI on `/resume` when an extension's custom-message renderer returned a non-`Component` value (such as a string). `CustomMessageComponent` now validates the renderer result exposes a `render()` method and falls back to the default boxed rendering otherwise ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).
+
 ### Changed
 
 - Improved Windows cold startup by lazily loading heavy bundled web-access/intercom/MCP implementation modules, moving fd/rg readiness checks after the first interactive frame, and adding detailed startup timing spans ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).

--- a/packages/coding-agent/src/modes/interactive/components/custom-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-message.ts
@@ -6,6 +6,21 @@ import type { CustomMessage } from "../../../core/messages.ts";
 import { getMarkdownTheme, theme } from "../theme/theme.ts";
 
 /**
+ * Type guard ensuring a value returned by an extension's custom renderer is a
+ * real TUI Component (exposes a callable `render`). Extension renderer output is
+ * untrusted at runtime: a renderer that returns a string or other non-Component
+ * value would otherwise be added as a child and crash `Container.render()` with
+ * "child.render is not a function".
+ */
+function isRenderableComponent(value: unknown): value is Component {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { render?: unknown }).render === "function"
+	);
+}
+
+/**
  * Component that renders a custom message entry from extensions.
  * Uses distinct styling to differentiate from user messages.
  */
@@ -59,7 +74,11 @@ export class CustomMessageComponent extends Container {
 		if (this.customRenderer) {
 			try {
 				const component = this.customRenderer(this.message, { expanded: this._expanded }, theme);
-				if (component) {
+				// Only mount the result if it is a real Component. A non-Component
+				// return (e.g. the workflows inline-form "snapshot lost" string on
+				// /resume) is ignored so we fall through to the default rendering
+				// path instead of crashing Container.render().
+				if (isRenderableComponent(component)) {
 					// Custom renderer provides its own styled component
 					this.customComponent = component;
 					this.addChild(component);

--- a/packages/coding-agent/test/custom-message-component.test.ts
+++ b/packages/coding-agent/test/custom-message-component.test.ts
@@ -1,0 +1,57 @@
+import { type Component, Text } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { MessageRenderer } from "../src/core/extensions/types.ts";
+import { createCustomMessage } from "../src/core/messages.ts";
+import { CustomMessageComponent } from "../src/modes/interactive/components/custom-message.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function makeMessage(customType = "workflows:input-form", content = "stack-workflow-test") {
+	return createCustomMessage(customType, content, true, { formId: "wf-missing" }, new Date(0).toISOString());
+}
+
+describe("CustomMessageComponent renderer guard (issue #1236)", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("does not crash when a custom renderer returns a non-Component string", () => {
+		// Reproduces the /resume crash: the workflows inline-form renderer returns a
+		// bare string on its "snapshot lost" path. Before the guard this string was
+		// added as a child and Container.render() threw
+		// "child.render is not a function".
+		const stringRenderer: MessageRenderer = () =>
+			"  stack-workflow-test  ·  (snapshot lost)" as unknown as Component;
+		const component = new CustomMessageComponent(makeMessage(), stringRenderer);
+
+		let rendered = "";
+		expect(() => {
+			rendered = stripAnsi(component.render(80).join("\n"));
+		}).not.toThrow();
+
+		// Falls through to the default boxed rendering (label + content) instead.
+		expect(rendered).toContain("[workflows:input-form]");
+		expect(rendered).toContain("stack-workflow-test");
+	});
+
+	test("ignores other non-Component return shapes and falls back to default", () => {
+		for (const bad of [42, true, { not: "a component" }, [], null]) {
+			const renderer: MessageRenderer = () => bad as unknown as Component;
+			const component = new CustomMessageComponent(makeMessage("my-type", "body text"), renderer);
+			let rendered = "";
+			expect(() => {
+				rendered = stripAnsi(component.render(80).join("\n"));
+			}).not.toThrow();
+			expect(rendered).toContain("[my-type]");
+		}
+	});
+
+	test("mounts a valid Component returned by the custom renderer", () => {
+		const renderer: MessageRenderer = () => new Text("hello-from-renderer", 0, 0);
+		const component = new CustomMessageComponent(makeMessage(), renderer);
+		const rendered = stripAnsi(component.render(80).join("\n"));
+		expect(rendered).toContain("hello-from-renderer");
+		// The custom component owns its styling, so the default label is absent.
+		expect(rendered).not.toContain("[workflows:input-form]");
+	});
+});

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the inline-form "snapshot lost" renderer and the `workflow.run.start`/`workflow.run.end` banner renderers returning bare strings, which crashed the host TUI with `child.render is not a function` when resuming a session containing persisted workflow custom messages. These renderers now return proper render components ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).
+
 ## [0.8.25] - 2026-06-04
 
 ### Changed

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -3756,11 +3756,14 @@ function factory(pi: ExtensionAPI): void {
   // duplicating it into chat scroll just creates visual noise and pushes
   // older chat content out of view every time a stage transitions.
   if (typeof pi.registerMessageRenderer === "function") {
+    // Wrap the string-producing banners in a render component: the host adds a
+    // renderer's result directly as a TUI child, so a bare string would crash
+    // `Container.render()` with "child.render is not a function".
     pi.registerMessageRenderer("workflow.run.start", (payload) =>
-      renderRunBanner(payload as RunStartPayload),
+      dynamicTextRenderComponent(() => renderRunBanner(payload as RunStartPayload)),
     );
     pi.registerMessageRenderer("workflow.run.end", (payload) =>
-      renderRunSummary(payload as RunEndPayload),
+      dynamicTextRenderComponent(() => renderRunSummary(payload as RunEndPayload)),
     );
     // Inline workflow-input form (Option C in the design conversation):
     // a sticky chat-history card driven by a custom EditorComponent. The

--- a/packages/workflows/src/tui/inline-form-overlay.ts
+++ b/packages/workflows/src/tui/inline-form-overlay.ts
@@ -79,7 +79,22 @@ interface CardComponent {
   invalidate?(): void;
 }
 
-type RawRenderer = (payload: unknown) => string | CardComponent | undefined;
+/**
+ * Wrap static text in the renderer's component contract. Used by the
+ * "snapshot lost" tombstone path so /resume rehydration never hands the host a
+ * bare string — the host adds the renderer result directly as a TUI child and a
+ * string crashes `Container.render()` with "child.render is not a function".
+ */
+function staticCard(text: string): CardComponent {
+  return {
+    render: () => [text],
+    invalidate: () => {
+      /* immutable fallback; nothing to recompute */
+    },
+  };
+}
+
+type RawRenderer = (payload: unknown) => CardComponent | undefined;
 
 /**
  * Wire the message renderer once per live ExtensionAPI host. pi creates a new
@@ -106,8 +121,9 @@ export function registerInlineFormRenderer(pi: ExtensionAPI, theme: GraphTheme):
     if (!formId) return undefined;
     const state = getForm(formId);
     if (!state) {
-      // Process restart / map evicted — tombstone the entry.
-      return `  ${message.content ?? "workflow form"}  ·  (snapshot lost)`;
+      // Process restart / map evicted — tombstone the entry. Return a real
+      // component (not a bare string) so resume rehydration stays renderable.
+      return staticCard(`  ${message.content ?? "workflow form"}  ·  (snapshot lost)`);
     }
     return {
       // The card is fully reactive: read fresh state on every render call,

--- a/test/integration/mock-extension-api.test.ts
+++ b/test/integration/mock-extension-api.test.ts
@@ -164,11 +164,17 @@ function getRenderer(
   return renderers.find((r) => r.event === event)?.renderer;
 }
 
-function expectStringRendererOutput(output: PiMessageRendererResult): string {
-  if (typeof output !== "string") {
-    throw new Error("Expected renderer to return a string");
+function rendererOutputText(output: PiMessageRendererResult): string {
+  if (output === undefined) {
+    throw new Error("Expected renderer to return output");
   }
-  return output;
+  // Lifecycle banners are wrapped in a render component (the host adds a
+  // renderer's result directly as a TUI child, so a bare string crashes
+  // `Container.render()`). Normalize to text for content assertions.
+  if (typeof output === "string") {
+    return output;
+  }
+  return output.render(120).join("\n");
 }
 
 function expectRegisteredCommand(
@@ -785,9 +791,9 @@ describe("MockExtensionAPI — message renderer registration", () => {
     });
   }
 
-  test("workflow.run.start renderer returns non-empty string", () => {
+  test("workflow.run.start renderer renders workflow name and runId", () => {
     const renderer = getRenderer(mock.renderers, "workflow.run.start")!;
-    const out = expectStringRendererOutput(renderer({ runId: "r1", name: "my-wf", inputs: { foo: "bar" } }));
+    const out = rendererOutputText(renderer({ runId: "r1", name: "my-wf", inputs: { foo: "bar" } }));
     assert.ok(out.length > 0);
     assert.ok(out.includes("my-wf"));
     assert.ok(out.includes("r1"));
@@ -795,20 +801,20 @@ describe("MockExtensionAPI — message renderer registration", () => {
 
   test("workflow.run.start renderer shows input count", () => {
     const renderer = getRenderer(mock.renderers, "workflow.run.start")!;
-    const out = expectStringRendererOutput(renderer({ runId: "r1", name: "wf", inputs: { a: 1, b: 2 } }));
+    const out = rendererOutputText(renderer({ runId: "r1", name: "wf", inputs: { a: 1, b: 2 } }));
     assert.ok(out.includes("2"));
   });
 
   test("workflow.run.end renderer ok status shows success marker", () => {
     const renderer = getRenderer(mock.renderers, "workflow.run.end")!;
-    const out = expectStringRendererOutput(renderer({ runId: "r1", status: "ok" }));
+    const out = rendererOutputText(renderer({ runId: "r1", status: "ok" }));
     assert.ok(out.includes("✓"));
     assert.ok(out.includes("r1"));
   });
 
   test("workflow.run.end renderer error status shows failure marker", () => {
     const renderer = getRenderer(mock.renderers, "workflow.run.end")!;
-    const out = expectStringRendererOutput(renderer({ runId: "r1", status: "error" }));
+    const out = rendererOutputText(renderer({ runId: "r1", status: "error" }));
     assert.ok(out.includes("✗"));
   });
 

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -951,6 +951,47 @@ test("overlay: registerInlineFormRenderer preserves class-backed pi method bindi
   assert.equal(replacementPi.calls, 1);
   assert.notEqual(replacementPi.renderers.get("workflows:input-form"), undefined);
 });
+
+test("overlay: renderer tombstones a lost snapshot into a renderable component (resume)", () => {
+  // Regression for issue #1236: on /resume the process restarts with an empty
+  // form store, so a rehydrated `workflows:input-form` message has no live
+  // state. The renderer must return a real component (with `render`) — not a
+  // bare string — or the host's Container.render() crashes with
+  // "child.render is not a function".
+  _resetForms();
+  const { pi, renderers } = makeFakePi();
+  registerInlineFormRenderer(pi as never, deriveGraphTheme({}));
+  const render = renderers.get("workflows:input-form");
+  assert.equal(typeof render, "function");
+
+  const message = {
+    role: "custom",
+    customType: "workflows:input-form",
+    content: "stack-workflow-test",
+    display: true,
+    details: { formId: "wf-missing" },
+    timestamp: 0,
+  };
+  const result = render!(message) as { render(width: number): string[] };
+
+  assert.equal(typeof result, "object");
+  assert.notEqual(result, null);
+  assert.equal(typeof result.render, "function");
+  const txt = plain(result.render(80));
+  assert.match(txt, /stack-workflow-test/);
+  assert.match(txt, /snapshot lost/);
+});
+
+test("overlay: renderer returns undefined (not a string) when the formId is absent", () => {
+  // A message with no formId must yield `undefined` so CustomMessageComponent
+  // falls back to its default boxed rendering rather than mounting a string.
+  _resetForms();
+  const { pi, renderers } = makeFakePi();
+  registerInlineFormRenderer(pi as never, deriveGraphTheme({}));
+  const render = renderers.get("workflows:input-form")!;
+  const result = render({ role: "custom", customType: "workflows:input-form", details: {} });
+  assert.equal(result, undefined);
+});
 // ── multi-line text field (rich-text prompt box) ──────────────────────────
 
 import { layoutTextField } from "../../packages/workflows/src/tui/inline-form-card.ts";


### PR DESCRIPTION
## Summary

Fixes `TypeError: child.render is not a function` that crashed the TUI on `/resume` (closes #1236). Extension custom-message renderers could return non-`Component` values (e.g. plain strings), which `CustomMessageComponent.rebuild()` mounted directly as TUI children — causing `Container.render()` to call `child.render()` on a string and throw.

## Root Cause

The host contract `MessageRenderer` (`core/extensions/types.ts`) requires `Component | undefined`, but `CustomMessageComponent.rebuild()` mounted **any** truthy renderer result via `addChild()` without validating the return type.

On `/resume`, the process restarts with an empty in-memory form store. A rehydrated `workflows:input-form` message hits the "snapshot lost" fallback, which returned a bare string → the string was added as a child → `Container.render()` crashed. The `workflow.run.start` / `workflow.run.end` banner renderers had the same string-return flaw.

## Changes

- **Host guard** (`packages/coding-agent/.../components/custom-message.ts`): add `isRenderableComponent()` type guard; only mount renderer results that expose a callable `render()` — otherwise fall through to the default boxed rendering. Central crash protection for any extension renderer.
- **Workflows inline-form** (`packages/workflows/src/tui/inline-form-overlay.ts`): the snapshot-lost tombstone path now returns a real `staticCard()` component instead of a bare string; tightened the `RawRenderer` return type from `string | CardComponent | undefined` to `CardComponent | undefined`.
- **Workflows banners** (`packages/workflows/src/extension/index.ts`): wrap the `workflow.run.start` / `workflow.run.end` string renderers in `dynamicTextRenderComponent()`.
- **Tests** (`packages/coding-agent/test/custom-message-component.test.ts`): vitest regression tests — no crash on non-Component returns (string, number, boolean, plain object, array, null), valid components still mount correctly.
- **Tests** (`test/unit/inline-form.test.ts`): two new regression tests — resume/tombstone returns a renderable component; missing `formId` returns `undefined`.
- **Tests** (`test/integration/mock-extension-api.test.ts`): update banner renderer assertions to unwrap the new component wrapper via `render()`.
- **CHANGELOGs**: `### Fixed` entries under `[Unreleased]` for both `@bastani/atomic` and `@bastani/workflows`.

## Validation

- Root typecheck + coding-agent source typecheck pass.
- `bun test test/unit` → 2032 pass / 0 fail.
- Vitest component tests → 25 pass.
- Pre-commit hooks (lint + unit) passed on commit and push.

## Trade-off

The host guard makes a misbehaving renderer degrade to the default custom-message box rather than crash the app — appropriate since extension renderer output is untrusted at runtime.

Closes #1236