### PR TITLE
fix(workflows): sanitize release-docs git subprocess env

### DIFF
--- a/.atomic/workflows/lib/release-docs.ts
+++ b/.atomic/workflows/lib/release-docs.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
+import { createGitEnvironment } from "../../../packages/coding-agent/src/utils/git-env.js";
 
 export type StaleDocTask = {
   id: string;
@@ -37,10 +38,17 @@ export const DEFAULT_RELEASE_DOCS_BASE_BRANCH = "main";
 
 const repoRoot = (): string => process.cwd();
 
+// Sanitize repository-local Git environment variables (GIT_DIR, GIT_WORK_TREE,
+// GIT_INDEX_FILE, ...) so subprocesses always target `cwd`. Git honors these
+// variables over cwd, so when this lib runs under a hook runner (e.g. prek
+// pre-commit/pre-push), inherited values would silently redirect every command
+// at the real repository — `git init` even persists `core.worktree` into the
+// shared .git/config of the invoking worktree (see git-env.ts).
 const runCommand = (command: string, args: string[], cwd = repoRoot()): string =>
   execFileSync(command, args, {
     cwd,
     encoding: "utf8",
+    env: createGitEnvironment(),
     maxBuffer: 1024 * 1024 * 20,
     stdio: ["ignore", "pipe", "pipe"],
   }).trim();

--- a/.atomic/workflows/lib/release-docs.ts
+++ b/.atomic/workflows/lib/release-docs.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
-import { createGitEnvironment } from "../../../packages/coding-agent/src/utils/git-env.js";
+import { createGitEnvironment } from "@bastani/atomic";
 
 export type StaleDocTask = {
   id: string;

--- a/test/unit/release-docs-workflow.test.ts
+++ b/test/unit/release-docs-workflow.test.ts
@@ -18,7 +18,7 @@ import {
     type StaleDocTask,
     type UpdateArtifactStatus,
 } from "../../.atomic/workflows/lib/release-docs.js";
-import { createGitEnvironment } from "../../packages/coding-agent/src/utils/git-env.js";
+import { createGitEnvironment } from "@bastani/atomic";
 
 const task = (id: string, ownerDocs: string[]): StaleDocTask => ({
     id,
@@ -104,8 +104,10 @@ describe("release-docs workflow guards", () => {
             );
 
             // The ambient Git env must be present at child-process startup to
-            // match hook runners. Without release-docs' sanitizer, nested Git
-            // commands would read the detached decoy repo instead of `repo`.
+            // match hook runners. The repo mandates Bun, so process.execPath is
+            // intentionally the Bun runtime for this child TypeScript script.
+            // Without release-docs' sanitizer, nested Git commands would read
+            // the detached decoy repo instead of `repo`.
             const output = execFileSync(process.execPath, [scriptPath], {
                 encoding: "utf8",
                 env: {

--- a/test/unit/release-docs-workflow.test.ts
+++ b/test/unit/release-docs-workflow.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import assert from "node:assert/strict";
 import {
     currentBranchName,
@@ -17,6 +18,7 @@ import {
     type StaleDocTask,
     type UpdateArtifactStatus,
 } from "../../.atomic/workflows/lib/release-docs.js";
+import { createGitEnvironment } from "../../packages/coding-agent/src/utils/git-env.js";
 
 const task = (id: string, ownerDocs: string[]): StaleDocTask => ({
     id,
@@ -28,8 +30,29 @@ const task = (id: string, ownerDocs: string[]): StaleDocTask => ({
     acceptance_criteria: [`Criteria ${id}`],
 });
 
+// Always sanitize the Git environment for fixture repos: under a hook runner
+// (e.g. prek) Git exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE, which Git
+// honors over cwd — an unsanitized `git init` would then re-initialize the
+// real repository and persist core.worktree into its shared .git/config
+// (see git-env.ts and the regression test below).
 const runGit = (cwd: string, args: string[]): void => {
-    execFileSync("git", args, { cwd, stdio: "ignore" });
+    execFileSync("git", args, { cwd, stdio: "ignore", env: createGitEnvironment() });
+};
+
+const commitAll = (repo: string, message: string): void => {
+    runGit(repo, [
+        "-c",
+        "user.name=Atomic Test",
+        "-c",
+        "user.email=atomic-test@example.com",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "commit",
+        "--no-gpg-sign",
+        "--message",
+        message,
+        "--quiet",
+    ]);
 };
 
 describe("release-docs workflow guards", () => {
@@ -39,19 +62,7 @@ describe("release-docs workflow guards", () => {
             runGit(repo, ["init", "--quiet"]);
             writeFileSync(join(repo, "README.md"), "# test\n");
             runGit(repo, ["add", "README.md"]);
-            runGit(repo, [
-                "-c",
-                "user.name=Atomic Test",
-                "-c",
-                "user.email=atomic-test@example.com",
-                "-c",
-                "core.hooksPath=/dev/null",
-                "commit",
-                "--no-gpg-sign",
-                "--message",
-                "initial",
-                "--quiet",
-            ]);
+            commitAll(repo, "initial");
             runGit(repo, ["checkout", "--detach", "HEAD", "--quiet"]);
 
             assert.throws(
@@ -60,6 +71,57 @@ describe("release-docs workflow guards", () => {
             );
         } finally {
             rmSync(repo, { recursive: true, force: true });
+        }
+    });
+
+    test("resolves branch state from the target repo despite ambient Git hook environment", () => {
+        const repo = mkdtempSync(join(tmpdir(), "release-docs-target-"));
+        const ambientRepo = mkdtempSync(join(tmpdir(), "release-docs-ambient-"));
+        const scriptPath = join(tmpdir(), `release-docs-current-branch-${process.pid}-${Date.now()}.ts`);
+        try {
+            // Target repo sits on a branch.
+            runGit(repo, ["init", "--quiet"]);
+            runGit(repo, ["checkout", "-b", "feature/docs", "--quiet"]);
+            writeFileSync(join(repo, "README.md"), "# target\n");
+            runGit(repo, ["add", "README.md"]);
+            commitAll(repo, "initial");
+
+            // Decoy repo is detached; a hook runner (e.g. prek) exports
+            // repository-local Git env vars pointing at the invoking repo.
+            runGit(ambientRepo, ["init", "--quiet"]);
+            writeFileSync(join(ambientRepo, "README.md"), "# ambient\n");
+            runGit(ambientRepo, ["add", "README.md"]);
+            commitAll(ambientRepo, "initial");
+            runGit(ambientRepo, ["checkout", "--detach", "HEAD", "--quiet"]);
+
+            const moduleUrl = pathToFileURL(join(process.cwd(), ".atomic/workflows/lib/release-docs.ts")).href;
+            writeFileSync(
+                scriptPath,
+                [
+                    `import { currentBranchName } from ${JSON.stringify(moduleUrl)};`,
+                    `console.log(currentBranchName(${JSON.stringify(repo)}));`,
+                ].join("\n"),
+            );
+
+            // The ambient Git env must be present at child-process startup to
+            // match hook runners. Without release-docs' sanitizer, nested Git
+            // commands would read the detached decoy repo instead of `repo`.
+            const output = execFileSync(process.execPath, [scriptPath], {
+                encoding: "utf8",
+                env: {
+                    ...process.env,
+                    GIT_DIR: join(ambientRepo, ".git"),
+                    GIT_WORK_TREE: ambientRepo,
+                    GIT_INDEX_FILE: join(ambientRepo, ".git", "index"),
+                },
+                stdio: ["ignore", "pipe", "pipe"],
+            }).trim();
+
+            assert.equal(output, "feature/docs");
+        } finally {
+            rmSync(scriptPath, { force: true });
+            rmSync(repo, { recursive: true, force: true });
+            rmSync(ambientRepo, { recursive: true, force: true });
         }
     });
 


### PR DESCRIPTION
## Summary

Strips repository-local Git environment variables (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, and others) from subprocesses in the release-docs workflow and test fixtures, preventing Git hook runners (e.g. `prek`) from silently redirecting commands at the wrong repository.

## Root Cause

Git honors repository-local env vars over `cwd` — hook runners like `prek` export these vars into the hook process environment, so any transitively spawned Git command (including `git init` on a temp directory) operates on the hook-invoking repo instead of the intended one. In the worst case, `git init` persists `core.worktree` into the shared `.git/config` of the real repo, corrupting it.

## Changes

- **`.atomic/workflows/lib/release-docs.ts`**: Pass `env: createGitEnvironment()` to `execFileSync` inside `runCommand()`, stripping all repository-local Git env vars so every Git subprocess always targets its explicit `cwd`.
- **`test/unit/release-docs-workflow.test.ts`**:
  - Apply the same `createGitEnvironment()` sanitization to `runGit()` in test fixtures, preventing fixture-repo `git init` calls from corrupting the real repo under hook runners.
  - Extract a `commitAll()` helper to deduplicate repeated commit invocations across tests.
  - Add a regression test that spawns a child Bun process with ambient hook-style env vars (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` pointing at a detached decoy repo) and asserts `currentBranchName()` still returns the correct branch of the target repo.

## Validation

- `bun run typecheck`
- `bun run lint`
- `AGENT=1 bun run test:unit`
- Pre-commit and pre-push hooks passed during commit/push