### PR TITLE
chore(release): prepare 0.8.26-alpha.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.26-alpha.6",
+      "version": "0.8.26-alpha.7",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.26-alpha.6",
+      "version": "0.8.26-alpha.7",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.26-alpha.6",
+      "version": "0.8.26-alpha.7",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.26-alpha.6",
+      "version": "0.8.26-alpha.7",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.26-alpha.6",
+      "version": "0.8.26-alpha.7",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.26-alpha.6",
+      "version": "0.8.26-alpha.7",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.26-alpha.7] - 2026-06-07
+
 ### Added
 
 - Added `/context-compact`, a fixed no-argument deletion-only compaction command that validates model-proposed logical deletion targets, preserves retained transcript content verbatim, and records `context_compaction` session entries.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.26-alpha.6",
+  "version": "0.8.26-alpha.7",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.26-alpha.7] - 2026-06-07
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.7 prerelease.
+
 ## [0.8.26-alpha.6] - 2026-06-06
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.26-alpha.6",
+  "version": "0.8.26-alpha.7",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.26-alpha.7] - 2026-06-07
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.7 prerelease.
+
 ## [0.8.26-alpha.6] - 2026-06-06
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.26-alpha.6",
+  "version": "0.8.26-alpha.7",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.8.26-alpha.7] - 2026-06-07
+
+### Added
+
+- Replaced the bundled browser-use subagent integration with the first-party `browser` skill for web interaction workflows.
+
 ## [0.8.26-alpha.6] - 2026-06-06
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.26-alpha.6",
+  "version": "0.8.26-alpha.7",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.26-alpha.7] - 2026-06-07
+
+### Changed
+
+- Bumped package version for the Atomic 0.8.26-alpha.7 prerelease.
+
 ## [0.8.26-alpha.6] - 2026-06-06
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.26-alpha.6",
+  "version": "0.8.26-alpha.7",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.26-alpha.7] - 2026-06-07
+
 ### Changed
 
 - Refined bundled workflow prompts to keep natural instructions inside meaningful XML sections while removing redundant wrapper noise.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.26-alpha.6",
+  "version": "0.8.26-alpha.7",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Prepare the Atomic `0.8.26-alpha.7` prerelease. This release ships the first-party `browser` skill as a replacement for the bundled browser-use subagent integration, alongside the `context-compact` command and workflow prompt refinements from earlier in the alpha series.

## Changes

- **All packages** bumped to `0.8.26-alpha.7` in `package.json` and `bun.lock`
- **subagents**: Replaced the bundled browser-use subagent integration with the first-party `browser` skill for web interaction workflows
- **coding-agent**: Added `/context-compact` — a fixed no-argument deletion-only compaction command that validates model-proposed logical deletion targets, preserves retained transcript content verbatim, and records `context_compaction` session entries
- **workflows**: Refined bundled workflow prompts — natural instructions kept inside meaningful XML sections, redundant wrapper noise removed
- **intercom / mcp / web-access**: Version bump only

## Validation

- `bun run typecheck`
- `bun run test:unit`
- Pre-commit / pre-push: `bun run lint`
- Pre-commit / pre-push: `bun run test:unit`