### PR TITLE
chore(release): prepare 0.8.26

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+## [0.8.26] - 2026-06-08
+
+### Added
+
+- Added deletion-only transcript compaction as the default `/compact` behavior, preserving retained transcript content verbatim while validating model-proposed logical deletion targets.
+- Added session entries and expandable summary-card rendering for completed context compaction results.
+
+### Changed
+
+- Improved Windows cold startup by lazily loading bundled web-access, intercom, and MCP implementation modules, deferring readiness checks until after the first interactive frame, and adding detailed startup timing spans ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+- Updated automatic compaction and manual `/compact` documentation to describe transcript-bound Verbatim Compaction, validated logical deletion targets, critical overflow behavior, and legacy summary-compaction settings.
+- Documented npm and pnpm installation options in Atomic docs and limited Mintlify validation to pull requests ([#1294](https://github.com/bastani-inc/atomic/pull/1294)).
+- Updated builtin `ralph` workflow docs to describe the safe default for PR creation, `create_pr=true` opt-in examples, omitted disabled `pr_report`, and final-stage-only provider-aware PR/MR/review creation instructions ([#1255](https://github.com/bastani-inc/atomic/issues/1255)).
+- Updated maintainer release guidance so prerelease and stable changelog entries summarize concrete user-facing changes instead of placeholder version-bump notes.
+- Bumped the `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` dependencies to 0.78.1.
+
+### Fixed
+
+- Fixed an uncaught `TypeError: child.render is not a function` crash on `/resume` when an extension custom-message renderer returned a non-`Component` value, and allowed custom-message renderers to return `null` to render nothing ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).
+- Fixed auto-compaction so queued in-progress work resumes without requiring a manual follow-up prompt ([#1280](https://github.com/bastani-inc/atomic/issues/1280)).
+- Clarified overflow auto-compaction warnings in the TUI footer so automatic transcript compaction is reported distinctly from user-triggered compaction ([#1250](https://github.com/bastani-inc/atomic/issues/1250)).
+- Fixed internal Git subprocesses to strip ambient repository-local Git environment variables before package-manager and footer branch lookups inspect a targeted working tree.
+- Fixed Mintlify MDX autolinks in package docs so documentation validation passes ([#1293](https://github.com/bastani-inc/atomic/pull/1293)).
+
+### Removed
+
+- Removed the `/context-compact` interactive and workflow-stage slash command; use `/compact` instead.
+- Removed the temporary manual `@earendil-works/pi-tui` patch, patched-dependency configuration, and bundled patched TUI packaging fallback.
+
 ## [0.8.26-alpha.11] - 2026-06-08
 
 ### Changed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.26-alpha.11",
+  "version": "0.8.26",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.26] - 2026-06-08
+
+### Changed
+
+- Deferred broker client/spawn and overlay UI modules until intercom connects or the overlay opens, reducing default CLI startup cost ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
 ## [0.8.26-alpha.11] - 2026-06-08
 
 ### Changed

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.26-alpha.11",
+  "version": "0.8.26",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.26] - 2026-06-08
+
+### Changed
+
+- Kept MCP startup registration cheap by lazily importing the heavy MCP command, initialization, proxy-mode, and OAuth/auth-flow modules, and by deferring config/cache-backed direct-tool discovery instead of loading them on the cold extension factory path ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
+### Fixed
+
+- Stopped logging a spurious stale-context MCP initialization error when a disposed session invalidates the captured extension context during deferred MCP `session_start` initialization; stale-context errors are now treated as cancellation for that path ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
 ## [0.8.26-alpha.11] - 2026-06-08
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.26-alpha.11",
+  "version": "0.8.26",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.8.26] - 2026-06-08
+
+### Added
+
+- Replaced the bundled browser-use subagent integration with the first-party `browser` skill for web interaction workflows.
+
+### Changed
+
+- Restricted the bundled codebase locator, analyzer, pattern-finder, research locator, and research analyzer agent tool allowlists to read/search/directory tools only, preventing these read-only helpers from invoking `bash` while they locate or analyze code.
+
+### Fixed
+
+- Fixed the `no-staged-files` acceptance runtime check and subagent worktree Git commands to ignore ambient Git repository environment variables, so subagents inspect the intended working tree instead of a parent hook or unrelated worktree.
+- Suppressed intermediate model fallback failure notes and live foreground failure updates from successful subagent runs while preserving final failures and raw per-attempt diagnostics ([#1226](https://github.com/bastani-inc/atomic/issues/1226)).
+
 ## [0.8.26-alpha.11] - 2026-06-08
 
 ### Changed

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.26-alpha.11",
+  "version": "0.8.26",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.26] - 2026-06-08
+
+### Changed
+
+- Deferred heavy search, fetch, curator, summary, provider-probing, and code-search modules until the relevant web-access tool or command is invoked, reducing default CLI startup cost ([#1223](https://github.com/bastani-inc/atomic/issues/1223)).
+
 ## [0.8.26-alpha.11] - 2026-06-08
 
 ### Changed

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.26-alpha.11",
+  "version": "0.8.26",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.26] - 2026-06-08
+
+### Changed
+
+- Updated workflow-stage chat so `/compact` is the no-argument compaction command and `/context-compact` is no longer handled locally.
+- Refined bundled workflow prompts to keep natural instructions inside meaningful XML sections while removing redundant wrapper noise.
+- Upgraded builtin workflow fallback model tiers so degraded runs land on stronger models across `deep-research-codebase`, `goal`, `ralph`, and `open-claude-design` ([#1259](https://github.com/bastani-inc/atomic/issues/1259)).
+- Changed the builtin `ralph` workflow to include the workflow current working directory in every stage prompt and to skip pull-request creation by default unless `create_pr=true`, omitting `pr_report` when disabled while keeping provider-aware PR/MR/review creation instructions in the final stage ([#1255](https://github.com/bastani-inc/atomic/issues/1255)).
+- Updated the `research-codebase` skill to capture and carry a `breaking_changes_allowed` compatibility posture through research fanout and downstream research documents ([#1225](https://github.com/bastani-inc/atomic/issues/1225)).
+
+### Fixed
+
+- Fixed workflow custom-message renderers for inline forms and workflow run banners so persisted workflow messages no longer crash the host TUI with `child.render is not a function` on `/resume` ([#1236](https://github.com/bastani-inc/atomic/issues/1236)).
+- Fixed the workflow input form so transient `/workflow <name>` argument selectors do not leak into model context and rehydrated stale input-form cards render nothing after `/resume`.
+- Made stage sessions emit `session_shutdown` before `dispose()`, giving bound extensions graceful shutdown and preventing leaked child MCP servers or stale-context MCP initialization noise.
+- Fixed stage-local workflow HIL `input` and `editor` prompts losing draft text across Ctrl+D detach/reattach; drafts are kept live-only in memory and cleared when the prompt or run/stage exits ([#1179](https://github.com/bastani-inc/atomic/issues/1179)).
+- Fixed workflow worktree Git commands to strip ambient repository-local Git environment variables before inspecting or creating targeted worktrees.
+- Suppressed intermediate model fallback failure warnings from successful workflow stages while preserving final failures and raw per-attempt diagnostics ([#1226](https://github.com/bastani-inc/atomic/issues/1226)).
+- Fixed the workflow global tool-event hook ignoring unscoped parent-session prompts instead of attributing them to running stages, preventing false `awaiting_input` / "needs attention" states from unrelated `ask_user_question` calls ([#1261](https://github.com/bastani-inc/atomic/issues/1261)).
+- Fixed the builtin `goal` and `ralph` workflows to fork looped worker/orchestrator-stage sessions from their matching prior iteration, preserving accumulated context while keeping reviewer stages independent ([#1275](https://github.com/bastani-inc/atomic/issues/1275)).
+- Fixed workflow completion gates to rely on structured decision fields instead of manual text/regex heuristics in `goal` and `open-claude-design`.
+
 ## [0.8.26-alpha.11] - 2026-06-08
 
 ### Changed

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.26-alpha.11",
+  "version": "0.8.26",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes the `0.8.26` prerelease line to a stable release by bumping all workspace package versions from `0.8.26-alpha.11` to `0.8.26` and adding comprehensive stable changelog entries across all packages.

## Changes

### Version bumps
- `@bastani/atomic` → `0.8.26`
- `@bastani/workflows` → `0.8.26`
- `@bastani/subagents` → `0.8.26`
- `@bastani/mcp` → `0.8.26`
- `@bastani/web-access` → `0.8.26`
- `@bastani/intercom` → `0.8.26`

### Changelog highlights (cumulative from 0.8.26 prerelease series)

**`@bastani/atomic`**
- Added deletion-only transcript compaction as the default `/compact` behavior with verbatim retention and validated logical deletion targets
- Added session entries and expandable summary-card rendering for completed context compaction results
- Improved Windows cold startup via lazy-loaded extension modules and deferred readiness checks (#1223)
- Updated `/compact` documentation to cover Verbatim Compaction, logical deletion validation, critical overflow behavior, and legacy settings
- Fixed `TypeError: child.render is not a function` crash on `/resume` with custom-message renderers (#1236)
- Fixed auto-compaction so queued in-progress work resumes without a manual follow-up prompt (#1280)
- Fixed internal Git subprocesses to strip ambient repository-local Git environment variables
- Removed `/context-compact` slash command — use `/compact` instead
- Removed temporary `@earendil-works/pi-tui` manual patch and bundled packaging fallback
- Bumped `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` to 0.78.1

**`@bastani/workflows`**
- Updated workflow-stage chat to use `/compact` (drops `/context-compact` local handling)
- Upgraded builtin workflow fallback model tiers for `deep-research-codebase`, `goal`, `ralph`, and `open-claude-design` (#1259)
- Changed `ralph` to include CWD in every stage prompt and skip PR creation unless `create_pr=true` (#1255)
- Updated `research-codebase` skill to carry `breaking_changes_allowed` through research fanout (#1225)
- Fixed workflow custom-message renderers to prevent `child.render is not a function` crash on `/resume` (#1236)
- Fixed stage sessions to emit `session_shutdown` before `dispose()` for graceful MCP server cleanup
- Fixed HIL `input`/`editor` draft text lost across Ctrl+D detach/reattach (#1179)
- Fixed workflow worktree Git commands to strip ambient repository-local Git env vars
- Fixed global tool-event hook falsely attributing unscoped parent-session prompts to running stages (#1261)
- Fixed `goal` and `ralph` workflows to fork looped sessions from prior iterations (#1275)
- Fixed completion gates to use structured decision fields instead of text/regex heuristics

**`@bastani/subagents`**
- Replaced browser-use integration with the first-party `browser` skill
- Restricted read-only agent tool allowlists to prevent `bash` invocation
- Fixed `no-staged-files` check and subagent worktree Git commands to strip ambient Git env vars
- Suppressed intermediate model fallback failure notes from successful subagent runs (#1226)

**`@bastani/mcp`**
- Lazy-loaded heavy MCP modules to reduce cold CLI startup cost (#1223)
- Fixed spurious stale-context MCP initialization error on disposed sessions (#1223)

**`@bastani/web-access`**
- Deferred heavy search/fetch/curator modules until the relevant tool is invoked, reducing startup cost (#1223)

**`@bastani/intercom`**
- Deferred broker client/spawn and overlay UI modules until intercom connects or overlay opens (#1223)

## Validation

- `bun run typecheck` ✓
- `bun run lint` ✓
- `bun run test:unit` ✓