### PR TITLE
fix(release): make shrinkwrap generation hermetic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -309,6 +309,9 @@ jobs:
             - name: Test
               run: bun run test:all
 
+            - name: Verify committed npm shrinkwrap
+              run: bun run check:shrinkwrap
+
             - name: Download Atomic native bindings
               uses: actions/download-artifact@v8
               with:
@@ -567,10 +570,9 @@ jobs:
                   bun pm pack --dry-run
                   npm publish --provenance --access public --tag "$NPM_TAG" --registry https://registry.npmjs.org
 
-            - name: Generate npm shrinkwrap for published package
+            - name: Verify prepared npm shrinkwrap for published package
               if: steps.registry.outputs.exists != 'true'
-              working-directory: ${{ env.PACKAGE_DIR }}
-              run: bun run shrinkwrap
+              run: bun run check:shrinkwrap
 
             - name: Verify npm tarball contents
               if: steps.registry.outputs.exists != 'true'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -30,6 +30,7 @@ Pull request / push
      ├─ resolve and validate the release tag
      ├─ bun install --frozen-lockfile
      ├─ bun run typecheck && bun run test:all
+     ├─ verify committed npm-shrinkwrap.json is deterministic and current
      ├─ download native NAPI artifacts
      ├─ prepare generated native optional packages
      ├─ cd packages/coding-agent && bun run docs:check
@@ -41,6 +42,7 @@ Pull request / push
      ├─ extract release notes from packages/coding-agent/CHANGELOG.md
      ├─ check whether the npm versions already exist
      ├─ npm publish --provenance --tag "$NPM_TAG" from packages/natives when needed
+     ├─ re-verify prepared npm-shrinkwrap.json without npm metadata lookups
      ├─ bun pm pack --dry-run from packages/coding-agent when publishing
      ├─ npm publish --provenance --tag "$NPM_TAG" from packages/coding-agent when needed
      ├─ determine GitHub Release type
