### PR TITLE
chore(release): prepare 0.8.28-alpha.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.28-alpha.2",
+      "version": "0.8.28-alpha.3",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -62,7 +62,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.28-alpha.2",
+      "version": "0.8.28-alpha.3",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -77,7 +77,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.28-alpha.2",
+      "version": "0.8.28-alpha.3",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -99,7 +99,7 @@
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.28-alpha.2",
+      "version": "0.8.28-alpha.3",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -119,7 +119,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.28-alpha.2",
+      "version": "0.8.28-alpha.3",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -138,7 +138,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.28-alpha.2",
+      "version": "0.8.28-alpha.3",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.28-alpha.3] - 2026-06-11
+
 ### Added
 
 - Added optional inline free-form text entry to the `ask_user_question` TUI's **Chat about this** footer row. Non-empty typed chat text now returns as a `kind: "chat"` answer and is surfaced to the agent without the legacy stop/wait termination envelope, while empty submissions keep the existing sentinel behavior.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.28-alpha.2",
+  "version": "0.8.28-alpha.3",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.28-alpha.2",
+  "version": "0.8.28-alpha.3",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.28-alpha.2",
+  "version": "0.8.28-alpha.3",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.28-alpha.2",
+  "version": "0.8.28-alpha.3",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.28-alpha.2",
+  "version": "0.8.28-alpha.3",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.28-alpha.3] - 2026-06-11
+
 ### Added
 
 - Added workflow stage/task `bashPolicy` wiring so individual workflow stages can constrain the built-in `bash` tool with command-level allow/deny rules, command-string glob matching, escaped glob bracket-class literal preservation, reserved/compound-head rejection, leading-redirection and attached command-head redirection rejection, non-leading `>|` noclobber redirection handling, assignment-head rejection, invalid glob range handling through `invalid-policy`, unknown top-level policy key rejection, runtime invalid-policy validation, and default-allow no-rule compatibility.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.28-alpha.2",
+  "version": "0.8.28-alpha.3",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Bumps all workspace packages from `0.8.28-alpha.2` to `0.8.28-alpha.3` and dates the accumulated `[Unreleased]` changelog entries for `coding-agent` and `workflows`.

## Changes

### `@bastani/atomic` (coding-agent)
- **Added** inline free-form text entry to the `ask_user_question` TUI's **Chat about this** footer row. Non-empty typed text returns as a `kind: "chat"` answer surfaced directly to the agent; empty submissions keep the existing sentinel behavior ([#1337](https://github.com/bastani-inc/atomic/pull/1337)).
- **Added** session-scoped `bashPolicy` support for the built-in `bash` tool with exact/prefix/glob/regex allow/deny rules and deny-over-allow precedence ([#1338](https://github.com/bastani-inc/atomic/pull/1338)).

### `@bastani/workflows`
- **Added** workflow stage/task `bashPolicy` wiring so individual stages can constrain the built-in `bash` tool with command-level allow/deny rules ([#1338](https://github.com/bastani-inc/atomic/pull/1338)).
- **Added** `ctx.exit(options?)` for graceful early terminal runs, widening run/detail/child status unions ([#1341](https://github.com/bastani-inc/atomic/pull/1341)).
- **Fixed** `ctx.ui.*` handling so partial/method-less adapters and headless runs degrade gracefully with clear errors instead of crashing ([#1339](https://github.com/bastani-inc/atomic/issues/1339), [#1340](https://github.com/bastani-inc/atomic/pull/1340)).

### Version-bump only (no functional changes since 0.8.27)
- `@bastani/intercom`
- `@bastani/mcp`
- `@bastani/subagents`
- `@bastani/web-access`

## Release type

Prerelease — tag `0.8.28-alpha.3` will be pushed after merge to trigger the npm publish + GitHub Release workflow.