### PR TITLE
fix(test): sanitize Git env in subagents-acceptance setup

### DIFF
--- a/test/unit/subagents-acceptance.test.ts
+++ b/test/unit/subagents-acceptance.test.ts
@@ -13,6 +13,7 @@ import {
 	resolveEffectiveAcceptance,
 	validateAcceptanceInput,
 } from "../../packages/subagents/src/runs/shared/acceptance.js";
+import { createGitEnvironment } from "../../packages/coding-agent/src/utils/git-env.js";
 
 function report(overrides: Record<string, unknown> = {}): string {
 	return [
@@ -238,9 +239,13 @@ describe("acceptance gates", () => {
 			GIT_INDEX_FILE: process.env.GIT_INDEX_FILE,
 		};
 		try {
-			spawnSync("git", ["init"], { cwd: ambientRepo, stdio: "ignore" });
+			// Sanitize the Git environment so this setup runs against `ambientRepo`
+			// and never inherits ambient GIT_DIR/GIT_WORK_TREE from a hook runner
+			// (e.g. prek): otherwise `git init` would target the real repo and write
+			// core.worktree into the shared config (see git-env.ts).
+			spawnSync("git", ["init"], { cwd: ambientRepo, stdio: "ignore", env: createGitEnvironment() });
 			fs.writeFileSync(path.join(ambientRepo, "staged.txt"), "staged\n", "utf-8");
-			spawnSync("git", ["add", "staged.txt"], { cwd: ambientRepo, stdio: "ignore" });
+			spawnSync("git", ["add", "staged.txt"], { cwd: ambientRepo, stdio: "ignore", env: createGitEnvironment() });
 			process.env.GIT_DIR = path.join(ambientRepo, ".git");
 			process.env.GIT_WORK_TREE = ambientRepo;
 			process.env.GIT_INDEX_FILE = path.join(ambientRepo, ".git", "index");


### PR DESCRIPTION
## Summary

Fix a test-isolation defect where unsanitized `git` spawns in the acceptance test setup could inherit ambient `GIT_DIR`/`GIT_WORK_TREE` from a hook runner (e.g. prek), causing `git init` to target the real shared repo and write `core.worktree` into the shared `.git/config` — corrupting the primary checkout's working-tree resolution.

## Problem

When a prek `pre-commit` hook runs the unit suite from inside a sibling Git worktree, Git exports `GIT_DIR` and `GIT_WORK_TREE` (pointing at that worktree) into the hook process. The test `"no-staged-files check ignores ambient Git hook environment"` set up a temporary repo using raw, unsanitized `spawnSync` calls:

```ts
spawnSync("git", ["init"], { cwd: ambientRepo, stdio: "ignore" });       // inherits ambient GIT_DIR
spawnSync("git", ["add", "staged.txt"], { cwd: ambientRepo, ... });       // inherits ambient GIT_DIR
```

Because `GIT_DIR` was already set, `git init` re-initialized the **real shared** git dir and wrote `core.worktree = $GIT_WORK_TREE` into the common `.git/config`. This key then hijacked the main checkout's working-tree resolution, causing `git status`/`git diff` to report the worktree's state — phantom "modified files" — and the issue recurred on every subsequent hooked commit.

## Key Changes

- **`test/unit/subagents-acceptance.test.ts`**: Pass `env: createGitEnvironment()` to both `spawnSync` calls in the ambient-repo setup so they target the temp repo and never inherit `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` from the hook environment
- Import `createGitEnvironment` from `packages/coding-agent/src/utils/git-env.js` (already used in production code paths: `acceptance.ts` and `runs/shared/worktree.ts`)

## Validation

- `bun test test/unit/subagents-acceptance.test.ts` → 14 pass
- `bun run typecheck` → pass · `bun run lint` → pass
- **Regression proof:** running the fixed test with prek-style ambient `GIT_DIR` pointing at a sandbox worktree writes **no** `core.worktree` into the shared config; committing this change ran the full prek suite in a primary checkout and left `core.worktree` absent

## Notes

- Test-isolation defect only — production code is already safe
- Independent of #1261/#1262
- Root-caused while running the `ralph` workflow in a shared-`.git` worktree, which surfaced this leak