### PR TITLE
feat(evals): add subscription-first Atomic auth

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -110,6 +110,49 @@ uv run pier run \
 
 For GHES use `COPILOT_API_TARGET=api.enterprise.githubcopilot.com`; for GHEC use `COPILOT_API_TARGET=copilot-api.<tenant>.ghe.com`.
 
+### Anthropic subscription with OpenRouter fallback
+
+Export `ANTHROPIC_OAUTH_TOKEN` to run Anthropic models through the subscription OAuth path. Also export `OPENROUTER_API_KEY` if you want the adapters to fall back to the equivalent `openrouter/anthropic/...` model when the subscription token is unavailable:
+
+```bash
+export ANTHROPIC_OAUTH_TOKEN="..."
+export OPENROUTER_API_KEY="..."  # optional fallback
+
+uv run pier run \
+  -p deep-swe/tasks \
+  --agent-import-path atomic_pier:Atomic \
+  --model anthropic/claude-opus-4-8 \
+  --agent-kwarg thinking=xhigh \
+  --agent-kwarg version=next \
+  --agent-timeout-multiplier 16 \
+  --n-tasks 1 \
+  --sample-seed 0 \
+  --force-build
+```
+
+The native Anthropic provider uses dash-form model ids such as `claude-opus-4-8`; when falling back, the adapters translate version suffixes to OpenRouter's matching dot-form slugs such as `openrouter/anthropic/claude-opus-4.8`.
+
+### OpenAI Codex subscription with OpenRouter fallback
+
+For `openai-codex/...` models, Atomic uses OAuth credentials stored in the agent auth file rather than an environment variable. Log in on the host so `~/.atomic/agent/auth.json` (or legacy `~/.pi/agent/auth.json`) contains an `openai-codex` entry. The Pier and Harbor adapters copy only that provider entry into the sandbox user's `~/.atomic/agent/auth.json` with `0600` permissions before launching Atomic. Export `OPENROUTER_API_KEY` if you want missing Codex subscription auth to fall back to the equivalent `openrouter/openai/...` model.
+
+```bash
+export OPENROUTER_API_KEY="..."  # optional fallback
+
+uv run pier run \
+  -p deep-swe/tasks \
+  --agent-import-path atomic_pier:Atomic \
+  --model openai-codex/gpt-5.5 \
+  --agent-kwarg thinking=xhigh \
+  --agent-kwarg version=next \
+  --agent-timeout-multiplier 16 \
+  --n-tasks 1 \
+  --sample-seed 0 \
+  --force-build
+```
+
+The adapters do not introduce Codex-specific auth environment variables and do not print the OAuth credential contents.
+
 ### OpenRouter
 
 Export an OpenRouter API key and use an OpenRouter model slug after the `openrouter/` provider prefix:
@@ -135,11 +178,12 @@ The Pier network allowlist automatically includes `openrouter.ai` when the model
 
 ## Adapter behavior
 
-The adapter is self-contained; it does not require patching Pier. It follows the Harbor/Pier installed-agent pattern:
+The adapter is self-contained; it does not require patching Pier or Harbor. It follows the installed-agent pattern:
 
 1. Install Atomic and required local search tools (`rg` and `fd`) during setup.
 2. Run the Atomic CLI in JSON mode.
-3. Tee Atomic's JSON stream to `/logs/agent/atomic.txt`.
-4. Collect usage and trajectory data from the logs.
+3. Keep Atomic's mutable agent state under the sandbox user's `~/.atomic/agent` directory by setting Atomic's existing agent-dir environment override, passing `--session-dir ~/.atomic/agent/atomic-sessions`, and exporting `ATOMIC_TODO_PATH=$HOME/.atomic/agent/todos` inside the sandbox so the default todo tool cannot create `.atomic/todos` in the benchmark repository.
+4. Tee Atomic's JSON stream to `/logs/agent/atomic.txt` and copy session transcripts to `/logs/agent/atomic-sessions/` after the run, with an exit trap to preserve transcripts on SIGTERM-based timeouts.
+5. Collect usage and trajectory data from the logs.
 
 Like the built-in Pier agents, it does not auto-commit work. Deep SWE tasks rely on the agent following the task instruction to commit.

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -1,6 +1,8 @@
 import json
 import os
