### PR TITLE
chore(deps): align all pi packages on 0.79.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
       "dependencies": {
         "@bastani/atomic-natives": "0.8.28",
         "@bufbuild/protobuf": "^2.0.0",
-        "@earendil-works/pi-agent-core": "^0.79.1",
-        "@earendil-works/pi-ai": "^0.79.1",
-        "@earendil-works/pi-tui": "^0.79.1",
+        "@earendil-works/pi-agent-core": "^0.79.3",
+        "@earendil-works/pi-ai": "^0.79.3",
+        "@earendil-works/pi-tui": "^0.79.3",
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@mozilla/readability": "^0.6.0",
@@ -84,7 +84,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.78.1",
+        "@earendil-works/pi-tui": "^0.79.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -103,8 +103,8 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-ai": "^0.78.1",
-        "@earendil-works/pi-tui": "^0.78.1",
+        "@earendil-works/pi-ai": "^0.79.3",
+        "@earendil-works/pi-tui": "^0.79.3",
         "zod": "^3.25.0 || ^4.0.0",
       },
       "optionalPeers": [
@@ -129,9 +129,9 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-agent-core": "^0.78.1",
-        "@earendil-works/pi-ai": "^0.78.1",
-        "@earendil-works/pi-tui": "^0.78.1",
+        "@earendil-works/pi-agent-core": "^0.79.3",
+        "@earendil-works/pi-ai": "^0.79.3",
+        "@earendil-works/pi-tui": "^0.79.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -152,7 +152,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.78.1",
+        "@earendil-works/pi-tui": "^0.79.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -168,7 +168,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.78.1",
+        "@earendil-works/pi-tui": "^0.79.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -249,11 +249,11 @@
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.1", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-PBPjBa2YBm9jauiLtHAKaSfVJ4Dvm3/nK/bR/oHebLjwBCS2tGx3aQDX7MSGAOXi6BejlhzbB/z82BkyAyNjjQ=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.3", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Ksvnu6CpQLYGbCSgnQEetzliI7yb+QkqtSlmmunJ69QluT45kd3DjQZRNHfRLk++Dd02Y8QvsRKMopSJCcWoWw=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-UnORwrcsTNLm4StEvoM8iEom0u87Te7BXEWxhec3iNXygWD6eEBosUoq9ddcveqtj/QpUZBMPWUu81cCtZxzkQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-lMSput/haP5uZAGbXhS5rAYd3GB7GYdJkoAUxg3VFummBeqGqGqllaTWrbHFN12kVGyVfWHhdySNXkiqVh65Iw=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-YvZCMfSE0YDSLNklAwMY6LC6SyEgnP0zMOoioTLNnXFNdexrCexMJdee7iDJsNcFlKt7+DVLccomuURtZS1C6g=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "15.0.12" } }, "sha512-cpmkEM1aEuGUx6YZM36VlzpulwLzqD5T2cUEkGHndDTNGEbnn5sj/9SYm+QBfKjvZsWoHfZuFBnu4+hh96/FbA=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atomic-extension-custom-provider-anthropic",
-  "version": "0.79.1",
+  "version": "0.79.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atomic-extension-custom-provider-anthropic",
-      "version": "0.79.1",
+      "version": "0.79.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"
       }

--- a/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-anthropic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atomic-extension-custom-provider-anthropic",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.79.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
+++ b/packages/coding-agent/examples/extensions/custom-provider-gitlab-duo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atomic-extension-custom-provider-gitlab-duo",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.79.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/gondolin/package-lock.json
+++ b/packages/coding-agent/examples/extensions/gondolin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atomic-extension-gondolin",
-  "version": "0.79.1",
+  "version": "0.79.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atomic-extension-gondolin",
-      "version": "0.79.1",
+      "version": "0.79.3",
       "dependencies": {
         "@earendil-works/gondolin": "0.12.0"
       }

--- a/packages/coding-agent/examples/extensions/gondolin/package.json
+++ b/packages/coding-agent/examples/extensions/gondolin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "atomic-extension-gondolin",
 	"private": true,
