### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: Report something that's broken
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before you start:** Read [CONTRIBUTING.md](https://github.com/bastani-inc/atomic/blob/main/CONTRIBUTING.md).
+
+        Maintainers review open issues regularly. Issues that do not meet the quality bar in [CONTRIBUTING.md](https://github.com/bastani-inc/atomic/blob/main/CONTRIBUTING.md) may need clarification before we can investigate.
+
+
+        **Important:** before reporting an issue in core, please validate first with `atomic -ne` that this is not caused by an extension you loaded.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Be specific. Include error messages if any.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: e.g. 0.49.0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -39,6 +39,6 @@ body:
     id: version
     attributes:
       label: Version
-      description: e.g. 0.49.0
+      description: Output of `atomic --version` (e.g. 0.9.5). If you are using a prerelease, include the exact alpha version (e.g. 0.9.5-alpha.5).
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions
+    url: https://discord.gg/9CvdXUGXR4
+    about: Ask questions on Discord instead of opening an issue

--- a/.github/ISSUE_TEMPLATE/contribution.yml
+++ b/.github/ISSUE_TEMPLATE/contribution.yml
@@ -1,0 +1,35 @@
+name: Contribution
+
+description: Propose a change or feature enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before you start:** Read [CONTRIBUTING.md](https://github.com/bastani-inc/atomic/blob/main/CONTRIBUTING.md).
+
+        Use this form to propose a focused change or feature enhancement. If you need help, have a question, or are unsure whether this belongs here, please ask on [Discord](https://discord.gg/9CvdXUGXR4) instead.
+
+  - type: textarea
+    id: change
+    attributes:
+      label: What do you want to change?
+      description: Be specific and concise.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How? (optional)
+      description: Brief technical approach if you have one in mind.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds GitHub issue templates so bug reports and contribution proposals are prefilled with the same structure used by the upstream pi project, adapted for Atomic.

## Changes

- Add `.github/ISSUE_TEMPLATE/bug.yml`, a bug report form with required "What happened?" and "Steps to reproduce" fields, optional "Expected behavior" and "Version" fields, and a note pointing to `CONTRIBUTING.md` and to validating with `atomic -ne` before reporting core issues.
- Add `.github/ISSUE_TEMPLATE/contribution.yml`, a form for proposing changes or feature enhancements with required "What do you want to change?" and "Why?" fields and an optional "How?" field.
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and route questions to the Atomic Discord instead of the issue tracker.

## Notes

Validation was handled by git hooks during commit/push, including YAML checks, lint, file length checks, and unit tests.