### PR TITLE
chore(release): prepare 0.8.28-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,16 +2,13 @@
 
 ## [Unreleased]
 
-### Changed
-
-- Changed the verbatim compaction critical-overflow recovery prompt to evict in an explicit priority order when context still exceeds the token budget after compaction: removable reasoning traces are evicted first, then removable user/custom/summary context. Existing safety/retention rules (recent entries, unresolved errors, failed commands, and at least one task-bearing entry) are preserved ([#1308](https://github.com/bastani-inc/atomic/issues/1308)).
-
-## [0.8.28-alpha.1] - 2026-06-08
+## [0.8.28-alpha.1] - 2026-06-09
 
 ### Changed
 
 - Changed Atomic compaction to be verbatim-only across manual `/compact`, automatic threshold/overflow compaction, SDK/RPC compaction, and extension-triggered compaction. All compaction now records validated `context_compaction` deletion targets and rebuilds active context with retained transcript content verbatim and unchanged. Retained file paths, exact commands, error strings, and line numbers are never paraphrased or rewritten.
 - Changed compaction extension hooks (`session_before_compact`, `session_compact`) to receive verbatim context-compaction preparations/results and allow cancellation or locally validated deletion requests instead of custom generated summaries. The before-compact hook now yields `ContextCompactionPreparation` and accepts `{ cancel: true }` or `{ deletionRequest }` returns; the after-compact hook now receives `ContextCompactionResult` and `contextCompactionEntry`.
+- Changed the verbatim compaction critical-overflow recovery prompt to evict in an explicit priority order when context still exceeds the token budget after compaction: removable reasoning traces are evicted first, then removable user/custom/summary context. Existing safety/retention rules (recent entries, unresolved errors, failed commands, and at least one task-bearing entry) are preserved ([#1308](https://github.com/bastani-inc/atomic/issues/1308)).
 
 ### Fixed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [0.8.28-alpha.1] - 2026-06-08
+## [0.8.28-alpha.1] - 2026-06-09
 
 ### Added
 


### PR DESCRIPTION
## Summary

Finalizes changelog entries for the **0.8.28-alpha.1** prerelease across `coding-agent` and `workflows` packages.

## Key Changes

- **`packages/coding-agent/CHANGELOG.md`**: Moves the verbatim-compaction critical-overflow reasoning-trace eviction change (#1308) from `[Unreleased]` into the `[0.8.28-alpha.1]` section, since that code ships in this prerelease. Corrects the release date to 2026-06-09.
- **`packages/workflows/CHANGELOG.md`**: Corrects the `[0.8.28-alpha.1]` release date to 2026-06-09.

## Notes

- Changelog-only changes; no source, config, or lockfile modifications.
- Package versions were already bumped to `0.8.28-alpha.1` in #1313 but no tag was cut; this PR completes the release notes so the published prerelease is accurate.
- The bundled `intercom`, `mcp`, `subagents`, and `web-access` extensions carry no functional changes since `0.8.27` (version-bump only) and receive no new changelog sections.
- After merge, the `0.8.28-alpha.1` tag will be pushed to trigger the Publish workflow (`@bastani/atomic`).