### PR TITLE
docs(coding-agent): release notes for 0.9.4-alpha.10

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.10] - 2026-07-03
+
 ### Fixed
 
 - Fixed every builtin extension (workflows, subagents, mcp, web-access, intercom, cursor) failing to load with `Package subpath './package.json' is not defined by "exports"` for npm/bun package installs of Atomic (regression in 0.9.4-alpha.9): the extension loader's installed-package alias fallback resolved host packages via `require.resolve("<pkg>/package.json")`, which Node's strict exports-map encapsulation rejects for packages like `@earendil-works/pi-ai` that do not export `./package.json` (the compiled binary and Bun-run dev paths were unaffected, which is why it slipped through). The loader now locates package roots by scanning the `node_modules` resolution chain directly, bypassing exports maps entirely while staying `import.meta.resolve()`-free to keep bytecode compilation intact. CI now guards this path with an installed-layout smoke test that runs the built package under the Node runtime on both Linux and Windows.


### PR DESCRIPTION
## Release 0.9.4-alpha.10

- **Release kind:** prerelease (`@next` dist-tag)
- **Version:** `0.9.4-alpha.10` (no leading `v`)
- **Tag base:** `main`
- **Head commit:** `a9bf125516ae6482e7ae2daf83ea915dd7fec278` (from source HEAD `0e00e920a137efb59b4c80d19daaf0a615459176`)

### Changes

CHANGELOG-only release-notes PR — no package versions are bumped on `main` (versionless main; all `packages/*/package.json` stay at the `0.0.0` placeholder). The real version is materialized only on the throwaway off-`main` tag commit produced by `scripts/cut-release.ts`.

- `packages/coding-agent/CHANGELOG.md`: stamped `## [0.9.4-alpha.10] - 2026-07-03` section header above the existing `[Unreleased]` content (2-line diff).

#### Changelog summary

- **Fixed:** every builtin extension (workflows, subagents, mcp, web-access, intercom, cursor) failing to load with `Package subpath './package.json' is not defined by "exports"` for npm/bun installs of Atomic (regression in 0.9.4-alpha.9). The extension loader now locates package roots by scanning the `node_modules` resolution chain directly instead of `require.resolve("<pkg>/package.json")`, bypassing exports-map encapsulation while staying `import.meta.resolve()`-free for bytecode compilation. CI now includes an installed-layout smoke test under the Node runtime on Linux and Windows.

### Validation

```
git branch --show-current   # prerelease/0.9.4-alpha.10
git rev-parse HEAD          # a9bf125516ae6482e7ae2daf83ea915dd7fec278
git status --short          # clean
bun run typecheck           # exit 0
bun run test:unit           # exit 0
```
