### PR TITLE
feat(workflows): add release-docs workflow

### DIFF
--- a/.atomic/workflow-utils/release-docs.ts
+++ b/.atomic/workflow-utils/release-docs.ts
@@ -67,6 +67,9 @@ export const sanitizeSegment = (value: string): string =>
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "") || "item";
 
+export const releaseDocsUpdateTaskKey = (task: Pick<StaleDocTask, "id">, index: number): string =>
+  `${String(index + 1).padStart(3, "0")}-${sanitizeSegment(task.id)}`;
+
 const normalizeOwnerDocPath = (path: string): string => {
   let normalized = path.trim().replace(/\\+/g, "/");
   while (normalized.startsWith("./")) {

--- a/.atomic/workflow-utils/release-docs.ts
+++ b/.atomic/workflow-utils/release-docs.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
 export type StaleDocTask = {
   id: string;
   title: string;
@@ -7,6 +10,56 @@ export type StaleDocTask = {
   update_instructions: string;
   acceptance_criteria: string[];
 };
+
+export type CommandResult = {
+  command: string;
+  ok: boolean;
+  output: string;
+};
+
+export type CommandRunner = (command: string, args: string[], cwd?: string) => CommandResult;
+
+export type DocsValidationPhase = "skip_repair" | "repair_then_revalidate";
+
+export type UpdateArtifactStatus = {
+  path: string;
+  exists: boolean;
+  empty: boolean;
+};
+
+export type GhPrVerification = {
+  ok: boolean;
+  summary: string;
+  url?: string;
+};
+
+export const DEFAULT_RELEASE_DOCS_BASE_BRANCH = "main";
+
+const repoRoot = (): string => process.cwd();
+
+const runCommand = (command: string, args: string[], cwd = repoRoot()): string =>
+  execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 20,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+export const runCommandResult: CommandRunner = (command, args, cwd = repoRoot()) => {
+  const rendered = [command, ...args].join(" ");
+  try {
+    const output = runCommand(command, args, cwd);
+    return { command: rendered, ok: true, output };
+  } catch (error) {
+    const failure = error as { stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
+    const stdout = String(failure.stdout ?? "");
+    const stderr = String(failure.stderr ?? "");
+    const message = String(failure.message ?? "");
+    return { command: rendered, ok: false, output: [stdout, stderr, message].filter(Boolean).join("\n") };
+  }
+};
+
+export const runGit = (args: string[], cwd = repoRoot()): string => runCommand("git", args, cwd);
 
 export const sanitizeSegment = (value: string): string =>
   value
@@ -44,6 +97,169 @@ const dedupeOwnerDocs = (paths: readonly string[]): string[] => {
     deduped.push(normalized);
   }
   return deduped;
+};
+
+export const requireNonBaseBranch = (
+  currentBranch: string,
+  baseBranch = DEFAULT_RELEASE_DOCS_BASE_BRANCH,
+): string => {
+  const current = currentBranch.trim();
+  const base = baseBranch.trim();
+
+  if (current.length === 0) {
+    throw new Error("release-docs requires a non-empty current branch name.");
+  }
+
+  if (base.length === 0) {
+    throw new Error("release-docs requires a non-empty PR base branch.");
+  }
+
+  if (current === base) {
+    throw new Error(
+      [
+        `release-docs refuses to run directly on the PR base branch '${base}'.`,
+        "Check out a feature branch before running this workflow.",
+      ].join("\n"),
+    );
+  }
+
+  return current;
+};
+
+export const currentBranchName = (cwd = repoRoot()): string => {
+  const branch = runGit(["branch", "--show-current"], cwd);
+  if (branch.length > 0) {
+    return branch;
+  }
+
+  const shortSha = runGit(["rev-parse", "--short", "HEAD"], cwd);
+  throw new Error(
+    [
+      "release-docs must run from a local branch, but HEAD is detached.",
+      `Current detached commit: ${shortSha}`,
+      "Check out or create a branch before running this workflow.",
+    ].join("\n"),
+  );
+};
+
+export const requireResearchDocPath = (path: string | undefined): string => {
+  const trimmed = path?.trim() ?? "";
+  if (trimmed.length === 0) {
+    throw new Error(
+      "deep-research-codebase did not return research_doc_path; release-docs cannot continue without a research artifact path.",
+    );
+  }
+  return trimmed;
+};
+
+export const extractJsonArray = (text: string): StaleDocTask[] => {
+  const trimmed = text.trim();
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
+  const jsonText = fenced?.[1]?.trim() ?? trimmed;
+  let parsed: StaleDocTask[];
+  try {
+    parsed = JSON.parse(jsonText) as StaleDocTask[];
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const excerpt = jsonText.length > 1_000 ? `${jsonText.slice(0, 1_000)}…` : jsonText;
+    throw new Error(
+      [
+        "stale-doc detector returned invalid JSON. Expected a JSON array.",
+        `Parse error: ${detail}`,
+        "Output excerpt:",
+        excerpt || "(empty output)",
+      ].join("\n"),
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("stale-doc detector did not return a JSON array.");
+  }
+  return parsed.map((task, index) => ({
+    id: sanitizeSegment(String(task.id || `doc-task-${index + 1}`)),
+    title: String(task.title || `Documentation task ${index + 1}`),
+    owner_docs: Array.isArray(task.owner_docs) ? task.owner_docs.map(String) : [],
+    reason: String(task.reason || ""),
+    source_refs: Array.isArray(task.source_refs) ? task.source_refs.map(String) : [],
+    update_instructions: String(task.update_instructions || ""),
+    acceptance_criteria: Array.isArray(task.acceptance_criteria) ? task.acceptance_criteria.map(String) : [],
+  }));
+};
+
+export const nextDocsValidationPhase = (initialValidationOk: boolean): DocsValidationPhase =>
+  initialValidationOk ? "skip_repair" : "repair_then_revalidate";
+
+export const findMissingOrEmptyUpdateArtifacts = (
+  artifacts: readonly UpdateArtifactStatus[],
+): UpdateArtifactStatus[] => artifacts.filter((artifact) => !artifact.exists || artifact.empty);
+
+export const verifyReleaseDocsPr = (
+  currentBranch: string,
+  baseBranch = DEFAULT_RELEASE_DOCS_BASE_BRANCH,
+  cwd = repoRoot(),
+  runner: CommandRunner = runCommandResult,
+): GhPrVerification => {
+  const result = runner(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--head",
+      currentBranch,
+      "--base",
+      baseBranch,
+      "--state",
+      "open",
+      "--json",
+      "url,headRefName,baseRefName,state",
+      "--limit",
+      "1",
+      "--jq",
+      ".[0]",
+    ],
+    cwd,
+  );
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      summary: ["Unable to verify release docs PR with gh.", `Command: ${result.command}`, result.output].join("\n"),
+    };
+  }
+
+  type GhPrRecord = {
+    url?: string;
+    headRefName?: string;
+    baseRefName?: string;
+    state?: string;
+  };
+
+  let parsed: GhPrRecord | null;
+  try {
+    parsed = JSON.parse(result.output || "null") as GhPrRecord | null;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      summary: ["Unable to parse gh PR verification output.", `Parse error: ${detail}`, result.output].join("\n"),
+    };
+  }
+
+  const ok =
+    parsed !== null &&
+    parsed.headRefName === currentBranch &&
+    parsed.baseRefName === baseBranch &&
+    parsed.state === "OPEN" &&
+    typeof parsed.url === "string" &&
+    parsed.url.length > 0;
+
+  const url = parsed?.url;
+  return {
+    ok,
+    url,
+    summary: ok
+      ? `Verified open PR ${url} from ${currentBranch} to ${baseBranch}.`
+      : `gh did not return an open PR matching head=${currentBranch} and base=${baseBranch}: ${result.output || "null"}`,
+  };
 };
 
 class DisjointSet {
@@ -129,4 +345,47 @@ export const mergeStaleDocTasksByOwnerDocs = (tasks: readonly StaleDocTask[]): S
   return [...components.values()]
     .sort((left, right) => left.firstIndex - right.firstIndex)
     .map((component) => mergeTaskGroup(component.tasks, component.firstIndex));
+};
+
+export const runDocsChecks = (): { ok: boolean; markdown: string } => {
+  const checks = [
+    {
+      label: "Hosted docs route/internal-link validation",
+      command: "bun",
+      args: ["run", "docs:check"],
+      cwd: join(repoRoot(), "packages/coding-agent"),
+    },
+    {
+      label: "Mintlify syntax validation",
+      command: "bunx",
+      args: ["--bun", "mintlify@latest", "validate"],
+      cwd: join(repoRoot(), "packages/coding-agent/docs"),
+    },
+    {
+      label: "Mintlify broken-link validation",
+      command: "bunx",
+      args: ["--bun", "mintlify@latest", "broken-links"],
+      cwd: join(repoRoot(), "packages/coding-agent/docs"),
+    },
+  ];
+
+  const results = checks.map((check) => ({ ...check, result: runCommandResult(check.command, check.args, check.cwd) }));
+  const ok = results.every((check) => check.result.ok);
+  const markdown = results
+    .map((check) =>
+      [
+        `## ${check.label}`,
+        "",
+        `Command: \`${check.result.command}\``,
+        `Cwd: \`${check.cwd}\``,
+        `Status: ${check.result.ok ? "pass" : "fail"}`,
+        "",
+        "```text",
+        check.result.output || "(no output)",
+        "```",
+      ].join("\n"),
+    )
+    .join("\n\n");
+
+  return { ok, markdown };
 };

--- a/.atomic/workflow-utils/release-docs.ts
+++ b/.atomic/workflow-utils/release-docs.ts
@@ -1,0 +1,132 @@
+export type StaleDocTask = {
+  id: string;
+  title: string;
+  owner_docs: string[];
+  reason: string;
+  source_refs: string[];
+  update_instructions: string;
+  acceptance_criteria: string[];
+};
+
+export const sanitizeSegment = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "item";
+
+const normalizeOwnerDocPath = (path: string): string => {
+  let normalized = path.trim().replace(/\\+/g, "/");
+  while (normalized.startsWith("./")) {
+    normalized = normalized.slice(2);
+  }
+  return normalized.replace(/\/+/g, "/");
+};
+
+const dedupeStrings = (values: readonly string[]): string[] => {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (normalized.length === 0 || seen.has(normalized)) continue;
+    seen.add(normalized);
+    deduped.push(normalized);
+  }
+  return deduped;
+};
+
+const dedupeOwnerDocs = (paths: readonly string[]): string[] => {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const path of paths) {
+    const normalized = normalizeOwnerDocPath(path);
+    if (normalized.length === 0 || seen.has(normalized)) continue;
+    seen.add(normalized);
+    deduped.push(normalized);
+  }
+  return deduped;
+};
+
+class DisjointSet {
+  private readonly parent: number[];
+
+  constructor(size: number) {
+    this.parent = Array.from({ length: size }, (_, index) => index);
+  }
+
+  find(index: number): number {
+    const parent = this.parent[index];
+    if (parent === index) return index;
+    const root = this.find(parent);
+    this.parent[index] = root;
+    return root;
+  }
+
+  union(left: number, right: number): void {
+    const leftRoot = this.find(left);
+    const rightRoot = this.find(right);
+    if (leftRoot !== rightRoot) {
+      this.parent[rightRoot] = leftRoot;
+    }
+  }
+}
+
+const mergeTaskGroup = (tasks: readonly StaleDocTask[], firstIndex: number): StaleDocTask => {
+  if (tasks.length === 1) {
+    const [task] = tasks;
+    return {
+      ...task,
+      owner_docs: dedupeOwnerDocs(task.owner_docs),
+      source_refs: dedupeStrings(task.source_refs),
+      acceptance_criteria: dedupeStrings(task.acceptance_criteria),
+    };
+  }
+
+  const ids = tasks.map((task) => sanitizeSegment(task.id));
+  const baseId = sanitizeSegment(`merged-${firstIndex + 1}-${ids.join("-")}`);
+  const id = baseId.length > 120 ? baseId.slice(0, 120).replace(/-+$/g, "") : baseId;
+
+  return {
+    id,
+    title: `Merged stale docs updates: ${tasks.map((task) => task.title).join("; ")}`,
+    owner_docs: dedupeOwnerDocs(tasks.flatMap((task) => task.owner_docs)),
+    reason: tasks.map((task) => `- ${task.id}: ${task.reason}`).join("\n"),
+    source_refs: dedupeStrings(tasks.flatMap((task) => task.source_refs)),
+    update_instructions: tasks.map((task) => `## ${task.id}: ${task.title}\n${task.update_instructions}`).join("\n\n"),
+    acceptance_criteria: dedupeStrings(tasks.flatMap((task) => task.acceptance_criteria)),
+  };
+};
+
+export const mergeStaleDocTasksByOwnerDocs = (tasks: readonly StaleDocTask[]): StaleDocTask[] => {
+  if (tasks.length < 2) {
+    return tasks.map((task, index) => mergeTaskGroup([task], index));
+  }
+
+  const groups = new DisjointSet(tasks.length);
+  const ownerDocToFirstTask = new Map<string, number>();
+
+  tasks.forEach((task, taskIndex) => {
+    for (const ownerDoc of dedupeOwnerDocs(task.owner_docs)) {
+      const firstTaskIndex = ownerDocToFirstTask.get(ownerDoc);
+      if (firstTaskIndex === undefined) {
+        ownerDocToFirstTask.set(ownerDoc, taskIndex);
+      } else {
+        groups.union(firstTaskIndex, taskIndex);
+      }
+    }
+  });
+
+  const components = new Map<number, { firstIndex: number; tasks: StaleDocTask[] }>();
+  tasks.forEach((task, taskIndex) => {
+    const root = groups.find(taskIndex);
+    const component = components.get(root);
+    if (component === undefined) {
+      components.set(root, { firstIndex: taskIndex, tasks: [task] });
+      return;
+    }
+    component.tasks.push(task);
+  });
+
+  return [...components.values()]
+    .sort((left, right) => left.firstIndex - right.firstIndex)
+    .map((component) => mergeTaskGroup(component.tasks, component.firstIndex));
+};

