### PR TITLE
fix(session): harden tool-call/result replay integrity and subagent dispatch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed custom tool renderer disposal to honor renderer-owned cleanup callbacks, preventing stale animation registry entries after terminal workflow tool rows are finalized ([#1518](https://github.com/bastani-inc/atomic/issues/1518)).
+- Hardened session replay and LLM conversion so persisted context-compaction filters cannot leave orphaned `toolResult` messages after deleting their paired assistant `toolCall`, preventing GitHub Copilot Claude/Anthropic replay failures after repeated subagent runs ([#1527](https://github.com/bastani-inc/atomic/issues/1527)).
 
 ## [0.9.3-alpha.1] - 2026-06-25
 

--- a/packages/coding-agent/docs/compaction.md
+++ b/packages/coding-agent/docs/compaction.md
@@ -60,6 +60,8 @@ Verbatim Compaction never asks a model to rewrite the conversation for the main 
 
 Replay-sensitive assistant messages that contain `thinking` or `redacted_thinking` blocks are all-or-nothing: Atomic may delete an old thinking-bearing assistant entry when dependency validation allows it, but it will not delete individual sibling blocks from a retained thinking-bearing assistant message. This keeps Anthropic/GitHub Copilot extended-thinking replay byte-for-byte compatible with provider requirements.
 
+Tool-call/tool-result pairs are also treated as replay dependencies. Validation repairs fresh deletion plans so deleting one side deletes or preserves the paired side consistently, and active-context rebuild applies the same invariant to persisted `context_compaction` entries from older sessions. As a final provider-safety guard, orphaned `toolResult` messages are dropped before LLM serialization if their matching assistant `toolCall` is no longer the immediately preceding tool-use group.
+
 Atomic records those targets in an append-only `context_compaction` entry. When the active branch is rebuilt, Atomic filters the targeted objects out and reuses every retained entry/content block unchanged. There is no generated summary, no paraphrasing, and no replacement message inserted.
 
 The raw session JSONL remains append-only. Deleted objects stay available in the stored session file and backup snapshot; they are only omitted from future active LLM context on that branch.

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -111,6 +111,49 @@ export function createCustomMessage(
 	return message;
 }
 
+function collectAssistantToolCallIds(message: Message): Set<string> {
+	const content = (message as { content?: unknown }).content;
+	const ids = new Set<string>();
+	if (!Array.isArray(content)) return ids;
+	for (const block of content) {
+		if (!block || typeof block !== "object") continue;
+		const candidate = block as { type?: unknown; id?: unknown };
+		if (candidate.type === "toolCall" && typeof candidate.id === "string") ids.add(candidate.id);
+	}
+	return ids;
+}
+
+function getToolResultCallId(message: Message): string | undefined {
+	if (message.role !== "toolResult") return undefined;
+	const toolCallId = (message as { toolCallId?: unknown }).toolCallId;
+	return typeof toolCallId === "string" ? toolCallId : undefined;
+}
+
+export function repairOrphanToolResults(messages: Message[]): Message[] {
+	let allowedToolCallIds: Set<string> | undefined;
+	let changed = false;
+	const repaired: Message[] = [];
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			allowedToolCallIds = collectAssistantToolCallIds(message);
+			repaired.push(message);
+			continue;
+		}
+		if (message.role === "toolResult") {
+			const toolCallId = getToolResultCallId(message);
+			if (toolCallId && allowedToolCallIds?.has(toolCallId)) {
+				repaired.push(message);
+				continue;
+			}
+			changed = true;
+			continue;
+		}
+		allowedToolCallIds = undefined;
+		repaired.push(message);
+	}
+	return changed ? repaired : messages;
+}
+
 /**
  * Transform AgentMessages (including custom types) to LLM-compatible Messages.
  *
@@ -120,7 +163,7 @@ export function createCustomMessage(
  * - Custom extensions and tools
  */
 export function convertToLlm(messages: AgentMessage[]): Message[] {
-	return messages
+	const converted = messages
 		.map((m): Message | undefined => {
 			switch (m.role) {
 				case "bashExecution":
@@ -167,4 +210,5 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 			}
 		})
 		.filter((m) => m !== undefined);
+	return repairOrphanToolResults(converted);
 }

--- a/packages/coding-agent/src/core/session-manager-history.ts
+++ b/packages/coding-agent/src/core/session-manager-history.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { createBranchSummaryMessage, createCustomMessage } from "./messages.ts";
 import { contentArrayHasAssistantThinkingBlock } from "./thinking-blocks.ts";
+import { reconcilePersistedToolDependencyFilters } from "./session-manager-tool-dependencies.ts";
 import type {
 	ContextCompactionEntry,
 	ContextDeletionFilters,
@@ -168,7 +169,7 @@ export function buildEffectiveContextDeletionFilters(path: SessionEntry[]): Cont
 		}
 	}
 
-	return effectiveFilters;
+	return reconcilePersistedToolDependencyFilters(path, effectiveFilters);
 }
 
 function filterContentArray<T>(content: T[], deletedBlocks: ReadonlySet<number>): T[] {

--- a/packages/coding-agent/src/core/session-manager-tool-dependencies.ts
+++ b/packages/coding-agent/src/core/session-manager-tool-dependencies.ts
@@ -97,6 +97,13 @@ function restoreResultEntry(filters: ContextDeletionFilters, entryId: string): b
 	return hadEntryDeletion || hadBlockDeletion;
 }
 
