### PR TITLE
docs: improve README promo GIF quality

### DIFF
--- a/assets/atomic-promo.gif
+++ b/assets/atomic-promo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44fcb0a5657e4ad3055ec8a89d4c6c708f340b6785a6eeb38d34a1f7b0e6a7cd
-size 42873977
+oid sha256:d51a09280e4dc558265db4e9c0642dc5347470c013eb499ed6ae0f274cb37d66
+size 45612468


### PR DESCRIPTION
## Summary

Replaces the README promo GIF with a higher-quality `gifski` encode generated from the original MP4 source. Asset-only change — no code or documentation text modifications.

## Changes

- Re-encoded `assets/atomic-promo.gif` from the original `atomic-promo.mp4` using `gifski`
- Increases playback from 12 fps to 18 fps for smoother animation
- Preserves existing 1280×720 dimensions referenced by the README `<img>` tag

## Validation

- `bun run lint`
- `bun run check:file-length`
- `bun run test:unit`