### PR TITLE
fix(subagents): keep running subagent widget expanded across workflow stage-node exit

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the running subagent widget so it preserves the last known expanded/open state across workflow stage-node exit re-renders instead of transiently collapsing when the live widget context is stale until the next subagent status update ([#1619](https://github.com/bastani-inc/atomic/issues/1619)).
+
 ## [0.9.4-alpha.9] - 2026-07-02
 
 ### Changed

--- a/packages/subagents/src/tui/render-widget.ts
+++ b/packages/subagents/src/tui/render-widget.ts
@@ -63,6 +63,7 @@ interface RenderRequestingContext {
 let latestWidgetCtx: ExtensionContext | undefined;
 let latestWidgetJobs: AsyncJobState[] = [];
 let latestWidgetFrameNow = 0;
+let latestWidgetExpanded = false;
 let widgetTimer: ReturnType<typeof setInterval> | undefined;
 let mountedWidgetCtx: ExtensionContext | undefined;
 let mountedWidgetOwnerKey: string | undefined;
@@ -78,16 +79,21 @@ function getLatestWidgetFrameNow(): number {
 
 function getLatestWidgetExpanded(): boolean {
 	// LiveWidgetComponent re-renders outside a specific renderWidget() call, so
-	// read expansion from the latest live singleton context. If that context was
-	// cleared or went stale, collapse safely instead of consulting a stale caller.
-	if (!latestWidgetCtx?.hasUI) return false;
-	return latestWidgetCtx.ui.getToolsExpanded?.() ?? false;
+	// remember the last expansion state observed from a live host UI. Workflow
+	// stage-node detach can briefly repaint the mounted singleton with a stale or
+	// no-UI context before the next subagent status update refreshes it; falling
+	// back to the cached value avoids a transient collapse while jobs keep running.
+	if (!latestWidgetCtx?.hasUI) return latestWidgetExpanded;
+	const expanded = latestWidgetCtx.ui.getToolsExpanded?.();
+	if (typeof expanded === "boolean") latestWidgetExpanded = expanded;
+	return latestWidgetExpanded;
 }
 
 function clearLatestWidgetState(): void {
 	latestWidgetCtx = undefined;
 	latestWidgetJobs = [];
 	latestWidgetFrameNow = 0;
+	latestWidgetExpanded = false;
 	mountedWidgetCtx = undefined;
 	mountedWidgetOwnerKey = undefined;
 	widgetMounted = false;

--- a/test/unit/subagents-render-stability-widget-lifecycle.ts
+++ b/test/unit/subagents-render-stability-widget-lifecycle.ts
@@ -21,7 +21,7 @@ describe("async widget animation ticker lifecycle", () => {
         };
     }
 
-    function mockLifecycleWidgetCtx(ownerCwd?: string): {
+    function mockLifecycleWidgetCtx(ownerCwd?: string, toolsExpanded = false): {
         ctx: ExtensionContext;
         widgetCalls: Array<{ key: string; content: unknown; options: unknown }>;
         renders: () => number;
@@ -43,7 +43,7 @@ describe("async widget animation ticker lifecycle", () => {
                 ) => {
                     widgetCalls.push({ key, content, options });
                 },
-                getToolsExpanded: () => false,
+                getToolsExpanded: () => toolsExpanded,
                 requestRender: () => {
                     renderCount++;
                 },
@@ -151,6 +151,61 @@ describe("async widget animation ticker lifecycle", () => {
             advanced,
             stableA,
             "widget status updates/ticks should still advance the captured widget clock",
+        );
+    });
+
+    test("mounted async widget keeps last expanded state across stale stage-exit context re-renders", () => {
+        type WidgetFactory = (
+            tui: unknown,
+            widgetTheme: RenderTheme,
+        ) => Component;
+
+        const { ctx, widgetCalls } = mockLifecycleWidgetCtx(undefined, true);
+        renderWidget(ctx, [
+            {
+                ...runningJob(),
+                mode: "chain",
+                chainStepCount: 1,
+                steps: [
+                    {
+                        agent: "worker",
+                        status: "running",
+                        durationMs: 1_000,
+                        toolCount: 1,
+                        tokens: { input: 20, output: 0, total: 20 },
+                        recentTools: [{ tool: "bash", args: "bun test", endMs: 10_000 }],
+                        recentOutput: ["still running"],
+                    },
+                ],
+            },
+        ]);
+
+        const factory = widgetCalls[0]?.content;
+        assert.equal(
+            typeof factory,
+            "function",
+            "mounted widget content should be a component factory",
+        );
+        const component = (factory as WidgetFactory)(undefined, theme);
+        const expanded = component.render(120).join("\n");
+        assert.match(
+            expanded,
+            /bash: bun test/,
+            "expanded widget should show live detail from the current UI state",
+        );
+
+        ctx.hasUI = false;
+
+        const staleContextRender = component.render(120).join("\n");
+        assert.match(
+            staleContextRender,
+            /bash: bun test/,
+            "stage-exit stale/no-UI re-renders should preserve the last expanded state while the job remains mounted",
+        );
+        assert.doesNotMatch(
+            staleContextRender,
+            /Press ctrl\+o for live detail/,
+            "stale context fallback must not transiently collapse the running widget",
         );
     });
 


### PR DESCRIPTION
## Summary
- Preserve the running subagent widget's last known expanded/open state when a workflow stage-node exit causes a stale or no-UI repaint.
- Reset the cached expansion state on full widget teardown so it does not leak across owners/remounts.
- Add a lifecycle regression test covering a mounted running widget re-rendering after `ctx.hasUI` becomes false.

## Root cause
`packages/subagents/src/tui/render-widget.ts` keeps the live widget as a singleton. `LiveWidgetComponent` can re-render outside a fresh `renderWidget()` status update, so `getLatestWidgetExpanded()` reads from `latestWidgetCtx.ui.getToolsExpanded?.()` using the most recent context. During workflow stage-node exit, the mounted widget can repaint while `latestWidgetCtx` is stale or temporarily has no UI; the old code returned `false` whenever `!latestWidgetCtx?.hasUI`, which hard-collapsed the still-running widget until the next subagent status update refreshed `latestWidgetCtx`.

## Fix
- Added a module-level `latestWidgetExpanded` cache in `render-widget.ts`.
- `getLatestWidgetExpanded()` now returns the cached boolean when the singleton re-renders with a stale/no-UI context, and updates the cache whenever a live host UI reports an expansion state.
- `clearLatestWidgetState()` resets `latestWidgetExpanded` back to `false` on full teardown so it doesn't leak across owners/remounts.
- Extended `subagents-render-stability-widget-lifecycle.ts` with a regression test that mounts a running widget, flips `ctx.hasUI` to `false`, and asserts the widget stays expanded instead of collapsing.
- Added a `CHANGELOG.md` entry under `@bastani/subagents` `[Unreleased] / Fixed`.

## Validation
- `bun test ./test/unit/subagents-render-stability-widget-lifecycle.ts` — 8/8 passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run check:file-length` — passed
- `bun run test:unit` — 2824/2824 passed
- Push hooks also re-ran `bun run lint`, `bun run check:file-length`, and `bun run test:unit` successfully

Fixes #1619