+/**
+ * Reconcile persisted context-compaction filters in place so replay never
+ * retains only one side of a tool-call/tool-result pair. Callers should pass a
+ * fresh, unshared filter set; this mutates and returns that same object. The
+ * fixpoint normally converges in one or two passes, while the bounded pass
+ * count is only a non-termination backstop for malformed historical sessions.
+ */
 export function reconcilePersistedToolDependencyFilters(
 	path: SessionEntry[],
 	filters: ContextDeletionFilters,

--- a/packages/coding-agent/src/core/session-manager-tool-dependencies.ts
+++ b/packages/coding-agent/src/core/session-manager-tool-dependencies.ts
@@ -1,0 +1,145 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { contentArrayHasAssistantThinkingBlock } from "./thinking-blocks.ts";
+import type { ContextDeletionFilters, SessionEntry, SessionMessageEntry } from "./session-manager-types.ts";
+
+interface ToolCallReference {
+	entry: SessionMessageEntry;
+	blockIndex: number;
+	hasThinkingContent: boolean;
+}
+
+interface ToolResultReference {
+	entry: SessionMessageEntry;
+}
+
+function getMessageContent(message: AgentMessage): readonly unknown[] | undefined {
+	return "content" in message && Array.isArray(message.content) ? message.content : undefined;
+}
+
+function getToolCallContentBlockId(block: unknown): string | undefined {
+	if (!block || typeof block !== "object") return undefined;
+	const candidate = block as { type?: unknown; id?: unknown };
+	return candidate.type === "toolCall" && typeof candidate.id === "string" ? candidate.id : undefined;
+}
+
+function getToolResultCallId(message: AgentMessage): string | undefined {
+	if (message.role !== "toolResult") return undefined;
+	const toolCallId = (message as { toolCallId?: unknown }).toolCallId;
+	return typeof toolCallId === "string" ? toolCallId : undefined;
+}
+
+function collectToolReferences(path: SessionEntry[]): {
+	callsById: Map<string, ToolCallReference[]>;
+	resultsByCallId: Map<string, ToolResultReference[]>;
+} {
+	const callsById = new Map<string, ToolCallReference[]>();
+	const resultsByCallId = new Map<string, ToolResultReference[]>();
+	for (const entry of path) {
+		if (entry.type !== "message") continue;
+		if (entry.message.role === "assistant") {
+			const content = getMessageContent(entry.message);
+			if (!content) continue;
+			const hasThinkingContent = contentArrayHasAssistantThinkingBlock(entry.message.content);
+			for (const [blockIndex, block] of content.entries()) {
+				const callId = getToolCallContentBlockId(block);
+				if (!callId) continue;
+				const refs = callsById.get(callId) ?? [];
+				refs.push({ entry, blockIndex, hasThinkingContent });
+				callsById.set(callId, refs);
+			}
+			continue;
+		}
+		const resultCallId = getToolResultCallId(entry.message);
+		if (!resultCallId) continue;
+		const refs = resultsByCallId.get(resultCallId) ?? [];
+		refs.push({ entry });
+		resultsByCallId.set(resultCallId, refs);
+	}
+	return { callsById, resultsByCallId };
+}
+
+function isMessageEntryEffectivelyDeleted(entry: SessionMessageEntry, filters: ContextDeletionFilters): boolean {
+	if (filters.deletedEntryIds.has(entry.id)) return true;
+	const deletedBlocks = filters.deletedContentBlocks.get(entry.id);
+	if (!deletedBlocks || deletedBlocks.size === 0) return false;
+	const content = getMessageContent(entry.message);
+	return content !== undefined && content.length > 0 && content.every((_block, index) => deletedBlocks.has(index));
+}
+
+function isToolCallDeleted(ref: ToolCallReference, filters: ContextDeletionFilters): boolean {
+	if (isMessageEntryEffectivelyDeleted(ref.entry, filters)) return true;
+	return filters.deletedContentBlocks.get(ref.entry.id)?.has(ref.blockIndex) === true;
+}
+
+function isToolResultDeleted(ref: ToolResultReference, filters: ContextDeletionFilters): boolean {
+	return isMessageEntryEffectivelyDeleted(ref.entry, filters);
+}
+
+function addEntryDeletion(filters: ContextDeletionFilters, entryId: string): boolean {
+	if (filters.deletedEntryIds.has(entryId)) return false;
+	filters.deletedEntryIds.add(entryId);
+	filters.deletedContentBlocks.delete(entryId);
+	return true;
+}
+
+function addToolCallDeletion(filters: ContextDeletionFilters, ref: ToolCallReference): boolean {
+	if (filters.deletedEntryIds.has(ref.entry.id)) return false;
+	const deletedBlocks = filters.deletedContentBlocks.get(ref.entry.id) ?? new Set<number>();
+	if (deletedBlocks.has(ref.blockIndex)) return false;
+	deletedBlocks.add(ref.blockIndex);
+	filters.deletedContentBlocks.set(ref.entry.id, deletedBlocks);
+	return true;
+}
+
+function restoreResultEntry(filters: ContextDeletionFilters, entryId: string): boolean {
+	const hadEntryDeletion = filters.deletedEntryIds.delete(entryId);
+	const hadBlockDeletion = filters.deletedContentBlocks.delete(entryId);
+	return hadEntryDeletion || hadBlockDeletion;
+}
+
+export function reconcilePersistedToolDependencyFilters(
+	path: SessionEntry[],
+	filters: ContextDeletionFilters,
+): ContextDeletionFilters {
+	const { callsById, resultsByCallId } = collectToolReferences(path);
+	if (callsById.size === 0 || resultsByCallId.size === 0) return filters;
+
+	let changed = true;
+	let remainingPasses = Math.max(1, path.length * 2);
+	while (changed && remainingPasses > 0) {
+		changed = false;
+		remainingPasses -= 1;
+
+		for (const [callId, callRefs] of callsById) {
+			const resultRefs = resultsByCallId.get(callId) ?? [];
+			if (resultRefs.length === 0) continue;
+			const callDeleted = callRefs.every((ref) => isToolCallDeleted(ref, filters));
+			if (callDeleted) {
+				for (const resultRef of resultRefs) {
+					if (!isToolResultDeleted(resultRef, filters)) {
+						changed = addEntryDeletion(filters, resultRef.entry.id) || changed;
+					}
+				}
+				continue;
+			}
+
+			for (const resultRef of resultRefs) {
+				if (!isToolResultDeleted(resultRef, filters)) continue;
+				const retainedThinkingCall = callRefs.some(
+					(ref) => ref.hasThinkingContent && !isToolCallDeleted(ref, filters),
+				);
+				if (retainedThinkingCall) {
+					changed = restoreResultEntry(filters, resultRef.entry.id) || changed;
+					continue;
+				}
+				for (const callRef of callRefs) {
+					if (!isToolCallDeleted(callRef, filters)) {
+						changed = addToolCallDeletion(filters, callRef) || changed;
+					}
+				}
+			}
+		}
+	}
+
+	return filters;
+}

--- a/packages/coding-agent/test/messages.test.ts
+++ b/packages/coding-agent/test/messages.test.ts
@@ -1,0 +1,59 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import { convertToLlm } from "../src/core/messages.ts";
+
+function assistantWithToolCalls(ids: string[]): AssistantMessage {
+	return {
+		role: "assistant",
+		content: ids.map((id) => ({ type: "toolCall" as const, id, name: "read", arguments: { path: `${id}.ts` } })),
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 1,
+	};
+}
+
+function toolResult(toolCallId: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [{ type: "text", text: `result for ${toolCallId}` }],
+		isError: false,
+		timestamp: 1,
+	};
+}
+
+describe("convertToLlm tool-result repair", () => {
+	test("keeps consecutive results paired with the previous assistant tool calls", () => {
+		const converted = convertToLlm([
+			assistantWithToolCalls(["call-a", "call-b"]),
+			toolResult("call-a"),
+			toolResult("call-b"),
+		]);
+
+		expect(converted.map((message) => message.role)).toEqual(["assistant", "toolResult", "toolResult"]);
+	});
+
+	test("drops orphaned tool results before provider serialization", () => {
+		const converted = convertToLlm([
+			{ role: "user", content: "hello", timestamp: 1 } as AgentMessage,
+			toolResult("missing-call"),
+			assistantWithToolCalls(["call-a"]),
+			{ role: "user", content: "intervening user", timestamp: 1 } as AgentMessage,
+			toolResult("call-a"),
+		]);
+
+		expect(converted.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
+	});
+});

--- a/packages/coding-agent/test/session-manager/build-context-02.suite.ts
+++ b/packages/coding-agent/test/session-manager/build-context-02.suite.ts
@@ -87,6 +87,26 @@ function toolResultMessage(toolCallId: string, text: string): ToolResultMessage 
 	};
 }
 
