### PR TITLE
ci: migrate native artifact jobs to Blacksmith runners

### DIFF
--- a/.atomic/workflows/publish-release.ts
+++ b/.atomic/workflows/publish-release.ts
@@ -129,6 +129,9 @@ function packageManifestPaths(): readonly string[] {
 function releaseChangedFileAllowed(path: string): boolean {
   return path === "package.json"
     || path === "bun.lock"
+    || path === "Cargo.toml"
+    || path === "Cargo.lock"
+    || path === "packages/natives/native/index.js"
     || /^packages\/[^/]+\/(?:package\.json|README\.md|CHANGELOG\.md)$/u.test(path);
 }
 
@@ -177,7 +180,14 @@ async function verifyReleasePreparation(
       failures.push(`${manifestPath} name was ${String(manifest.name)}, expected @bastani/atomic`);
     }
 
-    if (manifestPath !== "packages/coding-agent/package.json"
+    if (manifestPath === "packages/natives/package.json") {
+      if (manifest.name !== "@bastani/atomic-natives") {
+        failures.push(`${manifestPath} name was ${String(manifest.name)}, expected @bastani/atomic-natives`);
+      }
+      if (manifest.private === true) {
+        failures.push(`${manifestPath} must remain publishable because @bastani/atomic depends on it at runtime`);
+      }
+    } else if (manifestPath !== "packages/coding-agent/package.json"
       && manifestPath.startsWith("packages/")
       && manifest.private !== true) {
       failures.push(`${manifestPath} must remain private because it is bundled into @bastani/atomic`);

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,17 +178,17 @@ jobs:
 
     atomic-native-artifacts:
         name: Atomic native ${{ matrix.platform }}
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.runner }}
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - { os: ubuntu-latest, platform: linux-x64, target: "" }
-                    - { os: ubuntu-latest, platform: linux-arm64, target: aarch64-unknown-linux-gnu }
-                    - { os: macos-13, platform: darwin-x64, target: "" }
-                    - { os: macos-14, platform: darwin-arm64, target: "" }
-                    - { os: ubuntu-latest, platform: windows-x64, target: x86_64-pc-windows-msvc }
-                    - { os: ubuntu-latest, platform: windows-arm64, target: aarch64-pc-windows-msvc }
+                    - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux-x64, target: "" }
+                    - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux-arm64, target: "" }
+                    - { runner: macos-26-intel, platform: darwin-x64, target: "" }
+                    - { runner: blacksmith-6vcpu-macos-26, platform: darwin-arm64, target: "" }
+                    - { runner: blacksmith-4vcpu-ubuntu-2404, platform: windows-x64, target: x86_64-pc-windows-msvc }
+                    - { runner: blacksmith-4vcpu-ubuntu-2404, platform: windows-arm64, target: aarch64-pc-windows-msvc }
 
         steps:
             - uses: actions/checkout@v6.0.3

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,10 +1,10 @@
 # CI/CD Pipeline
 
-This document describes the GitHub Actions workflows for the Atomic monorepo and the single publishable npm package, `@bastani/atomic`.
+This document describes the GitHub Actions workflows for the Atomic monorepo and the publishable npm packages, `@bastani/atomic` and `@bastani/atomic-natives`.
 
-`@bastani/atomic` lives in `packages/coding-agent`. It is the Atomic-branded coding-agent CLI package and bundles the first-party workflows, subagents, MCP, web-access, and intercom packages into its published tarball under `dist/builtin/`.
+`@bastani/atomic` lives in `packages/coding-agent`. It is the Atomic-branded coding-agent CLI package and bundles the first-party workflows, subagents, MCP, web-access, intercom, cursor, and native-loader assets into its published tarball.
 
-No other workspace package is published. The companion packages under `packages/*` remain private and are copied into `@bastani/atomic` at build time.
+`@bastani/atomic-natives` lives in `packages/natives`. It is published alongside `@bastani/atomic` so the CLI can depend on a provenance-backed root native package plus generated optional platform packages. Other companion packages under `packages/*` remain private and are copied into `@bastani/atomic` at build time.
 
 ## Workflow Overview
 
@@ -24,10 +24,13 @@ Pull request / push
 <version> tag pushed
   ├─ smoke test Linux x64 release archive in a dedicated job
   ├─ smoke test Windows x64 release archive in a dedicated job
-  └─ publish after both smoke jobs pass
+  ├─ build native NAPI artifacts for Linux, Windows, and macOS
+  └─ publish after smoke and native-artifact jobs pass
      ├─ resolve and validate the release tag
      ├─ bun install --frozen-lockfile
      ├─ bun run typecheck && bun run test:all
