### PR TITLE
docs(evals): force-rebuild pier images and persist smoke-check containers

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -9,6 +9,7 @@ Run commands from this `evals/` directory. Choose one provider configuration bel
 Common options:
 
 - `--agent-kwarg version=next` installs `@bastani/atomic@next` inside the sandbox. Omit it for `@latest`, or pass a concrete npm version/tag without the leading `@` (for example `--agent-kwarg version=0.9.3-alpha.1`).
+- `--force-build` rebuilds the task image so the `npm install -g @bastani/atomic@...` layer re-runs. Without it, Docker layer caching reuses a previously installed Atomic even after a new version is published to the tag, so benchmark runs can silently test a stale build. All commands below include it.
 - `--agent-kwarg thinking=xhigh` configures Atomic's reasoning level for models that support it.
 - `--n-tasks` and `--include-task-name` control which Deep SWE tasks run.
 
@@ -18,7 +19,7 @@ Deep SWE tasks set `[agent] timeout_sec = 5400.0` (1.5 hours) in each `task.toml
 
 ## Smoke check (1 task, full debug logging)
 
-Use this before a long run to validate provider credentials, the sandbox install, and log capture. It runs a single deterministic task serially with Pier's debug logging enabled (`--debug` is Pier's only log-verbosity flag; `--n-concurrent 1` keeps the console output readable, and `--job-name` pins a predictable output directory):
+Use this before a long run to validate provider credentials, the sandbox install, and log capture. It runs a single deterministic task serially with Pier's debug logging enabled (`--debug` is Pier's only log-verbosity flag; `--n-concurrent 1` keeps the console output readable, and `--job-name` pins a predictable output directory). `--no-delete` persists the trial containers after completion so you can inspect the sandbox state post-mortem (remove them manually with `docker rm` when done):
 
 ```bash
 uv run pier run \
@@ -32,6 +33,8 @@ uv run pier run \
   --n-tasks 1 \
   --sample-seed 0 \
   --n-concurrent 1 \
+  --force-build \
+  --no-delete \
   --debug
 ```
 
@@ -51,7 +54,8 @@ uv run pier run \
   --agent-timeout-multiplier 16 \
   --job-name atomic-deep-swe \
   --n-concurrent 4 \
-  --sample-seed 0
+  --sample-seed 0 \
+  --force-build
 ```
 
 Add `--n-attempts <k>` for pass@k-style repeats. Sizing `--n-concurrent`: each trial's containers are capped at 2 CPUs / 8 GB but typically peak at 2–4 GB, so give the Docker VM at least **4 GB of memory and 2 CPUs per concurrent trial** (e.g. `--n-concurrent 4` wants a ≥ 16 GB / 8-CPU Docker VM); Pier does not schedule against host capacity, and overcommitting memory surfaces as confusing mid-run OOM kills. A single Copilot token also tends to rate-limit beyond ~4–6 concurrent agents. Interrupted jobs resume where they left off: re-run the same command with the same `--job-name` (the config must match), or use `uv run pier job resume -p jobs/atomic-deep-swe`.
@@ -73,7 +77,8 @@ uv run pier run \
   --agent-kwarg version=next \
   --agent-timeout-multiplier 16 \
   --n-tasks 1 \
-  --sample-seed 0
+  --sample-seed 0 \
+  --force-build
 ```
 
 The Atomic Pier adapter reads `COPILOT_GITHUB_TOKEN` from the Pier process environment and passes it into the sandbox for Atomic. If your launcher does not inherit shell exports, pass it explicitly with `--agent-env COPILOT_GITHUB_TOKEN=...` instead.
@@ -99,7 +104,8 @@ uv run pier run \
   --agent-env COPILOT_API_TARGET=api.githubcopilot.com \
   --agent-timeout-multiplier 16 \
   --n-tasks 1 \
-  --sample-seed 0
+  --sample-seed 0 \
+  --force-build
 ```
 
 For GHES use `COPILOT_API_TARGET=api.enterprise.githubcopilot.com`; for GHEC use `COPILOT_API_TARGET=copilot-api.<tenant>.ghe.com`.
@@ -119,7 +125,8 @@ uv run pier run \
   --agent-kwarg version=next \
   --agent-timeout-multiplier 16 \
   --n-tasks 1 \
-  --sample-seed 0
+  --sample-seed 0 \
+  --force-build
 ```
 
 The Atomic Pier adapter reads `OPENROUTER_API_KEY` from the Pier process environment and passes it into the sandbox for Atomic. If your launcher does not inherit shell exports, pass it explicitly with `--agent-env OPENROUTER_API_KEY=...` instead.


### PR DESCRIPTION
## Summary

Ensure benchmark runs always install the latest published Atomic build, and make the smoke-check run easier to debug post-mortem.

## Changes

- Added `--force-build` to all five `pier run` commands in `evals/README.md` (smoke check, full benchmark, and the three Copilot/OpenRouter examples) — Docker layer caching pins the `npm install -g @bastani/atomic@...` layer, so without a forced rebuild, runs can silently benchmark a stale Atomic even after a new version is published to the `next`/`latest` tag (the `PIER_AGENT_INSTALL_FINGERPRINT` build arg does not change when a dist-tag moves).
- Documented the rationale for `--force-build` in the "Common options" section.
- Added `--no-delete` to the smoke-check command so trial containers persist after completion for post-mortem inspection, with a note about cleaning them up manually via `docker rm`.

## Notes

Docs-only change (`evals/README.md`); no code affected.