### PR TITLE
fix(docs): replace raw autolinks and add Mintlify CI validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -221,6 +221,12 @@ jobs:
               working-directory: ${{ env.PACKAGE_DIR }}
               run: bun run docs:check
 
+            - name: Mintlify docs validation
+              working-directory: ${{ env.PACKAGE_DIR }}/docs
+              run: |
+                  bunx --bun mintlify@latest validate
+                  bunx --bun mintlify@latest broken-links
+
             - name: Validate single publish target and package metadata
               id: package
               shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,11 @@ jobs:
             - name: Docs link validation
               working-directory: packages/coding-agent
               run: bun run docs:check
+            - name: Mintlify docs validation
+              working-directory: packages/coding-agent/docs
+              run: |
+                  bunx --bun mintlify@latest validate
+                  bunx --bun mintlify@latest broken-links
             - name: Build @bastani/atomic package
               working-directory: packages/coding-agent
               run: bun run build

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,6 +13,8 @@ Pull request / push
   ├─ bun install --frozen-lockfile
   ├─ bun run typecheck
   ├─ cd packages/coding-agent && bun run docs:check
+  ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
+  ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
   ├─ cd packages/coding-agent && bun run build
   ├─ bun run test:unit
   ├─ bun run test:integration
@@ -27,6 +29,8 @@ Pull request / push
      ├─ bun install --frozen-lockfile
      ├─ bun run typecheck && bun run test:all
      ├─ cd packages/coding-agent && bun run docs:check
+     ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
+     ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
      ├─ validate package metadata, synced versions, and private bundled packages
      ├─ scripts/build-binaries.sh (regular build + cross-compile 6 targets)
      ├─ validate dist/builtin contains all bundled extensions
@@ -80,11 +84,13 @@ Steps:
 3. Install dependencies with `bun install --frozen-lockfile`.
 4. Run `bun run typecheck`.
 5. Validate hosted-docs routes and internal links with `cd packages/coding-agent && bun run docs:check`.
-6. Build `@bastani/atomic` with `cd packages/coding-agent && bun run build`.
-7. Run `bun run test:unit`.
-8. Run `bun run test:integration`.
-9. Build the native release binary with `scripts/build-binaries.sh --platform <native-x64>`.
-10. Extract the generated release archive, verify required bundled `builtin/*` and selected `node_modules/*` paths are present, run `atomic --version`, and run `atomic --no-session` far enough to catch extension-load diagnostics while allowing the expected no-models exit in CI.
+6. Validate Mintlify MDX/page syntax with `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`.
+7. Check Mintlify broken links with `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`.
+8. Build `@bastani/atomic` with `cd packages/coding-agent && bun run build`.
+9. Run `bun run test:unit`.
+10. Run `bun run test:integration`.
+11. Build the native release binary with `scripts/build-binaries.sh --platform <native-x64>`.
+12. Extract the generated release archive, verify required bundled `builtin/*` and selected `node_modules/*` paths are present, run `atomic --version`, and run `atomic --no-session` far enough to catch extension-load diagnostics while allowing the expected no-models exit in CI.
 
 ### Code Review (`code-review.yml`)
 
@@ -155,6 +161,8 @@ Publish @bastani/atomic
   · bun install --frozen-lockfile
   · bun run typecheck && bun run test:all
   · cd packages/coding-agent && bun run docs:check
+  · cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
+  · cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
   · validate tag matches packages/coding-agent/package.json
   · validate every package manifest has a synced version
   · validate bundled packages remain private and are not independently publishable
@@ -236,6 +244,8 @@ The meaningful pre-publish checks are:
 - TypeScript typechecking
 - unit and integration tests
 - docs route/internal-link validation with `cd packages/coding-agent && bun run docs:check`
+- Mintlify MDX/page syntax validation with `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`
+- Mintlify broken-link validation with `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`
 - `@bastani/atomic` build output validation
 - builtin extension/resource validation under `dist/builtin/`
 - `bun pm pack --dry-run` from `packages/coding-agent`
