### PR TITLE
chore(workflows): promote proxied providers to primary model slot in builtin workflows

### DIFF
--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -412,23 +412,23 @@ export default defineWorkflow("deep-research-codebase")
     );
 
     const plannerModelConfig = {
-      model: "openai/gpt-5.5:xhigh",
+      model: "openai-codex/gpt-5.5:xhigh",
       fallbackModels: [
-        "openai-codex/gpt-5.5:xhigh",
         "github-copilot/gpt-5.5:xhigh",
-        "anthropic/claude-opus-4-8:xhigh",
+        "openai/gpt-5.5:xhigh",
         "github-copilot/claude-opus-4.8:xhigh",
+        "anthropic/claude-opus-4-8:xhigh"
       ],
       excludedTools: ["ask_user_question"],
     };
 
     const explorerModelConfig = {
-      model: "openai/gpt-5.4-mini:low",
+      model: "openai-codex/gpt-5.4-mini:low",
       fallbackModels: [
-        "openai-codex/gpt-5.4-mini:low",
         "github-copilot/gpt-5.4-mini:low",
-        "anthropic/claude-haiku-4-5:low",
+        "openai/gpt-5.4-mini:low",
         "github-copilot/claude-haiku-4.5:low",
+        "anthropic/claude-haiku-4-5:low",
       ],
       excludedTools: ["ask_user_question"],
     };

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -1026,23 +1026,23 @@ export default defineWorkflow("goal")
     const { ledger, ledgerPath, artifactDir } = await createGoalLedger(objective);
 
     const workerModelConfig = {
-      model: "openai/gpt-5.5:medium",
+      model: "openai-codex/gpt-5.5:medium",
       fallbackModels: [
-        "openai-codex/gpt-5.5:medium",
-        "github-copilot/gpt-5.5:medium",
-        "anthropic/claude-opus-4-8:medium",
-        "github-copilot/claude-opus-4.8:medium",
+          "github-copilot/gpt-5.5:medium",
+          "openai/gpt-5.5:medium",
+          "github-copilot/claude-opus-4.8:medium",
+          "anthropic/claude-opus-4-8:medium",
       ],
       tools: goalRunnerTools,
     };
 
     const reviewerModelConfig = {
-      model: "openai/gpt-5.5:xhigh",
+      model: "openai-codex/gpt-5.5:xhigh",
       fallbackModels: [
-        "openai-codex/gpt-5.5:xhigh",
-        "github-copilot/gpt-5.5:xhigh",
-        "anthropic/claude-opus-4-8:xhigh",
-        "github-copilot/claude-opus-4.8:xhigh",
+          "github-copilot/gpt-5.5:xhigh",
+          "openai/gpt-5.5:xhigh",
+          "github-copilot/claude-opus-4.8:xhigh",
+          "anthropic/claude-opus-4-8:xhigh"
       ],
       tools: [...goalRunnerTools, reviewDecisionTool.name],
       customTools: [reviewDecisionTool],

--- a/packages/workflows/builtin/open-claude-design.ts
+++ b/packages/workflows/builtin/open-claude-design.ts
@@ -226,11 +226,11 @@ export default defineWorkflow("open-claude-design")
     const specFileUrl = `file://${specPath}`;
 
     const designModelConfig = {
-      model: "anthropic/claude-opus-4-8:xhigh",
+      model: "github-copilot/claude-opus-4.8:xhigh",
       fallbackModels: [
-        "github-copilot/claude-opus-4.8:xhigh",
-        "anthropic/claude-sonnet-4-6:high",
-        "github-copilot/claude-sonnet-4.6:high",
+          "anthropic/claude-opus-4-8:xhigh",
+          "github-copilot/claude-sonnet-4.6:high",
+          "anthropic/claude-sonnet-4-6:high",
       ],
     };
 

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -615,45 +615,45 @@ async function runRalphWorkflow(
   let iterationsCompleted = 0;
 
   const plannerModelConfig = {
-    model: "openai/gpt-5.5:xhigh",
+    model: "openai-codex/gpt-5.5:xhigh",
     fallbackModels: [
-      "openai-codex/gpt-5.5:xhigh",
-      "github-copilot/gpt-5.5:xhigh",
-      "anthropic/claude-opus-4-8:xhigh",
-      "github-copilot/claude-opus-4.8:xhigh",
+        "github-copilot/gpt-5.5:xhigh",
+        "openai/gpt-5.5:xhigh",
+        "github-copilot/claude-opus-4.8:xhigh",
+        "anthropic/claude-opus-4-8:xhigh",
     ],
     excludedTools: ["ask_user_question"],
   };
 
   const orchestratorModelConfig = {
-    model: "openai/gpt-5.5:medium",
+    model: "openai-codex/gpt-5.5:medium",
     fallbackModels: [
-      "openai-codex/gpt-5.5:medium",
-      "github-copilot/gpt-5.5:medium",
-      "anthropic/claude-opus-4-8:medium",
-      "github-copilot/claude-opus-4.8:medium",
+        "github-copilot/gpt-5.5:medium",
+        "openai/gpt-5.5:medium",
+        "github-copilot/claude-opus-4.8:medium",
+        "anthropic/claude-opus-4-8:medium",
     ],
     excludedTools: ["ask_user_question"],
   };
 
   const simplifierModelConfig = {
-    model: "openai/gpt-5.5:medium",
+    model: "openai-codex/gpt-5.5:medium",
     fallbackModels: [
-      "openai-codex/gpt-5.5:medium",
       "github-copilot/gpt-5.5:medium",
-      "anthropic/claude-opus-4-8:medium",
+      "openai/gpt-5.5:medium",
       "github-copilot/claude-opus-4.8:medium",
+      "anthropic/claude-opus-4-8:medium",
     ],
     excludedTools: ["ask_user_question"],
   };
 
   const reviewerModelConfig = {
-    model: "openai/gpt-5.5:xhigh",
+    model: "openai-codex/gpt-5.5:xhigh",
     fallbackModels: [
-      "openai-codex/gpt-5.5:xhigh",
       "github-copilot/gpt-5.5:xhigh",
-      "anthropic/claude-opus-4-8:xhigh",
+      "openai/gpt-5.5:xhigh",
       "github-copilot/claude-opus-4.8:xhigh",
+      "anthropic/claude-opus-4-8:xhigh"
     ],
     excludedTools: ["ask_user_question"],
     customTools: [reviewDecisionTool],


### PR DESCRIPTION
## Summary

Promotes proxied model providers (`openai-codex/*` for OpenAI models, `github-copilot/*` for Claude models) to the primary slot in four builtin workflows, and reorders fallback chains accordingly. This ensures requests route through the proxied provider first, with direct provider access as a fallback.

## Changes

- **`deep-research-codebase`** — planner & explorer agents: primary `openai/*` → `openai-codex/*`; fallback order updated to: `github-copilot` → `openai` → `github-copilot` (Claude) → `anthropic`
- **`goal`** — worker & reviewer agents: primary `openai/*` → `openai-codex/*`; fallback order updated to: `github-copilot` → `openai` → `github-copilot` (Claude) → `anthropic`
- **`open-claude-design`** — design agent: primary `anthropic/claude-opus-4-8` → `github-copilot/claude-opus-4.8`; fallback order updated to: `anthropic` → `github-copilot` (Sonnet) → `anthropic` (Sonnet)
- **`ralph`** — planner, orchestrator, simplifier & reviewer agents: primary `openai/*` → `openai-codex/*`; fallback order updated consistently across all four roles

No behavioral or logic changes — only model ID strings and fallback ordering within the existing `*ModelConfig` objects.

## Testing

- `bun run lint` (tsc --noEmit) — passed via pre-commit hook
- `bun run test:unit` — passed via pre-commit hook