### PR TITLE
fix(workflows): anchor Ralph prompts to workflow cwd

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Changed the builtin `ralph` workflow to include the workflow current working directory in every stage prompt so planner, implementation, simplification, review, and PR handoff stages keep repository work anchored to the workflow checkout.
 - Changed the builtin `ralph` workflow to skip pull-request creation by default unless `create_pr=true`, omit `pr_report` when disabled, and keep provider-aware PR/MR/review creation instructions in the final stage ([#1255](https://github.com/bastani-inc/atomic/issues/1255)).
 
 ## [0.8.26-alpha.2] - 2026-06-05

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -392,6 +392,18 @@ function taggedPrompt(sections: readonly PromptSection[]): string {
     .join("\n\n");
 }
 
+function workflowCwdContextSection(workflowCwd: string): PromptSection {
+  return [
+    "workflow_cwd_context",
+    [
+      `Current working directory: ${workflowCwd}`,
+      "Use this as the starting directory for repository work in this stage.",
+      "Shell commands and relative file paths should be relative to this directory unless you intentionally pass an explicit cwd override.",
+      "When delegating, pass along that this is the current working directory for the workflow.",
+    ].join("\n"),
+  ];
+}
+
 function positiveInteger(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
@@ -598,6 +610,7 @@ async function runRalphWorkflow(
   const workflowSpecPath = resolve(workflowStartCwd, defaultSpecPath(prompt));
   const implementationNotesPath = await createImplementationNotesFile(prompt);
   const artifactDir = await mkdtemp(join(tmpdir(), "atomic-ralph-run-"));
+  const workflowCwdContext = workflowCwdContextSection(workflowStartCwd);
   let approved = false;
   let iterationsCompleted = 0;
 
@@ -667,6 +680,7 @@ async function runRalphWorkflow(
           "task",
           `Plan iteration ${iteration}/${maxLoops} for this user specification:\n${prompt}`,
         ],
+        workflowCwdContext,
         [
           "latest_review_artifact",
           latestReviewReportPath === undefined
@@ -775,6 +789,7 @@ async function runRalphWorkflow(
           "objective",
           `Implement iteration ${iteration}/${maxLoops} for the task: ${prompt}`,
         ],
+        workflowCwdContext,
         [
           "spec_file",
           [
@@ -878,6 +893,7 @@ async function runRalphWorkflow(
           "objective",
           `Refine recently modified code for this task while preserving exact behavior: ${prompt}`,
         ],
+        workflowCwdContext,
         [
           "artifact_handoff",
           [
@@ -981,6 +997,7 @@ async function runRalphWorkflow(
         ].join("\n"),
       ],
       ["objective", `Review the current code delta for the task: ${prompt}`],
+      workflowCwdContext,
       [
         "comparison_baseline",
         [
@@ -1187,6 +1204,7 @@ async function runRalphWorkflow(
           "objective",
           `Review the changes since the base branch \`${comparisonBaseBranch}\` and create a provider-appropriate pull request, merge request, or code-review handoff if possible and credentials are available. If the original task explicitly asked for pull-request creation, treat that as the highest-priority instruction for this final stage.`,
         ],
+        workflowCwdContext,
         [
           "workflow_context",
           [

--- a/test/unit/builtin-workflows.test.ts
+++ b/test/unit/builtin-workflows.test.ts
@@ -2164,6 +2164,37 @@ describe("ralph", () => {
         assertEveryRalphStageCwd(ctx, undefined);
     });
 
+    test("adds workflow cwd context to every Ralph stage prompt", async () => {
+        const mod = await import("../../packages/workflows/builtin/ralph.js");
+        const cwd = requireRalphTempCwd();
+        const ctx = makeMockCtx({
+            prompt: "Add a small feature",
+            max_loops: 1,
+            base_branch: "main",
+            git_worktree_dir: "",
+            create_pr: true,
+        });
+
+        await mod.default.run({ ...ctx, cwd });
+
+        const prompts = [
+            ["planner-1", ctx.calls.prompts["planner-1"]?.[0] ?? ""],
+            ["orchestrator-1", ctx.calls.prompts["orchestrator-1"]?.[0] ?? ""],
+            ["code-simplifier-1", ctx.calls.prompts["code-simplifier-1"]?.[0] ?? ""],
+            ["reviewer-a", ctx.calls.prompts["reviewer-a"]?.[0] ?? ""],
+            ["reviewer-b", ctx.calls.prompts["reviewer-b"]?.[0] ?? ""],
+            ["pull-request", ctx.calls.prompts["pull-request"]?.[0] ?? ""],
+        ] as const;
+
+        for (const [label, prompt] of prompts) {
+            assert.match(prompt, /<workflow_cwd_context>/, label);
+            assert.match(prompt, /Current working directory:/i, label);
+            assert.equal(prompt.includes(cwd), true, label);
+            assert.match(prompt, /relative to this directory/i, label);
+            assert.match(prompt, /current working directory for the workflow/i, label);
+        }
+    });
+
     test("skips pull-request stage when create_pr is omitted", async () => {
         const mod = await import("../../packages/workflows/builtin/ralph.js");
         const ctx = makeMockCtx({


### PR DESCRIPTION
## Summary

Fixes missing working-directory context in Ralph stage prompts by injecting a reusable \`workflowCwdContextSection\` into every stage, ensuring that planner, implementation, simplification, review, and pull-request handoff work stays rooted in the workflow checkout directory.

## Changes

- Added `workflowCwdContextSection(workflowCwd)` helper that produces a tagged `<workflow_cwd_context>` prompt section instructing the delegated agent to treat the workflow's `cwd` as the starting directory for shell commands and relative paths.
- Injected the cwd context section into all five Ralph stages: **planner**, **orchestrator** (implementation), **code-simplifier** (simplification), **reviewer-a/b** (review), and **pull-request**.
- Added unit test asserting that `<workflow_cwd_context>`, the literal cwd path, and the key instructional phrases appear in every stage's captured prompt.
- Updated `packages/workflows/CHANGELOG.md` under `[Unreleased] > Changed`.

## Notes

Validation run:
- `bun test test/unit/builtin-workflows.test.ts -t "adds workflow cwd context to every Ralph stage prompt"`
- `bun test test/unit/builtin-workflows.test.ts`
- `bun test test/unit`
- Pre-commit/pre-push hooks: `bun run lint`, `bun run test:unit`