### PR TITLE
feat(workflows)!: durable cross-session workflow resumability

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.2] - 2026-06-27
+
 ### Fixed
 
 - Fixed custom tool renderer disposal to honor renderer-owned cleanup callbacks, preventing stale animation registry entries after terminal workflow tool rows are finalized ([#1518](https://github.com/bastani-inc/atomic/issues/1518)).

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.2] - 2026-06-27
+
 ### Added
 
 - Added scoped Cursor image-input support for known multimodal Claude, Composer, Gemini, GPT, and Kimi model families (`claude-`, `composer-`, `gemini-`, `gpt-`, `kimi-`), plus `cursor/grok-4.3`, including selected-image request serialization and mixed text/image MCP tool-result serialization.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.2] - 2026-06-27
+
 ### Fixed
 
 - Prevented the async subagent status widget from briefly unmounting during reset-and-hydrate cycles when active background runs are still present, including Atomic host updates that deliver fresh UI context wrappers for the same logical session ([#1517](https://github.com/bastani-inc/atomic/issues/1517)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.3-alpha.2] - 2026-06-27
+
 ### Breaking Changes
 
 - Workflow durability is now enabled by default with the zero-infrastructure per-workflow file backend rooted under `~/.atomic/workflow-durable`; the previous process-local in-memory default and `ATOMIC_WORKFLOW_DURABLE_DIR` opt-in path were removed. In-memory durability remains available for explicit test/custom backend overrides and for the privacy opt-out `ATOMIC_WORKFLOW_DURABLE=0`/`false`/`off`/`memory`. ([#1498](https://github.com/bastani-inc/atomic/issues/1498))


### PR DESCRIPTION
## Summary

Introduces durable cross-session workflow resumability as the new default in `@bastani/workflows`, backed by a per-workflow file store at `~/.atomic/workflow-durable`. Also delivers targeted fixes for subagent UI stability, Cursor image-input support, and session replay correctness.

## Breaking Changes

- **Workflow durability is now on by default.** The previous process-local in-memory default is removed. Opt out with `ATOMIC_WORKFLOW_DURABLE=0`/`false`/`off`/`memory`; Postgres-backed persistence is available when `DBOS_SYSTEM_DATABASE_URL` is set.

## Key Changes

### Workflows — durable resumability (`#1498`)
- New `packages/workflows/src/durable/` seam: `ctx.tool`, `ctx.ui`, `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, and child `ctx.workflow` all produce durable checkpoints; completed side effects are never re-run on resume.
- `ctx.tool(name, args, fn, options?)` — durable cached execution primitive with optional exponential-backoff retry.
- Durable `ctx.ui` checkpointing: `input`/`confirm`/`select`/`editor`/`custom` responses are cached by prompt identity and skipped on resume.
- `/workflow resume` now falls back to the cross-session durable catalog in fresh sessions; the interactive picker reuses the existing `/resume` session-selector chrome.
- Optional `@dbos-inc/dbos-sdk` integration: when `DBOS_SYSTEM_DATABASE_URL` is set, checkpoints are Postgres-backed with full read-side hydration on session start.
- File backend uses per-workflow JSON files (not a shared `state.json`), `0700`/`0600` permissions, stale-lock recovery, and automatic pruning of terminal workflows.
- Added cancellation/failure/retry semantics; killed workflows are excluded from auto-resume; recoverable failures remain resumable.

### Workflows — other fixes
- Added `StageContext.sendUserMessage(content, { deliverAs? })` for injecting follow-on user turns into a stage session after `prompt()` resolves (`#1520`).
- Fixed workflow graph node mouse-click activation — clicking a node now focuses, opens, and attaches it (`#1521`).
- Fixed stage chat wheel capture: default mode now captures scroll; `ctrl+t` toggles copy mode for terminal text selection (`#1519`).

### Subagents (`#1517`, `#1518`, `#1527`)
- Prevented the async subagent status widget from briefly unmounting during reset-and-hydrate cycles while active background runs are still present.
- Fixed live subagent result animation cleanup to register a host-row disposer, preventing stale animation registry entries.
- Eliminated foreground subagent widget flicker: the spinner now advances on real progress updates instead of an 80 ms wall-clock timer.
- Synced upstream hardening: compact delegated tool-call summaries preserved, fanout children keep nested subagent history, duplicate concurrent dispatches rejected, failed foreground runs include child output.

### Cursor
- Added scoped image-input support for multimodal model families: `claude-`, `composer-`, `gemini-`, `gpt-`, `kimi-`, and `cursor/grok-4.3`, including selected-image request serialization and mixed text/image MCP tool-result serialization.
- Added `cursor/grok-4.3` to the estimated fallback catalog; removed stale Grok 4.20 entries.
- Rejected empty or malformed base64 image payloads with sanitized local errors.

### Coding Agent (`#1518`, `#1527`)
- Fixed custom tool renderer disposal to honor renderer-owned cleanup callbacks, preventing stale animation registry entries after workflow tool rows finalize.
- Hardened session replay and LLM conversion so context-compaction filters cannot leave orphaned `toolResult` messages, preventing GitHub Copilot Claude/Anthropic replay failures after repeated subagent runs.

## Migration Notes

If you relied on the previous in-memory-by-default behavior (e.g., in tests or privacy-sensitive environments), set `ATOMIC_WORKFLOW_DURABLE=memory` (or `0`/`false`/`off`) to restore it. No migration is needed for existing durable workflows — the new file backend coexists with any DBOS-backed history.

---

- Release kind: prerelease
- Target version: `0.9.3-alpha.2`
- Base branch: `main`
- Head SHA: `241b1de9dc188bbe5208beffac7c5f372505bbf9`