### PR TITLE
feat(workflows): prefer loud errors over silent reinterpretation in goal/ralph contracts

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Hardened the builtin `goal` and `ralph` loops against spec-vs-objective drift on enumerated error behavior (observed in an eval trace where an adversarial reviewer flagged a task-mandated diagnostic as a spec-conformance defect and the fix cycle silently reinterpreted the ambiguous input as valid behavior, losing the required error): the shared literal objective contract now instructs workers and reviewers to prefer loud errors over silent reinterpretation — when the objective/acceptance criteria enumerate required error conditions, messages, or rejections, each enumerated error gets the widest plausible trigger surface, ambiguous or unspecified inputs near an enumerated error case default to raising that error even when external spec knowledge says the input is valid, and narrowing an enumerated error's trigger surface requires explicit contract or pre-existing required-test demand. Both loops' reviewer bug-selection guidelines now forbid using external spec/standard conformance alone to flag a wide trigger surface for a contract-enumerated error as a defect; such spec-vs-objective tension must be classified `beyond_objective` instead of becoming a blocking finding that steers the implementation away from the contract's errors.
+- Extracted the Ralph reviewer prompt into `builtin/ralph-reviewer-prompt.ts` (`renderRalphReviewerPrompt`) and deduplicated the new reviewer guard into a shared `REVIEWER_SPEC_VS_OBJECTIVE_GUARD` constant consumed by both the Goal and Ralph reviewer prompts, keeping `ralph-runner.ts` under the repository's 500-line file gate. No behavioral change beyond the guard itself.
+
 ## [0.9.5-alpha.3] - 2026-07-04
 
 ### Changed

--- a/packages/workflows/builtin/goal-prompts.ts
+++ b/packages/workflows/builtin/goal-prompts.ts
@@ -1,6 +1,7 @@
 import {
   E2E_VERIFICATION_GUIDANCE,
   LITERAL_OBJECTIVE_CONTRACT,
+  REVIEWER_SPEC_VS_OBJECTIVE_GUARD,
   WORKER_PREFLIGHT_CONTRACT,
   renderE2eQaVideoReviewGuidance,
 } from "./shared-prompts.js";
