### PR TITLE
fix(workflows): read release manifests without Bun global

### DIFF
--- a/.atomic/workflows/lib/publish-release-helpers.ts
+++ b/.atomic/workflows/lib/publish-release-helpers.ts
@@ -1,4 +1,5 @@
 import { existsSync, readdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import {
   commandSummary,
   runCommand,
@@ -67,7 +68,7 @@ function isJsonObject(value: JsonValue): value is { readonly [key: string]: Json
 }
 
 async function readPackageManifest(path: string): Promise<PackageManifest> {
-  const value = await Bun.file(path).json() as JsonValue;
+  const value = JSON.parse(await readFile(path, "utf8")) as JsonValue;
   if (!isJsonObject(value)) {
     throw new Error(`${path} did not contain a JSON object`);
   }


### PR DESCRIPTION
## Summary

Fixes the \`publish-release\` workflow verifier so it can run in Node-based contexts (e.g., GitHub Actions workflow runners). The verifier was failing with \`Bun is not defined\` because the manifest reader called \`Bun.file(path).json()\`, which is a Bun-only API.

## Changes

- Replace \`Bun.file(path).json()\` in \`readPackageManifest\` with \`node:fs/promises\` \`readFile\` + \`JSON.parse\`, which is portable across Bun and Node runtimes.
- All existing manifest object validation and release verification behavior is unchanged.

## Validation

- \`bun run typecheck\`
- \`bun test test/unit/publish-release-helpers.test.ts\`
- Pre-commit hooks: \`bun run lint\`, \`bun run check:file-length\`, \`bun run test:unit\`