### PR TITLE
fix(windows): guard native fs watcher paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows native filesystem watchers to canonicalize watched paths before calling `fs.watch`, reject unresolved 8.3 short-name paths, and fall back to polling for unsafe watcher paths. This prevents libuv fs-event assertion crashes when temp, session, footer, or theme paths contain short-name components such as `USERNA~1`.
+
 ## [0.9.5-alpha.8] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -16,6 +16,10 @@ For most users, [Git for Windows](https://git-scm.com/download/win) is sufficien
 }
 ```
 
+## Filesystem Watchers
+
+On Windows, Atomic canonicalizes paths before starting native filesystem watchers. If a watcher target cannot be canonicalized or still contains an unsafe 8.3 short-name component such as `USERNA~1`, Atomic avoids native `fs.watch` for that target and uses polling where the feature supports it. This protects long-running sessions, async subagent result notifications, footer git status refreshes, and custom theme reloads from Windows/libuv path-prefix assertion crashes.
+
 ## Self-Update Behavior
 
 `atomic update --self` can update Windows installations that Atomic can identify as writable global package-manager installs. `atomic update` includes the same self-update step before updating packages unless you pass `--extensions`.

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -1,7 +1,7 @@
 import { type ExecFileException, execFile, spawnSync } from "child_process";
 import { existsSync, type FSWatcher, readFileSync, type Stats, statSync, unwatchFile, watchFile } from "fs";
 import { dirname, join, resolve } from "path";
-import { closeWatcher, FS_WATCH_RETRY_DELAY_MS, watchWithErrorHandler } from "../utils/fs-watch.ts";
+import { closeWatcher, FS_WATCH_RETRY_DELAY_MS, isSafeFsWatchPathError, watchWithErrorHandler } from "../utils/fs-watch.ts";
 import { createGitEnvironment } from "../utils/git-env.ts";
 
 type GitPaths = {
@@ -295,6 +295,35 @@ export class FooterDataProvider {
 		}
 	}
 
+
+	private installHeadPollingFallback(): void {
+		if (!this.gitPaths || this.headWatchFilePath || this.headWatchFileListener) {
+			return;
+		}
+		this.headWatchFilePath = this.gitPaths.headPath;
+		this.headWatchFileListener = (current, previous) => {
+			if (current.mtimeMs !== previous.mtimeMs || current.ctimeMs !== previous.ctimeMs || current.size !== previous.size) {
+				this.scheduleRefresh();
+			}
+		};
+		watchFile(this.headWatchFilePath, { interval: 1000 }, this.headWatchFileListener);
+	}
+
+	private installReftableTablesListPolling(tablesListPath: string): void {
+		if (this.reftableTablesListWatchFileListener) {
+			return;
+		}
+		this.reftableTablesListWatchFileListener = (current, previous) => {
+			if (
+				current.mtimeMs !== previous.mtimeMs ||
+				current.ctimeMs !== previous.ctimeMs ||
+				current.size !== previous.size
+			) {
+				this.scheduleReftableRefresh();
+			}
+		};
+		watchFile(tablesListPath, { interval: 250 }, this.reftableTablesListWatchFileListener);
+	}
 	private scheduleGitWatcherRetry(): void {
 		if (this.disposed || this.gitWatcherRetryTimer) {
 			return;
@@ -360,18 +389,18 @@ export class FooterDataProvider {
 					this.scheduleRefresh();
 				}
 			},
-			() => this.handleGitWatcherError(),
+			(error) => {
+				if (isSafeFsWatchPathError(error)) {
+					this.installHeadPollingFallback();
+					return;
+				}
+				this.handleGitWatcherError();
+			},
 		);
 		if (pollGitHead) {
-			this.headWatchFilePath = this.gitPaths.headPath;
-			this.headWatchFileListener = (current, previous) => {
-				if (current.mtimeMs !== previous.mtimeMs || current.ctimeMs !== previous.ctimeMs || current.size !== previous.size) {
-					this.scheduleRefresh();
-				}
-			};
-			watchFile(this.headWatchFilePath, { interval: 1000 }, this.headWatchFileListener);
+			this.installHeadPollingFallback();
 		}
-		if (!this.headWatcher && !pollGitHead) {
+		if (!this.headWatcher && !this.headWatchFileListener) {
 			return;
 		}
 
@@ -386,11 +415,13 @@ export class FooterDataProvider {
 				(_eventType, filename) => {
 					this.handleReftableDirectoryEvent(filename);
 				},
-				() => this.handleGitWatcherError(),
+				(error) => {
+					if (isSafeFsWatchPathError(error)) {
+						return;
+					}
+					this.handleGitWatcherError();
+				},
 			);
-			if (!this.reftableWatcher) {
-				return;
-			}
 
 			const tablesListPath = this.reftableTablesListPath;
 			if (tablesListPath && existsSync(tablesListPath)) {
@@ -399,21 +430,15 @@ export class FooterDataProvider {
 					() => {
 						this.scheduleReftableRefresh();
 					},
-					() => this.handleGitWatcherError(),
+					(error) => {
+						if (isSafeFsWatchPathError(error)) {
+							this.installReftableTablesListPolling(tablesListPath);
+							return;
+						}
+						this.handleGitWatcherError();
+					},
 				);
-				if (!this.reftableTablesListWatcher) {
-					return;
-				}
-				this.reftableTablesListWatchFileListener = (current, previous) => {
-					if (
-						current.mtimeMs !== previous.mtimeMs ||
-						current.ctimeMs !== previous.ctimeMs ||
-						current.size !== previous.size
-					) {
-						this.scheduleReftableRefresh();
-					}
-				};
-				watchFile(tablesListPath, { interval: 250 }, this.reftableTablesListWatchFileListener);
+				this.installReftableTablesListPolling(tablesListPath);
 			}
 		}
 	}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -385,6 +385,16 @@ export {
 export { copyToClipboard } from "./utils/clipboard.ts";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.ts";
 export { createGitEnvironment, GIT_LOCAL_ENV_VARS } from "./utils/git-env.ts";
+export {
+	isSafeFsWatchPathError,
+	isUnsafeWindowsShortPath,
+	resolveNativeWatchPath,
+	SAFE_FS_WATCH_CANONICALIZATION_FAILED,
+	SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH,
+	watchWithErrorHandler,
+	type SafeFsWatchErrorCode,
+	type SafeFsWatchPathError,
+} from "./utils/fs-watch.ts";
 export { convertToPng } from "./utils/image-convert.ts";
 export { formatDimensionNote, type ResizedImage, resizeImage } from "./utils/image-resize.ts";
 // Shell utilities

--- a/packages/coding-agent/src/modes/interactive/theme/global-theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/global-theme.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getCustomThemesDir } from "../../../config.ts";
-import { closeWatcher, watchWithErrorHandler } from "../../../utils/fs-watch.ts";
+import { closeWatcher, isSafeFsWatchPathError, watchWithErrorHandler } from "../../../utils/fs-watch.ts";
 import { Theme } from "./theme-class.ts";
 import { getDefaultTheme } from "./terminal-detection.ts";
 import { getBuiltinThemes, loadTheme, loadThemeFromPath, setRegisteredTheme } from "./theme-loading.ts";
@@ -28,6 +28,8 @@ function setGlobalTheme(t: Theme): void {
 let currentThemeName: string | undefined;
 let themeWatcher: fs.FSWatcher | undefined;
 let themeReloadTimer: NodeJS.Timeout | undefined;
+let themeWatchFilePath: string | undefined;
+let themeWatchFileListener: ((current: fs.Stats, previous: fs.Stats) => void) | undefined;
 let onThemeChangeCallback: (() => void) | undefined;
 
 export function getCurrentThemeName(): string | undefined {
@@ -136,6 +138,23 @@ function startThemeWatcher(): void {
 		}, 100);
 	};
 
+	const startPollingFallback = () => {
+		if (themeWatchFilePath && themeWatchFileListener) {
+			return;
+		}
+		themeWatchFilePath = themeFile;
+		themeWatchFileListener = (current, previous) => {
+			if (
+				current.mtimeMs !== previous.mtimeMs ||
+				current.ctimeMs !== previous.ctimeMs ||
+				current.size !== previous.size
+			) {
+				scheduleReload();
+			}
+		};
+		fs.watchFile(themeFile, { interval: 1000 }, themeWatchFileListener);
+	};
+
 	themeWatcher =
 		watchWithErrorHandler(
 			customThemesDir,
@@ -152,9 +171,12 @@ function startThemeWatcher(): void {
 				}
 				scheduleReload();
 			},
-			() => {
+			(error) => {
 				closeWatcher(themeWatcher);
 				themeWatcher = undefined;
+				if (isSafeFsWatchPathError(error)) {
+					startPollingFallback();
+				}
 			},
 		) ?? undefined;
 }
@@ -166,4 +188,9 @@ export function stopThemeWatcher(): void {
 	}
 	closeWatcher(themeWatcher);
 	themeWatcher = undefined;
+	if (themeWatchFilePath && themeWatchFileListener) {
+		fs.unwatchFile(themeWatchFilePath, themeWatchFileListener);
+	}
+	themeWatchFilePath = undefined;
+	themeWatchFileListener = undefined;
 }

--- a/packages/coding-agent/src/utils/fs-watch.ts
+++ b/packages/coding-agent/src/utils/fs-watch.ts
@@ -1,6 +1,35 @@
-import { type FSWatcher, type WatchListener, watch } from "node:fs";
+import { type FSWatcher, realpathSync, type WatchListener, watch } from "node:fs";
 
 export const FS_WATCH_RETRY_DELAY_MS = 5000;
+
+export const SAFE_FS_WATCH_CANONICALIZATION_FAILED = "ERR_SAFE_FS_WATCH_CANONICALIZATION_FAILED";
+export const SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH = "ERR_SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH";
+
+export type SafeFsWatchErrorCode =
+	| typeof SAFE_FS_WATCH_CANONICALIZATION_FAILED
+	| typeof SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH;
+
+export interface SafeFsWatchPathError extends Error {
+	code: SafeFsWatchErrorCode;
+	watchedPath: string;
+	resolvedPath?: string;
+}
+
+export interface NativeWatchPathResult {
+	path: string;
+}
+
+export interface NativeWatchPathErrorResult {
+	error: SafeFsWatchPathError;
+}
+
+export type NativeWatchPathResolution = NativeWatchPathResult | NativeWatchPathErrorResult;
+
+export interface SafeFsWatchOptions {
+	platform?: NodeJS.Platform;
+	realpathSyncNative?: (path: string) => string;
+	watch?: (path: string, listener: WatchListener<string>) => FSWatcher;
+}
 
 export function closeWatcher(watcher: FSWatcher | null | undefined): void {
 	if (!watcher) {
@@ -14,17 +43,96 @@ export function closeWatcher(watcher: FSWatcher | null | undefined): void {
 	}
 }
 
+function createSafeFsWatchPathError(
+	code: SafeFsWatchErrorCode,
+	watchedPath: string,
+	message: string,
+	resolvedPath?: string,
+	cause?: Error,
+): SafeFsWatchPathError {
+	const error = new Error(message, cause ? { cause } : undefined) as SafeFsWatchPathError;
+	error.name = "SafeFsWatchPathError";
+	error.code = code;
+	error.watchedPath = watchedPath;
+	if (resolvedPath !== undefined) {
+		error.resolvedPath = resolvedPath;
+	}
+	return error;
+}
+
+export function isUnsafeWindowsShortPath(path: string, platform: NodeJS.Platform = process.platform): boolean {
+	if (platform !== "win32") {
+		return false;
+	}
+
+	return path
+		.split(/[\\/]+/)
+		.some((component) => /~\d+(?:\.|$)/i.test(component));
+}
+
+export function isSafeFsWatchPathError(error: unknown): error is SafeFsWatchPathError {
+	if (typeof error !== "object" || error === null || !("code" in error)) {
+		return false;
+	}
+	const code = (error as { code?: string }).code;
+	return code === SAFE_FS_WATCH_CANONICALIZATION_FAILED || code === SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH;
+}
+
+export function resolveNativeWatchPath(path: string, options: SafeFsWatchOptions = {}): NativeWatchPathResolution {
+	const platform = options.platform ?? process.platform;
+	if (platform !== "win32") {
+		return { path };
+	}
+
+	const resolvePath = options.realpathSyncNative ?? realpathSync.native;
+	let resolvedPath: string;
+	try {
+		resolvedPath = resolvePath(path);
+	} catch (error) {
+		return {
+			error: createSafeFsWatchPathError(
+				SAFE_FS_WATCH_CANONICALIZATION_FAILED,
+				path,
+				`Cannot canonicalize Windows fs.watch path '${path}'.`,
+				undefined,
+				error instanceof Error ? error : undefined,
+			),
+		};
+	}
+
+	if (isUnsafeWindowsShortPath(resolvedPath, platform)) {
+		return {
+			error: createSafeFsWatchPathError(
+				SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH,
+				path,
+				`Refusing native fs.watch for unsafe Windows short-name path '${resolvedPath}'.`,
+				resolvedPath,
+			),
+		};
+	}
+
+	return { path: resolvedPath };
+}
+
 export function watchWithErrorHandler(
 	path: string,
 	listener: WatchListener<string>,
-	onError: () => void,
+	onError: (error: Error) => void,
+	options: SafeFsWatchOptions = {},
 ): FSWatcher | null {
+	const resolved = resolveNativeWatchPath(path, options);
+	if ("error" in resolved) {
+		onError(resolved.error);
+		return null;
+	}
+
 	try {
-		const watcher = watch(path, listener);
+		const watchPath = options.watch ?? watch;
+		const watcher = watchPath(resolved.path, listener);
 		watcher.on("error", onError);
 		return watcher;
-	} catch {
-		onError();
+	} catch (error) {
+		onError(error instanceof Error ? error : new Error(String(error)));
 		return null;
 	}
 }

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed background async result watching on Windows to use Atomic's safe watcher path strategy and fall back to polling when native `fs.watch` would receive an unsafe or non-canonical watcher path.
+
 ## [0.9.5-alpha.8] - 2026-07-08
 
 ### Fixed

--- a/packages/subagents/src/runs/background/result-watcher.ts
+++ b/packages/subagents/src/runs/background/result-watcher.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { isSafeFsWatchPathError, watchWithErrorHandler } from "@bastani/atomic";
 import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";
 import {
@@ -21,7 +22,9 @@ import { projectNestedRegistryForRoot, sanitizeSummary } from "../shared/nested-
 const WATCHER_RESTART_DELAY_MS = 3000;
 const POLL_INTERVAL_MS = 3000;
 
-type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "watch">;
+type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "watch"> & {
+	realpathSync?: typeof fs.realpathSync;
+};
 
 type ResultWatcherTimers = {
 	setTimeout: typeof setTimeout;
@@ -30,9 +33,12 @@ type ResultWatcherTimers = {
 	clearInterval: typeof clearInterval;
 };
 
+type ResultWatcherSafeWatch = typeof watchWithErrorHandler;
+
 type ResultWatcherDeps = {
 	fs?: ResultWatcherFs;
 	timers?: ResultWatcherTimers;
+	safeWatch?: ResultWatcherSafeWatch;
 };
 
 type ResultFileChild = {
@@ -88,7 +94,7 @@ function isNotFoundError(error: unknown): boolean {
 
 function shouldFallBackToPolling(error: unknown): boolean {
 	const code = getErrorCode(error);
-	return code === "EMFILE" || code === "ENOSPC";
+	return code === "EMFILE" || code === "ENOSPC" || isSafeFsWatchPathError(error);
 }
 
 export function createResultWatcher(
@@ -104,6 +110,7 @@ export function createResultWatcher(
 } {
 	const fsApi = deps.fs ?? fs;
 	const timers = deps.timers ?? { setTimeout, clearTimeout, setInterval, clearInterval };
+	const safeWatch = deps.safeWatch ?? watchWithErrorHandler;
 
 	const handleResult = async (file: string) => {
 		const resultPath = path.join(resultsDir, file);
@@ -264,13 +271,7 @@ export function createResultWatcher(
 			state.watcherRestartTimer = null;
 		}
 		try {
-			state.watcher = fsApi.watch(resultsDir, (ev, file) => {
-				if (ev !== "rename" || !file) return;
-				const fileName = file.toString();
-				if (!fileName.endsWith(".json")) return;
-				state.resultFileCoalescer.schedule(fileName);
-			});
-			state.watcher.on("error", (error) => {
+			const handleWatcherError = (error: Error) => {
 				if (shouldFallBackToPolling(error)) {
 					startPollingFallback(error);
 					return;
@@ -279,8 +280,17 @@ export function createResultWatcher(
 				state.watcher?.close();
 				state.watcher = null;
 				scheduleRestart();
+			};
+			state.watcher = safeWatch(resultsDir, (ev, file) => {
+				if (ev !== "rename" || !file) return;
+				const fileName = file.toString();
+				if (!fileName.endsWith(".json")) return;
+				state.resultFileCoalescer.schedule(fileName);
+			}, handleWatcherError, {
+				watch: fsApi.watch,
+				realpathSyncNative: fsApi.realpathSync?.native,
 			});
-			state.watcher.unref?.();
+			state.watcher?.unref?.();
 		} catch (error) {
 			if (shouldFallBackToPolling(error)) {
 				startPollingFallback(error);

--- a/test/unit/fs-watch-safe-windows.test.ts
+++ b/test/unit/fs-watch-safe-windows.test.ts
@@ -1,0 +1,176 @@
+import { EventEmitter } from "node:events";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+	isSafeFsWatchPathError,
+	isUnsafeWindowsShortPath,
+	resolveNativeWatchPath,
+	SAFE_FS_WATCH_CANONICALIZATION_FAILED,
+	SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH,
+	watchWithErrorHandler,
+} from "../../packages/coding-agent/src/utils/fs-watch.js";
+import { createResultWatcher } from "../../packages/subagents/src/runs/background/result-watcher.js";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "../../packages/subagents/src/shared/types.js";
+
+class FakeWatcher extends EventEmitter {
+	closed = false;
+
+	close(): void {
+		this.closed = true;
+	}
+
+	ref(): this {
+		return this;
+	}
+
+	unref(): this {
+		return this;
+	}
+}
+
+function waitForTimers(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+function makeSubagentState(): SubagentState {
+	return {
+		baseCwd: "/repo",
+		currentSessionId: "session-1",
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: {
+			schedule: () => false,
+			clear: () => {},
+		},
+	};
+}
+
+describe("safe fs.watch path handling", () => {
+	test("detects Windows 8.3 short-name path components", () => {
+		assert.equal(isUnsafeWindowsShortPath(String.raw`C:\Users\USERNA~1\AppData\Local\Temp`, "win32"), true);
+		assert.equal(isUnsafeWindowsShortPath(String.raw`C:\PROGRA~1\Atomic\theme.json`, "win32"), true);
+		assert.equal(isUnsafeWindowsShortPath(String.raw`C:\Users\Alex Lavaee\AppData\Local\Temp`, "win32"), false);
+		assert.equal(isUnsafeWindowsShortPath(String.raw`/tmp/USERNA~1`, "linux"), false);
+	});
+
+	test("canonicalizes Windows watch paths before native fs.watch", () => {
+		const watchedPaths: string[] = [];
+		const watcher = watchWithErrorHandler(
+			String.raw`C:\Users\USERNA~1\AppData\Local\Temp\atomic`,
+			() => {},
+			() => assert.fail("canonicalized safe path should not report an error"),
+			{
+				platform: "win32",
+				realpathSyncNative: () => String.raw`C:\Users\Alex Lavaee\AppData\Local\Temp\atomic`,
+				watch: (path) => {
+					watchedPaths.push(path);
+					return new FakeWatcher();
+				},
+			},
+		);
+
+		assert.ok(watcher);
+		assert.deepEqual(watchedPaths, [String.raw`C:\Users\Alex Lavaee\AppData\Local\Temp\atomic`]);
+	});
+
+	test("rejects native fs.watch when canonicalization fails or remains unsafe", () => {
+		const errors: Error[] = [];
+		let watchCalls = 0;
+
+		const failed = watchWithErrorHandler(
+			String.raw`C:\Users\USERNA~1\AppData\Local\Temp\atomic`,
+			() => {},
+			(error) => errors.push(error),
+			{
+				platform: "win32",
+				realpathSyncNative: () => {
+					throw new Error("realpath failed");
+				},
+				watch: () => {
+					watchCalls += 1;
+					return new FakeWatcher();
+				},
+			},
+		);
+
+		const unsafe = resolveNativeWatchPath(String.raw`C:\Users\USERNA~1\AppData\Local\Temp\atomic`, {
+			platform: "win32",
+			realpathSyncNative: () => String.raw`C:\Users\USERNA~1\AppData\Local\Temp\atomic`,
+		});
+
+		assert.equal(failed, null);
+		assert.equal(watchCalls, 0);
+		assert.equal(errors[0]?.message.includes("Cannot canonicalize Windows fs.watch path"), true);
+		assert.equal(isSafeFsWatchPathError(errors[0]), true);
+		assert.equal(isSafeFsWatchPathError(errors[0]) ? errors[0].code : undefined, SAFE_FS_WATCH_CANONICALIZATION_FAILED);
+		assert.ok("error" in unsafe);
+		assert.equal("error" in unsafe ? unsafe.error.code : undefined, SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH);
+	});
+
+	test("subagent result watcher falls back to polling when safe watch refuses a path", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "atomic-result-watch-"));
+		const resultPath = join(dir, "run-1.json");
+		writeFileSync(resultPath, JSON.stringify({
+			id: "run-1",
+			agent: "worker",
+			success: true,
+			summary: "done",
+			sessionId: "session-1",
+			cwd: "/repo",
+		}));
+
+		const completed: unknown[] = [];
+		const completeHandlers: Array<(data: unknown) => void> = [];
+		const events = {
+			on: (channel: string, handler: (data: unknown) => void): (() => void) => {
+				if (channel === SUBAGENT_ASYNC_COMPLETE_EVENT) {
+					completeHandlers.push(handler);
+				}
+				return () => {};
+			},
+			emit: (channel: string, data: unknown): void => {
+				if (channel === SUBAGENT_ASYNC_COMPLETE_EVENT) {
+					completed.push(data);
+					for (const handler of completeHandlers) {
+						handler(data);
+					}
+				}
+			},
+		};
+		const state = makeSubagentState();
+		const safeWatchError = Object.assign(new Error("unsafe path"), {
+			code: SAFE_FS_WATCH_UNSAFE_WINDOWS_SHORT_PATH,
+			watchedPath: String.raw`C:\Users\USERNA~1\AppData\Local\Temp\atomic-results`,
+		});
+		let safeWatchCalled = false;
+
+		const watcher = createResultWatcher({ events }, state, dir, 60_000, {
+			safeWatch: (_path, _listener, onError) => {
+				safeWatchCalled = true;
+				onError(safeWatchError);
+				return null;
+			},
+		});
+
+		try {
+			watcher.startResultWatcher();
+			await waitForTimers();
+			assert.equal(safeWatchCalled, true);
+			assert.equal(completed.length, 1);
+			assert.equal(existsSync(resultPath), false);
+		} finally {
+			watcher.stopResultWatcher();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Windows can crash Atomic's libuv-backed `fs.watch` calls with a path-prefix assertion when a watched path resolves to (or contains) an unsafe 8.3 short-name component (e.g. `USERNA~1`). This PR adds a shared "safe watcher path" strategy that canonicalizes paths before handing them to native `fs.watch` and falls back to polling (`fs.watchFile`) whenever a path can't be made safe, and routes all of Atomic's native watchers through it.

## Changes

- **`packages/coding-agent/src/utils/fs-watch.ts`**: Adds `resolveNativeWatchPath()`, which canonicalizes Windows watcher paths via `realpathSync.native` and rejects any resolved path containing an unresolved 8.3 short-name component (`isUnsafeWindowsShortPath()`). Introduces typed `SafeFsWatchPathError` (`isSafeFsWatchPathError()`) with two error codes — canonicalization failure and unsafe short-name path — and updates `watchWithErrorHandler()` to resolve paths through this strategy before calling `fs.watch`, passing the underlying error to `onError` instead of calling it with no arguments.
- **`packages/coding-agent/src/index.ts`**: Exports the new safe-watch helpers/types (`resolveNativeWatchPath`, `isUnsafeWindowsShortPath`, `isSafeFsWatchPathError`, error code constants) so other packages (e.g. `@bastani/subagents`) can consume them.
- **`packages/coding-agent/src/core/footer-data-provider.ts`**: Routes the git HEAD and reftable watchers through the safe-watch strategy; on a `SafeFsWatchPathError`, falls back to `fs.watchFile` polling for the HEAD file and reftable tables-list file instead of treating it as a fatal watcher error.
- **`packages/coding-agent/src/modes/interactive/theme/global-theme.ts`**: Routes the custom-theme directory watcher through the safe-watch strategy, adding a polling fallback (`fs.watchFile`) for the theme file when native watching is unsafe, with matching cleanup in `stopThemeWatcher()`.
- **`packages/subagents/src/runs/background/result-watcher.ts`**: Routes the async subagent results watcher through `watchWithErrorHandler` (imported from `@bastani/atomic`), treating `SafeFsWatchPathError` the same as `EMFILE`/`ENOSPC` to trigger the existing polling fallback.
- **Docs/Changelog**: Documents the new watcher behavior in `packages/coding-agent/docs/windows.md` and adds `Fixed` entries to `packages/coding-agent/CHANGELOG.md` and `packages/subagents/CHANGELOG.md`.
- **Tests**: Adds `test/unit/fs-watch-safe-windows.test.ts` covering short-name detection, canonicalization-failure handling, native watch path selection, and the subagent result watcher's polling fallback.

## Validation

- `bun test test/unit/fs-watch-safe-windows.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run check:file-length`
- `bunx --bun --no-install tsc -p packages/coding-agent/tsconfig.build.json --noEmit`
- `cd packages/coding-agent && bun run test -- test/footer-data-provider.test.ts test/suite/regressions/2791-fswatch-error-crash.test.ts`
- `cd packages/coding-agent && bun run docs:check`