### PR TITLE
fix(workflows): inherit atomic -e stage resources

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed workflow stages launched from workflows discovered through `atomic -e` to inherit the parent chat's custom resource-loading snapshot (extensions/tools, subagents and agent definitions, skills, prompt templates, themes, workflows, packages, and trusted borrowed project-local resources) without sharing the parent resource-loader instance.
 - Fixed context compaction recent-entry and id-only deletion guards so `context_delete` attempts against disallowed context entries now return explicit non-terminating correction errors, exact deletion payloads with transcript text or replacement content are rejected instead of ignored, `context_grep_delete` silently ignores rejected matches while deleting allowed matches without counting rejected blocks as removals, and `context_grep_delete` keeps `maxMatches` scoped to one tool call without adding any cumulative deletion cap.
 - Fixed bundled workflow and subagent structured-output gates to recover from missing or invalid `structured_output` final answers by issuing up to three corrective retries that echo the actual contract or schema-validation error before failing.
 - Fixed bundled workflow failed-stage metadata so error-stage transcripts remain discoverable and follow-up messaging resumes from the failed conversation instead of resetting to an empty session.

--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -54,6 +54,8 @@ atomic -e git:github.com/user/repo
 
 For local directories, `-e <dir>` also borrows project-local Atomic resources under `<dir>/.atomic`, legacy `<dir>/.pi`, and `<dir>/.agents/skills` when present. Because borrowed extensions and workflows can execute code, Atomic resolves trust for that extension source before loading those borrowed project-local resources.
 
