### PR TITLE
docs(changelog): add release notes for 0.9.0-alpha.2

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
 ### Breaking Changes
 
 - Removed the Atomic-specific `bashPolicy` command-level allow/deny API from `createAgentSession()`, `AgentSession` internals, SDK exports, and the built-in `bash` tool so shell execution matches upstream pi behavior. Use `tools`/`excludedTools`/`noTools` to expose or hide `bash`, and use a sandbox or custom tool for command allowlisting.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
+### Changed
+
+- Published a synchronized Atomic 0.9.0-alpha.2 prerelease; no functional Cursor provider changes were made after 0.9.0-alpha.1.
+
 ## [0.9.0-alpha.1] - 2026-06-20
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
 ### Changed
 
 - Aligned the intercom extension peer dependency with upstream pi TUI `^0.79.9` so coordination overlays and rendered message surfaces inherit the latest shared TUI compatibility fixes, including stabilized partial code-fence rendering during Markdown streaming; no intercom extension source changes were needed for this dependency-covered sync.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
 ### Changed
 
 - Aligned the MCP extension peer dependencies with upstream pi AI/TUI `^0.79.9` so MCP-backed Atomic sessions inherit chat-template custom-provider thinking controls, GLM-5.2 provider metadata, GitHub Copilot model-availability filtering, Mistral prompt-cache accounting, Markdown streaming code-fence stability, and shared provider/TUI compatibility fixes; no MCP extension source changes were needed for this dependency-covered sync.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
+### Changed
+
+- Published a synchronized Atomic 0.9.0-alpha.2 prerelease; no functional native transport changes were made after 0.9.0-alpha.1.
+
 ## [0.9.0-alpha.1] - 2026-06-20
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
 ### Changed
 
 - Aligned the subagents extension peer dependencies with upstream pi `^0.79.9` runtime packages (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui`) so child sessions inherit chat-template custom-provider thinking controls, GLM-5.2 provider metadata, GitHub Copilot model-availability filtering, Mistral prompt-cache accounting, Markdown streaming code-fence stability, and shared agent/TUI compatibility fixes; no subagents extension source changes were needed for this dependency-covered sync.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
 ### Changed
 
 - Aligned the web-access extension peer dependency with upstream pi TUI `^0.79.9` so web-access curator, summary review, and rendered Markdown surfaces inherit the latest shared TUI compatibility fixes, including stabilized partial code-fence rendering during streaming; no web-access extension source changes were needed for this dependency-covered sync.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-21
+
 ### Breaking Changes
 
 - Replaced the removed `defineWorkflow(...).run(...).compile()` builder with the single `workflow({ name?, description, inputs, outputs, run })` authoring door. Authored workflows must import `workflow` from `@bastani/workflows`, import `Type` from `typebox`, provide an `outputs` map, and export the returned definition directly; `.compile()` and the builder types are no longer exported.


### PR DESCRIPTION
## Summary

Release-notes PR for prerelease `0.9.0-alpha.2` (2026-06-21): adds `## [0.9.0-alpha.2]` changelog entries across all packages. No version bumps or source changes — `main` remains at `0.0.0`; the real version is materialized by `scripts/cut-release.ts` off-`main`.

## Release details

- **Release kind:** prerelease (`@next`)
- **Target version:** `0.9.0-alpha.2`
- **Base / tag base:** `main`
- **Head branch:** `prerelease/0.9.0-alpha.2`
- **Head SHA:** `0a1bcc0ecf2e5110aaf7cc89e54167512b545897`
- **Source HEAD before release notes:** `830bd87d6c254533c917646a30ca99a8c6637e72`

## Key changes in 0.9.0-alpha.2

### Breaking changes

- **`@bastani/atomic`** — Removed the Atomic-specific `bashPolicy` command-level allow/deny API from `createAgentSession()`, `AgentSession`, SDK exports, and the built-in `bash` tool. Use `tools`/`excludedTools`/`noTools` to expose or hide `bash`; use a sandbox or custom tool for command allowlisting.
- **`@bastani/workflows`** — Replaced the `defineWorkflow(...).run(...).compile()` builder with the single `workflow({ name?, description, inputs, outputs, run })` authoring entry point; `.compile()` and builder types are no longer exported. Also removed the workflow-stage `bashPolicy` option.

### Added

- **`@bastani/atomic`** — Upstream Pi v0.79.9 chat-template thinking compatibility: `compat.thinkingFormat: "chat-template"` and `compat.chatTemplateKwargs` schema/merge support for OpenAI-compatible vLLM/Hugging Face chat templates.

### Changed

- **`@bastani/atomic`** — Aligned bundled upstream Pi runtime libraries (`pi-agent-core`, `pi-ai`, `pi-tui`) to `^0.79.9`, picking up GLM-5.2 provider metadata, GitHub Copilot model-availability filtering, Mistral prompt caching, OpenRouter Fusion, Markdown streaming code-fence stability, and runtime dependency fixes.
- **`@bastani/workflows`** — Decomposed the foreground workflow executor behind an internal `EngineRuntime.spawnStage(...)` chokepoint; agent stages, task/chain/parallel primitives, nested workflow boundary stages, MCP scope, continuation replay, and graph-frontier tracking now live under the engine seams — run, resume, kill, HIL, worktree, and model-fallback behavior are preserved.
- **`@bastani/mcp`, `@bastani/subagents`, `@bastani/intercom`, `@bastani/web-access`, `@bastani/workflows`** — Peer dependency alignment to upstream pi `^0.79.9`.
- **`@bastani/cursor`, `@bastani/natives`** — Synchronized prerelease with no functional changes since 0.9.0-alpha.1.

### Fixed

- **`@bastani/atomic`** — Multiple fixes: same-directory session/resource reloads now reuse imported extension modules; deep session branch path traversal builds linearly; fuzzy `edit` replacements preserve untouched line blocks; legacy WSL `bash.exe` execution sends scripts via stdin with `bash -s`; `/model` selector search ranking corrects exact provider-prefixed query ordering; successful overflow-sized assistant responses trigger compaction without retry or message drop.

## Changelog files updated

- `packages/coding-agent/CHANGELOG.md`
- `packages/cursor/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`
- `packages/mcp/CHANGELOG.md`
- `packages/natives/CHANGELOG.md`
- `packages/subagents/CHANGELOG.md`
- `packages/web-access/CHANGELOG.md`
- `packages/workflows/CHANGELOG.md`

## Validation

Push hooks ran and passed: `bun run lint`, `bun run check:file-length`, `bun run test:unit`.

```sh
git diff --name-only 830bd87d6c254533c917646a30ca99a8c6637e72..HEAD
# → 8 CHANGELOG.md files only
```