@@ -144,7 +146,9 @@ bun run scripts/cut-release.ts 0.8.0 --base main --push
 bun run scripts/cut-release.ts 0.8.0-alpha.1 --base main --push
 ```
 
-Internally the script validates a clean tree, creates a detached `git worktree` at the base commit, stamps every versioned manifest with `scripts/bump-version.ts` (all `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, and the Cargo manifests/lock), commits `Release <version>`, tags it, removes the worktree, and pushes only the tag. `main` is never advanced and the tag's commit is the only place the real version lives. `bun.lock` keeps `main`'s `0.0.0` workspace placeholders — it is not shipped in the npm tarball and `bun install --frozen-lockfile` tolerates the version-string mismatch.
+Internally the script validates a clean tree, creates a detached `git worktree` at the base commit, stamps every versioned manifest with `scripts/bump-version.ts` (all `packages/*/package.json`, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js`, and the Cargo manifests/lock), regenerates `packages/coding-agent/npm-shrinkwrap.json` inside that stamped worktree, commits `Release <version>`, tags it, removes the worktree, and pushes only the tag. `main` is never advanced and the tag's commit is the only place the real version lives. `bun.lock` keeps `main`'s `0.0.0` workspace placeholders — it is not shipped in the npm tarball and `bun install --frozen-lockfile` tolerates the version-string mismatch.
+
+The release shrinkwrap is prepared before the tag is published. Internal Atomic entries such as `@bastani/atomic-natives` and its generated platform optional packages are derived from the stamped local `package.json` metadata and deterministic npm tarball URLs like `https://registry.npmjs.org/@bastani/atomic-natives/-/atomic-natives-<version>.tgz`; the generator intentionally does not query npm metadata for the just-published native packages or require their registry `integrity` fields.
 
 ### Publish Flow
 
@@ -170,6 +174,7 @@ Publish @bastani/atomic
   · setup Bun and Node (Node 24 for npm provenance publish)
   · bun install --frozen-lockfile
   · bun run typecheck && bun run test:all
+  · verify the committed npm-shrinkwrap.json matches local deterministic generation
   · download native NAPI artifacts from the matrix jobs
   · prepare generated native optional packages with `bun run --cwd packages/natives create-npm-dirs` and `bun run --cwd packages/natives artifacts`
   · cd packages/coding-agent && bun run docs:check
@@ -188,6 +193,7 @@ Publish @bastani/atomic
   · determine npm tag: latest or next
   · skip publish if version already exists on npm
   · cd packages/natives && bun run prepublish:native && npm publish --provenance --access public --tag "$NPM_TAG" --registry https://registry.npmjs.org
+  · verify the prepared npm-shrinkwrap.json still matches local deterministic generation
   · cd packages/coding-agent && bun pm pack --dry-run
   · cd packages/coding-agent && npm publish --provenance --access public --tag "$NPM_TAG" --registry https://registry.npmjs.org
   · determine GitHub Release prerelease/latest settings
@@ -263,6 +269,7 @@ The meaningful pre-publish checks are:
 - docs route/internal-link validation with `cd packages/coding-agent && bun run docs:check`
 - Mintlify MDX/page syntax validation with `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`
 - Mintlify broken-link validation with `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`
+- deterministic `npm-shrinkwrap.json` validation for `@bastani/atomic`
 - `@bastani/atomic` build output validation
 - builtin extension/resource validation under `dist/builtin/`
 - `bun pm pack --dry-run` from `packages/coding-agent`
@@ -274,7 +281,7 @@ The meaningful pre-publish checks are:
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, enforce the tracked TS/JS/Rust file-length gate, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests, build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
-| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
+| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
 | `code-review.yml`    | PR opened/synchronized                        | Claude-powered code review                                                                                                                                                                                    |
 | `pr-description.yml` | PR opened/synchronized                        | Claude-powered PR description generation, skipped for Dependabot                                                                                                                                              |
 | `claude.yml`         | Issue/PR comments, issues, PR reviews         | Interactive Claude assistant gated on `@claude` mentions                                                                                                                                                      |
@@ -318,7 +325,7 @@ The meaningful pre-publish checks are:
 
     On Windows, substitute `--platform windows-x64`, extract `atomic-windows-x64.zip`, and run `atomic.exe --version` plus the equivalent `atomic.exe --no-session` smoke. (A `main` build reports the `0.0.0` placeholder for `--version`; a release build from the tag reports the real version.)
 
-3. From a clean `main`, cut and push the release tag. This stamps the version onto an off-`main` `Release 0.8.0` commit, tags it, and pushes only the tag (the publish trigger):
+3. From a clean `main`, cut and push the release tag. This stamps the version onto an off-`main` `Release 0.8.0` commit, regenerates the deterministic `@bastani/atomic` shrinkwrap from local metadata, tags it, and pushes only the tag (the publish trigger):
 
     ```sh
     bun run scripts/cut-release.ts 0.8.0 --base main --push

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test:all": "bun run test:unit && bun run test:integration",
     "typecheck": "tsc --noEmit",
     "check:file-length": "bun scripts/check-file-length.ts",
-    "check:shrinkwrap": "node scripts/generate-coding-agent-shrinkwrap.mjs --check",
-    "shrinkwrap:coding-agent": "node scripts/generate-coding-agent-shrinkwrap.mjs",
+    "check:shrinkwrap": "bun run scripts/generate-coding-agent-shrinkwrap.mjs --check",
+    "shrinkwrap:coding-agent": "bun run scripts/generate-coding-agent-shrinkwrap.mjs",
     "lint": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Made release shrinkwrap preparation hermetic by deriving `@bastani/atomic-natives` and generated platform optional package entries from local stamped package metadata with deterministic registry tarball URLs, removing post-native-publish npm metadata lookups that could race registry propagation.
+
 ## [0.9.4-alpha.2] - 2026-06-29
 
 ### Fixed

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -68,6 +68,16 @@ bun --cwd packages/coding-agent run test -- test/specific.test.ts
 
 The file-length gate scans tracked `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, and `.rs` files via `git ls-files`, falls back to a recursive walk outside Git, and counts physical lines with a no-final-newline correction. Only generated/vendored path globs (`node_modules`, `dist`, `target`, `binaries`, `.git`, `vendor`, minified bundles, and the bundled third-party `packages/workflows/skills/impeccable/**` skill) plus first-five-line generated markers are excluded; there is no grandfather/baseline allowlist for authored files.
 
+## Release shrinkwrap
+
+`@bastani/atomic` ships `packages/coding-agent/npm-shrinkwrap.json` for deterministic package-manager installs. Main stays versionless at `0.0.0`; `scripts/cut-release.ts` stamps the real version in an off-main worktree and regenerates the shrinkwrap there before tagging.
+
+The shrinkwrap generator is hermetic for Atomic-owned packages. It derives `@bastani/atomic-natives` and generated native optional package entries from local package metadata plus deterministic registry tarball URLs, so release publishing does not depend on npm metadata for native packages that were just published.
+
+```bash
+bun run scripts/generate-coding-agent-shrinkwrap.mjs --check
+```
+
 ## Project Structure
 
 ```

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -66,7 +66,7 @@
     "docs:check": "bun run scripts/validate-docs-links.ts",
     "verify:workflow-types": "bun run scripts/verify-workflow-sdk-types.ts",
     "test": "vitest --run",
-    "shrinkwrap": "node ../../scripts/generate-coding-agent-shrinkwrap.mjs",
+    "shrinkwrap": "bun run ../../scripts/generate-coding-agent-shrinkwrap.mjs",
     "prepublishOnly": "bun run clean && bun run build && bun run shrinkwrap"
   },
   "dependencies": {

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -15,8 +15,10 @@
  *   3. stamp the real version into the worktree via scripts/bump-version.ts
  *      (bun.lock keeps main's 0.0.0 placeholders; `bun install --frozen-lockfile`
  *      tolerates the workspace version-string mismatch, so the lockfile is left as-is)
- *   4. commit `Release <version>` and tag `<version>` inside the worktree
- *   5. remove the worktree — the tag (and its commit) persist in the repo
+ *   4. regenerate release artifacts that must carry the stamped version, including
+ *      packages/coding-agent/npm-shrinkwrap.json
+ *   5. commit `Release <version>` and tag `<version>` inside the worktree
+ *   6. remove the worktree — the tag (and its commit) persist in the repo
  *
  * Because publish.yml checks out the *tagged commit* (which now carries the
  * real version) every existing version validation passes unchanged.
@@ -145,8 +147,12 @@ async function main(): Promise<void> {
     await $`git -C ${ROOT} worktree add --detach ${worktreeDir} ${baseSha}`.quiet();
     worktreeAdded = true;
 
-    // Stamp the real version into the detached worktree only.
+    // Stamp the real version into the detached worktree only, then regenerate
+    // release artifacts that encode the stamped version. The shrinkwrap generator
+    // is hermetic: internal Atomic packages use deterministic registry tarball
+    // URLs derived from local package metadata rather than npm registry metadata.
     await $`bun run ${join(ROOT, "scripts/bump-version.ts")} ${version} --root ${worktreeDir}`;
+    await $`bun run ${join(worktreeDir, "scripts/generate-coding-agent-shrinkwrap.mjs")}`;
 
     // bun.lock intentionally keeps main's 0.0.0 workspace placeholders: it is not
     // shipped in the npm tarball and `bun install --frozen-lockfile` tolerates the

--- a/scripts/generate-coding-agent-shrinkwrap.d.mts
+++ b/scripts/generate-coding-agent-shrinkwrap.d.mts
@@ -1,0 +1,20 @@
+export interface CodingAgentShrinkwrapPackageEntry {
+	version?: string;
+	resolved?: string;
+	integrity?: string;
+	optional?: boolean;
+	optionalDependencies?: Record<string, string>;
+	os?: string[];
+	cpu?: string[];
+	libc?: string[];
+}
+
+export interface CodingAgentShrinkwrap {
+	name: string;
+	version: string;
+	lockfileVersion: 3;
+	requires: true;
+	packages: Record<string, CodingAgentShrinkwrapPackageEntry>;
+}
+
+export function generateShrinkwrap(): Promise<CodingAgentShrinkwrap>;

--- a/scripts/generate-coding-agent-shrinkwrap.mjs
+++ b/scripts/generate-coding-agent-shrinkwrap.mjs
@@ -10,9 +10,7 @@ const codingAgentDir = join(repoRoot, "packages/coding-agent");
 const rootLockfilePath = join(repoRoot, "package-lock.json");
 const shrinkwrapPath = join(codingAgentDir, "npm-shrinkwrap.json");
 const internalPackageNames = new Set(["@bastani/atomic-natives"]);
-const placeholderVersion = "0.0.0";
 const defaultNpmRegistry = "https://registry.npmjs.org";
-const npmRegistry = (process.env.npm_config_registry || process.env.NPM_CONFIG_REGISTRY || defaultNpmRegistry).replace(/\/$/, "");
 const allowedInstallScriptPackages = new Map([
 	["@google/genai@1.52.0", "preinstall is a no-op in the published package"],
 	["protobufjs@7.6.4", "postinstall only warns about protobufjs version scheme mismatches"],
@@ -132,48 +130,6 @@ function registryTarballUrl(packageName, version, registry = defaultNpmRegistry)
 	return `${registry}/${packageName}/-/${tarballName}-${version}.tgz`;
 }
 
-function registryMetadataUrl(packageName) {
-	return `${npmRegistry}/${encodeURIComponent(packageName)}`;
-}
-
-function assertRegistryMetadata(packageName, version, metadata) {
-	if (!metadata || metadata.name !== packageName || metadata.version !== version) {
-		throw new Error(`Registry metadata for ${packageName}@${version} is malformed.`);
-	}
-	if (!metadata.dist?.tarball || !metadata.dist?.integrity) {
-		throw new Error(`Registry metadata for ${packageName}@${version} is missing dist.tarball or dist.integrity.`);
-	}
-}
-
-async function fetchRegistryPackageVersion(packageName, version) {
-	if (version === placeholderVersion) {
-		return undefined;
-	}
-
-	const response = await fetch(registryMetadataUrl(packageName), {
-		headers: { accept: "application/vnd.npm.install-v1+json, application/json" },
-	});
-	if (!response.ok) {
-		throw new Error(`Unable to read npm metadata for ${packageName}@${version}: HTTP ${response.status}`);
-	}
-	const packument = await response.json();
-	const metadata = packument?.versions?.[version];
-	if (!metadata) {
-		throw new Error(
-			`npm metadata for ${packageName}@${version} is not available. Publish @bastani/atomic-natives and its optional platform packages before generating the @bastani/atomic shrinkwrap.`,
-		);
-	}
-	assertRegistryMetadata(packageName, version, metadata);
-	return metadata;
-}
-
-function copyRegistryPackageEntry(metadata) {
-	const entry = copyPackageJsonEntry(metadata, { includeName: false });
-	entry.resolved = metadata.dist.tarball;
-	entry.integrity = metadata.dist.integrity;
-	return sortedPackageEntry(entry);
-}
-
 function platformDescriptorFromNapiTarget(packageJson, target) {
 	const mappings = {
 		"x86_64-pc-windows-msvc": { suffix: "win32-x64-msvc", os: ["win32"], cpu: ["x64"] },
@@ -211,7 +167,7 @@ function generatedAtomicNativesOptionalPackages(packageJson) {
 	);
 }
 
-async function buildInternalPackageEntries(workspaces) {
+function buildInternalPackageEntries(workspaces) {
 	const entries = new Map();
 	for (const [name, workspace] of workspaces) {
 		const packageJson = workspace.packageJson;
@@ -219,30 +175,16 @@ async function buildInternalPackageEntries(workspaces) {
 			continue;
 		}
 
-		const metadata = await fetchRegistryPackageVersion(name, packageJson.version);
 		const optionalPackages = generatedAtomicNativesOptionalPackages(packageJson);
-		const mainEntry = metadata ? copyRegistryPackageEntry(metadata) : copyPackageJsonEntry(packageJson, { includeName: false });
-		mainEntry.resolved = metadata?.dist?.tarball ?? registryTarballUrl(name, packageJson.version);
-		if (metadata?.dist?.integrity) {
-			mainEntry.integrity = metadata.dist.integrity;
-		}
+		const mainEntry = copyPackageJsonEntry(packageJson, { includeName: false });
+		mainEntry.resolved = registryTarballUrl(name, packageJson.version);
 		mainEntry.optionalDependencies = sortedObject(
-			metadata?.optionalDependencies ??
-				Object.fromEntries([...optionalPackages].map(([packageName, descriptor]) => [packageName, descriptor.version])),
+			Object.fromEntries([...optionalPackages].map(([packageName, descriptor]) => [packageName, descriptor.version])),
 		);
 		entries.set(name, sortedPackageEntry(mainEntry));
 
 		for (const [packageName, descriptor] of optionalPackages) {
-			const optionalVersion = mainEntry.optionalDependencies[packageName];
-			const optionalMetadata = await fetchRegistryPackageVersion(packageName, optionalVersion);
-			const optionalEntry = optionalMetadata ? copyRegistryPackageEntry(optionalMetadata) : { ...descriptor.entry };
-			optionalEntry.os = descriptor.entry.os;
-			optionalEntry.cpu = descriptor.entry.cpu;
-			if (descriptor.entry.libc) {
-				optionalEntry.libc = descriptor.entry.libc;
-			}
-			optionalEntry.optional = true;
-			entries.set(packageName, sortedPackageEntry(optionalEntry));
+			entries.set(packageName, sortedPackageEntry({ ...descriptor.entry }));
 		}
 	}
 	return entries;
@@ -411,7 +353,7 @@ async function generateShrinkwrap() {
 	const lockPackages = rootLock.packages;
 	const codingAgentPackage = readJson(join(codingAgentDir, "package.json"));
 	const internalWorkspaces = getInternalWorkspaces(lockPackages);
-	const generatedInternalPackages = await buildInternalPackageEntries(internalWorkspaces);
+	const generatedInternalPackages = buildInternalPackageEntries(internalWorkspaces);
 	const shrinkwrapPackages = {
 		"": copyPackageJsonEntry(codingAgentPackage, { includeName: true }),
 	};

--- a/test/unit/shrinkwrap-atomic-natives.test.ts
+++ b/test/unit/shrinkwrap-atomic-natives.test.ts
@@ -1,32 +1,123 @@
 import { test } from "bun:test";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import assert from "node:assert/strict";
 
-test("checked-in coding-agent shrinkwrap includes generated atomic native optional packages", async () => {
-	const shrinkwrap = await Bun.file("packages/coding-agent/npm-shrinkwrap.json").json();
+import type { CodingAgentShrinkwrap as Shrinkwrap } from "../../scripts/generate-coding-agent-shrinkwrap.mjs";
+
+interface PackageJson {
+	name: string;
+	version: string;
+	dependencies?: Record<string, string>;
+}
+
+interface ShrinkwrapModule {
+	generateShrinkwrap(): Promise<Shrinkwrap>;
+}
+
+const stampedReleaseVersion = "9.8.7-alpha.1";
+
+const expectedNativeOptionalPackages = [
+	"@bastani/atomic-natives-darwin-arm64",
+	"@bastani/atomic-natives-darwin-x64",
+	"@bastani/atomic-natives-linux-arm64-gnu",
+	"@bastani/atomic-natives-linux-x64-gnu",
+	"@bastani/atomic-natives-win32-arm64-msvc",
+	"@bastani/atomic-natives-win32-x64-msvc",
+];
+
+function assertDeterministicNativeEntries(shrinkwrap: Shrinkwrap, expectedVersion?: string) {
 	const atomicNatives = shrinkwrap.packages["node_modules/@bastani/atomic-natives"];
 	assert.ok(atomicNatives, "@bastani/atomic-natives entry should be present");
+	if (expectedVersion) {
+		assert.equal(atomicNatives.version, expectedVersion);
+	}
+	const resolved = atomicNatives.resolved;
+	assert.equal(typeof resolved, "string", "@bastani/atomic-natives resolved URL should be present");
+	assert.match(
+		resolved ?? "",
+		/^https:\/\/registry\.npmjs\.org\/@bastani\/atomic-natives\/-\/atomic-natives-[^/]+\.tgz$/,
+	);
+	assert.equal(atomicNatives.integrity, undefined, "internal native root entry should not require registry integrity");
 
 	const optionalDependencies = atomicNatives.optionalDependencies ?? {};
-	const expectedPackages = [
-		"@bastani/atomic-natives-darwin-arm64",
-		"@bastani/atomic-natives-darwin-x64",
-		"@bastani/atomic-natives-linux-arm64-gnu",
-		"@bastani/atomic-natives-linux-x64-gnu",
-		"@bastani/atomic-natives-win32-arm64-msvc",
-		"@bastani/atomic-natives-win32-x64-msvc",
-	];
-
-	assert.deepEqual(Object.keys(optionalDependencies).sort(), expectedPackages);
-	for (const packageName of expectedPackages) {
+	assert.deepEqual(Object.keys(optionalDependencies).sort(), expectedNativeOptionalPackages);
+	for (const packageName of expectedNativeOptionalPackages) {
 		const entry = shrinkwrap.packages[`node_modules/${packageName}`];
 		assert.ok(entry, `${packageName} entry should be present`);
 		assert.equal(entry.version, optionalDependencies[packageName]);
+		if (expectedVersion) {
+			assert.equal(entry.version, expectedVersion);
+			assert.equal(optionalDependencies[packageName], expectedVersion);
+		}
 		assert.equal(entry.optional, true);
+		assert.equal(entry.integrity, undefined, `${packageName} should not require registry integrity`);
 		assert.ok(entry.resolved?.includes(`${packageName}/-/`), `${packageName} should resolve to its registry tarball`);
 		assert.ok(entry.os?.length, `${packageName} should declare supported OS`);
 		assert.ok(entry.cpu?.length, `${packageName} should declare supported CPU`);
 		if (packageName.includes("linux")) {
 			assert.deepEqual(entry.libc, ["glibc"], `${packageName} should constrain the GNU build to glibc`);
 		}
+	}
+}
+
+async function readPackageJson(path: string): Promise<PackageJson> {
+	return (await Bun.file(path).json()) as PackageJson;
+}
+
+async function writePackageJson(path: string, packageJson: PackageJson): Promise<void> {
+	await Bun.write(path, `${JSON.stringify(packageJson, null, 2)}\n`);
+}
+
+async function createStampedShrinkwrapFixture(version: string): Promise<string> {
+	const fixtureRoot = mkdtempSync(join(tmpdir(), "atomic-shrinkwrap-test-"));
+	mkdirSync(join(fixtureRoot, "scripts"), { recursive: true });
+	mkdirSync(join(fixtureRoot, "packages/coding-agent"), { recursive: true });
+	mkdirSync(join(fixtureRoot, "packages/natives"), { recursive: true });
+
+	copyFileSync("scripts/generate-coding-agent-shrinkwrap.mjs", join(fixtureRoot, "scripts/generate-coding-agent-shrinkwrap.mjs"));
+	copyFileSync("package-lock.json", join(fixtureRoot, "package-lock.json"));
+
+	const codingAgentPackage = await readPackageJson("packages/coding-agent/package.json");
+	codingAgentPackage.version = version;
+	if (codingAgentPackage.dependencies?.["@bastani/atomic-natives"]) {
+		codingAgentPackage.dependencies["@bastani/atomic-natives"] = version;
+	}
+	await writePackageJson(join(fixtureRoot, "packages/coding-agent/package.json"), codingAgentPackage);
+
+	const nativesPackage = await readPackageJson("packages/natives/package.json");
+	nativesPackage.version = version;
+	await writePackageJson(join(fixtureRoot, "packages/natives/package.json"), nativesPackage);
+
+	return fixtureRoot;
+}
+
+test("checked-in coding-agent shrinkwrap includes deterministic atomic native optional packages", async () => {
+	const shrinkwrap = await Bun.file("packages/coding-agent/npm-shrinkwrap.json").json();
+	assertDeterministicNativeEntries(shrinkwrap);
+});
+
+test("coding-agent shrinkwrap generation does not require npm metadata for a stamped native release version", async () => {
+	const originalFetch = globalThis.fetch;
+	const failFetchUse = (): never => {
+		throw new Error("shrinkwrap generation must not query npm registry metadata");
+	};
+	const rejectingFetch: typeof fetch = Object.assign(failFetchUse, {
+		preconnect: failFetchUse,
+	});
+	globalThis.fetch = rejectingFetch;
+	const fixtureRoot = await createStampedShrinkwrapFixture(stampedReleaseVersion);
+
+	try {
+		const fixtureScriptUrl = `${pathToFileURL(join(fixtureRoot, "scripts/generate-coding-agent-shrinkwrap.mjs")).href}?stamped=${stampedReleaseVersion}`;
+		const { generateShrinkwrap } = (await import(fixtureScriptUrl)) as ShrinkwrapModule;
+		const shrinkwrap = await generateShrinkwrap();
+		assert.equal(shrinkwrap.version, stampedReleaseVersion);
+		assertDeterministicNativeEntries(shrinkwrap, stampedReleaseVersion);
+	} finally {
+		globalThis.fetch = originalFetch;
+		rmSync(fixtureRoot, { recursive: true, force: true });
 	}
 });


### PR DESCRIPTION
## Summary

Removes a race condition in the release pipeline where `npm-shrinkwrap.json` generation for `@bastani/atomic` depended on npm registry metadata for `@bastani/atomic-natives` packages that had just been published and might not yet be propagated. The shrinkwrap is now fully hermetic: all internal Atomic package entries are derived from local, stamped package metadata with deterministic registry tarball URLs, and the file is committed as part of the release tag commit.

## Changes

- **`scripts/generate-coding-agent-shrinkwrap.mjs`** — Removed all npm registry fetching (`fetchRegistryPackageVersion`, `registryMetadataUrl`, `copyRegistryPackageEntry`); `buildInternalPackageEntries` is now synchronous and constructs `@bastani/atomic-natives` entries (including all generated native platform optionals) solely from local `package.json` metadata plus deterministic `registry.npmjs.org` tarball URLs. `integrity` fields are omitted for internal Atomic entries (by design; npm validates integrity on install from the registry).
- **`scripts/cut-release.ts`** — Invokes `generate-coding-agent-shrinkwrap.mjs` inside the stamped off-`main` release worktree after `bump-version.ts` runs, so the committed shrinkwrap always encodes the real release version before tagging.
- **`.github/workflows/publish.yml`** — Adds an early `check:shrinkwrap` verification step before native artifact download; replaces the post-native-publish "Generate npm shrinkwrap" step with a lighter `check:shrinkwrap` verification (no longer needs to regenerate from npm metadata).
- **`package.json` / `packages/coding-agent/package.json`** — Changed `node` → `bun run` for `check:shrinkwrap` and `shrinkwrap` scripts to stay consistent with the Bun-only toolchain rule.
- **`scripts/generate-coding-agent-shrinkwrap.d.mts`** — New type declaration file exposing `CodingAgentShrinkwrap`, `CodingAgentShrinkwrapPackageEntry`, and `generateShrinkwrap()` for typed imports in tests.
- **`test/unit/shrinkwrap-atomic-natives.test.ts`** — Expanded coverage: new test that patches `globalThis.fetch` to throw if called, creates a temp fixture with stamped version manifests, and asserts that `generateShrinkwrap()` completes without any registry network calls; verifies version pins, resolved URL shape, and absence of `integrity` fields on internal entries.
- **`docs/ci.md`** / **`packages/coding-agent/docs/development.md`** — Documented hermetic shrinkwrap generation, the new CI verification steps, and the `bun run check:shrinkwrap` command.
- **`packages/coding-agent/CHANGELOG.md`** — Added `[Unreleased] → Fixed` entry describing the change.

## Why this matters

Previously, `generate-coding-agent-shrinkwrap.mjs` fetched `/@bastani/atomic-natives/<version>` from npm immediately after the native packages were published. Registry propagation is not instantaneous, so this step could fail with a 404 on a fast CI runner. By generating the shrinkwrap in the release worktree before the tag is pushed, the file is committed alongside the version stamp and CI only needs to verify (not regenerate) it.

## Validation

```sh
bun test test/unit/shrinkwrap-atomic-natives.test.ts
bun run check:shrinkwrap
bun run lint
bun run check:file-length
bun run test:unit
```