-	"version": "0.79.1",
+	"version": "0.79.3",
 	"type": "module",
 	"scripts": {
 		"clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/sandbox/package-lock.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atomic-extension-sandbox",
-  "version": "1.9.1",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atomic-extension-sandbox",
-      "version": "1.9.1",
+      "version": "1.9.3",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.26"
       }

--- a/packages/coding-agent/examples/extensions/sandbox/package.json
+++ b/packages/coding-agent/examples/extensions/sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atomic-extension-sandbox",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/examples/extensions/with-deps/package-lock.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atomic-extension-with-deps",
-  "version": "0.79.1",
+  "version": "0.79.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atomic-extension-with-deps",
-      "version": "0.79.1",
+      "version": "0.79.3",
       "dependencies": {
         "ms": "^2.1.3"
       },

--- a/packages/coding-agent/examples/extensions/with-deps/package.json
+++ b/packages/coding-agent/examples/extensions/with-deps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atomic-extension-with-deps",
   "private": true,
-  "version": "0.79.1",
+  "version": "0.79.3",
   "type": "module",
   "scripts": {
     "clean": "echo 'nothing to clean'",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -70,9 +70,9 @@
   "dependencies": {
     "@bastani/atomic-natives": "0.8.28",
     "@bufbuild/protobuf": "^2.0.0",
-    "@earendil-works/pi-agent-core": "^0.79.1",
-    "@earendil-works/pi-ai": "^0.79.1",
-    "@earendil-works/pi-tui": "^0.79.1",
+    "@earendil-works/pi-agent-core": "^0.79.3",
+    "@earendil-works/pi-ai": "^0.79.3",
+    "@earendil-works/pi-tui": "^0.79.3",
     "@modelcontextprotocol/ext-apps": "^1.7.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@mozilla/readability": "^0.6.0",

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-tui": "^0.78.1"
+    "@earendil-works/pi-tui": "^0.79.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -32,8 +32,8 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-ai": "^0.78.1",
-    "@earendil-works/pi-tui": "^0.78.1",
+    "@earendil-works/pi-ai": "^0.79.3",
+    "@earendil-works/pi-tui": "^0.79.3",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -38,9 +38,9 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-agent-core": "^0.78.1",
-    "@earendil-works/pi-ai": "^0.78.1",
-    "@earendil-works/pi-tui": "^0.78.1"
+    "@earendil-works/pi-agent-core": "^0.79.3",
+    "@earendil-works/pi-ai": "^0.79.3",
+    "@earendil-works/pi-tui": "^0.79.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-tui": "^0.78.1"
+    "@earendil-works/pi-tui": "^0.79.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -83,7 +83,7 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-tui": "^0.78.1"
+    "@earendil-works/pi-tui": "^0.79.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {


### PR DESCRIPTION
## Summary

Aligns all `@earendil-works/pi-*` package versions across the monorepo on the `0.79.3` release, closing the gap between the `^0.78.1` peer ranges declared in companion packages and the `^0.79.1` direct dependencies in `@bastani/atomic`.

## Changes

- **`packages/coding-agent`** — bumps `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` direct dependencies from `^0.79.1` → `^0.79.3`
- **`packages/intercom`** — updates `@earendil-works/pi-tui` peer dependency from `^0.78.1` → `^0.79.3`
- **`packages/mcp`** — updates `@earendil-works/pi-ai` and `@earendil-works/pi-tui` peer dependencies from `^0.78.1` → `^0.79.3`
- **`packages/subagents`** — updates `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` peer dependencies from `^0.78.1` → `^0.79.3`
- **`packages/web-access`** — updates `@earendil-works/pi-tui` peer dependency from `^0.78.1` → `^0.79.3`
- **`packages/workflows`** — updates `@earendil-works/pi-tui` peer dependency from `^0.78.1` → `^0.79.3`
- **Example extensions** (`custom-provider-anthropic`, `custom-provider-gitlab-duo`, `gondolin`, `sandbox`, `with-deps`) — bumped to `0.79.3` (sandbox: `1.9.3`) to stay in sync with the pi release line
- **`bun.lock`** — refreshed to reflect the updated dependency graph