+import re
 import shlex
+import tempfile
 from pathlib import Path
 from typing import override
 
@@ -16,7 +18,10 @@ from harbor.models.agent.context import AgentContext
 class Atomic(BaseInstalledAgent):
     _OUTPUT_FILENAME = "atomic.txt"
     _SESSION_DIR_NAME = "atomic-sessions"
-    _CONTAINER_SESSION_DIR = f"/logs/agent/{_SESSION_DIR_NAME}"
+    _CONTAINER_SESSION_DIR = f"$HOME/.atomic/agent/{_SESSION_DIR_NAME}"
+    _LOG_SESSION_DIR = f"/logs/agent/{_SESSION_DIR_NAME}"
+    _OPENAI_CODEX_PROVIDER = "openai-codex"
+    _OPENAI_CODEX_UPLOAD_TARGET = "/tmp/atomic-openai-codex-auth.json"
 
     CLI_FLAGS = [
         CliFlag(
@@ -76,6 +81,121 @@ class Atomic(BaseInstalledAgent):
             f"$HOME/.agents/skills/ 2>/dev/null || true"
         )
 
+    @staticmethod
+    def _auth_config_paths() -> tuple[Path, ...]:
+        return (
+            Path.home() / ".atomic" / "agent" / "auth.json",
+            Path.home() / ".pi" / "agent" / "auth.json",
+        )
+
+    def _load_openai_codex_auth(self) -> dict[str, object] | None:
+        merged: dict[str, object] = {}
+        for auth_path in reversed(self._auth_config_paths()):
+            try:
+                data = json.loads(auth_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict):
+                merged.update(data)
+        entry = merged.get(self._OPENAI_CODEX_PROVIDER)
+        return entry if isinstance(entry, dict) else None
+
+    def _has_subscription_auth(self, provider: str) -> bool:
+        if provider == "anthropic":
+            return bool(self._get_env("ANTHROPIC_OAUTH_TOKEN"))
+        if provider == self._OPENAI_CODEX_PROVIDER:
+            return self._load_openai_codex_auth() is not None
+        return True
+
+    @staticmethod
+    def _openrouter_anthropic_model(model: str) -> str:
+        return re.sub(r"-(\d+)-(\d+)$", r"-\1.\2", model)
+
+    def _fallback_model(self, provider: str, model: str) -> tuple[str, str] | None:
+        if not self._get_env("OPENROUTER_API_KEY"):
+            return None
+        if provider == "anthropic":
+            return "openrouter", f"anthropic/{self._openrouter_anthropic_model(model)}"
+        if provider == self._OPENAI_CODEX_PROVIDER:
+            return "openrouter", f"openai/{model}"
+        return None
+
+    def _select_provider_model(self, provider: str, model: str) -> tuple[str, str]:
+        # The Atomic CLI has no top-level subscription->OpenRouter retry flag; its
+        # `fallbackModels` support is scoped to workflow/subagent attempts. For
+        # eval runs we therefore select the OpenRouter mirror before launch only
+        # when the subscription credential is absent, preserving subscription-first
+        # behavior while avoiding a failed primary attempt that cannot recover.
+        if not self._has_subscription_auth(provider):
+            fallback = self._fallback_model(provider, model)
+            if fallback:
+                return fallback
+        return provider, model
+
+    async def _provision_openai_codex_auth(
+        self,
+        environment: BaseEnvironment,
+        provider: str,
+    ) -> None:
+        if provider != self._OPENAI_CODEX_PROVIDER:
+            return
+        entry = self._load_openai_codex_auth()
+        if entry is None:
+            return
+        auth_data = {self._OPENAI_CODEX_PROVIDER: entry}
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            temp_path = Path(handle.name)
+            json.dump(auth_data, handle, indent=2)
+            handle.write("\n")
+        try:
+            os.chmod(temp_path, 0o600)
+            await environment.upload_file(temp_path, self._OPENAI_CODEX_UPLOAD_TARGET)
+        finally:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+        if environment.default_user is not None:
+            await self.exec_as_root(
+                environment,
+                command=(
+                    f"chown {shlex.quote(str(environment.default_user))} "
+                    f"{self._OPENAI_CODEX_UPLOAD_TARGET}"
+                ),
+            )
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "mkdir -p $HOME/.atomic/agent && chmod 700 $HOME/.atomic/agent && "
+                f"install -m 600 {self._OPENAI_CODEX_UPLOAD_TARGET} "
+                "$HOME/.atomic/agent/auth.json && "
+                f"rm -f {self._OPENAI_CODEX_UPLOAD_TARGET}"
+            ),
+        )
+
+    @staticmethod
+    def _agent_state_env() -> dict[str, str]:
+        return {"ATOMIC_CODING_AGENT_DIR": "~/.atomic/agent"}
+
+    @staticmethod
+    def _agent_state_setup_command() -> str:
+        return (
+            "mkdir -p $HOME/.atomic/agent/cache $HOME/.atomic/agent/todos && "
+            "chmod 700 $HOME/.atomic/agent && "
+            "export ATOMIC_TODO_PATH=\"$HOME/.atomic/agent/todos\"; "
+        )
+
+    @staticmethod
+    def _session_sync_trap_command(session_dir: str, log_session_dir: str) -> str:
+        return (
+            "sync_atomic_sessions() { "
+            f"mkdir -p {log_session_dir}; "
+            f"cp -a {session_dir}/. {log_session_dir}/ 2>/dev/null || true; "
+            "}; "
+            "trap sync_atomic_sessions EXIT; "
+            "trap 'sync_atomic_sessions; exit 143' TERM; "
+        )
+
     @with_prompt_template
     async def run(
         self,
@@ -88,50 +208,42 @@ class Atomic(BaseInstalledAgent):
         if not self.model_name or "/" not in self.model_name:
             raise ValueError("Model name must be in the format provider/model_name")
 
-        provider, _ = self.model_name.split("/", 1)
+        requested_provider, requested_model = self.model_name.split("/", 1)
+        provider, model = self._select_provider_model(requested_provider, requested_model)
 
         env: dict[str, str] = {}
-        keys: list[str] = []
-
-        if provider == "amazon-bedrock":
-            keys.extend(["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"])
-        elif provider == "anthropic":
-            keys.extend(["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"])
-        elif provider == "github-copilot":
-            keys.append("COPILOT_GITHUB_TOKEN")
-        elif provider == "google":
-            keys.extend(
-                [
-                    "GEMINI_API_KEY",
-                    "GOOGLE_GENERATIVE_AI_API_KEY",
-                    "GOOGLE_APPLICATION_CREDENTIALS",
-                    "GOOGLE_CLOUD_PROJECT",
-                    "GOOGLE_CLOUD_LOCATION",
-                    "GOOGLE_GENAI_USE_VERTEXAI",
-                    "GOOGLE_API_KEY",
-                ]
-            )
-        elif provider == "groq":
-            keys.append("GROQ_API_KEY")
-        elif provider == "huggingface":
-            keys.append("HF_TOKEN")
-        elif provider == "mistral":
-            keys.append("MISTRAL_API_KEY")
-        elif provider == "openai":
-            keys.append("OPENAI_API_KEY")
-        elif provider == "openrouter":
+        provider_env_keys: dict[str, tuple[str, ...]] = {
+            "amazon-bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"),
+            "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"),
+            "github-copilot": ("COPILOT_GITHUB_TOKEN",),
+            "google": (
+                "GEMINI_API_KEY",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+                "GOOGLE_APPLICATION_CREDENTIALS",
+                "GOOGLE_CLOUD_PROJECT",
+                "GOOGLE_CLOUD_LOCATION",
+                "GOOGLE_GENAI_USE_VERTEXAI",
+                "GOOGLE_API_KEY",
+            ),
+            "groq": ("GROQ_API_KEY",),
+            "huggingface": ("HF_TOKEN",),
+            "mistral": ("MISTRAL_API_KEY",),
+            "openai": ("OPENAI_API_KEY",),
+            "openai-codex": (),
+            "openrouter": ("OPENROUTER_API_KEY",),
+            "xai": ("XAI_API_KEY",),
+        }
+        keys = list(provider_env_keys.get(provider, ()))
+        if requested_provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}:
             keys.append("OPENROUTER_API_KEY")
