### PR TITLE
fix(workflows): poll publish runs until terminal status

### DIFF
--- a/.atomic/workflows/lib/publish-release-ephemeral.ts
+++ b/.atomic/workflows/lib/publish-release-ephemeral.ts
@@ -111,7 +111,7 @@ export async function runEphemeralRelease(
       "verify-release-branch-ci",
       `the Tests workflow run for ${release.branch} has headSha ${preparationVerification.releaseCommitOid}, status completed, and conclusion success`,
       [branchCi.summary, "", "CI wait stage output:", excerpt(ciWait.text, 2_000)].join("\n"),
-      "failed",
+      branchCi.pending === true ? "blocked" : "failed",
     );
   }
 
@@ -152,7 +152,7 @@ export async function runEphemeralRelease(
       "verify-publish-workflow-succeeded",
       "GitHub Actions Publish run for the release tag has matching headSha, status completed, and conclusion success",
       [publishVerification.summary, "", "Cut-release stage output:", excerpt(pushTag.text, 2_000)].join("\n"),
-      "failed",
+      publishVerification.pending === true ? "blocked" : "failed",
     );
   }
 

--- a/.atomic/workflows/lib/publish-release-gates.ts
+++ b/.atomic/workflows/lib/publish-release-gates.ts
@@ -2,17 +2,15 @@ import {
   commandSummary,
   parseJsonCommand,
   runCommand,
-  selectPublishWorkflowRunJson,
-  verifyPublishWorkflowRunJson,
   verifyPullRequestChecksJson,
   verifyPullRequestMergedJson,
   verifyReleasePullRequestReferenceJson,
-  type CommandResult,
   type PublishWorkflowRunVerification,
   type PullRequestMergeVerification,
   type PullRequestReferenceVerification,
   type ValidatedRelease,
 } from "./publish-release.js";
