### PR TITLE
Release 0.9.3-alpha.6

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
 ### Changed
 
 - Enabled provider/SDK retries by default (`retry.provider.maxRetries` `0` → `5`) so transient socket drops retry instead of surfacing as fatal `"Connection error"`. Connection failures (status-undefined) back off briefly while the existing `retry.provider.maxRetryDelayMs` cap still fails fast on long quota/rate-limit waits.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.6 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.3-alpha.5.
+
 ## [0.9.3-alpha.5] - 2026-06-28
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.6 prerelease for the intercom extension; no intercom extension changes were made after 0.9.3-alpha.5.
+
 ## [0.9.3-alpha.5] - 2026-06-28
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.6 prerelease for the MCP extension; no MCP extension changes were made after 0.9.3-alpha.5.
+
 ## [0.9.3-alpha.5] - 2026-06-28
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.6 prerelease for the native transport package; no native transport changes were made after 0.9.3-alpha.5.
+
 ## [0.9.3-alpha.5] - 2026-06-28
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
 ### Added
 
 - Added OpenRouter fallback coverage to the bundled subagent definitions so delegated codebase analysis, research, debugging, simplification, and worker sessions can recover through OpenRouter-hosted frontier, GLM, and Gemini providers when native providers are unavailable.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.3-alpha.6 prerelease for the web-access extension; no web-access extension changes were made after 0.9.3-alpha.5.
+
 ## [0.9.3-alpha.5] - 2026-06-28
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.3-alpha.6] - 2026-06-29
+
 ### Added
 
 - Added OpenRouter fallback coverage to the builtin `goal`, `ralph`, `deep-research-codebase`, and `open-claude-design` workflow model configs so workflow stages have additional frontier, GLM, and Gemini provider redundancy.


### PR DESCRIPTION
## Summary

Changelog-only release notes for the **0.9.3-alpha.6** prerelease, with entries appended under each package's `## [Unreleased]` section. No package version bump is included; `main` stays versionless at `0.0.0`. The real version is materialized by `scripts/cut-release.ts` on the throwaway off-main tag commit and is never merged into `main`.

## Release details

- **Release kind:** prerelease → `@next`
- **Target version:** `0.9.3-alpha.6`
- **Base branch:** `main`
- **Head branch:** `prerelease/0.9.3-alpha.6`
- **Head SHA:** `fdf3b5f6478fca5e0fe1d0399ec53efa55360674`
- **Version/package bump:** none on `main` (versionless)

## Changelog-only release notes (Unreleased) across

- `packages/coding-agent/CHANGELOG.md`
- `packages/cursor/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`
- `packages/mcp/CHANGELOG.md`
- `packages/natives/CHANGELOG.md`
- `packages/subagents/CHANGELOG.md`
- `packages/web-access/CHANGELOG.md`
- `packages/workflows/CHANGELOG.md`

## Key changes in this prerelease

- **Provider retries enabled by default** (`coding-agent`): `retry.provider.maxRetries` raised from `0` → `5`, so transient socket drops retry automatically instead of surfacing as fatal `"Connection error"`. Connection failures (status-undefined) back off briefly; the existing `retry.provider.maxRetryDelayMs` cap still fails fast on long quota/rate-limit waits.
- **OpenRouter fallback for subagents** (`subagents`): bundled subagent definitions (codebase analysis, research, debugging, simplification, worker sessions) now have OpenRouter-hosted frontier, GLM, and Gemini providers as fallbacks when native providers are unavailable.
- **OpenRouter fallback for workflows** (`workflows`): builtin `goal`, `ralph`, `deep-research-codebase`, and `open-claude-design` workflow model configs gain the same OpenRouter provider redundancy.

## Synchronized packages (no functional changes after alpha.5)

- `packages/cursor/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`
- `packages/mcp/CHANGELOG.md`
- `packages/natives/CHANGELOG.md`
- `packages/web-access/CHANGELOG.md`

## Validation

Local release checks passed deterministically.

```sh
$ git branch --show-current
prerelease/0.9.3-alpha.6

$ git rev-parse HEAD
fdf3b5f6478fca5e0fe1d0399ec53efa55360674

$ git status --short
(clean)

$ git diff --name-only 879ff63fd76b14f7b42a93aa116fa6d22d9c93a7..HEAD
packages/coding-agent/CHANGELOG.md
packages/cursor/CHANGELOG.md
packages/intercom/CHANGELOG.md
packages/mcp/CHANGELOG.md
packages/natives/CHANGELOG.md
packages/subagents/CHANGELOG.md
packages/web-access/CHANGELOG.md
packages/workflows/CHANGELOG.md
```

Reused existing PR #1558 for head `prerelease/0.9.3-alpha.6` → base `main`.
