### PR TITLE
fix(deps): revert @types/node bump and ignore it in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
       labels:
           - "dependencies"
           - "bun"
+      ignore:
+          # @types/node is pinned via a root `overrides` entry to match
+          # upstream Pi's resolved lockfile (see #1489); bumps here are no-ops.
+          - dependency-name: "@types/node"
 
     # Rust crates (workspace)
     - package-ecosystem: "cargo"

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "@types/diff": "7.0.2",
         "@types/hosted-git-info": "3.0.5",
         "@types/ms": "2.1.0",
-        "@types/node": "26.0.1",
+        "@types/node": "24.12.4",
         "@types/proper-lockfile": "4.1.4",
         "@types/semver": "7.7.1",
         "@typescript/native-preview": "7.0.0-dev.20260511.1",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Reverted the `@types/node` devDependency from `26.0.1` back to `24.12.4` to match the deliberate root `overrides` pin that aligns with upstream Pi's resolved lockfile (see [#1489](https://github.com/bastani-inc/atomic/pull/1489)); the dependabot bump in [#1548](https://github.com/bastani-inc/atomic/pull/1548) was a semantic no-op because the override forced resolution to `24.12.4`. Dependabot now ignores `@types/node` so it stops proposing inert bumps.
 - Fixed the `read` tool to parse colon-delimited `file:START:END` (and grep-style `file:LINE:COL`) path selectors as a line range instead of leaving the leading number glued to the path (`file:395`), which produced a bogus `ENOENT` and pushed models (e.g. Opus) to fall back to `sed` ([#1585](https://github.com/bastani-inc/atomic/issues/1585)).
 - Fixed GitHub Copilot models to use the live `max_output_tokens` value from the Copilot model catalog, preventing `github-copilot/claude-opus-4.8` from being capped by Atomic's stale built-in output-token limit after compaction ([#1582](https://github.com/bastani-inc/atomic/issues/1582)).
 - Fixed active GitHub Copilot sessions to adopt live catalog model metadata as soon as the catalog loads, so fallback models refresh their supported reasoning levels without requiring a restart.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -122,7 +122,7 @@
     "@types/diff": "7.0.2",
     "@types/hosted-git-info": "3.0.5",
     "@types/ms": "2.1.0",
-    "@types/node": "26.0.1",
+    "@types/node": "24.12.4",
     "@types/proper-lockfile": "4.1.4",
     "@types/semver": "7.7.1",
     "@typescript/native-preview": "7.0.0-dev.20260511.1",


### PR DESCRIPTION
## Summary

The dependabot bump of `@types/node` to `26.0.1` (#1548) was a **semantic no-op**: the root `package.json` carries a deliberate `overrides` pin at `24.12.4` (added in #1489) to match upstream Pi's resolved lockfile, so the installed copy never actually changed. Upstream Pi 0.80.3 still pins `24.12.4`.

## Changes

- Revert the `packages/coding-agent` devDependency `@types/node` from `26.0.1` back to `24.12.4` so the manifest matches the effective resolution
- Add a dependabot `ignore` rule for `@types/node` (bun ecosystem) so it stops proposing inert bumps; the pin should only move when intentionally re-synced with upstream Pi
- Regenerate `bun.lock` to match
- Add a changelog entry documenting the revert and the reasoning

## Validation

- `bun install` (lockfile regenerated, no hand edits)
- `bun run typecheck`, `bun run lint`, `bun run check:file-length`, `bun run test:unit` — all pass (via pre-commit hooks)