### PR TITLE
fix(workflows): classify transport failures as fallbackable transport_error

### DIFF
--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -165,11 +165,14 @@ class Atomic(BaseInstalledAgent):
     def network_allowlist(self) -> NetworkAllowlist:
         provider = self._parsed_model_provider
         defaults = set(self._INSTALL_DOMAINS)
-        if provider and provider in self._PROVIDER_DOMAINS:
-            defaults.update(self._PROVIDER_DOMAINS[provider])
-        else:
-            for domains in self._PROVIDER_DOMAINS.values():
-                defaults.update(domains)
+        # Atomic workflows can select fallback models from providers other than
+        # the top-level Pier --model provider. In Pier's restricted egress mode,
+        # narrowing the allowlist to only the requested provider makes valid
+        # workflow fallback attempts fail as generic SDK "Connection error"
+        # transport failures. Allow every Atomic-supported provider domain here;
+        # credentials/model config still decide which providers can actually run.
+        for domains in self._PROVIDER_DOMAINS.values():
+            defaults.update(domains)
         urls = [self._get_env(key) for key in self._BASE_URL_ENV_KEYS]
         if provider == "github-copilot":
             urls.append(self._copilot_api_base_url())

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -1814,7 +1814,7 @@ export default workflow({
 
 For lower-level integrations, `@bastani/workflows` also exports `setupGitWorktree({ gitWorktreeDir, baseBranch, cwd })`, returning `{ worktreeRoot, cwd, repositoryRoot, created }` with the same validation, symlink-preserving path handling, and cwd-preservation behavior used by workflow stages.
 
-`fallbackModels` retries transient provider/model failures with the primary `model` first, then each fallback, then the current Atomic-selected model when available. It is for rate limits, quota/auth/provider outages, unavailable models, network timeouts, and 5xx errors — not workflow-code errors, tool failures, validation failures, or cancellations.
+`fallbackModels` retries transient provider/model failures with the primary `model` first, then each fallback, then the current Atomic-selected model when available. It is for rate limits, quota/auth/provider outages, unavailable models, network timeouts, generic transport errors such as `Connection error.` / `fetch failed`, and 5xx errors — not workflow-code errors, tool failures, validation failures, or cancellations.
 
 When a finished stage's session is reattached for a follow-up (for example a post-completion follow-up, or after the CLI is reloaded), the stage resumes on the model the session last settled on — the one that actually worked — instead of replaying the chain from the primary. If that model fails again with a transient/retryable error, the full chain is retried from the primary.
 

--- a/packages/coding-agent/test/cli-test-helpers.ts
+++ b/packages/coding-agent/test/cli-test-helpers.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 const testDir = dirname(fileURLToPath(import.meta.url));
 export const cliPath = resolve(testDir, "../src/cli.ts");
 
+const defaultCliProcessTimeoutMs = process.platform === "win32" ? 75_000 : 30_000;
+
 export interface CliProcessResult {
 	stdout: string;
 	stderr: string;
@@ -57,7 +59,7 @@ export async function runCliProcess(args: string[], options: { cwd: string; env?
 	child.stderr?.on("data", (chunk) => { stderr += chunk.toString(); });
 
 	return await new Promise((resolvePromise, reject) => {
-		const timeout = setTimeout(() => { timedOut = true; killProcessTree(child.pid); }, options.timeoutMs ?? 30_000);
+		const timeout = setTimeout(() => { timedOut = true; killProcessTree(child.pid); }, options.timeoutMs ?? defaultCliProcessTimeoutMs);
 		const finish = (code: number | null, signal: NodeJS.Signals | null) => {
 			if (settled) return;
 			settled = true;

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -21,11 +21,13 @@ const workspaceSourceAliases: AliasOptions =
 			]
 		: [];
 
+const defaultTestTimeoutMs = process.platform === "win32" ? 90_000 : 30_000;
+
 export default defineConfig({
 	test: {
 		globals: true,
 		environment: "node",
-		testTimeout: 30000,
+		testTimeout: defaultTestTimeoutMs,
 		include: ["test/**/*.test.ts", "test/**/*.spec.ts", "test/**/*.suite.ts"],
 		exclude: [
 			"**/node_modules/**",

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Classified generic provider `Connection error.` / `fetch failed` transport outages as explicit workflow transport errors so stage fallback metadata can distinguish them from ordinary provider/model outages while preserving the normal next-model fallback order.
+
 ## [0.9.4-alpha.1] - 2026-06-29
 
 ### Fixed

--- a/packages/workflows/src/runs/shared/model-fallback-failures.ts
+++ b/packages/workflows/src/runs/shared/model-fallback-failures.ts
@@ -49,6 +49,7 @@ export type ModelFallbackFailureKind =
   | "rate_limit"
   | "provider_unavailable"
   | "network_timeout"
+  | "transport_error"
   | "model_unavailable"
   | "cancelled"
   | "task_failure"
@@ -76,6 +77,7 @@ const FALLBACKABLE_FAILURE_KINDS: ReadonlySet<ModelFallbackFailureKind> = new Se
   "rate_limit",
   "provider_unavailable",
   "network_timeout",
+  "transport_error",
   "model_unavailable",
 ]);
 
@@ -258,6 +260,17 @@ const PROVIDER_REFUSAL_FAILURE_PATTERNS: readonly RegExp[] = [
   /\bprovider\b[^\n]*\brefus(?:e|al|ed|es|ing)?\b[^\n]*\b(?:prompt|request|content|policy|safety)\b/i,
 ];
 
+const TRANSPORT_OUTAGE_FAILURE_PATTERNS: readonly RegExp[] = [
+  /^connection\s+error\.?$/i,
+  /^fetch\s+failed\.?$/i,
+];
+
+function transportOutageKindFromMessage(message: string): ModelFallbackFailureKind | undefined {
+  return TRANSPORT_OUTAGE_FAILURE_PATTERNS.some((pattern) => pattern.test(message.trim()))
+    ? "transport_error"
+    : undefined;
+}
+
 function refusalKindFromMessage(message: string): ModelFallbackFailureKind | undefined {
   if (CANCELLED_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "cancelled";
   if (NON_RETRYABLE_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return "task_failure";
@@ -268,6 +281,8 @@ function refusalKindFromMessage(message: string): ModelFallbackFailureKind | und
 function fallbackKindFromMessage(message: string, name: string | undefined): ModelFallbackFailureKind | undefined {
   const refusalKind = refusalKindFromMessage(message);
   if (refusalKind !== undefined) return refusalKind;
+  const transportOutageKind = transportOutageKindFromMessage(message);
+  if (transportOutageKind !== undefined) return transportOutageKind;
   const nameKind = kindFromCode(name);
   if (nameKind !== undefined) return nameKind;
   if (!RETRYABLE_MODEL_FAILURE_PATTERNS.some((pattern) => pattern.test(message))) return undefined;
@@ -303,6 +318,16 @@ function makeSignal(
     ...(code !== undefined ? { code } : {}),
     ...(name !== undefined ? { name } : {}),
   };
+}
+
+function fallbackSignalFromDirectMessage(
+  value: unknown,
+  source: ModelFallbackFailureSource | undefined,
+): ModelFallbackFailureSignal | undefined {
+  const message = directMessageFrom(value);
+  if (message === undefined) return undefined;
+  const kind = fallbackKindFromMessage(message, errorName(value));
+  return kind === undefined ? undefined : makeSignal(kind, value, source);
 }
 
 function fallbackSignalFromMessage(
@@ -345,6 +370,9 @@ function structuredSignal(
 
   const directRefusalSignal = classifyAssistantRefusalSignal(value, source);
   if (directRefusalSignal !== undefined) return directRefusalSignal;
+
+  const directMessageSignal = fallbackSignalFromDirectMessage(value, source);
+  if (directMessageSignal !== undefined) return directMessageSignal;
 
   const codeKind = kindFromCode(codeFrom(value));
   const nameKind = kindFromCode(errorName(value));

--- a/test/unit/model-fallback-transport.test.ts
+++ b/test/unit/model-fallback-transport.test.ts
@@ -1,0 +1,27 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+  isRetryableModelFailure,
+  normalizeModelFailureSignal,
+} from "../../packages/workflows/src/runs/shared/model-fallback.js";
+
+describe("workflow model fallback transport failures", () => {
+  test("classifies generic connection failures as transport errors for provider-aware fallback", () => {
+    const assistantFailure = {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "Connection error.",
+    };
+
+    const directSignal = normalizeModelFailureSignal(assistantFailure);
+    assert.equal(directSignal.kind, "transport_error");
+    assert.equal(directSignal.source, "assistant_message");
+    assert.equal(isRetryableModelFailure(assistantFailure), true);
+
+    const wrappedSignal = normalizeModelFailureSignal(
+      new Error("Connection error.", { cause: assistantFailure }),
+    );
+    assert.equal(wrappedSignal.kind, "transport_error");
+    assert.equal(isRetryableModelFailure(new Error("Connection error.", { cause: assistantFailure })), true);
+  });
+});


### PR DESCRIPTION
## Summary

Classifies bare `Connection error.` / `fetch failed` messages — emitted by provider SDKs when network egress is blocked — as an explicit `transport_error` failure kind so workflow stage fallback metadata can distinguish them from ordinary provider/model outages, while preserving the standard next-model fallback chain behavior.

## Changes

- **`packages/workflows/src/runs/shared/model-fallback-failures.ts`**: Adds `transport_error` to `ModelFallbackFailureKind` and `FALLBACKABLE_FAILURE_KINDS`; adds `TRANSPORT_OUTAGE_FAILURE_PATTERNS` with exact-match regexes for `Connection error.` and `fetch failed`; wires a new `fallbackSignalFromDirectMessage` helper into `structuredSignal` so these messages are classified before the generic retryable-patterns pass.
- **`evals/atomic_pier.py`**: Removes provider-conditional narrowing from `network_allowlist`; always opens all Atomic-supported provider domains so workflow fallback attempts to non-primary providers aren't blocked by Pier's restricted egress.
- **`packages/coding-agent/docs/workflows.md`**: Documents that `fallbackModels` covers generic transport errors such as `Connection error.` / `fetch failed` alongside existing retryable categories.
- **`packages/workflows/CHANGELOG.md`**: Adds `Fixed` entry under `[Unreleased]`.
- **`test/unit/model-fallback-transport.test.ts`**: New unit test confirming `Connection error.` is classified as `transport_error` and is retryable, both when surfaced as a direct assistant message and when wrapped in an `Error` cause chain.
- **`packages/coding-agent/test/cli-test-helpers.ts`** / **`vitest.config.ts`**: Relaxes default CLI process and test timeouts on Windows (75 s / 90 s) to reduce false-positive timeout failures on slower CI runners.

## Why

Provider SDKs surface blocked-egress failures as bare `Connection error.` strings with no error code. Without explicit classification these messages fell through to `undefined` (non-retryable), silently killing the fallback chain. The Pier allowlist narrowing compounded this: only the top-level `--model` provider's domains were allowed, so fallback attempts to any other provider were guaranteed to produce the same opaque transport error.