+import { waitForWorkflowRunSucceeded } from "./publish-release-run-wait.js";
 
 type GateVerification =
   | {
@@ -330,131 +328,11 @@ export function verifyReleaseTagPublished(release: ValidatedRelease, expectedPar
   return { ok: true, summary, tagTargetOid: releaseCommitOid };
 }
 
-async function verifyWorkflowRunSucceeded(
-  expectedHeadSha: string,
-  options: { readonly workflowFile: string; readonly expectedHeadBranch: string },
-): Promise<PublishWorkflowRunVerification> {
-  const { workflowFile, expectedHeadBranch } = options;
-  let runList: CommandResult | undefined;
-  let selectedRun: ReturnType<typeof selectPublishWorkflowRunJson> | undefined;
-
-  for (let attempt = 1; attempt <= 6; attempt += 1) {
-    runList = runCommand([
-      "gh",
-      "run",
-      "list",
-      "--workflow",
-      workflowFile,
-      "--event",
-      "push",
-      "--json",
-      "databaseId,status,conclusion,url,headBranch,event,workflowName,createdAt,headSha",
-      "--limit",
-      "50",
-    ]);
-
-    if (runList.exitCode !== 0) {
-      return {
-        ok: false,
-        summary: ["GitHub Actions publish run lookup command failed.", commandSummary(runList)].join("\n\n"),
-      };
-    }
-
-    const parsedList = parseJsonCommand(runList, "GitHub Actions publish run lookup returned invalid JSON.");
-    if (!parsedList.ok) return { ok: false, summary: parsedList.summary };
-
-    selectedRun = selectPublishWorkflowRunJson(parsedList.value, expectedHeadBranch);
-    if (selectedRun.ok) break;
-    if (attempt < 6) await Bun.sleep(10_000);
-  }
-
-  if (runList === undefined || selectedRun === undefined || !selectedRun.ok) {
-    return {
-      ok: false,
-      summary: [
-        selectedRun?.summary ?? "GitHub Actions publish run lookup did not execute.",
-        runList === undefined ? undefined : commandSummary(runList),
-      ].filter((line): line is string => line !== undefined).join("\n\n"),
-    };
-  }
-
-  const watch = selectedRun.status === "completed"
-    ? undefined
-    : runCommand(["gh", "run", "watch", String(selectedRun.runId), "--exit-status"]);
-
-  if (watch !== undefined && watch.exitCode !== 0) {
-    return {
-      ok: false,
-      runId: selectedRun.runId,
-      runUrl: selectedRun.runUrl,
-      summary: [
-        "GitHub Actions publish run did not complete successfully while watching.",
-        selectedRun.summary,
-        commandSummary(runList),
-        commandSummary(watch),
-      ].join("\n\n"),
-    };
-  }
-
-  const runView = runCommand([
-    "gh",
-    "run",
-    "view",
-    String(selectedRun.runId),
-    "--json",
-    "databaseId,status,conclusion,url,headBranch,event,workflowName,createdAt,headSha",
-  ]);
-
-  if (runView.exitCode !== 0) {
-    return {
-      ok: false,
-      runId: selectedRun.runId,
-      runUrl: selectedRun.runUrl,
-      summary: ["GitHub Actions publish run verification command failed.", commandSummary(runView)].join("\n\n"),
-    };
-  }
-
-  const parsedView = parseJsonCommand(runView, "GitHub Actions publish run verification returned invalid JSON.");
-  if (!parsedView.ok) {
-    return {
-      ok: false,
-      runId: selectedRun.runId,
-      runUrl: selectedRun.runUrl,
-      summary: parsedView.summary,
-    };
-  }
-
-  const publishVerification = verifyPublishWorkflowRunJson(parsedView.value, expectedHeadBranch, expectedHeadSha);
-  if (!publishVerification.ok) {
-    return {
-      ok: false,
-      runId: publishVerification.runId ?? selectedRun.runId,
-      runUrl: publishVerification.runUrl ?? selectedRun.runUrl,
-      summary: [publishVerification.summary, commandSummary(runList), commandSummary(runView)].join("\n\n"),
-    };
-  }
-
-  return {
-    ok: true,
-    runId: publishVerification.runId,
-    runUrl: publishVerification.runUrl,
-    status: publishVerification.status,
-    conclusion: publishVerification.conclusion,
-    headSha: publishVerification.headSha,
-    summary: [
-      publishVerification.summary,
-      commandSummary(runList),
-      watch === undefined ? undefined : commandSummary(watch),
-      commandSummary(runView),
-    ].filter((line): line is string => line !== undefined).join("\n\n"),
-  };
-}
-
 export function verifyPublishWorkflowSucceeded(
   release: ValidatedRelease,
   expectedHeadSha: string,
 ): Promise<PublishWorkflowRunVerification> {
-  return verifyWorkflowRunSucceeded(expectedHeadSha, {
+  return waitForWorkflowRunSucceeded(expectedHeadSha, {
     workflowFile: "publish.yml",
     expectedHeadBranch: release.version,
   });
@@ -464,7 +342,7 @@ export function verifyReleaseBranchCiSucceeded(
   release: ValidatedRelease,
   branchHeadSha: string,
 ): Promise<PublishWorkflowRunVerification> {
-  return verifyWorkflowRunSucceeded(branchHeadSha, {
+  return waitForWorkflowRunSucceeded(branchHeadSha, {
     workflowFile: "test.yml",
     expectedHeadBranch: release.branch,
   });

--- a/.atomic/workflows/lib/publish-release-run-wait.ts
+++ b/.atomic/workflows/lib/publish-release-run-wait.ts
@@ -1,0 +1,238 @@
+import {
+  commandSummary,
+  parseJsonCommand,
+  runCommand as defaultRunCommand,
+  selectPublishWorkflowRunJson,
+  verifyPublishWorkflowRunJson,
+  type CommandResult,
+  type JsonValue,
+  type PublishWorkflowRunVerification,
+} from "./publish-release.js";
+
+type RunCommand = (args: readonly string[]) => CommandResult;
+type Sleep = (durationMs: number) => Promise<void>;
+
+type WaitOptions = {
+  readonly workflowFile: string;
+  readonly expectedHeadBranch: string;
+  readonly runCommand?: RunCommand;
+  readonly sleep?: Sleep;
+  readonly listAttempts?: number;
+  readonly viewAttempts?: number;
+  readonly pollIntervalMs?: number;
+};
+
+type RunIdentity =
+  | {
+      readonly ok: true;
+      readonly runId: number;
+      readonly runUrl?: string;
+      readonly status: string;
+      readonly conclusion?: string;
+      readonly headSha?: string;
+    }
+  | {
+      readonly ok: false;
+      readonly summary: string;
+      readonly runId?: number;
+      readonly runUrl?: string;
+    };
+
+type JsonObject = { readonly [key: string]: JsonValue };
+
+const runJsonFields = "databaseId,status,conclusion,url,headBranch,event,workflowName,createdAt,headSha";
+
+function isJsonObject(value: JsonValue): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(object: JsonObject, key: string): string | undefined {
+  const value = object[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function positiveIntegerField(object: JsonObject, key: string): number | undefined {
+  const value = object[key];
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function nullableStringField(object: JsonObject, key: string): string | undefined {
+  const value = object[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function verifyRunIdentityJson(
+  value: JsonValue,
+  expectedRunId: number,
+  expectedHeadBranch: string,
+  expectedHeadSha: string,
+): RunIdentity {
+  if (!isJsonObject(value)) return { ok: false, summary: "GitHub Actions run response was not a JSON object." };
+
+  const runId = positiveIntegerField(value, "databaseId");
+  const headBranch = stringField(value, "headBranch");
+  const event = stringField(value, "event");
+  const status = stringField(value, "status");
+  const conclusion = nullableStringField(value, "conclusion");
+  const runUrl = stringField(value, "url");
+  const headSha = stringField(value, "headSha");
+  const failures: string[] = [];
+
+  if (runId === undefined) failures.push("databaseId was missing or invalid");
+  if (runId !== undefined && runId !== expectedRunId) failures.push(`databaseId was ${runId}, expected ${expectedRunId}`);
+  if (headBranch !== expectedHeadBranch) failures.push(`headBranch was ${headBranch ?? "missing"}, expected ${expectedHeadBranch}`);
+  if (event !== "push") failures.push(`event was ${event ?? "missing"}, expected push`);
+  if (status === undefined) failures.push("status was missing");
+  if (headSha !== expectedHeadSha) failures.push(`headSha was ${headSha ?? "missing"}, expected ${expectedHeadSha}`);
+
+  if (failures.length > 0 || runId === undefined || status === undefined) {
+    return {
+      ok: false,
+      summary: ["GitHub Actions publish run identity is not verified.", ...failures.map((failure) => `- ${failure}`)].join("\n"),
+      runId,
+      runUrl,
+    };
+  }
+
+  return { ok: true, runId, runUrl, status, conclusion, headSha };
+}
+
+function buildRunListCommand(workflowFile: string): readonly string[] {
+  return [
+    "gh",
+    "run",
+    "list",
+    "--workflow",
+    workflowFile,
+    "--event",
+    "push",
+    "--json",
+    runJsonFields,
+    "--limit",
+    "50",
+  ];
+}
+
+function buildRunViewCommand(runId: number): readonly string[] {
+  return ["gh", "run", "view", String(runId), "--json", runJsonFields];
+}
+
+export async function waitForWorkflowRunSucceeded(
+  expectedHeadSha: string,
+  options: WaitOptions,
+): Promise<PublishWorkflowRunVerification> {
+  const execute = options.runCommand ?? defaultRunCommand;
+  const sleep = options.sleep ?? Bun.sleep;
+  const listAttempts = options.listAttempts ?? 6;
+  const viewAttempts = options.viewAttempts ?? 120;
+  const pollIntervalMs = options.pollIntervalMs ?? 10_000;
+  let runList: CommandResult | undefined;
+  let selectedRun: ReturnType<typeof selectPublishWorkflowRunJson> | undefined;
+
+  for (let attempt = 1; attempt <= listAttempts; attempt += 1) {
+    runList = execute(buildRunListCommand(options.workflowFile));
+    if (runList.exitCode !== 0) {
+      return { ok: false, summary: ["GitHub Actions publish run lookup command failed.", commandSummary(runList)].join("\n\n") };
+    }
+
+    const parsedList = parseJsonCommand(runList, "GitHub Actions publish run lookup returned invalid JSON.");
+    if (!parsedList.ok) return { ok: false, summary: parsedList.summary };
+
+    selectedRun = selectPublishWorkflowRunJson(parsedList.value, options.expectedHeadBranch);
+    if (selectedRun.ok) break;
+    if (attempt < listAttempts) await sleep(pollIntervalMs);
+  }
+
+  if (runList === undefined || selectedRun === undefined || !selectedRun.ok) {
+    return {
+      ok: false,
+      summary: [selectedRun?.summary ?? "GitHub Actions publish run lookup did not execute.", runList === undefined ? undefined : commandSummary(runList)]
+        .filter((line): line is string => line !== undefined)
+        .join("\n\n"),
+    };
+  }
+
+  let lastRunView: CommandResult | undefined;
+  let lastPendingSummary = selectedRun.summary;
+
+  for (let attempt = 1; attempt <= viewAttempts; attempt += 1) {
+    lastRunView = execute(buildRunViewCommand(selectedRun.runId));
+    if (lastRunView.exitCode !== 0) {
+      if (attempt < viewAttempts) {
+        await sleep(pollIntervalMs);
+        continue;
+      }
+      return {
+        ok: false,
+        runId: selectedRun.runId,
+        runUrl: selectedRun.runUrl,
+        summary: ["GitHub Actions publish run verification command failed.", commandSummary(lastRunView)].join("\n\n"),
+      };
+    }
+
+    const parsedView = parseJsonCommand(lastRunView, "GitHub Actions publish run verification returned invalid JSON.");
+    if (!parsedView.ok) return { ok: false, runId: selectedRun.runId, runUrl: selectedRun.runUrl, summary: parsedView.summary };
+
+    const identity = verifyRunIdentityJson(parsedView.value, selectedRun.runId, options.expectedHeadBranch, expectedHeadSha);
+    if (!identity.ok) {
+      return {
+        ok: false,
+        runId: identity.runId ?? selectedRun.runId,
+        runUrl: identity.runUrl ?? selectedRun.runUrl,
+        summary: [identity.summary, commandSummary(runList), commandSummary(lastRunView)].join("\n\n"),
+      };
+    }
+
+    if (identity.status !== "completed") {
+      lastPendingSummary = [
+        "GitHub Actions publish run is still running; continuing to poll.",
+        `databaseId: ${identity.runId}`,
+        `headBranch: ${options.expectedHeadBranch}`,
+        `status: ${identity.status}`,
+        identity.conclusion === undefined ? undefined : `conclusion: ${identity.conclusion}`,
+        identity.headSha === undefined ? undefined : `headSha: ${identity.headSha}`,
+        identity.runUrl === undefined ? undefined : `url: ${identity.runUrl}`,
+      ].filter((line): line is string => line !== undefined).join("\n");
+      if (attempt < viewAttempts) {
+        await sleep(pollIntervalMs);
+        continue;
+      }
+      break;
+    }
+
+    const publishVerification = verifyPublishWorkflowRunJson(parsedView.value, options.expectedHeadBranch, expectedHeadSha);
+    if (!publishVerification.ok) {
+      return {
+        ok: false,
+        runId: publishVerification.runId ?? selectedRun.runId,
+        runUrl: publishVerification.runUrl ?? selectedRun.runUrl,
+        summary: [publishVerification.summary, commandSummary(runList), commandSummary(lastRunView)].join("\n\n"),
+      };
+    }
+
+    return {
+      ok: true,
+      runId: publishVerification.runId,
+      runUrl: publishVerification.runUrl,
+      status: publishVerification.status,
+      conclusion: publishVerification.conclusion,
+      headSha: publishVerification.headSha,
+      summary: [publishVerification.summary, commandSummary(runList), commandSummary(lastRunView)].join("\n\n"),
+    };
+  }
+
+  return {
+    ok: false,
+    runId: selectedRun.runId,
+    runUrl: selectedRun.runUrl,
+    pending: true,
+    summary: [
+      "GitHub Actions publish run did not reach a terminal status before the polling timeout.",
+      `attempts: ${viewAttempts}`,
+      `pollIntervalMs: ${pollIntervalMs}`,
+      lastPendingSummary,
+      commandSummary(runList),
+      lastRunView === undefined ? undefined : commandSummary(lastRunView),
+    ].filter((line): line is string => line !== undefined).join("\n\n"),
+  };
+}

--- a/.atomic/workflows/lib/publish-release-types.ts
+++ b/.atomic/workflows/lib/publish-release-types.ts
@@ -82,6 +82,7 @@ export type PublishWorkflowRunVerification =
       readonly summary: string;
       readonly runId?: number;
       readonly runUrl?: string;
+      readonly pending?: boolean;
     };
 
 export type PublishWorkflowRunReference =

--- a/.atomic/workflows/publish-release.ts
+++ b/.atomic/workflows/publish-release.ts
@@ -281,7 +281,7 @@ export default workflow({
         "verify-publish-workflow-succeeded",
         "GitHub Actions Publish run for the release tag has matching headSha, status completed, and conclusion success",
         [publishVerification.summary, "", "Cut-release stage output:", excerpt(pushTag.text, 2_000)].join("\n"),
-        "failed",
+        publishVerification.pending === true ? "blocked" : "failed",
       );
     }
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -328,4 +328,4 @@ The meaningful pre-publish checks are:
 
 4. Confirm `publish.yml` checks out the tag, runs docs link validation plus Mintlify syntax and broken-link checks, cross-compiles binaries, publishes `@bastani/atomic-natives` and `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
 
-For prereleases, substitute `0.8.0-alpha.1`. To run the fully guarded automation (release-notes PR + cut-release + publish monitoring) instead of these manual steps, use the `publish-release` Atomic workflow.
+For prereleases, substitute `0.8.0-alpha.1`. To run the fully guarded automation (release-notes PR + cut-release + publish monitoring) instead of these manual steps, use the `publish-release` Atomic workflow. Its final publish gate polls the matching `publish.yml` run until GitHub reports a terminal conclusion, so a long-running `in_progress` publish run is not treated as a release failure.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the repository `publish-release` workflow's final Publish-run verifier to poll GitHub Actions run JSON until a terminal state instead of treating a still-`in_progress` publish run as a failed prerelease.
+
 ## [0.9.0-alpha.2] - 2026-06-21
 
 ### Breaking Changes

--- a/test/unit/publish-release-helpers.test.ts
+++ b/test/unit/publish-release-helpers.test.ts
@@ -9,8 +9,10 @@ import {
   verifyPullRequestChecksJson,
   verifyPullRequestMergedJson,
   verifyReleasePullRequestReferenceJson,
+  type CommandResult,
   type JsonValue,
 } from "../../.atomic/workflows/lib/publish-release.js";
+import { waitForWorkflowRunSucceeded } from "../../.atomic/workflows/lib/publish-release-run-wait.js";
 
 describe("publish-release version validation", () => {
   test("accepts stable release versions only for release requests", () => {
@@ -253,5 +255,76 @@ describe("publish-release GitHub Actions publish verification", () => {
     assert.equal(result.ok, false);
     assert.match(result.summary, /headBranch was 1\.2\.4, expected 1\.2\.3/u);
     assert.match(result.summary, /conclusion was failure, expected success/u);
+  });
+
+  test("polls a selected publish run until GitHub reports terminal success", async () => {
+    const commands: string[] = [];
+    const sleeps: number[] = [];
+    const runningRun = { ...successfulRun, status: "in_progress", conclusion: null };
+    const responses: CommandResult[] = [
+      {
+        command: "gh run list",
+        exitCode: 0,
+        stdout: JSON.stringify([runningRun]),
+        stderr: "",
+      },
+      {
+        command: "gh run view 987654321",
+        exitCode: 0,
+        stdout: JSON.stringify(runningRun),
+        stderr: "",
+      },
+      {
+        command: "gh run view 987654321",
+        exitCode: 0,
+        stdout: JSON.stringify(successfulRun),
+        stderr: "",
+      },
+    ];
+
+    const result = await waitForWorkflowRunSucceeded("abc123", {
+      workflowFile: "publish.yml",
+      expectedHeadBranch: "1.2.3",
+      listAttempts: 1,
+      viewAttempts: 3,
+      pollIntervalMs: 25,
+      runCommand: (args) => {
+        commands.push(args.join(" "));
+        const response = responses.shift();
+        if (response === undefined) throw new Error(`unexpected command: ${args.join(" ")}`);
+        return { ...response, command: args.join(" ") };
+      },
+      sleep: (durationMs) => {
+        sleeps.push(durationMs);
+        return Promise.resolve();
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sleeps, [25]);
+    assert.equal(commands.some((command) => command.includes(" run watch ")), false);
+    assert.match(result.summary, /status: completed/u);
+  });
+
+  test("marks a still-running publish run as pending when polling times out", async () => {
+    const runningRun = { ...successfulRun, status: "in_progress", conclusion: null };
+    const result = await waitForWorkflowRunSucceeded("abc123", {
+      workflowFile: "publish.yml",
+      expectedHeadBranch: "1.2.3",
+      listAttempts: 1,
+      viewAttempts: 1,
+      pollIntervalMs: 25,
+      runCommand: (args) => ({
+        command: args.join(" "),
+        exitCode: 0,
+        stdout: JSON.stringify(args.includes("list") ? [runningRun] : runningRun),
+        stderr: "",
+      }),
+      sleep: () => Promise.resolve(),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.pending, true);
+    assert.match(result.summary, /did not reach a terminal status/u);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the \`publish-release\` workflow's final publish gate so a GitHub Actions Publish run that is still \`in_progress\` is not prematurely reported as a failed release. Replaces the one-shot \`gh run watch\` + \`gh run view\` approach with a JSON polling loop that waits up to ~20 minutes (120 × 10 s) for a terminal conclusion.

## Changes

- **New module** \`.atomic/workflows/lib/publish-release-run-wait.ts\`: exports \`waitForWorkflowRunSucceeded()\` which polls \`gh run view\` in a configurable loop, validates run identity on every poll (databaseId, headBranch, event, headSha), and returns \`pending: true\` when the timeout expires while the run is still \`in_progress\`.
- **Removed** the inline \`verifyWorkflowRunSucceeded()\` from \`publish-release-gates.ts\`; both \`verifyPublishWorkflowSucceeded()\` and \`verifyReleaseBranchCiSucceeded()\` now delegate to the new polling function.
- **Added** \`pending?: boolean\` to the \`PublishWorkflowRunVerification\` failure type so callers can distinguish a timeout from an actual failure.
- **Updated** \`publish-release.ts\` and \`publish-release-ephemeral.ts\` to surface polling timeouts as \`"blocked"\` rather than \`"failed"\`.
- **Tests** in \`test/unit/publish-release-helpers.test.ts\` covering: \`in_progress\` → \`completed/success\` transition across multiple poll cycles, and still-running timeout reporting \`pending: true\`.
- **Docs**: updated CI release checklist (\`docs/ci.md\`) and added a \`### Fixed\` changelog entry.

## Validation

- \`AGENT=1 bun run lint\`
- \`bun run check:file-length\`
- \`AGENT=1 bun run test:unit\`
- \`git diff --check\`

## Breaking Changes

None. The \`pending\` field is additive on the existing failure union type.