### PR TITLE
docs(release): changelog for 0.9.4-alpha.5

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
 ### Fixed
 
 - Routed `COPILOT_GITHUB_TOKEN` env auth through an endpoint resolver that honors explicit Copilot base URL overrides, GitHub Enterprise server URLs, and the public Copilot routing hub so env-token users avoid account-specific endpoint `421 Misdirected Request` failures ([#1569](https://github.com/bastani-inc/atomic/issues/1569)).

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.5 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.4] - 2026-06-30
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.5 prerelease for the intercom extension; no intercom extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.4] - 2026-06-30
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.5 prerelease for the MCP extension; no MCP extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.4] - 2026-06-30
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.5 prerelease for the native transport package; no native transport changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.4] - 2026-06-30
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.5 prerelease for the subagents extension; no subagents extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.4] - 2026-06-30
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.5 prerelease for the web-access extension; no web-access extension changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.4] - 2026-06-30
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.5] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.5 prerelease for the workflows extension; no workflow changes were made after 0.9.4-alpha.3.
+
 ## [0.9.4-alpha.4] - 2026-06-30
 
 ### Changed


### PR DESCRIPTION
## Summary

Release-notes-only PR that stamps `## [0.9.4-alpha.5] - 2026-07-01` changelog entries across the workspace ahead of tagging the `0.9.4-alpha.5` prerelease. No source code changes — `main` stays versionless (`0.0.0` placeholders).

## Key changes

- `packages/coding-agent/CHANGELOG.md`: closes out the `[Unreleased]` fix for `COPILOT_GITHUB_TOKEN` env-auth endpoint resolution ([#1569](https://github.com/bastani-inc/atomic/issues/1569)) under the new `0.9.4-alpha.5` section.
- `packages/cursor/CHANGELOG.md`, `packages/intercom/CHANGELOG.md`, `packages/mcp/CHANGELOG.md`, `packages/natives/CHANGELOG.md`, `packages/subagents/CHANGELOG.md`, `packages/web-access/CHANGELOG.md`: add synchronized `0.9.4-alpha.5` entries noting no functional changes in these packages since their last-tagged version.
- `packages/workflows/CHANGELOG.md`: add synchronized `0.9.4-alpha.5` entry noting no workflow changes since `0.9.4-alpha.3`.

## Notes

- No package version bumps — the real version is materialized only on the off-`main` tag commit produced by `scripts/cut-release.ts 0.9.4-alpha.5`.
- Verified via `bun run lint`, `bun run check:file-length`, and `bun run test:unit` at push time (push hooks passed).