### PR TITLE
docs: release notes for 0.9.5-alpha.2

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.2] - 2026-07-04
+
+### Changed
+
+- Refreshed the July 2026 builtin workflow and subagent frontier model rosters bundled with Atomic: high-capacity synthesis, planning, debugging, and review paths now lead or fall back through Claude Fable 5 `:xhigh`, GPT-5.5 `:xhigh`, Opus 4.8 long-context `:xhigh`, GLM-5.2, and the valid OpenRouter Fugu Ultra mirror while keeping dominated or unsupported model IDs out of shipped chains.
+
 ## [0.9.5-alpha.1] - 2026-07-04
 
 ### Breaking Changes

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.2] - 2026-07-04
+
+### Changed
+
+- Refreshed the builtin debugger agent's July 2026 frontier model roster: it now leads with Claude Fable 5 `:xhigh`, keeps GPT-5.5 `:xhigh`, Opus 4.8 long-context `:xhigh`, and GLM-5.2 fallbacks, and retains only the valid OpenRouter Fugu Ultra mirror rather than unsupported direct Sakana model IDs.
+
 ## [0.9.4] - 2026-07-03
 
 ### Added

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.2] - 2026-07-04
+
+### Changed
+
+- Refreshed the July 2026 frontier model rosters for the builtin Ralph, Goal, deep-research-codebase, and open-claude-design workflows: critical prompt-engineering, orchestration, planning, and review chains now use high-capacity Fable 5 `:xhigh` primaries or fallbacks with GPT-5.5, Opus 4.8 long-context `:xhigh`, GLM-5.2, and OpenRouter Fugu Ultra coverage, while Ralph research stays on the measured GPT-5.5 `:medium` / Fable 5 `:low` performance-per-dollar path and reviewer-C remains GLM-led for diversity.
+- Updated workflow model-option schema documentation to show `:xhigh` long-context examples and kept the fallback fixtures aligned so unsupported direct `sakana/` IDs stay out of workflow chains while the valid `openrouter/sakana/fugu-ultra:high` mirror remains available.
+
 ## [0.9.5-alpha.1] - 2026-07-04
 
 ### Breaking Changes


### PR DESCRIPTION
## Release

- Kind: prerelease
- Version: `0.9.5-alpha.2`
- Base branch and tag base: `main`
- Head branch: `prerelease/0.9.5-alpha.2`
- Head SHA: `2081b6cc969519138f5291aff3af10c83ba97eec`

## Summary

Adds `## [0.9.5-alpha.2]` release-notes entries to three package changelogs, documenting a refresh of the July 2026 builtin frontier model rosters used by workflows, subagents, and the coding agent. No source code, schemas, or package versions change in this PR — it is changelog-only.

## Changelog / version summary

- Updates only release notes under each package `## [Unreleased]` section.
- Changed files:
  - `packages/coding-agent/CHANGELOG.md` — refreshes the high-capacity synthesis/planning/debugging/review model roster (Claude Fable 5 `:xhigh`, GPT-5.5 `:xhigh`, Opus 4.8 long-context `:xhigh`, GLM-5.2, valid OpenRouter Fugu Ultra mirror) and drops dominated/unsupported model IDs from shipped chains.
  - `packages/subagents/CHANGELOG.md` — refreshes the builtin debugger agent's model roster with the same lead/fallback lineup and removes unsupported direct Sakana model IDs in favor of the OpenRouter Fugu Ultra mirror.
  - `packages/workflows/CHANGELOG.md` — refreshes model rosters for the builtin Ralph, Goal, deep-research-codebase, and open-claude-design workflows, updates the model-option schema docs with `:xhigh` long-context examples, and keeps fallback fixtures aligned so unsupported `sakana/` IDs stay out of workflow chains.
- No package versions were changed, and `scripts/bump-version.ts` was not run.
- `main` remains versionless at the `0.0.0` placeholders; the real version is materialized only by `scripts/cut-release.ts` on the throwaway off-main tag commit for `0.9.5-alpha.2`.

## Validation

Deterministic local release preparation and checks passed:

- `git branch --show-current` → `prerelease/0.9.5-alpha.2`
- `git rev-parse HEAD` → `2081b6cc969519138f5291aff3af10c83ba97eec`
- `git status --short` → clean
- `git diff --name-only a643153d4fe695a62995f0c87e747bc48024014c..HEAD` → changelog files only
- `bun run typecheck` → passed
- `bun run test:unit` → passed

Push-time hooks also passed during `git push -u origin prerelease/0.9.5-alpha.2`, including `bun run lint`, `bun run check:file-length`, and `bun run test:unit`.