### PR TITLE
fix(model-fallback): handle structured provider failure signals

### DIFF
--- a/packages/subagents/src/runs/background/subagent-runner.ts
+++ b/packages/subagents/src/runs/background/subagent-runner.ts
@@ -49,6 +49,11 @@ import { createStructuredOutputRuntime, readStructuredOutput } from "../shared/s
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
 import { nestedSummaryFromAsyncStatus, writeNestedEvent } from "../shared/nested-events.ts";
 import { formatModelAttemptNote, isRetryableModelFailure, modelFailureMessage } from "../shared/model-fallback.ts";
+import {
+	assistantStopReason,
+	isAssistantFailureStopReason,
+	shouldStartSubagentFinalDrain,
+} from "../shared/final-drain.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput } from "../../shared/utils.ts";
 import { evaluateCompletionMutationGuard } from "../shared/completion-guard.ts";
@@ -213,15 +218,6 @@ type ChildMessage = Message & {
 	usage?: ChildUsage;
 };
 
-function assistantStopReason(message: Message): string | undefined {
-	const stopReason = (message as { readonly stopReason?: unknown }).stopReason;
-	return typeof stopReason === "string" ? stopReason : undefined;
-}
-
-function isTerminalAssistantFailureStopReason(stopReason: string | undefined): boolean {
-	return stopReason === "error" || stopReason === "aborted";
-}
-
 interface ChildEvent {
 	type?: string;
 	message?: ChildMessage;
@@ -355,20 +351,16 @@ function runPiStreaming(
 					assistantError = event.message.errorMessage;
 					assistantFailureSignal = event.message;
 				}
-				if (isTerminalAssistantFailureStopReason(stopReason)) {
+				if (isAssistantFailureStopReason(stopReason)) {
 					assistantError = modelFailureMessage(event.message);
 					assistantFailureSignal = event.message;
 				}
-				const hasToolCall = Array.isArray(event.message.content)
-					&& event.message.content.some((part) => (part as { type?: string }).type === "toolCall");
-				if (stopReason === "stop" && !hasToolCall) {
-					if (!event.message.errorMessage && extractTextFromContent(event.message.content).trim()) {
+				if (shouldStartSubagentFinalDrain(event.message)) {
+					if (extractTextFromContent(event.message.content).trim()) {
 						assistantError = undefined;
 						assistantFailureSignal = undefined;
 					}
-					cleanTerminalAssistantStopReceived ||= !event.message.errorMessage;
-					startFinalDrain();
-				} else if (isTerminalAssistantFailureStopReason(stopReason) && !hasToolCall) {
+					cleanTerminalAssistantStopReceived = true;
 					startFinalDrain();
 				}
 			}

--- a/packages/subagents/src/runs/background/subagent-runner.ts
+++ b/packages/subagents/src/runs/background/subagent-runner.ts
@@ -218,6 +218,10 @@ function assistantStopReason(message: Message): string | undefined {
 	return typeof stopReason === "string" ? stopReason : undefined;
 }
 
+function isTerminalAssistantFailureStopReason(stopReason: string | undefined): boolean {
+	return stopReason === "error" || stopReason === "aborted";
+}
+
 interface ChildEvent {
 	type?: string;
 	message?: ChildMessage;
@@ -351,7 +355,7 @@ function runPiStreaming(
 					assistantError = event.message.errorMessage;
 					assistantFailureSignal = event.message;
 				}
-				if (stopReason === "error" || stopReason === "aborted") {
+				if (isTerminalAssistantFailureStopReason(stopReason)) {
 					assistantError = modelFailureMessage(event.message);
 					assistantFailureSignal = event.message;
 				}
@@ -364,7 +368,7 @@ function runPiStreaming(
 					}
 					cleanTerminalAssistantStopReceived ||= !event.message.errorMessage;
 					startFinalDrain();
-				} else if ((stopReason === "error" || stopReason === "aborted") && !hasToolCall) {
+				} else if (isTerminalAssistantFailureStopReason(stopReason) && !hasToolCall) {
 					startFinalDrain();
 				}
 			}

--- a/packages/subagents/src/runs/background/subagent-runner.ts
+++ b/packages/subagents/src/runs/background/subagent-runner.ts
@@ -48,7 +48,7 @@ import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/c
 import { createStructuredOutputRuntime, readStructuredOutput } from "../shared/structured-output.ts";
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
 import { nestedSummaryFromAsyncStatus, writeNestedEvent } from "../shared/nested-events.ts";
-import { formatModelAttemptNote, isRetryableModelFailure } from "../shared/model-fallback.ts";
+import { formatModelAttemptNote, isRetryableModelFailure, modelFailureMessage } from "../shared/model-fallback.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput } from "../../shared/utils.ts";
 import { evaluateCompletionMutationGuard } from "../shared/completion-guard.ts";
@@ -213,6 +213,11 @@ type ChildMessage = Message & {
 	usage?: ChildUsage;
 };
 
+function assistantStopReason(message: Message): string | undefined {
+	const stopReason = (message as { readonly stopReason?: unknown }).stopReason;
+	return typeof stopReason === "string" ? stopReason : undefined;
+}
+
 interface ChildEvent {
 	type?: string;
 	message?: ChildMessage;
@@ -230,6 +235,7 @@ interface RunPiStreamingResult {
 	finalOutput: string;
 	interrupted?: boolean;
 	observedMutationAttempt?: boolean;
+	modelFailureSignal?: unknown;
 }
 
 function runPiStreaming(
@@ -270,6 +276,7 @@ function runPiStreaming(
 		let model: string | undefined;
 		let error: string | undefined;
 		let assistantError: string | undefined;
+		let assistantFailureSignal: unknown;
 		let interrupted = false;
 		let observedMutationAttempt = false;
 		const rawStdoutLines: string[] = [];
@@ -330,7 +337,6 @@ function runPiStreaming(
 
 				if (event.type !== "message_end" || event.message.role !== "assistant") return;
 				if (event.message.model) model = event.message.model;
-				if (event.message.errorMessage) assistantError = event.message.errorMessage;
 				const eventUsage = event.message.usage;
 				if (eventUsage) {
 					usage.turns++;
@@ -340,12 +346,25 @@ function runPiStreaming(
 					usage.cacheWrite += eventUsage.cacheWrite ?? 0;
 					usage.cost += eventUsage.cost?.total ?? 0;
 				}
-				const stopReason = (event.message as { stopReason?: string }).stopReason;
+				const stopReason = assistantStopReason(event.message);
+				if (event.message.errorMessage) {
+					assistantError = event.message.errorMessage;
+					assistantFailureSignal = event.message;
+				}
+				if (stopReason === "error" || stopReason === "aborted") {
+					assistantError = modelFailureMessage(event.message);
+					assistantFailureSignal = event.message;
+				}
 				const hasToolCall = Array.isArray(event.message.content)
 					&& event.message.content.some((part) => (part as { type?: string }).type === "toolCall");
 				if (stopReason === "stop" && !hasToolCall) {
-					if (!event.message.errorMessage && extractTextFromContent(event.message.content).trim()) assistantError = undefined;
+					if (!event.message.errorMessage && extractTextFromContent(event.message.content).trim()) {
+						assistantError = undefined;
+						assistantFailureSignal = undefined;
+					}
 					cleanTerminalAssistantStopReceived ||= !event.message.errorMessage;
+					startFinalDrain();
+				} else if ((stopReason === "error" || stopReason === "aborted") && !hasToolCall) {
 					startFinalDrain();
 				}
 			}
@@ -448,6 +467,9 @@ function runPiStreaming(
 				finalOutput,
 				interrupted,
 				observedMutationAttempt,
+				...(assistantFailureSignal !== undefined && finalError === assistantError
+					? { modelFailureSignal: assistantFailureSignal }
+					: {}),
 			});
 		});
 
@@ -459,7 +481,20 @@ function runPiStreaming(
 			outputStream.end();
 			const finalOutput = getFinalOutput(messages) || rawStdoutLines.join("\n").trim();
 			const spawnErrorMessage = spawnError instanceof Error ? spawnError.message : String(spawnError);
-			resolve({ stderr, exitCode: 1, messages, usage, model, error: error ?? assistantError ?? spawnErrorMessage, finalOutput, observedMutationAttempt });
+			const finalError = error ?? assistantError ?? spawnErrorMessage;
+			resolve({
+				stderr,
+				exitCode: 1,
+				messages,
+				usage,
+				model,
+				error: finalError,
+				finalOutput,
+				observedMutationAttempt,
+				...(assistantFailureSignal !== undefined && finalError === assistantError
+					? { modelFailureSignal: assistantFailureSignal }
+					: {}),
+			});
 		});
 	});
 }
@@ -770,7 +805,14 @@ async function runSingleStep(
 		finalOutputSnapshot = outputSnapshot;
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput } as RunPiStreamingResult & { structuredOutput?: unknown };
 		if (attempt.success) break;
