### PR TITLE
docs: release notes for 0.9.2-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
 ### Changed
 
 - Removed the initial `prompt-refinement` stage and shared prompt-refinement helper from the bundled `goal` and `ralph` workflows so both now use the raw objective/prompt as the operative task text for their first downstream stages; the now-obsolete refined/original trace outputs were also removed.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
+### Changed
+
+- Published a synchronized Atomic 0.9.2-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.1.
+
 ## [0.9.1] - 2026-06-23
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
 ### Changed
 
 - Aligned the intercom extension peer dependency with upstream pi TUI `^0.79.10`; no intercom extension source changes were needed for this metadata sync.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
 ### Changed
 
 - Aligned the MCP extension peer dependencies with upstream pi AI/TUI `^0.79.10`; no MCP extension source changes were needed for this metadata sync.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
+### Changed
+
+- Published a synchronized Atomic 0.9.2-alpha.1 prerelease for the native transport package; no functional native transport changes were made after 0.9.1.
+
 ## [0.9.1] - 2026-06-23
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
 ### Changed
 
 - Aligned the subagents extension peer dependencies with upstream pi `^0.79.10` runtime packages (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui`); no subagents extension source changes were needed for this metadata sync.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
 ### Changed
 
 - Aligned the web-access extension peer dependency with upstream pi TUI `^0.79.10`; no web-access extension source changes were needed for this metadata sync.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.2-alpha.1] - 2026-06-23
+
 ### Changed
 
 - Removed the initial `prompt-refinement` stage and shared prompt-refinement helper from the builtin `goal` and `ralph` workflows so both now use the raw objective/prompt as the operative task text for their first downstream stages; the now-obsolete refined/original trace outputs were also removed.


### PR DESCRIPTION
## Summary

Changelog-only release-notes PR for `0.9.2-alpha.1`. The primary functional change is the removal of the `prompt-refinement` stage from the `goal` and `ralph` workflows; the remaining package updates are peer-dependency alignment and synchronized prerelease stamps.

## Key changes

### `@bastani/atomic` / `@bastani/workflows`
- **Removed** the initial `prompt-refinement` stage and its shared helper from the builtin `goal` and `ralph` workflows — both now operate directly on the raw objective/prompt text as the operative task for their first downstream stages
- Removed the now-obsolete `refined`/`original` trace outputs produced by the dropped stage

### `@bastani/subagents`, `@bastani/mcp`, `@bastani/web-access`, `@bastani/intercom`
- Aligned peer dependencies with upstream pi `^0.79.10` runtime packages (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui`); no functional source changes

### `@bastani/cursor`, `@bastani/natives`
- Synchronized Atomic `0.9.2-alpha.1` prerelease stamp; no functional changes since `0.9.1`

## Release metadata

- Release kind: prerelease (`@next`)
- Version: `0.9.2-alpha.1`
- Base branch: `main`
- Head branch: `prerelease/0.9.2-alpha.1`
- Head SHA: `bb17f8697cd0e7d602151a998b4abecf1a11c167`

## Changelog files updated

- `packages/coding-agent/CHANGELOG.md`
- `packages/cursor/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`
- `packages/mcp/CHANGELOG.md`
- `packages/natives/CHANGELOG.md`
- `packages/subagents/CHANGELOG.md`
- `packages/web-access/CHANGELOG.md`
- `packages/workflows/CHANGELOG.md`

> Versionless-main rules preserved: no `package.json` versions were changed. The real version is materialized only by the throwaway off-`main` tag commit produced by `scripts/cut-release.ts`.