### PR TITLE
fix(deps): bump shell-quote to 1.8.4 to resolve critical advisory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- Bumped the transitive `shell-quote` dependency from `1.8.3` to `1.8.4` in the `examples/extensions/sandbox` lockfile, resolving the critical advisory [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (`shell-quote` `quote()` does not escape newlines in object `.op` values). The bump stays within `@anthropic-ai/sandbox-runtime`'s existing `^1.8.3` range.
+
 ### Added
 
 - Added upstream pi 0.76.0-0.79.1 coding-agent compatibility exports for package asset path helpers (`getPackageDir`, bundled asset/documentation/example paths), CLI argument parsing (`Args`, `parseArgs`), `SettingsManagerCreateOptions`, image conversion (`convertToPng`), and RPC extension UI request/response types so extensions can reference the same public APIs as upstream while retaining Atomic package identity.

--- a/packages/coding-agent/examples/extensions/sandbox/package-lock.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package-lock.json
@@ -68,9 +68,9 @@
       "license": "MIT"
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Summary

Resolves the open **critical** Dependabot alert ([#3](https://github.com/bastani-inc/atomic/security/dependabot/3)) by bumping the transitive `shell-quote` dependency from `1.8.3` to `1.8.4` in the sandbox example's npm lockfile.

- **Advisory:** [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — `shell-quote` `quote()` does not escape newlines in object `.op` values, enabling potential shell injection
- **Vulnerable range:** `>= 1.1.0, <= 1.8.3`
- **First patched version:** `1.8.4`

## Changes

- Updated `node_modules/shell-quote` entry in `packages/coding-agent/examples/extensions/sandbox/package-lock.json` to `1.8.4` (version, resolved tarball URL, and sha512 integrity hash taken directly from the npm registry)
- Added a `### Security` entry to the coding-agent `CHANGELOG.md` under `[Unreleased]`

## Notes

- `shell-quote` is pulled in transitively by `@anthropic-ai/sandbox-runtime` via its `^1.8.3` semver range, which already permits `1.8.4` — only the locked entry needed updating; the direct dependency declaration is unchanged
- No runtime behavior changes; this is a pure lockfile pin update

🤖 Generated with [Claude Code](https://claude.com/claude-code)