### PR TITLE
feat(ask-user-question): allow typed chat responses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added optional inline free-form text entry to the `ask_user_question` TUI's **Chat about this** footer row. Non-empty typed chat text now returns as a `kind: "chat"` answer and is surfaced to the agent without the legacy stop/wait termination envelope, while empty submissions keep the existing sentinel behavior.
+
 ## [0.8.28-alpha.2] - 2026-06-10
 
 ### Security

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/inline-input.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/inline-input.ts
@@ -1,0 +1,65 @@
+import { ROW_INTENT_META } from "./row-intent.ts";
+import type { InlineInputOwner, QuestionnaireState } from "./state.ts";
+
+/**
+ * Shared owner-branching accessors/mutator for the two per-owner inline-input
+ * map pairs on `QuestionnaireState`:
+ * - `"chat"`  → `chatDraftByTab` / `chatCaretByTab`
+ * - `"other"` → `customDraftByTab` / `customCaretByTab`
+ *
+ * Both the pure reducer (`state-reducer.ts`) and the runtime
+ * (`questionnaire-session.ts`) read and write these maps. Hoisting the helpers
+ * here keeps the `owner === "chat"` branch in exactly one place instead of
+ * copying it into each caller (previously `withInlineDraft` was duplicated
+ * verbatim and the accessor pairs were near-duplicates split across the two
+ * files).
+ */
+
+/** Raw draft text persisted for `owner` at the current tab, or undefined when none is stored. */
+export function readInlineDraft(state: QuestionnaireState, owner: InlineInputOwner): string | undefined {
+	return owner === "chat" ? state.chatDraftByTab.get(state.currentTab) : state.customDraftByTab.get(state.currentTab);
+}
+
+/** Raw caret offset persisted for `owner` at the current tab, or undefined when none is stored. */
+export function readInlineCaret(state: QuestionnaireState, owner: InlineInputOwner): number | undefined {
+	return owner === "chat" ? state.chatCaretByTab.get(state.currentTab) : state.customCaretByTab.get(state.currentTab);
+}
+
+/** Immutably persist `value`/`caret` into `owner`'s draft+caret maps for the current tab. */
+export function withInlineDraft(
+	state: QuestionnaireState,
+	owner: InlineInputOwner,
+	value: string,
+	caret: number,
+): QuestionnaireState {
+	if (owner === "chat") {
+		const chatDraftByTab = new Map(state.chatDraftByTab);
+		const chatCaretByTab = new Map(state.chatCaretByTab);
+		chatDraftByTab.set(state.currentTab, value);
+		chatCaretByTab.set(state.currentTab, caret);
+		return { ...state, chatDraftByTab, chatCaretByTab };
+	}
+	const customDraftByTab = new Map(state.customDraftByTab);
+	const customCaretByTab = new Map(state.customCaretByTab);
+	customDraftByTab.set(state.currentTab, value);
+	customCaretByTab.set(state.currentTab, caret);
+	return { ...state, customDraftByTab, customCaretByTab };
+}
+
+/**
+ * Draft text used to hydrate the inline editor when (re)focusing `owner`: the
+ * in-flight draft when present, otherwise the prior committed answer for that
+ * owner. The `"chat"` owner excludes the reserved sentinel label so a prior
+ * signal-only chat (`"Chat about this"`) does not re-hydrate as editable text.
+ */
+export function resolveInlineDraftValue(state: QuestionnaireState, owner: InlineInputOwner): string {
+	const draft = readInlineDraft(state, owner);
+	if (draft !== undefined) return draft;
+	const prior = state.answers.get(state.currentTab);
+	if (owner === "other") {
+		return prior?.kind === "custom" && typeof prior.answer === "string" ? prior.answer : "";
+	}
+	return prior?.kind === "chat" && typeof prior.answer === "string" && prior.answer !== ROW_INTENT_META.chat.label
+		? prior.answer
+		: "";
+}

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/key-router.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/key-router.ts
@@ -58,24 +58,30 @@ function computeAutoAdvanceTab(state: QuestionnaireState, runtime: Questionnaire
 	return runtime.questions.length;
 }
 
