### PR TITLE
docs: release notes for 0.9.4-alpha.11

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.11] - 2026-07-03
+
 ### Fixed
 
 - Fixed async `bash({ async: true })` jobs finishing silently: completed or failed session-managed background bash jobs now enqueue an `async-job-result` follow-up message into the originating chat session automatically, while explicit completed-job polling, explicit cancellation, and parent aborts acknowledge the job and suppress duplicate or unwanted idle turns. Suppression is checked again at the streaming boundary so a completed job polled while its automatic follow-up is staged does not later deliver a duplicate. Async delivery bookkeeping is now bounded by the existing background-job retention defaults, suppressions stay tied to retained jobs so disposed-session running jobs cannot later fall back into the owner session, 12KB–50KB follow-up outputs persist their full output path before inline preview truncation, just-under-threshold raw outputs remain fully inline instead of being preview-truncated without a `fullOutputPath`, shared-manager lifecycle tracking prevents owner-session disposal from dropping later-session jobs while cleaning stale handlers from disposed fork/subagent sessions, and non-blocking delivery attempts keep one live streaming session from delaying unrelated async job completions.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.4-alpha.11] - 2026-07-03
+
 ### Fixed
 
 - Fixed subagent live-detail hints to render the configured `app.tools.expand` keybinding instead of hardcoding Ctrl+O, so remapped users see the same binding honored by attached workflow stage viewers ([#1607](https://github.com/bastani-inc/atomic/issues/1607)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.4-alpha.11] - 2026-07-03
+
 ### Fixed
 
 - Fixed attached workflow stage viewers so the host `app.tools.expand` keybinding (Ctrl+O by default) toggles live-detail/tool-output expansion just like the main chat, including custom keybinding remaps ([#1607](https://github.com/bastani-inc/atomic/issues/1607)).


### PR DESCRIPTION
## Release 0.9.4-alpha.11

Changelog-only release-notes PR that stamps each package's `[Unreleased]` entries into a dated `[0.9.4-alpha.11]` section ahead of the off-`main` tag cut. No package versions are bumped on `main` — `main` stays versionless at the `0.0.0` placeholder; the real version is materialized only on the throwaway tag commit produced by `scripts/cut-release.ts` and is never merged back.

- **Release kind:** prerelease (publishes to npm `@next` dist-tag)
- **Version / tag:** `0.9.4-alpha.11` (no leading `v`)
- **Head commit:** `6ff8d23c502ccc03242d218c76985a40d9adb409`

### Changelog updates

Each package `CHANGELOG.md` gains a `## [0.9.4-alpha.11] - 2026-07-03` section stamped from its `[Unreleased]` entries:

- `packages/coding-agent/CHANGELOG.md` — Fixed async `bash({ async: true })` jobs finishing silently: completed/failed session-managed background bash jobs now enqueue an `async-job-result` follow-up into the originating session, with duplicate-delivery suppression, bounded retention bookkeeping, full-output path persistence for 12KB–50KB outputs, and shared-manager lifecycle fixes.
- `packages/subagents/CHANGELOG.md` — Fixed subagent live-detail hints to render the configured `app.tools.expand` keybinding instead of hardcoding Ctrl+O ([#1607](https://github.com/bastani-inc/atomic/issues/1607)).
- `packages/workflows/CHANGELOG.md` — Fixed attached workflow stage viewers so the host `app.tools.expand` keybinding toggles live-detail/tool-output expansion, including custom remaps ([#1607](https://github.com/bastani-inc/atomic/issues/1607)).

### Validation

- `bun run typecheck` — passed
- `bun run test:unit` — passed
- `git status --short` — clean working tree
- `git diff --name-only 9e8195b05bf88fa394c0e784c596965d3197819f..HEAD` — CHANGELOG.md files only
- prek pre-push hooks (lint, file-length, unit tests, etc.) — passed on push