-        elif provider == "xai":
-            keys.append("XAI_API_KEY")
 
         for key in keys:
-            val = os.environ.get(key)
+            val = self._get_env(key)
             if val:
                 env[key] = val
+        env.update(self._agent_state_env())
 
-        model_args = (
-            f"--provider {provider} --model {self.model_name.split('/', 1)[1]} "
-        )
+        model_args = f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
 
         cli_flags = self.build_cli_flags()
         if cli_flags:
@@ -140,21 +252,27 @@ class Atomic(BaseInstalledAgent):
         skills_command = self._build_register_skills_command()
         if skills_command:
             await self.exec_as_agent(environment, command=skills_command)
+        await self._provision_openai_codex_auth(environment, requested_provider)
 
-        # Persist the main chat under /logs so workflow stage sessions inherit
-        # that directory and can be included in post-run usage accounting.
-        session_dir = shlex.quote(self._CONTAINER_SESSION_DIR)
+        # Atomic state stays under the container user's ~/.atomic/agent; after
+        # the run, transcripts are copied to /logs for Harbor artifact parsing.
+        session_dir = self._CONTAINER_SESSION_DIR
+        log_session_dir = shlex.quote(self._LOG_SESSION_DIR)
 
         await self.exec_as_agent(
             environment,
             command=(
-                f"rm -rf {session_dir} && mkdir -p {session_dir} && "
+                f"rm -rf {session_dir} {log_session_dir} && mkdir -p {session_dir} && "
+                f"{self._agent_state_setup_command()}"
+                f"{self._session_sync_trap_command(session_dir, log_session_dir)}"
                 f". ~/.nvm/nvm.sh && "
                 f"atomic --print --mode json --session-dir {session_dir} "
                 f"{model_args}"
                 f"{cli_flags}"
                 f"{escaped_instruction} "
-                f'2>&1 </dev/null | grep -v \'"type":"message_update"\' | stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}'
+                "2>&1 </dev/null | grep -v '\"type\":\"message_update\"' | "
+                f"stdbuf -oL tee /logs/agent/{self._OUTPUT_FILENAME}; status=$?; "
+                "exit $status"
             ),
             env=env,
         )

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
+import re
 import shlex
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -38,7 +41,11 @@ class Atomic(BaseInstalledAgent):
 
     _OUTPUT_FILENAME = "atomic.txt"
     _SESSION_DIR_NAME = "atomic-sessions"
