### PR TITLE
perf(tui): reduce startup input blocking

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved interactive startup responsiveness by keeping footer git watcher setup out of first paint and deferring it until the first input handler is ready, while preserving lazy footer branch reads and post-frame branch-change re-rendering. Deferred extension/resource loading no longer starts on a blind post-paint timer that can freeze live typing, and ordinary first prompts no longer wait for it before showing submission feedback and starting the model turn. Built-in slash commands stay available immediately, and bundled extension slash commands expose lightweight metadata for autocomplete before their heavy implementations load; explicitly submitted extension slash commands load the implementation on demand and then route the same command. Changelog and first-run notice materialization now happen after the first frame, and startup/input timing probes cover raw-mode enablement, first captured raw key, first frame, input-handler callback installation, and first submit for benchmark/probe runs.
+
 ### Fixed
 
 - Fixed Windows native filesystem watchers to canonicalize watched paths before calling `fs.watch`, reject unresolved 8.3 short-name paths, and fall back to polling for unsafe watcher paths. This prevents libuv fs-event assertion crashes when temp, session, footer, or theme paths contain short-name components such as `USERNA~1`.

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -54,6 +54,10 @@ Never use `__dirname` directly for package assets.
 - Rendered TUI lines with ANSI codes
 - Last messages sent to the LLM
 
