### PR TITLE
fix(subagents): use pulse dots for async widget spinners

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated async/background subagent status widgets so running job, parallel child-agent, chain-step, and nested child rows reuse the same foreground pulsing-dot glyph treatment instead of braille spinner glyphs, while preserving counts, metadata, live-detail hints, and output paths.
+
 ## [0.9.5-alpha.5] - 2026-07-06
 
 ### Changed

--- a/packages/subagents/src/tui/render-event-formatting.ts
+++ b/packages/subagents/src/tui/render-event-formatting.ts
@@ -5,7 +5,7 @@ import { formatDuration, formatModelThinking, shortenPath } from "../shared/form
 import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
 import { formatAgentRunningLabel } from "../shared/status-format.ts";
 import { buildLiveStatusLine, formatCurrentToolLine, formatTokenStat, formatToolUseStat, statJoin } from "./render-status-progress.ts";
-import { runningGlyph, runningSeed, truncLine, type Theme } from "./render-layout.ts";
+import { runningGlyph, runningPulseGlyph, truncLine, type Theme } from "./render-layout.ts";
 
 export function formatWidgetAgents(agents: string[]): string {
 	const distinct = [...new Set(agents)];
@@ -40,47 +40,9 @@ export function widgetActivity(job: AsyncJobState): string {
 	return "Done";
 }
 
-export function widgetStepRunningSeed(step: NonNullable<AsyncJobState["steps"]>[number], fallbackIndex?: number): number | undefined {
-	return runningSeed(
-		fallbackIndex,
-		step.index,
-		step.toolCount,
-		step.turnCount,
-		step.tokens?.total,
-		step.lastActivityAt,
-		step.currentToolStartedAt,
-		step.durationMs,
-	);
-}
 
-export function widgetStepsRunningSeed(steps: Array<NonNullable<AsyncJobState["steps"]>[number]> | undefined): number | undefined {
-	let seed: number | undefined;
-	for (const [index, step] of (steps ?? []).entries()) seed = runningSeed(seed, widgetStepRunningSeed(step, index));
-	return seed;
-}
-
-export function widgetJobRunningSeed(job: AsyncJobState): number | undefined {
-	return runningSeed(
-		job.updatedAt,
-		job.lastActivityAt,
-		job.toolCount,
-		job.turnCount,
-		job.totalTokens?.total,
-		job.currentStep,
-		job.runningSteps,
-		job.completedSteps,
-		widgetStepsRunningSeed(job.steps),
-	);
-}
-
-export function widgetJobsRunningSeed(jobs: AsyncJobState[]): number | undefined {
-	let seed: number | undefined;
-	for (const job of jobs) seed = runningSeed(seed, widgetJobRunningSeed(job));
-	return seed;
-}
-
-export function widgetStatusGlyph(job: AsyncJobState, theme: Theme, now?: number): string {
-	if (job.status === "running") return theme.fg("accent", runningGlyph(widgetJobRunningSeed(job), now));
+export function widgetStatusGlyph(job: AsyncJobState, theme: Theme, pulseFrame?: number): string {
+	if (job.status === "running") return theme.fg("accent", runningPulseGlyph(pulseFrame));
 	if (job.status === "queued") return theme.fg("muted", "◦");
 	if (job.status === "complete") return theme.fg("success", "✓");
 	if (job.status === "paused") return theme.fg("warning", "■");
@@ -89,6 +51,14 @@ export function widgetStatusGlyph(job: AsyncJobState, theme: Theme, now?: number
 
 export function widgetStepGlyph(status: AsyncJobStep["status"], theme: Theme, seed?: number, now?: number): string {
 	if (status === "running") return theme.fg("accent", runningGlyph(seed, now));
+	if (status === "complete" || status === "completed") return theme.fg("success", "✓");
+	if (status === "failed") return theme.fg("error", "✗");
+	if (status === "paused") return theme.fg("warning", "■");
+	return theme.fg("muted", "◦");
+}
+
+export function widgetStepPulseGlyph(status: AsyncJobStep["status"], theme: Theme, pulseFrame?: number): string {
+	if (status === "running") return theme.fg("accent", runningPulseGlyph(pulseFrame));
 	if (status === "complete" || status === "completed") return theme.fg("success", "✓");
 	if (status === "failed") return theme.fg("error", "✗");
 	if (status === "paused") return theme.fg("warning", "■");
@@ -186,17 +156,14 @@ export function nestedRunName(run: NestedRunSummary): string {
 	return run.id;
 }
 
-export function nestedStatusGlyph(state: NestedRunSummary["state"] | NestedStepSummary["status"], theme: Theme, seed?: number, now?: number): string {
-	if (state === "running") return theme.fg("accent", runningGlyph(seed, now));
+export function nestedStatusGlyph(state: NestedRunSummary["state"] | NestedStepSummary["status"], theme: Theme, pulseFrame?: number): string {
+	if (state === "running") return theme.fg("accent", runningPulseGlyph(pulseFrame));
 	if (state === "complete" || state === "completed") return theme.fg("success", "✓");
 	if (state === "failed") return theme.fg("error", "✗");
 	if (state === "paused") return theme.fg("warning", "■");
 	return theme.fg("muted", "◦");
 }
 
-export function nestedRunSeed(run: NestedRunSummary): number | undefined {
-	return runningSeed(run.lastUpdate, run.lastActivityAt, run.currentStep, run.toolCount, run.turnCount, run.totalTokens?.total, run.currentToolStartedAt);
-}
 
 export function nestedActivity(input: Pick<NestedRunSummary | NestedStepSummary, "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount">, state: NestedRunSummary["state"] | NestedStepSummary["status"], snapshotNow?: number): string {
 	const facts: string[] = [];
@@ -240,7 +207,7 @@ export function formatNestedWidgetLines(children: NestedRunSummary[] | undefined
 			}
 			const activity = nestedActivity(child, child.state, snapshotNow ?? child.lastUpdate);
 			const error = child.error ? ` · ${child.error}` : "";
-			lines.push(theme.fg("dim", `${prefix}↳ ${nestedStatusGlyph(child.state, theme, nestedRunSeed(child), now)} ${nestedRunName(child)} · ${child.state} · ${activity}${error}`));
+			lines.push(theme.fg("dim", `${prefix}↳ ${nestedStatusGlyph(child.state, theme, now)} ${nestedRunName(child)} · ${child.state} · ${activity}${error}`));
 			if (depth === maxDepth) {
 				const aggregate = formatNestedAggregate([...(child.steps?.flatMap((step) => step.children ?? []) ?? []), ...(child.children ?? [])]);
 				if (aggregate && lines.length < lineBudget) lines.push(theme.fg("dim", `${prefix}  ↳ ${aggregate}`));
@@ -248,7 +215,7 @@ export function formatNestedWidgetLines(children: NestedRunSummary[] | undefined
 			}
 			for (const step of child.steps ?? []) {
 				if (lines.length >= lineBudget) return;
-				lines.push(theme.fg("dim", `${prefix}  ↳ ${nestedStatusGlyph(step.status, theme, undefined, now)} ${step.agent} · ${step.status} · ${nestedActivity(step, step.status, snapshotNow ?? child.lastUpdate)}`));
+				lines.push(theme.fg("dim", `${prefix}  ↳ ${nestedStatusGlyph(step.status, theme, now)} ${step.agent} · ${step.status} · ${nestedActivity(step, step.status, snapshotNow ?? child.lastUpdate)}`));
 				append(step.children, depth + 1, `${prefix}    `);
 			}
 			append(child.children, depth + 1, `${prefix}  `);

--- a/packages/subagents/src/tui/render-layout.ts
+++ b/packages/subagents/src/tui/render-layout.ts
@@ -129,6 +129,15 @@ export function pulseGlyph(frame?: number): string {
 	return PULSE_FRAMES[index % PULSE_FRAMES.length]!;
 }
 
+/**
+ * Running async/background subagent pulse. It reuses the exact foreground pulse
+ * glyph frames while accepting an explicit frame advanced by the widget only on
+ * real async progress/status updates, matching foreground result semantics.
+ */
+export function runningPulseGlyph(frame?: number): string {
+	return pulseGlyph(frame);
+}
+
 export function progressRunningSeed(progress: ProgressSeedSource | undefined): number | undefined {
 	if (!progress) return undefined;
 	return runningSeed(

--- a/packages/subagents/src/tui/render-widget-graph.ts
+++ b/packages/subagents/src/tui/render-widget-graph.ts
@@ -14,15 +14,13 @@ import {
 	widgetStatusGlyph,
 	widgetStepActivity,
 	widgetStepActivityLine,
-	widgetStepGlyph,
-	widgetStepRunningSeed,
+	widgetStepPulseGlyph,
 	widgetStepStats,
 	widgetStepStatus,
-	widgetStepsRunningSeed,
 	widgetJobName,
 } from "./render-event-formatting.ts";
 
-export function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth(), now?: number): string[] {
+export function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth(), pulseFrame?: number): string[] {
 	if (!job.steps?.length) return [];
 	const total = job.chainStepCount ?? job.steps.length;
 	const lines: string[] = [];
@@ -30,7 +28,7 @@ export function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = 
 		const steps = job.steps.slice(span.start, span.start + span.count);
 		if (span.isParallel) {
 			const status = aggregateStepStatus(steps);
-			lines.push(`  ${widgetStepGlyph(status, theme, widgetStepsRunningSeed(steps), now)} Step ${span.stepIndex + 1}/${total}: ${themeBold(theme, "parallel group")} ${theme.fg("dim", "·")} ${theme.fg("dim", formatParallelOutcome(steps, span.count))}`);
+			lines.push(`  ${widgetStepPulseGlyph(status, theme, pulseFrame)} Step ${span.stepIndex + 1}/${total}: ${themeBold(theme, "parallel group")} ${theme.fg("dim", "·")} ${theme.fg("dim", formatParallelOutcome(steps, span.count))}`);
 			continue;
 		}
 		const step = steps[0];
@@ -38,15 +36,15 @@ export function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = 
 			lines.push(`  ${theme.fg("dim", `◦ Step ${span.stepIndex + 1}/${total}: pending`)}`);
 			continue;
 		}
-		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, "Step", span.stepIndex + 1, total, expanded, width, now));
+		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, "Step", span.stepIndex + 1, total, expanded, width, pulseFrame));
 	}
 	return lines;
 }
 
-export function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth(), now?: number): string[] {
+export function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded = false, width = getTermWidth(), _now?: number, pulseFrame?: number): string[] {
 	if (!job.steps?.length) return [];
 	if (job.mode !== "parallel" && job.mode !== "chain") return [];
-	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, now);
+	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, pulseFrame);
 	const total = job.stepsTotal ?? job.steps.length;
 	const lines: string[] = [];
 	for (const [index, step] of job.steps.entries()) {
@@ -54,8 +52,8 @@ export function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, exp
 		const activity = widgetStepActivity(step, job.updatedAt);
 		const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking, step.fastMode);
-		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), now)} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
-		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 8 : 1, now)) lines.push(`    ${nestedLine}`);
+		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepPulseGlyph(step.status, theme, pulseFrame)} ${itemTitle} ${index + 1}/${total}: ${step.agent} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
+		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 8 : 1, pulseFrame)) lines.push(`    ${nestedLine}`);
 	}
 	return lines;
 }