--- a/.atomic/workflows/release-docs.ts
+++ b/.atomic/workflows/release-docs.ts
@@ -45,7 +45,7 @@ const runResult = (command: string, args: string[], cwd = repoRoot()): CommandRe
   }
 };
 
-const runGit = (args: string[]): string => run("git", args);
+const runGit = (args: string[], cwd = repoRoot()): string => run("git", args, cwd);
 
 const ensureCleanWorkingTree = (): void => {
   const status = runGit(["status", "--porcelain=v1"]);
@@ -61,21 +61,51 @@ const ensureCleanWorkingTree = (): void => {
   }
 };
 
-const currentBranchName = (): string => {
-  const branch = runGit(["branch", "--show-current"]);
+export const currentBranchName = (cwd = repoRoot()): string => {
+  const branch = runGit(["branch", "--show-current"], cwd);
   if (branch.length > 0) {
     return branch;
   }
 
-  const shortSha = runGit(["rev-parse", "--short", "HEAD"]);
-  return `detached-${shortSha}`;
+  const shortSha = runGit(["rev-parse", "--short", "HEAD"], cwd);
+  throw new Error(
+    [
+      "release-docs must run from a local branch, but HEAD is detached.",
+      `Current detached commit: ${shortSha}`,
+      "Check out or create a branch before running this workflow.",
+    ].join("\n"),
+  );
 };
 
-const extractJsonArray = (text: string): StaleDocTask[] => {
+export const requireResearchDocPath = (path: string | undefined): string => {
+  const trimmed = path?.trim() ?? "";
+  if (trimmed.length === 0) {
+    throw new Error(
+      "deep-research-codebase did not return research_doc_path; release-docs cannot continue without a research artifact path.",
+    );
+  }
+  return trimmed;
+};
+
+export const extractJsonArray = (text: string): StaleDocTask[] => {
   const trimmed = text.trim();
   const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
   const jsonText = fenced?.[1]?.trim() ?? trimmed;
-  const parsed = JSON.parse(jsonText) as StaleDocTask[];
+  let parsed: StaleDocTask[];
+  try {
+    parsed = JSON.parse(jsonText) as StaleDocTask[];
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const excerpt = jsonText.length > 1_000 ? `${jsonText.slice(0, 1_000)}…` : jsonText;
+    throw new Error(
+      [
+        "stale-doc detector returned invalid JSON. Expected a JSON array.",
+        `Parse error: ${detail}`,
+        "Output excerpt:",
+        excerpt || "(empty output)",
+      ].join("\n"),
+    );
+  }
   if (!Array.isArray(parsed)) {
     throw new Error("stale-doc detector did not return a JSON array.");
   }
@@ -200,7 +230,7 @@ export default defineWorkflow("release-docs")
       },
     });
 