-    _CONTAINER_SESSION_DIR = str(EnvironmentPaths.agent_dir / _SESSION_DIR_NAME)
+    _CONTAINER_AGENT_DIR = "$HOME/.atomic/agent"
+    _CONTAINER_SESSION_DIR = f"{_CONTAINER_AGENT_DIR}/{_SESSION_DIR_NAME}"
+    _LOG_SESSION_DIR = str(EnvironmentPaths.agent_dir / _SESSION_DIR_NAME)
+    _OPENAI_CODEX_PROVIDER = "openai-codex"
+    _OPENAI_CODEX_UPLOAD_TARGET = "/tmp/atomic-openai-codex-auth.json"
 
     _PROVIDER_ENV_KEYS: dict[str, tuple[str, ...]] = {
         "amazon-bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"),
@@ -60,6 +67,7 @@ class Atomic(BaseInstalledAgent):
         # "huggingface": ("HF_TOKEN",),
         "mistral": ("MISTRAL_API_KEY",),
         "openai": ("OPENAI_API_KEY",),
+        "openai-codex": (),
         "openrouter": ("OPENROUTER_API_KEY",),
         "xai": ("XAI_API_KEY",),
     }
@@ -98,6 +106,7 @@ class Atomic(BaseInstalledAgent):
         # "huggingface": ("huggingface.co",),  # disabled: unused provider
         "mistral": ("api.mistral.ai",),
         "openai": ("api.openai.com",),
