### PR TITLE
feat(workflows): add per-model context-window token for model strings

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -969,7 +969,7 @@ workflow({
 })
 ```
 
-Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `tools`, `noTools`, `customTools`, `bashPolicy`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
+Direct mode supports top-level/default options and per-task options such as `context`, `forkFromSessionFile`, `model`, `fallbackModels`, `thinkingLevel`, `contextWindow`, `tools`, `noTools`, `customTools`, `bashPolicy`, `mcp`, `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, and `agentDir`. Direct chains also support `chainName`, `chainDir`, and `failFast`.
 
 For large fan-outs, prefer `outputMode: "file-only"` so the parent result contains compact file references instead of full output. Treat intercom payloads from async direct runs as user-visible workflow output.
 
@@ -1477,7 +1477,8 @@ Common task/stage options include:
 - `prompt` or `task`
 - `previous` for small handoff context; use artifact paths plus `reads` for large outputs, logs, research bundles, or reviewer payloads
 - `context: "fresh" | "fork"`, `forkFromSessionFile`
-- `model`, `fallbackModels`, `thinkingLevel`, `scopedModels`, `modelRegistry` — `model` and each `fallbackModels` entry accept a `model_name:thinking_effort` reasoning suffix; the standalone `thinkingLevel` is deprecated (see [Reasoning levels](#reasoning-levels))
+- `model`, `fallbackModels`, `thinkingLevel`, `scopedModels`, `modelRegistry` — `model` and each `fallbackModels` entry accept a `model_name:thinking_effort` reasoning suffix and an optional parenthesized context-window token such as `model (1m)` (see [Reasoning levels](#reasoning-levels) and [Context windows](#context-windows)); the standalone `thinkingLevel` is deprecated
+- `contextWindow`, `contextWindowStrict` — stage-wide context-window budget mapped to the SDK `createAgentSession` options of the same name (non-strict by default)
 - `tools`, `noTools`, `customTools`, `mcp: { allow?: string[], deny?: string[] }`, `bashPolicy`
 - `schema` for a structured final answer from this workflow item
 - `output`, `outputMode`, `reads`, `worktree`, `gitWorktreeDir`, `baseBranch`, `maxOutput`, `artifacts`, `sessionDir`, `cwd`, `agentDir`
@@ -1553,6 +1554,27 @@ The standalone `thinkingLevel` stage option is deprecated. It still applies as a
 ```
 
 This applies everywhere a stage accepts a model: direct `ctx.task`/`ctx.chain`/`ctx.parallel` options, `ctx.stage` options, builtin workflow stage definitions, and workflow parameters. `fallbackThinkingLevels` is an optional compatibility helper aligned by index to `fallbackModels`; it applies only to fallback entries that do not already carry a suffix. Each `WorkflowModelAttempt` reports the resolved model and the effective reasoning effort used for that attempt.
+
+### Context windows
+
+A `model`/`fallbackModels` entry may also request a context-window budget with a parenthesized size token in the model-name portion — placed *before* the optional `:reasoning` suffix so it never collides with the reasoning level. This mirrors GitHub Copilot's `Claude Opus 4.8 (1M context)` model-name convention:
+
+```ts
+await ctx.task("review", {
+  task: "Review the diff",
+  model: "anthropic/claude-fable-5:xhigh",
+  // The copilot opus fallback runs at its largest advertised (long-context) window.
+  fallbackModels: ["github-copilot/claude-opus-4.8 (1m):xhigh", "anthropic/claude-opus-4-8:xhigh"],
+});
+```
+
+The token accepts the same compact sizes as the `--context-window` flag (`1m`, `936k`, `400k`, or a raw token count) and is resolved against that specific candidate model's advertised windows:
+
+- an exact supported window is used as-is;
+- otherwise the largest supported window not exceeding the request is selected, so `(1m)` lands on a model's ~936K long-context tier;
+- when the model exposes no larger tier (or is unavailable), the request is dropped and the session keeps the model's default (short) window — a non-strict, automatic fallback.
+
+The budget applies only to the candidate that carries the token; other primary and fallback models in the same chain are unaffected. A parenthesized token that is not a valid size (for example `(preview)`) is left attached to the model id rather than being treated as a context window. For stage-wide selection you can instead set the `contextWindow` (and `contextWindowStrict`) stage option, which maps to the SDK `createAgentSession` options of the same name.
 
 ## Programmatic Usage
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a per-model context-window authoring token to workflow model strings: a parenthesized size token placed in the model-name portion, *before* the optional `:reasoning` suffix, e.g. `github-copilot/claude-opus-4.8 (1m):xhigh`. Adopting GitHub Copilot's `Claude Opus 4.8 (1M context)` naming convention keeps the window separate from the reasoning level so the two never collide. The token is resolved against the candidate model's advertised windows — an exact match wins, otherwise the largest supported window not exceeding the request (so `(1m)` selects a model's ~936K long-context tier), and it falls back to the model's default (short) window when no larger tier is available. It applies only to the candidate that carries the token, leaving primary and other fallback models untouched. Also surfaced `contextWindow`/`contextWindowStrict` on `StageOptions` and the workflow tool's direct-task schema for stage-level selection.
+
 ### Changed
 
+- Changed the builtin `deep-research-codebase`, `goal`, `ralph`, and `open-claude-design` workflows to run their GitHub Copilot `claude-opus-4.8` fallbacks at the model's largest advertised long-context (~1M/936K) window via the new `(1m)` token, automatically degrading to the 200K short window when Copilot's long-context tier is unavailable. Other models in each fallback chain are unaffected.
 - Aligned the workflows extension peer dependency with upstream pi TUI `^0.79.6` so workflow graph, custom UI, and prompt-broker integrations consume the latest shared TUI compatibility fixes; no workflows extension code changes were made for this metadata sync ([#1413](https://github.com/bastani-inc/atomic/issues/1413)).
 
 ## [0.8.30] - 2026-06-17

--- a/packages/workflows/builtin/deep-research-codebase.ts
+++ b/packages/workflows/builtin/deep-research-codebase.ts
@@ -399,7 +399,7 @@ export default defineWorkflow("deep-research-codebase")
         "openai-codex/gpt-5.5:xhigh",
         "github-copilot/gpt-5.5:xhigh",
         "openai/gpt-5.5:xhigh",
-        "github-copilot/claude-opus-4.8:xhigh",
+        "github-copilot/claude-opus-4.8 (1m):xhigh",
         "anthropic/claude-opus-4-8:xhigh"
       ],
       excludedTools: ["ask_user_question"],

--- a/packages/workflows/builtin/goal.ts
+++ b/packages/workflows/builtin/goal.ts
@@ -976,7 +976,7 @@ export default defineWorkflow("goal")
       fallbackModels: [
           "github-copilot/gpt-5.5:medium",
           "openai/gpt-5.5:medium",
-          "github-copilot/claude-opus-4.8:medium",
+          "github-copilot/claude-opus-4.8 (1m):medium",
           "anthropic/claude-opus-4-8:medium",
       ],
       tools: goalRunnerTools,
@@ -988,7 +988,7 @@ export default defineWorkflow("goal")
           "openai-codex/gpt-5.5:xhigh",
           "github-copilot/gpt-5.5:xhigh",
           "openai/gpt-5.5:xhigh",
-          "github-copilot/claude-opus-4.8:xhigh",
+          "github-copilot/claude-opus-4.8 (1m):xhigh",
           "anthropic/claude-opus-4-8:xhigh"
       ],
       tools: goalRunnerTools,

--- a/packages/workflows/builtin/open-claude-design.ts
+++ b/packages/workflows/builtin/open-claude-design.ts
@@ -407,7 +407,7 @@ export default defineWorkflow("open-claude-design")
     const designModelConfig = {
       model: "anthropic/claude-fable-5:xhigh",
       fallbackModels: [
-          "github-copilot/claude-opus-4.8:xhigh",
+          "github-copilot/claude-opus-4.8 (1m):xhigh",
           "anthropic/claude-opus-4-8:xhigh",
           "github-copilot/claude-sonnet-4.6:high",
           "anthropic/claude-sonnet-4-6:high",

--- a/packages/workflows/builtin/ralph.ts
+++ b/packages/workflows/builtin/ralph.ts
@@ -464,7 +464,7 @@ async function runRalphWorkflow(
       "openai-codex/gpt-5.5:xhigh",
       "github-copilot/gpt-5.5:xhigh",
       "openai/gpt-5.5:xhigh",
-      "github-copilot/claude-opus-4.8:xhigh",
+      "github-copilot/claude-opus-4.8 (1m):xhigh",
       "anthropic/claude-opus-4-8:xhigh"
     ],
     noTools: "all" as const,
@@ -475,7 +475,7 @@ async function runRalphWorkflow(
     fallbackModels: [
         "github-copilot/gpt-5.5:medium",
         "openai/gpt-5.5:medium",
-        "github-copilot/claude-opus-4.8:medium",
+        "github-copilot/claude-opus-4.8 (1m):medium",
         "anthropic/claude-opus-4-8:medium",
     ],
     excludedTools: ["ask_user_question"],
@@ -486,7 +486,7 @@ async function runRalphWorkflow(
     fallbackModels: [
         "github-copilot/gpt-5.5:medium",
         "openai/gpt-5.5:medium",
-        "github-copilot/claude-opus-4.8:medium",
+        "github-copilot/claude-opus-4.8 (1m):medium",
         "anthropic/claude-opus-4-8:medium",
     ],
     excludedTools: ["ask_user_question"],
@@ -498,7 +498,7 @@ async function runRalphWorkflow(
       "openai-codex/gpt-5.5:xhigh",
       "github-copilot/gpt-5.5:xhigh",
       "openai/gpt-5.5:xhigh",
-      "github-copilot/claude-opus-4.8:xhigh",
+      "github-copilot/claude-opus-4.8 (1m):xhigh",
       "anthropic/claude-opus-4-8:xhigh"
     ],
     excludedTools: ["ask_user_question"],

--- a/packages/workflows/src/extension/workflow-schema.ts
+++ b/packages/workflows/src/extension/workflow-schema.ts
@@ -66,7 +66,9 @@ const StageSessionOptionProperties = {
   agentDir: Type.Optional(Type.String()),
   authStorage: Type.Optional(SdkSessionOptionSchema("authStorage")),
   modelRegistry: Type.Optional(SdkSessionOptionSchema("modelRegistry")),
-  model: Type.Optional(Type.Unsafe<WorkflowModelValue>({ description: "Primary model id or SDK model object. String ids may include a reasoning suffix, e.g. openai/gpt-5:high; valid levels: off|minimal|low|medium|high|xhigh." })),
+  model: Type.Optional(Type.Unsafe<WorkflowModelValue>({ description: "Primary model id or SDK model object. String ids may include a reasoning suffix, e.g. openai/gpt-5:high; valid levels: off|minimal|low|medium|high|xhigh. A parenthesized context-window token may precede the suffix, e.g. github-copilot/claude-opus-4.8 (1m):high." })),
+  contextWindow: Type.Optional(Type.Number({ description: "Context-window token budget for the stage session (e.g. 1000000). Non-strict by default: an unsupported value keeps the model's default window. Prefer the per-model `(1m)` token in a model/fallbackModels entry when only specific models should use a larger window." })),
+  contextWindowStrict: Type.Optional(Type.Boolean({ description: "Treat an unsupported contextWindow as an error instead of falling back to the model's default window." })),
   thinkingLevel: Type.Optional(SdkSessionOptionSchema("thinkingLevel")),
   scopedModels: Type.Optional(Type.Array(SdkSessionOptionArrayElementSchema("scopedModels"))),
   noTools: Type.Optional(Type.Unsafe<NonNullable<CreateAgentSessionOptions["noTools"]>>({

--- a/packages/workflows/src/runs/foreground/stage-runner.ts
+++ b/packages/workflows/src/runs/foreground/stage-runner.ts
@@ -755,6 +755,11 @@ export function createStageContext(opts: StageRunnerOpts): InternalStageContext 
           ...(effectiveStageOptions ?? {}),
           model: candidate.value,
           ...(candidate.reasoningLevel !== undefined ? { thinkingLevel: candidate.reasoningLevel } : {}),
+          // A per-candidate context window (parsed from a parenthesized token in
+          // the model string) overrides any stage-level contextWindow so only
+          // that specific model — e.g. a github-copilot opus fallback — requests
+          // its larger window; other candidates keep the stage default.
+          ...(candidate.contextWindow !== undefined ? { contextWindow: candidate.contextWindow } : {}),
           fallbackModels: undefined,
           fallbackThinkingLevels: undefined,
         };

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -38,25 +38,36 @@ function makeCandidate(
 }
 
 /**
- * Trailing parenthesized context-window authoring token, e.g. the `(1m)` in
- * `github-copilot/claude-opus-4.8 (1m)`. Mirrors GitHub Copilot's model-name
- * convention (`Claude Opus 4.8 (1M context)`) and intentionally lives in the
- * model-name portion — *not* a `:` suffix — so it never collides with the
- * `:off|minimal|low|medium|high|xhigh` reasoning-level suffix.
+ * Extract a trailing parenthesized context-window authoring token, e.g. the
+ * `(1m)` in `github-copilot/claude-opus-4.8 (1m)`. Mirrors GitHub Copilot's
+ * model-name convention (`Claude Opus 4.8 (1M context)`) and intentionally
+ * lives in the model-name portion — *not* a `:` suffix — so it never collides
+ * with the `:off|minimal|low|medium|high|xhigh` reasoning-level suffix.
+ *
+ * Parsed with plain string scanning rather than a regular expression so that
+ * adversarial model strings (e.g. `(` followed by long whitespace runs) cannot
+ * trigger super-linear backtracking (CodeQL js/polynomial-redos).
  */
-const CONTEXT_WINDOW_TOKEN_PATTERN = /^(.*\S)\s*\(\s*([^()]+?)\s*\)\s*$/;
-
 function extractContextWindowToken(
   model: string,
 ): { readonly baseModel: string; readonly requestedContextWindow?: number } {
-  const match = CONTEXT_WINDOW_TOKEN_PATTERN.exec(model);
-  if (match === null) return { baseModel: model };
-  const parsed = parseContextWindowValue(match[2]!);
+  const trimmedEnd = model.trimEnd();
+  if (!trimmedEnd.endsWith(")")) return { baseModel: model };
+  const open = trimmedEnd.lastIndexOf("(");
+  // Require at least one character before the `(` so a bare `(1m)` is not a model.
+  if (open <= 0) return { baseModel: model };
+  const inner = trimmedEnd.slice(open + 1, -1);
+  // The token must be a single flat `(...)` group with no nested parentheses.
+  if (inner.includes("(") || inner.includes(")")) return { baseModel: model };
+  const token = inner.trim();
+  const baseModel = trimmedEnd.slice(0, open).trim();
+  if (token.length === 0 || baseModel.length === 0) return { baseModel: model };
+  const parsed = parseContextWindowValue(token);
   // A parenthesized token that does not parse as a context size (e.g. an
   // accidental `(preview)`) is left attached to the model id so the normal
   // "not available" lookup surfaces the typo instead of being silently dropped.
   if (parsed.value === undefined) return { baseModel: model };
-  return { baseModel: match[1]!.trim(), requestedContextWindow: parsed.value };
+  return { baseModel, requestedContextWindow: parsed.value };
 }
 
 /**

--- a/packages/workflows/src/runs/shared/model-fallback.ts
+++ b/packages/workflows/src/runs/shared/model-fallback.ts
@@ -1,3 +1,4 @@
+import { getModelDefaultContextWindow, getSupportedContextWindows, parseContextWindowValue } from "@bastani/atomic";
 import type { CreateAgentSessionOptions } from "@bastani/atomic";
 import type {
   WorkflowModelCatalogPort,
@@ -10,14 +11,80 @@ export interface WorkflowResolvedModelCandidate {
   readonly id: string;
   readonly value: WorkflowModelValue;
   readonly reasoningLevel?: WorkflowThinkingLevel;
+  /**
+   * Resolved context-window token budget for this candidate's session, parsed
+   * from a parenthesized authoring token in the model string (e.g.
+   * `github-copilot/claude-opus-4.8 (1m):xhigh`). Resolved against the
+   * candidate model's advertised windows: an exact match wins, otherwise the
+   * largest supported window <= the request (so `(1m)` selects a model's ~936K
+   * long-context tier). Left `undefined` when the model exposes no matching
+   * window, so the session keeps the model's default (short) window.
+   */
+  readonly contextWindow?: number;
 }
 
 function makeCandidate(
   id: string,
   value: WorkflowModelValue,
   level: WorkflowThinkingLevel | undefined,
+  contextWindow?: number,
 ): WorkflowResolvedModelCandidate {
-  return level !== undefined ? { id, value, reasoningLevel: level } : { id, value };
+  return {
+    id,
+    value,
+    ...(level !== undefined ? { reasoningLevel: level } : {}),
+    ...(contextWindow !== undefined ? { contextWindow } : {}),
+  };
+}
+
+/**
+ * Trailing parenthesized context-window authoring token, e.g. the `(1m)` in
+ * `github-copilot/claude-opus-4.8 (1m)`. Mirrors GitHub Copilot's model-name
+ * convention (`Claude Opus 4.8 (1M context)`) and intentionally lives in the
+ * model-name portion — *not* a `:` suffix — so it never collides with the
+ * `:off|minimal|low|medium|high|xhigh` reasoning-level suffix.
+ */
+const CONTEXT_WINDOW_TOKEN_PATTERN = /^(.*\S)\s*\(\s*([^()]+?)\s*\)\s*$/;
+
+function extractContextWindowToken(
+  model: string,
+): { readonly baseModel: string; readonly requestedContextWindow?: number } {
+  const match = CONTEXT_WINDOW_TOKEN_PATTERN.exec(model);
+  if (match === null) return { baseModel: model };
+  const parsed = parseContextWindowValue(match[2]!);
+  // A parenthesized token that does not parse as a context size (e.g. an
+  // accidental `(preview)`) is left attached to the model id so the normal
+  // "not available" lookup surfaces the typo instead of being silently dropped.
+  if (parsed.value === undefined) return { baseModel: model };
+  return { baseModel: match[1]!.trim(), requestedContextWindow: parsed.value };
+}
+
+/**
+ * Resolve a requested context-window budget against a candidate model's
+ * advertised windows. Returns the exact value when supported, otherwise the
+ * largest supported window that does not exceed the request (so `(1m)` lands on
+ * a ~936K long-context tier), or `undefined` when nothing fits — in which case
+ * the session keeps the model's default window. Model values that are plain
+ * strings (not resolved against the live catalog) cannot be introspected and
+ * yield `undefined`.
+ */
+function resolveRequestedContextWindow(
+  value: WorkflowModelValue,
+  requested: number,
+): number | undefined {
+  if (typeof value === "string") return undefined;
+  const supported = getSupportedContextWindows(value);
+  if (supported.length === 0) return undefined;
+  const chosen = supported.includes(requested)
+    ? requested
+    : (() => {
+        const atOrBelow = supported.filter((window) => window <= requested);
+        return atOrBelow.length > 0 ? Math.max(...atOrBelow) : undefined;
+      })();
+  if (chosen === undefined) return undefined;
+  // Only override when the request actually upgrades past the model's default
+  // window; otherwise leave it unset so the session simply keeps its default.
+  return chosen === getModelDefaultContextWindow(value) ? undefined : chosen;
 }
 
 const WORKFLOW_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const satisfies readonly WorkflowThinkingLevel[];
@@ -34,7 +101,7 @@ export function splitReasoningSuffix(model: string): { readonly baseModel: strin
 }
 
 function candidateKey(candidate: WorkflowResolvedModelCandidate): string {
-  return `${candidate.id}::${candidate.reasoningLevel ?? ""}`;
+  return `${candidate.id}::${candidate.reasoningLevel ?? ""}::${candidate.contextWindow ?? ""}`;
 }
 
 interface ModelResolutionFailure {
@@ -99,16 +166,25 @@ function resolveStringModel(
 ): WorkflowResolvedModelCandidate | ModelResolutionFailure {
   const input = rawInput.trim();
   if (!input) return { input: rawInput, reason: "empty model id" };
-  const { baseModel, level } = splitReasoningSuffix(input);
+  const { baseModel: afterReasoning, level } = splitReasoningSuffix(input);
+  const { baseModel, requestedContextWindow } = extractContextWindowToken(afterReasoning);
+
+  const candidate = (id: string, value: WorkflowModelValue): WorkflowResolvedModelCandidate =>
+    makeCandidate(
+      id,
+      value,
+      level,
+      requestedContextWindow === undefined ? undefined : resolveRequestedContextWindow(value, requestedContextWindow),
+    );
 
   if (availableModels === undefined) {
-    return makeCandidate(baseModel, baseModel, level);
+    return candidate(baseModel, baseModel);
   }
 
   const models = uniqueByFullId(availableModels);
   const explicit = models.find((model) => model.fullId === baseModel);
   if (explicit !== undefined) {
-    return makeCandidate(explicit.fullId, explicit.model ?? explicit.fullId, level);
+    return candidate(explicit.fullId, explicit.model ?? explicit.fullId);
   }
 
   if (baseModel.includes("/")) {
@@ -122,7 +198,7 @@ function resolveStringModel(
     // currentModel — discarding the workflow's defined primary and fallbacks.
     // Pass it through with the reasoning suffix split off; the runtime fallback
     // loop skips it only if the SDK genuinely cannot create a session for it.
-    return makeCandidate(baseModel, baseModel, level);
+    return candidate(baseModel, baseModel);
   }
 
   const byBareId = models.filter((model) => model.id === baseModel);
@@ -131,14 +207,14 @@ function resolveStringModel(
   }
   if (byBareId.length === 1) {
     const only = byBareId[0]!;
-    return makeCandidate(only.fullId, only.model ?? only.fullId, level);
+    return candidate(only.fullId, only.model ?? only.fullId);
   }
 
   const preferred = preferredProvider === undefined
     ? undefined
     : byBareId.find((model) => model.provider === preferredProvider);
   if (preferred !== undefined) {
-    return makeCandidate(preferred.fullId, preferred.model ?? preferred.fullId, level);
+    return candidate(preferred.fullId, preferred.model ?? preferred.fullId);
   }
 
   return {

--- a/packages/workflows/src/shared/authoring-contract.ts
+++ b/packages/workflows/src/shared/authoring-contract.ts
@@ -153,6 +153,17 @@ export interface StageOptions<TSchemaDef extends TSchema | undefined = TSchema |
   /** Optional structured final-answer schema. When set, the stage receives a schema-specific final-answer tool. */
   readonly schema?: TSchemaDef;
   readonly model?: WorkflowModelValue;
+  /**
+   * Context-window token budget for the stage session. May also be expressed
+   * per-model via a parenthesized token in a `model`/`fallbackModels` entry
+   * (e.g. `github-copilot/claude-opus-4.8 (1m):xhigh`), which is preferred when
+   * only specific fallbacks should use a larger window. Non-strict by default:
+   * an unsupported value keeps the model's default window (see
+   * `contextWindowStrict`).
+   */
+  readonly contextWindow?: number;
+  /** Treat an unsupported `contextWindow` as an error instead of falling back to the model default. */
+  readonly contextWindowStrict?: boolean;
   readonly mcp?: StageMcpOptions;
   readonly tools?: readonly string[];
   readonly noTools?: "all" | "builtin";

--- a/test/unit/executor.test.ts
+++ b/test/unit/executor.test.ts
@@ -4433,6 +4433,65 @@ describe("executor.run", () => {
         }
     });
 
+    test("dummy workflow: a (1m) token stage runs end-to-end and applies the long-context window to the SDK session", async () => {
+        const st = createStore();
+        let createdModel: string | undefined;
+        let createdContextWindow: number | undefined = -1;
+        const def = defineWorkflow("context-window-token-smoke")
+            .output("ok", Type.Boolean())
+            .run(async (ctx) => {
+                await ctx
+                    .stage("opus", { model: "github-copilot/claude-opus-4.8 (1m):xhigh" })
+                    .prompt("hello");
+                return { ok: true };
+            })
+            .compile();
+
+        const wfResult = await run(
+            def,
+            {},
+            {
+                models: {
+                    listModels: async () => [
+                        {
+                            provider: "github-copilot",
+                            id: "claude-opus-4.8",
+                            fullId: "github-copilot/claude-opus-4.8",
+                            // Tiered window mirroring the live CAPI catalog (200K default + ~936K long).
+                            model: {
+                                provider: "github-copilot",
+                                id: "claude-opus-4.8",
+                                contextWindow: 200_000,
+                                defaultContextWindow: 200_000,
+                                contextWindowOptions: [200_000, 936_000],
+                            } as unknown as NonNullable<CreateAgentSessionOptions["model"]>,
+                        },
+                    ],
+                },
+                adapters: {
+                    agentSession: {
+                        async create(options) {
+                            createdModel =
+                                typeof options.model === "string"
+                                    ? options.model
+                                    : `${String(options.model?.provider)}/${options.model?.id}`;
+                            createdContextWindow = options.contextWindow;
+                            return mockSession();
+                        },
+                    },
+                },
+                store: st,
+            },
+        );
+
+        assert.equal(wfResult.status, "completed");
+        assert.equal(wfResult.result?.["ok"], true);
+        // The `(1m)` token resolved against the opus model's advertised windows
+        // and reached createAgentSession as the ~936K long-context budget.
+        assert.equal(createdModel, "github-copilot/claude-opus-4.8");
+        assert.equal(createdContextWindow, 936_000);
+    });
+
     test("bare explicit model stage publishes running fast-mode metadata after catalog resolution", async () => {
         const promptGate = deferred<string | void>();
         const st = createStore();

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -476,3 +476,116 @@ describe("model fallback helpers", () => {
     assert.equal(isRetryableModelFailure("shell command failed with 503"), false);
   });
 });
+
+describe("context-window authoring token", () => {
+  // Minimal Model<Api>-shaped fixtures: getSupportedContextWindows only reads
+  // contextWindow / defaultContextWindow / contextWindowOptions.
+  function copilotOpus(options: {
+    readonly defaultWindow: number;
+    readonly contextWindowOptions?: readonly number[];
+  }): WorkflowModelInfo {
+    return {
+      provider: "github-copilot",
+      id: "claude-opus-4.8",
+      fullId: "github-copilot/claude-opus-4.8",
+      model: {
+        provider: "github-copilot",
+        id: "claude-opus-4.8",
+        contextWindow: options.defaultWindow,
+        defaultContextWindow: options.defaultWindow,
+        ...(options.contextWindowOptions !== undefined ? { contextWindowOptions: options.contextWindowOptions } : {}),
+      } as unknown as NonNullable<WorkflowModelInfo["model"]>,
+    };
+  }
+
+  // Copilot opus today: 200K default tier + ~936K long-context tier.
+  const tieredOpus = [copilotOpus({ defaultWindow: 200_000, contextWindowOptions: [200_000, 936_000] })];
+
+  test("(1m) selects the largest advertised window <= request and keeps the reasoning suffix", () => {
+    const [candidate] = buildModelCandidates({
+      primaryModel: "github-copilot/claude-opus-4.8 (1m):xhigh",
+      availableModels: tieredOpus,
+    });
+    assert.equal(candidate?.id, "github-copilot/claude-opus-4.8");
+    assert.equal(candidate?.reasoningLevel, "xhigh");
+    assert.equal(candidate?.contextWindow, 936_000);
+  });
+
+  test("an exact supported window is honored verbatim", () => {
+    const [candidate] = buildModelCandidates({
+      primaryModel: "github-copilot/claude-opus-4.8 (936k):medium",
+      availableModels: tieredOpus,
+    });
+    assert.equal(candidate?.contextWindow, 936_000);
+    assert.equal(candidate?.reasoningLevel, "medium");
+  });
+
+  test("(1m) falls back to the default window when the model exposes no long tier", () => {
+    const [candidate] = buildModelCandidates({
+      primaryModel: "github-copilot/claude-opus-4.8 (1m):xhigh",
+      availableModels: [copilotOpus({ defaultWindow: 200_000 })],
+    });
+    // No larger supported window -> leave unset so the session keeps 200K short.
+    assert.equal(candidate?.id, "github-copilot/claude-opus-4.8");
+    assert.equal(candidate?.contextWindow, undefined);
+  });
+
+  test("the token never collides with the reasoning suffix (split order)", () => {
+    const [candidate] = buildModelCandidates({
+      primaryModel: "github-copilot/claude-opus-4.8 (1m):high",
+      availableModels: tieredOpus,
+    });
+    assert.equal(candidate?.id, "github-copilot/claude-opus-4.8");
+    assert.equal(candidate?.reasoningLevel, "high");
+    assert.equal(candidate?.contextWindow, 936_000);
+  });
+
+  test("a bare token with no reasoning suffix is parsed", () => {
+    const [candidate] = buildModelCandidates({
+      primaryModel: "github-copilot/claude-opus-4.8 (1m)",
+      availableModels: tieredOpus,
+    });
+    assert.equal(candidate?.id, "github-copilot/claude-opus-4.8");
+    assert.equal(candidate?.reasoningLevel, undefined);
+    assert.equal(candidate?.contextWindow, 936_000);
+  });
+
+  test("only the tokened candidate carries a context window; siblings are untouched", () => {
+    const catalog: readonly WorkflowModelInfo[] = [
+      { provider: "anthropic", id: "claude-fable-5", fullId: "anthropic/claude-fable-5" },
+      ...tieredOpus,
+    ];
+    const candidates = buildModelCandidates({
+      primaryModel: "anthropic/claude-fable-5:xhigh",
+      fallbackModels: ["github-copilot/claude-opus-4.8 (1m):xhigh"],
+      availableModels: catalog,
+    });
+    const primary = candidates.find((c) => c.id === "anthropic/claude-fable-5");
+    const opus = candidates.find((c) => c.id === "github-copilot/claude-opus-4.8");
+    assert.equal(primary?.contextWindow, undefined);
+    assert.equal(opus?.contextWindow, 936_000);
+  });
+
+  test("a non-size parenthesized token is left attached (no silent strip)", () => {
+    // "(preview)" is not a context size, so it is NOT treated as a context
+    // token. Because the id contains "/", it is trusted as a literal model id
+    // passthrough (the runtime surfaces the bad id when it cannot create a
+    // session) rather than being silently dropped.
+    const [candidate] = buildModelCandidates({
+      primaryModel: "github-copilot/claude-opus-4.8 (preview)",
+      availableModels: tieredOpus,
+    });
+    assert.equal(candidate?.id, "github-copilot/claude-opus-4.8 (preview)");
+    assert.equal(candidate?.contextWindow, undefined);
+  });
+
+  test("buildModelCandidateIds preserves the cleaned id without the token", () => {
+    assert.deepEqual(
+      buildModelCandidateIds({
+        primaryModel: "github-copilot/claude-opus-4.8 (1m):xhigh",
+        availableModels: tieredOpus,
+      }),
+      ["github-copilot/claude-opus-4.8"],
+    );
+  });
+});

--- a/test/unit/stage-runner.test.ts
+++ b/test/unit/stage-runner.test.ts
@@ -25,6 +25,7 @@ import type {
 import type {
     StageExecutionMeta,
     CompleteStageOpts,
+    WorkflowModelInfo,
 } from "../../packages/workflows/src/shared/types.js";
 
 // ---------------------------------------------------------------------------
@@ -748,7 +749,129 @@ describe("createStageContext — structured_output corrective retry", () => {
     });
 });
 
+// A github-copilot opus catalog entry whose Model object advertises a tiered
+// context window (200K default + ~936K long-context), mirroring the live CAPI
+// catalog. Only contextWindow/defaultContextWindow/contextWindowOptions are read
+// by the resolver, so the rest of Model<Api> is intentionally omitted.
+function copilotOpusInfo(contextWindowOptions: readonly number[] = [200_000, 936_000]): WorkflowModelInfo {
+    return {
+        provider: "github-copilot",
+        id: "claude-opus-4.8",
+        fullId: "github-copilot/claude-opus-4.8",
+        model: {
+            provider: "github-copilot",
+            id: "claude-opus-4.8",
+            contextWindow: 200_000,
+            defaultContextWindow: 200_000,
+            contextWindowOptions,
+        } as unknown as NonNullable<WorkflowModelInfo["model"]>,
+    };
+}
+
 describe("createStageContext — model fallback", () => {
+    test("(1m) context-window token resolves the copilot opus session to its long-context window", async () => {
+        const seen: Array<{ model: string; contextWindow: number | undefined }> = [];
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const model =
+                    typeof options.model === "string"
+                        ? options.model
+                        : `${String(options.model?.provider)}/${options.model?.id}`;
+                seen.push({ model, contextWindow: options.contextWindow });
+                return makeMockSession().session;
+            },
+        };
+
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: { model: "github-copilot/claude-opus-4.8 (1m):xhigh" },
+                models: { listModels: async () => [copilotOpusInfo()] },
+            }),
+        ) as InternalStageContext;
+
+        // Just create the session (no prompt) and inspect the options handed to the SDK.
+        await ctx.__ensureSession();
+
+        assert.deepEqual(seen, [
+            { model: "github-copilot/claude-opus-4.8", contextWindow: 936_000 },
+        ]);
+    });
+
+    test("only the (1m) fallback candidate receives the long-context window; the primary is untouched", async () => {
+        const seen: Array<{ model: string; contextWindow: number | undefined }> = [];
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const model =
+                    typeof options.model === "string"
+                        ? options.model
+                        : `${String(options.model?.provider)}/${options.model?.id}`;
+                seen.push({ model, contextWindow: options.contextWindow });
+                const { session } = makeMockSession({
+                    async prompt() {
+                        if (model === "anthropic/claude-fable-5")
+                            throw new Error("429 rate limit exceeded");
+                    },
+                    getLastAssistantText() {
+                        return model === "github-copilot/claude-opus-4.8" ? "opus answer" : undefined;
+                    },
+                });
+                return session;
+            },
+        };
+
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: {
+                    model: "anthropic/claude-fable-5:xhigh",
+                    fallbackModels: ["github-copilot/claude-opus-4.8 (1m):xhigh"],
+                },
+                models: {
+                    listModels: async () => [
+                        { provider: "anthropic", id: "claude-fable-5", fullId: "anthropic/claude-fable-5" },
+                        copilotOpusInfo(),
+                    ],
+                },
+            }),
+        ) as InternalStageContext;
+
+        assert.equal(await ctx.prompt("go"), "opus answer");
+        assert.deepEqual(seen, [
+            { model: "anthropic/claude-fable-5", contextWindow: undefined },
+            { model: "github-copilot/claude-opus-4.8", contextWindow: 936_000 },
+        ]);
+    });
+
+    test("(1m) on a single-window copilot opus keeps the default short window (no override)", async () => {
+        const seen: Array<{ model: string; contextWindow: number | undefined }> = [];
+        const agentSession: AgentSessionAdapter = {
+            async create(options) {
+                const model =
+                    typeof options.model === "string"
+                        ? options.model
+                        : `${String(options.model?.provider)}/${options.model?.id}`;
+                seen.push({ model, contextWindow: options.contextWindow });
+                return makeMockSession().session;
+            },
+        };
+
+        const ctx = createStageContext(
+            makeOpts({
+                adapters: { agentSession },
+                stageOptions: { model: "github-copilot/claude-opus-4.8 (1m):xhigh" },
+                // No long-context tier advertised -> request cannot be honored.
+                models: { listModels: async () => [copilotOpusInfo([200_000])] },
+            }),
+        ) as InternalStageContext;
+
+        await ctx.__ensureSession();
+
+        assert.deepEqual(seen, [
+            { model: "github-copilot/claude-opus-4.8", contextWindow: undefined },
+        ]);
+    });
+
     test("primary retryable failure tries fallback and records metadata", async () => {
         const calls: string[] = [];
         const disposed: string[] = [];


### PR DESCRIPTION
## Summary

Adds a parenthesized context-window authoring token to `model`/`fallbackModels` entries (e.g. `github-copilot/claude-opus-4.8 (1m):xhigh`) so individual candidates in a fallback chain can request a larger context window without affecting other models in the chain. Builds on the configurable context-window support from #1417.

## Changes

### Core feature

- **Authoring token**: `model`/`fallbackModels` entries accept a parenthesized context-window token in the model-name portion, placed *before* the optional `:reasoning` suffix — e.g. `github-copilot/claude-opus-4.8 (1m):xhigh`. This mirrors GitHub Copilot's `Claude Opus 4.8 (1M context)` naming so the window token never collides with the `:{off|minimal|low|medium|high|xhigh}` reasoning level.

- **Resolution semantics**: The token is resolved against the candidate model's advertised windows — exact match wins, otherwise the largest supported window not exceeding the request (so `(1m)` lands on a model's ~936K long-context tier), falling back to the model's default window when no larger tier is available. It applies only to the candidate carrying the token; other models in the chain are untouched. A token that isn't a valid size (e.g. `(preview)`) is left attached to the model id rather than silently treated as a window.

- **ReDoS safety**: Context-window token extraction uses plain string scanning instead of a regex to prevent super-linear backtracking on adversarial model strings.

- **Stage-level options**: Surfaced `contextWindow` and `contextWindowStrict` on `StageOptions` and the workflow tool's direct-task schema for stage-wide selection (non-strict by default). A per-candidate token overrides the stage-level value for that specific model.

### Builtin workflows

Updated `deep-research-codebase`, `goal`, `ralph`, and `open-claude-design` to run their `github-copilot/claude-opus-4.8` fallbacks at the `(1m)` long-context window, automatically degrading to the 200K short window when Copilot's long-context tier is unavailable.

### Tests

Added 12 unit tests across 3 files:
- `model-fallback.test.ts` (8 cases): resolution, isolation, graceful degradation, suffix non-collision, non-size token passthrough
- `stage-runner.test.ts` (3 cases): session option passthrough and per-candidate isolation through the stage runner
- `executor.test.ts` (1 end-to-end smoke test): `(1m)` token resolves to 936K and reaches `createAgentSession`

### Docs & changelog

- Added a "Context windows" section to `packages/coding-agent/docs/workflows.md`
- Documented `contextWindow`/`contextWindowStrict` in the task/stage options reference
- Updated `packages/workflows/CHANGELOG.md` `[Unreleased]` section

## Usage

```ts
await ctx.task("review", {
  task: "Review the diff",
  model: "anthropic/claude-fable-5:xhigh",
  // The copilot opus fallback runs at its largest advertised (~936K) window.
  // Other candidates in the chain are unaffected.
  fallbackModels: ["github-copilot/claude-opus-4.8 (1m):xhigh", "anthropic/claude-opus-4-8:xhigh"],
});
```

For stage-wide selection without a per-model token:

```ts
await ctx.task("review", {
  task: "Review the diff",
  model: "anthropic/claude-fable-5:xhigh",
  contextWindow: 1_000_000, // non-strict: falls back to model default if unsupported
});
```

## Notes

- A per-candidate context window (from the model string token) overrides any stage-level `contextWindow`, so only the specific model requests its larger window while other candidates keep the stage default.
- Refs #1417.