### PR TITLE
docs: add npm/pnpm install options and gate Mintlify validation to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
               working-directory: packages/coding-agent
               run: bun run docs:check
             - name: Mintlify docs validation
+              if: github.event_name == 'pull_request'
               working-directory: packages/coding-agent/docs
               run: |
                   bunx --bun mintlify@latest validate

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -9,10 +9,24 @@ Atomic is a minimal terminal coding harness. It is designed to stay small at the
 
 ## Quick start
 
-Install Atomic with Bun:
+Install Atomic globally with npm, pnpm, or Bun:
+
+With npm:
 
 ```bash
-bun install -g @bastani/atomic
+npm install -g @bastani/atomic
+```
+
+With pnpm:
+
+```bash
+pnpm add -g @bastani/atomic
+```
+
+With Bun:
+
+```bash
+bun add -g @bastani/atomic
 ```
 
 Atomic does not require package install scripts. If you want to disable dependency lifecycle scripts during the Atomic install, you can add `--ignore-scripts` to the install command.

--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -4,16 +4,30 @@ This page gets you from install to a useful first Atomic session.
 
 ## Prerequisites
 
-- **Node.js 20.6 or newer** — required when running Atomic from the published npm package. Check with `node --version`.
-- **Bun 1.3.14 or newer** — use Bun for installation, Atomic repository development, validation commands, and workflow-authoring examples.
+- **Node.js 24 LTS or newer** — Atomic requires the latest Node LTS runtime. Check with `node --version`.
+- **A package manager** — use npm (included with Node), pnpm, Yarn, or Bun. Use Bun 1.3.14+ for Bun installs or workflow-authoring examples.
 - **Model-provider access** — Use `/login` after startup. Supports provider subscriptions and APIs.
 
 ## Install
 
-Install the published package with Bun:
+Install the published package globally with npm, pnpm, or Bun:
+
+With npm:
 
 ```bash
-bun install -g @bastani/atomic
+npm install -g @bastani/atomic
+```
+
+With pnpm:
+
+```bash
+pnpm add -g @bastani/atomic
+```
+
+With Bun:
+
+```bash
+bun add -g @bastani/atomic
 ```
 
 Atomic does not require package install scripts. If you want to disable dependency lifecycle scripts during the Atomic install, you can add `--ignore-scripts` to the install command.

--- a/packages/coding-agent/docs/sdk.md
+++ b/packages/coding-agent/docs/sdk.md
@@ -39,7 +39,21 @@ await session.prompt("What files are in the current directory?");
 
 ## Installation
 
-Install the SDK package with Bun:
+Install `@bastani/atomic` as a project dependency with npm, pnpm, or Bun:
+
+With npm:
+
+```bash
+npm install @bastani/atomic
+```
+
+With pnpm:
+
+```bash
+pnpm add @bastani/atomic
+```
+
+With Bun:
 
 ```bash
 bun add @bastani/atomic
@@ -47,7 +61,7 @@ bun add @bastani/atomic
 
 Atomic does not require package install scripts. If you want to disable dependency lifecycle scripts during the Atomic install, you can add `--ignore-scripts` to the install command.
 
-The SDK is included in the main package. No separate installation needed.
+The SDK is included in the main package. No separate SDK package is needed.
 
 ## Core Concepts
 

--- a/packages/coding-agent/docs/termux.md
+++ b/packages/coding-agent/docs/termux.md
@@ -20,7 +20,7 @@ pkg install nodejs termux-api git
 npm install -g @bastani/atomic
 
 # If you have installed Bun separately in Termux, you can use Bun instead:
-# bun install -g @bastani/atomic
+# bun add -g @bastani/atomic
 
 # Create config directory
 mkdir -p ~/.atomic/agent


### PR DESCRIPTION
## Summary

Expands install guidance across the docs to show npm, pnpm, and Bun options (rather than Bun-only), fixes the Bun global install command from \`bun install -g\` to \`bun add -g\`, updates the Node.js prerequisite to 24 LTS, and gates Mintlify validation in CI to pull request events only.

## Changes

### Docs
- **index.md, quickstart.md, sdk.md**: Replace single Bun install block with three parallel blocks for npm, pnpm, and Bun — aligns with root README options and reflects that Atomic is a standard npm package installable with any package manager.
- **quickstart.md**: Update Node.js prerequisite from "20.6 or newer" to "24 LTS or newer"; update package manager description to mention npm, pnpm, Yarn, and Bun.
- **termux.md, index.md, quickstart.md**: Fix incorrect `bun install -g` → `bun add -g` (Bun's global install flag).
- **sdk.md**: Clarify "No separate SDK package is needed" wording.

### CI
- **test.yml**: Gate the Mintlify docs validation step (`mintlify validate` + `mintlify broken-links`) to `pull_request` events only — prevents it from running on direct pushes to main where it isn't actionable.

## Notes

Mintlify production deploys are controlled by the Mintlify GitHub App/dashboard rather than a repository workflow. This change makes the repo-side validation a PR-only check; dashboard or branch-protection settings may still be needed to fully block external auto-deploys on direct pushes.

## Validation

- `cd packages/coding-agent && bun run docs:check`
- `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate && bunx --bun mintlify@latest broken-links`
- Git hooks: `bun run lint`, `bun run test:unit`