### PR TITLE
fix(extensions): resolve npm-install extension load failure under Node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ jobs:
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
+            # Node is required by test/integration/installed-package-node-extensions.test.ts,
+            # which smoke-tests the built npm package under the Node runtime (the
+            # `atomic` bin runs via `#!/usr/bin/env node` for npm/bun installs).
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
             - uses: dtolnay/rust-toolchain@stable
             - name: Install dependencies
               run: bun install --frozen-lockfile

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,6 +19,8 @@ Pull request / push
   ├─ cd packages/coding-agent && bun run build
   ├─ bun run test:unit
   ├─ bun run test:integration
+  │  └─ includes an installed-layout smoke that runs the built @bastani/atomic
+  │     package under the Node runtime and fails on extension-load diagnostics
   └─ scripts/build-binaries.sh --platform <native-x64>
      └─ extract archive, verify bundled paths, run --version and --no-session smoke tests
 
@@ -93,17 +95,18 @@ Steps:
 
 1. Check out the repository.
 2. Set up Bun.
-3. Install dependencies with `bun install --frozen-lockfile`.
-4. Run `bun run typecheck`.
-5. Run `bun run check:file-length` to enforce the 500-line maximum for tracked TS/JS/Rust source-like files after applying only the documented generated/vendored exclusions.
-6. Validate hosted-docs routes and internal links with `cd packages/coding-agent && bun run docs:check`.
-7. Validate Mintlify MDX/page syntax with `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`.
-8. Check Mintlify broken links with `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`.
-9. Build `@bastani/atomic` with `cd packages/coding-agent && bun run build`.
-10. Run `bun run test:unit`.
-11. Run `bun run test:integration`.
-12. Build the native release binary with `scripts/build-binaries.sh --platform <native-x64>`.
-13. Extract the generated release archive, verify required bundled `builtin/*` and selected `node_modules/*` paths are present, run `atomic --version`, and run `atomic --no-session` far enough to catch extension-load diagnostics while allowing the expected no-models exit in CI.
+3. Set up Node 24 (required by the installed-package Node smoke below; the published `atomic` bin runs under `#!/usr/bin/env node` for npm/bun installs).
+4. Install dependencies with `bun install --frozen-lockfile`.
+5. Run `bun run typecheck`.
+6. Run `bun run check:file-length` to enforce the 500-line maximum for tracked TS/JS/Rust source-like files after applying only the documented generated/vendored exclusions.
+7. Validate hosted-docs routes and internal links with `cd packages/coding-agent && bun run docs:check`.
+8. Validate Mintlify MDX/page syntax with `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`.
+9. Check Mintlify broken links with `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`.
+10. Build `@bastani/atomic` with `cd packages/coding-agent && bun run build`.
+11. Run `bun run test:unit`.
+12. Run `bun run test:integration`. This includes `test/integration/installed-package-node-extensions.test.ts`, which assembles an installed-like layout (built `dist/` copied next to linked `node_modules` siblings, outside the monorepo `packages/` tree) and runs `dist/cli.js --no-session` under **Node** — the runtime npm/bun installs actually use — failing on any `Failed to load extension` diagnostic. This guards the extension loader's installed-package alias fallback, which the compiled-binary smoke (virtualModules path) and Bun-run test suites (lenient exports-map resolution) cannot exercise; it runs on both the Linux and Windows matrix legs.
+13. Build the native release binary with `scripts/build-binaries.sh --platform <native-x64>`.
+14. Extract the generated release archive, verify required bundled `builtin/*` and selected `node_modules/*` paths are present, run `atomic --version`, and run `atomic --no-session` far enough to catch extension-load diagnostics while allowing the expected no-models exit in CI.
 
 ### Code Review (`code-review.yml`)
 
