### PR TITLE
fix(mcp): schema-aware unflattening preserves literal dotted argument keys

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Changed
 
 - Raised the bundled subagent and workflow-stage nesting budget to a hard maximum of five delegated levels, and documented the `0`-to-`5` recursion-guard range.
+- Extracted the schema-aware flattened-argument disambiguation into a shared canonical `unflattenArgumentsWithSchema` helper in `core/flattened-tool-arguments.ts` (exported from `@bastani/atomic`), now reused by both the GitHub Copilot Gemini per-tool normalization and the MCP `callTool` boundary so literal dotted argument keys are preserved unless the tool schema proves they are nested paths (issue [#1496](https://github.com/bastani-inc/atomic/issues/1496)).
 
 ### Fixed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Changed
 
 - Raised the bundled subagent and workflow-stage nesting budget to a hard maximum of five delegated levels, and documented the `0`-to-`5` recursion-guard range.
-- Extracted the schema-aware flattened-argument disambiguation into a shared canonical `unflattenArgumentsWithSchema` helper in `core/flattened-tool-arguments.ts` (exported from `@bastani/atomic`), now reused by both the GitHub Copilot Gemini per-tool normalization and the MCP `callTool` boundary so literal dotted argument keys are preserved unless the tool schema proves they are nested paths (issue [#1496](https://github.com/bastani-inc/atomic/issues/1496)).
+- Extracted the schema-aware flattened-argument disambiguation into a shared canonical `unflattenArgumentsWithSchema` helper in `core/flattened-tool-arguments.ts` (exported from `@bastani/atomic`), now reused by both the GitHub Copilot Gemini per-tool normalization and the MCP `callTool` boundary so literal dotted argument keys are preserved unless the tool schema proves they are nested paths. A literal dotted top-level property (e.g. `filter.name`) is preserved verbatim even when the schema also defines a same-head container property (e.g. `filter`) (issue [#1496](https://github.com/bastani-inc/atomic/issues/1496)).
 
 ### Fixed
 

--- a/packages/coding-agent/src/core/copilot-gemini-tool-arguments.ts
+++ b/packages/coding-agent/src/core/copilot-gemini-tool-arguments.ts
@@ -1,6 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { isCopilotGeminiModel } from "./copilot-gemini-payload-sanitizer.ts";
-import { reconstructFlattenedKeys } from "./flattened-tool-arguments.ts";
+import { unflattenArgumentsWithSchema } from "./flattened-tool-arguments.ts";
 
 /**
  * Normalizes GitHub Copilot Gemini tool-call arguments.
@@ -47,33 +47,6 @@ function isPlainObject(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** A flattened key contains a bracket index like `foo[0]`. */
-function hasFlattenedKey(keys: string[]): boolean {
-  return keys.some((key) => /\[\d+\]/.test(key));
-}
-
-/** A schema node that holds a nested object/array (so dotted keys are real paths). */
-function isContainerSchema(schema: unknown): boolean {
-  if (!isPlainObject(schema)) return false;
-  if (schema.type === "object" || schema.type === "array") return true;
-  if ("properties" in schema || "items" in schema) return true;
-  const union = schema.anyOf ?? schema.oneOf;
-  if (Array.isArray(union)) return union.some((branch) => isContainerSchema(branch));
-  return false;
-}
-
-/** Top-level property names whose schema is an object/array container. */
-function containerPropertyNames(schema: unknown): Set<string> {
-  const names = new Set<string>();
-  if (!isPlainObject(schema)) return names;
-  const properties = schema.properties;
-  if (!isPlainObject(properties)) return names;
-  for (const [name, sub] of Object.entries(properties)) {
-    if (isContainerSchema(sub)) names.add(name);
-  }
-  return names;
-}
-
 function schemaTypeIncludes(schema: JsonRecord, type: string): boolean {
   if (schema.type === type) return true;
   return Array.isArray(schema.type) && schema.type.includes(type);
@@ -107,26 +80,6 @@ function fillMissingRequiredArrayProperties(args: JsonRecord, schema: unknown): 
   return next;
 }
 
-/** Whether `key` is a pure dotted path (`parent.child`) headed by a container prop. */
-function isDottedContainerKey(key: string, containers: Set<string>): boolean {
-  const dot = key.indexOf(".");
-  if (dot <= 0) return false;
-  return containers.has(key.slice(0, dot));
-}
-
-/**
- * Decide whether a flattened key should be split into nested path segments.
- * Bracket-indexed keys always split. When a bracket key is present anywhere in
- * the payload, dotted keys split too (they are part of the same flattened
- * object). Otherwise a dotted key only splits when the schema marks its head as
- * a container property, which keeps legitimate dot-containing keys intact.
- */
-function shouldSplitKey(key: string, hasBracket: boolean, containers: Set<string>): boolean {
-  if (/\[\d+\]/.test(key)) return true;
-  if (hasBracket) return true;
-  return isDottedContainerKey(key, containers);
-}
-
 /**
  * Reconstruct flattened Gemini tool-call arguments into proper nested
  * arrays/objects. Returns the original reference unchanged when there is nothing
@@ -137,15 +90,7 @@ function shouldSplitKey(key: string, hasBracket: boolean, containers: Set<string
  */
 export function unflattenGeminiToolArguments(args: unknown, schema?: unknown): unknown {
   if (!isPlainObject(args)) return args;
-  const keys = Object.keys(args);
-  const hasBracket = hasFlattenedKey(keys);
-  const containers = hasBracket ? new Set<string>() : containerPropertyNames(schema);
-  const hasDottedContainer =
-    !hasBracket && keys.some((key) => isDottedContainerKey(key, containers));
-  const reconstructed = hasBracket || hasDottedContainer
-    ? reconstructFlattenedKeys(args, (key) => shouldSplitKey(key, hasBracket, containers))
-    : args;
-
+  const reconstructed = unflattenArgumentsWithSchema(args, schema);
   return isPlainObject(reconstructed)
     ? fillMissingRequiredArrayProperties(reconstructed, schema)
     : reconstructed;

--- a/packages/coding-agent/src/core/flattened-tool-arguments.ts
+++ b/packages/coding-agent/src/core/flattened-tool-arguments.ts
@@ -138,3 +138,104 @@ export function reconstructFlattenedKeys(
   }
   return compactSparseArrays(result) as Record<string, unknown>;
 }
+
+// ---------------------------------------------------------------------------
+// Schema-aware unflattening
+// ---------------------------------------------------------------------------
+//
+// A flattened key with a bracket index (`foo[0]`) is unambiguous and is always
+// reconstructed. A purely dotted key (`parent.child`) is ambiguous: it could be
+// a real nested path *or* a legitimate argument whose name literally contains
+// a dot (for example an MCP tool whose JSON Schema declares a property named
+// `filter.name`). To avoid corrupting such literal dotted keys, a dotted key is
+// only split when the tool's `inputSchema` proves its head segment is an
+// object/array container property. The presence of a bracket-indexed sibling
+// does NOT force a pure dotted key to split — the two are decided per key, so
+// a literal property such as `filter.name` survives intact even when a bracket
+// sibling like `ids[0]` is present (issue #1496). Callers that only want the
+// unambiguous bracket case can omit the schema.
+
+type JsonRecord = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A flattened key contains a bracket index like `foo[0]`. */
+function hasBracketIndex(key: string): boolean {
+  return /\[\d+\]/.test(key);
+}
+
+/** A schema node that holds a nested object/array (so dotted keys are real paths). */
+function isContainerSchema(schema: unknown): boolean {
+  if (!isPlainObject(schema)) return false;
+  if (schema.type === "object" || schema.type === "array") return true;
+  if ("properties" in schema || "items" in schema) return true;
+  const union = schema.anyOf ?? schema.oneOf;
+  if (Array.isArray(union)) return union.some((branch) => isContainerSchema(branch));
+  return false;
+}
+
+/** Top-level property names whose schema is an object/array container. */
+function containerPropertyNames(schema: unknown): Set<string> {
+  const names = new Set<string>();
+  if (!isPlainObject(schema)) return names;
+  const properties = schema.properties;
+  if (!isPlainObject(properties)) return names;
+  for (const [name, sub] of Object.entries(properties)) {
+    if (isContainerSchema(sub)) names.add(name);
+  }
+  return names;
+}
+
+/** Whether `key` is a pure dotted path (`parent.child`) headed by a container prop. */
+function isDottedContainerKey(key: string, containers: Set<string>): boolean {
+  const dot = key.indexOf(".");
+  if (dot <= 0) return false;
+  return containers.has(key.slice(0, dot));
+}
+
+/**
+ * Decide whether a flattened key should be split into nested path segments.
+ *
+ * - Bracket-indexed keys (`foo[0]`, `foo[0].bar`) always split: they are
+ *   unambiguous evidence of provider flattening.
+ * - Purely dotted keys (`parent.child`) split only when the schema marks their
+ *   head segment as an object/array container property. The presence of a
+ *   bracket-indexed sibling does NOT force a pure dotted key to split, so a
+ *   literal property name such as `filter.name` is preserved verbatim even when
+ *   a sibling like `ids[0]` is reconstructed (issue #1496).
+ */
+function shouldSplitKey(key: string, containers: Set<string>): boolean {
+  if (hasBracketIndex(key)) return true;
+  return isDottedContainerKey(key, containers);
+}
+
+/**
+ * Reconstruct flattened tool-call arguments into nested arrays/objects using
+ * schema-aware disambiguation for dotted keys.
+ *
+ * - Bracket-indexed keys (`ids[0]`, `files[0].path`) are always reconstructed.
+ * - Purely dotted keys (`parent.child`) are reconstructed only when the optional
+ *   `schema` marks their head segment as an object/array container property.
+ *   The presence of a bracket-indexed sibling does NOT force a pure dotted key
+ *   to split, so a literal property name such as `filter.name` survives intact
+ *   even when a sibling like `ids[0]` is present (issue #1496).
+ * - Otherwise dotted keys are preserved verbatim — fixing the regression where a
+ *   literal property name like `filter.name` was silently corrupted.
+ *
+ * Returns the original reference unchanged when there is nothing to
+ * reconstruct. Prototype-pollution safety is delegated to
+ * {@link reconstructFlattenedKeys}.
+ */
+export function unflattenArgumentsWithSchema(
+  args: Record<string, unknown>,
+  schema?: unknown,
+): Record<string, unknown> {
+  const keys = Object.keys(args);
+  const containers = containerPropertyNames(schema);
+  const hasBracket = keys.some((key) => hasBracketIndex(key));
+  const hasDottedContainer = keys.some((key) => isDottedContainerKey(key, containers));
+  if (!hasBracket && !hasDottedContainer) return args;
+  return reconstructFlattenedKeys(args, (key) => shouldSplitKey(key, containers));
+}

--- a/packages/coding-agent/src/core/flattened-tool-arguments.ts
+++ b/packages/coding-agent/src/core/flattened-tool-arguments.ts
@@ -176,6 +176,16 @@ function isContainerSchema(schema: unknown): boolean {
   return false;
 }
 
+/** Exact top-level `schema.properties` names (literal property keys). */
+function literalPropertyNames(schema: unknown): Set<string> {
+  const names = new Set<string>();
+  if (!isPlainObject(schema)) return names;
+  const properties = schema.properties;
+  if (!isPlainObject(properties)) return names;
+  for (const name of Object.keys(properties)) names.add(name);
+  return names;
+}
+
 /** Top-level property names whose schema is an object/array container. */
 function containerPropertyNames(schema: unknown): Set<string> {
   const names = new Set<string>();
@@ -201,13 +211,18 @@ function isDottedContainerKey(key: string, containers: Set<string>): boolean {
  * - Bracket-indexed keys (`foo[0]`, `foo[0].bar`) always split: they are
  *   unambiguous evidence of provider flattening.
  * - Purely dotted keys (`parent.child`) split only when the schema marks their
- *   head segment as an object/array container property. The presence of a
- *   bracket-indexed sibling does NOT force a pure dotted key to split, so a
- *   literal property name such as `filter.name` is preserved verbatim even when
- *   a sibling like `ids[0]` is reconstructed (issue #1496).
+ *   head segment as an object/array container property AND the schema does not
+ *   declare the full key as a literal top-level property. The latter guard
+ *   protects a schema that intentionally defines both a literal dotted property
+ *   (e.g. `filter.name`) and a same-head container (e.g. `filter`): the literal
+ *   property wins and is preserved verbatim (reviewer-b P2, issue #1496). The
+ *   presence of a bracket-indexed sibling does NOT force a pure dotted key to
+ *   split, so a literal property name such as `filter.name` is preserved
+ *   verbatim even when a sibling like `ids[0]` is reconstructed.
  */
-function shouldSplitKey(key: string, containers: Set<string>): boolean {
+function shouldSplitKey(key: string, containers: Set<string>, literals: Set<string>): boolean {
   if (hasBracketIndex(key)) return true;
+  if (literals.has(key)) return false; // explicit literal property wins
   return isDottedContainerKey(key, containers);
 }
 
@@ -233,9 +248,14 @@ export function unflattenArgumentsWithSchema(
   schema?: unknown,
 ): Record<string, unknown> {
   const keys = Object.keys(args);
+  const literals = literalPropertyNames(schema);
   const containers = containerPropertyNames(schema);
   const hasBracket = keys.some((key) => hasBracketIndex(key));
-  const hasDottedContainer = keys.some((key) => isDottedContainerKey(key, containers));
-  if (!hasBracket && !hasDottedContainer) return args;
-  return reconstructFlattenedKeys(args, (key) => shouldSplitKey(key, containers));
+  // A dotted key needs splitting only if it is not a literal property AND its
+  // head is a schema container. Literal dotted properties are always preserved.
+  const hasSplittableDotted = keys.some(
+    (key) => !literals.has(key) && isDottedContainerKey(key, containers),
+  );
+  if (!hasBracket && !hasSplittableDotted) return args;
+  return reconstructFlattenedKeys(args, (key) => shouldSplitKey(key, containers, literals));
 }

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -38,7 +38,11 @@ export {
 	VERSION,
 } from "./config.ts";
 export { type BashResult, executeBashWithOperations } from "./core/bash-executor.ts";
-export { parseFlattenedKeyPath, reconstructFlattenedKeys } from "./core/flattened-tool-arguments.ts";
+export {
+  parseFlattenedKeyPath,
+  reconstructFlattenedKeys,
+  unflattenArgumentsWithSchema,
+} from "./core/flattened-tool-arguments.ts";
 export {
 	AgentSession,
 	type AgentSessionConfig,

--- a/packages/coding-agent/test/copilot-gemini-tool-arguments.test.ts
+++ b/packages/coding-agent/test/copilot-gemini-tool-arguments.test.ts
@@ -68,11 +68,23 @@ describe("unflattenGeminiToolArguments", () => {
   });
 
   it("reconstructs dotted nested object keys", () => {
+    // `metadata` is an object container in the schema, so the dotted keys are
+    // real nested paths.
+    const schema = {
+      type: "object",
+      properties: {
+        metadata: {
+          type: "object",
+          properties: { confidence: { type: "number" }, tags: { type: "array" } },
+        },
+        name: { type: "string" },
+      },
+    };
     const result = unflattenGeminiToolArguments({
       "metadata.confidence": 0.5,
       "metadata.tags[0]": "x",
       name: "n",
-    });
+    }, schema);
     expect(result).toEqual({ metadata: { confidence: 0.5, tags: ["x"] }, name: "n" });
   });
 
@@ -120,9 +132,9 @@ describe("unflattenGeminiToolArguments", () => {
 
   describe("prototype pollution safety", () => {
     it("drops a __proto__ path and never reaches Object.prototype", () => {
-      // JSON.parse keeps `__proto__` as an own property (the real wire shape),
-      // unlike an object literal which would invoke the prototype setter.
-      const args = JSON.parse('{"x[0]":"a","__proto__.polluted":"yes"}');
+      // A bracket-indexed proto-pollution attempt is split into a path, then
+      // dropped because `__proto__` is an unsafe path segment.
+      const args = JSON.parse('{"x[0]":"a","__proto__[0].polluted":"yes"}');
       const result = unflattenGeminiToolArguments(args) as Record<string, unknown>;
       expect(({} as Record<string, unknown>).polluted).toBeUndefined();
       expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
@@ -138,7 +150,9 @@ describe("unflattenGeminiToolArguments", () => {
     });
 
     it("drops constructor/prototype paths", () => {
-      const args = JSON.parse('{"a[0]":1,"constructor.prototype.polluted":"x"}');
+      // A bracket-indexed constructor.prototype attempt is split and dropped
+      // because `constructor`/`prototype` are unsafe path segments.
+      const args = JSON.parse('{"a[0]":1,"constructor.prototype[0].polluted":"x"}');
       const result = unflattenGeminiToolArguments(args) as Record<string, unknown>;
       expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
       expect(result).toEqual({ a: [1] });

--- a/packages/coding-agent/test/copilot-gemini-tool-arguments.test.ts
+++ b/packages/coding-agent/test/copilot-gemini-tool-arguments.test.ts
@@ -130,6 +130,24 @@ describe("unflattenGeminiToolArguments", () => {
     expect(result).toEqual({ task: { agent: "researcher" } });
   });
 
+  it("same-head: literal dotted property wins over container (reviewer-b P2)", () => {
+    // Schema declares BOTH a literal dotted property `filter.name` AND a
+    // container property `filter`. The literal property must win, so
+    // `filter.name` is preserved verbatim while `filter.kind` still splits.
+    const schema = {
+      type: "object",
+      properties: {
+        "filter.name": { type: "string" },
+        filter: { type: "object", properties: { kind: { type: "string" } } },
+      },
+    };
+    const result = unflattenGeminiToolArguments(
+      { "filter.name": "status", "filter.kind": "open" },
+      schema,
+    );
+    expect(result).toEqual({ "filter.name": "status", filter: { kind: "open" } });
+  });
+
   describe("prototype pollution safety", () => {
     it("drops a __proto__ path and never reaches Object.prototype", () => {
       // A bracket-indexed proto-pollution attempt is split into a path, then

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `unflattenToolArguments` is now schema-aware and no longer corrupts literal dotted top-level argument keys (issue [#1496](https://github.com/bastani-inc/atomic/issues/1496)). Bracket-indexed keys (`ids[0]`, `files[0].path`) are always reconstructed, but a purely dotted key (`filter.name`) is only split into a nested path when the tool's `inputSchema` proves its head segment is an object/array container property. The tool `inputSchema` is now threaded through from both the direct-tool and proxy/gateway `callTool` paths. The schema-aware disambiguation is shared with the host runtime via a new canonical `unflattenArgumentsWithSchema` helper in `@bastani/atomic`, so the two paths cannot drift.
+- `unflattenToolArguments` is now schema-aware and no longer corrupts literal dotted top-level argument keys (issue [#1496](https://github.com/bastani-inc/atomic/issues/1496)). Bracket-indexed keys (`ids[0]`, `files[0].path`) are always reconstructed, but a purely dotted key (`filter.name`) is only split into a nested path when the tool's `inputSchema` proves its head segment is an object/array container property **and** the schema does not declare the full dotted key as a literal top-level property. The latter guard preserves a literal property such as `filter.name` verbatim even when the schema also defines a same-head container (e.g. `filter`). The tool `inputSchema` is now threaded through from both the direct-tool and proxy/gateway `callTool` paths. The schema-aware disambiguation is shared with the host runtime via a new canonical `unflattenArgumentsWithSchema` helper in `@bastani/atomic`, so the two paths cannot drift.
 
 ## [0.9.2] - 2026-06-23
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `unflattenToolArguments` is now schema-aware and no longer corrupts literal dotted top-level argument keys (issue [#1496](https://github.com/bastani-inc/atomic/issues/1496)). Bracket-indexed keys (`ids[0]`, `files[0].path`) are always reconstructed, but a purely dotted key (`filter.name`) is only split into a nested path when the tool's `inputSchema` proves its head segment is an object/array container property. The tool `inputSchema` is now threaded through from both the direct-tool and proxy/gateway `callTool` paths. The schema-aware disambiguation is shared with the host runtime via a new canonical `unflattenArgumentsWithSchema` helper in `@bastani/atomic`, so the two paths cannot drift.
+
 ## [0.9.2] - 2026-06-23
 
 ### Changed

--- a/packages/mcp/direct-tools.ts
+++ b/packages/mcp/direct-tools.ts
@@ -371,7 +371,9 @@ export function createDirectToolExecutor(
         name: spec.originalName,
         // Normalize provider-flattened argument keys (e.g. Gemini's `keywords[0]`)
         // back into arrays/objects before the MCP server validates them.
-        arguments: unflattenToolArguments(params),
+        // Schema-aware: literal dotted property names (e.g. `filter.name`) are
+        // preserved unless the schema proves the head is a container.
+        arguments: unflattenToolArguments(params, spec.inputSchema),
         _meta: uiSession?.requestMeta,
       });
 

--- a/packages/mcp/proxy-call.ts
+++ b/packages/mcp/proxy-call.ts
@@ -288,7 +288,9 @@ export async function executeCall(
       name: toolMeta.originalName,
       // Normalize provider-flattened argument keys (e.g. Gemini's `keywords[0]`)
       // back into arrays/objects before the MCP server validates them.
-      arguments: unflattenToolArguments(args),
+      // Schema-aware: literal dotted property names (e.g. `filter.name`) are
+      // preserved unless the schema proves the head is a container.
+      arguments: unflattenToolArguments(args, toolMeta.inputSchema),
       _meta: uiSession?.requestMeta,
     });
 

--- a/packages/mcp/utils.ts
+++ b/packages/mcp/utils.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@bastani/atomic";
-import { reconstructFlattenedKeys } from "@bastani/atomic";
+import { unflattenArgumentsWithSchema } from "@bastani/atomic";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { McpConfig, ServerEntry } from "./types.ts";
@@ -140,15 +140,26 @@ export function extractToolUiStreamMode(toolMeta: Record<string, unknown> | unde
  *
  * This normalizer runs at the MCP `callTool` boundary so arguments are correct
  * regardless of how the model/provider serialized them. It is provider-agnostic
- * and **self-gating**: it is a no-op unless at least one bracket-indexed key
- * (`name[<digit>]`) is present, so well-formed arguments pass through untouched
- * (including arguments already normalized upstream by the host runtime).
+ * and schema-aware:
+ *
+ * - Bracket-indexed keys (`ids[0]`, `files[0].path`) are **always**
+ *   reconstructed — they are unambiguous.
+ * - Purely dotted keys (`parent.child`) are reconstructed only when the tool's
+ *   `inputSchema` proves their head segment is an object/array container
+ *   property. The presence of a bracket-indexed sibling does NOT force a pure
+ *   dotted key to split, so a literal property name such as `filter.name`
+ *   survives intact even when a sibling like `ids[0]` is present (issue #1496).
+ * - Otherwise dotted keys are preserved verbatim — so a literal property name
+ *   such as `filter.name` (a legitimate top-level schema property) is no longer
+ *   silently split into `{ filter: { name } }`.
+ *
+ * When no schema is supplied (the legacy call shape), bracket-indexed payloads
+ * are still reconstructed while pure dotted keys are preserved verbatim.
  */
 export function unflattenToolArguments(
   args: Record<string, unknown> | null | undefined,
+  inputSchema?: unknown,
 ): Record<string, unknown> {
   if (args === null || args === undefined) return {};
-  const keys = Object.keys(args);
-  if (!keys.some((key) => /\[\d+\]/.test(key))) return args;
-  return reconstructFlattenedKeys(args, () => true);
+  return unflattenArgumentsWithSchema(args, inputSchema);
 }

--- a/test/unit/mcp-gemini-arguments.test.ts
+++ b/test/unit/mcp-gemini-arguments.test.ts
@@ -295,4 +295,34 @@ describe("unflattenToolArguments", () => {
     const result = unflattenToolArguments(args, schema);
     assert.deepEqual(result, { "filter.name": "tony" });
   });
+
+  test("same-head disambiguation: literal dotted property wins over container (reviewer-b P2)", () => {
+    // Schema declares BOTH a literal dotted property `filter.name` AND a
+    // container property `filter`. The literal property must win, so
+    // `filter.name` is preserved verbatim while a sibling `filter.kind` (not a
+    // literal property) still splits into the container. Bracket-indexed `ids`
+    // is reconstructed as usual (issue #1496).
+    const schema = {
+      type: "object",
+      properties: {
+        "filter.name": { type: "string" },
+        filter: {
+          type: "object",
+          properties: { kind: { type: "string" } },
+        },
+        ids: { type: "array", items: { type: "string" } },
+      },
+    };
+    const args = {
+      "filter.name": "status",
+      "filter.kind": "open",
+      "ids[0]": "123",
+    };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, {
+      "filter.name": "status",
+      filter: { kind: "open" },
+      ids: ["123"],
+    });
+  });
 });

--- a/test/unit/mcp-gemini-arguments.test.ts
+++ b/test/unit/mcp-gemini-arguments.test.ts
@@ -52,12 +52,27 @@ describe("unflattenToolArguments", () => {
   });
 
   test("reconstructs flattened nested object keys (dot notation)", () => {
+    // `metadata` is an object container in the schema, so the dotted keys
+    // `metadata.confidence` and `metadata.tags[0]` are real nested paths.
+    const schema = {
+      type: "object",
+      properties: {
+        metadata: {
+          type: "object",
+          properties: {
+            confidence: { type: "number" },
+            tags: { type: "array", items: { type: "string" } },
+          },
+        },
+        name: { type: "string" },
+      },
+    };
     const result = unflattenToolArguments({
       "metadata.confidence": 0.5,
       "metadata.tags[0]": "x",
       "metadata.tags[1]": "y",
       name: "n",
-    });
+    }, schema);
     assert.deepEqual(result, {
       metadata: { confidence: 0.5, tags: ["x", "y"] },
       name: "n",
@@ -80,8 +95,9 @@ describe("unflattenToolArguments", () => {
   });
 
   test("drops __proto__ path keys and does not pollute Object.prototype", () => {
-    // JSON.parse keeps `__proto__` as an own property (the real wire shape).
-    const args = JSON.parse('{"x[0]":"a","__proto__.polluted":"yes"}');
+    // A bracket-indexed proto-pollution attempt is split into a path, then
+    // dropped because `__proto__` is an unsafe path segment.
+    const args = JSON.parse('{"x[0]":"a","__proto__[0].polluted":"yes"}');
     const result = unflattenToolArguments(args);
     assert.equal(({} as Record<string, unknown>).polluted, undefined);
     assert.equal((Object.prototype as Record<string, unknown>).polluted, undefined);
@@ -96,9 +112,187 @@ describe("unflattenToolArguments", () => {
   });
 
   test("drops constructor.prototype paths", () => {
-    const args = JSON.parse('{"a[0]":1,"constructor.prototype.polluted":"x"}');
+    // A bracket-indexed constructor.prototype attempt is split into a path and
+    // dropped because `constructor`/`prototype` are unsafe path segments.
+    const args = JSON.parse('{"a[0]":1,"constructor.prototype[0].polluted":"x"}');
     const result = unflattenToolArguments(args);
     assert.equal((Object.prototype as Record<string, unknown>).polluted, undefined);
     assert.deepEqual(result, { a: [1] });
+  });
+
+  test("literal dotted __proto__ key is preserved but does not pollute", () => {
+    // Without a schema, `__proto__.polluted` is a pure dotted key and is
+    // preserved as a literal own-property name — it does NOT traverse the
+    // prototype chain and cannot pollute Object.prototype.
+    const args = JSON.parse('{"x[0]":"a","__proto__.polluted":"yes"}');
+    const result = unflattenToolArguments(args);
+    assert.equal((Object.prototype as Record<string, unknown>).polluted, undefined);
+    assert.deepEqual(result, { x: ["a"], "__proto__.polluted": "yes" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Schema-aware dotted-key disambiguation (issue #1496)
+  // -------------------------------------------------------------------------
+
+  test("preserves a literal dotted top-level key when no schema is supplied", () => {
+    // No bracket keys, no schema: `filter.name` is ambiguous and must be left
+    // intact rather than silently split into `{ filter: { name } }`.
+    const args = { "filter.name": "tony", limit: 10 };
+    const result = unflattenToolArguments(args);
+    assert.equal(result, args);
+  });
+
+  test("preserves a literal dotted key when the schema does not mark it a container", () => {
+    // The schema declares `filter.name` as a literal string property — its head
+    // segment `filter` is NOT a container, so the key must be preserved verbatim.
+    const schema = {
+      type: "object",
+      properties: {
+        "filter.name": { type: "string" },
+        limit: { type: "number" },
+      },
+    };
+    const args = { "filter.name": "tony", limit: 10 };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, { "filter.name": "tony", limit: 10 });
+  });
+
+  test("splits a dotted key when the schema marks its head as an object container", () => {
+    // `options` is an object container in the schema, so `options.verbose` is a
+    // real nested path and must be reconstructed.
+    const schema = {
+      type: "object",
+      properties: {
+        options: {
+          type: "object",
+          properties: { verbose: { type: "boolean" }, depth: { type: "number" } },
+        },
+      },
+    };
+    const args = { "options.verbose": true, "options.depth": 3 };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, { options: { verbose: true, depth: 3 } });
+  });
+
+  test("splits a dotted key whose head is an array container in the schema", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        filters: { type: "array", items: { type: "string" } },
+      },
+    };
+    // Even without brackets, an array-typed head is a container.
+    const args = { "filters.0": "a", "filters.1": "b" };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, { filters: { "0": "a", "1": "b" } });
+  });
+
+  test("always reconstructs bracket-indexed keys regardless of schema", () => {
+    const schema = {
+      type: "object",
+      properties: { ids: { type: "array", items: { type: "number" } } },
+    };
+    const args = { "ids[0]": 1, "ids[1]": 2 };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, { ids: [1, 2] });
+  });
+
+  test("reconstructs bracket-indexed keys even without a schema", () => {
+    const args = { "ids[0]": 1, "ids[1]": 2 };
+    const result = unflattenToolArguments(args);
+    assert.deepEqual(result, { ids: [1, 2] });
+  });
+
+  test("mixed schema: preserves literal dotted key while splitting container dotted key", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        "filter.name": { type: "string" },
+        options: { type: "object", properties: { verbose: { type: "boolean" } } },
+      },
+    };
+    const args = {
+      "filter.name": "tony",
+      "options.verbose": true,
+      limit: 5,
+    };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, {
+      "filter.name": "tony",
+      options: { verbose: true },
+      limit: 5,
+    });
+  });
+
+  test("bracket keys do not force literal dotted siblings to split (issue #1496)", () => {
+    // Without a schema, `meta.confidence` is a pure dotted key and must be
+    // preserved verbatim even though a bracket sibling (`tags[0]`) is present.
+    const args = {
+      "tags[0]": "a",
+      "tags[1]": "b",
+      "meta.confidence": 0.5,
+    };
+    const result = unflattenToolArguments(args);
+    assert.deepEqual(result, {
+      tags: ["a", "b"],
+      "meta.confidence": 0.5,
+    });
+  });
+
+  test("bracket sibling + schema container proof: dotted key splits", () => {
+    // With a schema proving `meta` is an object container, `meta.confidence`
+    // splits into a nested path even alongside bracket siblings.
+    const schema = {
+      type: "object",
+      properties: {
+        tags: { type: "array", items: { type: "string" } },
+        meta: {
+          type: "object",
+          properties: { confidence: { type: "number" } },
+        },
+      },
+    };
+    const args = {
+      "tags[0]": "a",
+      "tags[1]": "b",
+      "meta.confidence": 0.5,
+    };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, {
+      tags: ["a", "b"],
+      meta: { confidence: 0.5 },
+    });
+  });
+
+  test("issue #1496 exact regression: literal dotted key preserved with bracket sibling", () => {
+    // The exact payload from the bug report: a literal top-level property
+    // `filter.name` (schema-declared string) alongside a flattened array `ids`.
+    // The bracket-indexed `ids[0]` is always reconstructed, but `filter.name`
+    // must NOT split because the schema declares it as a literal string
+    // property (its head `filter` is not a container).
+    const schema = {
+      type: "object",
+      properties: {
+        "filter.name": { type: "string" },
+        ids: { type: "array", items: { type: "string" } },
+      },
+    };
+    const result = unflattenToolArguments(
+      { "filter.name": "status", "ids[0]": "123" },
+      schema,
+    );
+    assert.deepEqual(result, { "filter.name": "status", ids: ["123"] });
+  });
+
+  test("preserves a literal dotted key that happens to share a name with a non-container prop", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        filter: { type: "string" }, // `filter` is a scalar, not a container
+      },
+    };
+    const args = { "filter.name": "tony" };
+    const result = unflattenToolArguments(args, schema);
+    assert.deepEqual(result, { "filter.name": "tony" });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a regression (issue #1496) where MCP tool arguments with literal dotted top-level property names (e.g. `filter.name`) were silently corrupted into nested objects (`{ filter: { name } }`). The fix makes key-splitting decisions per-key and schema-aware: bracket-indexed keys always reconstruct, dotted keys reconstruct only when the tool's `inputSchema` proves the head segment is an object/array container — and never when the full dotted key is itself a literal schema property.

Closes #1496

## Key Changes

- **New shared helper**: Extracted `unflattenArgumentsWithSchema` in `packages/coding-agent/src/core/flattened-tool-arguments.ts` as the canonical schema-aware unflattening implementation, exported from `@bastani/atomic`.
- **MCP boundary** (`packages/mcp/utils.ts`): `unflattenToolArguments` now delegates to `unflattenArgumentsWithSchema` and accepts an optional `inputSchema` parameter.
- **Schema threading**: `inputSchema` is now passed through both the direct-tool path (`direct-tools.ts`) and the proxy/gateway `callTool` path (`proxy-call.ts`), so the schema is available at the unflattening boundary.
- **Copilot/Gemini path** (`copilot-gemini-tool-arguments.ts`): Simplified to use the shared helper; per-key logic was de-duplicated and removed from this file.
- **Same-head disambiguation**: When a schema declares both a literal dotted property (e.g. `filter.name`) and a same-head container (e.g. `filter`), the literal property wins per-key while other dotted keys whose head is proven a container still split correctly.
- **Prototype-pollution guard**: Pure dotted `__proto__` / `constructor.prototype` keys without bracket indices are now preserved as literal own-property names rather than traversed (they cannot pollute `Object.prototype`). Bracket-indexed pollution attempts continue to be dropped by `reconstructFlattenedKeys`.
- **Test coverage**: Regression tests for literal dotted keys, bracket-indexed arrays, nested object paths, mixed literal/container schemas, same-head disambiguation, and prototype-pollution scenarios added to both `test/unit/mcp-gemini-arguments.test.ts` and `packages/coding-agent/test/copilot-gemini-tool-arguments.test.ts`.
- **Changelogs**: Updated `packages/mcp/CHANGELOG.md` and `packages/coding-agent/CHANGELOG.md` under `[Unreleased]`.

## Decision Rules (per-key)

| Key form | Schema says head is container? | Schema declares full key as literal? | Result |
|---|---|---|---|
| `ids[0]` | — | — | Always splits (bracket = unambiguous) |
| `filter.name` | No | Yes | Preserved verbatim |
| `filter.name` | Yes | Yes | Preserved verbatim (literal wins) |
| `options.verbose` | Yes | No | Splits into `{ options: { verbose } }` |
| `meta.confidence` | No | No | Preserved verbatim (ambiguous, no proof) |

## Validation

- `bun test test/unit/mcp-gemini-arguments.test.ts`
- `bun test packages/coding-agent/test/copilot-gemini-tool-arguments.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run check:file-length`
- Commit hook (`bun run test:unit`)

## Notes

This is non-UI MCP/library argument-normalization behavior. No E2E video applicable; correctness is fully verified by the targeted unit tests and the exact issue regression case.