### PR TITLE
docs(release): add changelog entries for 0.9.4-alpha.6

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
 ### Added
 
 - Added `get_entries` and `get_tree` RPC commands for reading session entries and tree snapshots over RPC, with corresponding `RpcClient.getEntries`/`getTree` helpers and response types (inherited from upstream Pi [#6078](https://github.com/earendil-works/pi/pull/6078)).

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
+### Changed
+
+- Aligned the Cursor provider dependency with upstream pi-ai `^0.80.3`; no Cursor provider source changes were needed for this metadata sync.
+
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
+### Changed
+
+- Aligned the intercom extension peer dependency with upstream pi TUI `^0.80.3`; no intercom extension source changes were needed for this metadata sync.
+
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
+### Changed
+
+- Aligned the MCP extension peer dependencies with upstream pi AI/TUI `^0.80.3`; no MCP extension source changes were needed for this metadata sync.
+
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
+### Changed
+
+- Published a synchronized Atomic 0.9.4-alpha.6 prerelease for the native transport package; no native transport changes were made after 0.9.4-alpha.1.
+
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
+### Changed
+
+- Aligned the subagents extension peer dependencies with upstream pi `^0.80.3` runtime packages; no subagents extension source changes were needed for this metadata sync.
+
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
+### Changed
+
+- Aligned the web-access extension peer dependency with upstream pi TUI `^0.80.3`; no web-access extension source changes were needed for this metadata sync.
+
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.6] - 2026-07-01
+
+### Changed
+
+- Aligned the workflows extension peer dependency with upstream pi TUI `^0.80.3`; no workflows extension source changes were needed for this metadata sync.
+
 ## [0.9.4-alpha.5] - 2026-07-01
 
 ### Changed


### PR DESCRIPTION
## Summary

Release-notes-only PR that stamps the `## [Unreleased]` changelog sections as `## [0.9.4-alpha.6] - 2026-07-01` across all eight workspace packages. No source code, dependency versions, or `package.json` versions change — `main` stays versionless with every `packages/*/package.json` at the `0.0.0` placeholder, per the repo's versionless-`main` release flow.

## Changes

- `packages/coding-agent/CHANGELOG.md` — versions the existing `Added` entry (RPC `get_entries`/`get_tree` commands, inherited from upstream Pi #6078) under `0.9.4-alpha.6`.
- `packages/cursor/CHANGELOG.md` — notes the Cursor provider dependency alignment with upstream `pi-ai` `^0.80.3`.
- `packages/intercom/CHANGELOG.md` — notes the intercom extension peer dependency alignment with upstream pi TUI `^0.80.3`.
- `packages/mcp/CHANGELOG.md` — notes the MCP extension peer dependency alignment with upstream pi AI/TUI `^0.80.3`.
- `packages/natives/CHANGELOG.md` — records the synchronized prerelease publish for the native transport package (no native transport changes since `0.9.4-alpha.1`).
- `packages/subagents/CHANGELOG.md` — notes the subagents extension peer dependency alignment with upstream pi `^0.80.3` runtime packages.
- `packages/web-access/CHANGELOG.md` — notes the web-access extension peer dependency alignment with upstream pi TUI `^0.80.3`.
- `packages/workflows/CHANGELOG.md` — notes the workflows extension peer dependency alignment with upstream pi TUI `^0.80.3`.

## Test plan

- [x] `git status --short` clean before push
- [x] Pre-push hooks passed (`bun run lint`, `bun run check:file-length`, `bun run test:unit`)
- [x] `git diff --name-only` confirms only the eight `CHANGELOG.md` files changed