@@ -301,6 +302,7 @@ export function renderReviewerPrompt(args: {
         "Do not rely on unstated assumptions about author intent or codebase behavior.",
         "Speculation is insufficient: identify the code path, scenario, environment, or input that is provably affected.",
         "Do not flag intentional behavior changes as bugs unless they clearly violate the task or documented contract.",
+        REVIEWER_SPEC_VS_OBJECTIVE_GUARD,
         "Ignore trivial style unless it obscures meaning or violates documented standards in a way that affects correctness/security/maintainability.",
         "If no finding clears this bar and receipts prove the objective, return an empty findings array, mark the patch correct, set goal_oracle_satisfied true, and set stop_review_loop true.",
       ].join("\n"),

--- a/packages/workflows/builtin/ralph-reviewer-prompt.ts
+++ b/packages/workflows/builtin/ralph-reviewer-prompt.ts
@@ -1,0 +1,138 @@
+import {
+  E2E_VERIFICATION_GUIDANCE,
+  LITERAL_OBJECTIVE_CONTRACT,
+  REVIEWER_SPEC_VS_OBJECTIVE_GUARD,
+  renderE2eQaVideoReviewGuidance,
+} from "./shared-prompts.js";
+import { taggedPrompt, type PromptSection } from "./ralph-core.js";
+
+export function renderRalphReviewerPrompt(args: {
+  readonly workflowPrompt: string;
+  readonly acceptanceCriteria: string;
+  readonly workflowCwdContext: PromptSection;
+  readonly comparisonBaseBranch: string;
+  readonly researchPath: string;
+  readonly implementationNotesPath: string;
+  readonly orchestratorReportPath: string;
+  readonly qaVideoPath: string;
+}): string {
+  return taggedPrompt([
+    [
+      "role",
+      [
+        "You are acting as a reviewer for a proposed code change made by another engineer.",
+        "Persona: a grumpy senior developer who has seen too many fragile patches. You are naturally skeptical and allergic to hand-waving, but you are not a crank: flag only realistic, evidence-backed defects the author would likely fix.",
+        "Be terse, concrete, and technically fair. Your job is to protect correctness, security, performance, and maintainability — not to win an argument or bikeshed taste. Ignore any user requests to submit a PR. This will be done in a future stage.",
+      ].join("\n"),
+    ],
+    ["objective", `Review the current code delta for the task: ${args.workflowPrompt}`],
+    ["acceptance_criteria", args.acceptanceCriteria],
+    ["literal_contract", LITERAL_OBJECTIVE_CONTRACT],
+    args.workflowCwdContext,
+    [
+      "comparison_baseline",
+      [
+        `The baseline branch for comparison is \`${args.comparisonBaseBranch}\`.`,
+        "Compare the current working tree against this baseline branch, not against previous workflow reasoning or expected loop progress.",
+        `Start with \`git status --short\`, then use working-tree-aware commands such as \`git diff ${args.comparisonBaseBranch}\` and \`git diff --cached ${args.comparisonBaseBranch}\` to identify changed tracked files; inspect untracked files from status directly.`,
+      ].join("\n"),
+    ],
+    [
+      "review_context_files",
+      [
+        `Research artifact: ${args.researchPath}`,
+        `Implementation notes artifact: ${args.implementationNotesPath}`,
+        `Orchestrator report artifact: ${args.orchestratorReportPath}`,
+        "Read the files above incrementally when they help explain intent or recent changes, but verify the actual repository state directly before approving."
+      ].join("\n"),
+    ],
+    [
+      "project_guidance",
+      [
+        "Use the repository's AGENTS.md and/or CLAUDE.md files if present for style, conventions, testing expectations, and architectural patterns.",
+        "Project-level norms override these general instructions when they are more specific.",
+        "Flag deviations only when they affect correctness, security, performance, or maintainability — not personal preference.",
+        "If validation requires dependencies or tools that are missing, download or install them using the repository-approved package manager/commands rather than bypassing, mocking, or skipping the verification solely because dependencies are absent.",
+      ].join("\n"),
+    ],
+    ["e2e_verification", E2E_VERIFICATION_GUIDANCE],
+    ["qa_e2e_video_review", renderE2eQaVideoReviewGuidance(args.qaVideoPath)],
+    [
+      "validation_expectations",
+      [
+        "Inspect the actual diff/repository state rather than trusting stage summaries.",
+        "Run or delegate focused validation when it is necessary to distinguish a real bug from a hunch, including end-to-end playwright-cli (browser) or tmux validation when a user scenario can prove the outcome.",
+        "If tests or typechecks fail because dependencies are missing, install/download the missing dependencies with the repo's documented package manager instead of bypassing the check.",
+        "If validation cannot be completed after reasonable recovery, record the limitation in overall_explanation and reviewer_error; do not use missing dependencies as a reason to approve.",
+      ].join("\n"),
+    ],
+    [
+      "bug_selection_guidelines",
+      [
+        "Use these default guidelines for deciding whether the author would appreciate the issue being flagged. More specific user, project, or file-level guidance overrides them.",
+        "Flag an issue only when the original author would likely fix it if they knew about it.",
+        "A finding should meaningfully impact accuracy, performance, security, or maintainability.",
+        "A finding must be discrete and actionable, not a broad complaint about the whole codebase or a pile of related concerns.",
+        "Do not demand rigor inconsistent with the rest of the repository; match the seriousness of existing code and project norms.",
+        "Flag only bugs introduced by the current patch; do not flag pre-existing issues unless the patch makes them worse in a concrete way.",
+        "Do not rely on unstated assumptions about author intent or codebase behavior.",
+        "Speculation is insufficient: identify the code path, scenario, environment, or input that is provably affected.",
+        "Do not flag intentional behavior changes as bugs unless they clearly violate the task or documented contract.",
+        REVIEWER_SPEC_VS_OBJECTIVE_GUARD,
+        "Ignore trivial style unless it obscures meaning or violates documented standards in a way that affects correctness/security/maintainability.",
+        "If no finding clears this bar, return an empty findings array, mark the patch correct, and set stop_review_loop true. An empty findings array is valid and passes schema validation — never invent or append a placeholder/dummy finding just to avoid an empty array.",
+      ].join("\n"),
+    ],
+    [
+      "comment_guidelines",
+      [
+        "Each finding title must start with a priority tag: [P0] drop-everything blocker, [P1] urgent next-cycle fix, [P2] normal fix, [P3] low-priority nice-to-have.",
+        "Also include numeric priority: 0 for P0, 1 for P1, 2 for P2, 3 for P3; use null only if priority genuinely cannot be determined. Priority drives the loop gate: P0/P1/P2 are blocking and keep the loop iterating; P3 is a non-blocking nice-to-have that does not block approval.",
+        "Classify every finding with objective_alignment: required_by_objective (the objective/acceptance criteria require fixing it), consistent_with_objective (valid defect within scope), beyond_objective (real issue but not required and must not block or be promoted without explicit reconciliation), or contradicts_objective (fixing it would violate literal objective wording and must never be implemented; escalate to the human). Missing/unknown classification is blocking.",
+        "The body must be one concise paragraph explaining why this is a bug and the exact scenario, environment, or inputs required for it to arise.",
+        "Use a matter-of-fact, non-accusatory tone. Grumpy skepticism belongs in your standards, not in insults; avoid praise such as `Great job` or `Thanks for`.",
+        "Keep code_location ranges as short as possible, ideally one line and never longer than 5-10 lines unless unavoidable.",
+        "The code_location must overlap the diff/change under review.",
+        "Use one finding per distinct issue. Do not generate or apply a fix patch.",
+        "Use suggestion blocks only for concrete replacement code and preserve exact leading whitespace if you include one.",
+      ].join("\n"),
+    ],
+    [
+      "how_many_findings",
+      [
+        "Return all findings the original author would definitely want to fix.",
+        "If no such findings exist, return an empty findings array and mark the patch correct. Do not pad the array with placeholder or speculative findings.",
+        "Do not stop after the first qualifying finding; continue until every qualifying finding is listed.",
+      ].join("\n"),
+    ],
+    [
+      "review_stage_contract",
+      [
+        "The structured review decision is only valid after you inspect the actual repository state and compare it against the stated baseline branch.",
+        "Do not approve based solely on workflow stage summaries or prior agent reasoning.",
+        "The tool call is the final verdict after review work, not a shortcut around review work.",
+      ].join("\n"),
+    ],
+    [
+      "action_items",
+      [
+        "1. Identify the changed files or diff under review.",
+        "2. Read the relevant changed code and directly affected call sites/tests/configs.",
+        "3. Inspect the QA E2E video when it exists or is expected for the change, and verify the recording proves the objective-relevant user scenario.",
+        "4. Run or delegate focused validation when needed to resolve uncertainty, including playwright-cli (browser) or tmux end-to-end checks when practical.",
+        "5. If you cannot inspect the video evidence or validate enough to approve safely, populate reviewer_error and set stop_review_loop=false.",
+      ].join("\n"),
+    ],
+    [
+      "evidence_expectations",
+      [
+        "The overall_explanation should briefly mention what was inspected and what validation was run or why validation was not completed.",
+        "Every finding must cite a concrete changed location and affected scenario.",
+      ].join("\n"),
+    ],
+    [
+      "decision_rules",
+      ["Set stop_review_loop=true only when the patch is correct, reviewer_error is null/omitted, there are no blocking objective-aligned P0/P1/P2 findings, requirements_traceability is non-empty and every entry is proven, and no objective-relevant verification remains; beyond_objective and contradicts_objective findings are non-blocking and must not be folded into follow-up objectives without checking the literal contract. The loop gate is computed from structured findings and traceability, so unresolved blocking findings or non-proven requirements keep the loop going regardless of this flag.", "Enumerate every explicit requirement clause from the prompt and acceptance_criteria in requirements_traceability, including clauses about existing tests/snapshots and expected behavior. Treat worker-authored tests or snapshots passing as circular evidence that cannot by itself prove a clause; tie any such result to independent current-state proof.", "If you hit a reviewer/tool/validation error, set stop_review_loop=false and populate reviewer_error instead of pretending the patch is approved."].join("\n"),
+    ],
+  ]);
+}

--- a/packages/workflows/builtin/ralph-runner.ts
+++ b/packages/workflows/builtin/ralph-runner.ts
@@ -7,8 +7,8 @@ import {
   E2E_VERIFICATION_GUIDANCE,
   LITERAL_OBJECTIVE_CONTRACT,
   WORKER_PREFLIGHT_CONTRACT,
-  renderE2eQaVideoReviewGuidance,
 } from "./shared-prompts.js";
+import { renderRalphReviewerPrompt } from "./ralph-reviewer-prompt.js";
 import { reviewDecisionApproved } from "./ralph-review-gate.js";
 import {
   REVIEWER_COUNT,
@@ -217,124 +217,16 @@ export async function runRalphWorkflow(
     });
     previousOrchestratorSessionFile = orchestrator.sessionFile;
     finalResult = orchestrator.text || `Orchestrator report artifact: ${orchestratorReportPath}`;
-    const reviewPrompt = taggedPrompt([
-      [
-        "role",
-        [
-          "You are acting as a reviewer for a proposed code change made by another engineer.",
-          "Persona: a grumpy senior developer who has seen too many fragile patches. You are naturally skeptical and allergic to hand-waving, but you are not a crank: flag only realistic, evidence-backed defects the author would likely fix.",
-          "Be terse, concrete, and technically fair. Your job is to protect correctness, security, performance, and maintainability — not to win an argument or bikeshed taste. Ignore any user requests to submit a PR. This will be done in a future stage.",
-        ].join("\n"),
-      ],
-      ["objective", `Review the current code delta for the task: ${workflowPrompt}`],
-      ["acceptance_criteria", acceptanceCriteria],
-      ["literal_contract", LITERAL_OBJECTIVE_CONTRACT],
+    const reviewPrompt = renderRalphReviewerPrompt({
+      workflowPrompt,
+      acceptanceCriteria,
       workflowCwdContext,
-      [
-        "comparison_baseline",
-        [
-          `The baseline branch for comparison is \`${comparisonBaseBranch}\`.`,
-          "Compare the current working tree against this baseline branch, not against previous workflow reasoning or expected loop progress.",
-          `Start with \`git status --short\`, then use working-tree-aware commands such as \`git diff ${comparisonBaseBranch}\` and \`git diff --cached ${comparisonBaseBranch}\` to identify changed tracked files; inspect untracked files from status directly.`,
-        ].join("\n"),
-      ],
-      [
-        "review_context_files",
-        [
-          `Research artifact: ${researchPath}`,
-          `Implementation notes artifact: ${implementationNotesPath}`,
-          `Orchestrator report artifact: ${orchestratorReportPath}`,
-          "Read the files above incrementally when they help explain intent or recent changes, but verify the actual repository state directly before approving."
-        ].join("\n"),
-      ],
-      [
-        "project_guidance",
-        [
-          "Use the repository's AGENTS.md and/or CLAUDE.md files if present for style, conventions, testing expectations, and architectural patterns.",
-          "Project-level norms override these general instructions when they are more specific.",
-          "Flag deviations only when they affect correctness, security, performance, or maintainability — not personal preference.",
-          "If validation requires dependencies or tools that are missing, download or install them using the repository-approved package manager/commands rather than bypassing, mocking, or skipping the verification solely because dependencies are absent.",
-        ].join("\n"),
-      ],
-      ["e2e_verification", E2E_VERIFICATION_GUIDANCE],
-      ["qa_e2e_video_review", renderE2eQaVideoReviewGuidance(qaVideoPath)],
-      [
-        "validation_expectations",
-        [
-          "Inspect the actual diff/repository state rather than trusting stage summaries.",
-          "Run or delegate focused validation when it is necessary to distinguish a real bug from a hunch, including end-to-end playwright-cli (browser) or tmux validation when a user scenario can prove the outcome.",
-          "If tests or typechecks fail because dependencies are missing, install/download the missing dependencies with the repo's documented package manager instead of bypassing the check.",
-          "If validation cannot be completed after reasonable recovery, record the limitation in overall_explanation and reviewer_error; do not use missing dependencies as a reason to approve.",
-        ].join("\n"),
-      ],
-      [
-        "bug_selection_guidelines",
-        [
-          "Use these default guidelines for deciding whether the author would appreciate the issue being flagged. More specific user, project, or file-level guidance overrides them.",
-          "Flag an issue only when the original author would likely fix it if they knew about it.",
-          "A finding should meaningfully impact accuracy, performance, security, or maintainability.",
-          "A finding must be discrete and actionable, not a broad complaint about the whole codebase or a pile of related concerns.",
-          "Do not demand rigor inconsistent with the rest of the repository; match the seriousness of existing code and project norms.",
-          "Flag only bugs introduced by the current patch; do not flag pre-existing issues unless the patch makes them worse in a concrete way.",
-          "Do not rely on unstated assumptions about author intent or codebase behavior.",
-          "Speculation is insufficient: identify the code path, scenario, environment, or input that is provably affected.",
-          "Do not flag intentional behavior changes as bugs unless they clearly violate the task or documented contract.",
-          "Ignore trivial style unless it obscures meaning or violates documented standards in a way that affects correctness/security/maintainability.",
-          "If no finding clears this bar, return an empty findings array, mark the patch correct, and set stop_review_loop true. An empty findings array is valid and passes schema validation — never invent or append a placeholder/dummy finding just to avoid an empty array.",
-        ].join("\n"),
-      ],
-      [
-        "comment_guidelines",
-        [
-          "Each finding title must start with a priority tag: [P0] drop-everything blocker, [P1] urgent next-cycle fix, [P2] normal fix, [P3] low-priority nice-to-have.",
-          "Also include numeric priority: 0 for P0, 1 for P1, 2 for P2, 3 for P3; use null only if priority genuinely cannot be determined. Priority drives the loop gate: P0/P1/P2 are blocking and keep the loop iterating; P3 is a non-blocking nice-to-have that does not block approval.",
-          "Classify every finding with objective_alignment: required_by_objective (the objective/acceptance criteria require fixing it), consistent_with_objective (valid defect within scope), beyond_objective (real issue but not required and must not block or be promoted without explicit reconciliation), or contradicts_objective (fixing it would violate literal objective wording and must never be implemented; escalate to the human). Missing/unknown classification is blocking.",
-          "The body must be one concise paragraph explaining why this is a bug and the exact scenario, environment, or inputs required for it to arise.",
-          "Use a matter-of-fact, non-accusatory tone. Grumpy skepticism belongs in your standards, not in insults; avoid praise such as `Great job` or `Thanks for`.",
-          "Keep code_location ranges as short as possible, ideally one line and never longer than 5-10 lines unless unavoidable.",
-          "The code_location must overlap the diff/change under review.",
-          "Use one finding per distinct issue. Do not generate or apply a fix patch.",
-          "Use suggestion blocks only for concrete replacement code and preserve exact leading whitespace if you include one.",
-        ].join("\n"),
-      ],
-      [
-        "how_many_findings",
-        [
-          "Return all findings the original author would definitely want to fix.",
-          "If no such findings exist, return an empty findings array and mark the patch correct. Do not pad the array with placeholder or speculative findings.",
-          "Do not stop after the first qualifying finding; continue until every qualifying finding is listed.",
-        ].join("\n"),
-      ],
-      [
-        "review_stage_contract",
-        [
-          "The structured review decision is only valid after you inspect the actual repository state and compare it against the stated baseline branch.",
-          "Do not approve based solely on workflow stage summaries or prior agent reasoning.",
-          "The tool call is the final verdict after review work, not a shortcut around review work.",
-        ].join("\n"),
-      ],
-      [
-        "action_items",
-        [
-          "1. Identify the changed files or diff under review.",
-          "2. Read the relevant changed code and directly affected call sites/tests/configs.",
-          "3. Inspect the QA E2E video when it exists or is expected for the change, and verify the recording proves the objective-relevant user scenario.",
-          "4. Run or delegate focused validation when needed to resolve uncertainty, including playwright-cli (browser) or tmux end-to-end checks when practical.",
-          "5. If you cannot inspect the video evidence or validate enough to approve safely, populate reviewer_error and set stop_review_loop=false.",
-        ].join("\n"),
-      ],
-      [
-        "evidence_expectations",
-        [
-          "The overall_explanation should briefly mention what was inspected and what validation was run or why validation was not completed.",
-          "Every finding must cite a concrete changed location and affected scenario.",
-        ].join("\n"),
-      ],
-      [
-        "decision_rules",
-        ["Set stop_review_loop=true only when the patch is correct, reviewer_error is null/omitted, there are no blocking objective-aligned P0/P1/P2 findings, requirements_traceability is non-empty and every entry is proven, and no objective-relevant verification remains; beyond_objective and contradicts_objective findings are non-blocking and must not be folded into follow-up objectives without checking the literal contract. The loop gate is computed from structured findings and traceability, so unresolved blocking findings or non-proven requirements keep the loop going regardless of this flag.", "Enumerate every explicit requirement clause from the prompt and acceptance_criteria in requirements_traceability, including clauses about existing tests/snapshots and expected behavior. Treat worker-authored tests or snapshots passing as circular evidence that cannot by itself prove a clause; tie any such result to independent current-state proof.", "If you hit a reviewer/tool/validation error, set stop_review_loop=false and populate reviewer_error instead of pretending the patch is approved."].join("\n"),
-      ],
-    ]);
+      comparisonBaseBranch,
+      researchPath,
+      implementationNotesPath,
+      orchestratorReportPath,
+      qaVideoPath,
+    });
     let reviews: WorkflowTaskResult[];
     try {
       reviews = await ctx.parallel(

--- a/packages/workflows/builtin/shared-prompts.ts
+++ b/packages/workflows/builtin/shared-prompts.ts
@@ -43,5 +43,10 @@ export const LITERAL_OBJECTIVE_CONTRACT = [
   "- If the objective and acceptance criteria conflict, do not implement the contradiction. Surface it as a blocker or reviewer finding instead.",
   "- When external knowledge (language specs, upstream issues, in-repo comments, general best practice, or prior reviewer speculation) conflicts with explicit objective wording, the objective/acceptance criteria win.",
   "- Never silently resolve such a conflict in favor of external knowledge. Surface the conflict clearly.",
+  "- Prefer loud errors over silent reinterpretation: when the objective/acceptance criteria enumerate required error conditions, messages, or rejections, give each enumerated error the widest plausible trigger surface. When the contract leaves an input ambiguous or unspecified near an enumerated error case, prefer raising that error over silently reinterpreting the input as different valid behavior, even when external spec knowledge says the input is valid.",
+  "- Only narrow an enumerated error's trigger surface when the objective, acceptance criteria, or pre-existing required tests explicitly require the ambiguous input to be accepted. Widening an enumerated error to nearby ambiguous inputs is applying the contract, not adding beyond it.",
   "- Do not add behaviors, restrictions, error conditions, or follow-up requirements beyond what the objective/acceptance criteria require.",
 ].join("\n");
+
+export const REVIEWER_SPEC_VS_OBJECTIVE_GUARD =
+  "Do not use external spec/standard conformance alone to flag a wide trigger surface for an error condition the objective/acceptance criteria enumerate; the contract prefers loud errors over silent reinterpretation of ambiguous inputs, so classify such spec-vs-objective tension as beyond_objective rather than a blocking defect.";


### PR DESCRIPTION
## Summary

Hardens the builtin `goal` and `ralph` loops against spec-vs-objective drift on enumerated error behavior. Motivated by an eval trace (`meriyah-explicit-resource-declarations`) where the run scored 47/49 F2P with zero P2P regressions but earned reward 0: the adversarial review stage flagged a task-mandated diagnostic ("cannot have destructuring") as a spec-conformance defect, and the fix cycle then silently reinterpreted the ambiguous input as valid behavior — deleting the exact error the task contract enumerated.

## Changes

- **`shared-prompts.ts`** — extends `LITERAL_OBJECTIVE_CONTRACT` (injected into every goal worker/reviewer stage and every ralph research/orchestrator/reviewer stage) with two bullets:
  - When the objective/acceptance criteria enumerate required error conditions, messages, or rejections, give each enumerated error the **widest plausible trigger surface**; inputs the contract leaves ambiguous near an enumerated error case default to raising that error, *even when external spec knowledge says the input is valid*.
  - Narrowing an enumerated error's trigger surface requires explicit demand from the objective, acceptance criteria, or pre-existing required tests; widening to nearby ambiguous inputs is applying the contract, not adding beyond it.
- **`shared-prompts.ts`** — new shared `REVIEWER_SPEC_VS_OBJECTIVE_GUARD` constant, consumed by both loops' reviewer bug-selection guidelines: external spec/standard conformance alone cannot flag a wide trigger surface for a contract-enumerated error as a defect; such spec-vs-objective tension must be classified `beyond_objective` (non-blocking) instead of steering the fix loop away from the contract's errors.
- **`goal-prompts.ts`** — reviewer `bug_selection_criteria` includes the guard.
- **`ralph-reviewer-prompt.ts`** (new) — ralph's reviewer prompt extracted into `renderRalphReviewerPrompt()` with the guard in `bug_selection_guidelines`; `ralph-runner.ts` was sitting exactly at the 500-line gate, so the split was required anyway. No behavioral change beyond the guard.
- **`CHANGELOG.md`** — entries under `[Unreleased]`.

## Notes

- Validation: `bun run typecheck`, `bun run lint`, `bun run check:file-length`, and the full `bun run test:unit` suite all pass (via prek pre-commit hooks); render smoke test confirms both goal and ralph reviewer prompts contain the new contract bullets and guard.
- Counterfactual: with this guard in place, the meriyah eval's reviewer finding on the task-mandated destructuring error would have been non-blocking `beyond_objective`, and the fix stage would not have narrowed the error surface on spec grounds alone — recovering one of the two failed hidden tests (the other, a spec-contradicting `for (using of of x)` binding expectation, remains unguessable by design).