### PR TITLE
chore: add deepwiki MCP server config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,9 +85,14 @@ jobs:
 
                   # --version exits before builtin extensions are loaded. Start the
                   # non-interactive runtime far enough to surface extension diagnostics,
-                  # but allow the expected no-models exit in CI.
+                  # but allow the expected no-models exit in CI. Run from a clean temp
+                  # cwd so repo-local config (e.g. .mcp.json) can't leak into the smoke
+                  # run and hang startup.
+                  work_dir="$RUNNER_TEMP/atomic-linux-binary-smoke-cwd"
+                  rm -rf "$work_dir"
+                  mkdir -p "$work_dir"
                   set +e
-                  output=$(printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
+                  output=$(cd "$work_dir" && printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
                   status=$?
                   set -e
                   echo "$output"
@@ -164,9 +169,16 @@ jobs:
 
                   # --version exits before builtin extensions are loaded. Start the
                   # non-interactive runtime far enough to surface extension diagnostics,
-                  # but allow the expected no-models exit in CI.
+                  # but allow the expected no-models exit in CI. Run from a clean temp
+                  # cwd so repo-local config (e.g. .mcp.json) can't leak into the smoke
+                  # run and hang startup.
+                  $workDir = Join-Path $env:RUNNER_TEMP "atomic-windows-binary-smoke-cwd"
+                  Remove-Item -Recurse -Force $workDir -ErrorAction SilentlyContinue
+                  New-Item -ItemType Directory -Path $workDir | Out-Null
+                  Push-Location $workDir
                   $output = "" | & $atomic --no-session 2>&1 | Out-String
                   $status = $LASTEXITCODE
+                  Pop-Location
                   Write-Host $output
                   if ($output -match "Failed to load extension") {
                     exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,8 +95,13 @@ jobs:
                       exit 1
                     }
                   done
+                  # Run from a clean temp cwd so repo-local config (e.g. .mcp.json)
+                  # can't leak into the smoke run and hang startup.
+                  work_dir="$RUNNER_TEMP/atomic-binary-smoke-cwd"
+                  rm -rf "$work_dir"
+                  mkdir -p "$work_dir"
                   set +e
-                  output=$(printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
+                  output=$(cd "$work_dir" && printf '' | "$smoke_dir/atomic/atomic" --no-session 2>&1)
                   status=$?
                   set -e
                   echo "$output"
@@ -145,8 +150,15 @@ jobs:
                       throw "Missing release archive path: $requiredPath"
                     }
                   }
+                  # Run from a clean temp cwd so repo-local config (e.g. .mcp.json)
+                  # can't leak into the smoke run and hang startup.
+                  $workDir = Join-Path $env:RUNNER_TEMP "atomic-binary-smoke-cwd"
+                  Remove-Item -Recurse -Force $workDir -ErrorAction SilentlyContinue
+                  New-Item -ItemType Directory -Path $workDir | Out-Null
+                  Push-Location $workDir
                   $output = "" | & $atomic --no-session 2>&1 | Out-String
                   $status = $LASTEXITCODE
+                  Pop-Location
                   Write-Host $output
                   if ($output -match "Failed to load extension") {
                     exit 1

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+    "mcpServers": {
+        "deepwiki": {
+            "url": "https://mcp.deepwiki.com/mcp"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a project-level `.mcp.json` registering the [DeepWiki](https://deepwiki.com) MCP server so agent sessions in this repo can query DeepWiki (`https://mcp.deepwiki.com/mcp`) out of the box, without any per-developer local setup. Also hardens the binary smoke tests so this new repo-local config can't interfere with CI.

## Changes

- Add `.mcp.json` with a `deepwiki` entry under `mcpServers`
- Run the release and test-workflow binary smoke tests (`atomic --no-session`) from a clean temp working directory on Linux/macOS and Windows, so repo-local config like `.mcp.json` can't leak into the smoke run and hang startup

## Notes

- This file was previously removed in 75c7e9228 ("chore: remove local MCP config"); this PR intentionally re-adds it as shared project config rather than local-only config.
- The smoke-test cwd change (`.github/workflows/publish.yml`, `.github/workflows/test.yml`) was added after discovering the new `.mcp.json` caused smoke tests to pick up repo-local MCP config during startup.