@@ -280,7 +283,7 @@ The meaningful pre-publish checks are:
 
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, enforce the tracked TS/JS/Rust file-length gate, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests, build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
+| `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, enforce the tracked TS/JS/Rust file-length gate, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests (including the installed-package Node-runtime extension smoke on Linux and Windows), build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
 | `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
 | `code-review.yml`    | PR opened/synchronized                        | Claude-powered code review                                                                                                                                                                                    |
 | `pr-description.yml` | PR opened/synchronized                        | Claude-powered PR description generation, skipped for Dependabot                                                                                                                                              |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed every builtin extension (workflows, subagents, mcp, web-access, intercom, cursor) failing to load with `Package subpath './package.json' is not defined by "exports"` for npm/bun package installs of Atomic (regression in 0.9.4-alpha.9): the extension loader's installed-package alias fallback resolved host packages via `require.resolve("<pkg>/package.json")`, which Node's strict exports-map encapsulation rejects for packages like `@earendil-works/pi-ai` that do not export `./package.json` (the compiled binary and Bun-run dev paths were unaffected, which is why it slipped through). The loader now locates package roots by scanning the `node_modules` resolution chain directly, bypassing exports maps entirely while staying `import.meta.resolve()`-free to keep bytecode compilation intact. CI now guards this path with an installed-layout smoke test that runs the built package under the Node runtime on both Linux and Windows.
+
 ## [0.9.4-alpha.9] - 2026-07-02
 
 ### Changed

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -136,6 +136,25 @@ function extensionImportSpecifier(extensionPath: string, cacheToken: ExtensionCa
 }
 
 /**
+ * Locate an installed package's root directory without consulting its
+ * "exports" map: require.resolve("<pkg>/package.json") throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED under Node for packages that do not export
+ * "./package.json" (pi-ai does not), and import.meta.resolve() cannot be
+ * used because its mere presence silently disables bytecode generation for
+ * the compiled binary (CJS bundle). Scanning require.resolve.paths() walks
+ * the same node_modules chain Node would, without exports-map encapsulation.
+ */
+function findPackageRoot(packageName: string, searchPaths?: string[]): string {
+  for (const base of searchPaths ?? require.resolve.paths(packageName) ?? []) {
+    const candidate = path.join(base, packageName);
+    if (fs.existsSync(path.join(candidate, "package.json"))) {
+      return candidate;
+    }
+  }
+  throw new Error(`Cannot locate package directory for "${packageName}"`);
+}
+
+/**
  * Get aliases for jiti (used in Node.js/development mode).
  * In Bun binary mode, virtualModules is used instead.
  */
@@ -155,11 +174,7 @@ function getAliases(): Record<string, string> {
     if (fs.existsSync(workspacePath)) {
       return workspacePath;
     }
-    // Resolve via the package.json export and join the built-entry path, not
-    // import.meta.resolve: its mere presence silently breaks bytecode
-    // generation for the compiled binary (CJS bundle), and require.resolve
-    // fails on these ESM-only packages.
-    const packageRoot = path.dirname(require.resolve(`${packageName}/package.json`));
+    const packageRoot = findPackageRoot(packageName);
     const entryRelativePath = workspaceRelativePath.split("/").slice(1).join("/");
     return path.join(packageRoot, entryRelativePath);
   };
