### PR TITLE
feat(workflows): prefer Claude Fable 5 as primary model in builtin workflows

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the builtin `deep-research-codebase`, `goal`, `ralph`, and `open-claude-design` workflows to use `anthropic/claude-fable-5:xhigh` as the primary planner/reviewer/design model, demoting each previous primary (`openai-codex/gpt-5.5:xhigh` or `github-copilot/claude-opus-4.8:xhigh`) to the head of the fallback chain.
+
 ## [0.8.28-alpha.3] - 2026-06-11
 
 ### Added

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -415,8 +415,9 @@ export default defineWorkflow("deep-research-codebase")
     );
 
     const plannerModelConfig = {
-      model: "openai-codex/gpt-5.5:xhigh",
+      model: "anthropic/claude-fable-5:xhigh",
       fallbackModels: [
+        "openai-codex/gpt-5.5:xhigh",
         "github-copilot/gpt-5.5:xhigh",
         "openai/gpt-5.5:xhigh",
         "github-copilot/claude-opus-4.8:xhigh",

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -1072,8 +1072,9 @@ export default defineWorkflow("goal")
     };
 
     const reviewerModelConfig = {
-      model: "openai-codex/gpt-5.5:xhigh",
+      model: "anthropic/claude-fable-5:xhigh",
       fallbackModels: [
+          "openai-codex/gpt-5.5:xhigh",
           "github-copilot/gpt-5.5:xhigh",
           "openai/gpt-5.5:xhigh",
           "github-copilot/claude-opus-4.8:xhigh",

--- a/packages/workflows/builtin/open-claude-design.ts
+++ b/packages/workflows/builtin/open-claude-design.ts
@@ -471,8 +471,9 @@ export default defineWorkflow("open-claude-design")
     const specFileUrl = `file://${specPath}`;
 
     const designModelConfig = {
-      model: "github-copilot/claude-opus-4.8:xhigh",
+      model: "anthropic/claude-fable-5:xhigh",
       fallbackModels: [
+          "github-copilot/claude-opus-4.8:xhigh",
           "anthropic/claude-opus-4-8:xhigh",
           "github-copilot/claude-sonnet-4.6:high",
           "anthropic/claude-sonnet-4-6:high",

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -717,8 +717,9 @@ async function runRalphWorkflow(
   let previousOrchestratorSessionFile: string | undefined;
 
   const plannerModelConfig = {
-    model: "openai-codex/gpt-5.5:xhigh",
+    model: "anthropic/claude-fable-5:xhigh",
     fallbackModels: [
+        "openai-codex/gpt-5.5:xhigh",
         "github-copilot/gpt-5.5:xhigh",
         "openai/gpt-5.5:xhigh",
         "github-copilot/claude-opus-4.8:xhigh",
@@ -739,8 +740,9 @@ async function runRalphWorkflow(
   };
 
   const reviewerModelConfig = {
-    model: "openai-codex/gpt-5.5:xhigh",
+    model: "anthropic/claude-fable-5:xhigh",
     fallbackModels: [
+      "openai-codex/gpt-5.5:xhigh",
       "github-copilot/gpt-5.5:xhigh",
       "openai/gpt-5.5:xhigh",
       "github-copilot/claude-opus-4.8:xhigh",


### PR DESCRIPTION
## Summary

Promotes `anthropic/claude-fable-5:xhigh` to the primary planner/reviewer/design model across all four builtin workflows, demoting each previous primary to the head of the fallback chain so existing behavior is preserved when Fable 5 is unavailable.

## Changes

- **`deep-research-codebase`**: planner primary `openai-codex/gpt-5.5:xhigh` → `anthropic/claude-fable-5:xhigh`
- **`goal`**: reviewer primary `openai-codex/gpt-5.5:xhigh` → `anthropic/claude-fable-5:xhigh`
- **`ralph`**: both planner and reviewer primaries `openai-codex/gpt-5.5:xhigh` → `anthropic/claude-fable-5:xhigh`
- **`open-claude-design`**: design primary `github-copilot/claude-opus-4.8:xhigh` → `anthropic/claude-fable-5:xhigh`
- `packages/workflows/CHANGELOG.md`: added `### Changed` entry under `[Unreleased]`

In each case the previous primary becomes the first entry in `fallbackModels`, so the degradation path is unchanged.

## Notes

- No API or schema changes; only default model preference ordering.
- Existing fallback chains are otherwise untouched — provider diversity is preserved.
- Pre-commit hooks (lint, unit tests) passed on commit and push.