+function assistantToolCallMessage(toolCallId: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "old.ts" } }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-test",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 1,
+	};
+}
+
 function branchSummary(id: string, parentId: string | null, summary: string, fromId: string): BranchSummaryEntry {
 	return { type: "branch_summary", id, parentId, timestamp: "2025-01-01T00:00:00Z", summary, fromId };
 }
@@ -194,6 +214,56 @@ describe("buildSessionContext", () => {
 
 			expect(rebuiltAssistant?.content).toEqual([{ type: "text", text: "retain this note" }]);
 			expect(ctx.messages.some((message) => message.role === "toolResult")).toBe(false);
+		});
+		it("drops paired results when persisted compaction removes only non-thinking tool calls", () => {
+			const toolCallId = "toolu_split_call";
+			const task = msg("1", null, "user", "inspect old file");
+			const assistant = messageEntry("2", "1", {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "retain this note" },
+					{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "old.ts" } },
+				],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-test",
+				usage: {
+					input: 1,
+					output: 1,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: 1,
+			} as AssistantMessage);
+			const result = messageEntry("3", "2", toolResultMessage(toolCallId, "old file contents"));
+			const staleCompaction = contextCompaction("4", "3", [
+				{ kind: "content_block", entryId: assistant.id, blockIndex: 1 },
+			]);
+
+			const ctx = buildSessionContext([task, assistant, result, staleCompaction]);
+			const rebuiltAssistant = ctx.messages.find(
+				(message): message is AssistantMessage => message.role === "assistant",
+			);
+
+			expect(rebuiltAssistant?.content).toEqual([{ type: "text", text: "retain this note" }]);
+			expect(ctx.messages.some((message) => message.role === "toolResult")).toBe(false);
+		});
+		it("drops paired results when persisted compaction removes only tool-call entries", () => {
+			const toolCallId = "toolu_deleted_entry_call";
+			const task = msg("1", null, "user", "inspect old file");
+			const assistant = messageEntry("2", "1", {
+				...assistantToolCallMessage(toolCallId),
+				content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "old.ts" } }],
+			});
+			const result = messageEntry("3", "2", toolResultMessage(toolCallId, "old file contents"));
+			const staleCompaction = contextCompaction("4", "3", [{ kind: "entry", entryId: assistant.id }]);
+
+			const ctx = buildSessionContext([task, assistant, result, staleCompaction]);
+
+			expect(ctx.messages.map((message) => message.role)).toEqual(["user"]);
 		});
 		it("uses last entry when leafId not found", () => {
 			const entries: SessionEntry[] = [msg("1", null, "user", "hello"), msg("2", "1", "assistant", "hi")];

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Prevented the async subagent status widget from briefly unmounting during reset-and-hydrate cycles when active background runs are still present, including Atomic host updates that deliver fresh UI context wrappers for the same logical session ([#1517](https://github.com/bastani-inc/atomic/issues/1517)).
 - Fixed live subagent result animation cleanup to register a host-row disposer, so terminal workflow cleanup evicts animation registry entries instead of only clearing intervals ([#1518](https://github.com/bastani-inc/atomic/issues/1518)).
+- Synced recent upstream subagent hardening so compact delegated tool-call summaries are preserved, fanout children keep their live nested subagent call/result history, duplicate concurrent subagent dispatches are rejected, provider-hostile chain schema conditionals are removed, and failed foreground runs include captured child output for diagnostics ([#1527](https://github.com/bastani-inc/atomic/issues/1527)).
 
 ## [0.9.3-alpha.1] - 2026-06-25
 

--- a/packages/subagents/src/extension/fanout-child.ts
+++ b/packages/subagents/src/extension/fanout-child.ts
@@ -34,6 +34,7 @@ export function createChildSafeState(): SubagentState {
 		baseCwd: "",
 		currentSessionId: null,
 		asyncJobs: new Map(),
+		subagentInProgress: false,
 		foregroundRuns: new Map(),
 		foregroundControls: new Map(),
 		lastForegroundControlId: null,

--- a/packages/subagents/src/extension/index.ts
+++ b/packages/subagents/src/extension/index.ts
@@ -179,6 +179,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		baseCwd: "",
 		currentSessionId: null,
 		asyncJobs: new Map(),
+		subagentInProgress: false,
 		foregroundRuns: new Map(),
 		foregroundControls: new Map(),
 		lastForegroundControlId: null,

--- a/packages/subagents/src/extension/schemas.ts
+++ b/packages/subagents/src/extension/schemas.ts
@@ -137,11 +137,6 @@ const ChainItem = Type.Object({
 }, {
 	description: "Chain step: use {agent, task?, ...} for sequential, {parallel: [...]} for static concurrent execution, or {expand, parallel: {...}, collect} for dynamic fanout.",
 	additionalProperties: false,
-	allOf: [
-		{ if: { required: ["expand"] }, then: { required: ["parallel", "collect"], properties: { parallel: { type: "object" } } } },
-		{ if: { required: ["collect"] }, then: { required: ["expand", "parallel"], properties: { parallel: { type: "object" } } } },
-		{ not: { required: ["expand"], properties: { parallel: { type: "array", items: {} } } } },
-	],
 });
 
 const ControlOverrides = Type.Object({

--- a/packages/subagents/src/runs/foreground/subagent-executor-single.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-single.ts
@@ -25,10 +25,24 @@ import {
 	wrapForkTask,
 	type AgentProgress,
 	type ArtifactPaths,
+	type SingleResult,
 	type SubagentToolResult,
 } from "../../shared/types.ts";
 import type { ExecutionContextData, ResolvedExecutorDeps } from "./subagent-executor-types.ts";
 import { createForegroundControlNotifier, maybeBuildForegroundIntercomReceipt, rememberForegroundRun } from "./subagent-executor-status.ts";
+
+function formatFailedSingleRunOutput(result: SingleResult, displayOutput: string): string {
+	const error = result.error || "Failed";
+	const output = displayOutput.trim();
+	const lines = [error];
+	if (output && output !== error.trim()) {
+		lines.push("", "Output:", output);
+	}
+	if (result.artifactPaths?.outputPath) {
+		lines.push("", `Output artifact: ${result.artifactPaths.outputPath}`);
+	}
+	return lines.join("\n");
+}
 
 export async function runSinglePath(data: ExecutionContextData, deps: ResolvedExecutorDeps): Promise<SubagentToolResult> {
 	const {
@@ -309,7 +323,7 @@ export async function runSinglePath(data: ExecutionContextData, deps: ResolvedEx
 
 	if (r.exitCode !== 0)
 		return {
-			content: [{ type: "text", text: r.error || "Failed" }],
+			content: [{ type: "text", text: formatFailedSingleRunOutput(r, finalizedOutput.displayOutput) }],
 			details,
 			isError: true,
 		};

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -172,6 +172,23 @@ async function handleInterruptRequest(input: {
 	};
 }
 
+function inferExecutionMode(params: SubagentParamsLike): "single" | "parallel" | "chain" {
+	if ((params.chain?.length ?? 0) > 0) return "chain";
+	if ((params.tasks?.length ?? 0) > 0) return "parallel";
+	return "single";
+}
+
+function duplicateSubagentCallResult(params: SubagentParamsLike): SubagentToolResult {
+	return {
+		content: [{
+			type: "text",
+			text: "Rejected: a subagent call is already in progress. Issue exactly ONE subagent call per turn.",
+		}],
+		isError: true,
+		details: { mode: inferExecutionMode(params), results: [] },
+	};
+}
+
 export function createSubagentExecutor(rawDeps: ExecutorDeps): {
 	execute: (
 		id: string,
@@ -249,5 +266,22 @@ export function createSubagentExecutor(rawDeps: ExecutorDeps): {
 		}, prepared.effectiveParams.context);
 	};
 
-	return { execute };
+	const executeWithSingleDispatchGuard = async (
+		id: string,
+		params: SubagentParamsLike,
+		signal: AbortSignal,
+		onUpdate: ((r: SubagentToolResult) => void) | undefined,
+		ctx: ExtensionContext,
+	): Promise<SubagentToolResult> => {
+		if (params.action) return execute(id, params, signal, onUpdate, ctx);
+		if (deps.state.subagentInProgress === true) return duplicateSubagentCallResult(params);
+		deps.state.subagentInProgress = true;
+		try {
+			return await execute(id, params, signal, onUpdate, ctx);
+		} finally {
+			deps.state.subagentInProgress = false;
+		}
+	};
+
+	return { execute: executeWithSingleDispatchGuard };
 }

--- a/packages/subagents/src/runs/shared/subagent-prompt-runtime.ts
+++ b/packages/subagents/src/runs/shared/subagent-prompt-runtime.ts
@@ -31,6 +31,7 @@ export const CHILD_FANOUT_BOUNDARY_INSTRUCTIONS = [
 const PARENT_ONLY_CUSTOM_MESSAGE_TYPES = new Set([
 	"subagent-orchestration-instructions",
 	"subagent-slash-result",
+	"subagent-slash-text-result",
 	"subagent-notify",
 	"subagent_control_notice",
 	"subagent-control",
@@ -130,14 +131,15 @@ function stripAssistantSubagentToolCallBlocks(message: unknown): unknown | undef
 }
 
 export function stripParentOnlySubagentMessages(messages: unknown[]): unknown[] {
+	const preserveCurrentFanoutToolHistory = process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1";
 	let changed = false;
 	const filtered: unknown[] = [];
 	for (const message of messages) {
-		if (isParentOnlySubagentMessage(message) || isSubagentToolResultMessage(message)) {
+		if (isParentOnlySubagentMessage(message) || (!preserveCurrentFanoutToolHistory && isSubagentToolResultMessage(message))) {
 			changed = true;
 			continue;
 		}
-		const stripped = stripAssistantSubagentToolCallBlocks(message);
+		const stripped = preserveCurrentFanoutToolHistory ? message : stripAssistantSubagentToolCallBlocks(message);
 		if (stripped === undefined) {
 			changed = true;
 			continue;

--- a/packages/subagents/src/shared/types-async.ts
+++ b/packages/subagents/src/shared/types-async.ts
@@ -230,6 +230,7 @@ export interface SubagentState {
 	baseCwd: string;
 	currentSessionId: string | null;
 	asyncJobs: Map<string, AsyncJobState>;
+	subagentInProgress?: boolean;
 	foregroundRuns?: Map<string, ForegroundResumeRun>;
 	foregroundControls: Map<string, {
 		runId: string;

--- a/packages/subagents/src/slash/prompt-template-bridge.ts
+++ b/packages/subagents/src/slash/prompt-template-bridge.ts
@@ -213,35 +213,31 @@ function resolveProgressModel(
 	return firstWithModel?.model;
 }
 
-function toolCallNameFromSummary(summary: { text?: string; expandedText?: string }): string | undefined {
+function toolCallSummaryText(summary: { text?: string; expandedText?: string }): string | undefined {
 	const text = typeof summary.expandedText === "string" && summary.expandedText.trim().length > 0
 		? summary.expandedText.trim()
 		: typeof summary.text === "string"
 			? summary.text.trim()
 			: "";
-	if (!text) return undefined;
-	if (text.startsWith("$ ")) return "bash";
-	return text.match(/^[A-Za-z_][\w.-]*/)?.[0];
+	return text || undefined;
 }
 
 function buildDelegationMessages(
 	result: { messages?: unknown[]; finalOutput?: string; toolCalls?: Array<{ text?: string; expandedText?: string }> },
 	fallbackText?: string,
 ): unknown[] {
-	const toolCallParts = (result.toolCalls ?? []).flatMap((summary) => {
-		const name = toolCallNameFromSummary(summary);
-		return name ? [{ type: "toolCall", name, arguments: { summary: summary.expandedText ?? summary.text ?? "" } }] : [];
-	});
 	if (Array.isArray(result.messages) && result.messages.length > 0) return result.messages;
+	const toolCallSummaries = (result.toolCalls ?? []).flatMap((summary) => {
+		const text = toolCallSummaryText(summary);
+		return text ? [`- ${text}`] : [];
+	});
+	const toolCallText = toolCallSummaries.length > 0 ? `Tool calls:\n${toolCallSummaries.join("\n")}` : undefined;
 	const text = typeof result.finalOutput === "string" && result.finalOutput.trim().length > 0
 		? result.finalOutput.trim()
 		: fallbackText;
-	const content = [
-		...toolCallParts,
-		...(text ? [{ type: "text", text }] : []),
-	];
-	if (content.length === 0) return [];
-	return [{ role: "assistant", content }];
+	const contentText = [toolCallText, text].filter((part): part is string => Boolean(part)).join("\n\n");
+	if (!contentText) return [];
+	return [{ role: "assistant", content: [{ type: "text", text: contentText }] }];
 }
 
 function toDelegationUpdate(requestId: string, update: PromptTemplateBridgeResult): PromptTemplateDelegationUpdate | undefined {

--- a/packages/subagents/src/slash/prompt-template-bridge.ts
+++ b/packages/subagents/src/slash/prompt-template-bridge.ts
@@ -82,6 +82,7 @@ interface PromptTemplateBridgeResult {
 			exitCode?: number;
 			error?: string;
 			model?: string;
+			toolCalls?: Array<{ text?: string; expandedText?: string }>;
 		}>;
 		progress?: Array<{
 			index?: number;
@@ -147,10 +148,13 @@ function parsePromptTemplateRequest(data: unknown): PromptTemplateDelegationRequ
 	if (!hasSingle && tasks.length === 0) return undefined;
 
 	const fallbackTask = tasks[0];
+	const agent = hasSingle ? value.agent : fallbackTask?.agent;
+	const task = hasSingle ? value.task : fallbackTask?.task;
+	if (!agent || !task) return undefined;
 	return {
 		requestId: value.requestId,
-		agent: hasSingle ? value.agent : fallbackTask!.agent,
-		task: hasSingle ? value.task : fallbackTask!.task,
+		agent,
+		task,
 		...(tasks.length > 0 ? { tasks } : {}),
 		context: value.context,
 		model: value.model,
@@ -209,13 +213,35 @@ function resolveProgressModel(
 	return firstWithModel?.model;
 }
 
-function buildDelegationMessages(result: { messages?: unknown[]; finalOutput?: string }, fallbackText?: string): unknown[] {
+function toolCallNameFromSummary(summary: { text?: string; expandedText?: string }): string | undefined {
+	const text = typeof summary.expandedText === "string" && summary.expandedText.trim().length > 0
+		? summary.expandedText.trim()
+		: typeof summary.text === "string"
+			? summary.text.trim()
+			: "";
+	if (!text) return undefined;
+	if (text.startsWith("$ ")) return "bash";
+	return text.match(/^[A-Za-z_][\w.-]*/)?.[0];
+}
+
+function buildDelegationMessages(
+	result: { messages?: unknown[]; finalOutput?: string; toolCalls?: Array<{ text?: string; expandedText?: string }> },
+	fallbackText?: string,
+): unknown[] {
+	const toolCallParts = (result.toolCalls ?? []).flatMap((summary) => {
+		const name = toolCallNameFromSummary(summary);
+		return name ? [{ type: "toolCall", name, arguments: { summary: summary.expandedText ?? summary.text ?? "" } }] : [];
+	});
 	if (Array.isArray(result.messages) && result.messages.length > 0) return result.messages;
 	const text = typeof result.finalOutput === "string" && result.finalOutput.trim().length > 0
 		? result.finalOutput.trim()
 		: fallbackText;
-	if (!text) return [];
-	return [{ role: "assistant", content: [{ type: "text", text }] }];
+	const content = [
+		...toolCallParts,
+		...(text ? [{ type: "text", text }] : []),
+	];
+	if (content.length === 0) return [];
+	return [{ role: "assistant", content }];
 }
 
 function toDelegationUpdate(requestId: string, update: PromptTemplateBridgeResult): PromptTemplateDelegationUpdate | undefined {

--- a/test/unit/subagents-upstream-sync.test.ts
+++ b/test/unit/subagents-upstream-sync.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { convertToLlm } from "../../packages/coding-agent/src/core/messages.js";
 import { SubagentParams } from "../../packages/subagents/src/extension/schemas.js";
 import { createSubagentExecutor } from "../../packages/subagents/src/runs/foreground/subagent-executor.js";
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../../packages/subagents/src/runs/shared/pi-args.js";
@@ -12,6 +13,7 @@ import {
 	PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT,
 	registerPromptTemplateDelegationBridge,
 } from "../../packages/subagents/src/slash/prompt-template-bridge.js";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.js";
 import type { ExecutorDeps, SubagentExecutorRuntimeDeps } from "../../packages/subagents/src/runs/foreground/subagent-executor-types.js";
 import type { SingleResult, Usage } from "../../packages/subagents/src/shared/types.js";
@@ -175,10 +177,18 @@ describe("recent upstream subagent syncs", () => {
 			cwd: "/repo",
 		});
 
-		const response = await responsePromise as { messages: Array<{ content?: Array<{ type?: string; name?: string; text?: string }> }> };
+		const response = await responsePromise as { messages: Array<{ role?: string; content?: Array<{ type?: string; text?: string }> }> };
 		const content = response.messages[0]?.content ?? [];
-		assert.deepEqual(content.filter((part) => part.type === "toolCall").map((part) => part.name), ["write", "bash"]);
-		assert.equal(content.some((part) => part.type === "text" && part.text === "finished"), true);
+		const text = content.find((part) => part.type === "text")?.text ?? "";
+		assert.equal(content.some((part) => part.type === "toolCall"), false);
+		assert.match(text, /Tool calls:\n- write src\/output\.md\n- \$ bun test/);
+		assert.match(text, /finished/);
+		assert.equal(
+			convertToLlm(response.messages as AgentMessage[]).some(
+				(message) => message.role === "assistant" && message.content.some((part) => part.type === "toolCall"),
+			),
+			false,
+		);
 		bridge.dispose();
 	});
 
@@ -205,6 +215,39 @@ describe("recent upstream subagent syncs", () => {
 		const serialized = JSON.stringify(SubagentParams);
 		for (const keyword of ["allOf", "const", "if", "then", "not"]) {
 			assert.equal(serialized.includes(`\"${keyword}\"`), false, `schema should omit ${keyword}`);
+		}
+	});
+
+	test("returns clear runtime errors for malformed dynamic fanout shapes", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "atomic-subagent-malformed-chain-"));
+		try {
+			let runCount = 0;
+			const executor = makeExecutor({
+				cwd,
+				agents: [makeAgent("scout"), makeAgent("reviewer")],
+				runSync: async (_parentCwd, _agents, agentName, task) => {
+					runCount += 1;
+					return result(agentName, task);
+				},
+			});
+
+			const output = await executor.execute("malformed-chain", {
+				chain: [
+					{ agent: "scout", task: "Find targets", as: "targets", outputSchema: { type: "object" } },
+					{
+						expand: { from: { output: "targets", path: "/items" }, maxItems: 4 },
+						parallel: [{ agent: "reviewer", task: "Review" }],
+						collect: { as: "reviews" },
+					},
+				] as never,
+			}, new AbortController().signal, undefined, makeContext(cwd));
+			const text = output.content[0]?.type === "text" ? output.content[0].text : "";
+
+			assert.equal(output.isError, true);
+			assert.match(text, /requires expand, a single parallel template object, and collect/);
+			assert.equal(runCount, 0);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
 		}
 	});
 

--- a/test/unit/subagents-upstream-sync.test.ts
+++ b/test/unit/subagents-upstream-sync.test.ts
@@ -1,0 +1,262 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SubagentParams } from "../../packages/subagents/src/extension/schemas.js";
+import { createSubagentExecutor } from "../../packages/subagents/src/runs/foreground/subagent-executor.js";
+import { SUBAGENT_FANOUT_CHILD_ENV } from "../../packages/subagents/src/runs/shared/pi-args.js";
+import { stripParentOnlySubagentMessages } from "../../packages/subagents/src/runs/shared/subagent-prompt-runtime.js";
+import {
+	PROMPT_TEMPLATE_SUBAGENT_REQUEST_EVENT,
+	PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT,
+	registerPromptTemplateDelegationBridge,
+} from "../../packages/subagents/src/slash/prompt-template-bridge.js";
+import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.js";
+import type { ExecutorDeps, SubagentExecutorRuntimeDeps } from "../../packages/subagents/src/runs/foreground/subagent-executor-types.js";
+import type { SingleResult, Usage } from "../../packages/subagents/src/shared/types.js";
+import type { ExtensionContext } from "../../packages/coding-agent/src/index.js";
+
+type Handler = (data: unknown) => void;
+
+class FakeEvents {
+	private readonly handlers = new Map<string, Set<Handler>>();
+
+	on(event: string, handler: Handler): () => void {
+		const handlers = this.handlers.get(event) ?? new Set<Handler>();
+		handlers.add(handler);
+		this.handlers.set(event, handlers);
+		return () => handlers.delete(handler);
+	}
+
+	emit(event: string, data: unknown): void {
+		for (const handler of this.handlers.get(event) ?? []) handler(data);
+	}
+}
+
+function once(events: FakeEvents, event: string): Promise<unknown> {
+	return new Promise((resolve) => {
+		const unsubscribe = events.on(event, (data) => {
+			unsubscribe();
+			resolve(data);
+		});
+	});
+}
+
+const usage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	cost: 0,
+	turns: 0,
+};
+
+function makeAgent(name: string): AgentConfig {
+	return {
+		name,
+		description: `${name} test agent`,
+		systemPromptMode: "replace",
+		inheritProjectContext: false,
+		inheritSkills: false,
+		systemPrompt: "You are a test agent.",
+		source: "project",
+		filePath: `/tmp/${name}.md`,
+	};
+}
+
+function makeState(): ExecutorDeps["state"] {
+	return {
+		baseCwd: "",
+		currentSessionId: null,
+		asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: {
+			schedule: () => false,
+			clear: () => {},
+		},
+	};
+}
+
+function makeContext(cwd: string): ExtensionContext {
+	return {
+		cwd,
+		mode: "tui",
+		hasUI: false,
+		ui: { custom: async <T>() => undefined as T },
+		model: undefined,
+		modelRegistry: { getAvailable: () => [] },
+		sessionManager: {
+			getSessionFile: () => undefined,
+			getSessionId: () => "parent-session",
+			getLeafId: () => null,
+		},
+		isIdle: () => true,
+		isProjectTrusted: () => true,
+		signal: undefined,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	} as unknown as ExtensionContext;
+}
+
+function makeExecutor(input: {
+	cwd: string;
+	agents: AgentConfig[];
+	runSync: SubagentExecutorRuntimeDeps["runSync"];
+}): ReturnType<typeof createSubagentExecutor> {
+	const deps: ExecutorDeps = {
+		pi: {
+			events: { on: () => () => {}, emit: () => {} },
+			getSessionName: () => "parent-session-name",
+		} as unknown as ExecutorDeps["pi"],
+		state: makeState(),
+		config: { maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 8 } } as ExecutorDeps["config"],
+		asyncByDefault: false,
+		tempArtifactsDir: join(input.cwd, "artifacts"),
+		getSubagentSessionRoot: () => join(input.cwd, "sessions"),
+		expandTilde: (p) => p,
+		discoverAgents: () => ({ agents: input.agents }),
+		runtime: { runSync: input.runSync },
+	};
+	return createSubagentExecutor(deps);
+}
+
+function result(agent: string, task: string, exitCode = 0, finalOutput = "ok", error?: string): SingleResult {
+	return {
+		agent,
+		task,
+		exitCode,
+		messages: [],
+		usage,
+		finalOutput,
+		...(error ? { error } : {}),
+		artifactPaths: { inputPath: "/tmp/in.md", outputPath: "/tmp/out.md", jsonlPath: "/tmp/run.jsonl", metadataPath: "/tmp/meta.json" },
+	};
+}
+
+describe("recent upstream subagent syncs", () => {
+	test("rebuilds compact delegated tool-call summaries into response messages", async () => {
+		const events = new FakeEvents();
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => ({
+				details: {
+					results: [{
+						finalOutput: "finished",
+						toolCalls: [
+							{ text: "write src/output.md", expandedText: "write src/output.md" },
+							{ text: "$ bun test", expandedText: "$ bun test" },
+						],
+					}],
+				},
+			}),
+		});
+
+		const responsePromise = once(events, PROMPT_TEMPLATE_SUBAGENT_RESPONSE_EVENT);
+		events.emit(PROMPT_TEMPLATE_SUBAGENT_REQUEST_EVENT, {
+			requestId: "r-compact-tools",
+			agent: "worker",
+			task: "do work",
+			context: "fresh",
+			model: "openai/gpt-5",
+			cwd: "/repo",
+		});
+
+		const response = await responsePromise as { messages: Array<{ content?: Array<{ type?: string; name?: string; text?: string }> }> };
+		const content = response.messages[0]?.content ?? [];
+		assert.deepEqual(content.filter((part) => part.type === "toolCall").map((part) => part.name), ["write", "bash"]);
+		assert.equal(content.some((part) => part.type === "text" && part.text === "finished"), true);
+		bridge.dispose();
+	});
+
+	test("preserves live nested subagent history in fanout child context", () => {
+		const previous = process.env[SUBAGENT_FANOUT_CHILD_ENV];
+		process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
+		try {
+			const user = { role: "user", content: "Task" };
+			const subagentCall = { role: "assistant", content: [{ type: "toolCall", name: "subagent", input: { agent: "delegate" } }] };
+			const subagentResult = { role: "toolResult", toolName: "subagent", content: "OK" };
+			const slashTextResult = { role: "custom", customType: "subagent-slash-text-result", content: "Subagent profiles" };
+
+			assert.deepEqual(
+				stripParentOnlySubagentMessages([user, subagentCall, subagentResult, slashTextResult]),
+				[user, subagentCall, subagentResult],
+			);
+		} finally {
+			if (previous === undefined) delete process.env[SUBAGENT_FANOUT_CHILD_ENV];
+			else process.env[SUBAGENT_FANOUT_CHILD_ENV] = previous;
+		}
+	});
+
+	test("omits provider-rejected chain schema keywords", () => {
+		const serialized = JSON.stringify(SubagentParams);
+		for (const keyword of ["allOf", "const", "if", "then", "not"]) {
+			assert.equal(serialized.includes(`\"${keyword}\"`), false, `schema should omit ${keyword}`);
+		}
+	});
+
+	test("rejects duplicate concurrent execution calls but allows management", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "atomic-subagent-upstream-sync-"));
+		try {
+			const calls: string[] = [];
+			const executor = makeExecutor({
+				cwd,
+				agents: [makeAgent("echo")],
+				runSync: async (_parentCwd, _agents, agentName, task) => {
+					calls.push(agentName);
+					await new Promise((resolve) => setTimeout(resolve, 50));
+					return result(agentName, task);
+				},
+			});
+			const ctx = makeContext(cwd);
+
+			const first = executor.execute("first", { agent: "echo", task: "First" }, new AbortController().signal, undefined, ctx);
+			const second = await executor.execute("second", { agent: "echo", task: "Duplicate" }, new AbortController().signal, undefined, ctx);
+			const status = await executor.execute("status", { action: "status" }, new AbortController().signal, undefined, ctx);
+			const firstResult = await first;
+
+			assert.equal(firstResult.isError, undefined);
+			assert.equal(second.isError, true);
+			assert.match(second.content[0]?.type === "text" ? second.content[0].text : "", /Issue exactly ONE subagent call per turn/);
+			assert.equal(status.isError, undefined);
+			assert.equal(calls.length, 1);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("includes captured output when a foreground single run fails", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "atomic-subagent-failed-output-"));
+		try {
+			const executor = makeExecutor({
+				cwd,
+				agents: [makeAgent("oracle")],
+				runSync: async (_parentCwd, _agents, agentName, task) =>
+					result(agentName, task, 1, "Oracle review:\n- finding one\n- finding two", "completed without making edits"),
+			});
+
+			const output = await executor.execute("failed", { agent: "oracle", task: "Implement" }, new AbortController().signal, undefined, makeContext(cwd));
+			const text = output.content[0]?.type === "text" ? output.content[0].text : "";
+
+			assert.equal(output.isError, true);
+			assert.match(text, /completed without making edits/);
+			assert.match(text, /Output:\nOracle review:\n- finding one\n- finding two/);
+			assert.match(text, /Output artifact: \/tmp\/out\.md/);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Refs #1527. Prevents orphaned `toolResult` messages from reaching Anthropic/GitHub Copilot providers after context compaction, and hardens subagent dispatch to reject duplicate concurrent calls. The fix spans session-replay reconciliation, LLM serialization guarding, and upstream subagent sync.

## Changes

### Session replay repair (`packages/coding-agent`)

- **New** `session-manager-tool-dependencies.ts` — reconciles persisted `context_compaction` deletion filters during active-context rebuild so deleting one side of a tool-call/tool-result pair always deletes or preserves the paired side consistently; converges via a fixpoint loop bounded by `path.length * 2` passes.
- **New** `repairOrphanToolResults` in `messages.ts` — final LLM serialization guard that drops any `toolResult` message whose matching assistant `toolCall` is no longer the immediately preceding tool-use group, preventing provider replay failures.
- **Wired** `reconcilePersistedToolDependencyFilters` into `buildEffectiveContextDeletionFilters` in `session-manager-history.ts`.
- **Docs** `compaction.md` updated to document the tool-call/tool-result pair replay invariant and the two-layer guard strategy.

### Upstream subagent hardening (`packages/subagents`)

- **Duplicate dispatch guard** `subagent-executor.ts` wraps `execute` with `executeWithSingleDispatchGuard` — rejects concurrent subagent dispatches within the same turn with a clear error; `fanout-child.ts` and `index.ts` initialize the new `subagentInProgress` flag in safe state.
- **Fanout child history** `subagent-prompt-runtime.ts` preserves nested subagent call/result history for fanout children (`SUBAGENT_FANOUT_CHILD_ENV=1`) and adds `subagent-slash-text-result` to the parent-only strip set.
- **Failed-run diagnostics** `subagent-executor-single.ts` formats failed foreground run output with the error message, captured child output, and output artifact path for easier debugging.
- **Compact tool-call summaries** `prompt-template-bridge.ts` embeds `toolCall` content blocks from delegated run summaries into delegation messages as readable text; fixes a null-safety gap when `agent` or `task` is missing from a prompt template request.
- **Schema simplification** `schemas.ts` removes provider-hostile `allOf` conditionals from the chain step schema.

### Regression coverage

- New `test/unit/subagents-upstream-sync.test.ts`: duplicate dispatch rejection, fanout child history preservation, compact tool-call summary embedding, failed-run output formatting, schema keyword audit, and malformed fanout shape error.
- Extended `test/session-manager/build-context-02.suite.ts`: stale compaction split-pair replay cases (block-level and entry-level deletion).
- New `packages/coding-agent/test/messages.test.ts`: orphan `toolResult` repair in `convertToLlm`.

## Validation

```sh
bun test test/unit/subagents-upstream-sync.test.ts
bunx --bun --no-install vitest --run test/session-manager/build-context-01.suite.ts test/session-manager/build-context-02.suite.ts test/messages.test.ts
bun run typecheck
bun run check:file-length
git diff --check
```

Pre-commit/pre-push hooks: `bun run lint`, `bun run check:file-length`, `bun run test:unit`