@@ -69,15 +67,15 @@ export function foregroundStyleWidgetStepLines(
 	total: number,
 	expanded: boolean,
 	width: number,
-	now?: number,
+	pulseFrame?: number,
 ): string[] {
 	const status = widgetStepStatus(step.status, theme);
 	const stats = widgetStepStats(theme, step);
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking, step.fastMode);
-	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), now)} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
+	const lines = [`  ${widgetStepPulseGlyph(step.status, theme, pulseFrame)} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
 	const activity = widgetStepActivityLine(step, width, expanded, job.updatedAt);
 	if (activity) lines.push(`    ${theme.fg("dim", `⎿  ${activity}`)}`);
-	for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, undefined, now)) {
+	for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, undefined, pulseFrame)) {
 		lines.push(`    ${nestedLine}`);
 	}
 	if (step.status === "running") {
@@ -100,40 +98,40 @@ export function foregroundStyleWidgetStepLines(
 	return lines;
 }
 
-export function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, now?: number): string[] {
+export function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, pulseFrame?: number): string[] {
 	if (!job.steps?.length) return [
 		`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-		...formatNestedWidgetLines(job.nestedChildren, theme, width, expanded, job.updatedAt, undefined, now).map((line) => `  ${line}`),
+		...formatNestedWidgetLines(job.nestedChildren, theme, width, expanded, job.updatedAt, undefined, pulseFrame).map((line) => `  ${line}`),
 	];
