### PR TITLE
feat(resume): show workflow session provenance

### DIFF
--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -33,12 +33,29 @@ export interface SessionHeader {
 	id: string;
 	timestamp: string;
 	cwd: string;
+	/** Legacy relationship field; retained for compatibility. */
 	parentSession?: string;
+	/** Ownership/provenance parent used by threaded session views. */
+	originSession?: string;
+	/** Context lineage source used for fork annotations. */
+	forkedFromSession?: string;
+	/** Workflow run grouping identity for workflow-spawned sessions. */
+	workflowRunId?: string;
+	workflowName?: string;
+	/** Workflow stage identity for real stage session rows. */
+	workflowStageId?: string;
+	workflowStageName?: string;
 }
 
 export interface NewSessionOptions {
 	id?: string;
 	parentSession?: string;
+	originSession?: string;
+	forkedFromSession?: string;
+	workflowRunId?: string;
+	workflowName?: string;
+	workflowStageId?: string;
+	workflowStageName?: string;
 }
 
 export interface SessionEntryBase {
@@ -175,6 +192,14 @@ export interface SessionInfo {
 	name?: string;
 	/** Path to the parent session (if this session was forked). */
 	parentSessionPath?: string;
+	/** Path to the owning/origin session for provenance-based grouping. */
+	originSessionPath?: string;
+	/** Path to the source session this session copied context from. */
+	forkedFromSessionPath?: string;
+	workflowRunId?: string;
+	workflowName?: string;
+	workflowStageId?: string;
+	workflowStageName?: string;
 	created: Date;
 	modified: Date;
 	messageCount: number;
@@ -575,6 +600,30 @@ function getSessionModifiedDate(entries: FileEntry[], header: SessionHeader, sta
 	return !Number.isNaN(headerTime) ? new Date(headerTime) : statsMtime;
 }
 
+function isWorkflowStageFork(options: NewSessionOptions | undefined): boolean {
+	return options?.workflowStageId !== undefined || options?.workflowStageName !== undefined;
+}
+
+function effectiveSessionName(entries: readonly FileEntry[]): string | undefined {
+	let name: string | undefined;
+	for (const entry of entries) {
+		if (entry.type === "session_info") {
+			name = entry.name?.trim() || undefined;
+		}
+	}
+	return name;
+}
+
+function latestCopiedEntryId(entries: readonly FileEntry[]): string | null {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i]!;
+		if (entry.type !== "session") {
+			return entry.id;
+		}
+	}
+	return null;
+}
+
 async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 	try {
 		const content = await readFile(filePath, "utf8");
@@ -598,15 +647,9 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 		let messageCount = 0;
 		let firstMessage = "";
 		const allMessages: string[] = [];
-		let name: string | undefined;
+		const name = effectiveSessionName(entries);
 
 		for (const entry of entries) {
-			// Extract session name (use latest, including explicit clears)
-			if (entry.type === "session_info") {
-				const infoEntry = entry as SessionInfoEntry;
-				name = infoEntry.name?.trim() || undefined;
-			}
-
 			if (entry.type !== "message") continue;
 			messageCount++;
 
@@ -623,18 +666,27 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
 			}
 		}
 
-		const cwd = typeof (header as SessionHeader).cwd === "string" ? (header as SessionHeader).cwd : "";
-		const parentSessionPath = (header as SessionHeader).parentSession;
+		const sessionHeader = header as SessionHeader;
+		const cwd = typeof sessionHeader.cwd === "string" ? sessionHeader.cwd : "";
+		const parentSessionPath = sessionHeader.parentSession;
+		const originSessionPath = sessionHeader.originSession;
+		const forkedFromSessionPath = sessionHeader.forkedFromSession;
 
