### PR TITLE
chore(release): prepare 0.8.28-alpha.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.28-alpha.1",
+      "version": "0.8.28-alpha.2",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.28-alpha.1",
+      "version": "0.8.28-alpha.2",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.28-alpha.1",
+      "version": "0.8.28-alpha.2",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.28-alpha.1",
+      "version": "0.8.28-alpha.2",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.28-alpha.1",
+      "version": "0.8.28-alpha.2",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.28-alpha.1",
+      "version": "0.8.28-alpha.2",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.28-alpha.2] - 2026-06-10
+
 ### Security
 
 - Bumped the transitive `shell-quote` dependency from `1.8.3` to `1.8.4` in the `examples/extensions/sandbox` lockfile, resolving the critical advisory [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (`shell-quote` `quote()` does not escape newlines in object `.op` values). The bump stays within `@anthropic-ai/sandbox-runtime`'s existing `^1.8.3` range.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.28-alpha.1",
+  "version": "0.8.28-alpha.2",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.28-alpha.1",
+  "version": "0.8.28-alpha.2",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.28-alpha.1",
+  "version": "0.8.28-alpha.2",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.28-alpha.1",
+  "version": "0.8.28-alpha.2",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.28-alpha.1",
+  "version": "0.8.28-alpha.2",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.28-alpha.2] - 2026-06-10
+
 ### Fixed
 
 - Fixed the builtin `open-claude-design` workflow not installing the browser skill's `browse` CLI before it is needed. The workflow now runs an initial deterministic, best-effort setup step that probes `PATH` (`which`/`where browse`) and installs the CLI with `npm install -g browse` when missing (skipped under automated tests); per-run bootstrap guidance is derived from the outcome and injected into every browser-using stage (assume-available when ensured, with concrete recovery steps surfaced when the install failed), the install outcome is exposed via a new `browse_cli_status` output, and the read-only `read`/`grep`/`ls` tools are granted to the refinement and pre-export decision gates so they can inspect `preview.html` without mutating it. The step never throws or blocks the run, so stages keep their graceful-degradation fallback ([#1327](https://github.com/bastani-inc/atomic/issues/1327)).

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.28-alpha.1",
+  "version": "0.8.28-alpha.2",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Finalizes the `0.8.28-alpha.2` prerelease by bumping every workspace package from `0.8.28-alpha.1` to `0.8.28-alpha.2`, dating the accumulated `[Unreleased]` changelog entries in `coding-agent` and `workflows`, and refreshing `bun.lock`.

## Changes in this PR

- **Version bump** — all six workspace packages (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`) set to `0.8.28-alpha.2`
- **Changelogs** — added `## [0.8.28-alpha.2] - 2026-06-10` section header in `packages/coding-agent/CHANGELOG.md` and `packages/workflows/CHANGELOG.md`
- **Lockfile** — `bun.lock` refreshed to reflect the version bumps

## Changes since 0.8.28-alpha.1

**coding-agent**
- Security: bumped transitive `shell-quote` `1.8.3` → `1.8.4` in the sandbox example lockfile ([GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p)) (#1335)
- Synced upstream pi `0.76.0`–`0.79.1` (compat exports, project-trust selector UI/store, ported example extensions, security/containerization docs, prompt-template defaults, provider attribution rebranding, and broad regression coverage) (#1330)
- Fixed oversized tool-call results flooding context by persisting large results to disk with a compact preview (#1322/#1328)
- Fixed the Read tool to block text-file reads above 50,000 chars and return incremental-read guidance (#1323/#1326)

**workflows**
- Fixed builtin `open-claude-design` to ensure the browser skill's `browse` CLI is installed before use, exposed via a new `browse_cli_status` output (#1327/#1334)
- Fixed paused workflow runs being counted/rendered as running; paused runs now display distinctly with a `workflow resume` hint (#1283/#1325)

Bundled `intercom`, `mcp`, `subagents`, and `web-access` extensions carry no functional changes since `0.8.27`.

## Release

After merge, tag `0.8.28-alpha.2` and push to trigger the npm publish + GitHub Release workflow:

```sh
git tag 0.8.28-alpha.2 && git push origin 0.8.28-alpha.2
```