### PR TITLE
chore: release 0.8.30-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "atomic-natives"
-version = "0.8.30-alpha.2"
+version = "0.8.30-alpha.3"
 dependencies = [
  "bytes",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/atomic-natives"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.30-alpha.2"
+version = "0.8.30-alpha.3"
 edition = "2024"
 license = "MIT"
 authors = ["Bastani"]

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/coding-agent": {
       "name": "@bastani/atomic",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "bin": {
         "atomic": "dist/cli.js",
       },
@@ -66,9 +66,9 @@
     },
     "packages/cursor": {
       "name": "@bastani/cursor",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "dependencies": {
-        "@bastani/atomic-natives": "0.8.30-alpha.2",
+        "@bastani/atomic-natives": "0.8.30-alpha.3",
         "@bufbuild/protobuf": "^2.0.0",
       },
       "peerDependencies": {
@@ -80,7 +80,7 @@
     },
     "packages/intercom": {
       "name": "@bastani/intercom",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "dependencies": {
         "typebox": "^1.1.24",
       },
@@ -95,7 +95,7 @@
     },
     "packages/mcp": {
       "name": "@bastani/mcp",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -117,14 +117,14 @@
     },
     "packages/natives": {
       "name": "@bastani/atomic-natives",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "devDependencies": {
         "@napi-rs/cli": "3.7.0",
       },
     },
     "packages/subagents": {
       "name": "@bastani/subagents",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",
@@ -144,7 +144,7 @@
     },
     "packages/web-access": {
       "name": "@bastani/web-access",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12",
@@ -163,7 +163,7 @@
     },
     "packages/workflows": {
       "name": "@bastani/workflows",
-      "version": "0.8.30-alpha.2",
+      "version": "0.8.30-alpha.3",
       "dependencies": {
         "jiti": "^2.7.0",
         "typebox": "^1.1.24",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "description": "Atomic coding agent CLI with read, bash, edit, write tools and session management",
   "type": "module",
   "atomicConfig": {
@@ -68,7 +68,7 @@
     "prepublishOnly": "bun run clean && bun run build"
   },
   "dependencies": {
-    "@bastani/atomic-natives": "0.8.30-alpha.2",
+    "@bastani/atomic-natives": "0.8.30-alpha.3",
     "@bufbuild/protobuf": "^2.0.0",
     "@earendil-works/pi-agent-core": "^0.79.4",
     "@earendil-works/pi-ai": "^0.79.4",

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/cursor",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "private": true,
   "description": "Experimental first-party Atomic extension for Cursor OAuth, model discovery, and streaming provider registration.",
   "contributors": [
@@ -40,7 +40,7 @@
     }
   },
   "dependencies": {
-    "@bastani/atomic-natives": "0.8.30-alpha.2",
+    "@bastani/atomic-natives": "0.8.30-alpha.3",
     "@bufbuild/protobuf": "^2.0.0"
   }
 }

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/intercom",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "private": true,
   "description": "Atomic extension providing a private coordination channel between parent and child agent sessions. Fork of: https://github.com/nicobailon/pi-intercom",
   "contributors": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/mcp",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "private": true,
   "description": "Atomic extension that adapts MCP (Model Context Protocol) servers into the coding agent. Fork of: https://github.com/nicobailon/pi-mcp-adapter",
   "contributors": [

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-android-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-android-arm-eabi')
         const bindingPackageVersion = require('@bastani/atomic-natives-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-x64-gnu')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-x64-msvc')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-ia32-msvc')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-win32-arm64-msvc')
         const bindingPackageVersion = require('@bastani/atomic-natives-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@bastani/atomic-natives-darwin-universal')
       const bindingPackageVersion = require('@bastani/atomic-natives-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-darwin-x64')
         const bindingPackageVersion = require('@bastani/atomic-natives-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-darwin-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-freebsd-x64')
         const bindingPackageVersion = require('@bastani/atomic-natives-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-freebsd-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-x64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-x64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm-musleabihf')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-loong64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-loong64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-riscv64-musl')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@bastani/atomic-natives-linux-riscv64-gnu')
           const bindingPackageVersion = require('@bastani/atomic-natives-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-linux-ppc64-gnu')
         const bindingPackageVersion = require('@bastani/atomic-natives-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-linux-s390x-gnu')
         const bindingPackageVersion = require('@bastani/atomic-natives-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-openharmony-arm64')
         const bindingPackageVersion = require('@bastani/atomic-natives-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-openharmony-x64')
         const bindingPackageVersion = require('@bastani/atomic-natives-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@bastani/atomic-natives-openharmony-arm')
         const bindingPackageVersion = require('@bastani/atomic-natives-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.8.30-alpha.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.8.30-alpha.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.8.30-alpha.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/atomic-natives",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "description": "Native Rust bindings for Atomic via N-API",
   "homepage": "https://github.com/bastani-inc/atomic",
   "author": "Bastani",

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/subagents",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "private": true,
   "description": "Atomic extension for delegating tasks to subagents with chains, parallel execution, and TUI clarification. Fork of: https://github.com/nicobailon/pi-subagents",
   "contributors": [

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/web-access",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "private": true,
   "description": "Atomic extension for web search, URL fetching, GitHub repo cloning, PDF/video extraction. Fork of: https://github.com/nicobailon/pi-web-access",
   "contributors": [

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastani/workflows",
-  "version": "0.8.30-alpha.2",
+  "version": "0.8.30-alpha.3",
   "private": true,
   "description": "Atomic extension for multi-stage workflow authoring and execution.",
   "contributors": [


### PR DESCRIPTION
## Summary

Bumps all workspace packages and the Rust crate to `0.8.30-alpha.3`, incorporating two fixes that landed since `0.8.30-alpha.2`.

## Key changes

- **fix(compaction):** repair thinking-block replay and post-compaction context-usage accounting — extended-thinking assistant blocks now replay correctly after context compaction ([#1411](https://github.com/bastani-inc/atomic/pull/1411))
- **fix(workflows):** preserve `ctx.parallel` queued-branch parent frontier — parallel branches no longer lose their parent context node when queued
- **deps:** bump Rust `h2` from `0.4.14` to `0.4.15`
- **chore:** version bump across all workspace packages (`@bastani/atomic`, `@bastani/workflows`, `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`, `@bastani/atomic-natives`, `@bastani/cursor`) and Rust crate; native binding version-check strings updated accordingly

## Changed files

- `Cargo.lock`, `Cargo.toml`
- `bun.lock`
- `packages/coding-agent/package.json`
- `packages/cursor/package.json`
- `packages/intercom/package.json`
- `packages/mcp/package.json`
- `packages/natives/native/index.js`
- `packages/natives/package.json`
- `packages/subagents/package.json`
- `packages/web-access/package.json`
- `packages/workflows/package.json`

## Validation

Pre-push hooks ran on push: `cargo fmt --check`, `cargo clippy`, `bun run lint`, `bun run test:unit`.

**Release kind:** prerelease
**Target version:** `0.8.30-alpha.3`
**Base:** `main` ← **Head:** `prerelease/0.8.30-alpha.3`
**Source HEAD:** `5916bbe8cbf88828e501d3f67fd171c0e4e1c63a`
**Release commit:** `41413995b843039c8929df16fc19ff370936e8ab`