-		const modified = getSessionModifiedDate(entries, header as SessionHeader, stats.mtime);
+		const modified = getSessionModifiedDate(entries, sessionHeader, stats.mtime);
 
 		return {
 			path: filePath,
-			id: (header as SessionHeader).id,
+			id: sessionHeader.id,
 			cwd,
 			name,
 			parentSessionPath,
-			created: new Date((header as SessionHeader).timestamp),
+			originSessionPath,
+			forkedFromSessionPath,
+			workflowRunId: sessionHeader.workflowRunId,
+			workflowName: sessionHeader.workflowName,
+			workflowStageId: sessionHeader.workflowStageId,
+			workflowStageName: sessionHeader.workflowStageName,
+			created: new Date(sessionHeader.timestamp),
 			modified,
 			messageCount,
 			firstMessage: firstMessage || "(no messages)",
@@ -708,7 +760,13 @@ export class SessionManager {
 	private labelTimestampsById: Map<string, string> = new Map();
 	private leafId: string | null = null;
 
-	private constructor(cwd: string, sessionDir: string, sessionFile: string | undefined, persist: boolean) {
+	private constructor(
+		cwd: string,
+		sessionDir: string,
+		sessionFile: string | undefined,
+		persist: boolean,
+		newSessionOptions?: NewSessionOptions,
+	) {
 		this.cwd = resolvePath(cwd);
 		this.sessionDir = normalizePath(sessionDir);
 		this.persist = persist;
@@ -719,7 +777,7 @@ export class SessionManager {
 		if (sessionFile) {
 			this.setSessionFile(sessionFile);
 		} else {
-			this.newSession();
+			this.newSession(newSessionOptions);
 		}
 	}
 
@@ -766,6 +824,12 @@ export class SessionManager {
 			timestamp,
 			cwd: this.cwd,
 			parentSession: options?.parentSession,
+			originSession: options?.originSession,
+			forkedFromSession: options?.forkedFromSession,
+			workflowRunId: options?.workflowRunId,
+			workflowName: options?.workflowName,
+			workflowStageId: options?.workflowStageId,
+			workflowStageName: options?.workflowStageName,
 		};
 		this.fileEntries = [header];
 		this.byId.clear();
@@ -1297,10 +1361,11 @@ export class SessionManager {
 	 * Create a new session.
 	 * @param cwd Working directory (stored in session header)
 	 * @param sessionDir Optional session directory. If omitted, uses default (~/.atomic/agent/sessions/<encoded-cwd>/).
+	 * @param options Optional metadata to stamp onto the new session header.
 	 */
-	static create(cwd: string, sessionDir?: string): SessionManager {
+	static create(cwd: string, sessionDir?: string, options?: NewSessionOptions): SessionManager {
 		const dir = sessionDir ? normalizePath(sessionDir) : getDefaultSessionDir(cwd);
-		return new SessionManager(cwd, dir, undefined, true);
+		return new SessionManager(cwd, dir, undefined, true, options);
 	}
 
 	/**
@@ -1345,8 +1410,9 @@ export class SessionManager {
 	 * @param sourcePath Path to the source session file
 	 * @param targetCwd Target working directory (where the new session will be stored)
 	 * @param sessionDir Optional session directory. If omitted, uses default for targetCwd.
+	 * @param options Optional metadata to stamp onto the forked session header.
 	 */
-	static forkFrom(sourcePath: string, targetCwd: string, sessionDir?: string): SessionManager {
+	static forkFrom(sourcePath: string, targetCwd: string, sessionDir?: string, options?: NewSessionOptions): SessionManager {
 		const resolvedSourcePath = resolvePath(sourcePath);
 		const resolvedTargetCwd = resolvePath(targetCwd);
 		const sourceEntries = loadEntriesFromFile(resolvedSourcePath);
@@ -1365,7 +1431,7 @@ export class SessionManager {
 		}
 
 		// Create new session file with new ID but forked content
-		const newSessionId = createSessionId();
+		const newSessionId = options?.id ?? createSessionId();
 		const timestamp = new Date().toISOString();
 		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
 		const newSessionFile = join(dir, `${fileTimestamp}_${newSessionId}.jsonl`);
@@ -1378,6 +1444,12 @@ export class SessionManager {
 			timestamp,
 			cwd: resolvedTargetCwd,
 			parentSession: resolvedSourcePath,
+			originSession: options?.originSession,
+			forkedFromSession: options?.forkedFromSession ?? resolvedSourcePath,
+			workflowRunId: options?.workflowRunId,
+			workflowName: options?.workflowName,
+			workflowStageId: options?.workflowStageId,
+			workflowStageName: options?.workflowStageName,
 		};
 		appendFileSync(newSessionFile, `${JSON.stringify(newHeader)}\n`);
 
@@ -1386,6 +1458,18 @@ export class SessionManager {
 			if (entry.type !== "session") {
 				appendFileSync(newSessionFile, `${JSON.stringify(entry)}\n`);
 			}
+		}
+
+		if (isWorkflowStageFork(options) && effectiveSessionName(sourceEntries) !== undefined) {
+			const existingIds = new Set([...sourceEntries.map((entry) => entry.id), newSessionId]);
+			const clearInheritedNameEntry: SessionInfoEntry = {
+				type: "session_info",
+				id: generateId(existingIds),
+				parentId: latestCopiedEntryId(sourceEntries),
+				timestamp: new Date().toISOString(),
+				name: "",
+			};
+			appendFileSync(newSessionFile, `${JSON.stringify(clearInheritedNameEntry)}\n`);
 		}
 
 		return new SessionManager(resolvedTargetCwd, dir, newSessionFile, true);

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -258,6 +258,7 @@ export {
 	getLatestCompactionEntry,
 	type ModelChangeEntry,
 	migrateSessionEntries,
+	getDefaultSessionDir,
 	type NewSessionOptions,
 	parseSessionEntries,
 	type SessionContext,

--- a/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector-search.ts
@@ -24,16 +24,19 @@ function normalizeWhitespaceLower(text: string): string {
 }
 
 function getSessionSearchText(session: SessionInfo): string {
-	return `${session.id} ${session.name ?? ""} ${session.allMessagesText} ${session.cwd}`;
+	return [
+		session.id,
+		session.name ?? "",
+		session.workflowStageName ?? "",
+		session.allMessagesText,
+		session.cwd,
+		session.workflowName ?? "",
+		session.workflowRunId ?? "",
+	].join(" ");
 }
 
 export function hasSessionName(session: SessionInfo): boolean {
 	return Boolean(session.name?.trim());
-}
-
-function matchesNameFilter(session: SessionInfo, filter: NameFilter): boolean {
-	if (filter === "all") return true;
-	return hasSessionName(session);
 }
 
 export function parseSearchQuery(query: string): ParsedSearchQuery {
@@ -159,8 +162,7 @@ export function filterAndSortSessions(
 	sortMode: SortMode,
 	nameFilter: NameFilter = "all",
 ): SessionInfo[] {
-	const nameFiltered =
-		nameFilter === "all" ? sessions : sessions.filter((session) => matchesNameFilter(session, nameFilter));
+	const nameFiltered = nameFilter === "all" ? sessions : sessions.filter(hasSessionName);
 	const trimmed = query.trim();
 	if (!trimmed) return nameFiltered;
 

--- a/packages/coding-agent/src/modes/interactive/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/session-selector.ts
@@ -190,6 +190,8 @@ class SessionSelectorHeader implements Component {
 interface SessionTreeNode {
 	session: SessionInfo;
 	children: SessionTreeNode[];
+	selectable: boolean;
+	displayLabel?: string;
 }
 
 /** Flattened node for display with tree structure info */
@@ -197,30 +199,135 @@ interface FlatSessionNode {
 	session: SessionInfo;
 	depth: number;
 	isLast: boolean;
+	selectable: boolean;
+	displayLabel?: string;
 	/** For each ancestor level, whether there are more siblings after it */
 	ancestorContinues: boolean[];
 }
 
+function sessionForkSourceLabel(session: SessionInfo): string {
+	return session.name ?? session.workflowStageName ?? session.firstMessage;
+}
+
+function canonicalPathOrOriginal(path: string): string {
+	return canonicalizePath(path) ?? path;
+}
+
+function canonicalSessionPath(session: SessionInfo): string {
+	return canonicalPathOrOriginal(session.path);
+}
+
+function sessionDisplayLabel(session: SessionInfo): string {
+	if (session.workflowStageId !== undefined || session.workflowStageName !== undefined) {
+		return `⚙ ${session.name ?? session.workflowStageName ?? session.firstMessage}`;
+	}
+	return session.name ?? session.firstMessage;
+}
+
+function forkSourcePath(session: SessionInfo): string | undefined {
+	return session.forkedFromSessionPath ?? session.parentSessionPath;
+}
+
+const ROOT_WORKFLOW_ORIGIN = "<root>";
+
+function workflowRunKey(originPath: string | undefined, runId: string): string {
+	return `${originPath ?? ROOT_WORKFLOW_ORIGIN}\u0000${runId}`;
+}
+
+function fallbackWorkflowRunLabel(runId: string): string {
+	return runId.length > 0 ? runId : "workflow";
+}
+
+function buildSessionsByCanonicalPath(sessions: SessionInfo[]): Map<string, SessionInfo> {
+	return new Map(sessions.map((session) => [canonicalSessionPath(session), session]));
+}
+
+function createVirtualWorkflowRunNode(
+	originPath: string | undefined,
+	runId: string,
+	workflowName: string | undefined,
+	stage: SessionInfo,
+): SessionTreeNode {
+	const label = `⚙ ${workflowName ?? fallbackWorkflowRunLabel(runId)} (run)`;
+	return {
+		session: {
+			path: `virtual:workflow-run:${encodeURIComponent(originPath ?? ROOT_WORKFLOW_ORIGIN)}:${encodeURIComponent(runId)}`,
+			id: `workflow-run:${runId}`,
+			cwd: stage.cwd,
+			name: label,
+			originSessionPath: originPath,
+			workflowRunId: runId,
+			workflowName,
+			created: stage.created,
+			modified: stage.modified,
+			messageCount: 0,
+			firstMessage: label,
+			allMessagesText: label,
+		},
+		children: [],
+		selectable: false,
+		displayLabel: label,
+	};
+}
+
 /**
- * Build a tree structure from sessions based on parentSessionPath.
+ * Build a tree structure from sessions using workflow provenance for workflow
+ * stages and legacy parentSessionPath for standalone forks.
  * Returns root nodes sorted by modified date (descending).
  */
 function buildSessionTree(sessions: SessionInfo[]): SessionTreeNode[] {
 	const byPath = new Map<string, SessionTreeNode>();
+	const roots: SessionTreeNode[] = [];
+	const workflowRuns = new Map<string, SessionTreeNode>();
+	const attached = new Set<SessionTreeNode>();
 
 	for (const session of sessions) {
-		const sessionPath = canonicalizePath(session.path) ?? session.path;
-		byPath.set(sessionPath, { session, children: [] });
+		const sessionPath = canonicalSessionPath(session);
+		byPath.set(sessionPath, {
+			session,
+			children: [],
+			selectable: true,
+			displayLabel: sessionDisplayLabel(session),
+		});
 	}
 
-	const roots: SessionTreeNode[] = [];
+	for (const session of sessions) {
+		if (session.workflowRunId === undefined) continue;
+		const originPath = canonicalizePath(session.originSessionPath);
+		const key = workflowRunKey(originPath, session.workflowRunId);
+		let runNode = workflowRuns.get(key);
+		if (runNode === undefined) {
+			runNode = createVirtualWorkflowRunNode(originPath, session.workflowRunId, session.workflowName, session);
+			workflowRuns.set(key, runNode);
+		}
+		if (session.modified.getTime() > runNode.session.modified.getTime()) {
+			runNode.session.modified = session.modified;
+		}
+		const sessionPath = canonicalSessionPath(session);
+		const stageNode = byPath.get(sessionPath);
+		if (stageNode !== undefined) {
+			runNode.children.push(stageNode);
+			attached.add(stageNode);
+		}
+	}
+
+	for (const runNode of workflowRuns.values()) {
+		const originPath = canonicalizePath(runNode.session.originSessionPath);
+		if (originPath !== undefined && byPath.has(originPath)) {
+			byPath.get(originPath)!.children.push(runNode);
+		} else {
+			roots.push(runNode);
+		}
+		attached.add(runNode);
+	}
 
 	for (const session of sessions) {
-		const sessionPath = canonicalizePath(session.path) ?? session.path;
+		const sessionPath = canonicalSessionPath(session);
 		const node = byPath.get(sessionPath)!;
-		const parentPath = canonicalizePath(session.parentSessionPath);
+		if (attached.has(node)) continue;
 
-		if (parentPath && byPath.has(parentPath)) {
+		const parentPath = canonicalizePath(session.originSessionPath ?? session.parentSessionPath);
+		if (parentPath && parentPath !== sessionPath && byPath.has(parentPath)) {
 			byPath.get(parentPath)!.children.push(node);
 		} else {
 			roots.push(node);
@@ -246,7 +353,14 @@ function flattenSessionTree(roots: SessionTreeNode[]): FlatSessionNode[] {
 	const result: FlatSessionNode[] = [];
 
 	const walk = (node: SessionTreeNode, depth: number, ancestorContinues: boolean[], isLast: boolean): void => {
-		result.push({ session: node.session, depth, isLast, ancestorContinues });
+		result.push({
+			session: node.session,
+			depth,
+			isLast,
+			selectable: node.selectable,
+			displayLabel: node.displayLabel,
+			ancestorContinues,
+		});
 
 		for (let i = 0; i < node.children.length; i++) {
 			const childIsLast = i === node.children.length - 1;
@@ -268,10 +382,10 @@ function flattenSessionTree(roots: SessionTreeNode[]): FlatSessionNode[] {
  */
 class SessionList implements Component, Focusable {
 	public getSelectedSessionPath(): string | undefined {
-		const selected = this.filteredSessions[this.selectedIndex];
-		return selected?.session.path;
+		return this.selectedSelectableSessionPath();
 	}
 	private allSessions: SessionInfo[] = [];
+	private sessionsByCanonicalPath = new Map<string, SessionInfo>();
 	private filteredSessions: FlatSessionNode[] = [];
 	private selectedIndex: number = 0;
 	private searchInput: Input;
@@ -314,6 +428,7 @@ class SessionList implements Component, Focusable {
 		currentSessionFilePath?: string,
 	) {
 		this.allSessions = sessions;
+		this.sessionsByCanonicalPath = buildSessionsByCanonicalPath(sessions);
 		this.filteredSessions = [];
 		this.searchInput = new Input();
 		this.showCwd = showCwd;
@@ -325,12 +440,7 @@ class SessionList implements Component, Focusable {
 
 		// Handle Enter in search input - select current item
 		this.searchInput.onSubmit = () => {
-			if (this.filteredSessions[this.selectedIndex]) {
-				const selected = this.filteredSessions[this.selectedIndex];
-				if (this.onSelect) {
-					this.onSelect(selected.session.path);
-				}
-			}
+			this.selectCurrentSession();
 		};
 	}
 
@@ -346,6 +456,7 @@ class SessionList implements Component, Focusable {
 
 	setSessions(sessions: SessionInfo[], showCwd: boolean): void {
 		this.allSessions = sessions;
+		this.sessionsByCanonicalPath = buildSessionsByCanonicalPath(sessions);
 		this.showCwd = showCwd;
 		this.filterSessions(this.searchInput.getValue());
 	}
@@ -366,10 +477,55 @@ class SessionList implements Component, Focusable {
 				session,
 				depth: 0,
 				isLast: true,
+				selectable: true,
+				displayLabel: sessionDisplayLabel(session),
 				ancestorContinues: [],
 			}));
 		}
 		this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredSessions.length - 1));
+		this.ensureSelectableSelection();
+	}
+
+	private selectedSelectableSessionNode(): FlatSessionNode | undefined {
+		const selected = this.filteredSessions[this.selectedIndex];
+		return selected?.selectable === true ? selected : undefined;
+	}
+
+	private selectedSelectableSessionPath(): string | undefined {
+		return this.selectedSelectableSessionNode()?.session.path;
+	}
+
+	private selectCurrentSession(): void {
+		const selectedPath = this.selectedSelectableSessionPath();
+		if (selectedPath !== undefined) {
+			this.onSelect?.(selectedPath);
+		}
+	}
+
+	private isSelectableIndex(index: number): boolean {
+		return this.filteredSessions[index]?.selectable === true;
+	}
+
+	private findSelectableIndex(start: number, direction: 1 | -1): number | undefined {
+		for (let index = start; index >= 0 && index < this.filteredSessions.length; index += direction) {
+			if (this.isSelectableIndex(index)) return index;
+		}
+		return undefined;
+	}
+
+	private ensureSelectableSelection(): void {
+		if (this.filteredSessions.length === 0 || this.isSelectableIndex(this.selectedIndex)) return;
+		const next = this.findSelectableIndex(this.selectedIndex + 1, 1) ?? this.findSelectableIndex(this.selectedIndex - 1, -1);
+		this.selectedIndex = next ?? 0;
+	}
+
+	private moveSelectionBy(delta: number): void {
+		if (this.filteredSessions.length === 0) return;
+		const direction: 1 | -1 = delta >= 0 ? 1 : -1;
+		const start = Math.max(0, Math.min(this.filteredSessions.length - 1, this.selectedIndex + delta));
+		const reverseDirection: 1 | -1 = direction === 1 ? -1 : 1;
+		const next = this.findSelectableIndex(start, direction) ?? this.findSelectableIndex(start - direction, reverseDirection);
+		if (next !== undefined) this.selectedIndex = next;
 	}
 
 	private setConfirmingDeletePath(path: string | null): void {
@@ -378,8 +534,8 @@ class SessionList implements Component, Focusable {
 	}
 
 	private startDeleteConfirmationForSelectedSession(): void {
-		const selected = this.filteredSessions[this.selectedIndex];
-		if (!selected) return;
+		const selected = this.selectedSelectableSessionNode();
+		if (selected === undefined) return;
 
 		// Prevent deleting current session
 		if (this.isCurrentSessionPath(selected.session.path)) {
@@ -392,7 +548,12 @@ class SessionList implements Component, Focusable {
 
 	private isCurrentSessionPath(path: string): boolean {
 		if (!this.currentSessionCanonicalPath) return false;
-		return (canonicalizePath(path) ?? path) === this.currentSessionCanonicalPath;
+		return canonicalPathOrOriginal(path) === this.currentSessionCanonicalPath;
+	}
+
+	private forkSourceLabel(path: string): string {
+		const source = this.sessionsByCanonicalPath.get(canonicalPathOrOriginal(path));
+		return source ? sessionForkSourceLabel(source) : shortenPath(path);
 	}
 
 	invalidate(): void {}
@@ -442,10 +603,12 @@ class SessionList implements Component, Focusable {
 			// Build tree prefix
 			const prefix = this.buildTreePrefix(node);
 
-			// Session display text (name or first message)
-			const hasName = !!session.name;
-			const displayText = session.name ?? session.firstMessage;
-			const normalizedMessage = displayText.replace(/[\x00-\x1f\x7f]/g, " ").trim();
+			// Session display text (name, first message, or workflow label)
+			const hasName = !!session.name && node.selectable;
+			const displayText = node.displayLabel ?? sessionDisplayLabel(session);
+			const forkPath = node.selectable ? forkSourcePath(session) : undefined;
+			const forkAnnotation = forkPath ? `  ⑂ from ${this.forkSourceLabel(forkPath)}` : "";
+			const normalizedMessage = `${displayText}${forkAnnotation}`.replace(/[\x00-\x1f\x7f]/g, " ").trim();
 
 			// Right side: message count and age
 			const age = formatSessionDate(session.modified);
@@ -566,8 +729,8 @@ class SessionList implements Component, Focusable {
 
 		// Rename selected session
 		if (kb.matches(keyData, "app.session.rename")) {
-			const selected = this.filteredSessions[this.selectedIndex];
-			if (selected) {
+			const selected = this.selectedSelectableSessionNode();
+			if (selected !== undefined) {
 				this.onRenameSession?.(selected.session.path);
 			}
 			return;
@@ -588,26 +751,23 @@ class SessionList implements Component, Focusable {
 
 		// Up arrow
 		if (kb.matches(keyData, "tui.select.up")) {
-			this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+			this.moveSelectionBy(-1);
 		}
 		// Down arrow
 		else if (kb.matches(keyData, "tui.select.down")) {
-			this.selectedIndex = Math.min(this.filteredSessions.length - 1, this.selectedIndex + 1);
+			this.moveSelectionBy(1);
 		}
 		// Page up - jump up by maxVisible items
 		else if (kb.matches(keyData, "tui.select.pageUp")) {
-			this.selectedIndex = Math.max(0, this.selectedIndex - this.maxVisible);
+			this.moveSelectionBy(-this.maxVisible);
 		}
 		// Page down - jump down by maxVisible items
 		else if (kb.matches(keyData, "tui.select.pageDown")) {
-			this.selectedIndex = Math.min(this.filteredSessions.length - 1, this.selectedIndex + this.maxVisible);
+			this.moveSelectionBy(this.maxVisible);
 		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {
-			const selected = this.filteredSessions[this.selectedIndex];
-			if (selected && this.onSelect) {
-				this.onSelect(selected.session.path);
-			}
+			this.selectCurrentSession();
 		}
 		// Escape - cancel
 		else if (kb.matches(keyData, "tui.select.cancel")) {

--- a/packages/coding-agent/test/session-manager/custom-session-id.test.ts
+++ b/packages/coding-agent/test/session-manager/custom-session-id.test.ts
@@ -6,6 +6,28 @@ import { SessionManager } from "../../src/core/session-manager.ts";
 
 const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
+type AppendableMessage = Parameters<SessionManager["appendMessage"]>[0];
+
+function assistantMessage(text: string, timestamp = Date.now()): AppendableMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-5.4",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp,
+	} as AppendableMessage;
+}
+
 describe("SessionManager.newSession with custom id", () => {
 	it("uses the provided id instead of generating one", () => {
 		const session = SessionManager.inMemory();
@@ -40,6 +62,37 @@ describe("SessionManager.newSession with custom id", () => {
 		expect(header!.id).toBe("header-test-id");
 	});
 
+	it("persists and lists session provenance and workflow metadata", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-session-manager-metadata-"));
+		const session = SessionManager.create(tempDir, tempDir, {
+			originSession: "origin.jsonl",
+			forkedFromSession: "fork-source.jsonl",
+			workflowRunId: "run-123",
+			workflowName: "refactor",
+			workflowStageId: "stage-123",
+			workflowStageName: "plan",
+		});
+
+		session.appendMessage(assistantMessage("ready"));
+
+		const header = session.getHeader();
+		expect(header!.originSession).toBe("origin.jsonl");
+		expect(header!.forkedFromSession).toBe("fork-source.jsonl");
+		expect(header!.workflowRunId).toBe("run-123");
+		expect(header!.workflowName).toBe("refactor");
+		expect(header!.workflowStageId).toBe("stage-123");
+		expect(header!.workflowStageName).toBe("plan");
+
+		const listed = await SessionManager.list(tempDir, tempDir);
+		expect(listed).toHaveLength(1);
+		expect(listed[0]!.originSessionPath).toBe("origin.jsonl");
+		expect(listed[0]!.forkedFromSessionPath).toBe("fork-source.jsonl");
+		expect(listed[0]!.workflowRunId).toBe("run-123");
+		expect(listed[0]!.workflowName).toBe("refactor");
+		expect(listed[0]!.workflowStageId).toBe("stage-123");
+		expect(listed[0]!.workflowStageName).toBe("plan");
+	});
+
 	it("generates a UUIDv7 id when constructed without an explicit id", () => {
 		const session = SessionManager.inMemory();
 		expect(session.getSessionId()).toMatch(UUID_V7_RE);
@@ -58,6 +111,55 @@ describe("SessionManager.newSession with custom id", () => {
 
 		expect(session.getSessionId()).toMatch(UUID_V7_RE);
 		expect(session.getHeader()!.id).toBe(session.getSessionId());
+	});
+
+	it("clears copied source names for workflow stage forks", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-session-manager-workflow-name-"));
+		const source = SessionManager.create(tempDir, tempDir);
+		source.appendMessage(assistantMessage("source ready", Date.parse("2026-01-01T00:00:00.000Z")));
+		source.appendSessionInfo("my_chat");
+		const sourcePath = source.getSessionFile()!;
+
+		const forked = SessionManager.forkFrom(sourcePath, tempDir, tempDir, {
+			originSession: sourcePath,
+			workflowRunId: "run-789",
+			workflowName: "refactor-workflow",
+			workflowStageId: "stage-implement",
+			workflowStageName: "implement",
+		});
+
+		expect(source.getSessionName()).toBe("my_chat");
+		expect(forked.getSessionName()).toBeUndefined();
+		const header = forked.getHeader();
+		expect(header!.parentSession).toBe(sourcePath);
+		expect(header!.forkedFromSession).toBe(sourcePath);
+		expect(header!.originSession).toBe(sourcePath);
+		expect(header!.workflowStageName).toBe("implement");
+
+		const listed = await SessionManager.list(tempDir, tempDir);
+		const sourceInfo = listed.find((session) => session.path === sourcePath);
+		const forkInfo = listed.find((session) => session.path === forked.getSessionFile());
+		expect(sourceInfo!.name).toBe("my_chat");
+		expect(forkInfo!.name).toBeUndefined();
+		expect(forkInfo!.workflowStageName).toBe("implement");
+	});
+
+	it("preserves copied source names for non-workflow forks", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-session-manager-non-workflow-name-"));
+		const source = SessionManager.create(tempDir, tempDir);
+		source.appendMessage(assistantMessage("source ready", Date.parse("2026-01-01T00:00:00.000Z")));
+		source.appendSessionInfo("my_chat");
+		const sourcePath = source.getSessionFile()!;
+
+		const forked = SessionManager.forkFrom(sourcePath, tempDir, tempDir);
+
+		expect(source.getSessionName()).toBe("my_chat");
+		expect(forked.getSessionName()).toBe("my_chat");
+		const listed = await SessionManager.list(tempDir, tempDir);
+		const sourceInfo = listed.find((session) => session.path === sourcePath);
+		const forkInfo = listed.find((session) => session.path === forked.getSessionFile());
+		expect(sourceInfo!.name).toBe("my_chat");
+		expect(forkInfo!.name).toBe("my_chat");
 	});
 
 	it("generates a UUIDv7 id when forking from another session file", () => {
@@ -100,10 +202,22 @@ describe("SessionManager.newSession with custom id", () => {
 `,
 		);
 
-		const forked = SessionManager.forkFrom(sourcePath, tempDir, tempDir);
+		const forked = SessionManager.forkFrom(sourcePath, tempDir, tempDir, {
+			originSession: "origin.jsonl",
+			workflowRunId: "run-456",
+			workflowName: "workflow",
+			workflowStageId: "stage-456",
+			workflowStageName: "implement",
+		});
 		const header = forked.getHeader();
 		expect(header).not.toBeNull();
 		expect(header!.id).toMatch(UUID_V7_RE);
 		expect(header!.parentSession).toBe(sourcePath);
+		expect(header!.forkedFromSession).toBe(sourcePath);
+		expect(header!.originSession).toBe("origin.jsonl");
+		expect(header!.workflowRunId).toBe("run-456");
+		expect(header!.workflowName).toBe("workflow");
+		expect(header!.workflowStageId).toBe("stage-456");
+		expect(header!.workflowStageName).toBe("implement");
 	});
 });

--- a/packages/coding-agent/test/session-selector-path-delete.test.ts
+++ b/packages/coding-agent/test/session-selector-path-delete.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { setKeybindings } from "@earendil-works/pi-tui";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { KeybindingsManager } from "../src/core/keybindings.ts";
-import type { SessionInfo } from "../src/core/session-manager.ts";
+import { SessionManager, type SessionInfo } from "../src/core/session-manager.ts";
 import { SessionSelectorComponent } from "../src/modes/interactive/components/session-selector.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 
@@ -34,6 +34,28 @@ function stripAnsi(text: string): string {
 	return text.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
+type AppendableMessage = Parameters<SessionManager["appendMessage"]>[0];
+
+function assistantMessage(text: string, timestamp: string): AppendableMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-5.4",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.parse(timestamp),
+	} as AppendableMessage;
+}
+
 function makeSession(overrides: Partial<SessionInfo> & { id: string }): SessionInfo {
 	return {
 		path: overrides.path ?? `/tmp/${overrides.id}.jsonl`,
@@ -41,6 +63,12 @@ function makeSession(overrides: Partial<SessionInfo> & { id: string }): SessionI
 		cwd: overrides.cwd ?? "",
 		name: overrides.name,
 		parentSessionPath: overrides.parentSessionPath,
+		originSessionPath: overrides.originSessionPath,
+		forkedFromSessionPath: overrides.forkedFromSessionPath,
+		workflowRunId: overrides.workflowRunId,
+		workflowName: overrides.workflowName,
+		workflowStageId: overrides.workflowStageId,
+		workflowStageName: overrides.workflowStageName,
 		created: overrides.created ?? new Date(0),
 		modified: overrides.modified ?? new Date(0),
 		messageCount: overrides.messageCount ?? 1,
@@ -85,6 +113,7 @@ function createSymlinkedSessionPaths(): {
 
 const CTRL_D = "\x04";
 const CTRL_BACKSPACE = "\x1b[127;5u";
+const CTRL_S = "\x13";
 
 describe("session selector path/delete interactions", () => {
 	const keybindings = new KeybindingsManager();
@@ -280,6 +309,352 @@ describe("session selector path/delete interactions", () => {
 		const output = stripAnsi(selector.render(120).join("\n"));
 		expect(output).toContain("Parent");
 		expect(output).toContain("└─ Child");
+	});
+
+	it("groups workflow stages under a virtual run node and renders fork annotations", async () => {
+		const sessions = [
+			makeSession({
+				id: "chat",
+				path: "/tmp/chat.jsonl",
+				name: "Chat",
+				modified: new Date("2026-01-01T00:00:00.000Z"),
+			}),
+			makeSession({
+				id: "analyze",
+				path: "/tmp/analyze.jsonl",
+				originSessionPath: "/tmp/chat.jsonl",
+				workflowRunId: "run-1",
+				workflowName: "code-review",
+				workflowStageId: "stage-analyze",
+				workflowStageName: "analyze",
+				modified: new Date("2026-01-01T00:01:00.000Z"),
+			}),
+			makeSession({
+				id: "plan",
+				path: "/tmp/plan.jsonl",
+				parentSessionPath: "/tmp/analyze.jsonl",
+				forkedFromSessionPath: "/tmp/analyze.jsonl",
+				originSessionPath: "/tmp/chat.jsonl",
+				workflowRunId: "run-1",
+				workflowName: "code-review",
+				workflowStageId: "stage-plan",
+				workflowStageName: "plan",
+				modified: new Date("2026-01-01T00:02:00.000Z"),
+			}),
+		];
+
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(160).join("\n"));
+		expect(output).toContain("Chat");
+		expect(output).toContain("└─ ⚙ code-review (run)");
+		expect(output).toContain("├─ ⚙ plan  ⑂ from analyze");
+		expect(output).toContain("└─ ⚙ analyze");
+	});
+
+	it("renders real workflow stage forks by local stage names", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "pi-session-selector-workflow-fork-"));
+		tempDirs.push(tempDir);
+
+		const chat = SessionManager.create(tempDir, tempDir);
+		chat.appendMessage(assistantMessage("origin ready", "2026-01-01T00:00:00.000Z"));
+		chat.appendSessionInfo("my_chat");
+		const chatPath = chat.getSessionFile()!;
+
+		const analyze = SessionManager.forkFrom(chatPath, tempDir, tempDir, {
+			originSession: chatPath,
+			workflowRunId: "run-1",
+			workflowName: "refactor-workflow",
+			workflowStageId: "stage-analyze",
+			workflowStageName: "analyze",
+		});
+		analyze.appendMessage(assistantMessage("analyze complete", "2026-01-01T00:01:00.000Z"));
+		const analyzePath = analyze.getSessionFile()!;
+
+		const implement = SessionManager.forkFrom(analyzePath, tempDir, tempDir, {
+			originSession: chatPath,
+			workflowRunId: "run-1",
+			workflowName: "refactor-workflow",
+			workflowStageId: "stage-implement",
+			workflowStageName: "implement",
+		});
+		implement.appendMessage(assistantMessage("implement complete", "2026-01-01T00:02:00.000Z"));
+
+		const sessions = await SessionManager.list(tempDir, tempDir);
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(160).join("\n"));
+		expect(output).toContain("my_chat");
+		expect(output).toContain("└─ ⚙ refactor-workflow (run)");
+		expect(output).toContain("⚙ analyze  ⑂ from my_chat");
+		expect(output).toContain("⚙ implement  ⑂ from analyze");
+		expect(output).not.toContain("⚙ my_chat");
+	});
+
+	it("prefers renamed workflow stage names for real stage row labels", async () => {
+		const sessions = [
+			makeSession({
+				id: "chat",
+				path: "/tmp/chat.jsonl",
+				name: "Chat",
+				modified: new Date("2026-01-01T00:00:00.000Z"),
+			}),
+			makeSession({
+				id: "plan",
+				path: "/tmp/plan.jsonl",
+				name: "Bug hunt",
+				originSessionPath: "/tmp/chat.jsonl",
+				workflowRunId: "run-1",
+				workflowName: "code-review",
+				workflowStageId: "stage-plan",
+				workflowStageName: "plan",
+				modified: new Date("2026-01-01T00:01:00.000Z"),
+			}),
+		];
+
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(160).join("\n"));
+		expect(output).toContain("⚙ Bug hunt");
+		expect(output).not.toContain("⚙ plan");
+	});
+
+	it("searches renamed workflow stages by original workflow stage name", async () => {
+		const originalStageName = "XQZV Original Stage";
+		const renamedStageName = "Renamed customer investigation";
+		const sessions = [
+			makeSession({
+				id: "session-42",
+				path: "/tmp/renamed-stage.jsonl",
+				name: renamedStageName,
+				cwd: "/tmp/customer-workspace",
+				workflowRunId: "run-1",
+				workflowName: "review-flow",
+				workflowStageId: "stage-42",
+				workflowStageName: originalStageName,
+				firstMessage: "unrelated prompt",
+				allMessagesText: "unrelated transcript without the search token",
+				modified: new Date("2026-01-01T00:01:00.000Z"),
+			}),
+		];
+		expect(sessions[0]!.id).not.toContain(originalStageName);
+		expect(sessions[0]!.cwd).not.toContain(originalStageName);
+		expect(sessions[0]!.allMessagesText).not.toContain(originalStageName);
+
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		selector.getSessionList().handleInput(originalStageName);
+		const output = stripAnsi(selector.render(160).join("\n"));
+		expect(output).toContain(`⚙ ${renamedStageName}`);
+		expect(output).not.toContain(`⚙ ${originalStageName}`);
+		expect(output).not.toContain("⚙ review-flow (run)");
+	});
+
+	it("searches renamed workflow stages by renamed session name", async () => {
+		const originalStageName = "Triage Stage";
+		const renamedStageName = "Bug hunt";
+		const sessions = [
+			makeSession({
+				id: "session-99",
+				path: "/tmp/session-99.jsonl",
+				name: renamedStageName,
+				cwd: "/tmp/customer-workspace",
+				workflowRunId: "run-2",
+				workflowName: "review-flow",
+				workflowStageId: "stage-99",
+				workflowStageName: originalStageName,
+				firstMessage: "unrelated prompt",
+				allMessagesText: "unrelated transcript without the renamed label",
+				modified: new Date("2026-01-01T00:01:00.000Z"),
+			}),
+		];
+		const renamedTokens = renamedStageName.toLowerCase().split(/\s+/);
+		for (const field of [sessions[0]!.id, sessions[0]!.cwd, sessions[0]!.allMessagesText]) {
+			const normalizedField = field.toLowerCase();
+			expect(normalizedField).not.toContain(renamedStageName.toLowerCase());
+			for (const token of renamedTokens) {
+				expect(normalizedField).not.toContain(token);
+			}
+		}
+
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		selector.getSessionList().handleInput(renamedStageName);
+		const output = stripAnsi(selector.render(160).join("\n"));
+		expect(output).toContain(`⚙ ${renamedStageName}`);
+		expect(output).not.toContain(`⚙ ${originalStageName}`);
+		expect(output).not.toContain("⚙ review-flow (run)");
+	});
+
+	it("prefers renamed workflow stage names for fork source annotations", async () => {
+		const sessions = [
+			makeSession({
+				id: "chat",
+				path: "/tmp/chat.jsonl",
+				name: "Chat",
+				modified: new Date("2026-01-01T00:00:00.000Z"),
+			}),
+			makeSession({
+				id: "plan",
+				path: "/tmp/plan.jsonl",
+				name: "Bug hunt",
+				originSessionPath: "/tmp/chat.jsonl",
+				workflowRunId: "run-1",
+				workflowName: "code-review",
+				workflowStageId: "stage-plan",
+				workflowStageName: "plan",
+				modified: new Date("2026-01-01T00:01:00.000Z"),
+			}),
+			makeSession({
+				id: "implement",
+				path: "/tmp/implement.jsonl",
+				parentSessionPath: "/tmp/plan.jsonl",
+				forkedFromSessionPath: "/tmp/plan.jsonl",
+				originSessionPath: "/tmp/chat.jsonl",
+				workflowRunId: "run-1",
+				workflowName: "code-review",
+				workflowStageId: "stage-implement",
+				workflowStageName: "implement",
+				modified: new Date("2026-01-01T00:02:00.000Z"),
+			}),
+		];
+
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(160).join("\n"));
+		expect(output).toContain("⑂ from Bug hunt");
+		expect(output).not.toContain("⑂ from plan");
+	});
+
+	it("skips virtual workflow run rows for selection and keeps search/recent modes flat", async () => {
+		const sessions = [
+			makeSession({
+				id: "worker",
+				path: "/tmp/worker.jsonl",
+				workflowRunId: "run-root",
+				workflowName: "rootless",
+				workflowStageId: "workflow-step-1",
+				workflowStageName: "Blueprint Review",
+				allMessagesText: "unrelated prompt",
+			}),
+		];
+		const selected: string[] = [];
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			(path) => selected.push(path),
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const threadedOutput = stripAnsi(selector.render(160).join("\n"));
+		expect(threadedOutput).toContain("⚙ rootless (run)");
+		expect(selector.getSessionList().getSelectedSessionPath()).toBe("/tmp/worker.jsonl");
+		selector.getSessionList().handleInput("\r");
+		expect(selected).toEqual(["/tmp/worker.jsonl"]);
+
+		selector.getSessionList().handleInput("Blueprint Review");
+		const searchOutput = stripAnsi(selector.render(160).join("\n"));
+		expect(searchOutput).not.toContain("⚙ rootless (run)");
+		expect(searchOutput).toContain("⚙ Blueprint Review");
+
+		const recentSelector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+		recentSelector.getSessionList().handleInput(CTRL_S);
+		const recentOutput = stripAnsi(recentSelector.render(160).join("\n"));
+		expect(recentOutput).not.toContain("⚙ rootless (run)");
+		expect(recentOutput).toContain("⚙ Blueprint Review");
+	});
+
+	it("keeps standalone forks nested with fork annotations", async () => {
+		const sessions = [
+			makeSession({ id: "parent", path: "/tmp/parent.jsonl", name: "Parent" }),
+			makeSession({
+				id: "child",
+				path: "/tmp/child.jsonl",
+				parentSessionPath: "/tmp/parent.jsonl",
+				firstMessage: "Child",
+			}),
+		];
+		const selector = new SessionSelectorComponent(
+			async () => sessions,
+			async () => [],
+			() => {},
+			() => {},
+			() => {},
+			() => {},
+			{ keybindings },
+		);
+		await flushPromises();
+
+		const output = stripAnsi(selector.render(120).join("\n"));
+		expect(output).toContain("Parent");
+		expect(output).toContain("└─ Child  ⑂ from Parent");
 	});
 
 	it("treats the current session as active across symlink aliases", async () => {

--- a/packages/coding-agent/test/session-selector-search.test.ts
+++ b/packages/coding-agent/test/session-selector-search.test.ts
@@ -10,12 +10,39 @@ function makeSession(
 		id: overrides.id,
 		cwd: overrides.cwd ?? "",
 		name: overrides.name,
+		workflowRunId: overrides.workflowRunId,
+		workflowName: overrides.workflowName,
+		workflowStageName: overrides.workflowStageName,
 		created: overrides.created ?? new Date(0),
 		modified: overrides.modified,
 		messageCount: overrides.messageCount ?? 1,
 		firstMessage: overrides.firstMessage ?? "(no messages)",
 		allMessagesText: overrides.allMessagesText,
 	};
+}
+
+function makeWorkflowSearchSessions(
+	workflowFields: Partial<Pick<SessionInfo, "workflowName" | "workflowRunId">>,
+): SessionInfo[] {
+	return [
+		makeSession({
+			id: "stage-alpha",
+			name: "Visible Stage",
+			...workflowFields,
+			workflowStageName: "analyze",
+			modified: new Date("2026-01-02T00:00:00.000Z"),
+			allMessagesText: "alpha beta",
+			cwd: "/tmp/plain",
+		}),
+		makeSession({
+			id: "plain-alpha",
+			name: "Visible Stage",
+			workflowStageName: "analyze",
+			modified: new Date("2026-01-03T00:00:00.000Z"),
+			allMessagesText: "alpha beta",
+			cwd: "/tmp/plain",
+		}),
+	];
 }
 
 describe("session selector search", () => {
@@ -53,6 +80,20 @@ describe("session selector search", () => {
 
 		const result = filterAndSortSessions(sessions, "re:\\bbrave\\b", "recent");
 		expect(result.map((s) => s.id)).toEqual(["a"]);
+	});
+
+	it("matches workflowName when absent from other searchable fields", () => {
+		const sessions = makeWorkflowSearchSessions({ workflowName: "rootless" });
+
+		const result = filterAndSortSessions(sessions, "rootless", "recent");
+		expect(result.map((s) => s.id)).toEqual(["stage-alpha"]);
+	});
+
+	it("matches workflowRunId when absent from other searchable fields", () => {
+		const sessions = makeWorkflowSearchSessions({ workflowRunId: "run-root" });
+
+		const result = filterAndSortSessions(sessions, "run-root", "recent");
+		expect(result.map((s) => s.id)).toEqual(["stage-alpha"]);
 	});
 
 	it("recent sort preserves input order", () => {

--- a/packages/workflows/src/extension/dispatcher.ts
+++ b/packages/workflows/src/extension/dispatcher.ts
@@ -69,6 +69,8 @@ export interface DispatcherOpts {
   policy?: WorkflowExecutionPolicy;
   /** Invocation cwd used for workflow execution. */
   cwd?: string;
+  /** Internal: originating chat session file stamped onto workflow stage sessions. */
+  workflowOriginSessionFile?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -173,6 +175,7 @@ export async function dispatch(
         models: opts.models,
         executionMode: policy.mode,
         cwd: opts.cwd,
+        workflowOriginSessionFile: opts.workflowOriginSessionFile,
       });
       if (policy.awaitTerminalRun === true) {
         const tracker = opts.jobs ?? defaultJobTracker;

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -236,6 +236,9 @@ export interface PiCommandContext extends PiModelContext {
   ui: {
     notify: (message: string, type?: "info" | "warning" | "error") => void;
   } & PiUISurface;
+  sessionManager?: SessionManager & {
+    getSessionFile?: () => string | undefined;
+  };
   /**
    * False when the host bound a no-op UI surface (print/JSON `-p` modes).
    * Absent on older hosts and unit-test stubs; treat absence as interactive.
@@ -446,7 +449,7 @@ export interface ExtensionAPI {
   // -------------------------------------------------------------------------
   // Session manager (§5.6 restore)
   // -------------------------------------------------------------------------
-  sessionManager?: SessionManager;
+  sessionManager?: SessionManager & SessionFileProvider;
   ui?: {
     setWidget?: (
       key: string,
@@ -580,14 +583,34 @@ function directRequestsFork(args: WorkflowToolArgs): boolean {
   );
 }
 
+type SessionFileProvider = {
+  readonly getSessionFile?: () => string | undefined;
+};
+
+type SessionFileContext = {
+  readonly sessionManager?: SessionFileProvider;
+};
+
+function sessionFileFromManager(manager: SessionFileProvider | undefined): string | undefined {
+  const sessionFile = manager?.getSessionFile?.();
+  return typeof sessionFile === "string" && sessionFile.length > 0 ? sessionFile : undefined;
+}
+
+function currentSessionFileFromContext(
+  ctx: SessionFileContext | undefined,
+  fallback?: SessionFileContext,
+): string | undefined {
+  return sessionFileFromManager(ctx?.sessionManager) ?? sessionFileFromManager(fallback?.sessionManager);
+}
+
 function withForkParentSession(
   args: WorkflowToolArgs,
   ctx: PiExecuteContext,
 ): WorkflowToolArgs {
   if (!directRequestsFork(args) || args.forkFromSessionFile !== undefined)
     return args;
-  const sessionFile = ctx.sessionManager?.getSessionFile?.();
-  return typeof sessionFile === "string" && sessionFile.length > 0
+  const sessionFile = currentSessionFileFromContext(ctx);
+  return sessionFile !== undefined
     ? { ...args, forkFromSessionFile: sessionFile }
     : args;
 }
@@ -1270,6 +1293,7 @@ export function makeExecuteWorkflowTool(
     const activeRuntime =
       typeof runtime === "function" ? runtime(ctx) : runtime;
     const policy = workflowPolicyFromContext(ctx);
+    const workflowOriginSessionFile = currentSessionFileFromContext(ctx);
 
     switch (action) {
       case "get":
@@ -1288,13 +1312,13 @@ export function makeExecuteWorkflowTool(
           }
           const details = await activeRuntime.runDirect(
             withForkParentSession(args, ctx),
-            { policy },
+            { policy, workflowOriginSessionFile },
           );
           return workflowRunResultFromDetails(details);
         }
         // Delegate to registry-backed dispatcher.
         // Real errors propagate — no broad catch.
-        return activeRuntime.dispatch(args, { policy });
+        return activeRuntime.dispatch(args, { policy, workflowOriginSessionFile });
 
       case "status": {
         // Detail mode — single-run lookup via id.
@@ -1796,7 +1820,7 @@ export function makeExecuteWorkflowTool(
           run?.status === "paused" ||
           (run?.stages.some((s) => s.status === "paused") ?? false);
         if (!isPaused && run?.status === "failed" && run.endedAt !== undefined && run.resumable !== false) {
-          const continuation = activeRuntime.resumeFailedRun(stageRunId, stage.stageId, { policy });
+          const continuation = activeRuntime.resumeFailedRun(stageRunId, stage.stageId, { policy, workflowOriginSessionFile });
           return {
             action: "resume",
             runId: continuation.ok ? continuation.runId : stageRunId,
@@ -2675,6 +2699,7 @@ function factory(pi: ExtensionAPI): void {
     reporter: WorkflowCommandReporter = createWorkflowCommandReporter(ctx),
   ): Promise<boolean> {
     const policy = workflowPolicyFromContext(ctx);
+    const workflowOriginSessionFile = currentSessionFileFromContext(ctx, pi);
     const print = (msg: string): void => reporter.info(msg);
     const fail = (msg: string): void => reporter.error(msg);
     const canOpenPicker = (ui: PiCommandContext["ui"] | undefined): boolean =>
@@ -3134,7 +3159,7 @@ function factory(pi: ExtensionAPI): void {
         run?.status === "paused" ||
         (run?.stages.some((s) => s.status === "paused") ?? false);
       if (!isPaused && run?.status === "failed" && run.endedAt !== undefined && run.resumable !== false) {
-        const continuation = runtimeForContext(ctx).resumeFailedRun(stageRunId, stageId, { policy });
+        const continuation = runtimeForContext(ctx).resumeFailedRun(stageRunId, stageId, { policy, workflowOriginSessionFile });
         if (continuation.ok) {
           print(continuation.message);
         } else {
@@ -3182,6 +3207,7 @@ function factory(pi: ExtensionAPI): void {
         "Run or inspect Atomic workflows. Usage: /workflow <name> [key=value…] | /workflow [list|status|connect|attach|interrupt|kill|pause|resume|inputs|reload] [args]",
       handler: async (args: string, ctx: PiCommandContext) => {
         const policy = workflowPolicyFromContext(ctx);
+        const workflowOriginSessionFile = currentSessionFileFromContext(ctx, pi);
         const reporter = createWorkflowCommandReporter(ctx, policy, pi);
         const print = (msg: string): void => reporter.info(msg);
         const fail = (msg: string): void => reporter.error(msg);
@@ -3485,7 +3511,7 @@ function factory(pi: ExtensionAPI): void {
             workflow: workflowName,
             inputs: mergedInputs,
             action: "run",
-          }, { policy }),
+          }, { policy, workflowOriginSessionFile }),
         );
         if (result.action === "run" && "runId" in result) {
           const r = result as Extract<

--- a/packages/workflows/src/extension/runtime.ts
+++ b/packages/workflows/src/extension/runtime.ts
@@ -117,6 +117,7 @@ export interface ExtensionRuntime {
 
 export interface RuntimeDispatchOptions {
   readonly policy?: WorkflowExecutionPolicy;
+  readonly workflowOriginSessionFile?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -149,7 +150,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
   const jobs = opts.jobs;
   const runtimeCwd = opts.cwd ?? process.cwd();
 
-  function runOptions(args: WorkflowToolArgs, policy?: WorkflowExecutionPolicy): RunOpts {
+  function runOptions(args: WorkflowToolArgs, policy?: WorkflowExecutionPolicy, workflowOriginSessionFile?: string): RunOpts {
     const argConcurrency =
       typeof args.concurrency === "number" && Number.isFinite(args.concurrency)
         ? Math.max(1, Math.floor(args.concurrency))
@@ -176,6 +177,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
       ...(policy !== undefined ? { executionMode: policy.mode } : {}),
       registry,
       cwd: runtimeCwd,
+      ...(workflowOriginSessionFile !== undefined ? { workflowOriginSessionFile } : {}),
     };
   }
 
@@ -208,6 +210,11 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
       worktree,
       gitWorktreeDir,
       baseBranch,
+      workflowOriginSessionFile: _workflowOriginSessionFile,
+      workflowRunId: _workflowRunId,
+      workflowName: _workflowName,
+      workflowStageId: _workflowStageId,
+      workflowStageName: _workflowStageName,
       ...stageOptions
     } = args;
 
@@ -329,9 +336,10 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
     args: WorkflowToolArgs,
     runId?: string,
     policy?: WorkflowExecutionPolicy,
+    workflowOriginSessionFile?: string,
   ): Promise<WorkflowDetails> {
     const directRunOptions = directOptions(args);
-    const baseRunOptions = runOptions(args, policy);
+    const baseRunOptions = runOptions(args, policy, workflowOriginSessionFile);
     const effectiveRunOptions = runId === undefined
       ? baseRunOptions
       : { ...baseRunOptions, runId };
@@ -412,7 +420,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
       return { ok: false, reason: "insufficient_state", message: `insufficient_state: ${err instanceof Error ? err.message : String(err)}` };
     }
     const accepted = runDetached(def, sourceInputs, {
-      ...runOptions({ workflow: def.name, inputs: sourceInputs }, options?.policy),
+      ...runOptions({ workflow: def.name, inputs: sourceInputs }, options?.policy, options?.workflowOriginSessionFile),
       continuation: { source, resumeFromStageId: resolvedStage.stageId },
     });
     return {
@@ -424,7 +432,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
     };
   }
 
-  async function runDirectAsync(args: WorkflowToolArgs, policy?: WorkflowExecutionPolicy): Promise<WorkflowDetails> {
+  async function runDirectAsync(args: WorkflowToolArgs, policy?: WorkflowExecutionPolicy, workflowOriginSessionFile?: string): Promise<WorkflowDetails> {
     const runId = crypto.randomUUID();
     const mode = directMode(args);
     const delivery = effectiveIntercomDelivery(args, mode);
@@ -445,7 +453,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
         error: classifyWorkflowFailure(error).userMessage,
       }, delivery, parentSession);
     }
-    const background = runDirectForeground(args, runId, policy);
+    const background = runDirectForeground(args, runId, policy, workflowOriginSessionFile);
     void background.then(
       (details) => {
         emitDirectIntercom(details, delivery, parentSession);
@@ -489,6 +497,7 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
         config,
         models,
         policy: options?.policy,
+        workflowOriginSessionFile: options?.workflowOriginSessionFile,
         cwd: runtimeCwd,
       });
     },
@@ -496,12 +505,12 @@ export function createExtensionRuntime(opts: ExtensionRuntimeOpts = {}): Extensi
     runDirect(args: WorkflowToolArgs, options?: RuntimeDispatchOptions): Promise<WorkflowDetails> {
       const policy = options?.policy ?? INTERACTIVE_WORKFLOW_POLICY;
       if (args.async === true && policy.awaitTerminalRun !== true) {
-        return runDirectAsync(args, policy);
+        return runDirectAsync(args, policy, options?.workflowOriginSessionFile);
       }
       const mode = directMode(args);
       const delivery = effectiveIntercomDelivery(args, mode);
       const parentSession = intercomParentSession(args);
-      return runDirectForeground(args, undefined, policy).then((details) => {
+      return runDirectForeground(args, undefined, policy, options?.workflowOriginSessionFile).then((details) => {
         const summarized = withIntercomSummary(details, delivery, parentSession);
         emitDirectIntercom(summarized, delivery, parentSession);
         return summarized;

--- a/packages/workflows/src/extension/wiring.ts
+++ b/packages/workflows/src/extension/wiring.ts
@@ -22,7 +22,13 @@
  */
 
 import { basename } from "node:path";
-import type { ChatMessageRenderOptions, CreateAgentSessionOptions } from "@bastani/atomic";
+import {
+  getDefaultSessionDir,
+  SessionManager,
+  type ChatMessageRenderOptions,
+  type CreateAgentSessionOptions,
+  type NewSessionOptions,
+} from "@bastani/atomic";
 import type { StageAdapters, StageSessionCreateResult, StageSessionRuntime } from "../runs/foreground/stage-runner.js";
 import type { StageExecutionMeta, StageOptions } from "../shared/types.js";
 import { stageUiBroker, type StageUiBroker } from "../shared/stage-ui-broker.js";
@@ -241,8 +247,81 @@ async function createTestAgentSession(_options?: CreateAgentSessionOptions): Pro
 function stripWorkflowOnlyOptions(options: (StageOptions | CreateAgentSessionOptions) | undefined): CreateAgentSessionOptions | undefined {
   if (!options) return options;
   const maybeWorkflowOptions = options as StageOptions;
-  const { mcp: _mcp, fallbackModels: _fallbackModels, ...sessionOptions } = maybeWorkflowOptions;
+  const {
+    mcp: _mcp,
+    fallbackModels: _fallbackModels,
+    fallbackThinkingLevels: _fallbackThinkingLevels,
+    context: _context,
+    forkFromSessionFile: _forkFromSessionFile,
+    sessionDir: _sessionDir,
+    gitWorktreeDir: _gitWorktreeDir,
+    baseBranch: _baseBranch,
+    workflowOriginSessionFile: _workflowOriginSessionFile,
+    workflowRunId: _workflowRunId,
+    workflowName: _workflowName,
+    workflowStageId: _workflowStageId,
+    workflowStageName: _workflowStageName,
+    ...sessionOptions
+  } = maybeWorkflowOptions;
   return sessionOptions as CreateAgentSessionOptions;
+}
+
+function workflowSessionMetadata(options: Pick<
+  StageOptions,
+  "workflowOriginSessionFile" | "workflowRunId" | "workflowName" | "workflowStageId" | "workflowStageName"
+>): NewSessionOptions {
+  return {
+    ...(options.workflowOriginSessionFile !== undefined ? { originSession: options.workflowOriginSessionFile } : {}),
+    ...(options.workflowRunId !== undefined ? { workflowRunId: options.workflowRunId } : {}),
+    ...(options.workflowName !== undefined ? { workflowName: options.workflowName } : {}),
+    ...(options.workflowStageId !== undefined ? { workflowStageId: options.workflowStageId } : {}),
+    ...(options.workflowStageName !== undefined ? { workflowStageName: options.workflowStageName } : {}),
+  };
+}
+
+function hasWorkflowSessionMetadata(metadata: NewSessionOptions): boolean {
+  return Object.keys(metadata).length > 0;
+}
+
+function atomicSessionDir(
+  options: CreateAgentSessionOptions,
+  source: StageOptions,
+): string | undefined {
+  if (source.sessionDir !== undefined) return source.sessionDir;
+  const cwd = options.cwd ?? source.cwd ?? process.cwd();
+  const agentDir = options.agentDir ?? source.agentDir;
+  return agentDir !== undefined ? getDefaultSessionDir(cwd, agentDir) : undefined;
+}
+
+function withAtomicWorkflowSessionManager(
+  options: CreateAgentSessionOptions,
+  meta: StageExecutionMeta | undefined,
+): CreateAgentSessionOptions {
+  const source = meta?.stageOptions;
+  if (source === undefined || options.sessionManager !== undefined) return options;
+
+  const metadata = workflowSessionMetadata(source);
+  const cwd = options.cwd ?? source.cwd ?? process.cwd();
+  const sessionDir = atomicSessionDir(options, source);
+
+  if (source.context === "fork" && source.forkFromSessionFile !== undefined) {
+    return {
+      ...options,
+      sessionManager: SessionManager.forkFrom(source.forkFromSessionFile, cwd, sessionDir, {
+        ...metadata,
+        forkedFromSession: source.forkFromSessionFile,
+      }),
+    };
+  }
+
+  if (source.sessionDir !== undefined || hasWorkflowSessionMetadata(metadata)) {
+    return {
+      ...options,
+      sessionManager: SessionManager.create(cwd, sessionDir, metadata),
+    };
+  }
+
+  return options;
 }
 
 function makeWorkflowStageOrchestrationContext(meta: StageExecutionMeta): NonNullable<CreateAgentSessionOptions["orchestrationContext"]> {
@@ -372,10 +451,9 @@ export function buildRuntimeAdapters(
         // extensions, tools, prompts, and skills as the parent chat. Callers
         // can still opt into a custom resource set by passing `resourceLoader`
         // through `stage(name, options)`.
-        const sessionOptions = withWorkflowStageSessionOptions(
-          stripWorkflowOnlyOptions(stageOptions) ?? {},
-          meta,
-        );
+        const agentOptions = stripWorkflowOnlyOptions(stageOptions) ?? {};
+        const stageSessionOptions = withWorkflowStageSessionOptions(agentOptions, meta);
+        const sessionOptions = withAtomicWorkflowSessionManager(stageSessionOptions, meta);
         const result = await createSession(sessionOptions);
         const bindable = result.session as BindableStageSession;
         if (shouldBindStageUiContext(pi, meta) && typeof bindable.bindExtensions === "function") {

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -178,6 +178,8 @@ export interface RunOpts extends Omit<AuthoringContract.RunOpts, "adapters" | "s
    * the runId before starting the background promise.
    */
   runId?: string;
+  /** Internal: originating chat session file stamped onto workflow stage sessions. */
+  workflowOriginSessionFile?: string;
   /** Replay completed stages from a failed source run, then resume at this stage. */
   continuation?: RunContinuationOpts;
   /** Internal parent linkage for nested ctx.workflow(...) runs. */
@@ -944,6 +946,26 @@ function stageOptionsWithGitWorktree<T extends StageOptions>(options: T | undefi
   return { ...options, gitWorktreeDir: undefined, baseBranch: undefined, cwd: explicitCwd ?? setup.cwd };
 }
 
+function stageOptionsWithWorkflowMetadata(
+  options: StageOptions | undefined,
+  metadata: {
+    readonly originSessionFile?: string;
+    readonly runId: string;
+    readonly workflowName: string;
+    readonly stageId: string;
+    readonly stageName: string;
+  },
+): StageOptions {
+  return {
+    ...(options ?? {}),
+    ...(metadata.originSessionFile !== undefined ? { workflowOriginSessionFile: metadata.originSessionFile } : {}),
+    workflowRunId: metadata.runId,
+    workflowName: metadata.workflowName,
+    workflowStageId: metadata.stageId,
+    workflowStageName: metadata.stageName,
+  };
+}
+
 function workflowCwdWithInputWorktree(inputDefaults: Partial<StageOptions>, workflowInvocationCwd: string): string {
   if (typeof inputDefaults.gitWorktreeDir !== "string" || inputDefaults.gitWorktreeDir.trim().length === 0) {
     return workflowInvocationCwd;
@@ -1040,6 +1062,7 @@ function isRunOpts(value: WorkflowDirectOptions | RunOpts | undefined): value is
     "depth" in value ||
     "stageControlRegistry" in value ||
     "runId" in value ||
+    "workflowOriginSessionFile" in value ||
     "onRunStart" in value ||
     "onStageStart" in value ||
     "onStageEnd" in value ||
@@ -2462,9 +2485,16 @@ export async function run<TInputs extends WorkflowInputValues>(
     ui: opts.usePromptNodesForUi === true ? buildPromptNodeUiAdapter() : opts.ui ?? makeUnavailableUIContext(),
 
     stage(name: string, options?: StageOptions, stageFailFastScope?: ParallelFailFastScope) {
-      options = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(options, inputRuntimeDefaults), workflowInvocationCwd);
+      const baseStageOptions = stageOptionsWithGitWorktree(stageOptionsWithInputDefaults(options, inputRuntimeDefaults), workflowInvocationCwd);
       // a. Generate stageId
       const stageId = crypto.randomUUID();
+      options = stageOptionsWithWorkflowMetadata(baseStageOptions, {
+        originSessionFile: opts.workflowOriginSessionFile,
+        runId,
+        workflowName: def.name,
+        stageId,
+        stageName: name,
+      });
 
       // b. tracker.onSpawn → provisional parentIds
       const provisionalParentIds = tracker.onSpawn(stageId, name);

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -11,7 +11,6 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, resolve } from "node:path";
 import {
   shouldApplyCodexFastModeForScope,
-  SessionManager,
   type AgentSession,
   type CreateAgentSessionOptions,
   type PromptOptions,
@@ -170,21 +169,18 @@ function stripWorkflowOnlyOptions(options: StageOptions | undefined): CreateAgen
     mcp: _mcp,
     fallbackModels: _fallbackModels,
     fallbackThinkingLevels: _fallbackThinkingLevels,
-    context,
-    forkFromSessionFile,
-    sessionDir,
+    context: _context,
+    forkFromSessionFile: _forkFromSessionFile,
+    sessionDir: _sessionDir,
     gitWorktreeDir: _gitWorktreeDir,
     baseBranch: _baseBranch,
+    workflowOriginSessionFile: _workflowOriginSessionFile,
+    workflowRunId: _workflowRunId,
+    workflowName: _workflowName,
+    workflowStageId: _workflowStageId,
+    workflowStageName: _workflowStageName,
     ...sessionOptions
   } = options;
-  if (sessionOptions.sessionManager === undefined) {
-    const cwd = sessionOptions.cwd ?? process.cwd();
-    if (context === "fork" && forkFromSessionFile !== undefined) {
-      sessionOptions.sessionManager = SessionManager.forkFrom(forkFromSessionFile, cwd, sessionDir);
-    } else if (sessionDir !== undefined) {
-      sessionOptions.sessionManager = SessionManager.create(cwd, sessionDir);
-    }
-  }
   return sessionOptions as CreateAgentSessionOptions;
 }
 

--- a/packages/workflows/src/shared/types.ts
+++ b/packages/workflows/src/shared/types.ts
@@ -157,6 +157,14 @@ export interface StageOptions
   scopedModels?: CreateAgentSessionOptions["scopedModels"];
   sessionManager?: SessionManager;
   settingsManager?: SettingsManager;
+  /** Internal: originating chat session for workflow provenance. */
+  workflowOriginSessionFile?: string;
+  /** Internal: workflow run identity stamped onto child session headers. */
+  workflowRunId?: string;
+  workflowName?: string;
+  /** Internal: workflow stage identity stamped onto child session headers. */
+  workflowStageId?: string;
+  workflowStageName?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -16,7 +16,7 @@ import { WORKFLOW_AUTH_FAILURE_MESSAGE } from "../../packages/workflows/src/shar
 import { defineWorkflow } from "../../packages/workflows/src/workflows/define-workflow.js";
 import { createRegistry } from "../../packages/workflows/src/workflows/registry.js";
 import type { AgentSession, CreateAgentSessionOptions } from "@bastani/atomic";
-import type { WorkflowDefinition } from "../../packages/workflows/src/shared/types.js";
+import type { StageExecutionMeta, WorkflowDefinition } from "../../packages/workflows/src/shared/types.js";
 import type { StageSnapshot } from "../../packages/workflows/src/shared/store-types.js";
 
 async function waitForExecutorStagePendingPrompt(
@@ -4276,8 +4276,9 @@ describe("direct SDK helpers", () => {
         assert.throws(() => readFileSync(output, "utf8"));
     });
 
-    test("runTask direct options expose context and sessionDir", async () => {
+    test("runTask direct options expose context and sessionDir through stage metadata", async () => {
         const calls: CreateAgentSessionOptions[] = [];
+        const metas: StageExecutionMeta[] = [];
         const sessionDir = mkdtempSync(
             join(tmpdir(), "atomic-workflow-session-dir-"),
         );
@@ -4287,8 +4288,9 @@ describe("direct SDK helpers", () => {
             {
                 adapters: {
                     agentSession: {
-                        async create(options) {
+                        async create(options, meta) {
                             calls.push(options);
+                            metas.push(meta!);
                             return mockSession();
                         },
                     },
@@ -4298,7 +4300,10 @@ describe("direct SDK helpers", () => {
         );
 
         assert.equal(details.context, "fork");
-        assert.notEqual(calls[0]?.sessionManager, undefined);
+        assert.equal(calls[0]?.sessionManager, undefined);
+        assert.equal(Object.prototype.hasOwnProperty.call(calls[0], "sessionDir"), false);
+        assert.equal(metas[0]?.stageOptions?.context, "fork");
+        assert.equal(metas[0]?.stageOptions?.sessionDir, sessionDir);
     });
 
     test("runTask writes output artifacts and records them in WorkflowDetails", async () => {

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -15,8 +15,12 @@
 
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { dispatch } from "../../packages/workflows/src/extension/dispatcher.js";
 import { createExtensionRuntime } from "../../packages/workflows/src/extension/runtime.js";
+import { buildRuntimeAdapters } from "../../packages/workflows/src/extension/wiring.js";
 import { createRegistry } from "../../packages/workflows/src/workflows/registry.js";
 import { defineWorkflow } from "../../packages/workflows/src/workflows/define-workflow.js";
 import { Type } from "typebox";
@@ -383,33 +387,66 @@ describe("runtime.runDirect — workflow intercom", () => {
     });
 
     test("foreground direct single forwards top-level createAgentSession options", async () => {
-        const calls: CreateAgentSessionOptions[] = [];
-        const runtime = createExtensionRuntime({
-            adapters: {
-                agentSession: {
-                    async create(options) {
-                        calls.push(options);
-                        return fakeStageSession();
+        const agentDir = await mkdtemp(join(tmpdir(), "atomic-workflow-agent-"));
+        try {
+            const calls: CreateAgentSessionOptions[] = [];
+            const runtime = createExtensionRuntime({
+                adapters: {
+                    agentSession: {
+                        async create(options) {
+                            calls.push(options);
+                            return fakeStageSession();
+                        },
                     },
                 },
-            },
+            });
+
+            const result = await runtime.runDirect({
+                task: { name: "solo", task: "inspect solo" },
+                cwd: "/repo",
+                agentDir,
+                tools: ["read", "todo"],
+                noTools: "builtin",
+                thinkingLevel: "high",
+            });
+
+            assert.equal(result.status, "completed");
+            assert.equal(calls[0]?.cwd, "/repo");
+            assert.equal(calls[0]?.agentDir, agentDir);
+            assert.deepEqual(calls[0]?.tools, ["read", "todo"]);
+            assert.equal(calls[0]?.noTools, "builtin");
+            assert.equal(calls[0]?.thinkingLevel, "high");
+        } finally {
+            await rm(agentDir, { recursive: true, force: true });
+        }
+    });
+
+    test("foreground direct single stamps workflow provenance through the default Atomic adapter", async () => {
+        const calls: CreateAgentSessionOptions[] = [];
+        const runtime = createExtensionRuntime({
+            adapters: buildRuntimeAdapters(
+                {},
+                {
+                    createAgentSession: async (options) => {
+                        if (options !== undefined) calls.push(options);
+                        return { session: fakeStageSession() };
+                    },
+                },
+            ),
         });
 
-        const result = await runtime.runDirect({
-            task: { name: "solo", task: "inspect solo" },
-            cwd: "/repo",
-            agentDir: "/agent",
-            tools: ["read", "todo"],
-            noTools: "builtin",
-            thinkingLevel: "high",
-        });
+        const result = await runtime.runDirect(
+            { task: { name: "solo", task: "inspect solo" } },
+            { workflowOriginSessionFile: "/tmp/chat.jsonl" },
+        );
 
         assert.equal(result.status, "completed");
-        assert.equal(calls[0]?.cwd, "/repo");
-        assert.equal(calls[0]?.agentDir, "/agent");
-        assert.deepEqual(calls[0]?.tools, ["read", "todo"]);
-        assert.equal(calls[0]?.noTools, "builtin");
-        assert.equal(calls[0]?.thinkingLevel, "high");
+        const header = calls[0]?.sessionManager?.getHeader();
+        assert.equal(header?.originSession, "/tmp/chat.jsonl");
+        assert.equal(header?.workflowRunId, result.runId);
+        assert.equal(header?.workflowName, "direct-task");
+        assert.equal(header?.workflowStageId, calls[0]?.orchestrationContext?.workflowStageId);
+        assert.equal(header?.workflowStageName, "solo");
     });
 
     test("foreground direct single runs keep intercom off unless requested", async () => {
@@ -510,6 +547,41 @@ describe("dispatch — run", () => {
         assert.ok(
             typeof greeting === "string" && greeting.includes("Hello Alice"),
         );
+    });
+
+    test("named dispatch propagates workflow origin through the default Atomic adapter", async () => {
+        const registry = createRegistry([helloWorkflow]);
+        const activeStore = createStore();
+        const calls: CreateAgentSessionOptions[] = [];
+        const result = await dispatch(
+            {
+                workflow: "hello-world",
+                inputs: { name: "Alice" },
+                action: "run",
+            },
+            {
+                registry,
+                store: activeStore,
+                policy: NON_INTERACTIVE_WORKFLOW_POLICY,
+                workflowOriginSessionFile: "/tmp/chat.jsonl",
+                adapters: buildRuntimeAdapters(
+                    {},
+                    {
+                        createAgentSession: async (options) => {
+                            if (options !== undefined) calls.push(options);
+                            return { session: fakeStageSession() };
+                        },
+                    },
+                ),
+            },
+        );
+        const completed = asRun(result);
+        assert.equal(completed.status, "completed");
+        const header = calls[0]?.sessionManager?.getHeader();
+        assert.equal(header?.originSession, "/tmp/chat.jsonl");
+        assert.equal(header?.workflowRunId, completed.runId);
+        assert.equal(header?.workflowName, "hello-world");
+        assert.equal(header?.workflowStageName, "greet");
     });
 
     test("background run lands as `failed` when the workflow body throws", async () => {

--- a/test/unit/slash-dispatch.test.ts
+++ b/test/unit/slash-dispatch.test.ts
@@ -1540,6 +1540,55 @@ describe("tool run-control actions", () => {
         }
     });
 
+    test("makeExecuteWorkflowTool forwards current session file as workflow origin for direct and named runs", async () => {
+        const origins: string[] = [];
+        const runtime = {
+            async runDirect(_args: WorkflowToolArgs, options?: Parameters<ExtensionRuntime["runDirect"]>[1]) {
+                origins.push(`direct:${options?.workflowOriginSessionFile ?? ""}`);
+                return {
+                    mode: "single",
+                    runId: "direct-run",
+                    status: "completed",
+                    progress: { completed: 1, total: 1 },
+                };
+            },
+            async dispatch(_args: WorkflowToolArgs, options?: Parameters<ExtensionRuntime["dispatch"]>[1]) {
+                origins.push(`named:${options?.workflowOriginSessionFile ?? ""}`);
+                return {
+                    action: "run",
+                    name: "named",
+                    runId: "named-run",
+                    status: "running",
+                    stages: [],
+                };
+            },
+        } as unknown as ExtensionRuntime;
+        const handler = makeExecuteWorkflowTool(
+            runtime,
+            () => undefined,
+            () => undefined,
+        );
+        const ctx = {
+            sessionManager: {
+                getSessionFile: () => "/tmp/chat.jsonl",
+            },
+        } as never;
+
+        await handler(
+            { task: { name: "solo", task: "inspect" } },
+            ctx,
+        );
+        await handler(
+            { workflow: "named", inputs: {}, action: "run" },
+            ctx,
+        );
+
+        assert.deepEqual(origins, [
+            "direct:/tmp/chat.jsonl",
+            "named:/tmp/chat.jsonl",
+        ]);
+    });
+
     test("registered workflow tool suppresses lifecycle notices while awaiting a headless run", async () => {
         const resource = await makeRegisteredWorkflowToolWithResource(
             "tool-headless-lifecycle.ts",

--- a/test/unit/stage-runner.test.ts
+++ b/test/unit/stage-runner.test.ts
@@ -295,6 +295,122 @@ describe("createStageContext — prompt metadata propagation", () => {
             await rm(dir, { recursive: true, force: true });
         }
     });
+
+    test("custom adapters receive sanitized options and full workflow metadata without Atomic session materialization", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "pi-workflows-stage-metadata-"));
+        try {
+            const agentDir = join(dir, "agent");
+            const received: CreateAgentSessionOptions[] = [];
+            const metas: StageExecutionMeta[] = [];
+            const { session } = makeMockSession({
+                async prompt() {},
+                getLastAssistantText() {
+                    return "ok";
+                },
+            });
+            const agentSession: AgentSessionAdapter = {
+                async create(options, meta) {
+                    received.push(options);
+                    metas.push(meta!);
+                    return session;
+                },
+            };
+            const ctx = createStageContext(
+                makeOpts({
+                    adapters: { agentSession },
+                    stageOptions: {
+                        cwd: dir,
+                        agentDir,
+                        sessionDir: dir,
+                        workflowOriginSessionFile: "/tmp/chat.jsonl",
+                        workflowRunId: "run-1",
+                        workflowName: "workflow-name",
+                        workflowStageId: "stage-1",
+                        workflowStageName: "analyze",
+                    },
+                }),
+            ) as InternalStageContext;
+
+            await ctx.prompt("go");
+
+            const options = received[0]!;
+            assert.equal(options.cwd, dir);
+            assert.equal(options.agentDir, agentDir);
+            assert.equal(options.sessionManager, undefined);
+            for (const key of [
+                "sessionDir",
+                "workflowOriginSessionFile",
+                "workflowRunId",
+                "workflowName",
+                "workflowStageId",
+                "workflowStageName",
+            ]) {
+                assert.equal(Object.prototype.hasOwnProperty.call(options, key), false, key);
+            }
+            const source = metas[0]?.stageOptions;
+            assert.equal(source?.sessionDir, dir);
+            assert.equal(source?.workflowOriginSessionFile, "/tmp/chat.jsonl");
+            assert.equal(source?.workflowRunId, "run-1");
+            assert.equal(source?.workflowName, "workflow-name");
+            assert.equal(source?.workflowStageId, "stage-1");
+            assert.equal(source?.workflowStageName, "analyze");
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("forked custom-adapter stages keep fork provenance in meta only", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "pi-workflows-stage-fork-"));
+        try {
+            const source = join(dir, "source.jsonl");
+            const received: CreateAgentSessionOptions[] = [];
+            const metas: StageExecutionMeta[] = [];
+            const { session } = makeMockSession({
+                async prompt() {},
+                getLastAssistantText() {
+                    return "ok";
+                },
+            });
+            const agentSession: AgentSessionAdapter = {
+                async create(options, meta) {
+                    received.push(options);
+                    metas.push(meta!);
+                    return session;
+                },
+            };
+            const ctx = createStageContext(
+                makeOpts({
+                    adapters: { agentSession },
+                    stageOptions: {
+                        cwd: dir,
+                        sessionDir: dir,
+                        context: "fork",
+                        forkFromSessionFile: source,
+                        workflowOriginSessionFile: "/tmp/chat.jsonl",
+                        workflowRunId: "run-2",
+                        workflowName: "workflow-name",
+                        workflowStageId: "stage-2",
+                        workflowStageName: "plan",
+                    },
+                }),
+            ) as InternalStageContext;
+
+            await ctx.prompt("go");
+
+            const options = received[0]!;
+            assert.equal(options.sessionManager, undefined);
+            assert.equal(Object.prototype.hasOwnProperty.call(options, "forkFromSessionFile"), false);
+            assert.equal(Object.prototype.hasOwnProperty.call(options, "workflowStageName"), false);
+            const sourceOptions = metas[0]?.stageOptions;
+            assert.equal(sourceOptions?.context, "fork");
+            assert.equal(sourceOptions?.forkFromSessionFile, source);
+            assert.equal(sourceOptions?.workflowOriginSessionFile, "/tmp/chat.jsonl");
+            assert.equal(sourceOptions?.workflowRunId, "run-2");
+            assert.equal(sourceOptions?.workflowStageName, "plan");
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -480,7 +596,7 @@ import type {
     AgentSessionAdapter,
     StageSessionRuntime,
 } from "../../packages/workflows/src/runs/foreground/stage-runner.js";
-import type { AgentSession } from "@bastani/atomic";
+import { type AgentSession, type CreateAgentSessionOptions } from "@bastani/atomic";
 
 function makeMockSession(overrides: Partial<StageSessionRuntime> = {}): {
     session: StageSessionRuntime;

--- a/test/unit/wiring-adapters.test.ts
+++ b/test/unit/wiring-adapters.test.ts
@@ -8,6 +8,8 @@
 
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
     buildRuntimeAdapters,
@@ -15,14 +17,29 @@ import {
 } from "../../packages/workflows/src/extension/wiring.js";
 import { StageUiBroker } from "../../packages/workflows/src/shared/stage-ui-broker.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
-import type { CreateAgentSessionOptions } from "@bastani/atomic";
+import { SessionManager, type CreateAgentSessionOptions, type SessionHeader } from "@bastani/atomic";
 import type {
     PiCodingAgentSdk,
     PiSdkResourceLoader,
     PiSdkSettingsManager,
 } from "../../packages/workflows/src/extension/wiring.js";
-import type { StageSessionRuntime } from "../../packages/workflows/src/runs/foreground/stage-runner.js";
-import type { StageExecutionMeta } from "../../packages/workflows/src/shared/types.js";
+import type { StageSessionCreateOptions, StageSessionRuntime } from "../../packages/workflows/src/runs/foreground/stage-runner.js";
+import type { StageExecutionMeta, StageOptions } from "../../packages/workflows/src/shared/types.js";
+
+async function writeSessionHeader(path: string, cwd: string): Promise<void> {
+    const timestamp = new Date().toISOString();
+    await writeFile(
+        path,
+        `${JSON.stringify({
+            type: "session",
+            version: 3,
+            id: "source-session",
+            timestamp,
+            cwd,
+        })}\n`,
+        "utf8",
+    );
+}
 
 function fakeSession(): StageSessionRuntime {
     let last = "";
@@ -458,6 +475,181 @@ describe("buildRuntimeAdapters — SDK AgentSession adapter", () => {
             false,
         );
         assert.equal(calls[0]?.cwd, "/tmp/project");
+    });
+
+    test("strips workflow provenance internals before calling createAgentSession", async () => {
+        const calls: Array<CreateAgentSessionOptions | undefined> = [];
+        const adapters = buildRuntimeAdapters(
+            {},
+            {
+                createAgentSession: async (options) => {
+                    calls.push(options);
+                    return { session: fakeSession() };
+                },
+            },
+        );
+        const stageOptions: StageOptions = {
+            cwd: "/tmp/project",
+            context: "fork",
+            forkFromSessionFile: "/tmp/source.jsonl",
+            sessionDir: "/tmp/sessions",
+            gitWorktreeDir: "/tmp/worktree",
+            baseBranch: "main",
+            fallbackThinkingLevels: ["low"],
+            workflowOriginSessionFile: "/tmp/chat.jsonl",
+            workflowRunId: "run-1",
+            workflowName: "workflow",
+            workflowStageId: "stage-1",
+            workflowStageName: "plan",
+        };
+        await adapters.agentSession!.create(stageOptions as StageSessionCreateOptions);
+        const forwarded = calls[0]!;
+        for (const key of [
+            "context",
+            "forkFromSessionFile",
+            "sessionDir",
+            "gitWorktreeDir",
+            "baseBranch",
+            "fallbackThinkingLevels",
+            "workflowOriginSessionFile",
+            "workflowRunId",
+            "workflowName",
+            "workflowStageId",
+            "workflowStageName",
+        ]) {
+            assert.equal(Object.prototype.hasOwnProperty.call(forwarded, key), false, key);
+        }
+        assert.equal(forwarded.cwd, "/tmp/project");
+    });
+
+    test("default adapter creates Atomic session manager with workflow metadata from meta.stageOptions", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "pi-workflows-wiring-metadata-"));
+        try {
+            const calls: Array<CreateAgentSessionOptions | undefined> = [];
+            const adapters = buildRuntimeAdapters(
+                {},
+                {
+                    createAgentSession: async (options) => {
+                        calls.push(options);
+                        return { session: fakeSession() };
+                    },
+                },
+            );
+            const meta: StageExecutionMeta = {
+                runId: "run-1",
+                stageId: "stage-1",
+                stageName: "analyze",
+                stageOptions: {
+                    cwd: dir,
+                    sessionDir: dir,
+                    workflowOriginSessionFile: "/tmp/chat.jsonl",
+                    workflowRunId: "run-1",
+                    workflowName: "workflow-name",
+                    workflowStageId: "stage-1",
+                    workflowStageName: "analyze",
+                },
+            };
+
+            await adapters.agentSession!.create({ cwd: dir }, meta);
+
+            const forwarded = calls[0]!;
+            const header = forwarded.sessionManager?.getHeader() as SessionHeader | undefined;
+            assert.equal(header?.cwd, dir);
+            assert.equal(header?.originSession, "/tmp/chat.jsonl");
+            assert.equal(header?.workflowRunId, "run-1");
+            assert.equal(header?.workflowName, "workflow-name");
+            assert.equal(header?.workflowStageId, "stage-1");
+            assert.equal(header?.workflowStageName, "analyze");
+            assert.equal(Object.prototype.hasOwnProperty.call(forwarded, "workflowRunId"), false);
+            assert.equal(Object.prototype.hasOwnProperty.call(forwarded, "sessionDir"), false);
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("default adapter preserves explicit session managers instead of replacing them", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "pi-workflows-wiring-explicit-"));
+        try {
+            const explicitSessionManager = SessionManager.create(dir, dir);
+            const calls: Array<CreateAgentSessionOptions | undefined> = [];
+            const adapters = buildRuntimeAdapters(
+                {},
+                {
+                    createAgentSession: async (options) => {
+                        calls.push(options);
+                        return { session: fakeSession() };
+                    },
+                },
+            );
+            const meta: StageExecutionMeta = {
+                runId: "run-1",
+                stageId: "stage-1",
+                stageName: "analyze",
+                stageOptions: {
+                    cwd: dir,
+                    sessionDir: join(dir, "ignored-sessions"),
+                    workflowRunId: "run-1",
+                    workflowStageId: "stage-1",
+                    workflowStageName: "analyze",
+                },
+            };
+
+            await adapters.agentSession!.create(
+                { cwd: dir, sessionManager: explicitSessionManager },
+                meta,
+            );
+
+            assert.equal(calls[0]?.sessionManager, explicitSessionManager);
+            const header = explicitSessionManager.getHeader() as SessionHeader;
+            assert.equal(header.workflowRunId, undefined);
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("default adapter forks Atomic session manager and writes fork provenance from meta.stageOptions", async () => {
+        const dir = await mkdtemp(join(tmpdir(), "pi-workflows-wiring-fork-"));
+        try {
+            const source = join(dir, "source.jsonl");
+            await writeSessionHeader(source, dir);
+            const calls: Array<CreateAgentSessionOptions | undefined> = [];
+            const adapters = buildRuntimeAdapters(
+                {},
+                {
+                    createAgentSession: async (options) => {
+                        calls.push(options);
+                        return { session: fakeSession() };
+                    },
+                },
+            );
+            const meta: StageExecutionMeta = {
+                runId: "run-2",
+                stageId: "stage-2",
+                stageName: "plan",
+                stageOptions: {
+                    cwd: dir,
+                    sessionDir: dir,
+                    context: "fork",
+                    forkFromSessionFile: source,
+                    workflowOriginSessionFile: "/tmp/chat.jsonl",
+                    workflowRunId: "run-2",
+                    workflowName: "workflow-name",
+                    workflowStageId: "stage-2",
+                    workflowStageName: "plan",
+                },
+            };
+
+            await adapters.agentSession!.create({ cwd: dir }, meta);
+
+            const header = calls[0]?.sessionManager?.getHeader() as SessionHeader | undefined;
+            assert.equal(header?.parentSession, source);
+            assert.equal(header?.forkedFromSession, source);
+            assert.equal(header?.originSession, "/tmp/chat.jsonl");
+            assert.equal(header?.workflowRunId, "run-2");
+            assert.equal(header?.workflowStageName, "plan");
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
     });
 
     test("binds a broker-backed UI context even when the parent pi surface has no ui", async () => {

--- a/test/unit/workflow-package-boundary.test.ts
+++ b/test/unit/workflow-package-boundary.test.ts
@@ -1,0 +1,78 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
+import * as ts from "typescript";
+
+interface BoundaryViolation {
+  readonly file: string;
+  readonly specifier: string;
+}
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const workflowsSourceRoot = resolve(repoRoot, "packages/workflows/src");
+const codingAgentSourceImportPatterns: readonly RegExp[] = [
+  /(?:^|\/)packages\/coding-agent\/src(?:\/|$)/,
+  /(?:^|\/)(?:\.\.\/)+coding-agent\/src(?:\/|$)/,
+];
+
+async function collectTypeScriptFiles(directory: string): Promise<readonly string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of [...entries].sort((left, right) => left.name.localeCompare(right.name))) {
+    const entryPath = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectTypeScriptFiles(entryPath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function getStaticImportSpecifiers(filePath: string, sourceText: string): readonly string[] {
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const specifiers: string[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isImportDeclaration(statement) && ts.isStringLiteral(statement.moduleSpecifier)) {
+      specifiers.push(statement.moduleSpecifier.text);
+    }
+  }
+
+  return specifiers;
+}
+
+function isCodingAgentSourceImport(specifier: string): boolean {
+  const normalizedSpecifier = specifier.replace(/\\/g, "/");
+  return codingAgentSourceImportPatterns.some((pattern) => pattern.test(normalizedSpecifier));
+}
+
+function repoRelativePath(filePath: string): string {
+  return relative(repoRoot, filePath).split(sep).join("/");
+}
+
+describe("workflow package boundary", () => {
+  test("workflows source imports coding-agent APIs only through package public surfaces", async () => {
+    const violations: BoundaryViolation[] = [];
+
+    for (const filePath of await collectTypeScriptFiles(workflowsSourceRoot)) {
+      const sourceText = await readFile(filePath, "utf8");
+      for (const specifier of getStaticImportSpecifiers(filePath, sourceText)) {
+        if (isCodingAgentSourceImport(specifier)) {
+          violations.push({ file: repoRelativePath(filePath), specifier });
+        }
+      }
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      "packages/workflows/src must not import packages/coding-agent/src internals",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements the workflow-spawned \`/resume\` provenance tree requested in #1241. Workflow stage sessions are now grouped under virtual workflow-run rows in the threaded resume view, fork lineage is preserved as \`⑂ from <source>\` annotations, and workflow metadata is stamped onto session headers end-to-end through the Atomic session adapter.

## Changes

### \`packages/coding-agent\` — session model & UI
- Extend \`SessionHeader\` and \`NewSessionOptions\` with provenance fields: \`originSession\`, \`forkedFromSession\`, \`workflowRunId\`, \`workflowName\`, \`workflowStageId\`, \`workflowStageName\`.
- Surface the new fields on \`SessionInfo\` so the session selector can query them.
- Threaded \`/resume\` view renders a three-level tree: origin chat session → virtual workflow-run row → real stage sessions; search and recent modes stay flat.
- \`SessionManager.forkFrom\` and \`SessionManager.create\` accept an optional \`NewSessionOptions\` to stamp metadata onto new session headers.
- Clear inherited copied session names on workflow-stage forks so stage labels fall back to the workflow stage name unless explicitly renamed by the user.
- Export \`getDefaultSessionDir\`, \`SessionManager\`, and \`NewSessionOptions\` from \`packages/coding-agent\` public index.

### \`packages/workflows\` — propagation & wiring
- Add \`workflowOriginSessionFile\`, \`workflowRunId\`, \`workflowName\`, \`workflowStageId\`, \`workflowStageName\` to \`StageOptions\`.
- Move session-manager construction out of \`stage-runner.ts\` into \`wiring.ts\` so provenance metadata can be stamped at session-creation time.
- Thread \`workflowOriginSessionFile\` through \`RuntimeDispatchOptions\`, \`runDirect\`, \`runDirectAsync\`, \`runDirectForeground\`, and \`resumeFailedRun\`.
- Capture current session file in all workflow dispatch paths (tool execute, \`/workflow\` command, and resume) and pass it as \`workflowOriginSessionFile\`.
- Add \`SessionFileProvider\` type; surface \`getSessionFile\` on \`ExtensionAPI.sessionManager\` and \`PiCommandContext.sessionManager\`.

### Tests
- New \`test/unit/workflow-package-boundary.test.ts\` — validates that provenance fields cross the \`coding-agent\`/\`workflows\` package boundary correctly.
- Expanded \`test/unit/wiring-adapters.test.ts\` — metadata propagation through \`createAtomicAgentSession\` for both fork and create paths.
- Expanded \`test/unit/stage-runner.test.ts\` — workflow stage session creation with metadata stamping.
- Expanded \`test/unit/runtime.test.ts\` and \`test/unit/slash-dispatch.test.ts\` — origin session file flow through dispatch and resume.
- Expanded \`packages/coding-agent/test/session-selector-*\` — workflow search fields, threaded rendering, and fork annotation display.
- Expanded \`packages/coding-agent/test/session-manager/custom-session-id.test.ts\` — inherited name clearing on stage forks.

## Validation

- \`bun test packages/coding-agent/test/session-manager/custom-session-id.test.ts packages/coding-agent/test/session-selector-path-delete.test.ts\` — PASS, 25 pass / 0 fail.
- \`bun test packages/coding-agent/test/session-selector-search.test.ts packages/coding-agent/test/session-selector-path-delete.test.ts packages/coding-agent/test/session-manager/custom-session-id.test.ts test/unit/wiring-adapters.test.ts test/unit/stage-runner.test.ts test/unit/workflow-package-boundary.test.ts\` — PASS, 104 pass / 0 fail.
- \`bun run typecheck\` — PASS.
- \`git diff --check origin/main\` — PASS.
- \`bunx prek run --all-files\` — PASS.
- Pre-push hooks (\`bun run lint\`, \`bun run test:unit\`) — PASS.

Closes #1241