+     ├─ download native NAPI artifacts
+     ├─ prepare generated native optional packages
      ├─ cd packages/coding-agent && bun run docs:check
      ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
      ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
@@ -35,7 +38,8 @@ Pull request / push
      ├─ scripts/build-binaries.sh (regular build + cross-compile 6 targets)
      ├─ validate dist/builtin contains all bundled extensions
      ├─ extract release notes from packages/coding-agent/CHANGELOG.md
-     ├─ check whether the npm version already exists
+     ├─ check whether the npm versions already exist
+     ├─ npm publish --provenance --tag "$NPM_TAG" from packages/natives when needed
      ├─ bun pm pack --dry-run from packages/coding-agent when publishing
      ├─ npm publish --provenance --tag "$NPM_TAG" from packages/coding-agent when needed
      ├─ determine GitHub Release type
@@ -46,13 +50,18 @@ Pull request / push
 
 The repository root is a private workspace package named `atomic-monorepo`.
 
-The only publishable workspace package is `packages/coding-agent/package.json`:
+The publishable workspace packages are:
 
-- package name: `@bastani/atomic`
-- CLI binary: `atomic` → `dist/cli.js`
-- `main`: `./dist/index.js`
-- `types`: `./dist/index.d.ts`
-- package version: shared by all `packages/*` packages
+- `packages/coding-agent/package.json`
+  - package name: `@bastani/atomic`
+  - CLI binary: `atomic` → `dist/cli.js`
+  - `main`: `./dist/index.js`
+  - `types`: `./dist/index.d.ts`
+  - package version: shared by all `packages/*` packages
+- `packages/natives/package.json`
+  - package name: `@bastani/atomic-natives`
+  - NAPI-RS loader and generated optional platform packages for Atomic native bindings
+  - package version: shared with `@bastani/atomic`
 
 Bundled builtin packages copied into `packages/coding-agent/dist/builtin/` during `bun run build`:
 
@@ -62,7 +71,7 @@ Bundled builtin packages copied into `packages/coding-agent/dist/builtin/` durin
 - `web-access` from `packages/web-access` (`@bastani/web-access`)
 - `intercom` from `packages/intercom` (`@bastani/intercom`)
 
-These companion packages remain in the workspace for source organization and tests, but are marked `private: true` and must not be published independently.
+These companion packages remain in the workspace for source organization and tests, but are marked `private: true` and must not be published independently. `@bastani/atomic-natives` is the exception because `@bastani/atomic` depends on it at runtime.
 
 ---
 
@@ -160,12 +169,14 @@ Publish @bastani/atomic
   · setup Bun and Node (Node 24 for npm provenance publish)
   · bun install --frozen-lockfile
   · bun run typecheck && bun run test:all
+  · download native NAPI artifacts from the matrix jobs
+  · prepare generated native optional packages with `bun run --cwd packages/natives create-npm-dirs` and `bun run --cwd packages/natives artifacts`
   · cd packages/coding-agent && bun run docs:check
   · cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
   · cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
   · validate tag matches packages/coding-agent/package.json
   · validate every package manifest has a synced version
-  · validate bundled packages remain private and are not independently publishable
+  · validate bundled packages remain private, with `@bastani/atomic-natives` as the publishable native-package exception
   · scripts/build-binaries.sh
       - bun run build (regular dist/)
       - bun build --compile --target=bun-<platform> for all 6 targets
@@ -175,6 +186,7 @@ Publish @bastani/atomic
   · extract release notes from packages/coding-agent/CHANGELOG.md
   · determine npm tag: latest or next
   · skip publish if version already exists on npm
+  · cd packages/natives && bun run prepublish:native && npm publish --provenance --access public --tag "$NPM_TAG" --registry https://registry.npmjs.org
   · cd packages/coding-agent && bun pm pack --dry-run
   · cd packages/coding-agent && npm publish --provenance --access public --tag "$NPM_TAG" --registry https://registry.npmjs.org
   · determine GitHub Release prerelease/latest settings
@@ -189,7 +201,7 @@ Create GitHub Release with softprops/action-gh-release@v3
 
 npm versions are immutable. The workflow publishes to npm first so the GitHub Release is only created after the npm package is available.
 
-npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test jobs can use Blacksmith runners.
+npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test and most native-artifact jobs can use Blacksmith runners. The native-artifact matrix follows Blacksmith's architecture-aware runner pattern: Linux x64 uses `blacksmith-4vcpu-ubuntu-2404`, Linux arm64 uses `blacksmith-4vcpu-ubuntu-2404-arm`, Darwin arm64 uses `blacksmith-6vcpu-macos-26`, and Darwin x64 uses GitHub's Intel macOS runner (`macos-26-intel`) because Blacksmith does not provide Intel macOS runners.
 
 ### GitHub Release Creation
 
