### PR TITLE
docs(release): 0.9.3-alpha.4 changelog entries for workflow guidance and Cursor model fix

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
 ### Changed
 
 - Updated workflow, quickstart, Atomic guide, and workflow-playbook documentation to present workflows as the default path for non-trivial or structured requests with verifiable objectives, explicitly including implementation, build, debugging, bug-fix, migration, new-feature, scoped multi-file, and validation-heavy docs/code prompts alongside loop-shaped prompts such as `do X until Y`, `repeat until`, `iterate until`, and review/fix/test-until-passing.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
 ### Changed
 
 - Resolved Cursor model context windows and max output tokens from Atomic's bundled `@earendil-works/pi-ai` model catalog instead of flat placeholder estimates: Atomic matches each Cursor model ID's family/version against pi-ai metadata, preserves any positive limits Cursor sends, ignores non-positive bogus limits, and keeps a conservative 200k context / 64k output estimate only for Cursor-only models (such as `composer-*` and `default`/Auto) with no pi-ai match. Limit resolution matches on IDs only — not generic display names — so it never adds, drops, or mislabels models in the list.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.4 prerelease for the intercom extension; no intercom extension changes were made after 0.9.3-alpha.3.
+
 ## [0.9.3-alpha.3] - 2026-06-27
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.4 prerelease for the MCP extension; no MCP extension changes were made after 0.9.3-alpha.3.
+
 ## [0.9.3-alpha.3] - 2026-06-27
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.4 prerelease for the native transport package; no native transport changes were made after 0.9.3-alpha.3.
+
 ## [0.9.3-alpha.3] - 2026-06-27
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.4 prerelease for the subagents extension; no subagents extension changes were made after 0.9.3-alpha.3.
+
 ## [0.9.3-alpha.3] - 2026-06-27
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.4 prerelease for the web-access extension; no web-access extension changes were made after 0.9.3-alpha.3.
+
 ## [0.9.3-alpha.3] - 2026-06-27
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.3-alpha.4] - 2026-06-28
+
 ### Changed
 
 - Strengthened the model-facing workflow prompt guidance to treat workflows as the default path for non-trivial tasks and requests with inherent structure plus verifiable objectives, explicitly including implementation, build, debugging, bug-fix, migration, new-feature, scoped multi-file, and validation-heavy docs/code prompts alongside loop-shaped phrasing such as `do X until Y`, `repeat until`, `iterate until`, and review/fix/test-until-passing prompts.


### PR DESCRIPTION
## Summary

Adds `0.9.3-alpha.4` release notes across all package changelogs in preparation for the prerelease tag. Two packages have substantive changes; the rest are synchronized version bumps with no functional delta since alpha.3.

## Key changes

**`@bastani/atomic` (coding-agent)**
- Updated workflow, quickstart, Atomic guide, and workflow-playbook docs to present workflows as the **default path** for non-trivial or structured requests with verifiable objectives — including implementation, build, debugging, bug-fix, migration, new-feature, scoped multi-file, and validation-heavy prompts, as well as loop-shaped phrasing (`do X until Y`, `repeat until`, `iterate until`, review/fix/test-until-passing).

**`@bastani/workflows`**
- Strengthened model-facing workflow prompt guidance with the same positioning: workflows are the default for tasks with inherent structure and verifiable objectives, not just for explicit `do X until Y` loops.

**`@bastani/cursor`**
- Fixed Cursor model context-window and max-output-token resolution to use Atomic's bundled `@earendil-works/pi-ai` model catalog instead of flat placeholder estimates. Matches on model IDs (not display names), preserves positive limits Cursor sends, ignores non-positive bogus limits, and keeps a conservative 200k/64k fallback only for Cursor-only models (`composer-*`, `default`/Auto) with no pi-ai match.

**Other packages** (`intercom`, `mcp`, `natives`, `subagents`, `web-access`)
- Synchronized 0.9.3-alpha.4 changelog entries; no functional changes since 0.9.3-alpha.3.

## Release metadata

- Release kind: prerelease → `@next`
- Version: `0.9.3-alpha.4`
- Base: `main` (package manifests remain at `0.0.0`; real version materialized only on the off-main tag commit via `scripts/cut-release.ts`)
- Head branch: `prerelease/0.9.3-alpha.4` (`b9f1b4ce8`)