### PR TITLE
docs: release notes for 0.9.5-alpha.7

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.7] - 2026-07-07
+
 ### Changed
 
 - Changed interactive Ctrl+C to interrupt the agent when it is busy: a single Ctrl+C now aborts the running agent turn (restoring queued messages to the editor), a running bash command, an active context compaction, or an auto-retry countdown — matching Escape and common CLI muscle memory. When idle, Ctrl+C keeps its previous behavior (first press clears the editor, a quick double-press exits), and the Ctrl+C immediately following an interrupt clears rather than exits. Escape remains the primary interrupt key.


### PR DESCRIPTION
## Release

Prerelease `0.9.5-alpha.7` off `main` (`prerelease/0.9.5-alpha.7`). `main` remains versionless — package manifests stay at the `0.0.0` placeholder; the real version is materialized only by `scripts/cut-release.ts` on the throwaway, off-`main` tag commit.

## Changes

- `packages/coding-agent/CHANGELOG.md`: closed out the `[Unreleased]` section into a new `## [0.9.5-alpha.7] - 2026-07-07` entry covering:
  - **Changed**: Ctrl+C now interrupts a busy agent turn (aborting the running turn, a bash command, context compaction, or an auto-retry countdown) instead of only clearing/exiting, matching Escape.
  - **Fixed**: working-spinner startup delay, post-compaction provider request token scrubbing, OpenAI Responses `function_call.id` normalization after auto-compaction, auto-compaction stalling on max-output-token truncation ([#1662](https://github.com/bastani-inc/atomic/issues/1662)), Windows compiled-binary cold-start latency and keyboard responsiveness, startup notice/chat ordering on the deferred TUI fast path, and Windows release archives no longer crashing on Bun's `--bytecode` standalone executable path.

## Validation

- `bun run typecheck` — passed
- `bun run test:unit` — passed
- Pushed `prerelease/0.9.5-alpha.7`; push hooks (`lint`, `check:file-length`, `test:unit`) passed