### PR TITLE
docs: mention software factory use case in README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <b>The verifiable runtime for coding agents.</b><br>
-  <b>Run verifiable engineering loops with control, alignment, and confidence.</b><br>
+  <b>Run verifiable engineering loops with control, alignment, and confidence. Build your own software factory with verification built in.</b><br>
   <i>Define the work as stages, checks, gates, tools, artifacts, and approvals. Atomic runs the process so agent work is verifiable by design. Leverage Atomic to start building your software factory.</i>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <b>The verifiable runtime for coding agents.</b><br>
   <b>Run verifiable engineering loops with control, alignment, and confidence.</b><br>
-  <i>Define the work as stages, checks, gates, tools, artifacts, and approvals. Atomic runs the process so agent work is verifiable by design.</i>
+  <i>Define the work as stages, checks, gates, tools, artifacts, and approvals. Atomic runs the process so agent work is verifiable by design. Leverage Atomic to start building your software factory.</i>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
Updates the README's introductory tagline to highlight that Atomic can be used to build a software factory with verification built in, alongside its existing focus on verifiable engineering loops.

## Key changes
- Extended the bold tagline under the project header with "Build your own software factory with verification built in."
- Extended the italic description line with "Leverage Atomic to start building your software factory."