-    const researchDocPath = String(research.outputs.research_doc_path);
+    const researchDocPath = requireResearchDocPath(research.outputs.research_doc_path);
 
     await ctx.task("identify-stale-docs", {
       prompt: [

--- a/.atomic/workflows/release-docs.ts
+++ b/.atomic/workflows/release-docs.ts
@@ -9,6 +9,7 @@ import {
   findMissingOrEmptyUpdateArtifacts,
   mergeStaleDocTasksByOwnerDocs,
   nextDocsValidationPhase,
+  releaseDocsUpdateTaskKey,
   requireNonBaseBranch,
   requireResearchDocPath,
   runDocsChecks,
@@ -166,10 +167,11 @@ export default defineWorkflow("release-docs")
       };
     }
 
-    const updateArtifacts = staleTasks.map((task) => join(updatesRoot, `${sanitizeSegment(task.id)}.md`));
+    const updateTaskKeys = staleTasks.map(releaseDocsUpdateTaskKey);
+    const updateArtifacts = updateTaskKeys.map((key) => join(updatesRoot, `${key}.md`));
     await ctx.parallel(
       staleTasks.map((task, index) => ({
-        name: `update-docs-${sanitizeSegment(task.id)}`,
+        name: `update-docs-${updateTaskKeys[index]}`,
         prompt: [
           "Update Atomic release docs for one grouped stale-doc task.",
           `Release docs metadata artifact: ${metadataPath}`,
@@ -276,6 +278,28 @@ export default defineWorkflow("release-docs")
         stale_doc_tasks: staleTasks,
         validation_report_path: validationPath,
         pr_summary: "Validation failed; PR skipped.",
+      };
+    }
+
+    const docsStatusAfterValidation = runGit(["status", "--porcelain=v1", "packages/coding-agent/docs"]);
+    if (docsStatusAfterValidation.length === 0) {
+      const result = [
+        `No docs changes remained after validation for current branch ${currentBranch}.`,
+        "No release docs PR was opened because the docs tree is clean.",
+        `Research artifact: ${researchDocPath}`,
+        `Stale-doc task artifact: ${staleTasksPath}`,
+        `Validation report: ${validationPath}`,
+      ].join("\n");
+      return {
+        result,
+        status: "no_changes" as const,
+        current_branch: currentBranch,
+        artifact_root: artifactRoot,
+        research_doc_path: researchDocPath,
+        stale_doc_task_count: staleTasks.length,
+        stale_doc_tasks: staleTasks,
+        validation_report_path: validationPath,
+        pr_summary: "No docs changes after validation; PR skipped.",
       };
     }
 

--- a/.atomic/workflows/release-docs.ts
+++ b/.atomic/workflows/release-docs.ts
@@ -1,0 +1,455 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { defineWorkflow, Type } from "@bastani/workflows";
+import deepResearchCodebase from "../../packages/workflows/builtin/deep-research-codebase.js";
+
+const staleDocTaskSchema = Type.Object({
+  id: Type.String(),
+  title: Type.String(),
+  owner_docs: Type.Array(Type.String()),
+  reason: Type.String(),
+  source_refs: Type.Array(Type.String()),
+  update_instructions: Type.String(),
+  acceptance_criteria: Type.Array(Type.String()),
+});
+
+type StaleDocTask = {
+  id: string;
+  title: string;
+  owner_docs: string[];
+  reason: string;
+  source_refs: string[];
+  update_instructions: string;
+  acceptance_criteria: string[];
+};
+
+type CommandResult = {
+  command: string;
+  ok: boolean;
+  output: string;
+};
+
+const repoRoot = () => process.cwd();
+
+const run = (command: string, args: string[], cwd = repoRoot()): string =>
+  execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 20,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+const runResult = (command: string, args: string[], cwd = repoRoot()): CommandResult => {
+  const rendered = [command, ...args].join(" ");
+  try {
+    const output = run(command, args, cwd);
+    return { command: rendered, ok: true, output };
+  } catch (error) {
+    const failure = error as { stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
+    const stdout = String(failure.stdout ?? "");
+    const stderr = String(failure.stderr ?? "");
+    const message = String(failure.message ?? "");
+    return { command: rendered, ok: false, output: [stdout, stderr, message].filter(Boolean).join("\n") };
+  }
+};
+
+const runGit = (args: string[]): string => run("git", args);
+
+const gitOk = (args: string[]): boolean => runResult("git", args).ok;
+
+const ensureCleanWorkingTree = (): void => {
+  const status = runGit(["status", "--porcelain=v1"]);
+  if (status.length > 0) {
+    throw new Error(
+      [
+        "release-docs refuses to start on a dirty working tree because it creates a release docs branch before editing.",
+        "Commit, stash, or discard existing changes first.",
+        "Current status:",
+        status,
+      ].join("\n"),
+    );
+  }
+};
+
+const latestStableTag = (): string => {
+  const tags = runGit(["tag", "--list", "--sort=-v:refname"])
+    .split("\n")
+    .map((tag) => tag.trim())
+    .filter((tag) => /^v?\d+\.\d+\.\d+$/.test(tag));
+  const tag = tags[0];
+  if (!tag) {
+    throw new Error("release-docs could not find a stable semver release tag like 0.8.25.");
+  }
+  return tag;
+};
+
+const inferReleaseVersion = (targetRef: string): string => {
+  const match = /v?(\d+\.\d+\.\d+)(?:[-+][0-9A-Za-z.-]+)?/.exec(targetRef);
+  const version = match?.[1];
+  if (!version) {
+    throw new Error(
+      `release-docs could not infer a MAJOR.MINOR.PATCH release version from target_ref "${targetRef}".`,
+    );
+  }
+  return version;
+};
+
+const sanitizeSegment = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "item";
+
+const switchToDocsBranch = (branchName: string): void => {
+  const remoteBranch = `origin/${branchName}`;
+  if (gitOk(["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`])) {
+    runGit(["switch", branchName]);
+    return;
+  }
+
+  if (gitOk(["rev-parse", "--verify", `${remoteBranch}^{commit}`])) {
+    runGit(["switch", "--track", "-c", branchName, remoteBranch]);
+    return;
+  }
+
+  runGit(["switch", "-c", branchName]);
+};
+
+const prepareBranch = (targetRef: string): { baselineTag: string; branchName: string; releaseVersion: string } => {
+  ensureCleanWorkingTree();
+  runGit(["fetch", "--tags", "--prune", "origin"]);
+
+  if (!gitOk(["rev-parse", "--verify", `${targetRef}^{commit}`])) {
+    throw new Error(`release-docs could not resolve target_ref "${targetRef}" to a commit after fetching origin tags.`);
+  }
+
+  const releaseVersion = inferReleaseVersion(targetRef);
+  const baselineTag = latestStableTag();
+  const branchName = `docs/release-docs-${releaseVersion}`;
+  switchToDocsBranch(branchName);
+
+  return { baselineTag, branchName, releaseVersion };
+};
+
+const extractJsonArray = (text: string): StaleDocTask[] => {
+  const trimmed = text.trim();
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
+  const jsonText = fenced?.[1]?.trim() ?? trimmed;
+  const parsed = JSON.parse(jsonText) as StaleDocTask[];
+  if (!Array.isArray(parsed)) {
+    throw new Error("stale-doc detector did not return a JSON array.");
+  }
+  return parsed.map((task, index) => ({
+    id: sanitizeSegment(String(task.id || `doc-task-${index + 1}`)),
+    title: String(task.title || `Documentation task ${index + 1}`),
+    owner_docs: Array.isArray(task.owner_docs) ? task.owner_docs.map(String) : [],
+    reason: String(task.reason || ""),
+    source_refs: Array.isArray(task.source_refs) ? task.source_refs.map(String) : [],
+    update_instructions: String(task.update_instructions || ""),
+    acceptance_criteria: Array.isArray(task.acceptance_criteria) ? task.acceptance_criteria.map(String) : [],
+  }));
+};
+
+const runDocsChecks = (): { ok: boolean; markdown: string } => {
+  const checks = [
+    {
+      label: "Hosted docs route/internal-link validation",
+      command: "bun",
+      args: ["run", "docs:check"],
+      cwd: join(repoRoot(), "packages/coding-agent"),
+    },
+    {
+      label: "Mintlify syntax validation",
+      command: "bunx",
+      args: ["--bun", "mintlify@latest", "validate"],
+      cwd: join(repoRoot(), "packages/coding-agent/docs"),
+    },
+    {
+      label: "Mintlify broken-link validation",
+      command: "bunx",
+      args: ["--bun", "mintlify@latest", "broken-links"],
+      cwd: join(repoRoot(), "packages/coding-agent/docs"),
+    },
+  ];
+
+  const results = checks.map((check) => ({ ...check, result: runResult(check.command, check.args, check.cwd) }));
+  const ok = results.every((check) => check.result.ok);
+  const markdown = results
+    .map((check) =>
+      [
+        `## ${check.label}`,
+        "",
+        `Command: \`${check.result.command}\``,
+        `Cwd: \`${check.cwd}\``,
+        `Status: ${check.result.ok ? "pass" : "fail"}`,
+        "",
+        "```text",
+        check.result.output || "(no output)",
+        "```",
+      ].join("\n"),
+    )
+    .join("\n\n");
+
+  return { ok, markdown };
+};
+
+const writeJson = (path: string, value: object): void => {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+export default defineWorkflow("release-docs")
+  .description("Prepare Atomic release docs updates, validate Mintlify docs, and open a PR.")
+  .input("target_ref", Type.String({ description: "Target release ref/tag/branch/commit to compare against the latest stable release tag." }))
+  .output("result", Type.String({ description: "Human-readable release docs workflow summary." }))
+  .output(
+    "status",
+    Type.Union([Type.Literal("pr_created"), Type.Literal("no_changes"), Type.Literal("needs_investigation")], {
+      description: "Final workflow status.",
+    }),
+  )
+  .output("target_ref", Type.String({ description: "Target ref supplied by the caller." }))
+  .output("baseline_tag", Type.String({ description: "Latest stable release tag used as the comparison baseline." }))
+  .output("release_version", Type.String({ description: "Release version inferred from target_ref." }))
+  .output("branch_name", Type.String({ description: "Docs branch created or reused by the workflow." }))
+  .output("research_doc_path", Type.String({ description: "Research artifact path from the codebase research child workflow." }))
+  .output("stale_doc_task_count", Type.Number({ description: "Number of grouped stale-doc update tasks found." }))
+  .output("stale_doc_tasks", Type.Array(staleDocTaskSchema, { description: "Grouped stale-doc update tasks." }))
+  .output("validation_report_path", Type.String({ description: "Validation report artifact path." }))
+  .output("pr_summary", Type.Optional(Type.String({ description: "PR creation summary or no-op explanation." })))
+  .run(async (ctx) => {
+    const targetRef = ctx.inputs.target_ref.trim();
+    const { baselineTag, branchName, releaseVersion } = prepareBranch(targetRef);
+    const artifactRoot = join(".atomic", "workflows", "runs", "release-docs", releaseVersion);
+    const updatesRoot = join(artifactRoot, "updates");
+    mkdirSync(updatesRoot, { recursive: true });
+
+    const metadataPath = join(artifactRoot, "release-metadata.json");
+    const staleTasksPath = join(artifactRoot, "stale-doc-tasks.json");
+    const validationPath = join(artifactRoot, "validation.md");
+    const prPath = join(artifactRoot, "pr.md");
+
+    writeJson(metadataPath, {
+      target_ref: targetRef,
+      baseline_tag: baselineTag,
+      comparison_range: `${baselineTag}..${targetRef}`,
+      release_version: releaseVersion,
+      branch_name: branchName,
+      docs_root: "packages/coding-agent/docs",
+      pr_base: "main",
+    });
+
+    await ctx.stage("prepare-release-docs-branch", { noTools: "all" }).prompt(
+      [
+        "Release docs branch preparation is complete.",
+        `Baseline tag: ${baselineTag}`,
+        `Target ref: ${targetRef}`,
+        `Release version: ${releaseVersion}`,
+        `Branch: ${branchName}`,
+        `Metadata artifact: ${metadataPath}`,
+        "Reply exactly: RELEASE_DOCS_BRANCH_READY",
+        "Do not ask questions. Do not call tools.",
+      ].join("\n"),
+    );
+
+    const research = await ctx.workflow(deepResearchCodebase, {
+      stageName: "research-release-code-changes",
+      inputs: {
+        prompt: [
+          "Research Atomic code changes for release documentation updates.",
+          `Compare the latest stable baseline tag ${baselineTag} to target ref ${targetRef}.`,
+          "Use git diff/name-status/log evidence for that range and inspect the changed code paths.",
+          "Focus on developer-facing and user-facing behavior that should be reflected in docs under packages/coding-agent/docs.",
+          "Document concrete file paths, symbols, CLI/workflow/settings behavior, and docs implications.",
+          "Do not edit files; this stage is research only.",
+        ].join("\n"),
+        max_partitions: 100,
+        max_concurrency: 8,
+      },
+    });
+
+    const researchDocPath = String(research.outputs.research_doc_path);
+
+    await ctx.task("identify-stale-docs", {
+      prompt: [
+        "Identify stale Atomic docs entries for release prep.",
+        `Release metadata artifact: ${metadataPath}`,
+        `Research artifact: ${researchDocPath}`,
+        "Read the metadata and research artifacts before inspecting docs.",
+        "Docs scope is strictly packages/coding-agent/docs.",
+        "Inspect docs against the baseline-to-target changes and emit grouped, non-overlapping update tasks.",
+        "Group stale entries by owning docs files so parallel update workers do not edit the same file concurrently.",
+        "If multiple stale entries touch the same docs file, put them in the same task.",
+        "If no stale docs are found, write exactly [].",
+        "Write ONLY a JSON array to the output file. Do not wrap it in prose unless JSON fences are unavoidable.",
+        "Each array item must have this shape:",
+        "{",
+        "  \"id\": \"short-kebab-id\",",
+        "  \"title\": \"short human title\",",
+        "  \"owner_docs\": [\"packages/coding-agent/docs/path.mdx\"],",
+        "  \"reason\": \"why the current docs are stale\",",
+        "  \"source_refs\": [\"code or research references\"],",
+        "  \"update_instructions\": \"specific docs update instructions\",",
+        "  \"acceptance_criteria\": [\"observable criteria for this docs task\"]",
+        "}",
+      ].join("\n"),
+      reads: [metadataPath, researchDocPath],
+      output: staleTasksPath,
+      outputMode: "file-only",
+      context: "fresh",
+    });
+
+    const staleTasks = extractJsonArray(readFileSync(staleTasksPath, "utf8"));
+    writeJson(staleTasksPath, staleTasks);
+
+    if (staleTasks.length === 0) {
+      const result = [
+        `No stale docs entries were found for ${baselineTag}..${targetRef}.`,
+        "No docs changes were made, so no PR was opened.",
+        `Research artifact: ${researchDocPath}`,
+        `Stale-doc task artifact: ${staleTasksPath}`,
+      ].join("\n");
+      writeFileSync(validationPath, "Validation skipped because no stale docs tasks were found.\n");
+      return {
+        result,
+        status: "no_changes" as const,
+        target_ref: targetRef,
+        baseline_tag: baselineTag,
+        release_version: releaseVersion,
+        branch_name: branchName,
+        research_doc_path: researchDocPath,
+        stale_doc_task_count: 0,
+        stale_doc_tasks: staleTasks,
+        validation_report_path: validationPath,
+        pr_summary: "No docs changes; PR skipped.",
+      };
+    }
+
+    const updateArtifacts = staleTasks.map((task) => join(updatesRoot, `${sanitizeSegment(task.id)}.md`));
+    await ctx.parallel(
+      staleTasks.map((task, index) => ({
+        name: `update-docs-${sanitizeSegment(task.id)}`,
+        prompt: [
+          "Update Atomic release docs for one grouped stale-doc task.",
+          `Release metadata artifact: ${metadataPath}`,
+          `Research artifact: ${researchDocPath}`,
+          `Full stale-doc task list: ${staleTasksPath}`,
+          "Assigned stale-doc task JSON:",
+          JSON.stringify(task, null, 2),
+          "Read the listed artifacts and then edit only the owner_docs files unless a directly adjacent docs link/index must be fixed.",
+          "Do not edit code, changelogs, package manifests, or docs outside packages/coding-agent/docs.",
+          "Do not commit, push, or create a PR.",
+          "When finished, summarize changed files, evidence used, and residual risks.",
+        ].join("\n"),
+        reads: [metadataPath, researchDocPath, staleTasksPath, ...task.owner_docs.filter((path) => existsSync(path))],
+        output: updateArtifacts[index],
+        outputMode: "file-only" as const,
+        context: "fresh" as const,
+      })),
+      { concurrency: Math.min(4, staleTasks.length), failFast: false },
+    );
+
+    await ctx.task("validate-and-repair-release-docs", {
+      prompt: [
+        "Validate the release docs updates and repair docs-only validation failures.",
+        `Release metadata artifact: ${metadataPath}`,
+        `Research artifact: ${researchDocPath}`,
+        `Stale-doc task artifact: ${staleTasksPath}`,
+        "First discover the docs validation commands from package scripts and docs/ci.md.",
+        "The expected validation contract is:",
+        "1. cd packages/coding-agent && bun run docs:check",
+        "2. cd packages/coding-agent/docs && bunx --bun mintlify@latest validate",
+        "3. cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links",
+        "Run the checks with Bun/Bunx. If they fail, fix docs issues under packages/coding-agent/docs and rerun all checks.",
+        "Do not commit, push, or create a PR.",
+        "If failures remain after reasonable docs-only repairs, write INVESTIGATION REQUIRED with the exact failing command and output.",
+        "If all checks pass, write VALIDATION PASSED and summarize commands run.",
+      ].join("\n"),
+      reads: [metadataPath, researchDocPath, staleTasksPath, ...updateArtifacts],
+      output: validationPath,
+      outputMode: "file-only",
+      context: "fork",
+    });
+
+    const validation = runDocsChecks();
+    writeFileSync(
+      validationPath,
+      [readFileSync(validationPath, "utf8"), "\n\n# Deterministic validation replay\n\n", validation.markdown].join(""),
+    );
+
+    if (!validation.ok) {
+      const result = [
+        `Docs validation still fails for ${baselineTag}..${targetRef}.`,
+        "The workflow stopped before commit, push, and PR creation. Investigation is required.",
+        `Validation report: ${validationPath}`,
+      ].join("\n");
+      return {
+        result,
+        status: "needs_investigation" as const,
+        target_ref: targetRef,
+        baseline_tag: baselineTag,
+        release_version: releaseVersion,
+        branch_name: branchName,
+        research_doc_path: researchDocPath,
+        stale_doc_task_count: staleTasks.length,
+        stale_doc_tasks: staleTasks,
+        validation_report_path: validationPath,
+        pr_summary: "Validation failed; PR skipped.",
+      };
+    }
+
+    const pr = await ctx.task("commit-push-open-release-docs-pr", {
+      prompt: [
+        "Create the release docs PR now that deterministic validation passed.",
+        `Branch: ${branchName}`,
+        "PR base: main",
+        `Release version: ${releaseVersion}`,
+        `Comparison range: ${baselineTag}..${targetRef}`,
+        `Research artifact: ${researchDocPath}`,
+        `Validation report: ${validationPath}`,
+        "Start by inspecting git status --short.",
+        "If there are no changes, do not commit, push, or create a PR; summarize the no-op result.",
+        "If there are changes, stage only docs/workflow-run artifacts that are appropriate for the PR, commit with message:",
+        `docs: update release docs for ${releaseVersion}`,
+        "Push the branch to origin and create or update a GitHub PR targeting main using gh.",
+        "Use a PR title like:",
+        `docs: update release docs for ${releaseVersion}`,
+        "Include baseline, target, research artifact, stale-doc task count, and validation commands in the PR body.",
+        "Do not tag or publish a release.",
+      ].join("\n"),
+      reads: [metadataPath, researchDocPath, staleTasksPath, validationPath, ...updateArtifacts],
+      output: prPath,
+      outputMode: "file-only",
+      context: "fork",
+    });
+
+    const prSummary = readFileSync(prPath, "utf8").trim() || pr.text;
+    const status = runGit(["status", "--porcelain=v1", "packages/coding-agent/docs"]);
+    const finalStatus = status.length > 0 ? "needs_investigation" : "pr_created";
+    const result = [
+      finalStatus === "pr_created"
+        ? `Release docs PR stage completed for ${releaseVersion}.`
+        : `Release docs PR stage left uncommitted docs changes for ${releaseVersion}; investigation is required.`,
+      `Baseline: ${baselineTag}`,
+      `Target: ${targetRef}`,
+      `Branch: ${branchName}`,
+      `Research artifact: ${researchDocPath}`,
+      `Validation report: ${validationPath}`,
+      `PR summary artifact: ${prPath}`,
+    ].join("\n");
+
+    return {
+      result,
+      status: finalStatus,
+      target_ref: targetRef,
+      baseline_tag: baselineTag,
+      release_version: releaseVersion,
+      branch_name: branchName,
+      research_doc_path: researchDocPath,
+      stale_doc_task_count: staleTasks.length,
+      stale_doc_tasks: staleTasks,
+      validation_report_path: validationPath,
+      pr_summary: prSummary,
+    };
+  })
+  .compile();

--- a/.atomic/workflows/release-docs.ts
+++ b/.atomic/workflows/release-docs.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { defineWorkflow, Type } from "@bastani/workflows";
 import deepResearchCodebase from "../../packages/workflows/builtin/deep-research-codebase.js";
+import { mergeStaleDocTasksByOwnerDocs, sanitizeSegment, type StaleDocTask } from "../workflow-utils/release-docs.js";
 
 const staleDocTaskSchema = Type.Object({
   id: Type.String(),
@@ -13,16 +14,6 @@ const staleDocTaskSchema = Type.Object({
   update_instructions: Type.String(),
   acceptance_criteria: Type.Array(Type.String()),
 });
-
-type StaleDocTask = {
-  id: string;
-  title: string;
-  owner_docs: string[];
-  reason: string;
-  source_refs: string[];
-  update_instructions: string;
-  acceptance_criteria: string[];
-};
 
 type CommandResult = {
   command: string;
@@ -79,12 +70,6 @@ const currentBranchName = (): string => {
   const shortSha = runGit(["rev-parse", "--short", "HEAD"]);
   return `detached-${shortSha}`;
 };
-
-const sanitizeSegment = (value: string): string =>
-  value
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "") || "item";
 
 const extractJsonArray = (text: string): StaleDocTask[] => {
   const trimmed = text.trim();
@@ -246,7 +231,8 @@ export default defineWorkflow("release-docs")
       context: "fresh",
     });
 
-    const staleTasks = extractJsonArray(readFileSync(staleTasksPath, "utf8"));
+    const modelStaleTasks = extractJsonArray(readFileSync(staleTasksPath, "utf8"));
+    const staleTasks = mergeStaleDocTasksByOwnerDocs(modelStaleTasks);
     writeJson(staleTasksPath, staleTasks);
 
     if (staleTasks.length === 0) {
@@ -350,8 +336,9 @@ export default defineWorkflow("release-docs")
         `Validation report: ${validationPath}`,
         "Start by inspecting git status --short.",
         "If there are no changes, do not commit, push, or create a PR; summarize the no-op result.",
-        "If there are changes, stage only docs/workflow-run artifacts that are appropriate for the PR, commit with message:",
+        "If there are changes, stage only intentional documentation changes under packages/coding-agent/docs, commit with message:",
         "docs: update release docs",
+        "Do not stage .atomic/, .atomic/workflows/runs/, workflow artifacts, release metadata, stale-doc task files, validation reports, PR summaries, update artifacts, research artifacts, or files outside packages/coding-agent/docs.",
         "Push the current branch to origin and create or update a GitHub PR targeting main using gh.",
         "Use this PR title:",
         "docs: update release docs",

--- a/.atomic/workflows/release-docs.ts
+++ b/.atomic/workflows/release-docs.ts
@@ -56,14 +56,12 @@ const runResult = (command: string, args: string[], cwd = repoRoot()): CommandRe
 
 const runGit = (args: string[]): string => run("git", args);
 
-const gitOk = (args: string[]): boolean => runResult("git", args).ok;
-
 const ensureCleanWorkingTree = (): void => {
   const status = runGit(["status", "--porcelain=v1"]);
   if (status.length > 0) {
     throw new Error(
       [
-        "release-docs refuses to start on a dirty working tree because it creates a release docs branch before editing.",
+        "release-docs refuses to start on a dirty working tree because it edits docs, commits, and pushes on the current branch.",
         "Commit, stash, or discard existing changes first.",
         "Current status:",
         status,
@@ -72,27 +70,14 @@ const ensureCleanWorkingTree = (): void => {
   }
 };
 
-const latestStableTag = (): string => {
-  const tags = runGit(["tag", "--list", "--sort=-v:refname"])
-    .split("\n")
-    .map((tag) => tag.trim())
-    .filter((tag) => /^v?\d+\.\d+\.\d+$/.test(tag));
-  const tag = tags[0];
-  if (!tag) {
-    throw new Error("release-docs could not find a stable semver release tag like 0.8.25.");
+const currentBranchName = (): string => {
+  const branch = runGit(["branch", "--show-current"]);
+  if (branch.length > 0) {
+    return branch;
   }
-  return tag;
-};
 
-const inferReleaseVersion = (targetRef: string): string => {
-  const match = /v?(\d+\.\d+\.\d+)(?:[-+][0-9A-Za-z.-]+)?/.exec(targetRef);
-  const version = match?.[1];
-  if (!version) {
-    throw new Error(
-      `release-docs could not infer a MAJOR.MINOR.PATCH release version from target_ref "${targetRef}".`,
-    );
-  }
-  return version;
+  const shortSha = runGit(["rev-parse", "--short", "HEAD"]);
+  return `detached-${shortSha}`;
 };
 
 const sanitizeSegment = (value: string): string =>
@@ -100,37 +85,6 @@ const sanitizeSegment = (value: string): string =>
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/^-+|-+$/g, "") || "item";
-
-const switchToDocsBranch = (branchName: string): void => {
-  const remoteBranch = `origin/${branchName}`;
-  if (gitOk(["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`])) {
-    runGit(["switch", branchName]);
-    return;
-  }
-
-  if (gitOk(["rev-parse", "--verify", `${remoteBranch}^{commit}`])) {
-    runGit(["switch", "--track", "-c", branchName, remoteBranch]);
-    return;
-  }
-
-  runGit(["switch", "-c", branchName]);
-};
-
-const prepareBranch = (targetRef: string): { baselineTag: string; branchName: string; releaseVersion: string } => {
-  ensureCleanWorkingTree();
-  runGit(["fetch", "--tags", "--prune", "origin"]);
-
-  if (!gitOk(["rev-parse", "--verify", `${targetRef}^{commit}`])) {
-    throw new Error(`release-docs could not resolve target_ref "${targetRef}" to a commit after fetching origin tags.`);
-  }
-
-  const releaseVersion = inferReleaseVersion(targetRef);
-  const baselineTag = latestStableTag();
-  const branchName = `docs/release-docs-${releaseVersion}`;
-  switchToDocsBranch(branchName);
-
-  return { baselineTag, branchName, releaseVersion };
-};
 
 const extractJsonArray = (text: string): StaleDocTask[] => {
   const trimmed = text.trim();
@@ -199,8 +153,7 @@ const writeJson = (path: string, value: object): void => {
 };
 
 export default defineWorkflow("release-docs")
-  .description("Prepare Atomic release docs updates, validate Mintlify docs, and open a PR.")
-  .input("target_ref", Type.String({ description: "Target release ref/tag/branch/commit to compare against the latest stable release tag." }))
+  .description("Prepare Atomic release docs updates from the current branch, validate Mintlify docs, and open a PR.")
   .output("result", Type.String({ description: "Human-readable release docs workflow summary." }))
   .output(
     "status",
@@ -208,19 +161,18 @@ export default defineWorkflow("release-docs")
       description: "Final workflow status.",
     }),
   )
-  .output("target_ref", Type.String({ description: "Target ref supplied by the caller." }))
-  .output("baseline_tag", Type.String({ description: "Latest stable release tag used as the comparison baseline." }))
-  .output("release_version", Type.String({ description: "Release version inferred from target_ref." }))
-  .output("branch_name", Type.String({ description: "Docs branch created or reused by the workflow." }))
+  .output("current_branch", Type.String({ description: "Current git branch the workflow ran on." }))
+  .output("artifact_root", Type.String({ description: "Workflow artifact directory for this run." }))
   .output("research_doc_path", Type.String({ description: "Research artifact path from the codebase research child workflow." }))
   .output("stale_doc_task_count", Type.Number({ description: "Number of grouped stale-doc update tasks found." }))
   .output("stale_doc_tasks", Type.Array(staleDocTaskSchema, { description: "Grouped stale-doc update tasks." }))
   .output("validation_report_path", Type.String({ description: "Validation report artifact path." }))
   .output("pr_summary", Type.Optional(Type.String({ description: "PR creation summary or no-op explanation." })))
   .run(async (ctx) => {
-    const targetRef = ctx.inputs.target_ref.trim();
-    const { baselineTag, branchName, releaseVersion } = prepareBranch(targetRef);
-    const artifactRoot = join(".atomic", "workflows", "runs", "release-docs", releaseVersion);
+    ensureCleanWorkingTree();
+    const currentBranch = currentBranchName();
+    const artifactKey = sanitizeSegment(currentBranch);
+    const artifactRoot = join(".atomic", "workflows", "runs", "release-docs", artifactKey);
     const updatesRoot = join(artifactRoot, "updates");
     mkdirSync(updatesRoot, { recursive: true });
 
@@ -230,36 +182,31 @@ export default defineWorkflow("release-docs")
     const prPath = join(artifactRoot, "pr.md");
 
     writeJson(metadataPath, {
-      target_ref: targetRef,
-      baseline_tag: baselineTag,
-      comparison_range: `${baselineTag}..${targetRef}`,
-      release_version: releaseVersion,
-      branch_name: branchName,
+      current_branch: currentBranch,
       docs_root: "packages/coding-agent/docs",
       pr_base: "main",
+      mode: "current-branch-docs-refresh",
     });
 
-    await ctx.stage("prepare-release-docs-branch", { noTools: "all" }).prompt(
+    await ctx.stage("prepare-release-docs-current-branch", { noTools: "all" }).prompt(
       [
-        "Release docs branch preparation is complete.",
-        `Baseline tag: ${baselineTag}`,
-        `Target ref: ${targetRef}`,
-        `Release version: ${releaseVersion}`,
-        `Branch: ${branchName}`,
+        "Release docs current-branch preparation is complete.",
+        `Current branch: ${currentBranch}`,
         `Metadata artifact: ${metadataPath}`,
-        "Reply exactly: RELEASE_DOCS_BRANCH_READY",
+        "The workflow will compare the current codebase behavior against the current docs tree.",
+        "Reply exactly: RELEASE_DOCS_CURRENT_BRANCH_READY",
         "Do not ask questions. Do not call tools.",
       ].join("\n"),
     );
 
     const research = await ctx.workflow(deepResearchCodebase, {
-      stageName: "research-release-code-changes",
+      stageName: "research-current-code-docs-gaps",
       inputs: {
         prompt: [
-          "Research Atomic code changes for release documentation updates.",
-          `Compare the latest stable baseline tag ${baselineTag} to target ref ${targetRef}.`,
-          "Use git diff/name-status/log evidence for that range and inspect the changed code paths.",
-          "Focus on developer-facing and user-facing behavior that should be reflected in docs under packages/coding-agent/docs.",
+          "Research Atomic documentation gaps for the current branch.",
+          "Compare the current codebase behavior against docs under packages/coding-agent/docs.",
+          "Do not use release target refs, baseline tags, or git comparison ranges for this analysis.",
+          "Focus on developer-facing and user-facing behavior that should be reflected in the hosted docs.",
           "Document concrete file paths, symbols, CLI/workflow/settings behavior, and docs implications.",
           "Do not edit files; this stage is research only.",
         ].join("\n"),
@@ -272,12 +219,12 @@ export default defineWorkflow("release-docs")
 
     await ctx.task("identify-stale-docs", {
       prompt: [
-        "Identify stale Atomic docs entries for release prep.",
-        `Release metadata artifact: ${metadataPath}`,
+        "Identify stale Atomic docs entries for the current branch.",
+        `Release docs metadata artifact: ${metadataPath}`,
         `Research artifact: ${researchDocPath}`,
         "Read the metadata and research artifacts before inspecting docs.",
         "Docs scope is strictly packages/coding-agent/docs.",
-        "Inspect docs against the baseline-to-target changes and emit grouped, non-overlapping update tasks.",
+        "Inspect the current docs against the current codebase research and emit grouped, non-overlapping update tasks.",
         "Group stale entries by owning docs files so parallel update workers do not edit the same file concurrently.",
         "If multiple stale entries touch the same docs file, put them in the same task.",
         "If no stale docs are found, write exactly [].",
@@ -304,7 +251,7 @@ export default defineWorkflow("release-docs")
 
     if (staleTasks.length === 0) {
       const result = [
-        `No stale docs entries were found for ${baselineTag}..${targetRef}.`,
+        `No stale docs entries were found for current branch ${currentBranch}.`,
         "No docs changes were made, so no PR was opened.",
         `Research artifact: ${researchDocPath}`,
         `Stale-doc task artifact: ${staleTasksPath}`,
@@ -313,10 +260,8 @@ export default defineWorkflow("release-docs")
       return {
         result,
         status: "no_changes" as const,
-        target_ref: targetRef,
-        baseline_tag: baselineTag,
-        release_version: releaseVersion,
-        branch_name: branchName,
+        current_branch: currentBranch,
+        artifact_root: artifactRoot,
         research_doc_path: researchDocPath,
         stale_doc_task_count: 0,
         stale_doc_tasks: staleTasks,
@@ -331,7 +276,7 @@ export default defineWorkflow("release-docs")
         name: `update-docs-${sanitizeSegment(task.id)}`,
         prompt: [
           "Update Atomic release docs for one grouped stale-doc task.",
-          `Release metadata artifact: ${metadataPath}`,
+          `Release docs metadata artifact: ${metadataPath}`,
           `Research artifact: ${researchDocPath}`,
           `Full stale-doc task list: ${staleTasksPath}`,
           "Assigned stale-doc task JSON:",
@@ -352,7 +297,7 @@ export default defineWorkflow("release-docs")
     await ctx.task("validate-and-repair-release-docs", {
       prompt: [
         "Validate the release docs updates and repair docs-only validation failures.",
-        `Release metadata artifact: ${metadataPath}`,
+        `Release docs metadata artifact: ${metadataPath}`,
         `Research artifact: ${researchDocPath}`,
         `Stale-doc task artifact: ${staleTasksPath}`,
         "First discover the docs validation commands from package scripts and docs/ci.md.",
@@ -379,17 +324,15 @@ export default defineWorkflow("release-docs")
 
     if (!validation.ok) {
       const result = [
-        `Docs validation still fails for ${baselineTag}..${targetRef}.`,
+        `Docs validation still fails for current branch ${currentBranch}.`,
         "The workflow stopped before commit, push, and PR creation. Investigation is required.",
         `Validation report: ${validationPath}`,
       ].join("\n");
       return {
         result,
         status: "needs_investigation" as const,
-        target_ref: targetRef,
-        baseline_tag: baselineTag,
-        release_version: releaseVersion,
-        branch_name: branchName,
+        current_branch: currentBranch,
+        artifact_root: artifactRoot,
         research_doc_path: researchDocPath,
         stale_doc_task_count: staleTasks.length,
         stale_doc_tasks: staleTasks,
@@ -401,20 +344,18 @@ export default defineWorkflow("release-docs")
     const pr = await ctx.task("commit-push-open-release-docs-pr", {
       prompt: [
         "Create the release docs PR now that deterministic validation passed.",
-        `Branch: ${branchName}`,
+        `Current branch: ${currentBranch}`,
         "PR base: main",
-        `Release version: ${releaseVersion}`,
-        `Comparison range: ${baselineTag}..${targetRef}`,
         `Research artifact: ${researchDocPath}`,
         `Validation report: ${validationPath}`,
         "Start by inspecting git status --short.",
         "If there are no changes, do not commit, push, or create a PR; summarize the no-op result.",
         "If there are changes, stage only docs/workflow-run artifacts that are appropriate for the PR, commit with message:",
-        `docs: update release docs for ${releaseVersion}`,
-        "Push the branch to origin and create or update a GitHub PR targeting main using gh.",
-        "Use a PR title like:",
-        `docs: update release docs for ${releaseVersion}`,
-        "Include baseline, target, research artifact, stale-doc task count, and validation commands in the PR body.",
+        "docs: update release docs",
+        "Push the current branch to origin and create or update a GitHub PR targeting main using gh.",
+        "Use this PR title:",
+        "docs: update release docs",
+        "Include current branch, research artifact, stale-doc task count, and validation commands in the PR body.",
         "Do not tag or publish a release.",
       ].join("\n"),
       reads: [metadataPath, researchDocPath, staleTasksPath, validationPath, ...updateArtifacts],
@@ -428,11 +369,9 @@ export default defineWorkflow("release-docs")
     const finalStatus = status.length > 0 ? "needs_investigation" : "pr_created";
     const result = [
       finalStatus === "pr_created"
-        ? `Release docs PR stage completed for ${releaseVersion}.`
-        : `Release docs PR stage left uncommitted docs changes for ${releaseVersion}; investigation is required.`,
-      `Baseline: ${baselineTag}`,
-      `Target: ${targetRef}`,
-      `Branch: ${branchName}`,
+        ? `Release docs PR stage completed for current branch ${currentBranch}.`
+        : `Release docs PR stage left uncommitted docs changes on current branch ${currentBranch}; investigation is required.`,
+      `Current branch: ${currentBranch}`,
       `Research artifact: ${researchDocPath}`,
       `Validation report: ${validationPath}`,
       `PR summary artifact: ${prPath}`,
@@ -441,10 +380,8 @@ export default defineWorkflow("release-docs")
     return {
       result,
       status: finalStatus,
-      target_ref: targetRef,
-      baseline_tag: baselineTag,
-      release_version: releaseVersion,
-      branch_name: branchName,
+      current_branch: currentBranch,
+      artifact_root: artifactRoot,
       research_doc_path: researchDocPath,
       stale_doc_task_count: staleTasks.length,
       stale_doc_tasks: staleTasks,

--- a/.atomic/workflows/release-docs.ts
+++ b/.atomic/workflows/release-docs.ts
@@ -1,9 +1,21 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { defineWorkflow, Type } from "@bastani/workflows";
 import deepResearchCodebase from "../../packages/workflows/builtin/deep-research-codebase.js";
-import { mergeStaleDocTasksByOwnerDocs, sanitizeSegment, type StaleDocTask } from "../workflow-utils/release-docs.js";
+import {
+  currentBranchName,
+  DEFAULT_RELEASE_DOCS_BASE_BRANCH,
+  extractJsonArray,
+  findMissingOrEmptyUpdateArtifacts,
+  mergeStaleDocTasksByOwnerDocs,
+  nextDocsValidationPhase,
+  requireNonBaseBranch,
+  requireResearchDocPath,
+  runDocsChecks,
+  runGit,
+  sanitizeSegment,
+  verifyReleaseDocsPr,
+} from "../workflow-utils/release-docs.js";
 
 const staleDocTaskSchema = Type.Object({
   id: Type.String(),
@@ -14,38 +26,6 @@ const staleDocTaskSchema = Type.Object({
   update_instructions: Type.String(),
   acceptance_criteria: Type.Array(Type.String()),
 });
-
-type CommandResult = {
-  command: string;
-  ok: boolean;
-  output: string;
-};
-
-const repoRoot = () => process.cwd();
-
-const run = (command: string, args: string[], cwd = repoRoot()): string =>
-  execFileSync(command, args, {
-    cwd,
-    encoding: "utf8",
-    maxBuffer: 1024 * 1024 * 20,
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
-
-const runResult = (command: string, args: string[], cwd = repoRoot()): CommandResult => {
-  const rendered = [command, ...args].join(" ");
-  try {
-    const output = run(command, args, cwd);
-    return { command: rendered, ok: true, output };
-  } catch (error) {
-    const failure = error as { stdout?: Buffer | string; stderr?: Buffer | string; message?: string };
-    const stdout = String(failure.stdout ?? "");
-    const stderr = String(failure.stderr ?? "");
-    const message = String(failure.message ?? "");
-    return { command: rendered, ok: false, output: [stdout, stderr, message].filter(Boolean).join("\n") };
-  }
-};
-
-const runGit = (args: string[], cwd = repoRoot()): string => run("git", args, cwd);
 
 const ensureCleanWorkingTree = (): void => {
   const status = runGit(["status", "--porcelain=v1"]);
@@ -59,108 +39,6 @@ const ensureCleanWorkingTree = (): void => {
       ].join("\n"),
     );
   }
-};
-
-export const currentBranchName = (cwd = repoRoot()): string => {
-  const branch = runGit(["branch", "--show-current"], cwd);
-  if (branch.length > 0) {
-    return branch;
-  }
-
-  const shortSha = runGit(["rev-parse", "--short", "HEAD"], cwd);
-  throw new Error(
-    [
-      "release-docs must run from a local branch, but HEAD is detached.",
-      `Current detached commit: ${shortSha}`,
-      "Check out or create a branch before running this workflow.",
-    ].join("\n"),
-  );
-};
-
-export const requireResearchDocPath = (path: string | undefined): string => {
-  const trimmed = path?.trim() ?? "";
-  if (trimmed.length === 0) {
-    throw new Error(
-      "deep-research-codebase did not return research_doc_path; release-docs cannot continue without a research artifact path.",
-    );
-  }
-  return trimmed;
-};
-
-export const extractJsonArray = (text: string): StaleDocTask[] => {
-  const trimmed = text.trim();
-  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
-  const jsonText = fenced?.[1]?.trim() ?? trimmed;
-  let parsed: StaleDocTask[];
-  try {
-    parsed = JSON.parse(jsonText) as StaleDocTask[];
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    const excerpt = jsonText.length > 1_000 ? `${jsonText.slice(0, 1_000)}…` : jsonText;
-    throw new Error(
-      [
-        "stale-doc detector returned invalid JSON. Expected a JSON array.",
-        `Parse error: ${detail}`,
-        "Output excerpt:",
-        excerpt || "(empty output)",
-      ].join("\n"),
-    );
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error("stale-doc detector did not return a JSON array.");
-  }
-  return parsed.map((task, index) => ({
-    id: sanitizeSegment(String(task.id || `doc-task-${index + 1}`)),
-    title: String(task.title || `Documentation task ${index + 1}`),
-    owner_docs: Array.isArray(task.owner_docs) ? task.owner_docs.map(String) : [],
-    reason: String(task.reason || ""),
-    source_refs: Array.isArray(task.source_refs) ? task.source_refs.map(String) : [],
-    update_instructions: String(task.update_instructions || ""),
-    acceptance_criteria: Array.isArray(task.acceptance_criteria) ? task.acceptance_criteria.map(String) : [],
-  }));
-};
-
-const runDocsChecks = (): { ok: boolean; markdown: string } => {
-  const checks = [
-    {
-      label: "Hosted docs route/internal-link validation",
-      command: "bun",
-      args: ["run", "docs:check"],
-      cwd: join(repoRoot(), "packages/coding-agent"),
-    },
-    {
-      label: "Mintlify syntax validation",
-      command: "bunx",
-      args: ["--bun", "mintlify@latest", "validate"],
-      cwd: join(repoRoot(), "packages/coding-agent/docs"),
-    },
-    {
-      label: "Mintlify broken-link validation",
-      command: "bunx",
-      args: ["--bun", "mintlify@latest", "broken-links"],
-      cwd: join(repoRoot(), "packages/coding-agent/docs"),
-    },
-  ];
-
-  const results = checks.map((check) => ({ ...check, result: runResult(check.command, check.args, check.cwd) }));
-  const ok = results.every((check) => check.result.ok);
-  const markdown = results
-    .map((check) =>
-      [
-        `## ${check.label}`,
-        "",
-        `Command: \`${check.result.command}\``,
-        `Cwd: \`${check.cwd}\``,
-        `Status: ${check.result.ok ? "pass" : "fail"}`,
-        "",
-        "```text",
-        check.result.output || "(no output)",
-        "```",
-      ].join("\n"),
-    )
-    .join("\n\n");
-
-  return { ok, markdown };
 };
 
 const writeJson = (path: string, value: object): void => {
@@ -185,7 +63,8 @@ export default defineWorkflow("release-docs")
   .output("pr_summary", Type.Optional(Type.String({ description: "PR creation summary or no-op explanation." })))
   .run(async (ctx) => {
     ensureCleanWorkingTree();
-    const currentBranch = currentBranchName();
+    const prBase = DEFAULT_RELEASE_DOCS_BASE_BRANCH;
+    const currentBranch = requireNonBaseBranch(currentBranchName(), prBase);
     const artifactKey = sanitizeSegment(currentBranch);
     const artifactRoot = join(".atomic", "workflows", "runs", "release-docs", artifactKey);
     const updatesRoot = join(artifactRoot, "updates");
@@ -194,12 +73,13 @@ export default defineWorkflow("release-docs")
     const metadataPath = join(artifactRoot, "release-metadata.json");
     const staleTasksPath = join(artifactRoot, "stale-doc-tasks.json");
     const validationPath = join(artifactRoot, "validation.md");
+    const repairPath = join(artifactRoot, "validation-repair.md");
     const prPath = join(artifactRoot, "pr.md");
 
     writeJson(metadataPath, {
       current_branch: currentBranch,
       docs_root: "packages/coding-agent/docs",
-      pr_base: "main",
+      pr_base: prBase,
       mode: "current-branch-docs-refresh",
     });
 
@@ -297,7 +177,8 @@ export default defineWorkflow("release-docs")
           `Full stale-doc task list: ${staleTasksPath}`,
           "Assigned stale-doc task JSON:",
           JSON.stringify(task, null, 2),
-          "Read the listed artifacts and then edit only the owner_docs files unless a directly adjacent docs link/index must be fixed.",
+          "Read the listed artifacts and then edit only the owner_docs files.",
+          "Leave shared nav, index, and cross-link repairs to the serial validation/repair stage if needed.",
           "Do not edit code, changelogs, package manifests, or docs outside packages/coding-agent/docs.",
           "Do not commit, push, or create a PR.",
           "When finished, summarize changed files, evidence used, and residual risks.",
@@ -310,33 +191,74 @@ export default defineWorkflow("release-docs")
       { concurrency: Math.min(4, staleTasks.length), failFast: false },
     );
 
-    await ctx.task("validate-and-repair-release-docs", {
-      prompt: [
-        "Validate the release docs updates and repair docs-only validation failures.",
-        `Release docs metadata artifact: ${metadataPath}`,
-        `Research artifact: ${researchDocPath}`,
-        `Stale-doc task artifact: ${staleTasksPath}`,
-        "First discover the docs validation commands from package scripts and docs/ci.md.",
-        "The expected validation contract is:",
-        "1. cd packages/coding-agent && bun run docs:check",
-        "2. cd packages/coding-agent/docs && bunx --bun mintlify@latest validate",
-        "3. cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links",
-        "Run the checks with Bun/Bunx. If they fail, fix docs issues under packages/coding-agent/docs and rerun all checks.",
-        "Do not commit, push, or create a PR.",
-        "If failures remain after reasonable docs-only repairs, write INVESTIGATION REQUIRED with the exact failing command and output.",
-        "If all checks pass, write VALIDATION PASSED and summarize commands run.",
-      ].join("\n"),
-      reads: [metadataPath, researchDocPath, staleTasksPath, ...updateArtifacts],
-      output: validationPath,
-      outputMode: "file-only",
-      context: "fork",
+    const updateArtifactStatuses = updateArtifacts.map((path) => {
+      const exists = existsSync(path);
+      return {
+        path,
+        exists,
+        empty: !exists || readFileSync(path, "utf8").trim().length === 0,
+      };
     });
+    const missingOrEmptyUpdateArtifacts = findMissingOrEmptyUpdateArtifacts(updateArtifactStatuses);
+    if (missingOrEmptyUpdateArtifacts.length > 0) {
+      const result = [
+        `Docs update workers did not produce all required update artifacts for current branch ${currentBranch}.`,
+        "The workflow stopped before validation, commit, push, and PR creation. Investigation is required.",
+        "Missing or empty update artifacts:",
+        ...missingOrEmptyUpdateArtifacts.map((artifact) =>
+          `- ${artifact.path}: ${artifact.exists ? "empty" : "missing"}`,
+        ),
+      ].join("\n");
+      writeFileSync(validationPath, `${result}\n`);
+      return {
+        result,
+        status: "needs_investigation" as const,
+        current_branch: currentBranch,
+        artifact_root: artifactRoot,
+        research_doc_path: researchDocPath,
+        stale_doc_task_count: staleTasks.length,
+        stale_doc_tasks: staleTasks,
+        validation_report_path: validationPath,
+        pr_summary: "Update worker artifacts missing or empty; PR skipped.",
+      };
+    }
 
-    const validation = runDocsChecks();
-    writeFileSync(
-      validationPath,
-      [readFileSync(validationPath, "utf8"), "\n\n# Deterministic validation replay\n\n", validation.markdown].join(""),
-    );
+    let validation = runDocsChecks();
+    writeFileSync(validationPath, ["# Initial deterministic validation", "", validation.markdown].join("\n"));
+
+    if (nextDocsValidationPhase(validation.ok) === "repair_then_revalidate") {
+      await ctx.task("validate-and-repair-release-docs", {
+        prompt: [
+          "Repair docs-only validation failures found by deterministic release docs validation.",
+          `Release docs metadata artifact: ${metadataPath}`,
+          `Research artifact: ${researchDocPath}`,
+          `Stale-doc task artifact: ${staleTasksPath}`,
+          `Initial validation report: ${validationPath}`,
+          "Initial deterministic validation failed. Read the validation report before repairing.",
+          "Use the validation report to fix docs issues under packages/coding-agent/docs.",
+          "You may rerun focused docs checks while repairing, but the workflow will perform the final validation gate deterministically.",
+          "Do not commit, push, or create a PR.",
+          "If failures appear unrelated to docs-only repairs, write INVESTIGATION REQUIRED with the exact failing command and output.",
+          "When finished, summarize changed files, evidence used, commands you ran, and residual risks.",
+        ].join("\n"),
+        reads: [metadataPath, researchDocPath, staleTasksPath, validationPath, ...updateArtifacts],
+        output: repairPath,
+        outputMode: "file-only",
+        context: "fork",
+      });
+
+      validation = runDocsChecks();
+      writeFileSync(
+        validationPath,
+        [
+          readFileSync(validationPath, "utf8"),
+          "\n\n# Model repair summary\n\n",
+          readFileSync(repairPath, "utf8"),
+          "\n\n# Post-repair deterministic validation\n\n",
+          validation.markdown,
+        ].join(""),
+      );
+    }
 
     if (!validation.ok) {
       const result = [
@@ -361,7 +283,7 @@ export default defineWorkflow("release-docs")
       prompt: [
         "Create the release docs PR now that deterministic validation passed.",
         `Current branch: ${currentBranch}`,
-        "PR base: main",
+        `PR base: ${prBase}`,
         `Research artifact: ${researchDocPath}`,
         `Validation report: ${validationPath}`,
         "Start by inspecting git status --short.",
@@ -369,7 +291,7 @@ export default defineWorkflow("release-docs")
         "If there are changes, stage only intentional documentation changes under packages/coding-agent/docs, commit with message:",
         "docs: update release docs",
         "Do not stage .atomic/, .atomic/workflows/runs/, workflow artifacts, release metadata, stale-doc task files, validation reports, PR summaries, update artifacts, research artifacts, or files outside packages/coding-agent/docs.",
-        "Push the current branch to origin and create or update a GitHub PR targeting main using gh.",
+        `Push the current branch to origin and create or update a GitHub PR targeting ${prBase} using gh.`,
         "Use this PR title:",
         "docs: update release docs",
         "Include current branch, research artifact, stale-doc task count, and validation commands in the PR body.",
@@ -382,16 +304,26 @@ export default defineWorkflow("release-docs")
     });
 
     const prSummary = readFileSync(prPath, "utf8").trim() || pr.text;
+    const prVerification = verifyReleaseDocsPr(currentBranch, prBase);
     const status = runGit(["status", "--porcelain=v1", "packages/coding-agent/docs"]);
-    const finalStatus = status.length > 0 ? "needs_investigation" : "pr_created";
+    const finalStatus = status.length > 0 || !prVerification.ok ? "needs_investigation" : "pr_created";
+    const combinedPrSummary = [
+      prSummary,
+      "",
+      "# Deterministic PR verification",
+      "",
+      prVerification.summary,
+    ].join("\n");
     const result = [
       finalStatus === "pr_created"
-        ? `Release docs PR stage completed for current branch ${currentBranch}.`
-        : `Release docs PR stage left uncommitted docs changes on current branch ${currentBranch}; investigation is required.`,
+        ? `Release docs PR verified for current branch ${currentBranch}.`
+        : `Release docs PR stage could not be fully verified for current branch ${currentBranch}; investigation is required.`,
       `Current branch: ${currentBranch}`,
+      `PR base: ${prBase}`,
       `Research artifact: ${researchDocPath}`,
       `Validation report: ${validationPath}`,
       `PR summary artifact: ${prPath}`,
+      `PR verification: ${prVerification.summary}`,
     ].join("\n");
 
     return {
@@ -403,7 +335,7 @@ export default defineWorkflow("release-docs")
       stale_doc_task_count: staleTasks.length,
       stale_doc_tasks: staleTasks,
       validation_report_path: validationPath,
-      pr_summary: prSummary,
+      pr_summary: combinedPrSummary,
     };
   })
   .compile();

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ plans/
 collect.sh
 
 .atomic/todos
+.atomic/workflows/runs/
 # deep-research workflow artifacts written into <cwd>/research during tests and E2E runs
 /research/.deep-research-*/
 /research/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.md

--- a/specs/2026-06-07-release-docs-workflow.md
+++ b/specs/2026-06-07-release-docs-workflow.md
@@ -1,0 +1,158 @@
+# Release Docs Workflow Technical Design
+
+| Document Metadata | Details |
+| --- | --- |
+| Author(s) | Norin Lavaee |
+| Status | Approved for implementation |
+| Team / Owner | Atomic developers |
+| Created / Last Updated | 2026-06-07 |
+
+## 1. Executive Summary
+
+Create a project workflow at `.atomic/workflows/release-docs.ts` named `release-docs` that automates release documentation refreshes for Atomic developers. The workflow accepts a required `target_ref`, infers the release version from that ref, creates/switches to `docs/release-docs-<release-version>`, finds the latest non-prerelease release tag as the baseline, researches code changes between baseline and target, identifies stale docs under `packages/coding-agent/docs`, updates stale docs via parallel artifact-backed stages, validates docs with the repository's Mintlify/docs checks, then commits, pushes, and opens a PR only after validation passes.
+
+## 2. Context and Motivation
+
+Release prep currently requires developers to manually connect code changes, changelog/release tags, and hosted docs. The repo already has documented release docs checks in `docs/ci.md`: `cd packages/coding-agent && bun run docs:check`, `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`, and `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`. The workflow should package this repeatable process into a headless, inspectable Atomic workflow.
+
+## 3. Goals and Non-Goals
+
+### Goals
+
+- Create a reusable workflow named `release-docs` under `.atomic/workflows`.
+- Require `target_ref` and infer the release version from it.
+- Use the latest stable semver tag (`MAJOR.MINOR.PATCH`, no prereleases) as the baseline.
+- Create/switch to `docs/release-docs-<release-version>` before edits.
+- Use research-codebase style codebase research to document the baseline-to-target changes.
+- Detect stale docs only under `packages/coding-agent/docs`.
+- Fan out independent docs update tasks in parallel.
+- Run and repair docs validation issues before PR creation.
+- Commit, push, and create a GitHub PR targeting `main` only when validation passes and docs changed.
+
+### Non-Goals
+
+- Do not publish releases or push release tags.
+- Do not update changelogs or package versions.
+- Do not prompt for human input during the workflow run.
+- Do not open an empty/no-op PR when no docs changes are needed.
+- Do not edit docs outside `packages/coding-agent/docs` unless validation fixes require generated references in the same docs tree.
+
+## 4. Proposed Solution
+
+### 4.1 Starter Pattern
+
+Use **fan-out-and-synthesize** for stale-doc updates, followed by **adversarial verification** through a validation/repair gate.
+
+```mermaid
+flowchart TD
+  A[Input target_ref] --> B[Prepare branch and release range]
+  B --> C[Deep codebase research]
+  C --> D[Detect stale docs and emit JSON work items]
+  D --> E{Any stale entries?}
+  E -- no --> Z[Return no-op summary]
+  E -- yes --> F[Parallel docs update workers]
+  F --> G[Validation and repair gate]
+  G -- pass --> H[Commit, push, create PR]
+  G -- fail --> Y[Stop with investigation summary]
+```
+
+### 4.2 Key Components
+
+| Component | Responsibility |
+| --- | --- |
+| Deterministic helpers | Fetch tags, find latest stable baseline tag, infer release version, create/switch branch, parse stale-doc JSON. |
+| `deep-research-codebase` child workflow | Research the code delta and write a reusable research artifact. |
+| Stale-doc detector stage | Inspect docs and research, then produce grouped JSON update tasks with non-overlapping owning docs files. |
+| Parallel update stages | Apply doc edits for independent stale-doc groups. |
+| Validation/repair stage | Discover/run repo docs checks and fix failures until all pass or investigation is required. |
+| PR stage | Commit, push, and create/update the PR against `main` after validation passes and docs changed. |
+
+### 4.3 Door Set at a Glance
+
+- `prepare_release_docs_branch` ⚠
+- `research_release_changes`
+- `identify_stale_docs`
+- `update_stale_docs_in_parallel` ⚠
+- `validate_release_docs`
+- `open_release_docs_pr` ⚠
+
+## 5. Detailed Design
+
+### 5.1 Entrypoint Contracts
+
+```ts
+release_docs(target_ref: string): ReleaseDocsResult
+```
+
+Guarantee: refreshes Atomic release docs for a target ref and opens a PR only after docs validation passes.
+
+Failures/refusals:
+- Refuses to run when `target_ref` does not contain an inferable semver.
+- Refuses to run when no stable baseline tag exists.
+- Refuses to edit on a dirty working tree before branch preparation.
+- Refuses PR creation when validation cannot be made green.
+- Refuses concurrent docs file conflicts by grouping stale entries by owning docs files before fan-out.
+
+### 5.2 Branch and Version Rules
+
+- `target_ref` is required.
+- Infer the first semver from `target_ref`; strip prerelease/build metadata for the release branch version.
+  - Example: `0.8.26-alpha.1` → release version `0.8.26`.
+- Branch name: `docs/release-docs-<release-version>`.
+- Baseline tag: latest tag matching `^[0-9]+\.[0-9]+\.[0-9]+$`, excluding prerelease tags.
+
+### 5.3 Artifacts
+
+Use `.atomic/workflows/runs/release-docs/<release-version>/` for durable handoffs:
+
+- `release-metadata.json`
+- `stale-doc-tasks.json`
+- `stale-doc-tasks.md`
+- `updates/*.md`
+- `validation.md`
+- `pr.md`
+
+### 5.4 Validation Gate
+
+The validation stage discovers checks from repo docs/scripts, with known commands from `docs/ci.md` as the default contract:
+
+```sh
+cd packages/coding-agent && bun run docs:check
+cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
+cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
+```
+
+It must fix docs validation failures and rerun checks. If repeated failures remain, the workflow stops before commit/push/PR and returns an investigation summary.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+| --- | --- | --- | --- |
+| Zero-input workflow using `HEAD` | Fully headless by default | Cannot target a prerelease/ref explicitly | Rejected by user; use required `target_ref`. |
+| Always compare to `origin/main` | Simple | Wrong for prerelease/tag-specific release prep | Rejected. |
+| Create branch after research | Avoids branch churn | Research/edit stages can leak onto the caller branch | Rejected; branch first. |
+| Single docs update worker | Avoids conflicts | Slower and less isolated | Rejected; use grouped parallel workers. |
+
+## 7. Test Plan
+
+- Reload workflows with `workflow({ action: "reload" })`.
+- Inspect inputs for `release-docs` and confirm `target_ref` is required.
+- Run repository typecheck if workflow file is included by local tooling; otherwise rely on workflow discovery/reload diagnostics.
+- Do not execute the full workflow during implementation because it intentionally creates branches, edits docs, pushes, and opens a PR.
+
+## 8. Backwards Compatibility
+
+This is a new project-only developer workflow. It does not change Atomic runtime APIs, package exports, or existing workflow definitions.
+
+## 9. Open Questions / Resolved Decisions
+
+- Workflow name: `release-docs`.
+- Branch timing: create branch first.
+- Diff baseline: latest non-prerelease release tag.
+- Diff target: required `target_ref` input.
+- Release version: infer from `target_ref`.
+- Branch name: `docs/release-docs-<release-version>`.
+- Mintlify command: discover from repo scripts/docs, defaulting to CI-documented commands.
+- Validation failure policy: repair failures before commit/PR; stop with investigation summary if still failing.
+- PR base: `main`.
+- No-op policy: skip commit/push/PR and return a no-op summary when there are no docs changes.

--- a/specs/2026-06-07-release-docs-workflow.md
+++ b/specs/2026-06-07-release-docs-workflow.md
@@ -25,8 +25,8 @@ Release prep currently requires developers to manually connect code changes and 
 - Research current Atomic code behavior and compare it to docs under `packages/coding-agent/docs`.
 - Detect stale or missing docs only under `packages/coding-agent/docs`.
 - Fan out independent docs update tasks in parallel.
-- Run and repair docs validation issues before PR creation.
-- Commit, push, and create/update a GitHub PR targeting `main` only when validation passes and docs changed.
+- Run deterministic docs validation before PR creation, invoking repair only when validation fails.
+- Commit, push, and create/update a GitHub PR targeting `main` only when validation passes, docs changed, and the PR can be verified deterministically.
 
 ### Non-Goals
 
@@ -52,21 +52,25 @@ flowchart TD
   D --> E{Any stale entries?}
   E -- no --> Z[Return no-op summary]
   E -- yes --> F[Parallel docs update workers]
-  F --> G[Validation and repair gate]
+  F --> G[Deterministic validation]
   G -- pass --> H[Commit, push, create/update PR]
-  G -- fail --> Y[Stop with investigation summary]
+  G -- fail --> R[Docs-only repair]
+  R --> G2[Post-repair deterministic validation]
+  G2 -- pass --> H
+  G2 -- fail --> Y[Stop with investigation summary]
+  H --> I[Deterministically verify PR exists]
 ```
 
 ### 4.2 Key Components
 
 | Component | Responsibility |
 | --- | --- |
-| Deterministic helpers | Ensure the worktree is clean, capture the current branch, create artifact directories, parse stale-doc JSON, and replay validation commands. |
+| Deterministic helpers | Ensure the worktree is clean, reject base-branch runs, capture the current branch, create artifact directories, parse stale-doc JSON, verify update artifacts, run validation commands, and verify PR existence. |
 | `deep-research-codebase` child workflow | Research current code behavior and write a reusable research artifact. |
 | Stale-doc detector stage | Inspect docs and research, then produce grouped JSON update tasks with non-overlapping owning docs files. |
-| Parallel update stages | Apply doc edits for independent stale-doc groups. |
-| Validation/repair stage | Discover/run repo docs checks and fix failures until all pass or investigation is required. |
-| PR stage | Commit, push, and create/update the PR against `main` after validation passes and docs changed. |
+| Parallel update stages | Apply doc edits only to each task's owning docs files for independent stale-doc groups. |
+| Validation/repair stage | Run repo docs checks deterministically, invoke docs-only repair only on failure, then rerun deterministic checks. |
+| PR stage | Commit, push, create/update the PR against `main`, then verify the open PR exists for the current branch and base. |
 
 ### 4.3 Door Set at a Glance
 
@@ -89,15 +93,18 @@ Guarantee: refreshes Atomic hosted docs for the current branch and opens/updates
 
 Failures/refusals:
 - Refuses to run when the working tree is dirty before docs edits begin.
+- Refuses to run directly on the PR base branch (`main`).
 - Refuses PR creation when validation cannot be made green.
-- Refuses concurrent docs file conflicts by grouping stale entries by owning docs files before fan-out.
+- Refuses concurrent docs file conflicts by grouping stale entries by owning docs files before fan-out and requiring workers to edit only those owning docs files.
+- Refuses to report `pr_created` unless an open PR for the current branch and `main` can be verified deterministically.
 
 ### 5.2 Branch Rules
 
 - The workflow runs on the current branch.
+- The workflow refuses to run when the current branch is `main`, because the PR stage pushes the current branch and targets `main`.
 - The workflow does not create, switch, or track branches.
 - The current branch should already contain the code changes whose docs need refreshing.
-- The final PR stage pushes the current branch and creates/updates a PR targeting `main`.
+- The final PR stage pushes the current branch and creates/updates a PR targeting `main`, then the workflow verifies an open PR exists for the current branch and base.
 
 ### 5.3 Artifacts
 
@@ -107,6 +114,7 @@ Use `.atomic/workflows/runs/release-docs/<current-branch-slug>/` for durable han
 - `stale-doc-tasks.json`
 - `updates/*.md`
 - `validation.md`
+- `validation-repair.md` when repair is needed
 - `pr.md`
 
 The metadata artifact records:
@@ -130,7 +138,7 @@ cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
 cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
 ```
 
-It must fix docs validation failures and rerun checks. After the model stage, the workflow deterministically replays the same commands and appends the command output to `validation.md`. If failures remain, the workflow stops before commit/push/PR and returns an investigation summary.
+Before validation, the workflow verifies every parallel update worker produced its expected non-empty `updates/*.md` artifact; missing or empty artifacts stop the run before validation and PR creation. The workflow then runs these checks deterministically before invoking any repair model. If the initial deterministic validation passes, the repair stage is skipped and the workflow proceeds to PR creation. If validation fails, the workflow writes the command output to `validation.md`, invokes a docs-only repair stage using that report, then deterministically reruns the same checks. If failures remain after repair, the workflow stops before commit/push/PR and returns an investigation summary.
 
 ## 6. Alternatives Considered
 
@@ -159,7 +167,7 @@ This is a project-only developer workflow. Removing `target_ref`, baseline outpu
 - Branch behavior: use current branch; do not create/switch branch.
 - Code/docs comparison: current codebase behavior vs current docs under `packages/coding-agent/docs`.
 - Artifact path: `.atomic/workflows/runs/release-docs/<current-branch-slug>/`.
-- Mintlify/docs checks: discover/repair in stage and deterministically replay CI-documented docs checks.
-- Validation failure policy: repair failures before commit/PR; stop with investigation summary if still failing.
+- Mintlify/docs checks: run deterministically first, repair only on failure, then rerun deterministically.
+- Validation failure policy: repair failures before commit/PR only when deterministic validation fails; stop with investigation summary if still failing.
 - PR base: `main`.
 - No-op policy: skip commit/push/PR and return a no-op summary when there are no docs changes.

--- a/specs/2026-06-07-release-docs-workflow.md
+++ b/specs/2026-06-07-release-docs-workflow.md
@@ -3,37 +3,38 @@
 | Document Metadata | Details |
 | --- | --- |
 | Author(s) | Norin Lavaee |
-| Status | Approved for implementation |
+| Status | Updated after simplification |
 | Team / Owner | Atomic developers |
 | Created / Last Updated | 2026-06-07 |
 
 ## 1. Executive Summary
 
-Create a project workflow at `.atomic/workflows/release-docs.ts` named `release-docs` that automates release documentation refreshes for Atomic developers. The workflow accepts a required `target_ref`, infers the release version from that ref, creates/switches to `docs/release-docs-<release-version>`, finds the latest non-prerelease release tag as the baseline, researches code changes between baseline and target, identifies stale docs under `packages/coding-agent/docs`, updates stale docs via parallel artifact-backed stages, validates docs with the repository's Mintlify/docs checks, then commits, pushes, and opens a PR only after validation passes.
+Create a project workflow at `.atomic/workflows/release-docs.ts` named `release-docs` that automates release documentation refreshes for Atomic developers. The simplified workflow has **no inputs**. It assumes the developer launches it from the branch that already contains the code changes that need documentation. It researches the current codebase, compares current behavior against docs under `packages/coding-agent/docs`, identifies stale or missing docs, updates grouped docs tasks in parallel, validates the Mintlify/docs checks, then commits, pushes, and opens a PR only after validation passes.
 
 ## 2. Context and Motivation
 
-Release prep currently requires developers to manually connect code changes, changelog/release tags, and hosted docs. The repo already has documented release docs checks in `docs/ci.md`: `cd packages/coding-agent && bun run docs:check`, `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`, and `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`. The workflow should package this repeatable process into a headless, inspectable Atomic workflow.
+Release prep currently requires developers to manually connect code changes and hosted docs. The workflow should not require a target release ref or a baseline release tag because the current branch is the source of truth for the code that needs documentation. The repo already has documented release docs checks in `docs/ci.md`: `cd packages/coding-agent && bun run docs:check`, `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`, and `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`.
 
 ## 3. Goals and Non-Goals
 
 ### Goals
 
 - Create a reusable workflow named `release-docs` under `.atomic/workflows`.
-- Require `target_ref` and infer the release version from it.
-- Use the latest stable semver tag (`MAJOR.MINOR.PATCH`, no prereleases) as the baseline.
-- Create/switch to `docs/release-docs-<release-version>` before edits.
-- Use research-codebase style codebase research to document the baseline-to-target changes.
-- Detect stale docs only under `packages/coding-agent/docs`.
+- Declare no workflow inputs; the current branch/check-out is the target.
+- Do not create or switch branches.
+- Research current Atomic code behavior and compare it to docs under `packages/coding-agent/docs`.
+- Detect stale or missing docs only under `packages/coding-agent/docs`.
 - Fan out independent docs update tasks in parallel.
 - Run and repair docs validation issues before PR creation.
-- Commit, push, and create a GitHub PR targeting `main` only when validation passes and docs changed.
+- Commit, push, and create/update a GitHub PR targeting `main` only when validation passes and docs changed.
 
 ### Non-Goals
 
 - Do not publish releases or push release tags.
 - Do not update changelogs or package versions.
 - Do not prompt for human input during the workflow run.
+- Do not accept `target_ref` or model a baseline-vs-target release range.
+- Do not create or switch to a dedicated docs branch.
 - Do not open an empty/no-op PR when no docs changes are needed.
 - Do not edit docs outside `packages/coding-agent/docs` unless validation fixes require generated references in the same docs tree.
 
@@ -45,14 +46,14 @@ Use **fan-out-and-synthesize** for stale-doc updates, followed by **adversarial 
 
 ```mermaid
 flowchart TD
-  A[Input target_ref] --> B[Prepare branch and release range]
+  A[Launch from current branch] --> B[Prepare current-branch metadata]
   B --> C[Deep codebase research]
   C --> D[Detect stale docs and emit JSON work items]
   D --> E{Any stale entries?}
   E -- no --> Z[Return no-op summary]
   E -- yes --> F[Parallel docs update workers]
   F --> G[Validation and repair gate]
-  G -- pass --> H[Commit, push, create PR]
+  G -- pass --> H[Commit, push, create/update PR]
   G -- fail --> Y[Stop with investigation summary]
 ```
 
@@ -60,8 +61,8 @@ flowchart TD
 
 | Component | Responsibility |
 | --- | --- |
-| Deterministic helpers | Fetch tags, find latest stable baseline tag, infer release version, create/switch branch, parse stale-doc JSON. |
-| `deep-research-codebase` child workflow | Research the code delta and write a reusable research artifact. |
+| Deterministic helpers | Ensure the worktree is clean, capture the current branch, create artifact directories, parse stale-doc JSON, and replay validation commands. |
+| `deep-research-codebase` child workflow | Research current code behavior and write a reusable research artifact. |
 | Stale-doc detector stage | Inspect docs and research, then produce grouped JSON update tasks with non-overlapping owning docs files. |
 | Parallel update stages | Apply doc edits for independent stale-doc groups. |
 | Validation/repair stage | Discover/run repo docs checks and fix failures until all pass or investigation is required. |
@@ -69,8 +70,8 @@ flowchart TD
 
 ### 4.3 Door Set at a Glance
 
-- `prepare_release_docs_branch` ⚠
-- `research_release_changes`
+- `prepare_release_docs_current_branch` ⚠
+- `research_current_code_docs_gaps`
 - `identify_stale_docs`
 - `update_stale_docs_in_parallel` ⚠
 - `validate_release_docs`
@@ -81,36 +82,43 @@ flowchart TD
 ### 5.1 Entrypoint Contracts
 
 ```ts
-release_docs(target_ref: string): ReleaseDocsResult
+release_docs(): ReleaseDocsResult
 ```
 
-Guarantee: refreshes Atomic release docs for a target ref and opens a PR only after docs validation passes.
+Guarantee: refreshes Atomic hosted docs for the current branch and opens/updates a PR only after docs validation passes.
 
 Failures/refusals:
-- Refuses to run when `target_ref` does not contain an inferable semver.
-- Refuses to run when no stable baseline tag exists.
-- Refuses to edit on a dirty working tree before branch preparation.
+- Refuses to run when the working tree is dirty before docs edits begin.
 - Refuses PR creation when validation cannot be made green.
 - Refuses concurrent docs file conflicts by grouping stale entries by owning docs files before fan-out.
 
-### 5.2 Branch and Version Rules
+### 5.2 Branch Rules
 
-- `target_ref` is required.
-- Infer the first semver from `target_ref`; strip prerelease/build metadata for the release branch version.
-  - Example: `0.8.26-alpha.1` → release version `0.8.26`.
-- Branch name: `docs/release-docs-<release-version>`.
-- Baseline tag: latest tag matching `^[0-9]+\.[0-9]+\.[0-9]+$`, excluding prerelease tags.
+- The workflow runs on the current branch.
+- The workflow does not create, switch, or track branches.
+- The current branch should already contain the code changes whose docs need refreshing.
+- The final PR stage pushes the current branch and creates/updates a PR targeting `main`.
 
 ### 5.3 Artifacts
 
-Use `.atomic/workflows/runs/release-docs/<release-version>/` for durable handoffs:
+Use `.atomic/workflows/runs/release-docs/<current-branch-slug>/` for durable handoffs:
 
 - `release-metadata.json`
 - `stale-doc-tasks.json`
-- `stale-doc-tasks.md`
 - `updates/*.md`
 - `validation.md`
 - `pr.md`
+
+The metadata artifact records:
+
+```json
+{
+  "current_branch": "feature/example",
+  "docs_root": "packages/coding-agent/docs",
+  "pr_base": "main",
+  "mode": "current-branch-docs-refresh"
+}
+```
 
 ### 5.4 Validation Gate
 
@@ -122,37 +130,36 @@ cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
 cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
 ```
 
-It must fix docs validation failures and rerun checks. If repeated failures remain, the workflow stops before commit/push/PR and returns an investigation summary.
+It must fix docs validation failures and rerun checks. After the model stage, the workflow deterministically replays the same commands and appends the command output to `validation.md`. If failures remain, the workflow stops before commit/push/PR and returns an investigation summary.
 
 ## 6. Alternatives Considered
 
 | Option | Pros | Cons | Decision |
 | --- | --- | --- | --- |
-| Zero-input workflow using `HEAD` | Fully headless by default | Cannot target a prerelease/ref explicitly | Rejected by user; use required `target_ref`. |
-| Always compare to `origin/main` | Simple | Wrong for prerelease/tag-specific release prep | Rejected. |
-| Create branch after research | Avoids branch churn | Research/edit stages can leak onto the caller branch | Rejected; branch first. |
+| Require `target_ref` and compare to latest stable tag | Precise release-range analysis | Too much ceremony; branch already carries the target changes | Rejected after simplification. |
+| Create a dedicated docs branch | Isolates docs commits | Adds branch churn and does not match current-branch workflow | Rejected. |
+| Use current branch with no inputs | Fully headless and matches how developers run release prep | Requires developers to launch from the correct branch | Accepted. |
 | Single docs update worker | Avoids conflicts | Slower and less isolated | Rejected; use grouped parallel workers. |
 
 ## 7. Test Plan
 
 - Reload workflows with `workflow({ action: "reload" })`.
-- Inspect inputs for `release-docs` and confirm `target_ref` is required.
-- Run repository typecheck if workflow file is included by local tooling; otherwise rely on workflow discovery/reload diagnostics.
-- Do not execute the full workflow during implementation because it intentionally creates branches, edits docs, pushes, and opens a PR.
+- Inspect inputs for `release-docs` and confirm there are no required inputs.
+- Run repository typecheck with `bun run typecheck`.
+- Do not execute the full workflow during implementation because it intentionally edits docs, commits, pushes, and opens PRs.
 
 ## 8. Backwards Compatibility
 
-This is a new project-only developer workflow. It does not change Atomic runtime APIs, package exports, or existing workflow definitions.
+This is a project-only developer workflow. Removing `target_ref`, baseline outputs, and release-version outputs changes the workflow contract, but the workflow is new and not a published runtime API.
 
 ## 9. Open Questions / Resolved Decisions
 
 - Workflow name: `release-docs`.
-- Branch timing: create branch first.
-- Diff baseline: latest non-prerelease release tag.
-- Diff target: required `target_ref` input.
-- Release version: infer from `target_ref`.
-- Branch name: `docs/release-docs-<release-version>`.
-- Mintlify command: discover from repo scripts/docs, defaulting to CI-documented commands.
+- Inputs: none.
+- Branch behavior: use current branch; do not create/switch branch.
+- Code/docs comparison: current codebase behavior vs current docs under `packages/coding-agent/docs`.
+- Artifact path: `.atomic/workflows/runs/release-docs/<current-branch-slug>/`.
+- Mintlify/docs checks: discover/repair in stage and deterministically replay CI-documented docs checks.
 - Validation failure policy: repair failures before commit/PR; stop with investigation summary if still failing.
 - PR base: `main`.
 - No-op policy: skip commit/push/PR and return a no-op summary when there are no docs changes.

--- a/test/unit/release-docs-workflow.test.ts
+++ b/test/unit/release-docs-workflow.test.ts
@@ -10,6 +10,7 @@ import {
     findMissingOrEmptyUpdateArtifacts,
     mergeStaleDocTasksByOwnerDocs,
     nextDocsValidationPhase,
+    releaseDocsUpdateTaskKey,
     requireNonBaseBranch,
     requireResearchDocPath,
     verifyReleaseDocsPr,
@@ -223,5 +224,14 @@ describe("release-docs stale-doc task merging", () => {
         ]);
 
         assert.deepEqual(deduped?.owner_docs, ["packages/coding-agent/docs/a.mdx"]);
+    });
+
+    test("builds unique update task keys even when model ids repeat", () => {
+        const tasks = [
+            task("same-id", ["packages/coding-agent/docs/a.mdx"]),
+            task("same-id", ["packages/coding-agent/docs/b.mdx"]),
+        ];
+
+        assert.deepEqual(tasks.map(releaseDocsUpdateTaskKey), ["001-same-id", "002-same-id"]);
     });
 });

--- a/test/unit/release-docs-workflow.test.ts
+++ b/test/unit/release-docs-workflow.test.ts
@@ -1,6 +1,11 @@
 import { describe, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import assert from "node:assert/strict";
 import { mergeStaleDocTasksByOwnerDocs, type StaleDocTask } from "../../.atomic/workflow-utils/release-docs.js";
+import { currentBranchName, extractJsonArray, requireResearchDocPath } from "../../.atomic/workflows/release-docs.js";
 
 const task = (id: string, ownerDocs: string[]): StaleDocTask => ({
     id,
@@ -10,6 +15,58 @@ const task = (id: string, ownerDocs: string[]): StaleDocTask => ({
     source_refs: [`src/${id}.ts`],
     update_instructions: `Update ${id}`,
     acceptance_criteria: [`Criteria ${id}`],
+});
+
+const runGit = (cwd: string, args: string[]): void => {
+    execFileSync("git", args, { cwd, stdio: "ignore" });
+};
+
+describe("release-docs workflow guards", () => {
+    test("refuses to resolve a current branch from detached HEAD", () => {
+        const repo = mkdtempSync(join(tmpdir(), "release-docs-detached-"));
+        try {
+            runGit(repo, ["init", "--quiet"]);
+            writeFileSync(join(repo, "README.md"), "# test\n");
+            runGit(repo, ["add", "README.md"]);
+            runGit(repo, [
+                "-c",
+                "user.name=Atomic Test",
+                "-c",
+                "user.email=atomic-test@example.com",
+                "commit",
+                "--message",
+                "initial",
+                "--quiet",
+            ]);
+            runGit(repo, ["checkout", "--detach", "HEAD", "--quiet"]);
+
+            assert.throws(
+                () => currentBranchName(repo),
+                /release-docs must run from a local branch, but HEAD is detached/,
+            );
+        } finally {
+            rmSync(repo, { recursive: true, force: true });
+        }
+    });
+
+    test("requires deep research to return a concrete research artifact path", () => {
+        assert.equal(requireResearchDocPath("research/report.md"), "research/report.md");
+        assert.throws(
+            () => requireResearchDocPath(undefined),
+            /did not return research_doc_path/,
+        );
+        assert.throws(
+            () => requireResearchDocPath("   "),
+            /did not return research_doc_path/,
+        );
+    });
+
+    test("reports malformed stale-doc detector JSON with a descriptive error", () => {
+        assert.throws(
+            () => extractJsonArray("not valid json"),
+            /stale-doc detector returned invalid JSON/,
+        );
+    });
 });
 
 describe("release-docs stale-doc task merging", () => {

--- a/test/unit/release-docs-workflow.test.ts
+++ b/test/unit/release-docs-workflow.test.ts
@@ -4,8 +4,18 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import assert from "node:assert/strict";
-import { mergeStaleDocTasksByOwnerDocs, type StaleDocTask } from "../../.atomic/workflow-utils/release-docs.js";
-import { currentBranchName, extractJsonArray, requireResearchDocPath } from "../../.atomic/workflows/release-docs.js";
+import {
+    currentBranchName,
+    extractJsonArray,
+    findMissingOrEmptyUpdateArtifacts,
+    mergeStaleDocTasksByOwnerDocs,
+    nextDocsValidationPhase,
+    requireNonBaseBranch,
+    requireResearchDocPath,
+    verifyReleaseDocsPr,
+    type StaleDocTask,
+    type UpdateArtifactStatus,
+} from "../../.atomic/workflow-utils/release-docs.js";
 
 const task = (id: string, ownerDocs: string[]): StaleDocTask => ({
     id,
@@ -33,7 +43,10 @@ describe("release-docs workflow guards", () => {
                 "user.name=Atomic Test",
                 "-c",
                 "user.email=atomic-test@example.com",
+                "-c",
+                "core.hooksPath=/dev/null",
                 "commit",
+                "--no-gpg-sign",
                 "--message",
                 "initial",
                 "--quiet",
@@ -47,6 +60,23 @@ describe("release-docs workflow guards", () => {
         } finally {
             rmSync(repo, { recursive: true, force: true });
         }
+    });
+
+    test("allows release-docs from a non-base branch", () => {
+        assert.equal(requireNonBaseBranch("feature/docs", "main"), "feature/docs");
+    });
+
+    test("refuses to run release-docs on the base branch", () => {
+        assert.throws(
+            () => requireNonBaseBranch("main", "main"),
+            /refuses to run directly on the PR base branch 'main'/,
+        );
+    });
+
+    test("trims and validates branch names for the base branch guard", () => {
+        assert.equal(requireNonBaseBranch(" feature/docs ", " main "), "feature/docs");
+        assert.throws(() => requireNonBaseBranch("   ", "main"), /non-empty current branch/);
+        assert.throws(() => requireNonBaseBranch("feature/docs", "   "), /non-empty PR base branch/);
     });
 
     test("requires deep research to return a concrete research artifact path", () => {
@@ -66,6 +96,92 @@ describe("release-docs workflow guards", () => {
             () => extractJsonArray("not valid json"),
             /stale-doc detector returned invalid JSON/,
         );
+    });
+});
+
+describe("release-docs update artifact validation", () => {
+    test("detects missing update artifacts", () => {
+        const artifacts: UpdateArtifactStatus[] = [
+            { path: "a.md", exists: true, empty: false },
+            { path: "b.md", exists: false, empty: true },
+        ];
+
+        assert.deepEqual(findMissingOrEmptyUpdateArtifacts(artifacts), [
+            { path: "b.md", exists: false, empty: true },
+        ]);
+    });
+
+    test("detects empty update artifacts", () => {
+        const artifacts: UpdateArtifactStatus[] = [
+            { path: "a.md", exists: true, empty: true },
+            { path: "b.md", exists: true, empty: false },
+        ];
+
+        assert.deepEqual(findMissingOrEmptyUpdateArtifacts(artifacts), [
+            { path: "a.md", exists: true, empty: true },
+        ]);
+    });
+
+    test("accepts present non-empty update artifacts", () => {
+        assert.deepEqual(
+            findMissingOrEmptyUpdateArtifacts([{ path: "a.md", exists: true, empty: false }]),
+            [],
+        );
+    });
+});
+
+describe("release-docs PR verification", () => {
+    test("verifies a matching open PR returned by gh", () => {
+        const result = verifyReleaseDocsPr("feature/docs", "main", "/repo", () => ({
+            command: "gh pr list --head feature/docs --base main",
+            ok: true,
+            output: JSON.stringify({
+                url: "https://github.com/acme/repo/pull/1",
+                headRefName: "feature/docs",
+                baseRefName: "main",
+                state: "OPEN",
+            }),
+        }));
+
+        assert.equal(result.ok, true);
+        assert.equal(result.url, "https://github.com/acme/repo/pull/1");
+    });
+
+    test("rejects a gh PR result with the wrong base branch", () => {
+        const result = verifyReleaseDocsPr("feature/docs", "main", "/repo", () => ({
+            command: "gh pr list --head feature/docs --base main",
+            ok: true,
+            output: JSON.stringify({
+                url: "https://github.com/acme/repo/pull/1",
+                headRefName: "feature/docs",
+                baseRefName: "develop",
+                state: "OPEN",
+            }),
+        }));
+
+        assert.equal(result.ok, false);
+        assert.match(result.summary, /did not return an open PR matching/);
+    });
+
+    test("reports gh command failure during PR verification", () => {
+        const result = verifyReleaseDocsPr("feature/docs", "main", "/repo", () => ({
+            command: "gh pr list --head feature/docs --base main",
+            ok: false,
+            output: "not found",
+        }));
+
+        assert.equal(result.ok, false);
+        assert.match(result.summary, /Unable to verify release docs PR with gh/);
+    });
+});
+
+describe("release-docs validation flow", () => {
+    test("skips model repair when initial deterministic validation passes", () => {
+        assert.equal(nextDocsValidationPhase(true), "skip_repair");
+    });
+
+    test("repairs and revalidates when initial deterministic validation fails", () => {
+        assert.equal(nextDocsValidationPhase(false), "repair_then_revalidate");
     });
 });
 

--- a/test/unit/release-docs-workflow.test.ts
+++ b/test/unit/release-docs-workflow.test.ts
@@ -1,0 +1,54 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mergeStaleDocTasksByOwnerDocs, type StaleDocTask } from "../../.atomic/workflow-utils/release-docs.js";
+
+const task = (id: string, ownerDocs: string[]): StaleDocTask => ({
+    id,
+    title: `Task ${id}`,
+    owner_docs: ownerDocs,
+    reason: `Reason ${id}`,
+    source_refs: [`src/${id}.ts`],
+    update_instructions: `Update ${id}`,
+    acceptance_criteria: [`Criteria ${id}`],
+});
+
+describe("release-docs stale-doc task merging", () => {
+    test("merges tasks that share owner docs before fan-out", () => {
+        const merged = mergeStaleDocTasksByOwnerDocs([
+            task("cli-flags", ["packages/coding-agent/docs/cli.mdx"]),
+            task("workflows", ["packages/coding-agent/docs/workflows.mdx"]),
+            task("cli-examples", ["./packages/coding-agent/docs/cli.mdx"]),
+        ]);
+
+        assert.equal(merged.length, 2);
+        assert.deepEqual(merged[0]?.owner_docs, ["packages/coding-agent/docs/cli.mdx"]);
+        assert.match(merged[0]?.update_instructions ?? "", /cli-flags/);
+        assert.match(merged[0]?.update_instructions ?? "", /cli-examples/);
+        assert.deepEqual(merged[1]?.owner_docs, ["packages/coding-agent/docs/workflows.mdx"]);
+    });
+
+    test("merges transitive owner-doc overlaps into one component", () => {
+        const merged = mergeStaleDocTasksByOwnerDocs([
+            task("a", ["packages/coding-agent/docs/a.mdx"]),
+            task("b", ["packages/coding-agent/docs/a.mdx", "packages/coding-agent/docs/b.mdx"]),
+            task("c", ["packages/coding-agent/docs/b.mdx"]),
+            task("d", ["packages/coding-agent/docs/d.mdx"]),
+        ]);
+
+        assert.equal(merged.length, 2);
+        assert.deepEqual(merged[0]?.owner_docs, [
+            "packages/coding-agent/docs/a.mdx",
+            "packages/coding-agent/docs/b.mdx",
+        ]);
+        assert.match(merged[0]?.id ?? "", /^merged-/);
+        assert.deepEqual(merged[1]?.owner_docs, ["packages/coding-agent/docs/d.mdx"]);
+    });
+
+    test("deduplicates owner docs on standalone tasks", () => {
+        const [deduped] = mergeStaleDocTasksByOwnerDocs([
+            task("a", ["packages/coding-agent/docs/a.mdx", "./packages/coding-agent/docs/a.mdx"]),
+        ]);
+
+        assert.deepEqual(deduped?.owner_docs, ["packages/coding-agent/docs/a.mdx"]);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a zero-input `release-docs` workflow that automates Atomic documentation refresh end-to-end: from codebase research through stale-doc detection, parallel updates, Mintlify validation, and PR creation — all headlessly from the current branch.

## Key Changes

### `.atomic/workflows/release-docs.ts`
New workflow using the `defineWorkflow` API with five sequential pipeline stages:

1. **Working-tree guard** — refuses to start on a dirty tree (edits docs, commits, and pushes on the current branch)
2. **Codebase research** — delegates to the `deep-research-codebase` child workflow to map current code behavior against `packages/coding-agent/docs`
3. **Stale-doc detection** — inspects docs against the research artifact and emits grouped, non-overlapping JSON tasks (one task per owning file to prevent parallel write conflicts)
4. **Parallel docs updates** — fans out up to 4 concurrent workers via `ctx.parallel`, each scoped to their assigned docs files with `context: "fresh"` isolation
5. **Validation/repair gate + PR creation** — runs `bun run docs:check`, `mintlify validate`, and `mintlify broken-links`; attempts docs-only repairs on failure; commits, pushes, and opens a PR only after deterministic re-validation passes and docs actually changed

Typed outputs: `status` (`pr_created` | `no_changes` | `needs_investigation`), artifact paths for all intermediate handoffs, and the full stale-doc task list. Artifacts are written to `.atomic/workflows/runs/release-docs/<branch-slug>/`.

### `.atomic/workflow-utils/release-docs.ts`
New shared utility module with pure, testable logic extracted from the workflow:

- `StaleDocTask` / `CommandResult` / `DocsValidationPhase` — typed handoff structures
- `sanitizeSegment` — normalizes strings to safe kebab-case filesystem/ID segments
- `requireNonBaseBranch` / `currentBranchName` — working-tree and branch guards with precise error messages
- `requireResearchDocPath` — validates the deep-research child workflow output
- `extractJsonArray` — parses and normalizes model-emitted stale-doc JSON (strips prose/fences, validates array shape)
- `runDocsChecks` — runs all three Mintlify/docs CLI checks, returns structured `CommandResult[]` + `ok` + markdown
- `nextDocsValidationPhase` — decides between `skip_repair` and `repair_then_revalidate` based on validation outcome
- `verifyReleaseDocsPr` — deterministically verifies the open PR via `gh pr list` with base-branch filtering
- `findMissingOrEmptyUpdateArtifacts` — detects incomplete update worker output before committing
- `mergeStaleDocTasksByOwnerDocs` — **Union-Find (disjoint set)** algorithm that merges stale tasks sharing owner-doc files before fan-out, preventing concurrent write conflicts without serializing independent updates
- `releaseDocsUpdateTaskKey` — generates stable, sortable task keys for artifact naming

### `test/unit/release-docs-workflow.test.ts`
237-line unit test suite covering:
- **Guards**: detached HEAD detection, missing research artifact path, malformed stale-doc JSON, base-branch rejection, empty/whitespace branch name handling
- **Artifact validation**: missing and empty update artifact detection logic
- **PR verification**: matching open PR, wrong base branch, `gh` command failure
- **Validation flow**: `skip_repair` vs `repair_then_revalidate` branching based on check results
- **Stale-doc merging**: shared owner docs, transitive overlap (A↔B and B↔C collapse to one component), owner-docs deduplication with path normalization (`./packages/…` → `packages/…`)

### `specs/2026-06-07-release-docs-workflow.md`
Design spec covering the fan-out-and-synthesize + adversarial-verification pattern, branch/artifact rules, validation gate contract, alternatives considered (tag-range comparison, dedicated docs branch), and all resolved design decisions.

### `.gitignore`
Adds `.atomic/workflows/runs/` to prevent workflow run artifacts from being committed.

## Design Decisions

- **No inputs / current branch as target** — the current checkout already carries the code changes that need documentation; no `target_ref` or baseline-tag comparison required
- **Union-Find grouping** — stale entries touching the same file are merged into one task before fan-out, eliminating concurrent write conflicts without serializing independent updates
- **Deterministic validation replay** — after the model-driven repair stage, the workflow re-runs the same CLI commands and appends their verbatim output to `validation.md` before any commit/push
- **Utility/workflow split** — pure logic is extracted to `.atomic/workflow-utils/` so it can be unit-tested independently of the workflow runtime

## Validation

- `bun run typecheck` — passed
- `bun run test:unit` (including new merge utility tests) — passed
- Pre-commit hooks (`bun run lint`) — passed
- End-to-end execution intentionally deferred (workflow edits docs, commits, and pushes; not safe to run during development)