### PR TITLE
ci: switch Claude workflows to fable model

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,5 +36,5 @@ jobs:
                   claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
                   # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   claude_args: |
-                      --model opus
+                      --model fable
                       --allowedTools "Bash(*)"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -35,5 +35,5 @@ jobs:
                       Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
                   claude_args: |
-                      --model opus
+                      --model fable
                       --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"


### PR DESCRIPTION
## Summary

Switches both Claude GitHub Actions workflows from the `opus` model alias to `fable`.

## Changes

- `.github/workflows/claude.yml`: sets `--model fable` for the general Claude workflow (also adds the missing trailing newline).
- `.github/workflows/code-review.yml`: sets `--model fable` for the code-review Claude workflow.
- Preserves the existing allowed Bash/GitHub CLI tool restrictions in both workflows.

## Notes

Validation ran through the repository git hooks during commit and push, including YAML checks, `bun run lint`, `bun run check:file-length`, and `bun run test:unit`.