### PR TITLE
docs: cut release notes for 0.9.5-alpha.6

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.6] - 2026-07-06
+
 ### Fixed
 
 - Fixed deferred TUI extension loading so the editor keeps accepting and echoing keystrokes after first paint: startup now yields cooperatively between extension/resource-loading chunks, preserves text typed during completion, and safely queues Enter submissions made before the main prompt loop is ready.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.6] - 2026-07-06
+
 ### Fixed
 
 - Fixed workflow stage chats so attach, exit, and re-attach cycles during an in-flight `subagent` call replay the latest live tool partial result immediately instead of collapsing single, parallel, or chain calls back to the bare `renderCall` title until the next update; stage chats also prefer renderers from the stage's own agent session before falling back to the host chat so nested workflow stages can render tools that the parent chat does not expose. ([#1643](https://github.com/bastani-inc/atomic/issues/1643))


### PR DESCRIPTION
## Release 0.9.5-alpha.6

- **Kind:** prerelease (publishes to npm `@next`)
- **Version / tag:** `0.9.5-alpha.6` (no leading `v`)
- **Head commit:** `4fe0defa0f7c11d07b846db0c1fd798111e296fa` (release-notes commit off `9684f608edffbe1a14907ac1b43c48f7c5914d69`)

### Changelog-only changes (no version bumps — `main` stays versionless at `0.0.0`)

- `packages/coding-agent/CHANGELOG.md` — cut `## [0.9.5-alpha.6] - 2026-07-06` section from `[Unreleased]`:
  - Fixed deferred TUI extension loading so the editor keeps accepting and echoing keystrokes after first paint (cooperative startup yielding, preserved in-flight typed text, safe queuing of early Enter submissions).
- `packages/workflows/CHANGELOG.md` — cut `## [0.9.5-alpha.6] - 2026-07-06` section from `[Unreleased]`:
  - Fixed workflow stage chats to replay the latest live tool partial result after attach/exit/re-attach cycles during in-flight `subagent` calls, and to prefer renderers from the stage's own agent session before falling back to the host chat (#1643).

### Validation

- `bun run typecheck` — passed
- `bun run test:unit` — passed
- `git status --short` — clean working tree
- `git diff --name-only 9684f608...HEAD` — only the two CHANGELOG.md files changed
- Pre-push hooks (lint, file-length, unit tests, etc.) — passed

### Release flow

After this CHANGELOG-only PR merges, the real version is stamped on a throwaway off-`main` tag commit via `bun run scripts/cut-release.ts 0.9.5-alpha.6`; pushing the `0.9.5-alpha.6` tag triggers CI publish with OIDC provenance to `@next`. `main` is never version-bumped.