+        "openai-codex": ("chatgpt.com", "auth.openai.com"),
         "openrouter": ("openrouter.ai",),
         "xai": ("api.x.ai",),
     }
@@ -191,6 +200,121 @@ class Atomic(BaseInstalledAgent):
             "$HOME/.agents/skills/ 2>/dev/null || true"
         )
 
+    @staticmethod
+    def _auth_config_paths() -> tuple[Path, ...]:
+        return (
+            Path.home() / ".atomic" / "agent" / "auth.json",
+            Path.home() / ".pi" / "agent" / "auth.json",
+        )
+
+    def _load_openai_codex_auth(self) -> dict[str, object] | None:
+        merged: dict[str, object] = {}
+        for auth_path in reversed(self._auth_config_paths()):
+            try:
+                data = json.loads(auth_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict):
+                merged.update(data)
+        entry = merged.get(self._OPENAI_CODEX_PROVIDER)
+        return entry if isinstance(entry, dict) else None
+
+    def _has_subscription_auth(self, provider: str) -> bool:
+        if provider == "anthropic":
+            return bool(self._get_env("ANTHROPIC_OAUTH_TOKEN"))
+        if provider == self._OPENAI_CODEX_PROVIDER:
+            return self._load_openai_codex_auth() is not None
+        return True
+
+    @staticmethod
+    def _openrouter_anthropic_model(model: str) -> str:
+        return re.sub(r"-(\d+)-(\d+)$", r"-\1.\2", model)
+
+    def _fallback_model(self, provider: str, model: str) -> tuple[str, str] | None:
+        if not self._get_env("OPENROUTER_API_KEY"):
+            return None
+        if provider == "anthropic":
+            return "openrouter", f"anthropic/{self._openrouter_anthropic_model(model)}"
+        if provider == self._OPENAI_CODEX_PROVIDER:
+            return "openrouter", f"openai/{model}"
+        return None
+
+    def _select_provider_model(self, provider: str, model: str) -> tuple[str, str]:
+        # The Atomic CLI has no top-level subscription->OpenRouter retry flag; its
+        # `fallbackModels` support is scoped to workflow/subagent attempts. For
+        # eval runs we therefore select the OpenRouter mirror before launch only
+        # when the subscription credential is absent, preserving subscription-first
+        # behavior while avoiding a failed primary attempt that cannot recover.
+        if not self._has_subscription_auth(provider):
+            fallback = self._fallback_model(provider, model)
+            if fallback:
+                return fallback
+        return provider, model
+
+    async def _provision_openai_codex_auth(
+        self,
+        environment: BaseEnvironment,
+        provider: str,
+    ) -> None:
+        if provider != self._OPENAI_CODEX_PROVIDER:
+            return
+        entry = self._load_openai_codex_auth()
+        if entry is None:
+            return
+        auth_data = {self._OPENAI_CODEX_PROVIDER: entry}
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            temp_path = Path(handle.name)
+            json.dump(auth_data, handle, indent=2)
+            handle.write("\n")
+        try:
+            os.chmod(temp_path, 0o600)
+            await environment.upload_file(temp_path, self._OPENAI_CODEX_UPLOAD_TARGET)
+        finally:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+        if environment.default_user is not None:
+            await self.exec_as_root(
+                environment,
+                command=(
+                    f"chown {shlex.quote(str(environment.default_user))} "
+                    f"{self._OPENAI_CODEX_UPLOAD_TARGET}"
+                ),
+            )
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "mkdir -p $HOME/.atomic/agent && chmod 700 $HOME/.atomic/agent && "
+                f"install -m 600 {self._OPENAI_CODEX_UPLOAD_TARGET} "
+                "$HOME/.atomic/agent/auth.json && "
+                f"rm -f {self._OPENAI_CODEX_UPLOAD_TARGET}"
+            ),
+        )
+
+    @staticmethod
+    def _agent_state_env() -> dict[str, str]:
+        return {"ATOMIC_CODING_AGENT_DIR": "~/.atomic/agent"}
+
+    @staticmethod
+    def _agent_state_setup_command() -> str:
+        return (
+            "mkdir -p $HOME/.atomic/agent/cache $HOME/.atomic/agent/todos && "
+            "chmod 700 $HOME/.atomic/agent && "
+            "export ATOMIC_TODO_PATH=\"$HOME/.atomic/agent/todos\"; "
+        )
+
+    @staticmethod
+    def _session_sync_trap_command(session_dir: str, log_session_dir: str) -> str:
+        return (
+            "sync_atomic_sessions() { "
+            f"mkdir -p {log_session_dir}; "
+            f"cp -a {session_dir}/. {log_session_dir}/ 2>/dev/null || true; "
+            "}; "
+            "trap sync_atomic_sessions EXIT; "
+            "trap 'sync_atomic_sessions; exit 143' TERM; "
+        )
+
     @with_prompt_template
     async def run(
         self,
@@ -201,12 +325,21 @@ class Atomic(BaseInstalledAgent):
         if not self.model_name or "/" not in self.model_name:
             raise ValueError("Model name must be in the format provider/model_name")
 
-        provider, model = self.model_name.split("/", 1)
+        requested_provider, requested_model = self.model_name.split("/", 1)
+        provider, model = self._select_provider_model(requested_provider, requested_model)
         env = {
             key: value
-            for key in self._PROVIDER_ENV_KEYS.get(provider, ())
+            for key in (
+                *self._PROVIDER_ENV_KEYS.get(provider, ()),
+                *(
+                    ("OPENROUTER_API_KEY",)
+                    if requested_provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}
+                    else ()
+                ),
+            )
             if (value := self._get_env(key))
         }