+## Startup timing probes
+
+Set `ATOMIC_TIMING=1` when profiling startup. Normal interactive launches print the initial startup group before `interactiveMode.run()` starts the TUI loop, so marks reached later in the interactive lifecycle are not printed during ordinary sessions. Use `ATOMIC_STARTUP_BENCHMARK=1` for first-frame/deferred-startup probes; it initializes interactive mode, explicitly completes deferred startup work, emits marks such as `time-to-first-frame`, `startup-input-raw-mode-enabled`, `startup-input-first-raw-key`, and `deferred-extension-load` when reached, then exits without submitting a prompt. During normal startup, built-in commands and lightweight bundled extension command metadata are available for autocomplete immediately, while heavy extension implementations load only when an extension command or another extension-aware action is invoked. Targeted tests/probes can also assert later interactive marks such as `interactive-input-handler-ready` and `interactive-first-submit`.
+
 ## Testing
 
 ```bash

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -79,6 +79,7 @@ let _transpileCacheDir: string | null = null;
 function getTranspileCacheDir(): string {
   if (_transpileCacheDir) return _transpileCacheDir;
   _transpileCacheDir = getExtensionTranspileCacheDir();
+  fs.mkdirSync(_transpileCacheDir, { recursive: true });
   pruneStaleTranspileCaches(_transpileCacheDir);
   return _transpileCacheDir;
 }
@@ -218,11 +219,11 @@ function getAliases(): Record<string, string> {
   return _aliases;
 }
 
-/** Internal hooks for extension-loader alias regression tests. */
 export const extensionLoaderTestHooks = {
   loadVirtualModules,
   getAliases,
   findPackageRoot,
+  getTranspileCacheDir,
 };
 
 /**

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -121,16 +121,24 @@ export class FooterDataProvider {
 	private refreshInFlight = false;
 	private refreshPending = false;
 	private disposed = false;
+	private gitWatchersStarted = false;
 
 	constructor(cwd: string) {
 		this.cwd = cwd;
-		this.gitPaths = findGitPaths(cwd);
+	}
+
+	/** Start post-frame git branch watching. Branch discovery remains lazy for first render. */
+	startGitWatcher(): void {
+		if (this.disposed || this.gitWatchersStarted) return;
+		this.gitWatchersStarted = true;
+		this.ensureGitPaths();
 		this.setupGitWatcher();
 	}
 
 	/** Current git branch, null if not in repo, "detached" if detached HEAD */
 	getGitBranch(): string | null {
 		if (this.cachedBranch === undefined) {
+			this.ensureGitPaths();
 			this.cachedBranch = this.resolveGitBranchSync();
 		}
 		return this.cachedBranch;
@@ -176,6 +184,7 @@ export class FooterDataProvider {
 			return;
 		}
 
+		const restartGitWatcher = this.gitWatchersStarted;
 		this.cwd = cwd;
 		if (this.refreshTimer) {
 			clearTimeout(this.refreshTimer);
@@ -183,8 +192,11 @@ export class FooterDataProvider {
 		}
 		this.clearGitWatchers();
 		this.cachedBranch = undefined;
-		this.gitPaths = findGitPaths(cwd);
-		this.setupGitWatcher();
+		this.gitPaths = undefined;
+		if (restartGitWatcher) {
+			this.gitWatchersStarted = false;
+			this.startGitWatcher();
+		}
 		this.notifyBranchChange();
 	}
 
@@ -196,7 +208,13 @@ export class FooterDataProvider {
 			this.refreshTimer = null;
 		}
 		this.clearGitWatchers();
+		this.gitWatchersStarted = false;
 		this.branchChangeCallbacks.clear();
+	}
+
+	private ensureGitPaths(): void {
+		if (this.gitPaths !== undefined) return;
+		this.gitPaths = findGitPaths(this.cwd);
 	}
 
 	private notifyBranchChange(): void {
@@ -325,12 +343,13 @@ export class FooterDataProvider {
 		watchFile(tablesListPath, { interval: 250 }, this.reftableTablesListWatchFileListener);
 	}
 	private scheduleGitWatcherRetry(): void {
-		if (this.disposed || this.gitWatcherRetryTimer) {
+		if (this.disposed || !this.gitWatchersStarted || this.gitWatcherRetryTimer) {
 			return;
 		}
 
 		this.gitWatcherRetryTimer = setTimeout(() => {
 			this.gitWatcherRetryTimer = null;
+			this.ensureGitPaths();
 			this.setupGitWatcher();
 		}, FS_WATCH_RETRY_DELAY_MS);
 	}
@@ -375,8 +394,8 @@ export class FooterDataProvider {
 
 	private setupGitWatcher(): void {
 		this.clearGitWatchers();
+		this.ensureGitPaths();
 		if (!this.gitPaths) return;
-
 		const pollGitHead = shouldPollGitHead(this.gitPaths.repoDir);
 
 		// Watch the directory containing HEAD, not HEAD itself.

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -24,6 +24,142 @@ export interface BuiltinSlashCommand {
 	) => AutocompleteItem[] | null | Promise<AutocompleteItem[] | null>;
 }
 
+type WorkflowInputCompletionMetadata = {
+	description: string;
+	kind?: "boolean" | "number" | "string";
+};
+
+type WorkflowCompletionMetadata = {
+	name: string;
+	description: string;
+	inputs: Record<string, WorkflowInputCompletionMetadata>;
+};
+
+const WORKFLOW_ADMIN_COMPLETIONS: AutocompleteItem[] = [
+	{ value: "connect ", label: "connect", description: "Attach to a run (picker if no id)" },
+	{ value: "attach ", label: "attach", description: "Open the in-place attach pane on a node" },
+	{ value: "list ", label: "list", description: "List registered workflows" },
+	{ value: "status ", label: "status", description: "List current-session active and retained terminal runs" },
+	{ value: "interrupt ", label: "interrupt", description: "Interrupt a run" },
+	{ value: "kill ", label: "kill", description: "Kill and retain a run" },
+	{ value: "pause ", label: "pause", description: "Pause a run or stage" },
+	{ value: "resume ", label: "resume", description: "Re-open overlay for a run" },
+	{ value: "inputs ", label: "inputs", description: "Show a workflow's input schema" },
+	{ value: "reload ", label: "reload", description: "Reload workflow resources" },
+];
+
+const BUNDLED_WORKFLOW_COMPLETION_METADATA: WorkflowCompletionMetadata[] = [
+	{
+		name: "deep-research-codebase",
+		description: "Scout + research-history chain → parallel specialist waves → aggregator for deep codebase research.",
+		inputs: {
+			prompt: { description: "Research question or investigation focus for the codebase.", kind: "string" },
+			max_partitions: { description: "Maximum number of codebase partitions to explore in parallel.", kind: "number" },
+			max_concurrency: { description: "Maximum number of workflow stages to run concurrently during deep research.", kind: "number" },
+		},
+	},
+	{
+		name: "goal",
+		description: "Goal Runner workflow with bounded LM turns, acceptance criteria, ledger artifacts, reviewers, and reducer-gated completion.",
+		inputs: {
+			objective: { description: "The objective or delta for this Goal Runner workflow run.", kind: "string" },
+			acceptance_criteria: { description: "Original immutable task contract this run must remain consistent with.", kind: "string" },
+			max_turns: { description: "Maximum worker/review turns before Goal Runner stops as needs_human.", kind: "number" },
+			base_branch: { description: "Optional branch reviewers compare the current code delta against.", kind: "string" },
+			git_worktree_dir: { description: "Optional Git worktree path.", kind: "string" },
+			create_pr: { description: "Whether to run the final pull-request creation stage after approval.", kind: "boolean" },
+		},
+	},
+	{
+		name: "open-claude-design",
+		description: "AI-powered design workflow: discovery, reference research, HTML generation, refinement, and handoff.",
+		inputs: {
+			prompt: { description: "What to design, such as a dashboard, page, component, or prototype.", kind: "string" },
+			discover_references: { description: "Discover current reference designs and feed them to generation.", kind: "boolean" },
+			max_refinements: { description: "Maximum generate/user-feedback loop iterations.", kind: "number" },
+		},
+	},
+	{
+		name: "ralph",
+		description: "Raw prompt → research → orchestrate → multi-model parallel review loop with bounded iteration.",
+		inputs: {
+			prompt: { description: "The task or goal to research, execute, and refine.", kind: "string" },
+			acceptance_criteria: { description: "Original immutable task contract this run must remain consistent with.", kind: "string" },
+			max_loops: { description: "Maximum research/orchestrate/review iterations.", kind: "number" },
+			base_branch: { description: "Branch reviewers compare the current code delta against.", kind: "string" },
+			git_worktree_dir: { description: "Optional Git worktree path.", kind: "string" },
+			create_pr: { description: "Whether to run the final pull-request creation stage.", kind: "boolean" },
+		},
+	},
+];
+
+function completeWorkflowToken(argumentText: string, candidates: AutocompleteItem[]): AutocompleteItem[] | null {
+	const tokenStart = /\s$/.test(argumentText)
+		? argumentText.length
+		: Math.max(argumentText.lastIndexOf(" "), argumentText.lastIndexOf("\t")) + 1;
+	const head = argumentText.slice(0, tokenStart);
+	const token = argumentText.slice(tokenStart);
+	const normalizedToken = token.trimEnd();
+	const filtered = candidates
+		.filter((candidate) => candidate.value.startsWith(token) && candidate.value.trimEnd() !== normalizedToken)
+		.map((candidate) => ({ ...candidate, value: `${head}${candidate.value}` }));
+	return filtered.length > 0 ? filtered : null;
+}
+
+function bundledWorkflowNameItems(): AutocompleteItem[] {
+	return BUNDLED_WORKFLOW_COMPLETION_METADATA.map((workflow) => ({
+		value: `${workflow.name} `,
+		label: workflow.name,
+		description: `Run workflow: ${workflow.name}`,
+	}));
+}
+
+export function getBundledWorkflowArgumentCompletions(argumentPrefix: string): AutocompleteItem[] | null {
+	const parts = argumentPrefix.trim().split(/\s+/).filter(Boolean);
+	const subcommand = parts[0] ?? "";
+	const workflowItems = bundledWorkflowNameItems();
+	if (!argumentPrefix.includes(" ")) {
+		return completeWorkflowToken(argumentPrefix, [...WORKFLOW_ADMIN_COMPLETIONS, ...workflowItems]);
+	}
+	if (subcommand === "inputs") return completeWorkflowToken(argumentPrefix, workflowItems);
+	if (subcommand === "interrupt" || subcommand === "kill") {
+		const verb = subcommand === "kill" ? "Kill and retain" : "Interrupt";
+		return completeWorkflowToken(argumentPrefix, [
+			{ value: "--all ", label: "--all", description: `${verb} all in-flight runs` },
+			{ value: "--yes ", label: "--yes", description: "Skip confirmation" },
+			{ value: "-y ", label: "-y", description: "Skip confirmation" },
+		]);
+	}
+	if (!subcommand) return completeWorkflowToken(argumentPrefix, [...WORKFLOW_ADMIN_COMPLETIONS, ...workflowItems]);
+
+	const workflow = BUNDLED_WORKFLOW_COMPLETION_METADATA.find((candidate) => candidate.name === subcommand);
+	if (!workflow) return null;
+	const tokenStart = /\s$/.test(argumentPrefix)
+		? argumentPrefix.length
+		: Math.max(argumentPrefix.lastIndexOf(" "), argumentPrefix.lastIndexOf("\t")) + 1;
+	const token = argumentPrefix.slice(tokenStart);
+	const equalsIndex = token.indexOf("=");
+	if (equalsIndex > 0) {
+		const inputName = token.slice(0, equalsIndex);
+		const input = workflow.inputs[inputName];
+		if (input?.kind !== "boolean") return null;
+		return completeWorkflowToken(argumentPrefix, [
+			{ value: `${inputName}=true `, label: "true", description: inputName },
+			{ value: `${inputName}=false `, label: "false", description: inputName },
+		]);
+	}
+
+	return completeWorkflowToken(argumentPrefix, [
+		{ value: "--no-picker ", label: "--no-picker", description: "Skip interactive input picker" },
+		{ value: "--help ", label: "--help", description: "Show this workflow's input schema" },
+		...Object.entries(workflow.inputs).map(([name, input]) => ({
+			value: `${name}=`,
+			label: name,
+			description: input.description,
+		})),
+	]);
+}
+
 export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "settings", description: "Open settings menu" },
 	{ name: "model", description: "Select model (opens selector UI)" },
@@ -54,4 +190,24 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "reload", description: "Reload keybindings, extensions, skills, prompts, and themes" },
 	{ name: "exit", description: `Exit ${APP_NAME}` },
 	{ name: "quit", description: `Quit ${APP_NAME}` },
+];
+
+export const BUNDLED_EXTENSION_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
+	{
+		name: "workflow",
+		description: "Run or inspect Atomic workflows. Usage: /workflow <name> [key=value…] | /workflow [list|status|connect|attach|interrupt|kill|pause|resume|inputs|reload] [args]",
+		getArgumentCompletions: getBundledWorkflowArgumentCompletions,
+	},
+	{ name: "run", description: "Run a subagent directly: /run agent[output=file] [task] [--bg] [--fork]" },
+	{ name: "chain", description: "Run agents in sequence: /chain scout task -> planner [--bg] [--fork]" },
+	{ name: "run-chain", description: "Run a saved chain: /run-chain chainName -- task [--bg] [--fork]" },
+	{ name: "parallel", description: "Run agents in parallel: /parallel scout task1 -> reviewer task2 [--bg] [--fork]" },
+	{ name: "subagents-doctor", description: "Show subagent diagnostics" },
+	{ name: "mcp", description: "Show MCP server status" },
+	{ name: "mcp-auth", description: "Authenticate with an MCP server (OAuth)" },
+	{ name: "curator", description: "Toggle or configure the search curator workflow" },
+	{ name: "google-account", description: "Show the active Google account for Gemini Web" },
+	{ name: "search", description: "Browse stored web search results" },
+	{ name: "websearch", description: "Open web search curator" },
+	{ name: "intercom", description: "Open session intercom overlay" },
 ];

--- a/packages/coding-agent/src/main-deferred-startup.ts
+++ b/packages/coding-agent/src/main-deferred-startup.ts
@@ -63,9 +63,7 @@ export function computeDeferExtensions(input: ComputeDeferExtensionsInput): bool
 		input.resolvedExtensionPathCount === 0 &&
 		input.resolvedResourcePathCount === 0 &&
 		!input.hasSystemPromptInput &&
-		input.unknownFlagCount === 0 &&
-		input.provider === undefined &&
-		input.model === undefined
+		input.unknownFlagCount === 0
 	);
 }
 

--- a/packages/coding-agent/src/main-early-input.ts
+++ b/packages/coding-agent/src/main-early-input.ts
@@ -1,3 +1,5 @@
+import { recordTimeSinceReset } from "./core/timings.ts";
+
 export interface EarlyInputState {
 	text: string;
 	submissions: string[];
@@ -117,6 +119,7 @@ export function startEarlyInputCapture(options: StartEarlyInputCaptureOptions): 
 	const state: EarlyInputState = { text: "", submissions: [] };
 	const wasRaw = stdin.isRaw === true;
 	let consumed = false;
+	let firstRawKeyRecorded = false;
 	let onData: (chunk: Buffer | string) => void;
 	const registeredProcessListeners: Array<{ event: EarlyInputProcessEvent; listener: EarlyInputProcessListener }> = [];
 	let pendingEscapeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -154,6 +157,10 @@ export function startEarlyInputCapture(options: StartEarlyInputCaptureOptions): 
 		processLike.on(event, listener);
 	};
 	onData = (chunk: Buffer | string) => {
+		if (!firstRawKeyRecorded) {
+			firstRawKeyRecorded = true;
+			recordTimeSinceReset("startup-input-first-raw-key");
+		}
 		const text = chunk.toString();
 		if (text.includes("\x03")) {
 			forwardSignal("SIGINT");
@@ -165,6 +172,7 @@ export function startEarlyInputCapture(options: StartEarlyInputCaptureOptions): 
 	};
 
 	stdin.setRawMode(true);
+	recordTimeSinceReset("startup-input-raw-mode-enabled");
 	stdin.setEncoding?.("utf8");
 	stdin.on("data", onData);
 	registerProcessListener("exit", cleanup);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -467,7 +467,7 @@ export async function main(args: string[], options?: MainOptions) {
 		if (startupBenchmark) {
 			await interactiveMode.init();
 			time("interactiveMode.init");
-			await interactiveMode.deferredStartupPromise;
+			await interactiveMode.ensureDeferredStartupComplete();
 			printTimings();
 			interactiveMode.stop();
 			stopThemeWatcher();

--- a/packages/coding-agent/src/modes/interactive/interactive-autocomplete.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-autocomplete.ts
@@ -1,5 +1,5 @@
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
-import { type Api, type Model, type AutocompleteItem, type AutocompleteProvider, type AutocompleteSuggestions, type SlashCommand, type ExtensionRunner, type ResourceDiagnostic, type SourceInfo, CombinedAutocompleteProvider, fuzzyFilter, hasSupportedCodexFastModeModel, BUILTIN_SLASH_COMMANDS, parseGitUrl, getModelSearchText } from "./interactive-mode-deps.ts";
+import { type Api, type Model, type AutocompleteItem, type AutocompleteProvider, type AutocompleteSuggestions, type SlashCommand, type ExtensionRunner, type ResourceDiagnostic, type SourceInfo, CombinedAutocompleteProvider, fuzzyFilter, hasSupportedCodexFastModeModel, BUILTIN_SLASH_COMMANDS, BUNDLED_EXTENSION_SLASH_COMMANDS, parseGitUrl, getModelSearchText } from "./interactive-mode-deps.ts";
 import { BUILTIN_SLASH_COMMAND_NAMES } from "./interactive-mode-helpers.ts";
 
 const AT_MENTION_PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
@@ -235,18 +235,32 @@ InteractiveModeBase.prototype.createBaseAutocompleteProvider = function(this: In
     // Convert extension commands to SlashCommand format. Built-in command names
     // stay reserved even when a built-in is contextually hidden (for example,
     // /fast without a supported OpenAI model) so extension visibility cannot
-    // change as auth/model state changes.
-    const extensionCommands: SlashCommand[] = this.session.extensionRunner
+    // change as auth/model state changes. While extension loading is deferred,
+    // expose lightweight bundled command metadata without importing heavy
+    // implementations; the submit path loads the implementation on demand.
+    const registeredExtensionCommands = this.session.extensionRunner
       .getRegisteredCommands()
-      .filter((cmd) => !BUILTIN_SLASH_COMMAND_NAMES.has(cmd.name))
-      .map((cmd) => ({
+      .filter((cmd) => !BUILTIN_SLASH_COMMAND_NAMES.has(cmd.name));
+    const registeredNames = new Set(registeredExtensionCommands.map((cmd) => cmd.invocationName));
+    const extensionCommands: SlashCommand[] = [
+      ...(this.deferredStartupPending
+        ? BUNDLED_EXTENSION_SLASH_COMMANDS.filter(
+            (cmd) => !BUILTIN_SLASH_COMMAND_NAMES.has(cmd.name) && !registeredNames.has(cmd.name),
+          ).map((cmd) => ({
+            name: cmd.name,
+            description: cmd.description,
+            getArgumentCompletions: cmd.getArgumentCompletions,
+          }))
+        : []),
+      ...registeredExtensionCommands.map((cmd) => ({
         name: cmd.invocationName,
         description: this.prefixAutocompleteDescription(
           cmd.description,
           cmd.sourceInfo,
         ),
         getArgumentCompletions: cmd.getArgumentCompletions,
-      }));
+      })),
+    ];
 
     // Build skill commands from session.skills (if enabled)
     this.skillCommands.clear();

--- a/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
@@ -1,19 +1,22 @@
 import { InteractiveModeBase, seedStartupInput } from "./interactive-mode-base.ts";
-import { pasteClipboardImageToEditor } from "./interactive-mode-deps.ts";
+import { pasteClipboardImageToEditor, recordTimeSinceReset } from "./interactive-mode-deps.ts";
 import { yieldToEventLoop } from "../../utils/event-loop.ts";
 
 InteractiveModeBase.prototype.runUserPromptTurn = async function(this: InteractiveModeBase, userInput: string): Promise<void> {
     // Show the working spinner immediately on submit so there is no visible gap
     // while prompt preflight runs before the agent emits `agent_start`.
     this.showWorkingLoaderNow();
-    if (this.deferredStartupPending) {
+    const deferredStartupAlreadyRunning = this.deferredStartupPromise !== undefined;
+    if (deferredStartupAlreadyRunning) {
       this.deferLoadedResourcesDisclosureUntilAgentEnd = true;
     }
     // Yield once so the freshly-mounted spinner paints before synchronous
     // preflight work can block the event loop.
     await yieldToEventLoop();
     try {
-      await this.ensureDeferredStartupComplete();
+      if (deferredStartupAlreadyRunning) {
+        await this.ensureDeferredStartupComplete();
+      }
       await this.session.prompt(userInput);
       this.deferLoadedResourcesDisclosureUntilAgentEnd = false;
       if (this.pendingLoadedResourcesDisclosure) {
@@ -83,18 +86,27 @@ InteractiveModeBase.prototype.setupKeyHandlers = function(this: InteractiveModeB
     this.defaultEditor.onAction("app.thinking.cycle", () =>
       this.cycleThinkingLevel(),
     );
-    this.defaultEditor.onAction("app.model.cycleForward", () =>
-      this.cycleModel("forward"),
-    );
-    this.defaultEditor.onAction("app.model.cycleBackward", () =>
-      this.cycleModel("backward"),
-    );
+    this.defaultEditor.onAction("app.model.cycleForward", () => {
+      void (async () => {
+        await this.ensureDeferredStartupComplete();
+        await this.cycleModel("forward");
+      })();
+    });
+    this.defaultEditor.onAction("app.model.cycleBackward", () => {
+      void (async () => {
+        await this.ensureDeferredStartupComplete();
+        await this.cycleModel("backward");
+      })();
+    });
 
     // Global debug handler on TUI (works regardless of focus)
     this.ui.onDebug = () => this.handleDebugCommand();
-    this.defaultEditor.onAction("app.model.select", () =>
-      this.showModelSelector(),
-    );
+    this.defaultEditor.onAction("app.model.select", () => {
+      void (async () => {
+        await this.ensureDeferredStartupComplete();
+        this.showModelSelector();
+      })();
+    });
     this.defaultEditor.onAction("app.tools.expand", () =>
       this.toggleToolOutputExpansion(),
     );
@@ -237,6 +249,10 @@ InteractiveModeBase.prototype.advanceStartupInputReplay = function(this: Interac
 
 InteractiveModeBase.prototype.setupEditorSubmitHandler = function(this: InteractiveModeBase): void {
     this.defaultEditor.onSubmit = async (text: string) => {
+      if (!this.firstSubmitRecorded) {
+        this.firstSubmitRecorded = true;
+        recordTimeSinceReset("interactive-first-submit");
+      }
       text = text.trim();
       if (!text) return;
 
@@ -247,7 +263,6 @@ InteractiveModeBase.prototype.setupEditorSubmitHandler = function(this: Interact
         return;
       }
       try {
-
       // Handle commands
       if (text === "/settings") {
         this.showSettingsSelector();
@@ -261,6 +276,7 @@ InteractiveModeBase.prototype.setupEditorSubmitHandler = function(this: Interact
       }
       if (text === "/scoped-models") {
         this.editor.setText("");
+        await this.ensureDeferredStartupComplete();
         await this.showModelsSelector();
         return;
       }
@@ -269,6 +285,7 @@ InteractiveModeBase.prototype.setupEditorSubmitHandler = function(this: Interact
           ? text.slice(7).trim()
           : undefined;
         this.editor.setText("");
+        await this.ensureDeferredStartupComplete();
         await this.handleModelCommand(searchTerm);
         return;
       }
@@ -392,6 +409,15 @@ InteractiveModeBase.prototype.setupEditorSubmitHandler = function(this: Interact
         return;
       }
 
+      if (text.startsWith("/") && this.deferredStartupPending) {
+        this.editor.addToHistory?.(text);
+        this.editor.setText("");
+        this.ui.requestRender();
+        await yieldToEventLoop();
+        await this.ensureDeferredStartupComplete();
+        await this.session.prompt(text);
+        return;
+      }
       // Handle bash command (! for normal, !! for excluded from context)
       if (text.startsWith("!")) {
         const isExcluded = text.startsWith("!!");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -162,6 +162,7 @@ export class InteractiveModeBase {
   changelogMarkdown: string | undefined = undefined;
 
   startupNoticesShown = false;
+  startupNoticesPrepared = false;
 
   anthropicSubscriptionWarningShown = false;
 
@@ -262,8 +263,13 @@ export class InteractiveModeBase {
   // Deferred extension load state (first paint happens before extensions load)
   deferredStartupPending = false;
 
-
   deferredStartupPromise: Promise<void> | undefined = undefined;
+
+
+  inputHandlerReadyRecorded = false;
+
+  firstSubmitRecorded = false;
+
   deferLoadedResourcesDisclosureUntilAgentEnd = false;
 
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-deps.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-deps.ts
@@ -24,7 +24,7 @@ export { BUILT_IN_PROVIDER_DISPLAY_NAMES } from "../../core/provider-display-nam
 export type { ResourceDiagnostic } from "../../core/resource-loader.ts";
 export { formatMissingSessionCwdPrompt, MissingSessionCwdError } from "../../core/session-cwd.ts";
 export { type SessionContext, SessionManager } from "../../core/session-manager.ts";
-export { BUILTIN_SLASH_COMMANDS } from "../../core/slash-commands.ts";
+export { BUILTIN_SLASH_COMMANDS, BUNDLED_EXTENSION_SLASH_COMMANDS } from "../../core/slash-commands.ts";
 export type { SourceInfo } from "../../core/source-info.ts";
 export { isInstallTelemetryEnabled } from "../../core/telemetry.ts";
 export type { TruncationResult } from "../../core/tools/truncate.ts";

--- a/packages/coding-agent/src/modes/interactive/interactive-render-chat.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-render-chat.ts
@@ -1,5 +1,5 @@
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
-import { type AgentMessage, type Component, type ContextCompactionResult, type SessionContext, type TruncationResult, type ChatMessageEntry, type ChatMessageRenderOptions, Spacer, Text, parseSkillBlock, AssistantMessageComponent, BashExecutionComponent, BranchSummaryMessageComponent, chatEntriesFromAgentMessages, renderChatMessageEntry, addChatTranscriptEntry, ContextCompactionSummaryMessageComponent, CustomMessageComponent, SkillInvocationMessageComponent, ToolExecutionComponent, UserMessageComponent, theme } from "./interactive-mode-deps.ts";
+import { type AgentMessage, type Component, type ContextCompactionResult, type SessionContext, type TruncationResult, type ChatMessageEntry, type ChatMessageRenderOptions, Spacer, Text, parseSkillBlock, AssistantMessageComponent, BashExecutionComponent, BranchSummaryMessageComponent, chatEntriesFromAgentMessages, renderChatMessageEntry, addChatTranscriptEntry, ContextCompactionSummaryMessageComponent, CustomMessageComponent, SkillInvocationMessageComponent, ToolExecutionComponent, UserMessageComponent, recordTimeSinceReset, theme } from "./interactive-mode-deps.ts";
 import { yieldToEventLoop } from "../../utils/event-loop.ts";
 
 InteractiveModeBase.prototype.showStatus = function(this: InteractiveModeBase, message: string): void {
@@ -291,6 +291,14 @@ InteractiveModeBase.prototype.getUserInput = async function(this: InteractiveMod
           this.onInputCallback = undefined;
           resolve(text);
         };
+        if (!this.inputHandlerReadyRecorded) {
+          this.inputHandlerReadyRecorded = true;
+          recordTimeSinceReset("interactive-input-handler-ready");
+          void (async () => {
+            await yieldToEventLoop();
+            this.footerDataProvider.startGitWatcher();
+          })();
+        }
       });
     }
   };

--- a/packages/coding-agent/src/modes/interactive/interactive-session-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-session-routing.ts
@@ -255,6 +255,7 @@ InteractiveModeBase.prototype.showSessionSelector = function(this: InteractiveMo
   };
 
 InteractiveModeBase.prototype.handleResumeSession = async function(this: InteractiveModeBase, sessionPath: string, options?: Parameters<ExtensionCommandContext["switchSession"]>[1]): Promise<{ cancelled: boolean }> {
+    await this.ensureDeferredStartupComplete();
     if (this.loadingAnimation) {
       this.loadingAnimation.stop();
       this.loadingAnimation = undefined;

--- a/packages/coding-agent/src/modes/interactive/interactive-startup.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-startup.ts
@@ -3,10 +3,24 @@ import { type Container, type MarkdownTheme, os, path, Markdown, Spacer, Text, s
 import { ExpandableText } from "./interactive-mode-helpers.ts";
 import { ONBOARDING_COPY } from "./interactive-onboarding.ts";
 
+function prepareStartupNotices(mode: InteractiveModeBase): void {
+    if (mode.startupNoticesPrepared) return;
+    mode.startupNoticesPrepared = true;
+    mode.hadLastChangelogVersionAtStartup = Boolean(mode.settingsManager.getLastChangelogVersion?.());
+    if (mode.changelogMarkdown === undefined) {
+      mode.changelogMarkdown = mode.getChangelogForDisplay?.();
+    }
+    mode.initializeFirstRunOnboardingMarkers?.();
+    if (!mode.firstRunNoticeVisible) {
+      mode.firstRunNoticeVisible = mode.isFirstRunOnboardingEligible?.() ?? false;
+    }
+  }
+
 InteractiveModeBase.prototype.showStartupNoticesIfNeeded = function(this: InteractiveModeBase, targetContainer: Container = this.chatContainer): void {
     if (this.startupNoticesShown) {
       return;
     }
+    prepareStartupNotices(this);
     this.startupNoticesShown = true;
 
     const changelogMarkdown = this.changelogMarkdown;
@@ -71,10 +85,7 @@ InteractiveModeBase.prototype.init = async function(this: InteractiveModeBase): 
 
     this.registerSignalHandlers();
 
-    // Load changelog (only show new entries, skip for resumed sessions)
-    this.hadLastChangelogVersionAtStartup = Boolean(this.settingsManager.getLastChangelogVersion());
-    this.changelogMarkdown = this.getChangelogForDisplay();
-    this.initializeFirstRunOnboardingMarkers();
+    // Changelog and first-run onboarding are prepared lazily after first paint.
 
     // Add header container as first child. Populate it after theme initialization.
     this.ui.addChild(this.headerContainer);
@@ -101,8 +112,6 @@ InteractiveModeBase.prototype.init = async function(this: InteractiveModeBase): 
     this.setupKeyHandlers();
     this.setupEditorSubmitHandler();
 
-    this.firstRunNoticeVisible = this.isFirstRunOnboardingEligible();
-
     seedStartupInput(
       this.pendingUserInputs,
       this.defaultEditor,
@@ -116,17 +125,17 @@ InteractiveModeBase.prototype.init = async function(this: InteractiveModeBase): 
       },
     );
 
-    // Start the UI before initializing extensions so session_start handlers can use interactive dialogs.
-    // fd/rg readiness is intentionally checked after first paint because ensureTool may spawn
-    // or download tools on cold machines.
+    // Start UI before extension/session work; fd/rg readiness and git watching move after first paint.
     this.ui.start();
     recordTimeSinceReset("time-to-first-frame");
+    this.footerDataProvider.onBranchChange(() => {
+      this.ui.requestRender();
+    });
     this.isInitialized = true;
 
     await this.themeController.applyFromSettings();
 
-    // Add the quiet startup identity (unless silenced). Resource details are
-    // disclosed separately in the chat canvas via the tools/resources toggle.
+    // Add the quiet startup identity unless silenced.
     if (this.options.verbose || !this.settingsManager.getQuietStartup()) {
       this.builtInHeader = new ExpandableText(
         () => this.getStartupIdentityText(),
@@ -171,21 +180,10 @@ InteractiveModeBase.prototype.init = async function(this: InteractiveModeBase): 
     this.attachStartupNoticesContainer();
     // Render initial messages AFTER the initial session binding is in place.
     this.renderInitialMessages();
-	if (this.deferredStartupPending) {
-		setTimeout(() => {
-			if (!this.deferredStartupPending || this.deferredStartupPromise) return;
-			void this.ensureDeferredStartupComplete();
-		}, 2000);
-	}
     // Set up theme file watcher
     onThemeChange(() => {
       this.ui.invalidate();
       this.updateEditorBorderColor();
-      this.ui.requestRender();
-    });
-
-    // Set up git branch watcher (uses provider instead of footer)
-    this.footerDataProvider.onBranchChange(() => {
       this.ui.requestRender();
     });
 

--- a/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
+++ b/packages/coding-agent/test/extensions-loader-virtual-modules.test.ts
@@ -100,4 +100,11 @@ describe("extension loader package-root resolution", () => {
 			expect(exists, `alias ${specifier} -> ${target} does not exist`).toBe(true);
 		}
 	});
+
+	it("creates the versioned jiti fsCache directory before extension imports", () => {
+		const cacheDir = extensionLoaderTestHooks.getTranspileCacheDir();
+
+		expect(fs.existsSync(cacheDir)).toBe(true);
+		expect(fs.statSync(cacheDir).isDirectory()).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/footer-data-provider.test.ts
+++ b/packages/coding-agent/test/footer-data-provider.test.ts
@@ -4,6 +4,14 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+type MockedFunction<T> = T & {
+	mock: { calls: unknown[][] };
+	mockClear(): void;
+};
+
+function mocked<T>(fn: T): MockedFunction<T> {
+	return fn as MockedFunction<T>;
+}
 let resolvedBranch = "main";
 
 vi.mock("child_process", () => ({
@@ -87,6 +95,11 @@ async function waitFor(condition: () => boolean, timeoutMs = 10000): Promise<voi
 	}
 }
 
+async function advanceTimersByTime(ms: number): Promise<void> {
+	vi.advanceTimersByTime(ms);
+	await Promise.resolve();
+}
+
 describe("FooterDataProvider reftable branch detection", () => {
 	let originalCwd: string;
 	let tempDir: string;
@@ -95,8 +108,8 @@ describe("FooterDataProvider reftable branch detection", () => {
 		originalCwd = process.cwd();
 		tempDir = mkdtempSync(join(tmpdir(), "footer-data-provider-"));
 		resolvedBranch = "main";
-		vi.mocked(spawnSync).mockClear();
-		vi.mocked(execFile).mockClear();
+		mocked(spawnSync).mockClear();
+		mocked(execFile).mockClear();
 	});
 
 	afterEach(() => {
@@ -115,7 +128,25 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider(nestedDir);
 		try {
 			expect(provider.getGitBranch()).toBe("main");
-			expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+			expect(mocked(spawnSync)).not.toHaveBeenCalled();
+		} finally {
+			provider.dispose();
+		}
+	});
+
+	it("does not start git watchers until requested", () => {
+		const repoDir = createPlainRepo(tempDir);
+		process.chdir(repoDir);
+
+		const provider = new FooterDataProvider(repoDir);
+		try {
+			const providerWithInternals = provider as unknown as { headWatcher: FSWatcher | null };
+			expect(providerWithInternals.headWatcher).toBeNull();
+			expect(provider.getGitBranch()).toBe("main");
+			expect(providerWithInternals.headWatcher).toBeNull();
+
+			provider.startGitWatcher();
+			expect(providerWithInternals.headWatcher).not.toBeNull();
 		} finally {
 			provider.dispose();
 		}
@@ -128,7 +159,7 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider(repoDir);
 		try {
 			expect(provider.getGitBranch()).toBe("main");
-			expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
+			expect(mocked(spawnSync)).toHaveBeenCalledWith(
 				"git",
 				["--no-optional-locks", "symbolic-ref", "--quiet", "--short", "HEAD"],
 				expect.objectContaining({
@@ -174,15 +205,16 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider(worktreeDir);
 		try {
 			expect(provider.getGitBranch()).toBe("main");
-			vi.mocked(spawnSync).mockClear();
+			mocked(spawnSync).mockClear();
 			const onBranchChange = vi.fn();
 			provider.onBranchChange(onBranchChange);
+			provider.startGitWatcher();
 
 			writeFileSync(join(reftableDir, "tables.list"), "1\n");
-			await waitFor(() => vi.mocked(execFile).mock.calls.length === 1);
+			await waitFor(() => mocked(execFile).mock.calls.length === 1);
 
-			expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
-			expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+			expect(mocked(execFile)).toHaveBeenCalledTimes(1);
+			expect(mocked(spawnSync)).not.toHaveBeenCalled();
 			expect(provider.getGitBranch()).toBe("main");
 			expect(onBranchChange).not.toHaveBeenCalled();
 		} finally {
@@ -197,15 +229,16 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider(worktreeDir);
 		try {
 			expect(provider.getGitBranch()).toBe("main");
-			vi.mocked(execFile).mockClear();
+			mocked(execFile).mockClear();
+			provider.startGitWatcher();
 
 			writeFileSync(join(reftableDir, "tables.list"), "1\n");
 			writeFileSync(join(reftableDir, "tables.list"), "2\n");
 			writeFileSync(join(reftableDir, "tables.list"), "3\n");
-			await waitFor(() => vi.mocked(execFile).mock.calls.length === 1);
+			await waitFor(() => mocked(execFile).mock.calls.length === 1);
 			await new Promise((resolve) => setTimeout(resolve, 650));
 
-			expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
+			expect(mocked(execFile)).toHaveBeenCalledTimes(1);
 		} finally {
 			provider.dispose();
 		}
@@ -219,7 +252,8 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider(worktreeDir);
 		try {
 			expect(provider.getGitBranch()).toBe("main");
-			vi.mocked(execFile).mockClear();
+			mocked(execFile).mockClear();
+			provider.startGitWatcher();
 			const providerWithInternals = provider as unknown as {
 				scheduleReftableRefresh: () => void;
 			};
@@ -227,19 +261,19 @@ describe("FooterDataProvider reftable branch detection", () => {
 			writeFileSync(join(reftableDir, "tables.list"), "1\n");
 			providerWithInternals.scheduleReftableRefresh();
 			providerWithInternals.scheduleReftableRefresh();
-			await vi.advanceTimersByTimeAsync(500);
+			await advanceTimersByTime(500);
 
-			expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
+			expect(mocked(execFile)).toHaveBeenCalledTimes(1);
 
 			providerWithInternals.scheduleReftableRefresh();
-			await vi.advanceTimersByTimeAsync(650);
-			expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
+			await advanceTimersByTime(650);
+			expect(mocked(execFile)).toHaveBeenCalledTimes(1);
 
 			writeFileSync(join(reftableDir, "tables.list"), "2\n");
 			providerWithInternals.scheduleReftableRefresh();
-			await vi.advanceTimersByTimeAsync(500);
+			await advanceTimersByTime(500);
 
-			expect(vi.mocked(execFile)).toHaveBeenCalledTimes(2);
+			expect(mocked(execFile)).toHaveBeenCalledTimes(2);
 		} finally {
 			provider.dispose();
 			vi.useRealTimers();
@@ -254,15 +288,16 @@ describe("FooterDataProvider reftable branch detection", () => {
 		const provider = new FooterDataProvider(worktreeDir);
 		try {
 			expect(provider.getGitBranch()).toBe("main");
-			vi.mocked(execFile).mockClear();
+			mocked(execFile).mockClear();
+			provider.startGitWatcher();
 			const providerWithInternals = provider as unknown as {
 				handleReftableDirectoryEvent: (filename: string | null) => void;
 			};
 
 			providerWithInternals.handleReftableDirectoryEvent(null);
-			await vi.advanceTimersByTimeAsync(500);
+			await advanceTimersByTime(500);
 
-			expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
+			expect(mocked(execFile)).toHaveBeenCalledTimes(1);
 		} finally {
 			provider.dispose();
 			vi.useRealTimers();
@@ -279,12 +314,13 @@ describe("FooterDataProvider reftable branch detection", () => {
 			resolvedBranch = "foo";
 			const onBranchChange = vi.fn();
 			provider.onBranchChange(onBranchChange);
+			provider.startGitWatcher();
 
 			writeFileSync(join(reftableDir, "tables.list"), "1\n");
-			await waitFor(() => vi.mocked(execFile).mock.calls.length === 1);
+			await waitFor(() => mocked(execFile).mock.calls.length === 1);
 			await waitFor(() => provider.getGitBranch() === "foo");
 
-			expect(vi.mocked(execFile)).toHaveBeenCalledTimes(1);
+			expect(mocked(execFile)).toHaveBeenCalledTimes(1);
 			expect(provider.getGitBranch()).toBe("foo");
 			expect(onBranchChange).toHaveBeenCalledTimes(1);
 		} finally {
@@ -299,6 +335,7 @@ describe("FooterDataProvider reftable branch detection", () => {
 
 		const provider = new FooterDataProvider(repoDir);
 		try {
+			provider.startGitWatcher();
 			const providerWithInternals = provider as unknown as {
 				headWatcher: FSWatcher | null;
 			};
@@ -309,10 +346,10 @@ describe("FooterDataProvider reftable branch detection", () => {
 			originalWatcher?.emit("error", new Error("simulated EMFILE"));
 			expect(providerWithInternals.headWatcher).toBeNull();
 
-			await vi.advanceTimersByTimeAsync(4999);
+			await advanceTimersByTime(4999);
 			expect(providerWithInternals.headWatcher).toBeNull();
 
-			await vi.advanceTimersByTimeAsync(1);
+			await advanceTimersByTime(1);
 			expect(providerWithInternals.headWatcher).not.toBeNull();
 			expect(providerWithInternals.headWatcher).not.toBe(originalWatcher);
 		} finally {

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -16,8 +16,12 @@ type SubmitContext = {
 		isBashRunning: boolean;
 		prompt: (text: string, options?: unknown) => Promise<void>;
 	};
+	deferredStartupPending: boolean;
+	deferredStartupPromise?: Promise<void>;
 	flushPendingBashComponents: () => void;
 	handleBashCommand: (command: string, isExcluded: boolean) => Promise<void>;
+	ensureDeferredStartupComplete: () => Promise<void>;
+	showStatus: (message: string) => void;
 	updateEditorBorderColor: () => void;
 	isBashMode: boolean;
 	renderDeferredUserInput: (text: string) => void;
@@ -25,6 +29,8 @@ type SubmitContext = {
 	advanceStartupInputReplay: (text: string) => void;
 	drainStartupReplayCommands: () => Promise<void>;
 	recoverCookedStartupInput: () => boolean;
+	handleModelCommand: (searchTerm?: string) => Promise<void>;
+	showSettingsSelector: () => void;
 	onInputCallback?: (text: string) => void;
 	pendingUserInputs: string[];
 	startupReplayInputs: string[];
@@ -65,7 +71,10 @@ function createSubmitContext(): SubmitContext {
 			isBashRunning: false,
 			prompt: vi.fn(async () => {}),
 		},
+		deferredStartupPending: false,
 		handleBashCommand: vi.fn(async () => {}),
+		ensureDeferredStartupComplete: vi.fn(async () => {}),
+		showStatus: vi.fn(),
 		updateEditorBorderColor: vi.fn(),
 		isBashMode: false,
 		flushPendingBashComponents: vi.fn(),
@@ -74,6 +83,8 @@ function createSubmitContext(): SubmitContext {
 		advanceStartupInputReplay: InteractiveMode.prototype.advanceStartupInputReplay,
 		drainStartupReplayCommands: InteractiveMode.prototype.drainStartupReplayCommands,
 		recoverCookedStartupInput: InteractiveMode.prototype.recoverCookedStartupInput,
+		handleModelCommand: vi.fn(async () => {}),
+		showSettingsSelector: vi.fn(),
 		pendingUserInputs: [],
 		startupReplayInputs: [],
 	};
@@ -89,6 +100,48 @@ describe("InteractiveMode startup input", () => {
 		expect(context.pendingUserInputs).toEqual(["early prompt"]);
 		expect(context.flushPendingBashComponents).toHaveBeenCalledTimes(1);
 		expect(context.editor.addToHistory).toHaveBeenCalledWith("early prompt");
+	});
+
+	it("loads deferred startup before model slash commands", async () => {
+		const order: string[] = [];
+		const context = createSubmitContext();
+		context.ensureDeferredStartupComplete = vi.fn(async () => {
+			order.push("deferred");
+		});
+		context.handleModelCommand = vi.fn(async (searchTerm?: string) => {
+			order.push(`model:${searchTerm ?? ""}`);
+		});
+		interactiveModePrototype.setupEditorSubmitHandler.call(context);
+
+		await context.defaultEditor.onSubmit?.("/model gpt-5.5");
+
+		expect(order).toEqual(["deferred", "model:gpt-5.5"]);
+		expect(context.editor.setText).toHaveBeenCalledWith("");
+	});
+
+	it("keeps local slash commands responsive without deferred startup", async () => {
+		const context = createSubmitContext();
+		interactiveModePrototype.setupEditorSubmitHandler.call(context);
+
+		await context.defaultEditor.onSubmit?.("/settings");
+
+		expect(context.ensureDeferredStartupComplete).not.toHaveBeenCalled();
+		expect(context.showSettingsSelector).toHaveBeenCalledTimes(1);
+	});
+
+	it("loads deferred startup before explicit extension slash submissions", async () => {
+		const order: string[] = [], context = createSubmitContext();
+		context.deferredStartupPending = true;
+		context.ensureDeferredStartupComplete = vi.fn(async () => {
+			order.push("deferred");
+			context.deferredStartupPending = false;
+		});
+		context.session.prompt = vi.fn(async (text: string) => order.push(`prompt:${text}`));
+		interactiveModePrototype.setupEditorSubmitHandler.call(context);
+		await context.defaultEditor.onSubmit?.("/workflow list");
+		expect(order).toEqual(["deferred", "prompt:/workflow list"]);
+		expect(context.pendingUserInputs).toEqual([]);
+		expect(context.editor.addToHistory).toHaveBeenCalledWith("/workflow list");
 	});
 
 	it("returns queued startup input before installing a new input callback", async () => {

--- a/packages/coding-agent/test/interactive-mode-startup-latency.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-latency.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+const timingMock = vi.hoisted(() => ({ labels: [] as string[] }));
+
+vi.mock("../src/core/timings.ts", () => ({
+	recordTimeSinceReset: vi.fn((label: string) => {
+		timingMock.labels.push(label);
+	}),
+}));
+
+type TestNode = Record<string, never>;
+
+type InputContext = {
+	onInputCallback?: (text: string) => void;
+	pendingUserInputs: string[];
+	startupReplayActiveInput?: string;
+	startupCookedInputRecovered?: boolean;
+	inputHandlerReadyRecorded?: boolean;
+	drainStartupReplayCommands?: () => Promise<void>;
+	recoverCookedStartupInput?: () => boolean;
+	footerDataProvider: { startGitWatcher: () => void };
+};
+
+type StartupNoticesContext = {
+	startupNoticesShown: boolean;
+	startupNoticesPrepared: boolean;
+	hadLastChangelogVersionAtStartup: boolean;
+	changelogMarkdown?: string;
+	firstRunNoticeVisible: boolean;
+	firstRunOnboardingNoticeComponents?: TestNode[];
+	settingsManager: {
+		getLastChangelogVersion?: () => string | undefined;
+		setOnboardedVersion?: (version: string) => void;
+		getCollapseChangelog: () => boolean;
+	};
+	version?: string;
+	getChangelogForDisplay: () => string | undefined;
+	initializeFirstRunOnboardingMarkers: () => void;
+	isFirstRunOnboardingEligible: () => boolean;
+	chatContainer: { children: TestNode[]; addChild?: (child: TestNode) => void };
+	ui: { requestRender: () => void };
+};
+
+type InitContext = {
+	isInitialized: boolean;
+	registerSignalHandlers: () => void;
+	ui: {
+		addChild: (child: TestNode) => void;
+		setFocus: (target: TestNode) => void;
+		start: () => void;
+		requestRender: () => void;
+	};
+	headerContainer: TestNode;
+	chatContainer: TestNode;
+	pendingMessagesContainer: TestNode;
+	statusContainer: TestNode;
+	widgetContainerAbove: TestNode;
+	usageMeter: TestNode;
+	editorContainer: TestNode;
+	footer: TestNode;
+	widgetContainerBelow: TestNode;
+	editor: TestNode;
+	renderWidgets: () => void;
+	setupKeyHandlers: () => void;
+	setupEditorSubmitHandler: () => void;
+	pendingUserInputs: string[];
+	defaultEditor: { setText?: (text: string) => void };
+	options: { startupInputCapture?: { consume: () => { text: string; submissions: string[] } } };
+	startupReplayInputs: string[];
+	footerDataProvider: { onBranchChange: (callback: () => void) => void; startGitWatcher: () => void };
+	themeController: { applyFromSettings: () => Promise<void> };
+};
+
+type PromptTurnContext = {
+	deferredStartupPending: boolean;
+	deferredStartupPromise?: Promise<void>;
+	deferLoadedResourcesDisclosureUntilAgentEnd: boolean;
+	pendingLoadedResourcesDisclosure: boolean;
+	session: { isStreaming: boolean; prompt: (text: string) => Promise<void> };
+	showWorkingLoaderNow: () => void;
+	ensureDeferredStartupComplete: () => Promise<void>;
+	showLoadedResources: (options?: unknown) => void;
+	maybeWarnAboutAnthropicSubscriptionAuth: () => Promise<void>;
+	discardDeferredRenderedUserInput: (text: string) => void;
+	showError: (message: string) => void;
+	stopWorkingLoader: () => void;
+	startupNoticesContainer: TestNode;
+};
+
+
+type InteractiveModePrivate = {
+	getUserInput(this: InputContext): Promise<string>;
+	showStartupNoticesIfNeeded(this: StartupNoticesContext): void;
+	init(this: InitContext): Promise<void>;
+	runUserPromptTurn(this: PromptTurnContext, userInput: string): Promise<void>;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
+
+async function waitForImmediate(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function createPromptTurnContext(options: {
+	deferredStartupPending?: boolean;
+	deferredStartupPromise?: Promise<void>;
+} = {}): PromptTurnContext {
+	return {
+		deferredStartupPending: options.deferredStartupPending ?? false,
+		deferredStartupPromise: options.deferredStartupPromise,
+		deferLoadedResourcesDisclosureUntilAgentEnd: false,
+		pendingLoadedResourcesDisclosure: false,
+		session: { isStreaming: false, prompt: vi.fn(async () => {}) },
+		showWorkingLoaderNow: vi.fn(),
+		ensureDeferredStartupComplete: vi.fn(async () => {}),
+		showLoadedResources: vi.fn(),
+		maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(async () => {}),
+		discardDeferredRenderedUserInput: vi.fn(),
+		showError: vi.fn(),
+		stopWorkingLoader: vi.fn(),
+		startupNoticesContainer: {},
+	};
+}
+
+describe("InteractiveMode startup latency hooks", () => {
+	it("records input handler readiness when the input callback is installed", async () => {
+		timingMock.labels.length = 0;
+		const context: InputContext = {
+			pendingUserInputs: [],
+			startupCookedInputRecovered: true,
+			inputHandlerReadyRecorded: false,
+			footerDataProvider: { startGitWatcher: vi.fn() },
+		};
+
+		const inputPromise = interactiveModePrototype.getUserInput.call(context);
+
+		expect(context.onInputCallback).toBeTypeOf("function");
+		expect(timingMock.labels).toEqual(["interactive-input-handler-ready"]);
+		expect(context.footerDataProvider.startGitWatcher).not.toHaveBeenCalled();
+		await waitForImmediate();
+		expect(context.footerDataProvider.startGitWatcher).toHaveBeenCalledTimes(1);
+
+		context.onInputCallback?.("ready prompt");
+		await expect(inputPromise).resolves.toBe("ready prompt");
+	});
+
+	it("does not record input handler readiness for queued startup input", async () => {
+		timingMock.labels.length = 0;
+		const context: InputContext = {
+			pendingUserInputs: ["queued prompt"],
+			startupCookedInputRecovered: true,
+			inputHandlerReadyRecorded: false,
+			footerDataProvider: { startGitWatcher: vi.fn() },
+		};
+
+		await expect(interactiveModePrototype.getUserInput.call(context)).resolves.toBe("queued prompt");
+
+		expect(context.onInputCallback).toBeUndefined();
+		await waitForImmediate();
+		expect(context.footerDataProvider.startGitWatcher).not.toHaveBeenCalled();
+		expect(timingMock.labels).not.toContain("interactive-input-handler-ready");
+	});
+
+	it("does not start footer git watching during the inline init path", async () => {
+		const themeReady = new Promise<void>(() => {});
+		const context: InitContext = {
+			isInitialized: false,
+			registerSignalHandlers: vi.fn(),
+			ui: {
+				addChild: vi.fn(),
+				setFocus: vi.fn(),
+				start: vi.fn(),
+				requestRender: vi.fn(),
+			},
+			headerContainer: {},
+			chatContainer: {},
+			pendingMessagesContainer: {},
+			statusContainer: {},
+			widgetContainerAbove: {},
+			usageMeter: {},
+			editorContainer: {},
+			footer: {},
+			widgetContainerBelow: {},
+			editor: {},
+			renderWidgets: vi.fn(),
+			setupKeyHandlers: vi.fn(),
+			setupEditorSubmitHandler: vi.fn(),
+			pendingUserInputs: [],
+			defaultEditor: {},
+			options: {},
+			startupReplayInputs: [],
+			footerDataProvider: {
+				onBranchChange: vi.fn(),
+				startGitWatcher: vi.fn(),
+			},
+			themeController: { applyFromSettings: vi.fn(() => themeReady) },
+		};
+
+		void interactiveModePrototype.init.call(context);
+
+		expect(context.ui.start).toHaveBeenCalledTimes(1);
+		expect(context.footerDataProvider.onBranchChange).toHaveBeenCalledTimes(1);
+		expect(context.footerDataProvider.startGitWatcher).not.toHaveBeenCalled();
+
+		await waitForImmediate();
+		expect(context.footerDataProvider.startGitWatcher).not.toHaveBeenCalled();
+	});
+
+	it("does not block first normal prompt on deferred startup", async () => {
+		const context = createPromptTurnContext({ deferredStartupPending: true });
+
+		await interactiveModePrototype.runUserPromptTurn.call(context, "hello");
+
+		expect(context.ensureDeferredStartupComplete).not.toHaveBeenCalled();
+		expect(context.session.prompt).toHaveBeenCalledWith("hello");
+	});
+
+	it("waits for deferred startup already in flight before prompting", async () => {
+		const order: string[] = [];
+		const context = createPromptTurnContext({
+			deferredStartupPending: true,
+			deferredStartupPromise: Promise.resolve(),
+		});
+		context.ensureDeferredStartupComplete = vi.fn(async () => {
+			order.push("deferred");
+		});
+		context.session.prompt = vi.fn(async () => {
+			order.push("prompt");
+		});
+
+		await interactiveModePrototype.runUserPromptTurn.call(context, "hello");
+
+		expect(order).toEqual(["deferred", "prompt"]);
+	});
+
+
+	it("prepares startup notices only when notice rendering is requested", () => {
+		const context: StartupNoticesContext = {
+			startupNoticesShown: false,
+			startupNoticesPrepared: false,
+			hadLastChangelogVersionAtStartup: false,
+			firstRunNoticeVisible: false,
+			settingsManager: {
+				getLastChangelogVersion: vi.fn(() => "0.1.0"),
+				getCollapseChangelog: vi.fn(() => true),
+			},
+			getChangelogForDisplay: vi.fn(() => undefined),
+			initializeFirstRunOnboardingMarkers: vi.fn(),
+			isFirstRunOnboardingEligible: vi.fn(() => false),
+			chatContainer: { children: [] },
+			ui: { requestRender: vi.fn() },
+		};
+
+		expect(context.startupNoticesPrepared).toBe(false);
+
+		interactiveModePrototype.showStartupNoticesIfNeeded.call(context);
+
+		expect(context.startupNoticesPrepared).toBe(true);
+		expect(context.hadLastChangelogVersionAtStartup).toBe(true);
+		expect(context.getChangelogForDisplay).toHaveBeenCalledTimes(1);
+		expect(context.initializeFirstRunOnboardingMarkers).toHaveBeenCalledTimes(1);
+		expect(context.isFirstRunOnboardingEligible).toHaveBeenCalledTimes(1);
+		expect(context.ui.requestRender).not.toHaveBeenCalled();
+	});
+
+	it("prepares missing startup notice state without clearing visible onboarding", () => {
+		const children: TestNode[] = [];
+		const context: StartupNoticesContext = {
+			startupNoticesShown: false,
+			startupNoticesPrepared: false,
+			hadLastChangelogVersionAtStartup: false,
+			firstRunNoticeVisible: true,
+			firstRunOnboardingNoticeComponents: [],
+			settingsManager: {
+				getLastChangelogVersion: vi.fn(() => "0.1.0"),
+				setOnboardedVersion: vi.fn(),
+				getCollapseChangelog: vi.fn(() => true),
+			},
+			version: "0.2.0",
+			getChangelogForDisplay: vi.fn(() => undefined),
+			initializeFirstRunOnboardingMarkers: vi.fn(),
+			isFirstRunOnboardingEligible: vi.fn(() => false),
+			chatContainer: {
+				children,
+				addChild(child: TestNode) {
+					this.children.push(child);
+				},
+			},
+			ui: { requestRender: vi.fn() },
+		};
+
+		interactiveModePrototype.showStartupNoticesIfNeeded.call(context);
+
+		expect(context.startupNoticesPrepared).toBe(true);
+		expect(context.changelogMarkdown).toBeUndefined();
+		expect(context.firstRunNoticeVisible).toBe(true);
+		expect(context.getChangelogForDisplay).toHaveBeenCalledTimes(1);
+		expect(context.initializeFirstRunOnboardingMarkers).toHaveBeenCalledTimes(1);
+		expect(context.isFirstRunOnboardingEligible).not.toHaveBeenCalled();
+		expect(context.chatContainer.children.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status-autocomplete.suite.ts
+++ b/packages/coding-agent/test/interactive-mode-status-autocomplete.suite.ts
@@ -386,3 +386,44 @@ describe("InteractiveMode.createBaseAutocompleteProvider", () => {
 	});
 });
 
+
+describe("InteractiveMode deferred workflow autocomplete", () => {
+	function createDeferredWorkflowProvider(): AutocompleteProvider {
+		const fakeThis: any = {
+			deferredStartupPending: true,
+			session: {
+				scopedModels: [],
+				modelRegistry: { getAvailable: () => [] },
+				promptTemplates: [],
+				extensionRunner: { getRegisteredCommands: () => [] },
+				resourceLoader: { getSkills: () => ({ skills: [] }) },
+			},
+			settingsManager: { getEnableSkillCommands: () => false },
+			skillCommands: new Map(),
+			sessionManager: { getCwd: () => process.cwd() },
+			fdPath: null,
+		};
+		Object.setPrototypeOf(fakeThis, (InteractiveMode as any).prototype);
+		return (InteractiveMode as any).prototype.createBaseAutocompleteProvider.call(fakeThis) as AutocompleteProvider;
+	}
+
+	async function suggestionValues(provider: AutocompleteProvider, line: string): Promise<string[]> {
+		const suggestions = await provider.getSuggestions([line], 0, line.length, {
+			signal: new AbortController().signal,
+		});
+		return suggestions?.items.map((item) => item.value) ?? [];
+	}
+
+	test("offers workflow names and inputs before the workflow extension implementation loads", async () => {
+		const provider = createDeferredWorkflowProvider();
+
+		expect(await suggestionValues(provider, "/wor")).toContain("workflow");
+		expect(await suggestionValues(provider, "/workflow ")).toContain("deep-research-codebase ");
+		expect(await suggestionValues(provider, "/workflow list")).toEqual([]);
+		expect(await suggestionValues(provider, "/workflow de")).toEqual(["deep-research-codebase "]);
+		expect(await suggestionValues(provider, "/workflow inputs de")).toEqual(["inputs deep-research-codebase "]);
+		expect(await suggestionValues(provider, "/workflow deep-research-codebase p")).toEqual([
+			"deep-research-codebase prompt=",
+		]);
+	});
+});

--- a/packages/coding-agent/test/main-deferred-startup.test.ts
+++ b/packages/coding-agent/test/main-deferred-startup.test.ts
@@ -63,10 +63,13 @@ describe("computeDeferExtensions", () => {
 		expect(computeDeferExtensions(baseInput({ listModels: "all" }))).toBe(false);
 		expect(computeDeferExtensions(baseInput({ resolvedExtensionPathCount: 1 }))).toBe(false);
 		expect(computeDeferExtensions(baseInput({ unknownFlagCount: 1 }))).toBe(false);
-		expect(computeDeferExtensions(baseInput({ provider: "anthropic" }))).toBe(false);
-		expect(computeDeferExtensions(baseInput({ model: "claude-sonnet" }))).toBe(false);
 		expect(computeDeferExtensions(baseInput({ resolvedResourcePathCount: 1 }))).toBe(false);
 		expect(computeDeferExtensions(baseInput({ hasSystemPromptInput: true }))).toBe(false);
+	});
+
+	it("still defers when an interactive launch explicitly selects a provider or model", () => {
+		expect(computeDeferExtensions(baseInput({ provider: "anthropic" }))).toBe(true);
+		expect(computeDeferExtensions(baseInput({ model: "claude-sonnet" }))).toBe(true);
 	});
 
 	it("keeps unstored prompt-required trust on the synchronous path but defers once a decision exists", () => {
@@ -79,6 +82,10 @@ describe("computeDeferExtensions", () => {
 		expect(computeDeferExtensions(baseInput({ appMode: "print" }))).toBe(false);
 		expect(computeDeferExtensions(baseInput({ stdinIsTTY: false }))).toBe(false);
 		expect(computeDeferExtensions(baseInput({ hasSessionStartEvent: true }))).toBe(false);
+	});
+
+	it("keeps print prompts synchronous so slash commands load before atomic -p runs", () => {
+		expect(computeDeferExtensions(baseInput({ appMode: "print" }))).toBe(false);
 	});
 });
 

--- a/packages/workflows/src/extension/workflow-command-completions.ts
+++ b/packages/workflows/src/extension/workflow-command-completions.ts
@@ -13,8 +13,9 @@ function completeToken(
     : Math.max(argumentText.lastIndexOf(" "), argumentText.lastIndexOf("\t")) + 1;
   const head = argumentText.slice(0, tokenStart);
   const token = argumentText.slice(tokenStart);
+  const normalizedToken = token.trimEnd();
   const filtered = candidates
-    .filter((candidate) => candidate.value.startsWith(token))
+    .filter((candidate) => candidate.value.startsWith(token) && candidate.value.trimEnd() !== normalizedToken)
     .map((candidate) => ({ ...candidate, value: `${head}${candidate.value}` }));
   return filtered.length > 0 ? filtered : null;
 }

--- a/research/web/2026-07-08-bun-tui-first-input-responsiveness.md
+++ b/research/web/2026-07-08-bun-tui-first-input-responsiveness.md
@@ -1,0 +1,16 @@
+---
+source_urls:
+  - https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick
+  - https://nodejs.org/api/timers.html
+  - https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
+  - https://bun.sh/reference/globals/setImmediate
+  - https://bun.sh/reference/globals/queueMicrotask
+  - https://bun.sh/reference/node/timers/promises/setImmediate
+  - https://bun.sh/reference/bun/spawn
+  - https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session
+  - https://github.com/anomalyco/opentui
+fetched_at: 2026-07-08
+topic: Bun/TypeScript terminal UI first keyboard input responsiveness
+---
+
+Research cache for terminal/TUI first input responsiveness. Key findings: prefer render flush/idleness barriers, then macrotask yield (setImmediate/promisified setImmediate) before nonessential probes; avoid queueMicrotask/process.nextTick for yielding to input; make fs/git/network probes async/cancellable/budgeted; measure first byte/key/submit with performance.now; regression test through mock input/headless renderer and real PTY/ConPTY paths.

--- a/test/unit/intercom-atomic-compat.test.ts
+++ b/test/unit/intercom-atomic-compat.test.ts
@@ -59,7 +59,7 @@ function withEnv<T>(updates: Record<string, string | undefined>, fn: () => T): T
 describe("intercom Atomic agent-dir paths", () => {
   test("uses the default Atomic agent directory for broker runtime files", () => {
     const home = tempDir("atomic-intercom-home-");
-    withEnv({ HOME: home, USERPROFILE: undefined, ATOMIC_CODING_AGENT_DIR: undefined, PI_CODING_AGENT_DIR: undefined }, () => {
+    withEnv({ HOME: home, USERPROFILE: undefined, HOMEDRIVE: undefined, HOMEPATH: undefined, ATOMIC_CODING_AGENT_DIR: undefined, PI_CODING_AGENT_DIR: undefined }, () => {
       const agentDir = join(home, ".atomic", "agent");
       assert.equal(getIntercomDirPath(), join(agentDir, "intercom"));
       assert.equal(getBrokerSocketPath("darwin"), join(agentDir, "intercom", "broker.sock"));

--- a/test/unit/slash-dispatch-interrupt.ts
+++ b/test/unit/slash-dispatch-interrupt.ts
@@ -376,7 +376,7 @@ describe("/workflow interrupt chat command", () => {
                 true,
             );
             const completions =
-                workflowCmd.options.getArgumentCompletions?.("refresh-added");
+                workflowCmd.options.getArgumentCompletions?.("refresh-add");
             assert.equal(
                 completions?.some(
                     (completion) => completion.label === "refresh-added",
@@ -422,8 +422,8 @@ describe("/workflow interrupt chat command", () => {
             );
             const completions =
                 workflowCmd.options.getArgumentCompletions?.(
-                    "refresh-fallback",
-                );
+					"refresh-fall",
+				);
             assert.equal(
                 completions?.some(
                     (completion) => completion.label === "refresh-fallback",

--- a/test/unit/slash-dispatch-tool-reload-resume.ts
+++ b/test/unit/slash-dispatch-tool-reload-resume.ts
@@ -206,8 +206,8 @@ describe("tool run-control actions", () => {
             assert.ok(workflowCmd, "expected workflow command registration");
             const completions =
                 workflowCmd.options.getArgumentCompletions?.(
-                    "tool-refresh-added",
-                ) ?? [];
+					"tool-refresh-add",
+				) ?? [];
             assert.equal(
                 completions.some(
                     (completion) => completion.label === "tool-refresh-added",

--- a/test/unit/subagents-acceptance.test.ts
+++ b/test/unit/subagents-acceptance.test.ts
@@ -149,7 +149,7 @@ describe("subagent acceptance removal", () => {
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
-	});
+	}, 20_000);
 	test("foreground investigation/debugger runs can complete successfully without edits", async () => {
 		await withFakeCli(`
 			console.log(JSON.stringify({


### PR DESCRIPTION
## Summary

Reduces perceived and actual input latency during interactive TUI startup by moving non-essential work off the first-paint critical path, and lets slash-command autocomplete work before extension implementations finish loading.

## Key changes

- **Footer git watcher deferral** — `FooterDataProvider` no longer resolves git paths or starts filesystem watchers in its constructor. Branch discovery stays lazy (`ensureGitPaths()` on first read), and `startGitWatcher()` is called explicitly once the input handler is ready, so first paint doesn't block on git filesystem work.
- **Startup notices deferred past first frame** — changelog loading, first-run onboarding marker initialization, and `firstRunNoticeVisible` computation move from `init()` into a `prepareStartupNotices()` helper that runs lazily the first time notices are actually shown, instead of unconditionally during startup.
- **Deferred extension/resource loading no longer races a blind timer** — removed the `setTimeout(..., 2000)` fallback that could kick off deferred startup mid-keystroke and freeze live typing. `ensureDeferredStartupComplete()` is now invoked explicitly at the points that actually need it: first prompt submission, model selector/cycle actions, `/scoped-models`, `/model`, session resume, and any slash command submitted while startup is still deferred.
- **Lightweight bundled extension slash-command metadata** — new `BUNDLED_EXTENSION_SLASH_COMMANDS` and `getBundledWorkflowArgumentCompletions` in `slash-commands.ts` expose names, descriptions, and argument completions (including full `/workflow` subcommand and bundled-workflow input completions) for `workflow`, `run`, `chain`, `run-chain`, `parallel`, `subagents-doctor`, `mcp`, `mcp-auth`, `curator`, `google-account`, `search`, `websearch`, and `intercom` without importing their heavy implementations. `createBaseAutocompleteProvider` blends this bundled metadata in while `deferredStartupPending` is true, then swaps to real registered extension commands once loaded.
- **First-submit responsiveness for prompts and slash commands** — `runUserPromptTurn` only awaits deferred startup completion if it's already in flight, and a `text.startsWith("/")` guard now flushes the editor, re-renders, yields, completes deferred startup, and forwards the command via `session.prompt` for extension slash commands with arguments submitted before startup finishes.
- **Windows extension loader fix** — `getTranspileCacheDir()` now creates the versioned Jiti fsCache directory (`fs.mkdirSync(..., { recursive: true })`) before pruning/using it, fixing extension imports on Windows where the directory didn't exist yet.
- **`main-deferred-startup.ts`** — `computeDeferExtensions` no longer excludes runs with an explicit `provider`/`model` from deferral, so those startups can also benefit from deferred loading.
- **Timing probes** — new marks `startup-input-raw-mode-enabled`, `startup-input-first-raw-key`, `interactive-input-handler-ready`, and `interactive-first-submit` for benchmarking; `main.ts`'s benchmark path now calls `interactiveMode.ensureDeferredStartupComplete()` explicitly instead of awaiting the raw `deferredStartupPromise`. `docs/development.md` documents the new probes and `ATOMIC_STARTUP_BENCHMARK`/`ATOMIC_TIMING` behavior.

## Validation

- `bun run test -- test/main-early-input.test.ts test/interactive-mode-startup-input.test.ts test/interactive-deferred-startup-input.test.ts test/interactive-deferred-startup.test.ts test/main-deferred-startup.test.ts test/footer-data-provider.test.ts test/interactive-mode-startup-latency.test.ts test/custom-editor-prompt.test.ts test/extensions-loader-virtual-modules.test.ts`
- `bun test test/unit/intercom-atomic-compat.test.ts test/unit/subagents-acceptance.test.ts`
- `bun run typecheck && bun run lint && bun run check:file-length`
- `bun run test:unit`
- Compiled Windows binary tmux probes for key echo, normal chat submit, `/workflow reload/list/status`, dummy workflow dispatch/completion, print-mode `/workflow`, and `--provider github-copilot --model gpt-5.5`