### PR TITLE
test(coding-agent): init theme in subagents render stability tests

### DIFF
--- a/test/unit/subagents-render-stability.test.ts
+++ b/test/unit/subagents-render-stability.test.ts
@@ -1,3 +1,10 @@
+import { beforeAll } from "bun:test";
+import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.js";
+
+beforeAll(() => {
+	initTheme("dark");
+});
+
 import "./subagents-render-stability-fast-mode.js";
 import "./subagents-render-stability-running-spinner.js";
 import "./subagents-render-stability-running-widget.js";


### PR DESCRIPTION
## Summary
- `test/unit/subagents-render-stability.test.ts` is a barrel file that only re-imports several `subagents-render-stability-*.js` suites; it previously had no `beforeAll`, so it depended on another unit test file initializing the global interactive theme singleton first when run in isolation.
- Adds `beforeAll(() => initTheme("dark"))` to initialize the theme locally, removing that cross-file ordering dependency.
- Test-only change: no production render path or global theme singleton behavior is modified.

## Validation
- `bun install`
- `AGENT=1 bun test test/unit/subagents-render-stability.test.ts` — `23 pass / 0 fail`
- `AGENT=1 bun run test:unit` — `2833 pass / 0 fail`
- `bun run typecheck`
- `bun run lint`
- Push hooks also passed: `bun run lint`, `bun run check:file-length`, `bun run test:unit`

## Review evidence
- Goal ledger and reviewer artifacts report quorum complete with no findings.
- Reviewers reproduced the pre-fix failure on the base version: 7 `Theme not initialized. Call initTheme() first.` failures when the test file is run in isolation.
- Reviewers re-ran the isolated target test, full unit suite, typecheck, and lint successfully.

Note: the original objective referenced `packages/coding-agent/test/unit/subagents-render-stability.test.ts`; in this repo layout the actual unit test file is `test/unit/subagents-render-stability.test.ts`, which is what the test script runs and what reproduced the failure.