### PR TITLE
docs(changelog): stamp release notes for 0.9.4-alpha.7

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.7] - 2026-07-02
+
 ### Added
 
 - Added dynamic GitHub Copilot model population from the live CAPI `/models` catalog: picker-enabled, non-disabled plain chat ids are synthesized from catalog metadata (endpoints, capabilities, limits, and display names) while built-in `pi-ai` definitions still win, namespaced enterprise deployments such as `org/deployment/model` are skipped, and cached catalog metadata enables the same models on cold start.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.7] - 2026-07-02
+
 ### Fixed
 
 - Fixed subagent model fallback so request/context incompatibility failures (HTTP 400/413/422 bad/unprocessable/payload-too-large request, unsupported tool/parameter, context-length/context-window overflow, `invalid_request`/`bad_request`/`too_large` errors) advance the chain to the next candidate instead of stopping. When none of the configured candidates can serve the request, the subagent now falls back to the current user-selected model. Refusals, content-filter/safety blocks, cancellations, and task failures still stop the chain ([#1580](https://github.com/bastani-inc/atomic/issues/1580)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.7] - 2026-07-02
+
 ### Fixed
 
 - Fixed workflow stage model fallback so request/context incompatibility failures (HTTP 400/413/422 bad/unprocessable/payload-too-large request, unsupported tool/parameter, context-length/context-window overflow, `invalid_request`/`bad_request`/`too_large` errors) advance the chain to the next candidate instead of stopping. When none of the configured candidates can serve the request, the stage now falls back to the current user-selected model. Refusals, content-filter/safety blocks, cancellations, and task failures still stop the chain ([#1580](https://github.com/bastani-inc/atomic/issues/1580)).


### PR DESCRIPTION
## Release 0.9.4-alpha.7

Changelog-only release-notes PR that stamps the `[Unreleased]` sections into `## [0.9.4-alpha.7] - 2026-07-02` ahead of cutting the prerelease tag. No version bump on `main` — every `packages/*/package.json` stays at the `0.0.0` placeholder; the real version is materialized only on the throwaway off-`main` tag commit produced by `scripts/cut-release.ts` (tag `0.9.4-alpha.7`, no leading `v`), which is never merged back.

- **Release kind:** prerelease (`0.9.4-alpha.7` → npm `@next`)
- **Base:** `main`
- **Head:** `prerelease/0.9.4-alpha.7` @ `c11f1ca506aa79b02a8580b193a1f2ed9a9aa778`

### Changed files

- `packages/coding-agent/CHANGELOG.md` — stamps `## [0.9.4-alpha.7] - 2026-07-02`; documents dynamic GitHub Copilot model population from the live CAPI `/models` catalog (picker-enabled plain chat ids synthesized from catalog metadata, built-in `pi-ai` definitions still win, namespaced enterprise deployments skipped, cached catalog metadata enables models on cold start).
- `packages/subagents/CHANGELOG.md` — stamps `## [0.9.4-alpha.7] - 2026-07-02`; documents the subagent model-fallback fix so request/context incompatibility failures (HTTP 400/413/422, unsupported tool/parameter, context-window overflow) advance to the next candidate, falling back to the user-selected model when candidates are exhausted ([#1580](https://github.com/bastani-inc/atomic/issues/1580)).
- `packages/workflows/CHANGELOG.md` — stamps `## [0.9.4-alpha.7] - 2026-07-02`; documents the same model-fallback fix applied to workflow stage execution ([#1580](https://github.com/bastani-inc/atomic/issues/1580)).

Already-released changelog sections were not modified.

### Validation

- `git diff origin/main...HEAD` → 3 CHANGELOG.md files, 6 lines added, no other changes
- `bun run typecheck` → pass
- `bun run test:unit` → pass
- prek pre-push hooks (lint, file-length, unit tests, merge-conflict/large-file/private-key checks) → pass