### PR TITLE
chore(agents): rebrand pi to atomic, consolidate research guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Default to using **Bun**, not Node/npm/yarn/pnpm.
 
 ## Design Context
 
-Refer to `.impeccable.md`
+Refer to `DESIGN.md` and `PRODUCT.md`.
 
 ## Testing
 
@@ -95,8 +95,8 @@ Relevant resources (use your `browser` skill if the information is not available
     1. [`bun:test`](https://bun.sh/docs/cli/test)
     2. [Bun + TypeScript](https://bun.sh/docs/runtime/typescript)
     3. [`bunfig.toml`](https://bun.sh/docs/runtime/bunfig)
-2. pi: `can1357/pi`
-    1. Extension loading + SDK docs under `docs/`
+2. Pi: `earendil-works/pi`
+    1. [`docs/`](https://github.com/earendil-works/pi/tree/main/packages/coding-agent/docs)
 3. TypeScript: `microsoft/TypeScript`
     1. [Module resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html)
     2. [`paths`](https://www.typescriptlang.org/tsconfig#paths)
@@ -114,28 +114,18 @@ atomic:
 - extensions: `~/.atomic/agent/extensions/<name>/`
 - local: `.atomic/` in the project directory
 
-**Agent Skill Locations** - local: - `.agents/skills` (`.claude/skills` is a symlink to `.agents/skills`) - global: - `~/.agents/skills` for OpenCode and Copilot CLI - `~/.claude/skills` for Claude Code
-
 ## Releasing
 
 Atomic mirrors pi's tag-driven release flow: bump versions locally, commit, push a `<version>` git tag (no leading `v`, for example `0.8.24` or `0.8.24-alpha.1`), and CI publishes to npm with OIDC provenance and creates the GitHub Release with cross-compiled binaries attached.
 
 ### Agent publishing requests
 
-If a user asks you to publish the package or create a release/prerelease:
+If a user asks you to publish the package or create a release/prerelease, run the `publish-release` workflow using your workflow tool.
 
-1. Ask the user with the `ask_user_question`/ask-question tool what version to publish if they have not supplied a version.
-2. Ask whether they want a release or prerelease if that cannot be inferred from the supplied version, or if the version is in an incorrect format. Valid formats are `MAJOR.MINOR.PATCH` for releases and `MAJOR.MINOR.PATCH-alpha.REVISION` (revision starts at 1) for prereleases.
-3. Create a branch using the naming convention: `[prerelease | release]/<version>` (no leading `v`) where `[prerelease | release]` changes depending on whether the version if a release or prerelease version.
-4. Follow the guidance in the "Changelog" section to update the `CHANGELOG.md` files.
-5. Follow the "Bumping Versions" guidance to correctly bump the package version.
-6. Commit all unstaged changes in the current branch.
-7. Create a PR to merge the branch to main.
-8. Wait to make sure all of the CI checks pass using the `gh` tool.
-9. Auto-merge when all CI checks pass. If the checks don't pass, ask the user what they want to do using the `ask_user_question` tool.
-10. If/when the branch is merged to main, switch back to main, and pull the latest changes from `origin/main`.
-11. A branch push or PR merge alone does not publish, so if all the steps above succeed, create the new release by creating a git tag with: `git tag <version>` and push it with `git push origin <version>`.
-12. Wait for the release to finish and monitor the status of the publish action. If the publish checks don't pass, ask the user what they want to do using the `ask_user_question` tool. Otherwise, provide a summary to the user.
+## Docs
+
+- ALWAYS keep the user-facing docs in `packages/coding-agent/docs` up-to-date with the latest changes after you make changes. Prefer to keep other docs up-to-date as well, but the coding-agent docs are the most important since they are user-facing and often consulted by users and other agents.
+- To update docs, prefer using your `release-docs` workflow to thoroughly update all relevant docs with the latest changes. If you need to make a quick fix or update, you can also edit the markdown files directly, but make sure to keep them comprehensive and up-to-date.
 
 ## Changelog
 
@@ -190,11 +180,12 @@ Note: Remember that npm publishing with provenance does NOT require a token. Tha
 
 1. The workflows extension is bundled into `@bastani/atomic`. For local development against upstream pi, symlink `packages/workflows` into `~/.pi/agent/extensions/workflows` if you want host-level discovery outside Atomic.
 2. Rely on agent skills to provide information on best practices during implementation. Here is a short list of Agent Skills that are incredibly relevant to this project that you should try to use when applicable:
+    - bun
+    - gh-commit
+    - gh-create-pr
+    - prek
     - typescript-advanced-types
     - typescript-expert
-    - typescript-react-reviewer
-    - tdd
-    - impeccable
 3. Ask for clarity if you are unsure about a change. The developer is your best friend and oftentimes can clarify intent.
 4. When modifying this extension, follow pi's extension and SDK conventions.
 

--- a/packages/intercom/skills/intercom/SKILL.md
+++ b/packages/intercom/skills/intercom/SKILL.md
@@ -2,15 +2,15 @@
 name: intercom
 description: |
   Streamline session-to-session coordination with the intercom extension. Send
-  messages, delegate tasks, and coordinate work across multiple pi sessions on
+  messages, delegate tasks, and coordinate work across multiple atomic sessions on
   the same machine. Use for planner-worker workflows, cross-session context
   sharing, and real-time collaboration between sessions.
 ---
 
 # Intercom Skill
 
-Use this skill when you need to coordinate work across multiple pi sessions
-running on the same machine. Pi-intercom enables direct 1:1 messaging between
+Use this skill when you need to coordinate work across multiple atomic sessions
+running on the same machine. Intercom enables direct 1:1 messaging between
 sessions for delegation, context sharing, and collaborative workflows.
 
 When you are supervising with the `subagent` skill, delegated child agents can
@@ -204,9 +204,9 @@ message, treat it as a `contact_supervisor` escalation.
 | `list` | Returns all sessions with live status | You need to discover targets or choose an idle peer |
 | `status` | Returns your connection state | Troubleshooting |
 
-## Optional: Visible Peer Sessions via cmux or tmux
+## Optional: Visible Peer Sessions via cmux, tmux, or psmux (Windows rewrite of tmux that has fully parity with tmux)
 
-If no suitable intercom-connected peer session already exists and the task benefits from a long-lived visible conversation, you may spawn a new `pi` session.
+If no suitable intercom-connected peer session already exists and the task benefits from a long-lived visible conversation, you may spawn a new `atomic` session.
 
 Prefer `cmux new-split right` over new surfaces or workspaces so both sessions are visible side by side.
 

--- a/packages/subagents/agents/codebase-online-researcher.md
+++ b/packages/subagents/agents/codebase-online-researcher.md
@@ -1,16 +1,16 @@
 ---
 name: codebase-online-researcher
 description: Online research for up-to-date documentation and library-source knowledge. Use when you need authoritative external information — official docs, ecosystem context, version-specific behavior, GitHub permalinks into open-source libraries, or video tutorials.
-tools: read, grep, find, ls, bash, write, web_search, fetch_content, get_search_content
+tools: read, grep, find, ls, bash, web_search, fetch_content, get_search_content
 model: openai/gpt-5.5:low
 fallbackModels: openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, anthropic/claude-opus-4-8:low, github-copilot/claude-opus-4.7:low
 skills: browser
 ---
 
-You are an expert research specialist focused on finding accurate, relevant information from authoritative sources — including open-source library internals with GitHub permalinks. You have three web tools available from the `pi-web-access` extension:
+You are an expert research specialist focused on finding accurate, relevant information from authoritative sources — including open-source library internals with GitHub permalinks. You have three web tools available:
 
 - `web_search` — issue one or more queries and get a ranked list of candidate URLs/snippets.
-- `fetch_content` — fetch a specific URL and return clean reader-mode text/markdown (HTML pages, GitHub issues/PRs, Stack Overflow, npm, arXiv, Reddit, Wikipedia, JSON endpoints, PDFs, RSS/Atom, YouTube). `fetch_content` on a GitHub repo URL also clones the repo locally under `/tmp/pi-github-repos/<owner>/<repo>` and returns the file tree. Prefer this over a raw HTTP fetch.
+- `fetch_content` — fetch a specific URL and return clean reader-mode text/markdown (HTML pages, GitHub issues/PRs, Stack Overflow, npm, arXiv, Reddit, Wikipedia, JSON endpoints, PDFs, RSS/Atom, YouTube). `fetch_content` on a GitHub repo URL also clones the repo locally under `/tmp/atomic-github-repos/<owner>/<repo>` and returns the file tree. Prefer this over a raw HTTP fetch.
 - `get_search_content` — fetch the underlying content for the most promising results of a previous `web_search` in one call.
 
 For JS-heavy or auth-gated pages, load the `browser` skill and invoke its `browse` CLI through `bash`.
@@ -41,21 +41,6 @@ When fetching any external page, apply these techniques in order. They produce p
 3. **Request Markdown via `Accept: text/markdown`.** Sites behind Cloudflare with [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) return pre-converted Markdown when you set the header. Use `bash` with `curl <url> -H "Accept: text/markdown"` (look for `content-type: text/markdown` and the `x-markdown-tokens` header).
 4. **Fall back to a real browser.** Load the `browser` skill and drive its `browse` CLI through `bash` to render and interact with JS-heavy or auth-gated pages.
 
-## Persisting Findings — Store useful documents in `research/web/`
-
-When you fetch a document that is worth keeping for future sessions (reference docs, API schemas, SDK guides, release notes, troubleshooting writeups, architecture articles), `write` it to `research/web/<YYYY-MM-DD>-<kebab-case-topic>.md` with frontmatter capturing:
-
-```markdown
----
-source_url: <original URL>
-fetched_at: <YYYY-MM-DD>
-fetch_method: read | llms.txt | markdown-accept-header | browser | browse
-topic: <short description>
----
-```
-
-Followed by the extracted content (trimmed of nav chrome, ads, and irrelevant boilerplate). This lets future work reuse the lookup without re-fetching. Before fetching anything, quickly `find research/web/` for an existing, recent copy.
-
 ## Library Source Research with Permalinks
 
 When the question is about an open-source library — its internals, why something was changed, or how a behavior is implemented — every code-related claim needs a GitHub permalink pinned to a full commit SHA. Branch links rot; permalinks don't.
@@ -75,10 +60,10 @@ When the question is about an open-source library — its internals, why somethi
 
 **Implementation.** The core workflow is clone → find → permalink:
 
-1. `fetch_content` the GitHub repo URL — this clones it locally to `/tmp/pi-github-repos/<owner>/<repo>` and returns the file tree.
+1. `fetch_content` the GitHub repo URL — this clones it locally to `/tmp/atomic-github-repos/<owner>/<repo>` and returns the file tree.
 2. `grep -rn "function_name"` and `find . -name "*.ts"` inside the clone via `bash`.
 3. `read` the specific files once you've located them.
-4. Get the commit SHA: `cd /tmp/pi-github-repos/<owner>/<repo> && git rev-parse HEAD`.
+4. Get the commit SHA: `cd /tmp/atomic-github-repos/<owner>/<repo> && git rev-parse HEAD`.
 5. Construct the permalink: `https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<start>-L<end>`.
 
 Batch the initial calls (`fetch_content` to clone + `web_search` for recent discussions) in one turn, then dig into the clone with `grep`/`read` once it's available.
@@ -86,7 +71,7 @@ Batch the initial calls (`fetch_content` to clone + `web_search` for recent disc
 **Context / History.** Use git on the cloned repo and `gh` for issues/PRs:
 
 ```bash
-cd /tmp/pi-github-repos/<owner>/<repo>
+cd /tmp/atomic-github-repos/<owner>/<repo>
 
 # Recent changes to a specific file
 git log --oneline -n 20 -- path/to/file.ts
@@ -131,7 +116,7 @@ https://github.com/<owner>/<repo>/blob/<commit-sha>/<filepath>#L<start>-L<end>
 Get the SHA from a cloned repo:
 
 ```bash
-cd /tmp/pi-github-repos/<owner>/<repo> && git rev-parse HEAD
+cd /tmp/atomic-github-repos/<owner>/<repo> && git rev-parse HEAD
 ```
 
 Get the SHA from a tag when answering version-specific questions:
@@ -292,7 +277,7 @@ For library-source answers, every code claim should look like the citation examp
 - Check `research/web/` for an existing copy before fetching anything new.
 - Start by fetching the authoritative source (`fetch_content <url>` → `/llms.txt` → `Accept: text/markdown` → `browser`) rather than search-engine-style exploration.
 - Use `fetch_content` (or `get_search_content` after a `web_search`) to pull full content from the most promising 3-5 web pages.
-- Reuse already-cloned repos under `/tmp/pi-github-repos/` instead of re-cloning.
+- Reuse already-cloned repos under `/tmp/atomic-github-repos/` instead of re-cloning.
 - If initial results are insufficient, refine search terms and try again.
 - Use exact error messages and function names when available for higher precision.
 - Compare guidance across at least two sources when possible.
@@ -305,7 +290,7 @@ For library-source answers, every code claim should look like the citation examp
 | Failure                        | Recovery                                                                                                       |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | `grep` finds nothing           | Broaden the query; try concept names instead of exact function names.                                          |
-| `gh` CLI rate limited          | Use the already-cloned repo under `/tmp/pi-github-repos/` for git operations instead.                          |
+| `gh` CLI rate limited          | Use the already-cloned repo under `/tmp/atomic-github-repos/` for git operations instead.                          |
 | Repo too large to clone        | `fetch_content` returns an API-only view automatically; use that, or add `forceClone: true` if you must clone. |
 | File not found in the clone    | A branch name with slashes may have misresolved; list the repo tree and navigate manually.                     |
 | Uncertain about implementation | State your uncertainty explicitly, propose a hypothesis, and show what evidence you did find.                  |

--- a/packages/subagents/agents/debugger.md
+++ b/packages/subagents/agents/debugger.md
@@ -1,13 +1,13 @@
 ---
 name: debugger
 description: Debug errors, test failures, and unexpected behavior. Use PROACTIVELY when encountering issues, analyzing stack traces, or investigating system problems.
-tools: read, edit, write, grep, find, ls, bash, web_search, fetch_content, get_search_content
+tools: read, grep, find, ls, bash, web_search, fetch_content, get_search_content
 model: openai/gpt-5.5:xhigh
 fallbackModels: openai-codex/gpt-5.5:xhigh, github-copilot/gpt-5.5:xhigh, anthropic/claude-opus-4-8:xhigh, github-copilot/claude-opus-4.7:xhigh
 skills: tdd, browser, tmux
 ---
 
-You are tasked with debugging and identifying errors, test failures, and unexpected behavior in the codebase. Your goal is to identify root causes, generate a report detailing the issues and proposed fixes, and fix the problem from that report.
+You are tasked with debugging and identifying errors, test failures, and unexpected behavior in the codebase. Your goal is to identify root causes and generate a report detailing the issues and proposed fixes, so another agent can implement the solutions you suggest.
 
 ## Available helpers
 
@@ -42,12 +42,10 @@ You are tasked with debugging and identifying errors, test failures, and unexpec
 
 When you need to consult docs, forums, or issue trackers, apply these techniques in order for the cleanest, most token-efficient content:
 
-1. **`fetch_content <url>` first.** The `pi-web-access` fetch tool returns clean reader-mode text/markdown for HTML, GitHub issues/PRs, Stack Overflow, npm, arXiv, RSS, Wikipedia, Reddit, JSON endpoints, and PDFs — no browser needed.
+1. **`fetch_content <url>` first.** The fetch tool returns clean reader-mode text/markdown for HTML, GitHub issues/PRs, Stack Overflow, npm, arXiv, RSS, Wikipedia, Reddit, JSON endpoints, and PDFs — no browser needed.
 2. **Check `/llms.txt`.** Many modern docs sites publish an AI-friendly index at `/llms.txt` (spec: [llmstxt.org](https://llmstxt.org/llms.txt)). Try `fetch_content https://<site>/llms.txt` before anything else; it often links directly to the most relevant pages in plain text.
 3. **`Accept: text/markdown` header.** Some sites behind Cloudflare serve pre-converted Markdown via the header. If `fetch_content` returns thin or noisy content, try `bash` with `curl <url> -H "Accept: text/markdown"`.
 4. **Fall back to the browser skill** — only when JS execution, login, or interactive actions are required.
-
-**Persist useful findings to `research/web/`:** When you fetch a document worth keeping for future sessions (error-message writeups, API schemas, troubleshooting guides, release notes), save it to `research/web/<YYYY-MM-DD>-<kebab-case-topic>.md` with a short header noting the source URL and fetch date. Future debugging sessions can then reuse the lookup without re-fetching.
 
 ## Workflow
 

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -434,7 +434,7 @@ All notable changes to this project will be documented in this file.
 ## [0.5.0] - 2026-02-01
 
 ### Added
-- GitHub repository clone extraction for `fetch_content` -- detects GitHub code URLs, clones repos to `/tmp/pi-github-repos/`, and returns actual file contents plus local path for further exploration with `read` and `bash`
+- GitHub repository clone extraction for `fetch_content` -- detects GitHub code URLs, clones repos to `/tmp/atomic-github-repos/`, and returns actual file contents plus local path for further exploration with `read` and `bash`
 - Lightweight API fallback for oversized repos (>350MB) and commit SHA URLs via `gh api`
 - Clone cache with concurrent request deduplication (second request awaits first's clone)
 - `forceClone` parameter on `fetch_content` to override the size threshold

--- a/packages/web-access/README.md
+++ b/packages/web-access/README.md
@@ -265,7 +265,7 @@ All config lives in `~/.pi/web-search.json`. Every field is optional.
     "enabled": true,
     "maxRepoSizeMB": 350,
     "cloneTimeoutSeconds": 30,
-    "clonePath": "/tmp/pi-github-repos"
+    "clonePath": "/tmp/atomic-github-repos"
   },
   "youtube": {
     "enabled": true,

--- a/packages/web-access/github-extract.ts
+++ b/packages/web-access/github-extract.ts
@@ -78,7 +78,7 @@ function loadGitHubConfig(): GitHubCloneConfig {
 		enabled: true,
 		maxRepoSizeMB: 350,
 		cloneTimeoutSeconds: 30,
-		clonePath: "/tmp/pi-github-repos",
+		clonePath: "/tmp/atomic-github-repos",
 	};
 
 	if (!existsSync(CONFIG_PATH)) {

--- a/packages/workflows/skills/research-codebase/SKILL.md
+++ b/packages/workflows/skills/research-codebase/SKILL.md
@@ -65,10 +65,24 @@ The user's research question/request is: **$ARGUMENTS**
         - The agent fetches live web content using the **browser** skill's `browse` CLI (or `npx browse` / `curl`). Instruct it to apply the token-efficient fetch order: (1) try `curl https://<site>/llms.txt` for an AI-friendly index (see [llmstxt.org](https://llmstxt.org/llms.txt)), (2) try `curl <url> -H "Accept: text/markdown"` to get pre-converted Markdown (supported on Cloudflare-hosted docs via [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/)), (3) fall back to HTML parsing via `browse`
         - Instruct the agent to return LINKS with their findings and INCLUDE those links in the research document
         - The agent should persist reusable source documents under `research/web/<YYYY-MM-DD>-<kebab-case-topic>.md` (with frontmatter noting `source_url`, `fetched_at`, and `fetch_method`) so future research can reuse them without re-fetching
-        - Output directory for the synthesized research artifact: `research/docs/`
+        - Output directory for the synthesized web research artifacts: `research/web/`:
+
+          When you fetch a document that is worth keeping for future sessions (reference docs, API schemas, SDK guides, release notes, troubleshooting writeups, architecture articles), `write` it to `research/web/<YYYY-MM-DD>-<kebab-case-topic>.md` with frontmatter capturing:
+          
+          ```markdown
+          ---
+          source_url: <original URL>
+          fetched_at: <YYYY-MM-DD>
+          fetch_method: read | llms.txt | markdown-accept-header | browser | browse
+          topic: <short description>
+          ---
+          ```
+
+        - Followed by the extracted content (trimmed of nav chrome, ads, and irrelevant boilerplate). This lets future work reuse the lookup without re-fetching. Before fetching anything, quickly `find research/web/` for an existing, recent copy.
+
         - Examples:
-            - If researching `Redis` locks usage, the agent might find relevant usage and create a document `research/docs/2024-01-15-redis-locks-usage.md` with internal links to Redis docs and code references (and cache the fetched Redis docs under `research/web/`)
-            - If researching `OAuth` flows, the agent might find relevant external articles and create a document `research/docs/2024-01-16-oauth-flows.md` with links to those articles
+            - If researching `Redis` locks usage, the agent might find relevant usage and create a document `research/web/2024-01-15-redis-locks-usage.md` with internal links to Redis docs and code references (and cache the fetched Redis docs under `research/web/`)
+            - If researching `OAuth` flows, the agent might find relevant external articles and create a document `research/web/2024-01-16-oauth-flows.md` with links to those articles
 
     The key is to use these agents intelligently:
     - Start with locator agents to find what exists


### PR DESCRIPTION
## Summary

Renames `pi` references to `atomic` across agent configuration and skills, consolidates web-research persistence docs into the `research-codebase` skill, simplifies the release workflow instructions, and updates the GitHub clone cache path to `/tmp/atomic-github-repos`.

## Changes

### Rebranding & naming
- Updates all `pi` → `atomic` references in the intercom skill (`pi sessions` → `atomic sessions`, `pi-intercom` → `Intercom`, adds `psmux` to multiplexer list)
- Updates Pi upstream repo reference from `can1357/pi` to `earendil-works/pi` with a direct link to the packaged docs
- Renames GitHub clone cache from `/tmp/pi-github-repos` to `/tmp/atomic-github-repos` across `github-extract.ts`, `README.md`, `CHANGELOG.md`, and all agent markdown docs

### CLAUDE.md updates
- Replaces `.impeccable.md` design reference with `DESIGN.md` and `PRODUCT.md`
- Removes the verbose 12-step publishing checklist in favor of delegating to the `publish-release` workflow
- Adds a **Docs** section requiring `packages/coding-agent/docs` to be kept up-to-date after changes, with a `release-docs` workflow pointer
- Refreshes the skills list: replaces `typescript-react-reviewer`, `tdd`, `impeccable` with `bun`, `gh-commit`, `gh-create-pr`, `prek`
- Removes the now-redundant "Agent Skill Locations" paragraph

### Agent tool hardening
- **`debugger`**: removes `edit` and `write` from the tool list; changes role from self-fixing to report-only (produces a diagnosis + proposed fixes for another agent to apply); removes `pi-web-access` branding
- **`codebase-online-researcher`**: removes `write` from the tool list; removes the embedded "Persisting Findings" block (now consolidated below)

### Research guidance consolidation
- Moves all web-research persistence instructions (frontmatter schema, storage path `research/web/`, fetch-before-save check) from `codebase-online-researcher` and `debugger` into `research-codebase/SKILL.md` as a single source of truth
- Updates example output paths from `research/docs/` → `research/web/` for consistency

## Validation

- `bun run typecheck`
- Pre-commit hooks: `bun run lint`, `bun run test:unit`