### PR TITLE
docs: add 0.9.3 stable release notes across all packages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Breaking Changes
+
+- Replaced the legacy exact-replacement `edit` tool API with the hashline-only `input` script schema; callers must use snapshot tags from `read`/`search`/`write`/`edit` instead of `path` + `edits[]` or `oldText`/`newText`.
+- Tightened the model-facing `read`, `find`, and `search` schemas to the new builtin contracts (`read` path selectors, required `find.paths`, and the narrowed `search` option set).
+
+### Added
+
+- Added first-run onboarding that routes pasted tickets, specs, and tasks into normal Atomic sessions with scope-estimation guidance and workflow handoff next steps.
+- Added internal workflow-stage session marking so workflow-created sessions stay out of ordinary `/resume`, `atomic -r`, and `--continue` history while remaining accessible through workflow resume/status surfaces.
+- Added first-class `find`/`search` builtins, hashline snapshot anchors, hashline edit scripts with stale-tag safety, a disabled-by-default Bash Interceptor toggle, Rust-backed `pty:true` bash execution, and native glob/grep/search bindings for oh-my-pi parity.
+
+### Changed
+
+- Synced bundled upstream Pi runtime packages to `^0.80.2` and routed legacy pi-ai imports through the temporary `/compat` entrypoint, including virtual-module and Jiti aliases for first-party and user-installed extensions.
+- Enabled provider/SDK retries by default, raised the standard HTTP idle timeout to 10 minutes, and added a 10-second connect-phase timeout so transient socket drops retry while unreachable hosts fail fast.
+- Accounted for image content blocks in context-window estimates and compaction budgets, raised delegated workflow/subagent nesting to the shared five-level maximum, and exported the canonical schema-aware flattened-argument helper used by host and MCP tool execution.
+- Updated workflow and user-facing documentation so structured, validation-heavy, implementation, debugging, migration, and loop-shaped requests are routed to workflows by default.
+
+### Fixed
+
+- Fixed custom tool renderer cleanup, persisted-context replay after context compaction, and multiple first-run onboarding edge cases around placeholders, file references, isolated config discovery, saved tasks, `/import`, `/model`, and `/new`.
+- Completed the oh-my-pi builtin parity pass across `read`, `write`, `find`, `search`, `edit`, `bash`, archive, document, URL, internal-resource, conflict, and SQLite selectors, including pagination, truncation metadata, native cache invalidation, copied-hashline stripping, async/PTY behavior, and cross-platform path handling.
+- Hardened generated-file, URL, `local://`, SQLite, archive, native PTY/search, and bash-interceptor paths against traversal, SSRF, unsafe raw SQL/archive cases, stale cache writes, native panics, leaked async output, and provider-hostile argument shapes.
+- Fixed compiled release binary packaging and cross-platform package tests by externalizing `mupdf`, preparing native bindings and fixtures in CI, running the coding-agent Vitest suite under Bun, and hardening Windows path, color, and process-spawn coverage.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Changed

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Added
+
+- Added scoped Cursor image-input support for known multimodal Claude, Composer, Gemini, GPT, Kimi, and Grok 4.3 model families, including selected-image request serialization and mixed text/image MCP tool-result serialization.
+- Added `cursor/grok-4.3` to the estimated fallback catalog.
+
+### Changed
+
+- Aligned the Cursor provider dependency on upstream pi-ai `^0.80.2` and retargeted legacy provider/model imports to the `@earendil-works/pi-ai/compat` entrypoint.
+- Resolved Cursor model context windows and max output tokens from Atomic's bundled pi-ai model catalog while preserving positive live limits, ignoring bogus non-positive values, and keeping conservative estimates only for Cursor-only models.
+- Marked Cursor OAuth as **Cursor (Experimental)** in the `/login` picker.
+
+### Fixed
+
+- Fixed effort-variant-only Cursor models failing no-thinking requests by recording and sending a concrete default variant instead of an unsendable synthesized base id.
+- Preserved explicit `1M` Cursor context floors across fallback catalog matches and made the pi-ai catalog a runtime dependency so limit fallback remains available at provider startup.
+- Exposed `xhigh` only for Cursor models whose live or estimated catalog includes a real `xhigh`/`max` variant, with saved `xhigh` selections falling back to the nearest sendable variant.
+- Rejected empty or malformed base64 image payloads during Cursor selected-image and MCP image serialization while accepting valid MIME-wrapped base64 with whitespace.
+
+### Removed
+
+- Removed outdated Cursor Grok 4.20 fallback entries and stopped advertising unsupported Grok-family Cursor IDs as image-capable.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Changed
+
+- Published the stable Atomic 0.9.3 release for the intercom extension with its upstream pi TUI peer dependency aligned to `^0.80.2`; no intercom extension source changes were needed after 0.9.2.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Changed
+
+- Aligned the MCP extension peer dependencies with upstream pi `^0.80.2` and retargeted legacy provider/model imports to `@earendil-works/pi-ai/compat`, preserving MCP sampling behavior under the updated pi-ai package layout.
+
+### Fixed
+
+- Made `unflattenToolArguments` schema-aware so literal dotted top-level argument keys such as `filter.name` are preserved unless the tool input schema proves the key represents a nested path, while bracket-indexed array/object keys are still reconstructed for direct-tool and proxy/gateway calls.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Added
+
+- Added a Rust-backed `PtySession` N-API surface using `portable-pty`, enabling Atomic `bash` calls with `pty: true` to run through a real PTY/ConPTY with streaming output, resize, kill, timeout, cwd, shell, and environment support.
+- Added native `glob`, `grep`, in-memory `search`, `hasMatch`, and filesystem scan-cache invalidation bindings for Atomic's full-level `find`/`search` tool parity.
+
+### Changed
+
+- Refreshed the native build toolchain and transitive Rust dependencies, including `@napi-rs/cli` 3.7.2, `rustls` 0.23.41, `napi` 3.9.4, `bytes` 1.12.0, and `webpki-roots` 1.0.8.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Added
+
+- Added OpenRouter fallback coverage to bundled subagent definitions so delegated codebase analysis, research, debugging, simplification, and worker sessions can recover through OpenRouter-hosted frontier, GLM, and Gemini providers when native providers are unavailable.
+
+### Changed
+
+- Aligned the subagents extension peer dependencies with upstream pi `^0.80.2` runtime packages and retargeted legacy provider/model imports to `@earendil-works/pi-ai/compat`.
+- Raised the default and hard maximum subagent nesting budget to five delegated levels, extending nested-run observability to the same depth.
+
+### Fixed
+
+- Prevented async and foreground subagent status widgets from flickering or unmounting during host UI refreshes, tall-panel redraws, and reset-and-hydrate cycles with active background runs.
+- Fixed live subagent result animation cleanup so terminal workflow rows evict animation registry entries instead of leaving stale intervals.
+- Synced upstream subagent hardening for compact tool-call summaries, nested fanout call/result history, duplicate dispatch rejection, provider-safe chain schemas, failed foreground diagnostics, builtin `search` MCP allowlist filtering, and updated builtin `find`/`search` tool guidance.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Added

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Changed
+
+- Published the stable Atomic 0.9.3 release for the web-access extension with its upstream pi TUI peer dependency aligned to `^0.80.2` and legacy pi-ai summary/model helper imports retargeted to the `/compat` entrypoint; no web-access extension source changes were needed after 0.9.2.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-06-29
+
+### Breaking Changes
+
+- Enabled workflow durability by default with a zero-infrastructure per-workflow file backend under `~/.atomic/workflow-durable`, replacing the previous process-local in-memory default and removing the old `ATOMIC_WORKFLOW_DURABLE_DIR` opt-in path. Explicit in-memory durability remains available through custom/test backends or `ATOMIC_WORKFLOW_DURABLE=0`/`false`/`off`/`memory`.
+
+### Added
+
+- Added `StageContext.sendUserMessage(content, { deliverAs? })` so workflow authors can inject follow-on user turns into live stage sessions after `prompt()` resolves while preserving MCP scope, abort handling, and structured-output guards.
+- Added cross-session durable workflow resumability with cached `ctx.tool`, `ctx.ui`, `ctx.stage`/`ctx.task`/`ctx.chain`/`ctx.parallel`, and child-workflow checkpoints, plus `/workflow resume` discovery of durable workflow history from session metadata and the durable backend.
+- Added optional DBOS-backed durability through the lazily loaded `@dbos-inc/dbos-sdk`, including DBOS read-side hydration for resumable workflows when `DBOS_SYSTEM_DATABASE_URL` is set.
+- Added OpenRouter fallback coverage to builtin `goal`, `ralph`, `deep-research-codebase`, and `open-claude-design` workflow model configs.
+
+### Changed
+
+- Marked workflow stage sessions as internal so they are excluded from normal Atomic resume history while remaining inspectable and resumable through workflow-specific commands and tools.
+- Revised builtin `goal`, `ralph`, and `open-claude-design` prompts to emphasize full objective completion, stable non-ordinal artifacts, a shared five-level subagent nesting budget, and model-facing workflow guidance that routes non-trivial structured work to workflows by default.
+- Aligned the workflows extension peer dependency with upstream pi TUI `^0.80.2`.
+
+### Fixed
+
+- Fixed workflow graph and attached-stage chat interactions, including direct mouse-click activation, mouse/trackpad wheel capture, copy-mode toggling, stale `Working...` spinners, terminal-row animation cleanup, and post-terminal subagent progress handling.
+- Hardened durable resume, replay, checkpoint, and listing behavior across file and DBOS backends, including pending prompts, terminal/non-resumable states, stale cache entries, repeated quit/resume cycles, child workflow scope isolation, checkpoint identity hashing, retries, cancellation, and durable write failures.
+- Fixed `/workflow resume` picker behavior for live, paused, failed, and cross-session durable workflows so it matches the standard Atomic resume selector and handles empty, headless, mixed live/durable, and cache-only states consistently.
+- Fixed builtin workflow continuity and configuration edge cases, including `open-claude-design` generator/feedback forking, isolated workflow config discovery, durable schema-backed stage replay, parallel fail-fast finalization, and custom-backend propagation into child workflows.
+
 ## [0.9.3-alpha.6] - 2026-06-29
 
 ### Added


