### PR TITLE
docs(evals): document Deep SWE timeout multiplier and smoke/full-run recipes

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -12,6 +12,50 @@ Common options:
 - `--agent-kwarg thinking=xhigh` configures Atomic's reasoning level for models that support it.
 - `--n-tasks` and `--include-task-name` control which Deep SWE tasks run.
 
+## Timeouts
+
+Deep SWE tasks set `[agent] timeout_sec = 5400.0` (1.5 hours) in each `task.toml`. Pass `--agent-timeout-multiplier 16` to raise the agent deadline to 1 day (5400 × 16 = 86,400 s) without modifying the tasks; the commands below include it. The multiplier only scales the agent execution timeout — verifier, agent-setup, and environment-build timeouts are unaffected. Pier has no flag to disable the timeout entirely (a multiplier of `0` times out immediately), so a large multiplier is the supported way to run effectively untimed. The same flag works for Harbor runs with `atomic_harbor:Atomic`.
+
+## Smoke check (1 task, full debug logging)
+
+Use this before a long run to validate provider credentials, the sandbox install, and log capture. It runs a single deterministic task serially with Pier's debug logging enabled (`--debug` is Pier's only log-verbosity flag; `--n-concurrent 1` keeps the console output readable, and `--job-name` pins a predictable output directory):
+
+```bash
+uv run pier run \
+  -p deep-swe/tasks \
+  --agent-import-path atomic_pier:Atomic \
+  --model github-copilot/gpt-5.5 \
+  --agent-kwarg thinking=xhigh \
+  --agent-kwarg version=next \
+  --agent-timeout-multiplier 16 \
+  --job-name atomic-smoke \
+  --n-tasks 1 \
+  --sample-seed 0 \
+  --n-concurrent 1 \
+  --debug
+```
+
+Inspect the results under `jobs/atomic-smoke/`: each trial directory contains the agent logs (including Atomic's full JSON stream in `agent/atomic.txt` and session transcripts in `agent/atomic-sessions/`), `trajectory.json`, verifier output, and any exception message. Swap the model/provider flags per the Providers section below.
+
+## Full benchmark
+
+Run every Deep SWE task (omit `--n-tasks` to run all tasks in the path):
+
+```bash
+uv run pier run \
+  -p deep-swe/tasks \
+  --agent-import-path atomic_pier:Atomic \
+  --model github-copilot/gpt-5.5 \
+  --agent-kwarg thinking=xhigh \
+  --agent-kwarg version=next \
+  --agent-timeout-multiplier 16 \
+  --job-name atomic-deep-swe \
+  --n-concurrent 4 \
+  --sample-seed 0
+```
+
+Add `--n-attempts <k>` for pass@k-style repeats. Sizing `--n-concurrent`: each trial's containers are capped at 2 CPUs / 8 GB but typically peak at 2–4 GB, so give the Docker VM at least **4 GB of memory and 2 CPUs per concurrent trial** (e.g. `--n-concurrent 4` wants a ≥ 16 GB / 8-CPU Docker VM); Pier does not schedule against host capacity, and overcommitting memory surfaces as confusing mid-run OOM kills. A single Copilot token also tends to rate-limit beyond ~4–6 concurrent agents. Interrupted jobs resume where they left off: re-run the same command with the same `--job-name` (the config must match), or use `uv run pier job resume -p jobs/atomic-deep-swe`.
+
 ## Providers
 
 ### GitHub Copilot
@@ -27,6 +71,7 @@ uv run pier run \
   --model github-copilot/gpt-5.5 \
   --agent-kwarg thinking=xhigh \
   --agent-kwarg version=next \
+  --agent-timeout-multiplier 16 \
   --n-tasks 1 \
   --sample-seed 0
 ```
@@ -52,6 +97,7 @@ uv run pier run \
   --agent-kwarg thinking=xhigh \
   --agent-kwarg version=next \
   --agent-env COPILOT_API_TARGET=api.githubcopilot.com \
+  --agent-timeout-multiplier 16 \
   --n-tasks 1 \
   --sample-seed 0
 ```
@@ -71,6 +117,7 @@ uv run pier run \
   --model openrouter/openai/gpt-5.5 \
   --agent-kwarg thinking=xhigh \
   --agent-kwarg version=next \
+  --agent-timeout-multiplier 16 \
   --n-tasks 1 \
   --sample-seed 0
 ```


### PR DESCRIPTION
## Summary

Documents how to run Deep SWE evals with Atomic effectively untimed (agent deadline extended to 1 day) without modifying the vendored task files, and adds ready-to-copy smoke-check and full-benchmark commands to `evals/README.md`.

## Changes

- **Timeouts section**: Deep SWE tasks pin `[agent] timeout_sec = 5400.0` (1.5 h) and Pier/Harbor expose no disable flag (a multiplier of `0` times out immediately; `override_timeout_sec` falls back to the task value when falsy), so `--agent-timeout-multiplier 16` (5400 × 16 = 86,400 s = 1 day) is documented as the supported approach and added to every example command. Works identically for `atomic_pier:Atomic` and `atomic_harbor:Atomic`.
- **Smoke check recipe**: single deterministic task (`--n-tasks 1 --sample-seed 0`) run serially with Pier's debug logging (`--debug`, its only log-verbosity flag) and a pinned `--job-name`, plus pointers to the debug artifacts (`agent/atomic.txt` JSON stream, `agent/atomic-sessions/` transcripts, `trajectory.json`, verifier output, exception messages).
- **Full benchmark recipe**: runs all Deep SWE tasks with `--n-concurrent 4`, plus `--n-attempts <k>` for pass@k, concurrency sizing guidance (≥ 4 GB Docker VM memory + 2 CPUs per concurrent trial; Pier does not schedule against host capacity; a single Copilot token rate-limits beyond ~4–6 agents), and resume instructions (same `--job-name`/config or `pier job resume -p jobs/<name>`).

## Notes

- Docs-only change; no adapter (`atomic_pier.py`/`atomic_harbor.py`), vendored Pier, or `deep-swe` task files were modified.
- All flags and behaviors were verified against the vendored Pier source (`cli/jobs.py`, `trial/execution.py`, `job.py`) and the installed Harbor 0.16.0 package, including a runtime check that the multiplier resolves `5400 → 86,400 s`.