### PR TITLE
Release 0.9.0-alpha.4

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.0-alpha.4] - 2026-06-22
+
 ### Breaking Changes
 
 - Changed the bundled builtin `open-claude-design` workflow's inputs: removed `reference`, `output_type`, and `design_system` in favor of a new `discovery` interview stage that asks for the output type and references. Inputs are now `prompt`, `discover_references`, and `max_refinements`. Drop those removed arguments from existing invocations and let discovery ask (or describe them in `prompt`).
@@ -9,14 +11,11 @@
 ### Added
 
 - Restructured the bundled builtin `open-claude-design` workflow around the accessible `impeccable` skill. It now opens with one combined `discovery` stage that runs `/skill:impeccable shape` and `/skill:impeccable init` so PRODUCT.md/DESIGN.md are detected, created, or reconciled without a separate init stage, gathers context with `ds-locator` / `ds-analyzer` / `ds-patterns` (which directly capture/parse user-provided URL/file references), then runs optional gallery `reference-discovery` using that ds-* context and asks which curated direction the user prefers (or asks for a reference image/screenshot/URL/path if none fit), then runs a forked `generate-*` / `user-feedback-*` loop. `generate-1` is the first loop iteration, later generate stages fork from the previous generate session, and user-feedback stages fork from the previous feedback session while driving `/skill:impeccable live`. Export is now deliberately only `exporter` plus `final-display`; the separate `web-capture-*`, `file-parser-*`, `design-system-builder`, `pre-export-scan`, and `forced-fix` stages were removed. Updated the bundled workflow docs to describe the trimmed input set, combined discovery/init stage, context/reference phase, reference precedence, forked generate/user-feedback loop, and minimal export phase.
-
+- Added the bundled builtin `goal` workflow's safe-by-default `create_pr` toggle and final `pull-request` stage. Goal now mirrors Ralph's PR handoff behavior: omitted or `false` skips PR/MR/review creation and omits `pr_report`, while strict `create_pr=true` authorizes only the final stage after reviewer quorum plus reducer approval to inspect the goal ledger, worker receipts, reviewer artifacts, final report, repository state, and provider credentials before attempting a provider-appropriate PR/MR/review request. Intermediate Goal worker/reviewer prompts now tell stages to ignore PR-creation requests so PR handoff stays confined to the final stage. Updated the bundled workflow docs, quickstart, README, and `/atomic` guide copy to describe the opt-in behavior.
 
 ### Fixed
 
 - Fixed the bundled builtin `open-claude-design` feedback path so live annotations from `user-feedback-*` are parsed, persisted, and required to thread into the next `generate-*` prompt before another revision runs. Also kept final display read-only, constrained annotation snapshot artifact copies to the project/artifact dir, and preserved the browser-centric clean early exit when `playwright-cli` is unavailable (skipped under the test harness).
-
-
-- Added the bundled builtin `goal` workflow's safe-by-default `create_pr` toggle and final `pull-request` stage. Goal now mirrors Ralph's PR handoff behavior: omitted or `false` skips PR/MR/review creation and omits `pr_report`, while strict `create_pr=true` authorizes only the final stage after reviewer quorum plus reducer approval to inspect the goal ledger, worker receipts, reviewer artifacts, final report, repository state, and provider credentials before attempting a provider-appropriate PR/MR/review request. Intermediate Goal worker/reviewer prompts now tell stages to ignore PR-creation requests so PR handoff stays confined to the final stage. Updated the bundled workflow docs, quickstart, README, and `/atomic` guide copy to describe the opt-in behavior.
 
 ## [0.9.0-alpha.3] - 2026-06-21
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.0-alpha.4] - 2026-06-22
+
 ### Breaking Changes
 
 - Restructured the builtin `open-claude-design` workflow's input contract. Removed the `reference`, `output_type`, and `design_system` inputs; the workflow now gathers those through a new `discovery` interview stage instead. The remaining inputs are `prompt`, `discover_references`, and `max_refinements`. Existing invocations that passed `reference=…`, `output_type=…`, or `design_system=…` should drop those arguments and let the discovery stage ask for the output type and references (or describe them in `prompt`).
