### PR TITLE
chore(release): add 0.9.3-alpha.3 changelog entries across all packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published the Atomic 0.9.3-alpha.3 prerelease from the same code as 0.9.3-alpha.2; no coding-agent changes were made after the previous prerelease.
+
 ## [0.9.3-alpha.2] - 2026-06-27
 
 ### Fixed

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.3 prerelease for the Cursor provider from the same code as 0.9.3-alpha.2; no Cursor provider changes were made after the previous prerelease.
+
 ## [0.9.3-alpha.2] - 2026-06-27
 
 ### Added

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.3 prerelease for the intercom extension; no intercom extension changes were made after 0.9.2.
+
 ## [0.9.2] - 2026-06-23
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.3 prerelease for the MCP extension; no MCP extension changes were made after 0.9.3-alpha.1.
+
 ## [0.9.3-alpha.1] - 2026-06-25
 
 ### Fixed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.3 prerelease for the native transport package; no native transport changes were made after 0.9.3-alpha.1.
+
 ## [0.9.3-alpha.1] - 2026-06-25
 
 ### Added

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published the Atomic 0.9.3-alpha.3 prerelease for the subagents extension from the same code as 0.9.3-alpha.2; no subagents extension changes were made after the previous prerelease.
+
 ## [0.9.3-alpha.2] - 2026-06-27
 
 ### Fixed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.3 prerelease for the web-access extension; no web-access extension changes were made after 0.9.2.
+
 ## [0.9.2] - 2026-06-23
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.3-alpha.3] - 2026-06-27
+
+### Changed
+
+- Published the Atomic 0.9.3-alpha.3 prerelease for the workflows extension from the same code as 0.9.3-alpha.2; no workflow changes were made after the previous prerelease.
+
 ## [0.9.3-alpha.2] - 2026-06-27
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary

Adds `[0.9.3-alpha.3]` changelog sections to all eight package CHANGELOGs as the prerelease notes PR for the 0.9.3-alpha.3 synchronized re-publish. No code changes are included; `main` remains versionless at `0.0.0`.

## Release Details

| Field | Value |
|---|---|
| Kind | prerelease (`@next`) |
| Version | `0.9.3-alpha.3` |
| Head branch | `prerelease/0.9.3-alpha.3` |
| Head SHA | `137f3623a5857c2e6357c17e38760138852a28ac` |
| Base branch | `main` |

## Key Changes

- **`packages/coding-agent`** — synchronized re-publish; no changes since alpha.2
- **`packages/subagents`** — synchronized re-publish; no changes since alpha.2
- **`packages/workflows`** — synchronized re-publish; no changes since alpha.2
- **`packages/cursor`** — synchronized re-publish; no changes since alpha.2
- **`packages/mcp`** — synchronized re-publish; no changes since alpha.1
- **`packages/natives`** — synchronized re-publish; no changes since alpha.1
- **`packages/intercom`** — synchronized re-publish; no changes since 0.9.2
- **`packages/web-access`** — synchronized re-publish; no changes since 0.9.2

All entries document that the prerelease is a version-sync publish rather than a feature or bug-fix drop.

## Validation

- `git diff --name-only origin/main...HEAD` → changelog files only (no manifest or source changes)
- `git push -u origin prerelease/0.9.3-alpha.3` → passed all configured hooks (`bun run lint`, `bun run check:file-length`, `bun run test:unit`)
- `main` remains versionless; the real version is materialized only on the throwaway off-`main` tag commit via `scripts/cut-release.ts`