### PR TITLE
fix(subagents,workflows): suppress model fallback warnings on successful retries

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the `no-staged-files` acceptance runtime check to ignore ambient Git repository environment variables, so subagents inspect the intended working tree instead of a parent hook or unrelated worktree.
+- Suppressed intermediate model fallback failure notes and live foreground failure updates from successful subagent runs while preserving final failures and raw per-attempt diagnostics ([#1226](https://github.com/bastani-inc/atomic/issues/1226)).
 
 ## [0.8.26-alpha.1] - 2026-06-05
 

--- a/packages/subagents/src/runs/background/subagent-runner.ts
+++ b/packages/subagents/src/runs/background/subagent-runner.ts
@@ -650,6 +650,7 @@ async function runSingleStep(
 	const attemptedModels: string[] = [];
 	const modelAttempts: ModelAttempt[] = [];
 	const attemptNotes: string[] = [];
+	const pendingAttemptNotes: string[] = [];
 	const eventsPath = path.join(path.dirname(ctx.outputFile), "events.jsonl");
 	let finalResult: RunPiStreamingResult | undefined;
 	let finalFastMode: boolean | undefined;
@@ -768,9 +769,13 @@ async function runSingleStep(
 		finalFastMode = attemptFastMode;
 		finalOutputSnapshot = outputSnapshot;
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput } as RunPiStreamingResult & { structuredOutput?: unknown };
-		if (attempt.success || completionGuardTriggered) break;
-		if (!isRetryableModelFailure(error) || index === candidates.length - 1) break;
-		attemptNotes.push(formatModelAttemptNote(attempt, candidates[index + 1]));
+		if (attempt.success) break;
+		if (!completionGuardTriggered && isRetryableModelFailure(error) && index < candidates.length - 1) {
+			pendingAttemptNotes.push(formatModelAttemptNote(attempt, candidates[index + 1]));
+			continue;
+		}
+		attemptNotes.push(...pendingAttemptNotes);
+		break;
 	}
 
 	const rawOutput = finalResult?.finalOutput ?? "";

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -17,6 +17,7 @@ import {
 	type AgentProgress,
 	type ArtifactPaths,
 	type ControlEvent,
+	type Details,
 	type ModelAttempt,
 	type RunSyncOptions,
 	type SingleResult,
@@ -137,6 +138,29 @@ function snapshotResult(result: SingleResult, progress: AgentProgress): SingleRe
 		truncation: result.truncation ? { ...result.truncation } : undefined,
 		outputReference: result.outputReference ? { ...result.outputReference } : undefined,
 	};
+}
+
+type RunSyncUpdate = import("@earendil-works/pi-agent-core").AgentToolResult<Details>;
+
+function extractUpdateText(update: RunSyncUpdate): string | undefined {
+	const text = update.content
+		.map((item) => item.type === "text" ? item.text : undefined)
+		.filter((item): item is string => Boolean(item?.trim()))
+		.join("\n");
+	return text || undefined;
+}
+
+export function shouldSuppressIntermediateRetryableFailureUpdate(update: RunSyncUpdate): boolean {
+	const result = update.details?.results?.[0];
+	if (!result) return false;
+	const progress = update.details?.progress?.[0];
+	const status = result.progress?.status ?? progress?.status;
+	if (status !== "failed") return false;
+	const failureText = result.error
+		?? result.progress?.error
+		?? progress?.error
+		?? extractUpdateText(update);
+	return isRetryableModelFailure(failureText);
 }
 
 async function runSingleAttempt(
@@ -875,6 +899,7 @@ export async function runSync(
 	const modelAttempts: ModelAttempt[] = [];
 	const aggregateUsage = emptyUsage();
 	const attemptNotes: string[] = [];
+	const pendingAttemptNotes: string[] = [];
 	let totalToolCount = 0;
 	let totalDurationMs = 0;
 
@@ -897,7 +922,18 @@ export async function runSync(
 		const candidate = modelsToTry[i];
 		if (candidate) attemptedModels.push(candidate);
 		const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-		const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, options, {
+		let attemptOptions = options;
+		if (i < modelsToTry.length - 1 && options.onUpdate) {
+			const forwardUpdate = options.onUpdate;
+			attemptOptions = {
+				...options,
+				onUpdate: (update) => {
+					if (shouldSuppressIntermediateRetryableFailureUpdate(update)) return;
+					forwardUpdate(update);
+				},
+			};
+		}
+		const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, attemptOptions, {
 			sessionEnabled,
 			systemPrompt,
 			resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
@@ -928,10 +964,12 @@ export async function runSync(
 		if (attemptSucceeded) {
 			break;
 		}
-		if (!isRetryableModelFailure(result.error) || i === modelsToTry.length - 1) {
-			break;
+		if (isRetryableModelFailure(result.error) && i < modelsToTry.length - 1) {
+			pendingAttemptNotes.push(formatModelAttemptNote(attempt, modelsToTry[i + 1]));
+			continue;
 		}
-		attemptNotes.push(formatModelAttemptNote(attempt, modelsToTry[i + 1]));
+		attemptNotes.push(...pendingAttemptNotes);
+		break;
 	}
 
 	const result = lastResult ?? {

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fixed stage-local workflow HIL `input` and `editor` prompts losing draft text across Ctrl+D detach/reattach; drafts are kept live-only in memory and cleared when the prompt or run/stage exits ([#1179](https://github.com/bastani-inc/atomic/issues/1179)).
+- Suppressed intermediate model fallback failure warnings from successful workflow stages while preserving final failures and raw per-attempt diagnostics ([#1226](https://github.com/bastani-inc/atomic/issues/1226)).
 
 ## [0.8.26-alpha.1] - 2026-06-05
 

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -586,6 +586,7 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
   let selectedModel: string | undefined;
   const modelAttempts: WorkflowModelAttempt[] = [];
   const modelWarnings: string[] = [];
+  const pendingFallbackWarnings: string[] = [];
   const modelCatalog = opts.models === undefined
     ? undefined
     : {
@@ -796,15 +797,19 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
       try {
         await promptWithPauseResume(activeSession, text, sdkOptions);
         modelAttempts.push({ model: candidate.id, success: true, ...modelAttemptReasoning(candidate) });
+        pendingFallbackWarnings.length = 0;
         return;
       } catch (err) {
         const message = errorMessage(err);
         modelAttempts.push({ model: candidate.id, success: false, ...modelAttemptReasoning(candidate), error: message });
         if (signal?.aborted || !isRetryableModelFailure(message) || index === candidates.length - 1) {
+          modelWarnings.push(...pendingFallbackWarnings);
+          pendingFallbackWarnings.length = 0;
+          notifyModelFallbackMetaChange();
           throw err;
         }
         const nextCandidate = candidates[index + 1]!;
-        modelWarnings.push(`[fallback] ${candidateLabel(candidate)} failed: ${message}. Retrying with ${candidateLabel(nextCandidate)}.`);
+        pendingFallbackWarnings.push(`[fallback] ${candidateLabel(candidate)} failed: ${message}. Retrying with ${candidateLabel(nextCandidate)}.`);
         await disposeCurrentSession();
         index += 1;
       }

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -4204,6 +4204,9 @@ describe("direct SDK helpers", () => {
             ),
             [false, true],
         );
+        assert.equal(details.results?.[0]?.modelAttempts?.[0]?.error, "rate limit exceeded");
+        assert.equal(details.results?.[0]?.warnings, undefined);
+        assert.equal(details.warnings, undefined);
     });
 
     test("runTask reports classified auth guidance for direct stage failures", async () => {

--- a/test/unit/stage-runner.test.ts
+++ b/test/unit/stage-runner.test.ts
@@ -597,16 +597,17 @@ describe("createStageContext — model fallback", () => {
         assert.equal(text, "fallback answer");
         assert.deepEqual(calls, ["anthropic/primary", "openai/fallback"]);
         assert.deepEqual(disposed, ["anthropic/primary"]);
-        assert.deepEqual(ctx.__modelFallbackMeta().attemptedModels, [
+        const meta = ctx.__modelFallbackMeta();
+        assert.deepEqual(meta.attemptedModels, [
             "anthropic/primary",
             "openai/fallback",
         ]);
         assert.deepEqual(
-            ctx
-                .__modelFallbackMeta()
-                .modelAttempts?.map((attempt) => attempt.success),
+            meta.modelAttempts?.map((attempt) => attempt.success),
             [false, true],
         );
+        assert.equal(meta.modelAttempts?.[0]?.error, "429 rate limit exceeded");
+        assert.equal(meta.warnings, undefined);
     });
 
     test("workflow fast mode keeps raw model metadata with a structured fast flag", async () => {
@@ -792,6 +793,60 @@ describe("createStageContext — model fallback", () => {
             "current/model",
         ]);
         assert.deepEqual(ctx.__modelFallbackMeta().attemptedModels, calls);
+    });
+
+    test("all-candidate failure keeps fallback warning metadata", async () => {
+        const calls: string[] = [];
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const model = typeof options.model === "string"
+                    ? options.model
+                    : "object-model";
+                calls.push(model);
+                const { session } = makeMockSession({
+                    async prompt() {
+                        throw new Error(`${model} No API key found`);
+                    },
+                });
+                return session;
+            },
+        };
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: {
+                    model: "anthropic/primary",
+                    fallbackModels: ["openai/fallback"],
+                },
+            }),
+        ) as InternalStageContext;
+
+        await assert.rejects(ctx.prompt("go"), /openai\/fallback No API key found/);
+
+        const meta = ctx.__modelFallbackMeta();
+        assert.deepEqual(calls, ["anthropic/primary", "openai/fallback"]);
+        assert.deepEqual(
+            meta.modelAttempts?.map((attempt) => ({
+                model: attempt.model,
+                success: attempt.success,
+                error: attempt.error,
+            })),
+            [
+                {
+                    model: "anthropic/primary",
+                    success: false,
+                    error: "anthropic/primary No API key found",
+                },
+                {
+                    model: "openai/fallback",
+                    success: false,
+                    error: "openai/fallback No API key found",
+                },
+            ],
+        );
+        assert.deepEqual(meta.warnings, [
+            "[fallback] anthropic/primary failed: anthropic/primary No API key found. Retrying with openai/fallback.",
+        ]);
     });
 
     test("non-retryable failure does not try fallback", async () => {

--- a/test/unit/subagents-foreground-fallback-updates.test.ts
+++ b/test/unit/subagents-foreground-fallback-updates.test.ts
@@ -1,0 +1,96 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { shouldSuppressIntermediateRetryableFailureUpdate } from "../../packages/subagents/src/runs/foreground/execution.js";
+import type { AgentProgress, Details, SingleResult, Usage } from "../../packages/subagents/src/shared/types.js";
+
+const usage: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  cost: 0,
+  turns: 0,
+};
+
+function progress(status: AgentProgress["status"], error?: string): AgentProgress {
+  return {
+    index: 0,
+    agent: "debugger",
+    status,
+    task: "inspect",
+    recentTools: [],
+    recentOutput: [],
+    toolCount: 0,
+    tokens: 0,
+    durationMs: 1,
+    error,
+  };
+}
+
+function result(status: AgentProgress["status"], error?: string): SingleResult {
+  const currentProgress = progress(status, error);
+  return {
+    agent: "debugger",
+    task: "inspect",
+    exitCode: status === "failed" ? 1 : 0,
+    messages: [],
+    usage,
+    error,
+    progress: currentProgress,
+    finalOutput: error ?? "ok",
+  };
+}
+
+function update(input: {
+  status: AgentProgress["status"];
+  error?: string;
+  contentText?: string;
+}): AgentToolResult<Details> {
+  return {
+    content: [{ type: "text", text: input.contentText ?? input.error ?? "ok" }],
+    details: {
+      mode: "single",
+      results: [result(input.status, input.error)],
+      progress: [progress(input.status, input.error)],
+    },
+  };
+}
+
+describe("foreground subagent model fallback update suppression", () => {
+  test("suppresses terminal retryable API-key failures from intermediate attempts", () => {
+    assert.equal(
+      shouldSuppressIntermediateRetryableFailureUpdate(
+        update({ status: "failed", error: "API key missing for openai/gpt-5" }),
+      ),
+      true,
+    );
+  });
+
+  test("does not suppress running retryable output before an attempt is terminal", () => {
+    assert.equal(
+      shouldSuppressIntermediateRetryableFailureUpdate(
+        update({ status: "running", error: "API key missing for openai/gpt-5" }),
+      ),
+      false,
+    );
+  });
+
+  test("does not suppress non-retryable terminal failures", () => {
+    assert.equal(
+      shouldSuppressIntermediateRetryableFailureUpdate(
+        update({ status: "failed", error: "command failed: bun test" }),
+      ),
+      false,
+    );
+  });
+
+  test("detects retryable failures from terminal update text when error is absent", () => {
+    assert.equal(
+      shouldSuppressIntermediateRetryableFailureUpdate(
+        update({ status: "failed", contentText: "No API key found" }),
+      ),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

When a subagent or workflow stage falls back to a secondary model and ultimately succeeds, intermediate retryable failure notes (rate limits, missing API keys, etc.) are no longer surfaced as warnings. Previously, successful runs still reported failure messages from earlier model attempts, causing confusing noise even though execution completed successfully.

## Key Changes

- **`packages/subagents/src/runs/background/subagent-runner.ts`** — Buffer intermediate fallback notes in `pendingAttemptNotes`; only flush to `attemptNotes` if all candidates fail.
- **`packages/subagents/src/runs/foreground/execution.ts`** — Add `shouldSuppressIntermediateRetryableFailureUpdate()` to filter live `onUpdate` callbacks during intermediate model attempts; apply the same pending-notes buffer pattern as the background runner.
- **`packages/workflows/src/runs/foreground/stage-runner.ts`** — Buffer `pendingFallbackWarnings`; clear on success, flush to `modelWarnings` only on final failure, and trigger `notifyModelFallbackMetaChange()` when flushing.

Raw `modelAttempts` per-attempt diagnostics are preserved in all paths for observability — only the user-facing warning strings are suppressed on success.

## Tests

- New unit test file `test/unit/subagents-foreground-fallback-updates.test.ts` covering the `shouldSuppressIntermediateRetryableFailureUpdate` helper across all signal paths.
- Extended `stage-runner.test.ts`: verifies no warnings on successful fallback and adds an all-candidates-fail case to confirm warnings are preserved when every attempt fails.
- Extended `executor.test.ts`: asserts no `warnings` on a run that succeeds after a rate-limit retry.

Fixes [#1226](https://github.com/bastani-inc/atomic/issues/1226).