### PR TITLE
chore(release): 0.8.26-alpha.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.26-alpha.3",
+      "version": "0.8.26-alpha.4",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.26-alpha.3",
+      "version": "0.8.26-alpha.4",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.26-alpha.3",
+      "version": "0.8.26-alpha.4",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.26-alpha.3",
+      "version": "0.8.26-alpha.4",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.26-alpha.3",
+      "version": "0.8.26-alpha.4",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.26-alpha.3",
+      "version": "0.8.26-alpha.4",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.26-alpha.4] - 2026-06-05
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.4 prerelease.
+
 ## [0.8.26-alpha.3] - 2026-06-05
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.26-alpha.3",
+  "version": "0.8.26-alpha.4",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.26-alpha.4] - 2026-06-05
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.4 prerelease.
+
 ## [0.8.26-alpha.3] - 2026-06-05
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.26-alpha.3",
+  "version": "0.8.26-alpha.4",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.26-alpha.4] - 2026-06-05
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.4 prerelease.
+
 ## [0.8.26-alpha.3] - 2026-06-05
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.26-alpha.3",
+  "version": "0.8.26-alpha.4",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.26-alpha.4] - 2026-06-05
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.4 prerelease.
+
 ## [0.8.26-alpha.3] - 2026-06-05
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.26-alpha.3",
+  "version": "0.8.26-alpha.4",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.26-alpha.4] - 2026-06-05
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.4 prerelease.
+
 ## [0.8.26-alpha.3] - 2026-06-05
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.26-alpha.3",
+  "version": "0.8.26-alpha.4",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.26-alpha.4] - 2026-06-05
+
+### Changed
+
+- Upgraded builtin workflow fallback model tiers so degraded runs land on stronger models: bumped `github-copilot/claude-opus-4.8` fallbacks from `:medium` to `:xhigh` in `deep-research-codebase` and `ralph`, replaced `claude-sonnet-4-8`/`4.8` fallbacks with `claude-opus-4-8`/`4.8` in the `goal` and `ralph` runner configs, and raised `claude-sonnet-4-6`/`4.6` fallbacks from `:medium` to `:high` in `open-claude-design` ([#1259](https://github.com/bastani-inc/atomic/issues/1259)).
+
 ## [0.8.26-alpha.3] - 2026-06-05
 
 ### Changed

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.26-alpha.3",
+  "version": "0.8.26-alpha.4",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prerelease version bump from `0.8.26-alpha.3` → `0.8.26-alpha.4` across all workspace packages, driven by the workflow fallback model tier upgrade landed in [#1259](https://github.com/bastani-inc/atomic/issues/1259).

## Changes

### workflows
- **Upgraded fallback model tiers** so degraded runs land on stronger models ([#1259](https://github.com/bastani-inc/atomic/issues/1259)):
  - `deep-research-codebase`, `ralph`: `github-copilot/claude-opus-4.8` fallback tier promoted from `:medium` → `:xhigh`
  - `goal`, `ralph`: replaced `claude-sonnet-4-8`/`4.8` fallbacks with `claude-opus-4-8`/`4.8`
  - `open-claude-design`: `claude-sonnet-4-6`/`4.6` fallback tier promoted from `:medium` → `:high`

### All packages (`coding-agent`, `intercom`, `mcp`, `subagents`, `web-access`, `workflows`)
- Bumped `package.json` versions from `0.8.26-alpha.3` → `0.8.26-alpha.4`
- Updated `CHANGELOG.md` entries
- Refreshed `bun.lock`

## Release checklist

- [x] Bumped all `packages/*/package.json` to `0.8.26-alpha.4` via `scripts/bump-version.ts`
- [x] Refreshed `bun.lock`
- [x] Updated each package `CHANGELOG.md`
- [ ] Tag `0.8.26-alpha.4` pushed after merge to trigger publish