@@ -218,9 +230,12 @@ Binaries attached to every release:
 
 ---
 
-## Single-Package Publish Rule
+## Publish Package Rule
 
-CI must publish exactly one npm package: `@bastani/atomic` from `packages/coding-agent`.
+CI publishes exactly two npm package roots for each release:
+
+- `@bastani/atomic-natives` from `packages/natives`
+- `@bastani/atomic` from `packages/coding-agent`
 
 Do not add publish steps for:
 
@@ -229,6 +244,7 @@ Do not add publish steps for:
 - `@bastani/mcp`
 - `@bastani/web-access`
 - `@bastani/intercom`
+- `@bastani/cursor`
 - any other `packages/*` workspace
 
 Those extensions are bundled into `@bastani/atomic` by `packages/coding-agent/scripts/copy-builtin-packages.ts`.
@@ -257,7 +273,7 @@ The meaningful pre-publish checks are:
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests, build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
-| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, validate docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic`, create GitHub Release with binaries |
+| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
 | `code-review.yml`    | PR opened/synchronized                        | Claude-powered code review                                                                                                                                                                                    |
 | `pr-description.yml` | PR opened/synchronized                        | Claude-powered PR description generation, skipped for Dependabot                                                                                                                                              |
 | `claude.yml`         | Issue/PR comments, issues, PR reviews         | Interactive Claude assistant gated on `@claude` mentions                                                                                                                                                      |
@@ -318,6 +334,6 @@ The meaningful pre-publish checks are:
     git push origin 0.8.0
     ```
 
-5. Confirm `publish.yml` runs docs link validation plus Mintlify syntax and broken-link checks, cross-compiles binaries, publishes `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
+5. Confirm `publish.yml` runs docs link validation plus Mintlify syntax and broken-link checks, cross-compiles binaries, publishes `@bastani/atomic-natives` and `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
 
 For prereleases, substitute `0.8.0-alpha.1` and tag `0.8.0-alpha.1`.


### PR DESCRIPTION
## Summary

Migrates the native NAPI artifact build matrix onto architecture-aware Blacksmith runners where available, updates the publish-release verifier to handle Cargo/NAPI release metadata and the `@bastani/atomic-natives` package, and refreshes CI docs to describe the full native publish path.

## Key Changes

### CI (`publish.yml`)
- Switch native artifact runner matrix from generic GitHub-hosted runners to Blacksmith:
  - Linux x64: `ubuntu-latest` → `blacksmith-4vcpu-ubuntu-2404`
  - Linux arm64: cross-compile on `ubuntu-latest` → native `blacksmith-4vcpu-ubuntu-2404-arm`
  - Darwin arm64: `macos-14` → `blacksmith-6vcpu-macos-26`
  - Darwin x64: `macos-13` → `macos-26-intel` (GitHub-hosted; Blacksmith macOS is Apple Silicon only)
  - Windows x64/arm64: `ubuntu-latest` → `blacksmith-4vcpu-ubuntu-2404`
- Rename matrix field `os` → `runner` to reflect the new runner-centric naming

### Publish-release verifier (`.atomic/workflows/publish-release.ts`)
- Allow `Cargo.toml`, `Cargo.lock`, and `packages/natives/native/index.js` in the release-changed-file allowlist
- Add explicit validation for `packages/natives/package.json`: verifies name is `@bastani/atomic-natives` and that the package is not marked private (it must be publishable since `@bastani/atomic` depends on it at runtime)

### Docs (`docs/ci.md`)
- Document `@bastani/atomic-natives` as a second publishable npm package alongside `@bastani/atomic`
- Describe the NAPI artifact download, `create-npm-dirs`, and `artifacts` steps in the publish flow
- Update the publish rule section from "Single-Package" to "Two Packages"
- Document the full Blacksmith runner matrix and explain why Darwin x64 remains on a GitHub-hosted runner
- Add `@bastani/cursor` to the list of packages that must stay private/bundled

## Release Note

The previous `0.8.29-alpha.1` tag publish run was cancelled because the Darwin x64 native artifact job was queued on `macos-13`. After this lands, the tag can be republished with a manual `publish.yml` dispatch using tag `0.8.29-alpha.1`.

## Validation

- `bun test test/unit/package-metadata.test.ts test/unit/publish-release-helpers.test.ts`
- `bun run typecheck`
- Commit/push hooks passed `bun run lint` and `bun run test:unit`