### PR TITLE
docs: clarify changelog release summary guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,10 @@ Use these sections under `## [Unreleased]`:
 - Append to existing subsections (e.g., `### Fixed`), do not create duplicates
 - NEVER modify already-released version sections (e.g., `## [0.12.2]`)
 - Each version section is immutable once released
+- When updating the changelog entry you should:
+    1. Carefully note key features that were added for a particular `prerelease` revision and for each `release` version changelog you should note every key feature that was introduced in the cumulative `prerelease`(s) that led up to the `release`.
+    2. Do NOT be lazy and avoid saying something like: "Bumped package version for the Atomic prerelease." That is not helpful to users and does not provide any information on what was actually changed.
+    3. The changelog should be a comprehensive and detailed summary of all the key features, bug fixes, breaking changes, and other relevant information about the `release`/`prerelease` that would be helpful for users.
 
 ### Attribution
 


### PR DESCRIPTION
## Summary

Strengthens changelog authoring guidance to ensure release and prerelease entries contain meaningful, user-facing summaries rather than generic version-bump notes.

## Changes

- Adds a three-point rule under `### Rules` in the Changelog section:
  1. Prerelease entries must capture key features for that revision; release entries must summarize all cumulative changes from preceding prereleases.
  2. Vague entries (e.g., "Bumped package version for the Atomic prerelease") are explicitly discouraged.
  3. Changelog entries must be comprehensive — covering features, bug fixes, breaking changes, and any other information relevant to users.

## Notes

- Documentation-only change; no runtime or test code affected.