### PR TITLE
fix(workflows): prevent CLI crash from orphaned prompt promise on kill

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `AgentSession.prompt` surfacing the confusing `No API key found for undefined` error when a model never resolved to a real provider (for example an unknown/unresolved model id reaching the prompt path as a bare string). The prompt path now fails fast with a clear `Unknown model: "<id>" did not resolve to an available provider` message, and `No API key found` guidance no longer renders a literal `undefined` provider.
+
 ## [0.8.27] - 2026-06-08
 
 ### Fixed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -44,7 +44,11 @@ import {
 	isAtomicGuideHelpChoice,
 	normalizeAtomicGuideMode,
 } from "./atomic-guide-command.ts";
-import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.ts";
+import {
+	formatNoApiKeyFoundMessage,
+	formatNoModelSelectedMessage,
+	formatUnresolvedModelMessage,
+} from "./auth-guidance.ts";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.ts";
 import {
 	type CompactionResult,
@@ -1202,6 +1206,16 @@ export class AgentSession {
 			// Validate model
 			if (!this.model) {
 				throw new Error(formatNoModelSelectedMessage());
+			}
+
+			// Defensive guard: a model that never resolved to a real provider
+			// (for example an unknown/unresolved model id that reached this path
+			// as a bare string) has no `provider`, which would otherwise fail deep
+			// in auth resolution as the confusing "No API key found for undefined".
+			// Surface a clear, accurate "unknown model" error instead.
+			const resolvedProvider = (this.model as { provider?: unknown }).provider;
+			if (typeof resolvedProvider !== "string" || resolvedProvider.length === 0) {
+				throw new Error(formatUnresolvedModelMessage(this.model));
 			}
 
 			if (!this._modelRegistry.hasConfiguredAuth(this.model)) {

--- a/packages/coding-agent/src/core/auth-guidance.ts
+++ b/packages/coding-agent/src/core/auth-guidance.ts
@@ -19,7 +19,35 @@ export function formatNoModelSelectedMessage(): string {
 	return `No model selected.\n\n${getProviderLoginHelp()}\n\nThen use /model to select a model.`;
 }
 
-export function formatNoApiKeyFoundMessage(provider: string): string {
-	const providerDisplay = provider === UNKNOWN_PROVIDER ? "the selected model" : provider;
+export function formatNoApiKeyFoundMessage(provider: string | undefined): string {
+	const providerDisplay =
+		provider === undefined || provider.length === 0 || provider === UNKNOWN_PROVIDER
+			? "the selected model"
+			: provider;
 	return `No API key found for ${providerDisplay}.\n\n${getProviderLoginHelp()}`;
+}
+
+function modelLabelForMessage(model: unknown): string {
+	if (typeof model === "string" && model.trim().length > 0) return `"${model}"`;
+	if (model !== null && typeof model === "object") {
+		const id = (model as { id?: unknown }).id;
+		if (typeof id === "string" && id.length > 0) return `"${id}"`;
+	}
+	return "the selected model";
+}
+
+/**
+ * Message for a model that did not resolve to a real provider — e.g. an
+ * unknown/unresolved model id that reached the prompt path as a bare string
+ * (its `provider` is `undefined`). Surfaced instead of the misleading
+ * "No API key found for undefined", and phrased with "unknown model" so callers
+ * that classify failures by message (such as the workflows runtime) treat it as
+ * a model-configuration error rather than a missing API key.
+ */
+export function formatUnresolvedModelMessage(model: unknown): string {
+	return (
+		`Unknown model: ${modelLabelForMessage(model)} did not resolve to an available provider.\n\n` +
+		`${getProviderLoginHelp()}\n\n` +
+		"Then use /model to select an available model."
+	);
 }

--- a/packages/coding-agent/test/auth-guidance.test.ts
+++ b/packages/coding-agent/test/auth-guidance.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatNoApiKeyFoundMessage,
+	formatUnresolvedModelMessage,
+} from "../src/core/auth-guidance.ts";
+
+describe("formatNoApiKeyFoundMessage", () => {
+	it("never renders a literal 'undefined' provider", () => {
+		const message = formatNoApiKeyFoundMessage(undefined);
+		expect(message).toContain("No API key found for the selected model.");
+		expect(message).not.toContain("undefined");
+	});
+
+	it("falls back to a friendly target for an empty provider", () => {
+		expect(formatNoApiKeyFoundMessage("")).toContain("No API key found for the selected model.");
+	});
+
+	it("falls back to a friendly target for the sentinel 'unknown' provider", () => {
+		expect(formatNoApiKeyFoundMessage("unknown")).toContain("No API key found for the selected model.");
+	});
+
+	it("names a real provider", () => {
+		expect(formatNoApiKeyFoundMessage("anthropic")).toContain("No API key found for anthropic.");
+	});
+});
+
+describe("formatUnresolvedModelMessage", () => {
+	it("reads as an 'unknown model' error and names a string model id", () => {
+		const message = formatUnresolvedModelMessage("openai/ghost");
+		expect(message).toContain('Unknown model: "openai/ghost"');
+		expect(message).toContain("did not resolve to an available provider");
+		expect(message).not.toContain("undefined");
+	});
+
+	it("names an object model's id when present", () => {
+		expect(formatUnresolvedModelMessage({ id: "ghost" })).toContain('Unknown model: "ghost"');
+	});
+
+	it("falls back to a friendly target for unidentifiable models", () => {
+		expect(formatUnresolvedModelMessage(undefined)).toContain("Unknown model: the selected model");
+		expect(formatUnresolvedModelMessage({})).toContain("Unknown model: the selected model");
+	});
+});

--- a/packages/coding-agent/test/suite/agent-session-prompt.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-prompt.test.ts
@@ -312,6 +312,18 @@ describe("AgentSession prompt characterization", () => {
 		await expect(harness.session.prompt("hi")).rejects.toThrow("No model selected.");
 	});
 
+	it("throws a clear 'unknown model' error when the model has no provider", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		// Simulate an unknown/unresolved model id reaching the prompt path as a
+		// bare string (no `.provider`) — the shape that previously surfaced as the
+		// confusing "No API key found for undefined".
+		harness.session.agent.state.model = "openai/ghost" as unknown as Model<any>;
+
+		await expect(harness.session.prompt("hi")).rejects.toThrow('Unknown model: "openai/ghost"');
+		await expect(harness.session.prompt("hi")).rejects.not.toThrow("No API key found for undefined");
+	});
+
 	it("throws when prompting without configured auth", async () => {
 		const harness = await createHarness({ withConfiguredAuth: false });
 		harnesses.push(harness);

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Changed workflow transcript introspection to return `sessionFile`/`transcriptPath` metadata with a lazy-read prompt by default when a transcript path exists, while keeping bounded inline previews behind explicit `tail`/`limit` requests and falling back to a small preview when no path is available ([#1314](https://github.com/bastani-inc/atomic/issues/1314)).
 
+### Fixed
+
+- Fixed a workflow kill/abort race that could crash the entire CLI with a process-level uncaught exception (for example `No API key found for ...`). When a workflow was killed mid-prompt, the executor's `raceAbort` left the already-in-flight stage prompt promise unobserved; its later rejection escaped every workflow error boundary and became an unhandled rejection. `raceAbort` now always observes the in-flight promise in the already-aborted branch so a killed run can no longer orphan a rejecting prompt.
+
 ## [0.8.27] - 2026-06-08
 
 ### Changed

--- a/packages/workflows/src/runs/foreground/executor.ts
+++ b/packages/workflows/src/runs/foreground/executor.ts
@@ -1400,8 +1400,19 @@ export async function runChain(
   return workflowDetailsFromRun("chain", runResult, results, options, validationWarnings);
 }
 
-function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+export function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) {
+    // Callers invoke `raceAbort(call(), signal)`, so `call()` is evaluated —
+    // and the underlying work (e.g. a stage prompt) is already in flight —
+    // before this function observes an already-aborted signal. Attach a no-op
+    // rejection handler so that in-flight promise can never surface as an
+    // unhandled rejection. Without this, killing a workflow mid-prompt orphans
+    // the prompt promise; its eventual rejection (commonly
+    // "No API key found for ...") escapes every workflow error boundary and is
+    // raised as a process-level uncaught exception that crashes the whole CLI.
+    // The run is being aborted, so the orphaned settlement is intentionally
+    // discarded here.
+    void promise.catch(() => {});
     return Promise.reject(signal.reason ?? new DOMException("workflow killed", "AbortError"));
   }
   return new Promise<T>((resolve, reject) => {

--- a/test/unit/race-abort.test.ts
+++ b/test/unit/race-abort.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for `raceAbort` orphaning an in-flight promise.
+ *
+ * Background: stage turns run as `await raceAbort(call(), ownController.signal)`.
+ * `call()` is evaluated (and the prompt starts) before `raceAbort` runs, so when
+ * a workflow is killed mid-prompt the signal is already aborted by the time
+ * `raceAbort` is entered. The aborted branch must still observe the in-flight
+ * promise; otherwise its eventual rejection (commonly
+ * "No API key found for ...") becomes an unhandled rejection that escapes every
+ * workflow error boundary and crashes the entire CLI.
+ *
+ * cross-ref: packages/workflows/src/runs/foreground/executor.ts raceAbort
+ */
+
+import { afterEach, beforeEach, test } from "bun:test";
+import assert from "node:assert/strict";
+import { raceAbort } from "../../packages/workflows/src/runs/foreground/executor.js";
+
+let unhandled: unknown[] = [];
+const onUnhandled = (reason: unknown): void => {
+    unhandled.push(reason);
+};
+
+beforeEach(() => {
+    unhandled = [];
+    process.on("unhandledRejection", onUnhandled);
+});
+
+afterEach(() => {
+    process.off("unhandledRejection", onUnhandled);
+});
+
+/** Let microtasks and a couple of macrotask turns flush so any orphaned
+ * rejection is delivered to the process `unhandledRejection` listener. */
+async function flushPendingRejections(): Promise<void> {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("raceAbort does not orphan an in-flight rejection when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("workflow killed");
+    controller.abort(reason);
+
+    // Simulate `call()` already in flight: a prompt that rejects on a later tick
+    // (e.g. AgentSession.prompt throwing "No API key found for undefined").
+    const sentinel = new Error("late prompt failure: No API key found for undefined");
+    const inFlight = new Promise<void>((_resolve, rejectInFlight) => {
+        setTimeout(() => rejectInFlight(sentinel), 5);
+    });
+
+    await assert.rejects(raceAbort(inFlight, controller.signal), (err) => err === reason);
+
+    await flushPendingRejections();
+    assert.equal(
+        unhandled.includes(sentinel),
+        false,
+        "the orphaned in-flight rejection must be observed, not left unhandled",
+    );
+});
+
+test("raceAbort rejects with the abort reason yet still observes a later mid-flight rejection", async () => {
+    const controller = new AbortController();
+    const sentinel = new Error("late mid-flight failure");
+    const inFlight = new Promise<void>((_resolve, rejectInFlight) => {
+        setTimeout(() => rejectInFlight(sentinel), 5);
+    });
+
+    const raced = raceAbort(inFlight, controller.signal);
+    const reason = new Error("killed mid-flight");
+    controller.abort(reason);
+
+    await assert.rejects(raced, (err) => err === reason);
+
+    await flushPendingRejections();
+    assert.equal(unhandled.includes(sentinel), false);
+});
+
+test("raceAbort resolves with the promise value when the signal never aborts", async () => {
+    const controller = new AbortController();
+    const value = await raceAbort(Promise.resolve("ok"), controller.signal);
+    assert.equal(value, "ok");
+});
+
+test("raceAbort propagates a normal rejection when the signal never aborts", async () => {
+    const controller = new AbortController();
+    const failure = new Error("normal failure");
+    await assert.rejects(raceAbort(Promise.reject(failure), controller.signal), (err) => err === failure);
+});


### PR DESCRIPTION
## Summary

Killing a workflow mid-prompt could crash the entire CLI with a process-level uncaught exception (commonly observed as \`No API key found for undefined\`). This PR fixes the crash at its root in the workflow executor and also eliminates the misleading error message that propagated through it.

## Root cause

Two interacting bugs:

1. **Kill race orphans the in-flight prompt promise (the crash).** Stage turns run as \`await raceAbort(call(), ownController.signal)\`. Since \`call()\` is evaluated *before* \`raceAbort\` runs, the stage prompt is already in flight when a kill lands. The already-aborted early-return branch rejected immediately but **never attached a handler to the in-flight promise**. When that promise later rejected, the rejection had no observer — it escaped every workflow error boundary as an unhandled rejection, hit the process-level fatal handler, and caused \`process.exit(1)\`. In the non-kill path the promise *is* observed, so the same error is merely a recoverable failed stage.

2. **Misleading error message.** A model that never resolved to a real provider (an unknown model id reaching the prompt path as a bare string) has no \`.provider\`, so the auth check rendered the literal \`No API key found for undefined\`.

## Changes

### `@bastani/workflows`
- **`executor.ts`** — `raceAbort` now attaches a no-op rejection handler (`void promise.catch(() => {})`) in the already-aborted branch so a killed run can never orphan a rejecting prompt. Exported for testing.

### `@bastani/atomic` (coding-agent)
- **`agent-session.ts`** — `AgentSession.prompt` guards a missing/empty model provider and throws `Unknown model: "<id>" did not resolve to an available provider` before reaching the confusing auth path.
- **`auth-guidance.ts`** — `formatNoApiKeyFoundMessage` now accepts `string | undefined` and falls back gracefully; new `formatUnresolvedModelMessage` export produces a clear, actionable unknown-model error that the workflows runtime classifies as `unknown_model`/`model_unavailable` (so model fallback still advances).

## Tests

- **`test/unit/race-abort.test.ts`** (new) — regression suite proving that orphaned and mid-flight rejections are observed and that normal resolve/reject paths are intact.
- **`packages/coding-agent/test/auth-guidance.test.ts`** (new) — covers all fallback cases for `formatNoApiKeyFoundMessage` and `formatUnresolvedModelMessage`, including the `undefined`-provider case.
- **`packages/coding-agent/test/suite/agent-session-prompt.test.ts`** — added guard case asserting the clear unknown-model error is thrown instead of the misleading `undefined` message.
- Full workflows unit suite (2167 tests), coding-agent prompt/provider/retry/concurrent suites pass; both packages type-check clean.

## Notes

- No API or behavioral changes for correctly-configured models — the guard only fires when a model has no resolved provider.
- The shipped CLI runs the built `dist/`, so these source fixes take effect on the next build/release.