### PR TITLE
fix(compaction): protect latest retained thinking assistant blocks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed bundled workflow and subagent structured-output gates to recover from missing or invalid `structured_output` final answers by issuing up to three corrective retries that echo the actual contract or schema-validation error before failing.
 - Fixed bundled workflow failed-stage metadata so error-stage transcripts remain discoverable and follow-up messaging resumes from the failed conversation instead of resetting to an empty session.
 - Fixed context compaction so older assistant `thinking` and `redacted_thinking` blocks can be removed like other stale blocks, while `thinking` or `redacted_thinking` blocks in the latest assistant message remain rejected by validation and paired tool-result restoration still preserves active context integrity ([#1386](https://github.com/bastani-inc/atomic/issues/1386)).
+- Fixed context compaction to universally protect every content block in the latest retained assistant message when that message contains `thinking` or `redacted_thinking`, so `context_delete` and `context_grep_delete` cannot remove visible sibling blocks or make an older partially-filtered thinking-bearing assistant become the latest retained assistant ([#1405](https://github.com/bastani-inc/atomic/issues/1405)).
 
 ## [0.8.29] - 2026-06-15
 

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -370,9 +370,9 @@ Candidate cumulative deletion request
         │
         ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│ Gate 2: thinking-content guard                                       │
-│   assistant entries containing thinking/redacted_thinking cannot be   │
-│   deleted or partially block-deleted                                  │
+│ Gate 2: latest thinking-content guard                                │
+│   the latest retained assistant with thinking/redacted_thinking       │
+│   cannot be entry-deleted or partially content-block-deleted          │
 └─────────────────────────────────────────────────────────────────────┘
         │
         ▼
@@ -405,7 +405,8 @@ Candidate cumulative deletion request
         ▼
 ┌─────────────────────────────────────────────────────────────────────┐
 │ Gate 7: post-reconcile guards                                        │
-│   no recent targets, no thinking-bearing assistant targets            │
+│   no recent targets, no content-block deletion from the latest        │
+│   retained assistant when it has thinking/redacted_thinking           │
 └─────────────────────────────────────────────────────────────────────┘
         │
         ▼
@@ -544,7 +545,7 @@ The compaction assistant can only compact by using these internal tools. Exact d
 
 The planner is prompted to call `context_compaction_budget` before deleting and after deletion batches. The tool reports the current transcript token estimate as a percentage of the selected model's context window, the configured `compression_ratio`, the projected percentage after selected deletions, current reduction percentage, and how many more estimated tokens must be removed to reach the strict target. With the default `compression_ratio: 0.5`, the strict target is a 50% token reduction.
 
-`context_grep_delete` supports literal or regex matching, skips already-deleted or disallowed context, enforces a per-call `maxMatches` safety cap, can require `expectedMatchCount` when the planner wants an exact-match safety check, and routes every accepted match through the same validation pipeline as exact deletions. Disallowed matches are ignored before `matches`, `expectedMatchCount`, deletion stats, and selected targets are calculated, so a broad regex can still remove safe blocks without counting rejected candidates as removed. `maxMatches` limits only one tool call; there is no cumulative deletion cap across repeated `context_delete` or `context_grep_delete` calls. Exact deletion attempts that target disallowed entries/blocks return an explicit non-terminating tool error with correction guidance. Exact deletion payloads that include unsupported fields such as transcript `text`, block `content`, summaries, or replacement data are rejected as non-id-only requests.
+`context_grep_delete` supports literal or regex matching, skips already-deleted or disallowed context, enforces a per-call `maxMatches` safety cap, can require `expectedMatchCount` when the planner wants an exact-match safety check, and routes every accepted match through the same validation pipeline as exact deletions. Disallowed matches are ignored before `matches`, `expectedMatchCount`, deletion stats, and selected targets are calculated, so a broad regex can still remove safe blocks without counting rejected candidates as removed. This includes the universal latest-retained assistant guard: if the latest retained assistant message contains `thinking` or `redacted_thinking`, neither `context_delete` nor `context_grep_delete` may remove any content block from that assistant message, even a visible text sibling block. `maxMatches` limits only one tool call; there is no cumulative deletion cap across repeated `context_delete` or `context_grep_delete` calls. Exact deletion attempts that target disallowed entries/blocks return an explicit non-terminating tool error with correction guidance. Exact deletion payloads that include unsupported fields such as transcript `text`, block `content`, summaries, or replacement data are rejected as non-id-only requests.
 
 Tool calls are cumulative during one compaction run. The assistant can apply several small deletion batches, inspect the updated state, and stop only after the validated stats meet the strict reduction target. Atomic uses the validated tool state as the compaction result; ordinary assistant text is ignored for deletion targets.
 

--- a/packages/coding-agent/src/core/compaction/context-compaction.ts
+++ b/packages/coding-agent/src/core/compaction/context-compaction.ts
@@ -392,7 +392,7 @@ What Survives:
 - User instructions: The original task and any clarifications.
 
 Conditionally Deleted:
-- Old Reasoning decisions: If there is nothing else to remove and the target reduction is not met, you can remove any reasoning steps, EXCEPT thinking or redacted_thinking blocks in the latest assistant message.
+- Old Reasoning decisions: If there is nothing else to remove and the target reduction is not met, you can remove reasoning steps, EXCEPT do not delete any content block from the latest assistant message when that message contains thinking or redacted_thinking blocks.
 
 <output_format>
 Call the context_delete tool one or more times with deletion targets in this shape:
@@ -852,10 +852,41 @@ function assertNoRecentContextDeletionTargets(
 	}
 }
 
-function latestAssistantEntry(transcript: CompactableTranscript): CompactableTranscriptEntry | undefined {
+function latestAssistantEntry(
+	transcript: CompactableTranscript,
+	deletedEntryIds: ReadonlySet<string> = new Set<string>(),
+): CompactableTranscriptEntry | undefined {
 	for (let index = transcript.entries.length - 1; index >= 0; index--) {
 		const entry = transcript.entries[index];
-		if (entry.role === "assistant") return entry;
+		if (entry.role === "assistant" && !deletedEntryIds.has(entry.entryId)) return entry;
+	}
+	return undefined;
+}
+
+function findLatestAssistantThinkingDeletionViolation(
+	transcript: CompactableTranscript,
+	targets: readonly ContextDeletionTarget[],
+): ContextDeletionTarget | undefined {
+	const deletedEntryIds = getDeletedEntryIds(targets);
+	const latestRetainedAssistant = latestAssistantEntry(transcript, deletedEntryIds);
+
+	for (const target of targets) {
+		if (target.kind === "entry") {
+			const entry = findTranscriptEntry(transcript, target.entryId);
+			if (!entry || !assistantEntryHasThinkingContentBlock(entry)) continue;
+			const deletedEntryIdsIfTargetWereKept = new Set(deletedEntryIds);
+			deletedEntryIdsIfTargetWereKept.delete(target.entryId);
+			if (latestAssistantEntry(transcript, deletedEntryIdsIfTargetWereKept)?.entryId === target.entryId) {
+				return target;
+			}
+			continue;
+		}
+		if (
+			latestRetainedAssistant?.entryId === target.entryId &&
+			assistantEntryHasThinkingContentBlock(latestRetainedAssistant)
+		) {
+			return target;
+		}
 	}
 	return undefined;
 }
@@ -864,22 +895,16 @@ function assertNoLatestAssistantThinkingDeletionTargets(
 	transcript: CompactableTranscript,
 	targets: readonly ContextDeletionTarget[],
 ): void {
-	const latestAssistant = latestAssistantEntry(transcript);
-	if (!latestAssistant || !assistantEntryHasThinkingContentBlock(latestAssistant)) return;
-	for (const target of targets) {
-		if (target.entryId !== latestAssistant.entryId) continue;
-		if (target.kind === "entry") {
-			throw new Error(
-				`Cannot delete assistant entry ${target.entryId} because it is the latest assistant message and contains thinking/redacted_thinking content blocks`,
-			);
-		}
-		const block = latestAssistant.contentBlocks.find((candidate) => candidate.blockIndex === target.blockIndex);
-		if (block && isAssistantThinkingBlockType(block.type)) {
-			throw new Error(
-				`Cannot delete content block ${target.entryId}:${target.blockIndex} because it is a thinking/redacted_thinking block in the latest assistant message`,
-			);
-		}
+	const violation = findLatestAssistantThinkingDeletionViolation(transcript, targets);
+	if (!violation) return;
+	if (violation.kind === "entry") {
+		throw new Error(
+			`Cannot delete assistant entry ${violation.entryId} because it is the latest assistant message retained after other deletions and contains thinking/redacted_thinking content blocks`,
+		);
 	}
+	throw new Error(
+		`Cannot delete content block ${violation.entryId}:${violation.blockIndex} because a thinking/redacted_thinking block in the latest assistant message must remain unmodified; the latest retained assistant message contains thinking/redacted_thinking content blocks`,
+	);
 }
 
 function isToolCallBlockDeleted(
@@ -1508,6 +1533,33 @@ function filterProtectedGrepCandidates(
 			eligibleMatches.push(match);
 		}
 	}
+
+	// Some latest-assistant thinking violations only become visible after a grep batch also
+	// deletes newer assistant entries. Classify the newly-unsafe grep candidates as
+	// protected/skipped before maxMatches, expectedMatchCount, stats, or removals are computed.
+	let changed = true;
+	while (changed) {
+		changed = false;
+		const mergedTargets = mergeContextDeletionTargets(currentTargets, eligibleCandidates);
+		const violation = findLatestAssistantThinkingDeletionViolation(transcript, mergedTargets);
+		if (!violation) continue;
+		const violationKey = targetKey(violation);
+		let violationIndex = eligibleCandidates.findIndex((candidate) => targetKey(candidate) === violationKey);
+		if (violationIndex < 0) {
+			violationIndex = eligibleCandidates.findIndex((_candidate, candidateIndex) => {
+				const remainingCandidates = eligibleCandidates.filter((_candidateToKeep, index) => index !== candidateIndex);
+				const remainingTargets = mergeContextDeletionTargets(currentTargets, remainingCandidates);
+				const remainingViolation = findLatestAssistantThinkingDeletionViolation(transcript, remainingTargets);
+				return !remainingViolation || targetKey(remainingViolation) !== violationKey;
+			});
+		}
+		if (violationIndex < 0) continue;
+		const [skippedMatch] = eligibleMatches.splice(violationIndex, 1);
+		eligibleCandidates.splice(violationIndex, 1);
+		if (skippedMatch) pushProtectedGrepSkip(skipped, skippedMatch);
+		changed = true;
+	}
+
 	return { candidates: eligibleCandidates, matches: eligibleMatches };
 }
 

--- a/packages/coding-agent/test/context-compaction.test.ts
+++ b/packages/coding-agent/test/context-compaction.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildContextCompactionPrompt,
 	type CompactableTranscript,
+	createContextDeletionTool,
 	DEFAULT_COMPACTION_SETTINGS,
 	estimateContextTokens,
 	estimateTokens,
@@ -664,7 +665,7 @@ describe("context compaction", () => {
 		expect(safeValidated.deletedTargets).toEqual([{ kind: "content_block", entryId: safeAssistant.id, blockIndex: 0 }]);
 	});
 
-	it("rejects deleting thinking blocks in the latest assistant message", () => {
+	it("rejects deleting any content block in the latest thinking-bearing assistant message", () => {
 		resetIds();
 		const task = entry(user("Task must remain available"));
 		const latestAssistant = entry({
@@ -679,20 +680,158 @@ describe("context compaction", () => {
 
 		expect(() =>
 			validateContextDeletionRequest(
+				{ deletions: [{ kind: "content_block", entryId: latestAssistant.id, blockIndex: 0 }] },
+				preparation.transcript,
+			),
+		).toThrow(/latest retained assistant message contains thinking\/redacted_thinking/);
+		expect(() =>
+			validateContextDeletionRequest(
 				{ deletions: [{ kind: "content_block", entryId: latestAssistant.id, blockIndex: 1 }] },
 				preparation.transcript,
 			),
-		).toThrow(/thinking\/redacted_thinking block in the latest assistant message/);
+		).toThrow(/latest retained assistant message contains thinking\/redacted_thinking/);
 		expect(() =>
 			validateContextDeletionRequest({ deletions: [{ kind: "entry", entryId: latestAssistant.id }] }, preparation.transcript),
 		).toThrow(/latest assistant message.*thinking\/redacted_thinking/);
+	});
 
-		const visibleValidated = validateContextDeletionRequest(
-			{ deletions: [{ kind: "content_block", entryId: latestAssistant.id, blockIndex: 0 }] },
-			preparation.transcript,
-		);
-		expect(visibleValidated.deletedTargets).toEqual([
-			{ kind: "content_block", entryId: latestAssistant.id, blockIndex: 0 },
+	it("rejects content-block deletion when deleting newer assistants would make an older thinking assistant latest retained", () => {
+		resetIds();
+		const task = entry(user("Task must remain available"));
+		const olderThinkingAssistant = entry({
+			...assistantText(""),
+			content: [
+				{ type: "text", text: "older visible text" },
+				{ type: "thinking", thinking: "older thinking becomes latest", thinkingSignature: "sig-thinking" },
+			],
+		} as unknown as AssistantMessage);
+		const newerAssistant = entry(assistantText("newer assistant to delete"));
+		const entries: SessionEntry[] = [task, olderThinkingAssistant, newerAssistant];
+		const preparation = prepareContextCompaction(entries, DEFAULT_COMPACTION_SETTINGS, { preserve_recent: 0 })!;
+
+		expect(() =>
+			validateContextDeletionRequest(
+				{
+					deletions: [
+						{ kind: "content_block", entryId: olderThinkingAssistant.id, blockIndex: 0 },
+						{ kind: "entry", entryId: newerAssistant.id },
+					],
+				},
+				preparation.transcript,
+			),
+		).toThrow(/latest retained assistant message contains thinking\/redacted_thinking/);
+	});
+
+	it("rejects entry deletion when deleting newer assistants would make an older thinking assistant latest retained", () => {
+		resetIds();
+		const task = entry(user("Task must remain available"));
+		const olderThinkingAssistant = entry({
+			...assistantText(""),
+			content: [
+				{ type: "text", text: "older visible text" },
+				{ type: "thinking", thinking: "older thinking becomes latest", thinkingSignature: "sig-thinking" },
+			],
+		} as unknown as AssistantMessage);
+		const newerAssistant = entry(assistantText("newer assistant to delete"));
+		const preparation = prepareContextCompaction([task, olderThinkingAssistant, newerAssistant], DEFAULT_COMPACTION_SETTINGS, {
+			preserve_recent: 0,
+		})!;
+
+		expect(() =>
+			validateContextDeletionRequest(
+				{
+					deletions: [
+						{ kind: "entry", entryId: newerAssistant.id },
+						{ kind: "entry", entryId: olderThinkingAssistant.id },
+					],
+				},
+				preparation.transcript,
+			),
+		).toThrow(/latest assistant message retained after other deletions.*thinking\/redacted_thinking/);
+	});
+
+	it("context_grep_delete skips unsafe latest-retained thinking assistant content blocks without counting them as removals", async () => {
+		resetIds();
+		const task = entry(user("Task must remain available"));
+		const olderThinkingAssistant = entry({
+			...assistantText(""),
+			content: [
+				{ type: "text", text: "obsolete shared grep marker in visible sibling" },
+				{ type: "thinking", thinking: "private thinking remains", thinkingSignature: "sig-thinking" },
+			],
+		} as unknown as AssistantMessage);
+		const newerAssistant = entry(assistantText("obsolete shared grep marker newer assistant"));
+		const preparation = prepareContextCompaction([task, olderThinkingAssistant, newerAssistant], DEFAULT_COMPACTION_SETTINGS, {
+			preserve_recent: 0,
+		})!;
+		const controller = createContextDeletionTool(preparation.transcript, { preserve_recent: 0 });
+
+		const result = await controller.grepTool.execute("grep-call", {
+			pattern: "obsolete shared grep marker",
+			target: "content_block",
+		});
+
+		expect(result.details.error).toBeUndefined();
+		expect(result.details.matches).toEqual([
+			{
+				entryId: newerAssistant.id,
+				target: "entry",
+				text: "obsolete shared grep marker newer assistant",
+			},
+		]);
+		expect(result.details.skipped).toEqual([
+			expect.objectContaining({
+				entryId: olderThinkingAssistant.id,
+				target: "content_block",
+				blockIndex: 0,
+				reason: "protected_block",
+			}),
+		]);
+		expect(result.details.deletedTargets).toEqual([{ kind: "entry", entryId: newerAssistant.id }]);
+		expect(result.details.deletedTargets).toHaveLength(1);
+		expect(result.details.matches).toHaveLength(1);
+	});
+
+	it("context_grep_delete skips newer entries that would expose an already-filtered thinking assistant", async () => {
+		resetIds();
+		const task = entry(user("Task must remain available"));
+		const olderThinkingAssistant = entry({
+			...assistantText(""),
+			content: [
+				{ type: "text", text: "old visible block selected first" },
+				{ type: "thinking", thinking: "private thinking remains", thinkingSignature: "sig-thinking" },
+			],
+		} as unknown as AssistantMessage);
+		const newerAssistant = entry(assistantText("newer obsolete entry marker"));
+		const preparation = prepareContextCompaction([task, olderThinkingAssistant, newerAssistant], DEFAULT_COMPACTION_SETTINGS, {
+			preserve_recent: 0,
+		})!;
+		const controller = createContextDeletionTool(preparation.transcript, { preserve_recent: 0 });
+
+		const first = await controller.tool.execute("delete-old-visible", {
+			deletions: [{ kind: "content_block", entryId: olderThinkingAssistant.id, blockIndex: 0 }],
+		});
+		expect(first.details.error).toBeUndefined();
+		expect(controller.getDeletionRequest().deletions).toEqual([
+			{ kind: "content_block", entryId: olderThinkingAssistant.id, blockIndex: 0 },
+		]);
+
+		const second = await controller.grepTool.execute("grep-newer", {
+			pattern: "newer obsolete entry marker",
+			target: "entry",
+		});
+
+		expect(second.details.error).toBeUndefined();
+		expect(second.details.matches).toEqual([]);
+		expect(second.details.skipped).toEqual([
+			expect.objectContaining({
+				entryId: newerAssistant.id,
+				target: "entry",
+				reason: "protected_entry",
+			}),
+		]);
+		expect(controller.getDeletionRequest().deletions).toEqual([
+			{ kind: "content_block", entryId: olderThinkingAssistant.id, blockIndex: 0 },
 		]);
 	});
 


### PR DESCRIPTION
## Summary

Strengthens the compaction validation guard for assistant messages that contain `thinking` or `redacted_thinking` blocks. The previous guard only blocked deletion of the thinking blocks themselves; this fix extends protection to every content block in the latest *retained* assistant message, and accounts for cases where deleting newer assistant entries would promote an older thinking-bearing assistant into the latest-retained position.

Closes #1405

## Changes

- **`latestAssistantEntry`** now accepts a `deletedEntryIds` set so it computes the latest *retained* assistant after accounting for proposed entry deletions, not just the latest entry in the raw transcript.
- **Replaced `assertNoLatestAssistantThinkingDeletionTargets`** with `findLatestAssistantThinkingDeletionViolation` — a pure helper that:
  - Blocks deletion of *any* content block (not only `thinking`/`redacted_thinking` blocks) from the latest retained assistant when that message contains thinking content.
  - Catches the "promotion" edge case: an entry-deletion batch that deletes a newer assistant and would make an older thinking-bearing assistant the new latest retained is now rejected.
- **`filterProtectedGrepCandidates`** gains an iterative while-loop that removes unsafe `context_grep_delete` candidates before `matches`, `expectedMatchCount`, stats, or removals are computed, mirroring the same guard for exact deletions.
- **Compaction prompt** updated to accurately describe the expanded guard ("do not delete any content block from the latest assistant message when that message contains thinking/redacted_thinking").
- **Compaction docs** (`docs/compaction.md`) updated Gate 2, Gate 7, and the `context_grep_delete` paragraph to reflect the universal latest-retained protection.
- **Changelog entry** added under `### Fixed` in `packages/coding-agent/CHANGELOG.md`.
- **Regression tests** added covering:
  - Rejection of visible sibling block deletion in latest thinking-bearing assistant.
  - Rejection when a content-block deletion + entry deletion together would expose an older thinking assistant.
  - Rejection when two entry deletions together would promote an older thinking assistant.
  - `context_grep_delete` skipping unsafe sibling-block candidates without counting them as removals.
  - `context_grep_delete` skipping newer entries that would expose an already partially-filtered thinking assistant.

## Validation

```sh
bun test packages/coding-agent/test/context-compaction.test.ts packages/coding-agent/test/context-compaction-deletion-tool.test.ts packages/coding-agent/test/session-manager/build-context.test.ts
bun run typecheck
bun run lint
bun run test:unit
```