### PR TITLE
docs(release): add release notes for 0.9.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Changed the bundled `goal`/`ralph` workflow prompt-refinement stage to use a workflow-neutral, model-only rubric prompt that returns only the refined objective instead of invoking the `prompt-engineer` skill directly.
+
+### Fixed
+
+- Fixed the bundled `ralph` workflow reviewer-c model configuration to use Gemini 3.1 Pro as the third reviewer with Gemini 3.1 provider fallbacks, removing Gemini 3.5 Flash from that slot's fallback chain ([#1484](https://github.com/bastani-inc/atomic/issues/1484)).
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.1 release for the Cursor provider package; no functional Cursor provider changes were made after 0.9.0.
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.1 release for the intercom extension; no functional intercom changes were made after 0.9.0.
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.1 release for the MCP extension; no functional MCP changes were made after 0.9.0.
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.1 release for the native transport package; no functional native transport changes were made after 0.9.0.
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.1 release for the subagents extension; no functional subagents changes were made after 0.9.0.
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.1 release for the web-access extension; no functional web-access changes were made after 0.9.0.
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-23
+
+### Changed
+
+- Changed the shared `goal`/`ralph` prompt-refinement stage to use a workflow-neutral, model-only rubric prompt that returns only the refined objective instead of invoking the `prompt-engineer` skill directly.
+
+### Fixed
+
+- Fixed the builtin `ralph` reviewer-c model configuration to use Gemini 3.1 Pro as the third reviewer with Gemini 3.1 provider fallbacks, removing Gemini 3.5 Flash from that slot's fallback chain ([#1484](https://github.com/bastani-inc/atomic/issues/1484)).
+
 ## [0.9.1-alpha.1] - 2026-06-22
 
 ### Changed


### PR DESCRIPTION
## Summary

Adds `[0.9.1]` changelog entries across all packages for the Atomic 0.9.1 stable release. `main` remains versionless — manifests stay at `0.0.0` and the real version is materialized only by the off-`main` tag commit produced by `scripts/cut-release.ts`.

## Key changes in 0.9.1

- **Changed** (`coding-agent`, `workflows`): The shared `goal`/`ralph` prompt-refinement stage now uses a workflow-neutral, model-only rubric prompt that returns only the refined objective, instead of invoking the `prompt-engineer` skill directly.
- **Fixed** (`coding-agent`, `workflows`): The `ralph` reviewer-c model slot now uses Gemini 3.1 Pro with Gemini 3.1 provider fallbacks; Gemini 3.5 Flash has been removed from that fallback chain ([#1484](https://github.com/bastani-inc/atomic/issues/1484)).
- All other packages (`cursor`, `intercom`, `mcp`, `natives`, `subagents`, `web-access`) received version-bump changelog stubs with no functional changes since 0.9.0.

## Files changed

| File | Change |
|------|--------|
| `packages/coding-agent/CHANGELOG.md` | Added `[0.9.1]` section |
| `packages/workflows/CHANGELOG.md` | Added `[0.9.1]` section |
| `packages/cursor/CHANGELOG.md` | Added `[0.9.1]` version-bump stub |
| `packages/intercom/CHANGELOG.md` | Added `[0.9.1]` version-bump stub |
| `packages/mcp/CHANGELOG.md` | Added `[0.9.1]` version-bump stub |
| `packages/natives/CHANGELOG.md` | Added `[0.9.1]` version-bump stub |
| `packages/subagents/CHANGELOG.md` | Added `[0.9.1]` version-bump stub |
| `packages/web-access/CHANGELOG.md` | Added `[0.9.1]` version-bump stub |

## Release metadata

- Source head OID: `fa5f71270a5a260b81ab3e972f3759ac5998b505`
- Release-notes commit OID: `b700f38a1173d469dbcb960224a61ab18f935514`
- Head branch: `release/0.9.1`
- Base branch: `main`