+function chatAnswerValue(state: QuestionnaireState, runtime: QuestionnaireRuntime, sentinelLabel: string): string {
+	if (state.inlineInputOwner !== "chat") return sentinelLabel;
+	return runtime.inputBuffer.trim().length > 0 ? runtime.inputBuffer : sentinelLabel;
+}
+
 function buildSingleSelectAnswer(state: QuestionnaireState, runtime: QuestionnaireRuntime): QuestionAnswer | null {
 	const q = runtime.questions[state.currentTab];
 	if (!q) return null;
 
 	// Chat sentinel takes priority over inputMode: when chatFocused=true, the host overrides
-	// currentItem() to return the chat sentinel even if inputMode is still true (e.g. user
-	// navigated from "Type something." and DOWN focused the chat row).
+	// currentItem() to return the chat sentinel even though inputMode is true for the shared
+	// inline editor. Non-blank chat drafts become the chat answer; blank drafts preserve the
+	// legacy sentinel-only "Chat about this" answer.
 	const item = runtime.currentItem;
 	if (item?.kind === "chat") {
 		return {
 			questionIndex: state.currentTab,
 			question: q.question,
 			kind: "chat",
-			answer: item.label,
+			answer: chatAnswerValue(state, runtime, item.label),
 		};
 	}
 
-	if (state.inputMode) {
+	if (state.inputMode && state.inlineInputOwner === "other") {
 		const label = runtime.inputBuffer;
 		return {
 			questionIndex: state.currentTab,
@@ -170,6 +176,13 @@ export function routeKey(data: string, state: QuestionnaireState, runtime: Quest
 		}
 		if (kb.matches(data, KEYBIND_DOWN)) {
 			return { kind: "focus_options", optionIndex: 0 };
+		}
+		if (
+			state.inputMode &&
+			state.inlineInputOwner === "chat" &&
+			(matchesKey(data, Key.left) || matchesKey(data, Key.right))
+		) {
+			return { kind: "ignore" };
 		}
 		const tab = tabSwitchAction(data, state, runtime);
 		if (tab) return tab;

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/key-router.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/key-router.ts
@@ -58,6 +58,14 @@ function computeAutoAdvanceTab(state: QuestionnaireState, runtime: Questionnaire
 	return runtime.questions.length;
 }
 
+/**
+ * Resolve the chat answer text at confirm time. Reads the LIVE `runtime.inputBuffer`
+ * rather than a persisted draft because confirm only reaches here while chat is the
+ * focused row and therefore owns the live inline editor (`inlineInputOwner === "chat"`),
+ * so the in-flight buffer is authoritative. The blank-vs-typed decision uses `trim()`,
+ * but the returned text is left UNTRIMMED to preserve the user's literal message; a
+ * blank/whitespace buffer falls back to the reserved sentinel label (signal-only chat).
+ */
 function chatAnswerValue(state: QuestionnaireState, runtime: QuestionnaireRuntime, sentinelLabel: string): string {
 	if (state.inlineInputOwner !== "chat") return sentinelLabel;
 	return runtime.inputBuffer.trim().length > 0 ? runtime.inputBuffer : sentinelLabel;
@@ -177,6 +185,13 @@ export function routeKey(data: string, state: QuestionnaireState, runtime: Quest
 		if (kb.matches(data, KEYBIND_DOWN)) {
 			return { kind: "focus_options", optionIndex: 0 };
 		}
+		// Left/Right guard is intentionally asymmetric — it exists for the chat owner but
+		// NOT the "other" inline editor. The chatFocused branch falls through to
+		// `tabSwitchAction` below, which in multi-question mode consumes Left/Right for tab
+		// switching; swallowing them here keeps Left/Right as in-editor caret movement for
+		// the chat input. The "other" inline editor flows through the separate
+		// `state.inputMode` branch (further down), which never calls `tabSwitchAction`, so it
+		// needs no equivalent guard. Do not "simplify" by unifying the two paths.
 		if (
 			state.inputMode &&
 			state.inlineInputOwner === "chat" &&

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts
@@ -7,7 +7,7 @@ import { buildQuestionnaire } from "./build-questionnaire.ts";
 import { ROW_INTENT_META } from "./row-intent.ts";
 import { type QuestionnaireAction, routeKey } from "./key-router.ts";
 import { computeFocusedOptionHasPreview } from "./selectors/derivations.ts";
-import type { QuestionnaireRuntime, QuestionnaireState } from "./state.ts";
+import type { InlineInputOwner, QuestionnaireRuntime, QuestionnaireState } from "./state.ts";
 import { type ApplyContext, type Effect, reduce } from "./state-reducer.ts";
 
 function readInputCursor(input: Input): number {
@@ -21,6 +21,34 @@ function readInputCursor(input: Input): number {
 function writeInputCursor(input: Input, cursor: number): void {
 	const value = input.getValue();
 	Reflect.set(input, "cursor", Math.max(0, Math.min(cursor, value.length)));
+}
+
+function inlineDraftAt(state: QuestionnaireState, owner: InlineInputOwner): string | undefined {
+	return owner === "chat" ? state.chatDraftByTab.get(state.currentTab) : state.customDraftByTab.get(state.currentTab);
+}
+
+function inlineCaretAt(state: QuestionnaireState, owner: InlineInputOwner): number | undefined {
+	return owner === "chat" ? state.chatCaretByTab.get(state.currentTab) : state.customCaretByTab.get(state.currentTab);
+}
+
+function withInlineDraft(
+	state: QuestionnaireState,
+	owner: InlineInputOwner,
+	value: string,
+	caret: number,
+): QuestionnaireState {
+	if (owner === "chat") {
+		const chatDraftByTab = new Map(state.chatDraftByTab);
+		const chatCaretByTab = new Map(state.chatCaretByTab);
+		chatDraftByTab.set(state.currentTab, value);
+		chatCaretByTab.set(state.currentTab, caret);
+		return { ...state, chatDraftByTab, chatCaretByTab };
+	}
+	const customDraftByTab = new Map(state.customDraftByTab);
+	const customCaretByTab = new Map(state.customCaretByTab);
+	customDraftByTab.set(state.currentTab, value);
+	customCaretByTab.set(state.currentTab, caret);
+	return { ...state, customDraftByTab, customCaretByTab };
 }
 
 export interface QuestionnaireSessionConfig {
@@ -42,6 +70,7 @@ function initialState(): QuestionnaireState {
 		currentTab: 0,
 		optionIndex: 0,
 		inputMode: false,
+		inlineInputOwner: null,
 		notesVisible: false,
 		chatFocused: false,
 		answers: new Map(),
@@ -52,6 +81,8 @@ function initialState(): QuestionnaireState {
 		notesDraft: "",
 		customDraftByTab: new Map(),
 		customCaretByTab: new Map(),
+		chatDraftByTab: new Map(),
+		chatCaretByTab: new Map(),
 	};
 }
 
@@ -133,17 +164,14 @@ export class QuestionnaireSession {
 	}
 
 	private mirrorInlineInputDraft(s: QuestionnaireState): QuestionnaireState {
-		if (!s.inputMode) return s;
+		if (!s.inputMode || !s.inlineInputOwner) return s;
+		const owner = s.inlineInputOwner;
 		const value = this.inlineInput.getValue();
 		const caret = readInputCursor(this.inlineInput);
-		if (s.customDraftByTab.get(s.currentTab) === value && s.customCaretByTab.get(s.currentTab) === caret) {
+		if (inlineDraftAt(s, owner) === value && inlineCaretAt(s, owner) === caret) {
 			return s;
 		}
-		const customDraftByTab = new Map(s.customDraftByTab);
-		const customCaretByTab = new Map(s.customCaretByTab);
-		customDraftByTab.set(s.currentTab, value);
-		customCaretByTab.set(s.currentTab, caret);
-		return { ...s, customDraftByTab, customCaretByTab };
+		return withInlineDraft(s, owner, value, caret);
 	}
 
 	private runEffect(effect: Effect): void {
@@ -181,7 +209,7 @@ export class QuestionnaireSession {
 	 * latency profile from Phase 11.
 	 */
 	private handleIgnoreInline(data: string): void {
-		if (!this.state.inputMode) return;
+		if (!this.state.inputMode || !this.state.inlineInputOwner) return;
 		this.inlineInput.handleInput(data);
 		this.state = this.mirrorInlineInputDraft(this.state);
 		this.viewAdapter.apply(this.state);

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts
@@ -4,10 +4,11 @@ import type { QuestionData, QuestionnaireResult, QuestionParams } from "../tool/
 import type { WrappingSelectItem } from "../view/components/wrapping-select.ts";
 import type { QuestionnairePropsAdapter } from "../view/props-adapter.ts";
 import { buildQuestionnaire } from "./build-questionnaire.ts";
+import { readInlineCaret, readInlineDraft, withInlineDraft } from "./inline-input.ts";
 import { ROW_INTENT_META } from "./row-intent.ts";
 import { type QuestionnaireAction, routeKey } from "./key-router.ts";
 import { computeFocusedOptionHasPreview } from "./selectors/derivations.ts";
-import type { InlineInputOwner, QuestionnaireRuntime, QuestionnaireState } from "./state.ts";
+import type { QuestionnaireRuntime, QuestionnaireState } from "./state.ts";
 import { type ApplyContext, type Effect, reduce } from "./state-reducer.ts";
 
 function readInputCursor(input: Input): number {
@@ -21,34 +22,6 @@ function readInputCursor(input: Input): number {
 function writeInputCursor(input: Input, cursor: number): void {
 	const value = input.getValue();
 	Reflect.set(input, "cursor", Math.max(0, Math.min(cursor, value.length)));
-}
-
-function inlineDraftAt(state: QuestionnaireState, owner: InlineInputOwner): string | undefined {
-	return owner === "chat" ? state.chatDraftByTab.get(state.currentTab) : state.customDraftByTab.get(state.currentTab);
-}
-
-function inlineCaretAt(state: QuestionnaireState, owner: InlineInputOwner): number | undefined {
-	return owner === "chat" ? state.chatCaretByTab.get(state.currentTab) : state.customCaretByTab.get(state.currentTab);
-}
-
-function withInlineDraft(
-	state: QuestionnaireState,
-	owner: InlineInputOwner,
-	value: string,
-	caret: number,
-): QuestionnaireState {
-	if (owner === "chat") {
-		const chatDraftByTab = new Map(state.chatDraftByTab);
-		const chatCaretByTab = new Map(state.chatCaretByTab);
-		chatDraftByTab.set(state.currentTab, value);
-		chatCaretByTab.set(state.currentTab, caret);
-		return { ...state, chatDraftByTab, chatCaretByTab };
-	}
-	const customDraftByTab = new Map(state.customDraftByTab);
-	const customCaretByTab = new Map(state.customCaretByTab);
-	customDraftByTab.set(state.currentTab, value);
-	customCaretByTab.set(state.currentTab, caret);
-	return { ...state, customDraftByTab, customCaretByTab };
 }
 
 export interface QuestionnaireSessionConfig {
@@ -168,7 +141,7 @@ export class QuestionnaireSession {
 		const owner = s.inlineInputOwner;
 		const value = this.inlineInput.getValue();
 		const caret = readInputCursor(this.inlineInput);
-		if (inlineDraftAt(s, owner) === value && inlineCaretAt(s, owner) === caret) {
+		if (readInlineDraft(s, owner) === value && readInlineCaret(s, owner) === caret) {
 			return s;
 		}
 		return withInlineDraft(s, owner, value, caret);

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/row-intent.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/row-intent.ts
@@ -45,8 +45,9 @@ export const SENTINEL_KINDS: readonly SentinelKind[] = ["other", "chat", "next"]
  *   numberable=false row that lives in the list; chat is numbered=true but
  *   `livesInMainList=false` so the flag is moot for chat.
  * - `activatesInputMode` — true iff focusing the row should toggle
- *   `state.inputMode = true`. Read by `state-reducer.ts` `nav` /
- *   `focus_options` cases.
+ *   `state.inputMode = true` and hydrate that row's shared inline-input
+ *   owner. Read by `state-reducer.ts` `nav` / `focus_options` /
+ *   `focus_chat` cases.
  * - `blocksMultiToggle` — in multiSelect mode, Space (and Enter-as-toggle)
  *   on this row is suppressed. The Next sentinel is the only true.
  * - `autoSubmitsInMulti` — in multiSelect mode, Enter on this row commits
@@ -97,7 +98,7 @@ export const ROW_INTENT_META: Record<RowKind, RowIntentMeta> = {
 		reserved: true,
 		livesInMainList: false,
 		numbered: true,
-		activatesInputMode: false,
+		activatesInputMode: true,
 		blocksMultiToggle: false,
 		autoSubmitsInMulti: false,
 		autoAppendOnSingleSelectNoPreview: false,

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/contract.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/contract.ts
@@ -12,6 +12,8 @@ export interface BindingContext {
 	readonly activeView: ActiveView;
 	readonly inputBuffer: string;
 	readonly inputCaret: number;
+	readonly chatInputBuffer: string;
+	readonly chatInputCaret: number;
 	readonly activePreviewPane: StatefulView<PreviewPaneProps>;
 }
 

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/projections.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/selectors/projections.ts
@@ -75,6 +75,8 @@ export const selectChatRowProps: GlobalSelector<ChatRowViewProps> = (state, ctx)
 	return {
 		focused: ctx.activeView === "chat",
 		numbering: chatNumberingFor(activeItems),
+		inputBuffer: ctx.chatInputBuffer,
+		inputCaret: ctx.chatInputCaret,
 	};
 };
 

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/state-reducer.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/state-reducer.ts
@@ -3,7 +3,7 @@ import type { WrappingSelectItem } from "../view/components/wrapping-select.ts";
 import type { QuestionnaireAction } from "./key-router.ts";
 import { ROW_INTENT_META } from "./row-intent.ts";
 import { computeFocusedOptionHasPreview } from "./selectors/derivations.ts";
-import type { QuestionnaireState } from "./state.ts";
+import type { InlineInputOwner, QuestionnaireState } from "./state.ts";
 
 /** Session-lifetime constants. No live-component reads — peripheral values live on canonical state. */
 export interface ApplyContext {
@@ -92,22 +92,59 @@ function clampCaret(value: string, caret: number | undefined): number {
 	return Math.max(0, Math.min(caret, value.length));
 }
 
-function customDraftValue(state: QuestionnaireState): string {
-	const draft = state.customDraftByTab.get(state.currentTab);
-	if (draft !== undefined) return draft;
-	const prior = state.answers.get(state.currentTab);
-	return prior?.kind === "custom" && typeof prior.answer === "string" ? prior.answer : "";
+function inlineOwnerForItem(item: WrappingSelectItem | undefined): InlineInputOwner | null {
+	if (!item || !ROW_INTENT_META[item.kind].activatesInputMode) return null;
+	switch (item.kind) {
+		case "other":
+		case "chat":
+			return item.kind;
+		case "option":
+		case "next":
+			return null;
+	}
 }
 
-function hydrateCustomInputResult(state: QuestionnaireState): ApplyResult {
-	const value = customDraftValue(state);
-	const caret = clampCaret(value, state.customCaretByTab.get(state.currentTab));
+function inlineDraftValue(state: QuestionnaireState, owner: InlineInputOwner): string {
+	const draft = owner === "chat" ? state.chatDraftByTab.get(state.currentTab) : state.customDraftByTab.get(state.currentTab);
+	if (draft !== undefined) return draft;
+	const prior = state.answers.get(state.currentTab);
+	if (owner === "other") {
+		return prior?.kind === "custom" && typeof prior.answer === "string" ? prior.answer : "";
+	}
+	return prior?.kind === "chat" && typeof prior.answer === "string" && prior.answer !== ROW_INTENT_META.chat.label
+		? prior.answer
+		: "";
+}
+
+function inlineCaretValue(state: QuestionnaireState, owner: InlineInputOwner): number | undefined {
+	return owner === "chat" ? state.chatCaretByTab.get(state.currentTab) : state.customCaretByTab.get(state.currentTab);
+}
+
+function withInlineDraft(
+	state: QuestionnaireState,
+	owner: InlineInputOwner,
+	value: string,
+	caret: number,
+): QuestionnaireState {
+	if (owner === "chat") {
+		const chatDraftByTab = new Map(state.chatDraftByTab);
+		const chatCaretByTab = new Map(state.chatCaretByTab);
+		chatDraftByTab.set(state.currentTab, value);
+		chatCaretByTab.set(state.currentTab, caret);
+		return { ...state, chatDraftByTab, chatCaretByTab };
+	}
 	const customDraftByTab = new Map(state.customDraftByTab);
 	const customCaretByTab = new Map(state.customCaretByTab);
 	customDraftByTab.set(state.currentTab, value);
 	customCaretByTab.set(state.currentTab, caret);
+	return { ...state, customDraftByTab, customCaretByTab };
+}
+
+function hydrateInlineInputResult(state: QuestionnaireState, owner: InlineInputOwner): ApplyResult {
+	const value = inlineDraftValue(state, owner);
+	const caret = clampCaret(value, inlineCaretValue(state, owner));
 	return {
-		state: { ...state, customDraftByTab, customCaretByTab },
+		state: withInlineDraft({ ...state, inputMode: true, inlineInputOwner: owner }, owner, value, caret),
 		effects: [{ kind: "set_input_buffer", value, caret }],
 	};
 }
@@ -119,6 +156,7 @@ function switchTabResult(state: QuestionnaireState, nextTab: number, ctx: ApplyC
 		currentTab: nextTab,
 		optionIndex: 0,
 		inputMode: false,
+		inlineInputOwner: null,
 		notesVisible: false,
 		chatFocused: false,
 		submitChoiceIndex: 0,
@@ -153,9 +191,18 @@ type Handler<K extends QuestionnaireAction["kind"]> = (
 const navHandler: Handler<"nav"> = (state, action, ctx) => {
 	const items = ctx.itemsByTab[state.currentTab] ?? [];
 	const item = items[action.nextIndex];
-	const inputMode = item ? ROW_INTENT_META[item.kind].activatesInputMode : false;
-	const next = withFocusedOptionHasPreview({ ...state, optionIndex: action.nextIndex, inputMode }, ctx.questions);
-	return inputMode ? hydrateCustomInputResult(next) : { state: next, effects: [] };
+	const owner = inlineOwnerForItem(item);
+	const next = withFocusedOptionHasPreview(
+		{
+			...state,
+			chatFocused: false,
+			optionIndex: action.nextIndex,
+			inputMode: owner !== null,
+			inlineInputOwner: owner,
+		},
+		ctx.questions,
+	);
+	return owner ? hydrateInlineInputResult(next, owner) : { state: next, effects: [] };
 };
 
 const tabSwitchHandler: Handler<"tab_switch"> = (state, action, ctx) => switchTabResult(state, action.nextTab, ctx);
@@ -249,12 +296,18 @@ const notesExitHandler: Handler<"notes_exit"> = (state, _action, _ctx) => {
 const focusOptionsHandler: Handler<"focus_options"> = (state, action, ctx) => {
 	const items = ctx.itemsByTab[state.currentTab] ?? [];
 	const focused = items[action.optionIndex];
-	const inputMode = focused ? ROW_INTENT_META[focused.kind].activatesInputMode : false;
+	const owner = inlineOwnerForItem(focused);
 	const next = withFocusedOptionHasPreview(
-		{ ...state, chatFocused: false, optionIndex: action.optionIndex, inputMode },
+		{
+			...state,
+			chatFocused: false,
+			optionIndex: action.optionIndex,
+			inputMode: owner !== null,
+			inlineInputOwner: owner,
+		},
 		ctx.questions,
 	);
-	return inputMode ? hydrateCustomInputResult(next) : { state: next, effects: [] };
+	return owner ? hydrateInlineInputResult(next, owner) : { state: next, effects: [] };
 };
 
 const cancelHandler: Handler<"cancel"> = (s, _a, c) => doneFor(s, c, true);
@@ -263,10 +316,8 @@ const submitNavHandler: Handler<"submit_nav"> = (s, a, _c) => ({
 	state: { ...s, submitChoiceIndex: a.nextIndex },
 	effects: [],
 });
-const focusChatHandler: Handler<"focus_chat"> = (s, _a, _c) => ({
-	state: { ...s, chatFocused: true },
-	effects: [],
-});
+const focusChatHandler: Handler<"focus_chat"> = (s, _a, _c) =>
+	hydrateInlineInputResult({ ...s, chatFocused: true, inputMode: true, inlineInputOwner: "chat" }, "chat");
 const notesForwardHandler: Handler<"notes_forward"> = (s, a, _c) => ({
 	state: s,
 	effects: [{ kind: "forward_notes_keystroke", data: a.data }],

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/state-reducer.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/state-reducer.ts
@@ -1,6 +1,7 @@
 import type { QuestionAnswer, QuestionData, QuestionnaireResult } from "../tool/types.ts";
 import type { WrappingSelectItem } from "../view/components/wrapping-select.ts";
 import type { QuestionnaireAction } from "./key-router.ts";
+import { readInlineCaret, resolveInlineDraftValue, withInlineDraft } from "./inline-input.ts";
 import { ROW_INTENT_META } from "./row-intent.ts";
 import { computeFocusedOptionHasPreview } from "./selectors/derivations.ts";
 import type { InlineInputOwner, QuestionnaireState } from "./state.ts";
@@ -104,45 +105,9 @@ function inlineOwnerForItem(item: WrappingSelectItem | undefined): InlineInputOw
 	}
 }
 
-function inlineDraftValue(state: QuestionnaireState, owner: InlineInputOwner): string {
-	const draft = owner === "chat" ? state.chatDraftByTab.get(state.currentTab) : state.customDraftByTab.get(state.currentTab);
-	if (draft !== undefined) return draft;
-	const prior = state.answers.get(state.currentTab);
-	if (owner === "other") {
-		return prior?.kind === "custom" && typeof prior.answer === "string" ? prior.answer : "";
-	}
-	return prior?.kind === "chat" && typeof prior.answer === "string" && prior.answer !== ROW_INTENT_META.chat.label
-		? prior.answer
-		: "";
-}
-
-function inlineCaretValue(state: QuestionnaireState, owner: InlineInputOwner): number | undefined {
-	return owner === "chat" ? state.chatCaretByTab.get(state.currentTab) : state.customCaretByTab.get(state.currentTab);
-}
-
-function withInlineDraft(
-	state: QuestionnaireState,
-	owner: InlineInputOwner,
-	value: string,
-	caret: number,
-): QuestionnaireState {
-	if (owner === "chat") {
-		const chatDraftByTab = new Map(state.chatDraftByTab);
-		const chatCaretByTab = new Map(state.chatCaretByTab);
-		chatDraftByTab.set(state.currentTab, value);
-		chatCaretByTab.set(state.currentTab, caret);
-		return { ...state, chatDraftByTab, chatCaretByTab };
-	}
-	const customDraftByTab = new Map(state.customDraftByTab);
-	const customCaretByTab = new Map(state.customCaretByTab);
-	customDraftByTab.set(state.currentTab, value);
-	customCaretByTab.set(state.currentTab, caret);
-	return { ...state, customDraftByTab, customCaretByTab };
-}
-
 function hydrateInlineInputResult(state: QuestionnaireState, owner: InlineInputOwner): ApplyResult {
-	const value = inlineDraftValue(state, owner);
-	const caret = clampCaret(value, inlineCaretValue(state, owner));
+	const value = resolveInlineDraftValue(state, owner);
+	const caret = clampCaret(value, readInlineCaret(state, owner));
 	return {
 		state: withInlineDraft({ ...state, inputMode: true, inlineInputOwner: owner }, owner, value, caret),
 		effects: [{ kind: "set_input_buffer", value, caret }],

--- a/packages/coding-agent/src/core/tools/ask-user-question/state/state.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/state/state.ts
@@ -1,5 +1,8 @@
 import type { QuestionAnswer, QuestionData } from "../tool/types.ts";
 import type { WrappingSelectItem } from "../view/components/wrapping-select.ts";
+import type { RowKind } from "./row-intent.ts";
+
+export type InlineInputOwner = Extract<RowKind, "other" | "chat">;
 
 /**
  * Canonical state for the questionnaire dialog. Single source of truth — both the
@@ -11,6 +14,8 @@ export interface QuestionnaireState {
 	inputMode: boolean;
 	notesVisible: boolean;
 	chatFocused: boolean;
+	/** Active owner of the shared inline input, or null when no inline row is being edited. */
+	inlineInputOwner: InlineInputOwner | null;
 	answers: ReadonlyMap<number, QuestionAnswer>;
 	multiSelectChecked: ReadonlySet<number>;
 	/**
@@ -29,6 +34,10 @@ export interface QuestionnaireState {
 	customDraftByTab: ReadonlyMap<number, string>;
 	/** Caret offsets for in-flight custom drafts keyed by question tab. */
 	customCaretByTab: ReadonlyMap<number, number>;
+	/** In-flight "Chat about this" inline drafts keyed by question tab. */
+	chatDraftByTab: ReadonlyMap<number, string>;
+	/** Caret offsets for in-flight chat drafts keyed by question tab. */
+	chatCaretByTab: ReadonlyMap<number, number>;
 }
 
 /**

--- a/packages/coding-agent/src/core/tools/ask-user-question/tool/format-answer.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/tool/format-answer.ts
@@ -1,3 +1,4 @@
+import { ROW_INTENT_META } from "../state/row-intent.ts";
 import type { QuestionAnswer } from "./types.ts";
 
 /**
@@ -25,6 +26,18 @@ export const NO_INPUT_PLACEHOLDER = "(no input)";
 export type FormatAnswerVariant = "summary" | "envelope";
 
 /**
+ * Return the user-provided chat message, or undefined for the legacy signal-only
+ * chat answer. Whitespace-only text and the reserved sentinel label both keep
+ * the legacy stop/wait semantics.
+ */
+export function chatAnswerIntent(a: QuestionAnswer): string | undefined {
+	if (a.kind !== "chat" || typeof a.answer !== "string") return undefined;
+	const trimmed = a.answer.trim();
+	if (trimmed.length === 0 || trimmed === ROW_INTENT_META.chat.label) return undefined;
+	return a.answer;
+}
+
+/**
  * Format a `QuestionAnswer` to its scalar string form. Variant controls only the
  * `kind: "chat"` branch — the envelope's stop/wait directive is needed by the LLM,
  * the dialog summary's one-sentence reminder is not. All other branches return identical
@@ -34,8 +47,11 @@ export type FormatAnswerVariant = "summary" | "envelope";
  */
 export function formatAnswerScalar(a: QuestionAnswer, variant: FormatAnswerVariant): string {
 	switch (a.kind) {
-		case "chat":
+		case "chat": {
+			const typedChat = chatAnswerIntent(a);
+			if (typedChat !== undefined) return typedChat;
 			return variant === "envelope" ? CHAT_CONTINUATION_MESSAGE : CHAT_SUMMARY_MESSAGE;
+		}
 		case "multi":
 			return a.selected && a.selected.length > 0 ? a.selected.join(", ") : NO_INPUT_PLACEHOLDER;
 		case "custom":

--- a/packages/coding-agent/src/core/tools/ask-user-question/tool/response-envelope.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/tool/response-envelope.ts
@@ -1,4 +1,4 @@
-import { formatAnswerScalar } from "./format-answer.ts";
+import { chatAnswerIntent, formatAnswerScalar } from "./format-answer.ts";
 import type { QuestionAnswer, QuestionnaireResult, QuestionParams } from "./types.ts";
 
 export const DECLINE_MESSAGE = "User declined to answer questions";
@@ -6,6 +6,8 @@ export const ENVELOPE_PREFIX = "User has answered your questions:";
 export const ENVELOPE_SUFFIX = "You can now continue with the user's answers in mind.";
 const CHAT_TERMINATION_DIRECTIVE =
 	"User wants to chat about this before choosing. Stop the current task flow and wait for the user's next message.";
+const TYPED_CHAT_DIRECTIVE =
+	"User wants to chat about this before choosing and provided inline text. Stop the structured-choice flow and respond to the user's message.";
 
 /**
  * True when any answer in the result carries `kind: "chat"`.
@@ -21,8 +23,9 @@ export function hasChatAnswer(result: QuestionnaireResult): boolean {
  * `DECLINE_MESSAGE` so the model sees a single canonical "didn't answer" signal
  * regardless of why.
  *
- * Chat rule: when any non-cancelled answer is `kind: "chat"`, the result carries
- * `terminate: true` and stop/wait wording instead of the generic continuation suffix.
+ * Chat rule: signal-only chat keeps the legacy `terminate: true` stop/wait
+ * wording. Typed chat omits `terminate` and the generic continuation suffix so
+ * the model can respond to the inline user message in this same turn.
  */
 export function buildQuestionnaireResponse(result: QuestionnaireResult | null | undefined, params: QuestionParams) {
 	if (!result || result.cancelled) {
@@ -39,6 +42,10 @@ export function buildQuestionnaireResponse(result: QuestionnaireResult | null | 
 	}
 	if (containsChatAnswer) {
 		const answerSegments = segments.length > 0 ? ` ${segments.join(" ")}` : "";
+		const hasSignalOnlyChat = result.answers.some((a) => a.kind === "chat" && chatAnswerIntent(a) === undefined);
+		if (!hasSignalOnlyChat) {
+			return buildToolResult(`${TYPED_CHAT_DIRECTIVE}${answerSegments}`, result);
+		}
 		return buildToolResult(`${CHAT_TERMINATION_DIRECTIVE}${answerSegments}`, result, { terminate: true });
 	}
 	if (segments.length === 0) {

--- a/packages/coding-agent/src/core/tools/ask-user-question/tool/response-envelope.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/tool/response-envelope.ts
@@ -42,6 +42,12 @@ export function buildQuestionnaireResponse(result: QuestionnaireResult | null | 
 	}
 	if (containsChatAnswer) {
 		const answerSegments = segments.length > 0 ? ` ${segments.join(" ")}` : "";
+		// Mixed-dialog precedence: signal-only chat WINS. In a multi-question dialog where one
+		// question carried typed chat and another is signal-only, the whole envelope takes the
+		// `terminate: true` stop/wait path — a bare "chat about this" is an explicit request to
+		// pause the structured flow, so it dominates. The typed message is not lost: it still
+		// rides along in `answerSegments` for context. This precedence is a deliberate product
+		// decision; mixing typed + signal-only chat across questions is a rare edge.
 		const hasSignalOnlyChat = result.answers.some((a) => a.kind === "chat" && chatAnswerIntent(a) === undefined);
 		if (!hasSignalOnlyChat) {
 			return buildToolResult(`${TYPED_CHAT_DIRECTIVE}${answerSegments}`, result);

--- a/packages/coding-agent/src/core/tools/ask-user-question/tool/types.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/tool/types.ts
@@ -106,7 +106,8 @@ export type QuestionParams = Static<typeof QuestionParamsSchema>;
  * Variant semantics:
  * - `option`: user picked one of the author-defined options. `answer` is the option's label.
  * - `custom`: user typed free-text via the "Type something." row. `answer` is the typed text or null.
- * - `chat`: user picked the chat sentinel. `answer` is the literal "Chat about this".
+ * - `chat`: user picked the chat sentinel. `answer` is either typed inline chat text or the legacy
+ *   literal "Chat about this" when submitted empty / whitespace-only.
  * - `multi`: user committed multi-select choices. `selected` carries chosen labels; `answer` is null.
  */
 export interface QuestionAnswer {

--- a/packages/coding-agent/src/core/tools/ask-user-question/view/components/chat-row-view.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/view/components/chat-row-view.ts
@@ -5,12 +5,15 @@ import { WrappingSelect, type WrappingSelectItem, type WrappingSelectTheme } fro
 /**
  * Per-tick projection of chat-row state. The chat row is a single-item
  * `WrappingSelect` rendered in the question-tab footer; it owns no per-tab
- * state — only `focused` (whether the chat row is the active focus target)
- * and `numbering` (display number aligned with the active tab's items).
+ * state — only `focused` (whether the chat row is the active focus target),
+ * `numbering` (display number aligned with the active tab's items), and the
+ * owner-specific inline input projection supplied by the session.
  */
 export interface ChatRowViewProps {
 	focused: boolean;
 	numbering: { offset: number; total: number };
+	inputBuffer: string;
+	inputCaret: number;
 }
 
 export interface ChatRowViewConfig {
@@ -42,6 +45,8 @@ export class ChatRowView implements StatefulView<ChatRowViewProps>, Component {
 	setProps(props: ChatRowViewProps): void {
 		this.select.setFocused(props.focused);
 		this.select.setNumbering(props.numbering.offset, props.numbering.total);
+		this.select.setInputBuffer(props.inputBuffer);
+		this.select.setInputCursor(props.inputCaret);
 	}
 
 	handleInput(_data: string): void {}

--- a/packages/coding-agent/src/core/tools/ask-user-question/view/components/wrapping-select.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/view/components/wrapping-select.ts
@@ -1,5 +1,6 @@
 import type { Component } from "@earendil-works/pi-tui";
 import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { ROW_INTENT_META } from "../../state/row-intent.ts";
 
 /**
  * Row-intent discriminated union. `kind` is the single discriminator —
@@ -13,6 +14,7 @@ import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
  * - `other`: the inline free-text input row appended to single-select questions
  *   (label is "Type something."). Renders as inline `Input` when active.
  * - `chat`: the abandon-questionnaire escape-hatch row (label is "Chat about this").
+ *   Renders as inline `Input` when active.
  * - `next`: the explicit commit-and-advance row appended to multi-select questions
  *   (label is "Next"). Renders without a number / checkbox.
  */
@@ -209,7 +211,7 @@ export class WrappingSelect implements Component {
 	}
 
 	private shouldRenderAsInlineInput(item: WrappingSelectItem, isActive: boolean): boolean {
-		return item.kind === "other" && isActive;
+		return isActive && ROW_INTENT_META[item.kind].activatesInputMode;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/tools/ask-user-question/view/props-adapter.ts
+++ b/packages/coding-agent/src/core/tools/ask-user-question/view/props-adapter.ts
@@ -34,9 +34,9 @@ export interface QuestionnairePropsAdapterConfig {
  * two binding registries. `globalBindings` covers the cross-tab components
  * (chatRow, dialog, submitPicker?, tabBar?); `perTabBindings` covers the
  * per-tab kinds (optionList, preview, multiSelect?). The hand-coded fan-out
- * collapses to one global loop + one nested per-tab loop. The inline-Other
- * value is read from the headless `inlineInput` instance per tick into ctx so
- * `selectOptionListProps` sees the live value.
+ * collapses to one global loop + one nested per-tab loop. The shared inline
+ * input is projected through owner-specific draft slots so the option list and
+ * chat footer never display each other's in-flight text.
  */
 export class QuestionnairePropsAdapter {
 	private readonly tui: QuestionnairePropsAdapterConfig["tui"];
@@ -65,8 +65,15 @@ export class QuestionnairePropsAdapter {
 		const paneIndex = selectActivePreviewPaneIndex(state.currentTab, totalQuestions);
 		const activePreviewPane = this.tabsByIndex[paneIndex]?.preview ?? this.tabsByIndex[0]!.preview;
 
-		const inputBuffer = state.customDraftByTab.get(state.currentTab) ?? this.inlineInput.getValue();
+		const liveInlineValue = this.inlineInput.getValue();
+		const inputBuffer =
+			state.customDraftByTab.get(state.currentTab) ??
+			(state.inlineInputOwner === "other" ? liveInlineValue : "");
 		const inputCaret = state.customCaretByTab.get(state.currentTab) ?? inputBuffer.length;
+		const chatInputBuffer =
+			state.chatDraftByTab.get(state.currentTab) ??
+			(state.inlineInputOwner === "chat" ? liveInlineValue : "");
+		const chatInputCaret = state.chatCaretByTab.get(state.currentTab) ?? chatInputBuffer.length;
 		const ctx: BindingContext = {
 			questions: this.questions,
 			itemsByTab: this.itemsByTab,
@@ -74,6 +81,8 @@ export class QuestionnairePropsAdapter {
 			activeView,
 			inputBuffer,
 			inputCaret,
+			chatInputBuffer,
+			chatInputCaret,
 			activePreviewPane,
 		};
 

--- a/test/unit/ask-user-question-response-envelope.test.ts
+++ b/test/unit/ask-user-question-response-envelope.test.ts
@@ -1,0 +1,80 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+	CHAT_CONTINUATION_MESSAGE,
+	chatAnswerIntent,
+} from "../../packages/coding-agent/src/core/tools/ask-user-question/tool/format-answer.ts";
+import {
+	buildQuestionnaireResponse,
+	ENVELOPE_SUFFIX,
+	hasChatAnswer,
+} from "../../packages/coding-agent/src/core/tools/ask-user-question/tool/response-envelope.ts";
+import {
+	SENTINEL_LABELS,
+	type QuestionParams,
+	type QuestionnaireResult,
+} from "../../packages/coding-agent/src/core/tools/ask-user-question/tool/types.ts";
+
+const params: QuestionParams = {
+	questions: [
+		{
+			question: "Which option?",
+			header: "Choice",
+			options: [
+				{ label: "Alpha", description: "First option" },
+				{ label: "Beta", description: "Second option" },
+			],
+		},
+	],
+};
+
+function chatResult(answer: string | null): QuestionnaireResult {
+	return {
+		answers: [
+			{
+				questionIndex: 0,
+				question: params.questions[0]!.question,
+				kind: "chat",
+				answer,
+			},
+		],
+		cancelled: false,
+	};
+}
+
+describe("ask_user_question chat response envelope", () => {
+	test("typed chat is exposed without legacy termination or generic continuation suffix", () => {
+		const result = chatResult("Let's discuss another approach");
+		const envelope = buildQuestionnaireResponse(result, params);
+		const text = envelope.content[0]!.text;
+
+		assert.equal(hasChatAnswer(result), true);
+		assert.equal(chatAnswerIntent(result.answers[0]!), "Let's discuss another approach");
+		assert.equal(envelope.terminate, undefined);
+		assert.match(text, /Stop the structured-choice flow and respond to the user's message/);
+		assert.match(text, /"Which option\?"="Let's discuss another approach"\./);
+		assert.equal(text.includes(ENVELOPE_SUFFIX), false);
+		assert.equal(text.includes(CHAT_CONTINUATION_MESSAGE), false);
+	});
+
+	test("sentinel chat keeps legacy stop/wait termination semantics", () => {
+		const result = chatResult(SENTINEL_LABELS.chat);
+		const envelope = buildQuestionnaireResponse(result, params);
+		const text = envelope.content[0]!.text;
+
+		assert.equal(chatAnswerIntent(result.answers[0]!), undefined);
+		assert.equal(envelope.terminate, true);
+		assert.match(text, /Stop the current task flow and wait for the user's next message/);
+		assert.equal(text.includes(ENVELOPE_SUFFIX), false);
+	});
+
+	test("whitespace-only chat answers are treated as signal-only chat", () => {
+		const result = chatResult("   ");
+		const envelope = buildQuestionnaireResponse(result, params);
+		const text = envelope.content[0]!.text;
+
+		assert.equal(chatAnswerIntent(result.answers[0]!), undefined);
+		assert.equal(envelope.terminate, true);
+		assert.match(text, /Stop the current task flow and wait for the user's next message/);
+	});
+});

--- a/test/unit/ask-user-question-tui.test.ts
+++ b/test/unit/ask-user-question-tui.test.ts
@@ -2,7 +2,11 @@ import { test } from "bun:test";
 import assert from "node:assert/strict";
 import { buildItemsForQuestion } from "../../packages/coding-agent/src/core/tools/ask-user-question/ask-user-question.ts";
 import { QuestionnaireSession } from "../../packages/coding-agent/src/core/tools/ask-user-question/state/questionnaire-session.ts";
-import type { QuestionParams } from "../../packages/coding-agent/src/core/tools/ask-user-question/tool/types.ts";
+import {
+	SENTINEL_LABELS,
+	type QuestionParams,
+	type QuestionnaireResult,
+} from "../../packages/coding-agent/src/core/tools/ask-user-question/tool/types.ts";
 import { WrappingSelect, type WrappingSelectItem } from "../../packages/coding-agent/src/core/tools/ask-user-question/view/components/wrapping-select.ts";
 import { initTheme, theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";
 
@@ -12,6 +16,8 @@ const stripAnsi = (s: string): string => s.replace(ANSI_RE, "");
 const DOWN = "\x1b[B";
 const UP = "\x1b[A";
 const LEFT = "\x1b[D";
+const RIGHT = "\x1b[C";
+const ENTER = "\r";
 
 function makeParams(): QuestionParams {
 	return {
@@ -26,6 +32,47 @@ function makeParams(): QuestionParams {
 			},
 		],
 	};
+}
+
+function makePreviewParams(): QuestionParams {
+	return {
+		questions: [
+			{
+				question: "Which preview option?",
+				header: "Preview",
+				options: [
+					{ label: "Alpha", description: "First option", preview: "# Alpha" },
+					{ label: "Beta", description: "Second option" },
+				],
+			},
+		],
+	};
+}
+
+function makeMultiParams(): QuestionParams {
+	return {
+		questions: [
+			{
+				question: "Which options?",
+				header: "Multi",
+				multiSelect: true,
+				options: [
+					{ label: "Alpha", description: "First option" },
+					{ label: "Beta", description: "Second option" },
+				],
+			},
+		],
+	};
+}
+
+function makeSession(params: QuestionParams, done: (result: QuestionnaireResult) => void = () => {}): QuestionnaireSession {
+	return new QuestionnaireSession({
+		tui: { terminal: { columns: 100 }, requestRender() {} },
+		theme,
+		params,
+		itemsByTab: params.questions.map((q) => buildItemsForQuestion(q)),
+		done,
+	});
 }
 
 test("ask_user_question custom response draft survives moving to another option", () => {
@@ -85,4 +132,154 @@ test("ask_user_question custom response editor keeps typing at the moved caret",
 
 	const rendered = stripAnsi(session.component.render(100).join("\n"));
 	assert.match(rendered, /abXc/);
+});
+
+test("ask_user_question chat row captures typed inline text as a chat answer", () => {
+	initTheme("dark");
+	const params = makeParams();
+	let result: QuestionnaireResult | undefined;
+	const session = makeSession(params, (r) => {
+		result = r;
+	});
+
+	session.component.handleInput(UP);
+	for (const ch of "Let's discuss another approach") session.component.handleInput(ch);
+	session.component.handleInput(ENTER);
+
+	assert.ok(result);
+	assert.equal(result.cancelled, false);
+	assert.equal(result.answers[0]?.kind, "chat");
+	assert.equal(result.answers[0]?.answer, "Let's discuss another approach");
+});
+
+test("ask_user_question chat row arrow keys edit the inline caret in multi-question dialogs", () => {
+	initTheme("dark");
+	const params: QuestionParams = {
+		questions: [
+			{
+				question: "First question?",
+				header: "First",
+				options: [{ label: "Alpha", description: "First option" }],
+			},
+			{
+				question: "Second question?",
+				header: "Second",
+				options: [{ label: "Beta", description: "Second option" }],
+			},
+		],
+	};
+	let result: QuestionnaireResult | undefined;
+	const session = makeSession(params, (r) => {
+		result = r;
+	});
+
+	session.component.handleInput(UP);
+	for (const ch of "abc") session.component.handleInput(ch);
+	session.component.handleInput(LEFT);
+	session.component.handleInput(LEFT);
+	session.component.handleInput(RIGHT);
+	session.component.handleInput("X");
+	session.component.handleInput(ENTER);
+
+	assert.ok(result);
+	assert.equal(result.cancelled, false);
+	assert.equal(result.answers.length, 1);
+	assert.equal(result.answers[0]?.questionIndex, 0);
+	assert.equal(result.answers[0]?.kind, "chat");
+	assert.equal(result.answers[0]?.answer, "abXc");
+});
+
+test("ask_user_question chat row preserves legacy sentinel answer for empty or whitespace input", () => {
+	initTheme("dark");
+	for (const typed of ["", "   "]) {
+		const params = makeParams();
+		let result: QuestionnaireResult | undefined;
+		const session = makeSession(params, (r) => {
+			result = r;
+		});
+
+		session.component.handleInput(UP);
+		for (const ch of typed) session.component.handleInput(ch);
+		session.component.handleInput(ENTER);
+
+		assert.ok(result);
+		assert.equal(result.cancelled, false);
+		assert.equal(result.answers[0]?.kind, "chat");
+		assert.equal(result.answers[0]?.answer, SENTINEL_LABELS.chat);
+	}
+});
+
+test("ask_user_question chat and custom inline drafts stay isolated when focus moves", () => {
+	initTheme("dark");
+	const params = makeParams();
+	const session = makeSession(params);
+
+	session.component.handleInput(DOWN);
+	session.component.handleInput(DOWN);
+	for (const ch of "custom draft") session.component.handleInput(ch);
+	session.component.handleInput(DOWN);
+	let rendered = stripAnsi(session.component.render(100).join("\n"));
+	assert.doesNotMatch(rendered, /custom draft/);
+
+	for (const ch of "chat draft") session.component.handleInput(ch);
+	rendered = stripAnsi(session.component.render(100).join("\n"));
+	assert.match(rendered, /chat draft/);
+
+	session.component.handleInput(UP);
+	rendered = stripAnsi(session.component.render(100).join("\n"));
+	assert.match(rendered, /custom draft/);
+	assert.doesNotMatch(rendered, /chat draft/);
+
+	session.component.handleInput(DOWN);
+	rendered = stripAnsi(session.component.render(100).join("\n"));
+	assert.match(rendered, /chat draft/);
+	assert.doesNotMatch(rendered, /custom draft/);
+});
+
+test("ask_user_question chat row accepts typed text when preview suppresses custom input", () => {
+	initTheme("dark");
+	const params = makePreviewParams();
+	let result: QuestionnaireResult | undefined;
+	const session = makeSession(params, (r) => {
+		result = r;
+	});
+
+	session.component.handleInput(UP);
+	for (const ch of "Discuss the previews") session.component.handleInput(ch);
+	session.component.handleInput(ENTER);
+
+	assert.ok(result);
+	assert.equal(result.answers[0]?.kind, "chat");
+	assert.equal(result.answers[0]?.answer, "Discuss the previews");
+});
+
+test("ask_user_question chat row accepts typed text on multi-select questions", () => {
+	initTheme("dark");
+	const params = makeMultiParams();
+	let result: QuestionnaireResult | undefined;
+	const session = makeSession(params, (r) => {
+		result = r;
+	});
+
+	session.component.handleInput(UP);
+	for (const ch of "Discuss multi-select instead") session.component.handleInput(ch);
+	session.component.handleInput(ENTER);
+
+	assert.ok(result);
+	assert.equal(result.answers[0]?.kind, "chat");
+	assert.equal(result.answers[0]?.answer, "Discuss multi-select instead");
+});
+
+test("ask_user_question chat row renders inline input through WrappingSelect metadata", () => {
+	const items: WrappingSelectItem[] = [{ kind: "chat", label: SENTINEL_LABELS.chat }];
+	const select = new WrappingSelect(items, 1, {
+		selectedText: (s) => s,
+		description: (s) => s,
+		scrollInfo: (s) => s,
+	});
+	select.setInputBuffer("chat");
+	select.setInputCursor(4);
+
+	const rendered = select.render(40).join("\n");
+	assert.match(rendered, /chat\x1b\[7m \x1b\[0m/);
 });


### PR DESCRIPTION
## Summary

Extends the `ask_user_question` TUI's **Chat about this** footer row with optional inline free-form text entry. Non-empty typed messages are returned as `kind: "chat"` answers without the legacy stop/wait termination envelope, letting the model respond inline. Empty or whitespace-only submissions preserve the existing sentinel behavior.

## Changes

### Core feature
- Enables `activatesInputMode` on the chat sentinel row so focusing it opens an inline editor (previously only the "Type something." custom row had this)
- `chatAnswerValue()` resolves the answer at confirm time: non-blank typed text wins; blank/whitespace falls back to the sentinel label for legacy behavior

### State isolation
- Adds `InlineInputOwner = "other" | "chat"` type and `inlineInputOwner` field to `QuestionnaireState`
- Introduces owner-keyed draft/caret maps (`chatDraftByTab`, `chatCaretByTab`) alongside the existing `customDraftByTab`/`customCaretByTab` so navigating between rows never leaks text across the two inline editors
- Extracts shared `readInlineDraft`, `readInlineCaret`, `withInlineDraft`, and `resolveInlineDraftValue` helpers into a new `inline-input.ts` module (previously duplicated across `state-reducer.ts` and `questionnaire-session.ts`)
- Arrow-key left/right events are consumed inside the chat editor instead of being passed to the tab-navigation layer in multi-question dialogs

### Response envelope
- Adds `chatAnswerIntent()` helper that returns `undefined` for signal-only chat and the typed text string otherwise
- Typed chat answers use a new `TYPED_CHAT_DIRECTIVE` without `terminate: true`, keeping the model turn alive for a reply
- Signal-only chat retains `terminate: true` and the legacy stop/wait wording
- Mixed-dialog precedence: signal-only chat wins — if any answer is signal-only, the entire envelope takes the `terminate: true` path

### View / props propagation
- `ChatRowViewProps` now carries `inputBuffer` / `inputCaret` fields so the chat row's `WrappingSelect` renders the live editor state
- `BindingContext` gains `chatInputBuffer` / `chatInputCaret` computed via owner-specific projection
- `WrappingSelect.shouldRenderAsInlineInput` is now metadata-driven (`ROW_INTENT_META[item.kind].activatesInputMode`) instead of hardcoding `kind === "other"`

### Tests
- New `test/unit/ask-user-question-response-envelope.test.ts`: typed chat envelope, sentinel envelope, and whitespace-only handling
- Seven new cases in `test/unit/ask-user-question-tui.test.ts`: typed chat answers, caret movement in multi-question dialogs, empty/whitespace draft preservation, custom-vs-chat draft isolation, preview-suppressed custom input, multi-select questions, and `WrappingSelect` metadata-driven inline rendering

### Changelog
- Adds an `[Unreleased]` entry to `packages/coding-agent/CHANGELOG.md`

## Breaking changes

None. The chat sentinel's external answer shape (`kind: "chat"`) is unchanged; only the `answer` field may now carry typed text instead of always being the reserved label. The response envelope change (no `terminate`) only affects typed submissions — signal-only chat is fully backward-compatible.

## Validation

- Pre-commit hooks during commit: large-file/conflict/secret checks, `bun run lint`, and `bun run test:unit` all passed
- Focused `ask_user_question` tests, `bun run typecheck`, `bun run lint`, full `bun run test:unit`, and package build typecheck via `tsgo` all passed in prior implementation validation

> **Note:** No manual interactive Atomic session was run; behavior is covered by automated/simulated TUI tests.

Closes #1331.