### PR TITLE
docs(changelog): add release notes for 0.9.0-alpha.3

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.0-alpha.3] - 2026-06-21
+
 ### Fixed
 
 - Fixed the repository `publish-release` workflow's final Publish-run verifier to poll GitHub Actions run JSON until a terminal state instead of treating a still-`in_progress` publish run as a failed prerelease.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.0-alpha.3] - 2026-06-21
+
 ### Added
 
 - Added a shared `prompt-refinement` stage to the builtin `ralph` and `goal` workflows. Both now run one `prompt-refinement` stage at the start that invokes the `prompt-engineer` skill (`/skill:prompt-engineer`) to sharpen the raw user request into a clearer, more actionable objective using the Workflow Best Practices prompt anatomy documented in `packages/coding-agent/docs/workflows.md` (`## Workflow Best Practices`). The refined request replaces the original as the operative objective for all downstream stages (research, orchestration, worker/review loops); the original request is preserved for traceability. `ralph` exposes `original_prompt` and `refined_prompt` outputs, and `goal` exposes `original_objective` (omitted when refinement left it unchanged) and records the original objective in the ledger and final report. The stage uses the same model chain as ralph's prompt-engineering stage (`promptEngineerModelConfig`).


### PR DESCRIPTION
## Summary

Prepares the CHANGELOG entries for the `0.9.0-alpha.3` prerelease by adding version section headers to both package changelogs. No code or version bumps on `main` — the real version is materialized only on the off-`main` tag commit produced by `scripts/cut-release.ts`.

## Changes

- Added `## [0.9.0-alpha.3] - 2026-06-21` section header to `packages/coding-agent/CHANGELOG.md`, capturing:
  - **Fixed:** `publish-release` workflow's final Publish-run verifier now polls the GitHub Actions run JSON until a terminal state instead of treating an `in_progress` run as a failed prerelease.
- Added `## [0.9.0-alpha.3] - 2026-06-21` section header to `packages/workflows/CHANGELOG.md`, capturing:
  - **Added:** Shared `prompt-refinement` stage in the builtin `ralph` and `goal` workflows — both now invoke the `prompt-engineer` skill at the start to sharpen the raw user request before any downstream stages run; `ralph` exposes `original_prompt`/`refined_prompt` outputs and `goal` exposes `original_objective`.
  - **Added:** Renamed `ralph`'s per-iteration `prompt-engineer-${iteration}` stage to `research-prompt-refinement-${iteration}` (`renderPromptEngineerPrompt` → `renderResearchPromptRefinementPrompt`) to distinguish the clarity-refinement stage from the research-focused follow-up.

## Notes

- All `packages/*/package.json` versions remain at the `0.0.0` placeholder on `main`.
- The actual `0.9.0-alpha.3` version will be stamped on a throwaway off-`main` commit by `scripts/cut-release.ts` when the tag is pushed.