### PR TITLE
docs: release notes for 0.9.4-alpha.3

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
 ### Fixed
 
 - Made release shrinkwrap preparation hermetic by deriving `@bastani/atomic-natives` and generated platform optional package entries from local stamped package metadata with deterministic registry tarball URLs, removing post-native-publish npm metadata lookups that could race registry propagation.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.3 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.1] - 2026-06-29
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.3 prerelease for the intercom extension; no intercom extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.1] - 2026-06-29
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.3 prerelease for the MCP extension; no MCP extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.1] - 2026-06-29
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.3 prerelease for the native transport package; no native transport changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.1] - 2026-06-29
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.3 prerelease for the subagents extension; no subagents extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.1] - 2026-06-29
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.3 prerelease for the web-access extension; no web-access extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.1] - 2026-06-29
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.3] - 2026-06-30
+
 ### Fixed
 
 - Classified generic provider `Connection error.` / `fetch failed` transport outages as explicit workflow transport errors so stage fallback metadata can distinguish them from ordinary provider/model outages while preserving the normal next-model fallback order.


### PR DESCRIPTION
## Summary

Changelog-only release-prep PR for the `0.9.4-alpha.3` prerelease: stamps `## [0.9.4-alpha.3] - 2026-06-30` release-notes sections under `## [Unreleased]` in every package `CHANGELOG.md`. No source code or version manifests change — `packages/*/package.json` stays versionless at `0.0.0` per the [versionless `main` release flow](../blob/main/CLAUDE.md#releasing); the real version is materialized only by the off-`main` tag commit from `scripts/cut-release.ts`.

## Key changes

- `packages/coding-agent/CHANGELOG.md` — carries forward the existing `### Fixed` entry (hermetic release shrinkwrap preparation) under the new `0.9.4-alpha.3` heading.
- `packages/workflows/CHANGELOG.md` — carries forward the existing `### Fixed` entry (classify transport failures as `transport_error` for workflow stage fallback, #1567) under the new `0.9.4-alpha.3` heading.
- `packages/cursor/CHANGELOG.md`, `packages/intercom/CHANGELOG.md`, `packages/mcp/CHANGELOG.md`, `packages/natives/CHANGELOG.md`, `packages/subagents/CHANGELOG.md`, `packages/web-access/CHANGELOG.md` — each gets a `### Changed` note documenting that this is a synchronized version bump with no functional changes to that package since `0.9.4-alpha.1`.

## Validation

- `git diff origin/main...HEAD` confirms the change set is limited to the eight `CHANGELOG.md` files above (40 insertions, 0 deletions).
- `bun run lint`, `bun run check:file-length`, and `bun run test:unit` passed via pre-push hooks when the branch was pushed.