### PR TITLE
fix(workflows): require explicit scope for global tool-event attribution

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the workflow global tool-event hook ignoring unscoped parent-session prompts instead of attributing them to running stages, preventing false `awaiting_input` / "needs attention" states from unrelated `ask_user_question` calls ([#1261](https://github.com/bastani-inc/atomic/issues/1261)).
+
 ## [0.8.26-alpha.4] - 2026-06-05
 
 ### Changed

--- a/packages/workflows/src/tui/store-widget-installer.ts
+++ b/packages/workflows/src/tui/store-widget-installer.ts
@@ -160,121 +160,124 @@ export function installToolExecutionHooks(pi: LiveWidgetAPI, storeInstance: Stor
   const extensionOn = pi.on;
   if (typeof eventBusOn !== "function" && typeof extensionOn !== "function") return;
 
-  const activeAskUserQuestionCalls = new Map<string, { runId: string; stageId: string; callId: string }>();
+  interface StageScope {
+    readonly runId: string;
+    readonly stageId: string;
+  }
 
-  function resolveIds(payload: ToolExecutionStartPayload, includeAwaitingInput = false): { runId: string; stageId: string } | null {
-    const runId = payload.runId ?? payload.run_id ?? storeInstance.activeRunId();
-    if (!runId) return null;
+  interface ActiveToolCall extends StageScope {
+    readonly callId: string;
+    readonly name: string;
+    readonly startedAt: number;
+  }
 
-    const stageId = payload.stageId ?? payload.stage_id;
-    if (stageId) return { runId, stageId };
+  const terminalRunStatuses = new Set(["completed", "failed", "killed"]);
+  const terminalStageStatuses = new Set(["completed", "failed", "skipped"]);
+  const activeToolCalls = new Map<string, ActiveToolCall>();
 
-    const run = storeInstance.runs().find((candidate) => candidate.id === runId);
-    const runningStage = run?.stages.find((s) => s.status === "running");
-    if (runningStage) return { runId, stageId: runningStage.id };
+  function activeCallKey(runId: string, stageId: string, callId: string): string {
+    return `${runId}\0${stageId}\0${callId}`;
+  }
 
-    if (includeAwaitingInput) {
-      const awaitingStage = run?.stages.find((s) => s.status === "awaiting_input");
-      if (awaitingStage) return { runId, stageId: awaitingStage.id };
+  function firstNonEmptyString(...values: readonly unknown[]): string | null {
+    for (const value of values) {
+      if (typeof value === "string" && value.length > 0) return value;
     }
-
     return null;
   }
 
-  function activeCallKey(runId: string, stageId: string, callId: string): string {
-    return `${runId}:${stageId}:${callId}`;
+  function resolveExplicitStageScope(payload: ToolExecutionStartPayload): StageScope | null {
+    const runId = firstNonEmptyString(payload.runId, payload.run_id);
+    const stageId = firstNonEmptyString(payload.stageId, payload.stage_id);
+    if (runId === null || stageId === null) return null;
+    return { runId, stageId };
   }
 
-  function findActiveAskCall(payload: ToolExecutionStartPayload): { runId: string; stageId: string; callId: string } | undefined {
-    const runId = payload.runId ?? payload.run_id;
-    const stageId = payload.stageId ?? payload.stage_id;
-    const callId = toolCallId(payload);
-
-    if (runId !== undefined && stageId !== undefined) {
-      return activeAskUserQuestionCalls.get(activeCallKey(runId, stageId, callId));
-    }
-
-    const matches = [...activeAskUserQuestionCalls.values()].filter((entry) => {
-      if (entry.callId !== callId) return false;
-      if (runId !== undefined && entry.runId !== runId) return false;
-      if (stageId !== undefined && entry.stageId !== stageId) return false;
-      return true;
-    });
-    return matches.length === 1 ? matches[0] : undefined;
+  function hasLiveStageScope(scope: StageScope, snap: StoreSnapshot): boolean {
+    const run = snap.runs.find((candidate) => candidate.id === scope.runId);
+    if (!run || run.endedAt !== undefined || terminalRunStatuses.has(run.status)) return false;
+    const stage = run.stages.find((candidate) => candidate.id === scope.stageId);
+    return stage !== undefined && !terminalStageStatuses.has(stage.status);
   }
 
-  function stageHasActiveAskCall(runId: string, stageId: string): boolean {
-    return [...activeAskUserQuestionCalls.values()].some(
-      (entry) => entry.runId === runId && entry.stageId === stageId,
-    );
-  }
-
-  function recordAskUserQuestionStart(payload: ToolExecutionStartPayload, ids: { runId: string; stageId: string }): void {
-    if (!isAskUserQuestionToolName(toolName(payload))) return;
-    const callId = toolCallId(payload);
-    activeAskUserQuestionCalls.set(activeCallKey(ids.runId, ids.stageId, callId), {
-      ...ids,
-      callId,
-    });
-    storeInstance.recordStageAwaitingInput(ids.runId, ids.stageId, true, payload.ts);
-  }
-
-  function recordAskUserQuestionEnd(payload: ToolExecutionStartPayload, ids: { runId: string; stageId: string } | null): void {
-    const activeCall = findActiveAskCall(payload);
-    const resolvedIds = activeCall ?? ids;
-    if (resolvedIds === null || resolvedIds === undefined) return;
-
-    const shouldClear = activeCall !== undefined || isAskUserQuestionToolName(toolName(payload));
-    if (!shouldClear) return;
-
-    activeAskUserQuestionCalls.delete(activeCallKey(resolvedIds.runId, resolvedIds.stageId, toolCallId(payload)));
-    if (!stageHasActiveAskCall(resolvedIds.runId, resolvedIds.stageId)) {
-      storeInstance.recordStageAwaitingInput(resolvedIds.runId, resolvedIds.stageId, false);
+  function pruneActiveToolCalls(snap: StoreSnapshot): void {
+    for (const [key, call] of activeToolCalls) {
+      if (!hasLiveStageScope(call, snap)) activeToolCalls.delete(key);
     }
   }
+
+  storeInstance.subscribe(pruneActiveToolCalls);
 
   function recordToolStart(payload: unknown): void {
     if (!isToolExecutionPayload(payload)) return;
 
-    const ids = resolveIds(payload);
-    if (!ids) return;
+    const snap = storeInstance.snapshot();
+    pruneActiveToolCalls(snap);
 
-    storeInstance.recordToolStart(ids.runId, ids.stageId, {
-      name: toolName(payload),
+    const scope = resolveExplicitStageScope(payload);
+    if (!scope || !hasLiveStageScope(scope, snap)) return;
+
+    const callId = toolCallId(payload);
+    const key = activeCallKey(scope.runId, scope.stageId, callId);
+    if (activeToolCalls.has(key)) return;
+
+    const name = toolName(payload);
+    const startedAt = payload.ts ?? Date.now();
+    activeToolCalls.set(key, { ...scope, callId, name, startedAt });
+    storeInstance.recordToolStart(scope.runId, scope.stageId, {
+      name,
       input: toolInput(payload),
-      startedAt: payload.ts ?? Date.now(),
+      startedAt,
     });
-    recordAskUserQuestionStart(payload, ids);
+  }
+
+  function recordToolUpdate(payload: unknown): void {
+    if (!isToolExecutionPayload(payload)) return;
+
+    pruneActiveToolCalls(storeInstance.snapshot());
+
+    const scope = resolveExplicitStageScope(payload);
+    if (!scope) return;
+
+    const key = activeCallKey(scope.runId, scope.stageId, toolCallId(payload));
+    if (!activeToolCalls.has(key)) return;
+    // Updates are attach-only until the store has an explicit update API.
   }
 
   function recordToolEnd(payload: unknown): void {
     if (!isToolExecutionPayload(payload)) return;
 
-    const activeAskCall = findActiveAskCall(payload);
-    const ids = activeAskCall ?? resolveIds(payload, false);
-    if (!ids) return;
+    pruneActiveToolCalls(storeInstance.snapshot());
 
-    storeInstance.recordToolEnd(ids.runId, ids.stageId, {
-      name: toolName(payload),
+    const scope = resolveExplicitStageScope(payload);
+    if (!scope) return;
+
+    const key = activeCallKey(scope.runId, scope.stageId, toolCallId(payload));
+    const activeCall = activeToolCalls.get(key);
+    if (!activeCall) return;
+
+    storeInstance.recordToolEnd(activeCall.runId, activeCall.stageId, {
+      name: activeCall.name,
       input: toolInput(payload),
-      startedAt: payload.ts ?? Date.now(),
+      startedAt: activeCall.startedAt,
       endedAt: payload.endedAt ?? payload.ended_at ?? Date.now(),
       output: payload.output,
     });
-    recordAskUserQuestionEnd(payload, activeAskCall ?? ids);
+    activeToolCalls.delete(key);
   }
 
   const safeStart = safelyHandle(recordToolStart);
+  const safeUpdate = safelyHandle(recordToolUpdate);
   const safeEnd = safelyHandle(recordToolEnd);
 
   if (typeof eventBusOn === "function") {
     eventBusOn.call(pi.events, "tool_execution_start", safeStart);
-    eventBusOn.call(pi.events, "tool_execution_update", safeStart);
+    eventBusOn.call(pi.events, "tool_execution_update", safeUpdate);
     eventBusOn.call(pi.events, "tool_execution_end", safeEnd);
   }
   if (typeof extensionOn === "function") {
     extensionOn.call(pi, "tool_execution_start", safeStart);
-    extensionOn.call(pi, "tool_execution_update", safeStart);
+    extensionOn.call(pi, "tool_execution_update", safeUpdate);
     extensionOn.call(pi, "tool_execution_end", safeEnd);
     extensionOn.call(pi, "tool_call", safeStart);
     extensionOn.call(pi, "tool_result", safeEnd);
@@ -305,8 +308,4 @@ function toolCallId(payload: ToolExecutionStartPayload): string {
 
 function toolInput(payload: ToolExecutionStartPayload): Record<string, unknown> | undefined {
   return payload.input ?? payload.args;
-}
-
-function isAskUserQuestionToolName(name: string): boolean {
-  return name.toLowerCase().replace(/[^a-z0-9]/g, "") === "askuserquestion";
 }

--- a/packages/workflows/src/tui/store-widget-installer.ts
+++ b/packages/workflows/src/tui/store-widget-installer.ts
@@ -206,6 +206,15 @@ export function installToolExecutionHooks(pi: LiveWidgetAPI, storeInstance: Stor
     }
   }
 
+  function activeToolCallForPayload(payload: ToolExecutionStartPayload): { key: string; call: ActiveToolCall } | null {
+    const scope = resolveExplicitStageScope(payload);
+    if (!scope) return null;
+
+    const key = activeCallKey(scope.runId, scope.stageId, toolCallId(payload));
+    const call = activeToolCalls.get(key);
+    return call ? { key, call } : null;
+  }
+
   storeInstance.subscribe(pruneActiveToolCalls);
 
   function recordToolStart(payload: unknown): void {
@@ -236,11 +245,7 @@ export function installToolExecutionHooks(pi: LiveWidgetAPI, storeInstance: Stor
 
     pruneActiveToolCalls(storeInstance.snapshot());
 
-    const scope = resolveExplicitStageScope(payload);
-    if (!scope) return;
-
-    const key = activeCallKey(scope.runId, scope.stageId, toolCallId(payload));
-    if (!activeToolCalls.has(key)) return;
+    if (!activeToolCallForPayload(payload)) return;
     // Updates are attach-only until the store has an explicit update API.
   }
 
@@ -249,21 +254,17 @@ export function installToolExecutionHooks(pi: LiveWidgetAPI, storeInstance: Stor
 
     pruneActiveToolCalls(storeInstance.snapshot());
 
-    const scope = resolveExplicitStageScope(payload);
-    if (!scope) return;
+    const active = activeToolCallForPayload(payload);
+    if (!active) return;
 
-    const key = activeCallKey(scope.runId, scope.stageId, toolCallId(payload));
-    const activeCall = activeToolCalls.get(key);
-    if (!activeCall) return;
-
-    storeInstance.recordToolEnd(activeCall.runId, activeCall.stageId, {
-      name: activeCall.name,
+    storeInstance.recordToolEnd(active.call.runId, active.call.stageId, {
+      name: active.call.name,
       input: toolInput(payload),
-      startedAt: activeCall.startedAt,
+      startedAt: active.call.startedAt,
       endedAt: payload.endedAt ?? payload.ended_at ?? Date.now(),
       output: payload.output,
     });
-    activeToolCalls.delete(key);
+    activeToolCalls.delete(active.key);
   }
 
   const safeStart = safelyHandle(recordToolStart);

--- a/test/unit/store-widget-installer.test.ts
+++ b/test/unit/store-widget-installer.test.ts
@@ -533,40 +533,51 @@ describe("installToolExecutionHooks", () => {
     assert.equal(extensionHandlers.has("tool_result"), true);
   });
 
-  test("tool_execution_start records tool on active stage (fallback heuristic)", () => {
+  test("tool_execution_start ignores unscoped events instead of using active-stage fallback", () => {
     const { pi, eventHandlers } = makeMockPi();
     installToolExecutionHooks(pi, storeInstance);
 
     const handler = eventHandlers.get("tool_execution_start")!;
     handler({ toolName: "bash", input: { cmd: "ls" }, ts: Date.now() });
 
-    const snap = storeInstance.snapshot();
-    const run = snap.runs.find((r) => r.id === "r1")!;
-    const stage = run.stages.find((s) => s.id === "s1")!;
-    assert.equal(stage.toolEvents.length, 1);
-    assert.equal(stage.toolEvents[0]!.name, "bash");
+    const stage = storeInstance.snapshot().runs[0]!.stages[0]!;
+    assert.equal(stage.toolEvents.length, 0);
+    assert.equal(stage.status, "running");
+    assert.equal(stage.awaitingInputSince, undefined);
   });
 
-  test("tool_execution_start preserves SDK args for orchestrator tool UI", () => {
+  test("tool_execution_start preserves SDK args for scoped orchestrator tool UI", () => {
     const { pi, eventHandlers } = makeMockPi();
     installToolExecutionHooks(pi, storeInstance);
 
     const handler = eventHandlers.get("tool_execution_start")!;
-    handler({ toolName: "bash", args: { command: "echo hi" }, ts: Date.now() });
+    handler({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "bash-args",
+      args: { command: "echo hi" },
+      ts: Date.now(),
+    });
 
     const stage = storeInstance.snapshot().runs[0]!.stages[0]!;
     assert.deepEqual(stage.toolEvents[0]!.input, { command: "echo hi" });
   });
 
   test("tool_execution_start with explicit runId+stageId routes correctly", () => {
-    // Add a second stage
     storeInstance.recordStageStart("r1", makeStage("s2", "specialist"));
 
     const { pi, eventHandlers } = makeMockPi();
     installToolExecutionHooks(pi, storeInstance);
 
     const handler = eventHandlers.get("tool_execution_start")!;
-    handler({ toolName: "grep", runId: "r1", stageId: "s2", ts: Date.now() });
+    handler({
+      toolName: "grep",
+      runId: "r1",
+      stageId: "s2",
+      toolCallId: "grep-1",
+      ts: Date.now(),
+    });
 
     const snap = storeInstance.snapshot();
     const run = snap.runs.find((r) => r.id === "r1")!;
@@ -577,61 +588,209 @@ describe("installToolExecutionHooks", () => {
     assert.equal(s1.toolEvents.length, 0);
   });
 
-  test("tool_execution_end records tool end", () => {
+  test("tool_execution_update is attach-only and cannot create a stage tool event", () => {
+    const { pi, eventHandlers } = makeMockPi();
+    installToolExecutionHooks(pi, storeInstance);
+
+    eventHandlers.get("tool_execution_update")!({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "missing-call",
+      ts: Date.now(),
+    });
+
+    const stage = storeInstance.snapshot().runs[0]!.stages[0]!;
+    assert.equal(stage.toolEvents.length, 0);
+    assert.equal(stage.status, "running");
+    assert.equal(stage.awaitingInputSince, undefined);
+  });
+
+  test("tool_execution_end records tool end for the exact scoped active call", () => {
     const { pi, eventHandlers } = makeMockPi();
     installToolExecutionHooks(pi, storeInstance);
 
     const startTs = Date.now() - 500;
     const startHandler = eventHandlers.get("tool_execution_start")!;
-    startHandler({ toolName: "bash", ts: startTs });
+    startHandler({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "bash-1",
+      ts: startTs,
+    });
 
     const endHandler = eventHandlers.get("tool_execution_end")!;
-    endHandler({ toolName: "bash", ts: startTs, endedAt: Date.now(), output: "ok" });
+    endHandler({
+      toolName: "renamed-in-end-payload",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "bash-1",
+      ts: startTs + 123,
+      endedAt: Date.now(),
+      output: "ok",
+    });
 
     const snap = storeInstance.snapshot();
     const run = snap.runs.find((r) => r.id === "r1")!;
     const stage = run.stages.find((s) => s.id === "s1")!;
     const evt = stage.toolEvents.find((e) => e.name === "bash");
     assert.notEqual(evt, undefined);
+    assert.equal(evt!.startedAt, startTs);
     assert.equal(evt!.output, "ok");
     assert.notEqual(evt!.endedAt, undefined);
   });
 
-  test("ask_user_question start marks the active stage awaiting input", () => {
-    const { pi, eventHandlers } = makeMockPi();
-    installToolExecutionHooks(pi, storeInstance);
+  test("unscoped parent ask_user_question start/update is ignored across parallel stages", () => {
+    storeInstance.recordStageStart("r1", makeStage("s2", "reviewer-b"));
 
-    const startHandler = eventHandlers.get("tool_execution_start")!;
-    startHandler({ toolName: "ask_user_question", toolCallId: "ask-1", ts: 123 });
-
-    const stage = storeInstance.snapshot().runs[0]!.stages[0]!;
-    assert.equal(stage.status, "awaiting_input");
-    assert.equal(stage.awaitingInputSince, 123);
-  });
-
-  test("ask_user_question end clears awaiting input even after no stage is running", () => {
     const { pi, eventHandlers } = makeMockPi();
     installToolExecutionHooks(pi, storeInstance);
 
     eventHandlers.get("tool_execution_start")!({
       toolName: "ask_user_question",
-      toolCallId: "ask-1",
+      toolCallId: "parent-ask",
+      input: { questions: [{ question: "Parent prompt?" }] },
       ts: 123,
     });
-    assert.equal(storeInstance.snapshot().runs[0]!.stages[0]!.status, "awaiting_input");
+    eventHandlers.get("tool_execution_update")!({
+      toolName: "ask_user_question",
+      toolCallId: "parent-ask",
+      input: { questions: [{ question: "Parent prompt?" }] },
+      ts: 124,
+    });
 
+    const run = storeInstance.snapshot().runs[0]!;
+    for (const stage of run.stages) {
+      assert.equal(stage.toolEvents.length, 0, `${stage.id} should not receive parent ask telemetry`);
+      assert.equal(stage.status, "running", `${stage.id} should remain running`);
+      assert.equal(stage.awaitingInputSince, undefined, `${stage.id} should not be awaiting input`);
+    }
+  });
+
+  test("scoped ask_user_question records only own stage telemetry without awaiting input", () => {
+    storeInstance.recordStageStart("r1", makeStage("s2", "reviewer-b"));
+
+    const { pi, eventHandlers } = makeMockPi();
+    installToolExecutionHooks(pi, storeInstance);
+
+    eventHandlers.get("tool_execution_start")!({
+      toolName: "ask_user_question",
+      runId: "r1",
+      stageId: "s2",
+      toolCallId: "stage-ask",
+      input: { questions: [{ question: "Stage prompt?" }] },
+      ts: 123,
+    });
+
+    const run = storeInstance.snapshot().runs[0]!;
+    const s1 = run.stages.find((s) => s.id === "s1")!;
+    const s2 = run.stages.find((s) => s.id === "s2")!;
+    assert.equal(s1.toolEvents.length, 0);
+    assert.equal(s2.toolEvents.length, 1);
+    assert.equal(s2.toolEvents[0]!.name, "ask_user_question");
+    assert.equal(s1.status, "running");
+    assert.equal(s2.status, "running");
+    assert.equal(s1.awaitingInputSince, undefined);
+    assert.equal(s2.awaitingInputSince, undefined);
+  });
+
+  test("duplicate start/update cannot migrate a scoped call to a sibling stage", () => {
+    storeInstance.recordStageStart("r1", makeStage("s2", "reviewer-b"));
+
+    const { pi, eventHandlers } = makeMockPi();
+    installToolExecutionHooks(pi, storeInstance);
+
+    eventHandlers.get("tool_execution_start")!({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "call-1",
+      input: { cmd: "first" },
+      ts: 100,
+    });
+    eventHandlers.get("tool_execution_start")!({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "call-1",
+      input: { cmd: "duplicate" },
+      ts: 101,
+    });
+    eventHandlers.get("tool_execution_update")!({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "call-1",
+      input: { cmd: "attached-update" },
+      ts: 102,
+    });
+    eventHandlers.get("tool_execution_update")!({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s2",
+      toolCallId: "call-1",
+      input: { cmd: "must-not-migrate" },
+      ts: 103,
+    });
+    eventHandlers.get("tool_execution_update")!({
+      toolName: "bash",
+      toolCallId: "call-1",
+      input: { cmd: "unscoped-duplicate" },
+      ts: 104,
+    });
+
+    const run = storeInstance.snapshot().runs[0]!;
+    const s1 = run.stages.find((s) => s.id === "s1")!;
+    const s2 = run.stages.find((s) => s.id === "s2")!;
+    assert.equal(s1.toolEvents.length, 1);
+    assert.equal(s1.toolEvents[0]!.startedAt, 100);
+    assert.deepEqual(s1.toolEvents[0]!.input, { cmd: "first" });
+    assert.equal(s2.toolEvents.length, 0);
+    assert.equal(s1.status, "running");
+    assert.equal(s2.status, "running");
+  });
+
+  test("active tracking is pruned when a stage ends before late update/end events", () => {
+    const { pi, eventHandlers } = makeMockPi();
+    installToolExecutionHooks(pi, storeInstance);
+
+    eventHandlers.get("tool_execution_start")!({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "call-1",
+      ts: 100,
+    });
+    storeInstance.recordStageEnd("r1", {
+      ...makeStage("s1", "scout"),
+      status: "completed",
+      endedAt: 200,
+    });
+    eventHandlers.get("tool_execution_update")!({
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "call-1",
+      ts: 201,
+    });
     eventHandlers.get("tool_execution_end")!({
-      toolCallId: "ask-1",
-      endedAt: 456,
-      output: "answered",
+      toolName: "bash",
+      runId: "r1",
+      stageId: "s1",
+      toolCallId: "call-1",
+      endedAt: 202,
+      output: "late",
     });
 
     const stage = storeInstance.snapshot().runs[0]!.stages[0]!;
-    assert.equal(stage.status, "running");
-    assert.equal(stage.awaitingInputSince, undefined);
+    assert.equal(stage.status, "completed");
+    assert.equal(stage.toolEvents.length, 1);
+    assert.equal(stage.toolEvents[0]!.endedAt, undefined);
+    assert.equal(stage.toolEvents[0]!.output, undefined);
   });
 
-  test("ask_user_question tool_call/tool_result extension events update awaiting input", () => {
+  test("unscoped ask_user_question tool_call/tool_result extension events do not update awaiting input", () => {
     const { pi, extensionHandlers } = makeMockPi();
     installToolExecutionHooks(pi, storeInstance);
 
@@ -641,8 +800,6 @@ describe("installToolExecutionHooks", () => {
       toolCallId: "ask-2",
       input: { questions: [] },
     });
-    assert.equal(storeInstance.snapshot().runs[0]!.stages[0]!.status, "awaiting_input");
-
     extensionHandlers.get("tool_result")!({
       type: "tool_result",
       toolName: "ask_user_question",
@@ -655,6 +812,7 @@ describe("installToolExecutionHooks", () => {
     const stage = storeInstance.snapshot().runs[0]!.stages[0]!;
     assert.equal(stage.status, "running");
     assert.equal(stage.awaitingInputSince, undefined);
+    assert.equal(stage.toolEvents.length, 0);
   });
 
   test("unmatched main-chat ask_user_question result does not clear a workflow HIL prompt node", () => {
@@ -702,7 +860,13 @@ describe("installToolExecutionHooks", () => {
     installToolExecutionHooks(pi, emptyStore);
 
     const handler = eventHandlers.get("tool_execution_start")!;
-    assert.doesNotThrow(() => handler({ toolName: "bash", ts: Date.now() }));
+    assert.doesNotThrow(() => handler({
+      toolName: "bash",
+      runId: "missing-run",
+      stageId: "missing-stage",
+      toolCallId: "call-1",
+      ts: Date.now(),
+    }));
     const snap = emptyStore.snapshot();
     assert.equal(snap.runs.length, 0);
   });


### PR DESCRIPTION
## Summary

Fixes a TUI telemetry bug where unscoped parent-session tool events (e.g. `ask_user_question` from the main chat) were mis-attributed to arbitrary running workflow stages, falsely marking them as `awaiting_input` / "needs attention".

Closes #1261

## Root Cause

The global tool-event hook used a heuristic fallback: when a payload omitted `runId`/`stageId`, it guessed the active run and first running/awaiting stage. This caused any unscoped parent-session event to mutate unrelated parallel workflow stages.

## Changes

- **Require explicit scope**: Replace `resolveIds()` (heuristic fallback) with `resolveExplicitStageScope()` — both `runId` and `stageId` must be present in the payload for any tool event to be attributed to a stage.
- **Live-stage guard**: Add `hasLiveStageScope()` to reject events targeting terminated runs or stages.
- **Active call pruning**: Subscribe `pruneActiveToolCalls()` to the store so stale tracking is cleaned up when stages/runs end, preventing late events from resurrecting terminated telemetry.
- **Dedicated update handler**: `tool_execution_update` now uses its own attach-only `recordToolUpdate` handler (was incorrectly reusing `recordToolStart`), and only affects an already-tracked call.
- **Exact-scope end**: `tool_execution_end` only resolves against an active call with matching run, stage, and call ID; uses the recorded `startedAt` from the start event rather than the end payload timestamp.
- **Remove `ask_user_question` special-casing**: Drop `isAskUserQuestionToolName`, `activeAskUserQuestionCalls`, `recordAskUserQuestionStart/End` — scoped workflow prompt state is solely responsible for `awaiting_input` UI transitions.
- **Fix key collision risk**: Change active call key separator from `:` to `\0` to prevent ambiguous composite keys.

## Tests

- Unscoped parent `ask_user_question` start/update → no-op across all parallel stages.
- Scoped `ask_user_question` → records telemetry only on its own stage, does not set `awaiting_input`.
- Duplicate start/update events → cannot create a second entry or migrate an active call to a sibling stage.
- Active call pruning → late update/end events after stage ends are dropped cleanly.
- `tool_execution_update` → attach-only, cannot create a new stage tool event.
- `tool_execution_end` → uses the `startedAt` from the active call record, not the end-payload timestamp.
- Unscoped events with no active run → no throws, no state mutation.

## Validation

- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun test test/unit/store-widget-installer.test.ts` — 39 pass, 0 fail
- `bun run test:unit` — 2064 pass, 0 fail
- Git commit/push hooks — passed

No breaking changes. Only `packages/workflows/src/tui/store-widget-installer.ts`, `test/unit/store-widget-installer.test.ts`, and `packages/workflows/CHANGELOG.md` are modified.