-	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, now);
+	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, pulseFrame);
 	const total = job.stepsTotal ?? job.steps.length;
 	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 	const lines: string[] = [];
 	for (const [index, step] of job.steps.entries()) {
-		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index + 1, total, expanded, width, now));
+		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index + 1, total, expanded, width, pulseFrame));
 	}
 	const attached = new Set(job.steps.flatMap((step) => step.children?.map((child) => child.id) ?? []));
 	const unattached = job.nestedChildren?.filter((child) => !attached.has(child.id)) ?? [];
-	for (const nestedLine of formatNestedWidgetLines(unattached, theme, width, expanded, job.updatedAt, undefined, now)) {
+	for (const nestedLine of formatNestedWidgetLines(unattached, theme, width, expanded, job.updatedAt, undefined, pulseFrame)) {
 		lines.push(`  ${nestedLine}`);
 	}
 	return lines;
 }
 
-export function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, now?: number): string[] {
+export function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, _now?: number, pulseFrame?: number): string[] {
 	const stats = widgetStats(job, theme);
 	const count = job.mode === "chain" ? job.chainStepCount : job.stepsTotal ?? job.agents?.length ?? job.steps?.length;
 	const mode = widgetJobName(job);
 	const title = `async subagent ${mode}${count && count > 1 ? ` (${count})` : ""}`;
 	return [
 		`${theme.fg("toolTitle", themeBold(theme, title))} ${theme.fg("dim", "· background")}`,
-		`${widgetStatusGlyph(job, theme, now)} ${themeBold(theme, mode)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
-		...foregroundStyleWidgetDetails(job, theme, expanded, width, now),
+		`${widgetStatusGlyph(job, theme, pulseFrame)} ${themeBold(theme, mode)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+		...foregroundStyleWidgetDetails(job, theme, expanded, width, pulseFrame),
 	].map((line) => truncLine(line, width));
 }
 
-export function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, now?: number): string[] {
-	const fullLines = buildSingleWidgetLines(job, theme, width, false, now);
+export function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, _now?: number, pulseFrame?: number): string[] {
+	const fullLines = buildSingleWidgetLines(job, theme, width, false, _now, pulseFrame);
 	if (fullLines.length <= 10 || !job.steps?.length || (job.mode !== "parallel" && !job.activeParallelGroup)) return fullLines;
 
 	const total = job.stepsTotal ?? job.steps.length;
@@ -145,8 +143,12 @@ export function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width
 		const stepStats = widgetStepStats(theme, step);
 		const activitySuffix = activity ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", activity)}` : "";
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking, step.fastMode);
-		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), now)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
-		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, undefined, now)) lines.push(`    ${nestedLine}`);
+		lines.push(`  ${widgetStepPulseGlyph(step.status, theme, pulseFrame)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
+		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, undefined, pulseFrame)) lines.push(`    ${nestedLine}`);
+		if (step.status === "running") {
+			const output = widgetOutputPath(job, step);
+			if (output) lines.push(`    ${theme.fg("dim", `output: ${shortenPath(output)}`)}`);
+		}
 	}
 	if (job.steps.some((step) => step.status === "running")) lines.push(theme.fg("accent", `  Press ${keyHint("app.tools.expand", "for live detail")}`));
 	return lines.map((line) => truncLine(line, width));

--- a/packages/subagents/src/tui/render-widget.ts
+++ b/packages/subagents/src/tui/render-widget.ts
@@ -2,8 +2,10 @@ import type { ExtensionContext } from "@bastani/atomic";
 import { Container, Text, type Component } from "@earendil-works/pi-tui";
 import * as path from "node:path";
 import { MAX_WIDGET_JOBS, WIDGET_KEY, type AsyncJobState } from "../shared/types.ts";
-import { getTermWidth, RUNNING_ANIMATION_MS, runningGlyph, truncLine, type Theme } from "./render-layout.ts";
+import { getTermWidth, runningPulseGlyph, truncLine, type Theme } from "./render-layout.ts";
 import { themeBold } from "./render-status-progress.ts";
+import { advanceResultPulseFrame } from "./render-result-animation.ts";
+import { widgetRenderKey } from "./render-stable-output.ts";
 import {
 	buildSingleWidgetLines,
 	compactSingleWidgetLines,
@@ -13,7 +15,6 @@ import {
 import {
 	widgetActivity,
 	widgetJobName,
-	widgetJobsRunningSeed,
 	widgetStats,
 	widgetStatusGlyph,
 } from "./render-event-formatting.ts";
@@ -26,22 +27,24 @@ class LiveWidgetComponent implements Component {
 		private readonly theme: Theme,
 		private readonly getExpanded: () => boolean,
 		private readonly getNow: () => number,
+		private readonly getPulseFrame: () => number | undefined,
 	) {}
 
 	render(width: number): string[] {
 		const jobs = this.getJobs();
 		const expanded = this.getExpanded();
 		const now = this.getNow();
-		const lines = this.buildLines(jobs, width, expanded, now);
+		const pulseFrame = this.getPulseFrame();
+		const lines = this.buildLines(jobs, width, expanded, now, pulseFrame);
 		this.container.clear();
 		for (const line of fitWidgetLineBudget(lines, this.theme, width, expanded)) this.container.addChild(new Text(line, 1, 0));
 		return this.container.render(width);
 	}
 
-	private buildLines(jobs: AsyncJobState[], width: number, expanded: boolean, now: number): string[] {
-		if (expanded) return buildWidgetLines(jobs, this.theme, width, true, now);
-		if (jobs.length === 1) return compactSingleWidgetLines(jobs[0]!, this.theme, width, now);
-		return buildWidgetLines(jobs, this.theme, width, false, now);
+	private buildLines(jobs: AsyncJobState[], width: number, expanded: boolean, now: number, pulseFrame: number | undefined): string[] {
+		if (expanded) return buildWidgetLines(jobs, this.theme, width, true, now, pulseFrame);
+		if (jobs.length === 1) return compactSingleWidgetLines(jobs[0]!, this.theme, width, now, pulseFrame);
+		return buildWidgetLines(jobs, this.theme, width, false, now, pulseFrame);
 	}
 
 	invalidate(): void {
@@ -49,22 +52,23 @@ class LiveWidgetComponent implements Component {
 	}
 }
 
-function buildWidgetComponent(getJobs: () => AsyncJobState[], getExpanded: () => boolean, getNow: () => number): (_tui: unknown, theme: Theme) => Component {
-	return (_tui, theme) => new LiveWidgetComponent(getJobs, theme, getExpanded, getNow);
+function buildWidgetComponent(getJobs: () => AsyncJobState[], getExpanded: () => boolean, getNow: () => number, getPulseFrame: () => number | undefined): (_tui: unknown, theme: Theme) => Component {
+	return (_tui, theme) => new LiveWidgetComponent(getJobs, theme, getExpanded, getNow, getPulseFrame);
 }
 
 interface RenderRequestingContext {
 	ui: ExtensionContext["ui"] & { requestRender?: () => void };
 }
 
-// There is only ever one async-agents widget per host process, so the widget
-// ticker and mounted component read their driving context/jobs from module-level
+// There is only ever one async-agents widget per host process, so the mounted
+// component reads its driving context/jobs/pulse frame from module-level
 // singletons instead of remounting the widget for every visible update.
 let latestWidgetCtx: ExtensionContext | undefined;
 let latestWidgetJobs: AsyncJobState[] = [];
 let latestWidgetFrameNow = 0;
 let latestWidgetExpanded = false;
-let widgetTimer: ReturnType<typeof setInterval> | undefined;
+let latestWidgetSnapshotKey: string | undefined;
+let latestWidgetPulseFrame: number | undefined;
 let mountedWidgetCtx: ExtensionContext | undefined;
 let mountedWidgetOwnerKey: string | undefined;
 let widgetMounted = false;
@@ -75,6 +79,10 @@ function getLatestWidgetJobs(): AsyncJobState[] {
 
 function getLatestWidgetFrameNow(): number {
 	return latestWidgetFrameNow;
+}
+
+function getLatestWidgetPulseFrame(): number | undefined {
+	return latestWidgetPulseFrame;
 }
 
 function getLatestWidgetExpanded(): boolean {
@@ -94,6 +102,8 @@ function clearLatestWidgetState(): void {
 	latestWidgetJobs = [];
 	latestWidgetFrameNow = 0;
 	latestWidgetExpanded = false;
+	latestWidgetSnapshotKey = undefined;
+	latestWidgetPulseFrame = undefined;
 	mountedWidgetCtx = undefined;
 	mountedWidgetOwnerKey = undefined;
 	widgetMounted = false;
@@ -142,63 +152,35 @@ function unmountWidgetBestEffort(ctx: ExtensionContext | undefined): void {
 	}
 }
 
-function hasAnimatedWidgetJobs(jobs: AsyncJobState[]): boolean {
-	// Animate while any job — or any of its nested steps — is still running so the
-	// header/step spinners never freeze before the work actually settles.
-	return jobs.some((job) => job.status === "running" || job.steps?.some((step) => step.status === "running"));
+function widgetSnapshotKey(jobs: AsyncJobState[]): string {
+	return jobs.map(widgetRenderKey).join("\n");
 }
 
-function refreshAnimatedWidget(): void {
-	if (!latestWidgetCtx?.hasUI) return;
-	try {
-		latestWidgetFrameNow = Date.now();
-		requestWidgetRender(latestWidgetCtx);
-	} catch {
-		// A stale render context means the cosmetic ticker can no longer update the
-		// mounted widget safely; tear it down best-effort and let the next status
-		// update remount on the active host context.
-		stopWidgetAnimation();
-	}
+function refreshWidgetSnapshot(jobs: AsyncJobState[]): void {
+	const snapshotKey = widgetSnapshotKey(jobs);
+	if (snapshotKey === latestWidgetSnapshotKey) return;
+	latestWidgetSnapshotKey = snapshotKey;
+	latestWidgetFrameNow = Date.now();
+	latestWidgetPulseFrame = advanceResultPulseFrame(latestWidgetPulseFrame);
 }
 
-function ensureWidgetAnimation(): void {
-	if (widgetTimer) return;
-	widgetTimer = setInterval(() => {
-		if (!hasAnimatedWidgetJobs(latestWidgetJobs)) {
-			stopWidgetAnimation();
-			return;
-		}
-		refreshAnimatedWidget();
-	}, RUNNING_ANIMATION_MS);
-	widgetTimer.unref?.();
-}
-
-// Stop only the ticker, keeping the last-rendered widget context/jobs intact.
-function stopWidgetTicker(): void {
-	if (widgetTimer) {
-		clearInterval(widgetTimer);
-		widgetTimer = undefined;
-	}
-}
-
-// Full teardown: stop the ticker, clear the mounted widget if possible, and
-// forget the driving context/jobs entirely.
+// Full teardown: clear the mounted widget if possible, and forget the driving
+// context/jobs entirely.
 export function stopWidgetAnimation(): void {
-	stopWidgetTicker();
 	if (widgetMounted) unmountWidgetBestEffort(mountedWidgetCtx);
 	clearLatestWidgetState();
 }
 
-export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = getTermWidth(), expanded = false, now: number = Date.now()): string[] {
+export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = getTermWidth(), expanded = false, now: number = Date.now(), pulseFrame?: number): string[] {
 	if (jobs.length === 0) return [];
-	if (jobs.length === 1) return buildSingleWidgetLines(jobs[0]!, theme, width, expanded, now);
+	if (jobs.length === 1) return buildSingleWidgetLines(jobs[0]!, theme, width, expanded, now, pulseFrame);
 	const running = jobs.filter((job) => job.status === "running");
 	const queued = jobs.filter((job) => job.status === "queued");
 	const finished = jobs.filter((job) => job.status !== "running" && job.status !== "queued");
 
 	const lines: string[] = [];
 	const hasActive = running.length > 0 || queued.length > 0;
-	const headerGlyph = running.length > 0 ? runningGlyph(widgetJobsRunningSeed(running), now) : hasActive ? "●" : "○";
+	const headerGlyph = running.length > 0 ? runningPulseGlyph(pulseFrame) : hasActive ? "●" : "○";
 	lines.push(truncLine(`${theme.fg(hasActive ? "accent" : "dim", headerGlyph)} ${theme.fg(hasActive ? "accent" : "dim", "Async agents")} ${theme.fg("dim", "· background")}`, width));
 
 	const items: string[][] = [];
@@ -211,9 +193,9 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		if (slots <= 0) { hiddenRunning++; continue; }
 		const stats = widgetStats(job, theme);
 		items.push([
-			`${widgetStatusGlyph(job, theme, now)} ${themeBold(theme, widgetJobName(job))}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+			`${widgetStatusGlyph(job, theme, pulseFrame)} ${themeBold(theme, widgetJobName(job))}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-			...widgetParallelAgentDetails(job, theme, expanded, width, now),
+			...widgetParallelAgentDetails(job, theme, expanded, width, now, pulseFrame),
 		]);
 		slots--;
 	}
@@ -228,9 +210,9 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		if (slots <= 0) { hiddenFinished++; continue; }
 		const stats = widgetStats(job, theme);
 		items.push([
-			`${widgetStatusGlyph(job, theme, now)} ${themeBold(theme, widgetJobName(job))}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+			`${widgetStatusGlyph(job, theme, pulseFrame)} ${themeBold(theme, widgetJobName(job))}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-			...widgetParallelAgentDetails(job, theme, expanded, width, now),
+			...widgetParallelAgentDetails(job, theme, expanded, width, now, pulseFrame),
 		]);
 		slots--;
 	}
@@ -280,7 +262,7 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 	}
 	latestWidgetCtx = ctx;
 	latestWidgetJobs = [...jobs];
-	latestWidgetFrameNow = Date.now();
+	refreshWidgetSnapshot(jobs);
 	if (widgetMounted && mountedWidgetOwnerKey !== ownerKey) {
 		// Session rebinding can leave the previous host UI alive briefly; clear the
 		// old mount before installing the singleton widget on the new owner/context.
@@ -290,13 +272,10 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 		widgetMounted = false;
 	}
 	if (!widgetMounted) {
-		// belowEditor: the widget animates a running glyph / elapsed labels on a
-		// timer. pi-tui full-clears the screen+scrollback whenever a changed line
-		// sits above the viewport fold, so an aboveEditor widget flickers once the
-		// bottom region grows tall and pushes it above the fold. Rendering below the
-		// editor keeps the live line within the bottom viewport (flicker-free), and
-		// matches the workflow companion widget's placement (#1109).
-		ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(getLatestWidgetJobs, getLatestWidgetExpanded, getLatestWidgetFrameNow), {
+		// belowEditor keeps the live async widget pinned to the bottom viewport,
+		// matching the workflow companion widget's placement (#1109). The pulse frame
+		// is advanced only by semantic async status updates, not by a cosmetic timer.
+		ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(getLatestWidgetJobs, getLatestWidgetExpanded, getLatestWidgetFrameNow, getLatestWidgetPulseFrame), {
 			placement: "belowEditor",
 		});
 		mountedWidgetCtx = ctx;
@@ -311,8 +290,6 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 		mountedWidgetOwnerKey = ownerKey;
 		requestWidgetRender(ctx);
 	}
-	// Keep the just-rendered ctx/jobs as the last-rendered state; only the ticker
-	// is conditional on whether anything is still animating.
-	if (hasAnimatedWidgetJobs(jobs)) ensureWidgetAnimation();
-	else stopWidgetTicker();
+	// The async pulse is update-driven like foreground subagent results, so no
+	// periodic cosmetic ticker is needed.
 }

--- a/packages/subagents/src/tui/render.ts
+++ b/packages/subagents/src/tui/render.ts
@@ -5,7 +5,7 @@
  * rendering responsibility across sibling modules.
  */
 
-export { PULSE_FRAMES, RUNNING_ANIMATION_MS, RUNNING_FRAMES, currentRunningFrame, pulseGlyph } from "./render-layout.ts";
+export { PULSE_FRAMES, RUNNING_ANIMATION_MS, RUNNING_FRAMES, currentRunningFrame, pulseGlyph, runningPulseGlyph } from "./render-layout.ts";
 export {
 	advanceResultPulseFrame,
 	clearLegacyResultAnimationTimer,

--- a/test/unit/subagents-render-stability-running-spinner.ts
+++ b/test/unit/subagents-render-stability-running-spinner.ts
@@ -8,10 +8,12 @@ import {
     RUNNING_ANIMATION_MS,
     stopResultAnimations,
 } from "../../packages/subagents/src/tui/render.js";
+import { widgetStepGlyph } from "../../packages/subagents/src/tui/render-event-formatting.js";
 import {
     type AgentToolResult,
     type Details,
     firstPulseChar,
+    firstSpinnerChar,
     runningSingleResult,
     theme,
     withMockedNow,
@@ -207,6 +209,13 @@ describe("subagent running pulse (foreground flicker fix)", () => {
             "same pulse frame + same captured now must render byte-identically regardless of wall-clock",
         );
         assert.equal(firstPulseChar(a), pulseGlyph(2));
+    });
+
+    test("foreground chain placeholder rows keep their existing running glyph", () => {
+        const glyph = withMockedNow(10_000, () => widgetStepGlyph("running", theme));
+
+        assert.ok(firstSpinnerChar(glyph), "foreground placeholder helper keeps the preexisting running spinner glyph");
+        assert.notEqual(glyph, pulseGlyph(1), "foreground placeholder helper must not reuse the async/foreground pulse frame");
     });
 
     test("multi-agent compact rows stay stable until a progress update", () => {

--- a/test/unit/subagents-render-stability-running-widget.ts
+++ b/test/unit/subagents-render-stability-running-widget.ts
@@ -1,14 +1,14 @@
 import { afterEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { buildWidgetLines, currentRunningFrame, RUNNING_ANIMATION_MS, stopResultAnimations } from "../../packages/subagents/src/tui/render.js";
-import { type AsyncJobState, theme, withMockedNow } from "./subagents-render-stability-helpers.js";
+import { buildWidgetLines, currentRunningFrame, pulseGlyph, RUNNING_ANIMATION_MS, stopResultAnimations } from "../../packages/subagents/src/tui/render.js";
+import { firstSpinnerChar, type AsyncJobState, theme, withMockedNow } from "./subagents-render-stability-helpers.js";
 
-describe("subagent running spinner animation (issue #1084)", () => {
+describe("subagent running pulse animation (issue #1084)", () => {
     afterEach(() => {
         stopResultAnimations();
     });
 
-    test("async widget spinner advances with wall clock for running jobs", () => {
+    test("async widget running glyphs reuse foreground pulse frames and ignore wall-clock time", () => {
         const job: AsyncJobState = {
             asyncId: "abc123",
             asyncDir: "/tmp/abc123",
@@ -21,19 +21,26 @@ describe("subagent running spinner animation (issue #1084)", () => {
             turnCount: 2,
         };
         const first = withMockedNow(10_000, () =>
-            buildWidgetLines([job], theme, 120).join("\n"),
+            buildWidgetLines([job], theme, 120, false, 10_000, 1).join("\n"),
         );
-        const second = withMockedNow(10_000 + RUNNING_ANIMATION_MS, () =>
-            buildWidgetLines([job], theme, 120).join("\n"),
+        const sameFrameLater = withMockedNow(10_000 + RUNNING_ANIMATION_MS, () =>
+            buildWidgetLines([job], theme, 120, false, 10_000, 1).join("\n"),
         );
-        assert.notEqual(
-            second,
+        assert.equal(
+            sameFrameLater,
             first,
-            "running async widget spinner should animate over wall-clock time",
+            "async pulse must not advance from wall-clock time alone",
         );
+        const advanced = buildWidgetLines([job], theme, 120, false, 10_000, 2).join("\n");
+        assert.notEqual(advanced, first, "a semantic progress/status update pulse frame should change the glyph");
+        assert.equal([...first.split("\n")[1]!][0], pulseGlyph(1));
+        assert.equal([...advanced.split("\n")[1]!][0], pulseGlyph(2));
+        assert.equal(firstSpinnerChar(advanced), undefined, "async widget must not render spinner-style glyphs");
+        assert.equal(firstSpinnerChar(first), undefined, "async widget must not render spinner-style glyphs");
+        assert.equal(firstSpinnerChar(sameFrameLater), undefined, "async widget must not render spinner-style glyphs");
     });
 
-    test("async widget honours captured now for job, step, and nested running glyphs", () => {
+    test("async widget honours captured now for job, step, and nested running pulse glyphs", () => {
         const job: AsyncJobState = {
             asyncId: "abc123",
             asyncDir: "/tmp/abc123",
@@ -70,20 +77,27 @@ describe("subagent running spinner animation (issue #1084)", () => {
             ],
         };
 
-        const first = buildWidgetLines([job], theme, 120, true, 10_000).join(
+        const first = buildWidgetLines([job], theme, 120, true, 10_000, 1).join(
             "\n",
         );
-        const second = buildWidgetLines(
+        const sameFrameLater = buildWidgetLines(
             [job],
             theme,
             120,
             true,
             10_000 + RUNNING_ANIMATION_MS,
+            1,
         ).join("\n");
+        assert.equal(
+            sameFrameLater,
+            first,
+            "same pulse frame should keep job, step, and nested glyphs stable across wall-clock advances",
+        );
+        const second = buildWidgetLines([job], theme, 120, true, 10_000, 2).join("\n");
         assert.notEqual(
             second,
             first,
-            "sanity: widget running glyphs should still be sensitive to captured now",
+            "progress/status-update pulse frames should advance job, step, and nested glyphs",
         );
         assert.match(
             first,
@@ -95,12 +109,14 @@ describe("subagent running spinner animation (issue #1084)", () => {
             /leaf-worker/,
             "test fixture should exercise nested step glyphs",
         );
+        assert.equal(firstSpinnerChar(first), undefined, "job, step, and nested running glyphs must not render spinner-style glyphs");
+        assert.equal(firstSpinnerChar(second), undefined, "job, step, and nested running glyphs must not render spinner-style glyphs");
 
         const stableA = withMockedNow(20_000, () =>
-            buildWidgetLines([job], theme, 120, true, 10_000).join("\n"),
+            buildWidgetLines([job], theme, 120, true, 10_000, 1).join("\n"),
         );
         const stableB = withMockedNow(30_000, () =>
-            buildWidgetLines([job], theme, 120, true, 10_000).join("\n"),
+            buildWidgetLines([job], theme, 120, true, 10_000, 1).join("\n"),
         );
         assert.equal(
             stableB,
@@ -109,7 +125,7 @@ describe("subagent running spinner animation (issue #1084)", () => {
         );
     });
 
-    test("multi-job async widget list honours captured now for header and row glyphs", () => {
+    test("multi-job async widget list honours captured now for header and row pulse glyphs", () => {
         const base: AsyncJobState = {
             asyncId: "abc123",
             asyncDir: "/tmp/abc123",
@@ -132,27 +148,36 @@ describe("subagent running spinner animation (issue #1084)", () => {
             },
         ];
 
-        const first = buildWidgetLines(jobs, theme, 120, false, 10_000).join(
+        const first = buildWidgetLines(jobs, theme, 120, false, 10_000, 1).join(
             "\n",
         );
-        const second = buildWidgetLines(
+        const sameFrameLater = buildWidgetLines(
             jobs,
             theme,
             120,
             false,
             10_000 + RUNNING_ANIMATION_MS,
+            1,
         ).join("\n");
+        assert.equal(
+            sameFrameLater,
+            first,
+            "same pulse frame should keep multi-job widget glyphs stable across wall-clock advances",
+        );
+        const second = buildWidgetLines(jobs, theme, 120, false, 10_000, 2).join("\n");
         assert.notEqual(
             second,
             first,
-            "sanity: multi-job widget glyphs should still be sensitive to captured now",
+            "progress/status-update pulse frames should advance multi-job widget glyphs",
         );
+        assert.equal(firstSpinnerChar(first), undefined, "multi-job widget rows must not render spinner-style glyphs");
+        assert.equal(firstSpinnerChar(second), undefined, "multi-job widget rows must not render spinner-style glyphs");
 
         const stableA = withMockedNow(20_000, () =>
-            buildWidgetLines(jobs, theme, 120, false, 10_000).join("\n"),
+            buildWidgetLines(jobs, theme, 120, false, 10_000, 1).join("\n"),
         );
         const stableB = withMockedNow(30_000, () =>
-            buildWidgetLines(jobs, theme, 120, false, 10_000).join("\n"),
+            buildWidgetLines(jobs, theme, 120, false, 10_000, 1).join("\n"),
         );
         assert.equal(
             stableB,

--- a/test/unit/subagents-render-stability-widget-lifecycle.ts
+++ b/test/unit/subagents-render-stability-widget-lifecycle.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
-import { renderWidget, RUNNING_ANIMATION_MS, stopWidgetAnimation } from "../../packages/subagents/src/tui/render.js";
+import { renderWidget, stopWidgetAnimation } from "../../packages/subagents/src/tui/render.js";
 import { type AsyncJobState, type Component, type ExtensionContext, type RenderTheme, theme, withMockedNow } from "./subagents-render-stability-helpers.js";
 describe("async widget animation ticker lifecycle", () => {
     afterEach(() => {
@@ -112,7 +112,7 @@ describe("async widget animation ticker lifecycle", () => {
         );
     });
 
-    test("mounted async widget uses captured widget time across unrelated host re-renders", () => {
+    test("mounted async widget advances pulse only when the job snapshot changes", () => {
         type WidgetFactory = (
             tui: unknown,
             widgetTheme: RenderTheme,
@@ -132,25 +132,24 @@ describe("async widget animation ticker lifecycle", () => {
         const stableA = withMockedNow(20_000, () =>
             component.render(120).join("\n"),
         );
-        const stableB = withMockedNow(30_000, () =>
+        withMockedNow(30_000, () => renderWidget(ctx, [runningJob()]));
+        const stableB = withMockedNow(40_000, () =>
             component.render(120).join("\n"),
         );
         assert.equal(
             stableB,
             stableA,
-            "host re-renders must not advance the mounted widget spinner clock by themselves",
+            "same job snapshot must not advance the async pulse frame",
         );
 
-        withMockedNow(10_000 + RUNNING_ANIMATION_MS, () =>
-            renderWidget(ctx, [runningJob()]),
+        withMockedNow(50_000, () =>
+            renderWidget(ctx, [{ ...runningJob(), toolCount: 2, updatedAt: 11_000 }]),
         );
-        const advanced = withMockedNow(30_000, () =>
-            component.render(120).join("\n"),
-        );
+        const advanced = component.render(120).join("\n");
         assert.notEqual(
             advanced,
             stableA,
-            "widget status updates/ticks should still advance the captured widget clock",
+            "semantic job snapshot updates should advance the async pulse frame",
         );
     });
 
@@ -304,30 +303,71 @@ describe("async widget animation ticker lifecycle", () => {
         );
     });
 
-    test("running jobs drive periodic re-renders; finished jobs stop them", async () => {
+    test("running jobs do not drive periodic re-renders without status updates", async () => {
         const { ctx, renders } = mockLifecycleWidgetCtx();
         renderWidget(ctx, [runningJob()]);
         await new Promise((resolve) =>
-            setTimeout(resolve, RUNNING_ANIMATION_MS * 3 + 40),
-        );
-        const whileRunning = renders();
-        assert.ok(
-            whileRunning >= 1,
-            `expected periodic widget re-renders while running, saw ${whileRunning}`,
-        );
-
-        renderWidget(ctx, [{ ...runningJob(), status: "complete" }]);
-        const afterStop = renders();
-        await new Promise((resolve) =>
-            setTimeout(resolve, RUNNING_ANIMATION_MS * 3 + 40),
+            setTimeout(resolve, 300),
         );
         assert.equal(
             renders(),
-            afterStop,
-            "widget ticker must stop once no job is running",
+            0,
+            "async widget pulse must not schedule cosmetic timer re-renders",
+        );
+
+        renderWidget(ctx, [{ ...runningJob(), toolCount: 2, updatedAt: 11_000 }]);
+        assert.equal(
+            renders(),
+            1,
+            "semantic status updates still request an in-place widget render",
+        );
+
+        await new Promise((resolve) =>
+            setTimeout(resolve, 300),
+        );
+        assert.equal(
+            renders(),
+            1,
+            "no periodic widget ticker should run after the status update",
         );
     });
 
+
+    test("compact large parallel widgets preserve running output paths", () => {
+        type WidgetFactory = (
+            tui: unknown,
+            widgetTheme: RenderTheme,
+        ) => Component;
+
+        const { ctx, widgetCalls } = mockLifecycleWidgetCtx();
+        const steps = Array.from({ length: 3 }, (_, index) => ({
+            index,
+            agent: `worker-${index}`,
+            status: "running" as const,
+            durationMs: 1_000 + index,
+            toolCount: index + 1,
+            tokens: { input: 10, output: 0, total: 10 },
+        }));
+        renderWidget(ctx, [{
+            ...runningJob(),
+            asyncDir: "/tmp/parallel-job",
+            mode: "parallel",
+            agents: steps.map((step) => step.agent),
+            steps,
+            stepsTotal: steps.length,
+            runningSteps: steps.length,
+            completedSteps: 0,
+        }]);
+
+        const factory = widgetCalls[0]?.content;
+        assert.equal(typeof factory, "function");
+        const component = (factory as WidgetFactory)(undefined, theme);
+        const rendered = component.render(160).join("\n");
+
+        assert.match(rendered, /output-0\.log/, "compact parallel widget should keep the first running output path");
+        assert.match(rendered, /output-1\.log/, "compact parallel widget should keep the second running output path");
+        assert.match(rendered, /output-2\.log/, "compact parallel widget should keep the third running output path");
+    });
     test("mounts the async widget belowEditor so its live line stays within the viewport (flicker-free)", () => {
         const opts: unknown[] = [];
         const ctx = {


### PR DESCRIPTION
## Summary

Async/background subagent widgets (running jobs, parallel child agents, chain steps, and nested child rows) previously animated with braille spinner glyphs on a wall-clock timer. This switches them to the same pulsing-dot glyph used by foreground subagent results, advanced only on real status updates instead of a periodic ticker, so unchanged background rows stay visually stable between updates.

## Changes

- Added `runningPulseGlyph()` in `render-layout.ts` as a thin wrapper around the existing foreground `pulseGlyph()` frames.
- Replaced seed-based braille spinner glyphs (`runningGlyph`/`runningSeed`) with `runningPulseGlyph`/`pulseFrame` throughout `render-event-formatting.ts` and `render-widget-graph.ts` — job headers, job rows, chain/parallel step rows, and nested child rows all now take an explicit `pulseFrame` instead of computing a seed from job/step metadata.
- Removed the now-unused `widgetStepRunningSeed`, `widgetStepsRunningSeed`, `widgetJobRunningSeed`, `widgetJobsRunningSeed`, and `nestedRunSeed` helpers.
- Reworked `render-widget.ts` to drive the pulse frame from semantic snapshot changes: `refreshWidgetSnapshot()` computes a snapshot key via `widgetRenderKey()` and only calls `advanceResultPulseFrame()` when the key changes, replacing the old `setInterval`-based `widgetTimer`/`ensureWidgetAnimation`/`stopWidgetTicker` ticker machinery.
- Preserved job/step counts, tool/token/elapsed metadata, live-detail hints, and output paths, including in the compact large-parallel-widget path (which now also surfaces the running step's output path, matching the non-compact path).
- Left the foreground placeholder spinner (`runningGlyph`/`runningSeed`) untouched — only the async/background widget path changed.
- Added an `## [Unreleased]` changelog entry under `packages/subagents/CHANGELOG.md`.

## Tests

- Updated/added render-stability coverage for async pulse parity with the foreground glyph, unchanged foreground placeholder behavior, nested rows, no periodic re-renders absent a status change, and the compact output-path case.

## Validation

- `AGENT=1 bun test test/unit/subagents-render-stability.test.ts test/unit/subagents-async-widget-visibility.test.ts test/unit/subagents-render-widget-owner.test.ts`
- `AGENT=1 bun run typecheck`
- `git diff --check origin/main`
- Pre-push hooks: `bun run lint`, `bun run check:file-length`, `bun run test:unit`