### PR TITLE
fix(workflows): hide input form on /resume and exclude from LLM context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed an uncaught `TypeError: child.render is not a function` that crashed the TUI on `/resume` when an extension's custom-message renderer returned a non-`Component` value (such as a string). `CustomMessageComponent` now validates the renderer result exposes a `render()` method and falls back to the default boxed rendering otherwise ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).
+- Custom-message renderers can now return `null` to render nothing: `CustomMessageComponent` skips its default box and the leading spacer for a `null` result so the entry occupies zero rows. This lets extensions suppress a rehydrated entry whose backing state is gone (e.g. the workflows input form on `/resume`) without leaving a blank line.
 
 ### Changed
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1110,11 +1110,23 @@ export interface MessageRenderOptions {
 	expanded: boolean;
 }
 
+/**
+ * Custom message renderer.
+ *
+ * Return value semantics:
+ * - `Component`: mount this component (the renderer owns its styling).
+ * - `null`: the renderer handled the message but wants to render nothing —
+ *   the entry occupies zero rows (no leading spacer, no default box). Use this
+ *   to suppress a rehydrated entry whose backing state is gone (e.g. the
+ *   workflows input form on `/resume`).
+ * - `undefined`: the renderer did not handle the message; fall back to the
+ *   default boxed `[customType]` rendering.
+ */
 export type MessageRenderer<T = unknown> = (
 	message: CustomMessage<T>,
 	options: MessageRenderOptions,
 	theme: Theme,
-) => Component | undefined;
+) => Component | null | undefined;
 
 // ============================================================================
 // Command Registration

