### PR TITLE
docs(changelog): add 0.9.3-alpha.1 release notes across all packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.1] - 2026-06-25
+
 ### Breaking Changes
 
 - Replaced the previous exact-replacement `edit` input shape with the hashline-only `input` script schema; `path` + `edits[]` and top-level `oldText`/`newText` edit calls are no longer accepted ([#1483](https://github.com/bastani-inc/atomic/issues/1483)).
@@ -56,7 +58,6 @@
 - Addressed follow-up PR review findings by making hashline snapshot collision handling compare full snapshot text before treating 4-hex tags as identities, extending URL SSRF detection to the full IPv6 link-local `fe80::/10` range plus IPv4-compatible IPv6 forms, re-checking bash interceptor rules after `spawnHook` rewrites, surfacing search pagination collection caps without duplicate continuation banners, preserving truncated async bash output in a recoverable `fullOutputPath`, and passing per-path native search-cache invalidations through to the native binding ([#1490](https://github.com/bastani-inc/atomic/pull/1490)).
 - Addressed the latest PR review hardening pass by counting multi-file search per-file caps by match lines instead of context lines, making native filesystem scan cache insertion generation-aware so in-flight scans cannot repopulate after invalidation, rejecting SQLite raw-query `pragma_*` table-valued functions and double-quoted internal-name splices, and bounds-checking zip central-directory offsets during selective archive writes ([#1490](https://github.com/bastani-inc/atomic/pull/1490)).
 - Addressed the final PR review hardening pass by restoring header-only copied-hashline writes to their snapshot content instead of emptying files, decoding and sanitizing async bash output with a streaming UTF-8 decoder, cleaning up async bash temp output files on eviction/TTL, invalidating native search caches after bash commands, keeping URL protocol validation outside the private-read escape hatch, documenting single-file search skip handling, preserving CR-only hashline edit line endings, rejecting selective zip writes that would drop data descriptors, and exposing `search` in extension `tool_call`/`tool_result` type guards like other builtins ([#1490](https://github.com/bastani-inc/atomic/pull/1490)).
-
 
 ## [0.9.2] - 2026-06-23
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3-alpha.1] - 2026-06-25
+
 ### Fixed
 
 - `unflattenToolArguments` is now schema-aware and no longer corrupts literal dotted top-level argument keys (issue [#1496](https://github.com/bastani-inc/atomic/issues/1496)). Bracket-indexed keys (`ids[0]`, `files[0].path`) are always reconstructed, but a purely dotted key (`filter.name`) is only split into a nested path when the tool's `inputSchema` proves its head segment is an object/array container property **and** the schema does not declare the full dotted key as a literal top-level property. The latter guard preserves a literal property such as `filter.name` verbatim even when the schema also defines a same-head container (e.g. `filter`). The tool `inputSchema` is now threaded through from both the direct-tool and proxy/gateway `callTool` paths. The schema-aware disambiguation is shared with the host runtime via a new canonical `unflattenArgumentsWithSchema` helper in `@bastani/atomic`, so the two paths cannot drift.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.1] - 2026-06-25
+
 ### Added
 
 - Added a Rust-backed `PtySession` N-API surface using `portable-pty`, enabling Atomic's `bash` tool to execute `pty: true` calls through a real PTY/ConPTY with output streaming, resize, kill, timeout, shell, cwd, and environment support ([#1483](https://github.com/bastani-inc/atomic/issues/1483)).

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.1] - 2026-06-25
+
 ### Changed
 
 - Raised the default and hard maximum subagent nesting budget to five delegated levels, clamping environment, config, and frontmatter values above `5` and extending nested-run observability to the same depth.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.3-alpha.1] - 2026-06-25
+
 ### Changed
 
 - Revised the builtin `goal` worker/continuation prompts and the builtin `ralph` orchestrator prompts to emphasize implementing the requested task through full completion ("do not stop until the objective is complete") instead of preparing a partial implementation for incremental review.


### PR DESCRIPTION
## Summary

Adds changelog entries for the `0.9.3-alpha.1` prerelease across all packages. No package version files are modified — \`main\` remains versionless at \`0.0.0\`. The real version is materialized only on the off-\`main\` tag commit produced by \`scripts/cut-release.ts\`.

## Key changes by package

### \`@bastani/atomic\` (coding-agent)

**Breaking Changes**
- Replaced the previous exact-replacement \`edit\` input shape with a hashline-only \`input\` script schema; \`path\` + \`edits[]\` and top-level \`oldText\`/\`newText\` edit calls are no longer accepted ([#1483](https://github.com/bastani-inc/atomic/issues/1483)).

**Added**
- PTY support: \`bash\` tool now accepts \`pty: true\` to run commands through a real PTY/ConPTY via the new Rust-backed \`PtySession\` N-API surface (streaming output, resize, kill, timeout, cwd, env) ([#1483](https://github.com/bastani-inc/atomic/issues/1483)).
- Glob tool enhancements: \`.gitignore\`-aware filtering, \`limit\`/\`offset\` pagination, and \`--follow\` symlink support ([#1483](https://github.com/bastani-inc/atomic/issues/1483)).
- Unified search tool with per-file match caps, context-line counts, and native filesystem scan integration ([#1490](https://github.com/bastani-inc/atomic/pull/1490)).
- Multi-file search with path and content filtering, zip/archive inspection, and PDF text extraction ([#1490](https://github.com/bastani-inc/atomic/pull/1490)).
- Schema-aware MCP argument unflattening (shared \`unflattenArgumentsWithSchema\` helper) so literal dotted keys are not corrupted by proxy/gateway \`callTool\` paths.

**Security / Hardening**
- Native filesystem scan cache is now generation-aware (prevents in-flight scans from repopulating after invalidation).
- SQLite raw-query guard rejects \`pragma_*\` table-valued functions and double-quoted internal-name splices.
- Zip central-directory offset bounds-checking during selective archive writes.
- Async bash output decoded with a streaming UTF-8 decoder; temp output files cleaned up on eviction/TTL.

### \`@bastani/mcp\`

- \`unflattenToolArguments\` is now schema-aware: bracket-indexed keys (\`ids[0]\`, \`files[0].path\`) are always reconstructed, but purely dotted keys (\`filter.name\`) are only split when the tool's \`inputSchema\` confirms the head segment is an object/array container — preserving literal dotted top-level properties verbatim ([#1496](https://github.com/bastani-inc/atomic/issues/1496)).

### \`@bastani/natives\`

- New Rust-backed \`PtySession\` N-API surface using \`portable-pty\`, powering the \`bash\` tool's \`pty: true\` execution path.

### \`@bastani/subagents\`

- Raised the default and hard maximum subagent nesting budget from 3 to 5 delegated levels; environment, config, and frontmatter values above \`5\` are clamped, and nested-run observability extends to the same depth.

### \`@bastani/workflows\`

- Revised the builtin \`goal\` worker/continuation prompts and the \`ralph\` orchestrator prompts to emphasize full task completion ("do not stop until the objective is complete") rather than partial implementations staged for incremental review.

## Migration notes

- **\`edit\` tool input shape is breaking**: callers using \`path\` + \`edits[]\` or top-level \`oldText\`/\`newText\` must migrate to the new hashline-only \`input\` script schema.

## Validation

- `git branch --show-current` → `prerelease/0.9.3-alpha.1`
- `git rev-parse HEAD` → `3400e8c1f12971cc5f30b5f6a30e5c91b9399d7d`
- `git status --short` → clean
- `git diff --name-only 24dab9706dc3ede25406760d6271d661f442c054..HEAD` → expected changelog files only
- `bun run typecheck` → passed
- `bun run test:unit` → passed