### PR TITLE
docs(changelog): add 0.9.2 release notes across all packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Removed the initial `prompt-refinement` stage and shared prompt-refinement helper from the bundled `goal` and `ralph` workflows so both now use the raw objective/prompt as the operative task text for their first downstream stages; the now-obsolete refined/original trace outputs were also removed.
+- Updated bundled `goal` and `ralph` reviewer prompts to inspect referenced QA end-to-end video evidence before treating it as proof of user-visible behavior.
+- Synced bundled upstream Pi package dependencies to `^0.79.10` across Atomic's CLI and extension peer manifests, and aligned shared coding-agent direct runtime/dev dependency pins with upstream Pi v0.79.10.
+- Raised the published Node.js engine floor to `>=22.19.0` to match direct runtime dependency requirements, including `undici@8.5.0`.
+
+### Fixed
+
+- Fixed GitHub Copilot Gemini tool-call normalization to synthesize omitted required empty array properties before validation, preventing Ralph reviewer structured output such as `findings: []` from failing when CAPI drops the empty array from the tool call.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.2 release for the Cursor provider package; no functional Cursor provider changes were made after 0.9.1.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.2 release with the intercom extension peer dependency aligned to upstream pi TUI `^0.79.10`; no intercom extension source changes were needed for this metadata sync.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.2 release with MCP extension peer dependencies aligned to upstream pi AI/TUI `^0.79.10`; no MCP extension source changes were needed for this metadata sync.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.2 release for the native transport package; no functional native transport changes were made after 0.9.1.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.2 release with subagents extension peer dependencies aligned to upstream pi `^0.79.10` runtime packages (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui`); no subagents extension source changes were needed for this metadata sync.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Published the stable Atomic 0.9.2 release with the web-access extension peer dependency aligned to upstream pi TUI `^0.79.10`; no web-access extension source changes were needed for this metadata sync.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-23
+
+### Changed
+
+- Removed the initial `prompt-refinement` stage and shared prompt-refinement helper from the builtin `goal` and `ralph` workflows so both now use the raw objective/prompt as the operative task text for their first downstream stages; the now-obsolete refined/original trace outputs were also removed.
+- Updated builtin `goal` and `ralph` reviewer prompts to inspect referenced QA end-to-end video evidence before treating it as proof of user-visible behavior.
+- Aligned the workflows package peer dependency with upstream pi TUI `^0.79.10`; no workflow source changes were needed for this metadata sync.
+
 ## [0.9.2-alpha.1] - 2026-06-23
 
 ### Changed


### PR DESCRIPTION
## Summary

Adds `## [0.9.2]` release-note entries to every package changelog in preparation for the stable 0.9.2 release. No source code changes are included — only changelog documentation.

## Key changes

- **`packages/coding-agent`** — documents all substantive 0.9.2 changes:
  - Removed the `prompt-refinement` stage from bundled `goal` and `ralph` workflows; both now operate directly on the raw objective/prompt
  - Updated bundled reviewer prompts to inspect QA end-to-end video evidence before treating it as proof of user-visible behavior
  - Synced upstream Pi peer/runtime dependency pins to `^0.79.10`
  - Raised the Node.js engine floor to `>=22.19.0` (required by `undici@8.5.0`)
  - Fixed GitHub Copilot Gemini tool-call normalization: synthesizes omitted required empty array properties (e.g. `findings: []`) before validation so Ralph reviewer structured output no longer fails when CAPI drops the empty array

- **`packages/workflows`** — mirrors the `goal`/`ralph` prompt-refinement removal and reviewer-prompt updates; aligns peer dep to `^0.79.10`

- **`packages/subagents`, `packages/mcp`, `packages/intercom`, `packages/web-access`, `packages/cursor`, `packages/natives`** — peer dependency metadata sync to `^0.79.10`; no functional source changes in these packages

## Release notes

- Release kind: **stable**
- Version: **0.9.2**
- Base branch: `main` (versionless; version materialized off-main via `scripts/cut-release.ts`)
- Head SHA: `fd5b5ca6591644755745eec7d820fa69c2a22d78`
- Source SHA (tip of `main`): `609fc72790439471bb133476fd6f2965a46c3405`

## Validation

- `git diff --name-only 609fc727...HEAD` → changelog files only
- Pre-push checks passed: `bun run lint`, `bun run check:file-length`, `bun run test:unit`