### PR TITLE
chore(workflows): upgrade builtin workflow fallback model tiers

### DIFF
--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -417,7 +417,7 @@ export default defineWorkflow("deep-research-codebase")
         "openai-codex/gpt-5.5:xhigh",
         "github-copilot/gpt-5.5:xhigh",
         "anthropic/claude-opus-4-8:xhigh",
-        "github-copilot/claude-opus-4.8:medium",
+        "github-copilot/claude-opus-4.8:xhigh",
       ],
       excludedTools: ["ask_user_question"],
     };

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -1030,8 +1030,8 @@ export default defineWorkflow("goal")
       fallbackModels: [
         "openai-codex/gpt-5.5:medium",
         "github-copilot/gpt-5.5:medium",
-        "anthropic/claude-sonnet-4-8:medium",
-        "github-copilot/claude-sonnet-4.8:medium",
+        "anthropic/claude-opus-4-8:medium",
+        "github-copilot/claude-opus-4.8:medium",
       ],
       tools: goalRunnerTools,
     };
@@ -1041,8 +1041,8 @@ export default defineWorkflow("goal")
       fallbackModels: [
         "openai-codex/gpt-5.5:xhigh",
         "github-copilot/gpt-5.5:xhigh",
-        "anthropic/claude-sonnet-4-8:xhigh",
-        "github-copilot/claude-sonnet-4.8:medium",
+        "anthropic/claude-opus-4-8:xhigh",
+        "github-copilot/claude-opus-4.8:xhigh",
       ],
       tools: [...goalRunnerTools, reviewDecisionTool.name],
       customTools: [reviewDecisionTool],

--- a/packages/workflows/builtin/open-claude-design.ts
+++ b/packages/workflows/builtin/open-claude-design.ts
@@ -228,9 +228,9 @@ export default defineWorkflow("open-claude-design")
     const designModelConfig = {
       model: "anthropic/claude-opus-4-8:xhigh",
       fallbackModels: [
-        "github-copilot/claude-opus-4.8:medium",
-        "anthropic/claude-sonnet-4-6:xhigh",
-        "github-copilot/claude-sonnet-4.6:medium",
+        "github-copilot/claude-opus-4.8:xhigh",
+        "anthropic/claude-sonnet-4-6:high",
+        "github-copilot/claude-sonnet-4.6:high",
       ],
     };
 

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -620,7 +620,7 @@ async function runRalphWorkflow(
       "openai-codex/gpt-5.5:xhigh",
       "github-copilot/gpt-5.5:xhigh",
       "anthropic/claude-opus-4-8:xhigh",
-      "github-copilot/claude-opus-4.8:medium",
+      "github-copilot/claude-opus-4.8:xhigh",
     ],
     excludedTools: ["ask_user_question"],
   };
@@ -630,8 +630,8 @@ async function runRalphWorkflow(
     fallbackModels: [
       "openai-codex/gpt-5.5:medium",
       "github-copilot/gpt-5.5:medium",
-      "anthropic/claude-sonnet-4-6:medium",
-      "github-copilot/claude-sonnet-4.6:medium",
+      "anthropic/claude-opus-4-8:medium",
+      "github-copilot/claude-opus-4.8:medium",
     ],
     excludedTools: ["ask_user_question"],
   };
@@ -641,8 +641,8 @@ async function runRalphWorkflow(
     fallbackModels: [
       "openai-codex/gpt-5.5:medium",
       "github-copilot/gpt-5.5:medium",
-      "anthropic/claude-sonnet-4-6:medium",
-      "github-copilot/claude-sonnet-4.6:medium",
+      "anthropic/claude-opus-4-8:medium",
+      "github-copilot/claude-opus-4.8:medium",
     ],
     excludedTools: ["ask_user_question"],
   };
@@ -653,7 +653,7 @@ async function runRalphWorkflow(
       "openai-codex/gpt-5.5:xhigh",
       "github-copilot/gpt-5.5:xhigh",
       "anthropic/claude-opus-4-8:xhigh",
-      "github-copilot/claude-opus-4.8:medium",
+      "github-copilot/claude-opus-4.8:xhigh",
     ],
     excludedTools: ["ask_user_question"],
     customTools: [reviewDecisionTool],


### PR DESCRIPTION
## Summary

Upgrades fallback model configurations across four builtin workflows so that degraded/fallback runs consistently land on stronger models and higher reasoning effort tiers.

## Changes

### `deep-research-codebase`
- `github-copilot/claude-opus-4.8`: `:medium` → `:xhigh`

### `goal`
- Runner fallbacks: `claude-sonnet-4-8`/`claude-sonnet-4.8` → `claude-opus-4-8`/`claude-opus-4.8` (both providers, at `:medium`)
- Review runner fallbacks: same Sonnet → Opus swap at `:xhigh`, plus `github-copilot/claude-opus-4.8`: `:medium` → `:xhigh`

### `open-claude-design`
- `github-copilot/claude-opus-4.8`: `:medium` → `:xhigh`
- `anthropic/claude-sonnet-4-6`: `:xhigh` → `:high`
- `github-copilot/claude-sonnet-4.6`: `:medium` → `:high`

### `ralph`
- Main and planner runner fallbacks: `claude-sonnet-4-6`/`claude-sonnet-4.6` → `claude-opus-4-8`/`claude-opus-4.8` (both providers, at `:medium`)
- Reviewer runner fallbacks: same Sonnet → Opus swap; `github-copilot/claude-opus-4.8`: `:medium` → `:xhigh`

## Validation

- `bun run lint` and `bun run test:unit` pass via pre-commit/pre-push hooks.