### PR TITLE
docs(workflows): stamp changelog for 0.9.4-alpha.8

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.8] - 2026-07-02
+
 ### Changed
 
 - Changed the Claude Fable 5 reasoning level from `xhigh` to `high` across all builtin workflow model chains (`ralph` prompt-engineer/reviewer-a/reviewer-b/reviewer-c, `goal` reviewer, `deep-research-codebase` planner, and `open-claude-design`), covering both the native `anthropic/claude-fable-5` entries and their OpenRouter mirrors.


### PR DESCRIPTION
## Release 0.9.4-alpha.8

- **Release kind:** prerelease (`@next` dist-tag)
- **Version / tag:** `0.9.4-alpha.8` (no leading `v`)
- **Base branch:** `main`
- **Head:** `prerelease/0.9.4-alpha.8` @ `9dddfd825d362f36754c0dbbb659255e3d36b22b`

### Changes (changelog-only, no version bumps)

Stamps the `## [0.9.4-alpha.8] - 2026-07-02` section in `packages/workflows/CHANGELOG.md` from `[Unreleased]`:

- **Changed:** Claude Fable 5 reasoning level from `xhigh` to `high` across all builtin workflow model chains (`ralph` prompt-engineer/reviewer-a/reviewer-b/reviewer-c, `goal` reviewer, `deep-research-codebase` planner, and `open-claude-design`), covering both native `anthropic/claude-fable-5` entries and their OpenRouter mirrors.

`main` stays versionless — all `packages/*/package.json` remain at the `0.0.0` placeholder. The real version is materialized only on the throwaway off-`main` tag commit produced by `scripts/cut-release.ts` after this PR merges.

### Validation

- `git status --short` → clean
- `git diff --name-only fc39e4b8..HEAD` → `packages/workflows/CHANGELOG.md` only
- `bun run typecheck` → passed
- `bun run test:unit` → passed
- prek pre-push hooks (lint, file-length, unit tests, etc.) → passed