### PR TITLE
fix(ci): exempt @earendil-works/pi-ai from Bun minimum-release-age gate

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,6 +2,8 @@ telemetry = false
 
 [install]
 minimumReleaseAge = 259200 # 3 days in seconds
+# Trusted first-party upstream; exempt from the age gate (its releases are consumed same-day)
+minimumReleaseAgeExcludes = ["@earendil-works/pi-ai"]
 linker = "hoisted"
 exact = true
 saveTextLockfile = true


### PR DESCRIPTION
## Summary
Publish runs for tags `0.9.4-alpha.6`, `0.9.4-alpha.7`, and `0.9.4-alpha.8` all failed at `bun install` with:

```
error: No version matching "@earendil-works/pi-ai" found for specifier "^0.80.3" (blocked by minimum-release-age: 259200 seconds)
```

`@earendil-works/pi-ai@0.80.3` was published 2026-06-30T20:34Z and doesn't clear the repo's 3-day `minimumReleaseAge` gate until 2026-07-03T20:34Z, so every CI job that installs dependencies fails.

## Fix
Add `install.minimumReleaseAgeExcludes = ["@earendil-works/pi-ai"]` to `bunfig.toml`. pi-ai is our trusted first-party upstream and its releases are consumed same-day; the age gate remains active for all other dependencies.

## Validation
- Isolated repro: `bun add @earendil-works/pi-ai@^0.80.3` with this bunfig succeeds; without the exclusion it reproduces the exact CI error.
- prek hooks (lint, file-length, unit tests) passed on commit.

After merge, the stale `0.9.4-alpha.8` tag will be deleted and re-cut so the Publish workflow picks up the fixed config.