### PR TITLE
fix(compaction): prioritize reasoning trace eviction over user messages on overflow

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the verbatim compaction critical-overflow recovery prompt to evict in an explicit priority order when context still exceeds the token budget after compaction: removable reasoning traces are evicted first, then removable user/custom/summary context. Existing safety/retention rules (recent entries, unresolved errors, failed commands, and at least one task-bearing entry) are preserved ([#1308](https://github.com/bastani-inc/atomic/issues/1308)).
+
 ## [0.8.28-alpha.1] - 2026-06-08
 
 ### Changed

--- a/packages/coding-agent/src/core/compaction/context-compaction.ts
+++ b/packages/coding-agent/src/core/compaction/context-compaction.ts
@@ -1856,7 +1856,7 @@ function contextCompactionTranscriptManifest(transcript: CompactableTranscript, 
 
 function contextCompactionModePrompt(mode: ContextCompactionMode): string {
 	if (mode === "critical_overflow") {
-		return `\n<critical-overflow-mode>\nThe previous model request overflowed its context window. This is a critical LRU-style compaction pass. First delete stale unprotected context. If that is not enough, you may also delete the earliest protected entries or protected content shown in the manifest, especially old user/custom/summary context, while preserving recent entries, unresolved errors, failed commands, and enough task-bearing context for the assistant to continue.\n</critical-overflow-mode>`;
+		return `\n<critical-overflow-mode>\nThe previous model request overflowed its context window. This is a critical LRU-style compaction pass. First delete stale unprotected context. If that is not enough, you may also delete the earliest protected entries or protected content shown in the manifest. Evict in priority order: remove old reasoning traces first, then old user/custom/summary context, while preserving recent entries, unresolved errors, failed commands, and enough task-bearing context for the assistant to continue.\n</critical-overflow-mode>`;
 	}
 	return `\n<standard-mode>\nDo not delete entries or content blocks marked protected. Protected context is only eligible during critical overflow recovery, not during standard compaction.\n</standard-mode>`;
 }

--- a/packages/coding-agent/test/context-compaction-deletion-tool.test.ts
+++ b/packages/coding-agent/test/context-compaction-deletion-tool.test.ts
@@ -308,6 +308,9 @@ describe("context compaction deletion tools", () => {
 		expect(prompt).toContain("Do not delete entries or content blocks marked protected");
 		expect(overflowPrompt).toContain("critical LRU-style compaction pass");
 		expect(overflowPrompt).toContain("earliest protected entries");
+		// Overflow eviction must prioritize reasoning traces before user/custom/summary context (#1308).
+		expect(overflowPrompt).toContain("reasoning traces first");
+		expect(overflowPrompt.indexOf("reasoning traces")).toBeLessThan(overflowPrompt.indexOf("user/custom/summary context"));
 		expect(prompt.length).toBeLessThan(80_000);
 		expect(prompt).not.toContain("SENTINEL_FULL_TEXT_119");
 		expect(prompt).not.toContain("x".repeat(1000));


### PR DESCRIPTION
## Summary

Fixes a compaction priority bug where reasoning traces could be retained during critical-overflow LRU eviction while more important user/custom/summary context was removed. The `critical_overflow` prompt now explicitly orders eviction: reasoning traces first, then user/custom/summary context.

## Changes

- `packages/coding-agent/src/core/compaction/context-compaction.ts` — rewrites the `contextCompactionModePrompt("critical_overflow")` return value to declare an explicit eviction priority order: reasoning traces before user/custom/summary context. All existing safety/retention rules (recent entries, unresolved errors, failed commands, at least one task-bearing entry) are unchanged.
- `packages/coding-agent/test/context-compaction-deletion-tool.test.ts` — adds two assertions: the overflow prompt contains `"reasoning traces first"`, and the phrase `"reasoning traces"` appears before `"user/custom/summary context"` in the prompt string.
- `packages/coding-agent/CHANGELOG.md` — documents the change under `[Unreleased] > Changed`.

## Why `fix` over `feat`

The overflow eviction path already existed; this corrects its priority ordering rather than introducing new behavior, making `fix` the more accurate type.

## Testing

- `bun test packages/coding-agent/test/context-compaction-deletion-tool.test.ts` — 24 pass
- `bun test packages/coding-agent/test/context-compaction.test.ts packages/coding-agent/test/compaction-extensions-example.test.ts` — 26 pass
- `bun run typecheck` — clean
- `bun run lint` / `bun run test:unit` — pass

Closes #1308.