### PR TITLE
fix(evals): mirror atomic session transcripts during runs

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -183,7 +183,7 @@ The adapter is self-contained; it does not require patching Pier or Harbor. It f
 1. Install Atomic and required local search tools (`rg` and `fd`) during setup.
 2. Run the Atomic CLI in JSON mode.
 3. Keep Atomic's mutable agent state under the sandbox user's `~/.atomic/agent` directory by setting Atomic's existing agent-dir environment override, passing `--session-dir ~/.atomic/agent/atomic-sessions`, and exporting `ATOMIC_TODO_PATH=$HOME/.atomic/agent/todos` inside the sandbox so the default todo tool cannot create `.atomic/todos` in the benchmark repository.
-4. Tee Atomic's JSON stream to `/logs/agent/atomic.txt` and copy session transcripts to `/logs/agent/atomic-sessions/` after the run, with an exit trap to preserve transcripts on SIGTERM-based timeouts.
+4. Tee Atomic's JSON stream to `/logs/agent/atomic.txt` and continuously mirror session transcripts to `/logs/agent/atomic-sessions/` during the run, with a final exit-trap sync to preserve transcripts on normal exits and SIGTERM-based timeouts.
 5. Collect usage and trajectory data from the logs.
 
 Like the built-in Pier agents, it does not auto-commit work. Deep SWE tasks rely on the agent following the task instruction to commit.

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -201,8 +201,19 @@ class Atomic(BaseInstalledAgent):
             f"mkdir -p {log_session_dir}; "
             f"cp -a {session_dir}/. {log_session_dir}/ 2>/dev/null || true; "
             "}; "
-            "trap sync_atomic_sessions EXIT; "
-            "trap 'sync_atomic_sessions; exit 143' TERM; "
+            "sync_atomic_sessions_loop() { "
+            "while true; do sync_atomic_sessions; sleep 5; done; "
+            "}; "
+            "sync_atomic_sessions_loop & atomic_session_sync_pid=$!; "
+            "cleanup_atomic_sessions() { "
+            "status=${1:-$?}; "
+            "sync_atomic_sessions; "
+            "kill \"$atomic_session_sync_pid\" 2>/dev/null || true; "
+            "wait \"$atomic_session_sync_pid\" 2>/dev/null || true; "
+            "return \"$status\"; "
+            "}; "
+            "trap 'status=$?; cleanup_atomic_sessions \"$status\"; exit \"$status\"' EXIT; "
+            "trap 'cleanup_atomic_sessions 143; exit 143' TERM; "
         )
 
     @with_prompt_template

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -322,8 +322,19 @@ class Atomic(BaseInstalledAgent):
             f"mkdir -p {log_session_dir}; "
             f"cp -a {session_dir}/. {log_session_dir}/ 2>/dev/null || true; "
             "}; "
-            "trap sync_atomic_sessions EXIT; "
-            "trap 'sync_atomic_sessions; exit 143' TERM; "
+            "sync_atomic_sessions_loop() { "
+            "while true; do sync_atomic_sessions; sleep 5; done; "
+            "}; "
+            "sync_atomic_sessions_loop & atomic_session_sync_pid=$!; "
+            "cleanup_atomic_sessions() { "
+            "status=${1:-$?}; "
+            "sync_atomic_sessions; "
+            "kill \"$atomic_session_sync_pid\" 2>/dev/null || true; "
+            "wait \"$atomic_session_sync_pid\" 2>/dev/null || true; "
+            "return \"$status\"; "
+            "}; "
+            "trap 'status=$?; cleanup_atomic_sessions \"$status\"; exit \"$status\"' EXIT; "
+            "trap 'cleanup_atomic_sessions 143; exit 143' TERM; "
         )
 
     @with_prompt_template


### PR DESCRIPTION
## Summary

Previously the Harbor and Pier eval adapters only copied Atomic session transcripts once, via an `EXIT`/`TERM` trap. If a job was killed with `SIGKILL` (e.g. a hard timeout that doesn't allow trap handling) or hung uninterruptibly, transcripts were never synced and in-progress session details were lost. This PR adds a background sync loop so transcripts are mirrored continuously throughout the run, not just at exit.

## Changes

- `evals/atomic_harbor.py` / `evals/atomic_pier.py`: launch a `sync_atomic_sessions_loop` background process that re-syncs session transcripts to `/logs/agent/atomic-sessions/` every 5 seconds for the duration of the run.
- Add a `cleanup_atomic_sessions` helper that performs a final sync, then stops the background loop (`kill`/`wait` on its PID) before propagating the original exit status.
- Rewire the `EXIT` and `TERM` traps to call `cleanup_atomic_sessions` instead of a single one-shot `sync_atomic_sessions`, so both normal completions and SIGTERM-based timeouts get a final sync plus proper loop teardown.
- `evals/README.md`: update the adapter behavior docs to describe continuous transcript mirroring during the run, with a final exit-trap sync on normal exit or timeout.

## Validation

- `python3 -m py_compile evals/atomic_harbor.py evals/atomic_pier.py` (the `python` executable was not available in PATH)
- Commit/push hooks: `bun run lint`, `bun run check:file-length`, `bun run test:unit`