@@ -13,17 +15,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Restructured the builtin `open-claude-design` workflow around the accessible `impeccable` skill (`/skill:impeccable …`). The current phase order is: (1) **combined discovery/init** — one `discovery` stage runs `/skill:impeccable shape` to confirm the brief, output type, and references, then runs `/skill:impeccable init` so impeccable detects/creates/reconciles `PRODUCT.md` / `DESIGN.md` without a separate init stage; (2) **context/reference phase** — `ds-locator` / `ds-analyzer` / `ds-patterns` first gather project design-system evidence and handle user-provided URL/file reference capture/parsing, then optional `reference-discovery` browses curated galleries using the ds-* evidence and asks the user which curated direction they prefer (or asks for a reference image/screenshot/URL/path if none fit); (3) **forked generate/user-feedback loop** — `generate-1` produces the first `preview.html`, each `user-feedback-*` stage drives `/skill:impeccable live`, and meaningful feedback threads into the next forked `generate-*` stage; (4) **export** — export is now deliberately only `exporter` followed by `final-display`, with no `pre-export-scan`, `forced-fix`, `web-capture-*`, `file-parser-*`, or `design-system-builder` stages. User-provided references take **precedence over `DESIGN.md`/`PRODUCT.md`** through the `REFERENCE_PRECEDENCE` prompt block. Added unit coverage for the trimmed input contract, combined discovery/init stage, direct `ds-*` reference handling, forked generate/user-feedback continuity, removed export/parse/builder/init stages, and feedback persistence/threading.
-
-
 - Added a safe-by-default `create_pr` toggle to the builtin `goal` workflow, matching Ralph's final-stage PR handoff behavior. Goal now skips PR/MR/review creation unless `create_pr=true` **and** reviewer quorum plus the reducer mark the run `complete` within the turn budget, omits `pr_report` when disabled or not approved, and runs a provider-aware `pull-request` stage only at the end when explicitly authorized. The final stage reads the goal ledger, worker receipts, latest review artifact, final report, and sanitized `base_branch` before attempting GitHub, Azure Repos, GitLab, Bitbucket, Sapling, or Phabricator handoff tooling. Goal worker/reviewer prompts now include an intermediate-stage guardrail telling them to ignore PR-creation requests because only the final `pull-request` stage may attempt that handoff.
 
 ### Fixed
 
 - Fixed the builtin `open-claude-design` workflow feedback threading so `user-feedback-*` live annotations (`user_notes`, `live_changes`, and `annotated_snapshot`) are parsed, persisted under `<artifact_dir>/feedback/iteration-<n>.*`, and required to appear in the next `generate-*` prompt before a revision runs. The old internal critique/screenshot/apply stages were removed, so user feedback is now the sole refinement signal.
-
 - Fixed the builtin `open-claude-design` workflow polluting the project's `specs/design/` tree with per-run artifact folders during automated test runs; `prepareArtifactDir` now writes to the OS tmpdir when `NODE_ENV=test`.
 - Hardened the builtin `open-claude-design` browser and artifact safety paths: when the `playwright-cli` browser is unavailable the run exits cleanly up front (skipped under the test harness), annotation snapshot copies are constrained to the project/artifact dir, one-character real notes survive placeholder filtering, and the final `final-display` stage is read-only so it only surfaces the exported spec and re-run instructions.
-
 
 ## [0.9.0-alpha.3] - 2026-06-21
 


### PR DESCRIPTION
## Release

- Kind: prerelease
- Version: `0.9.0-alpha.4`
- Base / tag base: `main`
- Head branch: `prerelease/0.9.0-alpha.4`
- Head SHA: `09303fd5d81e710c3c8833f30b0a09d4a80561d5`

## Summary

- Prepares changelog-only release notes for `0.9.0-alpha.4` in `packages/coding-agent/CHANGELOG.md` and `packages/workflows/CHANGELOG.md`.
- Captures the prerelease notes for the Goal workflow `create_pr` handoff toggle/final PR stage plus the `open-claude-design` workflow restructuring, feedback threading, and safety fixes.
- Version bump summary: no package versions are changed on `main`; all `packages/*/package.json` files remain at the `0.0.0` placeholder. The real `0.9.0-alpha.4` version is materialized only by `scripts/cut-release.ts` on the throwaway off-main tag commit.

## Validation

- `git branch --show-current` → `prerelease/0.9.0-alpha.4`
- `git rev-parse HEAD` → `09303fd5d81e710c3c8833f30b0a09d4a80561d5`
- `git status --short` → clean
- `git diff --name-only acebde688d86c708a82f59156c546b922cadaf66..HEAD` → `packages/coding-agent/CHANGELOG.md`, `packages/workflows/CHANGELOG.md`
- `bun run typecheck` → passed
- `bun run test:unit` → passed
- `git push -u origin prerelease/0.9.0-alpha.4` → passed
- `gh auth status` → authenticated
- `gh repo view --json nameWithOwner,url,defaultBranchRef` → `bastani-inc/atomic`, default branch `main`
