### PR TITLE
test(codeql-gate): docs-only change to verify merge protection does not block irrelevant PRs

### DIFF
--- a/CODEQL_GATE_TEST_B.md
+++ b/CODEQL_GATE_TEST_B.md
@@ -1,0 +1,5 @@
+# CodeQL gate test B (throwaway)
+
+This file changes no analyzable JS/TS — it mirrors the dependabot lockfile case.
+Expectation: the CodeQL code-scanning merge-protection rule does NOT block this PR.
+DO NOT MERGE — this branch is for validation and will be deleted.


### PR DESCRIPTION
## Summary

Throwaway validation PR to confirm that the CodeQL code-scanning merge-protection rule does **not** block PRs that contain no analyzable JS/TS files — mirroring the dependabot lockfile case.

## Key Changes

- Adds `CODEQL_GATE_TEST_B.md` (docs-only, no source code changes)

## Notes

- **DO NOT MERGE** — this branch is for CI gate validation only and will be closed + deleted after the check passes.
- Expectation: CodeQL merge protection is skipped/bypassed for this PR since there are no JS/TS files to analyze.