### PR TITLE
fix(http): harden timeouts and disable idle limit for eval runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,5 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+# Pier/Harbor eval job artifacts (local only; not tracked)
+evals/jobs/

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -17,6 +17,11 @@ class Atomic(BaseInstalledAgent):
     _OUTPUT_FILENAME = "atomic.txt"
     _SESSION_DIR_NAME = "atomic-sessions"
     _CONTAINER_SESSION_DIR = f"/logs/agent/{_SESSION_DIR_NAME}"
+    # Disable Atomic's HTTP idle timeout (undici headers/body + SDK total timeout).
+    # Long-context + thinking=xhigh turns near the model's prompt cap can take
+    # minutes to first token; a finite cap surfaces as "Connection error." after
+    # 3 useless retries. 0 removes the cap so large requests can complete.
+    _HTTP_IDLE_TIMEOUT_MS: int = 0
 
     CLI_FLAGS = [
         CliFlag(
@@ -140,11 +145,13 @@ class Atomic(BaseInstalledAgent):
         # Persist the main chat under /logs so workflow stage sessions inherit
         # that directory and can be included in post-run usage accounting.
         session_dir = shlex.quote(self._CONTAINER_SESSION_DIR)
+        settings_config_command = self._atomic_settings_config_command()
 
         await self.exec_as_agent(
             environment,
             command=(
                 f"rm -rf {session_dir} && mkdir -p {session_dir} && "
+                f"{settings_config_command}"
                 f". ~/.nvm/nvm.sh && "
                 f"atomic --print --mode json --session-dir {session_dir} "
                 f"{model_args}"
@@ -153,6 +160,17 @@ class Atomic(BaseInstalledAgent):
                 f'2>&1 </dev/null | grep -v \'"type":"message_update"\' | stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}'
             ),
             env=env,
+        )
+
+    @classmethod
+    def _atomic_settings_config_command(cls) -> str:
+        settings = {"httpIdleTimeoutMs": cls._HTTP_IDLE_TIMEOUT_MS}
+        settings_json = json.dumps(settings, indent=2)
+        return (
+            "mkdir -p $HOME/.atomic/agent && "
+            "cat > $HOME/.atomic/agent/settings.json <<'ATOMIC_SETTINGS_JSON'\n"
+            f"{settings_json}\n"
+            "ATOMIC_SETTINGS_JSON\n"
         )
 
     @staticmethod

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -100,6 +100,11 @@ class Atomic(BaseInstalledAgent):
         "raw.githubusercontent.com",
         "registry.npmjs.org",
     )
+    # Disable Atomic's HTTP idle timeout (undici headers/body timeout) for evals.
+    # Long-context gpt-5.5 + thinking=xhigh requests near the model's prompt cap can
+    # take >5 min to first token; the 5-min default surfaces as "Connection error."
+    # 0 disables the cap so large requests can complete. See http-dispatcher.ts.
+    _HTTP_IDLE_TIMEOUT_MS: int = 0
 
     CLI_FLAGS = [
         CliFlag(
@@ -215,8 +220,10 @@ class Atomic(BaseInstalledAgent):
         session_dir = shlex.quote(self._CONTAINER_SESSION_DIR)
         output_file = shlex.quote(str(EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME))
         copilot_config_command = self._copilot_models_config_command(copilot_base_url)
+        settings_config_command = self._atomic_settings_config_command()
         command = (
             f"rm -rf {session_dir} && mkdir -p {session_dir} && "
+            f"{settings_config_command}"
             f"{copilot_config_command}"
             "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi && "
             f"atomic --print --mode json --session-dir {session_dir} "
@@ -267,6 +274,17 @@ class Atomic(BaseInstalledAgent):
             "cat > $HOME/.atomic/agent/models.json <<'ATOMIC_MODELS_JSON'\n"
             f"{config_json}\n"
             "ATOMIC_MODELS_JSON\n"
+        )
+
+    @classmethod
+    def _atomic_settings_config_command(cls) -> str:
+        settings = {"httpIdleTimeoutMs": cls._HTTP_IDLE_TIMEOUT_MS}
+        settings_json = json.dumps(settings, indent=2)
+        return (
+            "mkdir -p $HOME/.atomic/agent && "
+            "cat > $HOME/.atomic/agent/settings.json <<'ATOMIC_SETTINGS_JSON'\n"
+            f"{settings_json}\n"
+            "ATOMIC_SETTINGS_JSON\n"
         )
 
     @staticmethod

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Raised the default HTTP idle timeout from 5 to 10 minutes (`httpIdleTimeoutMs` 300000 → 600000) and added a fixed 10-second connect-phase timeout, so slow long-context turns finish instead of failing as "Connection error." while unreachable or firewall-blocked hosts fail fast instead of hanging.
+
 ### Fixed
 
 - Debounced duplicate reftable watcher notifications by de-duplicating unchanged `.git/reftable/tables.list` states, avoiding extra Windows footer branch refreshes while preserving real reftable branch updates.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -158,9 +158,9 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `httpIdleTimeoutMs` | number | `300000` | HTTP header/body idle timeout in milliseconds. Must be a non-negative finite number; decimals are rounded down. Set to `0` to disable the idle timeout. |
+| `httpIdleTimeoutMs` | number | `600000` | HTTP header/body idle timeout in milliseconds. Must be a non-negative finite number; decimals are rounded down. Set to `0` to disable the idle timeout. |
 
-Atomic applies this timeout to the global HTTP dispatcher used by `fetch` and provider SDK HTTP clients. The default is 300,000 ms (5 minutes), which keeps long-running requests working while reclaiming stale idle connections.
+Atomic applies this timeout to the global HTTP dispatcher used by `fetch` and provider SDK HTTP clients. The default is 600,000 ms (10 minutes), which keeps slow long-context requests working while reclaiming stale idle connections. The dispatcher also applies a fixed 10-second connect-phase timeout so an unreachable or firewall-blocked host fails fast instead of hanging until the OS TCP timeout.
 
 The `/settings` picker offers these presets:
 
@@ -175,7 +175,7 @@ The `/settings` picker offers these presets:
 
 ```json
 {
-  "httpIdleTimeoutMs": 300000
+  "httpIdleTimeoutMs": 600000
 }
 ```
 
@@ -186,7 +186,7 @@ The `/settings` picker offers these presets:
 | `steeringMode` | string | `"one-at-a-time"` | How steering messages are sent: `"all"` or `"one-at-a-time"` |
 | `followUpMode` | string | `"one-at-a-time"` | How follow-up messages are sent: `"all"` or `"one-at-a-time"` |
 | `transport` | string | `"auto"` | Preferred transport for providers that support multiple transports: `"sse"`, `"websocket"`, `"websocket-cached"`, or `"auto"` |
-| `httpIdleTimeoutMs` | number | `300000` | HTTP header/body idle timeout in milliseconds, also used by providers with explicit stream idle timeouts. Set to `0` to disable. |
+| `httpIdleTimeoutMs` | number | `600000` | HTTP header/body idle timeout in milliseconds, also used by providers with explicit stream idle timeouts. Set to `0` to disable. |
 | `websocketConnectTimeoutMs` | number | `15000` | WebSocket connect/open handshake timeout in milliseconds for providers that support WebSocket transports. Set to `0` to disable. |
 
 ### Terminal & Images

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -1,7 +1,10 @@
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { installCopilotGeminiReasoningInterceptor } from "./copilot-gemini-reasoning.ts";
 
-export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 300_000;
+export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 600_000;
+
+/** Connect-phase timeout so a black-holed/firewalled host fails fast instead of hanging until the OS TCP timeout. */
+export const HTTP_CONNECT_TIMEOUT_MS = 10_000;
 
 export const HTTP_IDLE_TIMEOUT_CHOICES = [
 	{ label: "30 sec", timeoutMs: 30_000 },
@@ -46,6 +49,7 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 			allowH2: false,
 			bodyTimeout: normalizedTimeoutMs,
 			headersTimeout: normalizedTimeoutMs,
+			connect: { timeout: HTTP_CONNECT_TIMEOUT_MS },
 		}),
 	);
 

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-handlers.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-handlers.ts
@@ -1,5 +1,5 @@
 import type { Transport } from "@earendil-works/pi-ai";
-import { HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-dispatcher.ts";
+import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, HTTP_IDLE_TIMEOUT_CHOICES } from "../../../core/http-dispatcher.ts";
 import { DEFAULT_PROJECT_TRUST_BY_LABEL } from "./settings-selector-options.ts";
 import type { DoubleEscapeAction, QueueDeliveryMode, SettingsCallbacks, TreeFilterMode } from "./settings-selector-types.ts";
 
@@ -35,7 +35,7 @@ export function createSettingsChangeHandler(callbacks: SettingsCallbacks): (id: 
 				break;
 			case "http-idle-timeout": {
 				const selected = HTTP_IDLE_TIMEOUT_CHOICES.find((choice) => choice.label === newValue);
-				callbacks.onHttpIdleTimeoutChange(selected?.timeoutMs ?? 300_000);
+				callbacks.onHttpIdleTimeoutChange(selected?.timeoutMs ?? DEFAULT_HTTP_IDLE_TIMEOUT_MS);
 				break;
 			}
 			case "bash-interceptor":


### PR DESCRIPTION
## Summary

Raises HTTP defaults to a 10-minute idle timeout and adds a 10-second connect-phase timeout so slow long-context model turns complete instead of failing as \"Connection error.\", while unreachable or firewalled hosts fail fast. Eval adapters (Pier/Harbor) inject `httpIdleTimeoutMs: 0` at startup to fully disable the cap for benchmark runs where individual requests can exceed 5 minutes.

## Changes

- **HTTP dispatcher** (`http-dispatcher.ts`): raises `DEFAULT_HTTP_IDLE_TIMEOUT_MS` from 300,000 ms (5 min) to 600,000 ms (10 min) and adds a fixed 10-second connect-phase timeout via `connect: { timeout: 10_000 }` so black-holed/firewalled hosts fail fast instead of hanging until the OS TCP timeout.
- **Settings selector** (`settings-selector-handlers.ts`): replaces the hardcoded `300_000` fallback with `DEFAULT_HTTP_IDLE_TIMEOUT_MS` so it stays in sync with the constant.
- **Eval adapters** (`atomic_pier.py`, `atomic_harbor.py`): each adapter now declares `_HTTP_IDLE_TIMEOUT_MS = 0` and injects it into `~/.atomic/agent/settings.json` before launching Atomic, fully disabling the idle cap for eval runs where long-context + `thinking=xhigh` requests can take several minutes to first token.
- **`.gitignore`**: excludes `evals/jobs/` so generated Pier/Harbor eval job artifacts are not tracked in the repository.
- **Docs** (`settings.md`): updates the `httpIdleTimeoutMs` default from 300,000 to 600,000 and documents the new connect-phase timeout behavior.
- **Changelog**: records the idle-timeout increase and connect-timeout addition under `[Unreleased] → Changed`.

## Notes

- Branch was already pushed as `origin/chore/deep-swe-eval-summaries`.
- Local tests were not run as part of PR creation.