### PR TITLE
fix(http): disable proxy connect timeout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Disabled Undici's default 10-second connect timeout in Atomic's global proxy-aware HTTP dispatcher so headless or sandboxed runs behind policy proxies can wait for slow provider CONNECT establishment instead of surfacing spurious `Connection error.` failures.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Fixed

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -49,6 +49,9 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 	undici.setGlobalDispatcher(
 		new undici.EnvHttpProxyAgent({
 			allowH2: false,
+			// Undici defaults to a 10s connect timeout; disable it so slow
+			// policy/proxy CONNECT establishment follows provider retry handling.
+			connectTimeout: 0,
 			bodyTimeout: normalizedTimeoutMs,
 			headersTimeout: normalizedTimeoutMs,
 		}),

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -30,6 +30,17 @@ export function formatHttpIdleTimeoutMs(timeoutMs: number): string {
 	return `${timeoutMs / 1000} sec`;
 }
 
+export function createHttpDispatcherOptions(timeoutMs: number): ConstructorParameters<typeof undici.EnvHttpProxyAgent>[0] {
+	return {
+		allowH2: false,
+		// Undici defaults to a 10s connect timeout; disable it so slow
+		// policy/proxy CONNECT establishment follows provider retry handling.
+		connectTimeout: 0,
+		bodyTimeout: timeoutMs,
+		headersTimeout: timeoutMs,
+	};
+}
+
 /**
  * Configure the global undici dispatcher used by fetch and SDK HTTP clients.
  *
@@ -47,14 +58,7 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 	}
 
 	undici.setGlobalDispatcher(
-		new undici.EnvHttpProxyAgent({
-			allowH2: false,
-			// Undici defaults to a 10s connect timeout; disable it so slow
-			// policy/proxy CONNECT establishment follows provider retry handling.
-			connectTimeout: 0,
-			bodyTimeout: normalizedTimeoutMs,
-			headersTimeout: normalizedTimeoutMs,
-		}),
+		new undici.EnvHttpProxyAgent(createHttpDispatcherOptions(normalizedTimeoutMs)),
 	);
 
 	// Keep fetch and the dispatcher on the same undici implementation. Some Node

--- a/packages/coding-agent/test/http-dispatcher.test.ts
+++ b/packages/coding-agent/test/http-dispatcher.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+const undiciMock = vi.hoisted(() => ({
+	EnvHttpProxyAgent: vi.fn(function EnvHttpProxyAgent(this: { options?: unknown }, options: unknown) {
+		this.options = options;
+	}),
+	install: vi.fn(),
+	setGlobalDispatcher: vi.fn(),
+}));
+
+vi.mock("undici", () => undiciMock);
+
+describe("configureHttpDispatcher", () => {
+	it("disables undici's default fixed connect timeout", async () => {
+		const { configureHttpDispatcher } = await import("../src/core/http-dispatcher.ts");
+
+		configureHttpDispatcher(123_456);
+
+		expect(undiciMock.EnvHttpProxyAgent).toHaveBeenCalledWith({
+			allowH2: false,
+			connectTimeout: 0,
+			bodyTimeout: 123_456,
+			headersTimeout: 123_456,
+		});
+		expect(undiciMock.setGlobalDispatcher).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/http-dispatcher.test.ts
+++ b/packages/coding-agent/test/http-dispatcher.test.ts
@@ -1,27 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { createHttpDispatcherOptions } from "../src/core/http-dispatcher.ts";
 
-const undiciMock = vi.hoisted(() => ({
-	EnvHttpProxyAgent: vi.fn(function EnvHttpProxyAgent(this: { options?: unknown }, options: unknown) {
-		this.options = options;
-	}),
-	install: vi.fn(),
-	setGlobalDispatcher: vi.fn(),
-}));
-
-vi.mock("undici", () => undiciMock);
-
-describe("configureHttpDispatcher", () => {
-	it("disables undici's default fixed connect timeout", async () => {
-		const { configureHttpDispatcher } = await import("../src/core/http-dispatcher.ts");
-
-		configureHttpDispatcher(123_456);
-
-		expect(undiciMock.EnvHttpProxyAgent).toHaveBeenCalledWith({
+describe("createHttpDispatcherOptions", () => {
+	it("disables undici's default fixed connect timeout", () => {
+		expect(createHttpDispatcherOptions(123_456)).toEqual({
 			allowH2: false,
 			connectTimeout: 0,
 			bodyTimeout: 123_456,
 			headersTimeout: 123_456,
 		});
-		expect(undiciMock.setGlobalDispatcher).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

Disables Undici's implicit 10-second connect timeout on Atomic's global proxy-aware HTTP dispatcher (`EnvHttpProxyAgent`). Under policy/proxy layers such as Pier, the CONNECT tunnel can legitimately take longer than 10 seconds to establish; without this change, Undici aborts the connection mid-handshake and the failure surfaces as a spurious provider `Connection error.` instead of going through normal provider/agent retry handling.

## Changes

- `packages/coding-agent/src/core/http-dispatcher.ts`: extract dispatcher construction options into a new exported `createHttpDispatcherOptions(timeoutMs)` helper and pass `connectTimeout: 0` to `undici.EnvHttpProxyAgent`, disabling the fixed connect-phase timeout while keeping the existing configurable `bodyTimeout`/`headersTimeout` idle timeout behavior. `configureHttpDispatcher` now delegates to the helper.
- `packages/coding-agent/test/http-dispatcher.test.ts`: new regression test asserting `createHttpDispatcherOptions` returns `connectTimeout: 0` alongside the configured idle timeouts. The helper is asserted directly rather than mocking `undici.EnvHttpProxyAgent`, avoiding brittle module-mocking of `undici`.
- `packages/coding-agent/CHANGELOG.md`: document the fix under `[Unreleased] / Fixed`.

## Validation

- `bun run --cwd packages/coding-agent test -- test/http-dispatcher.test.ts`
- `bun run typecheck`
- `bun run check:file-length`
- Pre-commit/pre-push hooks (`bun run lint`, `bun run check:file-length`, `bun run test:unit`)