--- a/packages/coding-agent/src/modes/interactive/components/custom-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/custom-message.ts
@@ -28,6 +28,7 @@ export class CustomMessageComponent extends Container {
 	private message: CustomMessage<unknown>;
 	private customRenderer?: MessageRenderer;
 	private box: Box;
+	private spacer?: Spacer;
 	private customComponent?: Component;
 	private markdownTheme: MarkdownTheme;
 	private _expanded = false;
@@ -42,11 +43,11 @@ export class CustomMessageComponent extends Container {
 		this.customRenderer = customRenderer;
 		this.markdownTheme = markdownTheme;
 
-		this.addChild(new Spacer(1));
-
 		// Create box with purple background (used for default rendering)
 		this.box = new Box(1, 1, (t) => theme.bg("customMessageBg", t));
 
+		// The leading spacer is mounted in rebuild() alongside actual content, so a
+		// renderer that suppresses output (returns null) leaves no blank row.
 		this.rebuild();
 	}
 
@@ -63,10 +64,14 @@ export class CustomMessageComponent extends Container {
 	}
 
 	private rebuild(): void {
-		// Remove previous content component
+		// Remove previously mounted content (spacer + content) before rebuilding.
 		if (this.customComponent) {
 			this.removeChild(this.customComponent);
 			this.customComponent = undefined;
+		}
+		if (this.spacer) {
+			this.removeChild(this.spacer);
+			this.spacer = undefined;
 		}
 		this.removeChild(this.box);
 
@@ -74,12 +79,21 @@ export class CustomMessageComponent extends Container {
 		if (this.customRenderer) {
 			try {
 				const component = this.customRenderer(this.message, { expanded: this._expanded }, theme);
-				// Only mount the result if it is a real Component. A non-Component
-				// return (e.g. the workflows inline-form "snapshot lost" string on
-				// /resume) is ignored so we fall through to the default rendering
-				// path instead of crashing Container.render().
+				// Explicit null = "handled; render nothing". Skip the leading spacer
+				// and the default box entirely so the entry occupies zero rows. The
+				// workflows inline-form renderer returns null for a rehydrated
+				// input-form card on /resume so the input widget does not reappear.
+				if (component === null) {
+					return;
+				}
+				// Only mount the result if it is a real Component. A non-Component,
+				// non-null return (string, number, plain object, …) is ignored so we
+				// fall through to the default rendering path instead of crashing
+				// Container.render().
 				if (isRenderableComponent(component)) {
 					// Custom renderer provides its own styled component
+					this.spacer = new Spacer(1);
+					this.addChild(this.spacer);
 					this.customComponent = component;
 					this.addChild(component);
 					return;
@@ -89,7 +103,9 @@ export class CustomMessageComponent extends Container {
 			}
 		}
 
-		// Default rendering uses our box
+		// Default rendering uses our box, preceded by the standard leading spacer.
+		this.spacer = new Spacer(1);
+		this.addChild(this.spacer);
 		this.addChild(this.box);
 		this.box.clear();
 

--- a/packages/coding-agent/test/custom-message-component.test.ts
+++ b/packages/coding-agent/test/custom-message-component.test.ts
@@ -16,10 +16,10 @@ describe("CustomMessageComponent renderer guard (issue #1236)", () => {
 	});
 
 	test("does not crash when a custom renderer returns a non-Component string", () => {
-		// Reproduces the /resume crash: the workflows inline-form renderer returns a
-		// bare string on its "snapshot lost" path. Before the guard this string was
-		// added as a child and Container.render() threw
-		// "child.render is not a function".
+		// Guard against a renderer that returns a bare string (a non-Component,
+		// non-null value). Before the guard such a string was added as a child and
+		// Container.render() threw "child.render is not a function"; it now falls
+		// through to the default boxed rendering instead.
 		const stringRenderer: MessageRenderer = () =>
 			"  stack-workflow-test  ·  (snapshot lost)" as unknown as Component;
 		const component = new CustomMessageComponent(makeMessage(), stringRenderer);
@@ -35,7 +35,9 @@ describe("CustomMessageComponent renderer guard (issue #1236)", () => {
 	});
 
 	test("ignores other non-Component return shapes and falls back to default", () => {
-		for (const bad of [42, true, { not: "a component" }, [], null]) {
+		// `null` is intentionally excluded here: it now means "render nothing"
+		// (covered by the dedicated test below), not "fall back to default".
+		for (const bad of [42, true, { not: "a component" }, []]) {
 			const renderer: MessageRenderer = () => bad as unknown as Component;
 			const component = new CustomMessageComponent(makeMessage("my-type", "body text"), renderer);
 			let rendered = "";
@@ -44,6 +46,21 @@ describe("CustomMessageComponent renderer guard (issue #1236)", () => {
 			}).not.toThrow();
 			expect(rendered).toContain("[my-type]");
 		}
+	});
+
+	test("renders nothing (no spacer, no default box) when the renderer returns null", () => {
+		// `null` = "handled; render nothing". The workflows inline-form renderer
+		// returns null for a rehydrated input-form card on /resume so the input
+		// widget must not reappear in chat. The entry must occupy zero rows — not
+		// even the leading spacer the default rendering path adds.
+		const renderer: MessageRenderer = () => null;
+		const component = new CustomMessageComponent(makeMessage("my-type", "body text"), renderer);
+		let rendered = "";
+		expect(() => {
+			rendered = stripAnsi(component.render(80).join("\n"));
+		}).not.toThrow();
+		expect(rendered.trim()).toBe("");
+		expect(rendered).not.toContain("[my-type]");
 	});
 
 	test("mounts a valid Component returned by the custom renderer", () => {

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fixed the inline-form "snapshot lost" renderer and the `workflow.run.start`/`workflow.run.end` banner renderers returning bare strings, which crashed the host TUI with `child.render is not a function` when resuming a session containing persisted workflow custom messages. These renderers now return proper render components ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).
+- Fixed the workflow input form (the `/workflow <name>` argument selector) leaking into model context: spawning the picker and exiting without running the workflow no longer sends the form to the LLM. The input-form card is now emitted with `excludeFromContext` since it is transient UI, not conversation.
+- Fixed the workflow input widget re-rendering in chat after `/resume`. Inline-form state is now cleared on `session_start`, and a rehydrated `workflows:input-form` card whose backing state is gone now renders nothing (returns `null`) instead of a stale form or "snapshot lost" placeholder.
 - Stage sessions now emit `session_shutdown` before `dispose()` (mirroring the host `AgentSessionRuntime` teardown) so bound extensions receive a graceful shutdown signal instead of being silently invalidated. This stops disposed stage sessions from leaking child MCP servers and from triggering spurious stale-context "MCP initialization failed" errors when an extension's deferred `session_start` work races with stage disposal.
 
 ## [0.8.25] - 2026-06-04

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -54,6 +54,7 @@ import {
   openInlineInputsForm,
   registerInlineFormRenderer,
 } from "../tui/inline-form-overlay.js";
+import { clearForms } from "../tui/inline-form-store.js";
 import {
   registerChatSurfaceRenderer,
   emitChatSurface,
@@ -166,7 +167,7 @@ export interface PiMessageRenderOptions {
   expanded: boolean;
 }
 
-export type PiMessageRendererResult = string | PiMessageRenderComponent | undefined;
+export type PiMessageRendererResult = string | PiMessageRenderComponent | null | undefined;
 export type PiMessageRenderer = (
   payload: unknown,
   options?: PiMessageRenderOptions,
@@ -3837,6 +3838,12 @@ function factory(pi: ExtensionAPI): void {
         persistence: persistenceRef.current,
       });
       store.clear();
+      // Drop any inline input-form state from a previous session in this pi
+      // process. A resumed/replaced session must not render a stale live form,
+      // and rehydrated `workflows:input-form` cards then resolve to no backing
+      // state so their renderer suppresses output (input widget hidden after
+      // /resume).
+      clearForms();
       resetWorkflowLifecycleNotificationState(lifecycleNotificationState);
       resetWorkflowHilAnswerNotificationState(hilAnswerNotificationState);
       stageControlRegistry.clear();

--- a/packages/workflows/src/tui/inline-form-overlay.ts
+++ b/packages/workflows/src/tui/inline-form-overlay.ts
@@ -79,22 +79,7 @@ interface CardComponent {
   invalidate?(): void;
 }
 
-/**
- * Wrap static text in the renderer's component contract. Used by the
- * "snapshot lost" tombstone path so /resume rehydration never hands the host a
- * bare string — the host adds the renderer result directly as a TUI child and a
- * string crashes `Container.render()` with "child.render is not a function".
- */
-function staticCard(text: string): CardComponent {
-  return {
-    render: () => [text],
-    invalidate: () => {
-      /* immutable fallback; nothing to recompute */
-    },
-  };
-}
-
-type RawRenderer = (payload: unknown) => CardComponent | undefined;
+type RawRenderer = (payload: unknown) => CardComponent | null | undefined;
 
 /**
  * Wire the message renderer once per live ExtensionAPI host. pi creates a new
@@ -121,9 +106,11 @@ export function registerInlineFormRenderer(pi: ExtensionAPI, theme: GraphTheme):
     if (!formId) return undefined;
     const state = getForm(formId);
     if (!state) {
-      // Process restart / map evicted — tombstone the entry. Return a real
-      // component (not a bare string) so resume rehydration stays renderable.
-      return staticCard(`  ${message.content ?? "workflow form"}  ·  (snapshot lost)`);
+      // No backing state — the session was resumed/replaced (the store is
+      // cleared on session_start) or the map was evicted. Return null so the
+      // host renders nothing: the input widget must not reappear in chat after
+      // /resume rather than showing a stale or "snapshot lost" placeholder.
+      return null;
     }
     return {
       // The card is fully reactive: read fresh state on every render call,
@@ -307,11 +294,17 @@ export async function openInlineInputsForm(
           display?: boolean;
           details?: FormMessageDetails;
         },
+        options?: { excludeFromContext?: boolean },
       ) => void).call(pi, {
         customType: CUSTOM_TYPE,
         content: opts.workflowName,
         display: true,
         details: { formId },
+      }, {
+        // The input form is a transient UI surface, not conversation. Keep it
+        // out of LLM context so spawning the picker and exiting without
+        // running the workflow never leaks the form into the model.
+        excludeFromContext: true,
       });
     } catch {
       activeEditor?.dispose?.();

--- a/packages/workflows/src/tui/inline-form-store.ts
+++ b/packages/workflows/src/tui/inline-form-store.ts
@@ -12,11 +12,12 @@
  *   `finalizeForm(id, "submit")` → status = "submitted", values frozen
  *   `finalizeForm(id, "cancel")` → status = "cancelled"
  *
- * After finalize the state stays in the map forever (module-lifetime). The
- * renderer reads it to display the historical card. If the process restarts,
- * the map is empty and the renderer falls back to a "form (snapshot lost)"
- * placeholder — acceptable because frozen cards are decorative, not
- * functional.
+ * After finalize the state stays in the map for the lifetime of the session.
+ * The renderer reads it to display the historical card. On a session boundary
+ * (`session_start`: new/resume/fork/reload) the store is cleared via
+ * {@link clearForms}, so a rehydrated `workflows:input-form` message has no
+ * backing state and its renderer suppresses output (returns null) — the input
+ * widget never reappears in chat after `/resume`.
  *
  * Why a global registry instead of closure capture: the message renderer is
  * registered ONCE at factory time and called many times for any number of
@@ -73,7 +74,17 @@ export function finalizeForm(formId: string, outcome: "submit" | "cancel"): void
   touch(s);
 }
 
+/**
+ * Clear all inline form state. Called on `session_start` so a resumed or
+ * replaced session never renders a stale live form, and so a rehydrated
+ * `workflows:input-form` message resolves to no backing state (its renderer
+ * then returns null and the host renders nothing).
+ */
+export function clearForms(): void {
+  FORMS.clear();
+}
+
 /** Test helper — clear the registry between tests. */
 export function _resetForms(): void {
-  FORMS.clear();
+  clearForms();
 }

--- a/test/integration/mock-extension-api.test.ts
+++ b/test/integration/mock-extension-api.test.ts
@@ -165,7 +165,7 @@ function getRenderer(
 }
 
 function rendererOutputText(output: PiMessageRendererResult): string {
-  if (output === undefined) {
+  if (output === undefined || output === null) {
     throw new Error("Expected renderer to return output");
   }
   // Lifecycle banners are wrapped in a render component (the host adds a

--- a/test/unit/inline-form.test.ts
+++ b/test/unit/inline-form.test.ts
@@ -15,6 +15,7 @@ import { test } from "bun:test";
 import assert from "node:assert/strict";
 import {
   _resetForms,
+  clearForms,
   createForm,
   finalizeForm,
   getForm,
@@ -621,10 +622,19 @@ test("editor: handleInput on a finalized form is a no-op", () => {
 // ── overlay (orchestration) ───────────────────────────────────────────────
 
 interface FakePiSurface {
-  sentMessages: Array<{ customType: string; details?: { formId?: string } }>;
+  sentMessages: Array<{
+    customType: string;
+    content?: string;
+    display?: boolean;
+    details?: { formId?: string };
+    options?: { excludeFromContext?: boolean };
+  }>;
   renderers: Map<string, (payload: unknown) => unknown>;
   pi: {
-    sendMessage: (m: { customType: string; content?: string; display?: boolean; details?: { formId?: string } }) => void;
+    sendMessage: (
+      m: { customType: string; content?: string; display?: boolean; details?: { formId?: string } },
+      options?: { excludeFromContext?: boolean },
+    ) => void;
     registerMessageRenderer: (event: string, r: (payload: unknown) => unknown) => void;
   };
 }
@@ -636,7 +646,8 @@ function makeFakePi(): FakePiSurface {
     sentMessages,
     renderers,
     pi: {
-      sendMessage: (m) => { sentMessages.push(m); },
+      // Capture the options arg so tests can assert context exclusion.
+      sendMessage: (m, options) => { sentMessages.push({ ...m, options }); },
       registerMessageRenderer: (event, r) => { renderers.set(event, r); },
     },
   };
@@ -681,6 +692,9 @@ test("overlay: openInlineInputsForm emits a custom message and swaps editor", as
   // The message was emitted synchronously.
   assert.equal(sentMessages.length, 1);
   assert.equal(sentMessages[0]!.customType, "workflows:input-form");
+  // The input form is transient UI and must be kept out of LLM context, so
+  // spawning the picker and exiting never leaks the form into the model.
+  assert.deepEqual(sentMessages[0]!.options, { excludeFromContext: true });
   const formId = sentMessages[0]!.details!.formId!;
   assert.match(formId, /^wf-/);
 
@@ -952,12 +966,11 @@ test("overlay: registerInlineFormRenderer preserves class-backed pi method bindi
   assert.notEqual(replacementPi.renderers.get("workflows:input-form"), undefined);
 });
 
-test("overlay: renderer tombstones a lost snapshot into a renderable component (resume)", () => {
-  // Regression for issue #1236: on /resume the process restarts with an empty
-  // form store, so a rehydrated `workflows:input-form` message has no live
-  // state. The renderer must return a real component (with `render`) — not a
-  // bare string — or the host's Container.render() crashes with
-  // "child.render is not a function".
+test("overlay: renderer returns null (render nothing) for a lost snapshot on resume", () => {
+  // On /resume the form store is cleared on session_start, so a rehydrated
+  // `workflows:input-form` message has no live state. The renderer returns
+  // null so CustomMessageComponent renders nothing — the input widget must not
+  // reappear in chat (no stale form, no "snapshot lost" placeholder, no gap).
   _resetForms();
   const { pi, renderers } = makeFakePi();
   registerInlineFormRenderer(pi as never, deriveGraphTheme({}));
@@ -972,14 +985,29 @@ test("overlay: renderer tombstones a lost snapshot into a renderable component (
     details: { formId: "wf-missing" },
     timestamp: 0,
   };
-  const result = render!(message) as { render(width: number): string[] };
+  const result = render!(message);
 
-  assert.equal(typeof result, "object");
-  assert.notEqual(result, null);
-  assert.equal(typeof result.render, "function");
-  const txt = plain(result.render(80));
-  assert.match(txt, /stack-workflow-test/);
-  assert.match(txt, /snapshot lost/);
+  assert.equal(result, null);
+});
+
+test("store: clearForms empties the registry so resumed sessions have no live forms", () => {
+  _resetForms();
+  createForm({
+    formId: "wf-clear",
+    workflowName: "ralph",
+    fields: FIELDS,
+    rawText: { prompt: "hi" },
+    focusedIdx: 0,
+    submitChoiceIdx: 0,
+    caret: 0,
+    status: "editing",
+  });
+  assert.notEqual(getForm("wf-clear"), undefined);
+
+  // session_start calls clearForms(); afterwards a rehydrated card's renderer
+  // finds no state and suppresses output.
+  clearForms();
+  assert.equal(getForm("wf-clear"), undefined);
 });
 
 test("overlay: renderer returns undefined (not a string) when the formId is absent", () => {


### PR DESCRIPTION
## Summary

Fixes two user-facing bugs with the \`/workflow <name>\` inline input form: the form widget reappearing after \`/resume\`, and the form leaking into LLM context when the picker is opened then exited without running a workflow.

## Changes

### Host TUI (`packages/coding-agent`)

- **`null` renderer support** — `MessageRenderer` return type is extended to `Component | null | undefined`. A `null` result in `CustomMessageComponent` means "handled; render nothing": both the leading spacer and the default box are skipped so the entry occupies **zero rows** (no blank gap). `undefined` still falls through to the default boxed rendering.
- The leading spacer is now added inside `rebuild()` only when actual content is mounted, rather than unconditionally in the constructor.

### Workflows extension (`packages/workflows`)

- **Hide on `/resume`** — `clearForms()` is called on `session_start`, clearing any inline form state from a prior session. A rehydrated `workflows:input-form` card with no backing state now returns `null` from its renderer (instead of the old "snapshot lost" tombstone), so the input widget never reappears in chat.
- **Exclude from model context** — `openInlineInputsForm` emits the input-form card with `{ excludeFromContext: true }` since it is transient UI, not conversation. Spawning the picker and exiting never leaks the form to the LLM.
- Removed the now-unnecessary `staticCard()` helper.
- `_resetForms()` now delegates to the new public `clearForms()`.

## Tests

- `packages/coding-agent/test/custom-message-component.test.ts` — new case asserting a `null` renderer result produces zero rows (no spacer, no default box); `null` removed from the "fall back to default" set.
- `test/unit/inline-form.test.ts` — renderer returns `null` for a lost snapshot on resume; new `clearForms()` test confirms the registry is emptied; `openInlineInputsForm` asserts `{ excludeFromContext: true }` on the emitted message.
- `test/integration/mock-extension-api.test.ts` — renderer-output helper treats `null` like `undefined` (no assertion failure when a renderer intentionally suppresses output).

Refs #1236