### PR TITLE
docs: release notes for 0.9.5-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.1] - 2026-07-04
+
 ### Breaking Changes
 
 - Hardened the builtin `goal` and `ralph` review contracts against objective-drift failures: review findings now require `objective_alignment`, Goal and Ralph review decisions require `requirements_traceability`, and reviewer approval rejects empty or non-proven traceability. Consumers that parse or synthesize these structured reviewer outputs must emit the new required fields.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.1] - 2026-07-04
+
 ### Breaking Changes
 
 - Hardened the builtin `goal` and `ralph` review contracts against objective-drift failures: review findings now require `objective_alignment`, Goal and Ralph review decisions require `requirements_traceability`, and reviewer approval rejects empty or non-proven traceability. Consumers that parse or synthesize these structured reviewer outputs must emit the new required fields.


### PR DESCRIPTION
## Summary

Adds the `[0.9.5-alpha.1] - 2026-07-04` version heading to both package changelogs, carving the accumulated `[Unreleased]` entries (the goal/ralph objective-drift hardening from #1625) into a dated release-notes section ahead of cutting the prerelease tag.

- **Release kind:** prerelease (publishes to npm `@next`)
- **Version:** `0.9.5-alpha.1` (no leading `v`)
- **Base:** `main` (release-notes PR target and tag base)
- **Head:** `prerelease/0.9.5-alpha.1` @ `e05660b623322765cffa23bc8d6d8873c5f568a3`

## Changes

CHANGELOG-only release-notes commit (`docs: release notes for 0.9.5-alpha.1`). No version bumps — `main` stays versionless with the `0.0.0` placeholder; the real version is materialized only on the throwaway off-`main` tag commit produced by `scripts/cut-release.ts`.

- `packages/coding-agent/CHANGELOG.md` — `[0.9.5-alpha.1]` heading added above the existing Breaking Changes/Added entries
- `packages/workflows/CHANGELOG.md` — `[0.9.5-alpha.1]` heading added above the existing Breaking Changes/Added entries

## Validation

- `git status --short` — clean working tree
- `bun run typecheck` — passed
- `bun run test:unit` — passed
- prek pre-push hooks (lint, file-length, unit tests, merge-conflict/large-file checks) — passed

## Next steps

After merge, cut and push the tag off-`main`:

```sh
bun run scripts/cut-release.ts 0.9.5-alpha.1 --base main --push
```