### PR TITLE
docs: release notes for 0.9.5-alpha.4

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.4] - 2026-07-05
+
 ### Changed
 
 - Simplified first-run onboarding to a one-time verifiable-coding-agent-runtime explanation shown after any What's New notes and directly above the normal input box; Atomic no longer intercepts pasted tasks, saves pre-login seeds, routes first-run input to `goal`/`ralph`, raises reasoning for onboarding, or requires `/chat` to continue normally. The notice now reminds unauthenticated users to run `/login` first, and starting a new session with `/new` clears any rendered first-run notice state from the previous session canvas.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.4] - 2026-07-05
+
 ### Changed
 
 - Hardened the builtin `goal` and `ralph` loops against spec-vs-objective drift on enumerated error behavior (observed in an eval trace where an adversarial reviewer flagged a task-mandated diagnostic as a spec-conformance defect and the fix cycle silently reinterpreted the ambiguous input as valid behavior, losing the required error): the shared literal objective contract now instructs workers and reviewers to prefer loud errors over silent reinterpretation — when the objective/acceptance criteria enumerate required error conditions, messages, or rejections, each enumerated error gets the widest plausible trigger surface, ambiguous or unspecified inputs near an enumerated error case default to raising that error even when external spec knowledge says the input is valid, and narrowing an enumerated error's trigger surface requires explicit contract or pre-existing required-test demand. Both loops' reviewer bug-selection guidelines now forbid using external spec/standard conformance alone to flag a wide trigger surface for a contract-enumerated error as a defect; such spec-vs-objective tension must be classified `beyond_objective` instead of becoming a blocking finding that steers the implementation away from the contract's errors.


### PR DESCRIPTION
## Release 0.9.5-alpha.4

Adds release-notes headers to the changelogs for the `0.9.5-alpha.4` prerelease, cutting over the accumulated `[Unreleased]` entries into a dated `[0.9.5-alpha.4]` section in each package. No code or version-bump changes.

- **Release kind:** prerelease (`@next` dist-tag)
- **Version / tag:** `0.9.5-alpha.4` (no leading `v`)
- **Base branch (PR target & tag base):** `main`
- **Head branch:** `prerelease/0.9.5-alpha.4`
- **Head SHA:** `91974112d7e7fe84cd94d2cb2a71a4e16a4d8a80` (from source HEAD `3f58508f67279bcb47e91f14473449004758e210`)

### Changes (release notes only — no version bumps)

- `packages/coding-agent/CHANGELOG.md` — inserts `## [0.9.5-alpha.4] - 2026-07-05` above the existing onboarding-simplification entry
- `packages/workflows/CHANGELOG.md` — inserts `## [0.9.5-alpha.4] - 2026-07-05` above the existing goal/ralph loud-error-vs-silent-reinterpretation entry

`main` remains versionless: all `packages/*/package.json` stay at the `0.0.0` placeholder. No `scripts/bump-version.ts` invocation and no package version changes are included in this PR. The real version `0.9.5-alpha.4` will be materialized only on a throwaway off-`main` tag commit via `scripts/cut-release.ts` after this PR merges; that tag commit is never merged back into `main`.

### Validation

```sh
git branch --show-current   # prerelease/0.9.5-alpha.4
git rev-parse HEAD          # 91974112d7e7fe84cd94d2cb2a71a4e16a4d8a80
git status --short          # clean
git diff --name-only 3f58508f67279bcb47e91f14473449004758e210..HEAD
bun run typecheck           # exit 0
bun run test:unit           # exit 0
```

Pre-push hooks (lint, file-length gate, unit tests, merge-conflict/large-file checks) passed on push.