### PR TITLE
fix(workflows): stop resumed stages once their task is already complete

### DIFF
--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -405,7 +405,7 @@ Named runs go to the background. Common controls:
 /workflow kill <run-id>                # abort and retain for inspection
 ```
 
-When a paused stage is resumed with a message, Atomic lets the stage answer that resume message, then (if the stage has not already finalized) injects `Continue where you left off.` into the same stage session before normal stage completion/readiness handling. This keeps interrupted work moving without asking you to manually type a second continuation prompt.
+When a paused stage is resumed with a message, Atomic lets the stage answer that resume message, then (if the stage has not already finalized) injects `Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop.` into the same stage session before normal stage completion/readiness handling. This keeps interrupted work moving without asking you to manually type a second continuation prompt while also preventing stages that already finished their scoped work from overstepping.
 
 Durable `/workflow resume` preserves completed stage metadata and graph topology. Replayed `ctx.stage`, `ctx.task`, `ctx.chain`, `ctx.parallel`, and child-workflow checkpoints keep their original summaries, timing, session/model metadata, and parallel fanout parentage in status and graph views instead of appearing as freshly flattened replay nodes.
 
@@ -953,7 +953,7 @@ Control behavior:
 - `pause`, `interrupt`, and `kill` can target one top-level run or `all: true`; `stageId` cannot be combined with `all: true`. Stage-scoped controls can target a visible nested child stage from the expanded graph; Atomic routes the operation to the owning nested run internally.
 - `interrupt` is resumable: it pauses live work when pausable stages exist and keeps the run in live history/status.
 - `pause` is useful for pausing a live run or a single live stage without treating it as a destructive abort.
-- `resume` can target a stage with `stageId`; the target may be a stage id, unique prefix, or stage name. `message` is forwarded to paused work. After the stage answers a non-empty resume message, Atomic automatically injects `Continue where you left off.` in that same session before normal readiness-gate completion when the stage has not already finalized, including when the resume-answer turn used `ask_user_question`.
+- `resume` can target a stage with `stageId`; the target may be a stage id, unique prefix, or stage name. `message` is forwarded to paused work. After the stage answers a non-empty resume message, Atomic automatically injects `Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop.` in that same session before normal readiness-gate completion when the stage has not already finalized, including when the resume-answer turn used `ask_user_question`.
 - `kill` aborts in-flight work, marks the run `killed`, and retains it in live history/status for inspection.
 - `reload` refreshes discovered workflow resources in-process; the optional `reason` is echoed in the result.
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Improved workflow extension startup by seeding only the bundled startup registry during extension registration/session start, then loading user, project, and package workflow modules in the background or when `/workflow` commands and workflow tool actions need the full registry.
+- Tightened the workflow-stage resume continuation prompt so resumed agents continue interrupted work only when needed and stop when the original or user-redefined task is already complete.
 
 ### Fixed
 

--- a/packages/workflows/src/runs/foreground/executor-hil.ts
+++ b/packages/workflows/src/runs/foreground/executor-hil.ts
@@ -310,7 +310,8 @@ export function toolResultHasChatAnswer(result: unknown): boolean {
   );
 }
 
-export const RESUME_CONTINUATION_PROMPT = "Continue where you left off.";
+export const RESUME_CONTINUATION_PROMPT =
+  "Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop.";
 
 export function shouldInjectResumeContinuation(state: {
   readonly resumeOccurred: boolean;

--- a/test/unit/resume-continuation-decision.test.ts
+++ b/test/unit/resume-continuation-decision.test.ts
@@ -7,7 +7,10 @@ import {
 
 describe("resume continuation decision", () => {
   test("uses the exact deterministic continuation prompt", () => {
-    assert.equal(RESUME_CONTINUATION_PROMPT, "Continue where you left off.");
+    assert.equal(
+      RESUME_CONTINUATION_PROMPT,
+      "Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop.",
+    );
   });
 
   test("resume + gate enabled + not aborted injects", () => {


### PR DESCRIPTION
## Summary

Tightens the deterministic workflow-stage resume continuation prompt so resumed agents only continue interrupted work when needed, and stop when their original (or user-redefined) task is already complete.

## Changes

- `RESUME_CONTINUATION_PROMPT` (`packages/workflows/src/runs/foreground/executor-hil.ts`) now reads: `"Continue where you left off. If you believe you are finished with your original task (or a redefined task if the user told you), stop."` — previously just `"Continue where you left off."`
- Updated `packages/coding-agent/docs/workflows.md` (two references) to match the new prompt text.
- Updated the exact-prompt assertion in `test/unit/resume-continuation-decision.test.ts`.
- Added an `## [Unreleased] / ### Changed` entry to `packages/workflows/CHANGELOG.md`.

## Validation

- `AGENT=1 bun test test/unit/resume-continuation-decision.test.ts`
- Pre-commit and pre-push hooks passed, including `bun run lint`, `bun run check:file-length`, `bun run test:unit`