### PR TITLE
docs: release notes for 0.9.4-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
 ### Changed
 
 - Restored upstream Pi's provider retry default by leaving `retry.provider.maxRetries` unset/zero unless users configure it explicitly, so Atomic's agent-level retry observes provider transport failures directly instead of the SDK retrying them first.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.3.
+
 ## [0.9.3] - 2026-06-29
 
 ### Added

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.1 prerelease for the intercom extension; no intercom extension changes were made after 0.9.3.
+
 ## [0.9.3] - 2026-06-29
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.1 prerelease for the MCP extension; no MCP extension changes were made after 0.9.3.
+
 ## [0.9.3] - 2026-06-29
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.1 prerelease for the native transport package; no native transport changes were made after 0.9.3.
+
 ## [0.9.3] - 2026-06-29
 
 ### Added

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.1 prerelease for the subagents extension; no subagents extension changes were made after 0.9.3.
+
 ## [0.9.3] - 2026-06-29
 
 ### Added

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.1 prerelease for the web-access extension; no web-access extension changes were made after 0.9.3.
+
 ## [0.9.3] - 2026-06-29
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.1] - 2026-06-29
+
 ### Fixed
 
 - Fixed workflow lifecycle notices for structured workflow outputs whose returned `status` is `failed` or `blocked`: the runtime now records those runs as failed/blocked instead of successful completions, preserves their returned output, carries blocked summaries into lifecycle notice reasons, marks returned failures non-resumable with explicit terminal failure metadata, and emits failure/blocked lifecycle cards rather than success/checkmark notices.


### PR DESCRIPTION
## Summary

Changelog-only release-notes PR for the Atomic prerelease `0.9.4-alpha.1`. Updates `## [Unreleased]` sections across all packages to document the changes shipping in this prerelease.

## Key Changes in 0.9.4-alpha.1

- **`@bastani/atomic` (coding-agent)** — Restored upstream Pi's provider retry default: `retry.provider.maxRetries` is now left unset/zero unless explicitly configured, so Atomic's agent-level retry observes provider transport failures directly rather than the SDK silently retrying them first ([#1562](https://github.com/bastani-inc/atomic/pull/1562)).

- **`@bastani/workflows`** — Fixed workflow lifecycle notices for structured outputs whose returned `status` is `failed` or `blocked`: the runtime now correctly records those runs as failed/blocked (not successful), preserves returned output, carries blocked summaries into lifecycle notice reasons, marks failures as non-resumable with terminal failure metadata, and emits failure/blocked lifecycle cards instead of success/checkmark notices.

- **All other packages** (`@bastani/mcp`, `@bastani/subagents`, `@bastani/web-access`, `@bastani/cursor`, `@bastani/intercom`, `@bastani/atomic-natives`) — Synchronized version bump to `0.9.4-alpha.1`; no functional changes since `0.9.3`.

## Release Details

- Release kind: prerelease → `@next`
- Target version: `0.9.4-alpha.1`
- Base branch: `main`
- Head branch: `prerelease/0.9.4-alpha.1`
- Source HEAD: `6cd311f0f1233e72dbf1aace10adec9517c19138`

No package versions are bumped on `main`; manifests remain at the `0.0.0` placeholder. The real `0.9.4-alpha.1` version is materialized only by `scripts/cut-release.ts` on the throwaway off-main tag commit.