@@ -246,8 +256,8 @@ The meaningful pre-publish checks are:
 
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, validate docs links, build `@bastani/atomic`, unit/integration tests, build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
-| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, validate docs links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic`, create GitHub Release with binaries |
+| `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests, build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
+| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, validate docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic`, create GitHub Release with binaries |
 | `code-review.yml`    | PR opened/synchronized                        | Claude-powered code review                                                                                                                                                                                    |
 | `pr-description.yml` | PR opened/synchronized                        | Claude-powered PR description generation, skipped for Dependabot                                                                                                                                              |
 | `claude.yml`         | Issue/PR comments, issues, PR reviews         | Interactive Claude assistant gated on `@claude` mentions                                                                                                                                                      |
@@ -270,6 +280,9 @@ The meaningful pre-publish checks are:
     ```sh
     bun run typecheck
     cd packages/coding-agent && bun run docs:check
+    cd docs && bunx --bun mintlify@latest validate
+    bunx --bun mintlify@latest broken-links
+    cd ..
     bun run build
     cd ../..
     bun run test:unit
@@ -305,6 +318,6 @@ The meaningful pre-publish checks are:
     git push origin 0.8.0
     ```
 
-5. Confirm `publish.yml` runs docs link validation, cross-compiles binaries, publishes `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
+5. Confirm `publish.yml` runs docs link validation plus Mintlify syntax and broken-link checks, cross-compiles binaries, publishes `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
 
 For prereleases, substitute `0.8.0-alpha.1` and tag `0.8.0-alpha.1`.

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -2,7 +2,7 @@
 
 LLMs have limited context windows. When conversations grow too long, Atomic uses a deletion-only form of Context Compaction called **Verbatim Compaction**: it deletes safe older transcript objects while preserving every retained object byte-for-byte. This page covers auto-compaction, manual compaction, and branch summarization.
 
-Atomic's default compaction design and terminology are informed by Morph's Context Compaction work: <https://www.morphllm.com/context-compaction>. In particular, Atomic follows the same core idea that coding agents benefit from deleting low-signal context instead of rewriting high-signal details like file paths, line numbers, and error strings into a lossy summary.
+Atomic's default compaction design and terminology are informed by Morph's Context Compaction work: [Morph's Context Compaction](https://www.morphllm.com/context-compaction). In particular, Atomic follows the same core idea that coding agents benefit from deleting low-signal context instead of rewriting high-signal details like file paths, line numbers, and error strings into a lossy summary.
 
 **Source files** ([atomic](https://github.com/bastani-inc/atomic)):
 - [`packages/coding-agent/src/core/compaction/compaction.ts`](https://github.com/bastani-inc/atomic/blob/main/packages/coding-agent/src/core/compaction/compaction.ts) - Summary compaction logic

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -950,7 +950,7 @@ if (usage && usage.tokens > 100_000) {
 
 ### ctx.compact()
 
-Trigger Atomic's default Verbatim Compaction without awaiting completion. This is deletion-only Context Compaction: retained transcript content stays unchanged, and older low-signal objects are omitted by validated logical deletion. The approach is informed by Morph's Context Compaction write-up: <https://www.morphllm.com/context-compaction>. Use `onComplete` and `onError` for follow-up actions.
+Trigger Atomic's default Verbatim Compaction without awaiting completion. This is deletion-only Context Compaction: retained transcript content stays unchanged, and older low-signal objects are omitted by validated logical deletion. The approach is informed by Morph's Context Compaction write-up: [Morph's Context Compaction](https://www.morphllm.com/context-compaction). Use `onComplete` and `onError` for follow-up actions.
 
 ```typescript
 ctx.compact({

--- a/packages/coding-agent/docs/json.md
+++ b/packages/coding-agent/docs/json.md
@@ -23,7 +23,7 @@ type AgentSessionEvent =
   | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 ```
 
-`queue_update` emits the full pending steering and follow-up queues whenever they change. `session_info_changed`, `model_changed`, and `thinking_level_changed` report interactive session metadata changes. `compaction_start` and `compaction_end` cover both manual and automatic Verbatim Compaction, Atomic's deletion-only Context Compaction approach inspired by <https://www.morphllm.com/context-compaction>.
+`queue_update` emits the full pending steering and follow-up queues whenever they change. `session_info_changed`, `model_changed`, and `thinking_level_changed` report interactive session metadata changes. `compaction_start` and `compaction_end` cover both manual and automatic Verbatim Compaction, Atomic's deletion-only Context Compaction approach inspired by [Morph's Context Compaction](https://www.morphllm.com/context-compaction).
 
 Base events come from `AgentEvent` in `@earendil-works/pi-agent-core` (installed as an Atomic dependency):
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -352,7 +352,7 @@ Response:
 
 #### compact
 
-Run Atomic's default Verbatim Compaction to reduce token usage. This command has no prompt/config fields; send no custom instructions. Atomic asks the selected model for deletion targets using a fixed internal prompt, validates them, appends a `context_compaction` entry, and rebuilds active context with surviving entries/content blocks reused verbatim. This deletion-only Context Compaction approach is informed by Morph's article: <https://www.morphllm.com/context-compaction>.
+Run Atomic's default Verbatim Compaction to reduce token usage. This command has no prompt/config fields; send no custom instructions. Atomic asks the selected model for deletion targets using a fixed internal prompt, validates them, appends a `context_compaction` entry, and rebuilds active context with surviving entries/content blocks reused verbatim. This deletion-only Context Compaction approach is informed by Morph's article: [Morph's Context Compaction](https://www.morphllm.com/context-compaction).
 
 ```json
 {"type": "compact"}

--- a/packages/coding-agent/docs/session-format.md
+++ b/packages/coding-agent/docs/session-format.md
@@ -235,7 +235,7 @@ Optional fields:
 
 ### ContextCompactionEntry
 
-Created by `/compact` and auto-compaction. Stores Atomic's default **Verbatim Compaction** data: validated logical deletion targets, not replacement text. During `buildSessionContext()`, matching entries/content blocks are filtered from active LLM context while retained content remains verbatim. This deletion-only Context Compaction approach is informed by Morph's write-up at <https://www.morphllm.com/context-compaction>.
+Created by `/compact` and auto-compaction. Stores Atomic's default **Verbatim Compaction** data: validated logical deletion targets, not replacement text. During `buildSessionContext()`, matching entries/content blocks are filtered from active LLM context while retained content remains verbatim. This deletion-only Context Compaction approach is informed by Morph's write-up at [Morph's Context Compaction](https://www.morphllm.com/context-compaction).
 
 ```json
 {"type":"context_compaction","id":"ctx12345","parentId":"f6g7h8i9","timestamp":"2024-12-03T14:12:00.000Z","promptVersion":1,"deletedTargets":[{"kind":"entry","entryId":"b2c3d4e5"}],"protectedEntryIds":["a1b2c3d4"],"stats":{"objectsBefore":20,"objectsAfter":19,"objectsDeleted":1,"tokensBefore":50000,"tokensAfter":43000,"percentReduction":14},"backupPath":"/path/session.jsonl.2024-12-03T14-12-00-000Z.compact.bak"}

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -89,7 +89,7 @@ Useful session commands:
 - `/tree` navigates the in-file session tree and can summarize abandoned branches.
 - `/fork` creates a new session from an earlier user message.
 - `/clone` duplicates the current active branch into a new session file.
-- `/compact` uses Verbatim Compaction: a fixed no-argument deletion-only planner applies only validated logical deletions; retained transcript content stays verbatim. Atomic's approach is informed by Morph's Context Compaction article: <https://www.morphllm.com/context-compaction>.
+- `/compact` uses Verbatim Compaction: a fixed no-argument deletion-only planner applies only validated logical deletions; retained transcript content stays verbatim. Atomic's approach is informed by Morph's Context Compaction article: [Morph's Context Compaction](https://www.morphllm.com/context-compaction).
 
 See [Sessions](/sessions) and [Compaction](/compaction) for details.
 


### PR DESCRIPTION
## Summary

Fixes a Mintlify deployment failure caused by raw angle-bracket autolinks (`<https://...>`) that the MDX parser treated as JSX tags. Also adds `mintlify validate` and `mintlify broken-links` checks to CI so the issue is caught before deployment.

## Changes

### Bug fixes
- Replaced raw `<https://www.morphllm.com/context-compaction>` autolinks with standard Markdown links in 6 docs files: `compaction.md`, `extensions.md`, `json.md`, `rpc.md`, `session-format.md`, and `usage.md`

### CI
- Added `mintlify validate` and `mintlify broken-links` steps to `test.yml` (PR and `main` push) and `publish.yml` (tag-triggered publish)

### Documentation
- Updated `docs/ci.md` workflow overview, Tests section, Publish Flow section, No Verdaccio Validation section, Workflow Files Reference table, and Release Checklist to document the new Mintlify validation steps

## Validation

```sh
# Verify no raw autolinks remain
grep -RInE '<https?://[^>]+>' packages/coding-agent/docs --include='*.md' || true

# Run Mintlify checks locally
cd packages/coding-agent && bun run docs:check
cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
```

## Notes

Relevant failed run: https://github.com/bastani-inc/atomic/runs/79986466729