### PR TITLE
fix(workflows): resolve release workflow discovery imports

### DIFF
--- a/.atomic/workflows/lib/publish-release.ts
+++ b/.atomic/workflows/lib/publish-release.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { createGitEnvironment } from "@bastani/atomic";
+import { createGitEnvironment } from "../../../packages/coding-agent/src/utils/git-env.js";
 
 export type ReleaseKind = "release" | "prerelease";
 export type ReleaseStatus = "completed" | "blocked" | "failed";

--- a/.atomic/workflows/lib/release-docs.ts
+++ b/.atomic/workflows/lib/release-docs.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
-import { createGitEnvironment } from "@bastani/atomic";
+import { createGitEnvironment } from "../../../packages/coding-agent/src/utils/git-env.js";
 
 export type StaleDocTask = {
   id: string;

--- a/.atomic/workflows/release-docs.ts
+++ b/.atomic/workflows/release-docs.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { defineWorkflow, Type } from "@bastani/workflows";
-import deepResearchCodebase from "../../packages/workflows/builtin/deep-research-codebase.js";
+import deepResearchCodebase from "@bastani/workflows/builtin/deep-research-codebase";
 import {
   currentBranchName,
   DEFAULT_RELEASE_DOCS_BASE_BRANCH,

--- a/test/unit/release-workflows-discovery.test.ts
+++ b/test/unit/release-workflows-discovery.test.ts
@@ -1,0 +1,43 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoFile = (path: string): string => readFileSync(join(process.cwd(), path), "utf8");
+
+describe("repo-local release workflow discovery imports", () => {
+  test("helpers avoid the @bastani/atomic package root during discovery", () => {
+    for (const path of [
+      ".atomic/workflows/lib/publish-release.ts",
+      ".atomic/workflows/lib/release-docs.ts",
+    ]) {
+      const source = repoFile(path);
+
+      assert.doesNotMatch(
+        source,
+        /from\s+["']@bastani\/atomic["']/,
+        `${path} must not import @bastani/atomic because workspace discovery resolves that package root to missing dist/index.js`,
+      );
+      assert.match(
+        source,
+        /packages\/coding-agent\/src\/utils\/git-env\.js/,
+        `${path} should import the Git environment helper from the workspace source file`,
+      );
+    }
+  });
+
+  test("release-docs imports builtin child workflows through the virtual workflow SDK", () => {
+    const source = repoFile(".atomic/workflows/release-docs.ts");
+
+    assert.match(
+      source,
+      /from\s+["']@bastani\/workflows\/builtin\/deep-research-codebase["']/,
+      "release-docs should use the builtin workflow specifier virtualized by the workflow module loader",
+    );
+    assert.doesNotMatch(
+      source,
+      /\.\.\/\.\.\/packages\/workflows\/builtin\/deep-research-codebase\.js/,
+      "release-docs should not bypass the workflow loader with a repo-relative builtin import",
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,8 @@
         "paths": {
             "@bastani/atomic": ["./packages/coding-agent/src/index.ts"],
             "@bastani/workflows": ["./packages/workflows/src/index.ts"],
+            "@bastani/workflows/builtin": ["./packages/workflows/builtin/index.ts"],
+            "@bastani/workflows/builtin/*": ["./packages/workflows/builtin/*"],
             "@bastani/workflows/*": ["./packages/workflows/src/*"],
             "@bastani/subagents": [
                 "./packages/subagents/src/extension/index.ts"


### PR DESCRIPTION
## Summary

Fixes two import-convention bugs that broke repo-local release workflow discovery: helper imports that required non-existent `dist` output from `@bastani/atomic`, and a builtin child workflow import that bypassed the workflow module loader.

## Root cause

Repo-local workflows in `.atomic/workflows/` are loaded directly from TypeScript source. Importing `createGitEnvironment` from `@bastani/atomic` causes discovery to fail because the package root resolves to `dist/index.js`, which does not exist in the workspace (companion packages ship as raw `.ts` with no build step). Similarly, importing the `deep-research-codebase` builtin via a repo-relative path bypasses the workflow module loader's virtual specifier resolution.

## Changes

- **`publish-release.ts` / `release-docs.ts` lib helpers**: Switch `createGitEnvironment` import from `@bastani/atomic` to the workspace source file directly (`packages/coding-agent/src/utils/git-env.js`), avoiding the missing `dist/` requirement during discovery.
- **`release-docs.ts` workflow**: Replace the repo-relative builtin import (`../../packages/workflows/builtin/deep-research-codebase.js`) with the virtual SDK specifier (`@bastani/workflows/builtin/deep-research-codebase`) so the workflow module loader resolves it correctly.
- **`tsconfig.json`**: Add `@bastani/workflows/builtin` and `@bastani/workflows/builtin/*` path mappings so TypeScript resolves the new virtual specifier during type checking.
- **`test/unit/release-workflows-discovery.test.ts`**: New unit tests that guard the import conventions—asserting helpers never import from `@bastani/atomic` and that `release-docs` uses the virtual builtin specifier.

## Validation

```
AGENT=1 bun test test/unit/release-workflows-discovery.test.ts
bun run typecheck
```

Pre-commit and pre-push hooks passed, including `bun run lint` and `bun run test:unit`.