### PR TITLE
docs(readme): format migration prompt as a code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ See [Programmatic Usage](./packages/coding-agent/README.md#programmatic-usage) f
 
 ### Migrating from another coding agent
 
-Atomic publishes an agent-readable **[`llms.txt`](https://docs.bastani.ai/llms.txt)**. Ask your current coding agent to “install and set up Atomic by following https://docs.bastani.ai/llms.txt”.
-
+Atomic publishes an agent-readable **[`llms.txt`](https://docs.bastani.ai/llms.txt)**. Ask your current coding agent to:
+```text 
+Install and set up Atomic by following https://docs.bastani.ai/llms.txt.
+```
 ---
 
 ## Spec-driven development


### PR DESCRIPTION
## Summary

Reformats the migration instructions in the README to display the prompt for existing coding agents as a fenced code block, making it easier to copy and visually distinct from surrounding prose.

## Key Changes

- Changed the migration prompt from inline text to a `text` code block for clarity and copy-friendliness
- Reworded the lead-in sentence slightly to introduce the block naturally

## Notes

No functional changes — documentation only.