@@ -201,6 +216,7 @@ function getAliases(): Record<string, string> {
 export const extensionLoaderTestHooks = {
   loadVirtualModules,
   getAliases,
+  findPackageRoot,
 };
 
 /**

--- a/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
+++ b/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { extensionLoaderTestHooks } from "../src/core/extensions/loader-virtual-modules.ts";
 
@@ -39,5 +42,62 @@ describe("extension loader pi-ai compat aliases", () => {
 		expect(typeof compat.complete).toBe("function");
 		expect(typeof compat.getModel).toBe("function");
 		expect(compat.StringEnum).toBe(root.StringEnum);
+	});
+});
+
+describe("extension loader package-root resolution", () => {
+	it("locates a package root without consulting its exports map", () => {
+		// Regression guard for #1600/#1609: pi-ai does not export
+		// "./package.json", so require.resolve("<pkg>/package.json") throws
+		// ERR_PACKAGE_PATH_NOT_EXPORTED under Node and broke every builtin
+		// extension for npm installs. findPackageRoot must scan node_modules
+		// directories directly, ignoring the exports map entirely.
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-pkg-root-"));
+		try {
+			const packageRoot = path.join(tmp, "node_modules", "@scope", "esm-only");
+			fs.mkdirSync(packageRoot, { recursive: true });
+			fs.writeFileSync(
+				path.join(packageRoot, "package.json"),
+				JSON.stringify({
+					name: "@scope/esm-only",
+					version: "1.0.0",
+					type: "module",
+					exports: { ".": "./dist/index.js" },
+				}),
+			);
+
+			const resolved = extensionLoaderTestHooks.findPackageRoot("@scope/esm-only", [
+				path.join(tmp, "node_modules"),
+			]);
+
+			expect(resolved).toBe(packageRoot);
+		} finally {
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves the real pi-ai package root from the loader's node_modules chain", () => {
+		const root = extensionLoaderTestHooks.findPackageRoot("@earendil-works/pi-ai");
+
+		expect(fs.existsSync(path.join(root, "package.json"))).toBe(true);
+		expect(fs.existsSync(path.join(root, "dist", "compat.js"))).toBe(true);
+		expect(fs.existsSync(path.join(root, "dist", "oauth.js"))).toBe(true);
+	});
+
+	it("throws a descriptive error for unknown packages", () => {
+		expect(() => extensionLoaderTestHooks.findPackageRoot("@scope/definitely-missing", [])).toThrow(
+			/Cannot locate package directory/,
+		);
+	});
+
+	it("maps every alias to an existing file (installed-fallback contract)", () => {
+		const aliases = extensionLoaderTestHooks.getAliases();
+
+		for (const [specifier, target] of Object.entries(aliases)) {
+			// When running from src/, the host-package alias uses the TypeScript
+			// ESM convention (.js specifier resolved to the .ts source by jiti).
+			const exists = fs.existsSync(target) || fs.existsSync(target.replace(/\.js$/, ".ts"));
+			expect(exists, `alias ${specifier} -> ${target} does not exist`).toBe(true);
+		}
 	});
 });

--- a/test/integration/installed-package-node-extensions.test.ts
+++ b/test/integration/installed-package-node-extensions.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Integration smoke: run the built @bastani/atomic package under Node from an
+ * installed-like layout (dependencies as node_modules siblings, no monorepo
+ * packages/ directories next to the loader).
+ *
+ * Regression guard for #1600/#1609: the extension-loader alias fallback used
+ * require.resolve("<pkg>/package.json"), which throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED under Node for packages that do not export
+ * "./package.json" (e.g. @earendil-works/pi-ai). Every builtin extension
+ * failed to load for npm installs (bin runs under `#!/usr/bin/env node`),
+ * while the compiled binary (virtualModules) and Bun-run dev/test paths
+ * (lenient exports-map resolution) stayed green — so only a Node-runtime
+ * smoke over the installed layout can catch this class of regression.
+ */
+import { afterAll, test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const repoNodeModules = join(repoRoot, "node_modules");
+const packageDir = join(repoRoot, "packages", "coding-agent");
+const distCli = join(packageDir, "dist", "cli.js");
+
+const distBuilt = fs.existsSync(distCli);
+const nodeAvailable = spawnSync("node", ["--version"], { encoding: "utf8" }).status === 0;
+const isCI = process.env.CI === "true" || process.env.CI === "1";
+
+if (isCI) {
+  // CI must never silently skip this regression guard.
+  assert.ok(distBuilt, "packages/coding-agent/dist/cli.js missing in CI — run the build step first");
+  assert.ok(nodeAvailable, "node is not on PATH in CI — required for the installed-package smoke");
+}
+
+const runTest = distBuilt && nodeAvailable ? test : test.skip;
+if (!distBuilt || !nodeAvailable) {
+  console.warn(
+    "[installed-package-node-extensions] skipped: requires a built packages/coding-agent/dist and node on PATH",
+  );
+}
+
+let tmpRoot: string | undefined;
+
+afterAll(() => {
+  if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/** Symlink (junction on Windows, so no elevation is needed) a real directory. */
+function linkDir(target: string, linkPath: string): void {
+  const linkType = process.platform === "win32" ? "junction" : "dir";
+  fs.symlinkSync(fs.realpathSync(target), linkPath, linkType);
+}
+
+/**
+ * Build <tmp>/install/node_modules mirroring the repo's node_modules via
+ * links, except @bastani/atomic itself, which is copied (not linked) so the
+ * loader's realpath does not lead back into the monorepo and re-enable the
+ * workspace-path short circuit.
+ */
+function buildInstalledLayout(): string {
+  tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "atomic-node-smoke-"));
+  const layoutNodeModules = join(tmpRoot, "install", "node_modules");
+  fs.mkdirSync(layoutNodeModules, { recursive: true });
+
+  for (const entry of fs.readdirSync(repoNodeModules)) {
+    if (entry === ".bin" || entry === ".cache") continue;
+    const source = join(repoNodeModules, entry);
+    if (!fs.statSync(source).isDirectory()) continue;
+    if (entry === "@bastani") {
+      const scopeDir = join(layoutNodeModules, entry);
+      fs.mkdirSync(scopeDir);
+      for (const scoped of fs.readdirSync(source)) {
+        if (scoped === "atomic") continue;
+        linkDir(join(source, scoped), join(scopeDir, scoped));
+      }
+      continue;
+    }
+    linkDir(source, join(layoutNodeModules, entry));
+  }
+
+  const atomicDest = join(layoutNodeModules, "@bastani", "atomic");
+  fs.mkdirSync(atomicDest, { recursive: true });
+  fs.copyFileSync(join(packageDir, "package.json"), join(atomicDest, "package.json"));
+  fs.cpSync(join(packageDir, "dist"), join(atomicDest, "dist"), { recursive: true, dereference: true });
+  return atomicDest;
+}
+
+runTest(
+  "installed @bastani/atomic loads builtin extensions under Node",
+  () => {
+    const atomicDest = buildInstalledLayout();
+    assert.ok(tmpRoot, "layout setup must assign tmpRoot");
+    // Isolated HOME + empty cwd: no repo-local or user config can leak in,
+    // and the run deterministically ends at the no-configured-models exit.
+    const homeDir = join(tmpRoot, "home");
+    const workDir = join(tmpRoot, "cwd");
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(workDir, { recursive: true });
+
+    const result = spawnSync("node", [join(atomicDest, "dist", "cli.js"), "--no-session"], {
+      cwd: workDir,
+      input: "",
+      encoding: "utf8",
+      timeout: 180_000,
+      env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+    });
+
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    assert.equal(result.signal, null, `smoke run killed by ${result.signal}:\n${output}`);
+    assert.ok(!output.includes("Failed to load extension"), `extension load failure under Node:\n${output}`);
+    assert.ok(!output.includes('is not defined by "exports"'), `exports-map resolution failure under Node:\n${output}`);
+    if (result.status !== 0) {
+      assert.match(
+        output,
+        /No models available|No model selected|No API key found/,
+        `unexpected non-zero exit (${result.status}):\n${output}`,
+      );
+    }
+  },
+  240_000,
+);

--- a/test/integration/installed-package-node-extensions.test.ts
+++ b/test/integration/installed-package-node-extensions.test.ts
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 
 const repoRoot = resolve(import.meta.dir, "../..");
 const repoNodeModules = join(repoRoot, "node_modules");
@@ -25,19 +25,51 @@ const packageDir = join(repoRoot, "packages", "coding-agent");
 const distCli = join(packageDir, "dist", "cli.js");
 
 const distBuilt = fs.existsSync(distCli);
-const nodeAvailable = spawnSync("node", ["--version"], { encoding: "utf8" }).status === 0;
 const isCI = process.env.CI === "true" || process.env.CI === "1";
+
+/**
+ * Locate a REAL Node runtime on PATH. The repo's bunfig `[run] bun = true`
+ * prepends a node->bun shim to PATH for package scripts (e.g.
+ * `bun run test:integration`), so a bare spawnSync("node") can hit bun
+ * masquerading as node — which exits 1 for `--version` here and, worse, would
+ * silently neuter this regression guard (Bun's lenient exports-map resolution
+ * hides the Node-only failure). Every candidate is therefore verified to be
+ * genuine Node via `typeof Bun === "undefined"`.
+ */
+function findRealNode(): string | null {
+  const names = process.platform === "win32" ? ["node.exe", "node.cmd"] : ["node"];
+  const seen = new Set<string>();
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = join(dir, name);
+      if (seen.has(candidate) || !fs.existsSync(candidate)) continue;
+      seen.add(candidate);
+      const probe = spawnSync(candidate, ["-e", "process.stdout.write(typeof Bun)"], {
+        encoding: "utf8",
+        timeout: 30_000,
+      });
+      if (probe.status === 0 && probe.stdout === "undefined") return candidate;
+    }
+  }
+  return null;
+}
+
+const nodeExe = findRealNode();
 
 if (isCI) {
   // CI must never silently skip this regression guard.
   assert.ok(distBuilt, "packages/coding-agent/dist/cli.js missing in CI — run the build step first");
-  assert.ok(nodeAvailable, "node is not on PATH in CI — required for the installed-package smoke");
+  assert.ok(
+    nodeExe,
+    `no real Node runtime found on PATH in CI (bun-as-node shims are rejected) — required for the installed-package smoke. PATH=${process.env.PATH}`,
+  );
 }
 