### PR DESCRIPTION
## Summary

Adds `[0.9.3]` changelog entries across all published packages, consolidating the cumulative `0.9.3-alpha.*` prerelease line into a stable release summary. No source code changes; `main` remains versionless.

## Key changes by package

### `@bastani/atomic` (coding-agent)
- **Breaking:** Replaced legacy `edit` tool API with hashline-only `input` script schema; tightened `read`/`find`/`search` builtin contracts
- Added first-run onboarding with ticket/spec/task routing and scope-estimation guidance
- Added internal workflow-stage session marking to keep workflow sessions out of normal resume history
- Added `find`/`search` builtins, hashline snapshot anchors, Rust-backed PTY bash execution, and native glob/grep/search bindings (oh-my-pi parity)
- Synced bundled upstream Pi runtime to `^0.80.2` with `/compat` entrypoint routing
- Enabled provider/SDK retries by default; raised HTTP idle timeout to 10 min with a 10 s connect-phase timeout
- Fixed custom tool renderer cleanup, persisted-context replay after compaction, and numerous first-run onboarding edge cases
- Hardened URL, SQLite, archive, native PTY/search, and bash-interceptor paths against traversal, SSRF, and unsafe raw SQL

### `@bastani/workflows`
- **Breaking:** Workflow durability is now enabled by default via a per-workflow file backend under `~/.atomic/workflow-durable`; opt out with `ATOMIC_WORKFLOW_DURABLE=0`
- Added `StageContext.sendUserMessage()` for injecting follow-on user turns into live stage sessions
- Added cross-session durable workflow resumability with full checkpoint coverage and `/workflow resume` discovery
- Added optional DBOS-backed durability via `@dbos-inc/dbos-sdk` when `DBOS_SYSTEM_DATABASE_URL` is set
- Fixed workflow graph mouse interactions, stale spinners, terminal-row animation cleanup, and durable resume edge cases

