### PR TITLE
docs: add llms.txt migration path for users switching to Atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ See [Programmatic Usage](./packages/coding-agent/README.md#programmatic-usage) f
 
 </details>
 
+### Migrating from another coding agent
+
+Atomic publishes an agent-readable **[`llms.txt`](https://docs.bastani.ai/llms.txt)**. Ask your current coding agent to “install and set up Atomic by following https://docs.bastani.ai/llms.txt”.
+
 ---
 
 ## Spec-driven development


### PR DESCRIPTION
## Summary

Adds a \"Migrating from another coding agent\" section to the README, giving users a single-command migration path via Atomic's agent-readable `llms.txt`.

## Changes

- Added a \"Migrating from another coding agent\" section to the root `README.md`
- Provides a one-liner prompt users can run in their current coding agent to install and set up Atomic by pointing it at `https://docs.bastani.ai/llms.txt`

## Notes

This is a pure documentation change with no code modifications. Pre-commit hooks passed during commit and push, including `bun run lint` and `bun run test:unit`.