### PR TITLE
fix(workflows): separate paused runs from active count; render distinctly

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed paused workflow runs being counted as running and displayed as pending/running in `/workflow status` and `/workflow status <id>`, with paused runs now shown separately as `❚❚ paused` ([#1283](https://github.com/bastani-inc/atomic/issues/1283)).
+
 ## [0.8.28-alpha.1] - 2026-06-09
 
 ### Added

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed paused workflow run detail cards to surface the natural `workflow resume` action hint while preserving the interrupt hint for non-paused active runs ([#1283](https://github.com/bastani-inc/atomic/issues/1283)).
 - Fixed paused workflow runs being counted as running and displayed as pending/running in `/workflow status` and `/workflow status <id>`, with paused runs now shown separately as `❚❚ paused` ([#1283](https://github.com/bastani-inc/atomic/issues/1283)).
 
 ## [0.8.28-alpha.1] - 2026-06-09

--- a/packages/workflows/src/tui/chat-surface.ts
+++ b/packages/workflows/src/tui/chat-surface.ts
@@ -461,33 +461,27 @@ export function progressStrip(
   budget: number,
   theme?: GraphTheme,
 ): string {
-  const CELL_WIDTH = 3;
   const usable = Math.max(0, Math.floor(budget));
-  const maxCells = Math.max(0, Math.floor(usable / CELL_WIDTH));
-  if (maxCells === 0 || cells.length === 0) return "";
+  if (usable < 3 || cells.length === 0) return "";
 
-  const truncated = cells.length > maxCells;
-  // Reserve 1 cell of width for the trailing ellipsis if truncating, so the
-  // rendered output still fits.
-  const visibleCount = truncated
-    ? Math.max(0, Math.floor((usable - 1) / CELL_WIDTH))
-    : cells.length;
-  const slice = cells.slice(0, visibleCount);
+  const ellipsisWidth = visibleWidth(ELLIPSIS);
+  const out: string[] = [];
+  let used = 0;
 
-  let out = "";
-  if (theme) {
-    for (const cell of slice) {
-      out += renderCellThemed(cell.status, theme);
-    }
-  } else {
-    for (const cell of slice) {
-      out += renderCellPlain(cell.status);
-    }
+  for (let i = 0; i < cells.length; i++) {
+    const rendered = theme ? renderCellThemed(cells[i]!.status, theme) : renderCellPlain(cells[i]!.status);
+    const renderedWidth = visibleWidth(rendered);
+    const isLast = i === cells.length - 1;
+    const reserved = isLast ? 0 : ellipsisWidth;
+    if (used + renderedWidth + reserved > usable) break;
+    out.push(rendered);
+    used += renderedWidth;
+    if (isLast) return out.join("");
   }
-  if (truncated) {
-    out += theme ? `${hexToAnsi(theme.dim)}${ELLIPSIS}${RESET}` : ELLIPSIS;
-  }
-  return out;
+
+  if (out.length === 0 && ellipsisWidth > usable) return "";
+  const suffix = theme ? `${hexToAnsi(theme.dim)}${ELLIPSIS}${RESET}` : ELLIPSIS;
+  return `${out.join("")}${suffix}`;
 }
 
 function renderCellThemed(status: StageStatus, theme: GraphTheme): string {
@@ -506,6 +500,7 @@ function stageGlyph(status: StageStatus): string {
   switch (status) {
     case "completed": return "✓";
     case "running":   return "●";
+    case "paused":    return "❚❚";
     case "failed":    return "✗";
     case "awaiting_input": return "？";
     case "skipped":   return "⊘";
@@ -518,6 +513,7 @@ function stageColor(status: StageStatus, theme: GraphTheme): string {
   switch (status) {
     case "completed": return hexToAnsi(theme.success);
     case "running":   return hexToAnsi(theme.warning);
+    case "paused":    return hexToAnsi(theme.warning);
     case "failed":    return hexToAnsi(theme.error);
     case "awaiting_input": return hexToAnsi(theme.info);
     case "skipped":   return hexToAnsi(theme.dim);

--- a/packages/workflows/src/tui/chat-surface.ts
+++ b/packages/workflows/src/tui/chat-surface.ts
@@ -11,9 +11,11 @@
  *    left, a `surface0` tag carrying the runId / workflow name, a
  *    bolded title beside it, and one optional second row indented past
  *    the stripe.
- *  - **Progress strip**: bracketed `[✓]` / `[●]` / `[○]` / `[✗]` cells,
- *    coloured by stage status. Truncates with a trailing `…` when the
- *    rendered cells exceed the available budget.
+ *  - **Progress strip**: bracketed status cells such as `[✓]`, `[●]`,
+ *    `[○]`, `[✗]`, and `[❚❚]`, coloured by stage status. Cells are
+ *    measured by visible width per rendered glyph rather than assumed to
+ *    be a fixed 3 columns, and the strip truncates with a trailing `…`
+ *    when the rendered cells exceed the available budget.
  *  - **Hint rows**: a single grammar — `▸ /slash command  verb-phrase
  *    hint`.
  *
@@ -440,7 +442,7 @@ function renderTaggedCardPlain(opts: RenderTaggedCardOpts, width: number): strin
 }
 
 // ---------------------------------------------------------------------------
-// Progress strip — `[✓][●][○][✗]` cells, coloured by stage status
+// Progress strip — variable-width bracketed cells, coloured by stage status
 // ---------------------------------------------------------------------------
 
 export interface ProgressCell {
@@ -449,12 +451,13 @@ export interface ProgressCell {
 
 /**
  * Render a progress strip whose visible width is at most `budget` cells.
- * Each cell renders as a 3-character bracket-glyph-bracket sequence
- * (`[✓]`). When the strip would exceed the budget, the rendered output
- * is truncated and a trailing `…` is appended.
+ * Each cell renders as a bracketed status glyph whose visible width can
+ * vary by status (`[✓]` is 3 cells, `[❚❚]` is 4 cells). Truncation uses
+ * the measured width of each rendered cell and appends a trailing `…`
+ * when the next whole cell would exceed the budget.
  *
  * Themed mode colours the glyphs by status; plain mode emits the same
- * ASCII shape so logs remain readable.
+ * bracketed shape so logs remain readable.
  */
 export function progressStrip(
   cells: readonly ProgressCell[],

--- a/packages/workflows/src/tui/run-detail.ts
+++ b/packages/workflows/src/tui/run-detail.ts
@@ -295,6 +295,8 @@ function stateBadges(detail: RunDetail, theme: GraphTheme): FlatBandBadge[] {
   switch (detail.status) {
     case "running":
       return [{ text: "● running", fg: theme.warning }];
+    case "paused":
+      return [{ text: "❚❚ paused", fg: theme.warning }];
     case "completed":
       return [{ text: "✓ completed", fg: theme.success }];
     case "failed":
@@ -310,6 +312,7 @@ function stateBadges(detail: RunDetail, theme: GraphTheme): FlatBandBadge[] {
 function stateLabel(detail: RunDetail): string {
   switch (detail.status) {
     case "running": return "● running";
+    case "paused": return "❚❚ paused";
     case "completed": return "✓ completed";
     case "failed": return "✗ failed";
     case "killed": return "⊘ killed";

--- a/packages/workflows/src/tui/run-detail.ts
+++ b/packages/workflows/src/tui/run-detail.ts
@@ -90,7 +90,10 @@ function renderPlain(detail: RunDetail, now: number, width: number): string {
   }
 
   if (detail.endedAt === undefined) {
-    out.push(truncateToWidth(` ▸ workflow interrupt   id=${sid}    cancel `, width - 2, "…"));
+    const hint = detail.status === "paused"
+      ? ` ▸ workflow resume id=${sid}    continue workflow `
+      : ` ▸ workflow interrupt   id=${sid}    cancel `;
+    out.push(truncateToWidth(hint, width - 2, "…"));
   } else {
     out.push(truncateToWidth(` ▸ workflow resume id=${sid}    reopen graph `, width - 2, "…"));
   }
@@ -143,9 +146,10 @@ function renderThemed(detail: RunDetail, now: number, theme: GraphTheme, width: 
   }
 
   if (detail.endedAt === undefined) {
-    out.push(
-      truncateToWidth(` ${dim}▸${RESET} ${accent}workflow interrupt   id=${sid}${RESET}${dim}    cancel${RESET} `, width - 2, "…"),
-    );
+    const hint = detail.status === "paused"
+      ? ` ${dim}▸${RESET} ${accent}workflow resume id=${sid}${RESET}${dim}    continue workflow${RESET} `
+      : ` ${dim}▸${RESET} ${accent}workflow interrupt   id=${sid}${RESET}${dim}    cancel${RESET} `;
+    out.push(truncateToWidth(hint, width - 2, "…"));
   } else {
     out.push(
       truncateToWidth(` ${dim}▸${RESET} ${accent}workflow resume id=${sid}${RESET}${dim}    reopen graph${RESET} `, width - 2, "…"),

--- a/packages/workflows/src/tui/status-list.ts
+++ b/packages/workflows/src/tui/status-list.ts
@@ -160,6 +160,7 @@ function runAccent(run: RunSnapshot, theme?: GraphTheme): string {
   switch (run.status) {
     case "completed": return theme.success;
     case "running":   return theme.warning;
+    case "paused":    return theme.warning;
     case "failed":    return theme.error;
     case "killed":    return theme.error;
     case "pending":
@@ -171,6 +172,7 @@ function runTrailing(run: RunSnapshot, theme?: GraphTheme): { text: string; fg?:
   switch (run.status) {
     case "completed": return { text: "✓ completed", fg: theme?.success };
     case "running":   return { text: "● running", fg: theme?.warning };
+    case "paused":    return { text: "❚❚ paused", fg: theme?.warning };
     case "failed":    return { text: "✗ failed", fg: theme?.error };
     case "killed":    return { text: "⊘ killed", fg: theme?.error };
     case "pending":
@@ -181,6 +183,7 @@ function runTrailing(run: RunSnapshot, theme?: GraphTheme): { text: string; fg?:
 function runCardMeta(run: RunSnapshot, now: number): string {
   // Builds the right-aligned meta tail.
   //   running  → `3/8 · review-a · 1m42s`
+  //   paused   → `3/8 · review-a · 1m42s` (elapsed is frozen by pausedAt)
   //   failed   → `failed at partition · 4m24s ago`
   //   killed   → `<stage> · <duration> · <when>` (mirrors mockup §2)
   //   completed→ `<stage> · <duration> · <when>`
@@ -199,6 +202,14 @@ function runCardMeta(run: RunSnapshot, now: number): string {
   if (run.status === "running") {
     if (isChain) parts.push(`${done}/${total}`);
     const labels = runningStageLabels(run);
+    if (labels) parts.push(labels);
+    if (ago) parts.push(ago);
+    return parts.join(" · ");
+  }
+
+  if (run.status === "paused") {
+    if (isChain) parts.push(`${done}/${total}`);
+    const labels = pausedStageLabels(run);
     if (labels) parts.push(labels);
     if (ago) parts.push(ago);
     return parts.join(" · ");
@@ -235,6 +246,13 @@ function runningStageLabels(run: RunSnapshot): string | undefined {
   return truncateToWidth(joined, STAGE_LABEL_BUDGET, ELLIPSIS);
 }
 
+function pausedStageLabels(run: RunSnapshot): string | undefined {
+  const paused = run.stages.filter((s) => s.status === "paused").map((s) => s.name);
+  if (paused.length === 0) return undefined;
+  const joined = paused.join(", ");
+  return truncateToWidth(joined, STAGE_LABEL_BUDGET, ELLIPSIS);
+}
+
 function lastStageDuration(run: RunSnapshot, now: number): string | undefined {
   // Pick a representative stage duration: the most-recent terminal stage,
   // or the running stage if everything's still in flight.
@@ -263,6 +281,7 @@ function stageStatusFromRun(run: RunSnapshot): StageStatus {
   switch (run.status) {
     case "completed": return "completed";
     case "running":   return "running";
+    case "paused":    return "paused";
     case "failed":    return "failed";
     case "killed":    return "failed";
     case "pending":
@@ -285,17 +304,21 @@ function effectiveWidth(width?: number): number {
 
 interface Counts {
   active: number;
+  paused: number;
   completed: number;
   failed: number;
   pending: number;
 }
 
 function countBuckets(runs: readonly RunSnapshot[]): Counts {
-  const c: Counts = { active: 0, completed: 0, failed: 0, pending: 0 };
+  const c: Counts = { active: 0, paused: 0, completed: 0, failed: 0, pending: 0 };
   for (const r of runs) {
     if (r.endedAt === undefined) {
       if (r.status === "pending") c.pending++;
-      else c.active++;
+      else if (r.status === "paused") c.paused++;
+      else if (r.status === "running") c.active++;
+      else if (r.status === "completed") c.completed++;
+      else c.failed++;
     } else if (r.status === "completed") c.completed++;
     else c.failed++;
   }
@@ -306,6 +329,7 @@ function themedBadges(c: Counts, theme: GraphTheme): FlatBandBadge[] {
   const out: FlatBandBadge[] = [];
   if (c.completed > 0) out.push({ text: `✓ ${c.completed}`, fg: theme.success });
   if (c.active > 0) out.push({ text: `● ${c.active}`, fg: theme.warning });
+  if (c.paused > 0) out.push({ text: `❚❚ ${c.paused} paused`, fg: theme.warning });
   if (c.pending > 0) out.push({ text: `○ ${c.pending}`, fg: theme.dim });
   if (c.failed > 0) out.push({ text: `⊘ ${c.failed}`, fg: theme.error });
   return out;
@@ -315,6 +339,7 @@ function plainBadges(c: Counts): FlatBandBadge[] {
   const out: FlatBandBadge[] = [];
   if (c.completed > 0) out.push({ text: `✓ ${c.completed}` });
   if (c.active > 0) out.push({ text: `● ${c.active}` });
+  if (c.paused > 0) out.push({ text: `❚❚ ${c.paused} paused` });
   if (c.pending > 0) out.push({ text: `○ ${c.pending}` });
   if (c.failed > 0) out.push({ text: `⊘ ${c.failed}` });
   return out;
@@ -344,6 +369,7 @@ function statusIconForRun(run: RunSnapshot): string {
   switch (run.status) {
     case "completed": return "✓";
     case "running": return "●";
+    case "paused": return "❚❚";
     case "failed": return "✗";
     case "killed": return "⊘";
     case "pending":

--- a/packages/workflows/src/tui/status-list.ts
+++ b/packages/workflows/src/tui/status-list.ts
@@ -329,6 +329,8 @@ function themedBadges(c: Counts, theme: GraphTheme): FlatBandBadge[] {
   const out: FlatBandBadge[] = [];
   if (c.completed > 0) out.push({ text: `✓ ${c.completed}`, fg: theme.success });
   if (c.active > 0) out.push({ text: `● ${c.active}`, fg: theme.warning });
+  // Keep the word label: the pause glyph is less familiar than the other
+  // status glyphs, so this intentional asymmetry improves scanability.
   if (c.paused > 0) out.push({ text: `❚❚ ${c.paused} paused`, fg: theme.warning });
   if (c.pending > 0) out.push({ text: `○ ${c.pending}`, fg: theme.dim });
   if (c.failed > 0) out.push({ text: `⊘ ${c.failed}`, fg: theme.error });
@@ -339,6 +341,8 @@ function plainBadges(c: Counts): FlatBandBadge[] {
   const out: FlatBandBadge[] = [];
   if (c.completed > 0) out.push({ text: `✓ ${c.completed}` });
   if (c.active > 0) out.push({ text: `● ${c.active}` });
+  // Keep the word label: the pause glyph is less familiar than the other
+  // status glyphs, so this intentional asymmetry improves scanability.
   if (c.paused > 0) out.push({ text: `❚❚ ${c.paused} paused` });
   if (c.pending > 0) out.push({ text: `○ ${c.pending}` });
   if (c.failed > 0) out.push({ text: `⊘ ${c.failed}` });

--- a/test/unit/run-detail-render.test.ts
+++ b/test/unit/run-detail-render.test.ts
@@ -37,6 +37,9 @@ function makeRun(over: Partial<RunSnapshot> = {}): RunSnapshot {
     startedAt: over.startedAt ?? 1000,
     endedAt: over.endedAt,
     durationMs: over.durationMs,
+    pausedDurationMs: over.pausedDurationMs,
+    pausedAt: over.pausedAt,
+    resumedAt: over.resumedAt,
     result: over.result,
     error: over.error,
   };
@@ -51,6 +54,9 @@ function detailFromRun(run: RunSnapshot): RunDetail {
     startedAt: run.startedAt,
     endedAt: run.endedAt,
     durationMs: run.durationMs,
+    pausedDurationMs: run.pausedDurationMs,
+    pausedAt: run.pausedAt,
+    resumedAt: run.resumedAt,
     inputs: run.inputs,
     stages: run.stages,
     result: run.result,
@@ -144,6 +150,27 @@ describe("renderRunDetail — themed", () => {
     assert.doesNotMatch(plain, /workflow resume/);
     // Pill label uses the short id too.
     assert.match(plain, /RUN abc123/);
+  });
+
+  test("paused run renders paused badges and summary state instead of pending", () => {
+    const now = 1_000_000;
+    const detail = detailFromRun(makeRun({
+      id: "pause123uuid",
+      name: "ralph",
+      status: "paused",
+      startedAt: now - 10_000,
+      pausedAt: now - 6_000,
+      stages: [makeStage("p1", "review", "paused", { startedAt: now - 10_000, pausedAt: now - 6_000 })],
+    }));
+
+    const out = renderRunDetail(detail, { theme: deriveGraphTheme({}), now, width: 100 });
+    const plain = stripAnsi(out);
+
+    assert.match(plain, /RUN pause1/);
+    assert.match(plain, /ralph/);
+    assert.match(plain, /❚❚ paused/);
+    assert.match(plain, /state\s+❚❚ paused/);
+    assert.doesNotMatch(plain, /○ pending/);
   });
 
   test("ended run swaps the action hint to resume and reports duration", () => {

--- a/test/unit/run-detail-render.test.ts
+++ b/test/unit/run-detail-render.test.ts
@@ -152,7 +152,7 @@ describe("renderRunDetail — themed", () => {
     assert.match(plain, /RUN abc123/);
   });
 
-  test("paused run renders paused badges and summary state instead of pending", () => {
+  test("paused run renders paused badges, summary state, and resume hint", () => {
     const now = 1_000_000;
     const detail = detailFromRun(makeRun({
       id: "pause123uuid",
@@ -170,6 +170,9 @@ describe("renderRunDetail — themed", () => {
     assert.match(plain, /ralph/);
     assert.match(plain, /❚❚ paused/);
     assert.match(plain, /state\s+❚❚ paused/);
+    assert.match(plain, /workflow resume\s+id=pause1/);
+    assert.match(plain, /continue workflow/);
+    assert.doesNotMatch(plain, /workflow interrupt/);
     assert.doesNotMatch(plain, /○ pending/);
   });
 

--- a/test/unit/status-list-render.test.ts
+++ b/test/unit/status-list-render.test.ts
@@ -49,6 +49,9 @@ function makeRun(over: Partial<RunSnapshot>): RunSnapshot {
     startedAt: over.startedAt ?? Date.now() - 5000,
     endedAt: over.endedAt,
     durationMs: over.durationMs,
+    pausedDurationMs: over.pausedDurationMs,
+    pausedAt: over.pausedAt,
+    resumedAt: over.resumedAt,
     result: over.result,
     error: over.error,
   };
@@ -125,6 +128,67 @@ describe("renderStatusList — populated", () => {
     // Trailing hint references the most-recently-active run (def456, 42s ago).
     assert.match(plain, /▸ \/workflow status def456/);
     assert.match(plain, /drill into a run/);
+  });
+
+  test("mixed running and paused snapshot keeps paused runs out of running counts and labels their rows", () => {
+    const now = 1_000_000;
+    const runs: RunSnapshot[] = [
+      makeRun({
+        id: "run111uuid",
+        name: "active-wf",
+        status: "running",
+        startedAt: now - 4_000,
+        stages: [makeStage("r1", "worker", "running", { startedAt: now - 4_000 })],
+      }),
+      makeRun({
+        id: "pause222uuid",
+        name: "paused-wf",
+        status: "paused",
+        startedAt: now - 10_000,
+        pausedAt: now - 6_000,
+        stages: [makeStage("p1", "review", "paused", { startedAt: now - 10_000, pausedAt: now - 6_000 })],
+      }),
+    ];
+
+    const out = renderStatusList(runs, { theme: deriveGraphTheme({}), now, width: 120, showDetailHint: false });
+    const plain = stripAnsi(out);
+
+    assert.match(plain, /╭ BACKGROUND  2 runs /);
+    assert.match(plain, /● 1/, "only the running run contributes to the running count");
+    assert.doesNotMatch(plain, /● 2/, "paused run must not be counted as running");
+    assert.match(plain, /❚❚ 1 paused/, "paused count is rendered separately");
+
+    const runningRow = plain.split("\n").find((line) => line.includes("active-wf"));
+    assert.ok(runningRow, "running run row is present");
+    assert.match(runningRow, /● running/);
+
+    const pausedRow = plain.split("\n").find((line) => line.includes("paused-wf"));
+    assert.ok(pausedRow, "paused run row is present");
+    assert.match(pausedRow, /❚❚\s+pause2\s+paused-wf\s+❚❚ paused/);
+    assert.doesNotMatch(pausedRow, /○ pending/);
+    assert.doesNotMatch(pausedRow, /● running/);
+  });
+
+  test("plain paused status output is ANSI-free and uses paused glyph and label", () => {
+    const now = 1_000_000;
+    const run = makeRun({
+      id: "pause333uuid",
+      name: "paused-plain",
+      status: "paused",
+      startedAt: now - 10_000,
+      pausedAt: now - 6_000,
+      stages: [makeStage("p1", "worker", "paused", { startedAt: now - 10_000, pausedAt: now - 6_000 })],
+    });
+
+    const out = renderStatusList([run], { width: 100, now, showDetailHint: false });
+
+    assert.doesNotMatch(out, /\x1b\[/);
+    assert.match(out, /^╭ BACKGROUND  1 run /);
+    assert.match(out, /❚❚ 1 paused/);
+    assert.match(out, /❚❚\s+pause3\s+paused-plain\s+❚❚ paused/);
+    assert.match(out, /single\s+\[❚❚\]/, "paused progress cell uses the paused glyph, not the pending cell");
+    assert.doesNotMatch(out, /○ pending/);
+    assert.doesNotMatch(out, /● 1(?:\s+running)?/);
   });
 
   test("active runs sort ahead of ended runs", () => {


### PR DESCRIPTION
## Summary

Paused workflow runs were incorrectly counted as active/running in \`/workflow status\` because the bucket logic treated every non-terminal, non-pending run as active. This fix separates paused runs into their own count bucket, adds explicit \`❚❚ paused\` rendering throughout the status UI, and corrects the action hint in run detail cards to show \`workflow resume\` instead of \`workflow interrupt\` for paused runs.

## Root Cause

\`status-list.ts\` bucketed every non-ended, non-pending run as active. Paused runs are intentionally non-terminal (resumable, \`endedAt === undefined\`), so they fell into the active bucket. Several renderers also lacked explicit \`paused\` cases, causing them to fall through to pending/running display logic.

## Key Changes

- **`status-list.ts`**: Adds a dedicated `paused` bucket in `countBuckets` so paused runs no longer inflate the running count; emits a separate `❚❚ N paused` badge in both themed and plain output; adds `paused` cases to `runAccent`, `runTrailing`, `stageStatusFromRun`, and `statusIconForRun`; adds `pausedStageLabels` helper and a `paused` branch in `runCardMeta`
- **`run-detail.ts`**: Adds explicit `paused` cases to `stateBadges` and `stateLabel` so `/workflow status <id>` renders `❚❚ paused`; fixes the action hint to show `workflow resume … continue workflow` for paused runs rather than `workflow interrupt … cancel`
- **`chat-surface.ts`**: Rewrites `progressStrip` to measure each cell's rendered width with `visibleWidth` rather than assuming a fixed 3-char cell, so the wider `❚❚` glyph doesn't overflow the budget; adds `paused` to `stageGlyph` and `stageColor`
- **Tests**: Adds focused unit coverage in `test/unit/status-list-render.test.ts` and `test/unit/run-detail-render.test.ts` verifying count separation, row labelling, ANSI-free plain output, and that paused runs never show as pending or running
- **Changelog**: Adds a `### Fixed` entry for [#1283](https://github.com/bastani-inc/atomic/issues/1283) under `[Unreleased]`

## Validation

```sh
git diff --check origin/main
AGENT=1 bun run typecheck
AGENT=1 bun test test/unit/status-list-render.test.ts test/unit/run-detail-render.test.ts
bun run lint       # pre-commit hook
bun run test:unit  # pre-push hook
```

Fixes #1283