-		if (!completionGuardTriggered && isRetryableModelFailure(error) && index < candidates.length - 1) {
+		const retrySignal = run.modelFailureSignal ?? error;
+		if (
+			!completionGuardTriggered
+			&& structuredError === undefined
+			&& hiddenError?.hasError !== true
+			&& isRetryableModelFailure(retrySignal)
+			&& index < candidates.length - 1
+		) {
 			pendingAttemptNotes.push(formatModelAttemptNote(attempt, candidates[index + 1]));
 			continue;
 		}

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -84,6 +84,10 @@ function assistantStopReason(message: Message): string | undefined {
 	return typeof stopReason === "string" ? stopReason : undefined;
 }
 
+function isTerminalAssistantFailureStopReason(stopReason: string | undefined): boolean {
+	return stopReason === "error" || stopReason === "aborted";
+}
+
 function emptyUsage(): Usage {
 	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
 }
@@ -560,7 +564,7 @@ async function runSingleAttempt(
 						assistantError = evt.message.errorMessage;
 						assistantFailureSignal = evt.message;
 					}
-					if (stopReason === "error" || stopReason === "aborted") {
+					if (isTerminalAssistantFailureStopReason(stopReason)) {
 						assistantError = modelFailureMessage(evt.message);
 						assistantFailureSignal = evt.message;
 					}
@@ -573,7 +577,7 @@ async function runSingleAttempt(
 						}
 						cleanTerminalAssistantStopReceived ||= !evt.message.errorMessage;
 						startFinalDrain();
-					} else if ((stopReason === "error" || stopReason === "aborted") && !hasToolCall) {
+					} else if (isTerminalAssistantFailureStopReason(stopReason) && !hasToolCall) {
 						startFinalDrain();
 					}
 				}

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -54,6 +54,7 @@ import {
 	buildModelCandidates,
 	formatModelAttemptNote,
 	isRetryableModelFailure,
+	modelFailureMessage,
 } from "../shared/model-fallback.ts";
 import {
 	createMutatingFailureState,
@@ -76,6 +77,12 @@ import { acceptanceFailureMessage, evaluateAcceptance, formatAcceptancePrompt, r
 
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
 const acceptanceOutputByResult = new WeakMap<SingleResult, string>();
+const modelFailureSignalByResult = new WeakMap<SingleResult, unknown>();
+
+function assistantStopReason(message: Message): string | undefined {
+	const stopReason = (message as { readonly stopReason?: unknown }).stopReason;
+	return typeof stopReason === "string" ? stopReason : undefined;
+}
 
 function emptyUsage(): Usage {
 	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
@@ -293,6 +300,7 @@ async function runSingleAttempt(
 		let detached = false;
 		let intercomStarted = false;
 		let assistantError: string | undefined;
+		let assistantFailureSignal: unknown;
 		let removeAbortListener: (() => void) | undefined;
 		let removeInterruptListener: (() => void) | undefined;
 		let activityTimer: NodeJS.Timeout | undefined;
@@ -544,16 +552,28 @@ async function runSingleAttempt(
 						progress.tokens = result.usage.input + result.usage.output;
 					}
 					if (!result.model && evt.message.model) result.model = evt.message.model;
-					if (evt.message.errorMessage) assistantError = evt.message.errorMessage;
 					const assistantText = extractTextFromContent(evt.message.content);
 					appendRecentOutput(progress, assistantText.split("\n").slice(-10));
 					// Final assistant message: start the exit drain window.
-					const stopReason = (evt.message as { stopReason?: string }).stopReason;
+					const stopReason = assistantStopReason(evt.message);
+					if (evt.message.errorMessage) {
+						assistantError = evt.message.errorMessage;
+						assistantFailureSignal = evt.message;
+					}
+					if (stopReason === "error" || stopReason === "aborted") {
+						assistantError = modelFailureMessage(evt.message);
+						assistantFailureSignal = evt.message;
+					}
 					const hasToolCall = Array.isArray(evt.message.content)
 						&& evt.message.content.some((part) => (part as { type?: string }).type === "toolCall");
 					if (stopReason === "stop" && !hasToolCall) {
-						if (!evt.message.errorMessage && assistantText.trim()) assistantError = undefined;
+						if (!evt.message.errorMessage && assistantText.trim()) {
+							assistantError = undefined;
+							assistantFailureSignal = undefined;
+						}
 						cleanTerminalAssistantStopReceived ||= !evt.message.errorMessage;
+						startFinalDrain();
+					} else if ((stopReason === "error" || stopReason === "aborted") && !hasToolCall) {
 						startFinalDrain();
 					}
 				}
@@ -633,6 +653,9 @@ async function runSingleAttempt(
 			processClosed = true;
 			if (buf.trim()) processLine(buf);
 			if (!result.error && assistantError) result.error = assistantError;
+			if (assistantFailureSignal !== undefined && result.error === assistantError) {
+				modelFailureSignalByResult.set(result, assistantFailureSignal);
+			}
 			const forcedDrainAfterFinalSuccess = forcedTerminationSignal && cleanTerminalAssistantStopReceived && !result.error;
 			if (code !== 0 && stderrBuf.trim() && !result.error && !forcedDrainAfterFinalSuccess) {
 				result.error = stderrBuf.trim();
@@ -964,7 +987,8 @@ export async function runSync(
 		if (attemptSucceeded) {
 			break;
 		}
-		if (isRetryableModelFailure(result.error) && i < modelsToTry.length - 1) {
+		const retrySignal = modelFailureSignalByResult.get(result) ?? result.error;
+		if (isRetryableModelFailure(retrySignal) && i < modelsToTry.length - 1) {
 			pendingAttemptNotes.push(formatModelAttemptNote(attempt, modelsToTry[i + 1]));
 			continue;
 		}

--- a/packages/subagents/src/runs/foreground/execution.ts
+++ b/packages/subagents/src/runs/foreground/execution.ts
@@ -57,6 +57,11 @@ import {
 	modelFailureMessage,
 } from "../shared/model-fallback.ts";
 import {
+	assistantStopReason,
+	isAssistantFailureStopReason,
+	shouldStartSubagentFinalDrain,
+} from "../shared/final-drain.ts";
+import {
 	createMutatingFailureState,
 	didMutatingToolFail,
 	isMutatingTool,
@@ -78,15 +83,6 @@ import { acceptanceFailureMessage, evaluateAcceptance, formatAcceptancePrompt, r
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
 const acceptanceOutputByResult = new WeakMap<SingleResult, string>();
 const modelFailureSignalByResult = new WeakMap<SingleResult, unknown>();
-
-function assistantStopReason(message: Message): string | undefined {
-	const stopReason = (message as { readonly stopReason?: unknown }).stopReason;
-	return typeof stopReason === "string" ? stopReason : undefined;
-}
-
-function isTerminalAssistantFailureStopReason(stopReason: string | undefined): boolean {
-	return stopReason === "error" || stopReason === "aborted";
-}
 
 function emptyUsage(): Usage {
 	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
@@ -558,26 +554,23 @@ async function runSingleAttempt(
 					if (!result.model && evt.message.model) result.model = evt.message.model;
 					const assistantText = extractTextFromContent(evt.message.content);
 					appendRecentOutput(progress, assistantText.split("\n").slice(-10));
-					// Final assistant message: start the exit drain window.
+					// Clean final assistant stops start the exit drain window; provider error/aborted
+					// stop reasons remain failure evidence so pi-ai can auto-retry before exit.
 					const stopReason = assistantStopReason(evt.message);
 					if (evt.message.errorMessage) {
 						assistantError = evt.message.errorMessage;
 						assistantFailureSignal = evt.message;
 					}
-					if (isTerminalAssistantFailureStopReason(stopReason)) {
+					if (isAssistantFailureStopReason(stopReason)) {
 						assistantError = modelFailureMessage(evt.message);
 						assistantFailureSignal = evt.message;
 					}
-					const hasToolCall = Array.isArray(evt.message.content)
-						&& evt.message.content.some((part) => (part as { type?: string }).type === "toolCall");
-					if (stopReason === "stop" && !hasToolCall) {
-						if (!evt.message.errorMessage && assistantText.trim()) {
+					if (shouldStartSubagentFinalDrain(evt.message)) {
+						if (assistantText.trim()) {
 							assistantError = undefined;
 							assistantFailureSignal = undefined;
 						}
-						cleanTerminalAssistantStopReceived ||= !evt.message.errorMessage;
-						startFinalDrain();
-					} else if (isTerminalAssistantFailureStopReason(stopReason) && !hasToolCall) {
+						cleanTerminalAssistantStopReceived = true;
 						startFinalDrain();
 					}
 				}

--- a/packages/subagents/src/runs/shared/final-drain.ts
+++ b/packages/subagents/src/runs/shared/final-drain.ts
@@ -1,0 +1,34 @@
+export interface SubagentAssistantDrainMessage {
+	readonly role?: unknown;
+	readonly content?: unknown;
+	readonly stopReason?: unknown;
+	readonly errorMessage?: unknown;
+}
+
+export function assistantStopReason(message: SubagentAssistantDrainMessage): string | undefined {
+	return typeof message.stopReason === "string" ? message.stopReason : undefined;
+}
+
+export function isAssistantFailureStopReason(stopReason: string | undefined): boolean {
+	return stopReason === "error" || stopReason === "aborted";
+}
+
+export function assistantMessageHasToolCall(message: SubagentAssistantDrainMessage): boolean {
+	return Array.isArray(message.content)
+		&& message.content.some((part) => part !== null
+			&& typeof part === "object"
+			&& (part as { readonly type?: unknown }).type === "toolCall");
+}
+
+function assistantMessageHasError(message: SubagentAssistantDrainMessage): boolean {
+	const errorMessage = message.errorMessage;
+	if (typeof errorMessage === "string") return errorMessage.trim().length > 0;
+	return errorMessage !== undefined && errorMessage !== null;
+}
+
+export function shouldStartSubagentFinalDrain(message: SubagentAssistantDrainMessage): boolean {
+	if (message.role !== undefined && message.role !== "assistant") return false;
+	return assistantStopReason(message) === "stop"
+		&& !assistantMessageHasError(message)
+		&& !assistantMessageHasToolCall(message);
+}

--- a/packages/subagents/src/runs/shared/model-fallback.ts
+++ b/packages/subagents/src/runs/shared/model-fallback.ts
@@ -192,6 +192,10 @@ function stopReasonFrom(value: unknown): string | undefined {
 	return stringField(value, "stopReason");
 }
 
+function finishReasonFrom(value: unknown): string | undefined {
+	return stringField(value, "finish_reason") ?? stringField(value, "finishReason");
+}
+
 function causeOf(value: unknown): unknown {
 	return value instanceof Error ? value.cause : field(value, "cause");
 }
@@ -234,9 +238,32 @@ function kindFromStatus(status: number | undefined): ModelFallbackFailureKind | 
 	}
 }
 
+function refusalKindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
+	const normalizedCode = normalizeCode(code);
+	if (normalizedCode === undefined) return undefined;
+	if (normalizedCode.includes("content_filter") || normalizedCode.includes("contentfilter")) return "task_failure";
+	if (normalizedCode.includes("safety") || normalizedCode.includes("policy")) return "task_failure";
+	switch (normalizedCode) {
+		case "blocked":
+		case "blocked_by_provider":
+		case "blocked_by_safety":
+		case "blocked_by_policy":
+		case "provider_refusal":
+		case "refusal":
+		case "tool_refusal":
+		case "tool_call_refusal":
+		case "tool_use_refusal":
+			return "task_failure";
+		default:
+			return undefined;
+	}
+}
+
 function kindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
 	const normalizedCode = normalizeCode(code);
 	if (normalizedCode === undefined) return undefined;
+	const refusalKind = refusalKindFromCode(code);
+	if (refusalKind !== undefined) return refusalKind;
 	const httpStatusKind = kindFromStatus(integerFrom(code));
 	if (httpStatusKind !== undefined) return httpStatusKind;
 
@@ -287,9 +314,22 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
 	}
 }
 
+const PROVIDER_REFUSAL_FAILURE_PATTERNS: readonly RegExp[] = [
+	/\bfinish[_\s-]?reason\b[^\n]*\bcontent[_\s-]?filter\b/i,
+	/\bcontent[_\s-]?filter(?:ed|ing)?\b/i,
+	/\b(?:safety|policy)\b[^\n]*\b(?:refus(?:e|al|ed|es|ing)?|block(?:ed|ing)?|filter(?:ed|ing)?|violat(?:e|ion|ed|ing)?|disallow(?:ed|ing)?|reject(?:ed|ion|ing)?)\b/i,
+	/\b(?:refus(?:e|al|ed|es|ing)?|block(?:ed|ing)?|filter(?:ed|ing)?|violat(?:e|ion|ed|ing)?|disallow(?:ed|ing)?|reject(?:ed|ion|ing)?)\b[^\n]*\b(?:safety|policy)\b/i,
+	/\btool[_\s-]?(?:call|use)?[_\s-]?refus(?:e|al|ed|es|ing)?\b/i,
+	/\btool(?:\s+call|\s+use)?\b[^\n]*\brefus(?:e|al|ed|es|ing)?\b/i,
+	/\brefus(?:e|al|ed|es|ing)?\b[^\n]*\btool(?:\s+call|\s+use)?\b/i,
+	/\bprovider[_\s-]?refus(?:e|al|ed|es|ing)?\b/i,
+	/\bprovider\b[^\n]*\brefus(?:e|al|ed|es|ing)?\b[^\n]*\b(?:prompt|request|content|policy|safety)\b/i,
+];
+
 function refusalKindFromMessage(message: string): ModelFallbackFailureKind | undefined {
 	if (CANCELLED_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "cancelled";
 	if (NON_RETRYABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "task_failure";
+	if (PROVIDER_REFUSAL_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "task_failure";
 	return undefined;
 }
 
@@ -343,6 +383,19 @@ function fallbackSignalFromMessage(
 	return kind === undefined ? undefined : makeSignal(kind, value, source);
 }
 
+function classifyAssistantRefusalSignal(
+	value: unknown,
+	source: ModelFallbackFailureSource | undefined,
+): ModelFallbackFailureSignal | undefined {
+	const codeRefusalKind = refusalKindFromCode(codeFrom(value))
+		?? refusalKindFromCode(errorName(value))
+		?? refusalKindFromCode(finishReasonFrom(value));
+	if (codeRefusalKind !== undefined) return makeSignal(codeRefusalKind, value, source);
+
+	const messageRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
+	return messageRefusalKind === undefined ? undefined : makeSignal(messageRefusalKind, value, source);
+}
+
 function isRefusalSignal(signal: ModelFallbackFailureSignal): boolean {
 	return signal.kind === "cancelled" || signal.kind === "task_failure";
 }
@@ -358,20 +411,21 @@ function structuredSignal(
 	const stopReason = stopReasonFrom(value)?.toLowerCase();
 	if (stopReason === "aborted") return makeSignal("cancelled", value, source);
 
+	const directRefusalSignal = classifyAssistantRefusalSignal(value, source);
+	if (directRefusalSignal !== undefined) return directRefusalSignal;
+
 	const codeKind = kindFromCode(codeFrom(value));
 	const nameKind = kindFromCode(errorName(value));
 	if (codeKind === "cancelled" || nameKind === "cancelled") return makeSignal("cancelled", value, source);
-	const directRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
-	if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
 
-	const nestedSignals: ModelFallbackFailureSignal[] = [];
+	let firstNestedFallbackSignal: ModelFallbackFailureSignal | undefined;
 	const nestedSeen = new Set(seen);
 	for (const diagnosticError of diagnosticErrors(value)) {
 		const diagnosticSignal = structuredSignal(diagnosticError, nestedSeen, "diagnostic")
 			?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
 		if (diagnosticSignal === undefined) continue;
 		if (isRefusalSignal(diagnosticSignal)) return diagnosticSignal;
-		nestedSignals.push(diagnosticSignal);
+		firstNestedFallbackSignal ??= diagnosticSignal;
 	}
 
 	const cause = causeOf(value);
@@ -379,7 +433,7 @@ function structuredSignal(
 		?? fallbackSignalFromMessage(cause, source);
 	if (causeSignal !== undefined) {
 		if (isRefusalSignal(causeSignal)) return causeSignal;
-		nestedSignals.push(causeSignal);
+		firstNestedFallbackSignal ??= causeSignal;
 	}
 
 	const statusKind = kindFromStatus(statusFrom(value));
@@ -387,8 +441,7 @@ function structuredSignal(
 	if (codeKind !== undefined) return makeSignal(codeKind, value, source);
 	if (nameKind !== undefined) return makeSignal(nameKind, value, source);
 
-	const nestedSignal = nestedSignals[0];
-	if (nestedSignal !== undefined) return nestedSignal;
+	if (firstNestedFallbackSignal !== undefined) return firstNestedFallbackSignal;
 
 	if (stopReason === "error") return makeSignal("provider_unavailable", value, source);
 
@@ -416,6 +469,8 @@ function messageFromUnknown(value: unknown, seen: Set<unknown>): string | undefi
 
 	const stopReason = stopReasonFrom(value);
 	if (stopReason !== undefined) return `Assistant message ended with stopReason:${stopReason}`;
+	const finishReason = finishReasonFrom(value);
+	if (finishReason !== undefined) return `Model request finished with finish_reason:${finishReason}`;
 	const status = statusFrom(value);
 	if (status !== undefined) return `Model request failed with status ${status}`;
 	const code = codeFrom(value);

--- a/packages/subagents/src/runs/shared/model-fallback.ts
+++ b/packages/subagents/src/runs/shared/model-fallback.ts
@@ -241,8 +241,6 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
 	if (httpStatusKind !== undefined) return httpStatusKind;
 
 	switch (normalizedCode) {
-		case "401":
-		case "403":
 		case "auth":
 		case "auth_required":
 		case "authentication_required":
@@ -252,7 +250,6 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
 		case "missing_api_key":
 		case "invalid_key":
 			return "auth_on_candidate_provider";
-		case "408":
 		case "etimedout":
 		case "econnreset":
 		case "econnrefused":
@@ -264,7 +261,6 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
 		case "timeout_error":
 		case "und_err_connect_timeout":
 			return "network_timeout";
-		case "429":
 		case "rate_limit":
 		case "rate_limit_exceeded":
 		case "too_many_requests":
@@ -275,16 +271,11 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
 		case "cancelled":
 		case "canceled":
 			return "cancelled";
-		case "404":
 		case "model_not_found":
 		case "model_unavailable":
 		case "model_disabled":
 		case "unknown_model":
 			return "model_unavailable";
-		case "500":
-		case "502":
-		case "503":
-		case "504":
 		case "provider_error":
 		case "api_error":
 		case "service_unavailable":
@@ -352,6 +343,10 @@ function fallbackSignalFromMessage(
 	return kind === undefined ? undefined : makeSignal(kind, value, source);
 }
 
+function isRefusalSignal(signal: ModelFallbackFailureSignal): boolean {
+	return signal.kind === "cancelled" || signal.kind === "task_failure";
+}
+
 function structuredSignal(
 	value: unknown,
 	seen: Set<unknown>,
@@ -369,21 +364,31 @@ function structuredSignal(
 	const directRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
 	if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
 
+	const nestedSignals: ModelFallbackFailureSignal[] = [];
+	const nestedSeen = new Set(seen);
+	for (const diagnosticError of diagnosticErrors(value)) {
+		const diagnosticSignal = structuredSignal(diagnosticError, nestedSeen, "diagnostic")
+			?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
+		if (diagnosticSignal === undefined) continue;
+		if (isRefusalSignal(diagnosticSignal)) return diagnosticSignal;
+		nestedSignals.push(diagnosticSignal);
+	}
+
+	const cause = causeOf(value);
+	const causeSignal = structuredSignal(cause, nestedSeen, source)
+		?? fallbackSignalFromMessage(cause, source);
+	if (causeSignal !== undefined) {
+		if (isRefusalSignal(causeSignal)) return causeSignal;
+		nestedSignals.push(causeSignal);
+	}
+
 	const statusKind = kindFromStatus(statusFrom(value));
 	if (statusKind !== undefined) return makeSignal(statusKind, value, source);
 	if (codeKind !== undefined) return makeSignal(codeKind, value, source);
 	if (nameKind !== undefined) return makeSignal(nameKind, value, source);
 
-	for (const diagnosticError of diagnosticErrors(value)) {
-		const diagnosticSignal = structuredSignal(diagnosticError, seen, "diagnostic")
-			?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
-		if (diagnosticSignal !== undefined) return diagnosticSignal;
-	}
-
-	const cause = causeOf(value);
-	const causeSignal = structuredSignal(cause, seen, source)
-		?? fallbackSignalFromMessage(cause, source);
-	if (causeSignal !== undefined) return causeSignal;
+	const nestedSignal = nestedSignals[0];
+	if (nestedSignal !== undefined) return nestedSignal;
 
 	if (stopReason === "error") return makeSignal("provider_unavailable", value, source);
 

--- a/packages/subagents/src/runs/shared/model-fallback.ts
+++ b/packages/subagents/src/runs/shared/model-fallback.ts
@@ -164,6 +164,12 @@ function errorName(value: unknown): string | undefined {
 	return value instanceof Error ? value.name : stringField(value, "name");
 }
 
+function directMessageFrom(value: unknown): string | undefined {
+	return stringField(value, "errorMessage")
+		?? stringField(value, "message")
+		?? stringField(value, "statusText");
+}
+
 function integerFrom(value: unknown): number | undefined {
 	if (typeof value === "number" && Number.isInteger(value)) return value;
 	if (typeof value !== "string" || value.trim().length === 0) return undefined;
@@ -222,20 +228,19 @@ function kindFromStatus(status: number | undefined): ModelFallbackFailureKind | 
 			return "model_unavailable";
 		case 429:
 			return "rate_limit";
-		case 500:
-		case 502:
-		case 503:
-		case 504:
-			return "provider_unavailable";
 		default:
+			if (status !== undefined && status >= 500 && status <= 599) return "provider_unavailable";
 			return undefined;
 	}
 }
 
 function kindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
-	switch (normalizeCode(code)) {
-		case undefined:
-			return undefined;
+	const normalizedCode = normalizeCode(code);
+	if (normalizedCode === undefined) return undefined;
+	const httpStatusKind = kindFromStatus(integerFrom(code));
+	if (httpStatusKind !== undefined) return httpStatusKind;
+
+	switch (normalizedCode) {
 		case "401":
 		case "403":
 		case "auth":
@@ -361,12 +366,7 @@ function structuredSignal(
 	const codeKind = kindFromCode(codeFrom(value));
 	const nameKind = kindFromCode(errorName(value));
 	if (codeKind === "cancelled" || nameKind === "cancelled") return makeSignal("cancelled", value, source);
-	const directRefusalKind = refusalKindFromMessage(
-		stringField(value, "errorMessage")
-			?? stringField(value, "message")
-			?? stringField(value, "statusText")
-			?? "",
-	);
+	const directRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
 	if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
 
 	const statusKind = kindFromStatus(statusFrom(value));
@@ -398,9 +398,7 @@ function messageFromUnknown(value: unknown, seen: Set<unknown>): string | undefi
 	seen.add(value);
 
 	if (value instanceof Error && value.message.trim().length > 0) return value.message;
-	const directMessage = stringField(value, "errorMessage")
-		?? stringField(value, "message")
-		?? stringField(value, "statusText");
+	const directMessage = directMessageFrom(value);
 	if (directMessage !== undefined) return directMessage;
 
 	for (const diagnosticError of diagnosticErrors(value)) {
@@ -433,14 +431,15 @@ export function normalizeModelFailureSignal(error: unknown): ModelFallbackFailur
 	if (structured !== undefined) return structured;
 
 	const message = modelFailureMessage(error);
+	const name = errorName(error);
 	const fallbackKind = message.trim().length > 0
-		? fallbackKindFromMessage(message, errorName(error))
+		? fallbackKindFromMessage(message, name)
 		: undefined;
 	return {
 		kind: fallbackKind ?? "unknown",
 		message,
 		source: "string_fallback",
-		...(errorName(error) !== undefined ? { name: errorName(error)! } : {}),
+		...(name !== undefined ? { name } : {}),
 	};
 }
 

--- a/packages/subagents/src/runs/shared/model-fallback.ts
+++ b/packages/subagents/src/runs/shared/model-fallback.ts
@@ -62,7 +62,7 @@ export function currentModelFullId(model: { provider: string; id: string } | und
 	return `${String(model.provider)}/${model.id}`;
 }
 
-const RETRYABLE_MODEL_FAILURE_PATTERNS = [
+const RETRYABLE_MODEL_FAILURE_PATTERNS: readonly RegExp[] = [
 	/rate\s*limit/i,
 	/too many requests/i,
 	/\b429\b/,
@@ -71,6 +71,7 @@ const RETRYABLE_MODEL_FAILURE_PATTERNS = [
 	/credit/i,
 	/auth(?:entication)?/i,
 	/unauthori[sz]ed/i,
+	/\b40[13]\b/,
 	/forbidden/i,
 	/api key/i,
 	/token expired/i,
@@ -90,14 +91,363 @@ const RETRYABLE_MODEL_FAILURE_PATTERNS = [
 	/upstream/i,
 	/timed? out/i,
 	/timeout/i,
-	/\b502\b/,
-	/\b503\b/,
-	/\b504\b/,
+	/\b50[0-4]\b/,
 ];
 
-export function isRetryableModelFailure(error: string | undefined): boolean {
-	if (!error) return false;
-	return RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(error));
+const NON_RETRYABLE_FAILURE_PATTERNS: readonly RegExp[] = [
+	/command failed/i,
+	/tests? failed/i,
+	/shell/i,
+	/missing file/i,
+	/no such file/i,
+	/completion guard/i,
+	/cancel/i,
+	/abort/i,
+	/interrupted/i,
+];
+
+const CANCELLED_FAILURE_PATTERNS: readonly RegExp[] = [
+	/cancel/i,
+	/abort/i,
+	/interrupted/i,
+];
+
+export type ModelFallbackFailureKind =
+	| "auth_on_candidate_provider"
+	| "rate_limit"
+	| "provider_unavailable"
+	| "network_timeout"
+	| "model_unavailable"
+	| "cancelled"
+	| "task_failure"
+	| "unknown";
+
+export type ModelFallbackFailureSource =
+	| "assistant_message"
+	| "diagnostic"
+	| "throw"
+	| "structured"
+	| "string_fallback";
+
+export interface ModelFallbackFailureSignal {
+	readonly kind: ModelFallbackFailureKind;
+	readonly message: string;
+	readonly source: ModelFallbackFailureSource;
+	readonly stopReason?: string;
+	readonly status?: number;
+	readonly code?: string | number;
+	readonly name?: string;
+}
+
+const FALLBACKABLE_FAILURE_KINDS: ReadonlySet<ModelFallbackFailureKind> = new Set([
+	"auth_on_candidate_provider",
+	"rate_limit",
+	"provider_unavailable",
+	"network_timeout",
+	"model_unavailable",
+]);
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" ? value as Record<string, unknown> : undefined;
+}
+
+function field(value: unknown, key: string): unknown {
+	return asRecord(value)?.[key];
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+	const raw = field(value, key);
+	return typeof raw === "string" && raw.trim().length > 0 ? raw : undefined;
+}
+
+function errorName(value: unknown): string | undefined {
+	return value instanceof Error ? value.name : stringField(value, "name");
+}
+
+function integerFrom(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isInteger(value)) return value;
+	if (typeof value !== "string" || value.trim().length === 0) return undefined;
+	const parsed = Number(value.trim());
+	return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function statusFrom(value: unknown): number | undefined {
+	return integerFrom(field(value, "status"))
+		?? integerFrom(field(value, "statusCode"))
+		?? integerFrom(field(value, "httpStatus"));
+}
+
+function codeFrom(value: unknown): string | number | undefined {
+	const rawCode = field(value, "code");
+	return typeof rawCode === "string" || typeof rawCode === "number" ? rawCode : undefined;
+}
+
+function stopReasonFrom(value: unknown): string | undefined {
+	return stringField(value, "stopReason");
+}
+
+function causeOf(value: unknown): unknown {
+	return value instanceof Error ? value.cause : field(value, "cause");
+}
+
+function diagnosticErrors(value: unknown): readonly unknown[] {
+	const diagnostics = field(value, "diagnostics");
+	if (!Array.isArray(diagnostics)) return [];
+	const errors: unknown[] = [];
+	for (const diagnostic of diagnostics) {
+		const diagnosticError = field(diagnostic, "error");
+		errors.push(diagnosticError ?? diagnostic);
+	}
+	return errors;
+}
+
+function normalizeCode(value: string | number | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	const normalized = String(value)
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+function kindFromStatus(status: number | undefined): ModelFallbackFailureKind | undefined {
+	switch (status) {
+		case 401:
+		case 403:
+			return "auth_on_candidate_provider";
+		case 408:
+			return "network_timeout";
+		case 404:
+			return "model_unavailable";
+		case 429:
+			return "rate_limit";
+		case 500:
+		case 502:
+		case 503:
+		case 504:
+			return "provider_unavailable";
+		default:
+			return undefined;
+	}
+}
+
+function kindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
+	switch (normalizeCode(code)) {
+		case undefined:
+			return undefined;
+		case "401":
+		case "403":
+		case "auth":
+		case "auth_required":
+		case "authentication_required":
+		case "unauthorized":
+		case "forbidden":
+		case "invalid_api_key":
+		case "missing_api_key":
+		case "invalid_key":
+			return "auth_on_candidate_provider";
+		case "408":
+		case "etimedout":
+		case "econnreset":
+		case "econnrefused":
+		case "enotfound":
+		case "eai_again":
+		case "fetch_failed":
+		case "network_error":
+		case "timeout":
+		case "timeout_error":
+		case "und_err_connect_timeout":
+			return "network_timeout";
+		case "429":
+		case "rate_limit":
+		case "rate_limit_exceeded":
+		case "too_many_requests":
+		case "quota_exceeded":
+			return "rate_limit";
+		case "aborterror":
+		case "aborted":
+		case "cancelled":
+		case "canceled":
+			return "cancelled";
+		case "404":
+		case "model_not_found":
+		case "model_unavailable":
+		case "model_disabled":
+		case "unknown_model":
+			return "model_unavailable";
+		case "500":
+		case "502":
+		case "503":
+		case "504":
+		case "provider_error":
+		case "api_error":
+		case "service_unavailable":
+		case "temporarily_unavailable":
+		case "overloaded":
+			return "provider_unavailable";
+		default:
+			return undefined;
+	}
+}
+
+function refusalKindFromMessage(message: string): ModelFallbackFailureKind | undefined {
+	if (CANCELLED_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "cancelled";
+	if (NON_RETRYABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "task_failure";
+	return undefined;
+}
+
+function fallbackKindFromMessage(message: string, name: string | undefined): ModelFallbackFailureKind | undefined {
+	const refusalKind = refusalKindFromMessage(message);
+	if (refusalKind !== undefined) return refusalKind;
+	const nameKind = kindFromCode(name);
+	if (nameKind !== undefined) return nameKind;
+	if (!RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return undefined;
+	if (/rate\s*limit|too many requests|\b429\b|quota|billing|credit/i.test(message)) return "rate_limit";
+	if (/auth|unauthori[sz]ed|\b40[13]\b|api key|token expired|forbidden|invalid key/i.test(message)) return "auth_on_candidate_provider";
+	if (/model.*(?:unavailable|disabled|not found|unknown)|(?:unavailable|disabled|not found|unknown).*model/i.test(message)) return "model_unavailable";
+	if (/network|fetch failed|socket|connection refused|timeout|timed? out/i.test(message)) return "network_timeout";
+	return "provider_unavailable";
+}
+
+function signalSource(value: unknown, fallback: ModelFallbackFailureSource | undefined): ModelFallbackFailureSource {
+	if (fallback !== undefined) return fallback;
+	if (stopReasonFrom(value) !== undefined || diagnosticErrors(value).length > 0) return "assistant_message";
+	if (value instanceof Error) return "throw";
+	return "structured";
+}
+
+function makeSignal(
+	kind: ModelFallbackFailureKind,
+	value: unknown,
+	source: ModelFallbackFailureSource | undefined,
+): ModelFallbackFailureSignal {
+	const status = statusFrom(value);
+	const code = codeFrom(value);
+	const name = errorName(value);
+	const stopReason = stopReasonFrom(value);
+	return {
+		kind,
+		message: modelFailureMessage(value),
+		source: signalSource(value, source),
+		...(stopReason !== undefined ? { stopReason } : {}),
+		...(status !== undefined ? { status } : {}),
+		...(code !== undefined ? { code } : {}),
+		...(name !== undefined ? { name } : {}),
+	};
+}
+
+function fallbackSignalFromMessage(
+	value: unknown,
+	source: ModelFallbackFailureSource | undefined,
+): ModelFallbackFailureSignal | undefined {
+	const message = modelFailureMessage(value);
+	if (!message.trim()) return undefined;
+	const kind = fallbackKindFromMessage(message, errorName(value));
+	return kind === undefined ? undefined : makeSignal(kind, value, source);
+}
+
+function structuredSignal(
+	value: unknown,
+	seen: Set<unknown>,
+	source?: ModelFallbackFailureSource,
+): ModelFallbackFailureSignal | undefined {
+	if (value === undefined || value === null || seen.has(value)) return undefined;
+	if (typeof value === "object") seen.add(value);
+
+	const stopReason = stopReasonFrom(value)?.toLowerCase();
+	if (stopReason === "aborted") return makeSignal("cancelled", value, source);
+
+	const codeKind = kindFromCode(codeFrom(value));
+	const nameKind = kindFromCode(errorName(value));
+	if (codeKind === "cancelled" || nameKind === "cancelled") return makeSignal("cancelled", value, source);
+	const directRefusalKind = refusalKindFromMessage(
+		stringField(value, "errorMessage")
+			?? stringField(value, "message")
+			?? stringField(value, "statusText")
+			?? "",
+	);
+	if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
+
+	const statusKind = kindFromStatus(statusFrom(value));
+	if (statusKind !== undefined) return makeSignal(statusKind, value, source);
+	if (codeKind !== undefined) return makeSignal(codeKind, value, source);
+	if (nameKind !== undefined) return makeSignal(nameKind, value, source);
+
+	for (const diagnosticError of diagnosticErrors(value)) {
+		const diagnosticSignal = structuredSignal(diagnosticError, seen, "diagnostic")
+			?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
+		if (diagnosticSignal !== undefined) return diagnosticSignal;
+	}
+
+	const cause = causeOf(value);
+	const causeSignal = structuredSignal(cause, seen, source)
+		?? fallbackSignalFromMessage(cause, source);
+	if (causeSignal !== undefined) return causeSignal;
+
+	if (stopReason === "error") return makeSignal("provider_unavailable", value, source);
+
+	return undefined;
+}
+
+function messageFromUnknown(value: unknown, seen: Set<unknown>): string | undefined {
+	if (value === undefined || value === null || seen.has(value)) return undefined;
+	if (typeof value === "string") return value.trim().length > 0 ? value : undefined;
+	if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value);
+	if (typeof value === "symbol" || typeof value === "function") return undefined;
+	seen.add(value);
+
+	if (value instanceof Error && value.message.trim().length > 0) return value.message;
+	const directMessage = stringField(value, "errorMessage")
+		?? stringField(value, "message")
+		?? stringField(value, "statusText");
+	if (directMessage !== undefined) return directMessage;
+
+	for (const diagnosticError of diagnosticErrors(value)) {
+		const diagnosticMessage = messageFromUnknown(diagnosticError, seen);
+		if (diagnosticMessage !== undefined) return diagnosticMessage;
+	}
+
+	const causeMessage = messageFromUnknown(causeOf(value), seen);
+	if (causeMessage !== undefined) return causeMessage;
+
+	const stopReason = stopReasonFrom(value);
+	if (stopReason !== undefined) return `Assistant message ended with stopReason:${stopReason}`;
+	const status = statusFrom(value);
+	if (status !== undefined) return `Model request failed with status ${status}`;
+	const code = codeFrom(value);
+	if (code !== undefined) return `Model request failed with code ${String(code)}`;
+
+	return undefined;
+}
+
+export function modelFailureMessage(error: unknown): string {
+	const structuredMessage = messageFromUnknown(error, new Set());
+	if (structuredMessage !== undefined) return structuredMessage;
+	const rendered = String(error);
+	return rendered === "[object Object]" ? "Model request failed" : rendered;
+}
+
+export function normalizeModelFailureSignal(error: unknown): ModelFallbackFailureSignal {
+	const structured = structuredSignal(error, new Set());
+	if (structured !== undefined) return structured;
+
+	const message = modelFailureMessage(error);
+	const fallbackKind = message.trim().length > 0
+		? fallbackKindFromMessage(message, errorName(error))
+		: undefined;
+	return {
+		kind: fallbackKind ?? "unknown",
+		message,
+		source: "string_fallback",
+		...(errorName(error) !== undefined ? { name: errorName(error)! } : {}),
+	};
+}
+
+export function isRetryableModelFailure(error: unknown): boolean {
+	if (error === undefined) return false;
+	const signal = normalizeModelFailureSignal(error);
+	return FALLBACKABLE_FAILURE_KINDS.has(signal.kind);
 }
 
 export function formatModelAttemptNote(attempt: ModelAttemptSummary, nextModel?: string): string {

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -267,28 +267,21 @@ function assistantErrorMessage(message: AgentSession["messages"][number]): strin
     : undefined;
 }
 
-type TerminalAssistantOutcome =
-  | { readonly kind: "failure"; readonly message: AgentSession["messages"][number] }
-  | { readonly kind: "recovered" }
-  | { readonly kind: "none" };
-
-function terminalAssistantOutcomeSince(
+function latestTerminalAssistantFailureSince(
   messages: AgentSession["messages"],
   startIndex: number,
-): TerminalAssistantOutcome {
+): AgentSession["messages"][number] | undefined {
   for (let index = messages.length - 1; index >= startIndex; index -= 1) {
     const message = messages[index];
     if (!message || message.role !== "assistant") continue;
     const stopReason = messageStopReason(message);
-    if (isTerminalAssistantFailureStopReason(stopReason)) {
-      return { kind: "failure", message };
-    }
-    if (isCleanAssistantStopReason(stopReason)) return { kind: "recovered" };
+    if (isTerminalAssistantFailureStopReason(stopReason)) return message;
+    if (isCleanAssistantStopReason(stopReason)) return undefined;
     if (assistantErrorMessage(message) === undefined && extractMessageText(message).trim().length > 0) {
-      return { kind: "recovered" };
+      return undefined;
     }
   }
-  return { kind: "none" };
+  return undefined;
 }
 
 class WorkflowPromptModelFailure extends Error {
@@ -860,9 +853,9 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
       notifyModelFallbackMetaChange();
       try {
         const { terminalScanStartIndex } = await promptWithPauseResume(activeSession, text, sdkOptions);
-        const terminalOutcome = terminalAssistantOutcomeSince(activeSession.messages, terminalScanStartIndex);
-        if (terminalOutcome.kind === "failure") {
-          throw new WorkflowPromptModelFailure(terminalOutcome.message);
+        const terminalFailure = latestTerminalAssistantFailureSince(activeSession.messages, terminalScanStartIndex);
+        if (terminalFailure !== undefined) {
+          throw new WorkflowPromptModelFailure(terminalFailure);
         }
         modelAttempts.push({ model: candidate.id, success: true, ...modelAttemptReasoning(candidate) });
         pendingFallbackWarnings.length = 0;

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -246,21 +246,49 @@ function messageStopReason(message: AgentSession["messages"][number]): string | 
   return typeof record.stopReason === "string" ? record.stopReason : undefined;
 }
 
-function isTerminalAssistantFailureStopReason(stopReason: string | undefined): boolean {
-  return stopReason === "error" || stopReason === "aborted";
+function normalizedStopReason(stopReason: string | undefined): string | undefined {
+  return stopReason?.toLowerCase().replace(/[_-]+/g, "");
 }
 
-function terminalAssistantFailureSince(
+function isTerminalAssistantFailureStopReason(stopReason: string | undefined): boolean {
+  const normalized = normalizedStopReason(stopReason);
+  return normalized === "error" || normalized === "aborted";
+}
+
+function isCleanAssistantStopReason(stopReason: string | undefined): boolean {
+  const normalized = normalizedStopReason(stopReason);
+  return normalized === "stop" || normalized === "tooluse" || normalized === "length";
+}
+
+function assistantErrorMessage(message: AgentSession["messages"][number]): string | undefined {
+  const record = message as { readonly errorMessage?: unknown };
+  return typeof record.errorMessage === "string" && record.errorMessage.trim().length > 0
+    ? record.errorMessage
+    : undefined;
+}
+
+type TerminalAssistantOutcome =
+  | { readonly kind: "failure"; readonly message: AgentSession["messages"][number] }
+  | { readonly kind: "recovered" }
+  | { readonly kind: "none" };
+
+function terminalAssistantOutcomeSince(
   messages: AgentSession["messages"],
   startIndex: number,
-): AgentSession["messages"][number] | undefined {
+): TerminalAssistantOutcome {
   for (let index = messages.length - 1; index >= startIndex; index -= 1) {
     const message = messages[index];
     if (!message || message.role !== "assistant") continue;
     const stopReason = messageStopReason(message);
-    if (isTerminalAssistantFailureStopReason(stopReason)) return message;
+    if (isTerminalAssistantFailureStopReason(stopReason)) {
+      return { kind: "failure", message };
+    }
+    if (isCleanAssistantStopReason(stopReason)) return { kind: "recovered" };
+    if (assistantErrorMessage(message) === undefined && extractMessageText(message).trim().length > 0) {
+      return { kind: "recovered" };
+    }
   }
-  return undefined;
+  return { kind: "none" };
 }
 
 class WorkflowPromptModelFailure extends Error {
@@ -832,9 +860,9 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
       notifyModelFallbackMetaChange();
       try {
         const { terminalScanStartIndex } = await promptWithPauseResume(activeSession, text, sdkOptions);
-        const terminalFailure = terminalAssistantFailureSince(activeSession.messages, terminalScanStartIndex);
-        if (terminalFailure !== undefined) {
-          throw new WorkflowPromptModelFailure(terminalFailure);
+        const terminalOutcome = terminalAssistantOutcomeSince(activeSession.messages, terminalScanStartIndex);
+        if (terminalOutcome.kind === "failure") {
+          throw new WorkflowPromptModelFailure(terminalOutcome.message);
         }
         modelAttempts.push({ model: candidate.id, success: true, ...modelAttemptReasoning(candidate) });
         pendingFallbackWarnings.length = 0;

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -241,6 +241,34 @@ function lastAssistantTextFromMessages(messages: AgentSession["messages"]): stri
   return undefined;
 }
 
+function messageStopReason(message: AgentSession["messages"][number]): string | undefined {
+  const record = message as { readonly stopReason?: unknown };
+  return typeof record.stopReason === "string" ? record.stopReason : undefined;
+}
+
+function terminalAssistantFailureSince(
+  messages: AgentSession["messages"],
+  startIndex: number,
+): AgentSession["messages"][number] | undefined {
+  for (let index = messages.length - 1; index >= startIndex; index -= 1) {
+    const message = messages[index];
+    if (!message || message.role !== "assistant") continue;
+    const stopReason = messageStopReason(message);
+    if (stopReason === "error" || stopReason === "aborted") return message;
+  }
+  return undefined;
+}
+
+class WorkflowPromptModelFailure extends Error {
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(errorMessage(cause));
+    this.name = "WorkflowPromptModelFailure";
+    this.cause = cause;
+  }
+}
+
 /**
  * When an agent turn ends on a tool that returned `terminate: true`, control
  * returns with the tool result as the final conversational message and no
@@ -795,14 +823,19 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
       selectedModel = candidate.id;
       notifyModelFallbackMetaChange();
       try {
+        const messageStartIndex = activeSession.messages.length;
         await promptWithPauseResume(activeSession, text, sdkOptions);
+        const terminalFailure = terminalAssistantFailureSince(activeSession.messages, messageStartIndex);
+        if (terminalFailure !== undefined) {
+          throw new WorkflowPromptModelFailure(terminalFailure);
+        }
         modelAttempts.push({ model: candidate.id, success: true, ...modelAttemptReasoning(candidate) });
         pendingFallbackWarnings.length = 0;
         return;
       } catch (err) {
         const message = errorMessage(err);
         modelAttempts.push({ model: candidate.id, success: false, ...modelAttemptReasoning(candidate), error: message });
-        if (signal?.aborted || !isRetryableModelFailure(message) || index === candidates.length - 1) {
+        if (signal?.aborted || !isRetryableModelFailure(err) || index === candidates.length - 1) {
           modelWarnings.push(...pendingFallbackWarnings);
           pendingFallbackWarnings.length = 0;
           notifyModelFallbackMetaChange();

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -246,6 +246,10 @@ function messageStopReason(message: AgentSession["messages"][number]): string | 
   return typeof record.stopReason === "string" ? record.stopReason : undefined;
 }
 
+function isTerminalAssistantFailureStopReason(stopReason: string | undefined): boolean {
+  return stopReason === "error" || stopReason === "aborted";
+}
+
 function terminalAssistantFailureSince(
   messages: AgentSession["messages"],
   startIndex: number,
@@ -254,7 +258,7 @@ function terminalAssistantFailureSince(
     const message = messages[index];
     if (!message || message.role !== "assistant") continue;
     const stopReason = messageStopReason(message);
-    if (stopReason === "error" || stopReason === "aborted") return message;
+    if (isTerminalAssistantFailureStopReason(stopReason)) return message;
   }
   return undefined;
 }
@@ -762,7 +766,7 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
     activeSession: StageSessionRuntime,
     initialText: string,
     sdkOptions: PromptOptions | undefined,
-  ): Promise<void> {
+  ): Promise<{ readonly terminalScanStartIndex: number }> {
     // Pause/resume loop: when a controlled pause aborts the SDK call,
     // swallow the resulting abort, suspend on `pauseRequest.deferred`,
     // and either re-issue with the user's resume message or return the
@@ -773,28 +777,32 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
       if (pendingPauseBeforePrompt) {
         const { message } = await pendingPauseBeforePrompt.deferred.promise;
         nextText = message;
-        if (nextText === undefined) return;
+        if (nextText === undefined) return { terminalScanStartIndex: activeSession.messages.length };
         continue;
       }
+      const promptStartIndex = activeSession.messages.length;
       try {
         await activeSession.prompt(nextText, sdkOptions);
         const pendingPauseAfterPrompt = pauseRequest;
         if (pendingPauseAfterPrompt) {
           const { message } = await pendingPauseAfterPrompt.deferred.promise;
           nextText = message;
-          if (nextText === undefined) return;
+          if (nextText === undefined) return { terminalScanStartIndex: activeSession.messages.length };
           continue;
         }
-        nextText = undefined;
+        return { terminalScanStartIndex: promptStartIndex };
       } catch (err) {
-        if (pauseRequest) {
-          const { message } = await pauseRequest.deferred.promise;
+        const pendingPauseAfterThrow = pauseRequest;
+        if (pendingPauseAfterThrow) {
+          const { message } = await pendingPauseAfterThrow.deferred.promise;
           nextText = message;
+          if (nextText === undefined) return { terminalScanStartIndex: activeSession.messages.length };
           continue;
         }
         throw err;
       }
     }
+    return { terminalScanStartIndex: activeSession.messages.length };
   }
 
   async function promptWithFallback(
@@ -823,9 +831,8 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
       selectedModel = candidate.id;
       notifyModelFallbackMetaChange();
       try {
-        const messageStartIndex = activeSession.messages.length;
-        await promptWithPauseResume(activeSession, text, sdkOptions);
-        const terminalFailure = terminalAssistantFailureSince(activeSession.messages, messageStartIndex);
+        const { terminalScanStartIndex } = await promptWithPauseResume(activeSession, text, sdkOptions);
+        const terminalFailure = terminalAssistantFailureSince(activeSession.messages, terminalScanStartIndex);
         if (terminalFailure !== undefined) {
           throw new WorkflowPromptModelFailure(terminalFailure);
         }

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -432,6 +432,10 @@ function stopReasonFrom(value: unknown): string | undefined {
   return stringField(value, "stopReason");
 }
 
+function finishReasonFrom(value: unknown): string | undefined {
+  return stringField(value, "finish_reason") ?? stringField(value, "finishReason");
+}
+
 function causeOf(value: unknown): unknown {
   return value instanceof Error ? value.cause : field(value, "cause");
 }
@@ -474,9 +478,32 @@ function kindFromStatus(status: number | undefined): ModelFallbackFailureKind | 
   }
 }
 
+function refusalKindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
+  const normalizedCode = normalizeCode(code);
+  if (normalizedCode === undefined) return undefined;
+  if (normalizedCode.includes("content_filter") || normalizedCode.includes("contentfilter")) return "task_failure";
+  if (normalizedCode.includes("safety") || normalizedCode.includes("policy")) return "task_failure";
+  switch (normalizedCode) {
+    case "blocked":
+    case "blocked_by_provider":
+    case "blocked_by_safety":
+    case "blocked_by_policy":
+    case "provider_refusal":
+    case "refusal":
+    case "tool_refusal":
+    case "tool_call_refusal":
+    case "tool_use_refusal":
+      return "task_failure";
+    default:
+      return undefined;
+  }
+}
+
 function kindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
   const normalizedCode = normalizeCode(code);
   if (normalizedCode === undefined) return undefined;
+  const refusalKind = refusalKindFromCode(code);
+  if (refusalKind !== undefined) return refusalKind;
   const httpStatusKind = kindFromStatus(integerFrom(code));
   if (httpStatusKind !== undefined) return httpStatusKind;
 
@@ -527,9 +554,22 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
   }
 }
 
+const PROVIDER_REFUSAL_FAILURE_PATTERNS: readonly RegExp[] = [
+  /\bfinish[_\s-]?reason\b[^\n]*\bcontent[_\s-]?filter\b/i,
+  /\bcontent[_\s-]?filter(?:ed|ing)?\b/i,
+  /\b(?:safety|policy)\b[^\n]*\b(?:refus(?:e|al|ed|es|ing)?|block(?:ed|ing)?|filter(?:ed|ing)?|violat(?:e|ion|ed|ing)?|disallow(?:ed|ing)?|reject(?:ed|ion|ing)?)\b/i,
+  /\b(?:refus(?:e|al|ed|es|ing)?|block(?:ed|ing)?|filter(?:ed|ing)?|violat(?:e|ion|ed|ing)?|disallow(?:ed|ing)?|reject(?:ed|ion|ing)?)\b[^\n]*\b(?:safety|policy)\b/i,
+  /\btool[_\s-]?(?:call|use)?[_\s-]?refus(?:e|al|ed|es|ing)?\b/i,
+  /\btool(?:\s+call|\s+use)?\b[^\n]*\brefus(?:e|al|ed|es|ing)?\b/i,
+  /\brefus(?:e|al|ed|es|ing)?\b[^\n]*\btool(?:\s+call|\s+use)?\b/i,
+  /\bprovider[_\s-]?refus(?:e|al|ed|es|ing)?\b/i,
+  /\bprovider\b[^\n]*\brefus(?:e|al|ed|es|ing)?\b[^\n]*\b(?:prompt|request|content|policy|safety)\b/i,
+];
+
 function refusalKindFromMessage(message: string): ModelFallbackFailureKind | undefined {
   if (CANCELLED_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "cancelled";
   if (NON_RETRYABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "task_failure";
+  if (PROVIDER_REFUSAL_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "task_failure";
   return undefined;
 }
 
@@ -583,6 +623,19 @@ function fallbackSignalFromMessage(
   return kind === undefined ? undefined : makeSignal(kind, value, source);
 }
 
+function classifyAssistantRefusalSignal(
+  value: unknown,
+  source: ModelFallbackFailureSource | undefined,
+): ModelFallbackFailureSignal | undefined {
+  const codeRefusalKind = refusalKindFromCode(codeFrom(value))
+    ?? refusalKindFromCode(errorName(value))
+    ?? refusalKindFromCode(finishReasonFrom(value));
+  if (codeRefusalKind !== undefined) return makeSignal(codeRefusalKind, value, source);
+
+  const messageRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
+  return messageRefusalKind === undefined ? undefined : makeSignal(messageRefusalKind, value, source);
+}
+
 function isRefusalSignal(signal: ModelFallbackFailureSignal): boolean {
   return signal.kind === "cancelled" || signal.kind === "task_failure";
 }
@@ -598,20 +651,21 @@ function structuredSignal(
   const stopReason = stopReasonFrom(value)?.toLowerCase();
   if (stopReason === "aborted") return makeSignal("cancelled", value, source);
 
+  const directRefusalSignal = classifyAssistantRefusalSignal(value, source);
+  if (directRefusalSignal !== undefined) return directRefusalSignal;
+
   const codeKind = kindFromCode(codeFrom(value));
   const nameKind = kindFromCode(errorName(value));
   if (codeKind === "cancelled" || nameKind === "cancelled") return makeSignal("cancelled", value, source);
-  const directRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
-  if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
 
-  const nestedSignals: ModelFallbackFailureSignal[] = [];
+  let firstNestedFallbackSignal: ModelFallbackFailureSignal | undefined;
   const nestedSeen = new Set(seen);
   for (const diagnosticError of diagnosticErrors(value)) {
     const diagnosticSignal = structuredSignal(diagnosticError, nestedSeen, "diagnostic")
       ?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
     if (diagnosticSignal === undefined) continue;
     if (isRefusalSignal(diagnosticSignal)) return diagnosticSignal;
-    nestedSignals.push(diagnosticSignal);
+    firstNestedFallbackSignal ??= diagnosticSignal;
   }
 
   const cause = causeOf(value);
@@ -619,7 +673,7 @@ function structuredSignal(
     ?? fallbackSignalFromMessage(cause, source);
   if (causeSignal !== undefined) {
     if (isRefusalSignal(causeSignal)) return causeSignal;
-    nestedSignals.push(causeSignal);
+    firstNestedFallbackSignal ??= causeSignal;
   }
 
   const statusKind = kindFromStatus(statusFrom(value));
@@ -627,8 +681,7 @@ function structuredSignal(
   if (codeKind !== undefined) return makeSignal(codeKind, value, source);
   if (nameKind !== undefined) return makeSignal(nameKind, value, source);
 
-  const nestedSignal = nestedSignals[0];
-  if (nestedSignal !== undefined) return nestedSignal;
+  if (firstNestedFallbackSignal !== undefined) return firstNestedFallbackSignal;
 
   if (stopReason === "error") return makeSignal("provider_unavailable", value, source);
 
@@ -656,6 +709,8 @@ function messageFromUnknown(value: unknown, seen: Set<unknown>): string | undefi
 
   const stopReason = stopReasonFrom(value);
   if (stopReason !== undefined) return `Assistant message ended with stopReason:${stopReason}`;
+  const finishReason = finishReasonFrom(value);
+  if (finishReason !== undefined) return `Model request finished with finish_reason:${finishReason}`;
   const status = statusFrom(value);
   if (status !== undefined) return `Model request failed with status ${status}`;
   const code = codeFrom(value);

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -404,6 +404,12 @@ function errorName(value: unknown): string | undefined {
   return value instanceof Error ? value.name : stringField(value, "name");
 }
 
+function directMessageFrom(value: unknown): string | undefined {
+  return stringField(value, "errorMessage")
+    ?? stringField(value, "message")
+    ?? stringField(value, "statusText");
+}
+
 function integerFrom(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isInteger(value)) return value;
   if (typeof value !== "string" || value.trim().length === 0) return undefined;
@@ -462,20 +468,19 @@ function kindFromStatus(status: number | undefined): ModelFallbackFailureKind | 
       return "model_unavailable";
     case 429:
       return "rate_limit";
-    case 500:
-    case 502:
-    case 503:
-    case 504:
-      return "provider_unavailable";
     default:
+      if (status !== undefined && status >= 500 && status <= 599) return "provider_unavailable";
       return undefined;
   }
 }
 
 function kindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
-  switch (normalizeCode(code)) {
-    case undefined:
-      return undefined;
+  const normalizedCode = normalizeCode(code);
+  if (normalizedCode === undefined) return undefined;
+  const httpStatusKind = kindFromStatus(integerFrom(code));
+  if (httpStatusKind !== undefined) return httpStatusKind;
+
+  switch (normalizedCode) {
     case "401":
     case "403":
     case "auth":
@@ -601,12 +606,7 @@ function structuredSignal(
   const codeKind = kindFromCode(codeFrom(value));
   const nameKind = kindFromCode(errorName(value));
   if (codeKind === "cancelled" || nameKind === "cancelled") return makeSignal("cancelled", value, source);
-  const directRefusalKind = refusalKindFromMessage(
-    stringField(value, "errorMessage")
-      ?? stringField(value, "message")
-      ?? stringField(value, "statusText")
-      ?? "",
-  );
+  const directRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
   if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
 
   const statusKind = kindFromStatus(statusFrom(value));
@@ -638,9 +638,7 @@ function messageFromUnknown(value: unknown, seen: Set<unknown>): string | undefi
   seen.add(value);
 
   if (value instanceof Error && value.message.trim().length > 0) return value.message;
-  const directMessage = stringField(value, "errorMessage")
-    ?? stringField(value, "message")
-    ?? stringField(value, "statusText");
+  const directMessage = directMessageFrom(value);
   if (directMessage !== undefined) return directMessage;
 
   for (const diagnosticError of diagnosticErrors(value)) {
@@ -673,14 +671,15 @@ export function normalizeModelFailureSignal(error: unknown): ModelFallbackFailur
   if (structured !== undefined) return structured;
 
   const message = errorMessage(error);
+  const name = errorName(error);
   const fallbackKind = message.trim().length > 0
-    ? fallbackKindFromMessage(message, errorName(error))
+    ? fallbackKindFromMessage(message, name)
     : undefined;
   return {
     kind: fallbackKind ?? "unknown",
     message,
     source: "string_fallback",
-    ...(errorName(error) !== undefined ? { name: errorName(error)! } : {}),
+    ...(name !== undefined ? { name } : {}),
   };
 }
 

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -481,8 +481,6 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
   if (httpStatusKind !== undefined) return httpStatusKind;
 
   switch (normalizedCode) {
-    case "401":
-    case "403":
     case "auth":
     case "auth_required":
     case "authentication_required":
@@ -492,7 +490,6 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
     case "missing_api_key":
     case "invalid_key":
       return "auth_on_candidate_provider";
-    case "408":
     case "etimedout":
     case "econnreset":
     case "econnrefused":
@@ -504,7 +501,6 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
     case "timeout_error":
     case "und_err_connect_timeout":
       return "network_timeout";
-    case "429":
     case "rate_limit":
     case "rate_limit_exceeded":
     case "too_many_requests":
@@ -515,16 +511,11 @@ function kindFromCode(code: string | number | undefined): ModelFallbackFailureKi
     case "cancelled":
     case "canceled":
       return "cancelled";
-    case "404":
     case "model_not_found":
     case "model_unavailable":
     case "model_disabled":
     case "unknown_model":
       return "model_unavailable";
-    case "500":
-    case "502":
-    case "503":
-    case "504":
     case "provider_error":
     case "api_error":
     case "service_unavailable":
@@ -592,6 +583,10 @@ function fallbackSignalFromMessage(
   return kind === undefined ? undefined : makeSignal(kind, value, source);
 }
 
+function isRefusalSignal(signal: ModelFallbackFailureSignal): boolean {
+  return signal.kind === "cancelled" || signal.kind === "task_failure";
+}
+
 function structuredSignal(
   value: unknown,
   seen: Set<unknown>,
@@ -609,21 +604,31 @@ function structuredSignal(
   const directRefusalKind = refusalKindFromMessage(directMessageFrom(value) ?? "");
   if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
 
+  const nestedSignals: ModelFallbackFailureSignal[] = [];
+  const nestedSeen = new Set(seen);
+  for (const diagnosticError of diagnosticErrors(value)) {
+    const diagnosticSignal = structuredSignal(diagnosticError, nestedSeen, "diagnostic")
+      ?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
+    if (diagnosticSignal === undefined) continue;
+    if (isRefusalSignal(diagnosticSignal)) return diagnosticSignal;
+    nestedSignals.push(diagnosticSignal);
+  }
+
+  const cause = causeOf(value);
+  const causeSignal = structuredSignal(cause, nestedSeen, source)
+    ?? fallbackSignalFromMessage(cause, source);
+  if (causeSignal !== undefined) {
+    if (isRefusalSignal(causeSignal)) return causeSignal;
+    nestedSignals.push(causeSignal);
+  }
+
   const statusKind = kindFromStatus(statusFrom(value));
   if (statusKind !== undefined) return makeSignal(statusKind, value, source);
   if (codeKind !== undefined) return makeSignal(codeKind, value, source);
   if (nameKind !== undefined) return makeSignal(nameKind, value, source);
 
-  for (const diagnosticError of diagnosticErrors(value)) {
-    const diagnosticSignal = structuredSignal(diagnosticError, seen, "diagnostic")
-      ?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
-    if (diagnosticSignal !== undefined) return diagnosticSignal;
-  }
-
-  const cause = causeOf(value);
-  const causeSignal = structuredSignal(cause, seen, source)
-    ?? fallbackSignalFromMessage(cause, source);
-  if (causeSignal !== undefined) return causeSignal;
+  const nestedSignal = nestedSignals[0];
+  if (nestedSignal !== undefined) return nestedSignal;
 
   if (stopReason === "error") return makeSignal("provider_unavailable", value, source);
 

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -313,9 +313,12 @@ const RETRYABLE_MODEL_FAILURE_PATTERNS: readonly RegExp[] = [
   /billing/i,
   /credit/i,
   /auth(?:entication|orization)?/i,
+  /unauthori[sz]ed/i,
+  /\b40[13]\b/,
   /api\s*key/i,
   /token\s*expired/i,
   /forbidden/i,
+  /invalid\s*key/i,
   /model.*(?:unavailable|disabled|not\s*found|unknown)/i,
   /(?:unavailable|disabled|not\s*found|unknown).*model/i,
   /overloaded/i,
@@ -324,10 +327,11 @@ const RETRYABLE_MODEL_FAILURE_PATTERNS: readonly RegExp[] = [
   /network/i,
   /fetch/i,
   /socket/i,
+  /connection\s*refused/i,
   /upstream/i,
   /timeout/i,
   /timed\s*out/i,
-  /\b50[234]\b/,
+  /\b50[0-4]\b/,
 ];
 
 const NON_RETRYABLE_FAILURE_PATTERNS: readonly RegExp[] = [
@@ -342,15 +346,346 @@ const NON_RETRYABLE_FAILURE_PATTERNS: readonly RegExp[] = [
   /interrupted/i,
 ];
 
-export function errorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return String(error);
+const CANCELLED_FAILURE_PATTERNS: readonly RegExp[] = [
+  /cancel/i,
+  /abort/i,
+  /interrupted/i,
+];
+
+export type ModelFallbackFailureKind =
+  | "auth_on_candidate_provider"
+  | "rate_limit"
+  | "provider_unavailable"
+  | "network_timeout"
+  | "model_unavailable"
+  | "cancelled"
+  | "task_failure"
+  | "unknown";
+
+export type ModelFallbackFailureSource =
+  | "assistant_message"
+  | "diagnostic"
+  | "throw"
+  | "structured"
+  | "string_fallback";
+
+export interface ModelFallbackFailureSignal {
+  readonly kind: ModelFallbackFailureKind;
+  readonly message: string;
+  readonly source: ModelFallbackFailureSource;
+  readonly stopReason?: string;
+  readonly status?: number;
+  readonly code?: string | number;
+  readonly name?: string;
 }
 
-export function isRetryableModelFailure(error: string | Error | undefined): boolean {
+const FALLBACKABLE_FAILURE_KINDS: ReadonlySet<ModelFallbackFailureKind> = new Set([
+  "auth_on_candidate_provider",
+  "rate_limit",
+  "provider_unavailable",
+  "network_timeout",
+  "model_unavailable",
+]);
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" ? value as Record<string, unknown> : undefined;
+}
+
+function field(value: unknown, key: string): unknown {
+  return asRecord(value)?.[key];
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const raw = field(value, key);
+  return typeof raw === "string" && raw.trim().length > 0 ? raw : undefined;
+}
+
+function errorName(value: unknown): string | undefined {
+  return value instanceof Error ? value.name : stringField(value, "name");
+}
+
+function integerFrom(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value !== "string" || value.trim().length === 0) return undefined;
+  const parsed = Number(value.trim());
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+function statusFrom(value: unknown): number | undefined {
+  return integerFrom(field(value, "status"))
+    ?? integerFrom(field(value, "statusCode"))
+    ?? integerFrom(field(value, "httpStatus"));
+}
+
+function codeFrom(value: unknown): string | number | undefined {
+  const rawCode = field(value, "code");
+  return typeof rawCode === "string" || typeof rawCode === "number" ? rawCode : undefined;
+}
+
+function stopReasonFrom(value: unknown): string | undefined {
+  return stringField(value, "stopReason");
+}
+
+function causeOf(value: unknown): unknown {
+  return value instanceof Error ? value.cause : field(value, "cause");
+}
+
+function diagnosticErrors(value: unknown): readonly unknown[] {
+  const diagnostics = field(value, "diagnostics");
+  if (!Array.isArray(diagnostics)) return [];
+  const errors: unknown[] = [];
+  for (const diagnostic of diagnostics) {
+    const diagnosticError = field(diagnostic, "error");
+    errors.push(diagnosticError ?? diagnostic);
+  }
+  return errors;
+}
+
+function normalizeCode(value: string | number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const normalized = String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function kindFromStatus(status: number | undefined): ModelFallbackFailureKind | undefined {
+  switch (status) {
+    case 401:
+    case 403:
+      return "auth_on_candidate_provider";
+    case 408:
+      return "network_timeout";
+    case 404:
+      return "model_unavailable";
+    case 429:
+      return "rate_limit";
+    case 500:
+    case 502:
+    case 503:
+    case 504:
+      return "provider_unavailable";
+    default:
+      return undefined;
+  }
+}
+
+function kindFromCode(code: string | number | undefined): ModelFallbackFailureKind | undefined {
+  switch (normalizeCode(code)) {
+    case undefined:
+      return undefined;
+    case "401":
+    case "403":
+    case "auth":
+    case "auth_required":
+    case "authentication_required":
+    case "unauthorized":
+    case "forbidden":
+    case "invalid_api_key":
+    case "missing_api_key":
+    case "invalid_key":
+      return "auth_on_candidate_provider";
+    case "408":
+    case "etimedout":
+    case "econnreset":
+    case "econnrefused":
+    case "enotfound":
+    case "eai_again":
+    case "fetch_failed":
+    case "network_error":
+    case "timeout":
+    case "timeout_error":
+    case "und_err_connect_timeout":
+      return "network_timeout";
+    case "429":
+    case "rate_limit":
+    case "rate_limit_exceeded":
+    case "too_many_requests":
+    case "quota_exceeded":
+      return "rate_limit";
+    case "aborterror":
+    case "aborted":
+    case "cancelled":
+    case "canceled":
+      return "cancelled";
+    case "404":
+    case "model_not_found":
+    case "model_unavailable":
+    case "model_disabled":
+    case "unknown_model":
+      return "model_unavailable";
+    case "500":
+    case "502":
+    case "503":
+    case "504":
+    case "provider_error":
+    case "api_error":
+    case "service_unavailable":
+    case "temporarily_unavailable":
+    case "overloaded":
+      return "provider_unavailable";
+    default:
+      return undefined;
+  }
+}
+
+function refusalKindFromMessage(message: string): ModelFallbackFailureKind | undefined {
+  if (CANCELLED_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "cancelled";
+  if (NON_RETRYABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "task_failure";
+  return undefined;
+}
+
+function fallbackKindFromMessage(message: string, name: string | undefined): ModelFallbackFailureKind | undefined {
+  const refusalKind = refusalKindFromMessage(message);
+  if (refusalKind !== undefined) return refusalKind;
+  const nameKind = kindFromCode(name);
+  if (nameKind !== undefined) return nameKind;
+  if (!RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return undefined;
+  if (/rate\s*limit|too\s*many\s*requests|\b429\b|quota|billing|credit/i.test(message)) return "rate_limit";
+  if (/auth|unauthori[sz]ed|\b40[13]\b|api\s*key|token\s*expired|forbidden|invalid\s*key/i.test(message)) return "auth_on_candidate_provider";
+  if (/model.*(?:unavailable|disabled|not\s*found|unknown)|(?:unavailable|disabled|not\s*found|unknown).*model/i.test(message)) return "model_unavailable";
+  if (/network|fetch|socket|connection\s*refused|timeout|timed\s*out/i.test(message)) return "network_timeout";
+  return "provider_unavailable";
+}
+
+function signalSource(value: unknown, fallback: ModelFallbackFailureSource | undefined): ModelFallbackFailureSource {
+  if (fallback !== undefined) return fallback;
+  if (stopReasonFrom(value) !== undefined || diagnosticErrors(value).length > 0) return "assistant_message";
+  if (value instanceof Error) return "throw";
+  return "structured";
+}
+
+function makeSignal(
+  kind: ModelFallbackFailureKind,
+  value: unknown,
+  source: ModelFallbackFailureSource | undefined,
+): ModelFallbackFailureSignal {
+  const status = statusFrom(value);
+  const code = codeFrom(value);
+  const name = errorName(value);
+  const stopReason = stopReasonFrom(value);
+  return {
+    kind,
+    message: errorMessage(value),
+    source: signalSource(value, source),
+    ...(stopReason !== undefined ? { stopReason } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(name !== undefined ? { name } : {}),
+  };
+}
+
+function fallbackSignalFromMessage(
+  value: unknown,
+  source: ModelFallbackFailureSource | undefined,
+): ModelFallbackFailureSignal | undefined {
+  const message = errorMessage(value);
+  if (!message.trim()) return undefined;
+  const kind = fallbackKindFromMessage(message, errorName(value));
+  return kind === undefined ? undefined : makeSignal(kind, value, source);
+}
+
+function structuredSignal(
+  value: unknown,
+  seen: Set<unknown>,
+  source?: ModelFallbackFailureSource,
+): ModelFallbackFailureSignal | undefined {
+  if (value === undefined || value === null || seen.has(value)) return undefined;
+  if (typeof value === "object") seen.add(value);
+
+  const stopReason = stopReasonFrom(value)?.toLowerCase();
+  if (stopReason === "aborted") return makeSignal("cancelled", value, source);
+
+  const codeKind = kindFromCode(codeFrom(value));
+  const nameKind = kindFromCode(errorName(value));
+  if (codeKind === "cancelled" || nameKind === "cancelled") return makeSignal("cancelled", value, source);
+  const directRefusalKind = refusalKindFromMessage(
+    stringField(value, "errorMessage")
+      ?? stringField(value, "message")
+      ?? stringField(value, "statusText")
+      ?? "",
+  );
+  if (directRefusalKind !== undefined) return makeSignal(directRefusalKind, value, source);
+
+  const statusKind = kindFromStatus(statusFrom(value));
+  if (statusKind !== undefined) return makeSignal(statusKind, value, source);
+  if (codeKind !== undefined) return makeSignal(codeKind, value, source);
+  if (nameKind !== undefined) return makeSignal(nameKind, value, source);
+
+  for (const diagnosticError of diagnosticErrors(value)) {
+    const diagnosticSignal = structuredSignal(diagnosticError, seen, "diagnostic")
+      ?? fallbackSignalFromMessage(diagnosticError, "diagnostic");
+    if (diagnosticSignal !== undefined) return diagnosticSignal;
+  }
+
+  const cause = causeOf(value);
+  const causeSignal = structuredSignal(cause, seen, source)
+    ?? fallbackSignalFromMessage(cause, source);
+  if (causeSignal !== undefined) return causeSignal;
+
+  if (stopReason === "error") return makeSignal("provider_unavailable", value, source);
+
+  return undefined;
+}
+
+function messageFromUnknown(value: unknown, seen: Set<unknown>): string | undefined {
+  if (value === undefined || value === null || seen.has(value)) return undefined;
+  if (typeof value === "string") return value.trim().length > 0 ? value : undefined;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value);
+  if (typeof value === "symbol" || typeof value === "function") return undefined;
+  seen.add(value);
+
+  if (value instanceof Error && value.message.trim().length > 0) return value.message;
+  const directMessage = stringField(value, "errorMessage")
+    ?? stringField(value, "message")
+    ?? stringField(value, "statusText");
+  if (directMessage !== undefined) return directMessage;
+
+  for (const diagnosticError of diagnosticErrors(value)) {
+    const diagnosticMessage = messageFromUnknown(diagnosticError, seen);
+    if (diagnosticMessage !== undefined) return diagnosticMessage;
+  }
+
+  const causeMessage = messageFromUnknown(causeOf(value), seen);
+  if (causeMessage !== undefined) return causeMessage;
+
+  const stopReason = stopReasonFrom(value);
+  if (stopReason !== undefined) return `Assistant message ended with stopReason:${stopReason}`;
+  const status = statusFrom(value);
+  if (status !== undefined) return `Model request failed with status ${status}`;
+  const code = codeFrom(value);
+  if (code !== undefined) return `Model request failed with code ${String(code)}`;
+
+  return undefined;
+}
+
+export function errorMessage(error: unknown): string {
+  const structuredMessage = messageFromUnknown(error, new Set());
+  if (structuredMessage !== undefined) return structuredMessage;
+  const rendered = String(error);
+  return rendered === "[object Object]" ? "Model request failed" : rendered;
+}
+
+export function normalizeModelFailureSignal(error: unknown): ModelFallbackFailureSignal {
+  const structured = structuredSignal(error, new Set());
+  if (structured !== undefined) return structured;
+
+  const message = errorMessage(error);
+  const fallbackKind = message.trim().length > 0
+    ? fallbackKindFromMessage(message, errorName(error))
+    : undefined;
+  return {
+    kind: fallbackKind ?? "unknown",
+    message,
+    source: "string_fallback",
+    ...(errorName(error) !== undefined ? { name: errorName(error)! } : {}),
+  };
+}
+
+export function isRetryableModelFailure(error: unknown): boolean {
   if (error === undefined) return false;
-  const message = typeof error === "string" ? error : error.message;
-  if (!message.trim()) return false;
-  if (NON_RETRYABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return false;
-  return RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(message));
+  const signal = normalizeModelFailureSignal(error);
+  return FALLBACKABLE_FAILURE_KINDS.has(signal.kind);
 }

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -414,6 +414,52 @@ describe("model fallback helpers", () => {
     }
   });
 
+  test("retry classifier refuses provider content filters and refusal signals", () => {
+    const refusalCases: ReadonlyArray<{
+      label: string;
+      failure: unknown;
+      expectedSource?: "diagnostic";
+    }> = [
+      {
+        label: "assistant content_filter message",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "content_filter" },
+      },
+      {
+        label: "assistant finish_reason content_filter field",
+        failure: { role: "assistant", stopReason: "error", finish_reason: "content_filter" },
+      },
+      {
+        label: "diagnostic content_filter code",
+        failure: {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "localized provider error",
+          diagnostics: [{ error: { code: "content_filter", message: "blocked by provider" } }],
+        },
+        expectedSource: "diagnostic",
+      },
+      {
+        label: "safety policy refusal",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "request blocked by safety policy" },
+      },
+      {
+        label: "tool refusal",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "tool call refused by provider" },
+      },
+      {
+        label: "provider refusal",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "provider refused this request" },
+      },
+    ];
+
+    for (const { label, failure, expectedSource } of refusalCases) {
+      const signal = normalizeModelFailureSignal(failure);
+      assert.equal(signal.kind, "task_failure", label);
+      if (expectedSource !== undefined) assert.equal(signal.source, expectedSource, label);
+      assert.equal(isRetryableModelFailure(failure), false, label);
+    }
+  });
+
   test("retry classifier follows causes before regex fallback", () => {
     const err = new Error("outer localized failure", {
       cause: { diagnostics: [{ error: { code: "service_unavailable", message: "provider down" } }] },

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -356,6 +356,64 @@ describe("model fallback helpers", () => {
     assert.equal(isRetryableModelFailure("completion guard failed after 599"), false);
   });
 
+  test("retry classifier lets nested refusals outrank wrapper structured provider signals", () => {
+    const refusalCases: ReadonlyArray<{
+      label: string;
+      failure: unknown;
+      expectedKind: "cancelled" | "task_failure";
+      expectedSource?: "diagnostic";
+    }> = [
+      {
+        label: "5xx wrapper with abort cause",
+        failure: { status: 503, cause: { name: "AbortError", message: "aborted by user" } },
+        expectedKind: "cancelled",
+      },
+      {
+        label: "429 wrapper with abort cause",
+        failure: { code: "429", cause: { name: "AbortError", message: "rate-limit wrapper hid abort" } },
+        expectedKind: "cancelled",
+      },
+      {
+        label: "auth wrapper with diagnostic task failure",
+        failure: {
+          statusCode: 401,
+          diagnostics: [{ error: { message: "completion guard failed after provider wrapper" } }],
+        },
+        expectedKind: "task_failure",
+        expectedSource: "diagnostic",
+      },
+      {
+        label: "timeout wrapper with diagnostic task failure",
+        failure: {
+          status: 408,
+          diagnostics: [{ error: { message: "shell command failed after timeout wrapper" } }],
+        },
+        expectedKind: "task_failure",
+        expectedSource: "diagnostic",
+      },
+      {
+        label: "model unavailable wrapper with task failure cause",
+        failure: { status: 404, cause: { message: "command failed: bun test" } },
+        expectedKind: "task_failure",
+      },
+      {
+        label: "nested abort below diagnostic 5xx",
+        failure: {
+          code: 529,
+          diagnostics: [{ error: { status: 503, cause: { name: "AbortError", message: "nested abort" } } }],
+        },
+        expectedKind: "cancelled",
+      },
+    ];
+
+    for (const { label, failure, expectedKind, expectedSource } of refusalCases) {
+      const signal = normalizeModelFailureSignal(failure);
+      assert.equal(signal.kind, expectedKind, label);
+      if (expectedSource !== undefined) assert.equal(signal.source, expectedSource, label);
+      assert.equal(isRetryableModelFailure(failure), false, label);
+    }
+  });
+
   test("retry classifier follows causes before regex fallback", () => {
     const err = new Error("outer localized failure", {
       cause: { diagnostics: [{ error: { code: "service_unavailable", message: "provider down" } }] },

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -6,6 +6,7 @@ import {
   buildModelCandidatesFromCatalog,
   splitReasoningSuffix,
   isRetryableModelFailure,
+  normalizeModelFailureSignal,
   validateWorkflowModels,
   WorkflowModelValidationError,
 } from "../../packages/workflows/src/runs/shared/model-fallback.js";
@@ -298,5 +299,52 @@ describe("model fallback helpers", () => {
     assert.equal(isRetryableModelFailure("model not found"), true);
     assert.equal(isRetryableModelFailure("command failed: bun test"), false);
     assert.equal(isRetryableModelFailure("user cancelled"), false);
+  });
+
+  test("retry classifier uses structured diagnostics before localized text", () => {
+    const signal = normalizeModelFailureSignal({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "地域化されたプロバイダー エラー",
+      diagnostics: [{ error: { code: 429, message: "quota exhausted" } }],
+    });
+
+    assert.equal(signal.kind, "rate_limit");
+    assert.equal(signal.source, "diagnostic");
+    assert.equal(isRetryableModelFailure({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "地域化されたプロバイダー エラー",
+      diagnostics: [{ error: { code: 429, message: "quota exhausted" } }],
+    }), true);
+    assert.equal(isRetryableModelFailure({
+      message: "localized wrapper",
+      diagnostics: [{ error: { message: "service unavailable" } }],
+    }), true);
+  });
+
+  test("retry classifier uses structured status and codes including auth failures", () => {
+    assert.equal(isRetryableModelFailure({ status: 503, message: "localized" }), true);
+    assert.equal(isRetryableModelFailure({ statusCode: 401, message: "localized" }), true);
+    assert.equal(isRetryableModelFailure({ httpStatus: 403, message: "localized" }), true);
+    assert.equal(isRetryableModelFailure({ code: "invalid_api_key", message: "localized" }), true);
+  });
+
+  test("retry classifier follows causes before regex fallback", () => {
+    const err = new Error("outer localized failure", {
+      cause: { diagnostics: [{ error: { code: "service_unavailable", message: "provider down" } }] },
+    });
+
+    assert.equal(isRetryableModelFailure(err), true);
+    assert.equal(normalizeModelFailureSignal(err).kind, "provider_unavailable");
+  });
+
+  test("retry classifier refuses cancellation and task failures despite structured-looking text", () => {
+    assert.equal(isRetryableModelFailure({ name: "AbortError", status: 503, message: "request aborted" }), false);
+    assert.equal(isRetryableModelFailure({ status: 503, message: "request cancelled" }), false);
+    assert.equal(isRetryableModelFailure({ stopReason: "aborted", status: 503, errorMessage: "aborted" }), false);
+    assert.equal(isRetryableModelFailure({ status: 503, message: "shell command failed" }), false);
+    assert.equal(isRetryableModelFailure("completion guard failed after 429"), false);
+    assert.equal(isRetryableModelFailure("shell command failed with 503"), false);
   });
 });

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -328,6 +328,32 @@ describe("model fallback helpers", () => {
     assert.equal(isRetryableModelFailure({ statusCode: 401, message: "localized" }), true);
     assert.equal(isRetryableModelFailure({ httpStatus: 403, message: "localized" }), true);
     assert.equal(isRetryableModelFailure({ code: "invalid_api_key", message: "localized" }), true);
+    assert.equal(normalizeModelFailureSignal({ status: 408, message: "localized" }).kind, "network_timeout");
+    assert.equal(normalizeModelFailureSignal({ status: 404, message: "localized" }).kind, "model_unavailable");
+    assert.equal(normalizeModelFailureSignal({ code: "429", message: "localized" }).kind, "rate_limit");
+  });
+
+  test("retry classifier treats every structured HTTP-like 5xx status/code as provider unavailable", () => {
+    const cases: readonly unknown[] = [
+      { status: 529, message: "localized" },
+      { statusCode: 520, message: "localized" },
+      { httpStatus: 599, message: "localized" },
+      { code: 529, message: "localized" },
+      { code: "520", message: "localized" },
+      { diagnostics: [{ error: { code: "529", message: "localized" } }] },
+    ];
+
+    for (const failure of cases) {
+      assert.equal(normalizeModelFailureSignal(failure).kind, "provider_unavailable");
+      assert.equal(isRetryableModelFailure(failure), true);
+    }
+  });
+
+  test("retry classifier preserves refusal precedence over structured 5xx", () => {
+    assert.equal(isRetryableModelFailure({ stopReason: "aborted", status: 599, code: 529 }), false);
+    assert.equal(isRetryableModelFailure({ name: "AbortError", statusCode: 520, message: "request aborted" }), false);
+    assert.equal(isRetryableModelFailure({ httpStatus: 529, message: "shell command failed" }), false);
+    assert.equal(isRetryableModelFailure("completion guard failed after 599"), false);
   });
 
   test("retry classifier follows causes before regex fallback", () => {

--- a/test/unit/stage-runner.test.ts
+++ b/test/unit/stage-runner.test.ts
@@ -681,6 +681,68 @@ describe("createStageContext — model fallback", () => {
         assert.equal(meta.warnings, undefined);
     });
 
+    test("recovered non-throwing assistant failure in the same prompt does not try fallback", async () => {
+        const calls: string[] = [];
+        const disposed: string[] = [];
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const modelValue = options.model as unknown;
+                const model = typeof modelValue === "string"
+                    ? modelValue
+                    : "object-model";
+                calls.push(model);
+                const messages: AgentSession["messages"] = [];
+                const { session } = makeMockSession({
+                    messages,
+                    async prompt() {
+                        messages.push({
+                            role: "assistant",
+                            content: [],
+                            stopReason: "error",
+                            errorMessage: "429 rate limit exceeded",
+                            diagnostics: [{ error: { code: 429, message: "rate limit" } }],
+                        } as unknown as AgentSession["messages"][number]);
+                        messages.push({
+                            role: "assistant",
+                            content: [{ type: "text", text: "primary recovered answer" }],
+                            stopReason: "stop",
+                        } as unknown as AgentSession["messages"][number]);
+                    },
+                    dispose() {
+                        disposed.push(model);
+                    },
+                    getLastAssistantText() {
+                        return "primary recovered answer";
+                    },
+                });
+                return session;
+            },
+        };
+
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: {
+                    model: "anthropic/primary",
+                    fallbackModels: ["openai/fallback"],
+                },
+            }),
+        ) as InternalStageContext;
+
+        const text = await ctx.prompt("go");
+
+        assert.equal(text, "primary recovered answer");
+        assert.deepEqual(calls, ["anthropic/primary"]);
+        assert.deepEqual(disposed, []);
+        const meta = ctx.__modelFallbackMeta();
+        assert.deepEqual(meta.attemptedModels, ["anthropic/primary"]);
+        assert.deepEqual(
+            meta.modelAttempts?.map((attempt) => ({ model: attempt.model, success: attempt.success })),
+            [{ model: "anthropic/primary", success: true }],
+        );
+        assert.equal(meta.warnings, undefined);
+    });
+
     test("non-throwing assistant stopReason aborted does not try fallback", async () => {
         const calls: string[] = [];
         const agentSession: AgentSessionAdapter = {

--- a/test/unit/stage-runner.test.ts
+++ b/test/unit/stage-runner.test.ts
@@ -720,6 +720,85 @@ describe("createStageContext — model fallback", () => {
         assert.deepEqual(calls, ["anthropic/primary"]);
     });
 
+    test("controlled pause/resume ignores stale aborted assistant messages when fallback is enabled", async () => {
+        const calls: string[] = [];
+        const promptTexts: string[] = [];
+        const messages: AgentSession["messages"] = [];
+        const firstPromptStarted = Promise.withResolvers<void>();
+        let resolveFirstPrompt: (() => void) | undefined;
+        let abortCalls = 0;
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const modelValue = options.model as unknown;
+                const model = typeof modelValue === "string"
+                    ? modelValue
+                    : "object-model";
+                calls.push(model);
+                const { session } = makeMockSession({
+                    messages,
+                    async prompt(text) {
+                        promptTexts.push(text);
+                        if (promptTexts.length === 1) {
+                            return new Promise<void>((resolve) => {
+                                resolveFirstPrompt = resolve;
+                                firstPromptStarted.resolve();
+                            });
+                        }
+                        messages.push({
+                            role: "assistant",
+                            content: [{ type: "text", text: "resumed answer" }],
+                            stopReason: "stop",
+                        } as unknown as AgentSession["messages"][number]);
+                    },
+                    async abort() {
+                        abortCalls += 1;
+                        messages.push({
+                            role: "assistant",
+                            content: [],
+                            stopReason: "aborted",
+                            status: 503,
+                        } as unknown as AgentSession["messages"][number]);
+                        resolveFirstPrompt?.();
+                    },
+                    getLastAssistantText() {
+                        return promptTexts.length >= 2 ? "resumed answer" : undefined;
+                    },
+                });
+                return session;
+            },
+        };
+
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: {
+                    model: "anthropic/primary",
+                    fallbackModels: ["openai/fallback"],
+                },
+            }),
+        ) as InternalStageContext;
+
+        const promptPromise = ctx.prompt("first");
+        void promptPromise.catch(() => {});
+        await firstPromptStarted.promise;
+
+        await ctx.__requestPause();
+        await flushMicrotasks();
+        assert.equal(abortCalls, 1);
+        assert.equal(ctx.__isPaused(), true);
+
+        await ctx.__resume("continue after pause");
+        const text = await promptPromise;
+
+        assert.equal(text, "resumed answer");
+        assert.deepEqual(promptTexts, ["first", "continue after pause"]);
+        assert.deepEqual(calls, ["anthropic/primary"]);
+        const meta = ctx.__modelFallbackMeta();
+        assert.deepEqual(meta.attemptedModels, ["anthropic/primary"]);
+        assert.deepEqual(meta.modelAttempts?.map((attempt) => attempt.success), [true]);
+        assert.equal(meta.warnings, undefined);
+    });
+
     test("workflow fast mode keeps raw model metadata with a structured fast flag", async () => {
         const agentSession: AgentSessionAdapter = {
             async create() {

--- a/test/unit/stage-runner.test.ts
+++ b/test/unit/stage-runner.test.ts
@@ -610,6 +610,116 @@ describe("createStageContext — model fallback", () => {
         assert.equal(meta.warnings, undefined);
     });
 
+    test("non-throwing assistant stopReason error tries fallback and records metadata", async () => {
+        const calls: string[] = [];
+        const disposed: string[] = [];
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const modelValue = options.model as unknown;
+                const model = typeof modelValue === "string"
+                    ? modelValue
+                    : "object-model";
+                calls.push(model);
+                const messages: AgentSession["messages"] = [];
+                const { session } = makeMockSession({
+                    messages,
+                    async prompt() {
+                        if (model === "anthropic/primary") {
+                            messages.push({
+                                role: "assistant",
+                                content: [],
+                                stopReason: "error",
+                                errorMessage: "地域化されたプロバイダー エラー",
+                                diagnostics: [{ error: { code: 429, message: "quota exhausted" } }],
+                            } as unknown as AgentSession["messages"][number]);
+                            return;
+                        }
+                        messages.push({
+                            role: "assistant",
+                            content: [{ type: "text", text: "fallback answer" }],
+                            stopReason: "stop",
+                        } as unknown as AgentSession["messages"][number]);
+                    },
+                    dispose() {
+                        disposed.push(model);
+                    },
+                    getLastAssistantText() {
+                        return model === "openai/fallback"
+                            ? "fallback answer"
+                            : undefined;
+                    },
+                });
+                return session;
+            },
+        };
+
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: {
+                    model: "anthropic/primary",
+                    fallbackModels: ["openai/fallback"],
+                },
+            }),
+        ) as InternalStageContext;
+
+        const text = await ctx.prompt("go");
+
+        assert.equal(text, "fallback answer");
+        assert.deepEqual(calls, ["anthropic/primary", "openai/fallback"]);
+        assert.deepEqual(disposed, ["anthropic/primary"]);
+        const meta = ctx.__modelFallbackMeta();
+        assert.deepEqual(meta.attemptedModels, [
+            "anthropic/primary",
+            "openai/fallback",
+        ]);
+        assert.deepEqual(
+            meta.modelAttempts?.map((attempt) => attempt.success),
+            [false, true],
+        );
+        assert.equal(meta.modelAttempts?.[0]?.error, "地域化されたプロバイダー エラー");
+        assert.equal(meta.warnings, undefined);
+    });
+
+    test("non-throwing assistant stopReason aborted does not try fallback", async () => {
+        const calls: string[] = [];
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const modelValue = options.model as unknown;
+                const model = typeof modelValue === "string"
+                    ? modelValue
+                    : "object-model";
+                calls.push(model);
+                const messages: AgentSession["messages"] = [];
+                const { session } = makeMockSession({
+                    messages,
+                    async prompt() {
+                        messages.push({
+                            role: "assistant",
+                            content: [],
+                            stopReason: "aborted",
+                            status: 503,
+                        } as unknown as AgentSession["messages"][number]);
+                    },
+                });
+                return session;
+            },
+        };
+
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: {
+                    model: "anthropic/primary",
+                    fallbackModels: ["openai/fallback"],
+                },
+            }),
+        );
+
+        await assert.rejects(ctx.prompt("go"), /stopReason:aborted/);
+        assert.deepEqual(calls, ["anthropic/primary"]);
+    });
+
     test("workflow fast mode keeps raw model metadata with a structured fast flag", async () => {
         const agentSession: AgentSessionAdapter = {
             async create() {

--- a/test/unit/subagents-final-drain.test.ts
+++ b/test/unit/subagents-final-drain.test.ts
@@ -1,0 +1,44 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+	assistantStopReason,
+	isAssistantFailureStopReason,
+	shouldStartSubagentFinalDrain,
+} from "../../packages/subagents/src/runs/shared/final-drain.js";
+
+describe("subagent final-drain predicate", () => {
+	test("records failure stop reasons separately from final-drain eligibility", () => {
+		for (const stopReason of ["error", "aborted"] as const) {
+			const message = {
+				role: "assistant",
+				stopReason,
+				content: [{ type: "text", text: "provider attempt failed" }],
+			};
+
+			assert.equal(assistantStopReason(message), stopReason);
+			assert.equal(isAssistantFailureStopReason(stopReason), true);
+			assert.equal(shouldStartSubagentFinalDrain(message), false);
+		}
+	});
+
+	test("starts final-drain only for a clean assistant stop without tool calls", () => {
+		assert.equal(shouldStartSubagentFinalDrain({
+			role: "assistant",
+			stopReason: "stop",
+			content: [{ type: "text", text: "done" }],
+		}), true);
+
+		assert.equal(shouldStartSubagentFinalDrain({
+			role: "assistant",
+			stopReason: "stop",
+			content: [{ type: "toolCall", name: "read" }],
+		}), false);
+
+		assert.equal(shouldStartSubagentFinalDrain({
+			role: "assistant",
+			stopReason: "stop",
+			errorMessage: "provider transport failed",
+			content: [{ type: "text", text: "failed" }],
+		}), false);
+	});
+});

--- a/test/unit/subagents-model-fallback.test.ts
+++ b/test/unit/subagents-model-fallback.test.ts
@@ -157,6 +157,52 @@ describe("subagent model fallback helpers", () => {
     }
   });
 
+  test("retry classifier refuses provider content filters and refusal signals", () => {
+    const refusalCases: ReadonlyArray<{
+      label: string;
+      failure: unknown;
+      expectedSource?: "diagnostic";
+    }> = [
+      {
+        label: "assistant content_filter message",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "content_filter" },
+      },
+      {
+        label: "assistant finish_reason content_filter field",
+        failure: { role: "assistant", stopReason: "error", finish_reason: "content_filter" },
+      },
+      {
+        label: "diagnostic content_filter code",
+        failure: {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "localized provider error",
+          diagnostics: [{ error: { code: "content_filter", message: "blocked by provider" } }],
+        },
+        expectedSource: "diagnostic",
+      },
+      {
+        label: "safety policy refusal",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "request blocked by safety policy" },
+      },
+      {
+        label: "tool refusal",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "tool call refused by provider" },
+      },
+      {
+        label: "provider refusal",
+        failure: { role: "assistant", stopReason: "error", errorMessage: "provider refused this request" },
+      },
+    ];
+
+    for (const { label, failure, expectedSource } of refusalCases) {
+      const signal = normalizeModelFailureSignal(failure);
+      assert.equal(signal.kind, "task_failure", label);
+      if (expectedSource !== undefined) assert.equal(signal.source, expectedSource, label);
+      assert.equal(isRetryableModelFailure(failure), false, label);
+    }
+  });
+
   test("assistant stopReason error without an errorMessage is fallbackable", () => {
     const failure = { role: "assistant", stopReason: "error", diagnostics: [] };
 

--- a/test/unit/subagents-model-fallback.test.ts
+++ b/test/unit/subagents-model-fallback.test.ts
@@ -99,6 +99,64 @@ describe("subagent model fallback helpers", () => {
     assert.equal(isRetryableModelFailure("completion guard failed after 599"), false);
   });
 
+  test("retry classifier lets nested refusals outrank wrapper structured provider signals", () => {
+    const refusalCases: ReadonlyArray<{
+      label: string;
+      failure: unknown;
+      expectedKind: "cancelled" | "task_failure";
+      expectedSource?: "diagnostic";
+    }> = [
+      {
+        label: "5xx wrapper with abort cause",
+        failure: { status: 503, cause: { name: "AbortError", message: "aborted by user" } },
+        expectedKind: "cancelled",
+      },
+      {
+        label: "429 wrapper with abort cause",
+        failure: { code: "429", cause: { name: "AbortError", message: "rate-limit wrapper hid abort" } },
+        expectedKind: "cancelled",
+      },
+      {
+        label: "auth wrapper with diagnostic task failure",
+        failure: {
+          statusCode: 401,
+          diagnostics: [{ error: { message: "completion guard failed after provider wrapper" } }],
+        },
+        expectedKind: "task_failure",
+        expectedSource: "diagnostic",
+      },
+      {
+        label: "timeout wrapper with diagnostic task failure",
+        failure: {
+          status: 408,
+          diagnostics: [{ error: { message: "shell command failed after timeout wrapper" } }],
+        },
+        expectedKind: "task_failure",
+        expectedSource: "diagnostic",
+      },
+      {
+        label: "model unavailable wrapper with task failure cause",
+        failure: { status: 404, cause: { message: "command failed: bun test" } },
+        expectedKind: "task_failure",
+      },
+      {
+        label: "nested abort below diagnostic 5xx",
+        failure: {
+          code: 529,
+          diagnostics: [{ error: { status: 503, cause: { name: "AbortError", message: "nested abort" } } }],
+        },
+        expectedKind: "cancelled",
+      },
+    ];
+
+    for (const { label, failure, expectedKind, expectedSource } of refusalCases) {
+      const signal = normalizeModelFailureSignal(failure);
+      assert.equal(signal.kind, expectedKind, label);
+      if (expectedSource !== undefined) assert.equal(signal.source, expectedSource, label);
+      assert.equal(isRetryableModelFailure(failure), false, label);
+    }
+  });
+
   test("assistant stopReason error without an errorMessage is fallbackable", () => {
     const failure = { role: "assistant", stopReason: "error", diagnostics: [] };
 

--- a/test/unit/subagents-model-fallback.test.ts
+++ b/test/unit/subagents-model-fallback.test.ts
@@ -3,6 +3,9 @@ import assert from "node:assert/strict";
 import {
   buildModelCandidates,
   currentModelFullId,
+  isRetryableModelFailure,
+  modelFailureMessage,
+  normalizeModelFailureSignal,
 } from "../../packages/subagents/src/runs/shared/model-fallback.js";
 import type { AvailableModelInfo } from "../../packages/subagents/src/runs/shared/model-fallback.js";
 
@@ -44,5 +47,45 @@ describe("subagent model fallback helpers", () => {
       currentModelFullId({ provider: "openai", id: "gpt-5-mini" }),
       "openai/gpt-5-mini",
     );
+  });
+
+  test("retry classifier uses structured diagnostics before localized text", () => {
+    const failure = {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "プロバイダー エラー",
+      diagnostics: [{ error: { code: 429, message: "quota exhausted" } }],
+    };
+
+    assert.equal(normalizeModelFailureSignal(failure).kind, "rate_limit");
+    assert.equal(isRetryableModelFailure(failure), true);
+    assert.equal(isRetryableModelFailure({
+      message: "localized wrapper",
+      diagnostics: [{ error: { message: "service unavailable" } }],
+    }), true);
+  });
+
+  test("retry classifier uses status, code, name, and causes", () => {
+    assert.equal(isRetryableModelFailure({ status: 503, message: "localized" }), true);
+    assert.equal(isRetryableModelFailure({ statusCode: 401, message: "localized" }), true);
+    assert.equal(isRetryableModelFailure({ httpStatus: 403, message: "localized" }), true);
+    assert.equal(isRetryableModelFailure({ code: "invalid_api_key", message: "localized" }), true);
+    assert.equal(isRetryableModelFailure(new Error("outer", { cause: { code: "overloaded" } })), true);
+  });
+
+  test("assistant stopReason error without an errorMessage is fallbackable", () => {
+    const failure = { role: "assistant", stopReason: "error", diagnostics: [] };
+
+    assert.equal(modelFailureMessage(failure), "Assistant message ended with stopReason:error");
+    assert.equal(normalizeModelFailureSignal(failure).kind, "provider_unavailable");
+    assert.equal(isRetryableModelFailure(failure), true);
+  });
+
+  test("retry classifier refuses aborted and task failures", () => {
+    assert.equal(isRetryableModelFailure({ stopReason: "aborted", status: 503 }), false);
+    assert.equal(isRetryableModelFailure({ name: "AbortError", status: 503, message: "aborted" }), false);
+    assert.equal(isRetryableModelFailure({ status: 503, message: "shell command failed" }), false);
+    assert.equal(isRetryableModelFailure("completion guard failed after 429"), false);
+    assert.equal(isRetryableModelFailure("command failed: bun test"), false);
   });
 });

--- a/test/unit/subagents-model-fallback.test.ts
+++ b/test/unit/subagents-model-fallback.test.ts
@@ -70,7 +70,33 @@ describe("subagent model fallback helpers", () => {
     assert.equal(isRetryableModelFailure({ statusCode: 401, message: "localized" }), true);
     assert.equal(isRetryableModelFailure({ httpStatus: 403, message: "localized" }), true);
     assert.equal(isRetryableModelFailure({ code: "invalid_api_key", message: "localized" }), true);
+    assert.equal(normalizeModelFailureSignal({ status: 408, message: "localized" }).kind, "network_timeout");
+    assert.equal(normalizeModelFailureSignal({ status: 404, message: "localized" }).kind, "model_unavailable");
+    assert.equal(normalizeModelFailureSignal({ code: "429", message: "localized" }).kind, "rate_limit");
     assert.equal(isRetryableModelFailure(new Error("outer", { cause: { code: "overloaded" } })), true);
+  });
+
+  test("retry classifier treats every structured HTTP-like 5xx status/code as provider unavailable", () => {
+    const cases: readonly unknown[] = [
+      { status: 529, message: "localized" },
+      { statusCode: 520, message: "localized" },
+      { httpStatus: 599, message: "localized" },
+      { code: 529, message: "localized" },
+      { code: "520", message: "localized" },
+      { diagnostics: [{ error: { code: "529", message: "localized" } }] },
+    ];
+
+    for (const failure of cases) {
+      assert.equal(normalizeModelFailureSignal(failure).kind, "provider_unavailable");
+      assert.equal(isRetryableModelFailure(failure), true);
+    }
+  });
+
+  test("retry classifier preserves refusal precedence over structured 5xx", () => {
+    assert.equal(isRetryableModelFailure({ stopReason: "aborted", status: 599, code: 529 }), false);
+    assert.equal(isRetryableModelFailure({ name: "AbortError", statusCode: 520, message: "request aborted" }), false);
+    assert.equal(isRetryableModelFailure({ httpStatus: 529, message: "shell command failed" }), false);
+    assert.equal(isRetryableModelFailure("completion guard failed after 599"), false);
   });
 
   test("assistant stopReason error without an errorMessage is fallbackable", () => {


### PR DESCRIPTION
## Summary

Replaces string-only model-failure classification with structured signal normalization across both the `workflows` and `subagents` packages. Failures expressed as objects (`status`, `statusCode`, `httpStatus`, `code`, `diagnostics`, `cause`, `stopReason`) are now resolved to typed `ModelFallbackFailureKind` values before the retry decision, so localized error messages and non-throwing assistant failures no longer silently suppress fallback.

## Key Changes

### Structured failure normalization (`model-fallback.ts` — workflows & subagents)
- Added `normalizeModelFailureSignal(error: unknown): ModelFallbackFailureSignal` — inspects structured fields (`status`/`statusCode`/`httpStatus`, `code`, `name`, `diagnostics`, `cause`, `stopReason`) depth-first before falling back to regex pattern matching on the message string
- `isRetryableModelFailure` now accepts `unknown` (was `string | Error`) and delegates to the normalized signal kind
- All `500–599` HTTP status/codes now classify as `provider_unavailable`; previously only 502–504 were covered
- Added `401`/`403`, `invalid_key`, and `connection refused` patterns to retryable sets
- **Refusal precedence**: `cancelled` and `task_failure` kinds (abort/cancel/interrupted, command failed, tests failed, completion guard) surface first and block fallback even when nested inside a structured provider-error wrapper
- Exported `ModelFallbackFailureKind` and `ModelFallbackFailureSignal` types

### Non-throwing assistant failure signals (`final-drain.ts` — subagents, new file)
- Extracted `assistantStopReason`, `isAssistantFailureStopReason`, and `shouldStartSubagentFinalDrain` predicates into a shared module
- `stopReason: "error"` and `stopReason: "aborted"` messages are now captured as failure evidence and passed as structured `modelFailureSignal` through `RunPiStreamingResult`
- Both background (`subagent-runner.ts`) and foreground (`execution.ts`) paths forward the structured signal object — not just the string — to `isRetryableModelFailure`
- Uses a `WeakMap<SingleResult, unknown>` to associate the signal with the result in the foreground path without mutating the result type

### Controlled pause/resume scope (`stage-runner.ts` — workflows)
- `promptWithPauseResume` now returns `{ terminalScanStartIndex }` — the message index at the start of the current prompt attempt
- `promptWithFallback` scans only messages added since `terminalScanStartIndex` for terminal assistant failures, preventing a controlled-pause `stopReason: "aborted"` from a prior attempt being misclassified as a model failure on resume
- Non-retryable throwing errors are passed as `err` (not `errorMessage(err)`) to `isRetryableModelFailure` so structured fields are preserved

## Test Coverage

- `test/unit/subagents-final-drain.test.ts` — new: covers `shouldStartSubagentFinalDrain` predicates
- `test/unit/model-fallback.test.ts` — structured diagnostics/statuses, generic 5xx codes, refusal precedence, nested abort/task-failure outranking provider wrappers, cause traversal
- `test/unit/subagents-model-fallback.test.ts` — mirrors workflow classifier tests for the subagents copy
- `test/unit/stage-runner.test.ts` — non-throwing `stopReason: "error"` triggers fallback; `stopReason: "aborted"` does not; controlled pause/resume with fallback enabled succeeds on resume without misclassification

```
bun test test/unit/model-fallback.test.ts test/unit/subagents-model-fallback.test.ts test/unit/stage-runner.test.ts
# 82 pass, 0 fail

bun test test/unit/executor.test.ts test/unit/subagents-foreground-fallback-updates.test.ts test/unit/subagents-reasoning-suffix.test.ts
# 155 pass, 0 fail

bun run typecheck  # passed
bun run lint       # passed
```

## Breaking Changes

None. `attemptedModels`, `modelAttempts`, warnings, and fallback reasoning suffix behavior remain compatible.

Closes #1270