### `@bastani/subagents`
- Added OpenRouter fallback coverage to bundled subagent definitions for frontier, GLM, and Gemini providers
- Raised default and hard maximum subagent nesting budget to five delegated levels
- Fixed async/foreground status widget flickering during host UI refreshes and stale animation interval cleanup

### `@bastani/cursor`
- Added scoped multimodal image-input support for Claude, Composer, Gemini, GPT, Kimi, and Grok 4.3 model families
- Fixed effort-variant-only models failing no-thinking requests; fixed `xhigh` exposure and context-window limit resolution
- Removed outdated Grok 4.20 fallback entries

### `@bastani/natives`
- Added Rust-backed `PtySession` N-API surface using `portable-pty` for real PTY/ConPTY execution
- Added native `glob`, `grep`, in-memory `search`, `hasMatch`, and scan-cache invalidation bindings
- Refreshed native build toolchain and Rust dependency tree

### `@bastani/mcp`
- Made `unflattenToolArguments` schema-aware so literal dotted top-level keys are preserved when the tool schema confirms they are not nested paths

### `@bastani/intercom` / `@bastani/web-access`
- Dependency alignment to upstream pi `^0.80.2`; no source changes since 0.9.2

## Breaking changes

| Package | Change |
|---|---|
| `@bastani/atomic` | `edit` tool now uses hashline-only `input` script schema; `path`+`edits[]` / `oldText`/`newText` removed |
| `@bastani/atomic` | `read`, `find`, `search` schemas tightened to new builtin contracts |
| `@bastani/workflows` | Workflow durability enabled by default (file backend); set `ATOMIC_WORKFLOW_DURABLE=0` to revert to in-memory |

## Validation

- `bun run typecheck`
- Commit hooks: `bun run lint`, `bun run check:file-length`, `bun run test:unit`