### PR TITLE
docs(changelog): release notes for 0.9.4-alpha.4

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
 ### Fixed
 
 - Disabled Undici's default 10-second connect timeout in Atomic's global proxy-aware HTTP dispatcher so headless or sandboxed runs behind policy proxies can wait for slow provider CONNECT establishment instead of surfacing spurious `Connection error.` failures.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.4 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.4 prerelease for the intercom extension; no intercom extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.4 prerelease for the MCP extension; no MCP extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.4 prerelease for the native transport package; no native transport changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.4 prerelease for the subagents extension; no subagents extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.4 prerelease for the web-access extension; no web-access extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.4] - 2026-06-30
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.4 prerelease for the workflows extension; no workflow changes were made after 0.9.4-alpha.3.
+
 ## [0.9.4-alpha.3] - 2026-06-30
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds `## [0.9.4-alpha.4]` release-note sections to the package changelogs ahead of cutting the `0.9.4-alpha.4` prerelease tag. No source changes and no `package.json` version bumps — `main` stays versionless per the [release flow](../blob/main/CLAUDE.md#releasing).

## Changes

- `packages/coding-agent/CHANGELOG.md` — moves the Undici proxy-connect-timeout fix under `## [0.9.4-alpha.4] - 2026-06-30`.
- `packages/cursor/CHANGELOG.md`, `packages/intercom/CHANGELOG.md`, `packages/mcp/CHANGELOG.md`, `packages/natives/CHANGELOG.md`, `packages/subagents/CHANGELOG.md`, `packages/web-access/CHANGELOG.md` — add `## [0.9.4-alpha.4]` entries noting these packages were republished in sync with no functional changes since `0.9.4-alpha.1`.
- `packages/workflows/CHANGELOG.md` — adds `## [0.9.4-alpha.4]` entry noting a synchronized republish with no workflow changes since `0.9.4-alpha.3`.

## Validation

- `bun run lint`, `bun run check:file-length`, `bun run test:unit` — all passed via pre-push hooks
- `git diff --name-only b001b49b..HEAD -- 'packages/*/package.json'` — empty (confirms no version bumps)

The real `0.9.4-alpha.4` version is materialized only on the throwaway off-`main` tag commit via `scripts/cut-release.ts`.