### PR TITLE
fix(http): retry dropped provider connections by default

### DIFF
--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -17,11 +17,6 @@ class Atomic(BaseInstalledAgent):
     _OUTPUT_FILENAME = "atomic.txt"
     _SESSION_DIR_NAME = "atomic-sessions"
     _CONTAINER_SESSION_DIR = f"/logs/agent/{_SESSION_DIR_NAME}"
-    # Disable Atomic's HTTP idle timeout (undici headers/body + SDK total timeout).
-    # Long-context + thinking=xhigh turns near the model's prompt cap can take
-    # minutes to first token; a finite cap surfaces as "Connection error." after
-    # 3 useless retries. 0 removes the cap so large requests can complete.
-    _HTTP_IDLE_TIMEOUT_MS: int = 0
 
     CLI_FLAGS = [
         CliFlag(
@@ -49,7 +44,11 @@ class Atomic(BaseInstalledAgent):
     async def install(self, environment: BaseEnvironment) -> None:
         await self.exec_as_root(
             environment,
-            command="apt-get update && apt-get install -y curl",
+            command=(
+                "apt-get update && "
+                "apt-get install -y --no-install-recommends curl fd-find git ripgrep && "
+                "ln -sf /usr/bin/fdfind /usr/local/bin/fd"
+            ),
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         version_spec = f"@{self._version}" if self._version else "@latest"
@@ -145,13 +144,11 @@ class Atomic(BaseInstalledAgent):
         # Persist the main chat under /logs so workflow stage sessions inherit
         # that directory and can be included in post-run usage accounting.
         session_dir = shlex.quote(self._CONTAINER_SESSION_DIR)
-        settings_config_command = self._atomic_settings_config_command()
 
         await self.exec_as_agent(
             environment,
             command=(
                 f"rm -rf {session_dir} && mkdir -p {session_dir} && "
-                f"{settings_config_command}"
                 f". ~/.nvm/nvm.sh && "
                 f"atomic --print --mode json --session-dir {session_dir} "
                 f"{model_args}"
@@ -160,17 +157,6 @@ class Atomic(BaseInstalledAgent):
                 f'2>&1 </dev/null | grep -v \'"type":"message_update"\' | stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}'
             ),
             env=env,
-        )
-
-    @classmethod
-    def _atomic_settings_config_command(cls) -> str:
-        settings = {"httpIdleTimeoutMs": cls._HTTP_IDLE_TIMEOUT_MS}
-        settings_json = json.dumps(settings, indent=2)
-        return (
-            "mkdir -p $HOME/.atomic/agent && "
-            "cat > $HOME/.atomic/agent/settings.json <<'ATOMIC_SETTINGS_JSON'\n"
-            f"{settings_json}\n"
-            "ATOMIC_SETTINGS_JSON\n"
         )
 
     @staticmethod

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -100,11 +100,6 @@ class Atomic(BaseInstalledAgent):
         "raw.githubusercontent.com",
         "registry.npmjs.org",
     )
-    # Disable Atomic's HTTP idle timeout (undici headers/body timeout) for evals.
-    # Long-context gpt-5.5 + thinking=xhigh requests near the model's prompt cap can
-    # take >5 min to first token; the 5-min default surfaces as "Connection error."
-    # 0 disables the cap so large requests can complete. See http-dispatcher.ts.
-    _HTTP_IDLE_TIMEOUT_MS: int = 0
 
     CLI_FLAGS = [
         CliFlag(
@@ -220,10 +215,8 @@ class Atomic(BaseInstalledAgent):
         session_dir = shlex.quote(self._CONTAINER_SESSION_DIR)
         output_file = shlex.quote(str(EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME))
         copilot_config_command = self._copilot_models_config_command(copilot_base_url)
-        settings_config_command = self._atomic_settings_config_command()
         command = (
             f"rm -rf {session_dir} && mkdir -p {session_dir} && "
-            f"{settings_config_command}"
             f"{copilot_config_command}"
             "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi && "
             f"atomic --print --mode json --session-dir {session_dir} "
@@ -274,17 +267,6 @@ class Atomic(BaseInstalledAgent):
             "cat > $HOME/.atomic/agent/models.json <<'ATOMIC_MODELS_JSON'\n"
             f"{config_json}\n"
             "ATOMIC_MODELS_JSON\n"
-        )
-
-    @classmethod
-    def _atomic_settings_config_command(cls) -> str:
-        settings = {"httpIdleTimeoutMs": cls._HTTP_IDLE_TIMEOUT_MS}
-        settings_json = json.dumps(settings, indent=2)
-        return (
-            "mkdir -p $HOME/.atomic/agent && "
-            "cat > $HOME/.atomic/agent/settings.json <<'ATOMIC_SETTINGS_JSON'\n"
-            f"{settings_json}\n"
-            "ATOMIC_SETTINGS_JSON\n"
         )
 
     @staticmethod

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Enabled provider/SDK retries by default (`retry.provider.maxRetries` `0` → `5`) so transient socket drops retry instead of surfacing as fatal `"Connection error"`. Connection failures (status-undefined) back off briefly while the existing `retry.provider.maxRetryDelayMs` cap still fails fast on long quota/rate-limit waits.
-- Raised the default HTTP idle timeout from 10 to ~12 minutes (`httpIdleTimeoutMs` 600000 → 700000) and added a `~12 min` preset, so long no-token windows (long-context + `thinking=xhigh` first-token latency) survive without disabling the cap. Eval harness adapters (`atomic_pier.py`, `atomic_harbor.py`) no longer hard-code `httpIdleTimeoutMs:0`; they inherit the new defaults.
+- Removed the hard-coded `httpIdleTimeoutMs:0` override from the eval harness adapters (`atomic_pier.py`, `atomic_harbor.py`); they now inherit the standard 10-minute idle timeout default.
 
 ## [0.9.3-alpha.5] - 2026-06-28
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Enabled provider/SDK retries by default (`retry.provider.maxRetries` `0` → `5`) so transient socket drops retry instead of surfacing as fatal `"Connection error"`. Connection failures (status-undefined) back off briefly while the existing `retry.provider.maxRetryDelayMs` cap still fails fast on long quota/rate-limit waits.
+- Raised the default HTTP idle timeout from 10 to ~12 minutes (`httpIdleTimeoutMs` 600000 → 700000) and added a `~12 min` preset, so long no-token windows (long-context + `thinking=xhigh` first-token latency) survive without disabling the cap. Eval harness adapters (`atomic_pier.py`, `atomic_harbor.py`) no longer hard-code `httpIdleTimeoutMs:0`; they inherit the new defaults.
+
 ## [0.9.3-alpha.5] - 2026-06-28
 
 ### Changed

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -132,12 +132,12 @@ Set `ATOMIC_SKIP_VERSION_CHECK=1` to disable the Atomic version update check. Us
 | `retry.maxRetries` | number | `3` | Maximum agent-level retry attempts |
 | `retry.baseDelayMs` | number | `2000` | Base delay for agent-level exponential backoff (2s, 4s, 8s) |
 | `retry.provider.timeoutMs` | number | SDK default | Provider/SDK request timeout in milliseconds |
-| `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
+| `retry.provider.maxRetries` | number | `5` | Provider/SDK retry attempts (also retries dropped connections / `Connection error`) |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay before failing (60s) |
 
 When a provider requests a retry delay longer than `retry.provider.maxRetryDelayMs` (e.g., Google's "quota will reset after 5h"), the request fails immediately with an informative error instead of waiting silently. Set to `0` to disable the cap.
 
-Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explicitly needed. Setting it above `0` can make SDK/provider retries handle out-of-usage-limit errors before Atomic sees them, which may block the agent until the provider quota resets in some circumstances.
+`retry.provider.maxRetries` defaults to `5` so transient socket drops (sandbox proxies, prod edge idle-closes) retry instead of failing as `Connection error`. The `maxRetryDelayMs` cap keeps this safe: connection errors back off briefly, while quota/rate-limit replies asking for a long delay still fail fast instead of blocking on usage limits. Set to `0` to disable provider-level retries.
 
 ```json
 {
@@ -147,7 +147,7 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
     "baseDelayMs": 2000,
     "provider": {
       "timeoutMs": 3600000,
-      "maxRetries": 0,
+      "maxRetries": 5,
       "maxRetryDelayMs": 60000
     }
   }
@@ -158,9 +158,9 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `httpIdleTimeoutMs` | number | `600000` | HTTP header/body idle timeout in milliseconds. Must be a non-negative finite number; decimals are rounded down. Set to `0` to disable the idle timeout. |
+| `httpIdleTimeoutMs` | number | `700000` | HTTP header/body idle timeout in milliseconds. Must be a non-negative finite number; decimals are rounded down. Set to `0` to disable the idle timeout. |
 
-Atomic applies this timeout to the global HTTP dispatcher used by `fetch` and provider SDK HTTP clients. The default is 600,000 ms (10 minutes), which keeps slow long-context requests working while reclaiming stale idle connections. The dispatcher also applies a fixed 10-second connect-phase timeout so an unreachable or firewall-blocked host fails fast instead of hanging until the OS TCP timeout.
+Atomic applies this timeout to the global HTTP dispatcher used by `fetch` and provider SDK HTTP clients. The default is 700,000 ms (~12 minutes), which tolerates long no-token windows (long-context + `thinking=xhigh` first-token latency) while reclaiming stale idle connections. The dispatcher also applies a fixed 10-second connect-phase timeout so an unreachable or firewall-blocked host fails fast instead of hanging until the OS TCP timeout.
 
 The `/settings` picker offers these presets:
 
@@ -170,12 +170,13 @@ The `/settings` picker offers these presets:
 | `1 min` | `60000` |
 | `5 min` | `300000` |
 | `10 min` | `600000` |
+| `~12 min` | `700000` |
 | `30 min` | `1800000` |
 | `Disabled` | `0` |
 
 ```json
 {
-  "httpIdleTimeoutMs": 600000
+  "httpIdleTimeoutMs": 700000
 }
 ```
 
@@ -186,7 +187,7 @@ The `/settings` picker offers these presets:
 | `steeringMode` | string | `"one-at-a-time"` | How steering messages are sent: `"all"` or `"one-at-a-time"` |
 | `followUpMode` | string | `"one-at-a-time"` | How follow-up messages are sent: `"all"` or `"one-at-a-time"` |
 | `transport` | string | `"auto"` | Preferred transport for providers that support multiple transports: `"sse"`, `"websocket"`, `"websocket-cached"`, or `"auto"` |
-| `httpIdleTimeoutMs` | number | `600000` | HTTP header/body idle timeout in milliseconds, also used by providers with explicit stream idle timeouts. Set to `0` to disable. |
+| `httpIdleTimeoutMs` | number | `700000` | HTTP header/body idle timeout in milliseconds, also used by providers with explicit stream idle timeouts. Set to `0` to disable. |
 | `websocketConnectTimeoutMs` | number | `15000` | WebSocket connect/open handshake timeout in milliseconds for providers that support WebSocket transports. Set to `0` to disable. |
 
 ### Terminal & Images

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -158,9 +158,9 @@ When a provider requests a retry delay longer than `retry.provider.maxRetryDelay
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `httpIdleTimeoutMs` | number | `700000` | HTTP header/body idle timeout in milliseconds. Must be a non-negative finite number; decimals are rounded down. Set to `0` to disable the idle timeout. |
+| `httpIdleTimeoutMs` | number | `600000` | HTTP header/body idle timeout in milliseconds. Must be a non-negative finite number; decimals are rounded down. Set to `0` to disable the idle timeout. |
 
-Atomic applies this timeout to the global HTTP dispatcher used by `fetch` and provider SDK HTTP clients. The default is 700,000 ms (~12 minutes), which tolerates long no-token windows (long-context + `thinking=xhigh` first-token latency) while reclaiming stale idle connections. The dispatcher also applies a fixed 10-second connect-phase timeout so an unreachable or firewall-blocked host fails fast instead of hanging until the OS TCP timeout.
+Atomic applies this timeout to the global HTTP dispatcher used by `fetch` and provider SDK HTTP clients. The default is 600,000 ms (10 minutes), which keeps slow long-context requests working while reclaiming stale idle connections. The dispatcher also applies a fixed 10-second connect-phase timeout so an unreachable or firewall-blocked host fails fast instead of hanging until the OS TCP timeout.
 
 The `/settings` picker offers these presets:
 
@@ -170,13 +170,12 @@ The `/settings` picker offers these presets:
 | `1 min` | `60000` |
 | `5 min` | `300000` |
 | `10 min` | `600000` |
-| `~12 min` | `700000` |
 | `30 min` | `1800000` |
 | `Disabled` | `0` |
 
 ```json
 {
-  "httpIdleTimeoutMs": 700000
+  "httpIdleTimeoutMs": 600000
 }
 ```
 
@@ -187,7 +186,7 @@ The `/settings` picker offers these presets:
 | `steeringMode` | string | `"one-at-a-time"` | How steering messages are sent: `"all"` or `"one-at-a-time"` |
 | `followUpMode` | string | `"one-at-a-time"` | How follow-up messages are sent: `"all"` or `"one-at-a-time"` |
 | `transport` | string | `"auto"` | Preferred transport for providers that support multiple transports: `"sse"`, `"websocket"`, `"websocket-cached"`, or `"auto"` |
-| `httpIdleTimeoutMs` | number | `700000` | HTTP header/body idle timeout in milliseconds, also used by providers with explicit stream idle timeouts. Set to `0` to disable. |
+| `httpIdleTimeoutMs` | number | `600000` | HTTP header/body idle timeout in milliseconds, also used by providers with explicit stream idle timeouts. Set to `0` to disable. |
 | `websocketConnectTimeoutMs` | number | `15000` | WebSocket connect/open handshake timeout in milliseconds for providers that support WebSocket transports. Set to `0` to disable. |
 
 ### Terminal & Images

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -1,7 +1,7 @@
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { installCopilotGeminiReasoningInterceptor } from "./copilot-gemini-reasoning.ts";
 
-export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 600_000;
+export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 700_000;
 
 /** Connect-phase timeout so a black-holed/firewalled host fails fast instead of hanging until the OS TCP timeout. */
 export const HTTP_CONNECT_TIMEOUT_MS = 10_000;
@@ -11,6 +11,7 @@ export const HTTP_IDLE_TIMEOUT_CHOICES = [
 	{ label: "1 min", timeoutMs: 60_000 },
 	{ label: "5 min", timeoutMs: 300_000 },
 	{ label: "10 min", timeoutMs: 600_000 },
+	{ label: "~12 min", timeoutMs: 700_000 },
 	{ label: "30 min", timeoutMs: 1_800_000 },
 	{ label: "Disabled", timeoutMs: 0 },
 ] as const;

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -1,7 +1,7 @@
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { installCopilotGeminiReasoningInterceptor } from "./copilot-gemini-reasoning.ts";
 
-export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 700_000;
+export const DEFAULT_HTTP_IDLE_TIMEOUT_MS = 600_000;
 
 /** Connect-phase timeout so a black-holed/firewalled host fails fast instead of hanging until the OS TCP timeout. */
 export const HTTP_CONNECT_TIMEOUT_MS = 10_000;
@@ -11,7 +11,6 @@ export const HTTP_IDLE_TIMEOUT_CHOICES = [
 	{ label: "1 min", timeoutMs: 60_000 },
 	{ label: "5 min", timeoutMs: 300_000 },
 	{ label: "10 min", timeoutMs: 600_000 },
-	{ label: "~12 min", timeoutMs: 700_000 },
 	{ label: "30 min", timeoutMs: 1_800_000 },
 	{ label: "Disabled", timeoutMs: 0 },
 ] as const;

--- a/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
@@ -360,7 +360,7 @@ const basicAccessors: SettingsManagerBasicAccessors = {
 	getProviderRetrySettings() {
 		return {
 			timeoutMs: settingsInternals(this).settings.retry?.provider?.timeoutMs,
-			maxRetries: settingsInternals(this).settings.retry?.provider?.maxRetries,
+			maxRetries: settingsInternals(this).settings.retry?.provider?.maxRetries ?? 5,
 			maxRetryDelayMs: settingsInternals(this).settings.retry?.provider?.maxRetryDelayMs ?? 60000,
 		};
 	},


### PR DESCRIPTION
## Summary

Eval runs against `github-copilot` intermittently failed mid-run with `{"error":"Connection error"}` after a long `thinking=xhigh` turn. Root cause: a multi-minute no-token window (model thinking) lets the eval sandbox proxy / prod Copilot edge close the idle stream → undici socket reset → OpenAI SDK throws a **fatal** `APIConnectionError`, because provider/SDK retries were pinned to `0`. Disabling the client idle timeout (`httpIdleTimeoutMs:0`) didn't help — it only lets Atomic wait on a socket the server already severed. The fix is to make socket-drop recovery the default.

## Changes

- **`retry.provider.maxRetries` default `0` → `5`** so status-undefined connection drops retry instead of aborting. The existing `retry.provider.maxRetryDelayMs` (60s) cap still fails fast on long quota/rate-limit waits, so this does not block on usage limits.
- **Evals:** removed hard-coded `httpIdleTimeoutMs:0` from `atomic_pier.py` and `atomic_harbor.py`; both now inherit the standard 10-minute idle timeout default.
- **Evals:** `atomic_harbor.py` install mirrors pier — installs `fd-find`/`ripgrep` (+ `git`, `curl`) and symlinks `fdfind`→`fd`.
- Updated `docs/settings.md` and `CHANGELOG.md`.

The idle timeout default is unchanged (10 min / `600000`).

## Notes

`typecheck`, `lint`, `check:file-length`, and `test:unit` all pass via prek. Recovery now comes from retrying drops, not from waiting forever on a severed socket; the finite idle timeout still reclaims stale connections.