### PR TITLE
ci: restore opus for Claude review workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,5 +36,5 @@ jobs:
                   claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
                   # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   claude_args: |
-                      --model fable
+                      --model opus
                       --allowedTools "Bash(*)"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -35,5 +35,5 @@ jobs:
                       Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
                   claude_args: |
-                      --model fable
+                      --model opus
                       --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"


### PR DESCRIPTION
## Summary

Switches the Claude Code review workflows back to the `opus` model alias, moving off `fable` to avoid its current credit exhaustion path.

## Changes

- `.github/workflows/claude.yml`: interactive `@claude` workflow now runs with `--model opus` instead of `--model fable`.
- `.github/workflows/code-review.yml`: automatic Claude Code Review workflow now runs with `--model opus` instead of `--model fable`.

## Validation

- Pre-commit hooks passed: YAML check, lint, file-length, and `bun run test:unit`.
- Pre-push hooks passed: JSON/YAML checks, lint, file-length, and `bun run test:unit`.