### PR TITLE
fix(git): isolate repository env for Git subprocesses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed internal Git subprocesses to strip ambient repository-local Git environment variables before package-manager and footer branch lookups inspect a targeted working tree.
+
 ## [0.8.26-alpha.1] - 2026-06-05
 
 ### Fixed

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -2,6 +2,7 @@ import { type ExecFileException, execFile, spawnSync } from "child_process";
 import { existsSync, type FSWatcher, readFileSync, statSync, unwatchFile, watchFile } from "fs";
 import { dirname, join, resolve } from "path";
 import { closeWatcher, FS_WATCH_RETRY_DELAY_MS, watchWithErrorHandler } from "../utils/fs-watch.ts";
+import { createGitEnvironment } from "../utils/git-env.ts";
 
 type GitPaths = {
 	repoDir: string;
@@ -52,6 +53,7 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
 	const result = spawnSync("git", ["--no-optional-locks", "symbolic-ref", "--quiet", "--short", "HEAD"], {
 		cwd: repoDir,
 		encoding: "utf8",
+		env: createGitEnvironment(),
 		stdio: ["ignore", "pipe", "ignore"],
 	});
 	const branch = result.status === 0 ? result.stdout.trim() : "";
@@ -67,6 +69,7 @@ function resolveBranchWithGitAsync(repoDir: string): Promise<string | null> {
 			{
 				cwd: repoDir,
 				encoding: "utf8",
+				env: createGitEnvironment(),
 			},
 			(error: ExecFileException | null, stdout: string) => {
 				if (error) {

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -29,6 +29,7 @@ import ignore from "ignore";
 import { minimatch } from "minimatch";
 import { APP_NAME, CONFIG_DIR_NAME, ENV_OFFLINE, getAgentDir, getAgentDirs, getEnvValue, getProjectConfigDirs } from "../config.ts";
 import { spawnProcess, spawnProcessSync } from "../utils/child-process.ts";
+import { createGitEnvironment } from "../utils/git-env.ts";
 import { type GitSource, parseGitUrl } from "../utils/git.ts";
 import { canonicalizePath, isLocalPath, markPathIgnoredByCloudSync, resolvePath } from "../utils/paths.ts";
 import { isStdoutTakenOver } from "./output-guard.ts";
@@ -42,6 +43,17 @@ function isOfflineModeEnabled(): boolean {
 	const value = getEnvValue(ENV_OFFLINE);
 	if (!value) return false;
 	return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
+}
+
+function isGitCommand(command: string): boolean {
+	const commandName = basename(command).toLowerCase();
+	return commandName === "git" || commandName === "git.exe";
+}
+
+function getCommandEnv(command: string, overrides?: Record<string, string>): NodeJS.ProcessEnv {
+	const baseEnv = getEnv();
+	if (isGitCommand(command)) return createGitEnvironment(overrides, baseEnv);
+	return overrides ? { ...baseEnv, ...overrides } : baseEnv;
 }
 
 export interface PathMetadata {
@@ -2560,11 +2572,10 @@ export class DefaultPackageManager implements PackageManager {
 	}
 
 	private spawnCommand(command: string, args: string[], options?: { cwd?: string }): ChildProcess {
-		const env = getEnv();
 		return spawnProcess(command, args, {
 			cwd: options?.cwd,
 			stdio: isStdoutTakenOver() ? ["ignore", 2, 2] : "inherit",
-			env,
+			env: getCommandEnv(command),
 		});
 	}
 
@@ -2573,12 +2584,10 @@ export class DefaultPackageManager implements PackageManager {
 		args: string[],
 		options?: { cwd?: string; env?: Record<string, string> },
 	): ChildProcessByStdio<null, Readable, Readable> {
-		const baseEnv = getEnv();
-		const env = options?.env ? { ...baseEnv, ...options.env } : baseEnv;
 		return spawnProcess(command, args, {
 			cwd: options?.cwd,
 			stdio: ["ignore", "pipe", "pipe"],
-			env,
+			env: getCommandEnv(command, options?.env),
 		});
 	}
 
@@ -2641,11 +2650,10 @@ export class DefaultPackageManager implements PackageManager {
 	}
 
 	private runCommandSync(command: string, args: string[]): string {
-		const env = getEnv();
 		const result = spawnProcessSync(command, args, {
 			stdio: ["ignore", "pipe", "pipe"],
 			encoding: "utf-8",
-			env,
+			env: getCommandEnv(command),
 		});
 		if (result.error || result.status !== 0) {
 			throw new Error(

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -430,6 +430,7 @@ export {
 // Clipboard utilities
 export { copyToClipboard } from "./utils/clipboard.ts";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.ts";
+export { createGitEnvironment, GIT_LOCAL_ENV_VARS } from "./utils/git-env.ts";
 export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.ts";
 // Shell utilities
 export { getShellConfig } from "./utils/shell.ts";

--- a/packages/coding-agent/src/utils/git-env.ts
+++ b/packages/coding-agent/src/utils/git-env.ts
@@ -1,0 +1,34 @@
+export const GIT_LOCAL_ENV_VARS = [
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_CONFIG",
+	"GIT_CONFIG_PARAMETERS",
+	"GIT_CONFIG_COUNT",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_IMPLICIT_WORK_TREE",
+	"GIT_GRAFT_FILE",
+	"GIT_INDEX_FILE",
+	"GIT_NO_REPLACE_OBJECTS",
+	"GIT_REPLACE_REF_BASE",
+	"GIT_PREFIX",
+	"GIT_SHALLOW_FILE",
+	"GIT_COMMON_DIR",
+] as const;
+
+/**
+ * Create an environment for Git subprocesses that target an explicit cwd/path.
+ *
+ * Git honors repository-local environment variables over cwd and `git -C`, so
+ * inherited values from hooks or unrelated worktrees can make a subprocess
+ * inspect the wrong repository. This list mirrors `git rev-parse --local-env-vars`.
+ */
+export function createGitEnvironment(
+	overrides?: NodeJS.ProcessEnv,
+	baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...baseEnv };
+	if (overrides) Object.assign(env, overrides);
+	for (const key of GIT_LOCAL_ENV_VARS) delete env[key];
+	return env;
+}

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the `no-staged-files` acceptance runtime check to ignore ambient Git repository environment variables, so subagents inspect the intended working tree instead of a parent hook or unrelated worktree.
+- Fixed the `no-staged-files` acceptance runtime check and subagent worktree Git commands to ignore ambient Git repository environment variables, so subagents inspect the intended working tree instead of a parent hook or unrelated worktree.
 - Suppressed intermediate model fallback failure notes and live foreground failure updates from successful subagent runs while preserving final failures and raw per-attempt diagnostics ([#1226](https://github.com/bastani-inc/atomic/issues/1226)).
 
 ## [0.8.26-alpha.1] - 2026-06-05

--- a/packages/subagents/src/runs/shared/acceptance.ts
+++ b/packages/subagents/src/runs/shared/acceptance.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { spawnSync } from "node:child_process";
 import * as path from "node:path";
+import { createGitEnvironment } from "@bastani/atomic";
 import type {
 	AcceptanceConfig,
 	AcceptanceEvidenceKind,
@@ -398,32 +399,8 @@ function reportEvidencePresent(report: AcceptanceReport, kind: AcceptanceEvidenc
 	}
 }
 
-const GIT_LOCAL_ENV_VARS = [
-	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
-	"GIT_CONFIG",
-	"GIT_CONFIG_PARAMETERS",
-	"GIT_CONFIG_COUNT",
-	"GIT_OBJECT_DIRECTORY",
-	"GIT_DIR",
-	"GIT_WORK_TREE",
-	"GIT_IMPLICIT_WORK_TREE",
-	"GIT_GRAFT_FILE",
-	"GIT_INDEX_FILE",
-	"GIT_NO_REPLACE_OBJECTS",
-	"GIT_REPLACE_REF_BASE",
-	"GIT_PREFIX",
-	"GIT_SHALLOW_FILE",
-	"GIT_COMMON_DIR",
-] as const;
-
-function gitStatusEnv(): NodeJS.ProcessEnv {
-	const env = { ...process.env };
-	for (const key of GIT_LOCAL_ENV_VARS) delete env[key];
-	return env;
-}
-
 function checkNoStagedFiles(cwd: string): AcceptanceRuntimeCheck {
-	const result = spawnSync("git", ["status", "--short"], { cwd, env: gitStatusEnv(), encoding: "utf-8" });
+	const result = spawnSync("git", ["status", "--short"], { cwd, env: createGitEnvironment(), encoding: "utf-8" });
 	if (result.status !== 0) {
 		return { id: "no-staged-files", status: "not-applicable", message: "git status unavailable; no staged-files check skipped" };
 	}

--- a/packages/subagents/src/runs/shared/worktree.ts
+++ b/packages/subagents/src/runs/shared/worktree.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { APP_NAME } from "@bastani/atomic";
+import { APP_NAME, createGitEnvironment } from "@bastani/atomic";
 
 export interface WorktreeSetup {
 	cwd: string;
@@ -82,7 +82,7 @@ interface RepoState {
 const DEFAULT_WORKTREE_SETUP_HOOK_TIMEOUT_MS = 30000;
 
 function runGit(cwd: string, args: string[]): GitResult {
-	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
+	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", env: createGitEnvironment() });
 	return {
 		stdout: result.stdout ?? "",
 		stderr: result.stderr ?? "",

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fixed stage-local workflow HIL `input` and `editor` prompts losing draft text across Ctrl+D detach/reattach; drafts are kept live-only in memory and cleared when the prompt or run/stage exits ([#1179](https://github.com/bastani-inc/atomic/issues/1179)).
+- Fixed workflow worktree Git commands to strip ambient repository-local Git environment variables before inspecting or creating targeted worktrees.
 - Suppressed intermediate model fallback failure warnings from successful workflow stages while preserving final failures and raw per-attempt diagnostics ([#1226](https://github.com/bastani-inc/atomic/issues/1226)).
 
 ## [0.8.26-alpha.1] - 2026-06-05

--- a/packages/workflows/src/runs/shared/worktree.ts
+++ b/packages/workflows/src/runs/shared/worktree.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { APP_NAME } from "@bastani/atomic";
+import { APP_NAME, createGitEnvironment } from "@bastani/atomic";
 
 export interface WorktreeSetup {
 	cwd: string;
@@ -110,7 +110,7 @@ function runGit(cwd: string, args: string[]): GitResult {
 	], {
 		cwd,
 		encoding: "utf-8",
-		env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+		env: createGitEnvironment({ GIT_OPTIONAL_LOCKS: "0" }),
 		timeout: 5000,
 	});
 	return {

--- a/test/unit/git-env.test.ts
+++ b/test/unit/git-env.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { createGitEnvironment, GIT_LOCAL_ENV_VARS } from "../../packages/coding-agent/src/utils/git-env.js";
+
+test("createGitEnvironment removes Git-local env while preserving unrelated entries", () => {
+	const baseEnv: NodeJS.ProcessEnv = {
+		PATH: "/usr/bin",
+		GIT_DIR: "/tmp/wrong/.git",
+		GIT_WORK_TREE: "/tmp/wrong",
+		GIT_INDEX_FILE: "/tmp/wrong/.git/index",
+		GIT_OPTIONAL_LOCKS: "1",
+	};
+
+	const env = createGitEnvironment({ GIT_TERMINAL_PROMPT: "0" }, baseEnv);
+
+	for (const key of GIT_LOCAL_ENV_VARS) assert.equal(env[key], undefined, `${key} should be removed`);
+	assert.equal(env.PATH, "/usr/bin");
+	assert.equal(env.GIT_OPTIONAL_LOCKS, "1");
+	assert.equal(env.GIT_TERMINAL_PROMPT, "0");
+	assert.equal(baseEnv.GIT_DIR, "/tmp/wrong/.git");
+});


### PR DESCRIPTION
## Summary

Centralizes Git repository-local environment variable sanitization into a shared `createGitEnvironment()` utility and applies it across all programmatic Git subprocesses in the monorepo. Follow-up to #1248.

Git honors repository-local env vars (e.g., `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`) over both `cwd` and `git -C`, so any subprocess targeting a specific working tree must strip these inherited values or it may inspect the wrong repository.

## Changes

- **New utility** (`packages/coding-agent/src/utils/git-env.ts`): exports `GIT_LOCAL_ENV_VARS` (mirrors `git rev-parse --local-env-vars`) and `createGitEnvironment(overrides?, baseEnv?)` from `@bastani/atomic`
- **Refactored** `subagents` acceptance check: removes the local `gitStatusEnv()` / `GIT_LOCAL_ENV_VARS` duplicate in favor of the shared helper
- **Applied** to subagent worktree Git wrapper (`packages/subagents/src/runs/shared/worktree.ts`)
- **Applied** to workflow worktree Git wrapper (`packages/workflows/src/runs/shared/worktree.ts`), preserving the `GIT_OPTIONAL_LOCKS: "0"` override
- **Applied** to coding-agent footer branch lookups (`footer-data-provider.ts`) for both sync and async paths
- **Applied** to coding-agent package-manager Git subprocesses via a new `getCommandEnv()` helper that selectively sanitizes only Git commands while leaving other spawned processes unaffected
- **Tests**: new unit coverage in `test/unit/git-env.test.ts` verifying that local env vars are stripped, unrelated vars are preserved, and overrides are applied correctly

## Validation

```sh
AGENT=1 bun test test/unit/git-env.test.ts test/unit/subagents-acceptance.test.ts
bun run typecheck
bun run lint
cd packages/coding-agent && AGENT=1 bun run test -- test/footer-data-provider.test.ts test/package-manager.test.ts
AGENT=1 bun run test:unit
```