### PR TITLE
chore(release): bump prerelease to 0.8.26-alpha.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.25-alpha.1",
+      "version": "0.8.26-alpha.1",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.25-alpha.1",
+      "version": "0.8.26-alpha.1",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.25-alpha.1",
+      "version": "0.8.26-alpha.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.25-alpha.1",
+      "version": "0.8.26-alpha.1",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.25-alpha.1",
+      "version": "0.8.26-alpha.1",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.25-alpha.1",
+      "version": "0.8.26-alpha.1",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.26-alpha.1] - 2026-06-05
+
 ### Fixed
 
 - Fixed an uncaught `TypeError: child.render is not a function` that crashed the TUI on `/resume` when an extension's custom-message renderer returned a non-`Component` value (such as a string). `CustomMessageComponent` now validates the renderer result exposes a `render()` method and falls back to the default boxed rendering otherwise ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.25",
+  "version": "0.8.26-alpha.1",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.26-alpha.1] - 2026-06-05
+
 ### Changed
 
 - Deferred broker client/spawn and overlay UI modules until intercom connects or the overlay opens, reducing default CLI startup cost ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.25",
+  "version": "0.8.26-alpha.1",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.26-alpha.1] - 2026-06-05
+
 ### Changed
 
 - Kept MCP startup registration cheap by lazily importing the heavy MCP command, initialization, proxy-mode, and OAuth/auth-flow modules (and deferring config/cache-backed direct-tool discovery) instead of loading them on the cold extension factory path, while keeping the result renderer synchronous so restored MCP tool results still render ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.25",
+  "version": "0.8.26-alpha.1",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.26-alpha.1] - 2026-06-05
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.1 prerelease.
+
 ## [0.8.25] - 2026-06-04
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.25",
+  "version": "0.8.26-alpha.1",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.26-alpha.1] - 2026-06-05
+
 ### Changed
 
 - Deferred heavy search, fetch, curator, summary, provider-probing, and code-search modules until the relevant web-access tool or command is invoked, reducing default CLI startup cost ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.25",
+  "version": "0.8.26-alpha.1",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.26-alpha.1] - 2026-06-05
+
 ### Fixed
 
 - Fixed the inline-form "snapshot lost" renderer and the `workflow.run.start`/`workflow.run.end` banner renderers returning bare strings, which crashed the host TUI with `child.render is not a function` when resuming a session containing persisted workflow custom messages. These renderers now return proper render components ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.25",
+  "version": "0.8.26-alpha.1",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Bumps all workspace packages from `0.8.25` → `0.8.26-alpha.1` and finalizes changelog sections for this prerelease. Merging does not publish — publishing happens when the `0.8.26-alpha.1` git tag is pushed after merge.

## Changes

- **Version bumps**: All `packages/*/package.json` versions updated via `scripts/bump-version.ts`
- **Lock file**: `bun.lock` refreshed to reflect new workspace versions
- **Changelogs**: `[Unreleased]` content promoted to `## [0.8.26-alpha.1] - 2026-06-05` in each package

## Changelog highlights

### Bug Fixes
- **coding-agent**: Fixed `TypeError: child.render is not a function` TUI crash on `/resume` when an extension's custom-message renderer returned a string or `null` instead of a `Component` — `CustomMessageComponent` now validates the renderer result and falls back to default boxed rendering ([#1236](https://github.com/bastani-inc/atomic/issues/1236))
- **coding-agent**: Windows cold-startup lazy-loading fix
- **workflows**: Fixed inline-form "snapshot lost" renderer and `workflow.run.start`/`workflow.run.end` banner renderers returning bare strings, crashing the host TUI on `/resume` ([#1236](https://github.com/bastani-inc/atomic/issues/1236))
- **workflows**: Input form no longer leaks into model context on `/resume`
- **mcp**: Stale-context initialization fix

### Performance
- **mcp**: Lazily imports heavy MCP command, init, proxy-mode, and OAuth modules — cheaper cold-start ([#1223](https://github.com/bastani-inc/atomic/issues/1223))
- **intercom**: Deferred broker client/spawn and overlay UI modules until first use ([#1223](https://github.com/bastani-inc/atomic/issues/1223))
- **web-access**: Deferred heavy search, fetch, curator, summary, and provider-probing modules until invoked ([#1223](https://github.com/bastani-inc/atomic/issues/1223))

### Other
- **workflows**: Stage sessions now emit `session_shutdown` before dispose
- **subagents**: Version bump only