### PR TITLE
chore: release 0.8.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "atomic-natives"
-version = "0.8.29-alpha.4"
+version = "0.8.29"
 dependencies = [
  "bytes",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/atomic-natives"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.29-alpha.4"
+version = "0.8.29"
 edition = "2024"
 license = "MIT"
 authors = ["Bastani"]

--- a/bun.lock
+++ b/bun.lock
@@ -12,12 +12,12 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "bin": {
         "atomic": "dist/cli.js",
       },
       "dependencies": {
-        "@bastani/atomic-natives": "0.8.29-alpha.2",
+        "@bastani/atomic-natives": "0.8.29",
         "@bufbuild/protobuf": "^2.0.0",
         "@earendil-works/pi-agent-core": "^0.79.3",
         "@earendil-works/pi-ai": "^0.79.3",
@@ -64,9 +64,9 @@
     },
     "packages/cursor": {
       "name": "@bastani/cursor",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "dependencies": {
-        "@bastani/atomic-natives": "0.8.29-alpha.4",
+        "@bastani/atomic-natives": "0.8.29",
         "@bufbuild/protobuf": "^2.0.0",
       },
       "peerDependencies": {
@@ -78,7 +78,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -93,7 +93,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -115,14 +115,14 @@
     },
     "packages/natives": {
       "name": "@bastani/atomic-natives",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "devDependencies": {
         "@napi-rs/cli": "3.7.0",
       },
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -142,7 +142,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -161,7 +161,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.29-alpha.4",
+      "version": "0.8.29",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Added
 
 - Added support for local `-e <dir>` extension sources to borrow project-local Atomic resources from `<dir>/.atomic`, legacy `<dir>/.pi`, and `<dir>/.agents/skills` after resolving trust for that extension source, preserving package-manager provenance and explicit-path workflow forwarding while avoiding untrusted borrowed resources ([#1354](https://github.com/bastani-inc/atomic/issues/1354)).

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {
@@ -68,7 +68,7 @@
     "prepublishOnly": "bun run clean && bun run build"
   },
   "dependencies": {
-    "@bastani/atomic-natives": "0.8.29-alpha.4",
+    "@bastani/atomic-natives": "0.8.29",
     "@bufbuild/protobuf": "^2.0.0",
     "@earendil-works/pi-agent-core": "^0.79.3",
     "@earendil-works/pi-ai": "^0.79.3",

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Added
 
 - Added a prototype Rust/N-API HTTP/2 native binding and loader so the Cursor transport uses the generated `@bastani/atomic-natives` NAPI-RS package without requiring Node.js on `PATH`.

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/cursor",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "private": true,
   "description": "Experimental first-party Atomic extension for Cursor OAuth, model discovery, and streaming provider registration.",
   "contributors": [
@@ -40,7 +40,7 @@
     }
   },
   "dependencies": {
-    "@bastani/atomic-natives": "0.8.29-alpha.4",
+    "@bastani/atomic-natives": "0.8.29",
     "@bufbuild/protobuf": "^2.0.0"
   }
 }

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Changed
 
-- Published a synchronized Atomic 0.8.29-alpha.4 prerelease with the upstream pi TUI dependency aligned to `^0.79.3`; no functional changes were made in the intercom extension.
+- Published a synchronized Atomic 0.8.29 stable release with the upstream pi TUI dependency aligned to `^0.79.3`; no functional changes were made in the intercom extension.
 
 ## [0.8.28] - 2026-06-11
 

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Changed
 
-- Published a synchronized Atomic 0.8.29-alpha.4 prerelease with upstream pi AI/TUI dependencies aligned to `^0.79.3`; no functional changes were made in the MCP extension.
+- Published a synchronized Atomic 0.8.29 stable release with upstream pi AI/TUI dependencies aligned to `^0.79.3`; no functional changes were made in the MCP extension.
 
 ## [0.8.28] - 2026-06-11
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Added
 
 - Added the initial `@bastani/atomic-natives` NAPI-RS package with a Cursor HTTP/2 native transport binding.

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-android-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-android-arm-eabi')
         const bindingPackageVersion = require('@bastani/atomic-natives-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-x64-gnu')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-x64-msvc')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-ia32-msvc')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-arm64-msvc')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@bastani/atomic-natives-darwin-universal')
       const bindingPackageVersion = require('@bastani/atomic-natives-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-darwin-x64')
         const bindingPackageVersion = require('@bastani/atomic-natives-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-darwin-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-freebsd-x64')
         const bindingPackageVersion = require('@bastani/atomic-natives-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-freebsd-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-x64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-x64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm-musleabihf')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-loong64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-loong64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-riscv64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-riscv64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-linux-ppc64-gnu')
         const bindingPackageVersion = require('@bastani/atomic-natives-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-linux-s390x-gnu')
         const bindingPackageVersion = require('@bastani/atomic-natives-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-openharmony-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-openharmony-x64')
         const bindingPackageVersion = require('@bastani/atomic-natives-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-openharmony-arm')
         const bindingPackageVersion = require('@bastani/atomic-natives-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.8.29-alpha.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.29-alpha.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.29' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.29 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-natives",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "description": "Native Rust bindings for Atomic via N-API",
   "homepage": "https://github.com/bastani-inc/atomic",
   "author": "Bastani",

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Changed
 
 - Aligned the subagents extension with upstream pi `^0.79.3` runtime packages (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui`) so child sessions inherit the latest shared agent, provider, and TUI compatibility fixes.

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Changed
 
-- Published a synchronized Atomic 0.8.29-alpha.4 prerelease with the upstream pi TUI dependency aligned to `^0.79.3`; no functional changes were made in the web-access extension.
+- Published a synchronized Atomic 0.8.29 stable release with the upstream pi TUI dependency aligned to `^0.79.3`; no functional changes were made in the web-access extension.
 
 ## [0.8.28] - 2026-06-11
 

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.29] - 2026-06-15
+
 ### Added
 
 - Added opt-in schema-backed workflow item results: `ctx.stage(..., { schema })`, `ctx.task(..., { schema })`, `ctx.chain` items, and `ctx.parallel` items now receive a schema-specific `structured_output` tool only for that item, return the captured value from `ctx.stage().prompt(...)`, and expose parsed task values as `result.structured` while preserving formatted JSON handoff text ([#1350](https://github.com/bastani-inc/atomic/issues/1350)).

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.29-alpha.4",
+  "version": "0.8.29",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Promotes Atomic 0.8.29 from the accumulated 0.8.29-alpha prerelease series to a stable release. Bumps all package and native metadata versions, finalizes changelogs, and refreshes lockfiles.

## Key Changes

**Version bumps**
- All `packages/*/package.json` versions promoted from `0.8.29-alpha.4` → `0.8.29`
- `Cargo.toml` and `Cargo.lock` updated to `0.8.29`
- `packages/natives/native/index.js` N-API version-check strings updated from `0.8.29-alpha.4` → `0.8.29` across all platform targets (Android, Win32, macOS)
- `bun.lock` refreshed for updated package metadata

**Changelog finalization**
- `packages/coding-agent/CHANGELOG.md` — `## [0.8.29] - 2026-06-15` section created, consolidating all alpha entries
- `packages/intercom/CHANGELOG.md`, `packages/mcp/CHANGELOG.md`, `packages/web-access/CHANGELOG.md`, `packages/cursor/CHANGELOG.md`, `packages/natives/CHANGELOG.md`, `packages/subagents/CHANGELOG.md`, `packages/workflows/CHANGELOG.md` — release sections added, alpha prerelease wording updated to stable

## What's in 0.8.29

### Added
- Local `-e <dir>` extension sources to borrow project-local Atomic resources from `<dir>/.atomic`, `<dir>/.pi`, and `<dir>/.agents/skills` ([#1354](https://github.com/bastani-inc/atomic/issues/1354))
- Rust/N-API Cursor HTTP/2 native transport binding (`@bastani/atomic-natives`) — in-process HTTP/2 without requiring Node.js on `PATH`
- Experimental bundled `@bastani/cursor` provider scaffold with Cursor OAuth, streaming, MCP tool advertisement/decoding, and protobuf Connect transport
- `createStructuredOutputTool({ schema, capture, output, name })` factory for machine-readable structured final answers ([#1350](https://github.com/bastani-inc/atomic/issues/1350))

### Changed
- `ralph` workflow now runs `/skill:prompt-engineer` and `/skill:research-codebase` before orchestration and feeds unresolved reviewer findings into later research passes ([#1371](https://github.com/bastani-inc/atomic/issues/1371))
- `goal`, `ralph`, and `open-claude-design` decision gates migrated to schema-backed `structured_output` workflow stages
- Bumped upstream pi runtime libraries (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui`) from `^0.79.1` → `^0.79.3`

### Fixed
- Root `@bastani/atomic` package export now includes a `default` condition for broader loader compatibility
- Extension custom UI focus deferral for full-screen overlays ([#1353](https://github.com/bastani-inc/atomic/issues/1353))
- Text print mode emits trailing JSON from factory-created structured-output tools with custom names (e.g. `final_decision`) ([#1350](https://github.com/bastani-inc/atomic/issues/1350))
- Bundled workflow stage sessions keep package skills available while disabling recursive workflow extension in children
- Bundled subagent handling: explicit `tools: []` + `outputSchema` grants only the schema-backed `structured_output` tool ([#1350](https://github.com/bastani-inc/atomic/issues/1350))
- Cursor provider: per-request stream deadlines, timed-out stream resets, safe cleanup of replaced paused turns, non-MCP protocol message tolerance, and protobuf KV conversation state ([#1286](https://github.com/bastani-inc/atomic/issues/1286))
- Release archive startup for Cursor provider: `@bufbuild/protobuf` declared as runtime dependency ([#1286](https://github.com/bastani-inc/atomic/issues/1286))
- Prerelease publishing for native Atomic artifacts: architecture-matched runners and two-package publish flow documented

### Security
- Cursor credentials remain OAuth-only with PKCE poll-secret redaction; CWD no longer sent as `previousWorkspaceUris` by default

## Validation

- `bun run typecheck`
- `CLAUDECODE=1 AGENT=1 bun run test:unit`
- Pre-push hooks: `cargo fmt --check`, `cargo clippy`, `bun run lint`, `bun run test:unit`

## Notes

The `publish-release` workflow prepared this branch but stopped before publishing due to a workflow verifier host issue (`Bun is not defined`). This PR continues the release from the verified release commit.