### PR TITLE
chore(coding-agent): sync with upstream Pi v0.80.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
       "dependencies": {
         "@bastani/atomic-natives": "0.0.0",
         "@bufbuild/protobuf": "^2.0.0",
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-agent-core": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@mozilla/readability": "^0.6.0",
@@ -73,7 +73,7 @@
       "dependencies": {
         "@bastani/atomic-natives": "0.0.0",
         "@bufbuild/protobuf": "^2.0.0",
-        "@earendil-works/pi-ai": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.3",
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
@@ -90,7 +90,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-tui": "^0.80.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -109,8 +109,8 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
         "zod": "^3.25.0 || ^4.0.0",
       },
       "optionalPeers": [
@@ -135,9 +135,9 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-agent-core": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -158,7 +158,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-tui": "^0.80.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -174,7 +174,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-tui": "^0.80.3",
       },
       "optionalPeers": [
         "@bastani/atomic",
@@ -262,11 +262,11 @@
 
     "@dbos-inc/dbos-sdk": ["@dbos-inc/dbos-sdk@4.20.11", "", { "dependencies": { "commander": "^12.0.0", "pg": "^8.11.3", "serialize-error": "^8.1.0", "superjson": "^1.13.3", "ws": "^8.18.1", "yaml": "^2.8.3" }, "bin": { "dbos": "dist/src/cli/cli.js", "dbos-sdk": "dist/src/cli/cli.js" } }, "sha512-gh2y5yFpRLTfTa5vboAj7NuoWOF4ST4Kam0/13Ixa36oi+4n6YgI+xCsfhpu3r/iPGUDTtL5z8trU+dCyNK22w=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.2", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.2", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.3", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.2", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.2", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,16 +112,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.24.tgz",
-      "integrity": "sha512-vWB/qJl21vxGKBkBN8fKPTVXgm14v/bUQWTtR5oikrfAZbIN2bxuSiCY5rRAMR4gs3vtR2Vw0aTfVDU4tdfIPg==",
+      "version": "3.974.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.25.tgz",
+      "integrity": "sha512-fJFkx6u6wCqGMV/v6EAxiwa2UzEukbvr1hNPv4MrD3yj4IFz011jZg42/eSTOP/u5kJ0tlILqEjCWtT8GiKZvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.14",
         "@aws-sdk/xml-builder": "^3.972.32",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.27.0",
-        "@smithy/signature-v4": "^5.5.3",
+        "@smithy/core": "^3.28.0",
+        "@smithy/signature-v4": "^5.6.0",
         "@smithy/types": "^4.15.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -131,14 +131,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.50.tgz",
-      "integrity": "sha512-l8bWzhPFTi9tDcvtURxeMlfsboul5/0sEN3SwwXxdpYudVB9+EuQcxo2pwlTzXwDo4Gm2VLGyiZ8zti3nfdOLw==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.51.tgz",
+      "integrity": "sha512-Xo+/zf5k5pZdo53X8aVXN4MJGfU/M1P7yMM/GbNY/x9fyRZGEzjhKqW38GA0FSQQ9TYKs+bfPyz5ja4bi6pjTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
+        "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -147,16 +147,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.52.tgz",
-      "integrity": "sha512-FjAlnsIvemWzO3JTM3ObuuxpqCyrqkXOewlYY2+NiR1MYO1JuFYSIJ8SJN5Q2KD1jkL5lIuab8awjb/AxsvjiQ==",
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.53.tgz",
+      "integrity": "sha512-7E9oFUcf9YWe+ttGiWhe/cCSI+pswwelzgQMoKXgPJi1AIfS27TK6et5ZULqEqHu30zbN+jh1RqlwcXqY/aXyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
+        "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -179,22 +179,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.57.tgz",
-      "integrity": "sha512-8qwNhQ0sK/1KaOpVEFC7TFxrWP3fxzJV1K049MzjouiMIbvTDvIGDEUtj5ND5aTmlHVK/YZxjoYnLCeV/GZU0w==",
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.58.tgz",
+      "integrity": "sha512-MPr0hD8pyDGfF3dWXvFOILhcKTB9ptqJOJK9JEuDQzpc2HgKisY16eR7IrKUXxSbz8LZj+LHz/CS8Y5G1ai7yw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/credential-provider-env": "^3.972.50",
-        "@aws-sdk/credential-provider-http": "^3.972.52",
-        "@aws-sdk/credential-provider-login": "^3.972.56",
-        "@aws-sdk/credential-provider-process": "^3.972.50",
-        "@aws-sdk/credential-provider-sso": "^3.972.56",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.56",
-        "@aws-sdk/nested-clients": "^3.997.24",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-env": "^3.972.51",
+        "@aws-sdk/credential-provider-http": "^3.972.53",
+        "@aws-sdk/credential-provider-login": "^3.972.57",
+        "@aws-sdk/credential-provider-process": "^3.972.51",
+        "@aws-sdk/credential-provider-sso": "^3.972.57",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.57",
+        "@aws-sdk/nested-clients": "^3.997.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/credential-provider-imds": "^4.4.3",
+        "@smithy/core": "^3.28.0",
+        "@smithy/credential-provider-imds": "^4.4.4",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -203,15 +203,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.56.tgz",
-      "integrity": "sha512-S36dCrDaafakFMlaCVGAF4advbQKoJuMcyMtNWVBpUz65uqhbIAsUfvAyp+djA+jkzaEfgZGd+AELjIGzTqyhw==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.57.tgz",
+      "integrity": "sha512-kPWc/SCrl9agKeywxKwPEoQHanWag0LcNQrcZpEQpjNifkxq6tQENhgrrS9al317CF6yytyihlX+FhPHlk0QjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -220,20 +220,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.59.tgz",
-      "integrity": "sha512-LkczBXaEsdManijlEZwbKfEoo1C98Yri3LHF8gQI7CYWv+uFkmpS3OZH3BSew8g1A2ppKsScdPUSlhI6NV7a9g==",
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.60.tgz",
+      "integrity": "sha512-hE2hIBJQjCDRx8TbSqpVQ+/o2mIrJZQZbQ3LlwE2bJf7z47x5GmhcvGwZPqJH7Oq//SzTXEBGSZ4qSpK3yPbhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.50",
-        "@aws-sdk/credential-provider-http": "^3.972.52",
-        "@aws-sdk/credential-provider-ini": "^3.972.57",
-        "@aws-sdk/credential-provider-process": "^3.972.50",
-        "@aws-sdk/credential-provider-sso": "^3.972.56",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.56",
+        "@aws-sdk/credential-provider-env": "^3.972.51",
+        "@aws-sdk/credential-provider-http": "^3.972.53",
+        "@aws-sdk/credential-provider-ini": "^3.972.58",
+        "@aws-sdk/credential-provider-process": "^3.972.51",
+        "@aws-sdk/credential-provider-sso": "^3.972.57",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.57",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/credential-provider-imds": "^4.4.3",
+        "@smithy/core": "^3.28.0",
+        "@smithy/credential-provider-imds": "^4.4.4",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -242,14 +242,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.50.tgz",
-      "integrity": "sha512-ARBEVkOQzmowTU0a35smGVyldJ9FN/f57XIGrPatrul4mYN+vvOKxoc1njDOX3nugVze+0sHzQZWJ8kPARAtUA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.51.tgz",
+      "integrity": "sha512-081dD2RlnmY+G05v6E73KfACvDjPjnttrLjGHE2SSglbID25UcuijbWpL4g+XR5T2Kl4oIJoVBXi64s+2f009Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
+        "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -258,16 +258,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.56.tgz",
-      "integrity": "sha512-LvbWiFcLI/D5RPaT68TrpLLHyv7x5X+dm59wJ5dFizyGPZggBC7OdgJTlP0X1bVjiSSAgE1u1oxxcBps0GCEnA==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.57.tgz",
+      "integrity": "sha512-dC7ZyX3EHKHLOeVUEDzzGvk0L1s6N06YDrau7P0rGXL/j1cO+DzN2w1x9vcEh7zljVCR3019f5mi1Th+GGTURw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/token-providers": "3.1076.0",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/token-providers": "3.1077.0",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -276,15 +276,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1076.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1076.0.tgz",
-      "integrity": "sha512-4rTHETRKe2JWAsFUMo5ENmlzc3i9FD4KqBVXgoaF8DLTADjGid8SA+1LR2nJWjefoafvKAHcQH9F2iKa8uHc6Q==",
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1077.0.tgz",
+      "integrity": "sha512-sRUkfZ3fpOco95jZHsQUQiXvuIVLvCmWVclFg6dRFDyfsYs6Pdr/NuZ2+yJxeHN+6WAfDh2aZ8nlZntnvuhZUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -293,15 +293,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.56.tgz",
-      "integrity": "sha512-OV3JxmqMphVGMLWupYD2UhZxX07ATk1NwyYk7RgCnAEh0y3owHmtEnkWZ3ciCZ6liiFEwS8dYQpJGmKsR6ml4Q==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.57.tgz",
+      "integrity": "sha512-HtWM3FV2o7NJFJSUqFLBlxmV9RxQRHpzCvQaP1n1Qo4CxQSvwpJ8ERWHiLqXMFDgDXyELt+EZNFcpG6XQRcJbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -310,13 +310,13 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.23.tgz",
-      "integrity": "sha512-palwWdW4JouKu2IFI6biJ9r6FlWLqr2pvVe/tNU1TkVEOjtPElD2aYF6Cox8TickL5OiOFkPDThixYPQ8LAr1g==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.24.tgz",
+      "integrity": "sha512-O2tFBFQnP68GRNahxYJYZ4NVlGZ/hBe2oH58EKPPjbf7Yc04ZhKFdzAMblRrzeGdun9pBwE+CyLjFH/tr4pYNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -325,13 +325,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.19.tgz",
-      "integrity": "sha512-r3CGU8gnLe+ugV2rcR8IPUE8AKg7znWkzrKR+pvnjFr8eXrTo1TU0O31CD3eCjNH5jUY4+r4d35MDFzazYWFkQ==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.20.tgz",
+      "integrity": "sha512-VAI4wBVWOg5h1pZVmSEKe8kAW/7odKfbzO9uB23e1AICQh2pp/ROUhFacDXmwgJZZt49dIF6nEvzPTvHiO1cUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
+        "@smithy/core": "^3.28.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -340,16 +340,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.32.tgz",
-      "integrity": "sha512-Qkg0Na1Xr4tSL1o/01Z6YhxWqvmJE0wTNFLNwDx9h3m/uVvgav4FPalqq7uh9qRRvwaPBwIfEvurXFi9Td57mg==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.33.tgz",
+      "integrity": "sha512-e24VZXVZjpfVxpQ4ghf4LYV/i/x0znERdVcSzPU0+ktjmnd0k1fdPlcYsImDqIDaLZilbbwMLhuQY8d/dBzrGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
+        "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/signature-v4": "^5.5.3",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/signature-v4": "^5.6.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -358,19 +358,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.24.tgz",
-      "integrity": "sha512-+wFVfVofxeiXdRhUjRwYISB2mVfBCdiCq1wThkRipTeOc10Kyr+LS9QJTjgZuhWsna7jyLMPndrCnzLGWWvZXg==",
+      "version": "3.997.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.25.tgz",
+      "integrity": "sha512-VpRQ3wR6l+fwRHV5veJL2ehtyQFrGyH/2CJG9DVtb8H3xyqqnZWSTSrq/CJJ7DvDlDgrPRiW2SkYA8pN6VWCFQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.36",
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.37",
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -393,13 +391,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.36.tgz",
-      "integrity": "sha512-VSOWIPkI+g3a7NkxIBCO24HnsR0BZXJAi3wrKaGIZwVKyrMtNRdHxPrQI/igazgla5J9FhDzmg4RgnOSr6UQBw==",
+      "version": "3.996.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.37.tgz",
+      "integrity": "sha512-u8qd064XsHzM0Mk+yH4IPKn/ZC9rdniEKs+neBHNlsPZirw3rcLvmrH4ImoKC4yF7A0I/MbcC3dseARnJLiAhg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.14",
-        "@smithy/signature-v4": "^5.5.3",
+        "@smithy/signature-v4": "^5.6.0",
         "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
@@ -554,12 +552,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
-      "integrity": "sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q==",
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.3",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -569,9 +567,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
-      "integrity": "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==",
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -594,9 +592,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
-      "integrity": "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA==",
+      "version": "0.80.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -8223,9 +8221,9 @@
       "dependencies": {
         "@bastani/atomic-natives": "0.0.0",
         "@bufbuild/protobuf": "^2.0.0",
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-agent-core": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
         "@modelcontextprotocol/ext-apps": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@mozilla/readability": "^0.6.0",
@@ -8298,7 +8296,7 @@
       "dependencies": {
         "@bastani/atomic-natives": "0.0.0",
         "@bufbuild/protobuf": "^2.0.0",
-        "@earendil-works/pi-ai": "^0.80.2"
+        "@earendil-works/pi-ai": "^0.80.3"
       },
       "engines": {
         "bun": ">=1.3.14"
@@ -8324,7 +8322,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.80.2"
+        "@earendil-works/pi-tui": "^0.80.3"
       },
       "peerDependenciesMeta": {
         "@bastani/atomic": {
@@ -8351,8 +8349,8 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -8392,9 +8390,9 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-agent-core": "^0.80.2",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "@earendil-works/pi-tui": "^0.80.2"
+        "@earendil-works/pi-agent-core": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-tui": "^0.80.3"
       },
       "peerDependenciesMeta": {
         "@bastani/atomic": {
@@ -8427,7 +8425,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.80.2"
+        "@earendil-works/pi-tui": "^0.80.3"
       },
       "peerDependenciesMeta": {
         "@bastani/atomic": {
@@ -8451,7 +8449,7 @@
       },
       "peerDependencies": {
         "@bastani/atomic": "*",
-        "@earendil-works/pi-tui": "^0.80.2"
+        "@earendil-works/pi-tui": "^0.80.3"
       },
       "peerDependenciesMeta": {
         "@bastani/atomic": {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## [Unreleased]
 
+### Synced with upstream Pi v0.80.3
+
+Atomic is a fork of Pi. This release syncs Atomic's `@earendil-works/pi-agent-core`, `pi-ai`, and `pi-tui` runtime dependencies from `^0.80.2` to `^0.80.3` and ports the relevant coding-agent changes, while preserving Atomic branding, package names, the versionless-`main` release convention, bundled first-party extensions, and user-facing Atomic docs.
+
+### Added
+
+- Added `get_entries` and `get_tree` RPC commands for reading session entries and tree snapshots over RPC, with corresponding `RpcClient.getEntries`/`getTree` helpers and response types (inherited from upstream Pi [#6078](https://github.com/earendil-works/pi/pull/6078)).
+- Added a package `./rpc-entry` export and `src/rpc-entry.ts` entrypoint for launching Atomic directly in RPC mode (inherited from upstream Pi).
+- Added `session_info_changed` as an extension event so extensions can observe session name changes, wired through `AgentSession.setSessionName` to the extension runner (inherited from upstream Pi [#6175](https://github.com/earendil-works/pi/pull/6175)).
+- Added an `externalEditor` settings.json override for Ctrl+G external editor commands, with default fallbacks to Notepad on Windows and `nano` elsewhere (inherited from upstream Pi [#6122](https://github.com/earendil-works/pi/issues/6122)).
+- Added an `outputPad` setting (`0 | 1`, default `1`) controlling horizontal padding for user messages, assistant messages, and thinking blocks (inherited from upstream Pi [#6168](https://github.com/earendil-works/pi/issues/6168)).
+- Added BMP image detection and shared `processImage`/`convertImageBytesToPng` helpers so unsupported image formats are normalized (converted to PNG) before inlining (inherited from upstream Pi [#6047](https://github.com/earendil-works/pi/issues/6047)).
+- Added `resetTimings`/`time` timing namespaces so extension load timings are recorded and reset separately from main startup timings (inherited from upstream Pi [#6030](https://github.com/earendil-works/pi/pull/6030), [#6063](https://github.com/earendil-works/pi/pull/6063)).
+
+### Changed
+
+- Bumped `@earendil-works/pi-agent-core`, `pi-ai`, and `pi-tui` from `^0.80.2` to `^0.80.3` across `@bastani/atomic` and all bundled first-party extensions, and regenerated `bun.lock`, `package-lock.json`, and `npm-shrinkwrap.json`.
+- Changed the default OpenAI model to `gpt-5.5` (inherited from upstream Pi). The Atomic-specific `github-copilot` default remains `gpt-5.4`.
+
+### Fixed
+
+- Fixed extension `setActiveTools` changes to apply before the next provider request in the same run, by installing a `prepareNextTurnWithContext` hook that refreshes system prompt and tools (inherited from upstream Pi [#6162](https://github.com/earendil-works/pi/issues/6162)).
+- Fixed `before_agent_start` system prompt overrides to survive when extension tool changes occur mid-run (inherited from upstream Pi [#6162](https://github.com/earendil-works/pi/issues/6162)).
+- Fixed invalid session file errors at CLI entry to print a clean red error message instead of a stack trace, via `openSessionOrExit` wrappers around `SessionManager.open` call sites (inherited from upstream Pi [#6002](https://github.com/earendil-works/pi/issues/6002)).
+- Fixed resumed/transcript chat rendering to respect the `outputPad` setting for user and assistant messages rendered through `renderChatMessageEntry` and the chat-session-host render path (inherited from upstream Pi [#6168](https://github.com/earendil-works/pi/issues/6168)).
+- Fixed the dedicated `rpc-entry` to use Atomic's APP_NAME-based env marker (`ATOMIC_CODING_AGENT`) instead of the upstream `PI_CODING_AGENT`, and to force `--mode rpc` as the last CLI argument so a caller-supplied `--mode` cannot override it.
+- Fixed pre-prompt compaction to stop after compaction instead of continuing immediately (already present in Atomic; documented for parity with upstream Pi [#6074](https://github.com/earendil-works/pi/pull/6074)).
+- Fixed `--session` and `SessionManager` to reject non-empty invalid session files without overwriting them (inherited from upstream Pi [#6002](https://github.com/earendil-works/pi/issues/6002)).
+- Fixed user-message transcript rendering to keep visible backslashes in Markdown escape sequences such as `\"` (inherited from upstream Pi [#6105](https://github.com/earendil-works/pi/issues/6105)).
+- Fixed assistant messages stopped by output length to show a visible incomplete-response error (inherited from upstream Pi [#4290](https://github.com/earendil-works/pi/issues/4290)).
+- Fixed `--no-session --session-id` so ephemeral CLI runs can use deterministic session IDs for provider cache affinity (inherited from upstream Pi [#6070](https://github.com/earendil-works/pi/issues/6070)).
+- Fixed disk BMP image files to be detected, converted to PNG, and attached through `read` and CLI `@file` inputs (inherited from upstream Pi [#6047](https://github.com/earendil-works/pi/issues/6047)).
+- Fixed a crash when undici emits an internal client error while terminating a mid-stream HTTP response, by attaching error-suppressing listeners to the global dispatcher and per-origin pools (inherited from upstream Pi [#6133](https://github.com/earendil-works/pi/issues/6133)).
+
+### Notes
+
+- The shared `isRetryableAssistantError` retry classifier is intentionally deferred. Atomic's `_isRetryableError` (`agent-session-retry.ts`) carries Atomic-specific Copilot Gemini handling (`content_filter`/`finish_reason: error` for CAPI-mapped MALFORMED_FUNCTION_CALL) that the shared pi-ai helper does not cover; replacing it wholesale would regress those code paths. Adopting the shared helper requires merging Atomic's extra patterns back in and will be evaluated for a follow-up sync.
+- The interactive status-indicator stabilization refactor (Loader → StatusIndicator classes) is deferred; it is a large TUI refactor that needs visual QA.
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Synced with upstream Pi v0.80.3
-
-Atomic is a fork of Pi. This release syncs Atomic's `@earendil-works/pi-agent-core`, `pi-ai`, and `pi-tui` runtime dependencies from `^0.80.2` to `^0.80.3` and ports the relevant coding-agent changes, while preserving Atomic branding, package names, the versionless-`main` release convention, bundled first-party extensions, and user-facing Atomic docs.
-
 ### Added
 
 - Added `get_entries` and `get_tree` RPC commands for reading session entries and tree snapshots over RPC, with corresponding `RpcClient.getEntries`/`getTree` helpers and response types (inherited from upstream Pi [#6078](https://github.com/earendil-works/pi/pull/6078)).
@@ -18,8 +14,11 @@ Atomic is a fork of Pi. This release syncs Atomic's `@earendil-works/pi-agent-co
 
 ### Changed
 
+- Synced Atomic's `@earendil-works/pi-agent-core`, `pi-ai`, and `pi-tui` runtime dependencies from `^0.80.2` to `^0.80.3` and ported the relevant coding-agent changes while preserving Atomic branding, package names, the versionless-`main` release convention, bundled first-party extensions, and user-facing Atomic docs.
 - Bumped `@earendil-works/pi-agent-core`, `pi-ai`, and `pi-tui` from `^0.80.2` to `^0.80.3` across `@bastani/atomic` and all bundled first-party extensions, and regenerated `bun.lock`, `package-lock.json`, and `npm-shrinkwrap.json`.
 - Changed the default OpenAI model to `gpt-5.5` (inherited from upstream Pi). The Atomic-specific `github-copilot` default remains `gpt-5.4`.
+- Deferred the shared `isRetryableAssistantError` retry classifier because Atomic's `_isRetryableError` carries Atomic-specific Copilot Gemini handling (`content_filter`/`finish_reason: error` for CAPI-mapped MALFORMED_FUNCTION_CALL); adopting it safely requires merging Atomic's extra patterns back in during a follow-up sync.
+- Deferred the interactive status-indicator stabilization refactor (Loader → StatusIndicator classes) because it is a large TUI refactor that needs visual QA.
 
 ### Fixed
 
@@ -36,10 +35,6 @@ Atomic is a fork of Pi. This release syncs Atomic's `@earendil-works/pi-agent-co
 - Fixed disk BMP image files to be detected, converted to PNG, and attached through `read` and CLI `@file` inputs (inherited from upstream Pi [#6047](https://github.com/earendil-works/pi/issues/6047)).
 - Fixed a crash when undici emits an internal client error while terminating a mid-stream HTTP response, by attaching error-suppressing listeners to the global dispatcher and per-origin pools (inherited from upstream Pi [#6133](https://github.com/earendil-works/pi/issues/6133)).
 
-### Notes
-
-- The shared `isRetryableAssistantError` retry classifier is intentionally deferred. Atomic's `_isRetryableError` (`agent-session-retry.ts`) carries Atomic-specific Copilot Gemini handling (`content_filter`/`finish_reason: error` for CAPI-mapped MALFORMED_FUNCTION_CALL) that the shared pi-ai helper does not cover; replacing it wholesale would regress those code paths. Adopting the shared helper requires merging Atomic's extra patterns back in and will be evaluated for a follow-up sync.
-- The interactive status-indicator stabilization refactor (Loader → StatusIndicator classes) is deferred; it is a large TUI refactor that needs visual QA.
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -402,6 +402,17 @@ pi.on("session_start", async (event, ctx) => {
 });
 ```
 
+#### session_info_changed
+
+Fired when the current session display name is set via `/name`, RPC, or `pi.setSessionName()`.
+
+```typescript
+pi.on("session_info_changed", async (event, ctx) => {
+  // event.name - current normalized name, or undefined if cleared
+  ctx.ui.notify(`Session renamed: ${event.name ?? "(none)"}`, "info");
+});
+```
+
 #### session_before_switch
 
 Fired before starting a new session (`/new`) or switching sessions (`/resume`).

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -722,6 +722,64 @@ Response:
 }
 ```
 
+#### get_entries
+
+Get all session entries in append order (excluding the session header). The session is an append-only tree of entries with stable ids, so an entry id works as a durable cursor: pass the last entry id you have seen as `since` to get only entries strictly after it, even across client restarts. Unlike `get_messages`, this includes pre-compaction history and abandoned branches.
+
+```json
+{"type": "get_entries"}
+```
+
+With a cursor:
+```json
+{"type": "get_entries", "since": "abc123"}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "get_entries",
+  "success": true,
+  "data": {
+    "entries": [
+      {"type": "message", "id": "def456", "parentId": "abc123", "timestamp": "...", "message": {"role": "user", "...": "..."}}
+    ],
+    "leafId": "def456"
+  }
+}
+```
+
+`leafId` is the id of the current leaf entry (`null` for an empty session), so a client can tell in one round trip whether the active branch moved. If `since` does not match any entry id, the response is `success: false`.
+
+#### get_tree
+
+Get the session as a tree of entries. Each node is `{entry, children, label?, labelTimestamp?}`. A well-formed session has a single root; orphaned entries (broken parent chain) also appear as roots.
+
+```json
+{"type": "get_tree"}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "get_tree",
+  "success": true,
+  "data": {
+    "tree": [
+      {
+        "entry": {"type": "message", "id": "abc123", "parentId": null, "...": "..."},
+        "children": [
+          {"entry": {"type": "message", "id": "def456", "parentId": "abc123", "...": "..."}, "children": []}
+        ]
+      }
+    ],
+    "leafId": "def456"
+  }
+}
+```
+
 #### get_last_assistant_text
 
 Get the text content of the last assistant message.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -78,6 +78,8 @@ Use `/fast` in interactive mode to edit these settings. Atomic applies fast mode
 | `doubleEscapeAction` | string | `"tree"` | Action for double-escape: `"tree"`, `"fork"`, or `"none"` |
 | `treeFilterMode` | string | `"default"` | Default filter for `/tree`: `"default"`, `"no-tools"`, `"user-only"`, `"labeled-only"`, `"all"` |
 | `editorPaddingX` | number | `0` | Horizontal padding for input editor (0-3) |
+| `outputPad` | number | `1` | Horizontal padding for chat message output (user messages, assistant messages, thinking blocks). `0` or `1` |
+| `externalEditor` | string | - | Command for the Ctrl+G external editor; takes precedence over `$VISUAL`/`$EDITOR`. Defaults to Notepad on Windows and `nano` elsewhere |
 | `autocompleteMaxVisible` | number | `5` | Max visible items in autocomplete dropdown (3-20) |
 | `showHardwareCursor` | boolean | `false` | Show the terminal cursor while TUI positions it for IME support |
 

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -11,9 +11,9 @@
 			"dependencies": {
 				"@bastani/atomic-natives": "0.0.0",
 				"@bufbuild/protobuf": "^2.0.0",
-				"@earendil-works/pi-agent-core": "^0.80.2",
-				"@earendil-works/pi-ai": "^0.80.2",
-				"@earendil-works/pi-tui": "^0.80.2",
+				"@earendil-works/pi-agent-core": "^0.80.3",
+				"@earendil-works/pi-ai": "^0.80.3",
+				"@earendil-works/pi-tui": "^0.80.3",
 				"@modelcontextprotocol/ext-apps": "^1.7.2",
 				"@modelcontextprotocol/sdk": "^1.25.1",
 				"@mozilla/readability": "^0.6.0",
@@ -147,16 +147,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.24",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.24.tgz",
-			"integrity": "sha512-vWB/qJl21vxGKBkBN8fKPTVXgm14v/bUQWTtR5oikrfAZbIN2bxuSiCY5rRAMR4gs3vtR2Vw0aTfVDU4tdfIPg==",
+			"version": "3.974.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.25.tgz",
+			"integrity": "sha512-fJFkx6u6wCqGMV/v6EAxiwa2UzEukbvr1hNPv4MrD3yj4IFz011jZg42/eSTOP/u5kJ0tlILqEjCWtT8GiKZvA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.14",
 				"@aws-sdk/xml-builder": "^3.972.32",
 				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/core": "^3.27.0",
-				"@smithy/signature-v4": "^5.5.3",
+				"@smithy/core": "^3.28.0",
+				"@smithy/signature-v4": "^5.6.0",
 				"@smithy/types": "^4.15.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
@@ -166,14 +166,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.50",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.50.tgz",
-			"integrity": "sha512-l8bWzhPFTi9tDcvtURxeMlfsboul5/0sEN3SwwXxdpYudVB9+EuQcxo2pwlTzXwDo4Gm2VLGyiZ8zti3nfdOLw==",
+			"version": "3.972.51",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.51.tgz",
+			"integrity": "sha512-Xo+/zf5k5pZdo53X8aVXN4MJGfU/M1P7yMM/GbNY/x9fyRZGEzjhKqW38GA0FSQQ9TYKs+bfPyz5ja4bi6pjTQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
+				"@aws-sdk/core": "^3.974.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -182,16 +182,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.52",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.52.tgz",
-			"integrity": "sha512-FjAlnsIvemWzO3JTM3ObuuxpqCyrqkXOewlYY2+NiR1MYO1JuFYSIJ8SJN5Q2KD1jkL5lIuab8awjb/AxsvjiQ==",
+			"version": "3.972.53",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.53.tgz",
+			"integrity": "sha512-7E9oFUcf9YWe+ttGiWhe/cCSI+pswwelzgQMoKXgPJi1AIfS27TK6et5ZULqEqHu30zbN+jh1RqlwcXqY/aXyg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
+				"@aws-sdk/core": "^3.974.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
-				"@smithy/fetch-http-handler": "^5.6.0",
-				"@smithy/node-http-handler": "^4.9.0",
+				"@smithy/core": "^3.28.0",
+				"@smithy/fetch-http-handler": "^5.6.1",
+				"@smithy/node-http-handler": "^4.9.1",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -214,22 +214,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.57",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.57.tgz",
-			"integrity": "sha512-8qwNhQ0sK/1KaOpVEFC7TFxrWP3fxzJV1K049MzjouiMIbvTDvIGDEUtj5ND5aTmlHVK/YZxjoYnLCeV/GZU0w==",
+			"version": "3.972.58",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.58.tgz",
+			"integrity": "sha512-MPr0hD8pyDGfF3dWXvFOILhcKTB9ptqJOJK9JEuDQzpc2HgKisY16eR7IrKUXxSbz8LZj+LHz/CS8Y5G1ai7yw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
-				"@aws-sdk/credential-provider-env": "^3.972.50",
-				"@aws-sdk/credential-provider-http": "^3.972.52",
-				"@aws-sdk/credential-provider-login": "^3.972.56",
-				"@aws-sdk/credential-provider-process": "^3.972.50",
-				"@aws-sdk/credential-provider-sso": "^3.972.56",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.56",
-				"@aws-sdk/nested-clients": "^3.997.24",
+				"@aws-sdk/core": "^3.974.25",
+				"@aws-sdk/credential-provider-env": "^3.972.51",
+				"@aws-sdk/credential-provider-http": "^3.972.53",
+				"@aws-sdk/credential-provider-login": "^3.972.57",
+				"@aws-sdk/credential-provider-process": "^3.972.51",
+				"@aws-sdk/credential-provider-sso": "^3.972.57",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.57",
+				"@aws-sdk/nested-clients": "^3.997.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
-				"@smithy/credential-provider-imds": "^4.4.3",
+				"@smithy/core": "^3.28.0",
+				"@smithy/credential-provider-imds": "^4.4.4",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -238,15 +238,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.56",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.56.tgz",
-			"integrity": "sha512-S36dCrDaafakFMlaCVGAF4advbQKoJuMcyMtNWVBpUz65uqhbIAsUfvAyp+djA+jkzaEfgZGd+AELjIGzTqyhw==",
+			"version": "3.972.57",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.57.tgz",
+			"integrity": "sha512-kPWc/SCrl9agKeywxKwPEoQHanWag0LcNQrcZpEQpjNifkxq6tQENhgrrS9al317CF6yytyihlX+FhPHlk0QjA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
-				"@aws-sdk/nested-clients": "^3.997.24",
+				"@aws-sdk/core": "^3.974.25",
+				"@aws-sdk/nested-clients": "^3.997.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -255,20 +255,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.59",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.59.tgz",
-			"integrity": "sha512-LkczBXaEsdManijlEZwbKfEoo1C98Yri3LHF8gQI7CYWv+uFkmpS3OZH3BSew8g1A2ppKsScdPUSlhI6NV7a9g==",
+			"version": "3.972.60",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.60.tgz",
+			"integrity": "sha512-hE2hIBJQjCDRx8TbSqpVQ+/o2mIrJZQZbQ3LlwE2bJf7z47x5GmhcvGwZPqJH7Oq//SzTXEBGSZ4qSpK3yPbhw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.50",
-				"@aws-sdk/credential-provider-http": "^3.972.52",
-				"@aws-sdk/credential-provider-ini": "^3.972.57",
-				"@aws-sdk/credential-provider-process": "^3.972.50",
-				"@aws-sdk/credential-provider-sso": "^3.972.56",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.56",
+				"@aws-sdk/credential-provider-env": "^3.972.51",
+				"@aws-sdk/credential-provider-http": "^3.972.53",
+				"@aws-sdk/credential-provider-ini": "^3.972.58",
+				"@aws-sdk/credential-provider-process": "^3.972.51",
+				"@aws-sdk/credential-provider-sso": "^3.972.57",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.57",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
-				"@smithy/credential-provider-imds": "^4.4.3",
+				"@smithy/core": "^3.28.0",
+				"@smithy/credential-provider-imds": "^4.4.4",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -277,14 +277,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.50",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.50.tgz",
-			"integrity": "sha512-ARBEVkOQzmowTU0a35smGVyldJ9FN/f57XIGrPatrul4mYN+vvOKxoc1njDOX3nugVze+0sHzQZWJ8kPARAtUA==",
+			"version": "3.972.51",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.51.tgz",
+			"integrity": "sha512-081dD2RlnmY+G05v6E73KfACvDjPjnttrLjGHE2SSglbID25UcuijbWpL4g+XR5T2Kl4oIJoVBXi64s+2f009Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
+				"@aws-sdk/core": "^3.974.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -293,16 +293,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.56",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.56.tgz",
-			"integrity": "sha512-LvbWiFcLI/D5RPaT68TrpLLHyv7x5X+dm59wJ5dFizyGPZggBC7OdgJTlP0X1bVjiSSAgE1u1oxxcBps0GCEnA==",
+			"version": "3.972.57",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.57.tgz",
+			"integrity": "sha512-dC7ZyX3EHKHLOeVUEDzzGvk0L1s6N06YDrau7P0rGXL/j1cO+DzN2w1x9vcEh7zljVCR3019f5mi1Th+GGTURw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
-				"@aws-sdk/nested-clients": "^3.997.24",
-				"@aws-sdk/token-providers": "3.1076.0",
+				"@aws-sdk/core": "^3.974.25",
+				"@aws-sdk/nested-clients": "^3.997.25",
+				"@aws-sdk/token-providers": "3.1077.0",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -311,15 +311,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.1076.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1076.0.tgz",
-			"integrity": "sha512-4rTHETRKe2JWAsFUMo5ENmlzc3i9FD4KqBVXgoaF8DLTADjGid8SA+1LR2nJWjefoafvKAHcQH9F2iKa8uHc6Q==",
+			"version": "3.1077.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1077.0.tgz",
+			"integrity": "sha512-sRUkfZ3fpOco95jZHsQUQiXvuIVLvCmWVclFg6dRFDyfsYs6Pdr/NuZ2+yJxeHN+6WAfDh2aZ8nlZntnvuhZUQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
-				"@aws-sdk/nested-clients": "^3.997.24",
+				"@aws-sdk/core": "^3.974.25",
+				"@aws-sdk/nested-clients": "^3.997.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -328,15 +328,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.56",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.56.tgz",
-			"integrity": "sha512-OV3JxmqMphVGMLWupYD2UhZxX07ATk1NwyYk7RgCnAEh0y3owHmtEnkWZ3ciCZ6liiFEwS8dYQpJGmKsR6ml4Q==",
+			"version": "3.972.57",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.57.tgz",
+			"integrity": "sha512-HtWM3FV2o7NJFJSUqFLBlxmV9RxQRHpzCvQaP1n1Qo4CxQSvwpJ8ERWHiLqXMFDgDXyELt+EZNFcpG6XQRcJbQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
-				"@aws-sdk/nested-clients": "^3.997.24",
+				"@aws-sdk/core": "^3.974.25",
+				"@aws-sdk/nested-clients": "^3.997.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -345,13 +345,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.23.tgz",
-			"integrity": "sha512-palwWdW4JouKu2IFI6biJ9r6FlWLqr2pvVe/tNU1TkVEOjtPElD2aYF6Cox8TickL5OiOFkPDThixYPQ8LAr1g==",
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.24.tgz",
+			"integrity": "sha512-O2tFBFQnP68GRNahxYJYZ4NVlGZ/hBe2oH58EKPPjbf7Yc04ZhKFdzAMblRrzeGdun9pBwE+CyLjFH/tr4pYNw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -360,13 +360,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.19",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.19.tgz",
-			"integrity": "sha512-r3CGU8gnLe+ugV2rcR8IPUE8AKg7znWkzrKR+pvnjFr8eXrTo1TU0O31CD3eCjNH5jUY4+r4d35MDFzazYWFkQ==",
+			"version": "3.972.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.20.tgz",
+			"integrity": "sha512-VAI4wBVWOg5h1pZVmSEKe8kAW/7odKfbzO9uB23e1AICQh2pp/ROUhFacDXmwgJZZt49dIF6nEvzPTvHiO1cUA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
+				"@smithy/core": "^3.28.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -375,16 +375,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.32",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.32.tgz",
-			"integrity": "sha512-Qkg0Na1Xr4tSL1o/01Z6YhxWqvmJE0wTNFLNwDx9h3m/uVvgav4FPalqq7uh9qRRvwaPBwIfEvurXFi9Td57mg==",
+			"version": "3.972.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.33.tgz",
+			"integrity": "sha512-e24VZXVZjpfVxpQ4ghf4LYV/i/x0znERdVcSzPU0+ktjmnd0k1fdPlcYsImDqIDaLZilbbwMLhuQY8d/dBzrGA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.24",
+				"@aws-sdk/core": "^3.974.25",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
-				"@smithy/fetch-http-handler": "^5.6.0",
-				"@smithy/signature-v4": "^5.5.3",
+				"@smithy/core": "^3.28.0",
+				"@smithy/fetch-http-handler": "^5.6.1",
+				"@smithy/signature-v4": "^5.6.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -393,19 +393,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.24",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.24.tgz",
-			"integrity": "sha512-+wFVfVofxeiXdRhUjRwYISB2mVfBCdiCq1wThkRipTeOc10Kyr+LS9QJTjgZuhWsna7jyLMPndrCnzLGWWvZXg==",
+			"version": "3.997.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.25.tgz",
+			"integrity": "sha512-VpRQ3wR6l+fwRHV5veJL2ehtyQFrGyH/2CJG9DVtb8H3xyqqnZWSTSrq/CJJ7DvDlDgrPRiW2SkYA8pN6VWCFQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.24",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.36",
+				"@aws-sdk/core": "^3.974.25",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.37",
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/core": "^3.27.0",
-				"@smithy/fetch-http-handler": "^5.6.0",
-				"@smithy/node-http-handler": "^4.9.0",
+				"@smithy/core": "^3.28.0",
+				"@smithy/fetch-http-handler": "^5.6.1",
+				"@smithy/node-http-handler": "^4.9.1",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -428,13 +426,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.36.tgz",
-			"integrity": "sha512-VSOWIPkI+g3a7NkxIBCO24HnsR0BZXJAi3wrKaGIZwVKyrMtNRdHxPrQI/igazgla5J9FhDzmg4RgnOSr6UQBw==",
+			"version": "3.996.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.37.tgz",
+			"integrity": "sha512-u8qd064XsHzM0Mk+yH4IPKn/ZC9rdniEKs+neBHNlsPZirw3rcLvmrH4ImoKC4yF7A0I/MbcC3dseARnJLiAhg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.14",
-				"@smithy/signature-v4": "^5.5.3",
+				"@smithy/signature-v4": "^5.6.0",
 				"@smithy/types": "^4.15.0",
 				"tslib": "^2.6.2"
 			},
@@ -652,12 +650,12 @@
 			]
 		},
 		"node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
-			"integrity": "sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q==",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+			"integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.2",
+				"@earendil-works/pi-ai": "^0.80.3",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -667,9 +665,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
-			"integrity": "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+			"integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
@@ -692,9 +690,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
-			"integrity": "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA==",
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+			"integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -25,7 +25,9 @@
       "default": "./dist/index.js"
     },
     "./rpc-entry": {
-      "import": "./dist/rpc-entry.js"
+      "types": "./dist/rpc-entry.d.ts",
+      "import": "./dist/rpc-entry.js",
+      "default": "./dist/rpc-entry.js"
     },
     "./hooks": {
       "types": "./dist/core/hooks/index.d.ts",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -24,6 +24,9 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./rpc-entry": {
+      "import": "./dist/rpc-entry.js"
+    },
     "./hooks": {
       "types": "./dist/core/hooks/index.d.ts",
       "import": "./dist/core/hooks/index.js"
@@ -57,7 +60,7 @@
   "scripts": {
     "clean": "shx rm -rf dist",
     "dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
-    "build": "tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js && bun run copy-assets",
+    "build": "tsgo -p tsconfig.build.json && shx chmod +x dist/cli.js dist/rpc-entry.js && bun run copy-assets",
     "build:binary": "bun --cwd ../tui run build && bun --cwd ../ai run build && bun --cwd ../agent run build && bun run build && bun build --compile ./dist/bun/cli.js ./src/utils/image-resize-worker.ts --outfile dist/atomic && bun run copy-binary-assets",
     "copy-assets": "shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor dist/core/export-html/template-js && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/template-js/*.js dist/core/export-html/template-js/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/ && bun run copy-builtin-packages",
     "copy-binary-assets": "shx cp package.json dist/ && shx cp README.md dist/ && shx cp CHANGELOG.md dist/ && shx mkdir -p dist/theme && shx cp src/modes/interactive/theme/*.json dist/theme/ && shx mkdir -p dist/assets && shx cp src/modes/interactive/assets/*.png dist/assets/ && shx mkdir -p dist/export-html/vendor dist/export-html/template-js && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/export-html/ && shx cp src/core/export-html/template-js/*.js dist/export-html/template-js/ && shx cp src/core/export-html/vendor/*.js dist/export-html/vendor/ && shx cp -r docs dist/ && shx cp -r examples dist/ && shx cp ../../node_modules/@silvia-odwyer/photon-node/photon_rs_bg.wasm dist/ && bun run copy-builtin-packages",
@@ -72,9 +75,9 @@
   "dependencies": {
     "@bastani/atomic-natives": "0.0.0",
     "@bufbuild/protobuf": "^2.0.0",
-    "@earendil-works/pi-agent-core": "^0.80.2",
-    "@earendil-works/pi-ai": "^0.80.2",
-    "@earendil-works/pi-tui": "^0.80.2",
+    "@earendil-works/pi-agent-core": "^0.80.3",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3",
     "@modelcontextprotocol/ext-apps": "^1.7.2",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@mozilla/readability": "^0.6.0",

--- a/packages/coding-agent/src/cli/file-processor.ts
+++ b/packages/coding-agent/src/cli/file-processor.ts
@@ -7,7 +7,7 @@ import type { ImageContent } from "@earendil-works/pi-ai/compat";
 import chalk from "chalk";
 import { resolve } from "path";
 import { resolveReadPath } from "../core/tools/path-utils.ts";
-import { formatDimensionNote, resizeImage } from "../utils/image-resize.ts";
+import { processImage } from "../utils/image-process.ts";
 import { detectSupportedImageMimeTypeFromFile } from "../utils/mime.ts";
 
 export interface ProcessedFiles {
@@ -50,35 +50,23 @@ export async function processFileArguments(fileArgs: string[], options?: Process
 		if (mimeType) {
 			// Handle image file
 			const content = await readFile(absolutePath);
+			const processed = await processImage(content, mimeType, { autoResizeImages });
 
-			let attachment: ImageContent;
-			let dimensionNote: string | undefined;
-
-			if (autoResizeImages) {
-				const resized = await resizeImage(content, mimeType);
-				if (!resized) {
-					text += `<file name="${absolutePath}">[Image omitted: could not be resized below the inline image size limit.]</file>\n`;
-					continue;
-				}
-				dimensionNote = formatDimensionNote(resized);
-				attachment = {
-					type: "image",
-					mimeType: resized.mimeType,
-					data: resized.data,
-				};
-			} else {
-				attachment = {
-					type: "image",
-					mimeType,
-					data: content.toString("base64"),
-				};
+			if (!processed.ok) {
+				text += `<file name="${absolutePath}">${processed.message}</file>\n`;
+				continue;
 			}
 
+			const attachment: ImageContent = {
+				type: "image",
+				mimeType: processed.mimeType,
+				data: processed.data,
+			};
 			images.push(attachment);
 
-			// Add text reference to image with optional dimension note
-			if (dimensionNote) {
-				text += `<file name="${absolutePath}">${dimensionNote}</file>\n`;
+			// Add text reference to image with optional processing hints
+			if (processed.hints.length > 0) {
+				text += `<file name="${absolutePath}">${processed.hints.join("\n")}</file>\n`;
 			} else {
 				text += `<file name="${absolutePath}"></file>\n`;
 			}

--- a/packages/coding-agent/src/core/agent-session-extension-bindings.ts
+++ b/packages/coding-agent/src/core/agent-session-extension-bindings.ts
@@ -52,7 +52,7 @@ export async function extendResourcesFromExtensions(this: AgentSession, reason: 
 
 	this._resourceLoader.extendResources(extensionPaths);
 	this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
-	this.agent.state.systemPrompt = this._baseSystemPrompt;
+	this.agent.state.systemPrompt = this._systemPromptOverride ?? this._baseSystemPrompt;
 }
 
 

--- a/packages/coding-agent/src/core/agent-session-methods.ts
+++ b/packages/coding-agent/src/core/agent-session-methods.ts
@@ -103,6 +103,7 @@ export interface AgentSessionMethodSurface {
 	_handleAgentEvent(event: AgentEvent): void;
 	_getRequiredRequestAuth(model: Model<Api>): Promise<{ apiKey: string; headers?: Record<string, string> }>;
 	_installAgentToolHooks(): void;
+	_installAgentNextTurnRefresh(): void;
 	_emit(event: AgentSessionEvent): void;
 	_emitQueueUpdate(): void;
 	_createRetryPromiseForAgentEnd(event: AgentEvent): void;
@@ -370,6 +371,7 @@ export interface AgentSessionInternalSurface extends AgentSessionMethodSurface, 
 	_toolPromptGuidelines: Map<string, string[]>;
 	_baseSystemPrompt: string;
 	_baseSystemPromptOptions: BuildSystemPromptOptions;
+	_systemPromptOverride?: string;
 	_lastAssistantMessage: AssistantMessage | undefined;
 }
 

--- a/packages/coding-agent/src/core/agent-session-prompt.ts
+++ b/packages/coding-agent/src/core/agent-session-prompt.ts
@@ -163,10 +163,12 @@ export async function prompt(this: AgentSession, text: string, options?: PromptO
 			}
 		}
 		// Apply extension-modified system prompt, or reset to base
-		if (result?.systemPrompt) {
+		if (result?.systemPrompt !== undefined) {
+			this._systemPromptOverride = result.systemPrompt;
 			this.agent.state.systemPrompt = result.systemPrompt;
 		} else {
 			// Ensure we're using the base prompt (in case previous turn had modifications)
+			this._systemPromptOverride = undefined;
 			this.agent.state.systemPrompt = this._baseSystemPrompt;
 		}
 	} catch (error) {
@@ -180,9 +182,13 @@ export async function prompt(this: AgentSession, text: string, options?: PromptO
 
 
 export async function _runAgentPrompt(this: AgentSession, messages: AgentMessage | AgentMessage[]): Promise<void> {
-	await this.agent.prompt(messages);
-	await this.waitForRetry();
-	await this._continueQueuedAgentMessages();
+	try {
+		await this.agent.prompt(messages);
+		await this.waitForRetry();
+		await this._continueQueuedAgentMessages();
+	} finally {
+		this._systemPromptOverride = undefined;
+	}
 }
 
 export async function _runAgentContinue(this: AgentSession): Promise<void> {

--- a/packages/coding-agent/src/core/agent-session-state.ts
+++ b/packages/coding-agent/src/core/agent-session-state.ts
@@ -48,7 +48,7 @@ export function setActiveToolsByName(this: AgentSession, toolNames: string[]): v
 
 	// Rebuild base system prompt with new tool set
 	this._baseSystemPrompt = this._rebuildSystemPrompt(validToolNames);
-	this.agent.state.systemPrompt = this._baseSystemPrompt;
+	this.agent.state.systemPrompt = this._systemPromptOverride ?? this._baseSystemPrompt;
 }
 
 /** Whether compaction or branch summarization is currently running */
@@ -127,7 +127,7 @@ export function _rebuildSystemPrompt(this: AgentSession, toolNames: string[]): s
 
 export function _refreshBaseSystemPromptFromActiveTools(this: AgentSession): void {
 	this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
-	this.agent.state.systemPrompt = this._baseSystemPrompt;
+	this.agent.state.systemPrompt = this._systemPromptOverride ?? this._baseSystemPrompt;
 }
 
 // =========================================================================

--- a/packages/coding-agent/src/core/agent-session-tool-hooks.ts
+++ b/packages/coding-agent/src/core/agent-session-tool-hooks.ts
@@ -1,3 +1,4 @@
+import type { PrepareNextTurnContext } from "@earendil-works/pi-agent-core";
 import type { AgentSessionInternalSurface as AgentSession } from "./agent-session-methods.ts";
 import { redirectOversizedToolResult } from "./tools/oversized-tool-result.js";
 
@@ -69,12 +70,35 @@ export function _installAgentToolHooks(this: AgentSession): void {
 	};
 }
 
-// =========================================================================
-// Event Subscription
-// =========================================================================
+/**
+ * Install a prepareNextTurnWithContext hook so that extension tool changes
+ * (e.g. setActiveTools) and before_agent_start systemPrompt overrides are
+ * applied to the next provider request within the same run.
+ */
+export function _installAgentNextTurnRefresh(this: AgentSession): void {
+	const previousPrepareNextTurnWithContext =
+		this.agent.prepareNextTurnWithContext ??
+		(this.agent.prepareNextTurn
+			? async (_turn: PrepareNextTurnContext, signal?: AbortSignal) => await this.agent.prepareNextTurn?.(signal)
+			: undefined);
+	this.agent.prepareNextTurnWithContext = async (turn, signal) => {
+		const previousSnapshot = await previousPrepareNextTurnWithContext?.(turn, signal);
+		const previousContext = previousSnapshot?.context ?? turn.context;
 
-/** Emit an event to all listeners */
+		return {
+			...previousSnapshot,
+			context: {
+				...previousContext,
+				systemPrompt: this._systemPromptOverride ?? this._baseSystemPrompt,
+				tools: this.agent.state.tools.slice(),
+			},
+			model: this.agent.state.model,
+			thinkingLevel: this.agent.state.thinkingLevel,
+		};
+	};
+}
 
 export const agentSessionToolHooksMethods = {
 	_installAgentToolHooks,
+	_installAgentNextTurnRefresh,
 };

--- a/packages/coding-agent/src/core/agent-session-tree.ts
+++ b/packages/coding-agent/src/core/agent-session-tree.ts
@@ -5,7 +5,9 @@ import type { AgentSessionInternalSurface as AgentSession } from "./agent-sessio
 
 export function setSessionName(this: AgentSession, name: string): void {
 	this.sessionManager.appendSessionInfo(name);
-	this._emit({ type: "session_info_changed", name: this.sessionManager.getSessionName() });
+	const event = { type: "session_info_changed", name: this.sessionManager.getSessionName() } as const;
+	this._emit(event);
+	void this._extensionRunner.emit(event);
 }
 
 // =========================================================================

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -115,6 +115,7 @@ export class AgentSession {
 	protected _toolPromptGuidelines: Map<string, string[]> = new Map();
 	protected _baseSystemPrompt = "";
 	protected _baseSystemPromptOptions!: BuildSystemPromptOptions;
+	protected _systemPromptOverride?: string;
 	protected _lastAssistantMessage: AssistantMessage | undefined = undefined;
 
 	constructor(config: AgentSessionConfig) {
@@ -138,6 +139,7 @@ export class AgentSession {
 		internals._handleAgentEvent = internals._handleAgentEvent.bind(this);
 		this._unsubscribeAgent = this.agent.subscribe(internals._handleAgentEvent);
 		internals._installAgentToolHooks();
+		internals._installAgentNextTurnRefresh();
 		internals._buildRuntime({
 			activeToolNames: this._initialActiveToolNames,
 			includeAllExtensionTools: true,

--- a/packages/coding-agent/src/core/extensions/api-types.ts
+++ b/packages/coding-agent/src/core/extensions/api-types.ts
@@ -55,6 +55,7 @@ import type {
 	SessionBeforeSwitchEvent,
 	SessionBeforeTreeEvent,
 	SessionCompactEvent,
+	SessionInfoChangedEvent,
 	SessionShutdownEvent,
 	SessionStartEvent,
 	SessionTreeEvent,
@@ -75,6 +76,7 @@ export interface ExtensionAPI {
 	// =========================================================================
 
 	on(event: "resources_discover", handler: ExtensionHandler<ResourcesDiscoverEvent, ResourcesDiscoverResult>): void;
+	on(event: "session_info_changed", handler: ExtensionHandler<SessionInfoChangedEvent>): void;
 	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
 	on(
 		event: "session_before_switch",

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -132,6 +132,7 @@ export type {
 	SessionBeforeTreeEvent,
 	SessionBeforeTreeResult,
 	SessionCompactEvent,
+	SessionInfoChangedEvent,
 	SessionEvent,
 	SessionShutdownEvent,
 	// Events - Session

--- a/packages/coding-agent/src/core/extensions/loader-core.ts
+++ b/packages/coding-agent/src/core/extensions/loader-core.ts
@@ -51,7 +51,7 @@ async function loadExtension(
   const resolvedPath = resolvePath(extensionPath, cwd, { normalizeUnicodeSpaces: true });
 
   try {
-    const moduleSpan = startTimingSpan(`loadExtensions.${extensionPath}.module`);
+    const moduleSpan = startTimingSpan(`loadExtensions.${extensionPath}.module`, "extensions");
     const factory = await loadExtensionModule(resolvedPath, cacheToken);
     endTimingSpan(moduleSpan);
     if (!factory) {
@@ -70,7 +70,7 @@ async function loadExtension(
       workflowResourceProvider,
       resourceLoaderInheritanceSnapshotProvider,
     );
-    const factorySpan = startTimingSpan(`loadExtensions.${extensionPath}.factory`);
+    const factorySpan = startTimingSpan(`loadExtensions.${extensionPath}.factory`, "extensions");
     await factory(api);
     endTimingSpan(factorySpan);
 
@@ -127,7 +127,7 @@ async function loadExtensionsInternal(
   const resolvedRuntime = runtime ?? createExtensionRuntime();
 
   for (const extPath of paths) {
-    const extensionSpan = startTimingSpan(`loadExtensions.${extPath}.total`);
+    const extensionSpan = startTimingSpan(`loadExtensions.${extPath}.total`, "extensions");
     const { extension, error } = await loadExtension(
       extPath,
       resolvedCwd,

--- a/packages/coding-agent/src/core/extensions/session-events.ts
+++ b/packages/coding-agent/src/core/extensions/session-events.ts
@@ -32,6 +32,13 @@ export interface SessionStartEvent {
 	previousSessionFile?: string;
 }
 
+/** Fired when the current session metadata changes. */
+export interface SessionInfoChangedEvent {
+	type: "session_info_changed";
+	/** Current normalized session name. Undefined when the name is cleared. */
+	name: string | undefined;
+}
+
 /** Fired before switching to another session (can be cancelled) */
 export interface SessionBeforeSwitchEvent {
 	type: "session_before_switch";
@@ -107,6 +114,7 @@ export interface SessionTreeEvent {
 
 export type SessionEvent =
 	| SessionStartEvent
+	| SessionInfoChangedEvent
 	| SessionBeforeSwitchEvent
 	| SessionBeforeForkEvent
 	| SessionBeforeCompactEvent

--- a/packages/coding-agent/src/core/http-dispatcher.ts
+++ b/packages/coding-agent/src/core/http-dispatcher.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import * as undici from "undici";
 import { installCopilotGeminiReasoningInterceptor } from "./copilot-gemini-reasoning.ts";
 
@@ -38,7 +39,38 @@ export function createHttpDispatcherOptions(timeoutMs: number): ConstructorParam
 		connectTimeout: 0,
 		bodyTimeout: timeoutMs,
 		headersTimeout: timeoutMs,
+		clientFactory: createUndiciClient,
+		factory: createUndiciOriginDispatcher,
 	};
+}
+
+const ignoreUndiciDispatcherError = (_error: unknown): void => {};
+
+// Undici can emit an internal Client "error" while terminating a mid-stream
+// fetch body. The body stream still rejects through reader.read(); this listener
+// only prevents EventEmitter's unhandled "error" special case from crashing.
+function withUndiciErrorListener<T extends undici.Dispatcher>(dispatcher: T): T {
+	if (dispatcher instanceof EventEmitter) {
+		EventEmitter.prototype.on.call(dispatcher, "error", ignoreUndiciDispatcherError);
+	}
+	return dispatcher;
+}
+
+function createUndiciClient(origin: string | URL, options: object): undici.Dispatcher {
+	return withUndiciErrorListener(new undici.Client(origin, options as undici.Client.Options));
+}
+
+function createUndiciOriginDispatcher(origin: string | URL, options: object): undici.Dispatcher {
+	const dispatcherOptions = options as undici.Pool.Options;
+	if (dispatcherOptions.connections === 1) {
+		return createUndiciClient(origin, dispatcherOptions);
+	}
+	return withUndiciErrorListener(
+		new undici.Pool(origin, {
+			...dispatcherOptions,
+			factory: createUndiciClient,
+		}),
+	);
 }
 
 /**
@@ -57,9 +89,10 @@ export function configureHttpDispatcher(timeoutMs: number = DEFAULT_HTTP_IDLE_TI
 		throw new Error(`Invalid HTTP idle timeout: ${String(timeoutMs)}`);
 	}
 
-	undici.setGlobalDispatcher(
+	const dispatcher = withUndiciErrorListener(
 		new undici.EnvHttpProxyAgent(createHttpDispatcherOptions(normalizedTimeoutMs)),
 	);
+	undici.setGlobalDispatcher(dispatcher);
 
 	// Keep fetch and the dispatcher on the same undici implementation. Some Node
 	// releases use a bundled fetch that can ignore the npm undici dispatcher or

--- a/packages/coding-agent/src/core/model-resolver-defaults.ts
+++ b/packages/coding-agent/src/core/model-resolver-defaults.ts
@@ -4,7 +4,7 @@ import type { Api, Model } from "@earendil-works/pi-ai/compat";
 export const defaultModelPerProvider: Record<string, string> = {
   "amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
   anthropic: "claude-opus-4-8",
-  openai: "gpt-5.4",
+  openai: "gpt-5.5",
   "azure-openai-responses": "gpt-5.4",
   "openai-codex": "gpt-5.5",
   deepseek: "deepseek-v4-pro",

--- a/packages/coding-agent/src/core/resource-loader-reload.ts
+++ b/packages/coding-agent/src/core/resource-loader-reload.ts
@@ -4,7 +4,7 @@ import { isLocalPath } from "../utils/paths.ts";
 import { clearExtensionCache, loadExtensionsCached } from "./extensions/loader.ts";
 import type { LoadExtensionsResult } from "./extensions/types.ts";
 import type { PathMetadata, ResolvedPaths } from "./package-manager.ts";
-import { startTimingSpan, endTimingSpan } from "./timings.ts";
+import { resetTimings, startTimingSpan, endTimingSpan } from "./timings.ts";
 import { loadProjectContextFiles, resolvePromptInput } from "./resource-loader-context-files.ts";
 import { discoverAppendSystemPromptFile, discoverSystemPromptFile } from "./resource-loader-discovery.ts";
 import { loadExtensionFactories, loadFinalExtensionSet } from "./resource-loader-extensions.ts";
@@ -124,6 +124,7 @@ export async function reloadDefaultResourceLoader(
 	options?: ResourceLoaderReloadOptions,
 ): Promise<void> {
 	const state = resourceInternals(loader);
+	resetTimings("extensions");
 	if (state.loaded) {
 		clearExtensionCache();
 	}

--- a/packages/coding-agent/src/core/session-manager-core.ts
+++ b/packages/coding-agent/src/core/session-manager-core.ts
@@ -1,5 +1,5 @@
 import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai/compat";
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { resolve } from "path";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import type { BashExecutionMessage, CustomMessage } from "./messages.ts";
@@ -53,17 +53,7 @@ import type {
 } from "./session-manager-types.ts";
 import { assertValidSessionId, createSessionId } from "./session-manager-validation.ts";
 
-/**
- * Manages conversation sessions as append-only trees stored in JSONL files.
- *
- * Each session entry has an id and parentId forming a tree structure. The "leaf"
- * pointer tracks the current position. Appending creates a child of the current leaf.
- * Branching moves the leaf to an earlier entry, allowing new branches without
- * modifying history.
- *
- * Use buildSessionContext() to get the resolved message list for the LLM, which
- * applies context-deletion filtering and follows the path from root to current leaf.
- */
+/** Manages conversation sessions as append-only trees stored in JSONL files.  Each session entry has an id and parentId forming a tree structure. The "leaf" pointer tracks the current position. Appending creates a child of the current leaf. Branching moves the leaf to an earlier entry, allowing new branches without modifying history.  Use buildSessionContext() to get the resolved message list for the LLM, which applies context-deletion filtering and follows the path from root to current leaf. */
 export class SessionManager {
 	private sessionId: string = "";
 	private sessionFile: string | undefined;
@@ -104,10 +94,12 @@ export class SessionManager {
 		if (existsSync(this.sessionFile)) {
 			this.fileEntries = loadEntriesFromFile(this.sessionFile);
 
-			// If file was empty or corrupted (no valid header), truncate and start fresh
-			// to avoid appending messages without a session header (which breaks the session)
+			// If file was empty, initialize it with a valid session header. If it was non-empty but did not parse as a pi session, fail without modifying it.
 			if (this.fileEntries.length === 0) {
 				const explicitPath = this.sessionFile;
+				if (statSync(explicitPath).size > 0) {
+					throw new Error(`Session file is not a valid pi session: ${explicitPath}`);
+				}
 				this.newSession();
 				this.sessionFile = explicitPath;
 				this._rewriteFile();
@@ -458,8 +450,8 @@ export class SessionManager {
 	}
 
 	/** Create an in-memory session (no file persistence) */
-	static inMemory(cwd: string = process.cwd()): SessionManager {
-		return new SessionManager(cwd, "", undefined, false);
+	static inMemory(cwd: string = process.cwd(), options?: NewSessionOptions): SessionManager {
+		return new SessionManager(cwd, "", undefined, false, options);
 	}
 
 	/** Fork a session from another project directory into the current project. */

--- a/packages/coding-agent/src/core/settings-manager-resource-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-resource-accessors.ts
@@ -4,6 +4,7 @@ import type { DefaultProjectTrust, PackageSource, ThinkingBudgetsSettings } from
 
 interface SettingsManagerResourceAccessors {
 	getHideThinkingBlock(): boolean;
+	getExternalEditorCommand(): string | undefined;
 	setHideThinkingBlock(hide: boolean): void;
 	getShellPath(): string | undefined;
 	setShellPath(path: string | undefined): void;
@@ -50,6 +51,18 @@ declare module "./settings-manager-core.ts" {
 const resourceAccessors: SettingsManagerResourceAccessors = {
 	getHideThinkingBlock() {
 		return settingsInternals(this).settings.hideThinkingBlock ?? false;
+	},
+
+	getExternalEditorCommand() {
+		const configuredEditor = settingsInternals(this).settings.externalEditor;
+		if (typeof configuredEditor === "string" && configuredEditor.trim() !== "") {
+			return configuredEditor;
+		}
+		const environmentEditor = process.env.VISUAL || process.env.EDITOR;
+		if (environmentEditor) {
+			return environmentEditor;
+		}
+		return process.platform === "win32" ? "notepad" : "nano";
 	},
 
 	setHideThinkingBlock(hide) {

--- a/packages/coding-agent/src/core/settings-manager-ui-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-ui-accessors.ts
@@ -26,6 +26,8 @@ interface SettingsManagerUiAccessors {
 	setShowHardwareCursor(enabled: boolean): void;
 	getEditorPaddingX(): number;
 	setEditorPaddingX(padding: number): void;
+	getOutputPad(): 0 | 1;
+	setOutputPad(padding: 0 | 1): void;
 	getAutocompleteMaxVisible(): number;
 	setAutocompleteMaxVisible(maxVisible: number): void;
 	getCodeBlockIndent(): string;
@@ -187,6 +189,17 @@ const uiAccessors: SettingsManagerUiAccessors = {
 		const state = settingsInternals(this);
 		state.globalSettings.editorPaddingX = Math.max(0, Math.min(3, Math.floor(padding)));
 		state.markModified("editorPaddingX");
+		state.save();
+	},
+
+	getOutputPad() {
+		return settingsInternals(this).settings.outputPad === 0 ? 0 : 1;
+	},
+
+	setOutputPad(padding) {
+		const state = settingsInternals(this);
+		state.globalSettings.outputPad = padding;
+		state.markModified("outputPad");
 		state.save();
 	},
 

--- a/packages/coding-agent/src/core/settings-types.ts
+++ b/packages/coding-agent/src/core/settings-types.ts
@@ -103,6 +103,7 @@ export interface Settings {
 	branchSummary?: BranchSummarySettings;
 	retry?: RetrySettings;
 	hideThinkingBlock?: boolean;
+	externalEditor?: string; // Command for Ctrl+G external editor; takes precedence over VISUAL/EDITOR
 	shellPath?: string; // Custom shell path (e.g., for Cygwin users on Windows)
 	quietStartup?: boolean;
 	defaultProjectTrust?: DefaultProjectTrust; // default: "ask"; global setting only
@@ -126,6 +127,7 @@ export interface Settings {
 	treeFilterMode?: "default" | "no-tools" | "user-only" | "labeled-only" | "all"; // Default filter when opening /tree
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
+	outputPad?: 0 | 1; // Horizontal padding for chat message output (default: 1)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;

--- a/packages/coding-agent/src/core/timings.ts
+++ b/packages/coding-agent/src/core/timings.ts
@@ -6,61 +6,90 @@
 import { ENV_TIMING, getEnvValue } from "../config.ts";
 
 const ENABLED = getEnvValue(ENV_TIMING) === "1";
-const timings: Array<{ label: string; ms: number }> = [];
-let lastTime = Date.now();
-let resetTime = lastTime;
+
+interface TimingNamespace {
+	timings: Array<{ label: string; ms: number }>;
+	lastTime: number;
+	resetTime: number;
+}
+
+export type TimingLabel = "main" | "extensions";
+
+const timingNamespaces = new Map<TimingLabel, TimingNamespace>();
 
 export interface TimingSpan {
 	label: string;
 	start: number;
+	namespace: TimingLabel;
 }
 
 export function isTimingEnabled(): boolean {
 	return ENABLED;
 }
 
-export function resetTimings(): void {
-	if (!ENABLED) return;
-	timings.length = 0;
-	lastTime = Date.now();
-	resetTime = lastTime;
+function ensureNamespace(namespace: TimingLabel): TimingNamespace {
+	let entry = timingNamespaces.get(namespace);
+	if (!entry) {
+		const now = Date.now();
+		entry = { timings: [], lastTime: now, resetTime: now };
+		timingNamespaces.set(namespace, entry);
+	}
+	return entry;
 }
 
-export function time(label: string): void {
+export function resetTimings(namespace: TimingLabel = "main"): void {
 	if (!ENABLED) return;
 	const now = Date.now();
-	timings.push({ label, ms: now - lastTime });
-	lastTime = now;
+	timingNamespaces.set(namespace, { timings: [], lastTime: now, resetTime: now });
 }
 
-export function startTimingSpan(label: string): TimingSpan | null {
+export function time(label: string, namespace: TimingLabel = "main"): void {
+	if (!ENABLED) return;
+	const now = Date.now();
+	const timingNamespace = ensureNamespace(namespace);
+	timingNamespace.timings.push({ label, ms: now - timingNamespace.lastTime });
+	timingNamespace.lastTime = now;
+}
+
+export function startTimingSpan(label: string, namespace: TimingLabel = "main"): TimingSpan | null {
 	if (!ENABLED) return null;
-	return { label, start: Date.now() };
+	return { label, start: Date.now(), namespace };
 }
 
 export function endTimingSpan(span: TimingSpan | null): void {
 	if (!ENABLED || !span) return;
 	const now = Date.now();
-	timings.push({ label: span.label, ms: now - span.start });
-	lastTime = now;
+	const timingNamespace = ensureNamespace(span.namespace);
+	timingNamespace.timings.push({ label: span.label, ms: now - span.start });
+	timingNamespace.lastTime = now;
 }
 
-export function recordTiming(label: string, ms: number): void {
+export function recordTiming(label: string, ms: number, namespace: TimingLabel = "main"): void {
 	if (!ENABLED) return;
-	timings.push({ label, ms });
+	const timingNamespace = ensureNamespace(namespace);
+	timingNamespace.timings.push({ label, ms });
 }
 
-export function recordTimeSinceReset(label: string): void {
+export function recordTimeSinceReset(label: string, namespace: TimingLabel = "main"): void {
 	if (!ENABLED) return;
-	timings.push({ label, ms: Date.now() - resetTime });
+	const timingNamespace = ensureNamespace(namespace);
+	timingNamespace.timings.push({ label, ms: Date.now() - timingNamespace.resetTime });
+}
+
+function printTimingGroup(title: string, namespace: TimingNamespace): void {
+	const printableTimings = namespace.timings.filter((timing) => timing.ms >= 0);
+	if (printableTimings.length === 0) return;
+	console.error(`\n--- ${title} ---`);
+	for (const t of printableTimings) {
+		console.error(`  ${t.label}: ${t.ms}ms`);
+	}
+	console.error(`  TOTAL initialization time: ${Date.now() - namespace.resetTime}ms`);
+	console.error(`${"-".repeat(title.length + 8)}\n`);
 }
 
 export function printTimings(): void {
-	if (!ENABLED || timings.length === 0) return;
-	console.error("\n--- Startup Timings ---");
-	for (const t of timings) {
-		console.error(`  ${t.label}: ${t.ms}ms`);
+	if (!ENABLED) return;
+	for (const [namespace, timingNamespace] of timingNamespaces) {
+		printTimingGroup(`Startup Timings: ${namespace}`, timingNamespace);
 	}
-	console.error(`  TOTAL initialization time: ${Date.now() - resetTime}ms`);
-	console.error("------------------------\n");
 }

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -9,7 +9,7 @@ import { getReadmePath } from "../../config.ts";
 import { keyHint, keyText } from "../../modes/interactive/components/keybinding-hints.ts";
 import { parseConflictBlocks, registerConflictBlocks } from "./conflict-registry.ts";
 import { getLanguageFromPath, highlightCode, type Theme } from "../../modes/interactive/theme/theme.ts";
-import { formatDimensionNote, resizeImage } from "../../utils/image-resize.ts";
+import { processImage } from "../../utils/image-process.ts";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.ts";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.ts";
 import { buildDirectoryTree } from "./directory-tree.ts";
@@ -342,29 +342,20 @@ export function createReadToolDefinition(cwd: string, options?: ReadToolOptions)
 							const mimeType = ops.detectImageMimeType ? await ops.detectImageMimeType(absolutePath) : undefined;
 							const nonVisionImageNote = getNonVisionImageNote(ctx?.model);
 							if (mimeType) {
+								// Read image as binary.
 								const buffer = await ops.readFile(absolutePath);
-								if (autoResizeImages) {
-									const resized = await resizeImage(buffer, mimeType);
-									if (!resized) {
-										let textNote = `Read image file [${mimeType}]\n[Image omitted: could not be resized below the inline image size limit.]`;
-										if (nonVisionImageNote) textNote += `\n${nonVisionImageNote}`;
-										content = [{ type: "text", text: textNote }];
-									} else {
-										const dimensionNote = formatDimensionNote(resized);
-										let textNote = `Read image file [${resized.mimeType}]`;
-										if (dimensionNote) textNote += `\n${dimensionNote}`;
-										if (nonVisionImageNote) textNote += `\n${nonVisionImageNote}`;
-										content = [
-											{ type: "text", text: textNote },
-											{ type: "image", data: resized.data, mimeType: resized.mimeType },
-										];
-									}
+								const processed = await processImage(buffer, mimeType, { autoResizeImages });
+								if (!processed.ok) {
+									let textNote = `Read image file [${mimeType}]\n${processed.message}`;
+									if (nonVisionImageNote) textNote += `\n${nonVisionImageNote}`;
+									content = [{ type: "text", text: textNote }];
 								} else {
-									let textNote = `Read image file [${mimeType}]`;
+									let textNote = `Read image file [${processed.mimeType}]`;
+									if (processed.hints.length > 0) textNote += `\n${processed.hints.join("\n")}`;
 									if (nonVisionImageNote) textNote += `\n${nonVisionImageNote}`;
 									content = [
 										{ type: "text", text: textNote },
-										{ type: "image", data: buffer.toString("base64"), mimeType },
+										{ type: "image", data: processed.data, mimeType: processed.mimeType },
 									];
 								}
 							} else {

--- a/packages/coding-agent/src/index-extensions.ts
+++ b/packages/coding-agent/src/index-extensions.ts
@@ -74,6 +74,7 @@ export type {
 	SessionBeforeSwitchEvent,
 	SessionBeforeTreeEvent,
 	SessionCompactEvent,
+	SessionInfoChangedEvent,
 	SessionShutdownEvent,
 	SessionStartEvent,
 	SessionTreeEvent,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -215,6 +215,7 @@ export {
 	type SessionInfoEntry,
 	SessionManager,
 	type SessionMessageEntry,
+	type SessionTreeNode,
 	type ThinkingLevelChangeEntry,
 } from "./core/session-manager.ts";
 export {

--- a/packages/coding-agent/src/main-session.ts
+++ b/packages/coding-agent/src/main-session.ts
@@ -100,7 +100,6 @@ export function validateSessionIdFlags(parsed: Args): void {
 		parsed.session ? "--session" : undefined,
 		parsed.continue ? "--continue" : undefined,
 		parsed.resume ? "--resume" : undefined,
-		parsed.noSession ? "--no-session" : undefined,
 	].filter((flag): flag is string => flag !== undefined);
 
 	if (conflictingFlags.length > 0) {
@@ -116,10 +115,19 @@ export function validateSessionIdFlags(parsed: Args): void {
 		process.exit(1);
 	}
 }
-
 function forkSessionOrExit(sourcePath: string, cwd: string, sessionDir?: string, sessionId?: string): SessionManager {
 	try {
 		return SessionManager.forkFrom(sourcePath, cwd, sessionDir, { id: sessionId });
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(chalk.red(`Error: ${message}`));
+		process.exit(1);
+	}
+}
+
+function openSessionOrExit(path: string, sessionDir?: string): SessionManager {
+	try {
+		return SessionManager.open(path, sessionDir);
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
 		console.error(chalk.red(`Error: ${message}`));
@@ -134,7 +142,7 @@ export async function createSessionManager(
 	settingsManager: SettingsManager,
 ): Promise<SessionManager> {
 	if (parsed.noSession || parsed.help || parsed.listModels !== undefined) {
-		return SessionManager.inMemory(cwd);
+		return SessionManager.inMemory(cwd, parsed.sessionId !== undefined ? { id: parsed.sessionId } : undefined);
 	}
 
 	if (parsed.fork) {
@@ -166,7 +174,7 @@ export async function createSessionManager(
 		switch (resolved.type) {
 			case "path":
 			case "local":
-				return SessionManager.open(resolved.path, sessionDir);
+				return openSessionOrExit(resolved.path, sessionDir);
 
 			case "global": {
 				console.log(chalk.yellow(`Session found in different project: ${resolved.cwd}`));
@@ -195,7 +203,7 @@ export async function createSessionManager(
 				console.log(chalk.dim("No session selected"));
 				process.exit(0);
 			}
-			return SessionManager.open(selectedPath, sessionDir);
+			return openSessionOrExit(selectedPath, sessionDir);
 		} finally {
 			stopThemeWatcher();
 		}
@@ -208,7 +216,7 @@ export async function createSessionManager(
 	if (parsed.sessionId) {
 		const existingSession = await findLocalSessionByExactId(parsed.sessionId, cwd, sessionDir);
 		if (existingSession) {
-			return SessionManager.open(existingSession.path, sessionDir);
+			return openSessionOrExit(existingSession.path, sessionDir);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -14,6 +14,7 @@ export class AssistantMessageComponent extends Container {
 	private hideThinkingBlock: boolean;
 	private markdownTheme: MarkdownTheme;
 	private hiddenThinkingLabel: string;
+	private outputPad: number;
 	private lastMessage?: AssistantMessage;
 	private hasToolCalls = false;
 
@@ -22,13 +23,14 @@ export class AssistantMessageComponent extends Container {
 		hideThinkingBlock = false,
 		markdownTheme: MarkdownTheme = getMarkdownTheme(),
 		hiddenThinkingLabel = "Thinking...",
+		outputPad = 1,
 	) {
 		super();
 
 		this.hideThinkingBlock = hideThinkingBlock;
 		this.markdownTheme = markdownTheme;
 		this.hiddenThinkingLabel = hiddenThinkingLabel;
-
+		this.outputPad = outputPad;
 		// Container for text/thinking content
 		this.contentContainer = new Container();
 		this.addChild(this.contentContainer);
@@ -54,6 +56,13 @@ export class AssistantMessageComponent extends Container {
 
 	setHiddenThinkingLabel(label: string): void {
 		this.hiddenThinkingLabel = label;
+		if (this.lastMessage) {
+			this.updateContent(this.lastMessage);
+		}
+	}
+
+	setOutputPad(padding: number): void {
+		this.outputPad = padding;
 		if (this.lastMessage) {
 			this.updateContent(this.lastMessage);
 		}
@@ -90,7 +99,7 @@ export class AssistantMessageComponent extends Container {
 			if (content.type === "text" && content.text.trim()) {
 				// Assistant text messages with no background - trim the text
 				// Set paddingY=0 to avoid extra spacing before tool executions
-				this.contentContainer.addChild(new Markdown(content.text.trim(), 1, 0, this.markdownTheme));
+				this.contentContainer.addChild(new Markdown(content.text.trim(), this.outputPad, 0, this.markdownTheme));
 			} else if (content.type === "thinking" && content.thinking.trim()) {
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
@@ -101,7 +110,7 @@ export class AssistantMessageComponent extends Container {
 				if (this.hideThinkingBlock) {
 					// Show static thinking label when hidden
 					this.contentContainer.addChild(
-						new Text(theme.italic(theme.fg("muted", this.hiddenThinkingLabel)), 1, 0),
+						new Text(theme.italic(theme.fg("muted", this.hiddenThinkingLabel)), this.outputPad, 0),
 					);
 					if (hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
@@ -109,7 +118,7 @@ export class AssistantMessageComponent extends Container {
 				} else {
 					// Thinking traces in muted color, italic
 					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
+						new Markdown(content.thinking.trim(), this.outputPad, 0, this.markdownTheme, {
 							color: (text: string) => theme.fg("muted", text),
 							italic: true,
 						}),
@@ -121,26 +130,35 @@ export class AssistantMessageComponent extends Container {
 			}
 		}
 
-		// Check if aborted - show after partial content
-		// But only if there are no tool calls (tool execution components will show the error)
+		// Check if incomplete/failed - show after partial content.
+		// For aborted/error tool calls, tool execution components show the error.
+		// Length stops can happen before a tool call is complete, so surface them here too.
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall");
 		this.hasToolCalls = hasToolCalls;
-		if (!hasToolCalls) {
+		if (message.stopReason === "length") {
+			this.contentContainer.addChild(new Spacer(1));
+			this.contentContainer.addChild(
+				new Text(
+					theme.fg(
+						"error",
+						"Error: Model stopped because it reached the maximum output token limit. The response may be incomplete.",
+					),
+					this.outputPad,
+					0,
+				),
+			);
+		} else if (!hasToolCalls) {
 			if (message.stopReason === "aborted") {
 				const abortMessage =
 					message.errorMessage && message.errorMessage !== "Request was aborted"
 						? message.errorMessage
 						: "Operation aborted";
-				if (hasVisibleContent) {
-					this.contentContainer.addChild(new Spacer(1));
-				} else {
-					this.contentContainer.addChild(new Spacer(1));
-				}
-				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), 1, 0));
+				this.contentContainer.addChild(new Spacer(1));
+				this.contentContainer.addChild(new Text(theme.fg("error", abortMessage), this.outputPad, 0));
 			} else if (message.stopReason === "error") {
 				const errorMsg = message.errorMessage || "Unknown error";
 				this.contentContainer.addChild(new Spacer(1));
-				this.contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), 1, 0));
+				this.contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), this.outputPad, 0));
 			}
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/components/chat-message-renderer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-message-renderer.ts
@@ -24,8 +24,7 @@ export type ChatMessageEntry =
 export interface ChatMessageRenderOptions {
   ui: Pick<TUI, "requestRender">; cwd: string; markdownTheme?: MarkdownTheme;
   hideThinkingBlock?: boolean; hiddenThinkingLabel?: string; toolOutputExpanded?: boolean;
-  showImages?: boolean; imageWidthCells?: number;
-  getToolDefinition?: (toolName: string) => ToolDefinition<TSchema, unknown> | undefined;
+  showImages?: boolean; imageWidthCells?: number; outputPad?: number; getToolDefinition?: (toolName: string) => ToolDefinition<TSchema, unknown> | undefined;
   getCustomMessageRenderer?: (customType: string) => MessageRenderer | undefined;
 }
 export function chatEntriesFromAgentMessages(
@@ -410,6 +409,7 @@ export function renderChatMessageEntry(
         options.hideThinkingBlock ?? false,
         markdownTheme,
         options.hiddenThinkingLabel ?? "Thinking...",
+        options.outputPad ?? 1,
       );
     case "tool": {
       const component = new ToolExecutionComponent(
@@ -448,7 +448,7 @@ export function renderChatMessageEntry(
       return component;
     }
     case "user":
-      return userMessageComponent(messageEntry.text, markdownTheme, options.toolOutputExpanded ?? false);
+      return userMessageComponent(messageEntry.text, markdownTheme, options.toolOutputExpanded ?? false, options.outputPad ?? 1);
     case "custom": {
       const component = new CustomMessageComponent(
         messageEntry.message,
@@ -467,15 +467,15 @@ export function renderChatMessageEntry(
       return new Text(theme.fg("dim", messageEntry.text), 1, 0);
   }
 }
-function userMessageComponent(text: string, markdownTheme: MarkdownTheme, expanded: boolean): Component {
+function userMessageComponent(text: string, markdownTheme: MarkdownTheme, expanded: boolean, outputPad = 1): Component {
   const skillBlock = parseSkillBlock(text);
-  if (!skillBlock) return new UserMessageComponent(text, markdownTheme);
+  if (!skillBlock) return new UserMessageComponent(text, markdownTheme, outputPad);
   const container = new Container();
   const skillComponent = new SkillInvocationMessageComponent(skillBlock, markdownTheme);
   skillComponent.setExpanded(expanded);
   container.addChild(skillComponent);
   if (skillBlock.userMessage) {
-    container.addChild(new UserMessageComponent(skillBlock.userMessage, markdownTheme));
+    container.addChild(new UserMessageComponent(skillBlock.userMessage, markdownTheme, outputPad));
   }
   return container;
 }

--- a/packages/coding-agent/src/modes/interactive/components/chat-session-host-rendering.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-session-host-rendering.ts
@@ -217,6 +217,7 @@ function chatRenderSettingsCacheKey<TExtraEntry extends ChatTranscriptEntryLike>
     inherited?.toolOutputExpanded === true,
     inherited?.showImages !== false,
     inherited?.imageWidthCells ?? null,
+    inherited?.outputPad ?? null,
     state.getCwd?.() ?? state.getAgentSession?.()?.sessionManager.getCwd() ?? process.cwd(),
     state.bodyViewport.getScrollFromBottom() === 0,
     isChatSessionStreaming(state),

--- a/packages/coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/user-message.ts
@@ -9,24 +9,39 @@ const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
  * Component that renders a user message
  */
 export class UserMessageComponent extends Container {
-	private contentBox: Box;
+	private text: string;
+	private markdownTheme: MarkdownTheme;
+	private outputPad: number;
 
-	constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
+	constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme(), outputPad = 1) {
 		super();
-		this.contentBox = new Box(1, 1, (content: string) => theme.bg("userMessageBg", content));
-		this.contentBox.addChild(
+		this.text = text;
+		this.markdownTheme = markdownTheme;
+		this.outputPad = outputPad;
+		this.rebuild();
+	}
+
+	setOutputPad(padding: number): void {
+		this.outputPad = padding;
+		this.rebuild();
+	}
+
+	private rebuild(): void {
+		this.clear();
+		const contentBox = new Box(this.outputPad, 1, (content: string) => theme.bg("userMessageBg", content));
+		contentBox.addChild(
 			new Markdown(
-				text,
+				this.text,
 				0,
 				0,
-				markdownTheme,
+				this.markdownTheme,
 				{
 					color: (content: string) => theme.fg("userMessageText", content),
 				},
-				{ preserveOrderedListMarkers: true },
+				{ preserveOrderedListMarkers: true, preserveBackslashEscapes: true },
 			),
 		);
-		this.addChild(this.contentBox);
+		this.addChild(contentBox);
 	}
 
 	override render(width: number): string[] {

--- a/packages/coding-agent/src/modes/interactive/interactive-agent-events.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-agent-events.ts
@@ -100,6 +100,7 @@ InteractiveModeBase.prototype.handleEvent = async function(this: InteractiveMode
             this.hideThinkingBlock,
             this.getMarkdownThemeWithSettings(),
             this.hiddenThinkingLabel,
+            this.outputPad,
           );
           this.streamingMessage = event.message;
           this.chatContainer.addChild(this.streamingComponent);

--- a/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
@@ -96,6 +96,7 @@ InteractiveModeBase.prototype.toggleThinkingBlockVisibility = function(this: Int
 InteractiveModeBase.prototype.openExternalEditor = function(this: InteractiveModeBase): void {
     const currentText = this.editor.getExpandedText?.() ?? this.editor.getText();
     const updated = openExternalEditorForText(currentText, this.ui, {
+      editorCommand: this.settingsManager.getExternalEditorCommand(),
       showWarning: (message) => this.showWarning(message),
     });
     if (updated !== undefined) this.editor.setText(updated);

--- a/packages/coding-agent/src/modes/interactive/interactive-extension-context.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-extension-context.ts
@@ -175,6 +175,7 @@ InteractiveModeBase.prototype.createExtensionUIContext = function(this: Interact
         toolOutputExpanded: this.toolOutputExpanded,
         showImages: this.settingsManager.getShowImages(),
         imageWidthCells: this.settingsManager.getImageWidthCells(),
+        outputPad: this.outputPad,
         getToolDefinition: (toolName: string) =>
           this.getRegisteredToolDefinition(toolName),
         getCustomMessageRenderer: (customType: string) =>

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -161,6 +161,7 @@ export class InteractiveModeBase {
 
   // Thinking block visibility state
   hideThinkingBlock = false;
+  outputPad: 0 | 1 = 1;
 
 
 
@@ -369,6 +370,7 @@ export class InteractiveModeBase {
 
     // Load hide thinking block setting
     this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
+    this.outputPad = this.settingsManager.getOutputPad();
 
     // Register themes from resource loader and initialize
     setRegisteredThemes(this.session.resourceLoader.getThemes().themes);

--- a/packages/coding-agent/src/modes/interactive/interactive-render-chat.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-render-chat.ts
@@ -38,6 +38,7 @@ InteractiveModeBase.prototype.chatMessageRenderOptions = function(this: Interact
       toolOutputExpanded: this.toolOutputExpanded,
       showImages: this.settingsManager.getShowImages(),
       imageWidthCells: this.settingsManager.getImageWidthCells(),
+      outputPad: this.outputPad,
       getToolDefinition: (toolName) => this.getRegisteredToolDefinition(toolName),
       getCustomMessageRenderer: (customType) =>
         this.session.extensionRunner.getMessageRenderer(customType),
@@ -127,6 +128,7 @@ InteractiveModeBase.prototype.addMessageToChat = function(this: InteractiveModeB
               const userComponent = new UserMessageComponent(
                 skillBlock.userMessage,
                 this.getMarkdownThemeWithSettings(),
+                this.outputPad,
               );
               this.chatContainer.addChild(userComponent);
             }
@@ -134,6 +136,7 @@ InteractiveModeBase.prototype.addMessageToChat = function(this: InteractiveModeB
             const userComponent = new UserMessageComponent(
               textContent,
               this.getMarkdownThemeWithSettings(),
+              this.outputPad,
             );
             this.chatContainer.addChild(userComponent);
           }
@@ -149,6 +152,7 @@ InteractiveModeBase.prototype.addMessageToChat = function(this: InteractiveModeB
           this.hideThinkingBlock,
           this.getMarkdownThemeWithSettings(),
           this.hiddenThinkingLabel,
+          this.outputPad,
         );
         this.chatContainer.addChild(assistantComponent);
         break;

--- a/packages/coding-agent/src/modes/interactive/interactive-session-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-session-runtime.ts
@@ -97,6 +97,7 @@ InteractiveModeBase.prototype.applyRuntimeSettings = function(this: InteractiveM
     this.usageMeter.setAutoCompactEnabled(this.session.autoCompactionEnabled);
     this.footerDataProvider.setCwd(this.sessionManager.getCwd());
     this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
+    this.outputPad = this.settingsManager.getOutputPad();
     this.ui.setShowHardwareCursor(this.settingsManager.getShowHardwareCursor());
     this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
     const editorPaddingX = this.settingsManager.getEditorPaddingX();

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -10,6 +10,7 @@ import type { ImageContent } from "@earendil-works/pi-ai/compat";
 import type { SessionStats } from "../../core/agent-session.ts";
 import type { BashResult } from "../../core/bash-executor.ts";
 import type { ContextCompactionResult } from "../../core/compaction/index.ts";
+import type { SessionEntry, SessionTreeNode } from "../../core/session-manager.ts";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.ts";
 import type {
 	RpcCommand,
@@ -77,9 +78,7 @@ export class RpcClient {
 		this.options = options;
 	}
 
-	/**
-	 * Start the RPC agent process.
-	 */
+	/** Start the RPC agent process. */
 	async start(): Promise<void> {
 		if (this.process) {
 			throw new Error("Client already started");
@@ -142,9 +141,7 @@ export class RpcClient {
 		}
 	}
 
-	/**
-	 * Stop the RPC agent process.
-	 */
+	/** Stop the RPC agent process. */
 	async stop(): Promise<void> {
 		if (!this.process) return;
 
@@ -169,9 +166,7 @@ export class RpcClient {
 		this.pendingRequests.clear();
 	}
 
-	/**
-	 * Subscribe to agent events.
-	 */
+	/** Subscribe to agent events. */
 	onEvent(listener: RpcEventListener): () => void {
 		this.eventListeners.push(listener);
 		return () => {
@@ -182,9 +177,7 @@ export class RpcClient {
 		};
 	}
 
-	/**
-	 * Get collected stderr output (useful for debugging).
-	 */
+	/** Get collected stderr output (useful for debugging). */
 	getStderr(): string {
 		return this.stderr;
 	}
@@ -202,23 +195,17 @@ export class RpcClient {
 		await this.send({ type: "prompt", message, images });
 	}
 
-	/**
-	 * Queue a steering message to interrupt the agent mid-run.
-	 */
+	/** Queue a steering message to interrupt the agent mid-run. */
 	async steer(message: string, images?: ImageContent[]): Promise<void> {
 		await this.send({ type: "steer", message, images });
 	}
 
-	/**
-	 * Queue a follow-up message to be processed after the agent finishes.
-	 */
+	/** Queue a follow-up message to be processed after the agent finishes. */
 	async followUp(message: string, images?: ImageContent[]): Promise<void> {
 		await this.send({ type: "follow_up", message, images });
 	}
 
-	/**
-	 * Abort current operation.
-	 */
+	/** Abort current operation. */
 	async abort(): Promise<void> {
 		await this.send({ type: "abort" });
 	}
@@ -233,25 +220,19 @@ export class RpcClient {
 		return this.getData(response);
 	}
 
-	/**
-	 * Get current session state.
-	 */
+	/** Get current session state. */
 	async getState(): Promise<RpcSessionState> {
 		const response = await this.send({ type: "get_state" });
 		return this.getData(response);
 	}
 
-	/**
-	 * Set model by provider and ID.
-	 */
+	/** Set model by provider and ID. */
 	async setModel(provider: string, modelId: string): Promise<{ provider: string; id: string }> {
 		const response = await this.send({ type: "set_model", provider, modelId });
 		return this.getData(response);
 	}
 
-	/**
-	 * Cycle to next model.
-	 */
+	/** Cycle to next model. */
 	async cycleModel(): Promise<{
 		model: { provider: string; id: string };
 		thinkingLevel: ThinkingLevel;
@@ -261,24 +242,18 @@ export class RpcClient {
 		return this.getData(response);
 	}
 
-	/**
-	 * Get list of available models.
-	 */
+	/** Get list of available models. */
 	async getAvailableModels(): Promise<ModelInfo[]> {
 		const response = await this.send({ type: "get_available_models" });
 		return this.getData<{ models: ModelInfo[] }>(response).models;
 	}
 
-	/**
-	 * Set thinking level.
-	 */
+	/** Set thinking level. */
 	async setThinkingLevel(level: ThinkingLevel): Promise<void> {
 		await this.send({ type: "set_thinking_level", level });
 	}
 
-	/**
-	 * Cycle thinking level.
-	 */
+	/** Cycle thinking level. */
 	async cycleThinkingLevel(): Promise<{ level: ThinkingLevel } | null> {
 		const response = await this.send({ type: "cycle_thinking_level" });
 		return this.getData(response);
@@ -293,31 +268,23 @@ export class RpcClient {
 		this.assertSuccess(response);
 	}
 
-	/**
-	 * Get selectable context-window token budgets for the current model.
-	 */
+	/** Get selectable context-window token budgets for the current model. */
 	async getAvailableContextWindows(): Promise<RpcContextWindowInfo> {
 		const response = await this.send({ type: "get_available_context_windows" });
 		return this.getData(response);
 	}
 
-	/**
-	 * Set steering mode.
-	 */
+	/** Set steering mode. */
 	async setSteeringMode(mode: "all" | "one-at-a-time"): Promise<void> {
 		await this.send({ type: "set_steering_mode", mode });
 	}
 
-	/**
-	 * Set follow-up mode.
-	 */
+	/** Set follow-up mode. */
 	async setFollowUpMode(mode: "all" | "one-at-a-time"): Promise<void> {
 		await this.send({ type: "set_follow_up_mode", mode });
 	}
 
-	/**
-	 * Compact session context with deletion-only verbatim context compaction.
-	 */
+	/** Compact session context with deletion-only verbatim context compaction. */
 	async compact(): Promise<ContextCompactionResult> {
 		const response = await this.send({ type: "compact" });
 		return this.getData(response);
@@ -367,6 +334,18 @@ export class RpcClient {
 	async getForkMessages(): Promise<Array<{ entryId: string; text: string }>> {
 		const response = await this.send({ type: "get_fork_messages" });
 		return this.getData<{ messages: Array<{ entryId: string; text: string }> }>(response).messages;
+	}
+
+	/** Session entries in append order, optionally only those after the `since` entry id. */
+	async getEntries(since?: string): Promise<{ entries: SessionEntry[]; leafId: string | null }> {
+		const response = await this.send({ type: "get_entries", since });
+		return this.getData<{ entries: SessionEntry[]; leafId: string | null }>(response);
+	}
+
+	/** The session entry tree. */
+	async getTree(): Promise<{ tree: SessionTreeNode[]; leafId: string | null }> {
+		const response = await this.send({ type: "get_tree" });
+		return this.getData<{ tree: SessionTreeNode[]; leafId: string | null }>(response);
 	}
 	async getLastAssistantText(): Promise<string | null> {
 		const response = await this.send({ type: "get_last_assistant_text" });

--- a/packages/coding-agent/src/modes/rpc/rpc-command-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-command-handler.ts
@@ -226,6 +226,27 @@ export function createRpcCommandHandler({
 				return createRpcSuccessResponse(id, "get_fork_messages", { messages });
 			}
 
+			case "get_entries": {
+				const sessionManager = session.sessionManager;
+				let entries = sessionManager.getEntries();
+				if (command.since !== undefined) {
+					const sinceIndex = entries.findIndex((e) => e.id === command.since);
+					if (sinceIndex === -1) {
+						return createRpcErrorResponse(id, "get_entries", `Entry not found: ${command.since}`);
+					}
+					entries = entries.slice(sinceIndex + 1);
+				}
+				return createRpcSuccessResponse(id, "get_entries", { entries, leafId: sessionManager.getLeafId() });
+			}
+
+			case "get_tree": {
+				const sessionManager = session.sessionManager;
+				return createRpcSuccessResponse(id, "get_tree", {
+					tree: sessionManager.getTree(),
+					leafId: sessionManager.getLeafId(),
+				});
+			}
+
 			case "get_last_assistant_text": {
 				const text = session.getLastAssistantText();
 				return createRpcSuccessResponse(id, "get_last_assistant_text", { text });

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -10,6 +10,7 @@ import type { Api, ImageContent, Model } from "@earendil-works/pi-ai/compat";
 import type { AgentSessionEvent, SessionStats } from "../../core/agent-session.ts";
 import type { BashResult } from "../../core/bash-executor.ts";
 import type { ContextCompactionResult } from "../../core/compaction/index.ts";
+import type { SessionEntry, SessionTreeNode } from "../../core/session-manager.ts";
 import type { SourceInfo } from "../../core/source-info.ts";
 
 // ============================================================================
@@ -64,6 +65,8 @@ export type RpcCommand =
 	| { id?: string; type: "fork"; entryId: string }
 	| { id?: string; type: "clone" }
 	| { id?: string; type: "get_fork_messages" }
+	| { id?: string; type: "get_entries"; since?: string }
+	| { id?: string; type: "get_tree" }
 	| { id?: string; type: "get_last_assistant_text" }
 	| { id?: string; type: "set_session_name"; name: string }
 
@@ -202,6 +205,20 @@ export type RpcResponse =
 			command: "get_fork_messages";
 			success: true;
 			data: { messages: Array<{ entryId: string; text: string }> };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "get_entries";
+			success: true;
+			data: { entries: SessionEntry[]; leafId: string | null };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "get_tree";
+			success: true;
+			data: { tree: SessionTreeNode[]; leafId: string | null };
 	  }
 	| {
 			id?: string;

--- a/packages/coding-agent/src/rpc-entry.ts
+++ b/packages/coding-agent/src/rpc-entry.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { APP_NAME } from "./config.ts";
+import { configureHttpDispatcher } from "./core/http-dispatcher.ts";
+import { main } from "./main.ts";
+
+process.title = `${APP_NAME}-rpc`;
+process.env[`${APP_NAME.toUpperCase()}_CODING_AGENT`] = "true";
+process.emitWarning = (() => {}) as typeof process.emitWarning;
+
+configureHttpDispatcher();
+
+// rpc-entry is the dedicated RPC entry point, so --mode rpc must always win
+// over any --mode the caller passes (the last --mode in the args wins).
+main([...process.argv.slice(2), "--mode", "rpc"]);

--- a/packages/coding-agent/src/utils/image-convert.ts
+++ b/packages/coding-agent/src/utils/image-convert.ts
@@ -1,6 +1,28 @@
 import { applyExifOrientation } from "./exif-orientation.ts";
 import { loadPhoton } from "./photon.ts";
 
+export async function convertImageBytesToPng(bytes: Uint8Array): Promise<Uint8Array | null> {
+	const photon = await loadPhoton();
+	if (!photon) {
+		// Photon not available, can't convert
+		return null;
+	}
+
+	try {
+		const rawImage = photon.PhotonImage.new_from_byteslice(bytes);
+		const image = applyExifOrientation(photon, rawImage, bytes);
+		if (image !== rawImage) rawImage.free();
+		try {
+			return new Uint8Array(image.get_bytes());
+		} finally {
+			image.free();
+		}
+	} catch {
+		// Conversion failed
+		return null;
+	}
+}
+
 /**
  * Convert image to PNG format for terminal display.
  * Kitty graphics protocol requires PNG format (f=100).
@@ -14,28 +36,14 @@ export async function convertToPng(
 		return { data: base64Data, mimeType };
 	}
 
-	const photon = await loadPhoton();
-	if (!photon) {
-		// Photon not available, can't convert
+	const bytes = new Uint8Array(Buffer.from(base64Data, "base64"));
+	const pngBytes = await convertImageBytesToPng(bytes);
+	if (!pngBytes) {
 		return null;
 	}
 
-	try {
-		const bytes = new Uint8Array(Buffer.from(base64Data, "base64"));
-		const rawImage = photon.PhotonImage.new_from_byteslice(bytes);
-		const image = applyExifOrientation(photon, rawImage, bytes);
-		if (image !== rawImage) rawImage.free();
-		try {
-			const pngBuffer = image.get_bytes();
-			return {
-				data: Buffer.from(pngBuffer).toString("base64"),
-				mimeType: "image/png",
-			};
-		} finally {
-			image.free();
-		}
-	} catch {
-		// Conversion failed
-		return null;
-	}
+	return {
+		data: Buffer.from(pngBytes).toString("base64"),
+		mimeType: "image/png",
+	};
 }

--- a/packages/coding-agent/src/utils/image-process.ts
+++ b/packages/coding-agent/src/utils/image-process.ts
@@ -1,0 +1,119 @@
+import { convertImageBytesToPng } from "./image-convert.ts";
+import { formatDimensionNote, type ImageResizeOptions, resizeImage } from "./image-resize.ts";
+
+export interface ProcessImageOptions {
+	/** Whether to resize images to inline provider limits. Default: true */
+	autoResizeImages?: boolean;
+	/** Optional resize overrides. Uses resizeImage defaults when omitted. */
+	resizeOptions?: ImageResizeOptions;
+}
+
+export type ProcessImageResult =
+	| {
+			ok: true;
+			data: string;
+			mimeType: string;
+			hints: string[];
+	  }
+	| {
+			ok: false;
+			message: string;
+	  };
+
+interface NormalizedImage {
+	bytes: Uint8Array;
+	mimeType: string;
+	convertedFrom?: string;
+}
+
+function baseMimeType(mimeType: string): string {
+	return mimeType.split(";")[0]?.trim().toLowerCase() ?? mimeType.toLowerCase();
+}
+
+function normalizeSupportedImageMimeType(mimeType: string): string | null {
+	switch (baseMimeType(mimeType)) {
+		case "image/png":
+			return "image/png";
+		case "image/jpeg":
+		case "image/jpg":
+			return "image/jpeg";
+		case "image/gif":
+			return "image/gif";
+		case "image/webp":
+			return "image/webp";
+		default:
+			return null;
+	}
+}
+
+async function normalizeImage(bytes: Uint8Array, mimeType: string): Promise<NormalizedImage | null> {
+	const normalizedMimeType = normalizeSupportedImageMimeType(mimeType);
+	if (normalizedMimeType) {
+		return { bytes, mimeType: normalizedMimeType };
+	}
+
+	const pngBytes = await convertImageBytesToPng(bytes);
+	if (!pngBytes) {
+		return null;
+	}
+
+	return {
+		bytes: pngBytes,
+		mimeType: "image/png",
+		convertedFrom: baseMimeType(mimeType),
+	};
+}
+
+function conversionHint(from: string | undefined, to: string): string | undefined {
+	if (!from || from === to) return undefined;
+	return `[Image converted from ${from} to ${to}.]`;
+}
+
+export async function processImage(
+	bytes: Uint8Array,
+	mimeType: string,
+	options?: ProcessImageOptions,
+): Promise<ProcessImageResult> {
+	const autoResizeImages = options?.autoResizeImages ?? true;
+	const normalized = await normalizeImage(bytes, mimeType);
+	if (!normalized) {
+		return {
+			ok: false,
+			message: "[Image omitted: could not be converted to a supported inline image format.]",
+		};
+	}
+
+	if (autoResizeImages) {
+		const resized = await resizeImage(normalized.bytes, normalized.mimeType, options?.resizeOptions);
+		if (!resized) {
+			return {
+				ok: false,
+				message: "[Image omitted: could not be resized below the inline image size limit.]",
+			};
+		}
+
+		const hints: string[] = [];
+		const convertedHint = conversionHint(normalized.convertedFrom, resized.mimeType);
+		if (convertedHint) hints.push(convertedHint);
+		const dimensionNote = formatDimensionNote(resized);
+		if (dimensionNote) hints.push(dimensionNote);
+
+		return {
+			ok: true,
+			data: resized.data,
+			mimeType: resized.mimeType,
+			hints,
+		};
+	}
+
+	const hints: string[] = [];
+	const convertedHint = conversionHint(normalized.convertedFrom, normalized.mimeType);
+	if (convertedHint) hints.push(convertedHint);
+
+	return {
+		ok: true,
+		data: Buffer.from(normalized.bytes).toString("base64"),
+		mimeType: normalized.mimeType,
+		hints,
+	};
+}

--- a/packages/coding-agent/src/utils/mime.ts
+++ b/packages/coding-agent/src/utils/mime.ts
@@ -16,6 +16,9 @@ export function detectSupportedImageMimeType(buffer: Uint8Array): string | null 
 	if (startsWithAscii(buffer, 0, "RIFF") && startsWithAscii(buffer, 8, "WEBP")) {
 		return "image/webp";
 	}
+	if (startsWithAscii(buffer, 0, "BM") && isBmp(buffer)) {
+		return "image/bmp";
+	}
 	return null;
 }
 
@@ -51,12 +54,51 @@ function isAnimatedPng(buffer: Uint8Array): boolean {
 	return false;
 }
 
+function isBmp(buffer: Uint8Array): boolean {
+	if (buffer.length < 26) return false;
+
+	const declaredFileSize = readUint32LE(buffer, 2);
+	const pixelDataOffset = readUint32LE(buffer, 10);
+	const dibHeaderSize = readUint32LE(buffer, 14);
+	if (declaredFileSize !== 0 && declaredFileSize < 26) return false;
+	if (pixelDataOffset < 14 + dibHeaderSize) return false;
+	if (declaredFileSize !== 0 && pixelDataOffset >= declaredFileSize) return false;
+
+	let colorPlanes: number;
+	let bitsPerPixel: number;
+	if (dibHeaderSize === 12) {
+		colorPlanes = readUint16LE(buffer, 22);
+		bitsPerPixel = readUint16LE(buffer, 24);
+	} else if (dibHeaderSize >= 40 && dibHeaderSize <= 124) {
+		if (buffer.length < 30) return false;
+		colorPlanes = readUint16LE(buffer, 26);
+		bitsPerPixel = readUint16LE(buffer, 28);
+	} else {
+		return false;
+	}
+
+	return colorPlanes === 1 && [1, 4, 8, 16, 24, 32].includes(bitsPerPixel);
+}
+
+function readUint16LE(buffer: Uint8Array, offset: number): number {
+	return (buffer[offset] ?? 0) + ((buffer[offset + 1] ?? 0) << 8);
+}
+
 function readUint32BE(buffer: Uint8Array, offset: number): number {
 	return (
 		(buffer[offset] ?? 0) * 0x1000000 +
 		((buffer[offset + 1] ?? 0) << 16) +
 		((buffer[offset + 2] ?? 0) << 8) +
 		(buffer[offset + 3] ?? 0)
+	);
+}
+
+function readUint32LE(buffer: Uint8Array, offset: number): number {
+	return (
+		(buffer[offset] ?? 0) +
+		((buffer[offset + 1] ?? 0) << 8) +
+		((buffer[offset + 2] ?? 0) << 16) +
+		(buffer[offset + 3] ?? 0) * 0x1000000
 	);
 }
 

--- a/packages/coding-agent/test/http-dispatcher.test.ts
+++ b/packages/coding-agent/test/http-dispatcher.test.ts
@@ -3,11 +3,14 @@ import { createHttpDispatcherOptions } from "../src/core/http-dispatcher.ts";
 
 describe("createHttpDispatcherOptions", () => {
 	it("disables undici's default fixed connect timeout", () => {
-		expect(createHttpDispatcherOptions(123_456)).toEqual({
-			allowH2: false,
-			connectTimeout: 0,
-			bodyTimeout: 123_456,
-			headersTimeout: 123_456,
-		});
+		const options = createHttpDispatcherOptions(123_456);
+		expect(options.allowH2).toBe(false);
+		expect(options.connectTimeout).toBe(0);
+		expect(options.bodyTimeout).toBe(123_456);
+		expect(options.headersTimeout).toBe(123_456);
+		// v0.80.3: attach undici error-suppressing factories so mid-stream
+		// client errors do not crash the process.
+		expect(typeof options.clientFactory).toBe("function");
+		expect(typeof options.factory).toBe("function");
 	});
 });

--- a/packages/coding-agent/test/image-process.test.ts
+++ b/packages/coding-agent/test/image-process.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { processImage } from "../src/utils/image-process.ts";
+import { detectSupportedImageMimeType } from "../src/utils/mime.ts";
+
+function createTinyBmp1x1Red24bpp(): Buffer {
+	const buffer = Buffer.alloc(58);
+	buffer.write("BM", 0, "ascii");
+	buffer.writeUInt32LE(buffer.length, 2);
+	buffer.writeUInt32LE(54, 10);
+	buffer.writeUInt32LE(40, 14);
+	buffer.writeInt32LE(1, 18);
+	buffer.writeInt32LE(1, 22);
+	buffer.writeUInt16LE(1, 26);
+	buffer.writeUInt16LE(24, 28);
+	buffer.writeUInt32LE(0, 30);
+	buffer.writeUInt32LE(4, 34);
+	buffer[56] = 0xff;
+	return buffer;
+}
+
+function expectPngMagic(base64Data: string): void {
+	const buffer = Buffer.from(base64Data, "base64");
+	expect(buffer[0]).toBe(0x89);
+	expect(buffer[1]).toBe(0x50);
+	expect(buffer[2]).toBe(0x4e);
+	expect(buffer[3]).toBe(0x47);
+}
+
+describe("image processing pipeline", () => {
+	it("detects BMP files from magic bytes", () => {
+		expect(detectSupportedImageMimeType(createTinyBmp1x1Red24bpp())).toBe("image/bmp");
+	});
+
+	it("converts BMP files to PNG attachments when auto-resize is disabled", async () => {
+		const result = await processImage(createTinyBmp1x1Red24bpp(), "image/bmp", { autoResizeImages: false });
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.mimeType).toBe("image/png");
+		expect(result.hints).toContain("[Image converted from image/bmp to image/png.]");
+		expectPngMagic(result.data);
+	});
+
+	it("converts BMP files before auto-resizing", async () => {
+		const result = await processImage(createTinyBmp1x1Red24bpp(), "image/bmp");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.mimeType).toBe("image/png");
+		expect(result.hints).toContain("[Image converted from image/bmp to image/png.]");
+		expectPngMagic(result.data);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-runtime-settings.test.ts
+++ b/packages/coding-agent/test/interactive-mode-runtime-settings.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveModeBase } from "../src/modes/interactive/interactive-mode-base.ts";
+import "../src/modes/interactive/interactive-session-runtime.ts";
+
+type SessionLike = { autoCompactionEnabled: boolean };
+type Setter<T> = (value: T) => void;
+
+interface RuntimeSettingsHarness {
+	footer: { setSession: Setter<SessionLike> };
+	usageMeter: { setSession: Setter<SessionLike>; setAutoCompactEnabled: Setter<boolean> };
+	footerDataProvider: { setCwd: Setter<string> };
+	session: SessionLike;
+	sessionManager: { getCwd: () => string };
+	hideThinkingBlock: boolean;
+	outputPad: 0 | 1;
+	settingsManager: {
+		getHideThinkingBlock: () => boolean;
+		getOutputPad: () => 0 | 1;
+		getShowHardwareCursor: () => boolean;
+		getClearOnShrink: () => boolean;
+		getEditorPaddingX: () => number;
+		getAutocompleteMaxVisible: () => number;
+	};
+	ui: { setShowHardwareCursor: Setter<boolean>; setClearOnShrink: Setter<boolean> };
+	defaultEditor: { setPaddingX: Setter<number>; setAutocompleteMaxVisible: Setter<number> };
+	editor: { setPaddingX?: Setter<number>; setAutocompleteMaxVisible?: Setter<number> };
+}
+
+const applyRuntimeSettings = InteractiveModeBase.prototype.applyRuntimeSettings as (this: RuntimeSettingsHarness) => void;
+
+describe("InteractiveMode runtime settings", () => {
+	it("reloads outputPad alongside other mutable runtime settings", () => {
+		const secondaryEditor = {
+			setPaddingX: vi.fn(),
+			setAutocompleteMaxVisible: vi.fn(),
+		};
+		const harness: RuntimeSettingsHarness = {
+			footer: { setSession: vi.fn() },
+			usageMeter: { setSession: vi.fn(), setAutoCompactEnabled: vi.fn() },
+			footerDataProvider: { setCwd: vi.fn() },
+			session: { autoCompactionEnabled: true },
+			sessionManager: { getCwd: () => "/repo" },
+			hideThinkingBlock: false,
+			outputPad: 1,
+			settingsManager: {
+				getHideThinkingBlock: () => true,
+				getOutputPad: () => 0,
+				getShowHardwareCursor: () => true,
+				getClearOnShrink: () => true,
+				getEditorPaddingX: () => 2,
+				getAutocompleteMaxVisible: () => 7,
+			},
+			ui: { setShowHardwareCursor: vi.fn(), setClearOnShrink: vi.fn() },
+			defaultEditor: { setPaddingX: vi.fn(), setAutocompleteMaxVisible: vi.fn() },
+			editor: secondaryEditor,
+		};
+
+		applyRuntimeSettings.call(harness);
+
+		expect(harness.hideThinkingBlock).toBe(true);
+		expect(harness.outputPad).toBe(0);
+		expect(harness.defaultEditor.setPaddingX).toHaveBeenCalledWith(2);
+		expect(secondaryEditor.setPaddingX).toHaveBeenCalledWith(2);
+		expect(secondaryEditor.setAutocompleteMaxVisible).toHaveBeenCalledWith(7);
+	});
+});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -391,7 +391,7 @@ describe("resolveCliModel", () => {
 });
 describe("default model selection", () => {
 	test("openai defaults track current models", () => {
-		expect(defaultModelPerProvider.openai).toBe("gpt-5.4");
+		expect(defaultModelPerProvider.openai).toBe("gpt-5.5");
 		expect(defaultModelPerProvider["openai-codex"]).toBe("gpt-5.5");
 	});
 	test("zai, minimax, cerebras, and ant-ling defaults track current models", () => {

--- a/packages/coding-agent/test/rpc-entry.test.ts
+++ b/packages/coding-agent/test/rpc-entry.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const RPC_ENTRY_SOURCE = readFileSync(new URL("../src/rpc-entry.ts", import.meta.url), "utf-8");
+
+describe("rpc-entry env marker and forced RPC mode", () => {
+	it("uses APP_NAME-based env marker (not hard-coded PI_CODING_AGENT)", () => {
+		expect(RPC_ENTRY_SOURCE).not.toContain("PI_CODING_AGENT");
+		expect(RPC_ENTRY_SOURCE).toContain("APP_NAME.toUpperCase()");
+	});
+
+	it("forces --mode rpc as the last argument so it cannot be overridden", () => {
+		// The main() call should append --mode rpc at the end so the last --mode wins.
+		expect(RPC_ENTRY_SOURCE).toMatch(/main\(\[\.\.\.process\.argv\.slice\(2\),\s*"--mode",\s*"rpc"\]\)/);
+	});
+});

--- a/packages/coding-agent/test/session-manager/custom-session-id.test.ts
+++ b/packages/coding-agent/test/session-manager/custom-session-id.test.ts
@@ -13,6 +13,11 @@ describe("SessionManager.newSession with custom id", () => {
 		expect(session.getSessionId()).toBe("my-custom-id");
 	});
 
+	it("uses a provided id for inMemory sessions (no-session --session-id)", () => {
+		const session = SessionManager.inMemory(process.cwd(), { id: "ephemeral-id" });
+		expect(session.getSessionId()).toBe("ephemeral-id");
+	});
+
 	it("allows alphanumeric session ids with interior punctuation", () => {
 		const session = SessionManager.inMemory();
 		session.newSession({ id: "abc-123_def.456" });

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -281,28 +281,19 @@ describe("SessionManager.setSessionFile with corrupted files", () => {
 		expect(header.id).toBe(sm.getSessionId());
 	});
 
-	it("truncates and rewrites file without valid header", () => {
+	it("rejects non-empty file without a valid session header instead of overwriting it", () => {
 		const noHeaderFile = join(tempDir, "no-header.jsonl");
 		// File with messages but no session header (corrupted state)
-		writeFileSync(
-			noHeaderFile,
-			'{"type":"message","id":"abc","parentId":"orphaned","timestamp":"2025-01-01T00:00:00Z","message":{"role":"assistant","content":"test"}}\n',
+		const originalContent =
+			'{"type":"message","id":"abc","parentId":"orphaned","timestamp":"2025-01-01T00:00:00Z","message":{"role":"assistant","content":"test"}}\n';
+		writeFileSync(noHeaderFile, originalContent);
+
+		expect(() => SessionManager.open(noHeaderFile, tempDir)).toThrow(
+			`Session file is not a valid pi session: ${noHeaderFile}`,
 		);
 
-		const sm = SessionManager.open(noHeaderFile, tempDir);
-
-		// Should have created a new session with valid header
-		expect(sm.getSessionId()).toBeTruthy();
-		expect(sm.getHeader()).toBeTruthy();
-		expect(sm.getHeader()?.type).toBe("session");
-
-		// File should now contain only a valid header (old content truncated)
-		const content = readFileSync(noHeaderFile, "utf-8");
-		const lines = content.trim().split("\n").filter(Boolean);
-		expect(lines.length).toBe(1);
-		const header = JSON.parse(lines[0]);
-		expect(header.type).toBe("session");
-		expect(header.id).toBe(sm.getSessionId());
+		// The corrupted file must be left untouched.
+		expect(readFileSync(noHeaderFile, "utf-8")).toBe(originalContent);
 	});
 
 	it("preserves explicit session file path when recovering from corrupted file", () => {
@@ -315,9 +306,9 @@ describe("SessionManager.setSessionFile with corrupted files", () => {
 		expect(sm.getSessionFile()).toBe(explicitPath);
 	});
 
-	it("subsequent loads of recovered file work correctly", () => {
+	it("subsequent loads of recovered empty file work correctly", () => {
 		const corruptedFile = join(tempDir, "corrupted.jsonl");
-		writeFileSync(corruptedFile, "garbage content\n");
+		writeFileSync(corruptedFile, "");
 
 		// First open recovers the file
 		const sm1 = SessionManager.open(corruptedFile, tempDir);

--- a/packages/coding-agent/test/session-manager/invalid-session-file.test.ts
+++ b/packages/coding-agent/test/session-manager/invalid-session-file.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+describe("SessionManager.open rejects invalid non-empty session files", () => {
+	it("throws a friendly error and preserves the original file content", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "atomic-invalid-session-"));
+		const sessionFile = join(tempDir, "not-a-session.log");
+		const originalContent = '{"type":"event","data":"not a session"}\n';
+		writeFileSync(sessionFile, originalContent);
+
+		expect(() => SessionManager.open(sessionFile, tempDir)).toThrow(
+			`Session file is not a valid pi session: ${sessionFile}`,
+		);
+		// The invalid file must not be modified or truncated.
+		expect(readFileSync(sessionFile, "utf8")).toBe(originalContent);
+	});
+
+	it("initializes a valid header for an empty file instead of throwing", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "atomic-empty-session-"));
+		const sessionFile = join(tempDir, "empty.jsonl");
+		writeFileSync(sessionFile, "");
+
+		const session = SessionManager.open(sessionFile, tempDir);
+		expect(session.getHeader()).not.toBeNull();
+		expect(session.getSessionId()).toBeDefined();
+	});
+});

--- a/packages/coding-agent/test/settings-ui-accessors.test.ts
+++ b/packages/coding-agent/test/settings-ui-accessors.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+
+describe("outputPad and externalEditor settings", () => {
+	const testDir = join(process.cwd(), "test-settings-ui-tmp");
+	const agentDir = join(testDir, "agent");
+	const projectDir = join(testDir, "project");
+
+	beforeEach(() => {
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true });
+		}
+		mkdirSync(agentDir, { recursive: true });
+		mkdirSync(join(projectDir, ".pi"), { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true });
+		}
+	});
+
+	it("defaults outputPad to 1 and clamps to 0 | 1", () => {
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getOutputPad()).toBe(1);
+		manager.setOutputPad(0);
+		expect(manager.getOutputPad()).toBe(0);
+		manager.setOutputPad(1);
+		expect(manager.getOutputPad()).toBe(1);
+	});
+
+	it("prefers externalEditor setting over env vars and platform default", () => {
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(settingsPath, JSON.stringify({ externalEditor: "code --wait" }));
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getExternalEditorCommand()).toBe("code --wait");
+	});
+
+	it("falls back to platform default when nothing is configured", () => {
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(settingsPath, JSON.stringify({}));
+		const manager = SettingsManager.create(projectDir, agentDir);
+		const cmd = manager.getExternalEditorCommand();
+		expect(typeof cmd).toBe("string");
+		expect(cmd.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/3686-session-name-event.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3686-session-name-event.test.ts
@@ -37,4 +37,25 @@ describe("regression #3686: session name changes emit an event", () => {
 		expect(harness.sessionManager.getSessionName()).toBe("from extension");
 		expect(harness.eventsOfType("session_info_changed").map((event) => event.name)).toEqual(["from extension"]);
 	});
+
+	it("emits session_info_changed to extensions", async () => {
+		let api: ExtensionAPI | undefined;
+		const events: Array<{ name: string | undefined }> = [];
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					api = pi;
+					pi.on("session_info_changed", (event) => {
+						events.push({ name: event.name });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		api?.setSessionName("first");
+		harness.session.setSessionName("second");
+
+		expect(events).toEqual([{ name: "first" }, { name: "second" }]);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/6162-extension-active-tools-next-turn.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6162-extension-active-tools-next-turn.test.ts
@@ -1,0 +1,134 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionFactory } from "../../../src/index.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+describe("regression #6162: extension active tools next-turn refresh", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("applies pi.setActiveTools before the next provider request in the same run", async () => {
+		const extensionFactories: ExtensionFactory[] = [
+			(pi) => {
+				pi.registerTool({
+					name: "switch_tools",
+					label: "Switch Tools",
+					description: "Switch the active extension tool set",
+					promptSnippet: "Switch to the next extension tool",
+					parameters: Type.Object({}),
+					execute: async () => {
+						pi.setActiveTools(["after_switch"]);
+						return {
+							content: [{ type: "text", text: "switched" }],
+							details: {},
+						};
+					},
+				});
+
+				pi.registerTool({
+					name: "after_switch",
+					label: "After Switch",
+					description: "Tool that should be available after switching",
+					promptSnippet: "Run after the active tool set changes",
+					parameters: Type.Object({}),
+					execute: async () => ({
+						content: [{ type: "text", text: "after" }],
+						details: {},
+					}),
+				});
+			},
+		];
+		const harness = await createHarness({ extensionFactories });
+		harnesses.push(harness);
+
+		harness.session.setActiveToolsByName(["switch_tools"]);
+
+		const providerToolNames: string[][] = [];
+		harness.setResponses([
+			(context) => {
+				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());
+				return fauxAssistantMessage(fauxToolCall("switch_tools", {}), { stopReason: "toolUse" });
+			},
+			(context) => {
+				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());
+				return fauxAssistantMessage("done");
+			},
+		]);
+
+		expect(harness.session.getActiveToolNames()).toEqual(["switch_tools"]);
+
+		await harness.session.prompt("start");
+
+		expect(harness.session.getActiveToolNames()).toEqual(["after_switch"]);
+		expect(providerToolNames).toEqual([["switch_tools"], ["after_switch"]]);
+	});
+
+	it("preserves before_agent_start system prompt overrides when tools change mid-run", async () => {
+		const extensionFactories: ExtensionFactory[] = [
+			(pi) => {
+				pi.on("before_agent_start", async (event) => ({
+					systemPrompt: `${event.systemPrompt}\n\nkeep this run override`,
+				}));
+
+				pi.registerTool({
+					name: "switch_tools",
+					label: "Switch Tools",
+					description: "Switch the active extension tool set",
+					promptSnippet: "Switch to the next extension tool",
+					parameters: Type.Object({}),
+					execute: async () => {
+						pi.setActiveTools(["after_switch"]);
+						return {
+							content: [{ type: "text", text: "switched" }],
+							details: {},
+						};
+					},
+				});
+
+				pi.registerTool({
+					name: "after_switch",
+					label: "After Switch",
+					description: "Tool that should be available after switching",
+					promptSnippet: "Run after the active tool set changes",
+					parameters: Type.Object({}),
+					execute: async () => ({
+						content: [{ type: "text", text: "after" }],
+						details: {},
+					}),
+				});
+			},
+		];
+		const harness = await createHarness({ extensionFactories });
+		harnesses.push(harness);
+
+		harness.session.setActiveToolsByName(["switch_tools"]);
+
+		const providerSystemPrompts: string[] = [];
+		const providerToolNames: string[][] = [];
+		harness.setResponses([
+			(context) => {
+				providerSystemPrompts.push(context.systemPrompt ?? "");
+				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());
+				return fauxAssistantMessage(fauxToolCall("switch_tools", {}), { stopReason: "toolUse" });
+			},
+			(context) => {
+				providerSystemPrompts.push(context.systemPrompt ?? "");
+				providerToolNames.push((context.tools ?? []).map((tool) => tool.name).sort());
+				return fauxAssistantMessage("done");
+			},
+		]);
+
+		await harness.session.prompt("start");
+
+		expect(providerToolNames).toEqual([["switch_tools"], ["after_switch"]]);
+		expect(providerSystemPrompts).toHaveLength(2);
+		expect(providerSystemPrompts[0]).toContain("keep this run override");
+		expect(providerSystemPrompts[1]).toContain("keep this run override");
+	});
+});

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -42,6 +42,6 @@
   "dependencies": {
     "@bastani/atomic-natives": "0.0.0",
     "@bufbuild/protobuf": "^2.0.0",
-    "@earendil-works/pi-ai": "^0.80.2"
+    "@earendil-works/pi-ai": "^0.80.3"
   }
 }

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-tui": "^0.80.2"
+    "@earendil-works/pi-tui": "^0.80.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -32,8 +32,8 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-ai": "^0.80.2",
-    "@earendil-works/pi-tui": "^0.80.2",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -38,9 +38,9 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-agent-core": "^0.80.2",
-    "@earendil-works/pi-ai": "^0.80.2",
-    "@earendil-works/pi-tui": "^0.80.2"
+    "@earendil-works/pi-agent-core": "^0.80.3",
+    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-tui": "^0.80.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {

--- a/packages/web-access/package.json
+++ b/packages/web-access/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-tui": "^0.80.2"
+    "@earendil-works/pi-tui": "^0.80.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -83,7 +83,7 @@
   },
   "peerDependencies": {
     "@bastani/atomic": "*",
-    "@earendil-works/pi-tui": "^0.80.2"
+    "@earendil-works/pi-tui": "^0.80.3"
   },
   "peerDependenciesMeta": {
     "@bastani/atomic": {


### PR DESCRIPTION
## Summary

Syncs Atomic with upstream Pi v0.80.3 while preserving Atomic branding, `@bastani/*` package names, versionless `0.0.0` manifests, and bundled first-party extensions.

## Changes

- Bumps `@earendil-works/pi-agent-core`, `@earendil-works/pi-ai`, and `@earendil-works/pi-tui` pins to `^0.80.3` across the coding-agent package and bundled extensions, with regenerated Bun lockfile, npm lockfile, and coding-agent shrinkwrap.
- Ports relevant Pi v0.80.3 runtime/features:
  - RPC `get_entries` / `get_tree` support plus `RpcClient.getEntries`/`getTree` helpers
  - Dedicated `rpc-entry` package export for launching Atomic directly in RPC mode (using Atomic's `ATOMIC_CODING_AGENT` env marker and a forced `--mode rpc`)
  - `session_info_changed` extension event wired through `AgentSession.setSessionName`
  - `externalEditor` settings.json override for Ctrl+G, with OS-specific defaults
  - `outputPad` setting controlling horizontal padding for user/assistant/thinking blocks
  - BMP image detection and shared `processImage`/`convertImageBytesToPng` helpers to normalize unsupported image formats to PNG
  - Invalid-session-file handling that prints a clean error instead of a stack trace and refuses to overwrite non-empty invalid files
  - `--no-session --session-id` for deterministic session IDs on ephemeral CLI runs
  - Visible incomplete-response messaging when output is stopped by length
  - Undici mid-stream client-error suppression to prevent crashes on early stream termination
  - Timing namespaces separating extension-load timings from main startup timings
  - `setActiveTools` changes now apply before the next provider request via a `prepareNextTurnWithContext` hook
- Preserves existing Atomic-specific fixes from current `main` (Copilot env-token routing, compaction continuation, patched Pier eval dependency, release notes) and documents intentional deferrals (shared retry classifier, status-indicator TUI refactor) as follow-up work.
- Documents the sync under `[Unreleased]` in `packages/coding-agent/CHANGELOG.md` and updates user-facing docs (`extensions.md`, `rpc.md`, `settings.md`) and tests.

## Validation

- `AGENT=1 bun run --cwd packages/coding-agent test -- test/interactive-mode-runtime-settings.test.ts`
- `AGENT=1 bun run typecheck`
- `bun run check:file-length`
- `bun run check:shrinkwrap`
- `AGENT=1 bun run test:unit` — 2793 pass / 0 fail
- pre-push hooks passed (`bun run lint`, `bun run check:file-length`, `bun run test:unit`)

## Notes

A few upstream refactors were intentionally deferred because Atomic has diverged in those areas and they need dedicated follow-up validation: shared retry classifier adoption, the broader status-indicator TUI refactor, and minor startup/resource notification differences.