### PR TITLE
docs(changelog): add 0.9.4-alpha.2 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.2] - 2026-06-29
+
 ### Fixed
 
 - Hardened the coding-agent npm shrinkwrap generator so release publishes resolve the already-published `@bastani/atomic-natives` registry metadata and generated platform optional packages before packing `@bastani/atomic`, while versionless main keeps deterministic placeholder native package entries for shrinkwrap checks.


### PR DESCRIPTION
## Summary

Adds the `0.9.4-alpha.2` version header to `packages/coding-agent/CHANGELOG.md`, documenting the shrinkwrap generator hardening that shipped in this prerelease.

## Key Changes

- Promotes the `### Fixed` shrinkwrap entry from `[Unreleased]` to `[0.9.4-alpha.2] - 2026-06-29` in `packages/coding-agent/CHANGELOG.md`
- Documents the fix: the coding-agent npm shrinkwrap generator now resolves the already-published `@bastani/atomic-natives` registry metadata and generated platform optional packages before packing `@bastani/atomic`; versionless `main` retains deterministic placeholder native package entries for shrinkwrap checks

## Release Metadata

| Field | Value |
|---|---|
| Kind | prerelease |
| Version | `0.9.4-alpha.2` |
| npm tag | `@next` |
| Base branch | `main` |
| Head branch | `prerelease/0.9.4-alpha.2` |
| Head SHA | `9b7522242cd32e67312fdcbf03de74d442a48290` |

## Notes

No package versions are bumped in this branch — `main` stays versionless at `0.0.0`. The real version is materialized only on the off-`main` tag commit produced by `scripts/cut-release.ts`.

## Validation

- `bun run typecheck` → passed
- `bun run test:unit` → passed (2791 tests)
- `bun run lint` + `bun run check:file-length` → passed (via push hooks)