### PR TITLE
docs: release notes for 0.9.5-alpha.3

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.3] - 2026-07-04
+
+### Changed
+
+- Hardened the bundled workflows extension's workflow-tool prompt guidance against inline analysis-paralysis drift: the agent must now decide and state the inline-vs-workflow execution mode before its first tool call (reconnaissance explicitly counts as inline execution), budget pre-workflow scoping to a few quick reads that only sharpen the objective and validation criteria, course-correct after roughly ten deliverable-free exploration tool calls (or repeated "let me verify one more thing" loops) by writing findings to a context file and handing off to the best-fit workflow via `reads` (named or user-defined workflows discovered with `action: "list"` first, builtin `goal`/`ralph` as fallbacks when nothing more specific fits), and treat sunk inline research as transferable via files rather than a reason to stay inline. The same "Decide before you explore" and "Course-correct instead of drifting" guidance is mirrored in `docs/workflows.md` under "When to Use Workflows".
+
 ## [0.9.5-alpha.2] - 2026-07-04
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.3] - 2026-07-04
+
 ### Changed
 
 - Hardened the workflow-tool prompt guidance against inline analysis-paralysis drift (observed in eval transcripts where an agent spent ~2 hours of pure reconnaissance on a workflow-fit task without ever considering a workflow): the agent must now decide and state the inline-vs-workflow execution mode before its first tool call (reconnaissance explicitly counts as inline execution), budget pre-workflow scoping to a few quick reads that only sharpen the objective and validation criteria, course-correct after roughly ten deliverable-free exploration tool calls (or repeated "let me verify one more thing" loops) by writing findings to a context file and handing off to the best-fit workflow via `reads` (named or user-defined workflows discovered with `action: "list"` first, builtin `goal`/`ralph` as fallbacks when nothing more specific fits), and treat sunk inline research as transferable via files rather than a reason to stay inline. Mirrored the same "Decide before you explore" and "Course-correct instead of drifting" guidance in `docs/workflows.md` under "When to Use Workflows".


### PR DESCRIPTION
## Release 0.9.5-alpha.3

- **Release kind:** prerelease (publishes to npm `@next`)
- **Version / tag:** `0.9.5-alpha.3` (no leading `v`)
- **Base (tag base):** `main`
- **Head:** `prerelease/0.9.5-alpha.3` @ `4ccf0945d8ea3a0439bc8eff52fee36addc176f4`

### Scope

Changelog-only release-notes PR — **no version bumps**. `main` stays versionless (`0.0.0` placeholders in every `packages/*/package.json`); the real version is materialized only on the throwaway off-`main` tag commit produced by `scripts/cut-release.ts` and is never merged back.

### Changed files

- `packages/coding-agent/CHANGELOG.md` — new `## [0.9.5-alpha.3] - 2026-07-04` section (6 lines added)
- `packages/workflows/CHANGELOG.md` — new `## [0.9.5-alpha.3] - 2026-07-04` section (2 lines added)

### Changelog summary

**@bastani/atomic (coding-agent)** and **@bastani/workflows** — Changed:

- Hardened the workflows extension's workflow-tool prompt guidance against inline analysis-paralysis drift (observed in eval transcripts where an agent spent ~2 hours of pure reconnaissance on a workflow-fit task without ever considering a workflow): the agent must decide and state the inline-vs-workflow execution mode before its first tool call (reconnaissance counts as inline execution), budget pre-workflow scoping to a few quick reads that only sharpen the objective and validation criteria, course-correct after roughly ten deliverable-free exploration tool calls (or repeated "let me verify one more thing" loops) by writing findings to a context file and handing off to the best-fit workflow via `reads` (named or user-defined workflows discovered with `action: "list"` first, builtin `goal`/`ralph` as fallbacks when nothing more specific fits), and treat sunk inline research as transferable via files rather than a reason to stay inline. The same "Decide before you explore" and "Course-correct instead of drifting" guidance is mirrored in `docs/workflows.md` under "When to Use Workflows".

### Validation

Run locally at head commit `4ccf0945` (all passed):

```sh
bun run typecheck   # exit 0
bun run test:unit   # exit 0
git status --short  # clean
git diff --name-only 4206e63659f85ab804a67f98164ef17300508bbf..HEAD  # CHANGELOG.md files only
```

Pre-push hooks (prek) also passed: lint, check:file-length, test:unit, merge-conflict / large-file / private-key checks.

### Next steps

After this PR merges, tag the release off-`main` via:

```sh
bun run scripts/cut-release.ts 0.9.5-alpha.3 --base main --push
```