### PR TITLE
chore(subagents): restrict codebase agents to read-only tools

### DIFF
--- a/packages/subagents/agents/codebase-analyzer.md
+++ b/packages/subagents/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components.
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls
 model: openai/gpt-5.5:low
 fallbackModels: openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.7:low
 ---

--- a/packages/subagents/agents/codebase-locator.md
+++ b/packages/subagents/agents/codebase-locator.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Basically a "super search/find/ls tool."
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls
 model: openai/gpt-5.4-mini:low
 fallbackModels: openai-codex/gpt-5.4-mini:low, github-copilot/gpt-5.4-mini:low, anthropic/claude-haiku-4-5:low, github-copilot/claude-haiku-4.5:low
 ---

--- a/packages/subagents/agents/codebase-pattern-finder.md
+++ b/packages/subagents/agents/codebase-pattern-finder.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-pattern-finder
 description: Find similar implementations, usage examples, or existing patterns in the codebase that can be modeled after.
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls
 model: openai/gpt-5.4-mini:low
 fallbackModels: openai-codex/gpt-5.4-mini:low, github-copilot/gpt-5.4-mini:low, anthropic/claude-haiku-4-5:low, github-copilot/claude-haiku-4.5:low
 ---

--- a/packages/subagents/agents/codebase-research-analyzer.md
+++ b/packages/subagents/agents/codebase-research-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-research-analyzer
 description: Analyzes local research documents to extract high-value insights, decisions, and technical details while filtering out noise. Use this when you want to deep dive on a research topic or understand the rationale behind decisions.
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls
 model: openai/gpt-5.5:low
 fallbackModels: openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.7:low
 ---

--- a/packages/subagents/agents/codebase-research-locator.md
+++ b/packages/subagents/agents/codebase-research-locator.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-research-locator
 description: Discovers local research documents that are relevant to the current research task.
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls
 model: openai/gpt-5.4-mini:low
 fallbackModels: openai-codex/gpt-5.4-mini:low, github-copilot/gpt-5.4-mini:low, anthropic/claude-haiku-4-5:low, github-copilot/claude-haiku-4.5:low
 ---


### PR DESCRIPTION
## Summary

Removes `bash` access from all built-in codebase discovery and research agents, restricting them to read-only/search tools (`read`, `grep`, `find`, `ls`). This limits the blast radius of these agents to pure observation with no ability to execute arbitrary shell commands.

## Changes

- `codebase-analyzer`: removed `bash` from tool list
- `codebase-locator`: removed `bash` from tool list
- `codebase-pattern-finder`: removed `bash` from tool list
- `codebase-research-analyzer`: removed `bash` from tool list
- `codebase-research-locator`: removed `bash` from tool list

## Rationale

Codebase discovery/research agents only need to read and search files. Granting `bash` access is unnecessarily broad and creates risk of unintended side-effects (file mutations, process execution) during what should be passive analysis tasks.

## Validation

- `bun run lint` ✓
- `bun run test:unit` ✓