### PR TITLE
docs(changelog): release notes for 0.9.5-alpha.5

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.5] - 2026-07-06
+
 ### Added
 
 - Added an internal tiered fallback ladder for automatic Verbatim Compaction when the strict `compression_ratio` target is not achievable: threshold and overflow auto-compaction now keep the standard strict planner pass as tier 1, tier 2 can accept a validated below-target result with at least one deletion when projected `tokensAfter` clears the relevant budget (`effectiveInputBudget - reserveTokens` for threshold, effective input budget for overflow), overflow commits from Atomic's internal ladder are gated on fitting the effective input budget even when the strict target is met, overflow-only tier 3 reruns the planner with critical LRU-style protected-entry eligibility for stale task-bearing user/custom/branch-summary context and an effective recent floor of `max(preserve_recent, 5)` across all compactable entries, and overflow-only tier 4 performs deterministic code-level LRU eviction without a model call or API credentials while enforcing the same effective last-5 recent floor until the effective input budget fits or no more safe deletion remains. The fallback tiers remain internal: extension hooks keep their existing shapes, extension-provided deletion requests still bypass the ladder including the overflow budget gate, and no public compaction mode API is exposed.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.5] - 2026-07-06
+
 ### Changed
 
 - Changed the Claude Fable 5 reasoning level from `xhigh` to `high` in the builtin `debugger` agent, covering the `anthropic/claude-fable-5` primary and its OpenRouter mirror in the fallback chain.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.5] - 2026-07-06
+
 ### Added
 
 - Added `git_worktree_dir` to the builtin `goal` workflow with Ralph-parity input binding so Goal runs can create or reuse a repository worktree from `base_branch` while preserving the invoking repo-relative cwd for worker, reviewer, and optional final PR stages.


### PR DESCRIPTION
## Release 0.9.5-alpha.5

- **Release kind:** prerelease (`@next` dist-tag)
- **Version / tag:** `0.9.5-alpha.5` (no leading `v`)
- **Head commit:** `fc1bc0e4c0ffba1cda73b0060a7c48a7c65bb577` (from `main` @ `397b09acda1503300a9f64980bfa802ca76a4e1e`)

### Scope

CHANGELOG-only release-notes PR: closes out each package's `[Unreleased]` section into a new `## [0.9.5-alpha.5] - 2026-07-06` section. No version bump on `main` — packages stay at the `0.0.0` placeholder; the real version is materialized only on the throwaway off-`main` tag commit produced by `scripts/cut-release.ts`.

### Changelog updates

- `packages/coding-agent/CHANGELOG.md` — **Added:** internal tiered fallback ladder for automatic Verbatim Compaction when the strict `compression_ratio` target is unachievable (strict planner tier 1, budget-gated below-target acceptance tier 2, overflow-only protected-entry rerun tier 3, deterministic code-level LRU eviction tier 4); extension hook shapes unchanged, no public compaction mode API exposed.
- `packages/subagents/CHANGELOG.md` — **Changed:** builtin `debugger` agent Claude Fable 5 reasoning level from `xhigh` to `high` (primary `anthropic/claude-fable-5` and its OpenRouter fallback mirror).
- `packages/workflows/CHANGELOG.md` — **Added:** `git_worktree_dir` input on the builtin `goal` workflow with Ralph-parity binding, enabling worktree create/reuse from `base_branch` while preserving repo-relative cwd across worker, reviewer, and final PR stages.

### Validation

```sh
bun run typecheck   # exit 0
bun run test:unit   # exit 0
git status --short  # clean
git diff --name-only 397b09acda1503300a9f64980bfa802ca76a4e1e..HEAD  # CHANGELOG.md files only
```

Pre-push hooks (lint, file-length gate, unit tests, merge-conflict/large-file checks) passed on push.

### After merge

Tag `0.9.5-alpha.5` is cut off-`main` via `bun run scripts/cut-release.ts 0.9.5-alpha.5 --base main --push`; CI publishes to npm with OIDC provenance under the `@next` dist-tag and attaches cross-compiled binaries to the GitHub Release.