### PR TITLE
docs: release notes for 0.9.3-alpha.5

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Synced bundled upstream Pi runtime packages to `^0.80.2` (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui`) across the coding-agent direct/peer dependency pins, aligning Atomic with upstream Pi's 0.80.x "Models runtime migration" where the `@earendil-works/pi-ai` root entrypoint became core-only and the legacy global provider/model API moved to the temporary `@earendil-works/pi-ai/compat` entrypoint.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Aligned the Cursor provider direct dependency on `@earendil-works/pi-ai` with upstream pi `^0.80.2` and retargeted its provider/model imports to the `@earendil-works/pi-ai/compat` entrypoint, preserving the legacy provider APIs Cursor uses under the updated pi-ai package layout.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Aligned the intercom extension peer dependency with upstream pi TUI `^0.80.2`; no intercom extension source changes were needed for this metadata sync.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Aligned the MCP extension peer dependencies with upstream pi `^0.80.2` (`@earendil-works/pi-ai` and `@earendil-works/pi-tui`) and retargeted legacy provider/model imports to `@earendil-works/pi-ai/compat`, preserving the MCP sampling provider behavior under the updated pi-ai package layout.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Bumped the native build toolchain devDependency `@napi-rs/cli` from 3.7.0 to 3.7.2 (includes the Node 12-compatible CJS binding-loader fix and an esbuild 0.28.1 security update), and refreshed transitive Cargo crates used by the `@bastani/atomic-natives` Rust build: `rustls` 0.23.40 → 0.23.41, `napi` 3.9.2 → 3.9.4, `bytes` 1.11.1 → 1.12.0, and `webpki-roots` 1.0.7 → 1.0.8 (the latter removing the Mozilla-deprecated `SecureSign Root CA12` root). No native transport source changes were needed.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Aligned the subagents extension peer dependencies with upstream pi `^0.80.2` runtime packages (`@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui`) and retargeted legacy provider/model imports to `@earendil-works/pi-ai/compat`, preserving delegated model resolution and streaming behavior under the updated pi-ai package layout.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Aligned the web-access extension peer dependency with upstream pi TUI `^0.80.2` and retargeted its legacy pi-ai summary/model helper imports to the `/compat` entrypoint, preserving the old `complete`/`getModel` API under the updated pi-ai package layout.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.3-alpha.5] - 2026-06-28
+
 ### Changed
 
 - Aligned the workflows extension peer dependency with upstream pi TUI `^0.80.2`; no workflows extension source changes were needed for this metadata sync.


### PR DESCRIPTION
## Summary

Changelog-only release-notes PR for the `0.9.3-alpha.5` prerelease. All eight package changelogs are updated under their `## [Unreleased]` sections to document the Pi 0.80.2 runtime upgrade and related compat-entrypoint migration shipped in this alpha.

## Key changes

- **Pi runtime upgrade to `^0.80.2`** across all extension packages (`coding-agent`, `cursor`, `intercom`, `mcp`, `subagents`, `web-access`, `workflows`): aligns peer/direct dependency pins with upstream Pi's "Models runtime migration" where `@earendil-works/pi-ai`'s root entrypoint became core-only and the legacy provider/model API moved to `@earendil-works/pi-ai/compat`.
- **`/compat` entrypoint aliasing**: packages that consumed legacy `complete`/`getModel`/provider APIs (`cursor`, `mcp`, `subagents`, `web-access`) had their imports retargeted to `@earendil-works/pi-ai/compat` to preserve existing behavior under the new layout.
- **Natives toolchain refresh** (`natives`): `@napi-rs/cli` bumped from 3.7.0 → 3.7.2 (Node 12-compatible CJS loader fix + esbuild 0.28.1 security update); Cargo crates refreshed (`rustls` 0.23.40 → 0.23.41, `napi` 3.9.2 → 3.9.4, `bytes` 1.11.1 → 1.12.0, `webpki-roots` 1.0.7 → 1.0.8).

## Release metadata

- Kind: prerelease → `@next`
- Version: `0.9.3-alpha.5`
- Source head: `b759fc1f92886ef36556bdfbf9e1b51f6804c837`

## Notes

- No package versions were bumped in this branch — `main` remains versionless at `0.0.0`.
- The real `0.9.3-alpha.5` version is materialized only by `scripts/cut-release.ts` on the throwaway off-`main` tag commit.