+        env.update(self._agent_state_env())
         copilot_base_url = (
             self._copilot_api_base_url() if provider == "github-copilot" else None
         )
@@ -214,23 +347,29 @@ class Atomic(BaseInstalledAgent):
         skills_command = self._build_register_skills_command()
         if skills_command:
             await self.exec_as_agent(environment, command=skills_command)
+        await self._provision_openai_codex_auth(environment, requested_provider)
 
         cli_flags = self.build_cli_flags()
         if cli_flags:
             cli_flags += " "
 
-        session_dir = shlex.quote(self._CONTAINER_SESSION_DIR)
+        session_dir = self._CONTAINER_SESSION_DIR
+        log_session_dir = shlex.quote(self._LOG_SESSION_DIR)
         output_file = shlex.quote(str(EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME))
         copilot_config_command = self._copilot_models_config_command(copilot_base_url)
         command = (
-            f"rm -rf {session_dir} && mkdir -p {session_dir} && "
+            f"rm -rf {session_dir} {log_session_dir} && mkdir -p {session_dir} && "
+            f"{self._agent_state_setup_command()}"
+            f"{self._session_sync_trap_command(session_dir, log_session_dir)}"
             f"{copilot_config_command}"
             "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi && "
             f"atomic --print --mode json --session-dir {session_dir} "
             f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
             f"{cli_flags}"
             f"{shlex.quote(instruction)} "
-            f"2>&1 </dev/null | grep -v '\"type\":\"message_update\"' | stdbuf -oL tee {output_file}"
+            "2>&1 </dev/null | grep -v '\"type\":\"message_update\"' | "
+            f"stdbuf -oL tee {output_file}; status=$?; "
+            "exit $status"
         )
         await self.exec_as_agent(environment, command=command, env=env)
         self.populate_context_post_run(context)
