### PR TITLE
feat(coding-agent): add main-chat model fallbacks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added main-chat `fallbackModels` support for retryable provider/model failures ([#1418](https://github.com/bastani-inc/atomic/issues/1418)). Users can configure an ordered fallback chain in settings or SDK session options with per-candidate reasoning suffixes such as `:high` and `:xhigh`; normal same-model retry remains first when enabled, fallback switches are recorded as session model changes, and the UI reports fallback progress.
+
 ### Fixed
 
 - Fixed provider context-window overflow recovery so an exhausted overflow auto-compaction attempt emits an explicit unresolved-overflow signal instead of silently leaving callers to retry the same model, and planner calls that themselves overflow now degrade through the deterministic overflow-eviction ladder rather than throwing before non-model reduction can run. Planner overflow is now recognized whether it is returned as an assistant error message or thrown by the provider stream before `agent.prompt()` completes, so overflow recovery skips the critical planner retry and goes directly to deterministic non-model reduction in both forms.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -36,6 +36,7 @@ Settings and trust JSON files may start with a UTF-8 BOM, as commonly written by
 | `defaultThinkingLevel` | string | - | `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"` |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level |
+| `fallbackModels` | string[] | - | Ordered main-chat fallback models, written as `"provider/model"` with optional reasoning suffixes such as `:high` or `:xhigh` |
 
 #### thinkingBudgets
 
@@ -49,6 +50,28 @@ Settings and trust JSON files may start with a UTF-8 BOM, as commonly written by
   }
 }
 ```
+
+#### fallbackModels
+
+`fallbackModels` gives ordinary main-chat turns an ordered model fallback chain. Atomic starts with the selected/default model. If that model exhausts the normal same-model auto-retry loop for a retryable provider/model failure, Atomic switches to the next configured fallback model and continues the same turn. If `retry.enabled` is `false`, Atomic skips same-model retries and moves directly to the next fallback for retryable failures. Non-retryable task failures, cancellations, and context-overflow compaction paths do not trigger model fallback.
+
+Fallback entries should be fully qualified `provider/model` ids. Add a reasoning suffix to a candidate to override the effort for that fallback only; valid suffixes are `:off`, `:minimal`, `:low`, `:medium`, `:high`, and `:xhigh`.
+
+```json
+{
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.5",
+  "defaultThinkingLevel": "high",
+  "fallbackModels": [
+    "anthropic/claude-opus-4-8:xhigh",
+    "github-copilot/gpt-5.5:high"
+  ]
+}
+```
+
+Fallback attempts are visible as model changes in the session transcript and as a fallback status in the UI. Switching providers can change latency, billing, data-handling terms, and subscription/credit usage. Configure only providers you are comfortable sending the current conversation and tool context to.
+
+`enabledModels` is separate: it only controls the interactive Ctrl+P model cycle list and is not used as an implicit fallback chain.
 
 ### Codex Fast Mode
 
@@ -251,6 +274,7 @@ When multiple sources specify a session directory, precedence is `--session-dir`
 ```json
 {
   "enabledModels": ["claude-*", "gpt-4o", "gemini-2*"],
+  "fallbackModels": ["anthropic/claude-opus-4-8:xhigh", "github-copilot/gpt-5.5:high"],
   "defaultContextWindow": "1m",
   "defaultContextWindows": {
     "github-copilot/claude-opus-4.8": "936k",
@@ -261,6 +285,8 @@ When multiple sources specify a session directory, precedence is `--session-dir`
 ```
 
 Context-window settings are independent of `defaultThinkingLevel`: selecting a larger context window does not change reasoning effort. Interactive users can change the active model's budget through the `/model` selection flow, which prompts for a context window whenever the chosen model supports more than one window and persists the effective selection under `defaultContextWindows["provider/modelId"]`. Atomic treats `defaultContextWindow` as a broad fallback only: if the active model does not support that value, the model's own default is used without a startup warning; targeted `defaultContextWindows` entries still warn when they become unsupported for their exact model. Larger provider context windows can carry higher usage cost. For catalog-advertised GitHub Copilot long-context models (including dynamically populated plain catalog ids such as `github-copilot/claude-sonnet-5`, while namespaced enterprise deployment ids containing `/` are skipped), selecting `1m` raises Atomic's local prompt budget to the largest advertised long-context tier at or below that rounded request (for example `922k` or `936k`) and sends `X-GitHub-Api-Version: 2026-06-01`; GitHub then applies the long-context tier server-side by prompt token count. That tier consumes more Copilot AI credits and requires Copilot long-context/usage-based billing entitlement, otherwise requests over the server cap are rejected with a friendly hint. Custom providers and explicit model overrides can still declare their own selectable `contextWindowOptions`.
+
+`fallbackModels` is independent of both context-window defaults and `enabledModels`: it is consulted only after a retryable main-chat provider/model failure, and each fallback candidate applies its own model-specific context-window defaults when selected.
 
 ### Markdown
 

--- a/packages/coding-agent/src/core/agent-session-events.ts
+++ b/packages/coding-agent/src/core/agent-session-events.ts
@@ -48,7 +48,7 @@ export function _createRetryPromiseForAgentEnd(this: AgentSession, event: AgentE
 	}
 
 	const settings = this.settingsManager.getRetrySettings();
-	if (!settings.enabled) {
+	if (!settings.enabled && this._fallbackModels.length === 0) {
 		return;
 	}
 
@@ -84,6 +84,7 @@ export async function _processAgentEvent(this: AgentSession, event: AgentEvent):
 	// This ensures the UI sees the updated queue state
 	if (event.type === "message_start" && event.message.role === "user") {
 		this._overflowRecoveryAttempted = false;
+		this._fallbackAttemptedKeys.clear();
 		const messageText = this._getUserMessageText(event.message);
 		if (messageText) {
 			// Check steering queue first
@@ -148,6 +149,7 @@ export async function _processAgentEvent(this: AgentSession, event: AgentEvent):
 			// retries instead of honoring maxRetries.
 			const assistantFailed = assistantMsg.stopReason === "error" || this._isEmptyCompletion(assistantMsg) || this._isSafetyRefusal(assistantMsg);
 			if (!assistantFailed) {
+				this._fallbackAttemptedKeys.clear();
 				this._overflowRecoveryAttempted = false;
 			}
 

--- a/packages/coding-agent/src/core/agent-session-methods.ts
+++ b/packages/coding-agent/src/core/agent-session-methods.ts
@@ -168,8 +168,8 @@ export interface AgentSessionMethodSurface {
 	setSteeringMode(mode: "all" | "one-at-a-time"): void;
 	setFollowUpMode(mode: "all" | "one-at-a-time"): void;
 
-	_emitModelChanged(nextModel: Model<Api>, previousModel: Model<Api> | undefined, source: "set" | "cycle" | "restore"): void;
-	_emitModelSelect(nextModel: Model<Api>, previousModel: Model<Api> | undefined, source: "set" | "cycle" | "restore"): Promise<void>;
+	_emitModelChanged(nextModel: Model<Api>, previousModel: Model<Api> | undefined, source: "set" | "cycle" | "restore" | "fallback"): void;
+	_emitModelSelect(nextModel: Model<Api>, previousModel: Model<Api> | undefined, source: "set" | "cycle" | "restore" | "fallback"): Promise<void>;
 	setModel(model: Model<Api>): Promise<void>;
 	cycleModel(direction?: "forward" | "backward"): Promise<ModelCycleResult | undefined>;
 	_cycleScopedModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined>;
@@ -223,6 +223,7 @@ export interface AgentSessionMethodSurface {
 	_isEmptyCompletion(message: AssistantMessage): boolean;
 	_isSafetyRefusal(message: AssistantMessage): boolean;
 	_handleRetryableError(message: AssistantMessage): Promise<boolean>;
+	_trySwitchToFallbackModel(message: AssistantMessage): Promise<boolean>;
 	abortRetry(): void;
 	waitForRetry(): Promise<void>;
 	setAutoRetryEnabled(enabled: boolean): void;
@@ -330,6 +331,9 @@ export interface AgentSessionPublicSurface extends Pick<AgentSessionMethodSurfac
 
 export interface AgentSessionInternalSurface extends AgentSessionMethodSurface, AgentSessionPublicSurface {
 	_scopedModels: Array<{ model: Model<Api>; thinkingLevel?: ThinkingLevel }>;
+	_fallbackModels: string[];
+	_fallbackAttemptedKeys: Set<string>;
+
 	_unsubscribeAgent?: () => void;
 	_eventListeners: AgentSessionEventListener[];
 	_agentEventQueue: Promise<void>;

--- a/packages/coding-agent/src/core/agent-session-models.ts
+++ b/packages/coding-agent/src/core/agent-session-models.ts
@@ -45,7 +45,7 @@ export async function _getRequiredRequestAuth(this: AgentSession, model: Model<A
 export function _emitModelChanged(this: AgentSession, 
 	nextModel: Model<Api>,
 	previousModel: Model<Api> | undefined,
-	source: "set" | "cycle" | "restore",
+	source: "set" | "cycle" | "restore" | "fallback",
 ): void {
 	if (modelsAreEqual(previousModel, nextModel)) return;
 	this._emit({
@@ -60,7 +60,7 @@ export function _emitModelChanged(this: AgentSession,
 export async function _emitModelSelect(this: AgentSession, 
 	nextModel: Model<Api>,
 	previousModel: Model<Api> | undefined,
-	source: "set" | "cycle" | "restore",
+	source: "set" | "cycle" | "restore" | "fallback",
 ): Promise<void> {
 	if (modelsAreEqual(previousModel, nextModel)) return;
 	await this._extensionRunner.emit({

--- a/packages/coding-agent/src/core/agent-session-retry.ts
+++ b/packages/coding-agent/src/core/agent-session-retry.ts
@@ -1,16 +1,95 @@
-import type { AssistantMessage } from "@earendil-works/pi-ai/compat";
-import { isContextOverflow } from "@earendil-works/pi-ai/compat";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai/compat";
+import { clampThinkingLevel, isContextOverflow, modelsAreEqual } from "@earendil-works/pi-ai/compat";
 import { sleep } from "../utils/sleep.ts";
+import { DEFAULT_THINKING_LEVEL } from "./defaults.ts";
 import { isCopilotGeminiModel } from "./copilot-gemini-payload-sanitizer.ts";
 import { normalizeToolArgumentsForModel } from "./copilot-gemini-tool-arguments.ts";
 import type { AgentSessionInternalSurface as AgentSession } from "./agent-session-methods.ts";
 
+
+const THINKING_SUFFIXES = ["off", "minimal", "low", "medium", "high", "xhigh"] as const satisfies readonly ThinkingLevel[];
+const THINKING_SUFFIX_SET: ReadonlySet<string> = new Set(THINKING_SUFFIXES);
+
+function modelLabel(model: Model<Api> | undefined): string {
+	return model ? `${model.provider}/${model.id}` : "unknown model";
+}
+
+function splitFallbackModel(value: string): { modelId: string; thinkingLevel?: ThinkingLevel } {
+	const trimmed = value.trim();
+	const index = trimmed.lastIndexOf(":");
+	if (index < 0) return { modelId: trimmed };
+	const suffix = trimmed.slice(index + 1);
+	if (!THINKING_SUFFIX_SET.has(suffix)) return { modelId: trimmed };
+	return { modelId: trimmed.slice(0, index), thinkingLevel: suffix as ThinkingLevel };
+}
+
+function resolveFallbackModel(this: AgentSession, value: string): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined {
+	const parsed = splitFallbackModel(value);
+	if (!parsed.modelId.includes("/")) {
+		const available = this._modelRegistry.getAvailable().filter((model) => model.id === parsed.modelId);
+		const preferredProvider = this.model?.provider ?? this.settingsManager.getDefaultProvider();
+		const model = available.find((candidate) => candidate.provider === preferredProvider) ?? (available.length === 1 ? available[0] : undefined);
+		return model ? { model, thinkingLevel: parsed.thinkingLevel } : undefined;
+	}
+	const slash = parsed.modelId.indexOf("/");
+	const provider = parsed.modelId.slice(0, slash);
+	const modelId = parsed.modelId.slice(slash + 1);
+	const model = this._modelRegistry.find(provider, modelId);
+	if (!model || !this._modelRegistry.hasConfiguredAuth(model)) return undefined;
+	return { model, thinkingLevel: parsed.thinkingLevel };
+}
+
+function fallbackKey(model: Model<Api>, thinkingLevel: ThinkingLevel | undefined): string {
+	return `${model.provider}/${model.id}:${thinkingLevel ?? ""}`;
+}
+
+function hasProviderTransportDiagnostic(value: unknown, seen = new Set<unknown>(), includeMessageFields = false): boolean {
+	if (value === null || value === undefined || seen.has(value)) return false;
+	if (typeof value !== "object") {
+		return /provider_transport_failure|websocket.*error|sse.*404/i.test(String(value));
+	}
+	seen.add(value);
+	const record = value as Record<string, unknown>;
+	const fields = includeMessageFields
+		? [record.type, record.code, record.name, record.message, record.errorMessage, record.status, record.statusCode]
+		: [record.type, record.code, record.name, record.status, record.statusCode];
+	for (const field of fields) {
+		 if (typeof field === "string" || typeof field === "number") {
+			if (/provider_transport_failure|websocket.*error|sse.*404|\b404\b/i.test(String(field))) return true;
+		}
+	}
+	for (const nested of [record.error, record.cause, ...(Array.isArray(record.diagnostics) ? record.diagnostics : [])]) {
+		if (hasProviderTransportDiagnostic(nested, seen, true)) return true;
+	}
+	return false;
+}
+
+function hasProviderModelUnavailableDiagnostic(value: unknown, seen = new Set<unknown>(), includeMessageFields = false): boolean {
+	if (value === null || value === undefined || seen.has(value)) return false;
+	if (typeof value !== "object") return false;
+	seen.add(value);
+	const record = value as Record<string, unknown>;
+	const fields = includeMessageFields
+		? [record.type, record.code, record.name, record.message, record.errorMessage]
+		: [record.type, record.code, record.name, record.errorMessage];
+	for (const field of fields) {
+		if (typeof field === "string" && /model(?:[_\s-].*)?(?:not[_\s-]?found|unavailable|unknown|disabled)|model[_-]?not[_-]?found/i.test(field)) return true;
+	}
+	for (const nested of [record.error, record.cause, ...(Array.isArray(record.diagnostics) ? record.diagnostics : [])]) {
+		if (hasProviderModelUnavailableDiagnostic(nested, seen, true)) return true;
+	}
+	return false;
+}
 export function _isRetryableError(this: AgentSession, message: AssistantMessage): boolean {
-	if (message.stopReason !== "error" || !message.errorMessage) return false;
+	if (message.stopReason !== "error") return false;
 
 	// Context overflow is handled by compaction, not retry
 	const contextWindow = this.model?.contextWindow ?? 0;
 	if (isContextOverflow(message, contextWindow)) return false;
+
+	if (hasProviderTransportDiagnostic(message) || hasProviderModelUnavailableDiagnostic(message)) return true;
+	if (!message.errorMessage) return false;
 
 	const err = message.errorMessage;
 
@@ -157,11 +236,79 @@ export function _isSafetyRefusal(this: AgentSession, message: AssistantMessage):
  * @returns true if retry was initiated, false if max retries exceeded or disabled
  */
 
+export async function _trySwitchToFallbackModel(this: AgentSession, message: AssistantMessage): Promise<boolean> {
+	if (this._fallbackModels.length === 0 || !this.model) return false;
+
+	this._fallbackAttemptedKeys.add(fallbackKey(this.model, this.thinkingLevel));
+	const fromModel = this.model;
+	for (const rawCandidate of this._fallbackModels) {
+		const candidate = resolveFallbackModel.call(this, rawCandidate);
+		if (!candidate) continue;
+		const key = fallbackKey(candidate.model, candidate.thinkingLevel);
+		if (this._fallbackAttemptedKeys.has(key)) continue;
+		const nextModel = this._withContextWindowForModelSwitch(candidate.model);
+		const nextLevel = clampThinkingLevel(
+			nextModel,
+			candidate.thinkingLevel ?? this.settingsManager.getDefaultThinkingLevel() ?? this.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
+		) as ThinkingLevel;
+		if (modelsAreEqual(candidate.model, fromModel) && nextLevel === this.thinkingLevel) continue;
+		if (this._retryAttempt > 0) {
+			this._emit({
+				type: "auto_retry_end",
+				success: true,
+				attempt: Math.max(0, this._retryAttempt - 1),
+			});
+		}
+		this._fallbackAttemptedKeys.add(key);
+		this._emit({
+			type: "model_fallback_start",
+			from: modelLabel(fromModel),
+			to: `${nextModel.provider}/${nextModel.id}`,
+			reason: message.errorMessage || "Retryable model error",
+			attempt: this._fallbackAttemptedKeys.size - 1,
+		});
+
+		const messages = this.agent.state.messages;
+		if (messages.length > 0 && messages[messages.length - 1]?.role === "assistant") {
+			this.agent.state.messages = messages.slice(0, -1);
+		}
+		this.agent.state.model = nextModel;
+		this.sessionManager.appendModelChange(nextModel.provider, nextModel.id);
+		this._appendContextWindowChangeIfChanged(fromModel, nextModel);
+		this.agent.state.thinkingLevel = nextLevel;
+		this.sessionManager.appendThinkingLevelChange(nextLevel);
+		this._refreshBaseSystemPromptFromActiveTools();
+		this._emitModelChanged(nextModel, fromModel, "fallback");
+		await this._emitModelSelect(nextModel, fromModel, "fallback");
+		this._retryAttempt = 0;
+
+		setTimeout(() => {
+			this.agent.continue().then(
+				() => {
+					// A resolved continuation may still have produced an assistant
+					// error that will be classified by agent_end and may advance to
+					// the next fallback. Do not emit a successful fallback end here;
+					// agent_end/turn_end clear UI state for successful turns, while
+					// fallback exhaustion emits the failure end event.
+				},
+				(error: unknown) => {
+					const finalError = error instanceof Error ? error.message : String(error);
+					this._emit({ type: "model_fallback_end", success: false, from: modelLabel(fromModel), to: modelLabel(nextModel), finalError });
+					this._retryAttempt = 0;
+					this._resolveRetry();
+				},
+			);
+		}, 0);
+		return true;
+	}
+	this._emit({ type: "model_fallback_end", success: false, from: modelLabel(fromModel), finalError: message.errorMessage });
+	return false;
+}
+
 export async function _handleRetryableError(this: AgentSession, message: AssistantMessage): Promise<boolean> {
 	const settings = this.settingsManager.getRetrySettings();
 	if (!settings.enabled) {
-		this._resolveRetry();
-		return false;
+		return this._trySwitchToFallbackModel(message);
 	}
 
 	// Retry promise is created synchronously in _handleAgentEvent for agent_end.
@@ -175,6 +322,9 @@ export async function _handleRetryableError(this: AgentSession, message: Assista
 	this._retryAttempt++;
 
 	if (this._retryAttempt > settings.maxRetries) {
+		if (await this._trySwitchToFallbackModel(message)) {
+			return true;
+		}
 		// Max retries exceeded, emit final failure and reset
 		this._emit({
 			type: "auto_retry_end",
@@ -282,6 +432,7 @@ export const agentSessionRetryMethods = {
 	_isEmptyCompletion,
 	_isSafetyRefusal,
 	_handleRetryableError,
+	_trySwitchToFallbackModel,
 	abortRetry,
 	waitForRetry,
 	setAutoRetryEnabled,

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -59,6 +59,7 @@ export interface CreateAgentSessionFromServicesOptions {
 	sessionStartEvent?: SessionStartEvent;
 	model?: Model<Api>;
 	thinkingLevel?: ThinkingLevel;
+	fallbackModels?: CreateAgentSessionOptions["fallbackModels"];
 	contextWindow?: number;
 	contextWindowStrict?: boolean;
 	scopedModels?: Array<{ model: Model<Api>; thinkingLevel?: ThinkingLevel }>;
@@ -212,6 +213,7 @@ export async function createAgentSessionFromServices(
 		sessionManager: options.sessionManager,
 		model: options.model,
 		thinkingLevel: options.thinkingLevel,
+		fallbackModels: options.fallbackModels,
 		contextWindow: options.contextWindow,
 		contextWindowStrict: options.contextWindowStrict,
 		scopedModels: options.scopedModels,

--- a/packages/coding-agent/src/core/agent-session-types.ts
+++ b/packages/coding-agent/src/core/agent-session-types.ts
@@ -40,7 +40,7 @@ export type AgentSessionEvent =
 			type: "model_changed";
 			model: Model<Api>;
 			previousModel: Model<Api> | undefined;
-			source: "set" | "cycle" | "restore";
+			source: "set" | "cycle" | "restore" | "fallback";
 	  }
 	| { type: "thinking_level_changed"; level: ThinkingLevel }
 	| { type: "context_window_changed"; contextWindow: number }
@@ -63,7 +63,9 @@ export type AgentSessionEvent =
 	  }
 	| { type: "agent_continue_error"; source: "post_compaction"; errorMessage: string }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
-	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
+	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
+	| { type: "model_fallback_start"; from: string; to: string; reason: string; attempt: number }
+	| { type: "model_fallback_end"; success: boolean; from?: string; to?: string; finalError?: string };
 
 export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
 
@@ -145,6 +147,7 @@ export interface AgentSessionConfig {
 	settingsManager: SettingsManager;
 	cwd: string;
 	scopedModels?: Array<{ model: Model<Api>; thinkingLevel?: ThinkingLevel }>;
+	fallbackModels?: string[];
 	resourceLoader: ResourceLoader;
 	customTools?: ToolDefinition[];
 	modelRegistry: ModelRegistry;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -71,6 +71,8 @@ export class AgentSession {
 	readonly settingsManager: SettingsManager;
 
 	protected _scopedModels: Array<{ model: Model<Api>; thinkingLevel?: ThinkingLevel }>;
+	protected _fallbackModels: string[];
+	protected _fallbackAttemptedKeys: Set<string> = new Set();
 	protected _unsubscribeAgent?: () => void;
 	protected _eventListeners: AgentSessionEventListener[] = [];
 	protected _agentEventQueue: Promise<void> = Promise.resolve();
@@ -128,6 +130,7 @@ export class AgentSession {
 		this.sessionManager = config.sessionManager;
 		this.settingsManager = config.settingsManager;
 		this._scopedModels = config.scopedModels ?? [];
+		this._fallbackModels = config.fallbackModels ?? [];
 		this._resourceLoader = config.resourceLoader;
 		this._customTools = config.customTools ?? [];
 		this._cwd = config.cwd;

--- a/packages/coding-agent/src/core/extensions/agent-events.ts
+++ b/packages/coding-agent/src/core/extensions/agent-events.ts
@@ -115,7 +115,7 @@ export interface ToolExecutionEndEvent {
 // Model Events
 // ============================================================================
 
-export type ModelSelectSource = "set" | "cycle" | "restore";
+export type ModelSelectSource = "set" | "cycle" | "restore" | "fallback";
 
 /** Fired when a new model is selected */
 export interface ModelSelectEvent {

--- a/packages/coding-agent/src/core/sdk-types.ts
+++ b/packages/coding-agent/src/core/sdk-types.ts
@@ -23,6 +23,8 @@ export interface CreateAgentSessionOptions {
   model?: Model<Api>;
   /** Thinking level. Default: from settings, else 'medium' (clamped to model capabilities) */
   thinkingLevel?: ThinkingLevel;
+  /** Ordered fallback models for main chat, as provider/model strings with optional :thinkingLevel suffix. Default: settings.fallbackModels */
+  fallbackModels?: string[];
   /** Context window token count. Default: model scalar contextWindow, or settings/session override when supported. */
   contextWindow?: number;
   /** Treat unsupported contextWindow as an error instead of a warning/fallback. */

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -472,6 +472,7 @@ export async function createAgentSession(
     settingsManager,
     cwd,
     scopedModels: options.scopedModels,
+    fallbackModels: options.fallbackModels ?? settingsManager.getFallbackModels(),
     resourceLoader,
     customTools: options.customTools,
     modelRegistry,

--- a/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
@@ -27,6 +27,7 @@ interface SettingsManagerBasicAccessors {
 	setTheme(theme: string): void;
 	getDefaultThinkingLevel(): "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
 	setDefaultThinkingLevel(level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"): void;
+	getFallbackModels(): string[];
 	getDefaultContextWindow(): number | undefined;
 	getDefaultContextWindowForModel(provider: string, modelId: string): number | undefined;
 	setDefaultContextWindow(contextWindow: number | undefined): void;
@@ -194,6 +195,13 @@ const basicAccessors: SettingsManagerBasicAccessors = {
 		state.globalSettings.defaultThinkingLevel = level;
 		state.markModified("defaultThinkingLevel");
 		state.save();
+	},
+
+	getFallbackModels() {
+		return (settingsInternals(this).settings.fallbackModels ?? [])
+			.filter((model): model is string => typeof model === "string")
+			.map((model) => model.trim())
+			.filter((model) => model.length > 0);
 	},
 
 	getDefaultContextWindow() {

--- a/packages/coding-agent/src/core/settings-types.ts
+++ b/packages/coding-agent/src/core/settings-types.ts
@@ -93,6 +93,7 @@ export interface Settings {
 	defaultProvider?: string;
 	defaultModel?: string;
 	defaultThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	fallbackModels?: string[]; // Ordered main-chat fallback models, optionally suffixed with :thinkingLevel
 	defaultContextWindow?: ContextWindowSetting; // Optional global fallback; model picker writes defaultContextWindows instead.
 	defaultContextWindows?: ModelContextWindowSettings; // Per-model defaults keyed as "provider/modelId".
 	transport?: TransportSetting; // default: "auto"

--- a/packages/coding-agent/src/modes/interactive/components/chat-session-host-events.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-session-host-events.ts
@@ -120,6 +120,21 @@ export function applyChatSessionAgentEvent<
       state.statusMessage = "retrying…";
       changed = true;
       break;
+    case "model_fallback_start":
+      state.sdkBusy = true;
+      state.statusMessage = "switching model…";
+      changed = true;
+      break;
+    case "model_fallback_end": {
+      const fallback = event as Extract<AgentSessionEvent, { type: "model_fallback_end" }>;
+      state.statusMessage = fallback.success ? "" : (fallback.finalError ?? "model fallback failed");
+      if (!fallback.success) {
+        state.sdkBusy = false;
+        state.workingMessage = undefined;
+      }
+      changed = true;
+      break;
+    }
     case "auto_retry_end": {
       const retry = event as Extract<AgentSessionEvent, { type: "auto_retry_end" }>;
       state.statusMessage = "";

--- a/packages/coding-agent/src/modes/interactive/interactive-agent-events.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-agent-events.ts
@@ -34,6 +34,10 @@ InteractiveModeBase.prototype.handleEvent = async function(this: InteractiveMode
           this.retryLoader.stop();
           this.retryLoader = undefined;
         }
+        if (this.fallbackLoader) {
+          this.fallbackLoader.stop();
+          this.fallbackLoader = undefined;
+        }
         this.stopWorkingLoader();
         if (this.workingVisible) {
           this.loadingAnimation = this.createWorkingLoader();
@@ -414,6 +418,33 @@ InteractiveModeBase.prototype.handleEvent = async function(this: InteractiveMode
         break;
       }
 
+
+      case "model_fallback_start": {
+        this.statusContainer.clear();
+        if (this.fallbackLoader) {
+          this.fallbackLoader.stop();
+          this.fallbackLoader = undefined;
+        }
+        this.fallbackLoader = new Loader(
+          this.ui,
+          (spinner) => theme.fg("warning", spinner),
+          (text) => theme.fg("muted", text),
+          `Falling back from ${event.from} to ${event.to}...`,
+        );
+        this.statusContainer.addChild(this.fallbackLoader);
+        this.ui.requestRender();
+        break;
+      }
+
+      case "model_fallback_end": {
+        if (this.fallbackLoader) {
+          this.fallbackLoader.stop();
+          this.fallbackLoader = undefined;
+        }
+        this.statusContainer.clear();
+        this.ui.requestRender();
+        break;
+      }
       case "auto_retry_end": {
         // Restore escape handler
         if (this.retryEscapeHandler) {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -245,7 +245,7 @@ export class InteractiveModeBase {
 
   // Auto-retry state
   retryLoader: Loader | undefined = undefined;
-
+  fallbackLoader: Loader | undefined = undefined;
 
   retryCountdown: CountdownTimer | undefined = undefined;
 

--- a/test/unit/chat-session-host-02.test.ts
+++ b/test/unit/chat-session-host-02.test.ts
@@ -47,6 +47,24 @@ function makeHost(
     ...overrides,
   });
 }
+
+test("ChatSessionHost clears busy state when model fallback fails", () => {
+  const host = makeHost();
+  host.applyAgentEvent({ type: "model_fallback_start", from: "a", to: "b", reason: "retryable", attempt: 1 } as never);
+  assert.equal(host.isStreaming(), true);
+
+  host.applyAgentEvent({
+    type: "model_fallback_end",
+    success: false,
+    from: "a",
+    to: "b",
+    finalError: "fallback auth failed",
+  } as never);
+
+  assert.equal(host.isStreaming(), false);
+  assert.equal(host.hasAnimationTick(), false);
+  host.dispose();
+});
 test("ChatSessionHost preserves compaction queued messages when flush fails", async () => {
   const host = makeHost({
     getActionKeyDisplay: (action) => (action === "app.message.dequeue" ? "⌥↑" : action),

--- a/test/unit/main-chat-model-fallback.test.ts
+++ b/test/unit/main-chat-model-fallback.test.ts
@@ -1,0 +1,336 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai/compat";
+import type { CreateAgentSessionFromServicesOptions } from "../../packages/coding-agent/src/core/agent-session-services.js";
+import { _createRetryPromiseForAgentEnd } from "../../packages/coding-agent/src/core/agent-session-events.js";
+import {
+  _handleRetryableError,
+  _isRetryableError,
+  _trySwitchToFallbackModel,
+} from "../../packages/coding-agent/src/core/agent-session-retry.js";
+
+function model(provider: string, id: string): Model<Api> {
+  return {
+    provider,
+    id,
+    api: provider as Api,
+    contextWindow: 200_000,
+    defaultContextWindow: 200_000,
+    reasoning: true,
+  } as Model<Api>;
+}
+
+function retryableMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    stopReason: "error",
+    errorMessage: "Not Found",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    ...overrides,
+  } as AssistantMessage;
+}
+
+test("main-chat retry classifies structured provider transport diagnostics", () => {
+  const session = { model: model("openai-codex", "gpt-5.5") };
+  const diagnostics = [
+    {
+      type: "provider_transport_failure",
+      timestamp: Date.now(),
+      error: { message: "WebSocket error", status: 404 },
+    },
+  ];
+  const message = retryableMessage({ diagnostics } as unknown as Partial<AssistantMessage>);
+  const diagnosticOnlyMessage = retryableMessage({
+    errorMessage: undefined,
+    diagnostics,
+  } as unknown as Partial<AssistantMessage>);
+
+  assert.equal(_isRetryableError.call(session as never, message), true);
+  assert.equal(_isRetryableError.call(session as never, diagnosticOnlyMessage), true);
+  assert.equal(_isRetryableError.call(session as never, retryableMessage({ errorMessage: "Tool not found" })), false);
+  assert.equal(_isRetryableError.call(session as never, retryableMessage({ errorMessage: "model not found" })), true);
+  assert.equal(_isRetryableError.call(session as never, retryableMessage({ errorMessage: undefined, code: "model_not_found" } as unknown as Partial<AssistantMessage>)), true);
+});
+
+test("main-chat fallback switches models after same-model retry exhaustion", async () => {
+  const primary = model("openai-codex", "gpt-5.5");
+  const fallback = model("anthropic", "claude-opus-4-8");
+  const events: Array<{ type: string; [key: string]: unknown }> = [];
+  let continued = false;
+  const session = {
+    model: primary,
+    thinkingLevel: "high" as ThinkingLevel,
+    _fallbackModels: ["anthropic/claude-opus-4-8:high"],
+    _fallbackAttemptedKeys: new Set<string>(),
+    _retryAttempt: 0,
+    settingsManager: {
+      getRetrySettings: () => ({ enabled: true, maxRetries: 0, baseDelayMs: 1 }),
+      getDefaultThinkingLevel: () => "high" as ThinkingLevel,
+      getDefaultProvider: () => "openai-codex",
+    },
+    _modelRegistry: {
+      getAvailable: () => [primary, fallback],
+      find: (provider: string, id: string) => provider === fallback.provider && id === fallback.id ? fallback : undefined,
+      hasConfiguredAuth: (candidate: Model<Api>) => candidate.provider === fallback.provider || candidate.provider === primary.provider,
+    },
+    agent: {
+      state: {
+        model: primary,
+        thinkingLevel: "high" as ThinkingLevel,
+        messages: [retryableMessage()],
+      },
+      continue: async () => { continued = true; },
+    },
+    sessionManager: {
+      appendModelChange: (provider: string, id: string) => events.push({ type: "session_model", provider, id }),
+      appendThinkingLevelChange: (level: ThinkingLevel) => events.push({ type: "session_thinking", level }),
+    },
+    _withContextWindowForModelSwitch: (candidate: Model<Api>) => candidate,
+    _appendContextWindowChangeIfChanged: () => undefined,
+    _refreshBaseSystemPromptFromActiveTools: () => undefined,
+    _emitModelChanged: (next: Model<Api>, previous: Model<Api> | undefined, source: string) => events.push({ type: "model_changed", next: next.id, previous: previous?.id, source }),
+    _emitModelSelect: async (next: Model<Api>, previous: Model<Api> | undefined, source: string) => events.push({ type: "model_select", next: next.id, previous: previous?.id, source }),
+    _emit: (event: { type: string; [key: string]: unknown }) => events.push(event),
+    _resolveRetry: () => events.push({ type: "resolve_retry" }),
+    _trySwitchToFallbackModel,
+  };
+
+  const handled = await _handleRetryableError.call(session as never, retryableMessage());
+  const autoRetryEndIndex = events.findIndex((event) => event.type === "auto_retry_end");
+  const fallbackStartIndex = events.findIndex((event) => event.type === "model_fallback_start");
+  assert.ok(autoRetryEndIndex >= 0, "retry exhaustion should close the retry lifecycle before fallback");
+  assert.ok(fallbackStartIndex >= 0, "fallback should start after retry exhaustion");
+  assert.ok(autoRetryEndIndex < fallbackStartIndex, "retry cleanup should be emitted before fallback start");
+  assert.equal(events.some((event) => event.type === "model_fallback_end"), false);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(handled, true);
+  assert.equal(session.agent.state.model, fallback);
+  assert.equal(session.agent.state.thinkingLevel, "high");
+  assert.equal(session.agent.state.messages.length, 0);
+  assert.equal(continued, true);
+  assert.ok(events.some((event) => event.type === "model_fallback_start" && event.to === "anthropic/claude-opus-4-8"));
+  assert.ok(events.some((event) => event.type === "model_changed" && event.source === "fallback"));
+  assert.ok(events.some((event) => event.type === "session_model" && event.provider === "anthropic"));
+});
+
+test("main-chat fallback can change reasoning on the same provider/model", async () => {
+  const primary = model("openai", "gpt-5-mini");
+  const events: Array<{ type: string; [key: string]: unknown }> = [];
+  const session = {
+    model: primary,
+    thinkingLevel: "high" as ThinkingLevel,
+    _fallbackModels: ["openai/gpt-5-mini:low"],
+    _fallbackAttemptedKeys: new Set<string>(),
+    _retryAttempt: 0,
+    settingsManager: {
+      getDefaultThinkingLevel: () => "high" as ThinkingLevel,
+      getDefaultProvider: () => "openai",
+    },
+    _modelRegistry: {
+      getAvailable: () => [primary],
+      find: (provider: string, id: string) => provider === primary.provider && id === primary.id ? primary : undefined,
+      hasConfiguredAuth: () => true,
+    },
+    agent: {
+      state: { model: primary, thinkingLevel: "high" as ThinkingLevel, messages: [retryableMessage()] },
+      continue: async () => undefined,
+    },
+    sessionManager: {
+      appendModelChange: (provider: string, id: string) => events.push({ type: "session_model", provider, id }),
+      appendThinkingLevelChange: (level: ThinkingLevel) => events.push({ type: "session_thinking", level }),
+    },
+    _withContextWindowForModelSwitch: (candidate: Model<Api>) => candidate,
+    _appendContextWindowChangeIfChanged: () => undefined,
+    _refreshBaseSystemPromptFromActiveTools: () => undefined,
+    _emitModelChanged: () => undefined,
+    _emitModelSelect: async () => undefined,
+    _emit: (event: { type: string; [key: string]: unknown }) => events.push(event),
+  };
+
+  const handled = await _trySwitchToFallbackModel.call(session as never, retryableMessage());
+
+  assert.equal(handled, true);
+  assert.equal(session.agent.state.model, primary);
+  assert.equal(session.agent.state.thinkingLevel, "low");
+  assert.ok(events.some((event) => event.type === "model_fallback_start"));
+  assert.ok(events.some((event) => event.type === "session_thinking" && event.level === "low"));
+});
+
+test("service-based SDK session options include fallbackModels", () => {
+  const fallbackModels = ["anthropic/claude-opus-4-8:high"] satisfies NonNullable<CreateAgentSessionFromServicesOptions["fallbackModels"]>;
+  assert.deepEqual(fallbackModels, ["anthropic/claude-opus-4-8:high"]);
+});
+
+test("main-chat retry-disabled fallback keeps prompt waiting for fallback completion", async () => {
+  const primary = model("openai-codex", "gpt-5.5");
+  const fallback = model("anthropic", "claude-opus-4-8");
+  const message = retryableMessage({ errorMessage: "rate limit" });
+  let continued = false;
+  const session = {
+    model: primary,
+    thinkingLevel: "high" as ThinkingLevel,
+    _fallbackModels: ["anthropic/claude-opus-4-8:high"],
+    _fallbackAttemptedKeys: new Set<string>(),
+    _retryAttempt: 0,
+    _retryPromise: undefined as Promise<void> | undefined,
+    _retryResolve: undefined as (() => void) | undefined,
+    settingsManager: {
+      getRetrySettings: () => ({ enabled: false, maxRetries: 0, baseDelayMs: 1 }),
+      getDefaultThinkingLevel: () => "high" as ThinkingLevel,
+      getDefaultProvider: () => "openai-codex",
+    },
+    _modelRegistry: {
+      getAvailable: () => [primary, fallback],
+      find: (provider: string, id: string) => provider === fallback.provider && id === fallback.id ? fallback : undefined,
+      hasConfiguredAuth: (candidate: Model<Api>) => candidate.provider === fallback.provider || candidate.provider === primary.provider,
+    },
+    agent: {
+      state: { model: primary, thinkingLevel: "high" as ThinkingLevel, messages: [message] },
+      continue: async () => { continued = true; },
+    },
+    sessionManager: {
+      appendModelChange: () => undefined,
+      appendThinkingLevelChange: () => undefined,
+    },
+    _findLastAssistantInMessages: () => message,
+    _isRetryableError,
+    _isEmptyCompletion: () => false,
+    _isSafetyRefusal: () => false,
+    _withContextWindowForModelSwitch: (candidate: Model<Api>) => candidate,
+    _appendContextWindowChangeIfChanged: () => undefined,
+    _refreshBaseSystemPromptFromActiveTools: () => undefined,
+    _emitModelChanged: () => undefined,
+    _emitModelSelect: async () => undefined,
+    _emit: () => undefined,
+    _resolveRetry() {
+      this._retryResolve?.();
+      this._retryPromise = undefined;
+      this._retryResolve = undefined;
+    },
+    _trySwitchToFallbackModel,
+  };
+
+  _createRetryPromiseForAgentEnd.call(session as never, { type: "agent_end", messages: [message] });
+  assert.ok(session._retryPromise, "retry-disabled fallback should create a wait promise");
+
+  const handled = await _handleRetryableError.call(session as never, message);
+  assert.equal(handled, true);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(continued, true);
+
+  const waitState = await Promise.race([
+    session._retryPromise!.then(() => "resolved"),
+    new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 5)),
+  ]);
+  assert.equal(waitState, "pending");
+
+  session._resolveRetry();
+  await session._retryPromise;
+});
+
+test("main-chat fallback rejection settles the retry wait", async () => {
+  const primary = model("openai-codex", "gpt-5.5");
+  const fallback = model("anthropic", "claude-opus-4-8");
+  const events: Array<{ type: string; [key: string]: unknown }> = [];
+  let resolveRetry: (() => void) | undefined;
+  const retryPromise = new Promise<void>((resolve) => {
+    resolveRetry = resolve;
+  });
+  const session = {
+    model: primary,
+    thinkingLevel: "high" as ThinkingLevel,
+    _fallbackModels: ["anthropic/claude-opus-4-8:high"],
+    _fallbackAttemptedKeys: new Set<string>(),
+    _retryAttempt: 1,
+    _retryPromise: retryPromise as Promise<void> | undefined,
+    _retryResolve: resolveRetry as (() => void) | undefined,
+    settingsManager: {
+      getDefaultThinkingLevel: () => "high" as ThinkingLevel,
+      getDefaultProvider: () => "openai-codex",
+    },
+    _modelRegistry: {
+      getAvailable: () => [primary, fallback],
+      find: (provider: string, id: string) => provider === fallback.provider && id === fallback.id ? fallback : undefined,
+      hasConfiguredAuth: (candidate: Model<Api>) => candidate.provider === fallback.provider || candidate.provider === primary.provider,
+    },
+    agent: {
+      state: { model: primary, thinkingLevel: "high" as ThinkingLevel, messages: [retryableMessage()] },
+      continue: async () => { throw new Error("fallback auth failed"); },
+    },
+    sessionManager: {
+      appendModelChange: () => undefined,
+      appendThinkingLevelChange: () => undefined,
+    },
+    _withContextWindowForModelSwitch: (candidate: Model<Api>) => candidate,
+    _appendContextWindowChangeIfChanged: () => undefined,
+    _refreshBaseSystemPromptFromActiveTools: () => undefined,
+    _emitModelChanged: () => undefined,
+    _emitModelSelect: async () => undefined,
+    _emit: (event: { type: string; [key: string]: unknown }) => events.push(event),
+    _resolveRetry() {
+      this._retryResolve?.();
+      this._retryPromise = undefined;
+      this._retryResolve = undefined;
+    },
+  };
+
+  const handled = await _trySwitchToFallbackModel.call(session as never, retryableMessage());
+  assert.equal(handled, true);
+
+  const waitState = await Promise.race([
+    retryPromise.then(() => "resolved"),
+    new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 20)),
+  ]);
+
+  assert.equal(waitState, "resolved");
+  assert.equal(session._retryPromise, undefined);
+  assert.ok(events.some((event) => event.type === "model_fallback_end" && event.success === false && event.finalError === "fallback auth failed"));
+});
+
+test("main-chat fallback continuation resolution does not mark assistant errors successful", async () => {
+  const primary = model("openai-codex", "gpt-5.5");
+  const fallback = model("anthropic", "claude-opus-4-8");
+  const fallbackError = retryableMessage({ errorMessage: "rate limit" });
+  const events: Array<{ type: string; [key: string]: unknown }> = [];
+  const session = {
+    model: primary,
+    thinkingLevel: "high" as ThinkingLevel,
+    _fallbackModels: ["anthropic/claude-opus-4-8:high"],
+    _fallbackAttemptedKeys: new Set<string>(),
+    _retryAttempt: 0,
+    settingsManager: {
+      getDefaultThinkingLevel: () => "high" as ThinkingLevel,
+      getDefaultProvider: () => "openai-codex",
+    },
+    _modelRegistry: {
+      getAvailable: () => [primary, fallback],
+      find: (provider: string, id: string) => provider === fallback.provider && id === fallback.id ? fallback : undefined,
+      hasConfiguredAuth: (candidate: Model<Api>) => candidate.provider === fallback.provider || candidate.provider === primary.provider,
+    },
+    agent: {
+      state: { model: primary, thinkingLevel: "high" as ThinkingLevel, messages: [retryableMessage()] },
+      async continue() {
+        this.state.messages.push(fallbackError);
+      },
+    },
+    sessionManager: {
+      appendModelChange: () => undefined,
+      appendThinkingLevelChange: () => undefined,
+    },
+    _withContextWindowForModelSwitch: (candidate: Model<Api>) => candidate,
+    _appendContextWindowChangeIfChanged: () => undefined,
+    _refreshBaseSystemPromptFromActiveTools: () => undefined,
+    _emitModelChanged: () => undefined,
+    _emitModelSelect: async () => undefined,
+    _emit: (event: { type: string; [key: string]: unknown }) => events.push(event),
+  };
+
+  const handled = await _trySwitchToFallbackModel.call(session as never, retryableMessage());
+  assert.equal(handled, true);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+
+  assert.equal(session.agent.state.messages.at(-1), fallbackError);
+  assert.equal(events.some((event) => event.type === "model_fallback_end" && event.success === true), false);
+});


### PR DESCRIPTION
## Summary

Adds ordered `fallbackModels` support for main-chat `AgentSession`s so retryable provider/model failures automatically switch to a configured fallback model (and optional reasoning level) instead of failing the turn, closing #1418.

## Changes

- **Settings/SDK plumbing**: adds `Settings.fallbackModels` and `CreateAgentSessionOptions.fallbackModels` (ordered `provider/model[:thinkingLevel]` strings), wired through `AgentSessionConfig`, `settings-manager-basic-accessors.ts`, and `sdk.ts`.
- **Retry/fallback core** (`agent-session-retry.ts`):
  - `_isRetryableError` now also classifies structured provider transport failures (e.g. `provider_transport_failure`, WebSocket/SSE 404s) and model-unavailable diagnostics (not-found/unavailable/unknown/disabled) as retryable, even without a plain `errorMessage`.
  - New `_trySwitchToFallbackModel` parses/resolves each candidate (by `provider/model` or bare model id, with optional `:thinkingLevel` suffix), skips already-attempted candidates, swaps `agent.state.model`/`thinkingLevel`, records the change via `sessionManager`, and re-invokes `agent.continue()` under the same prompt lifecycle.
  - `_handleRetryableError` falls back to fallback-model switching once retries are exhausted (or immediately when auto-retry is disabled) instead of just resolving the retry as failed.
- **New events**: `model_fallback_start` / `model_fallback_end`, and `model_changed` gains a `"fallback"` source, so hosts can distinguish fallback switches from manual `set`/`cycle`/`restore`.
- **Interactive UI**: `interactive-agent-events.ts` shows a status loader ("Falling back from X to Y...") during a fallback switch and clears it on completion; `chat-session-host-events.ts` clears busy state when a fallback continuation ultimately fails.
- **Docs**: `docs/settings.md` documents `fallbackModels` behavior, its interaction with retry, reasoning suffixes, the `enabledModels` distinction, context-window independence, and cross-provider privacy/cost considerations.
- **Changelog**: adds an `## [Unreleased] / ### Added` entry for #1418.
- **Tests**: adds `test/unit/main-chat-model-fallback.test.ts` (structured diagnostics, retry exhaustion, retry-disabled direct fallback, reasoning-only fallback, SDK options, fallback continuation rejection, assistant-error continuation) and extends `test/unit/chat-session-host-02.test.ts` for busy-state cleanup on failed fallback continuations.

## Validation

- `bun run typecheck`, `bun run check:file-length`, `git diff --check` — passed
- `bun test test/unit/main-chat-model-fallback.test.ts test/unit/subagents-model-fallback.test.ts test/unit/model-fallback.test.ts test/unit/stage-runner-model-fallback-1.test.ts test/unit/stage-runner-model-fallback-2.test.ts` — passed
- `bun test packages/coding-agent/test/agent-session-retry.test.ts packages/coding-agent/test/agent-session-safety-refusal.test.ts` — passed
- `bun test test/unit/chat-session-host-02.test.ts` — passed
- Commit/push hooks: `bun run lint`, `bun run check:file-length`, `bun run test:unit` — passed

Closes #1418