+Workflows discovered through `-e` keep that same trusted resource set when they create child stage sessions. Stage agents get fresh resource loaders seeded from the parent snapshot, so package tools/extensions, subagents and agent definitions, skills, prompt templates, themes, workflows, and trusted borrowed project-local resources remain available in workflow stages unless the stage supplies its own explicit `resourceLoader`.
+
 ## Package Sources
 
 Atomic accepts three source types in settings and `atomic install`.

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -725,6 +725,8 @@ atomic -e npm:my-atomic-workflows
 atomic -e ./local-workflow-package
 ```
 
+Workflow stage sessions inherit the same package and temporary `-e` resource discovery snapshot as the main chat. That means a workflow loaded from an external package or directory can start stages that see the package's extensions/tools, subagents and agent definitions, skills, prompt templates, themes, workflows, and trusted borrowed project-local resources without sharing the parent chat's resource-loader instance. Passing an explicit `resourceLoader` in stage options still opts that stage out of this inheritance.
+
 ## Settings
 
 Settings can list package sources directly:

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -33,6 +33,7 @@ import { resolvePath } from "../../utils/paths.ts";
 import { createEventBus, type EventBus } from "../event-bus.ts";
 import type { ExecOptions } from "../exec.ts";
 import type { ResolvedResource } from "../package-manager.ts";
+import type { DefaultResourceLoaderInheritanceSnapshot } from "../resource-loader.ts";
 import { execCommand } from "../exec.ts";
 import { createSyntheticSourceInfo } from "../source-info.ts";
 import { endTimingSpan, startTimingSpan } from "../timings.ts";
@@ -149,6 +150,8 @@ export interface WorkflowResourceProvider {
 
 export type WorkflowResourceProviderInput = WorkflowResourceProvider | ResolvedResource[];
 
+export type ResourceLoaderInheritanceSnapshotProvider = () => DefaultResourceLoaderInheritanceSnapshot;
+
 function createStaticWorkflowResourceProvider(workflowResources: ResolvedResource[]): WorkflowResourceProvider {
   return {
     get: () => workflowResources,
@@ -232,6 +235,7 @@ function createExtensionAPI(
   cwd: string,
   eventBus: EventBus,
   workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
+  resourceLoaderInheritanceSnapshotProvider?: ResourceLoaderInheritanceSnapshotProvider,
 ): ExtensionAPI {
   const workflowResources = normalizeWorkflowResourceProvider(workflowResourceProvider);
   const api = {
@@ -324,6 +328,11 @@ function createExtensionAPI(
       runtime.assertActive();
       const refreshed = await workflowResources.refresh?.();
       return [...(refreshed ?? workflowResources.get())];
+    },
+
+    getResourceLoaderInheritanceSnapshot(): DefaultResourceLoaderInheritanceSnapshot {
+      runtime.assertActive();
+      return resourceLoaderInheritanceSnapshotProvider?.() ?? {};
     },
 
     // Action methods - delegate to shared runtime
@@ -463,6 +472,7 @@ async function loadExtension(
   eventBus: EventBus,
   runtime: ExtensionRuntime,
   workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
+  resourceLoaderInheritanceSnapshotProvider?: ResourceLoaderInheritanceSnapshotProvider,
 ): Promise<{ extension: Extension | null; error: string | null }> {
   const resolvedPath = resolvePath(extensionPath, cwd, { normalizeUnicodeSpaces: true });
 
@@ -484,6 +494,7 @@ async function loadExtension(
       cwd,
       eventBus,
       workflowResourceProvider,
+      resourceLoaderInheritanceSnapshotProvider,
     );
     const factorySpan = startTimingSpan(`loadExtensions.${extensionPath}.factory`);
     await factory(api);
@@ -506,6 +517,7 @@ export async function loadExtensionFromFactory(
   runtime: ExtensionRuntime,
   extensionPath = "<inline>",
   workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
+  resourceLoaderInheritanceSnapshotProvider?: ResourceLoaderInheritanceSnapshotProvider,
 ): Promise<Extension> {
   const extension = createExtension(extensionPath, extensionPath);
   const resolvedCwd = resolvePath(cwd);
@@ -515,6 +527,7 @@ export async function loadExtensionFromFactory(
     resolvedCwd,
     eventBus,
     workflowResourceProvider,
+    resourceLoaderInheritanceSnapshotProvider,
   );
   await factory(api);
   return extension;
@@ -529,6 +542,7 @@ export async function loadExtensions(
   eventBus?: EventBus,
   workflowResourceProvider: WorkflowResourceProviderInput = emptyWorkflowResourceProvider,
   runtime?: ExtensionRuntime,
+  resourceLoaderInheritanceSnapshotProvider?: ResourceLoaderInheritanceSnapshotProvider,
 ): Promise<LoadExtensionsResult> {
   const extensions: Extension[] = [];
   const errors: Array<{ path: string; error: string }> = [];
@@ -544,6 +558,7 @@ export async function loadExtensions(
       resolvedEventBus,
       resolvedRuntime,
       workflowResourceProvider,
+      resourceLoaderInheritanceSnapshotProvider,
     );
     endTimingSpan(extensionSpan);
 

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -42,6 +42,7 @@ import type {
 import type { Static, TSchema } from "typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.ts";
 import type { ResolvedResource } from "../package-manager.ts";
+import type { DefaultResourceLoaderInheritanceSnapshot } from "../resource-loader.ts";
 import type { BashResult } from "../bash-executor.ts";
 import type { ContextCompactionPreparation, ContextCompactionResult, ContextDeletionRequest } from "../compaction/index.ts";
 import type { EventBus } from "../event-bus.ts";
@@ -1323,6 +1324,11 @@ export interface ExtensionAPI {
 	 * Does not reload extensions, skills, prompts, themes, or context files.
 	 */
 	refreshWorkflowResources?: () => Promise<ResolvedResource[]>;
+
+	/**
+	 * Return the resource-loader options that child Atomic sessions should inherit without sharing this loader instance.
+	 */
+	getResourceLoaderInheritanceSnapshot?: () => DefaultResourceLoaderInheritanceSnapshot;
 
 	// =========================================================================
 	// Message Rendering

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -136,11 +136,30 @@ export function loadProjectContextFiles(options: {
 	return contextFiles;
 }
 
+export interface DefaultResourceLoaderInheritanceSnapshot {
+	readonly projectTrusted?: boolean;
+	readonly additionalExtensionPaths?: readonly string[];
+	readonly additionalSkillPaths?: readonly string[];
+	readonly additionalPromptTemplatePaths?: readonly string[];
+	readonly additionalThemePaths?: readonly string[];
+	readonly builtinPackagePaths?: readonly PackageSource[];
+	readonly extensionFactories?: readonly ExtensionFactory[];
+	readonly noExtensions?: boolean;
+	readonly noSkills?: boolean;
+	readonly noPromptTemplates?: boolean;
+	readonly noThemes?: boolean;
+	readonly noContextFiles?: boolean;
+	readonly systemPrompt?: string;
+	readonly appendSystemPrompt?: readonly string[];
+	readonly trustedBorrowedProjectLocalSources?: readonly string[];
+}
+
 export interface DefaultResourceLoaderOptions {
 	cwd: string;
 	agentDir: string;
 	settingsManager?: SettingsManager;
 	eventBus?: EventBus;
+	resourceLoaderInheritanceSnapshot?: DefaultResourceLoaderInheritanceSnapshot;
 	additionalExtensionPaths?: string[];
 	additionalSkillPaths?: string[];
 	additionalPromptTemplatePaths?: string[];
@@ -172,6 +191,35 @@ export interface DefaultResourceLoaderOptions {
 	};
 	systemPromptOverride?: (base: string | undefined) => string | undefined;
 	appendSystemPromptOverride?: (base: string[]) => string[];
+}
+
+function cloneStringArray(values: readonly string[] | undefined): string[] {
+	return values === undefined ? [] : [...values];
+}
+
+function mergeInheritedStrings(
+	inherited: readonly string[] | undefined,
+	current: readonly string[] | undefined,
+): string[] {
+	return [...cloneStringArray(inherited), ...cloneStringArray(current)];
+}
+
+function clonePackageSource(source: PackageSource): PackageSource {
+	if (typeof source === "string") {
+		return source;
+	}
+	return {
+		source: source.source,
+		...(source.extensions === undefined ? {} : { extensions: [...source.extensions] }),
+		...(source.skills === undefined ? {} : { skills: [...source.skills] }),
+		...(source.prompts === undefined ? {} : { prompts: [...source.prompts] }),
+		...(source.themes === undefined ? {} : { themes: [...source.themes] }),
+		...(source.workflows === undefined ? {} : { workflows: [...source.workflows] }),
+	};
+}
+
+function clonePackageSources(sources: readonly PackageSource[] | undefined): PackageSource[] {
+	return sources === undefined ? [] : sources.map((source) => clonePackageSource(source));
 }
 
 export class DefaultResourceLoader implements ResourceLoader {
@@ -232,28 +280,57 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private lastThemePaths: string[];
 
 	constructor(options: DefaultResourceLoaderOptions) {
+		const inheritanceSnapshot = options.resourceLoaderInheritanceSnapshot;
+		const inheritedSettingsOptions = inheritanceSnapshot?.projectTrusted === undefined
+			? undefined
+			: { projectTrusted: inheritanceSnapshot.projectTrusted };
 		this.cwd = resolvePath(options.cwd);
 		this.agentDir = resolvePath(options.agentDir);
-		this.settingsManager = options.settingsManager ?? SettingsManager.create(this.cwd, this.agentDir);
+		this.settingsManager = options.settingsManager ?? SettingsManager.create(
+			this.cwd,
+			this.agentDir,
+			inheritedSettingsOptions,
+		);
 		this.eventBus = options.eventBus ?? createEventBus();
 		this.packageManager = new DefaultPackageManager({
 			cwd: this.cwd,
 			agentDir: this.agentDir,
 			settingsManager: this.settingsManager,
 		});
-		this.additionalExtensionPaths = options.additionalExtensionPaths ?? [];
-		this.additionalSkillPaths = options.additionalSkillPaths ?? [];
-		this.additionalPromptTemplatePaths = options.additionalPromptTemplatePaths ?? [];
-		this.additionalThemePaths = options.additionalThemePaths ?? [];
-		this.builtinPackagePaths = options.builtinPackagePaths ?? [];
-		this.extensionFactories = options.extensionFactories ?? [];
-		this.noExtensions = options.noExtensions ?? false;
-		this.noSkills = options.noSkills ?? false;
-		this.noPromptTemplates = options.noPromptTemplates ?? false;
-		this.noThemes = options.noThemes ?? false;
-		this.noContextFiles = options.noContextFiles ?? false;
-		this.systemPromptSource = options.systemPrompt;
-		this.appendSystemPromptSource = options.appendSystemPrompt;
+		this.additionalExtensionPaths = mergeInheritedStrings(
+			inheritanceSnapshot?.additionalExtensionPaths,
+			options.additionalExtensionPaths,
+		);
+		this.additionalSkillPaths = mergeInheritedStrings(
+			inheritanceSnapshot?.additionalSkillPaths,
+			options.additionalSkillPaths,
+		);
+		this.additionalPromptTemplatePaths = mergeInheritedStrings(
+			inheritanceSnapshot?.additionalPromptTemplatePaths,
+			options.additionalPromptTemplatePaths,
+		);
+		this.additionalThemePaths = mergeInheritedStrings(
+			inheritanceSnapshot?.additionalThemePaths,
+			options.additionalThemePaths,
+		);
+		this.builtinPackagePaths = options.builtinPackagePaths !== undefined
+			? clonePackageSources(options.builtinPackagePaths)
+			: clonePackageSources(inheritanceSnapshot?.builtinPackagePaths);
+		this.extensionFactories = [
+			...(inheritanceSnapshot?.extensionFactories ?? []),
+			...(options.extensionFactories ?? []),
+		];
+		this.noExtensions = options.noExtensions ?? inheritanceSnapshot?.noExtensions ?? false;
+		this.noSkills = options.noSkills ?? inheritanceSnapshot?.noSkills ?? false;
+		this.noPromptTemplates = options.noPromptTemplates ?? inheritanceSnapshot?.noPromptTemplates ?? false;
+		this.noThemes = options.noThemes ?? inheritanceSnapshot?.noThemes ?? false;
+		this.noContextFiles = options.noContextFiles ?? inheritanceSnapshot?.noContextFiles ?? false;
+		this.systemPromptSource = options.systemPrompt ?? inheritanceSnapshot?.systemPrompt;
+		this.appendSystemPromptSource = options.appendSystemPrompt !== undefined
+			? [...options.appendSystemPrompt]
+			: inheritanceSnapshot?.appendSystemPrompt === undefined
+				? undefined
+				: [...inheritanceSnapshot.appendSystemPrompt];
 		this.extensionsOverride = options.extensionsOverride;
 		this.skillsOverride = options.skillsOverride;
 		this.promptsOverride = options.promptsOverride;
@@ -272,7 +349,9 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.agentsFiles = [];
 		this.appendSystemPrompt = [];
 		this.workflowResources = [];
-		this.trustedBorrowedProjectLocalSources = undefined;
+		this.trustedBorrowedProjectLocalSources = inheritanceSnapshot?.trustedBorrowedProjectLocalSources === undefined
+			? undefined
+			: new Set(inheritanceSnapshot.trustedBorrowedProjectLocalSources);
 		this.lastSkillPaths = [];
 		this.extensionSkillSourceInfos = new Map();
 		this.extensionPromptSourceInfos = new Map();
@@ -311,6 +390,30 @@ export class DefaultResourceLoader implements ResourceLoader {
 
 	getWorkflowResources(): ResolvedResource[] {
 		return [...this.workflowResources];
+	}
+
+	getInheritanceSnapshot(): DefaultResourceLoaderInheritanceSnapshot {
+		return {
+			projectTrusted: this.settingsManager.isProjectTrusted(),
+			additionalExtensionPaths: [...this.additionalExtensionPaths],
+			additionalSkillPaths: [...this.additionalSkillPaths],
+			additionalPromptTemplatePaths: [...this.additionalPromptTemplatePaths],
+			additionalThemePaths: [...this.additionalThemePaths],
+			builtinPackagePaths: clonePackageSources(this.builtinPackagePaths),
+			extensionFactories: [...this.extensionFactories],
+			noExtensions: this.noExtensions,
+			noSkills: this.noSkills,
+			noPromptTemplates: this.noPromptTemplates,
+			noThemes: this.noThemes,
+			noContextFiles: this.noContextFiles,
+			...(this.systemPromptSource === undefined ? {} : { systemPrompt: this.systemPromptSource }),
+			...(this.appendSystemPromptSource === undefined
+				? {}
+				: { appendSystemPrompt: [...this.appendSystemPromptSource] }),
+			...(this.trustedBorrowedProjectLocalSources === undefined
+				? {}
+				: { trustedBorrowedProjectLocalSources: [...this.trustedBorrowedProjectLocalSources] }),
+		};
 	}
 
 	async refreshWorkflowResources(): Promise<ResolvedResource[]> {
@@ -393,11 +496,23 @@ export class DefaultResourceLoader implements ResourceLoader {
 		const workflowResources = this.collectWorkflowResources(resolvedPaths, cliExtensionPaths, builtinPackagePaths);
 		this.workflowResources = workflowResources;
 		const workflowResourceProvider = this.createWorkflowResourceProvider();
+		const inheritanceSnapshotProvider = this.createInheritanceSnapshotProvider();
 		const extensionPaths = this.noExtensions
 			? cliEnabledExtensions
 			: this.mergePaths(cliEnabledExtensions, [...enabledExtensions, ...builtinEnabledExtensions]);
-		const extensionsResult = await loadExtensions(extensionPaths, this.cwd, this.eventBus, workflowResourceProvider);
-		const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime, workflowResourceProvider);
+		const extensionsResult = await loadExtensions(
+			extensionPaths,
+			this.cwd,
+			this.eventBus,
+			workflowResourceProvider,
+			undefined,
+			inheritanceSnapshotProvider,
+		);
+		const inlineExtensions = await this.loadExtensionFactories(
+			extensionsResult.runtime,
+			workflowResourceProvider,
+			inheritanceSnapshotProvider,
+		);
 		extensionsResult.extensions.push(...inlineExtensions.extensions);
 		extensionsResult.errors.push(...inlineExtensions.errors);
 		this.applyExtensionSourceInfo(extensionsResult.extensions, metadataByPath);
@@ -513,10 +628,12 @@ export class DefaultResourceLoader implements ResourceLoader {
 			? cliEnabledExtensions
 			: this.mergePaths(cliEnabledExtensions, [...enabledExtensions, ...builtinEnabledExtensions]);
 
+		const inheritanceSnapshotProvider = this.createInheritanceSnapshotProvider();
 		const extensionsResult = await this.loadFinalExtensionSet(
 			extensionPaths,
 			preTrustExtensions,
 			workflowResourceProvider,
+			inheritanceSnapshotProvider,
 		);
 
 		for (const p of this.additionalExtensionPaths) {
@@ -730,6 +847,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 			get: () => this.workflowResources,
 			refresh: () => this.refreshWorkflowResources(),
 		};
+	}
+
+	private createInheritanceSnapshotProvider(): () => DefaultResourceLoaderInheritanceSnapshot {
+		return () => this.getInheritanceSnapshot();
 	}
 
 	private normalizeExtensionPaths(
@@ -1031,6 +1152,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		extensionPaths: string[],
 		preTrustExtensions: LoadExtensionsResult | undefined,
 		workflowResourceProvider: WorkflowResourceProvider,
+		inheritanceSnapshotProvider: () => DefaultResourceLoaderInheritanceSnapshot,
 	): Promise<LoadExtensionsResult> {
 		if (!preTrustExtensions) {
 			const loadExtensionsSpan = startTimingSpan("DefaultResourceLoader.reload.loadExtensions");
@@ -1039,10 +1161,16 @@ export class DefaultResourceLoader implements ResourceLoader {
 				this.cwd,
 				this.eventBus,
 				workflowResourceProvider,
+				undefined,
+				inheritanceSnapshotProvider,
 			);
 			endTimingSpan(loadExtensionsSpan);
 			const inlineExtensionsSpan = startTimingSpan("DefaultResourceLoader.reload.loadInlineExtensionFactories");
-			const inlineExtensions = await this.loadExtensionFactories(extensionsResult.runtime, workflowResourceProvider);
+			const inlineExtensions = await this.loadExtensionFactories(
+				extensionsResult.runtime,
+				workflowResourceProvider,
+				inheritanceSnapshotProvider,
+			);
 			endTimingSpan(inlineExtensionsSpan);
 			extensionsResult.extensions.push(...inlineExtensions.extensions);
 			extensionsResult.errors.push(...inlineExtensions.errors);
@@ -1069,6 +1197,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 			this.eventBus,
 			workflowResourceProvider,
 			preTrustExtensions.runtime,
+			inheritanceSnapshotProvider,
 		);
 		endTimingSpan(loadExtensionsSpan);
 		const loadedByPath = new Map(preloadedByPath);
@@ -1103,7 +1232,11 @@ export class DefaultResourceLoader implements ResourceLoader {
 	}
 
 
-	private async loadExtensionFactories(runtime: ExtensionRuntime, workflowResourceProvider: WorkflowResourceProvider): Promise<{
+	private async loadExtensionFactories(
+		runtime: ExtensionRuntime,
+		workflowResourceProvider: WorkflowResourceProvider,
+		inheritanceSnapshotProvider: () => DefaultResourceLoaderInheritanceSnapshot,
+	): Promise<{
 		extensions: Extension[];
 		errors: Array<{ path: string; error: string }>;
 	}> {
@@ -1120,6 +1253,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 					runtime,
 					extensionPath,
 					workflowResourceProvider,
+					inheritanceSnapshotProvider,
 				);
 				extensions.push(extension);
 			} catch (error) {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -245,7 +245,12 @@ export type {
 } from "./core/package-manager.ts";
 export { getBuiltinPackagePaths } from "./core/builtin-packages.ts";
 export { DefaultPackageManager } from "./core/package-manager.ts";
-export type { ResourceCollision, ResourceDiagnostic, ResourceLoader } from "./core/resource-loader.ts";
+export type {
+	DefaultResourceLoaderInheritanceSnapshot,
+	ResourceCollision,
+	ResourceDiagnostic,
+	ResourceLoader,
+} from "./core/resource-loader.ts";
 export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
 // SDK for programmatic usage
 export {

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed workflow stage sessions for workflows loaded through `atomic -e` to build fresh child resource loaders from the parent Atomic resource snapshot, preserving custom extensions/tools, subagents and agent definitions, skills, prompt templates, themes, packages, workflows, trusted borrowed project-local resources, explicit `resourceLoader` overrides, and recursive workflow-extension filtering.
 - Fixed schema-backed workflow stages to send up to three corrective follow-up prompts when a turn finishes without the required `structured_output` call or with an invalid `structured_output` call, echoing the concrete contract/validation error before failing the stage.
 - Fixed failed workflow stages to retain and persist SDK `sessionId`/`sessionFile` metadata, so post-error transcript inspection and follow-up messaging resume from the failed conversation instead of silently creating a fresh empty session.
 - Fixed schema-backed workflow stages with `noTools: "all"` to keep the restrictive allowlist while still exposing the required `structured_output` final-answer tool.

--- a/packages/workflows/src/extension/index.ts
+++ b/packages/workflows/src/extension/index.ts
@@ -120,7 +120,12 @@ import {
   stageMatchesExpandedIdentifier,
 } from "../shared/expanded-workflow-graph.js";
 import { topLevelWorkflowRuns } from "../shared/run-visibility.js";
-import { WORKFLOW_STAGE_SUBAGENT_GUARD_ENV, getEnvValue, type CreateAgentSessionOptions } from "@bastani/atomic";
+import {
+  WORKFLOW_STAGE_SUBAGENT_GUARD_ENV,
+  getEnvValue,
+  type CreateAgentSessionOptions,
+  type DefaultResourceLoaderInheritanceSnapshot,
+} from "@bastani/atomic";
 
 export const WORKFLOW_TOOL_DESCRIPTION =
   "Run named workflows or direct one-off task/tasks/chain workflows; " +
@@ -377,6 +382,8 @@ export interface ExtensionAPI {
   getWorkflowResources?: () => readonly WorkflowResourceInfo[];
   /** Refresh package-provided workflow files before rediscovery, when supported by host. */
   refreshWorkflowResources?: () => Promise<readonly WorkflowResourceInfo[]>;
+  /** Return resource-loader options child Atomic workflow stages should inherit. */
+  getResourceLoaderInheritanceSnapshot?: () => DefaultResourceLoaderInheritanceSnapshot | undefined;
   /**
    * Register a keyboard shortcut.
    * Present on pi >= 1.x; absent on older runtimes.

--- a/packages/workflows/src/extension/wiring.ts
+++ b/packages/workflows/src/extension/wiring.ts
@@ -22,7 +22,12 @@
  */
 
 import { basename } from "node:path";
-import type { ChatMessageRenderOptions, CreateAgentSessionOptions, PackageSource } from "@bastani/atomic";
+import type {
+  ChatMessageRenderOptions,
+  CreateAgentSessionOptions,
+  DefaultResourceLoaderInheritanceSnapshot,
+  PackageSource,
+} from "@bastani/atomic";
 import type { StageAdapters, StageSessionCreateResult, StageSessionRuntime } from "../runs/foreground/stage-runner.js";
 import type { StageExecutionMeta, StageOptions } from "../shared/types.js";
 import { stageUiBroker, type StageUiBroker } from "../shared/stage-ui-broker.js";
@@ -55,6 +60,8 @@ export interface PiExecOpts {
 export interface RuntimeWiringSurface {
   exec?: (command: string, args: string[], opts?: PiExecOpts) => Promise<PiExecResult>;
   ui?: PiUISurface;
+  /** Resource-loader inheritance snapshot supplied by Atomic's ExtensionAPI. */
+  getResourceLoaderInheritanceSnapshot?: () => DefaultResourceLoaderInheritanceSnapshot | undefined;
   /** Test seam: inject a stub session factory instead of importing the SDK. */
   createAgentSession?: (options?: CreateAgentSessionOptions) => Promise<StageSessionCreateResult>;
 }
@@ -103,13 +110,14 @@ export interface PiCodingAgentSdk {
   getAgentDir(): string;
   getBuiltinPackagePaths?: () => string[];
   SettingsManager: {
-    create(cwd?: string, agentDir?: string): PiSdkSettingsManager;
+    create(cwd?: string, agentDir?: string, options?: { projectTrusted?: boolean }): PiSdkSettingsManager;
   };
   DefaultResourceLoader: new (options: {
     cwd: string;
     agentDir: string;
     settingsManager?: PiSdkSettingsManager;
     builtinPackagePaths?: PackageSource[];
+    resourceLoaderInheritanceSnapshot?: DefaultResourceLoaderInheritanceSnapshot;
   }) => PiSdkResourceLoader;
   createAgentSession(options?: AtomicCreateAgentSessionOptions): Promise<{ session: StageSessionRuntime }>;
 }
@@ -118,6 +126,10 @@ type AtomicCreateAgentSessionOptions = Omit<CreateAgentSessionOptions, "settings
   resourceLoader?: PiSdkResourceLoader;
   sessionManager?: PiSdkSessionManager;
 };
+
+export interface PrepareAtomicStageSessionOptions {
+  resourceLoaderInheritanceSnapshot?: DefaultResourceLoaderInheritanceSnapshot;
+}
 
 function resolveSessionCwd(options: AtomicCreateAgentSessionOptions | undefined): string {
   return options?.cwd ?? options?.sessionManager?.getCwd() ?? process.cwd();
@@ -141,20 +153,33 @@ function resolveSessionCwd(options: AtomicCreateAgentSessionOptions | undefined)
 export async function prepareAtomicStageSessionOptions(
   options: CreateAgentSessionOptions | undefined,
   sdk: PiCodingAgentSdk,
+  prepareOptions: PrepareAtomicStageSessionOptions = {},
 ): Promise<AtomicCreateAgentSessionOptions | undefined> {
   const atomicOptions = options as AtomicCreateAgentSessionOptions | undefined;
   if (atomicOptions?.resourceLoader !== undefined) return atomicOptions;
 
+  const inheritanceSnapshot = prepareOptions.resourceLoaderInheritanceSnapshot;
   const cwd = resolveSessionCwd(atomicOptions);
   const hasAgentDirOverride = atomicOptions?.agentDir !== undefined;
   const agentDir = atomicOptions?.agentDir ?? sdk.getAgentDir();
   const settingsManager =
-    atomicOptions?.settingsManager ?? sdk.SettingsManager.create(cwd, agentDir);
+    atomicOptions?.settingsManager ?? sdk.SettingsManager.create(
+      cwd,
+      agentDir,
+      inheritanceSnapshot?.projectTrusted === undefined
+        ? undefined
+        : { projectTrusted: inheritanceSnapshot.projectTrusted },
+    );
+  const inheritedBuiltinPackagePaths = inheritanceSnapshot?.builtinPackagePaths;
+  const builtinPackagePaths = inheritedBuiltinPackagePaths === undefined
+    ? sdk.getBuiltinPackagePaths?.() ?? []
+    : [...inheritedBuiltinPackagePaths];
   const resourceLoader = new sdk.DefaultResourceLoader({
     cwd,
     agentDir,
     settingsManager,
-    builtinPackagePaths: stageBuiltinPackagePaths(sdk.getBuiltinPackagePaths?.() ?? []),
+    resourceLoaderInheritanceSnapshot: inheritanceSnapshot,
+    builtinPackagePaths: stageBuiltinPackagePaths(builtinPackagePaths),
   });
   await reloadWorkflowStageResources(resourceLoader);
 
@@ -167,15 +192,39 @@ export async function prepareAtomicStageSessionOptions(
   };
 }
 
-function stageBuiltinPackagePaths(paths: readonly string[]): PackageSource[] {
+function clonePackageSource(source: PackageSource): PackageSource {
+  if (typeof source === "string") return source;
+  return {
+    source: source.source,
+    ...(source.extensions === undefined ? {} : { extensions: [...source.extensions] }),
+    ...(source.skills === undefined ? {} : { skills: [...source.skills] }),
+    ...(source.prompts === undefined ? {} : { prompts: [...source.prompts] }),
+    ...(source.themes === undefined ? {} : { themes: [...source.themes] }),
+    ...(source.workflows === undefined ? {} : { workflows: [...source.workflows] }),
+  };
+}
+
+function packageSourcePath(source: PackageSource): string {
+  return typeof source === "string" ? source : source.source;
+}
+
+function disablePackageExtensions(source: PackageSource): PackageSource {
+  if (typeof source === "string") return { source, extensions: [] };
+  return { ...source, extensions: [] };
+}
+
+function stageBuiltinPackagePaths(paths: readonly PackageSource[]): PackageSource[] {
   // Workflow stages are child AgentSessions owned by the workflow extension.
   // Loading the workflows extension again inside that child session replays its
   // `session_start` lifecycle and clears/kills the parent workflow store. Keep
   // the workflows package itself so its bundled skills/prompts/resources remain
   // available, but disable only its extension entry for stage sessions.
-  return paths.map((path) =>
-    basename(path) === "workflows" ? { source: path, extensions: [] } : path,
-  );
+  return paths.map((path) => {
+    const cloned = clonePackageSource(path);
+    return basename(packageSourcePath(cloned)) === "workflows"
+      ? disablePackageExtensions(cloned)
+      : cloned;
+  });
 }
 
 const SUBAGENT_CHILD_EXTENSION_ENV_KEYS = [
@@ -225,9 +274,10 @@ async function reloadWorkflowStageResourcesWithEnvIsolation(resourceLoader: PiSd
 
 async function createPiSdkAgentSession(
   options?: CreateAgentSessionOptions,
+  prepareOptions?: PrepareAtomicStageSessionOptions,
 ): Promise<StageSessionCreateResult> {
   const sdk = await import("@bastani/atomic") as PiCodingAgentSdk;
-  const sessionOptions = await prepareAtomicStageSessionOptions(options, sdk);
+  const sessionOptions = await prepareAtomicStageSessionOptions(options, sdk, prepareOptions);
   const result = await sdk.createAgentSession(sessionOptions);
   // `CreateAgentSessionResult` is `{ session, extensionsResult, modelFallbackMessage? }`;
   // workflow stages only consume `.session` (structurally an `AgentSession`,
@@ -420,7 +470,12 @@ export function buildRuntimeAdapters(
   const createSession =
     options.createAgentSession ??
     pi.createAgentSession ??
-    (isTestContext() ? createTestAgentSession : createPiSdkAgentSession);
+    (isTestContext()
+      ? createTestAgentSession
+      : (sessionOptions?: CreateAgentSessionOptions) =>
+        createPiSdkAgentSession(sessionOptions, {
+          resourceLoaderInheritanceSnapshot: pi.getResourceLoaderInheritanceSnapshot?.(),
+        }));
   const broker = options.stageUiBroker ?? stageUiBroker;
   const adapters: StageAdapters = {
     agentSession: {

--- a/test/unit/resource-loader-inheritance.test.ts
+++ b/test/unit/resource-loader-inheritance.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    DefaultResourceLoader,
+    type DefaultResourceLoaderInheritanceSnapshot,
+} from "../../packages/coding-agent/src/core/resource-loader.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+        if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+function tempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+}
+
+describe("DefaultResourceLoader inheritance snapshots", () => {
+    test("ExtensionAPI exposes inherited resource options and child loaders consume them without sharing the parent loader", async () => {
+        const cwd = tempDir("atomic-resource-inheritance-parent-");
+        const childCwd = tempDir("atomic-resource-inheritance-child-");
+        const agentDir = join(cwd, "agent");
+        const externalPackage = tempDir("atomic-resource-inheritance-external-");
+        const skillDir = join(externalPackage, "inherited-skill");
+        const skillFile = join(skillDir, "SKILL.md");
+        mkdirSync(agentDir, { recursive: true });
+        mkdirSync(skillDir, { recursive: true });
+        writeFileSync(
+            skillFile,
+            [
+                "---",
+                "name: inherited-skill",
+                "description: Skill inherited by workflow stage resource loaders.",
+                "---",
+                "Use inherited instructions.",
+            ].join("\n"),
+        );
+
+        const observedSnapshots: DefaultResourceLoaderInheritanceSnapshot[] = [];
+        const parentLoader = new DefaultResourceLoader({
+            cwd,
+            agentDir,
+            additionalExtensionPaths: [externalPackage],
+            additionalSkillPaths: [skillFile],
+            builtinPackagePaths: ["/repo/packages/workflows"],
+            appendSystemPrompt: ["Parent append prompt"],
+            extensionFactories: [
+                (pi) => {
+                    observedSnapshots.push(
+                        pi.getResourceLoaderInheritanceSnapshot?.() ?? {},
+                    );
+                },
+            ],
+        });
+
+        await parentLoader.reload();
+
+        assert.equal(observedSnapshots.length, 1);
+        assert.deepEqual(observedSnapshots[0]?.additionalExtensionPaths, [
+            externalPackage,
+        ]);
+        assert.deepEqual(observedSnapshots[0]?.additionalSkillPaths, [skillFile]);
+        assert.deepEqual(observedSnapshots[0]?.builtinPackagePaths, [
+            "/repo/packages/workflows",
+        ]);
+        assert.deepEqual(observedSnapshots[0]?.appendSystemPrompt, [
+            "Parent append prompt",
+        ]);
+
+        const childLoader = new DefaultResourceLoader({
+            cwd: childCwd,
+            agentDir,
+            resourceLoaderInheritanceSnapshot: {
+                ...observedSnapshots[0],
+                trustedBorrowedProjectLocalSources: [externalPackage],
+            },
+            builtinPackagePaths: [],
+        });
+        await childLoader.reload();
+
+        const childSkills = childLoader.getSkills().skills.map((skill) => skill.name);
+        assert.ok(
+            childSkills.includes("inherited-skill"),
+            "expected child resource loader to load the inherited skill path",
+        );
+        const childSnapshot = childLoader.getInheritanceSnapshot();
+        assert.deepEqual(childSnapshot.additionalExtensionPaths, [externalPackage]);
+        assert.deepEqual(childSnapshot.additionalSkillPaths, [skillFile]);
+        assert.deepEqual(childSnapshot.builtinPackagePaths, []);
+        assert.deepEqual(childSnapshot.trustedBorrowedProjectLocalSources, [
+            externalPackage,
+        ]);
+        assert.notEqual(childLoader, parentLoader);
+    });
+});

--- a/test/unit/wiring-adapters.test.ts
+++ b/test/unit/wiring-adapters.test.ts
@@ -15,7 +15,12 @@ import {
 } from "../../packages/workflows/src/extension/wiring.js";
 import { StageUiBroker } from "../../packages/workflows/src/shared/stage-ui-broker.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
-import type { CreateAgentSessionOptions, PackageSource } from "@bastani/atomic";
+import {
+    DefaultResourceLoader,
+    type CreateAgentSessionOptions,
+    type DefaultResourceLoaderInheritanceSnapshot,
+    type PackageSource,
+} from "@bastani/atomic";
 import type {
     PiCodingAgentSdk,
     PiSdkResourceLoader,
@@ -106,8 +111,13 @@ function makeFakeAtomicSdk(
         agentDir: string;
         settingsManager?: PiSdkSettingsManager;
         builtinPackagePaths?: PackageSource[];
+        resourceLoaderInheritanceSnapshot?: DefaultResourceLoaderInheritanceSnapshot;
     }>;
-    readonly settingsCalls: Array<{ cwd?: string; agentDir?: string }>;
+    readonly settingsCalls: Array<{
+        cwd?: string;
+        agentDir?: string;
+        options?: { projectTrusted?: boolean };
+    }>;
     readonly reloads: PiSdkResourceLoader[];
 } {
     const loaderOptions: Array<{
@@ -115,8 +125,13 @@ function makeFakeAtomicSdk(
         agentDir: string;
         settingsManager?: PiSdkSettingsManager;
         builtinPackagePaths?: PackageSource[];
+        resourceLoaderInheritanceSnapshot?: DefaultResourceLoaderInheritanceSnapshot;
     }> = [];
-    const settingsCalls: Array<{ cwd?: string; agentDir?: string }> = [];
+    const settingsCalls: Array<{
+        cwd?: string;
+        agentDir?: string;
+        options?: { projectTrusted?: boolean };
+    }> = [];
     const reloads: PiSdkResourceLoader[] = [];
 
     class FakeResourceLoader implements PiSdkResourceLoader {
@@ -125,6 +140,7 @@ function makeFakeAtomicSdk(
             agentDir: string;
             settingsManager?: PiSdkSettingsManager;
             builtinPackagePaths?: PackageSource[];
+            resourceLoaderInheritanceSnapshot?: DefaultResourceLoaderInheritanceSnapshot;
         }) {
             loaderOptions.push(options);
         }
@@ -138,8 +154,12 @@ function makeFakeAtomicSdk(
         getAgentDir: () => defaultAgentDir,
         getBuiltinPackagePaths: () => builtinPackagePaths,
         SettingsManager: {
-            create(cwd?: string, agentDir?: string): PiSdkSettingsManager {
-                settingsCalls.push({ cwd, agentDir });
+            create(
+                cwd?: string,
+                agentDir?: string,
+                options?: { projectTrusted?: boolean },
+            ): PiSdkSettingsManager {
+                settingsCalls.push({ cwd, agentDir, options });
                 return {
                     getCodexFastModeSettings: () => ({
                         chat: false,
@@ -217,6 +237,72 @@ describe("prepareAtomicStageSessionOptions", () => {
             "/repo/packages/web-access",
             "/repo/packages/intercom",
         ]);
+    });
+
+    test("passes inherited atomic -e resource options to fresh workflow stage loaders", async () => {
+        const projectDir = join("/tmp", "project");
+        const atomicAgentDir = join("/home", "user", ".atomic", "agent");
+        const inheritedSnapshot: DefaultResourceLoaderInheritanceSnapshot = {
+            projectTrusted: false,
+            additionalExtensionPaths: ["/external-package/extensions/index.ts"],
+            additionalSkillPaths: ["/external-package/.atomic/skills/inherited/SKILL.md"],
+            additionalPromptTemplatePaths: ["/external-package/.atomic/prompts/review.md"],
+            additionalThemePaths: ["/external-package/.atomic/themes/theme.json"],
+            builtinPackagePaths: [
+                "/repo/packages/workflows",
+                {
+                    source: "/repo/packages/subagents",
+                    skills: ["skills/**"],
+                },
+            ],
+            trustedBorrowedProjectLocalSources: ["/external-package"],
+        };
+        const { sdk, loaderOptions, settingsCalls, reloads } = makeFakeAtomicSdk(
+            atomicAgentDir,
+            ["/should/not/use/sdk/builtins"],
+        );
+
+        await prepareAtomicStageSessionOptions({ cwd: projectDir }, sdk, {
+            resourceLoaderInheritanceSnapshot: inheritedSnapshot,
+        });
+
+        assert.equal(settingsCalls[0]?.options?.projectTrusted, false);
+        assert.deepEqual(
+            loaderOptions[0]?.resourceLoaderInheritanceSnapshot,
+            inheritedSnapshot,
+        );
+        assert.deepEqual(loaderOptions[0]?.builtinPackagePaths, [
+            { source: "/repo/packages/workflows", extensions: [] },
+            { source: "/repo/packages/subagents", skills: ["skills/**"] },
+        ]);
+        assert.equal(reloads.length, 1);
+    });
+
+    test("preserves explicit resourceLoader overrides instead of inheriting parent resources", async () => {
+        const projectDir = join("/tmp", "project");
+        const atomicAgentDir = join("/home", "user", ".atomic", "agent");
+        const { sdk, loaderOptions, settingsCalls, reloads } =
+            makeFakeAtomicSdk(atomicAgentDir);
+        const explicitResourceLoader = new DefaultResourceLoader({
+            cwd: projectDir,
+            agentDir: atomicAgentDir,
+        });
+
+        const options = await prepareAtomicStageSessionOptions(
+            { cwd: projectDir, resourceLoader: explicitResourceLoader },
+            sdk,
+            {
+                resourceLoaderInheritanceSnapshot: {
+                    additionalExtensionPaths: ["/external-package"],
+                    builtinPackagePaths: ["/repo/packages/workflows"],
+                },
+            },
+        );
+
+        assert.equal(options?.resourceLoader, explicitResourceLoader);
+        assert.equal(loaderOptions.length, 0);
+        assert.equal(settingsCalls.length, 0);
+        assert.equal(reloads.length, 0);
     });
 
     test("serializes workflow stage resource reload env isolation", async () => {


### PR DESCRIPTION
## Summary

Workflow stages launched from workflows discovered via `atomic -e` now inherit the parent chat's full resource-loading configuration — including custom extensions, skills, subagents, prompt templates, themes, and trusted borrowed project-local resources — without sharing the parent loader instance.

Closes #1396.

## Changes

### Core: resource-loader inheritance snapshot (`packages/coding-agent`)

- Adds `DefaultResourceLoaderInheritanceSnapshot` interface capturing parent loader options: project trust state, additional extension/skill/prompt/theme paths, builtin package sources, inline extension factories, system prompt overrides, and trusted borrowed `-e` sources
- Adds `DefaultResourceLoader.getInheritanceSnapshot()` to produce a deep-cloned snapshot from the current loader state
- `DefaultResourceLoader` constructor now accepts `resourceLoaderInheritanceSnapshot` to seed a fresh loader from inherited state (merging path arrays rather than replacing)
- Exposes `getResourceLoaderInheritanceSnapshot()` on `ExtensionAPI` and propagates it through `loadExtensions` / `loadExtensionFromFactory`
- Exports `DefaultResourceLoaderInheritanceSnapshot` type from `@bastani/atomic`

### Workflows: stage session wiring (`packages/workflows`)

- `RuntimeWiringSurface` now exposes `getResourceLoaderInheritanceSnapshot` sourced from the host's `ExtensionAPI`
- `prepareAtomicStageSessionOptions` accepts a new `PrepareAtomicStageSessionOptions` param and forwards the snapshot into fresh `DefaultResourceLoader` instances for each stage
- `stageBuiltinPackagePaths` now accepts `PackageSource[]` (not just `string[]`) and deep-clones each entry to avoid mutating the parent snapshot while still disabling the recursive workflows extension
- Explicit `resourceLoader` in stage options still opts out of inheritance entirely

### Tests

- `test/unit/resource-loader-inheritance.test.ts`: verifies snapshot exposure via `ExtensionAPI` and that child loaders consume inherited paths (e.g. skill files from an `-e` package) without sharing the parent instance
- `test/unit/wiring-adapters.test.ts`: adds coverage for snapshot forwarding to stage loaders, project-trust inheritance, and preservation of explicit `resourceLoader` overrides

### Docs & changelog

- Updates `packages/coding-agent/docs/packages.md` and `docs/workflows.md` to document stage inheritance behavior
- Updates `packages/coding-agent/CHANGELOG.md` and `packages/workflows/CHANGELOG.md`

## Validation

- `bun test test/unit/wiring-adapters.test.ts test/unit/resource-loader-inheritance.test.ts` — passed (20 tests)
- `bun run typecheck` — passed
- `AGENT=1 bun run test:unit` — passed (review validation)
- CLI smoke: `atomic -e <package>` workflow stage used a provider registered by the external package and returned `{"answer":"atomic-e2e-inherited-stage-ok"}`

## Notes / Risks

- Workflow stages continue creating fresh loader instances; parent loader state is never shared
- Explicit stage `resourceLoader` remains a full opt-out from inheritance
- `builtinPackagePaths` entries are deep-cloned to prevent mutation of the inherited snapshot