### PR TITLE
fix(workflows): harden returned-status classification and PR check polling

### DIFF
--- a/.atomic/workflows/lib/publish-release-gates.ts
+++ b/.atomic/workflows/lib/publish-release-gates.ts
@@ -12,6 +12,7 @@ import {
   type ValidatedRelease,
 } from "./publish-release.js";
 import { waitForWorkflowRunSucceeded } from "./publish-release-run-wait.js";
+import { defaultSleep } from "./publish-release-helpers.js";
 
 type GateVerification =
   | {
@@ -34,9 +35,6 @@ type CheckGateOptions = {
 const defaultCheckGateAttempts = 30;
 const defaultCheckGatePollIntervalMs = 30_000;
 
-function defaultSleep(durationMs: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, durationMs));
-}
 
 type MainReadyVerification =
   | {

--- a/.atomic/workflows/lib/publish-release-gates.ts
+++ b/.atomic/workflows/lib/publish-release-gates.ts
@@ -6,6 +6,7 @@ import {
   verifyPullRequestMergedJson,
   verifyReleasePullRequestReferenceJson,
   type PublishWorkflowRunVerification,
+  type CommandResult,
   type PullRequestMergeVerification,
   type PullRequestReferenceVerification,
   type ValidatedRelease,
@@ -20,7 +21,22 @@ type GateVerification =
   | {
       readonly ok: false;
       readonly summary: string;
+      readonly pending?: boolean;
     };
+
+type CheckGateOptions = {
+  readonly attempts?: number;
+  readonly pollIntervalMs?: number;
+  readonly runCommand?: (args: readonly string[]) => CommandResult;
+  readonly sleep?: (durationMs: number) => Promise<void>;
+};
+
+const defaultCheckGateAttempts = 30;
+const defaultCheckGatePollIntervalMs = 30_000;
+
+function defaultSleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
 
 type MainReadyVerification =
   | {
@@ -116,12 +132,46 @@ export function captureReleasePrReference(
   };
 }
 
-export function verifyReleasePrChecksPassed(
+export async function verifyReleasePrChecksPassed(
   release: ValidatedRelease,
   prReference: Extract<PullRequestReferenceVerification, { readonly ok: true }>,
   baseRef: string,
+  options: CheckGateOptions = {},
+): Promise<GateVerification> {
+  const attempts = options.attempts ?? defaultCheckGateAttempts;
+  const pollIntervalMs = options.pollIntervalMs ?? defaultCheckGatePollIntervalMs;
+  const sleep = options.sleep ?? defaultSleep;
+  let lastPendingSummary: string | undefined;
+
+  const execute = options.runCommand ?? runCommand;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const verification = verifyReleasePrChecksOnce(release, prReference, baseRef, execute);
+    if (verification.ok) return verification;
+    if (verification.pending !== true) return verification;
+
+    lastPendingSummary = verification.summary;
+    if (attempt < attempts) await sleep(pollIntervalMs);
+  }
+
+  return {
+    ok: false,
+    pending: true,
+    summary: [
+      "GitHub PR required checks did not finish before the polling timeout.",
+      `attempts: ${attempts}`,
+      `pollIntervalMs: ${pollIntervalMs}`,
+      lastPendingSummary,
+    ].filter((line): line is string => line !== undefined).join("\n\n"),
+  };
+}
+
+function verifyReleasePrChecksOnce(
+  release: ValidatedRelease,
+  prReference: Extract<PullRequestReferenceVerification, { readonly ok: true }>,
+  baseRef: string,
+  execute: (args: readonly string[]) => CommandResult,
 ): GateVerification {
-  const prView = runCommand([
+  const prView = execute([
     "gh",
     "pr",
     "view",
@@ -148,7 +198,7 @@ export function verifyReleasePrChecksPassed(
     return { ok: false, summary: [refreshedReference.summary, commandSummary(prView)].join("\n\n") };
   }
 
-  const checks = runCommand([
+  const checks = execute([
     "gh",
     "pr",
     "checks",
@@ -158,16 +208,28 @@ export function verifyReleasePrChecksPassed(
     "name,state,bucket,link,workflow,description",
   ]);
 
-  if (checks.exitCode !== 0) {
+  const parsedChecks = parseJsonCommand(checks, "GitHub PR required checks returned invalid JSON.");
+  if (checks.exitCode !== 0 && checks.exitCode !== 8) {
     return { ok: false, summary: ["GitHub PR required checks command failed.", commandSummary(checks)].join("\n\n") };
   }
-
-  const parsedChecks = parseJsonCommand(checks, "GitHub PR required checks returned invalid JSON.");
-  if (!parsedChecks.ok) return { ok: false, summary: parsedChecks.summary };
+  if (!parsedChecks.ok) {
+    if (checks.exitCode === 8) {
+      return {
+        ok: false,
+        pending: true,
+        summary: ["GitHub PR required checks are still pending.", commandSummary(checks)].join("\n\n"),
+      };
+    }
+    return { ok: false, summary: parsedChecks.summary };
+  }
 
   const checkVerification = verifyPullRequestChecksJson(parsedChecks.value);
   if (!checkVerification.ok) {
-    return { ok: false, summary: [checkVerification.summary, commandSummary(prView), commandSummary(checks)].join("\n\n") };
+    return {
+      ok: false,
+      pending: checkVerification.pending,
+      summary: [checkVerification.summary, commandSummary(prView), commandSummary(checks)].join("\n\n"),
+    };
   }
 
   return {

--- a/.atomic/workflows/lib/publish-release-helpers.ts
+++ b/.atomic/workflows/lib/publish-release-helpers.ts
@@ -14,6 +14,10 @@ export function excerpt(text: string, limit = 1_200): string {
   return `${text.slice(0, limit)}\n…[truncated ${text.length - limit} chars]`;
 }
 
+export function defaultSleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
 export function blockedOutput(
   release: ValidatedRelease,
   stage: string,

--- a/.atomic/workflows/lib/publish-release-run-wait.ts
+++ b/.atomic/workflows/lib/publish-release-run-wait.ts
@@ -8,6 +8,7 @@ import {
   type JsonValue,
   type PublishWorkflowRunVerification,
 } from "./publish-release.js";
+import { defaultSleep } from "./publish-release-helpers.js";
 
 type RunCommand = (args: readonly string[]) => CommandResult;
 type Sleep = (durationMs: number) => Promise<void>;
@@ -41,11 +42,6 @@ type RunIdentity =
 type JsonObject = { readonly [key: string]: JsonValue };
 
 const runJsonFields = "databaseId,status,conclusion,url,headBranch,event,workflowName,createdAt,headSha";
-function defaultSleep(durationMs: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, durationMs));
-}
-
-
 function isJsonObject(value: JsonValue): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/.atomic/workflows/lib/publish-release-run-wait.ts
+++ b/.atomic/workflows/lib/publish-release-run-wait.ts
@@ -41,6 +41,10 @@ type RunIdentity =
 type JsonObject = { readonly [key: string]: JsonValue };
 
 const runJsonFields = "databaseId,status,conclusion,url,headBranch,event,workflowName,createdAt,headSha";
+function defaultSleep(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
 
 function isJsonObject(value: JsonValue): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -122,7 +126,7 @@ export async function waitForWorkflowRunSucceeded(
   options: WaitOptions,
 ): Promise<PublishWorkflowRunVerification> {
   const execute = options.runCommand ?? defaultRunCommand;
-  const sleep = options.sleep ?? Bun.sleep;
+  const sleep = options.sleep ?? defaultSleep;
   const listAttempts = options.listAttempts ?? 6;
   const viewAttempts = options.viewAttempts ?? 120;
   const pollIntervalMs = options.pollIntervalMs ?? 10_000;

--- a/.atomic/workflows/lib/publish-release-types.ts
+++ b/.atomic/workflows/lib/publish-release-types.ts
@@ -65,6 +65,7 @@ export type PullRequestChecksVerification =
   | {
       readonly ok: false;
       readonly summary: string;
+      readonly pending?: boolean;
     };
 
 export type PublishWorkflowRunVerification =

--- a/.atomic/workflows/lib/publish-release.ts
+++ b/.atomic/workflows/lib/publish-release.ts
@@ -266,6 +266,14 @@ function checkPassed(value: { readonly [key: string]: JsonValue }): boolean {
   return state === "SUCCESS" || state === "PASSING" || state === "PASSED";
 }
 
+function checkPending(value: { readonly [key: string]: JsonValue }): boolean {
+  const bucket = stringField(value, "bucket")?.toLowerCase();
+  if (bucket !== undefined) return bucket === "pending";
+
+  const state = stringField(value, "state")?.toUpperCase();
+  return state === "PENDING" || state === "QUEUED" || state === "IN_PROGRESS" || state === "WAITING" || state === "REQUESTED";
+}
+
 export function verifyPullRequestChecksJson(value: JsonValue): PullRequestChecksVerification {
   if (!Array.isArray(value)) {
     return { ok: false, summary: "GitHub PR checks response was not a JSON array." };
@@ -276,18 +284,24 @@ export function verifyPullRequestChecksJson(value: JsonValue): PullRequestChecks
   }
 
   const failures: string[] = [];
+  const pending: string[] = [];
   for (const [index, check] of value.entries()) {
     if (!isJsonObject(check)) {
       failures.push(`check[${index}] was not a JSON object`);
       continue;
     }
 
-    if (!checkPassed(check)) {
-      const name = checkName(check, index);
-      const bucket = stringField(check, "bucket") ?? "missing";
-      const state = stringField(check, "state") ?? "missing";
-      const link = stringField(check, "link");
-      failures.push(`${name} bucket=${bucket} state=${state}${link === undefined ? "" : ` link=${link}`}`);
+    if (checkPassed(check)) continue;
+
+    const name = checkName(check, index);
+    const bucket = stringField(check, "bucket") ?? "missing";
+    const state = stringField(check, "state") ?? "missing";
+    const link = stringField(check, "link");
+    const line = `${name} bucket=${bucket} state=${state}${link === undefined ? "" : ` link=${link}`}`;
+    if (checkPending(check)) {
+      pending.push(line);
+    } else {
+      failures.push(line);
     }
   }
 
@@ -297,6 +311,17 @@ export function verifyPullRequestChecksJson(value: JsonValue): PullRequestChecks
       summary: [
         "GitHub PR required checks are not verified as passing.",
         ...failures.map((failure) => `- ${failure}`),
+      ].join("\n"),
+    };
+  }
+
+  if (pending.length > 0) {
+    return {
+      ok: false,
+      pending: true,
+      summary: [
+        "GitHub PR required checks are still pending.",
+        ...pending.map((check) => `- ${check}`),
       ].join("\n"),
     };
   }

--- a/.atomic/workflows/publish-release.ts
+++ b/.atomic/workflows/publish-release.ts
@@ -172,14 +172,14 @@ export default workflow({
       ].join("\n"),
     });
 
-    const ciVerification = verifyReleasePrChecksPassed(release, prReference, baseRef);
+    const ciVerification = await verifyReleasePrChecksPassed(release, prReference, baseRef);
     if (!ciVerification.ok) {
       return blockedOutput(
         release,
         "verify-release-pr-checks-passed",
         "GitHub PR required checks are passing for the exact captured PR head SHA before merge",
         [ciVerification.summary, "", "CI wait stage output:", excerpt(ciWait.text, 2_000)].join("\n"),
-        "failed",
+        ciVerification.pending === true ? "blocked" : "failed",
       );
     }
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated user-facing workflow documentation for the blocked lifecycle notice state and the default `workflowNotifications.notifyOn` set, matching the workflows runtime behavior for failed/blocked structured results.
+
 ## [0.9.3] - 2026-06-29
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Updated user-facing workflow documentation for the blocked lifecycle notice state and the default `workflowNotifications.notifyOn` set, matching the workflows runtime behavior for failed/blocked structured results.
+- Updated user-facing workflow documentation for the blocked lifecycle notice state, the default `workflowNotifications.notifyOn` set, and the reserved top-level workflow output `status` convention for returned `failed`/`blocked` run statuses.
 
 ## [0.9.3] - 2026-06-29
 

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -1290,6 +1290,8 @@ Workflow outputs are runtime contracts for completed workflow runs and for paren
 
 **Return convention:** outputs are return-object keys. Atomic never infers child workflow outputs from stage names, stage order, or the final assistant message. If a parent should read `child.outputs.foo`, the child workflow's `run` must both declare `outputs: { foo: schema }` and return `{ foo: value }`. `result` is not special and is never added for you: to expose `result`, declare it in `outputs` and return `{ result }` exactly like any other output. Returning a key that is not declared in `outputs` fails the run with `atomic-workflows: workflow "<name>" returned undeclared output "<key>"; declare it in outputs or remove it from the run return`.
 
+**Reserved `status` output convention:** if a workflow declares and returns a top-level `status` output with the string value `"failed"` or `"blocked"`, Atomic treats that as the workflow's terminal run status instead of recording a successful completion. When present, a non-empty top-level `summary` string becomes the run error/reason shown in lifecycle notices and status surfaces. Use this convention only when the workflow is intentionally reporting its own terminal state (for example, a deterministic release gate that returns `{ status: "blocked", summary: "required checks are pending" }`). Do not use a top-level `status` field for unrelated external state such as a deployment/check you merely inspected; choose a domain-specific name like `deployment_status` or `gate_status` instead.
+
 The `outputs` object is a schema contract, not an automatic stage selector. To expose values from any stage, capture the stage/task/child result in normal TypeScript and return it from `run` under the desired key:
 
 ```ts

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -696,7 +696,7 @@ Example config:
   "resumeInFlight": "ask",
   "workflowNotifications": {
     "enabled": true,
-    "notifyOn": ["completed", "failed", "awaiting_input"]
+    "notifyOn": ["completed", "failed", "blocked", "awaiting_input"]
   }
 }
 ```
@@ -711,7 +711,7 @@ Runtime config defaults:
 | `statusFile` | `false` | Write a derived status file; defaults under `.atomic/workflows/status.json` when enabled |
 | `resumeInFlight` | `"ask"` | Behavior when discovering resumable in-flight work |
 | `workflowNotifications.enabled` | `true` | Emit terminal workflow lifecycle notices into the active main chat |
-| `workflowNotifications.notifyOn` | `["completed", "failed", "awaiting_input"]` | Lifecycle states to track; terminal `completed`/`failed` states create main-chat notices, while `awaiting_input` is tracked for dedupe/restore without waking the main agent |
+| `workflowNotifications.notifyOn` | `["completed", "failed", "blocked", "awaiting_input"]` | Lifecycle states to track; terminal `completed`/`failed`/`blocked` states create main-chat notices, while `awaiting_input` is tracked for dedupe/restore without waking the main agent |
 
 Invalid JSON or invalid shapes produce `CONFIG_INVALID` diagnostics. Missing config files are ignored.
 
@@ -1007,7 +1007,7 @@ The default file backend needs no environment variable or database. It writes on
 
 ## Lifecycle Notices and Human Input
 
-Atomic emits deduplicated main-chat notices when top-level workflow runs complete or fail. Nested child workflow completion/failure is reflected inside the expanded parent graph instead of producing separate top-level completion cards. These terminal notices are queued into the active main chat as steering/context messages (`triggerTurn: true`, `deliverAs: "steer"`) so the model can react without the user manually polling status. Awaiting-input workflow states are tracked for dedupe/restore, but they do not enqueue main-chat connect cards or wake the model; prompt state remains visible through workflow status/connect surfaces. Configure lifecycle behavior with `workflowNotifications.enabled` (default `true`) and `workflowNotifications.notifyOn` (default `["completed", "failed", "awaiting_input"]`).
+Atomic emits deduplicated main-chat notices when top-level workflow runs complete, fail, or end blocked. Nested child workflow completion/failure is reflected inside the expanded parent graph instead of producing separate top-level completion cards. These terminal notices are queued into the active main chat as steering/context messages (`triggerTurn: true`, `deliverAs: "steer"`) so the model can react without the user manually polling status. Awaiting-input workflow states are tracked for dedupe/restore, but they do not enqueue main-chat connect cards or wake the model; prompt state remains visible through workflow status/connect surfaces. Configure lifecycle behavior with `workflowNotifications.enabled` (default `true`) and `workflowNotifications.notifyOn` (default `["completed", "failed", "blocked", "awaiting_input"]`).
 
 Human input is runtime-only: call `ctx.ui.input`, `ctx.ui.confirm`, `ctx.ui.select`, `ctx.ui.editor`, or `ctx.ui.custom<T>` at the point where the workflow actually needs a decision. No builder-level declaration is required or supported.
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Fixed workflow lifecycle notices for structured workflow outputs whose returned `status` is `failed` or `blocked`: the runtime now records those runs as failed/blocked instead of successful completions, preserves their returned output, and emits failure/blocked lifecycle cards rather than success/checkmark notices.
+- Fixed workflow lifecycle notices for structured workflow outputs whose returned `status` is `failed` or `blocked`: the runtime now records those runs as failed/blocked instead of successful completions, preserves their returned output, carries blocked summaries into lifecycle notice reasons, marks returned failures non-resumable with explicit terminal failure metadata, and emits failure/blocked lifecycle cards rather than success/checkmark notices.
 
 ## [0.9.3] - 2026-06-29
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed workflow lifecycle notices for structured workflow outputs whose returned `status` is `failed` or `blocked`: the runtime now records those runs as failed/blocked instead of successful completions, preserves their returned output, and emits failure/blocked lifecycle cards rather than success/checkmark notices.
+
 ## [0.9.3] - 2026-06-29
 
 ### Breaking Changes

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -31,18 +31,18 @@ Adding workflow files under `.atomic/workflows/` (project scope) or `~/.atomic/a
 
 ### Workflow lifecycle notifications
 
-Workflow lifecycle notices are enabled by default. They send steer prompts into the main chat/model context when a run completes or fails. Awaiting-input prompts are tracked for dedupe/restore, but they do not wake the main chat agent. Configure lifecycle tracking in the same extension config file:
+Workflow lifecycle notices are enabled by default. They send steer prompts into the main chat/model context when a run completes, fails, or ends blocked. Awaiting-input prompts are tracked for dedupe/restore, but they do not wake the main chat agent. Configure lifecycle tracking in the same extension config file:
 
 ```json
 {
   "workflowNotifications": {
     "enabled": true,
-    "notifyOn": ["completed", "failed", "awaiting_input"]
+    "notifyOn": ["completed", "failed", "blocked", "awaiting_input"]
   }
 }
 ```
 
-Set `enabled` to `false` to disable all lifecycle notices, or narrow `notifyOn` to a non-empty list of selected events. Completion and failure lifecycle notices are emitted for top-level workflow runs, use steer delivery, and wake an idle model so the lifecycle update enters the model context when it happens. Nested child workflow completion/failure is reflected inside the expanded parent graph instead of producing separate top-level completion cards. Awaiting-input states are tracked for dedupe/restore, but workflows do not enqueue main-chat `/workflow connect` cards for them; prompt state remains visible through workflow status/connect surfaces, avoiding stale actionable cards if a prompt resolves while the main chat is streaming.
+Set `enabled` to `false` to disable all lifecycle notices, or narrow `notifyOn` to a non-empty list of selected events. Completion, failure, and blocked lifecycle notices are emitted for top-level workflow runs, use steer delivery, and wake an idle model so the lifecycle update enters the model context when it happens. Nested child workflow completion/failure is reflected inside the expanded parent graph instead of producing separate top-level completion cards. Awaiting-input states are tracked for dedupe/restore, but workflows do not enqueue main-chat `/workflow connect` cards for them; prompt state remains visible through workflow status/connect surfaces, avoiding stale actionable cards if a prompt resolves while the main chat is streaming.
 
 When a stage human-in-the-loop prompt is answered from the workflow TUI/stage chat, workflows also emits a separate display-only `workflows:hil-answer-notice` custom message. It records the answer for user-visible audit, but it does not wake the main agent, enter LLM context, or authorize answering later workflow prompts. Answers sent by the main-chat `workflow` tool do not emit this notice because the tool result already tells the main agent what happened.
 
@@ -736,7 +736,7 @@ Config-based discovery (`~/.atomic/agent/extensions/workflow/config.json` or `.a
   },
   "workflowNotifications": {
     "enabled": true,
-    "notifyOn": ["completed", "failed", "awaiting_input"]
+    "notifyOn": ["completed", "failed", "blocked", "awaiting_input"]
   }
 }
 ```

--- a/packages/workflows/src/engine/run-durable-finalize.ts
+++ b/packages/workflows/src/engine/run-durable-finalize.ts
@@ -33,11 +33,13 @@ export async function finalizeDurableTerminalStatus(input: DurableTerminalFinali
   if (!input.isRoot) return;
   const status = input.runSnapshot.status;
   const isExitTerminal = input.runSnapshot.exited === true && status !== "running";
-  if (status !== "failed" && status !== "killed" && !isExitTerminal) return;
+  const isReturnedBlockedTerminal = status === "blocked" && input.runSnapshot.endedAt !== undefined;
+  if (status !== "failed" && status !== "killed" && !isExitTerminal && !isReturnedBlockedTerminal) return;
 
   const durableStatus = toDurableStatus(status);
   if (durableStatus !== undefined) {
-    input.durableBackend.setWorkflowStatus(input.runId, durableStatus, undefined, input.runSnapshot.resumable);
+    const resumable = status === "blocked" ? false : input.runSnapshot.resumable;
+    input.durableBackend.setWorkflowStatus(input.runId, durableStatus, undefined, resumable);
   }
   try {
     await input.durableBackend.flush?.();

--- a/packages/workflows/src/engine/run-returned-status.ts
+++ b/packages/workflows/src/engine/run-returned-status.ts
@@ -1,8 +1,10 @@
+import type { RunEndMetadata } from "../shared/store-public-types.js";
 import type { WorkflowOutputValues } from "../shared/types.js";
 
 export interface ReturnedRunStatus {
   readonly status: "completed" | "failed" | "blocked";
   readonly error?: string;
+  readonly metadata?: RunEndMetadata;
 }
 
 export function classifyReturnedRunStatus(result: WorkflowOutputValues | undefined): ReturnedRunStatus {
@@ -15,5 +17,25 @@ export function classifyReturnedRunStatus(result: WorkflowOutputValues | undefin
   const error = typeof summary === "string" && summary.trim().length > 0
     ? summary.trim()
     : `Workflow returned status ${JSON.stringify(returnedStatus)}.`;
-  return { status: returnedStatus, error };
+  return {
+    status: returnedStatus,
+    error,
+    metadata: returnedStatus === "failed"
+      ? returnedFailureMetadata(error)
+      : returnedBlockedMetadata(),
+  };
+}
+
+function returnedFailureMetadata(error: string): RunEndMetadata {
+  return {
+    failureKind: "unknown",
+    failureRecoverability: "non_recoverable",
+    failureDisposition: "terminal_failed",
+    failureMessage: error,
+    resumable: false,
+  };
+}
+
+function returnedBlockedMetadata(): RunEndMetadata {
+  return { resumable: false };
 }

--- a/packages/workflows/src/engine/run-returned-status.ts
+++ b/packages/workflows/src/engine/run-returned-status.ts
@@ -1,0 +1,19 @@
+import type { WorkflowOutputValues } from "../shared/types.js";
+
+export interface ReturnedRunStatus {
+  readonly status: "completed" | "failed" | "blocked";
+  readonly error?: string;
+}
+
+export function classifyReturnedRunStatus(result: WorkflowOutputValues | undefined): ReturnedRunStatus {
+  const returnedStatus = result?.["status"];
+  if (returnedStatus !== "failed" && returnedStatus !== "blocked") {
+    return { status: "completed" };
+  }
+
+  const summary = result?.["summary"];
+  const error = typeof summary === "string" && summary.trim().length > 0
+    ? summary.trim()
+    : `Workflow returned status ${JSON.stringify(returnedStatus)}.`;
+  return { status: returnedStatus, error };
+}

--- a/packages/workflows/src/engine/run.ts
+++ b/packages/workflows/src/engine/run.ts
@@ -425,9 +425,9 @@ export async function run<
     assertWorkflowCreatedStage(runSnapshot);
     await durableBackend.flush?.();
     const returned = classifyReturnedRunStatus(result);
-    const recorded = activeStore.recordRunEnd(runId, returned.status, result, returned.error);
-    appendRunEndWhenRecorded(opts.persistence, recorded, { runId, status: returned.status, result, ...(returned.error !== undefined ? { error: returned.error } : {}), ts: Date.now() });
-    durableBackend.setWorkflowStatus(runId, returned.status);
+    const recorded = activeStore.recordRunEnd(runId, returned.status, result, returned.error, returned.metadata);
+    appendRunEndWhenRecorded(opts.persistence, recorded, { runId, status: returned.status, result, ...(returned.error !== undefined ? { error: returned.error } : {}), ...(returned.metadata ?? {}), ts: Date.now() });
+    durableBackend.setWorkflowStatus(runId, returned.status, undefined, returned.metadata?.resumable);
     await durableBackend.flush?.();
     if (opts.persistence && durableBackend.persistent) {
       const cacheEntry = durableBackend.toCacheEntry(runId);

--- a/packages/workflows/src/engine/run.ts
+++ b/packages/workflows/src/engine/run.ts
@@ -41,6 +41,7 @@ import {
 import { assertWorkflowRunOutputs, normalizeWorkflowRunOutput } from "../runs/foreground/executor-outputs.js";
 import { isWorkflowDefinition, workflowDefinitionRequirementMessage } from "../runs/foreground/executor-child-helpers.js";
 import { getDurableBackend } from "../durable/factory.js";
+import { classifyReturnedRunStatus } from "./run-returned-status.js";
 import { createToolPrimitive, createCheckpointIdGenerator } from "../durable/tool-primitive.js";
 import { persistDurableCacheEntry } from "../durable/resume-catalog.js";
 import { createDurableStagePrimitive, createDurableTaskPrimitive, recordStageCheckpoint, createStageReplayKeyGenerator, recordCachedStageWithTracker } from "../durable/stage-primitive.js";
@@ -423,15 +424,16 @@ export async function run<
     assertWorkflowRunOutputs(def.name, result, def.outputs);
     assertWorkflowCreatedStage(runSnapshot);
     await durableBackend.flush?.();
-    const recorded = activeStore.recordRunEnd(runId, "completed", result);
-    appendRunEndWhenRecorded(opts.persistence, recorded, { runId, status: "completed", result, ts: Date.now() });
-    durableBackend.setWorkflowStatus(runId, "completed");
+    const returned = classifyReturnedRunStatus(result);
+    const recorded = activeStore.recordRunEnd(runId, returned.status, result, returned.error);
+    appendRunEndWhenRecorded(opts.persistence, recorded, { runId, status: returned.status, result, ...(returned.error !== undefined ? { error: returned.error } : {}), ts: Date.now() });
+    durableBackend.setWorkflowStatus(runId, returned.status);
     await durableBackend.flush?.();
     if (opts.persistence && durableBackend.persistent) {
       const cacheEntry = durableBackend.toCacheEntry(runId);
       if (cacheEntry) persistDurableCacheEntry(opts.persistence, cacheEntry);
     }
-    return reconcileTerminalRunResult(runId, runSnapshot, activeStore, { status: "completed", result }, opts.onRunEnd);
+    return reconcileTerminalRunResult(runId, runSnapshot, activeStore, { status: returned.status, result, error: returned.error }, opts.onRunEnd);
   } catch (err) {
     const selectedExit = findWorkflowExitSignal(err, exitScope) ?? findWorkflowExitSignal(ownController.signal.reason, exitScope);
     if (selectedExit !== undefined) return await finalizers.finalizeWorkflowExit(selectedExit);

--- a/packages/workflows/src/extension/config-file-loader.ts
+++ b/packages/workflows/src/extension/config-file-loader.ts
@@ -68,7 +68,7 @@ function validateConfig(value: unknown): string | null {
       }
       for (const item of notifyOn) {
         if (!isWorkflowLifecycleNoticeKind(item)) {
-          return `"workflowNotifications.notifyOn" entries must be "completed", "failed", or "awaiting_input", got ${JSON.stringify(item)}`;
+          return `"workflowNotifications.notifyOn" entries must be "completed", "failed", "blocked", or "awaiting_input", got ${JSON.stringify(item)}`;
         }
       }
     }

--- a/packages/workflows/src/extension/config-loader.ts
+++ b/packages/workflows/src/extension/config-loader.ts
@@ -182,7 +182,7 @@ export const WORKFLOW_CONFIG_DEFAULTS = {
   resumeInFlight: "ask" as const,
   workflowNotifications: {
     enabled: true,
-    notifyOn: ["completed", "failed", "awaiting_input"] as const,
+    notifyOn: ["completed", "failed", "blocked", "awaiting_input"] as const,
   },
 } as const;
 

--- a/packages/workflows/src/extension/lifecycle-notifications.ts
+++ b/packages/workflows/src/extension/lifecycle-notifications.ts
@@ -21,11 +21,12 @@ import { renderWorkflowNoticeCard, type WorkflowNoticeTone } from "../tui/workfl
 export const LIFECYCLE_NOTICE_CUSTOM_TYPE = "workflows:lifecycle-notice";
 export const LIFECYCLE_NOTICE_SNIPPET_LIMIT = 240;
 
-export type WorkflowLifecycleNoticeKind = "completed" | "failed" | "awaiting_input";
+export type WorkflowLifecycleNoticeKind = "completed" | "failed" | "blocked" | "awaiting_input";
 
 export const WORKFLOW_LIFECYCLE_NOTICE_KINDS = [
   "completed",
   "failed",
+  "blocked",
   "awaiting_input",
 ] as const satisfies readonly WorkflowLifecycleNoticeKind[];
 
@@ -95,8 +96,9 @@ export function seedWorkflowLifecycleNotificationState(
 ): void {
   for (const run of snapshot.runs) {
     if (!isTopLevelWorkflowRun(run)) continue;
-    if ((run.status === "completed" || run.status === "failed") && run.endedAt !== undefined) {
-      state.deliveredTerminalRuns.add(terminalRunKey(run.status, run.id));
+    const noticeKind = terminalNoticeKind(run);
+    if (noticeKind !== undefined && run.endedAt !== undefined) {
+      state.deliveredTerminalRuns.add(terminalRunKey(noticeKind, run.id));
     }
     if (run.pendingPrompt !== undefined) {
       state.deliveredInputPrompts.add(runAwaitingInputKey(run.id, run.pendingPrompt));
@@ -186,9 +188,10 @@ export function installWorkflowLifecycleNotifications(
 
   const emitTerminalNoticeOnce = (
     run: RunSnapshot,
-    kind: "completed" | "failed",
+    kind: "completed" | "failed" | "blocked",
   ): void => {
-    if (run.status !== kind || run.endedAt === undefined || !notifyOn.has(kind)) {
+    const noticeKind = terminalNoticeKind(run);
+    if (noticeKind !== kind || run.endedAt === undefined || !notifyOn.has(kind)) {
       return;
     }
 
@@ -231,6 +234,7 @@ export function installWorkflowLifecycleNotifications(
       if (!isTopLevelWorkflowRun(run)) continue;
       emitTerminalNoticeOnce(run, "completed");
       emitTerminalNoticeOnce(run, "failed");
+      emitTerminalNoticeOnce(run, "blocked");
 
       if (!notifyOn.has("awaiting_input")) continue;
       emitRunAwaitingInputNoticeOnce(run);
@@ -273,6 +277,10 @@ export function formatWorkflowLifecycleNoticeText(details: WorkflowLifecycleNoti
     const errorText = details.error ? `: ${details.error}` : "";
     return `✗ Workflow "${workflowName}" failed (run ${details.runId}${stageText})${errorText}. Inspect: /workflow status ${details.runId}`;
   }
+  if (details.kind === "blocked") {
+    const errorText = details.error ? `: ${details.error}` : "";
+    return `! Workflow "${workflowName}" ended blocked (run ${details.runId})${errorText}. Inspect: /workflow status ${details.runId}`;
+  }
   const prompt = details.promptMessage ? ` Prompt: ${details.promptMessage}` : "";
   if (details.scope === "run") {
     return `？ Workflow "${workflowName}" needs input (run ${details.runId}).${prompt} Respond: /workflow connect ${details.runId} to answer this run-level prompt.`;
@@ -286,7 +294,7 @@ export function formatWorkflowLifecycleNoticeText(details: WorkflowLifecycleNoti
 
 function makeTerminalNotice(
   run: RunSnapshot,
-  kind: "completed" | "failed",
+  kind: "completed" | "failed" | "blocked",
 ): WorkflowLifecycleNoticeDetails {
   const failedStage = run.failedStageId
     ? run.stages.find((stage) => stage.id === run.failedStageId)
@@ -320,7 +328,15 @@ function jsonString(value: string): string {
   return JSON.stringify(value);
 }
 
-function terminalRunKey(kind: "completed" | "failed", runId: string): string {
+function terminalNoticeKind(run: RunSnapshot): "completed" | "failed" | "blocked" | undefined {
+  if (run.status === "failed" || run.status === "blocked") return run.status;
+  if (run.status !== "completed") return undefined;
+  const returnedStatus = run.result?.["status"];
+  if (returnedStatus === "failed" || returnedStatus === "blocked") return returnedStatus;
+  return "completed";
+}
+
+function terminalRunKey(kind: "completed" | "failed" | "blocked", runId: string): string {
   return `${kind}:${runId}`;
 }
 
@@ -361,19 +377,27 @@ function renderLifecycleNoticeCard(
   details: WorkflowLifecycleNoticeDetails,
   opts: { width: number; theme?: GraphTheme; fallbackText: string },
 ): string[] {
-  const tone: WorkflowNoticeTone = details.kind === "failed" ? "error" : details.kind === "awaiting_input" ? "warning" : "success";
+  const tone: WorkflowNoticeTone = details.kind === "failed"
+    ? "error"
+    : details.kind === "awaiting_input" || details.kind === "blocked"
+      ? "warning"
+      : "success";
   const title = details.kind === "failed"
     ? "WORKFLOW FAILED"
     : details.kind === "awaiting_input"
       ? "WORKFLOW INPUT"
-      : "WORKFLOW COMPLETE";
-  const glyph = details.kind === "failed" ? "✗" : details.kind === "awaiting_input" ? "？" : "✓";
+      : details.kind === "blocked"
+        ? "WORKFLOW BLOCKED"
+        : "WORKFLOW COMPLETE";
+  const glyph = details.kind === "failed" ? "✗" : details.kind === "awaiting_input" ? "？" : details.kind === "blocked" ? "!" : "✓";
   const stage = details.stageName ?? details.failedStageId ?? details.stageId;
   const headline = details.kind === "failed"
     ? `Workflow "${details.workflowName}" failed`
     : details.kind === "awaiting_input"
       ? `Workflow "${details.workflowName}" needs input`
-      : `Workflow "${details.workflowName}" completed`;
+      : details.kind === "blocked"
+        ? `Workflow "${details.workflowName}" ended blocked`
+        : `Workflow "${details.workflowName}" completed`;
   return renderWorkflowNoticeCard({
     title,
     glyph,

--- a/packages/workflows/src/extension/lifecycle-notifications.ts
+++ b/packages/workflows/src/extension/lifecycle-notifications.ts
@@ -299,13 +299,14 @@ function makeTerminalNotice(
   const failedStage = run.failedStageId
     ? run.stages.find((stage) => stage.id === run.failedStageId)
     : undefined;
+  const error = run.error ?? (kind === "blocked" ? run.exitReason : undefined);
   return {
     kind,
     scope: "run",
     runId: run.id,
     workflowName: run.name,
     status: run.status,
-    ...(run.error ? { error: truncateSnippet(run.error) } : {}),
+    ...(error ? { error: truncateSnippet(error) } : {}),
     ...(run.failedStageId ? { failedStageId: run.failedStageId } : {}),
     ...(failedStage ? { stageId: failedStage.id, stageName: failedStage.name } : {}),
     ...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),

--- a/packages/workflows/src/shared/persistence-restore-helpers.ts
+++ b/packages/workflows/src/shared/persistence-restore-helpers.ts
@@ -335,7 +335,7 @@ export function restoreTerminalRuns(entries: readonly SessionEntry[], store: Sto
     const exitReason = end["exitReason"];
     const resumable = end["resumable"];
     const restoredAuthorExit = isWorkflowExitTerminalStatus(status) &&
-      (exited === true || status !== "completed" || typeof exitReason === "string" || resumable === false);
+      (exited === true || typeof exitReason === "string");
     if (status === "completed" && !restoredAuthorExit && stages.some((stage) => stage.status !== "completed")) continue;
     store.recordRunStart({
       id: runId,

--- a/packages/workflows/src/shared/store-public-types.ts
+++ b/packages/workflows/src/shared/store-public-types.ts
@@ -83,8 +83,9 @@ export interface Store {
    * Records the end of a run.
    * Returns `true` if state changed, `false` if the run was not found or
    * already in a terminal state (completed | failed | killed | skipped | cancelled | blocked).
-   * `result` is applied for intentional success/exit statuses (completed | skipped | cancelled | blocked).
-   * `error` is only applied for status "failed" | "killed".
+   * `result` is applied for intentional success/exit statuses (completed | skipped | cancelled | blocked)
+   * and for workflows that intentionally return a failed status with structured outputs.
+   * `error` is applied for status "failed" | "killed" | "blocked".
    */
   recordRunEnd(
     runId: string,

--- a/packages/workflows/src/shared/store-run-methods.ts
+++ b/packages/workflows/src/shared/store-run-methods.ts
@@ -82,10 +82,10 @@ export function createRunStoreMethods(context: StoreContext): RunStoreMethods {
         run.pausedAt = undefined;
       }
       run.durationMs = elapsedRunMs(run, run.endedAt);
+      if (result !== undefined && shouldStoreRunResult(status)) run.result = result;
       const wasBlocked = run.blockedAt !== undefined || run.failureDisposition === "active_blocked";
       delete run.blockedAt;
       if (status === "completed" || status === "skipped" || status === "cancelled" || status === "blocked") {
-        if (result !== undefined) run.result = result;
         clearRunFailureMetadata(run);
         if (metadata !== undefined) applyRunEndMetadata(run, metadata);
       } else {
@@ -226,4 +226,9 @@ export function createRunStoreMethods(context: StoreContext): RunStoreMethods {
       };
     },
   };
+}
+
+
+function shouldStoreRunResult(status: RunStatus): boolean {
+  return status === "completed" || status === "skipped" || status === "cancelled" || status === "blocked" || status === "failed";
 }

--- a/packages/workflows/src/shared/store-run-methods.ts
+++ b/packages/workflows/src/shared/store-run-methods.ts
@@ -87,6 +87,7 @@ export function createRunStoreMethods(context: StoreContext): RunStoreMethods {
       delete run.blockedAt;
       if (status === "completed" || status === "skipped" || status === "cancelled" || status === "blocked") {
         clearRunFailureMetadata(run);
+        if (status === "blocked" && error !== undefined) run.error = error;
         if (metadata !== undefined) applyRunEndMetadata(run, metadata);
       } else {
         if (wasBlocked && error === undefined) delete run.error;
@@ -227,7 +228,6 @@ export function createRunStoreMethods(context: StoreContext): RunStoreMethods {
     },
   };
 }
-
 
 function shouldStoreRunResult(status: RunStatus): boolean {
   return status === "completed" || status === "skipped" || status === "cancelled" || status === "blocked" || status === "failed";

--- a/test/unit/config-loader-helpers.test.ts
+++ b/test/unit/config-loader-helpers.test.ts
@@ -162,7 +162,7 @@ describe("withWorkflowDefaults — WORKFLOW_CONFIG_DEFAULTS constants", () => {
   test("WORKFLOW_CONFIG_DEFAULTS.workflowNotifications enables all lifecycle steer notices", () => {
     assert.deepEqual(WORKFLOW_CONFIG_DEFAULTS.workflowNotifications, {
       enabled: true,
-      notifyOn: ["completed", "failed", "awaiting_input"],
+      notifyOn: ["completed", "failed", "blocked", "awaiting_input"],
     });
   });
 });

--- a/test/unit/publish-release-helpers.test.ts
+++ b/test/unit/publish-release-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   prereleaseVersionPattern,
   releaseVersionPattern,
@@ -13,6 +14,8 @@ import {
   type JsonValue,
 } from "../../.atomic/workflows/lib/publish-release.js";
 import { waitForWorkflowRunSucceeded } from "../../.atomic/workflows/lib/publish-release-run-wait.js";
+import { verifyReleasePrChecksPassed } from "../../.atomic/workflows/lib/publish-release-gates.js";
+
 
 describe("publish-release version validation", () => {
   test("accepts stable release versions only for release requests", () => {
@@ -152,17 +155,111 @@ describe("publish-release GitHub PR checks verification", () => {
     });
   });
 
-  test("rejects empty, failing, pending, or malformed required check lists", () => {
+  test("distinguishes failing checks from pending checks", () => {
     assert.equal(verifyPullRequestChecksJson([]).ok, false);
-
-    const result = verifyPullRequestChecksJson([
+    const failed = verifyPullRequestChecksJson([
       { name: "typecheck", bucket: "fail", state: "FAILURE", link: "https://example.test/check" },
+    ]);
+    assert.equal(failed.ok, false);
+    assert.equal(failed.pending, undefined);
+    assert.match(failed.summary, /typecheck bucket=fail state=FAILURE link=https:\/\/example\.test\/check/u);
+
+    const pending = verifyPullRequestChecksJson([
       { name: "unit", bucket: "pending", state: "PENDING" },
     ]);
+    assert.equal(pending.ok, false);
+    assert.equal(pending.pending, true);
+    assert.match(pending.summary, /unit bucket=pending state=PENDING/u);
+  });
+
+  test("polls pending PR checks until they pass", async () => {
+    const release = validateReleaseRequest("release", "1.2.3");
+    const prReference = {
+      ok: true as const,
+      summary: "GitHub PR reference is verified.",
+      prUrl: "https://github.com/earendil-works/pi-mono/pull/123",
+      prNumber: 123,
+      headRefOid: "def456",
+      state: "OPEN",
+    };
+    const prView = {
+      number: 123,
+      state: "OPEN",
+      baseRefName: "main",
+      headRefName: "release/1.2.3",
+      headRefOid: "def456",
+      url: prReference.prUrl,
+    };
+    const responses: CommandResult[] = [
+      { command: "gh pr view", exitCode: 0, stdout: JSON.stringify(prView), stderr: "" },
+      { command: "gh pr checks", exitCode: 8, stdout: JSON.stringify([{ name: "unit", bucket: "pending", state: "PENDING" }]), stderr: "" },
+      { command: "gh pr view", exitCode: 0, stdout: JSON.stringify(prView), stderr: "" },
+      { command: "gh pr checks", exitCode: 0, stdout: JSON.stringify([{ name: "unit", bucket: "pass", state: "SUCCESS" }]), stderr: "" },
+    ];
+    const sleeps: number[] = [];
+
+    const result = await verifyReleasePrChecksPassed(release, prReference, "main", {
+      attempts: 2,
+      pollIntervalMs: 25,
+      runCommand: (args) => {
+        const response = responses.shift();
+        if (response === undefined) throw new Error(`unexpected command: ${args.join(" ")}`);
+        return { ...response, command: args.join(" ") };
+      },
+      sleep: (durationMs) => {
+        sleeps.push(durationMs);
+        return Promise.resolve();
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(sleeps, [25]);
+    assert.equal(responses.length, 0);
+  });
+
+  test("marks PR checks as pending when polling times out", async () => {
+    const release = validateReleaseRequest("release", "1.2.3");
+    const prReference = {
+      ok: true as const,
+      summary: "GitHub PR reference is verified.",
+      prUrl: "https://github.com/earendil-works/pi-mono/pull/123",
+      prNumber: 123,
+      headRefOid: "def456",
+      state: "OPEN",
+    };
+    const prView = {
+      number: 123,
+      state: "OPEN",
+      baseRefName: "main",
+      headRefName: "release/1.2.3",
+      headRefOid: "def456",
+      url: prReference.prUrl,
+    };
+    const result = await verifyReleasePrChecksPassed(release, prReference, "main", {
+      attempts: 1,
+      pollIntervalMs: 25,
+      runCommand: (args) => ({
+        command: args.join(" "),
+        exitCode: args.includes("checks") ? 8 : 0,
+        stdout: JSON.stringify(args.includes("checks") ? [{ name: "unit", bucket: "pending", state: "PENDING" }] : prView),
+        stderr: "",
+      }),
+      sleep: () => Promise.resolve(),
+    });
 
     assert.equal(result.ok, false);
-    assert.match(result.summary, /typecheck bucket=fail state=FAILURE link=https:\/\/example\.test\/check/u);
-    assert.match(result.summary, /unit bucket=pending state=PENDING/u);
+    assert.equal(result.pending, true);
+    assert.match(result.summary, /did not finish before the polling timeout/u);
+  });
+
+  test("publish-release polling helpers do not reference Bun globals", () => {
+    const helpers = [
+      ".atomic/workflows/lib/publish-release-gates.ts",
+      ".atomic/workflows/lib/publish-release-run-wait.ts",
+    ];
+    for (const helper of helpers) {
+      assert.doesNotMatch(readFileSync(helper, "utf8"), /\bBun\./u, helper);
+    }
   });
 
   test("does not treat completed check status as passing without a pass bucket", () => {
@@ -304,6 +401,11 @@ describe("publish-release GitHub Actions publish verification", () => {
     assert.deepEqual(sleeps, [25]);
     assert.equal(commands.some((command) => command.includes(" run watch ")), false);
     assert.match(result.summary, /status: completed/u);
+  });
+
+  test("publish-release run polling helper does not reference Bun globals", () => {
+    const source = readFileSync(".atomic/workflows/lib/publish-release-run-wait.ts", "utf8");
+    assert.doesNotMatch(source, /\bBun\./u);
   });
 
   test("marks a still-running publish run as pending when polling times out", async () => {

--- a/test/unit/store-terminal-guard.test.ts
+++ b/test/unit/store-terminal-guard.test.ts
@@ -139,14 +139,14 @@ describe("recordRunEnd — terminal guard", () => {
 
   // --- result/error field rules ---
 
-  test("result stored only for completed", () => {
+  test("result stored for completed", () => {
     s.recordRunEnd("r1", "completed", { answer: 42 });
     assert.deepEqual(s.runs().find((r) => r.id === "r1")!.result, { answer: 42 });
   });
 
-  test("result NOT stored for failed (wrong status)", () => {
+  test("result stored for failed", () => {
     s.recordRunEnd("r1", "failed", { answer: 42 });
-    assert.equal(s.runs().find((r) => r.id === "r1")!.result, undefined);
+    assert.deepEqual(s.runs().find((r) => r.id === "r1")!.result, { answer: 42 });
   });
 
   test("result NOT stored for killed", () => {

--- a/test/unit/workflow-lifecycle-notifications-01.test.ts
+++ b/test/unit/workflow-lifecycle-notifications-01.test.ts
@@ -124,13 +124,32 @@ describe("installWorkflowLifecycleNotifications", () => {
     const { store, sent } = install();
     store.recordRunStart({ id: "run-blocked", name: "release", inputs: {}, status: "running", stages: [], startedAt: 1 });
 
-    assert.equal(store.recordRunEnd("run-blocked", "blocked", { status: "blocked", summary: "checks are still pending" }), true);
+    assert.equal(store.recordRunEnd("run-blocked", "blocked", { status: "blocked", summary: "checks are still pending" }, "checks are still pending"), true);
 
     assert.equal(sent.length, 1);
     assert.equal(sent[0]?.details?.kind, "blocked");
     assert.equal(sent[0]?.details?.status, "blocked");
-    assert.match(sent[0]?.content ?? "", /ended blocked/);
+    assert.equal(sent[0]?.details?.error, "checks are still pending");
+    assert.match(sent[0]?.content ?? "", /ended blocked.*checks are still pending/u);
     assert.doesNotMatch(sent[0]?.content ?? "", /✓/u);
+  });
+
+  test("includes ctx.exit blocked reasons in lifecycle notices", () => {
+    const { store, sent } = install();
+    startRun(store, "run-exit-blocked", "release");
+
+    assert.equal(
+      store.recordRunEnd("run-exit-blocked", "blocked", undefined, undefined, {
+        exited: true,
+        exitReason: "waiting for approval",
+      }),
+      true,
+    );
+
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0]?.details?.kind, "blocked");
+    assert.equal(sent[0]?.details?.error, "waiting for approval");
+    assert.match(sent[0]?.content ?? "", /ended blocked.*waiting for approval/u);
   });
 
   test("seeds historical completed runs using returned failed or blocked status", () => {

--- a/test/unit/workflow-lifecycle-notifications-01.test.ts
+++ b/test/unit/workflow-lifecycle-notifications-01.test.ts
@@ -43,7 +43,7 @@ type SendOptions = {
 
 const config = {
   enabled: true,
-  notifyOn: ["completed", "failed", "awaiting_input"] as const,
+  notifyOn: ["completed", "failed", "blocked", "awaiting_input"] as const,
 };
 
 function runningStage(overrides: Partial<StageSnapshot> = {}): StageSnapshot {
@@ -118,6 +118,38 @@ describe("installWorkflowLifecycleNotifications", () => {
     assert.equal(sent[0]?.details?.scope, "run");
     assert.equal(sent[0]?.details?.workflowName, "release");
     assert.match(sent[0]?.content ?? "", /\/workflow status run-1/);
+  });
+
+  test("uses blocked lifecycle notices for runs ending with blocked status", () => {
+    const { store, sent } = install();
+    store.recordRunStart({ id: "run-blocked", name: "release", inputs: {}, status: "running", stages: [], startedAt: 1 });
+
+    assert.equal(store.recordRunEnd("run-blocked", "blocked", { status: "blocked", summary: "checks are still pending" }), true);
+
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0]?.details?.kind, "blocked");
+    assert.equal(sent[0]?.details?.status, "blocked");
+    assert.match(sent[0]?.content ?? "", /ended blocked/);
+    assert.doesNotMatch(sent[0]?.content ?? "", /✓/u);
+  });
+
+  test("seeds historical completed runs using returned failed or blocked status", () => {
+    const store = createStore();
+    const sent: SentMessage[] = [];
+    startRun(store, "run-legacy-failed", "legacy failed");
+    store.recordRunEnd("run-legacy-failed", "completed", { status: "failed", summary: "old failure" });
+    startRun(store, "run-legacy-blocked", "legacy blocked");
+    store.recordRunEnd("run-legacy-blocked", "completed", { status: "blocked", summary: "old blocker" });
+
+    installWorkflowLifecycleNotifications({
+      store,
+      config,
+      state: createWorkflowLifecycleNotificationState(),
+      sendMessage(message) { sent.push(message as SentMessage); },
+    });
+    store.recordNotice({ id: "history-tick", level: "info", message: "tick", createdAt: 13 });
+
+    assert.deepEqual(sent, []);
   });
 
   test("emits failure notice with stage and truncated error context", () => {

--- a/test/unit/workflow-lifecycle-notifications-02.test.ts
+++ b/test/unit/workflow-lifecycle-notifications-02.test.ts
@@ -43,7 +43,7 @@ type SendOptions = {
 
 const config = {
   enabled: true,
-  notifyOn: ["completed", "failed", "awaiting_input"] as const,
+  notifyOn: ["completed", "failed", "blocked", "awaiting_input"] as const,
 };
 
 function runningStage(overrides: Partial<StageSnapshot> = {}): StageSnapshot {

--- a/test/unit/workflow-returned-status.test.ts
+++ b/test/unit/workflow-returned-status.test.ts
@@ -4,6 +4,8 @@ import { Type } from "typebox";
 import { run } from "../../packages/workflows/src/runs/foreground/executor.js";
 import { createStore } from "../../packages/workflows/src/shared/store.js";
 import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
+import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
+import { restoreOnSessionStart, type SessionEntry } from "../../packages/workflows/src/shared/persistence-restore.js";
 
 describe("workflow returned status outputs", () => {
   test("failed result.status makes the run fail instead of completing successfully", async () => {
@@ -30,6 +32,11 @@ describe("workflow returned status outputs", () => {
     assert.equal(result.error, "deterministic gate failed");
     assert.deepEqual(result.result, { status: "failed", summary: "deterministic gate failed" });
     assert.deepEqual(snapshot?.result, { status: "failed", summary: "deterministic gate failed" });
+    assert.equal(snapshot?.failureKind, "unknown");
+    assert.equal(snapshot?.failureRecoverability, "non_recoverable");
+    assert.equal(snapshot?.failureDisposition, "terminal_failed");
+    assert.equal(snapshot?.failureMessage, "deterministic gate failed");
+    assert.equal(snapshot?.resumable, false);
   });
 
   test("blocked result.status makes the run blocked instead of completing successfully", async () => {
@@ -48,12 +55,62 @@ describe("workflow returned status outputs", () => {
       },
     });
 
-    const result = await run(def, {}, { store, adapters: { complete: { complete: async (text) => text } } });
+    const durableBackend = new InMemoryDurableBackend();
+    const calls: Array<{ type: string; payload: Record<string, unknown> }> = [];
+    const persistence = {
+      appendEntry(type: string, payload: Record<string, unknown>): string {
+        calls.push({ type, payload });
+        return `entry-${calls.length}`;
+      },
+      setLabel(_entryId: string, _label: string): void {},
+    };
+    const result = await run(def, {}, {
+      store,
+      durableBackend,
+      persistence,
+      adapters: { complete: { complete: async (text) => text } },
+    });
     const snapshot = store.runs().find((candidate) => candidate.id === result.runId);
+    const durableHandle = durableBackend.getWorkflow(result.runId);
+    const runEnd = calls.find((call) => call.type === "workflow.run.end");
 
     assert.equal(result.status, "blocked");
     assert.equal(snapshot?.status, "blocked");
-    assert.equal(result.error, undefined);
+    assert.equal(result.error, "required checks are pending");
+    assert.equal(snapshot?.error, "required checks are pending");
+    assert.equal(snapshot?.resumable, false);
+    assert.equal(durableHandle?.status, "blocked");
+    assert.equal(durableHandle?.resumable, false);
+    assert.deepEqual(durableBackend.listResumableWorkflows(), []);
+    assert.equal(runEnd?.payload["resumable"], false);
     assert.deepEqual(result.result, { status: "blocked", summary: "required checks are pending" });
+  });
+
+  test("restores returned blocked run metadata without marking it as ctx.exit", () => {
+    const store = createStore();
+    const entries: SessionEntry[] = [
+      { id: "e1", type: "workflow.run.start", payload: { runId: "run-returned-blocked", name: "returned-blocked", inputs: {}, ts: 1 } },
+      {
+        id: "e2",
+        type: "workflow.run.end",
+        payload: {
+          runId: "run-returned-blocked",
+          status: "blocked",
+          result: { status: "blocked", summary: "required checks are pending" },
+          error: "required checks are pending",
+          resumable: false,
+          ts: 2,
+        },
+      },
+    ];
+
+    restoreOnSessionStart({ getEntries: () => entries }, { resumeInFlight: "never", persistRuns: true }, store);
+    const snapshot = store.runs().find((candidate) => candidate.id === "run-returned-blocked");
+
+    assert.equal(snapshot?.status, "blocked");
+    assert.equal(snapshot?.error, "required checks are pending");
+    assert.equal(snapshot?.resumable, false);
+    assert.equal(snapshot?.exited, undefined);
+    assert.deepEqual(snapshot?.result, { status: "blocked", summary: "required checks are pending" });
   });
 });

--- a/test/unit/workflow-returned-status.test.ts
+++ b/test/unit/workflow-returned-status.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { Type } from "typebox";
+import { run } from "../../packages/workflows/src/runs/foreground/executor.js";
+import { createStore } from "../../packages/workflows/src/shared/store.js";
+import { workflow } from "../../packages/workflows/src/authoring/workflow.js";
+
+describe("workflow returned status outputs", () => {
+  test("failed result.status makes the run fail instead of completing successfully", async () => {
+    const store = createStore();
+    const def = workflow({
+      name: "returned-failed-status",
+      description: "",
+      inputs: {},
+      outputs: {
+        status: Type.Union([Type.Literal("completed"), Type.Literal("failed"), Type.Literal("blocked")]),
+        summary: Type.String(),
+      },
+      run: async (ctx) => {
+        await ctx.stage("work").complete("done");
+        return { status: "failed" as const, summary: "deterministic gate failed" };
+      },
+    });
+
+    const result = await run(def, {}, { store, adapters: { complete: { complete: async (text) => text } } });
+    const snapshot = store.runs().find((candidate) => candidate.id === result.runId);
+
+    assert.equal(result.status, "failed");
+    assert.equal(snapshot?.status, "failed");
+    assert.equal(result.error, "deterministic gate failed");
+    assert.deepEqual(result.result, { status: "failed", summary: "deterministic gate failed" });
+    assert.deepEqual(snapshot?.result, { status: "failed", summary: "deterministic gate failed" });
+  });
+
+  test("blocked result.status makes the run blocked instead of completing successfully", async () => {
+    const store = createStore();
+    const def = workflow({
+      name: "returned-blocked-status",
+      description: "",
+      inputs: {},
+      outputs: {
+        status: Type.Union([Type.Literal("completed"), Type.Literal("failed"), Type.Literal("blocked")]),
+        summary: Type.String(),
+      },
+      run: async (ctx) => {
+        await ctx.stage("work").complete("done");
+        return { status: "blocked" as const, summary: "required checks are pending" };
+      },
+    });
+
+    const result = await run(def, {}, { store, adapters: { complete: { complete: async (text) => text } } });
+    const snapshot = store.runs().find((candidate) => candidate.id === result.runId);
+
+    assert.equal(result.status, "blocked");
+    assert.equal(snapshot?.status, "blocked");
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.result, { status: "blocked", summary: "required checks are pending" });
+  });
+});


### PR DESCRIPTION
## Summary

Two hardening fixes: (1) workflow outputs returning `status: "failed"` or `status: "blocked"` are now correctly recorded as terminal failed/blocked runs with proper lifecycle notices; (2) the `publish-release` PR check gate polls pending checks with configurable retry and surfaces timeout as `blocked` rather than `failed`.

## Key Changes

### Workflow engine
- New `classifyReturnedRunStatus` helper (`run-returned-status.ts`) inspects structured workflow output for a returned `status` field (`"failed"` | `"blocked"`) and maps it to the correct terminal state
- `run.ts` uses returned status to record runs as `failed`/`blocked` instead of always `completed`
- `store-run-methods.ts`: `shouldStoreRunResult` now persists the result payload for `failed` runs (previously only `completed`/`blocked`)

### Lifecycle notifications
- Added `"blocked"` to `WorkflowLifecycleNoticeKind`, the default `notifyOn` set, and the config validator
- New `terminalNoticeKind` helper reads both `run.status` and `run.result.status` so historically-stored runs with a failed/blocked return value are correctly seeded and deduped
- Renders `WORKFLOW BLOCKED` cards with `!` glyph and warning tone

### publish-release gate hardening
- `verifyReleasePrChecksPassed` is now `async` with configurable `attempts` / `pollIntervalMs` / `runCommand` / `sleep` options (defaults: 30 attempts × 30 s)
- Exit code 8 from `gh pr checks` is treated as "checks still pending" — not a hard failure
- Pending check states (`PENDING`, `QUEUED`, `IN_PROGRESS`, `WAITING`, `REQUESTED`) are separated from true failures; polling timeout surfaces as `blocked`
- Replaced `Bun.sleep` with portable `setTimeout`-based sleep in `publish-release-gates.ts` and `publish-release-run-wait.ts`

### Tests
- New `workflow-returned-status.test.ts`: end-to-end coverage for `failed`/`blocked` returned-status runs
- `publish-release-helpers.test.ts`: polling success path, pending-timeout, and Bun-global-free source assertions
- `store-terminal-guard.test.ts`: updated expectations — results now stored for `failed` runs
- Lifecycle notification tests updated for the new `blocked` kind and deduplication behavior

### Docs / Changelogs
- `packages/coding-agent/docs/workflows.md`, `packages/workflows/README.md`: `"blocked"` added to default `notifyOn` examples
- `packages/coding-agent/CHANGELOG.md`, `packages/workflows/CHANGELOG.md`: unreleased entries for both fixes

## Validation

- `AGENT=1 bun test test/unit/store-terminal-guard.test.ts test/unit/workflow-returned-status.test.ts`
- `AGENT=1 bun run typecheck`
- `AGENT=1 bun run check:file-length`
- `git commit` hook: `bun run lint`, `bun run check:file-length`, and `bun run test:unit` passed
- `git push` hook: `bun run lint`, `bun run check:file-length`, and `bun run test:unit` passed

## Notes

No release tags, publishing, release PR merges, or release branch mutations were performed.