-const runTest = distBuilt && nodeAvailable ? test : test.skip;
-if (!distBuilt || !nodeAvailable) {
+const runTest = distBuilt && nodeExe ? test : test.skip;
+if (!distBuilt || !nodeExe) {
   console.warn(
-    "[installed-package-node-extensions] skipped: requires a built packages/coding-agent/dist and node on PATH",
+    "[installed-package-node-extensions] skipped: requires a built packages/coding-agent/dist and a real (non-bun-shim) node on PATH",
   );
 }
 
@@ -99,7 +131,8 @@ runTest(
     fs.mkdirSync(homeDir, { recursive: true });
     fs.mkdirSync(workDir, { recursive: true });
 
-    const result = spawnSync("node", [join(atomicDest, "dist", "cli.js"), "--no-session"], {
+    assert.ok(nodeExe, "real node executable must be resolved before the smoke runs");
+    const result = spawnSync(nodeExe, [join(atomicDest, "dist", "cli.js"), "--no-session"], {
       cwd: workDir,
       input: "",
       encoding: "utf8",


### PR DESCRIPTION
## Summary

Fixes the 0.9.4-alpha.9 regression where **every builtin extension** (workflows, subagents, mcp, web-access, intercom, cursor) failed to load for npm/bun package installs of Atomic with:

```
Failed to load extension: Package subpath './package.json' is not defined by "exports" in .../@earendil-works/pi-ai/package.json
```

## Root cause

#1600 replaced the extension loader's `import.meta.resolve()` alias fallback (removed because its mere presence disables bytecode compilation) with `require.resolve("<pkg>/package.json")`. Node's strict exports-map encapsulation rejects that subpath for packages that don't export `./package.json` — `@earendil-works/pi-ai` doesn't. The published `atomic` bin runs under `#!/usr/bin/env node`, so npm/bun installs hit Node semantics, while:

- the **compiled binary** uses the `virtualModules` path (unaffected),
- **dev/CI** runs everything under **Bun**, whose resolver is lenient about exports maps (unaffected),
- the monorepo has no `packages/ai|tui|agent` dirs, so even in-repo the fallback runs — but always under Bun.

No CI leg exercised the installed package under the Node runtime, on any OS.

## Changes

- **`loader-virtual-modules.ts`**: new `findPackageRoot()` scans the `require.resolve.paths()` node_modules chain directly — no exports-map resolution, still `import.meta.resolve()`-free (bytecode stays intact).
- **`test/integration/installed-package-node-extensions.test.ts`** (new): assembles an installed-like layout (built `dist/` copied beside linked node_modules siblings, outside `packages/`) and runs `dist/cli.js --no-session` under **Node**, failing on any `Failed to load extension` diagnostic. Runs on **both Linux and Windows** matrix legs; hard-fails (never skips) in CI. Windows uses junctions (no elevation needed) and `USERPROFILE` isolation.
- **vitest regression tests**: `findPackageRoot` fixture whose exports map lacks `./package.json`, real pi-ai root resolution, and an every-alias-target-exists contract.
- **`test.yml`**: pins Node 24 via `actions/setup-node` so the Node-runtime smoke is deterministic.
- `docs/ci.md` + CHANGELOG updated.

## Validation

- Rebuilt `dist` from the broken revision: the new integration test reproduces the exact reported failure verbatim; passes with the fix.
- Reproduced/verified end-to-end against a real bun-global install (0.9.4-alpha.9) in tmux: broken before, `RESOURCES … 6 extensions` with no `[Extension issues]` after applying the fix.
- `bun run typecheck`, `bun run lint`, `bun run check:file-length`, `bun run test:unit` (2823), `bun run test:integration` (249), coding-agent vitest loader suite — all green.