@@ -270,7 +409,7 @@ class Atomic(BaseInstalledAgent):
         models_config = {"providers": {"github-copilot": {"baseUrl": base_url}}}
         config_json = json.dumps(models_config, indent=2)
         return (
-            "mkdir -p $HOME/.atomic/agent && "
+            "mkdir -p $HOME/.atomic/agent && chmod 700 $HOME/.atomic/agent && "
             "cat > $HOME/.atomic/agent/models.json <<'ATOMIC_MODELS_JSON'\n"
             f"{config_json}\n"
             "ATOMIC_MODELS_JSON\n"


### PR DESCRIPTION
## Summary

Adds subscription-first authentication for the Atomic Pier/Harbor eval adapters, with an OpenRouter fallback when subscription credentials are unavailable, and isolates Atomic's mutable agent state from the benchmark git workspace.

## Key changes

- **Anthropic subscription auth**: adapters check for `ANTHROPIC_OAUTH_TOKEN` and pass it through to the sandbox; both adapters accept the credential without requiring `ANTHROPIC_API_KEY`.
- **OpenAI Codex subscription auth**: since Codex has no env-var credential, the adapters read the `openai-codex` entry out of the host's `~/.atomic/agent/auth.json` (falling back to legacy `~/.pi/agent/auth.json`), write just that entry to a temp file, upload it into the sandbox, `chown`/`chmod 600` it into `$HOME/.atomic/agent/auth.json`, and remove the temp copy. No Codex-specific auth env vars are introduced, and credential contents are never printed.
- **OpenRouter fallback selection**: `_select_provider_model` swaps to the equivalent `openrouter/anthropic/...` or `openrouter/openai/...` model *before* launch when the subscription credential is missing and `OPENROUTER_API_KEY` is set, since Atomic's CLI has no subscription→OpenRouter retry at the top level. Includes dash-to-dot slug translation (e.g. `claude-opus-4-8` → `claude-opus-4.8`) for Anthropic's OpenRouter mirrors.
- **Sandboxed agent state**: routes Atomic's agent dir, session dir, cache, and todo path under the sandbox user's `~/.atomic/agent` (via `ATOMIC_CODING_AGENT_DIR`, `--session-dir`, and `ATOMIC_TODO_PATH`) instead of the benchmark repo, preventing the todo tool or session state from polluting the git workspace under evaluation. Directories are created with `700` permissions.
- **Session artifact preservation**: session transcripts are copied from the sandbox agent dir to `/logs` after the run for Harbor/Pier artifact parsing, with an `EXIT`/`TERM` trap so transcripts are preserved even when a run is killed on timeout.
- **`openai-codex` provider registration**: added to both adapters' provider env-key and (Pier) network-allowlist maps (`chatgpt.com`, `auth.openai.com`), with no required env keys since auth flows through the uploaded `auth.json` instead.
- **Docs**: `evals/README.md` documents the Anthropic and OpenAI Codex subscription-first flows, their OpenRouter fallback options, and the updated adapter behavior (agent-state isolation, session-copy-on-exit).

## Validation

- `cd evals && uv run python -c "import atomic_pier, atomic_harbor"`
- `cd evals && uv run python -m py_compile atomic_pier.py atomic_harbor.py`
- `! rg 'CODEX_AUTH|CODEX.*AUTH|AUTH.*CODEX|CODEX_AUTH_JSON|CODEX_TOKEN' evals/atomic_pier.py evals/atomic_harbor.py evals/README.md`
- `git diff --check -- evals/atomic_pier.py evals/atomic_harbor.py evals/README.md`
- `git push -u origin feat/evals-subscription-auth` ran repository pre-push hooks successfully, including `bun run lint`, `bun run check:file-length`, and `bun run test:unit`.

## Goal-run evidence used

The goal ledger and worker receipt reported the eval objective complete: import/py_compile checks passed, forbidden Codex auth-env grep had no matches, Codex auth provisioning reached live `openai-codex` model execution in a smoke run, and reviewer quorum accepted remaining P3 findings as non-blocking. The PR focuses on the accepted scope and does not include unrelated `.atomic/context` artifacts.