### PR TITLE
Release 0.9.0

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Breaking Changes
+
+- Changed the bundled `open-claude-design` workflow input contract by removing `reference`, `output_type`, and `design_system`; discovery now gathers output type, design-system context, and references during the run.
+- Removed the Atomic-specific `bashPolicy` command allow/deny API from the SDK/session surface and built-in `bash` tool; use `tools`/`excludedTools`/`noTools`, custom tools, or an external sandbox for command scoping.
+
+### Added
+
+- Added configurable context-window selection for models with multiple context tiers, including GitHub Copilot live-catalog support, CLI/settings/RPC controls, SDK helpers and exported types, per-session persistence, model picker UI, and long-context workflow model tokens.
+- Added upstream Pi 0.79.7/0.79.9 capabilities including automatic light/dark themes, chat-template thinking compatibility for custom OpenAI-compatible providers, expanded SDK exports, updated model/provider metadata, and Markdown streaming stability.
+- Replaced browser automation with the bundled `playwright-cli` skill/command and added the `effective-liteparse` document-extraction skill for local PDF/DOCX/PPTX/XLSX/image extraction.
+- Added the builtin `goal` workflow's safe-by-default `create_pr` toggle and final PR/MR/review handoff stage.
+- Restructured the builtin `open-claude-design` workflow around `impeccable` discovery/init, design-system/reference gathering, forked generation plus user-feedback loops, and a minimal export/display phase.
+
+### Changed
+
+- Aligned Atomic's bundled upstream Pi runtime packages through `^0.79.9`, carrying provider catalog updates, GitHub Copilot model filtering, GLM-5.2 metadata, Mistral prompt-cache accounting, OpenRouter Fusion, and shared TUI/runtime fixes.
+- Changed GitHub Copilot context-window handling to derive tiers from the live CAPI model catalog, display full long-context windows while tracking effective prompt budgets internally, seed cached tiers at startup, and keep per-model persisted selections isolated.
+- Synced the Atomic CLI with upstream behavior such as self-only `atomic update` by default, improved model search/autocomplete, generated model catalog updates, theme mode support, and extension documentation/API clarifications.
+- Updated bundled workflows, subagents, docs, and verification guidance to use `playwright-cli` instead of the removed `browser` skill / `browse` CLI.
+- Changed repository validation to include the monorepo-wide Bun/prek/CI file-length gate for tracked TS/JS/Rust files with only documented generated/vendored exclusions.
+- Switched the repository to versionless `main`: package manifests stay at `0.0.0`, release notes land as CHANGELOG-only PRs, and real versions are stamped only on off-main tag commits via `scripts/cut-release.ts`.
+
+### Fixed
+
+- Fixed GitHub Copilot Gemini request/stream failures by sanitizing Gemini-incompatible tool schemas, reconstructing flattened and dotted tool arguments for execution and replay, preserving Gemini thought signatures through `reasoning_opaque`, retrying degenerate empty/error completions appropriately, and hardening reconstruction against prototype pollution.
+- Fixed context-window startup, session-switch, settings, RPC, picker, SDK, and GitHub Copilot restart edge cases so selected windows are validated and persisted consistently without leaking unsupported defaults across providers.
+- Fixed credential-store load failures and concurrent session creation by surfacing real auth-store read errors, avoiding throwaway `AuthStorage` instances when a registry is supplied, and making credential reads lock-free while retaining atomic locked writes.
+- Fixed workflow and extension resource/session behavior, including default session-dir visibility for extensions, same-directory resource reload reuse, workflow stage inheritance from non-default session dirs, and custom resource snapshots for `atomic -e` workflows.
+- Fixed model and runtime polish including RPC unknown-command ids, `/model` query ranking, WSL bash stdin execution, fuzzy `edit` patch generation, overflow compaction after oversized successful responses, source-CLI Bun subprocess tests, and stale update banners on `0.0.0` dev builds.
+- Fixed release and workflow reliability issues including the `publish-release` Publish-run verifier, `open-claude-design` feedback threading/artifact safety/browser handling, and successful overflow-sized assistant response compaction.
+
 ## [0.9.0-alpha.4] - 2026-06-22
 
 ### Breaking Changes

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Changed
+
+- Published the stable Atomic 0.9.0 release for the Cursor provider package; no functional Cursor provider changes were made after the 0.9.0 prerelease line.
+- Changed contributor validation to include the monorepo-wide file-length gate for tracked TS/JS/Rust files in local `prek` hooks and PR CI, with only documented generated/vendored exclusions and no grandfathered baseline allowlist.
+
 ## [0.9.0-alpha.2] - 2026-06-21
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Changed
+
+- Published the stable Atomic 0.9.0 release with the intercom extension peer dependency aligned through upstream pi TUI `^0.79.9`, so coordination overlays and rendered message surfaces inherit the latest shared TUI compatibility fixes, including stabilized partial code-fence rendering during Markdown streaming.
+- Changed contributor validation to include the monorepo-wide file-length gate for tracked TS/JS/Rust files in local `prek` hooks and PR CI, with only documented generated/vendored exclusions and no grandfathered baseline allowlist.
+- No intercom extension source changes were needed after the 0.9.0 prerelease line.
+
 ## [0.9.0-alpha.2] - 2026-06-21
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Fixed
+
+- Fixed MCP tool calls under GitHub Copilot Gemini models by normalizing flattened array/object and dotted arguments at the `callTool` boundary before they reach direct-tool or proxy/gateway MCP servers.
+- Hardened flattened tool-argument reconstruction against prototype pollution by dropping any reconstructed key path that walks through `__proto__`, `constructor`, or `prototype`, using the canonical host implementation shared with `@bastani/atomic`.
+
+### Changed
+
+- Published the stable Atomic 0.9.0 release with MCP peer dependencies aligned through upstream pi AI/TUI `^0.79.9`, so MCP-backed sessions inherit chat-template custom-provider thinking controls, GLM-5.2 provider metadata, GitHub Copilot model-availability filtering, Mistral prompt-cache accounting, Markdown streaming stability, and shared provider/TUI fixes.
+- Changed contributor validation to include the monorepo-wide file-length gate for tracked TS/JS/Rust files in local `prek` hooks and PR CI, with only documented generated/vendored exclusions and no grandfathered baseline allowlist.
+
 ## [0.9.0-alpha.2] - 2026-06-21
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Changed
+
+- Published the stable Atomic 0.9.0 release for the native transport package; no functional native transport changes were made after the 0.9.0 prerelease line.
+- Changed contributor validation to include the monorepo-wide file-length gate for tracked TS/JS/Rust files in local `prek` hooks and PR CI, with only documented generated/vendored exclusions and no grandfathered baseline allowlist.
+
 ## [0.9.0-alpha.2] - 2026-06-21
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Added
+
+- Added the `playwright-cli` builtin skill for browser automation, end-to-end UI checks, screenshots, reviewable video recording, and Playwright test workflows.
+- Added the `effective-liteparse` builtin skill for fast, local, model-free text/table/value extraction from PDF, DOCX, PPTX, XLSX, and image files via the `lit` CLI.
+
+### Changed
+
+- Changed the `debugger` and `codebase-online-researcher` subagents to load `playwright-cli` and drive the `playwright-cli` command for JS-heavy, auth-gated, or interactive web work instead of the removed `browser` skill / `browse` CLI.
+- Published the stable Atomic 0.9.0 release with subagents peer dependencies aligned through upstream pi `^0.79.9` runtime packages, so child sessions inherit provider catalog, RPC id handling, model search, theme/color-scheme, Warp image capability, Markdown streaming stability, and shared agent/TUI fixes.
+- Changed contributor validation to include the monorepo-wide file-length gate for tracked TS/JS/Rust files in local `prek` hooks and PR CI, with only documented generated/vendored exclusions and no grandfathered baseline allowlist.
+
+### Removed
+
+- Removed the bundled `browser` skill and remaining references to its `browse` CLI in favor of `playwright-cli`.
+
 ## [0.9.0-alpha.2] - 2026-06-21
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Changed
+
+- Published the stable Atomic 0.9.0 release with the web-access extension peer dependency aligned through upstream pi TUI `^0.79.9`, so curator, summary review, and rendered Markdown surfaces inherit the latest shared TUI compatibility fixes, including stabilized partial code-fence rendering during streaming.
+- Changed contributor validation to include the monorepo-wide file-length gate for tracked TS/JS/Rust files in local `prek` hooks and PR CI, with only documented generated/vendored exclusions and no grandfathered baseline allowlist.
+- No web-access extension source changes were needed after the 0.9.0 prerelease line.
+
 ## [0.9.0-alpha.2] - 2026-06-21
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-22
+
+### Breaking Changes
+
+- Replaced the removed `defineWorkflow(...).run(...).compile()` builder with the single `workflow({ name?, description, inputs, outputs, run })` authoring door; authored workflows now import and export the `workflow` definition directly.
+- Removed the workflow stage/task/direct-mode `bashPolicy` option and schema so workflow-launched `bash` tools match upstream pi behavior; use `tools`/`noTools`, custom tools, or external sandboxing for command scoping.
+- Changed the builtin `open-claude-design` workflow contract by renaming `browse_cli_status` to `playwright_cli_status` and removing the `reference`, `output_type`, and `design_system` inputs in favor of discovery-stage questioning.
+
+### Added
+
+- Added per-model context-window workflow authoring tokens such as `github-copilot/claude-opus-4.8 (1m):xhigh`, plus `contextWindow`/`contextWindowStrict` stage and direct-task options.
+- Added deterministic workflow-stage resume handling that suppresses duplicate readiness prompts after interactive resumes and continues promptable stages exactly once.
+- Added a `playwright-cli` QA proof-video path to the builtin `ralph` workflow and a safe final-stage attachment/link handoff when `create_pr=true`.
+- Added shared initial prompt-refinement stages to the builtin `ralph` and `goal` workflows so raw requests are clarified with the `prompt-engineer` skill before research and orchestration.
+- Added the builtin `goal` workflow's safe-by-default `create_pr` toggle and final `pull-request` stage for GitHub, Azure Repos, GitLab, Bitbucket, Sapling, or Phabricator handoff after reviewer/reducer approval.
+- Restructured the builtin `open-claude-design` workflow around `impeccable` discovery/init, design-system/reference gathering, optional reference discovery, forked generate/user-feedback iterations, and a minimal exporter/final-display phase.
+
+### Changed
+
+- Decomposed the foreground workflow executor behind an internal `EngineRuntime.spawnStage(...)` chokepoint while preserving run, resume, kill, HIL, worktree, model-fallback, graph-frontier, and continuation behavior.
+- Changed builtin `ralph`, `goal`, and `open-claude-design` browser automation guidance from the removed `browser` skill / `browse` CLI to the `playwright-cli` skill and command.
+- Changed builtin `ralph` review fan-out to three independent model-family reviewers with severity-aware unanimous approval, stronger implementation-notes evidence requirements, and non-blocking P3 nit handling.
+- Changed builtin workflows to use long-context GitHub Copilot fallback model tokens where available and to inherit upstream pi TUI `^0.79.9` compatibility fixes.
+- Changed contributor validation to include the monorepo-wide file-length gate for tracked TS/JS/Rust files in local `prek` hooks and PR CI, with only documented generated/vendored exclusions and no grandfathered baseline allowlist.
+
+### Fixed
+
+- Fixed workflow stage sessions to inherit the host's non-default session directory in headless/forked runs while preserving explicit per-stage overrides.
+- Fixed manual workflow pause/resume state so attached-stage controls update the main run status the same way `/workflow pause` and `/workflow resume` do.
+- Fixed the builtin `ralph` review loop to stop on deterministic severity-aware unanimous approval instead of treating non-blocking P3 findings or placeholder findings as blockers.
+- Fixed workflow model fallback to reuse the initially loaded credential/model registry, report real credential-store load failures, and resume follow-ups on the settled fallback model instead of replaying from the unavailable primary.
+- Fixed `open-claude-design` user-feedback threading, test artifact placement, browser-unavailable early exits, snapshot copy safety, placeholder filtering, and read-only final display behavior.
+
 ## [0.9.0-alpha.4] - 2026-06-22
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary

Release notes PR for Atomic 0.9.0.

- Release kind: release
- Target version: 0.9.0
- Base branch / tag base: main
- Head branch: release/0.9.0
- Head SHA: 2227e43dbb416354a25b100e59e1b81023014775

## Changelog / version bump summary

- Updated only the `## [Unreleased]` changelog sections for:
  - `packages/coding-agent/CHANGELOG.md`
  - `packages/cursor/CHANGELOG.md`
  - `packages/intercom/CHANGELOG.md`
  - `packages/mcp/CHANGELOG.md`
  - `packages/natives/CHANGELOG.md`
  - `packages/subagents/CHANGELOG.md`
  - `packages/web-access/CHANGELOG.md`
  - `packages/workflows/CHANGELOG.md`
- No package versions were bumped in this PR; `main` remains versionless with package manifests at the `0.0.0` placeholder.
- The real `0.9.0` version is expected to be materialized only by the off-main tag commit produced by `scripts/cut-release.ts`.

## Validation

- `git branch --show-current` -> `release/0.9.0`
- `git rev-parse HEAD` -> `2227e43dbb416354a25b100e59e1b81023014775`
- `git status --short` -> clean
- `git diff --name-only 6b26b8de49167d9962267ded82a3440013b96516..HEAD` -> changelog files only
- `git push -u origin release/0.9.0` completed successfully and ran pre-push hooks, including:
  - `bun run lint`
  - `bun run check:file-length`
  - `bun run test:unit`
- `gh auth status` succeeded
- `gh repo view --json nameWithOwner,defaultBranchRef,url` succeeded for `bastani-inc/atomic`
