### PR TITLE
chore(impeccable): sync bundled skill to 3.9.1 and harden scripts

### DIFF
--- a/packages/coding-agent/docs/quickstart.md
+++ b/packages/coding-agent/docs/quickstart.md
@@ -147,7 +147,7 @@ Skills are reusable expert instructions. Trigger one with `/skill:<name>` follow
 | `create-spec` | Turn research into an implementation-ready plan. | `/skill:create-spec from research/docs/2026-03-rate-limit.md` |
 | `prompt-engineer` | Tighten a vague prompt before a long run. | `/skill:prompt-engineer Draft a sharper repo-research prompt for payment retries end to end.` |
 | `tdd` | Test-first feature or bug work. | `/skill:tdd` |
-| `impeccable` | Critique or refine frontend and product UI. | `/skill:impeccable` |
+| `impeccable` | Critique or refine web/native frontend and product UI; includes detector hooks. | `/skill:impeccable` |
 | `playwright-cli` | Drive a real browser for end-to-end UI checks, screenshots, and reviewable proof videos. | `/skill:playwright-cli` |
 | `effective-liteparse` | Pull text, tables, or values out of PDF, DOCX, PPTX, XLSX, and image files locally. | `/skill:effective-liteparse` |
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Improved workflow extension startup by seeding only the bundled startup registry during extension registration/session start, then loading user, project, and package workflow modules in the background or when `/workflow` commands and workflow tool actions need the full registry.
 - Tightened the workflow-stage resume continuation prompt so resumed agents continue interrupted work only when needed and stop when the original or user-redefined task is already complete.
+- Updated the bundled `impeccable` skill from upstream 3.8.0 to 3.9.1, adding native platform guidance, hooks support, expanded detector rules, and the latest reference/script fixes ([#1696](https://github.com/bastani-inc/atomic/issues/1696)).
 
 ### Fixed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Hardened the bundled `impeccable` skill's local detector/live scripts against CodeQL-reported sanitization and command-injection patterns by tightening HTML block stripping, avoiding shell interpolation for `git check-ignore`, escaping Svelte preview CSS selectors correctly, and fixing the `ms*` JSX style prefix conversion.
 - Fixed lazy workflow startup follow-through so `session_start` loads only workflow config before restore/cleanup, discovery diagnostics are reported after deferred discovery settles, failed lazy discovery attempts are retryable, direct workflow-tool `task`/`tasks`/`chain` runs bypass full workflow discovery, named workflow-tool runs and failed-run resume re-resolve their runtime after discovery, paused/current live-run resume and live resume pickers avoid registry discovery, failed/durable resume still loads resources before registry-dependent lookups, and command autocomplete falls back to current/admin completions when lazy discovery fails without evaluating workflow modules on the startup path.
 - Fixed workflow lazy-startup session generation so session restarts and shutdowns invalidate in-flight background discovery before it can publish stale workflow registries into later sessions.
 

--- a/packages/workflows/skills/impeccable/SKILL.md
+++ b/packages/workflows/skills/impeccable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: impeccable
 description: Use when the user wants to design, redesign, shape, critique, audit, polish, clarify, distill, harden, optimize, adapt, animate, colorize, extract, or otherwise improve a frontend interface. Covers websites, landing pages, dashboards, product UI, app shells, components, forms, settings, onboarding, and empty states. Handles UX review, visual hierarchy, information architecture, cognitive load, accessibility, performance, responsive behavior, theming, anti-patterns, typography, fonts, spacing, layout, alignment, color, motion, micro-interactions, UX copy, error states, edge cases, i18n, and reusable design systems or tokens. Also use for bland designs that need to become bolder or more delightful, loud designs that should become quieter, live browser iteration on UI elements, or ambitious visual effects that should feel technically extraordinary. Not for backend-only or non-UI tasks.
-version: 3.8.0
+version: 3.9.1
 ---
 
 Designs and iterates production-grade frontend interfaces. Real working code, committed design choices, exceptional craft.
@@ -10,10 +10,12 @@ Designs and iterates production-grade frontend interfaces. Real working code, co
 
 You MUST do these steps before proceeding:
 
-1. If the user invoked a sub-command (`craft`, `shape`, `audit`, `polish`, ...), you MUST read `reference/<command>.md` next. Non-optional. The reference defines the command's flow; without it you will skip steps the user expects.
-2. Familiarize yourself with any existing design system, conventions, and components in the code. Read at least one project file (CSS / tokens / theme / a representative component or page). **Required even when you've loaded a sub-command reference in step 2.** Don't reinvent the wheel; use what's there when it works, branch out when the UX wins.
-3. Read the matching register reference. **This is non-optional; skipping it produces generic output.** If the project is marketing, a landing page, a campaign, long-form content, or a portfolio (design IS the product), read `reference/brand.md`. If it is app UI, admin, a dashboard, or a tool (design SERVES the product), read `reference/product.md`. Pick by first match: (1) task cue ("landing page" vs "dashboard"); (2) surface in focus (the page, file, or route being worked on); (3) `register` field in PRODUCT.md.
-4. **If the project is brand-new (no existing CSS tokens / theme / committed brand colors found in step 3)**, run `node .agents/skills/impeccable/scripts/palette.mjs` to receive a brand seed color and composition guidance. This is the anchor for your primary brand color. Compose the rest of the palette (bg, surface, ink, accent, muted) around it per the script's instructions. Use OKLCH throughout. **Skip this step only if step 3 found committed brand colors in existing tokens; in that case identity-preservation wins.**
+1. Run `node .agents/skills/impeccable/scripts/context.mjs` once per session; if the runtime shows this skill's loaded base directory, run `node <skill-base-dir>/scripts/context.mjs` instead. Keep cwd/workdir at the user's project, not the skill directory. If the request names or implies a file, route, or app inside a monorepo, infer the concrete path and append `--target <path>` to the same command. If you've already seen its output in this conversation, do not re-run it. The script either prints the project's PRODUCT.md (and DESIGN.md when present) as a markdown block, or tells you it's missing. Follow whatever it prints. **If it reports `NO_PRODUCT_MD`:** divert into `reference/init.md` first when the user invoked `init`, `teach`, `craft`, or `shape`, or when their wording clearly maps to one of those from-scratch build flows (for example: "build/create/make a landing page", "design a new app", or "shape a feature"). Captured product context is the point of those flows. For any other command, a scoped evaluate / refine / enhance / fix / iterate request against existing code, do **not** divert into init. The existing code is the context: proceed with the requested command, infer the register from the surface in focus (step 4), and offer `$impeccable init` once as a suggestion the user can take later. A missing PRODUCT.md must never block a scoped request. If the output ends with an `UPDATE_AVAILABLE` directive, follow it (ask the user once about updating, then continue). It never blocks the current task.
+2. If the user invoked a sub-command (`craft`, `shape`, `audit`, `polish`, ...), you MUST read the command's reference next: **`reference/<command>.md`, or the native variant from the Commands table** (e.g. `reference/audit.native.md`) **when the project platform is native** (`ios` / `android` / `adaptive`, per the `context.mjs` directive). One file, not both. Non-optional. The reference defines the command's flow; without it you will skip steps the user expects.
+3. Familiarize yourself with any existing design system, conventions, and components in the code. Read at least one project file (CSS / tokens / theme / a representative component or page). **Required even when you've loaded a sub-command reference in step 2.** Don't reinvent the wheel; use what's there when it works, branch out when the UX wins.
+4. Read the matching register reference. **This is non-optional; skipping it produces generic output.** If the project is marketing, a landing page, a campaign, long-form content, or a portfolio (design IS the product), read `reference/brand.md`. If it is app UI, admin, a dashboard, or a tool (design SERVES the product), read `reference/product.md`. Pick by first match: (1) task cue ("landing page" vs "dashboard"); (2) surface in focus (the page, file, or route being worked on); (3) `register` field in PRODUCT.md.
+5. **If PRODUCT.md's `## Platform` is `ios` or `android`**, also read `reference/<platform>.md` (HIG / Material 3 conventions). `adaptive` (cross-platform, ships both) reads both files. `web`, absent, or unrecognized: nothing extra to read. `context.mjs` prints the directive when one applies.
+6. **If the project is brand-new (no existing CSS tokens / theme / committed brand colors found in step 3)**, run `node .agents/skills/impeccable/scripts/palette.mjs` to receive a brand seed color and composition guidance. This is the anchor for your primary brand color. Compose the rest of the palette (bg, surface, ink, accent, muted) around it per the script's instructions. Use OKLCH throughout. **Skip this step only if step 3 found committed brand colors in existing tokens; in that case identity-preservation wins.**
 
 ## Design guidance
 
@@ -92,6 +94,7 @@ Match-and-refuse. If you're about to write any of these, rewrite the element wit
 - **`border-radius: 32px+` on cards / sections / inputs.** You over-round. Cards top out at 12–16px; full-pill is fine for tags/buttons. Picking 24/28/32/40px on a card is the codex tell; no brand wants "insanely rounded".
 - **Hand-drawn / sketchy SVG illustrations.** Class names like `loose-sketch`, `*-sketch`, `doodle`, `wavy`; `feTurbulence` / `feDisplacementMap` "paper grain" filters; 5-to-30 path crude scenes meant to depict a tangible subject (an otter, a table-and-fork, an album cover). All of these read as amateurish, not whimsical. If you can't render the scene with real assets, ship no illustration. Don't attempt sketchy SVG as a fallback.
 - **`repeating-linear-gradient(...)` stripe backgrounds.** Diagonal stripes in `body:before` or section backgrounds are pure codex decoration. Don't.
+- **Decorative grid backgrounds.** Two-axis CSS grid overlays built from `linear-gradient(... 1px, transparent 1px)` plus `background-size` are a Codex tell unless the surface is an actual canvas, map, blueprint, or measurement tool. Use product structure, real artifacts, or a plain surface instead.
 - **Meta-criticism copy.** Naming a concept then layering an ironic modifier, or staging a strawman to "correct" it. Make the specific claim instead.
 
 ### The AI slop test
@@ -113,7 +116,7 @@ If someone could look at this interface and say "AI made that" without doubt, it
 | `document` | Build | Generate DESIGN.md from existing project code | [reference/document.md](reference/document.md) |
 | `extract [target]` | Build | Pull reusable tokens and components into design system | [reference/extract.md](reference/extract.md) |
 | `critique [target]` | Evaluate | UX design review with heuristic scoring | [reference/critique.md](reference/critique.md) |
-| `audit [target]` | Evaluate | Technical quality checks (a11y, perf, responsive) | [reference/audit.md](reference/audit.md) |
+| `audit [target]` | Evaluate | Technical quality checks (a11y, perf, responsive) | [reference/audit.md](reference/audit.md) · native: [reference/audit.native.md](reference/audit.native.md) |
 | `polish [target]` | Refine | Final quality pass before shipping | [reference/polish.md](reference/polish.md) |
 | `bolder [target]` | Refine | Amplify safe or bland designs | [reference/bolder.md](reference/bolder.md) |
 | `quieter [target]` | Refine | Tone down aggressive or overstimulating designs | [reference/quieter.md](reference/quieter.md) |
@@ -127,7 +130,7 @@ If someone could look at this interface and say "AI made that" without doubt, it
 | `delight [target]` | Enhance | Add personality and memorable touches | [reference/delight.md](reference/delight.md) |
 | `overdrive [target]` | Enhance | Push past conventional limits | [reference/overdrive.md](reference/overdrive.md) |
 | `clarify [target]` | Fix | Improve UX copy, labels, and error messages | [reference/clarify.md](reference/clarify.md) |
-| `adapt [target]` | Fix | Adapt for different devices and screen sizes | [reference/adapt.md](reference/adapt.md) |
+| `adapt [target]` | Fix | Adapt for different devices and screen sizes | [reference/adapt.md](reference/adapt.md) · native: [reference/adapt.native.md](reference/adapt.native.md) |
 | `optimize [target]` | Fix | Diagnose and fix UI performance | [reference/optimize.md](reference/optimize.md) |
 | `live` | Iterate | Visual variant mode: pick elements in the browser, generate alternatives | [reference/live.md](reference/live.md) |
 
@@ -135,26 +138,26 @@ Plus three management commands: `pin <command>`, `unpin <command>`, and `hooks <
 
 ### Routing rules
 
-1. **No argument**: the user is asking "what should I do?" Make the menu context-aware instead of static. Setup has already run `context.mjs`; if that reported `NO_PRODUCT_MD` you are already in init (setup), so finish that and skip this. Otherwise run `node .agents/skills/impeccable/scripts/context-signals.mjs` once and read its JSON, then lead with the **2-3 highest-value next commands**, each with a one-line reason pulled from the signals, followed by the full menu (the table above, grouped by category). **Never auto-run a command; the recommendation is a suggestion the user confirms.**
+1. **No argument**: the user is asking "what should I do?" Make the menu context-aware instead of static. Setup has already run `context.mjs`; if that reported `NO_PRODUCT_MD` the project has no captured context yet, so lead the menu with `$impeccable init` as the top recommendation (one line on why) and still show the rest below; don't silently jump into init. Otherwise run `node .agents/skills/impeccable/scripts/context-signals.mjs` once and read its JSON, then lead with the **2-3 highest-value next commands**, each with a one-line reason pulled from the signals, followed by the full menu (the table above, grouped by category). **Never auto-run a command; the recommendation is a suggestion the user confirms.**
 
    Reason over the signals; there is no score to obey:
    - `setup.hasDesign` false while `setup.hasCode` true → `document` (capture the visual system).
    - `critique.latest` is `null` → the project has never been critiqued; for a set-up project with a real surface, offering `$impeccable critique <surface>` is a strong default.
    - `critique.latest` with a low `score` or non-zero `p0` / `p1` → `polish` (it reads that snapshot as its backlog), or re-run `critique` if the snapshot looks stale.
    - `git.changedFiles` pointing at one surface → scope `audit` or `polish` to those files specifically, naming them.
-   - `devServer.running` true → `live` is available for in-browser iteration; if false, don't lead with `live`.
+   - `devServer.running` true → `live` is available for in-browser iteration; if false, don't lead with `live`. **`live` and the bundled `detect.mjs` are web-only.** If `setup.platform` is `ios`, `android`, or `adaptive`, don't lead with either; the browser overlay and the HTML rule engine don't apply to native app code.
    - Otherwise group by intent exactly as init's "Recommend starting points" step does (build new / improve what's there / iterate visually), tailored to `setup.register`.
 
-   **If `scan.targets` is non-empty, run `node .agents/skills/impeccable/scripts/detect.mjs --json <scan.targets joined by spaces>` once** (the bundled detector over local files: no network, no npx). `scan.via` tells you what they are: `git-changes` (the markup/style files in your dirty tree, the most relevant set), `source-dir` (e.g. `src`, `app`), `html`, or `root`. Fold the hits into your picks: many quality / contrast hits → `audit` or `polish`; a specific slop family → the matching command (gradient text or eyebrows → `quieter` / `typeset`, flat or gray palette → `colorize`, and so on). It's a real, current signal that beats guessing. If detect errors or the tree is large and slow, skip it and recommend the user run `audit` themselves; never block the suggestion on it.
+   **If `scan.targets` is non-empty and `setup.platform` is not `ios`/`android`/`adaptive`, run `node .agents/skills/impeccable/scripts/detect.mjs --json <scan.targets joined by spaces>` once** (the bundled detector over local files: no network, no npx; it reads HTML/CSS, so skip it for native projects). `scan.via` tells you what they are: `git-changes` (the markup/style files in your dirty tree, the most relevant set), `source-dir` (e.g. `src`, `app`), `html`, or `root`. Fold the hits into your picks: many quality / contrast hits → `audit` or `polish`; a specific slop family → the matching command (gradient text or eyebrows → `quieter` / `typeset`, flat or gray palette → `colorize`, and so on). It's a real, current signal that beats guessing. If detect errors or the tree is large and slow, skip it and recommend the user run `audit` themselves; never block the suggestion on it.
 
    Keep it to 2-3 pointed picks with the exact command to type. The menu stays the fallback; the recommendation is the lede.
-2. **First word matches a command** (table above OR `pin` / `unpin` / `hooks`): load its reference file and follow its instructions. Everything after the command name is the target.
-3. **First word doesn't match, but the intent clearly maps to one command** (e.g. "fix the spacing" → `layout`, "rewrite this error message" → `clarify`, "the colors feel flat" → `colorize`): load that command's reference and proceed as if invoked. If two commands could fit, ask once which.
+2. **First word matches a command** (table above OR `pin` / `unpin` / `hooks`): load its reference file (on native platforms, the table's native variant; Setup step 2's one-file rule) and follow its instructions. Everything after the command name is the target.
+3. **First word doesn't match, but the intent clearly maps to one command** (e.g. "fix the spacing" → `layout`, "rewrite this error message" → `clarify`, "the colors feel flat" → `colorize`): load that command's reference (same native-variant rule) and proceed as if invoked. If two commands could fit, ask once which.
 4. **No clear command match**: general design invocation. Apply the setup steps, the General rules, and the loaded register reference, using the full argument as context.
 
 Setup (context gathering, register) is already loaded by then; sub-commands don't re-invoke `$impeccable`.
 
-If the first word is `craft`, setup still runs first, but [reference/craft.md](reference/craft.md) owns the rest of the flow. If setup invokes `init` as a blocker, finish init, refresh context, then resume the original command and target.
+If the first word is `craft` or `shape`, or routing rule 3 clearly maps the user's intent to either command, setup still runs first, but the matching reference ([reference/craft.md](reference/craft.md) or [reference/shape.md](reference/shape.md)) owns the rest of the flow. Both are from-scratch build flows: if setup invokes `init` as a blocker, finish init, refresh context, then resume the original command and target.
 
 `teach` is a deprecated alias for `init`: if the user types it, load [reference/init.md](reference/init.md) and proceed as if they ran `init`.
 

--- a/packages/workflows/skills/impeccable/reference/adapt.md
+++ b/packages/workflows/skills/impeccable/reference/adapt.md
@@ -2,6 +2,7 @@
 
 Adapt an existing design to a different context: another screen size, device, platform, or use case. The trap is treating adaptation as scaling. The job is rethinking the experience for the new context.
 
+**Web only** (mobile web included). Native platforms (`ios` / `android` / `adaptive`) route to [adapt.native.md](adapt.native.md) instead; if the project is native, switch to it now.
 
 ---
 

--- a/packages/workflows/skills/impeccable/reference/adapt.native.md
+++ b/packages/workflows/skills/impeccable/reference/adapt.native.md
@@ -1,0 +1,58 @@
+> **Additional context needed**: target platforms/devices and usage contexts.
+
+Adapt an existing **native** design (`ios` / `android` / `adaptive`) to a different context: another device class, orientation, platform, or origin. The trap is treating adaptation as scaling. The job is rethinking the experience for the new context, inside the platform conventions of [ios.md](ios.md) / [android.md](android.md); read the target platform's reference before planning if Setup hasn't already.
+
+## Assess Adaptation Challenge
+
+1. **Source context**: what was it designed for, and what assumptions did it make? (Phone-only? Portrait-only? One platform's idioms? A website?)
+2. **Target context**: which device class (phone, tablet, foldable), orientation, platform, and usage posture (one-handed on the go vs two-handed at rest)?
+3. **What breaks**: navigation that doesn't fit the target, layouts that stretch instead of restructure, gestures or controls that don't exist there?
+
+## Adaptation Strategies
+
+### Phone → Tablet (iPad / large screens)
+
+- **Restructure, don't stretch.** A scaled-up phone UI on a tablet is the failure mode. Use size classes (iOS) / window size classes (Android) to switch structure.
+- **Navigation changes shape**: tab bar stays or becomes a sidebar on iPad; Android navigation bar becomes a rail or drawer on expanded width.
+- **Use the width**: split view / master-detail (list + detail side by side), multi-column grids, popovers where phones used sheets.
+- **Multitasking is a size, not an edge case**: iPad Split View and Android multi-window can hand you a phone-width window on a tablet; size-class-driven layout handles both for free.
+
+### Orientation & foldables
+
+- Landscape restructures (side-by-side panes, repositioned controls); never clip or letterbox. Lock orientation only when the task truly demands it.
+- Foldables (Android): react to posture and hinge via window size classes; test folded, unfolded, and tabletop.
+
+### Platform → platform (iOS ↔ Android)
+
+Translate idioms; never transplant them:
+
+| iOS | Android |
+|---|---|
+| Tab bar | Navigation bar / rail / drawer |
+| Edge-swipe back, back chevron | Predictive Back gesture / button |
+| Switch, segmented control, system pickers | Material switch, chips, Material pickers |
+| Action sheet | Bottom sheet / Material dialog |
+| SF Symbols, SF Pro, Dynamic Type | Material Symbols, Roboto, sp scaling |
+| Semantic system colors, materials | Material color roles, tonal elevation |
+| System push/sheet transitions | Container transform, shared-axis, fade-through |
+
+Rebuild navigation and controls in the target's vocabulary; carry over the brand's expressive layer (palette intent, type accent, motion personality) through the target's theming system.
+
+### Web → native (porting a website or web app)
+
+Reconform, don't reflow. Replace web navigation with the platform's model, HTML-shaped controls with platform controls, hover affordances with touch-first ones, and px-based type with Dynamic Type / sp. Then treat the result to the full platform reference; the slop test there is the acceptance bar.
+
+## Implement & Verify
+
+- Drive structure from **size classes / window size classes**, never from device-model checks.
+- Respect safe areas and window insets in every new configuration (notch, hinge, status bar, keyboard).
+- Test on simulators for breadth, then real hardware for truth: at least one phone and one tablet per shipped platform, both orientations, split-screen where supported.
+
+When the adaptation feels native to each context, hand off to `$impeccable polish` for the final pass.
+
+**NEVER**:
+- Ship a stretched phone layout on a tablet
+- Port one platform's controls or navigation onto the other
+- Hide core functionality on smaller devices (if it matters, make it work)
+- Lock orientation to dodge a layout bug
+- Trust simulators alone (posture, gestures, and performance need hardware)

--- a/packages/workflows/skills/impeccable/reference/android.md
+++ b/packages/workflows/skills/impeccable/reference/android.md
@@ -1,0 +1,40 @@
+# Android platform
+
+For native Android apps: Jetpack Compose, Android Views, React Native, Expo, Flutter shipping to Android hardware.
+
+On native, register narrows. Material Design 3 governs structure, navigation, and interaction whatever the register; brand expresses through Material's theming (color roles, type scale, shape, motion). A Material-everywhere cross-platform app that also ships to iPhone still owes iOS its OS guarantees on that hardware: safe-area insets, Reduce Motion, edge-swipe back.
+
+## The Android slop test
+
+Would a fluent Android user trust this app, or trip on off-spec components? The most common tell is an iOS app wearing Android's skin: a bottom-only navigation copied from iPhone, a back arrow that ignores the system Back gesture, Cupertino-shaped switches and dialogs. Material 3 is the rulebook; follow its components and theme the brand through it.
+
+## Layout & structure
+
+- **Material navigation, matched to size.** Navigation bar (bottom, 3–5 destinations) on compact width; navigation rail or drawer on expanded width. Never ship a phone bottom-bar untouched on a tablet.
+- **System Back always works.** Honor the predictive Back gesture and Back button; never trap the user or hijack the gesture.
+- **Edge-to-edge with window insets.** Apply the status bar, navigation bar, display cutout, and IME insets so content never hides behind system bars or the keyboard.
+- **Top app bar for screen context**; pair with a FAB when the screen has a single primary action.
+
+## Touch targets
+
+- **48×48 dp minimum** for every touch target, with at least 8 dp between them.
+
+## Typography
+
+- **Material type scale.** Display, Headline, Title, Body, Label roles (large/medium/small each). Map text to roles; never hand-pick sizes per screen.
+- **Roboto is the system face**; theme a brand face in through the type scale, keeping body, labels, and controls legible and consistent.
+- **sp units, never fixed px**, so type follows the system font-size setting.
+
+## Color & theming
+
+- **Material color roles** (primary, on-primary, surface, surface-variant, secondary-container, outline, error). Role tokens resolve light/dark and contrast variants automatically; raw hex breaks there.
+- **Dynamic Color (Material You)** where it fits: derive the scheme from the user's wallpaper on Android 12+, with a static fallback.
+- **Dark theme is a first-class scheme.** Design and test it; never a quick invert.
+- **Tonal elevation.** Convey elevation through the standard surface tonal levels (plus shadow where appropriate); no arbitrary drop shadows.
+
+## Components & motion
+
+- **Material components.** Buttons (filled / tonal / outlined / text), FAB, switches, chips, snackbars, bottom sheets, Material dialogs, navigation bar/rail/drawer. Never port iOS controls or invent equivalents.
+- **One FAB, one primary action.** Never stack FABs or spend one on a secondary task.
+- **Snackbars for transient feedback** (actionable when useful, never a toast for that); dialogs only for decisions that must interrupt.
+- **Material motion patterns.** Container transform, shared-axis, fade-through, with standard easing and durations; honor the system Remove animations setting with a crossfade or instant cut.

--- a/packages/workflows/skills/impeccable/reference/animate.md
+++ b/packages/workflows/skills/impeccable/reference/animate.md
@@ -10,6 +10,8 @@ Brand: motion is part of the voice; one well-rehearsed entrance beats scattered 
 
 Product: 150–250 ms on most transitions. Motion conveys state: feedback, reveal, loading, transitions between views. No page-load choreography; users are in a task and won't wait for it.
 
+Native (`ios` / `android` / `adaptive`): implementation follows the Motion section of [ios.md](ios.md) / [android.md](android.md) (read it first if Setup hasn't already): system transitions and OS Reduce Motion, never the web tooling below.
+
 ---
 
 ## Assess Animation Opportunities

--- a/packages/workflows/skills/impeccable/reference/audit.md
+++ b/packages/workflows/skills/impeccable/reference/audit.md
@@ -2,6 +2,8 @@ Run systematic **technical** quality checks and generate a comprehensive report.
 
 This is a code-level audit, not a design critique. Check what's measurable and verifiable in the implementation.
 
+**Web only.** Native platforms (`ios` / `android` / `adaptive`) route to [audit.native.md](audit.native.md) instead; if the project is native, switch to it now.
+
 ## Diagnostic Scan
 
 Run comprehensive checks across 5 dimensions. Score each dimension 0-4 using the criteria below.

--- a/packages/workflows/skills/impeccable/reference/audit.native.md
+++ b/packages/workflows/skills/impeccable/reference/audit.native.md
@@ -1,0 +1,139 @@
+Run systematic **technical** quality checks on a native app (`ios` / `android` / `adaptive`) and generate a comprehensive report. Don't fix issues; document them for other commands to address.
+
+This is a code-level audit, not a design critique. Audit from source (SwiftUI / UIKit / Compose / React Native / Flutter); no browser tooling or `detect.mjs` applies. Score against the platform reference(s): [ios.md](ios.md) / [android.md](android.md), both for `adaptive`. Read them before scoring if Setup hasn't already. The report skeleton mirrors [audit.md](audit.md); keep the two in sync when changing it.
+
+## Diagnostic Scan
+
+Run comprehensive checks across 5 dimensions. Score each dimension 0-4 using the criteria below.
+
+### 1. Accessibility (VoiceOver / TalkBack)
+
+**Check for**:
+- **Missing labels**: interactive elements without accessibility labels, traits/roles, or state announcements
+- **Reading and focus order**: illogical traversal, unreachable controls, focus lost on navigation
+- **Text scaling**: fixed point sizes defeating Dynamic Type (iOS) or px instead of sp (Android); layouts that clip or overlap at large sizes
+- **Touch targets**: below 44 pt (iOS) / 48 dp (Android), or crammed without spacing
+- **Reduce Motion ignored**: parallax and large slides with no crossfade alternative
+- **Contrast**: text failing contrast in either appearance, light or dark
+
+**Score 0-4**: 0=Screen reader unusable, 1=Major gaps (unlabeled controls, no scaling), 2=Partial (labels exist, order or scaling breaks), 3=Good (minor gaps), 4=Excellent (labeled, ordered, scales cleanly, Reduce Motion honored)
+
+### 2. Performance
+
+**Check for**:
+- **Slow startup**: heavy work on launch before first frame
+- **Unvirtualized lists**: long content without FlatList / LazyColumn / List recycling
+- **Main-thread jank**: synchronous work in scroll or gesture paths, dropped frames on 60/120 Hz
+- **Wasted rendering**: unnecessary re-renders (React Native) or recompositions (Compose); missing memoization/keys
+- **Image handling**: full-size images decoded for thumbnails, no caching
+- **App weight**: bloated JS bundle or binary, unused dependencies
+
+**Score 0-4**: 0=Janky everywhere, 1=Major problems (unvirtualized lists, slow launch), 2=Partial, 3=Good (minor improvements possible), 4=Excellent (fast launch, smooth scroll, lean)
+
+### 3. Appearance & Theming
+
+**Check for**:
+- **Hard-coded colors**: raw hex instead of semantic system colors (iOS) / Material color roles (Android) / design tokens
+- **Broken dark appearance**: missing dark variants, poor contrast in dark, quick inverts
+- **Dynamic Color** (Android 12+): no static fallback scheme, or ignored where it fits
+- **Off-platform materials**: hand-rolled blur/glassmorphism instead of system materials or tonal elevation
+
+**Score 0-4**: 0=Hard-coded everything, 1=Minimal tokens, 2=Partial (tokens exist, inconsistently used), 3=Good (minor hard-coded values), 4=Excellent (semantic throughout, both appearances first-class)
+
+### 4. Platform Conformance (CRITICAL)
+
+Score against the loaded platform reference(s), including their slop tests. **Check for**:
+- **Broken system gestures**: edge-swipe back disabled (iOS), predictive Back hijacked (Android)
+- **Inset violations**: content under the notch, Dynamic Island, home indicator, status bar, or keyboard
+- **Off-platform navigation**: custom global nav, overloaded tab bars, iOS patterns on Android or vice versa
+- **Web-shaped controls**: HTML-style buttons, custom toggles, hover-dependent affordances
+- **Icon drift**: mixed icon sets instead of SF Symbols / Material Symbols
+- **AI tells**: the shared absolute bans still apply (AI palette, gradient text, hero metrics)
+
+**Score 0-4**: 0=Web port (nothing native), 1=Heavy violations (3-4 kinds), 2=Some (1-2 noticeable), 3=Mostly conformant (subtle issues), 4=Fully native (a fluent user trusts every screen)
+
+### 5. Adaptivity
+
+**Check for**:
+- **Stretched phone layouts**: tablet/iPad rendering a scaled-up phone UI instead of using size classes / window size classes
+- **Orientation breakage**: landscape clipping, ignored, or locked without reason
+- **Keyboard/IME handling**: inputs hidden behind the keyboard, no inset adjustment
+- **Multitasking**: iPad Split View / Android multi-window breaking layout
+- **Foldables**: hinge-unaware layouts on posture change (Android)
+
+**Score 0-4**: 0=One screen size only, 1=Major breakage (landscape or tablet broken), 2=Partial, 3=Good (minor edge cases), 4=Excellent (adapts across sizes, orientations, and windowing)
+
+## Generate Report
+
+### Audit Health Score
+
+| # | Dimension | Score | Key Finding |
+|---|-----------|-------|-------------|
+| 1 | Accessibility | ? | [most critical issue or "--"] |
+| 2 | Performance | ? | |
+| 3 | Appearance & Theming | ? | |
+| 4 | Platform Conformance | ? | |
+| 5 | Adaptivity | ? | |
+| **Total** | | **??/20** | **[Rating band]** |
+
+**Rating bands**: 18-20 Excellent (minor polish), 14-17 Good (address weak dimensions), 10-13 Acceptable (significant work needed), 6-9 Poor (major overhaul), 0-5 Critical (fundamental issues)
+
+### Platform Conformance Verdict
+**Start here.** Pass/fail: does this read as a native app or a ported website? List specific violations. Be brutally honest.
+
+### Executive Summary
+- Audit Health Score: **??/20** ([rating band])
+- Total issues found (count by severity: P0/P1/P2/P3)
+- Top 3-5 critical issues
+- Recommended next steps
+
+### Detailed Findings by Severity
+
+Tag every issue with **P0-P3 severity**:
+- **P0 Blocking**: Prevents task completion. Fix immediately
+- **P1 Major**: Significant difficulty or platform-guideline violation. Fix before release
+- **P2 Minor**: Annoyance, workaround exists. Fix in next pass
+- **P3 Polish**: Nice-to-fix, no real user impact. Fix if time permits
+
+For each issue, document:
+- **[P?] Issue name**
+- **Location**: Screen, file, line
+- **Category**: Accessibility / Performance / Theming / Conformance / Adaptivity
+- **Impact**: How it affects users
+- **Guideline**: The HIG / Material rule it violates (if applicable)
+- **Recommendation**: How to fix it
+- **Suggested command**: Which command to use (prefer: $impeccable adapt, $impeccable animate, $impeccable audit, $impeccable bolder, $impeccable clarify, $impeccable colorize, $impeccable critique, $impeccable delight, $impeccable distill, $impeccable document, $impeccable harden, $impeccable layout, $impeccable onboard, $impeccable optimize, $impeccable overdrive, $impeccable polish, $impeccable quieter, $impeccable shape, $impeccable typeset)
+
+### Patterns & Systemic Issues
+
+Identify recurring problems that indicate systemic gaps rather than one-off mistakes:
+- "Hard-coded colors appear in 15+ screens, should use semantic colors"
+- "Touch targets consistently below 44 pt throughout the tab bar and list rows"
+
+### Positive Findings
+
+Note what's working well: good practices to maintain and replicate.
+
+## Recommended Actions
+
+List recommended commands in priority order (P0 first, then P1, then P2):
+
+1. **[P?] `$command-name`**: Brief description (specific context from audit findings)
+2. **[P?] `$command-name`**: Brief description (specific context)
+
+**Rules**: Only recommend commands from: $impeccable adapt, $impeccable animate, $impeccable audit, $impeccable bolder, $impeccable clarify, $impeccable colorize, $impeccable critique, $impeccable delight, $impeccable distill, $impeccable document, $impeccable harden, $impeccable layout, $impeccable onboard, $impeccable optimize, $impeccable overdrive, $impeccable polish, $impeccable quieter, $impeccable shape, $impeccable typeset. Map findings to the most appropriate command. End with `$impeccable polish` as the final step if any fixes were recommended.
+
+After presenting the summary, tell the user:
+
+> You can ask me to run these one at a time, all at once, or in any order you prefer.
+>
+> Re-run `$impeccable audit` after fixes to see your score improve.
+
+**IMPORTANT**: Be thorough but actionable. Too many P3 issues creates noise. Focus on what actually matters.
+
+**NEVER**:
+- Report issues without explaining impact (why does this matter?)
+- Provide generic recommendations (be specific and actionable)
+- Skip positive findings (celebrate what works)
+- Forget to prioritize (everything can't be P0)
+- Report false positives without verification

--- a/packages/workflows/skills/impeccable/reference/bolder.md
+++ b/packages/workflows/skills/impeccable/reference/bolder.md
@@ -1,12 +1,12 @@
-When asked for "bolder," AI defaults to the same tired tricks: cyan/purple gradients, glassmorphism, neon accents on dark backgrounds, gradient text on metrics. These are the opposite of bold. Reject them first, then increase visual impact and personality through stronger hierarchy, committed scale, and decisive type.
+When asked for "bolder," AI defaults to the same tired tricks: cyan/purple gradients, glassmorphism, neon accents on dark backgrounds, gradient text on metrics. These are the opposite of bold. Reject them first, then increase visual impact by making the existing design language more decisive, specific, and committed.
 
 ---
 
 ## Register
 
-Brand: "bolder" means distinctive. Extreme scale, unexpected color, typographic risk, committed POV.
+Brand: "bolder" means distinctive. Express a stronger point of view through hierarchy, pacing, proportion, copy, evidence, and one committed visual idea.
 
-Product: "bolder" rarely means theatrics; those undermine trust. It means stronger hierarchy, clearer weight contrast, one sharper accent, more committed density. The amplification is in clarity, not drama.
+Product: "bolder" rarely means theatrics; those undermine trust. It means stronger hierarchy, clearer weight contrast, sharper information density, and more decisive prioritization. The amplification is in clarity, not drama.
 
 ---
 
@@ -15,98 +15,105 @@ Product: "bolder" rarely means theatrics; those undermine trust. It means strong
 Analyze what makes the design feel too safe or boring:
 
 1. **Identify weakness sources**:
-   - **Generic choices**: System fonts, basic colors, standard layouts
-   - **Timid scale**: Everything is medium-sized with no drama
-   - **Low contrast**: Everything has similar visual weight
-   - **Static**: No motion, no energy, no life
-   - **Predictable**: Standard patterns with no surprises
-   - **Flat hierarchy**: Nothing stands out or commands attention
+   - **Generic choices**: The page could belong to any product in the category.
+   - **Timid scale**: Everything is medium-sized with no clear lead.
+   - **Low contrast**: Important and supporting elements have similar visual weight.
+   - **Static**: The surface has no meaningful moment of emphasis.
+   - **Predictable**: The composition follows a default pattern without a point of view.
+   - **Flat hierarchy**: Nothing stands out or commands attention.
 
 2. **Understand the context**:
-   - What's the brand personality? (How far can we push?)
-   - What's the purpose? (Marketing can be bolder than financial dashboards)
-   - Who's the audience? (What will resonate?)
-   - What are the constraints? (Brand guidelines, accessibility, performance)
+   - What is the brand personality?
+   - What is the purpose of this surface?
+   - Who is the audience?
+   - What design system, tokens, components, and visual conventions already exist?
 
 If any of these are unclear from the codebase, STOP and use Codex's structured user-input/question tool when available; if unavailable, ask directly in chat to clarify what you cannot infer.
 
-**CRITICAL**: "Bolder" doesn't mean chaotic or garish. It means distinctive, memorable, and confident. Think intentional drama, not random chaos.
+**CRITICAL**: "Bolder" does not mean chaotic or garish. It means distinctive, memorable, and confident. Think intentional drama, not random noise.
 
 **WARNING - AI SLOP TRAP**: Review ALL the DON'T guidelines from the parent impeccable skill (already loaded in this context) before proceeding. Bold means distinctive, not "more effects."
+
+## Design-System Lock
+
+If the project has `DESIGN.md`, tokens, theme variables, or established component styles, treat that system as the boundary. Make the existing language stronger before adding new language.
+
+Do not invent new colors, gradients, radii, shadows, fonts, decorative backgrounds, or effects just because the request says "bolder." A bolder pass should usually change emphasis, proportion, rhythm, density, contrast, copy, artifact specificity, and layout relationships while staying inside the documented system.
+
+If the existing system is genuinely too limited to express the bolder direction, stop and ask the user before expanding it. Name the exact additions, the role each would play, and why the current system cannot do the job. If the user approves expansion, update the design system or tokens alongside the implementation.
 
 ## Plan Amplification
 
 Create a strategy to increase impact while maintaining coherence:
 
-- **Focal point**: What should be the hero moment? (Pick ONE, make it amazing)
-- **Personality direction**: Maximalist chaos? Elegant drama? Playful energy? Dark moody? Choose a lane.
-- **Risk budget**: How experimental can we be? Push boundaries within constraints.
-- **Hierarchy amplification**: Make big things BIGGER, small things smaller (increase contrast)
+- **Focal point**: Pick one thing the viewer should remember, then make the rest support it.
+- **System levers**: Identify which existing tokens, components, layout patterns, and copy structures can carry more weight.
+- **Risk budget**: Decide how far the surface can push while still feeling like the same product or brand.
+- **Hierarchy amplification**: Increase contrast between primary, secondary, and tertiary content instead of making every element louder.
 
 **IMPORTANT**: Bold design must still be usable. Impact without function is just decoration.
 
 ## Amplify the Design
 
-Systematically increase impact across these dimensions:
+Systematically increase impact through intention, not a menu of effects:
 
 ### Typography Amplification
-- **Replace generic fonts**: Swap system fonts for distinctive choices (see the parent skill's typography guidelines and the [Reference Material section of typeset.md](typeset.md#reference-material) for inspiration)
-- **Extreme scale**: Create dramatic size jumps (3x-5x differences, not 1.5x)
-- **Weight contrast**: Pair 900 weights with 200 weights, not 600 with 400
-- **Unexpected choices**: Variable fonts, display fonts for headlines, condensed/extended widths, monospace as intentional accent (not as lazy "dev tool" default)
+- Strengthen the existing type hierarchy before changing typefaces.
+- Make important text meaningfully more dominant, and make supporting text quieter.
+- Use weight, measure, spacing, and line breaks to sharpen the point of view.
+- Add or replace fonts only after user-approved design-system expansion.
 
-### Color Intensification
-- **Increase saturation**: Shift to more vibrant, energetic colors (but not neon)
-- **Bold palette**: Introduce unexpected color combinations. Avoid the purple-blue gradient AI slop
-- **Dominant color strategy**: Let one bold color own 60% of the design
-- **Sharp accents**: High-contrast accent colors that pop
-- **Tinted neutrals**: Replace pure grays with tinted grays that harmonize with your palette
-- **Rich gradients**: Intentional multi-stop gradients (not generic purple-to-blue)
+### Color Amplification
+- Use the existing palette more decisively before adding colors.
+- Shift the proportion, placement, and contrast of documented colors to clarify meaning.
+- Treat any new color, gradient, or tint ramp as a design-system expansion that requires user approval.
+- Keep color tied to hierarchy, state, or brand meaning; do not use it as surface decoration.
 
-### Spatial Drama
-- **Extreme scale jumps**: Make important elements 3-5x larger than surroundings
-- **Break the grid**: Let hero elements escape containers and cross boundaries
-- **Asymmetric layouts**: Replace centered, balanced layouts with tension-filled asymmetry
-- **Generous space**: Use white space dramatically (100-200px gaps, not 20-40px)
-- **Overlap**: Layer elements intentionally for depth
+### Spatial Amplification
+- Change proportion, density, alignment, and sequencing so the composition has a stronger point of view.
+- Create clearer contrast between dense evidence and open breathing room.
+- Let layout express priority and narrative order before adding ornament.
+- Preserve responsive behavior and avoid text overflow at every breakpoint.
 
-### Visual Effects
-- **Dramatic shadows**: Large, soft shadows for elevation (but not generic drop shadows on rounded rectangles)
-- **Background treatments**: Mesh patterns, noise textures, geometric patterns, intentional gradients (not purple-to-blue)
-- **Texture & depth**: Grain, halftone, duotone, layered elements. NOT glassmorphism (it's overused AI slop)
-- **Borders & frames**: Thick borders, decorative frames, custom shapes (not rounded rectangles with colored border on one side)
-- **Custom elements**: Illustrative elements, custom icons, decorative details that reinforce brand
+### Surface Amplification
+- Use existing surface, border, radius, and shadow rules more deliberately.
+- Remove timid half-measures: either give an element a clear role or simplify it.
+- Add texture, depth, illustration, or decorative treatments only when already established by the system or explicitly approved.
+- Make real product artifacts, imagery, data, or copy carry attention before reaching for effects.
 
 ### Motion & Animation
-- **Hero moment**: One signature entrance, once. Not on every visit and not on every section.
-- **Micro-interactions**: Satisfying hover effects, click feedback, state changes.
-- **Transitions**: Smooth, noticeable transitions using ease-out-quart/quint/expo (not bounce or elastic, which cheapen the effect).
-- **Bolder ≠ scroll-fade-rise on every section.** That's the saturated AI default, the opposite of bold.
+- Design one meaningful moment of emphasis when motion genuinely supports the point.
+- Make interaction feedback feel more decisive without becoming distracting.
+- Keep transitions smooth and intentional.
+- **Bolder != scroll-fade-rise on every section.** That's the saturated AI default, the opposite of bold.
 
 ### Composition Boldness
-- **Hero moments**: Create clear focal points with dramatic treatment
-- **Diagonal flows**: Escape horizontal/vertical rigidity with diagonal arrangements
-- **Full-bleed elements**: Use full viewport width/height for impact
-- **Unexpected proportions**: Golden ratio? Throw it out. Try 70/30, 80/20 splits
+- Make the dominant idea unmistakable.
+- Use layout tension, sequencing, contrast, and restraint to create a stronger read.
+- Let the page's structure communicate priority before adding decorative layers.
+- If every element is louder, the composition is not bolder; it is flatter.
 
 **NEVER**:
-- Add effects randomly without purpose (chaos ≠ bold)
-- Sacrifice readability for aesthetics (body text must be readable)
-- Make everything bold (then nothing is bold; you need contrast)
-- Ignore accessibility (bold design must still meet WCAG standards)
-- Overwhelm with motion (animation fatigue is real)
-- Copy trendy aesthetics blindly (bold means distinctive, not derivative)
+- Add undocumented design-system primitives without user approval
+- Add effects randomly without purpose
+- Hide weak hierarchy behind decoration
+- Sacrifice readability for aesthetics
+- Make everything bold; contrast is the point
+- Ignore accessibility
+- Overwhelm with motion
+- Copy trendy aesthetics blindly
 
 ## Verify Quality
 
 Ensure amplification maintains usability and coherence:
 
+- **System-faithful**: Did the pass make the existing design language stronger before adding anything new?
+- **No undocumented drift**: Are new colors, gradients, shadows, radii, fonts, and effects either absent or explicitly approved and documented?
 - **NOT AI slop**: Does this look like every other AI-generated "bold" design? If yes, start over.
 - **Still functional**: Can users accomplish tasks without distraction?
 - **Coherent**: Does everything feel intentional and unified?
-- **Memorable**: Will users remember this experience?
-- **Performant**: Do all these effects run smoothly?
-- **Accessible**: Does it still meet accessibility standards?
+- **Memorable**: Will users remember this experience for the intended reason?
+- **Performant and accessible**: Does the result stay fast, readable, responsive, and WCAG-conscious?
 
 **The test**: If you showed this to someone and said "AI made this bolder," would they believe you immediately? If yes, you've failed. Bold means distinctive, not "more AI effects."
 

--- a/packages/workflows/skills/impeccable/reference/critique.md
+++ b/packages/workflows/skills/impeccable/reference/critique.md
@@ -5,8 +5,9 @@ Resolve one stable target, run two independent assessments, synthesize a design 
 ### Hard Invariants
 
 - Assessment A (design review) and Assessment B (detector/browser evidence) are both required.
+- Assessment A and B MUST run as two isolated sub-agents whenever a sub-agent/Task tool is exposed. Running them inline in this context is "possible" but is NOT permitted; it is a degraded run. Inline is allowed ONLY when no sub-agent tool exists (or the user declined, on harnesses that ask).
+- If you degrade for any reason, the report's first line MUST be a banner: `⚠️ DEGRADED: single-context (<reason>)`. A silent degraded critique is a failed critique.
 - Assessment A must finish before detector findings enter the parent synthesis context. Detector output is deterministic, but it still anchors judgment.
-- If sub-agents are unavailable, fall back sequentially: finish and record Assessment A first, then run Assessment B, then synthesize.
 - A skipped detector is a failed critique run unless `detect.mjs` is missing or crashes after a real attempt.
 - Viewable targets require browser inspection when available.
 - Any local server started only for critique visualization must run in the background, have a recorded stop method, and be stopped before final reporting unless the user asks to keep it.
@@ -27,14 +28,21 @@ Resolve one stable target, run two independent assessments, synthesize a design 
 
 ### Assessment Orchestration
 
-Delegate Assessment A and Assessment B to separate sub-agents when possible. They must not see each other's output. Do not show findings to the user until synthesis.
+Delegate Assessment A and Assessment B to separate sub-agents. They must not see each other's output. Do not show findings to the user until synthesis.
 
-Codex sub-agent gate:
+Sub-agent gate (all harnesses):
+- Unless a harness-specific gate below overrides this, spawn A and B as two isolated, parallel sub-agents whenever a sub-agent/Task tool is exposed. This is the default and is mandatory; do not run them inline because it is faster.
+- "Unavailable" means exactly one thing: no sub-agent/Task tool is exposed in this session (or, on harnesses that ask, the user declined). It does not mean inconvenient.
+- If and only if sub-agents are unavailable, fall back sequentially: finish and record Assessment A, then run Assessment B, then synthesize, and emit the degraded banner.
+- Whichever path you take, declare it in the report header (see Report header provenance). Skipping sub-agents without the banner is the most common failure of this command.
+
+Codex sub-agent gate (overrides the default above; Codex's permission model requires asking before spawning):
+- Asking is the normal path, not a degradation. Approving and spawning is the dual-agent path; do not emit the degraded banner just for asking.
 - If `spawn_agent` is exposed and the user explicitly allowed sub-agents, delegation, or parallel agent work, spawn A and B immediately.
 - If `spawn_agent` is exposed but the user did not explicitly allow sub-agents, ask exactly once: "Impeccable critique is designed to run two independent sub-agents for an unanchored assessment. May I use sub-agents for this critique?" Then stop until the user answers.
-- If allowed, spawn A and B. If declined, run sequentially and report `Assessment independence: degraded (sub-agents declined by user)`.
-- If `spawn_agent` is not exposed, do not ask; run sequentially and report `Assessment independence: degraded (spawn_agent unavailable in this session)`.
-- If spawning fails after permission, run sequentially and report `Assessment independence: degraded (sub-agent spawn failed: <exact error>)`.
+- If allowed, spawn A and B. If declined, run sequentially and lead the report with `⚠️ DEGRADED: single-context (sub-agents declined by user)`.
+- If `spawn_agent` is not exposed, do not ask; run sequentially and lead with `⚠️ DEGRADED: single-context (spawn_agent unavailable in this session)`.
+- If spawning fails after permission, run sequentially and lead with `⚠️ DEGRADED: single-context (sub-agent spawn failed: <exact error>)`.
 Prefer `fork_context: false` with self-contained prompts containing cwd, target, live URL, references, product context, and output contract. If using `fork_context: true`, omit `agent_type`, `model`, and `reasoning_effort`.
 
 If browser automation is available, each assessment creates its own new tab. Never reuse an existing tab, even if it is already at the right URL.
@@ -69,7 +77,7 @@ node .agents/skills/impeccable/scripts/detect.mjs --json [target]
 
 Browser visualization is required for a viewable target when browser automation is available. Use a localhost dev/static URL for local files; avoid `file://` unless the available browser explicitly supports this workflow. Overlay flow:
 
-1. Create a fresh tab and navigate.
+1. Create a fresh tab and navigate. Prefer the harness's native/browser-canvas screenshot path before hand-rolling a Playwright/Puppeteer script; only fall back to a custom script when no native browser tool is exposed.
 2. Preflight mutable injection by setting `document.title` and appending a `<script>` tag. Read-only evaluate APIs do not count.
 3. If mutation is unavailable, skip live server, browser presentation, and injection; report fallback signal.
 4. If mutation is available, start `node .agents/skills/impeccable/scripts/live-server.mjs --background`, present the browser if supported, label `[Human]`, scroll top, inject `http://localhost:PORT/detect.js`, wait 2-3 seconds, read `impeccable` console messages, then stop the live server.
@@ -92,6 +100,12 @@ The chat response is the primary user-facing deliverable. Present the full struc
 Codex final-answer note: `$impeccable critique` produces a report artifact, so the final chat response should intentionally exceed the usual concise close-out style. Do not title the final response "Critique Summary" unless the user explicitly asked for a summary.
 
 Structure your feedback as a design director would:
+
+#### Report header provenance
+
+The report's first line MUST declare how the assessments were run, so a degraded run is never silent:
+- Dual-agent: `Method: dual-agent (A: <agent-id> · B: <agent-id>)`
+- Degraded: `⚠️ DEGRADED: single-context (<reason, e.g. no sub-agent tool exposed>)`
 
 #### Design Health Score
 > *Consult the [Heuristics Scoring Guide](#heuristics-scoring-guide) section below.*

--- a/packages/workflows/skills/impeccable/reference/document.md
+++ b/packages/workflows/skills/impeccable/reference/document.md
@@ -1,6 +1,6 @@
 Generate a `DESIGN.md` file at the project root that captures the current visual design system, so AI agents generating new screens stay on-brand.
 
-DESIGN.md follows the [official Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/format/): YAML frontmatter carrying machine-readable design tokens, followed by a markdown body with exactly six sections in a fixed order. **Tokens are normative; prose provides context for how to apply them.** Sections may be omitted when not relevant, but **do not reorder them and do not rename them**. Section headers must match the spec character-for-character so the file stays parseable by other DESIGN.md-aware tools (Stitch itself, awesome-design-md, skill-rest, etc.).
+DESIGN.md follows the [official DESIGN.md format spec](https://raw.githubusercontent.com/google-labs-code/design.md/main/docs/spec.md): YAML frontmatter carrying machine-readable design tokens, followed by a markdown body with exactly six sections in a fixed order. **Tokens are normative; prose provides context for how to apply them.** Sections may be omitted when not relevant, but **do not reorder them and do not rename them**. Section headers must match the spec character-for-character so the file stays parseable by other DESIGN.md-aware tools (Stitch itself, awesome-design-md, skill-rest, etc.).
 
 ## The frontmatter: token schema
 

--- a/packages/workflows/skills/impeccable/reference/hooks.md
+++ b/packages/workflows/skills/impeccable/reference/hooks.md
@@ -1,0 +1,92 @@
+# $impeccable hooks
+
+Manage the **design detector hook** for the current project.
+
+The hook runs the impeccable design detector on direct file edits to design-relevant files (`.tsx`, `.jsx`, `.html`, `.vue`, `.svelte`, `.astro`, `.css`, `.scss`, `.sass`, `.less`, `.ts`, `.js`). Claude Code, Codex, and GitHub Copilot use a post-tool-use hook and push a short system reminder into the agent's context after the edit; findings get a correction prompt, pending issues get a re-nudge, and clean UI-ish files get a short ack unless quiet mode is on (`hook.quiet` in config). Plain `.ts` and `.js` files are still scanned, but stay quiet unless the detector finds something. Cursor uses `preToolUse` to block bad proposed writes before they land and stays silent when it allows a clean write.
+
+This command toggles the hook **per project** by editing `.impeccable/config.json` (the unified Impeccable config; hook runtime settings live under its `hook` key, and shared detector ignores live under `detector`). Per-developer overrides, including the install consent decision (`hook.consent`) the CLI records, live in the gitignored `.impeccable/config.local.json`. Set `hook.enabled: false` to turn the hook off, `hook.quiet: true` to silence the clean/pending acks, or `hook.auditLog` to a file path for an NDJSON log. The legacy `IMPECCABLE_HOOK_DISABLED`, `IMPECCABLE_HOOK_QUIET`, and `IMPECCABLE_HOOK_LOG` env vars are still honored and override these config values when set.
+
+Declare server-side template extensions under **`detector.extensions`** when the project uses Blade, Twig, ERB, or Handlebars files; the hook skips them otherwise because they sit outside the built-in extension list. One entry per extension, `{ "ext": ".blade.php", "engine": "html" }`. `engine` picks the analyzer (`html` for markup templates, `text` for JS/TS/CSS-like files) and defaults to `html`. Match against the end of the filename, so double extensions like `.blade.php` and `.html.erb` work. Config only adds extensions; the built-in list always applies.
+
+Manual `npx impeccable detect` scans use the same project filter config by default: `detector.ignoreRules`, `detector.ignoreFiles`, `detector.ignoreValues`, and `detector.designSystem.enabled`. `hook.enabled` only controls automatic hook execution, not manual CLI scans. Use `npx impeccable detect --no-config ...` for a raw detector run that ignores project config/context. Use `npx impeccable ignores ...` for direct CLI CRUD on the same detector ignores.
+
+Supported harnesses: Claude Code (`.claude/settings.local.json` in the project, which is gitignored so the hook stays machine-local; a hook you move into the shared `settings.json` is honored in place too), Codex (`.codex/hooks.json` in the project), Cursor (`.cursor/hooks.json` in the project), and GitHub Copilot (`.github/hooks$impeccable.json` in the project, a team-shared committed file that both the Copilot CLI and the cloud agent read). For the Copilot CLI, repo-level hooks fire once `.github/hooks$impeccable.json` is committed to the repository's default branch.
+
+On **Cursor**, `preToolUse` checks proposed Write/Edit/Shell write content and denies only when the real detector finds an issue. The denial message is visible to the agent as the tool error, so the agent can reconsider before the bad write lands.
+
+## Routing
+
+The first argument is the action. Defaults to `status`.
+
+| Action | What it does |
+|---|---|
+| `status` | Print current state, shared/local config paths, ignored rules / files / values, env override. |
+| `on` | Set `enabled: true` in `.impeccable/config.json`, record local hook consent as accepted, and install/repair provider hook manifests when the skill is installed. |
+| `off` | Set `enabled: false` in `.impeccable/config.json`. |
+| `ignore-rule <id>` | Append `<id>` to `detector.ignoreRules`; for `overused-font`, requires `--all-values`. |
+| `ignore-file <glob>` | Append `<glob>` to `detector.ignoreFiles`. |
+| `ignore-value <id> <value> [--shared] [--reason "..."]` | Append a rule/value suppression to shared `.impeccable/config.json`. |
+| `ignore-value <id> <value> --local [--reason "..."]` | Append a private rule/value suppression to `.impeccable/config.local.json`. |
+| `reset` | Delete the project config, dedup cache, and Cursor pending queue. |
+
+## Flow
+
+1. Resolve the action from the user's argument. If no action was given, default to `status`.
+2. Invoke the admin script and pass the user's output through verbatim:
+
+   ```bash
+   node .agents/skills/impeccable/scripts/hook-admin.mjs <action> [args...]
+   ```
+
+3. If `<action>` is `off`, follow up with a one-line note: "Done. New edits will not trigger the design hook in this project until you run `$impeccable hooks on`."
+4. If `<action>` is `on`, follow up with: "Done. The design hook will fire after the next Edit/Write/MultiEdit on a UI file."
+5. If `<action>` is `ignore-value`, `ignore-file`, or `ignore-rule`, just print the script output. The default scope is shared `.impeccable/config.json`; add `--local` only when the user explicitly asks for a private exception.
+6. If `<action>` is `status`, just print the script output. Do not add commentary unless the user asked a follow-up question.
+
+## Intentional findings
+
+The hook itself never writes ignore config. Persist an exception only after the user explicitly confirms the flagged issue is intentional, and always go through `hook-admin.mjs`.
+
+Prefer the narrowest exception:
+
+- If the finding line shows an exact `ignore-value` command, run that command. This writes shared `.impeccable/config.json` by default.
+- For value-specific findings such as `overused-font` and `bounce-easing`, use `ignore-value` when the user confirms the specific value. Do not use `ignore-rule overused-font` for a specific font.
+- If the finding has no value-specific command, such as `side-tab`, prefer `ignore-file <path>` for the current file.
+- Use `ignore-rule <id>` only when the user asks to suppress that whole rule across the project. For broad overused-font suppression, use `ignore-rule overused-font --all-values` only when the user asks to ignore overused fonts generally.
+- Prefer config ignores (the commands above) by default; they keep suppressions in one reviewable place. Reach for an inline comment only when the waiver must travel with a single file that leaves the repo (a generated/exported standalone document, an emailed HTML file). The supported marker is `impeccable-disable <rule>` (whole file) or `impeccable-disable-line` / `impeccable-disable-next-line` (one line), in any comment syntax, with an optional reason after `:` or `--`. The detector honors it by default; `--no-inline-ignores` or `--no-config` bypasses it.
+
+Example value-specific exception:
+
+```bash
+node .agents/skills/impeccable/scripts/hook-admin.mjs ignore-value overused-font Inter --shared --reason "User confirmed Inter is intentional"
+```
+
+Example intentional motion exception:
+
+```bash
+node .agents/skills/impeccable/scripts/hook-admin.mjs ignore-value bounce-easing bounce-ball --shared --reason "User confirmed ball bounce animation is intentional"
+```
+
+Example whole-rule font exception:
+
+```bash
+node .agents/skills/impeccable/scripts/hook-admin.mjs ignore-rule overused-font --all-values --reason "User asked to ignore overused fonts generally"
+```
+
+Example file-scoped exception:
+
+```bash
+node .agents/skills/impeccable/scripts/hook-admin.mjs ignore-file "src/legacy/Card.tsx"
+```
+
+## Constraints
+
+- Never modify `.impeccable/config.json` or `.impeccable/config.local.json` by hand from this command. Always go through `hook-admin.mjs` so writes stay validated and the file shape stays consistent. One exception: `detector.extensions` has no admin action, so when the user asks to cover a template stack, edit that one field in `.impeccable/config.json` directly and leave the rest of the file untouched.
+- Do not edit the hook scripts themselves (`hook.mjs`, `hook-lib.mjs`, `hook-before-edit.mjs`) from this flow. Those are skill plumbing.
+- Cursor can block a proposed write when the detector finds a real issue. Claude Code, Codex, and GitHub Copilot do not block the edit; they emit a post-edit reminder instead. Disabling stops both blocking and reminders.
+- The hook is bundled with the Impeccable skill and installed through project-local manifests: `.claude/settings.local.json`, `.codex/hooks.json`, `.cursor/hooks.json`, and `.github/hooks$impeccable.json`. On Codex, the user must approve the hook via `/hooks` the first time. On Cursor, confirm hooks are enabled under Settings -> Hooks. On GitHub Copilot, the CLI loads `.github/hooks$impeccable.json` once it is committed to the repository's default branch, and the cloud agent reads it from the repo directly.
+
+## Failure modes
+
+- If `.impeccable/config.json` or `.impeccable/config.local.json` is unreadable or malformed, the hook ignores that file and uses the remaining valid config/defaults. `hook-admin.mjs status` will show malformed files as ignored.
+- If the user asks to "disable the hook" globally, lead with `$impeccable hooks off` (persistent for this project; writes `hook.enabled: false` to config). The legacy `IMPECCABLE_HOOK_DISABLED=1` env var also works as a one-shot override that follows the shell.

--- a/packages/workflows/skills/impeccable/reference/init.md
+++ b/packages/workflows/skills/impeccable/reference/init.md
@@ -3,7 +3,7 @@
 The setup command for a project. One codebase crawl feeds everything it writes:
 
 - **PRODUCT.md** (strategic): root project file for register, target users, product purpose, brand personality, anti-references, strategic design principles. Answers "who/what/why".
-- **DESIGN.md** (visual): root project file for visual theme, color palette, typography, components, layout. Follows the [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/format/). Answers "how it looks".
+- **DESIGN.md** (visual): root project file for visual theme, color palette, typography, components, layout. Follows the [DESIGN.md format spec](https://raw.githubusercontent.com/google-labs-code/design.md/main/docs/spec.md). Answers "how it looks".
 - **`.impeccable/live/config.json`** (live mode): pre-configured so `$impeccable live` boots straight into variant mode with no first-time detour.
 
 It closes by pointing the user at the best command to run next. Every other impeccable command reads PRODUCT.md and DESIGN.md before doing any work.
@@ -16,6 +16,7 @@ Decision tree:
 - **Neither file exists (empty project or no context yet)**: do Steps 2-4 (write PRODUCT.md), then decide on DESIGN.md based on whether there's code to analyze.
 - **PRODUCT.md exists, DESIGN.md missing**: skip to Step 5 and offer to run `$impeccable document` for DESIGN.md.
 - **PRODUCT.md exists but has no `## Register` section (legacy)**: add it. Infer a hypothesis from the codebase (see Step 2), confirm with the user, write the field.
+- **PRODUCT.md exists but has no `## Platform` section (legacy)**: add it the same way, but only when the project is native (`ios` / `android` / `adaptive`) or the user wants it explicit; a missing field already means `web`.
 - **Both exist**: STOP and use Codex's structured user-input/question tool when available; if unavailable, ask directly in chat to clarify what you cannot infer. Ask which file to refresh. Skip the one the user doesn't want changed.
 - **Just DESIGN.md exists (unusual)**: do Steps 2-4 to produce PRODUCT.md.
 
@@ -41,6 +42,13 @@ Also form a **register hypothesis** from what you find:
 
 Register is a hypothesis at this point, not a decision; Step 3 confirms it.
 
+Also form a **platform hypothesis**:
+
+- Native signals: React Native / Expo (`react-native`, `expo`), Flutter (`pubspec.yaml`, `flutter`), SwiftUI / UIKit (`.swift`, `.xcodeproj`, an `ios/` app target), Jetpack Compose / Android (`build.gradle`, an `android/` app module, `AndroidManifest.xml`). An `ios/` and/or `android/` directory that is a real app target, not just a Capacitor/Cordova wrapper around a website.
+- Web signals (the default): a web framework (Vite, Next, Nuxt, SvelteKit, Astro), an HTML entry, a CSS/Tailwind setup, no native app target.
+
+Values: `web` / `ios` / `android` / `adaptive` (one codebase, ships both, adapts per OS). Mobile web is still `web`. Like register, this is a hypothesis; Step 3 confirms it.
+
 Note what you've learned and what remains unclear. Also note any rough edges worth a follow-up command (thin hierarchy, flat or gray palette, missing error/empty states, dull copy); Step 7 turns these into concrete recommendations without re-analyzing.
 
 ## Step 3: Ask strategic questions (for PRODUCT.md)
@@ -55,12 +63,12 @@ If the repo is empty or the user's brief is sparse, run a short interview before
 - Ask **2-3 questions per round**, then wait for answers.
 - Use inferred answers as hypotheses or options, not as finished facts.
 - Complete at least one real user-answer round before drafting PRODUCT.md, unless every required answer is directly discoverable from repo docs.
-- Round 1 should establish register, users/purpose, and desired outcome.
+- Round 1 should establish register, platform, users/purpose, and desired outcome.
 - Round 2 should establish brand personality or references, anti-references, and accessibility needs.
 
 ### Minimum viable interview
 
-Ask enough to complete PRODUCT.md. At minimum, cover register confirmation, users and purpose, brand personality, anti-references, and accessibility needs unless each answer is directly discoverable from repo context. After at least one interview round, you may propose inferred answers, but the user must confirm them before you write PRODUCT.md. Never synthesize PRODUCT.md from the original task prompt alone.
+Ask enough to complete PRODUCT.md. At minimum, cover register confirmation, **platform confirmation** (`web` / `ios` / `android` / `adaptive`), users and purpose, brand personality, anti-references, and accessibility needs unless each answer is directly discoverable from repo context. Never let the template's default `web` stand unconfirmed for a native or cross-platform repo. After at least one interview round, you may propose inferred answers, but the user must confirm them before you write PRODUCT.md. Never synthesize PRODUCT.md from the original task prompt alone.
 
 ### Register (ask first; it shapes everything below)
 
@@ -69,6 +77,14 @@ Every design task is either **brand** (marketing, landing, campaign, long-form c
 If Step 2 produced a clear hypothesis, lead with it: *"From the codebase, this looks like a [brand / product] surface. Does that match your intent, or should we treat it differently?"*
 
 If the signal is genuinely split (e.g. a product with a big marketing landing), STOP and use Codex's structured user-input/question tool when available; if unavailable, ask directly in chat to clarify what you cannot infer. Ask which register describes the **primary** surface. The register can be overridden per task later, but PRODUCT.md carries one default.
+
+### Platform (ask right after register)
+
+Every project targets **web** (includes responsive mobile web), **ios**, **android**, or **adaptive** (one codebase, ships both, adapts per OS: Flutter, React Native, KMP). Platform picks the native rulebook: HIG for `ios`, Material 3 for `android`, both for `adaptive`, none for `web`.
+
+If Step 2 produced a clear hypothesis, lead with it: *"From the codebase, this looks like a [web / ios / android / adaptive] project. Does that match?"* For cross-platform apps, decide by the **design language the app renders**, not the toolchain: one look on both platforms (Flutter's Material-everywhere default) takes that platform's value; genuine per-OS adaptation (Cupertino on iOS, Material on Android) is `adaptive`. When in doubt, `web`.
+
+A monorepo shipping both a website and a native app gets a PRODUCT.md per app, each with its own `## Platform`; the root PRODUCT.md carries the primary surface's platform.
 
 ### Users & Purpose
 - Who uses this? What's their context when using it?
@@ -101,6 +117,10 @@ Synthesize into a strategic document:
 
 product
 
+## Platform
+
+web
+
 ## Users
 [Who they are, their context, the job to be done]
 
@@ -120,7 +140,7 @@ product
 [WCAG level, known user needs, considerations]
 ```
 
-Register is either `brand` or `product` as a bare value. No prose, no commentary.
+Register is either `brand` or `product` as a bare value. No prose, no commentary. Platform is `web`, `ios`, `android`, or `adaptive`, also a bare value; omit the section only on legacy files you're leaving untouched, otherwise write `web` explicitly.
 
 Write to `PROJECT_ROOT/PRODUCT.md`. If `.impeccable.md` existed, the loader already renamed it; merge into that content rather than starting from scratch.
 
@@ -136,6 +156,8 @@ If the user agrees, delegate to `$impeccable document` (it auto-detects scan vs 
 If the user prefers to skip, mention they can run `$impeccable document` any time later.
 
 ## Step 6: Configure live mode (when code exists)
+
+**Skip this step when the platform is native** (`ios` / `android` / `adaptive`): live mode drives a browser overlay. A hybrid wrapper or Expo web target serving HTML doesn't change that.
 
 If the project has code with HTML entries and a dev server (the same "code exists" condition that puts `$impeccable document` in scan mode), pre-configure live mode now. You already identified the framework and the served HTML entry in Step 2, so this is nearly free, and it spares the user the first-time setup detour when they later run `$impeccable live`.
 
@@ -154,16 +176,16 @@ Writing the config file is harmless and needs no consent; only the CSP **source-
 ## Step 7: Recommend starting points, then wrap up
 
 Summarize tersely:
-- Register captured (brand / product)
+- Register captured (brand / product) and platform captured (web / ios / android / adaptive)
 - What was written (PRODUCT.md, DESIGN.md, live config, or a subset)
 - The 3-5 strategic principles from PRODUCT.md that will guide future work
 - If DESIGN.md or live config is pending, one line on how to set it up later
 
-Then recommend the **best commands to run next**, drawn from what your Step 2 crawl already surfaced. Do not run a fresh analysis here; surface observations you already have. Tailor to register and to what you saw, offer the 2-4 most relevant (not a menu dump), and give the exact command to type. Group by intent:
+Then recommend the **best commands to run next**, drawn from what your Step 2 crawl already surfaced. Do not run a fresh analysis here; surface observations you already have. Tailor to register **and platform**, offer the 2-4 most relevant (not a menu dump), and give the exact command to type. Group by intent:
 
 - **Build something new**: `$impeccable craft <feature>` (shape, then build end-to-end) or `$impeccable shape <feature>` (plan first). Lead with this for empty or early-stage projects.
 - **Improve what's there**: name the specific surface. `$impeccable critique <page>` for a scored UX review; `$impeccable audit <area>` for a11y / perf / responsive checks; `$impeccable polish <component>` for a pre-ship pass. When the crawl flagged a specific weakness, point the matching command at it: thin hierarchy or spacing → `layout`, flat or gray palette → `colorize`, missing error / empty states → `harden` or `onboard`, dull or unclear copy → `clarify`.
-- **Iterate visually**: `$impeccable live` (configured in Step 6) to pick elements in the browser and generate variants in place.
+- **Iterate visually** (web only): `$impeccable live` (configured in Step 6) to pick elements in the browser and generate variants in place. **Skip this group for native platforms.**
 
 The full command menu is one bare `$impeccable` away; keep this list short and pointed.
 

--- a/packages/workflows/skills/impeccable/reference/ios.md
+++ b/packages/workflows/skills/impeccable/reference/ios.md
@@ -1,0 +1,45 @@
+# iOS platform
+
+For native iOS / iPadOS apps: SwiftUI, UIKit, React Native, Expo, Flutter shipping to Apple hardware.
+
+On native, register narrows. HIG conformance governs structure, navigation, and interaction whatever the register; brand expresses through the expressive layer the platform provides (tint, type, motion, content). Calm, Duolingo, and Spotify carry strong identity entirely inside HIG conventions.
+
+## The iOS slop test
+
+Would a fluent iPhone user trust this app, or pause at off-spec controls? The tell is "ported from a website": reinvented navigation bars, custom back gestures, web-shaped buttons, hover-dependent affordances. Default to the platform's components; depart only for a reason the user would thank you for.
+
+## Layout & structure
+
+- **Safe area.** Lay out inside the safe-area insets. No controls under the notch, Dynamic Island, home indicator, or rounded corners.
+- **System navigation.** Tab bar for 2–5 top-level sections (sections, never actions), navigation stack for hierarchy, sheet for self-contained tasks. No custom global nav, no mixed metaphors.
+- **Edge-swipe back stays alive.** The left-edge back gesture is muscle memory; never disable or overlay it.
+- **Large titles** on top-level screens, collapsing to inline on scroll. Deep detail screens stay inline.
+
+## Touch targets
+
+- **44×44 pt minimum** for every tappable control, with breathing room between adjacent targets.
+
+## Typography
+
+- **Dynamic Type.** Use the system text styles (Large Title through Caption) so text follows the user's reading size. No hard-coded point sizes.
+- **San Francisco carries the UI.** Body, labels, and controls stay on SF Pro / SF Compact; a brand face may appear in display moments.
+- **11 pt floor**; Body is 17 pt.
+
+## Color & materials
+
+- **Semantic system colors** (label, secondaryLabel, systemBackground, separator, tint). They adapt to Dark Mode and increased contrast automatically; raw hex breaks there.
+- **Dark Mode is a first-class appearance.** Design and test both.
+- **One tint color** drives interactive elements; decoration is not its job.
+- **System materials** for blur and translucency behind bars and sheets; no hand-rolled glassmorphism.
+
+## Components & controls
+
+- **Platform controls.** Switch, segmented control, stepper, system pickers, action sheets, alerts, context menus, swipe actions. Reinventing these for flavor is the most common native slop.
+- **SF Symbols** for iconography: baseline-aligned, Dynamic Type-aware, weight and scale variants. Don't mix in a web icon set.
+- **Deliberate modality.** Sheet for a focused dismissible sub-task, full-screen cover for immersion. Clear Cancel/Done; honor swipe-to-dismiss unless data loss requires a guard.
+- **Grouped/inset lists** for settings-shaped content; no bespoke card stacks.
+
+## Motion
+
+- **System transitions.** Push slides, sheets rise, dismiss reverses the entrance. Custom transitions that fight the navigation model disorient.
+- **Honor Reduce Motion.** Crossfade instead of parallax and large slides.

--- a/packages/workflows/skills/impeccable/reference/layout.md
+++ b/packages/workflows/skills/impeccable/reference/layout.md
@@ -8,11 +8,33 @@ Brand: asymmetric compositions, fluid spacing with `clamp()`, intentional grid-b
 
 Product: predictable grids, consistent densities, familiar navigation patterns. Responsive behavior is structural (collapse sidebar, responsive table), not fluid typography. Consistency IS an affordance.
 
+Native (`ios` / `android` / `adaptive`): structure follows the Layout section of [ios.md](ios.md) / [android.md](android.md) (read it first if Setup hasn't already): platform navigation, insets, and touch targets, never the CSS tooling below.
+
+---
+
+## Two isolated assessments (required)
+
+Spawn two parallel sub-agents whenever a sub-agent/Task tool is exposed: one for the layout assessment, one for the mechanical pre-scan. If the harness needs explicit user permission for sub-agents, stop and ask before proceeding. Isolation is the point: detector output anchors visual judgment toward what the scan can see, so neither sub-agent gets the other's output. Each assessment runs in its own sub-agent; running either one in this context when a sub-agent tool exists is not permitted, even when it is faster; the fallback below is only for sessions with no sub-agent tool. Give each a self-contained prompt (target files, register, documented spacing scale when present, and its instructions below); do not assume it can read this file.
+
+**Sub-agent A (layout assessment)**: give it the full [Assess Current Layout](#assess-current-layout) checklist below, verbatim, in its prompt. It works through every item and returns per-item findings citing file, selector, or value.
+
+**Sub-agent B (mechanical pre-scan)**: run the bundled detector scoped to layout:
+
+```bash
+node .agents/skills/impeccable/scripts/detect.mjs --json --scope layout [target files or dirs]
+```
+
+A missing `node` on PATH is not permission to skip: hunt for a runtime (`command -v node`, nvm or Homebrew paths, the harness's own bundled node) and run it by full path. If none exists, halt the scan and report that Node must be installed (the parent relays this to the user); do **not** substitute grep for the detector or proceed unscanned. The detector abstains on arbitrary Tailwind spacing (`gap-[13px]`, `p-[7px]`) and ad-hoc `z-index` stacks, so when the project documents a spacing scale, also grep `gap-\[`, `p[trblxy]?-\[`, `m[trblxy]?-\[`, `z-\[` and judge those hits against it. Return the findings JSON plus the grep verdicts.
+
+**If no sub-agent tool is exposed (or the user declined)**: run both yourself, assessment first, pre-scan second, so the deterministic findings can't anchor the visual judgment. Keep that order even when the scan feels quicker to start with.
+
+**Synthesize** once both are done: merge into a single findings list, noting where they agree and what each caught alone. Fix every finding, or list it as a deliberate exception for the user to accept. A clean scan is a floor, not a verdict: a monotone grid with uniform spacing passes every detector rule, which is exactly what the assessment exists to catch. State in your final summary which path ran (parallel sub-agents or single-context fallback).
+
 ---
 
 ## Assess Current Layout
 
-Analyze what's weak about the current spatial design:
+This checklist is sub-agent A's brief (on the fallback path, work through it yourself before the pre-scan). Analyze what's weak about the current spatial design:
 
 1. **Spacing**:
    - Is spacing consistent or arbitrary? (Random padding/margin values)
@@ -137,6 +159,8 @@ Create a systematic plan:
 - **Breathing room**: Does the layout feel comfortable, not cramped or wasteful?
 - **Consistency**: Is the spacing system applied uniformly?
 - **Responsiveness**: Does the layout adapt gracefully across screen sizes?
+
+Answer each item above by citing the file, selector, or value that satisfies it; never a bare yes. Then re-run the pre-scan and fix until the count of unresolved items and unaccepted findings is zero.
 
 When the rhythm and hierarchy land, hand off to `$impeccable polish` for the final pass.
 

--- a/packages/workflows/skills/impeccable/reference/typeset.md
+++ b/packages/workflows/skills/impeccable/reference/typeset.md
@@ -10,9 +10,29 @@ Product: system fonts and familiar sans stacks are legitimate here. One well-tun
 
 ---
 
+## Two isolated assessments (required)
+
+Spawn two parallel sub-agents whenever a sub-agent/Task tool is exposed: one for the typography assessment, one for the mechanical pre-scan. If the harness needs explicit user permission for sub-agents, stop and ask before proceeding. Isolation is the point: detector output anchors visual judgment toward what the scan can see, so neither sub-agent gets the other's output. Each assessment runs in its own sub-agent; running either one in this context when a sub-agent tool exists is not permitted, even when it is faster; the fallback below is only for sessions with no sub-agent tool. Give each a self-contained prompt (target files, register, **DESIGN.md** content when present, and its instructions below); do not assume it can read this file.
+
+**Sub-agent A (typography assessment)**: give it the full [Assess Current Typography](#assess-current-typography) checklist below, verbatim, in its prompt. It works through every item and returns per-item findings citing file, selector, or value.
+
+**Sub-agent B (mechanical pre-scan)**: run the bundled detector scoped to type:
+
+```bash
+node .agents/skills/impeccable/scripts/detect.mjs --json --scope type [target files or dirs]
+```
+
+A missing `node` on PATH is not permission to skip: hunt for a runtime (`command -v node`, nvm or Homebrew paths, the harness's own bundled node) and run it by full path. If none exists, halt the scan and report that Node must be installed (the parent relays this to the user); do **not** substitute grep for the detector or proceed unscanned. The scan checks literal font sizes against the **DESIGN.md** ramp but abstains on `em`, `%`, `clamp()`, and line-heights, so also grep `font-size\s*:`, `fontSize`, `text-\[`, `leading-\[` and judge those hits against the spec. Return the findings JSON plus the grep verdicts.
+
+**If no sub-agent tool is exposed (or the user declined)**: run both yourself, assessment first, pre-scan second, so the deterministic findings can't anchor the visual judgment. Keep that order even when the scan feels quicker to start with.
+
+**Synthesize** once both are done: merge into a single findings list, noting where they agree and what each caught alone. Fix every finding, or list it as a deliberate exception for the user to accept. A clean scan is a floor, not a verdict: a generic font stack at a flat scale passes every detector rule, which is exactly what the assessment exists to catch. State in your final summary which path ran (parallel sub-agents or single-context fallback).
+
+---
+
 ## Assess Current Typography
 
-Analyze what's weak or generic about the current type:
+This checklist is sub-agent A's brief (on the fallback path, work through it yourself before the pre-scan). Analyze what's weak or generic about the current type:
 
 1. **Font choices**:
    - Are we using invisible defaults? (Inter, Roboto, Arial, Open Sans, system defaults)
@@ -108,6 +128,8 @@ Build a clear type scale:
 - **Personality**: Does the typography reflect the brand?
 - **Performance**: Are web fonts loading efficiently without layout shift?
 - **Accessibility**: Does text meet WCAG contrast ratios? Is it zoomable to 200%?
+
+Answer each item above by citing the file, selector, or value that satisfies it; never a bare yes. Then re-run the pre-scan and fix until the count of unresolved items and unaccepted findings is zero.
 
 When the type carries the hierarchy on its own, hand off to `$impeccable polish` for the final pass.
 

--- a/packages/workflows/skills/impeccable/scripts/context-signals.mjs
+++ b/packages/workflows/skills/impeccable/scripts/context-signals.mjs
@@ -21,7 +21,7 @@ import net from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
-import { loadContext, extractRegister } from './context.mjs';
+import { loadContext, extractRegister, extractPlatform } from './context.mjs';
 import { getCritiqueDir } from './lib/impeccable-paths.mjs';
 
 /** Is there code here at all, or just context files / an empty repo? */
@@ -197,6 +197,7 @@ export async function gatherSignals(cwd = process.cwd()) {
       designPath: ctx.designPath,
       hasCode: hasCode(cwd),
       register: extractRegister(ctx.product),
+      platform: extractPlatform(ctx.product),
     },
     critique: { latest: latestCritique(cwd) },
     git,

--- a/packages/workflows/skills/impeccable/scripts/context.mjs
+++ b/packages/workflows/skills/impeccable/scripts/context.mjs
@@ -1,8 +1,10 @@
 /**
  * Context loader: prints PRODUCT.md (and DESIGN.md if present) as one
- * markdown block on stdout, or exits with empty stdout when no PRODUCT.md
- * is found anywhere. The skill keys off "empty stdout" to branch into the
- * init flow.
+ * markdown block on stdout, or prints a `NO_PRODUCT_MD:` message when no
+ * PRODUCT.md is found anywhere. The skill keys off that message to branch:
+ * from-scratch build commands (init / teach / craft / shape) and clear
+ * build/shape intent divert into the init flow, while scoped commands proceed
+ * using the existing code as context.
  *
  * Path resolution (first match wins):
  *   1. Active project root, if PRODUCT.md or DESIGN.md is there
@@ -692,23 +694,59 @@ function escapeRegExp(value) {
 }
 
 /**
+ * Read the first non-empty line under a bare `## <heading>` section of
+ * PRODUCT.md (e.g. `## Register`, `## Platform`). Returns null when the
+ * section is absent. The heading match is exact (`\s*$`) so near-miss
+ * headings like `## Register guidelines` don't shadow the real field.
+ */
+export function extractSectionValue(product, heading) {
+  if (!product) return null;
+  const headingRe = new RegExp(`^##\\s+${escapeRegExp(heading)}\\s*$`, 'i');
+  const lines = product.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (headingRe.test(lines[i].trim())) {
+      for (let j = i + 1; j < lines.length; j++) {
+        const next = lines[j].trim();
+        // A new heading before any value means the section is empty.
+        if (/^#{1,6}\s/.test(next)) return null;
+        if (next) return next;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Pull the register (`brand` or `product`) out of PRODUCT.md by looking
  * for a `## Register` section and reading the first non-empty line that
  * follows it. Returns null when the file is legacy / register-less.
  */
 export function extractRegister(product) {
-  if (!product) return null;
-  const lines = product.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    if (/^##\s+Register\b/i.test(lines[i].trim())) {
-      for (let j = i + 1; j < lines.length; j++) {
-        const next = lines[j].trim();
-        if (!next) continue;
-        const word = next.toLowerCase();
-        if (word === 'brand' || word === 'product') return word;
-        return null;
-      }
-    }
+  const word = (extractSectionValue(product, 'Register') || '').toLowerCase();
+  return word === 'brand' || word === 'product' ? word : null;
+}
+
+/**
+ * Pull the platform (`web`, `ios`, `android`, or `adaptive`) out of PRODUCT.md
+ * by looking for a `## Platform` section and reading the first non-empty line
+ * that follows it. `adaptive` is for cross-platform apps (Flutter, React
+ * Native) that ship both iOS and Android from one codebase; a line that names
+ * both targets (e.g. `ios, android`) is also read as `adaptive`. Returns null
+ * when the file is legacy / platform-less, which the skill treats as `web`
+ * (the default the general rules already assume).
+ */
+export function extractPlatform(product) {
+  const value = (extractSectionValue(product, 'Platform') || '').toLowerCase();
+  if (!value) return null;
+  if (value === 'web' || value === 'ios' || value === 'android' || value === 'adaptive') return value;
+  // A short list naming both native targets (`ios, android`, `ios and
+  // android`) = adaptive. Only list separators and the two platform words may
+  // appear; anything else (prose, negations) is unrecognized and falls
+  // through to the CLI's WARNING path.
+  const tokens = value.split(/[\s,+&/]+/).filter(t => t && t !== 'and');
+  if (tokens.length >= 2 && tokens.every(t => t === 'ios' || t === 'android')
+    && tokens.includes('ios') && tokens.includes('android')) {
+    return 'adaptive';
   }
   return null;
 }
@@ -860,8 +898,11 @@ async function cli() {
     // — cheap models miss the empty case more often than the explicit one.
     const parts = [
       'NO_PRODUCT_MD: This project has no PRODUCT.md yet. ' +
-      'Stop the current task, load reference/init.md, and follow its ' +
-      'instructions to write PRODUCT.md before resuming.',
+      'Follow SKILL.md Setup step 1: for `init`, `teach`, `craft`, `shape`, ' +
+      'or wording that clearly maps to a from-scratch build/shape flow, load ' +
+      'reference/init.md and write PRODUCT.md first; for any other (scoped) ' +
+      'command against existing code, proceed using the code as context and ' +
+      'offer `/impeccable init` as a suggestion (do not block).',
     ];
     parts.push(buildResolvedContextDirective(ctx, cliOptions, { targetExists }));
     if (shouldWarnMissingTarget(ctx, targetProvided, targetExists)) {
@@ -884,6 +925,26 @@ async function cli() {
     ? `NEXT STEP: This project's register is \`${register}\`. You MUST now read \`reference/${register}.md\` before producing any design output.`
     : `NEXT STEP: You MUST now read the matching register reference (\`reference/brand.md\` or \`reference/product.md\`) before producing any design output. Pick based on PRODUCT.md above.`;
   parts.push(next);
+  const platform = extractPlatform(ctx.product);
+  const nativeRefs =
+    platform === 'adaptive' ? ['ios', 'android'] : platform === 'ios' || platform === 'android' ? [platform] : [];
+  if (nativeRefs.length) {
+    const refList = nativeRefs.map(p => `\`reference/${p}.md\``).join(' and ');
+    const label = platform === 'adaptive' ? '`adaptive` (both iOS and Android)' : `\`${platform}\``;
+    parts.push(
+      `NEXT STEP: This project targets ${label}. Also read ${refList} for native conventions, in addition to the register reference.`,
+    );
+  } else if (!platform) {
+    // A `## Platform` section that names something we don't recognize (a
+    // toolchain like `flutter`, a typo) would otherwise silently fall back to
+    // web — the wrong default exactly when the user tried to say "native".
+    const rawPlatform = extractSectionValue(ctx.product, 'Platform');
+    if (rawPlatform) {
+      parts.push(
+        `WARNING: PRODUCT.md's \`## Platform\` value \`${rawPlatform}\` is not recognized; treating the project as \`web\`. Valid values are \`web\`, \`ios\`, \`android\`, or \`adaptive\` (cross-platform, ships both). If this project is native, fix the field (name the design language the app renders, not the toolchain) and surface it to the user.`,
+      );
+    }
+  }
   if (updateDirective) parts.push(updateDirective);
   process.stdout.write(parts.join('\n\n---\n\n') + '\n');
 }

--- a/packages/workflows/skills/impeccable/scripts/detector/browser/injected/index.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/browser/injected/index.mjs
@@ -1276,7 +1276,7 @@ if (IS_BROWSER) {
 
   function browserPrimaryFont(stack) {
     if (!stack || /var\(/i.test(stack)) return '';
-    return String(stack)
+    return String(stack || '')
       .split(',')
       .map(normalizeBrowserFontName)
       .find(font => font && !GENERIC_FONTS.has(font)) || '';

--- a/packages/workflows/skills/impeccable/scripts/detector/cli/main.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/cli/main.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { loadDesignSystemForCwd } from '../design-system.mjs';
+import { RULE_SCOPES, filterByScopes } from '../registry/antipatterns.mjs';
 import { createBrowserDetector, detectUrl } from '../engines/browser/detect-url.mjs';
 import { detectHtml } from '../engines/static-html/detect-html.mjs';
 import { detectText } from '../engines/regex/detect-text.mjs';
@@ -93,6 +94,8 @@ Options:
   --quiet             In text mode, only print the final findings count
   --gpt               Also report GPT-specific provider tells (off by default)
   --gemini            Also report Gemini-specific provider tells (off by default)
+  --scope <name>      Only report rules in the given design domain
+                      (type, layout). Comma-separated.
   --no-config         Do not apply project config, detector ignores, inline
                       ignore comments, or DESIGN.md
   --no-inline-ignores Do not honor in-file impeccable-disable* ignore comments
@@ -151,6 +154,33 @@ async function detectCli() {
   const providers = [];
   if (args.includes('--gpt')) providers.push('gpt');
   if (args.includes('--gemini')) providers.push('gemini');
+  const scopes = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== '--scope' && !args[i].startsWith('--scope=')) continue;
+    const inline = args[i].startsWith('--scope=');
+    const value = inline ? args[i].slice('--scope='.length) : args[i + 1];
+    const parsed = (value && !value.startsWith('--'))
+      ? value.split(',').map(s => s.trim()).filter(Boolean)
+      : [];
+    // A bare `--scope` would otherwise fall out of `targets` and scan unscoped;
+    // fail loudly so a mistyped pre-scan never runs the wrong rule set.
+    if (parsed.length === 0) {
+      process.stderr.write(
+        `Error: --scope requires a value. Valid scopes: ${[...RULE_SCOPES].join(', ')}\n`,
+      );
+      process.exit(1);
+    }
+    scopes.push(...parsed);
+    args.splice(i, inline ? 1 : 2);
+    i -= 1;
+  }
+  const unknownScopes = scopes.filter(s => !RULE_SCOPES.has(s));
+  if (unknownScopes.length > 0) {
+    process.stderr.write(
+      `Error: unknown --scope value(s): ${unknownScopes.join(', ')}. Valid scopes: ${[...RULE_SCOPES].join(', ')}\n`,
+    );
+    process.exit(1);
+  }
   const designSystemEnabled = configEnabled && !args.includes('--no-design-system') && detectionConfig.designSystem?.enabled !== false;
   const designSystem = designSystemEnabled ? loadDesignSystemForCwd(process.cwd()) : null;
   // Inline `impeccable-disable*` waivers are part of the scanned file, so they
@@ -276,6 +306,7 @@ async function detectCli() {
   }
 
   allFindings = filterDetectionFindings(allFindings, detectionConfig);
+  allFindings = filterByScopes(allFindings, scopes);
 
   if (allFindings.length > 0) {
     if (jsonMode) process.stdout.write(formatFindings(allFindings, true) + '\n');

--- a/packages/workflows/skills/impeccable/scripts/detector/design-system.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/design-system.mjs
@@ -9,6 +9,8 @@ const DESIGN_NAMES = ['DESIGN.md', 'Design.md', 'design.md'];
 const FALLBACK_DIRS = ['.agents/context', 'docs'];
 const COLOR_CHANNEL_TOLERANCE = 6;
 const RADIUS_TOLERANCE_PX = 0.5;
+const FONT_SIZE_TOLERANCE_PX = 0.5;
+const FONT_SIZE_LITERAL_RE = /^-?[\d.]+(?:px|rem)$/;
 
 const CSS_COLOR_RE = /#[0-9a-f]{3,8}\b|rgba?\([^)]+\)|oklch\([^)]+\)|hsla?\([^)]+\)/gi;
 const FONT_DECL_RE = /font-family\s*:\s*([^;}\n]+)/gi;
@@ -16,6 +18,9 @@ const FONT_JS_RE = /fontFamily\s*[:=]\s*["'`]([^"'`]+)["'`]/g;
 const GOOGLE_FONT_RE = /fonts\.googleapis\.com\/css2?\?[^"'\s)<>]*/gi;
 const BORDER_RADIUS_RE = /border-radius\s*:\s*([^;}\n]+)/gi;
 const BORDER_RADIUS_JS_RE = /borderRadius\s*[:=]\s*["'`]([^"'`]+)["'`]/g;
+const FONT_SIZE_DECL_RE = /font-size\s*:\s*([^;}\n]+)/gi;
+const FONT_SIZE_JS_RE = /fontSize\s*[:=]\s*["'`]([^"'`]+)["'`]/g;
+const TAILWIND_FONT_SIZE_RE = /\btext-\[(-?[\d.]+(?:px|rem))\]/g;
 const STATIC_DESIGN_SKIP_TAGS = new Set(['head', 'title', 'meta', 'link', 'style', 'script', 'noscript', 'template', 'source']);
 
 function firstExisting(dir, names) {
@@ -283,6 +288,18 @@ function addTypographyFonts(out, typography) {
   }
 }
 
+function addTypographySizes(out, typography) {
+  if (!typography || typeof typography !== 'object') return;
+  for (const role of Object.values(typography)) {
+    if (!role || typeof role !== 'object') continue;
+    const raw = String(role.fontSize ?? '').trim().toLowerCase();
+    if (!FONT_SIZE_LITERAL_RE.test(raw)) continue;
+    const px = resolveLengthPx(raw, 16);
+    if (px == null || !Number.isFinite(px) || px <= 0) continue;
+    out.allowedFontSizes.push({ value: raw, px });
+  }
+}
+
 function addRoundedScale(out, rounded) {
   if (!rounded || typeof rounded !== 'object') return;
   for (const [rawName, value] of Object.entries(rounded)) {
@@ -340,10 +357,12 @@ function normalizeDesignSystem(input = {}) {
     allowedFonts: new Set(),
     allowedColorKeys: new Map(),
     allowedRadii: [],
+    allowedFontSizes: [],
     hasPillRadius: false,
   };
 
   addTypographyFonts(out, frontmatter.typography);
+  addTypographySizes(out, frontmatter.typography);
   addColorObject(out, frontmatter.colors);
   addSidecarColors(out, sidecar);
   addRoundedScale(out, frontmatter.rounded);
@@ -352,6 +371,7 @@ function normalizeDesignSystem(input = {}) {
   out.hasFonts = out.allowedFonts.size > 0;
   out.hasColors = out.allowedColorKeys.size > 0;
   out.hasRadii = out.allowedRadii.length > 0;
+  out.hasFontSizes = out.allowedFontSizes.length > 0;
   return out;
 }
 
@@ -416,6 +436,17 @@ function isAllowedRadiusRaw(raw, designSystem) {
   if (px == null || !Number.isFinite(px) || px <= RADIUS_TOLERANCE_PX) return true;
   if (designSystem.hasPillRadius && px >= 99) return true;
   return designSystem.allowedRadii.some(entry => Math.abs(entry.px - px) <= RADIUS_TOLERANCE_PX);
+}
+
+function isAllowedFontSizeRaw(raw, designSystem) {
+  if (!designSystem?.hasFontSizes) return true;
+  const text = String(raw || '').trim().toLowerCase().replace(/\s*!important\s*$/, '');
+  if (!FONT_SIZE_LITERAL_RE.test(text)) return true;
+  const px = resolveLengthPx(text, 16);
+  if (px == null || !Number.isFinite(px) || px <= 0) return true;
+  return designSystem.allowedFontSizes.some(
+    entry => Math.abs(entry.px - px) <= FONT_SIZE_TOLERANCE_PX,
+  );
 }
 
 function lineLooksCommented(line) {
@@ -509,6 +540,18 @@ function checkRadiusValue(value, filePath, line, designSystem, context) {
   return findings;
 }
 
+function checkFontSizeValue(value, filePath, line, designSystem, context) {
+  const token = String(value || '').trim();
+  if (isAllowedFontSizeRaw(token, designSystem)) return [];
+  return [makeDesignFinding(
+    'design-system-font-size',
+    filePath,
+    `${context}: ${token} is off the DESIGN.md type ramp`,
+    line,
+    { ignoreValue: token },
+  )];
+}
+
 function checkSourceDesignSystem(content, filePath, options = {}) {
   const designSystem = options.designSystem;
   if (!designSystem?.present) return [];
@@ -567,6 +610,18 @@ function checkSourceDesignSystem(content, filePath, options = {}) {
         findings.push(...checkRadiusValue(match[1], filePath, lineNum, designSystem, 'borderRadius'));
       }
     }
+
+    if (designSystem.hasFontSizes) {
+      for (const match of line.matchAll(FONT_SIZE_DECL_RE)) {
+        findings.push(...checkFontSizeValue(match[1], filePath, lineNum, designSystem, 'font-size'));
+      }
+      for (const match of line.matchAll(FONT_SIZE_JS_RE)) {
+        findings.push(...checkFontSizeValue(match[1], filePath, lineNum, designSystem, 'fontSize'));
+      }
+      for (const match of line.matchAll(TAILWIND_FONT_SIZE_RE)) {
+        findings.push(...checkFontSizeValue(match[1], filePath, lineNum, designSystem, 'text-[…] class'));
+      }
+    }
   }
 
   return dedupeDesignFindings(findings);
@@ -581,6 +636,8 @@ function sampleText(el) {
   return text ? ` "${text.slice(0, 40)}"` : '';
 }
 
+// Font-size design-system checks are source-scan-only (see checkSourceDesignSystem).
+// Computed font-size cascades and clamp() ramps resolve to off-ramp px in the browser.
 function collectStaticDesignSystemFindings(document, window, filePath, designSystem) {
   if (!designSystem?.present) return [];
   const findings = [];
@@ -698,6 +755,12 @@ function canonicalDesignFindingKey(item) {
     const label = String(value || '').trim().toLowerCase();
     return label ? `${item.antipattern}:radius:${label}` : null;
   }
+  if (item.antipattern === 'design-system-font-size') {
+    const px = resolveLengthPx(String(value || '').trim(), 16);
+    if (px != null && Number.isFinite(px)) return `${item.antipattern}:font-size:${Math.round(px * 100) / 100}`;
+    const label = String(value || '').trim().toLowerCase();
+    return label ? `${item.antipattern}:font-size:${label}` : null;
+  }
   return null;
 }
 
@@ -744,6 +807,7 @@ export {
   isAllowedFont,
   isAllowedColorRaw,
   isAllowedRadiusRaw,
+  isAllowedFontSizeRaw,
   checkSourceDesignSystem,
   collectStaticDesignSystemFindings,
   mergeDesignSystemFindings,

--- a/packages/workflows/skills/impeccable/scripts/detector/detect-antipatterns-browser.js
+++ b/packages/workflows/skills/impeccable/scripts/detector/detect-antipatterns-browser.js
@@ -1289,8 +1289,8 @@ function checkHtmlPatterns(html) {
   // runs in the bundled browser path too, not just the CLI/static path.
   {
     const bodyText = html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
       .replace(/<[^>]+>/g, ' ');
     const tm = /\b(\w+)\s+theater\b/i.exec(bodyText);
     if (tm) findings.push({ id: 'theater-slop-phrase', snippet: `"${tm[0].trim()}"` });

--- a/packages/workflows/skills/impeccable/scripts/detector/detect-antipatterns-browser.js
+++ b/packages/workflows/skills/impeccable/scripts/detector/detect-antipatterns-browser.js
@@ -1289,8 +1289,8 @@ function checkHtmlPatterns(html) {
   // runs in the bundled browser path too, not just the CLI/static path.
   {
     const bodyText = html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
       .replace(/<[^>]+>/g, ' ');
     const tm = /\b(\w+)\s+theater\b/i.exec(bodyText);
     if (tm) findings.push({ id: 'theater-slop-phrase', snippet: `"${tm[0].trim()}"` });

--- a/packages/workflows/skills/impeccable/scripts/detector/detect-antipatterns-browser.js
+++ b/packages/workflows/skills/impeccable/scripts/detector/detect-antipatterns-browser.js
@@ -123,6 +123,7 @@ const ANTIPATTERNS = [
   {
     id: 'overused-font',
     category: 'slop',
+    scopes: ['type'],
     name: 'Overused font',
     description:
       'Inter, Roboto, Fraunces, Geist, Plus Jakarta Sans, and Space Grotesk are used on so many sites they no longer feel distinctive. Each new wave of AI-generated UIs converges on the same handful of faces. Choose a face that gives your interface personality.',
@@ -132,6 +133,7 @@ const ANTIPATTERNS = [
   {
     id: 'single-font',
     category: 'slop',
+    scopes: ['type'],
     name: 'Single font for everything',
     description:
       'Only one font family is used for the entire page. Pair a distinctive display font with a refined body font to create typographic hierarchy.',
@@ -141,6 +143,7 @@ const ANTIPATTERNS = [
   {
     id: 'flat-type-hierarchy',
     category: 'slop',
+    scopes: ['type'],
     name: 'Flat type hierarchy',
     description:
       'Font sizes are too close together — no clear visual hierarchy. Use fewer sizes with more contrast (aim for at least a 1.25 ratio between steps).',
@@ -177,6 +180,7 @@ const ANTIPATTERNS = [
   {
     id: 'nested-cards',
     category: 'slop',
+    scopes: ['layout'],
     name: 'Nested cards',
     description:
       'Cards inside cards create visual noise and excessive depth. Flatten the hierarchy — use spacing, typography, and dividers instead of nesting containers.',
@@ -186,6 +190,7 @@ const ANTIPATTERNS = [
   {
     id: 'monotonous-spacing',
     category: 'slop',
+    scopes: ['layout'],
     name: 'Monotonous spacing',
     description:
       'The same spacing value used everywhere — no rhythm, no variation. Use tight groupings for related items and generous separations between sections.',
@@ -213,6 +218,7 @@ const ANTIPATTERNS = [
   {
     id: 'icon-tile-stack',
     category: 'slop',
+    scopes: ['layout'],
     name: 'Icon tile stacked above heading',
     description:
       'A small rounded-square icon container above a heading is the universal AI feature-card template — every generator outputs this exact shape. Try a side-by-side icon and heading, or let the icon sit in flow without its own container.',
@@ -222,6 +228,7 @@ const ANTIPATTERNS = [
   {
     id: 'italic-serif-display',
     category: 'slop',
+    scopes: ['type'],
     name: 'Italic serif display headline',
     description:
       'Oversized italic serif (Fraunces, Recoleta, Playfair, Newsreader-italic) as the primary hero headline reads as taste in isolation but has become the universal AI-startup landing page hero. Set roman, or move to a non-serif display face. Editorial / magazine register may legitimately want this — judge by context.',
@@ -231,6 +238,7 @@ const ANTIPATTERNS = [
   {
     id: 'hero-eyebrow-chip',
     category: 'slop',
+    scopes: ['type'],
     name: 'Hero eyebrow / pill chip',
     description:
       'A tiny uppercase letter-spaced label sitting immediately above an oversized hero headline — or the same shape rendered as a pill chip — is now the default AI SaaS hero. Drop the eyebrow, integrate the kicker into the headline, or run it as a navigation breadcrumb instead.',
@@ -240,6 +248,7 @@ const ANTIPATTERNS = [
   {
     id: 'repeated-section-kickers',
     category: 'slop',
+    scopes: ['type'],
     severity: 'advisory',
     name: 'Repeated section kicker labels',
     description:
@@ -250,6 +259,7 @@ const ANTIPATTERNS = [
   {
     id: 'numbered-section-markers',
     category: 'slop',
+    scopes: ['layout'],
     severity: 'advisory',
     name: 'Numbered section markers (01 / 02 / 03)',
     description:
@@ -287,6 +297,7 @@ const ANTIPATTERNS = [
   {
     id: 'oversized-h1',
     category: 'slop',
+    scopes: ['type'],
     name: 'Oversized hero headline',
     description:
       'A full-sentence headline set at display size ends up dominating the viewport, leaving no room for anything else above the fold. A punchy one- or two-word headline at that size is fine — the problem is a long headline blown up too large. Set long headlines smaller, or tighten the copy.',
@@ -296,6 +307,7 @@ const ANTIPATTERNS = [
   {
     id: 'extreme-negative-tracking',
     category: 'slop',
+    scopes: ['type'],
     name: 'Crushed letter spacing',
     description:
       'Letter-spacing pulled tighter than the point where characters keep their own shapes costs legibility. Tighten display type optically, not destructively.',
@@ -341,6 +353,7 @@ const ANTIPATTERNS = [
   {
     id: 'line-length',
     category: 'quality',
+    scopes: ['type', 'layout'],
     name: 'Line length too long',
     description:
       'Text lines wider than ~80 characters are hard to read. The eye loses its place tracking back to the start of the next line. Add a max-width (65ch to 75ch) to text containers.',
@@ -350,6 +363,7 @@ const ANTIPATTERNS = [
   {
     id: 'cramped-padding',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Cramped padding',
     description:
       'Text is too close to the edge of its container. Two shapes: (1) an element with its own text where the padding is too low for the font size, and (2) a wrapper with text-bearing children and near-zero padding against a visible boundary (border, outline, or non-transparent background) — children land flush against the boundary line. Add at least 8px (ideally 12–16px) of padding inside bordered, outlined, or colored containers.',
@@ -359,6 +373,7 @@ const ANTIPATTERNS = [
   {
     id: 'body-text-viewport-edge',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Body text touching viewport edge',
     description:
       'Body paragraphs render flush against the left or right viewport edge with no container providing horizontal padding. Wrap content in a container with at least 16px (ideally 24-32px) of horizontal padding, or apply max-width with mx-auto.',
@@ -366,6 +381,7 @@ const ANTIPATTERNS = [
   {
     id: 'tight-leading',
     category: 'quality',
+    scopes: ['type'],
     name: 'Tight line height',
     description:
       'Line height below 1.3x the font size makes multi-line text hard to read. Use 1.5 to 1.7 for body text so lines have room to breathe.',
@@ -373,6 +389,7 @@ const ANTIPATTERNS = [
   {
     id: 'skipped-heading',
     category: 'quality',
+    scopes: ['type'],
     name: 'Skipped heading level',
     description:
       'Heading levels should not skip (e.g. h1 then h3 with no h2). Screen readers use heading hierarchy for navigation. Skipping levels breaks the document outline.',
@@ -380,6 +397,7 @@ const ANTIPATTERNS = [
   {
     id: 'justified-text',
     category: 'quality',
+    scopes: ['type'],
     name: 'Justified text',
     description:
       'Justified text without hyphenation creates uneven word spacing ("rivers of white"). Use text-align: left for body text, or enable hyphens: auto if you must justify.',
@@ -387,6 +405,7 @@ const ANTIPATTERNS = [
   {
     id: 'tiny-text',
     category: 'quality',
+    scopes: ['type'],
     name: 'Tiny body text',
     description:
       'Body text below 12px is hard to read, especially on high-DPI screens. Use at least 14px for body content, 16px is ideal.',
@@ -394,6 +413,7 @@ const ANTIPATTERNS = [
   {
     id: 'all-caps-body',
     category: 'quality',
+    scopes: ['type'],
     name: 'All-caps body text',
     description:
       'Long passages in uppercase are hard to read. We recognize words by shape (ascenders and descenders), which all-caps removes. Reserve uppercase for short labels and headings.',
@@ -403,6 +423,7 @@ const ANTIPATTERNS = [
   {
     id: 'wide-tracking',
     category: 'quality',
+    scopes: ['type'],
     name: 'Wide letter spacing on body text',
     description:
       'Letter spacing above 0.05em on body text disrupts natural character groupings and slows reading. Reserve wide tracking for short uppercase labels only.',
@@ -410,6 +431,7 @@ const ANTIPATTERNS = [
   {
     id: 'text-overflow',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Content overflowing its container',
     description:
       'Content renders wider than its container, spilling out or forcing a horizontal scrollbar. Let text wrap, constrain widths, or give the region a deliberate scroll affordance.',
@@ -419,6 +441,7 @@ const ANTIPATTERNS = [
   {
     id: 'clipped-overflow-container',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Positioned child clipped by overflow container',
     description:
       'A clipping container (overflow hidden or clip) wrapping an absolutely-positioned child cuts off tooltips, menus, and popovers that need to escape. Let the overflow be visible, or move the positioned layer out of the clip.',
@@ -428,6 +451,7 @@ const ANTIPATTERNS = [
   {
     id: 'design-system-font',
     category: 'quality',
+    scopes: ['type'],
     name: 'Font outside DESIGN.md',
     description:
       'A font is used that is not declared in DESIGN.md typography. Use the documented type system or update DESIGN.md if this is an intentional brand addition.',
@@ -454,6 +478,17 @@ const ANTIPATTERNS = [
     skillSection: 'Visual Details',
     skillGuideline: 'border radius outside the project design system',
   },
+  {
+    id: 'design-system-font-size',
+    category: 'quality',
+    severity: 'advisory',
+    scopes: ['type'],
+    name: 'Font size outside DESIGN.md',
+    description:
+      'A literal font-size is off the type ramp documented in DESIGN.md typography. Use a documented size step or update the design system if the new step is intentional.',
+    skillSection: 'Typography',
+    skillGuideline: 'font size outside the project design system',
+  },
 
   // ── Provider tells: opt-in via --gpt / --gemini (gated off by default) ──
   {
@@ -477,6 +512,17 @@ const ANTIPATTERNS = [
       'Repeating-gradient stripes used as surface decoration are a recurring generated-UI signature. Reach for a deliberate texture or leave the surface plain.',
     skillSection: 'Visual Details',
     skillGuideline: 'repeating-gradient decorative stripes',
+  },
+  {
+    id: 'codex-grid-background',
+    category: 'slop',
+    severity: 'advisory',
+    gated: 'gpt',
+    name: 'Decorative grid-line background',
+    description:
+      'A two-axis grid drawn with hairline linear-gradient layers ("1px, transparent 1px" on both axes) is a recurring generated-UI signature. Reserve grid overlays for actual canvas, map, blueprint, or measurement surfaces; elsewhere use product structure or a plain surface.',
+    skillSection: 'Visual Details',
+    skillGuideline: 'two-axis grid-line gradient background',
   },
   {
     id: 'theater-slop-phrase',
@@ -615,6 +661,36 @@ function getHue(c) {
 function colorToHex(c) {
   if (!c) return '?';
   return '#' + [c.r, c.g, c.b].map(v => v.toString(16).padStart(2, '0')).join('');
+}
+
+// --- cli/engine/shared/fonts.mjs ---
+const GOOGLE_FONTS_URL_RE = /fonts\.googleapis\.com\/css2?\?[^"'\s)<>]*/gi;
+
+function normalizeGoogleFontFamilyParam(value) {
+  return String(value || '')
+    .split('|')
+    .map(part => part.split(':')[0].trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function extractGoogleFontFamilies(text) {
+  const families = [];
+  if (!text) return families;
+
+  GOOGLE_FONTS_URL_RE.lastIndex = 0;
+  let urlMatch;
+  while ((urlMatch = GOOGLE_FONTS_URL_RE.exec(text)) !== null) {
+    const url = urlMatch[0];
+    const queryStart = url.indexOf('?');
+    if (queryStart === -1) continue;
+
+    const params = new URLSearchParams(url.slice(queryStart + 1).replace(/&amp;/g, '&'));
+    for (const value of params.getAll('family')) {
+      families.push(...normalizeGoogleFontFamilyParam(value));
+    }
+  }
+
+  return families;
 }
 
 // --- cli/engine/rules/checks.mjs ---
@@ -1172,13 +1248,49 @@ function checkHtmlPatterns(html) {
     findings.push({ id: 'repeating-stripes-gradient', snippet: 'repeating-gradient decorative stripes' });
   }
 
+  // --- Provider tells (gated): two-axis grid-line background (Codex/GPT) ---
+  // The Codex grid tell is two hairline `linear-gradient(... <color> 1px,
+  // transparent 1px)` layers (one per axis) tiled by a repeating
+  // `background-size` cell. Both signals must co-occur in the SAME style block
+  // (a CSS rule body or one inline `style="..."`): two hairline stops WITHOUT a
+  // tiling background-size is a fixed crosshair, not a grid, and a single
+  // hairline is a legitimate ruled line. Scoping to one block also stops
+  // unrelated single-axis rules on separate elements from adding up across the
+  // page. Count hairlines only inside `background`/`background-image` values so
+  // a hairline in an unrelated property (mask-image, border-image) can't stand
+  // in for the second axis. Colors like `oklch(96% 0.012 82 / 0.055)` carry
+  // nested parens, so match the hairline stop directly rather than parsing
+  // whole gradient layers.
+  {
+    const hairlineRe = /\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi;
+    const gridSizeRe = /background-size\s*:[^;{}"']*\b\d{1,3}px\b/i;
+    const bgDeclRe = /\bbackground(?:-image)?\s*:\s*([^;{}"']*)/gi;
+    const blockRe = /\{([^{}]*)\}|style\s*=\s*"([^"]*)"|style\s*=\s*'([^']*)'/gi;
+    let blk;
+    while ((blk = blockRe.exec(html)) !== null) {
+      const block = blk[1] || blk[2] || blk[3] || '';
+      if (!gridSizeRe.test(block)) continue;
+      let hairlineCount = 0;
+      let bm;
+      bgDeclRe.lastIndex = 0;
+      while ((bm = bgDeclRe.exec(block)) !== null) {
+        const stops = bm[1].match(hairlineRe);
+        if (stops) hairlineCount += stops.length;
+      }
+      if (hairlineCount >= 2) {
+        findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
+        break;
+      }
+    }
+  }
+
   // --- Provider tells (gated): "X theater" framing copy (GPT) ---
   // Lives here (regex-on-HTML) rather than in the text-content analyzers so it
   // runs in the bundled browser path too, not just the CLI/static path.
   {
     const bodyText = html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
       .replace(/<[^>]+>/g, ' ');
     const tm = /\b(\w+)\s+theater\b/i.exec(bodyText);
     if (tm) findings.push({ id: 'theater-slop-phrase', snippet: `"${tm[0].trim()}"` });
@@ -2635,14 +2747,9 @@ function checkPageTypography(doc, win) {
 
   // Check Google Fonts links in HTML
   const html = doc.documentElement?.outerHTML || '';
-  const gfRe = /fonts\.googleapis\.com\/css2?\?family=([^&"'\s]+)/gi;
-  let m;
-  while ((m = gfRe.exec(html)) !== null) {
-    const families = m[1].split('|').map(f => f.split(':')[0].replace(/\+/g, ' ').toLowerCase());
-    for (const f of families) {
-      fonts.add(f);
-      if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
-    }
+  for (const f of extractGoogleFontFamilies(html)) {
+    fonts.add(f);
+    if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
   }
 
   // Also parse raw HTML/style content for font-family (jsdom may not expose all via CSSOM)
@@ -4475,7 +4582,7 @@ if (IS_BROWSER) {
 
   function browserPrimaryFont(stack) {
     if (!stack || /var\(/i.test(stack)) return '';
-    return String(stack)
+    return String(stack || '')
       .split(',')
       .map(normalizeBrowserFontName)
       .find(font => font && !GENERIC_FONTS.has(font)) || '';

--- a/packages/workflows/skills/impeccable/scripts/detector/engines/regex/detect-text.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/engines/regex/detect-text.mjs
@@ -20,8 +20,8 @@ const isSafeElement = (line) => /<(?:blockquote|nav[\s>]|pre[\s>]|code[\s>]|a\s|
  *  content-text analyzers don't false-positive on code or CSS. */
 function stripHtmlToText(html) {
   return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/<[^>]+>/g, ' ')
     .replace(/\s+/g, ' ');
@@ -352,7 +352,7 @@ function extractStyleBlocks(content, ext) {
   ext = ext.toLowerCase();
   if (ext !== '.vue' && ext !== '.svelte') return [];
   const blocks = [];
-  const re = /<style[^>]*>([\s\S]*?)<\/style\s*>/gi;
+  const re = /<style[^>]*>([\s\S]*?)<\/style\b[^>]*>/gi;
   let m;
   while ((m = re.exec(content)) !== null) {
     const before = content.substring(0, m.index);

--- a/packages/workflows/skills/impeccable/scripts/detector/engines/regex/detect-text.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/engines/regex/detect-text.mjs
@@ -20,8 +20,8 @@ const isSafeElement = (line) => /<(?:blockquote|nav[\s>]|pre[\s>]|code[\s>]|a\s|
  *  content-text analyzers don't false-positive on code or CSS. */
 function stripHtmlToText(html) {
   return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/<[^>]+>/g, ' ')
     .replace(/\s+/g, ' ');
@@ -352,7 +352,7 @@ function extractStyleBlocks(content, ext) {
   ext = ext.toLowerCase();
   if (ext !== '.vue' && ext !== '.svelte') return [];
   const blocks = [];
-  const re = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+  const re = /<style[^>]*>([\s\S]*?)<\/style\s*>/gi;
   let m;
   while ((m = re.exec(content)) !== null) {
     const before = content.substring(0, m.index);

--- a/packages/workflows/skills/impeccable/scripts/detector/engines/regex/detect-text.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/engines/regex/detect-text.mjs
@@ -1,5 +1,6 @@
-import { GENERIC_FONTS } from '../../shared/constants.mjs';
+import { GENERIC_FONTS, OVERUSED_FONTS } from '../../shared/constants.mjs';
 import { isNeutralColor } from '../../shared/color.mjs';
+import { extractGoogleFontFamilies } from '../../shared/fonts.mjs';
 import { checkSourceDesignSystem } from '../../design-system.mjs';
 import { isFullPage } from '../../shared/page.mjs';
 import { applyInlineIgnores } from '../../shared/inline-ignores.mjs';
@@ -19,8 +20,8 @@ const isSafeElement = (line) => /<(?:blockquote|nav[\s>]|pre[\s>]|code[\s>]|a\s|
  *  content-text analyzers don't false-positive on code or CSS. */
 function stripHtmlToText(html) {
   return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/<[^>]+>/g, ' ')
     .replace(/\s+/g, ' ');
@@ -36,6 +37,10 @@ function shouldRunPageAnalyzers(content, filePath) {
   if (!isFullPage(content)) return false;
   const ext = extFromFilePath(filePath);
   return !ext || PAGE_ANALYZER_EXTS.has(ext);
+}
+
+function firstOverusedGoogleFont(text) {
+  return extractGoogleFontFamilies(text).find(f => OVERUSED_FONTS.has(f)) || '';
 }
 
 function isNeutralBorderColor(str) {
@@ -88,9 +93,12 @@ const REGEX_MATCHERS = [
   { id: 'overused-font', regex: /font-family\s*:\s*['"]?(Inter|Roboto|Open Sans|Lato|Montserrat|Arial|Helvetica|Fraunces|Geist Sans|Geist Mono|Geist|Mona Sans|Plus Jakarta Sans|Space Grotesk|Recoleta|Instrument Sans|Instrument Serif)\b/gi,
     test: () => true,
     fmt: (m) => m[0] },
-  { id: 'overused-font', regex: /fonts\.googleapis\.com\/css2?\?family=(Inter|Roboto|Open\+Sans|Lato|Montserrat|Fraunces|Plus\+Jakarta\+Sans|Space\+Grotesk|Instrument\+Sans|Instrument\+Serif|Mona\+Sans|Geist)\b/gi,
-    test: () => true,
-    fmt: (m) => `Google Fonts: ${m[1].replace(/\+/g, ' ')}` },
+  { id: 'overused-font', regex: /fonts\.googleapis\.com\/css2?\?[^"'\s)<>]*/gi,
+    test: (m) => {
+      m.overusedGoogleFont = firstOverusedGoogleFont(m[0]);
+      return Boolean(m.overusedGoogleFont);
+    },
+    fmt: (m) => `Google Fonts: ${m.overusedGoogleFont || firstOverusedGoogleFont(m[0])}` },
   // --- Gradient text ---
   { id: 'gradient-text', regex: /background-clip\s*:\s*text|-webkit-background-clip\s*:\s*text/gi,
     test: (m, line) => /gradient/i.test(line),
@@ -170,10 +178,7 @@ const REGEX_ANALYZERS = [
         if (f && !GENERIC_FONTS.has(f)) fonts.add(f);
       }
     }
-    const gfRe = /fonts\.googleapis\.com\/css2?\?family=([^&"'\s]+)/gi;
-    while ((m = gfRe.exec(content)) !== null) {
-      for (const f of m[1].split('|').map(f => f.split(':')[0].replace(/\+/g, ' ').toLowerCase())) fonts.add(f);
-    }
+    for (const f of extractGoogleFontFamilies(content)) fonts.add(f);
     if (fonts.size !== 1 || content.split('\n').length < 20) return [];
     const name = [...fonts][0];
     const lines = content.split('\n');
@@ -347,7 +352,7 @@ function extractStyleBlocks(content, ext) {
   ext = ext.toLowerCase();
   if (ext !== '.vue' && ext !== '.svelte') return [];
   const blocks = [];
-  const re = /<style[^>]*>([\s\S]*?)<\/style[^>]*>/gi;
+  const re = /<style[^>]*>([\s\S]*?)<\/style>/gi;
   let m;
   while ((m = re.exec(content)) !== null) {
     const before = content.substring(0, m.index);

--- a/packages/workflows/skills/impeccable/scripts/detector/registry/antipatterns.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/registry/antipatterns.mjs
@@ -21,6 +21,7 @@ const ANTIPATTERNS = [
   {
     id: 'overused-font',
     category: 'slop',
+    scopes: ['type'],
     name: 'Overused font',
     description:
       'Inter, Roboto, Fraunces, Geist, Plus Jakarta Sans, and Space Grotesk are used on so many sites they no longer feel distinctive. Each new wave of AI-generated UIs converges on the same handful of faces. Choose a face that gives your interface personality.',
@@ -30,6 +31,7 @@ const ANTIPATTERNS = [
   {
     id: 'single-font',
     category: 'slop',
+    scopes: ['type'],
     name: 'Single font for everything',
     description:
       'Only one font family is used for the entire page. Pair a distinctive display font with a refined body font to create typographic hierarchy.',
@@ -39,6 +41,7 @@ const ANTIPATTERNS = [
   {
     id: 'flat-type-hierarchy',
     category: 'slop',
+    scopes: ['type'],
     name: 'Flat type hierarchy',
     description:
       'Font sizes are too close together — no clear visual hierarchy. Use fewer sizes with more contrast (aim for at least a 1.25 ratio between steps).',
@@ -75,6 +78,7 @@ const ANTIPATTERNS = [
   {
     id: 'nested-cards',
     category: 'slop',
+    scopes: ['layout'],
     name: 'Nested cards',
     description:
       'Cards inside cards create visual noise and excessive depth. Flatten the hierarchy — use spacing, typography, and dividers instead of nesting containers.',
@@ -84,6 +88,7 @@ const ANTIPATTERNS = [
   {
     id: 'monotonous-spacing',
     category: 'slop',
+    scopes: ['layout'],
     name: 'Monotonous spacing',
     description:
       'The same spacing value used everywhere — no rhythm, no variation. Use tight groupings for related items and generous separations between sections.',
@@ -111,6 +116,7 @@ const ANTIPATTERNS = [
   {
     id: 'icon-tile-stack',
     category: 'slop',
+    scopes: ['layout'],
     name: 'Icon tile stacked above heading',
     description:
       'A small rounded-square icon container above a heading is the universal AI feature-card template — every generator outputs this exact shape. Try a side-by-side icon and heading, or let the icon sit in flow without its own container.',
@@ -120,6 +126,7 @@ const ANTIPATTERNS = [
   {
     id: 'italic-serif-display',
     category: 'slop',
+    scopes: ['type'],
     name: 'Italic serif display headline',
     description:
       'Oversized italic serif (Fraunces, Recoleta, Playfair, Newsreader-italic) as the primary hero headline reads as taste in isolation but has become the universal AI-startup landing page hero. Set roman, or move to a non-serif display face. Editorial / magazine register may legitimately want this — judge by context.',
@@ -129,6 +136,7 @@ const ANTIPATTERNS = [
   {
     id: 'hero-eyebrow-chip',
     category: 'slop',
+    scopes: ['type'],
     name: 'Hero eyebrow / pill chip',
     description:
       'A tiny uppercase letter-spaced label sitting immediately above an oversized hero headline — or the same shape rendered as a pill chip — is now the default AI SaaS hero. Drop the eyebrow, integrate the kicker into the headline, or run it as a navigation breadcrumb instead.',
@@ -138,6 +146,7 @@ const ANTIPATTERNS = [
   {
     id: 'repeated-section-kickers',
     category: 'slop',
+    scopes: ['type'],
     severity: 'advisory',
     name: 'Repeated section kicker labels',
     description:
@@ -148,6 +157,7 @@ const ANTIPATTERNS = [
   {
     id: 'numbered-section-markers',
     category: 'slop',
+    scopes: ['layout'],
     severity: 'advisory',
     name: 'Numbered section markers (01 / 02 / 03)',
     description:
@@ -185,6 +195,7 @@ const ANTIPATTERNS = [
   {
     id: 'oversized-h1',
     category: 'slop',
+    scopes: ['type'],
     name: 'Oversized hero headline',
     description:
       'A full-sentence headline set at display size ends up dominating the viewport, leaving no room for anything else above the fold. A punchy one- or two-word headline at that size is fine — the problem is a long headline blown up too large. Set long headlines smaller, or tighten the copy.',
@@ -194,6 +205,7 @@ const ANTIPATTERNS = [
   {
     id: 'extreme-negative-tracking',
     category: 'slop',
+    scopes: ['type'],
     name: 'Crushed letter spacing',
     description:
       'Letter-spacing pulled tighter than the point where characters keep their own shapes costs legibility. Tighten display type optically, not destructively.',
@@ -239,6 +251,7 @@ const ANTIPATTERNS = [
   {
     id: 'line-length',
     category: 'quality',
+    scopes: ['type', 'layout'],
     name: 'Line length too long',
     description:
       'Text lines wider than ~80 characters are hard to read. The eye loses its place tracking back to the start of the next line. Add a max-width (65ch to 75ch) to text containers.',
@@ -248,6 +261,7 @@ const ANTIPATTERNS = [
   {
     id: 'cramped-padding',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Cramped padding',
     description:
       'Text is too close to the edge of its container. Two shapes: (1) an element with its own text where the padding is too low for the font size, and (2) a wrapper with text-bearing children and near-zero padding against a visible boundary (border, outline, or non-transparent background) — children land flush against the boundary line. Add at least 8px (ideally 12–16px) of padding inside bordered, outlined, or colored containers.',
@@ -257,6 +271,7 @@ const ANTIPATTERNS = [
   {
     id: 'body-text-viewport-edge',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Body text touching viewport edge',
     description:
       'Body paragraphs render flush against the left or right viewport edge with no container providing horizontal padding. Wrap content in a container with at least 16px (ideally 24-32px) of horizontal padding, or apply max-width with mx-auto.',
@@ -264,6 +279,7 @@ const ANTIPATTERNS = [
   {
     id: 'tight-leading',
     category: 'quality',
+    scopes: ['type'],
     name: 'Tight line height',
     description:
       'Line height below 1.3x the font size makes multi-line text hard to read. Use 1.5 to 1.7 for body text so lines have room to breathe.',
@@ -271,6 +287,7 @@ const ANTIPATTERNS = [
   {
     id: 'skipped-heading',
     category: 'quality',
+    scopes: ['type'],
     name: 'Skipped heading level',
     description:
       'Heading levels should not skip (e.g. h1 then h3 with no h2). Screen readers use heading hierarchy for navigation. Skipping levels breaks the document outline.',
@@ -278,6 +295,7 @@ const ANTIPATTERNS = [
   {
     id: 'justified-text',
     category: 'quality',
+    scopes: ['type'],
     name: 'Justified text',
     description:
       'Justified text without hyphenation creates uneven word spacing ("rivers of white"). Use text-align: left for body text, or enable hyphens: auto if you must justify.',
@@ -285,6 +303,7 @@ const ANTIPATTERNS = [
   {
     id: 'tiny-text',
     category: 'quality',
+    scopes: ['type'],
     name: 'Tiny body text',
     description:
       'Body text below 12px is hard to read, especially on high-DPI screens. Use at least 14px for body content, 16px is ideal.',
@@ -292,6 +311,7 @@ const ANTIPATTERNS = [
   {
     id: 'all-caps-body',
     category: 'quality',
+    scopes: ['type'],
     name: 'All-caps body text',
     description:
       'Long passages in uppercase are hard to read. We recognize words by shape (ascenders and descenders), which all-caps removes. Reserve uppercase for short labels and headings.',
@@ -301,6 +321,7 @@ const ANTIPATTERNS = [
   {
     id: 'wide-tracking',
     category: 'quality',
+    scopes: ['type'],
     name: 'Wide letter spacing on body text',
     description:
       'Letter spacing above 0.05em on body text disrupts natural character groupings and slows reading. Reserve wide tracking for short uppercase labels only.',
@@ -308,6 +329,7 @@ const ANTIPATTERNS = [
   {
     id: 'text-overflow',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Content overflowing its container',
     description:
       'Content renders wider than its container, spilling out or forcing a horizontal scrollbar. Let text wrap, constrain widths, or give the region a deliberate scroll affordance.',
@@ -317,6 +339,7 @@ const ANTIPATTERNS = [
   {
     id: 'clipped-overflow-container',
     category: 'quality',
+    scopes: ['layout'],
     name: 'Positioned child clipped by overflow container',
     description:
       'A clipping container (overflow hidden or clip) wrapping an absolutely-positioned child cuts off tooltips, menus, and popovers that need to escape. Let the overflow be visible, or move the positioned layer out of the clip.',
@@ -326,6 +349,7 @@ const ANTIPATTERNS = [
   {
     id: 'design-system-font',
     category: 'quality',
+    scopes: ['type'],
     name: 'Font outside DESIGN.md',
     description:
       'A font is used that is not declared in DESIGN.md typography. Use the documented type system or update DESIGN.md if this is an intentional brand addition.',
@@ -352,6 +376,17 @@ const ANTIPATTERNS = [
     skillSection: 'Visual Details',
     skillGuideline: 'border radius outside the project design system',
   },
+  {
+    id: 'design-system-font-size',
+    category: 'quality',
+    severity: 'advisory',
+    scopes: ['type'],
+    name: 'Font size outside DESIGN.md',
+    description:
+      'A literal font-size is off the type ramp documented in DESIGN.md typography. Use a documented size step or update the design system if the new step is intentional.',
+    skillSection: 'Typography',
+    skillGuideline: 'font size outside the project design system',
+  },
 
   // ── Provider tells: opt-in via --gpt / --gemini (gated off by default) ──
   {
@@ -375,6 +410,17 @@ const ANTIPATTERNS = [
       'Repeating-gradient stripes used as surface decoration are a recurring generated-UI signature. Reach for a deliberate texture or leave the surface plain.',
     skillSection: 'Visual Details',
     skillGuideline: 'repeating-gradient decorative stripes',
+  },
+  {
+    id: 'codex-grid-background',
+    category: 'slop',
+    severity: 'advisory',
+    gated: 'gpt',
+    name: 'Decorative grid-line background',
+    description:
+      'A two-axis grid drawn with hairline linear-gradient layers ("1px, transparent 1px" on both axes) is a recurring generated-UI signature. Reserve grid overlays for actual canvas, map, blueprint, or measurement surfaces; elsewhere use product structure or a plain surface.',
+    skillSection: 'Visual Details',
+    skillGuideline: 'two-axis grid-line gradient background',
   },
   {
     id: 'theater-slop-phrase',
@@ -437,12 +483,32 @@ function filterByProviders(findings, providers = []) {
   });
 }
 
+
+// Set of scope tags rules can declare (e.g. 'type', 'layout'). Used by the
+// CLI --scope flag to narrow output to one design domain.
+const RULE_SCOPES = new Set(
+  ANTIPATTERNS.flatMap(rule => rule.scopes || []),
+);
+
+// Keep only findings whose rule declares at least one of the requested
+// scopes. An empty scope list means no filtering (default CLI behavior).
+function filterByScopes(findings, scopes = []) {
+  if (!scopes || scopes.length === 0) return findings;
+  const enabled = new Set(scopes);
+  return findings.filter(f => {
+    const rule = getAntipattern(f.antipattern);
+    return (rule?.scopes || []).some(scope => enabled.has(scope));
+  });
+}
+
 export {
   ANTIPATTERNS,
+  RULE_SCOPES,
   RULE_ENGINE_SUPPORT,
   GATED_PROVIDERS,
   getAntipattern,
   getRulesForCategory,
   getRuleEngineSupport,
   filterByProviders,
+  filterByScopes,
 };

--- a/packages/workflows/skills/impeccable/scripts/detector/rules/checks.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/rules/checks.mjs
@@ -615,8 +615,8 @@ function checkHtmlPatterns(html) {
   // runs in the bundled browser path too, not just the CLI/static path.
   {
     const bodyText = html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
       .replace(/<[^>]+>/g, ' ');
     const tm = /\b(\w+)\s+theater\b/i.exec(bodyText);
     if (tm) findings.push({ id: 'theater-slop-phrase', snippet: `"${tm[0].trim()}"` });

--- a/packages/workflows/skills/impeccable/scripts/detector/rules/checks.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/rules/checks.mjs
@@ -615,8 +615,8 @@ function checkHtmlPatterns(html) {
   // runs in the bundled browser path too, not just the CLI/static path.
   {
     const bodyText = html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
       .replace(/<[^>]+>/g, ' ');
     const tm = /\b(\w+)\s+theater\b/i.exec(bodyText);
     if (tm) findings.push({ id: 'theater-slop-phrase', snippet: `"${tm[0].trim()}"` });

--- a/packages/workflows/skills/impeccable/scripts/detector/rules/checks.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/rules/checks.mjs
@@ -18,6 +18,7 @@ import {
   parseRgb,
   relativeLuminance,
 } from '../shared/color.mjs';
+import { extractGoogleFontFamilies } from '../shared/fonts.mjs';
 
 const DETECTOR_IS_BROWSER = typeof window !== 'undefined';
 
@@ -573,13 +574,49 @@ function checkHtmlPatterns(html) {
     findings.push({ id: 'repeating-stripes-gradient', snippet: 'repeating-gradient decorative stripes' });
   }
 
+  // --- Provider tells (gated): two-axis grid-line background (Codex/GPT) ---
+  // The Codex grid tell is two hairline `linear-gradient(... <color> 1px,
+  // transparent 1px)` layers (one per axis) tiled by a repeating
+  // `background-size` cell. Both signals must co-occur in the SAME style block
+  // (a CSS rule body or one inline `style="..."`): two hairline stops WITHOUT a
+  // tiling background-size is a fixed crosshair, not a grid, and a single
+  // hairline is a legitimate ruled line. Scoping to one block also stops
+  // unrelated single-axis rules on separate elements from adding up across the
+  // page. Count hairlines only inside `background`/`background-image` values so
+  // a hairline in an unrelated property (mask-image, border-image) can't stand
+  // in for the second axis. Colors like `oklch(96% 0.012 82 / 0.055)` carry
+  // nested parens, so match the hairline stop directly rather than parsing
+  // whole gradient layers.
+  {
+    const hairlineRe = /\b\d{1,3}px\s*,\s*transparent\s+\d{1,3}px/gi;
+    const gridSizeRe = /background-size\s*:[^;{}"']*\b\d{1,3}px\b/i;
+    const bgDeclRe = /\bbackground(?:-image)?\s*:\s*([^;{}"']*)/gi;
+    const blockRe = /\{([^{}]*)\}|style\s*=\s*"([^"]*)"|style\s*=\s*'([^']*)'/gi;
+    let blk;
+    while ((blk = blockRe.exec(html)) !== null) {
+      const block = blk[1] || blk[2] || blk[3] || '';
+      if (!gridSizeRe.test(block)) continue;
+      let hairlineCount = 0;
+      let bm;
+      bgDeclRe.lastIndex = 0;
+      while ((bm = bgDeclRe.exec(block)) !== null) {
+        const stops = bm[1].match(hairlineRe);
+        if (stops) hairlineCount += stops.length;
+      }
+      if (hairlineCount >= 2) {
+        findings.push({ id: 'codex-grid-background', snippet: 'two-axis grid-line gradient background' });
+        break;
+      }
+    }
+  }
+
   // --- Provider tells (gated): "X theater" framing copy (GPT) ---
   // Lives here (regex-on-HTML) rather than in the text-content analyzers so it
   // runs in the bundled browser path too, not just the CLI/static path.
   {
     const bodyText = html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ')
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
       .replace(/<[^>]+>/g, ' ');
     const tm = /\b(\w+)\s+theater\b/i.exec(bodyText);
     if (tm) findings.push({ id: 'theater-slop-phrase', snippet: `"${tm[0].trim()}"` });
@@ -2036,14 +2073,9 @@ function checkPageTypography(doc, win) {
 
   // Check Google Fonts links in HTML
   const html = doc.documentElement?.outerHTML || '';
-  const gfRe = /fonts\.googleapis\.com\/css2?\?family=([^&"'\s]+)/gi;
-  let m;
-  while ((m = gfRe.exec(html)) !== null) {
-    const families = m[1].split('|').map(f => f.split(':')[0].replace(/\+/g, ' ').toLowerCase());
-    for (const f of families) {
-      fonts.add(f);
-      if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
-    }
+  for (const f of extractGoogleFontFamilies(html)) {
+    fonts.add(f);
+    if (OVERUSED_FONTS.has(f)) overusedFound.add(f);
   }
 
   // Also parse raw HTML/style content for font-family (jsdom may not expose all via CSSOM)

--- a/packages/workflows/skills/impeccable/scripts/detector/shared/fonts.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/shared/fonts.mjs
@@ -1,0 +1,30 @@
+const GOOGLE_FONTS_URL_RE = /fonts\.googleapis\.com\/css2?\?[^"'\s)<>]*/gi;
+
+function normalizeGoogleFontFamilyParam(value) {
+  return String(value || '')
+    .split('|')
+    .map(part => part.split(':')[0].trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function extractGoogleFontFamilies(text) {
+  const families = [];
+  if (!text) return families;
+
+  GOOGLE_FONTS_URL_RE.lastIndex = 0;
+  let urlMatch;
+  while ((urlMatch = GOOGLE_FONTS_URL_RE.exec(text)) !== null) {
+    const url = urlMatch[0];
+    const queryStart = url.indexOf('?');
+    if (queryStart === -1) continue;
+
+    const params = new URLSearchParams(url.slice(queryStart + 1).replace(/&amp;/g, '&'));
+    for (const value of params.getAll('family')) {
+      families.push(...normalizeGoogleFontFamilyParam(value));
+    }
+  }
+
+  return families;
+}
+
+export { extractGoogleFontFamilies };

--- a/packages/workflows/skills/impeccable/scripts/detector/shared/page.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/shared/page.mjs
@@ -1,13 +1,6 @@
 /** Check if content looks like a full page (not a component/partial) */
 function isFullPage(content) {
-  // Strip comments to a fixpoint so nested/overlapping comment markers cannot
-  // survive a single pass (CodeQL: complete sanitization).
-  let stripped = String(content);
-  let prev;
-  do {
-    prev = stripped;
-    stripped = stripped.replace(/<!--[\s\S]*?-->/g, '');
-  } while (stripped !== prev);
+  const stripped = content.replace(/<!--[\s\S]*?-->/g, '');
   return /<!doctype\s|<html[\s>]|<head[\s>]/i.test(stripped);
 }
 

--- a/packages/workflows/skills/impeccable/scripts/detector/shared/page.mjs
+++ b/packages/workflows/skills/impeccable/scripts/detector/shared/page.mjs
@@ -1,6 +1,11 @@
 /** Check if content looks like a full page (not a component/partial) */
 function isFullPage(content) {
-  const stripped = content.replace(/<!--[\s\S]*?-->/g, '');
+  let stripped = String(content || '');
+  let previous;
+  do {
+    previous = stripped;
+    stripped = stripped.replace(/<!--[\s\S]*?-->/g, '');
+  } while (stripped !== previous);
   return /<!doctype\s|<html[\s>]|<head[\s>]/i.test(stripped);
 }
 

--- a/packages/workflows/skills/impeccable/scripts/hook-admin.mjs
+++ b/packages/workflows/skills/impeccable/scripts/hook-admin.mjs
@@ -1,0 +1,660 @@
+#!/usr/bin/env node
+/**
+ * `/impeccable hooks <on|off|status|reset>` — manage the design hook runtime
+ * via the `hook` key and shared detector ignores via the `detector` key in
+ * .impeccable/config.json / .impeccable/config.local.json.
+ *
+ * Usage:
+ *   node hook-admin.mjs status                         # print current state
+ *   node hook-admin.mjs on                             # set enabled: true
+ *   node hook-admin.mjs off                            # set enabled: false
+ *   node hook-admin.mjs ignore-rule <rule-id>          # append to ignoreRules
+ *   node hook-admin.mjs ignore-rule overused-font --all-values
+ *   node hook-admin.mjs ignore-file <glob>             # append to ignoreFiles
+ *   node hook-admin.mjs ignore-value <rule> <value>    # append to shared ignoreValues
+ *   node hook-admin.mjs ignore-value <rule> <value> --local
+ *   node hook-admin.mjs reset                          # remove all config + cache
+ *
+ * Designed to be invoked by the LLM from the reference/hooks.md flow.
+ * Output is human-readable; the harness will pass it back to the user.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  getConfigPath,
+  getLocalConfigPath,
+  getCachePath,
+  getPendingPath,
+  readConfig,
+  DEFAULT_CONFIG,
+  ensureHookGitExcludes,
+  normalizeIgnoreValue,
+  normalizeIgnoreValueEntries,
+} from './hook-lib.mjs';
+
+const ACTIONS = new Set(['status', 'on', 'off', 'ignore-rule', 'ignore-file', 'ignore-value', 'reset']);
+const IMPECCABLE_HOOK_COMMAND_MARKERS = [
+  'skills/impeccable/scripts/hook-probe.mjs',
+  'skills/impeccable/scripts/hook.mjs',
+  'skills/impeccable/scripts/hook-before-edit.mjs',
+  'skills/impeccable/scripts/hook-after-edit.mjs',
+  'skills/impeccable/scripts/hook-stop.mjs',
+];
+const TIMEOUT_SECONDS = 5;
+const STATUS_MESSAGE = 'Checking UI changes';
+
+const HOOK_MANIFEST_TARGETS = [
+  {
+    provider: '.claude',
+    skillRel: '.claude/skills/impeccable',
+    destRel: '.claude/settings.local.json',
+    sharedDestRel: '.claude/settings.json',
+    manifest: () => ({
+      description: 'Impeccable design detector: runs after Edit/Write/MultiEdit on UI files and surfaces findings as system reminders.',
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit|Write|MultiEdit',
+            hooks: [
+              {
+                type: 'command',
+                command: 'node "${CLAUDE_PROJECT_DIR}/.claude/skills/impeccable/scripts/hook.mjs"',
+                timeout: TIMEOUT_SECONDS,
+                statusMessage: STATUS_MESSAGE,
+              },
+            ],
+          },
+        ],
+      },
+    }),
+  },
+  {
+    provider: '.agents',
+    skillRel: '.agents/skills/impeccable',
+    destRel: '.codex/hooks.json',
+    manifest: () => ({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit|Write|apply_patch',
+            hooks: [
+              {
+                type: 'command',
+                command: 'node ".agents/skills/impeccable/scripts/hook.mjs"',
+                timeout: TIMEOUT_SECONDS,
+                statusMessage: STATUS_MESSAGE,
+              },
+            ],
+          },
+        ],
+      },
+    }),
+  },
+  {
+    provider: '.cursor',
+    skillRel: '.cursor/skills/impeccable',
+    destRel: '.cursor/hooks.json',
+    manifest: () => ({
+      version: 1,
+      hooks: {
+        preToolUse: [
+          {
+            command: 'node ".cursor/skills/impeccable/scripts/hook-before-edit.mjs"',
+            timeout: TIMEOUT_SECONDS,
+          },
+        ],
+      },
+    }),
+  },
+  {
+    // GitHub Copilot reads repo-level hooks from `.github/hooks/*.json`. The same
+    // manifest is honored by the CLI (once committed to the default branch) and
+    // the cloud/app agent. Schema differs: lowercase `postToolUse`, flat entries,
+    // `bash`/`timeoutSec`, and a `matcher` regex against the `edit`/`create` tools.
+    provider: '.github',
+    skillRel: '.github/skills/impeccable',
+    destRel: '.github/hooks/impeccable.json',
+    manifest: () => ({
+      version: 1,
+      hooks: {
+        postToolUse: [
+          {
+            type: 'command',
+            matcher: 'edit|create|apply_patch',
+            bash: 'node "$(git rev-parse --show-toplevel)/.github/skills/impeccable/scripts/hook.mjs"',
+            timeoutSec: TIMEOUT_SECONDS,
+          },
+        ],
+      },
+    }),
+  },
+];
+
+function readRawConfigFile(filePath) {
+  if (!fs.existsSync(filePath)) return { exists: false, malformed: false, raw: null };
+  try {
+    return { exists: true, malformed: false, raw: JSON.parse(fs.readFileSync(filePath, 'utf-8')) };
+  } catch {
+    return { exists: true, malformed: true, raw: null };
+  }
+}
+
+const DETECTOR_CONFIG_KEYS = new Set(['ignoreRules', 'ignoreFiles', 'ignoreValues', 'designSystem']);
+
+function hookSection(unified) {
+  return unified && typeof unified === 'object' && !Array.isArray(unified) && unified.hook && typeof unified.hook === 'object' && !Array.isArray(unified.hook)
+    ? unified.hook
+    : null;
+}
+
+function detectorSection(unified) {
+  return unified && typeof unified === 'object' && !Array.isArray(unified) && unified.detector && typeof unified.detector === 'object' && !Array.isArray(unified.detector)
+    ? unified.detector
+    : null;
+}
+
+function readRawHookConfig(cwd, opts = {}) {
+  const unified = readRawConfigFile(opts.local ? getLocalConfigPath(cwd) : getConfigPath(cwd)).raw;
+  return hookSection(unified);
+}
+
+function readRawDetectorConfig(cwd, opts = {}) {
+  const unified = readRawConfigFile(opts.local ? getLocalConfigPath(cwd) : getConfigPath(cwd)).raw;
+  const merged = mergeDetectorConfig(hookSection(unified));
+  return mergeDetectorConfig(detectorSection(unified), merged);
+}
+
+function stripDetectorKeys(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (!DETECTOR_CONFIG_KEYS.has(key)) out[key] = value;
+  }
+  return out;
+}
+
+// Write hook runtime config under `hook`, leaving detector filters in
+// `detector` and preserving sibling keys such as updateCheck.
+function writeHookConfig(cwd, hookConfig, opts = {}) {
+  const filePath = opts.local ? getLocalConfigPath(cwd) : getConfigPath(cwd);
+  if (opts.local) ensureHookGitExcludes(cwd);
+  const existingRaw = readRawConfigFile(filePath).raw;
+  const existing = existingRaw && typeof existingRaw === 'object' && !Array.isArray(existingRaw) ? existingRaw : {};
+  const existingHook = stripDetectorKeys(hookSection(existing));
+  // Merge over the existing hook object so fields the merge helpers don't manage
+  // (consent, quiet, auditLog) survive a `/impeccable hooks` edit.
+  const next = { ...existing, hook: { ...existingHook, ...hookConfig } };
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(next, null, 2) + '\n');
+  return filePath;
+}
+
+function writeDetectorConfig(cwd, detectorConfig, opts = {}) {
+  const filePath = opts.local ? getLocalConfigPath(cwd) : getConfigPath(cwd);
+  if (opts.local) ensureHookGitExcludes(cwd);
+  const existingRaw = readRawConfigFile(filePath).raw;
+  const existing = existingRaw && typeof existingRaw === 'object' && !Array.isArray(existingRaw) ? existingRaw : {};
+  const nextHook = stripDetectorKeys(hookSection(existing));
+  const existingDetector = mergeDetectorConfig(detectorSection(existing));
+  const next = {
+    ...existing,
+    detector: mergeDetectorConfig(detectorConfig, existingDetector),
+  };
+  if (Object.keys(nextHook).length > 0) next.hook = nextHook;
+  else delete next.hook;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(next, null, 2) + '\n');
+  return filePath;
+}
+
+function mergeHookConfig(existing) {
+  const base = existing && typeof existing === 'object' ? existing : {};
+  return {
+    enabled: base.enabled === false ? false : true,
+    limits: {
+      maxFindings: Number.isFinite(base?.limits?.maxFindings) ? base.limits.maxFindings : DEFAULT_CONFIG.limits.maxFindings,
+      maxChars: Number.isFinite(base?.limits?.maxChars) ? base.limits.maxChars : DEFAULT_CONFIG.limits.maxChars,
+    },
+  };
+}
+
+function mergeDetectorConfig(existing, seed = null) {
+  const base = existing && typeof existing === 'object' ? existing : {};
+  const out = seed ? {
+    ignoreRules: [...seed.ignoreRules],
+    ignoreFiles: [...seed.ignoreFiles],
+    ignoreValues: normalizeIgnoreValueEntries(seed.ignoreValues),
+  } : {
+    ignoreRules: [],
+    ignoreFiles: [],
+    ignoreValues: [],
+  };
+  if (seed?.designSystem && typeof seed.designSystem === 'object' && !Array.isArray(seed.designSystem)) {
+    out.designSystem = { ...seed.designSystem };
+  }
+  if (base.designSystem && typeof base.designSystem === 'object' && !Array.isArray(base.designSystem)) {
+    out.designSystem = {
+      ...(out.designSystem || {}),
+      enabled: base.designSystem.enabled === false ? false : true,
+    };
+  }
+  if (Array.isArray(base.ignoreRules)) {
+    out.ignoreRules = Array.from(new Set([...out.ignoreRules, ...base.ignoreRules.map(String)]));
+  }
+  if (Array.isArray(base.ignoreFiles)) {
+    out.ignoreFiles = Array.from(new Set([...out.ignoreFiles, ...base.ignoreFiles.map(String)]));
+  }
+  if (Array.isArray(base.ignoreValues)) {
+    out.ignoreValues = mergeIgnoreValueEntries(out.ignoreValues, base.ignoreValues);
+  }
+  return out;
+}
+
+function mergeIgnoreValueEntries(existing, incoming) {
+  const map = new Map();
+  for (const entry of normalizeIgnoreValueEntries(existing)) {
+    map.set(ignoreValueEntryKey(entry), entry);
+  }
+  for (const entry of normalizeIgnoreValueEntries(incoming)) {
+    map.set(ignoreValueEntryKey(entry), entry);
+  }
+  return Array.from(map.values());
+}
+
+function ignoreValueEntryKey(entry) {
+  const files = Array.isArray(entry.files) && entry.files.length > 0 ? entry.files.join('\x1f') : '';
+  return `${entry.rule}\0${entry.value}\0${files}`;
+}
+
+function statusReport(cwd) {
+  const shared = readRawConfigFile(getConfigPath(cwd));
+  const local = readRawConfigFile(getLocalConfigPath(cwd));
+  const cfg = readConfig(cwd);
+  const envKill = process.env.IMPECCABLE_HOOK_DISABLED;
+  const envState = envKill ? `IMPECCABLE_HOOK_DISABLED=${envKill}` : 'unset';
+  const cfgPath = path.relative(cwd, getConfigPath(cwd)) || '.impeccable/config.json';
+  const localPath = path.relative(cwd, getLocalConfigPath(cwd)) || '.impeccable/config.local.json';
+  const cachePath = path.relative(cwd, getCachePath(cwd)) || '.impeccable/hook.cache.json';
+  const fileState = (info, relPath, absent) => {
+    if (info.malformed) return `${relPath} (malformed; ignored)`;
+    if (info.exists) return relPath;
+    return `${relPath} (${absent})`;
+  };
+  const ignoreValues = cfg.ignoreValues.map((entry) => `${entry.rule}=${entry.value}`);
+
+  const lines = [
+    `Impeccable design hook`,
+    `  state:        ${cfg.enabled ? 'enabled' : 'disabled'}`,
+    `  shared file:  ${fileState(shared, cfgPath, 'using defaults; file not present')}`,
+    `  local file:   ${fileState(local, localPath, 'not present')}`,
+    `  ignoreRules:  ${cfg.ignoreRules.length ? cfg.ignoreRules.join(', ') : '(none)'}`,
+    `  ignoreFiles:  ${cfg.ignoreFiles.length ? cfg.ignoreFiles.join(', ') : '(none)'}`,
+    `  ignoreValues: ${ignoreValues.length ? ignoreValues.join(', ') : '(none)'}`,
+    `  maxFindings:  ${cfg.limits.maxFindings}`,
+    `  maxChars:     ${cfg.limits.maxChars}`,
+    `  env override: ${envState}`,
+    `  cache file:   ${fs.existsSync(getCachePath(cwd)) ? cachePath : `${cachePath} (not present)`}`,
+  ];
+  return lines.join('\n');
+}
+
+function setEnabled(cwd, value) {
+  const config = mergeHookConfig(readRawHookConfig(cwd));
+  config.enabled = value;
+  const target = writeHookConfig(cwd, config);
+  if (!value) {
+    return `Design hook disabled for this project (wrote ${path.relative(cwd, target) || target}).`;
+  }
+
+  const localTarget = writeHookConfig(cwd, { consent: 'accepted' }, { local: true });
+  const repaired = repairHookManifests(cwd);
+  const parts = [
+    `Design hook enabled for this project (wrote ${path.relative(cwd, target) || target}).`,
+    `Recorded local hook consent in ${path.relative(cwd, localTarget) || localTarget}.`,
+  ];
+  if (repaired.written.length > 0) {
+    parts.push(`Installed or repaired hook manifests for: ${repaired.written.join(', ')}.`);
+  } else if (repaired.already.length > 0) {
+    parts.push(`Hook manifests already installed for: ${repaired.already.join(', ')}.`);
+  } else {
+    parts.push('No installed provider skill folders found to repair.');
+  }
+  if (repaired.backups.length > 0) {
+    parts.push(`Backed up malformed manifest(s): ${repaired.backups.map((filePath) => path.relative(cwd, filePath) || filePath).join(', ')}.`);
+  }
+  return parts.join(' ');
+}
+
+function repairHookManifests(cwd) {
+  const result = { written: [], already: [], backups: [] };
+  for (const target of HOOK_MANIFEST_TARGETS) {
+    if (!fs.existsSync(path.join(cwd, target.skillRel))) continue;
+    const dest = path.join(cwd, target.destRel);
+    const sharedDest = target.sharedDestRel ? path.join(cwd, target.sharedDestRel) : null;
+
+    if (sharedDest && fileHasImpeccableHookMarker(sharedDest)) {
+      pruneImpeccableHookFromManifest(dest);
+      result.already.push(target.provider);
+      continue;
+    }
+
+    const fresh = target.manifest();
+    let next = fresh;
+    if (fs.existsSync(dest)) {
+      try {
+        next = mergeHookManifests(JSON.parse(fs.readFileSync(dest, 'utf-8')), fresh);
+      } catch {
+        const backup = `${dest}.bak`;
+        fs.copyFileSync(dest, backup);
+        result.backups.push(backup);
+      }
+    }
+
+    const serialized = `${JSON.stringify(next, null, 2)}\n`;
+    const current = fs.existsSync(dest) ? safeReadText(dest) : null;
+    if (current === serialized) {
+      result.already.push(target.provider);
+      continue;
+    }
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, serialized);
+    result.written.push(target.provider);
+  }
+  return result;
+}
+
+function safeReadText(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function mergeHookManifests(existing, fresh) {
+  const existingObject = existing && typeof existing === 'object' && !Array.isArray(existing) ? existing : {};
+  const freshObject = fresh && typeof fresh === 'object' && !Array.isArray(fresh) ? fresh : {};
+  const existingHooks = existingObject.hooks && typeof existingObject.hooks === 'object' && !Array.isArray(existingObject.hooks)
+    ? existingObject.hooks
+    : {};
+  const freshHooks = freshObject.hooks && typeof freshObject.hooks === 'object' && !Array.isArray(freshObject.hooks)
+    ? freshObject.hooks
+    : {};
+
+  const merged = { ...existingObject, hooks: {} };
+  if (freshObject.version !== undefined) merged.version = freshObject.version;
+  if (freshObject.description !== undefined) merged.description = freshObject.description;
+
+  const hookEvents = new Set([...Object.keys(existingHooks), ...Object.keys(freshHooks)]);
+  for (const event of hookEvents) {
+    const preserved = stripImpeccableHookEntries(existingHooks[event]);
+    const added = Array.isArray(freshHooks[event]) ? freshHooks[event] : [];
+    const mergedEntries = [...preserved, ...added];
+    if (mergedEntries.length > 0) merged.hooks[event] = mergedEntries;
+  }
+  return merged;
+}
+
+function fileHasImpeccableHookMarker(filePath) {
+  if (!fs.existsSync(filePath)) return false;
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return false;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+  if (!parsed.hooks || typeof parsed.hooks !== 'object') return false;
+  return valueHasImpeccableHookMarker(parsed.hooks);
+}
+
+function valueHasImpeccableHookMarker(value) {
+  if (typeof value === 'string') {
+    return IMPECCABLE_HOOK_COMMAND_MARKERS.some((marker) => value.includes(marker));
+  }
+  if (Array.isArray(value)) return value.some(valueHasImpeccableHookMarker);
+  if (value && typeof value === 'object') return Object.values(value).some(valueHasImpeccableHookMarker);
+  return false;
+}
+
+function stripImpeccableHookEntry(entry) {
+  if (!entry || typeof entry !== 'object') return entry;
+  // `command`/`args`: Claude/Codex/Cursor. `bash`/`powershell`: GitHub Copilot's
+  // flat entry shape, where the marker lives under the shell-command keys.
+  if (valueHasImpeccableHookMarker(entry.command) || valueHasImpeccableHookMarker(entry.args)
+    || valueHasImpeccableHookMarker(entry.bash) || valueHasImpeccableHookMarker(entry.powershell)) {
+    return null;
+  }
+  if (!Array.isArray(entry.hooks)) return entry;
+
+  const strippedHooks = entry.hooks
+    .map(stripImpeccableHookEntry)
+    .filter(Boolean);
+
+  if (strippedHooks.length === 0 && entry.hooks.some(valueHasImpeccableHookMarker)) {
+    return null;
+  }
+  return { ...entry, hooks: strippedHooks };
+}
+
+function stripImpeccableHookEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .map(stripImpeccableHookEntry)
+    .filter(Boolean);
+}
+
+function pruneImpeccableHookFromManifest(manifestPath) {
+  if (!fileHasImpeccableHookMarker(manifestPath)) return false;
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch {
+    return false;
+  }
+
+  const existingHooks = parsed.hooks && typeof parsed.hooks === 'object' && !Array.isArray(parsed.hooks)
+    ? parsed.hooks
+    : {};
+  const cleanedHooks = {};
+  for (const [event, entries] of Object.entries(existingHooks)) {
+    const kept = stripImpeccableHookEntries(entries);
+    if (kept.length > 0) cleanedHooks[event] = kept;
+  }
+
+  const next = { ...parsed };
+  if (Object.keys(cleanedHooks).length > 0) {
+    next.hooks = cleanedHooks;
+  } else {
+    delete next.hooks;
+    delete next.description;
+    delete next.version;
+  }
+
+  if (Object.keys(next).length === 0) {
+    fs.rmSync(manifestPath, { force: true });
+  } else {
+    fs.writeFileSync(manifestPath, `${JSON.stringify(next, null, 2)}\n`);
+  }
+  return true;
+}
+
+function normalizeRuleId(rule) {
+  return String(rule || '').trim().toLowerCase();
+}
+
+function parseIgnoreRuleArgs(args) {
+  const positionals = [];
+  let allValues = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = String(args[i] || '');
+    if (arg === '--all-values') {
+      allValues = true;
+    } else if (arg === '--reason') {
+      while (i + 1 < args.length && !String(args[i + 1]).startsWith('--')) i++;
+    } else if (arg.startsWith('--reason=')) {
+      // Accepted for command symmetry; ignoreRules stores rule ids only.
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown ignore-rule flag: ${arg}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  return {
+    rule: normalizeRuleId(positionals[0]),
+    allValues,
+  };
+}
+
+function addIgnoreRule(cwd, args) {
+  const parsed = parseIgnoreRuleArgs(args);
+  const rule = parsed.rule;
+  if (!rule) throw new Error('Pass a rule id, e.g. /impeccable hooks ignore-rule side-tab');
+  if (rule === 'overused-font' && !parsed.allValues) {
+    throw new Error('overused-font is value-specific by default. Use /impeccable hooks ignore-value overused-font <font> for a confirmed font, or /impeccable hooks ignore-rule overused-font --all-values only when the user asked to ignore overused fonts generally.');
+  }
+  const config = mergeDetectorConfig(readRawDetectorConfig(cwd));
+  if (!config.ignoreRules.includes(rule)) config.ignoreRules.push(rule);
+  writeDetectorConfig(cwd, config);
+  return `Added "${rule}" to detector.ignoreRules. Current: ${config.ignoreRules.join(', ')}`;
+}
+
+function addIgnoreFile(cwd, glob) {
+  if (!glob) throw new Error('Pass a glob, e.g. /impeccable hooks ignore-file "src/legacy/**"');
+  const config = mergeDetectorConfig(readRawDetectorConfig(cwd));
+  if (!config.ignoreFiles.includes(glob)) config.ignoreFiles.push(glob);
+  writeDetectorConfig(cwd, config);
+  return `Added "${glob}" to detector.ignoreFiles. Current: ${config.ignoreFiles.join(', ')}`;
+}
+
+function parseIgnoreValueArgs(args) {
+  const positionals = [];
+  let shared = false;
+  let local = false;
+  let reason = '';
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--shared') {
+      shared = true;
+    } else if (arg === '--local') {
+      local = true;
+    } else if (arg === '--reason') {
+      const chunks = [];
+      while (i + 1 < args.length && !String(args[i + 1]).startsWith('--')) {
+        chunks.push(args[++i]);
+      }
+      reason = chunks.join(' ').trim();
+    } else if (String(arg).startsWith('--reason=')) {
+      reason = String(arg).slice('--reason='.length).trim();
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  const [rule, ...valueParts] = positionals;
+  return {
+    rule: String(rule || '').trim().toLowerCase(),
+    value: normalizeIgnoreValue(valueParts.join(' ')),
+    shared,
+    local,
+    reason,
+  };
+}
+
+function addIgnoreValue(cwd, args) {
+  const parsed = parseIgnoreValueArgs(args);
+  if (!parsed.rule || !parsed.value) {
+    throw new Error('Pass a rule id and value, e.g. /impeccable hooks ignore-value overused-font Inter');
+  }
+
+  if (parsed.shared && parsed.local) {
+    throw new Error('Pass only one scope flag: --shared or --local');
+  }
+
+  const local = parsed.local;
+  const config = mergeDetectorConfig(readRawDetectorConfig(cwd, { local }));
+  const key = `${parsed.rule}\0${parsed.value}`;
+  const existing = config.ignoreValues.find((entry) => `${entry.rule}\0${entry.value}` === key);
+
+  if (existing) {
+    if (parsed.reason) existing.reason = parsed.reason;
+  } else {
+    const entry = {
+      rule: parsed.rule,
+      value: parsed.value,
+      createdAt: new Date().toISOString(),
+    };
+    if (parsed.reason) entry.reason = parsed.reason;
+    config.ignoreValues.push(entry);
+  }
+
+  const target = writeDetectorConfig(cwd, config, { local });
+  const scope = local ? 'local detector.ignoreValues' : 'shared detector.ignoreValues';
+  return `Added ${parsed.rule}=${parsed.value} to ${scope} (${path.relative(cwd, target) || target}).`;
+}
+
+function reset(cwd) {
+  const removed = [];
+  // Unified files may hold non-hook keys (e.g. updateCheck); strip only the
+  // hook/detector subtrees and keep the rest, deleting the file only if nothing remains.
+  for (const filePath of [getConfigPath(cwd), getLocalConfigPath(cwd)]) {
+    try {
+      const raw = readRawConfigFile(filePath).raw;
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw) || (!('hook' in raw) && !('detector' in raw))) continue;
+      const { hook, detector, ...rest } = raw;
+      if (Object.keys(rest).length === 0) {
+        fs.unlinkSync(filePath);
+      } else {
+        fs.writeFileSync(filePath, JSON.stringify(rest, null, 2) + '\n');
+      }
+      removed.push(path.relative(cwd, filePath) || filePath);
+    } catch { /* ignore */ }
+  }
+  // State files are wholly ours; delete outright.
+  for (const filePath of [getCachePath(cwd), getPendingPath(cwd)]) {
+    try {
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+        removed.push(path.relative(cwd, filePath) || filePath);
+      }
+    } catch { /* ignore */ }
+  }
+  return removed.length
+    ? `Reset design hook config and cache (removed: ${removed.join(', ')}).`
+    : 'No hook config or cache to remove. Already at defaults.';
+}
+
+function main() {
+  const [, , actionArg, ...rest] = process.argv;
+  const action = (actionArg || 'status').toLowerCase();
+  const cwd = process.cwd();
+
+  if (!ACTIONS.has(action)) {
+    process.stderr.write(`Unknown action: ${action}\nValid: ${Array.from(ACTIONS).join(', ')}\n`);
+    process.exit(1);
+  }
+
+  try {
+    let out = '';
+    switch (action) {
+      case 'status': out = statusReport(cwd); break;
+      case 'on':     out = setEnabled(cwd, true); break;
+      case 'off':    out = setEnabled(cwd, false); break;
+      case 'ignore-rule': out = addIgnoreRule(cwd, rest); break;
+      case 'ignore-file': out = addIgnoreFile(cwd, rest[0]); break;
+      case 'ignore-value': out = addIgnoreValue(cwd, rest); break;
+      case 'reset':  out = reset(cwd); break;
+    }
+    process.stdout.write(out + '\n');
+  } catch (err) {
+    process.stderr.write(`Error: ${err.message || err}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/workflows/skills/impeccable/scripts/hook-before-edit.mjs
+++ b/packages/workflows/skills/impeccable/scripts/hook-before-edit.mjs
@@ -1,0 +1,516 @@
+#!/usr/bin/env node
+/**
+ * Impeccable design hook — Cursor preToolUse write gate.
+ *
+ * Cursor's stop hook is not consistently dispatched by the headless agent, so
+ * this hook checks proposed Write/Edit content before it lands. It only denies
+ * writes when the real detector finds an issue in the proposed UI content.
+ *
+ * Contract: never break a turn accidentally. On malformed input or internal
+ * errors, allow the tool and exit 0.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  ALLOWED_EXTS,
+  EDIT_COUNT_THRESHOLD,
+  GENERATED_PATH,
+  SENSITIVE_PATH,
+  appendDesignSystemNote,
+  designSystemOptions,
+  filterFindings,
+  isNativePlatform,
+  loadDetector,
+  matchConfiguredExtension,
+  matchesAnyGlob,
+  persistCache,
+  readCache,
+  readConfig,
+  renderTemplate,
+  resolveCacheCwd,
+  resolveProjectCwd,
+  resolveProjectPlatform,
+  truthy,
+  writeAuditLog,
+} from './hook-lib.mjs';
+
+async function readStdin() {
+  if (process.stdin.isTTY) return '';
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function done(payload = null) {
+  if (payload) process.stdout.write(JSON.stringify(payload));
+  process.exit(0);
+}
+
+function allow(extra = {}, payload = {}) {
+  writeAuditLog(process.env, {
+    ts: new Date().toISOString(),
+    event: 'preToolUse',
+    ...extra,
+  });
+  return done({ permission: 'allow', ...payload });
+}
+
+function deny(message, audit) {
+  writeAuditLog(process.env, {
+    ts: new Date().toISOString(),
+    event: 'preToolUse',
+    blocked: true,
+    ...audit,
+  });
+  return done({
+    permission: 'deny',
+    user_message: message,
+    agent_message: message,
+  });
+}
+
+function toolInput(event) {
+  return event?.tool_input && typeof event.tool_input === 'object' ? event.tool_input : {};
+}
+
+function proposedFilePath(event, cwd) {
+  const input = toolInput(event);
+  const raw = input.file_path || input.path || input.target_file || event?.file_path;
+  const candidate = typeof raw === 'string' && raw.trim()
+    ? raw
+    : shellWriteDestination(shellCommand(input));
+  if (typeof candidate !== 'string' || !candidate.trim()) return '';
+  return path.isAbsolute(candidate) ? candidate : path.resolve(cwd, candidate);
+}
+
+function proposedContent(event, cwd, filePath) {
+  const input = toolInput(event);
+  for (const key of ['content', 'streamContent', 'text']) {
+    if (typeof input[key] === 'string') return input[key];
+  }
+
+  const editProjection = projectedEditContent(input, filePath, cwd);
+  if (editProjection !== undefined) return editProjection;
+
+  if (hasFragmentEditContent(input)) {
+    return { skipped: 'fragment-only-edit' };
+  }
+
+  const command = shellCommand(input);
+  const pythonContent = shellPythonWriteContent(command);
+  if (pythonContent) return pythonContent;
+  const shellContent = shellHereDocContent(command);
+  if (shellContent) return shellContent;
+  const copiedContent = shellCopiedFileContent(command, cwd);
+  if (copiedContent) return copiedContent;
+  return '';
+}
+
+function hasFragmentEditContent(input) {
+  if (!input || typeof input !== 'object') return false;
+  if (typeof input.new_string === 'string' || typeof input.newString === 'string' || typeof input.new_str === 'string' || typeof input.replacement === 'string') {
+    return true;
+  }
+  return Array.isArray(input.edits) && input.edits.some((edit) => edit && typeof edit === 'object');
+}
+
+function projectedEditContent(input, filePath, cwd) {
+  if (!filePath) return undefined;
+  const singleOld = firstString(input, ['old_string', 'oldString', 'old_str', 'target']);
+  const singleNew = firstString(input, ['new_string', 'newString', 'new_str', 'replacement']);
+  if (singleOld !== undefined || singleNew !== undefined) {
+    if (singleOld === undefined || singleNew === undefined) return { skipped: 'fragment-only-edit' };
+    const original = readExistingProjectFile(filePath, cwd);
+    if (original === null) return { skipped: 'edit-original-unreadable' };
+    const projected = replaceOnce(original, singleOld, singleNew);
+    return projected === null ? { skipped: 'edit-old-string-missing' } : projected;
+  }
+
+  if (!Array.isArray(input.edits)) return undefined;
+  const original = readExistingProjectFile(filePath, cwd);
+  if (original === null) return { skipped: 'edit-original-unreadable' };
+
+  let projected = original;
+  for (const edit of input.edits) {
+    if (!edit || typeof edit !== 'object') return { skipped: 'fragment-only-edit' };
+    const oldString = firstString(edit, ['old_string', 'oldString', 'old_str', 'target']);
+    const newString = firstString(edit, ['new_string', 'newString', 'new_str', 'replacement']);
+    if (oldString === undefined || newString === undefined) return { skipped: 'fragment-only-edit' };
+    const next = replaceOnce(projected, oldString, newString);
+    if (next === null) return { skipped: 'edit-old-string-missing' };
+    projected = next;
+  }
+  return projected;
+}
+
+function firstString(obj, keys) {
+  for (const key of keys) {
+    if (typeof obj?.[key] === 'string') return obj[key];
+  }
+  return undefined;
+}
+
+function replaceOnce(original, oldString, newString) {
+  if (oldString === '') return null;
+  const index = original.indexOf(oldString);
+  if (index === -1) return null;
+  return `${original.slice(0, index)}${newString}${original.slice(index + oldString.length)}`;
+}
+
+function readExistingProjectFile(filePath, cwd) {
+  if (!isInsideProject(filePath, cwd)) return null;
+  if (SENSITIVE_PATH.test(filePath) || GENERATED_PATH.test(filePath)) return null;
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile() || stat.size > 1024 * 1024) return null;
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function shellCommand(input) {
+  if (typeof input.command === 'string') return input.command;
+  if (input.args && typeof input.args.command === 'string') return input.args.command;
+  return '';
+}
+
+function shellRedirectPath(command) {
+  if (!command || typeof command !== 'string') return '';
+  const match = command.match(/(?:^|[\s;&|])(?:>>?|1>>?)\s*(?:"([^"]+)"|'([^']+)'|([^<>\s]+))/);
+  return (match?.[1] || match?.[2] || match?.[3] || '').trim();
+}
+
+function shellWriteDestination(command) {
+  return shellRedirectPath(command) || shellTeeDestination(command) || shellCopyPaths(command)?.dest || shellPythonWriteDestination(command) || '';
+}
+
+function shellPythonWriteDestination(command) {
+  if (!/\bpython(?:3)?\b/.test(command || '')) return '';
+  const directPath = firstMatch(command, /(?:^|[^\w.])(?:pathlib\.)?Path\(\s*(["'])(.*?)\1\s*\)\s*\.write_text\s*\(/);
+  if (directPath) return directPath;
+
+  const pathsByVar = new Map();
+  const assignmentRe = /\b([A-Za-z_]\w*)\s*=\s*(?:pathlib\.)?Path\(\s*(["'])(.*?)\2\s*\)/g;
+  let assignment;
+  while ((assignment = assignmentRe.exec(command))) {
+    pathsByVar.set(assignment[1], assignment[3]);
+  }
+
+  const writeVarRe = /\b([A-Za-z_]\w*)\.write_text\s*\(/g;
+  let writeVar;
+  while ((writeVar = writeVarRe.exec(command))) {
+    const candidate = pathsByVar.get(writeVar[1]);
+    if (candidate) return candidate;
+  }
+
+  return firstMatch(command, /\bopen\(\s*(["'])(.*?)\1\s*,\s*(["'])[wax](?:\+)?b?\3/);
+}
+
+function firstMatch(value, re) {
+  const match = String(value || '').match(re);
+  return (match?.[2] || '').trim();
+}
+
+function shellTeeDestination(command) {
+  const words = shellWords(command);
+  const teeIndex = words.findIndex((word) => path.basename(word) === 'tee');
+  if (teeIndex === -1) return '';
+  for (const word of words.slice(teeIndex + 1)) {
+    if (['&&', '||', ';', '|'].includes(word)) break;
+    if (word === '--') continue;
+    if (word.startsWith('-')) continue;
+    return word;
+  }
+  return '';
+}
+
+function shellCopiedFileContent(command, cwd) {
+  const source = shellCopyPaths(command)?.source;
+  if (!source) return '';
+  const sourcePath = path.isAbsolute(source) ? source : path.resolve(cwd, source);
+  if (!isInsideProject(sourcePath, cwd)) return '';
+  if (SENSITIVE_PATH.test(sourcePath) || GENERATED_PATH.test(sourcePath)) return '';
+  try {
+    const stat = fs.statSync(sourcePath);
+    if (!stat.isFile() || stat.size > 1024 * 1024) return '';
+    return fs.readFileSync(sourcePath, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+function shellCopyPaths(command) {
+  const words = shellWords(command);
+  if (words.length < 3 || path.basename(words[0]) !== 'cp') return null;
+  const args = [];
+  for (const word of words.slice(1)) {
+    if (['&&', '||', ';', '|'].includes(word)) break;
+    if (word === '--') continue;
+    if (word.startsWith('-')) continue;
+    args.push(word);
+  }
+  if (args.length < 2) return null;
+  return { source: args[args.length - 2], dest: args[args.length - 1] };
+}
+
+function shellWords(command) {
+  if (!command || typeof command !== 'string') return [];
+  const words = [];
+  const re = /"((?:\\"|[^"])*)"|'((?:\\'|[^'])*)'|([^\s]+)/g;
+  let match;
+  while ((match = re.exec(command))) {
+    words.push((match[1] ?? match[2] ?? match[3] ?? '').replace(/\\(["'])/g, '$1'));
+  }
+  return words;
+}
+
+function shellHereDocContent(command) {
+  if (!command || typeof command !== 'string') return '';
+  const markerMatch = command.match(/<<-?\s*['"]?([A-Za-z0-9_.-]+)['"]?[^\r\n]*\r?\n/);
+  if (!markerMatch) return '';
+  const marker = markerMatch[1];
+  const start = (markerMatch.index || 0) + markerMatch[0].length;
+  const rest = command.slice(start);
+  const endRe = new RegExp(`\\r?\\n${escapeRegExp(marker)}(?:\\r?\\n|$)`);
+  const end = rest.search(endRe);
+  return end >= 0 ? rest.slice(0, end) : '';
+}
+
+function shellPythonWriteContent(command) {
+  if (!/\bpython(?:3)?\b/.test(command || '')) return '';
+  const script = shellHereDocContent(command) || command;
+  return pythonStringArg(script, /\.write_text\s*\(\s*/g) || pythonStringArg(script, /\.write\s*\(\s*/g);
+}
+
+function pythonStringArg(script, prefixRe) {
+  let prefix;
+  while ((prefix = prefixRe.exec(script))) {
+    const start = prefixRe.lastIndex;
+    const triple = script.slice(start, start + 3);
+    if (triple === "'''" || triple === '"""') {
+      const end = script.indexOf(triple, start + 3);
+      if (end !== -1) return script.slice(start + 3, end);
+      continue;
+    }
+    const quote = script[start];
+    if (quote !== '"' && quote !== "'") continue;
+    let out = '';
+    for (let i = start + 1; i < script.length; i++) {
+      const ch = script[i];
+      if (ch === '\\') {
+        out += script[i + 1] || '';
+        i += 1;
+      } else if (ch === quote) {
+        return out;
+      } else {
+        out += ch;
+      }
+    }
+  }
+  return '';
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function relativePath(filePath, cwd) {
+  try {
+    const rel = path.relative(cwd, filePath);
+    if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return filePath;
+    return rel.split(path.sep).join('/');
+  } catch {
+    return filePath;
+  }
+}
+
+function isInsideProject(filePath, cwd) {
+  try {
+    const rel = path.relative(cwd, filePath);
+    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  } catch {
+    return false;
+  }
+}
+
+// The static HTML engine reads its input from disk, but preToolUse only has
+// the proposed content. Stage it in a temp file so html-engine targets get the
+// same DOM-structural rules pre-write that runHook applies post-edit.
+async function detectProposedHtml(detector, content, filePath, scanOptions) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'impeccable-pre-'));
+  const tmpFile = path.join(dir, path.basename(filePath));
+  try {
+    fs.writeFileSync(tmpFile, content);
+    const findings = await detector.detectHtml(tmpFile, scanOptions);
+    // Findings carry the temp path; remap so file-scoped ignores still match.
+    return (findings || []).map((f) => (f && typeof f === 'object' ? { ...f, file: filePath } : f));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function cursorBlockMessage(findings, filePath, config, cwd) {
+  const rendered = renderTemplate(findings, filePath, config, { cwd });
+  const blocked = rendered.replace(
+    '[impeccable@1] Design hook findings requiring review',
+    '[impeccable@1] Impeccable design hook blocked this write before it landed. Design hook findings requiring review',
+  );
+  return blocked.length > 4000 ? `${blocked.slice(0, 3984)}\n...(truncated)` : blocked;
+}
+
+function findingSignature(findings) {
+  return findings
+    .map((finding) => `${finding.antipattern || 'unknown'}:${finding.line || 0}`)
+    .sort()
+    .join('|');
+}
+
+function bumpCursorDenial(cache, sessionId, filePath, findings) {
+  const session = cache.sessions[sessionId] || { updatedAt: Date.now(), files: {} };
+  cache.sessions[sessionId] = session;
+  session.updatedAt = Date.now();
+  const fileEntry = session.files[filePath] || { editCount: 0, findings: [] };
+  session.files[filePath] = fileEntry;
+  const key = findingSignature(findings);
+  fileEntry.cursorDenials = fileEntry.cursorDenials && typeof fileEntry.cursorDenials === 'object'
+    ? fileEntry.cursorDenials
+    : {};
+  fileEntry.cursorDenials[key] = (fileEntry.cursorDenials[key] || 0) + 1;
+  return { key, count: fileEntry.cursorDenials[key] };
+}
+
+async function main() {
+  if (truthy(process.env.IMPECCABLE_HOOK_DISABLED)) {
+    return allow({ skipped: 'env-disabled' });
+  }
+
+  let event = null;
+  try {
+    const raw = await readStdin();
+    if (raw) event = JSON.parse(raw);
+  } catch {
+    return allow({ skipped: 'stdin-malformed' });
+  }
+
+  if (!event || typeof event !== 'object') {
+    return allow({ skipped: 'stdin-empty' });
+  }
+
+  const sessionCwd = resolveProjectCwd(event);
+  const started = Date.now();
+  const filePath = proposedFilePath(event, sessionCwd);
+  // Re-key config/cache to the edited file's project root when the session
+  // was launched from a non-project umbrella directory (issue #305).
+  const cwd = resolveCacheCwd(filePath, sessionCwd);
+  const audit = {
+    harness: 'cursor',
+    cwd,
+    tool: event.tool_name || null,
+    file: filePath || null,
+  };
+
+  if (!filePath) return allow({ ...audit, skipped: 'no-file-path', durationMs: Date.now() - started });
+  if (!isInsideProject(filePath, cwd)) return allow({ ...audit, skipped: 'outside-project', durationMs: Date.now() - started });
+  if (SENSITIVE_PATH.test(filePath)) return allow({ ...audit, skipped: 'sensitive', durationMs: Date.now() - started });
+  if (GENERATED_PATH.test(filePath)) return allow({ ...audit, skipped: 'generated', durationMs: Date.now() - started });
+
+  // Config is read before the extension gate so `detector.extensions` entries
+  // (e.g. `.blade.php` template files, issue #316) can widen it.
+  const config = readConfig(cwd);
+  const ext = path.extname(filePath).toLowerCase();
+  const configuredExt = matchConfiguredExtension(filePath, config.extensions);
+  audit.ext = configuredExt ? configuredExt.ext : ext;
+  if (!ALLOWED_EXTS.has(ext) && !configuredExt) return allow({ ...audit, skipped: 'extension', durationMs: Date.now() - started });
+
+  const contentResult = proposedContent(event, cwd, filePath);
+  if (contentResult && typeof contentResult === 'object' && contentResult.skipped) {
+    return allow({ ...audit, skipped: contentResult.skipped, durationMs: Date.now() - started });
+  }
+  const content = typeof contentResult === 'string' ? contentResult : '';
+  if (!content) return allow({ ...audit, skipped: 'no-proposed-content', durationMs: Date.now() - started });
+
+  if (config.enabled === false) return allow({ ...audit, skipped: 'config-disabled', durationMs: Date.now() - started });
+
+  // Web rule engine, native project: stand aside (see resolveProjectPlatform).
+  const platform = resolveProjectPlatform(cwd);
+  if (isNativePlatform(platform)) {
+    return allow({ ...audit, skipped: 'native-platform', platform, durationMs: Date.now() - started });
+  }
+
+  const rel = relativePath(filePath, cwd);
+  if (matchesAnyGlob(rel, config.ignoreFiles) || matchesAnyGlob(filePath, config.ignoreFiles)) {
+    return allow({ ...audit, skipped: 'config-ignore-file', durationMs: Date.now() - started });
+  }
+
+  const detector = await loadDetector();
+  if (!detector || typeof detector.detectText !== 'function') {
+    return allow({ ...audit, skipped: 'detector-missing', durationMs: Date.now() - started });
+  }
+  const scanOptions = designSystemOptions(config, detector, cwd);
+
+  // Mirror runHook's engine routing so template issues the HTML engine catches
+  // post-edit cannot slip past the pre-write gate.
+  const useHtmlEngine = configuredExt
+    ? configuredExt.engine === 'html'
+    : (ext === '.html' || ext === '.htm');
+  let findings = [];
+  try {
+    findings = useHtmlEngine && typeof detector.detectHtml === 'function'
+      ? await detectProposedHtml(detector, content, filePath, scanOptions)
+      : await detector.detectText(content, filePath, scanOptions);
+  } catch {
+    return allow({ ...audit, error: 'detector-threw', durationMs: Date.now() - started });
+  }
+
+  const filtered = filterFindings(findings || [], content, ext, config);
+  if (filtered.length === 0) {
+    return allow({
+      ...audit,
+      findings: (findings || []).length,
+      blockedFindings: 0,
+      durationMs: Date.now() - started,
+    });
+  }
+
+  const message = appendDesignSystemNote(cursorBlockMessage(filtered, filePath, config, cwd), scanOptions);
+  const sessionId = event.session_id || event.conversation_id || 'unknown';
+  const cache = readCache(cwd);
+  const denial = bumpCursorDenial(cache, sessionId, filePath, filtered);
+  persistCache(cwd, cache);
+  if (denial.count > EDIT_COUNT_THRESHOLD) {
+    const warning = `${message}\n\nThis is the ${denial.count}th repeated denial for the same file and finding signature, so Impeccable is allowing this write to avoid a loop. Reconsider the issue immediately after the tool runs.`;
+    return allow({
+      ...audit,
+      findings: (findings || []).length,
+      blockedFindings: filtered.length,
+      cursorDenialKey: denial.key,
+      cursorDenialCount: denial.count,
+      downgraded: true,
+      chars: warning.length,
+      durationMs: Date.now() - started,
+    }, {
+      user_message: warning,
+      agent_message: warning,
+    });
+  }
+  return deny(message, {
+    ...audit,
+    findings: (findings || []).length,
+    blockedFindings: filtered.length,
+    cursorDenialKey: denial.key,
+    cursorDenialCount: denial.count,
+    chars: message.length,
+    durationMs: Date.now() - started,
+  });
+}
+
+main().catch((err) => {
+  if (process.env.IMPECCABLE_HOOK_DEBUG) {
+    process.stderr.write(`[impeccable-hook-before-edit] ${err}\n`);
+  }
+  done({ permission: 'allow' });
+});

--- a/packages/workflows/skills/impeccable/scripts/hook-lib.mjs
+++ b/packages/workflows/skills/impeccable/scripts/hook-lib.mjs
@@ -1,0 +1,1764 @@
+/**
+ * Shared library for the Impeccable design hook.
+ *
+ * Pure-ish helpers split out from `hook.mjs` so unit tests can exercise
+ * config parsing, finding filtering, dedup, render, and cache logic without
+ * spawning a subprocess. `hook.mjs` itself is the thin stdin/stdout shim.
+ *
+ * Public surface (everything exported is part of the contract):
+ *   ENVELOPE_PREFIX, ALLOWED_EXTS, ACK_EXTS, SENSITIVE_PATH, GENERATED_PATH, TRUTHY
+ *   truthy(value)
+ *   readConfig(cwd) / DEFAULT_CONFIG / getConfigPath(cwd) / getLocalConfigPath(cwd)
+ *   resolveProjectPlatform(cwd) / isNativePlatform(platform)
+ *   normalizeIgnoreValue(value)
+ *   readCache(cwd) / persistCache(cwd, cache) / resolveCacheCwd(primaryFile, sessionCwd)
+ *   bumpEditCount(cache, sessionId, filePath) -> number
+ *   suppressionNotice(filePath)
+ *   filterFindings(findings, content, ext, config)
+ *   matchConfiguredExtension(filePath, extensions)
+ *   dedupeAgainstCache(findings, cache, sessionId, filePath)
+ *   renderTemplate(findings, filePath, config, opts)
+ *   renderCleanAck(filePath, opts) / renderPendingAck(filePath, known, opts)
+ *   shouldEmitAckForFile(filePath, config?)
+ *   writeAuditLog(env, entry)
+ *   loadDetector() -> Promise<{ detectText, detectHtml }>
+ *   matchesAnyGlob(filePath, globs)
+ *   normalizeScanTargets(primaryTargets, projectCwd)
+ *   runHook(deps) -> { exitCode, stdout, audit, reason? }
+ *
+ * Design notes:
+ * - All errors are swallowed at the runHook seam. The detector throwing must
+ *   never break a turn. See PRD §5 "Failure modes".
+ * - Cache shape is JSON-friendly; we gc the oldest sessions when there are
+ *   more than 8 to keep file size predictable across long-lived projects.
+ * - The detector loader looks for `detector/detect-antipatterns.mjs` next to
+ *   this file first (built skill layout) and falls back to the repo root's
+ *   `cli/engine/detect-antipatterns.mjs` (running from source).
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { extractPlatform, loadContext } from './context.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const ENVELOPE_PREFIX = '[impeccable@1]';
+
+export const ALLOWED_EXTS = new Set([
+  '.tsx', '.jsx', '.html', '.htm', '.vue', '.svelte', '.astro',
+  '.css', '.scss', '.sass', '.less', '.ts', '.js',
+]);
+
+export const ACK_EXTS = new Set([
+  '.tsx', '.jsx', '.html', '.htm', '.vue', '.svelte', '.astro',
+  '.css', '.scss', '.sass', '.less',
+]);
+
+// Hard-skip regex for sensitive files. Cannot be turned off via config.
+// Match tokenized secret/credential filenames, not UI names such as
+// CredentialForm.tsx, SecretPage.jsx, or secretary-dashboard.vue.
+export const SENSITIVE_PATH = new RegExp([
+  String.raw`(?:^|[/\\])\.env(?:\.|$)`,
+  String.raw`(?:^|[/\\])\.git(?:[/\\]|$)`,
+  String.raw`(?:^|[/\\])id_rsa(?:$|[._-])[^/\\]*$`,
+  String.raw`(?:^|[/\\])[^/\\]*\.pem$`,
+  String.raw`(?:^|[/\\])(?:[^/\\]*[._-])?(?:secret|secrets|credential|credentials)(?=[._-])[^/\\]*\.(?:json|ya?ml|toml|ini|conf|config|env|txt|key|cert|crt|pem|js|ts)$`,
+].join('|'), 'i');
+
+// Hard-skip regex for generated, lock, minified, and build-output paths.
+export const GENERATED_PATH = /(?:\.generated\.[a-z]+$|\.d\.ts$|\.min\.[a-z]+$|[/\\]node_modules[/\\]|[/\\](?:dist|build|out|\.next|\.cache|coverage)[/\\]|[/\\]?[^/\\]+\.lock(?:\.json)?$)/i;
+
+export const TRUTHY = /^(1|true|yes|on)$/i;
+
+export const DEFAULT_CONFIG = Object.freeze({
+  enabled: true,
+  quiet: false,
+  auditLog: null,
+  designSystem: { enabled: true },
+  ignoreRules: [],
+  ignoreFiles: [],
+  ignoreValues: [],
+  extensions: [],
+  limits: { maxFindings: 5, maxChars: 8000 },
+});
+
+export const HOOK_LOCAL_IGNORE_PATTERNS = Object.freeze([
+  '.impeccable/hook.cache.json',
+  '.impeccable/hook.pending.json',
+  '.impeccable/config.local.json',
+]);
+
+const HOOK_IGNORE_MARKER_OPEN = '# impeccable-hook-ignore-start';
+const HOOK_IGNORE_MARKER_CLOSE = '# impeccable-hook-ignore-end';
+const CACHE_MAX_SESSIONS = 8;
+export const EDIT_COUNT_THRESHOLD = 6;
+
+export function truthy(value) {
+  return typeof value === 'string' && TRUTHY.test(value);
+}
+
+function depthIsSet(value) {
+  if (value === undefined || value === null) return false;
+  const text = String(value).trim();
+  if (!text) return false;
+  if (TRUTHY.test(text)) return true;
+  return /^\d+$/.test(text) && Number(text) > 0;
+}
+
+function safeReadJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function getConfigPath(cwd) {
+  return path.join(cwd, '.impeccable', 'config.json');
+}
+
+export function getLocalConfigPath(cwd) {
+  return path.join(cwd, '.impeccable', 'config.local.json');
+}
+
+export function getCachePath(cwd) {
+  return path.join(cwd, '.impeccable', 'hook.cache.json');
+}
+
+export function getPendingPath(cwd) {
+  return path.join(cwd, '.impeccable', 'hook.pending.json');
+}
+
+export function resolveProjectCwd(event, fallback = process.cwd()) {
+  return event?.cwd
+    || (Array.isArray(event?.workspace_roots) && event.workspace_roots[0])
+    || envProjectDir(fallback)
+    || fallback;
+}
+
+function looksLikeProjectRoot(dir) {
+  return ['.git', 'package.json', '.impeccable'].some((marker) => {
+    try { return fs.existsSync(path.join(dir, marker)); } catch { return false; }
+  });
+}
+
+// Where `.impeccable/` (cache + config) lives for this event. Normally the
+// session cwd, untouched. But when the agent was launched from an umbrella
+// directory that is not itself a project (no .git, package.json, or
+// .impeccable), key to the edited file's nearest project root instead, so a
+// multi-project launch dir doesn't accumulate a shared cross-project cache
+// (issue #305). Climbing stops at the home dir, falling back to the session
+// cwd when no marker is found.
+export function resolveCacheCwd(primaryFile, sessionCwd) {
+  const base = path.resolve(sessionCwd || process.cwd());
+  if (!primaryFile || typeof primaryFile !== 'string' || hasPathTraversal(primaryFile)) return base;
+  if (looksLikeProjectRoot(base)) return base;
+  let dir;
+  try {
+    dir = path.dirname(path.resolve(primaryFile));
+  } catch {
+    return base;
+  }
+  const home = path.resolve(os.homedir());
+  while (true) {
+    if (dir === home) return base;
+    if (looksLikeProjectRoot(dir)) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return base;
+    dir = parent;
+  }
+}
+
+// The detector's rules are web rules (HTML/CSS shapes), but a React Native or
+// Flutter project is made of the exact extensions the hook watches (.tsx, .ts,
+// .js), so without this gate every native screen edit would draw web-shaped
+// findings that contradict the native platform references. PRODUCT.md's
+// `## Platform` field decides: `ios` / `android` / `adaptive` projects skip
+// the scan entirely. Resolution goes through loadContext so the hook reads the
+// same PRODUCT.md the skill does (alternate context dirs, monorepo fallback).
+export function resolveProjectPlatform(cwd) {
+  try {
+    const ctx = loadContext(cwd);
+    return extractPlatform(ctx && ctx.product);
+  } catch {
+    return null;
+  }
+}
+
+export function isNativePlatform(platform) {
+  return platform === 'ios' || platform === 'android' || platform === 'adaptive';
+}
+
+export function readConfig(cwd) {
+  const config = cloneDefaultConfig();
+  // Hook runtime settings live under `hook`; detector filters live under
+  // `detector`. Back-compat: older configs stored detector filters in `hook`,
+  // so read those first and let canonical `detector` settings win.
+  for (const filePath of [getConfigPath(cwd), getLocalConfigPath(cwd)]) {
+    const raw = safeReadJson(filePath);
+    applyConfigSource(config, hookSection(raw));
+    applyDetectorConfigSource(config, detectorSection(raw));
+  }
+  return config;
+}
+
+// The hook settings subtree of a unified config.json / config.local.json.
+function hookSection(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  return raw.hook && typeof raw.hook === 'object' && !Array.isArray(raw.hook) ? raw.hook : null;
+}
+
+function detectorSection(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  return raw.detector && typeof raw.detector === 'object' && !Array.isArray(raw.detector) ? raw.detector : null;
+}
+
+function numberOr(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function cloneDefaultConfig() {
+  return {
+    ...DEFAULT_CONFIG,
+    ignoreRules: [],
+    ignoreFiles: [],
+    ignoreValues: [],
+    extensions: [],
+    designSystem: { ...DEFAULT_CONFIG.designSystem },
+    limits: { ...DEFAULT_CONFIG.limits },
+  };
+}
+
+function applyDetectorConfigSource(config, raw) {
+  if (!raw || typeof raw !== 'object') return config;
+  if (raw.designSystem && typeof raw.designSystem === 'object' && !Array.isArray(raw.designSystem)) {
+    config.designSystem = {
+      ...config.designSystem,
+      enabled: raw.designSystem.enabled === false ? false : true,
+    };
+  }
+  if (Array.isArray(raw.ignoreRules)) {
+    config.ignoreRules = uniqueStrings([...config.ignoreRules, ...raw.ignoreRules]);
+  }
+  if (Array.isArray(raw.ignoreFiles)) {
+    config.ignoreFiles = uniqueStrings([...config.ignoreFiles, ...raw.ignoreFiles]);
+  }
+  if (Array.isArray(raw.ignoreValues)) {
+    config.ignoreValues = mergeIgnoreValues(config.ignoreValues, raw.ignoreValues);
+  }
+  if (Array.isArray(raw.extensions)) {
+    config.extensions = mergeExtensions(config.extensions, raw.extensions);
+  }
+  return config;
+}
+
+// Extra scanned extensions from `detector.extensions` config. Entries are
+// `{ ext, engine }` (engine 'html' | 'text', default 'html' — the common case
+// for server-side templates) or bare strings as shorthand. Extensions are
+// matched against the end of the filename, not path.extname, so double
+// extensions like `.blade.php` and `.html.erb` work (issue #316).
+function normalizeExtensionEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  const out = [];
+  for (const entry of entries) {
+    const raw = typeof entry === 'string' ? entry : entry?.ext;
+    if (typeof raw !== 'string') continue;
+    let ext = raw.trim().toLowerCase();
+    if (!ext) continue;
+    if (!ext.startsWith('.')) ext = `.${ext}`;
+    const engine = (!(typeof entry === 'string') && entry?.engine === 'text') ? 'text' : 'html';
+    out.push({ ext, engine });
+  }
+  return out;
+}
+
+function mergeExtensions(existing, incoming) {
+  const map = new Map();
+  for (const entry of normalizeExtensionEntries(existing)) map.set(entry.ext, entry);
+  for (const entry of normalizeExtensionEntries(incoming)) map.set(entry.ext, entry);
+  return Array.from(map.values());
+}
+
+export function matchConfiguredExtension(filePath, extensions) {
+  if (!Array.isArray(extensions) || extensions.length === 0) return null;
+  const name = path.basename(String(filePath || '')).toLowerCase();
+  if (!name) return null;
+  // The longest matching suffix wins, so `.blade.php` beats a broader `.php`
+  // entry regardless of config order.
+  let best = null;
+  for (const entry of normalizeExtensionEntries(extensions)) {
+    if (name.length > entry.ext.length && name.endsWith(entry.ext)
+      && (!best || entry.ext.length > best.ext.length)) {
+      best = entry;
+    }
+  }
+  return best;
+}
+
+function applyConfigSource(config, raw) {
+  if (!raw || typeof raw !== 'object') return config;
+  if (Object.prototype.hasOwnProperty.call(raw, 'enabled')) {
+    config.enabled = raw.enabled === false ? false : true;
+  }
+  if (Object.prototype.hasOwnProperty.call(raw, 'quiet')) {
+    config.quiet = raw.quiet === true;
+  }
+  if (typeof raw.auditLog === 'string' && raw.auditLog.trim()) {
+    config.auditLog = raw.auditLog.trim();
+  }
+  applyDetectorConfigSource(config, raw);
+  if (raw.limits && typeof raw.limits === 'object') {
+    config.limits = {
+      maxFindings: numberOr(raw.limits.maxFindings, config.limits.maxFindings),
+      maxChars: numberOr(raw.limits.maxChars, config.limits.maxChars),
+    };
+  }
+  return config;
+}
+
+function uniqueStrings(values) {
+  return Array.from(new Set(values.map(String)));
+}
+
+export function normalizeIgnoreValue(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .replace(/\+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function normalizeIgnoreRule(rule) {
+  return String(rule || '').trim().toLowerCase();
+}
+
+function colorIgnoreKey(value) {
+  const color = parseIgnoreColor(value);
+  if (!color) return '';
+  return `${color.r},${color.g},${color.b},${Math.round(color.a * 255)}`;
+}
+
+function parseIgnoreColor(value) {
+  const text = String(value || '').trim().toLowerCase();
+  if (!text) return null;
+
+  const hex = text.match(/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
+  if (hex) return parseHexIgnoreColor(hex[1]);
+
+  const rgb = text.match(/^rgba?\((.*)\)$/i);
+  if (rgb) {
+    const parts = splitColorArgs(rgb[1]);
+    if (parts.length < 3 || parts.length > 4) return null;
+    const r = parseRgbChannel(parts[0]);
+    const g = parseRgbChannel(parts[1]);
+    const b = parseRgbChannel(parts[2]);
+    const a = parts[3] === undefined ? 1 : parseAlphaChannel(parts[3]);
+    if ([r, g, b, a].some((v) => v === null)) return null;
+    return { r, g, b, a };
+  }
+
+  const hsl = text.match(/^hsla?\((.*)\)$/i);
+  if (hsl) {
+    const parts = splitColorArgs(hsl[1]);
+    if (parts.length < 3 || parts.length > 4) return null;
+    const h = parseHueChannel(parts[0]);
+    const s = parsePercentChannel(parts[1]);
+    const l = parsePercentChannel(parts[2]);
+    const a = parts[3] === undefined ? 1 : parseAlphaChannel(parts[3]);
+    if ([h, s, l, a].some((v) => v === null)) return null;
+    return hslToRgb(h, s, l, a);
+  }
+
+  return null;
+}
+
+function parseHexIgnoreColor(hex) {
+  if (hex.length === 3 || hex.length === 4) {
+    const r = parseInt(hex[0] + hex[0], 16);
+    const g = parseInt(hex[1] + hex[1], 16);
+    const b = parseInt(hex[2] + hex[2], 16);
+    const a = hex.length === 4 ? parseInt(hex[3] + hex[3], 16) / 255 : 1;
+    return { r, g, b, a };
+  }
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const a = hex.length === 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1;
+  return { r, g, b, a };
+}
+
+function splitColorArgs(body) {
+  const text = String(body || '').trim();
+  if (!text) return [];
+  if (text.includes(',')) {
+    const parts = text.split(',').map((part) => part.trim()).filter(Boolean);
+    const last = parts[parts.length - 1];
+    if (last && last.includes('/')) {
+      const split = last.split('/').map((part) => part.trim()).filter(Boolean);
+      return [...parts.slice(0, -1), ...split];
+    }
+    return parts;
+  }
+  return text.replace(/\s*\/\s*/g, ' / ').split(/\s+/).filter((part) => part && part !== '/');
+}
+
+function parseRgbChannel(raw) {
+  const text = String(raw || '').trim();
+  const match = text.match(/^(-?\d*\.?\d+)(%)?$/);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return null;
+  const scaled = match[2] ? value * 2.55 : value;
+  if (scaled < 0 || scaled > 255) return null;
+  return Math.round(scaled);
+}
+
+function parseAlphaChannel(raw) {
+  const text = String(raw || '').trim();
+  const match = text.match(/^(-?\d*\.?\d+)(%)?$/);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return null;
+  const alpha = match[2] ? value / 100 : value;
+  return alpha >= 0 && alpha <= 1 ? alpha : null;
+}
+
+function parseHueChannel(raw) {
+  const text = String(raw || '').trim();
+  const match = text.match(/^(-?\d*\.?\d+)(deg|rad|turn|grad)?$/);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return null;
+  const unit = match[2] || 'deg';
+  if (unit === 'turn') return value * 360;
+  if (unit === 'rad') return value * (180 / Math.PI);
+  if (unit === 'grad') return value * 0.9;
+  return value;
+}
+
+function parsePercentChannel(raw) {
+  const text = String(raw || '').trim();
+  const match = text.match(/^(-?\d*\.?\d+)%$/);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return null;
+  return value >= 0 && value <= 100 ? value / 100 : null;
+}
+
+function hslToRgb(hue, saturation, lightness, alpha) {
+  const h = (((hue % 360) + 360) % 360) / 360;
+  if (saturation === 0) {
+    const gray = clampByte(Math.round(lightness * 255));
+    return { r: gray, g: gray, b: gray, a: alpha };
+  }
+  const q = lightness < 0.5
+    ? lightness * (1 + saturation)
+    : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+  const toRgb = (t) => {
+    let channel = t;
+    if (channel < 0) channel += 1;
+    if (channel > 1) channel -= 1;
+    if (channel < 1 / 6) return p + (q - p) * 6 * channel;
+    if (channel < 1 / 2) return q;
+    if (channel < 2 / 3) return p + (q - p) * (2 / 3 - channel) * 6;
+    return p;
+  };
+  return {
+    r: clampByte(Math.round(toRgb(h + 1 / 3) * 255)),
+    g: clampByte(Math.round(toRgb(h) * 255)),
+    b: clampByte(Math.round(toRgb(h - 1 / 3) * 255)),
+    a: alpha,
+  };
+}
+
+function clampByte(value) {
+  return Math.min(255, Math.max(0, value));
+}
+
+function ignoreValueMatches(rule, entryValue, findingValue) {
+  if (entryValue === findingValue) return true;
+  if (rule !== 'design-system-color') return false;
+  const entryColor = colorIgnoreKey(entryValue);
+  return Boolean(entryColor && entryColor === colorIgnoreKey(findingValue));
+}
+
+export function normalizeIgnoreValueEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  const out = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    const rule = normalizeIgnoreRule(entry.rule);
+    const value = normalizeIgnoreValue(entry.value);
+    if (!rule || !value) continue;
+    const normalized = { rule, value };
+    const files = uniqueStrings([
+      ...(typeof entry.file === 'string' && entry.file.trim() ? [entry.file.trim()] : []),
+      ...(Array.isArray(entry.files) ? entry.files.filter(v => typeof v === 'string' && v.trim()).map(v => v.trim()) : []),
+    ]);
+    if (files.length > 0) normalized.files = files;
+    if (typeof entry.reason === 'string' && entry.reason.trim()) {
+      normalized.reason = entry.reason.trim();
+    }
+    if (typeof entry.createdAt === 'string' && entry.createdAt.trim()) {
+      normalized.createdAt = entry.createdAt.trim();
+    }
+    out.push(normalized);
+  }
+  return out;
+}
+
+function mergeIgnoreValues(existing, incoming) {
+  const map = new Map();
+  for (const entry of normalizeIgnoreValueEntries(existing)) {
+    map.set(`${entry.rule}\0${entry.value}\0${ignoreValueFilesKey(entry.files)}`, entry);
+  }
+  for (const entry of normalizeIgnoreValueEntries(incoming)) {
+    map.set(`${entry.rule}\0${entry.value}\0${ignoreValueFilesKey(entry.files)}`, entry);
+  }
+  return Array.from(map.values());
+}
+
+function ignoreValueFilesKey(files) {
+  return Array.isArray(files) && files.length > 0 ? files.join('\x1f') : '';
+}
+
+export function readCache(cwd) {
+  const raw = safeReadJson(getCachePath(cwd));
+  if (!raw || typeof raw !== 'object' || raw.version !== 1) {
+    return { version: 1, sessions: {} };
+  }
+  return {
+    version: 1,
+    sessions: raw.sessions && typeof raw.sessions === 'object' ? raw.sessions : {},
+  };
+}
+
+export function persistCache(cwd, cache) {
+  const sessions = cache.sessions || {};
+  const ids = Object.keys(sessions);
+  if (ids.length > CACHE_MAX_SESSIONS) {
+    // Garbage-collect oldest sessions by updatedAt.
+    const ordered = ids
+      .map((id) => [id, sessions[id]?.updatedAt || 0])
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, CACHE_MAX_SESSIONS);
+    const next = {};
+    for (const [id] of ordered) next[id] = sessions[id];
+    cache = { ...cache, sessions: next };
+  }
+  const target = getCachePath(cwd);
+  try {
+    ensureHookGitExcludes(cwd);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, JSON.stringify(cache));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function ensureHookGitExcludes(cwd = process.cwd()) {
+  try {
+    const target = resolveHookGitExcludeTarget(cwd);
+    if (!target) {
+      return { mode: 'none', changed: false, patterns: [...HOOK_LOCAL_IGNORE_PATTERNS] };
+    }
+
+    const patterns = target.patternPrefix
+      ? HOOK_LOCAL_IGNORE_PATTERNS.map((pattern) => `${target.patternPrefix}/${pattern}`)
+      : [...HOOK_LOCAL_IGNORE_PATTERNS];
+    const markerSuffix = target.patternPrefix || '.';
+    const markerOpen = `${HOOK_IGNORE_MARKER_OPEN} ${markerSuffix}`;
+    const markerClose = `${HOOK_IGNORE_MARKER_CLOSE} ${markerSuffix}`;
+    const existing = fs.existsSync(target.path) ? fs.readFileSync(target.path, 'utf-8') : '';
+    const block = [markerOpen, ...patterns, markerClose].join('\n');
+    const markerRe = new RegExp(`${escapeRegExp(markerOpen)}[\\s\\S]*?${escapeRegExp(markerClose)}`);
+
+    let updated;
+    if (markerRe.test(existing)) {
+      updated = existing.replace(markerRe, block);
+    } else {
+      const prefix = existing.length === 0 ? '' : existing.endsWith('\n') ? existing : `${existing}\n`;
+      updated = `${prefix}${prefix.endsWith('\n\n') || prefix === '' ? '' : '\n'}${block}\n`;
+    }
+
+    if (updated !== existing) {
+      fs.mkdirSync(path.dirname(target.path), { recursive: true });
+      fs.writeFileSync(target.path, updated, 'utf-8');
+    }
+
+    return {
+      mode: 'git-info-exclude',
+      file: path.relative(path.resolve(cwd), target.path).split(path.sep).join('/'),
+      changed: updated !== existing,
+      patterns,
+    };
+  } catch {
+    return { mode: 'error', changed: false, patterns: [...HOOK_LOCAL_IGNORE_PATTERNS] };
+  }
+}
+
+function resolveHookGitExcludeTarget(cwd) {
+  const start = path.resolve(cwd);
+  let dir = start;
+  while (true) {
+    const dotGit = path.join(dir, '.git');
+    if (fs.existsSync(dotGit)) {
+      const gitDir = resolveGitDir(dotGit, dir);
+      if (!gitDir) return null;
+      const relPrefix = path.relative(dir, start).split(path.sep).join('/');
+      return {
+        path: path.join(gitDir, 'info', 'exclude'),
+        patternPrefix: relPrefix && relPrefix !== '.' ? relPrefix : '',
+      };
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function resolveGitDir(dotGit, worktreeDir) {
+  const stat = fs.statSync(dotGit);
+  if (stat.isDirectory()) return dotGit;
+  if (!stat.isFile()) return null;
+
+  const body = fs.readFileSync(dotGit, 'utf-8').trim();
+  const match = body.match(/^gitdir:\s*(.+)$/i);
+  if (!match) return null;
+  return path.isAbsolute(match[1]) ? match[1] : path.resolve(worktreeDir, match[1]);
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function ensureSession(cache, sessionId) {
+  if (!cache.sessions[sessionId]) {
+    cache.sessions[sessionId] = { updatedAt: Date.now(), files: {} };
+  }
+  return cache.sessions[sessionId];
+}
+
+function ensureFile(cache, sessionId, filePath) {
+  const session = ensureSession(cache, sessionId);
+  if (!session.files[filePath]) {
+    session.files[filePath] = { editCount: 0, findings: [] };
+  }
+  return session.files[filePath];
+}
+
+export function bumpEditCount(cache, sessionId, filePath) {
+  const fileEntry = ensureFile(cache, sessionId, filePath);
+  fileEntry.editCount = (fileEntry.editCount || 0) + 1;
+  ensureSession(cache, sessionId).updatedAt = Date.now();
+  return fileEntry.editCount;
+}
+
+export function suppressionNotice(filePath) {
+  return `${ENVELOPE_PREFIX} Suppressing further design hints on ${filePath}. More than ${EDIT_COUNT_THRESHOLD} edits in this session reached. Run /impeccable audit to revisit.`;
+}
+
+// Glob → RegExp. Supports `**`, `*`, `?`, and `{a,b}` alternation.
+function globToRegex(glob) {
+  let re = '^';
+  let i = 0;
+  while (i < glob.length) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*';
+        i += 2;
+        if (glob[i] === '/') i += 1;
+      } else {
+        re += '[^/]*';
+        i += 1;
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+      i += 1;
+    } else if (c === '{') {
+      const end = glob.indexOf('}', i);
+      if (end === -1) { re += '\\{'; i += 1; continue; }
+      const parts = glob.slice(i + 1, end).split(',').map((p) => p.replace(/[.+^$()|[\]\\]/g, '\\$&'));
+      re += `(?:${parts.join('|')})`;
+      i = end + 1;
+    } else if (/[.+^$()|[\]\\]/.test(c)) {
+      re += `\\${c}`;
+      i += 1;
+    } else {
+      re += c;
+      i += 1;
+    }
+  }
+  re += '$';
+  return new RegExp(re);
+}
+
+export function matchesAnyGlob(filePath, globs) {
+  if (!Array.isArray(globs) || globs.length === 0) return false;
+  const normalized = filePath.split(path.sep).join('/');
+  for (const glob of globs) {
+    try {
+      const re = globToRegex(String(glob));
+      if (re.test(normalized)) return true;
+      // Match against basename too for convenience: `*.generated.tsx` should
+      // catch `src/foo.generated.tsx` without requiring `**/`.
+      const base = normalized.split('/').pop();
+      if (re.test(base)) return true;
+    } catch {
+      /* malformed glob, skip */
+    }
+  }
+  return false;
+}
+
+export function filterFindings(findings, _content, _ext, config) {
+  if (!Array.isArray(findings) || findings.length === 0) return [];
+  const ignoreRules = new Set((config.ignoreRules || []).map((rule) => normalizeIgnoreRule(rule)));
+  const ignoreValues = normalizeIgnoreValueEntries(config.ignoreValues || []);
+  return findings.filter((f) => {
+    if (!f || typeof f !== 'object') return false;
+    if (ignoreRules.has(normalizeIgnoreRule(f.antipattern))) return false;
+    if (isIgnoredFindingValue(f, ignoreValues)) return false;
+    return true;
+  });
+}
+
+function isIgnoredFindingValue(finding, ignoreValues) {
+  if (!Array.isArray(ignoreValues) || ignoreValues.length === 0) return false;
+  const rule = normalizeIgnoreRule(finding.antipattern);
+  if (!rule) return false;
+  // File-scoped wildcards suppress rules with no extractable value, such as side-tab.
+  const value = extractFindingIgnoreValue(finding);
+  return ignoreValues.some((entry) => {
+    if (entry.rule !== rule) return false;
+    const wildcardValue = entry.value === '*';
+    if (!wildcardValue && (!value || !ignoreValueMatches(rule, entry.value, value))) return false;
+    if (!Array.isArray(entry.files) || entry.files.length === 0) return !wildcardValue;
+    return findingMatchesScopedIgnoreFile(finding, entry.files);
+  });
+}
+
+function findingMatchesScopedIgnoreFile(finding, globs) {
+  const filePath = String(finding?.file || '').trim();
+  if (!filePath) return false;
+  if (matchesAnyGlob(filePath, globs)) return true;
+
+  const normalized = filePath.split(path.sep).join('/');
+  const parts = normalized.split('/').filter(Boolean);
+  for (let i = 0; i < parts.length; i++) {
+    const suffix = parts.slice(i).join('/');
+    if (matchesAnyGlob(suffix, globs)) return true;
+  }
+  return false;
+}
+
+export function extractFindingIgnoreValue(finding) {
+  if (!finding || typeof finding !== 'object') return '';
+  const rule = normalizeIgnoreRule(finding.antipattern);
+  const directValueRules = new Set([
+    'overused-font',
+    'bounce-easing',
+    'design-system-font',
+    'design-system-color',
+    'design-system-radius',
+  ]);
+  if (!directValueRules.has(rule)) return '';
+  return normalizeIgnoreValue(extractFindingIgnoreValueRaw(finding, rule));
+}
+
+function extractFindingIgnoreValueRaw(finding, rule = normalizeIgnoreRule(finding?.antipattern)) {
+  const direct = cleanIgnoreValueDisplay(finding.ignoreValue || finding.value || '');
+  if (direct) return direct;
+
+  const candidates = [finding.detail, finding.snippet].filter((v) => typeof v === 'string' && v);
+  for (const text of candidates) {
+    if (rule === 'bounce-easing') {
+      const motion = extractMotionIgnoreValue(text);
+      if (motion) return motion;
+      continue;
+    }
+
+    const primary = text.match(/Primary font:\s*([^()\n;]+)/i);
+    if (primary) return cleanIgnoreValueDisplay(primary[1]);
+
+    const family = text.match(/font-family\s*:\s*["']?([^'",;\n]+)/i);
+    if (family) return cleanIgnoreValueDisplay(family[1]);
+
+    const google = text.match(/[?&]family=([^&:;\n]+)/i);
+    if (google) {
+      try {
+        return cleanIgnoreValueDisplay(decodeURIComponent(google[1]));
+      } catch {
+        return cleanIgnoreValueDisplay(google[1]);
+      }
+    }
+  }
+
+  return '';
+}
+
+function extractMotionIgnoreValue(text) {
+  const tailwind = text.match(/\banimate-bounce\b/i);
+  if (tailwind) return cleanIgnoreValueDisplay(tailwind[0]);
+
+  const bezier = text.match(/cubic-bezier\([^)]+\)/i);
+  if (bezier) return cleanIgnoreValueDisplay(bezier[0]);
+
+  const animation = text.match(/animation(?:-name)?\s*:\s*([^;\n]+)/i);
+  if (animation) {
+    const token = animation[1]
+      .split(/[,\s]+/)
+      .find((part) => /bounce|elastic|wobble|jiggle|spring/i.test(part));
+    if (token) return cleanIgnoreValueDisplay(token);
+  }
+
+  return '';
+}
+
+function cleanIgnoreValueDisplay(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .replace(/\+/g, ' ')
+    .replace(/\s+/g, ' ');
+}
+
+export function dedupeAgainstCache(findings, cache, sessionId, filePath) {
+  if (!Array.isArray(findings) || findings.length === 0) return [];
+  const fileEntry = ensureFile(cache, sessionId, filePath);
+  const known = new Set(fileEntry.findings || []);
+  const fresh = [];
+  for (const f of findings) {
+    const key = findingCacheKey(f);
+    if (known.has(key)) continue;
+    known.add(key);
+    fresh.push(f);
+  }
+  return fresh;
+}
+
+export function rememberFindings(cache, sessionId, filePath, findings) {
+  const fileEntry = ensureFile(cache, sessionId, filePath);
+  const known = new Set(fileEntry.findings || []);
+  for (const f of findings) known.add(findingCacheKey(f));
+  fileEntry.findings = Array.from(known);
+  ensureSession(cache, sessionId).updatedAt = Date.now();
+}
+
+function findingCacheKey(finding) {
+  const line = finding?.line || 0;
+  const value = extractFindingIgnoreValue(finding);
+  if (line > 0 && value) return `${finding.antipattern}:${line}:${value}`;
+  if (line > 0) return `${finding.antipattern}:${line}`;
+  if (value) return `${finding.antipattern}:0:${value}`;
+  const snippet = String(finding?.snippet || '').trim().slice(0, 80);
+  return snippet ? `${finding.antipattern}:0:${snippet}` : `${finding.antipattern}:0`;
+}
+
+export function renderTemplate(findings, filePath, config, opts = {}) {
+  if (!Array.isArray(findings) || findings.length === 0) return '';
+  const limits = config?.limits || DEFAULT_CONFIG.limits;
+  const cap = Math.max(1, limits.maxFindings || DEFAULT_CONFIG.limits.maxFindings);
+  const maxChars = Math.max(500, limits.maxChars || DEFAULT_CONFIG.limits.maxChars);
+
+  const cwd = opts.cwd || process.cwd();
+  const display = relativize(filePath, cwd);
+  const total = findings.length;
+  const shown = findings.slice(0, cap);
+  const remaining = total - shown.length;
+
+  const header = `${ENVELOPE_PREFIX} Design hook findings requiring review in ${display} (${total} issue(s)):`;
+  const lines = shown.map((f) => formatFindingLine(f));
+  const more = remaining > 0
+    ? `... and ${remaining} more (see /impeccable audit).`
+    : null;
+  const footer = directiveFooter(display);
+
+  const blocks = [header, ...lines];
+  if (more) blocks.push(more);
+  blocks.push('');
+  blocks.push(footer);
+  let text = blocks.join('\n');
+
+  if (text.length > maxChars) {
+    text = clampToBudget(header, lines, more, footer, maxChars);
+  }
+  return text;
+}
+
+function renderGroupedTemplate(groups, config, opts = {}) {
+  const realGroups = groups.filter((group) => Array.isArray(group.findings) && group.findings.length > 0);
+  if (realGroups.length === 0) return '';
+  if (realGroups.length === 1) {
+    const [group] = realGroups;
+    return renderTemplate(group.findings, group.filePath, config, opts);
+  }
+
+  const limits = config?.limits || DEFAULT_CONFIG.limits;
+  const cap = Math.max(1, limits.maxFindings || DEFAULT_CONFIG.limits.maxFindings);
+  const maxChars = Math.max(500, limits.maxChars || DEFAULT_CONFIG.limits.maxChars);
+  const cwd = opts.cwd || process.cwd();
+  const total = realGroups.reduce((sum, group) => sum + group.findings.length, 0);
+  const header = `${ENVELOPE_PREFIX} Design hook findings requiring review across ${realGroups.length} files (${total} issue(s)):`;
+  const lines = [];
+  let shownCount = 0;
+
+  for (const group of realGroups) {
+    const display = relativize(group.filePath, cwd);
+    lines.push(`${display} (${group.findings.length} issue(s)):`);
+    const remainingCap = Math.max(0, cap - shownCount);
+    const shown = group.findings.slice(0, remainingCap);
+    for (const finding of shown) {
+      lines.push(formatFindingLine(finding));
+    }
+    shownCount += shown.length;
+    const hidden = group.findings.length - shown.length;
+    if (hidden > 0) {
+      lines.push(`- ... ${hidden} more in ${display} (see /impeccable audit).`);
+    }
+  }
+
+  const footer = directiveFooter('the affected files', { grouped: true });
+  let text = [header, ...lines, '', footer].join('\n');
+  if (text.length > maxChars) {
+    text = clampGroupedToBudget(header, lines, footer, maxChars);
+  }
+  return text;
+}
+
+function clampGroupedToBudget(header, lines, footer, maxChars) {
+  const assemble = (linesArr, omitted) => [
+    header,
+    ...linesArr,
+    ...(omitted ? ['... and more (see /impeccable audit).'] : []),
+    '',
+    footer,
+  ].join('\n');
+
+  let working = lines.slice();
+  let omitted = false;
+  let assembled = assemble(working, omitted);
+  while (assembled.length > maxChars && working.length > 1) {
+    working.pop();
+    omitted = true;
+    assembled = assemble(working, omitted);
+  }
+  if (assembled.length > maxChars) {
+    assembled = `${assembled.slice(0, maxChars - 1)}…`;
+  }
+  return assembled;
+}
+
+function clampToBudget(header, lines, more, footer, maxChars) {
+  const assemble = (linesArr, moreText) => {
+    const blocks = [header, ...linesArr];
+    if (moreText) blocks.push(moreText);
+    blocks.push('');
+    blocks.push(footer);
+    return blocks.join('\n');
+  };
+
+  let working = lines.slice();
+  let moreText = more;
+  let assembled = assemble(working, moreText);
+  while (assembled.length > maxChars && working.length > 1) {
+    working.pop();
+    moreText = '... and more (see /impeccable audit).';
+    assembled = assemble(working, moreText);
+  }
+  if (assembled.length > maxChars) {
+    assembled = `${assembled.slice(0, maxChars - 1)}…`;
+  }
+  return assembled;
+}
+
+function formatFindingLine(f) {
+  const prefix = f.line && f.line > 0 ? `- L${f.line}` : '-';
+  const desc = (f.description || '').trim();
+  const name = (f.name || '').trim();
+  // Description from the registry already ends in punctuation; join with a
+  // single space. `name` may have a trailing period already, keep it clean.
+  const nameSegment = name ? `${name.replace(/\.+\s*$/, '')}.` : '';
+  const ignoreCommand = formatFindingIgnoreCommand(f);
+  const ignoreSegment = ignoreCommand
+    ? ` If the user explicitly confirms this value is intentional: \`${ignoreCommand}\`.`
+    : '';
+  return `${prefix} [${f.antipattern}] ${nameSegment} ${desc}${ignoreSegment}`.replace(/\s+/g, ' ').trim();
+}
+
+function formatFindingIgnoreCommand(finding) {
+  if (!finding || typeof finding !== 'object') return '';
+  const rule = normalizeIgnoreRule(finding.antipattern);
+  if (!rule) return '';
+  const normalizedValue = extractFindingIgnoreValue(finding);
+  if (!normalizedValue) return '';
+  const value = extractFindingIgnoreValueRaw(finding);
+  const valueArg = quoteCommandArg(value);
+  const reason = quoteCommandArg(`User confirmed ${value} is intentional`);
+  return `/impeccable hooks ignore-value ${rule} ${valueArg} --shared --reason ${reason}`;
+}
+
+function quoteCommandArg(value) {
+  const text = String(value || '').trim();
+  if (/^[A-Za-z0-9._:-]+$/.test(text)) return text;
+  return `"${text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function relativize(filePath, cwd) {
+  try {
+    const rel = path.relative(cwd, filePath);
+    if (!rel || rel.startsWith('..')) return filePath;
+    return rel.split(path.sep).join('/');
+  } catch {
+    return filePath;
+  }
+}
+
+// Codex `apply_patch` exposes the raw patch in `tool_input.command`, not
+// `tool_input.file_path`. Claude Code may send both; parse the patch body
+// so we can scan the file(s) the tool actually touched.
+// https://developers.openai.com/codex/hooks#posttooluse
+const APPLY_PATCH_FILE_RE = /^\*\*\* (?:Update|Add) File: (.+)$/gm;
+
+export function parseApplyPatchPaths(command, projectCwd) {
+  if (!command || typeof command !== 'string') return [];
+  const out = [];
+  for (const m of command.matchAll(APPLY_PATCH_FILE_RE)) {
+    let p = (m[1] || '').trim();
+    if (!p) continue;
+    if (!path.isAbsolute(p)) p = path.resolve(projectCwd, p);
+    out.push(p);
+  }
+  return out;
+}
+
+export function resolveTargetFiles(event, projectCwd) {
+  const ti = event?.tool_input;
+  const out = [];
+  const add = (filePath) => {
+    if (typeof filePath !== 'string' || !filePath) return;
+    if (!out.includes(filePath)) out.push(filePath);
+  };
+
+  if (event?.tool_name === 'apply_patch' && ti && typeof ti.command === 'string') {
+    for (const filePath of parseApplyPatchPaths(ti.command, projectCwd)) add(filePath);
+  }
+  if (ti && typeof ti.file_path === 'string' && ti.file_path) {
+    add(ti.file_path);
+  }
+  // Cursor Write / StrReplace use `path`, not `file_path`.
+  if (ti && typeof ti.path === 'string' && ti.path) {
+    add(ti.path);
+  }
+  if (typeof event?.file_path === 'string' && event.file_path) {
+    add(event.file_path);
+  }
+  return out;
+}
+
+export function resolveHarness(env = {}, event = null) {
+  const explicit = env?.IMPECCABLE_HOOK_HARNESS;
+  if (explicit === 'cursor') return 'cursor';
+  if (explicit === 'github') return 'github';
+  if (explicit === 'claude' || explicit === 'codex') return 'claude';
+  // GitHub Copilot's postToolUse event uses camelCase `toolName`/`toolArgs` and
+  // has no `tool_name`/`tool_input`. That shape is the discriminator.
+  if (event && typeof event === 'object'
+    && (typeof event.toolName === 'string' || event.toolArgs !== undefined)
+    && event.tool_name === undefined && event.tool_input === undefined) {
+    return 'github';
+  }
+  if (typeof event?.conversation_id === 'string' && event.conversation_id) return 'cursor';
+  return 'claude';
+}
+
+// GitHub Copilot's postToolUse payload is
+//   { sessionId, timestamp, cwd, toolName, toolArgs, toolResult }
+// mapped onto the internal `{ tool_name, tool_input, cwd, session_id }` shape.
+// `toolArgs` shape depends on the tool: the `edit`/`create`/`view` tools send a
+// JSON *string* (double-encoded) carrying the file under `path`, e.g.
+//   "{\"path\":\"/abs/app.tsx\",\"old_str\":\"...\",\"new_str\":\"...\"}",
+// while `apply_patch` sends a raw OpenAI-format patch string (handled below in
+// normalizeGitHubEvent). The detector reads the file from disk after the tool
+// ran, so only the path (not the proposed content) is needed here.
+export function parseGitHubToolArgs(toolArgs) {
+  if (toolArgs && typeof toolArgs === 'object' && !Array.isArray(toolArgs)) return toolArgs;
+  if (typeof toolArgs === 'string' && toolArgs.trim()) {
+    try {
+      const parsed = JSON.parse(toolArgs);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+// Copilot's `apply_patch` tool (used by interactive sessions and the cloud
+// agent) sends a raw OpenAI-format patch string in toolArgs, not JSON:
+//   *** Begin Patch
+//   *** Add File: /abs/app.css
+//   +body { ... }
+//   *** End Patch
+// The `view`/`edit`/`create` tools (seen in `copilot -p` runs) instead send a
+// JSON string with the path under `path`. Both must map onto the internal shape.
+const APPLY_PATCH_MARKER = /\*\*\* (?:Begin Patch|Add File:|Update File:|Delete File:)/;
+
+function looksLikeApplyPatch(rawArgs) {
+  if (typeof rawArgs !== 'string' || !APPLY_PATCH_MARKER.test(rawArgs)) return false;
+  // Guard against an edit/create payload whose edited *content* happens to
+  // contain patch markers: that payload is a JSON object string, whereas a real
+  // apply_patch payload is a raw patch string that does not parse as JSON. Only
+  // treat non-JSON-object strings as apply_patch so edit events still get their
+  // `path` extracted.
+  try {
+    const parsed = JSON.parse(rawArgs);
+    if (parsed && typeof parsed === 'object') return false;
+  } catch { /* not JSON → genuine raw patch */ }
+  return true;
+}
+
+function applyPatchText(rawArgs) {
+  if (typeof rawArgs === 'string') {
+    if (APPLY_PATCH_MARKER.test(rawArgs)) return rawArgs;
+    // Defensive: a future Copilot build might JSON-wrap the patch.
+    const parsed = parseGitHubToolArgs(rawArgs);
+    return parsed.patch || parsed.input || parsed.command || '';
+  }
+  if (rawArgs && typeof rawArgs === 'object' && !Array.isArray(rawArgs)) {
+    return rawArgs.patch || rawArgs.input || rawArgs.command || '';
+  }
+  return '';
+}
+
+function normalizeGitHubEvent(event, projectCwd) {
+  const cwd = event.cwd || envProjectDir(projectCwd) || projectCwd;
+  const sessionId = event.sessionId || event.session_id || 'unknown';
+  const toolName = event.toolName || event.tool_name || null;
+  const toolInput = event.tool_input && typeof event.tool_input === 'object' ? { ...event.tool_input } : {};
+  const rawArgs = event.toolArgs;
+
+  let normalizedToolName = toolName;
+  if (toolName === 'apply_patch' || looksLikeApplyPatch(rawArgs)) {
+    // resolveTargetFiles() reads the touched paths from tool_input.command when
+    // tool_name is 'apply_patch', so normalize the name even if a future build
+    // sends the patch under a different tool label.
+    const patch = applyPatchText(rawArgs);
+    if (patch) {
+      toolInput.command = patch;
+      normalizedToolName = 'apply_patch';
+    }
+  } else {
+    const args = parseGitHubToolArgs(rawArgs);
+    const filePath = args.path || args.file_path || args.filePath || args.target_file;
+    if (typeof filePath === 'string' && filePath) toolInput.file_path = filePath;
+  }
+
+  return {
+    ...event,
+    cwd,
+    session_id: sessionId,
+    tool_name: normalizedToolName,
+    tool_input: toolInput,
+  };
+}
+
+export function normalizeHookEvent(event, projectCwd, harness = 'claude') {
+  if (!event || typeof event !== 'object') return event;
+  if (harness === 'github') return normalizeGitHubEvent(event, projectCwd);
+  if (harness !== 'cursor') return event;
+
+  const cwd = event.cwd
+    || (Array.isArray(event.workspace_roots) && event.workspace_roots[0])
+    || envProjectDir(projectCwd)
+    || projectCwd;
+  const sessionId = event.session_id || event.conversation_id || 'unknown';
+
+  const ti = event.tool_input && typeof event.tool_input === 'object' ? event.tool_input : {};
+  const filePath = ti.file_path || ti.path || event.file_path;
+  if (filePath) {
+    return {
+      ...event,
+      cwd,
+      session_id: sessionId,
+      tool_input: { ...ti, file_path: filePath },
+    };
+  }
+
+  return { ...event, cwd, session_id: sessionId };
+}
+
+function envProjectDir(fallback) {
+  if (typeof process.env.CURSOR_PROJECT_DIR === 'string' && process.env.CURSOR_PROJECT_DIR) {
+    return process.env.CURSOR_PROJECT_DIR;
+  }
+  return fallback;
+}
+
+// UI components often keep slop in a sibling/co-located stylesheet while the
+// JSX edit is what triggered PostToolUse. Scan those styles too so an App.jsx
+// patch doesn't report "clean" while styles.css still has Inter/bounce/etc.
+const UI_CODE_EXTS = new Set(['.jsx', '.tsx', '.vue', '.svelte', '.astro']);
+const STYLE_EXTS = new Set(['.css', '.scss', '.sass', '.less']);
+const CO_SCAN_STYLE_NAMES = [
+  'styles.css', 'styles.scss', 'styles.sass', 'styles.less',
+  'index.css', 'index.scss', 'index.sass', 'index.less',
+  'global.css', 'global.scss', 'global.sass', 'global.less',
+  'globals.css', 'globals.scss', 'globals.sass', 'globals.less',
+];
+const MAX_SCAN_TARGETS = 6;
+
+const STATIC_STYLE_IMPORT_RE = /import\s+(?:[\w*{}\s,$]+\s+from\s+)?['"]([^'"]+\.(?:css|scss|sass|less))['"]/gi;
+
+function hasPathTraversal(filePath) {
+  return typeof filePath === 'string' && filePath.includes('..');
+}
+
+function isInsideProject(filePath, projectCwd) {
+  if (!filePath || !projectCwd || hasPathTraversal(filePath)) return false;
+  try {
+    const rel = path.relative(projectCwd, filePath);
+    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  } catch {
+    return false;
+  }
+}
+
+export function parseStaticStyleImports(content, fromFile, projectCwd) {
+  if (!content || typeof content !== 'string') return [];
+  const dir = path.dirname(fromFile);
+  const out = [];
+  for (const m of content.matchAll(STATIC_STYLE_IMPORT_RE)) {
+    let p = (m[1] || '').trim();
+    if (!p) continue;
+    if (p.startsWith('.')) p = path.resolve(dir, p);
+    else if (!path.isAbsolute(p)) p = path.resolve(projectCwd, p);
+    if (!isInsideProject(p, projectCwd)) continue;
+    out.push(p);
+  }
+  return out;
+}
+
+export function coLocatedStylesheets(filePath) {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath, path.extname(filePath));
+  const candidates = new Set([
+    path.join(dir, `${base}.css`),
+    path.join(dir, `${base}.module.css`),
+    path.join(dir, `${base}.scss`),
+    path.join(dir, `${base}.module.scss`),
+    path.join(dir, `${base}.sass`),
+    path.join(dir, `${base}.module.sass`),
+    path.join(dir, `${base}.less`),
+    path.join(dir, `${base}.module.less`),
+  ]);
+  for (const name of CO_SCAN_STYLE_NAMES) {
+    candidates.add(path.join(dir, name));
+  }
+  return [...candidates].filter((p) => fs.existsSync(p));
+}
+
+export function normalizeScanTargets(primaryTargets, projectCwd) {
+  if (!Array.isArray(primaryTargets) || primaryTargets.length === 0) return [];
+  const ordered = [];
+  const seen = new Set();
+  const baseCwd = projectCwd || process.cwd();
+  const normalizeTarget = (p) => {
+    // Preserve literal `..` segments so downstream sensitive-path checks
+    // still fire. path.resolve would collapse `/foo/../etc/passwd`.
+    if (hasPathTraversal(p)) return p;
+    return path.isAbsolute(p) ? p : path.resolve(baseCwd, p);
+  };
+  const add = (p) => {
+    if (ordered.length >= MAX_SCAN_TARGETS) return;
+    const abs = normalizeTarget(p);
+    if (seen.has(abs)) return;
+    seen.add(abs);
+    ordered.push(abs);
+    return abs;
+  };
+
+  for (const p of primaryTargets) add(p);
+  return ordered;
+}
+
+export function expandScanTargets(primaryTargets, projectCwd) {
+  const ordered = normalizeScanTargets(primaryTargets, projectCwd);
+  if (ordered.length === 0) return [];
+  const seen = new Set(ordered);
+  const baseCwd = projectCwd || process.cwd();
+  const add = (p) => {
+    if (ordered.length >= MAX_SCAN_TARGETS) return;
+    const abs = hasPathTraversal(p) ? p : (path.isAbsolute(p) ? p : path.resolve(baseCwd, p));
+    if (seen.has(abs)) return;
+    seen.add(abs);
+    ordered.push(abs);
+    return abs;
+  };
+
+  const normalizedPrimaries = [];
+  for (const p of ordered) normalizedPrimaries.push(p);
+
+  for (const p of normalizedPrimaries) {
+    if (ordered.length >= MAX_SCAN_TARGETS) break;
+    if (!isInsideProject(p, baseCwd)) continue;
+    const ext = path.extname(p).toLowerCase();
+    if (STYLE_EXTS.has(ext) || !UI_CODE_EXTS.has(ext)) continue;
+
+    let content = '';
+    try { content = fs.readFileSync(p, 'utf-8'); } catch { /* unreadable primary */ }
+
+    for (const imp of parseStaticStyleImports(content, p, projectCwd)) {
+      add(imp);
+      if (ordered.length >= MAX_SCAN_TARGETS) break;
+    }
+    for (const col of coLocatedStylesheets(p)) {
+      add(col);
+      if (ordered.length >= MAX_SCAN_TARGETS) break;
+    }
+  }
+
+  return ordered;
+}
+
+export function writeAuditLog(env, entry, cwd = process.cwd()) {
+  // The event's project root (entry.cwd) when present, else the passed cwd. Both
+  // config reads and relative log paths resolve against this, since the hook
+  // process cwd can differ from the project being edited.
+  const baseCwd = entry && typeof entry.cwd === 'string' && entry.cwd ? entry.cwd : cwd;
+  // Env wins; otherwise fall back to the unified config's hook.auditLog path.
+  let target = env?.IMPECCABLE_HOOK_LOG;
+  if (!target || typeof target !== 'string') {
+    try { target = readConfig(baseCwd).auditLog; } catch { target = null; }
+  }
+  if (!target || typeof target !== 'string') return false;
+  try {
+    let expanded;
+    if (target.startsWith('~/')) {
+      expanded = path.join(process.env.HOME || process.env.USERPROFILE || '.', target.slice(2));
+    } else if (path.isAbsolute(target)) {
+      expanded = target;
+    } else {
+      expanded = path.resolve(baseCwd, target);
+    }
+    fs.mkdirSync(path.dirname(expanded), { recursive: true });
+    const line = JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n';
+    fs.appendFileSync(expanded, line);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const DETECTOR_CANDIDATES = [
+  path.join(__dirname, 'detector', 'detect-antipatterns.mjs'),
+  path.join(__dirname, '..', '..', 'cli', 'engine', 'detect-antipatterns.mjs'),
+  path.join(__dirname, '..', '..', '..', 'cli', 'engine', 'detect-antipatterns.mjs'),
+];
+
+let detectorCache = null;
+export async function loadDetector(candidates = DETECTOR_CANDIDATES) {
+  if (detectorCache) return detectorCache;
+  const found = candidates.find((c) => fs.existsSync(c));
+  if (!found) return null;
+  const mod = await import(pathToFileURL(found));
+  detectorCache = {
+    detectText: mod.detectText,
+    detectHtml: mod.detectHtml,
+    loadDesignSystemForCwd: mod.loadDesignSystemForCwd,
+  };
+  return detectorCache;
+}
+
+// For tests: allow injecting a detector implementation.
+export function setDetectorForTesting(impl) {
+  detectorCache = impl;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Nudge/steer messages for the no-silent-fires policy.
+//
+// The hook is designed to be a conversational presence: every fire that
+// actually scans a file emits a developer-role message into the model's
+// next turn. Three states map to three templates:
+//
+//   1. **Fresh findings**  → `renderTemplate` (existing, imperative).
+//   2. **Pending findings** → `renderPendingAck` (re-nudge for issues the
+//                              model was already told about in this
+//                              session but hasn't fixed yet).
+//   3. **Truly clean**      → `renderCleanAck` (short positive nudge that
+//                              keeps the design discipline in context).
+//
+// All three are short (≤ ~40 tokens each) so the cumulative cost stays
+// bounded across a long active editing session. Users who explicitly want
+// silence-on-clean can set `IMPECCABLE_HOOK_QUIET=1` — runHook checks that
+// env before emitting #2 or #3.
+//
+// Why not stay silent on dedup-clean? Earlier versions did. The model
+// quickly forgets the prior reminder once tool output scrolls past it, so
+// re-nudging on the same file with a short "still pending" line keeps the
+// pressure on. The wording deliberately points back to "earlier this
+// session" so the model knows it's a re-mind, not a new finding.
+// ────────────────────────────────────────────────────────────────────────
+
+const STEER_LINE = 'That does not mean the design is good: keep following the project design system and the impeccable skill guidance.';
+
+export function renderCleanAck(filePath, opts = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const display = relativize(filePath, cwd);
+  return `${ENVELOPE_PREFIX} Design hook scanned ${display}. No deterministic design-quality issues found. ${STEER_LINE}`;
+}
+
+export function renderPendingAck(filePath, knownFindings, opts = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const display = relativize(filePath, cwd);
+  const count = knownFindings.length;
+  // `knownFindings` here are the cache strings like "side-tab:3".
+  const sample = knownFindings.slice(0, 3).join(', ');
+  const more = count > 3 ? `, +${count - 3} more` : '';
+  return `${ENVELOPE_PREFIX} Design hook scanned ${display}. Still has ${count} finding(s) flagged earlier this session (${sample}${more}). Handle them before finalizing — the previous reminder still applies.`;
+}
+
+export function shouldEmitAckForFile(filePath, config = null) {
+  if (ACK_EXTS.has(path.extname(String(filePath || '')).toLowerCase())) return true;
+  // Configured html-engine extensions are declared UI markup, so they get the
+  // clean/pending acks; text-engine ones stay quiet like plain .ts/.js.
+  const configured = matchConfiguredExtension(filePath, config?.extensions);
+  return Boolean(configured && configured.engine === 'html');
+}
+
+export function designSystemOptions(config, detector, projectCwd) {
+  if (config?.designSystem?.enabled === false) return {};
+  if (!detector || typeof detector.loadDesignSystemForCwd !== 'function') return {};
+  try {
+    const designSystem = detector.loadDesignSystemForCwd(projectCwd);
+    return designSystem ? { designSystem } : {};
+  } catch {
+    return {};
+  }
+}
+
+export function appendDesignSystemNote(text, scanOptions) {
+  if (!text || !scanOptions?.designSystem?.mdNewerThanJson) return text;
+  return `${text}\n\n${ENVELOPE_PREFIX} DESIGN.md is newer than .impeccable/design.json. Run /impeccable document to refresh the design-system sidecar.`;
+}
+
+// The directive footer is the part of the hook output that steers model
+// behavior. Three intentional moves:
+//   1. **Imperative, not advisory.** "Handle these..." beats "Consider
+//      revising..." which the model treats as a soft suggestion it can
+//      override when the user asked for any kind of throwaway / demo UI.
+//   2. **Explicit judgment clause.** Without it, the model will try to
+//      "fix" intentional motion, bad fixtures, anti-pattern examples in
+//      docs, or test cases. Naming the judgment inline beats hoping the
+//      model infers it from context.
+//   3. **Acknowledgement instruction.** Hook output is injected as
+//      developer-role context, not a chat turn, so the user never sees the
+//      raw envelope. Asking the model to surface the resolution in its
+//      reply is the cheapest way to make the feedback loop visible.
+function directiveFooter(display, opts = {}) {
+  const ignoreFileCommand = `/impeccable hooks ignore-file ${quoteCommandArg(display)}`;
+  const fileIgnoreGuidance = opts.grouped
+    ? 'run `/impeccable hooks ignore-file <path>` for the specific file'
+    : `run \`${ignoreFileCommand}\``;
+  return [
+    'Handle these before finalizing: fix findings that are real design problems, or explicitly classify contextually intentional findings as false positives. Acknowledge what you changed or why you are leaving a finding unchanged.',
+    '',
+    'Use context judgment before editing. A finding is not automatically a defect; literal or domain-appropriate motion, intentional demos or fixtures, documentation of bad design, and user-confirmed choices can be valid as-is.',
+    '',
+    `Do not change intentional design just to satisfy the hook, and do not silence a real finding with an inline ignore comment to skip fixing it. Suppress a finding only after the user explicitly confirms it is intentional. Prefer a config ignore (one reviewable place, the commands below); reach for an inline \`impeccable-disable <rule>\` comment only when the waiver must travel with a file that leaves the repo, such as an exported or standalone document. Prefer the narrowest persisted exception: run the exact \`/impeccable hooks ignore-value ... --shared\` command shown next to a value-specific finding. For \`overused-font\`, use \`ignore-value\` for a specific font and use \`/impeccable hooks ignore-rule overused-font --all-values\` only when the user asks to ignore overused fonts generally. For file-specific findings without an ignore-value command, ${fileIgnoreGuidance}; use \`/impeccable hooks ignore-rule <id>\` only when the user asks to suppress the whole non-value-specific rule. Run /impeccable audit for the full pass.`,
+  ].join('\n');
+}
+
+/**
+ * Run the hook with explicit dependencies. Returns a result object:
+ *   { exitCode, stdout, audit, reason? }
+ *
+ * Never throws. All errors are converted to `exitCode: 0` + audit entry.
+ */
+export async function runHook({ stdinJson, env = {}, cwd = process.cwd(), now = Date.now, detector } = {}) {
+  const audit = { ts: new Date(now()).toISOString(), event: 'PostToolUse' };
+  const result = (extra) => ({ exitCode: 0, stdout: '', audit: { ...audit, ...extra } });
+
+  try {
+    // Re-entrancy guard.
+    if (depthIsSet(env.IMPECCABLE_HOOK_DEPTH) || depthIsSet(env.CLAUDE_HOOK_DEPTH)) {
+      return result({ reentrant: true, durationMs: 0 });
+    }
+
+    if (truthy(env.IMPECCABLE_HOOK_DISABLED)) {
+      return result({ skipped: 'env-disabled', durationMs: 0 });
+    }
+
+    const started = Date.now();
+
+    let event;
+    try {
+      event = typeof stdinJson === 'string' ? JSON.parse(stdinJson) : stdinJson;
+    } catch {
+      return result({ skipped: 'stdin-malformed', durationMs: Date.now() - started });
+    }
+    if (!event || typeof event !== 'object') {
+      return result({ skipped: 'stdin-empty', durationMs: Date.now() - started });
+    }
+
+    const harness = resolveHarness(env, event);
+    event = normalizeHookEvent(event, cwd, harness);
+    audit.harness = harness;
+
+    const sessionCwd = event.cwd || cwd;
+    const primaryFiles = normalizeScanTargets(resolveTargetFiles(event, sessionCwd), sessionCwd);
+    const projectCwd = resolveCacheCwd(primaryFiles[0], sessionCwd);
+    audit.cwd = projectCwd;
+    const primaryFileSet = new Set(primaryFiles);
+    const targetFiles = expandScanTargets(primaryFiles, projectCwd);
+    audit.session = event.session_id || null;
+    if (event.tool_name) audit.tool = event.tool_name;
+
+    if (targetFiles.length === 0) {
+      return result({ skipped: 'no-file-path', durationMs: Date.now() - started });
+    }
+
+    const config = readConfig(projectCwd);
+    if (config.enabled === false) {
+      return result({ skipped: 'config-disabled', durationMs: Date.now() - started });
+    }
+
+    const platform = resolveProjectPlatform(projectCwd);
+    if (isNativePlatform(platform)) {
+      return result({ skipped: 'native-platform', platform, durationMs: Date.now() - started });
+    }
+
+    const cache = readCache(projectCwd);
+    const sessionId = event.session_id || 'unknown';
+    const det = detector || await loadDetector();
+    if (!det || typeof det.detectText !== 'function') {
+      // Cache is not mutated yet at this point; nothing to persist.
+      return result({ skipped: 'detector-missing', durationMs: Date.now() - started });
+    }
+    const scanOptions = designSystemOptions(config, det, projectCwd);
+
+    let pendingWinner = null;
+    let cleanWinner = null;
+    const freshGroups = [];
+    let suppressionWinner = null;
+    let detectorThrewAny = false;
+    let lastSkip = 'no-scannable-file';
+    let suppressedHit = false;
+    let cacheDirty = false;
+
+    for (const filePath of targetFiles) {
+      audit.file = filePath;
+
+      if (hasPathTraversal(filePath) || SENSITIVE_PATH.test(filePath)) {
+        lastSkip = 'sensitive';
+        continue;
+      }
+      if (GENERATED_PATH.test(filePath)) {
+        lastSkip = 'generated';
+        continue;
+      }
+
+      const ext = path.extname(filePath).toLowerCase();
+      const configuredExt = matchConfiguredExtension(filePath, config.extensions);
+      audit.ext = configuredExt ? configuredExt.ext : ext;
+      if (!ALLOWED_EXTS.has(ext) && !configuredExt) {
+        lastSkip = 'extension';
+        continue;
+      }
+
+      const relForMatch = relativize(filePath, projectCwd);
+      if (matchesAnyGlob(relForMatch, config.ignoreFiles) || matchesAnyGlob(filePath, config.ignoreFiles)) {
+        lastSkip = 'config-ignore-file';
+        continue;
+      }
+      if (!fs.existsSync(filePath)) {
+        lastSkip = 'file-missing';
+        continue;
+      }
+
+      if (primaryFileSet.has(filePath)) {
+        const editCount = bumpEditCount(cache, sessionId, filePath);
+        cacheDirty = true;
+        audit.editCount = editCount;
+
+        if (editCount > EDIT_COUNT_THRESHOLD) {
+          const wasJustCrossed = editCount === EDIT_COUNT_THRESHOLD + 1;
+          if (wasJustCrossed && !suppressionWinner) {
+            suppressionWinner = { filePath };
+          }
+          lastSkip = 'suppressed';
+          suppressedHit = true;
+          continue;
+        }
+      }
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      let findings;
+      let detectorThrew = false;
+      const useHtmlEngine = configuredExt
+        ? configuredExt.engine === 'html'
+        : (ext === '.html' || ext === '.htm');
+      if (useHtmlEngine && typeof det.detectHtml === 'function') {
+        try { findings = await det.detectHtml(filePath, scanOptions); } catch { findings = []; detectorThrew = true; }
+      } else {
+        try { findings = await det.detectText(content, filePath, scanOptions); } catch { findings = []; detectorThrew = true; }
+      }
+
+      const filtered = filterFindings(findings || [], content, ext, config);
+      const fresh = dedupeAgainstCache(filtered, cache, sessionId, filePath);
+      audit.findings = (findings || []).length;
+      audit.freshFindings = fresh.length;
+
+      if (fresh.length > 0) {
+        rememberFindings(cache, sessionId, filePath, fresh);
+        cacheDirty = true;
+        freshGroups.push({ filePath, findings: fresh });
+        continue;
+      }
+
+      if (detectorThrew) {
+        detectorThrewAny = true;
+        continue;
+      }
+
+      if (filtered.length > 0 && !pendingWinner) {
+        const known = (ensureFile(cache, sessionId, filePath).findings || []).slice();
+        pendingWinner = { filePath, known };
+      } else if (filtered.length === 0 && !cleanWinner) {
+        cleanWinner = { filePath };
+      }
+    }
+
+    // Persist only when the write is earned: fresh findings justify creating
+    // `.impeccable/` (dedup and suppression need it), and an already-present
+    // `.impeccable/` dir marks a project that opted in. A non-UI edit, or a
+    // clean UI edit in a project with no Impeccable footprint, must be a
+    // no-op on disk (issues #344, #305).
+    if (freshGroups.length > 0
+      || (cacheDirty && fs.existsSync(path.join(projectCwd, '.impeccable')))) {
+      persistCache(projectCwd, cache);
+    }
+
+    if (freshGroups.length > 0) {
+      const firstGroup = freshGroups[0];
+      const text = appendDesignSystemNote(renderGroupedTemplate(freshGroups, config, { cwd: projectCwd }), scanOptions);
+      const allFindings = freshGroups.flatMap((group) => group.findings);
+      return {
+        exitCode: 0,
+        stdout: payload(text, 'PostToolUse', harness),
+        emission: {
+          kind: 'fresh',
+          file: firstGroup.filePath,
+          findings: firstGroup.findings,
+          groups: freshGroups,
+        },
+        audit: {
+          ...audit,
+          file: firstGroup.filePath,
+          emitted: true,
+          freshFiles: freshGroups.length,
+          freshFindings: allFindings.length,
+          chars: text.length,
+          durationMs: Date.now() - started,
+        },
+      };
+    }
+
+    if (detectorThrewAny && !pendingWinner && !cleanWinner) {
+      return result({ emitted: false, error: 'detector-threw', durationMs: Date.now() - started });
+    }
+
+    if (truthy(env.IMPECCABLE_HOOK_QUIET) || config.quiet === true) {
+      return result({ emitted: false, quiet: true, durationMs: Date.now() - started });
+    }
+
+    if (pendingWinner && shouldEmitAckForFile(pendingWinner.filePath, config)) {
+      const text = appendDesignSystemNote(renderPendingAck(pendingWinner.filePath, pendingWinner.known, { cwd: projectCwd }), scanOptions);
+      return {
+        exitCode: 0,
+        stdout: payload(text, 'PostToolUse', harness),
+        emission: { kind: 'pending', file: pendingWinner.filePath, known: pendingWinner.known },
+        audit: {
+          ...audit,
+          file: pendingWinner.filePath,
+          emitted: true,
+          kind: 'pending',
+          pending: pendingWinner.known.length,
+          chars: text.length,
+          durationMs: Date.now() - started,
+        },
+      };
+    }
+
+    if (suppressionWinner) {
+      const text = suppressionNotice(relativize(suppressionWinner.filePath, projectCwd));
+      return {
+        exitCode: 0,
+        stdout: payload(text, 'PostToolUse', harness),
+        emission: { kind: 'suppression', file: suppressionWinner.filePath },
+        audit: {
+          ...audit,
+          file: suppressionWinner.filePath,
+          suppressed: true,
+          emitted: true,
+          durationMs: Date.now() - started,
+        },
+      };
+    }
+
+    if (cleanWinner && shouldEmitAckForFile(cleanWinner.filePath, config)) {
+      const text = appendDesignSystemNote(renderCleanAck(cleanWinner.filePath, { cwd: projectCwd }), scanOptions);
+      return {
+        exitCode: 0,
+        stdout: payload(text, 'PostToolUse', harness),
+        emission: { kind: 'clean', file: cleanWinner.filePath },
+        audit: {
+          ...audit,
+          file: cleanWinner.filePath,
+          emitted: true,
+          kind: 'clean',
+          chars: text.length,
+          durationMs: Date.now() - started,
+        },
+      };
+    }
+
+    if (pendingWinner || cleanWinner) {
+      return result({ emitted: false, skipped: 'non-ui-ack', durationMs: Date.now() - started });
+    }
+
+    if (suppressedHit) {
+      return result({ suppressed: true, emitted: false, durationMs: Date.now() - started });
+    }
+
+    return result({ skipped: lastSkip, durationMs: Date.now() - started });
+  } catch (err) {
+    return {
+      exitCode: 0,
+      stdout: '',
+      audit: { ...audit, error: String(err && err.message ? err.message : err) },
+    };
+  }
+}
+
+export function payload(text, eventName = 'PostToolUse', harness = 'claude') {
+  if (harness === 'cursor') {
+    return JSON.stringify({ additional_context: text });
+  }
+  // GitHub Copilot's postToolUse hook injects context via a top-level
+  // `additionalContext` string (alongside an optional `modifiedResult`).
+  if (harness === 'github') {
+    return JSON.stringify({ additionalContext: text });
+  }
+  return JSON.stringify({
+    hookSpecificOutput: { hookEventName: eventName, additionalContext: text },
+  });
+}

--- a/packages/workflows/skills/impeccable/scripts/hook.mjs
+++ b/packages/workflows/skills/impeccable/scripts/hook.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Impeccable design hook — PostToolUse entry point.
+ *
+ * Reads the Claude Code / Codex / Cursor hook event from stdin, runs the design
+ * detector against the touched file, and emits a system reminder via
+ * `hookSpecificOutput.additionalContext` when findings exist.
+ *
+ * Contract: never break a turn. Always exit 0. Clean files emit a small ack
+ * unless quiet mode is enabled.
+ *
+ * Most logic lives in `hook-lib.mjs` so it is unit-testable without a
+ * subprocess. This file is the thin stdin/stdout adapter.
+ */
+
+import { runHook, writeAuditLog } from './hook-lib.mjs';
+
+async function readStdin() {
+  if (process.stdin.isTTY) return '';
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+async function main() {
+  // Snapshot the inherited env FIRST so the re-entrancy guard checks the
+  // parent's value, not the value we are about to export for any child
+  // processes the hook might ever spawn.
+  const inheritedEnv = { ...process.env };
+  process.env.IMPECCABLE_HOOK_DEPTH = process.env.IMPECCABLE_HOOK_DEPTH || '1';
+
+  let stdinJson = '';
+  try { stdinJson = await readStdin(); } catch { /* fall through */ }
+
+  const result = await runHook({
+    stdinJson,
+    env: inheritedEnv,
+    cwd: process.cwd(),
+  });
+
+  writeAuditLog(process.env, result.audit, process.cwd());
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  process.exit(result.exitCode || 0);
+}
+
+main().catch((err) => {
+  // Last-ditch: never break the agent's turn even if something we did not
+  // anticipate goes wrong. Audit-log the failure if logging is enabled.
+  try {
+    writeAuditLog(process.env, {
+      ts: new Date().toISOString(),
+      event: 'PostToolUse',
+      error: String(err && err.message ? err.message : err),
+    });
+  } catch { /* swallow */ }
+  if (process.env.IMPECCABLE_HOOK_DEBUG) {
+    process.stderr.write(`[impeccable-hook] ${err}\n`);
+  }
+  process.exit(0);
+});

--- a/packages/workflows/skills/impeccable/scripts/lib/impeccable-config.mjs
+++ b/packages/workflows/skills/impeccable/scripts/lib/impeccable-config.mjs
@@ -459,11 +459,13 @@ export function filterDetectionFindings(findings, config) {
 function isIgnoredFindingValue(finding, ignoreValues) {
   if (!Array.isArray(ignoreValues) || ignoreValues.length === 0) return false;
   const rule = normalizeIgnoreRule(finding.antipattern);
+  if (!rule) return false;
+  // File-scoped wildcards suppress rules with no extractable value, such as side-tab.
   const value = extractFindingIgnoreValue(finding);
-  if (!rule || !value) return false;
   return ignoreValues.some((entry) => {
+    if (entry.rule !== rule) return false;
     const wildcardValue = entry.value === '*';
-    if (entry.rule !== rule || (!wildcardValue && !ignoreValueMatches(rule, entry.value, value))) return false;
+    if (!wildcardValue && (!value || !ignoreValueMatches(rule, entry.value, value))) return false;
     if (!Array.isArray(entry.files) || entry.files.length === 0) return !wildcardValue;
     return findingMatchesScopedIgnoreFile(finding, entry.files);
   });

--- a/packages/workflows/skills/impeccable/scripts/lib/is-generated.mjs
+++ b/packages/workflows/skills/impeccable/scripts/lib/is-generated.mjs
@@ -13,7 +13,7 @@
  *      within the first ~300 characters — catches non-git projects.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -41,7 +41,7 @@ export function isGeneratedFile(filePath, options = {}) {
 
 function isGitIgnored(absPath, cwd) {
   try {
-    execFileSync('git', ['check-ignore', '--quiet', absPath], {
+    execSync(`git check-ignore --quiet ${JSON.stringify(absPath)}`, {
       cwd,
       stdio: 'ignore',
     });

--- a/packages/workflows/skills/impeccable/scripts/lib/is-generated.mjs
+++ b/packages/workflows/skills/impeccable/scripts/lib/is-generated.mjs
@@ -13,7 +13,7 @@
  *      within the first ~300 characters — catches non-git projects.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -41,12 +41,12 @@ export function isGeneratedFile(filePath, options = {}) {
 
 function isGitIgnored(absPath, cwd) {
   try {
-    execSync(`git check-ignore --quiet ${JSON.stringify(absPath)}`, {
+    execFileSync('git', ['check-ignore', '--quiet', '--', absPath], {
       cwd,
       stdio: 'ignore',
     });
     return true; // exit 0 = ignored
-  } catch (err) {
+  } catch {
     // Exit code 1 = not ignored. Exit code 128 = not a git repo or other error.
     // In both cases, treat as "not known to be ignored."
     return false;

--- a/packages/workflows/skills/impeccable/scripts/live-accept.mjs
+++ b/packages/workflows/skills/impeccable/scripts/live-accept.mjs
@@ -537,8 +537,8 @@ function stripStyleAndJoin(lines, block) {
       // Strip any complete <style> elements on this line (self-closed or
       // same-line-closed), including their body content.
       line = line
-        .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/g, '')
-        .replace(/<style\b[^>]*\/\s*>/g, '');
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/g, ' ')
+        .replace(/<style\b[^>]*\/\s*>/g, ' ');
 
       // If a <style> opener remains (multi-line body starts here), strip from
       // the opener to end-of-line and flip into skip mode.
@@ -550,10 +550,10 @@ function stripStyleAndJoin(lines, block) {
       out.push(line);
     } else {
       // In multi-line style body; drop everything until we see </style>.
-      const closeIdx = line.search(/<\/style\s*>/);
+      const closeIdx = line.search(/<\/style\b[^>]*>/);
       if (closeIdx !== -1) {
         inStyle = false;
-        out.push(line.slice(closeIdx).replace(/<\/style\s*>/, ''));
+        out.push(line.slice(closeIdx).replace(/<\/style\b[^>]*>/, ' '));
       }
       // else: skip line entirely
     }
@@ -643,7 +643,7 @@ function extractCss(lines, block, id) {
       // Self-closing: nothing to carbonize.
       if (/<style\b[^>]*\/\s*>/.test(line)) return null;
       // Same-line open + close: extract inner text.
-      const sameLine = line.match(/<style\b[^>]*>([\s\S]*?)<\/style\s*>/);
+      const sameLine = line.match(/<style\b[^>]*>([\s\S]*?)<\/style\b[^>]*>/);
       if (sameLine) {
         const inner = stripJsxTemplateWrap(sameLine[1]);
         return inner.length > 0 ? inner.split('\n') : null;
@@ -656,7 +656,7 @@ function extractCss(lines, block, id) {
       // Detect </style> anywhere on the line — JSX template-literal closes
       // (`}</style>`) put the close mid-line, and we don't want to absorb the
       // template-literal punctuation as CSS content.
-      const closeIdx = line.indexOf('</style>');
+      const closeIdx = line.search(/<\/style\b[^>]*>/);
       if (closeIdx !== -1) break;
       content.push(line);
     }

--- a/packages/workflows/skills/impeccable/scripts/live-accept.mjs
+++ b/packages/workflows/skills/impeccable/scripts/live-accept.mjs
@@ -400,12 +400,18 @@ function readHtmlAttr(tag, name) {
   return decodeHtmlAttr(match[2]);
 }
 
+const HTML_ATTR_ENTITIES = {
+  '&quot;': '"',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&amp;': '&',
+};
+
 function decodeHtmlAttr(value) {
-  return String(value || '')
-    .replace(/&quot;/g, '"')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&');
+  return String(value || '').replace(
+    /&(?:quot|lt|gt|amp);/g,
+    (entity) => HTML_ATTR_ENTITIES[entity] || entity,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/skills/impeccable/scripts/live-accept.mjs
+++ b/packages/workflows/skills/impeccable/scripts/live-accept.mjs
@@ -531,7 +531,7 @@ function stripStyleAndJoin(lines, block) {
       // Strip any complete <style> elements on this line (self-closed or
       // same-line-closed), including their body content.
       line = line
-        .replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/g, '')
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/g, '')
         .replace(/<style\b[^>]*\/\s*>/g, '');
 
       // If a <style> opener remains (multi-line body starts here), strip from
@@ -637,7 +637,7 @@ function extractCss(lines, block, id) {
       // Self-closing: nothing to carbonize.
       if (/<style\b[^>]*\/\s*>/.test(line)) return null;
       // Same-line open + close: extract inner text.
-      const sameLine = line.match(/<style\b[^>]*>([\s\S]*?)<\/style[^>]*>/);
+      const sameLine = line.match(/<style\b[^>]*>([\s\S]*?)<\/style\s*>/);
       if (sameLine) {
         const inner = stripJsxTemplateWrap(sameLine[1]);
         return inner.length > 0 ? inner.split('\n') : null;

--- a/packages/workflows/skills/impeccable/scripts/live-browser.js
+++ b/packages/workflows/skills/impeccable/scripts/live-browser.js
@@ -153,6 +153,7 @@
   let scrollLockRaf = null;
   let scrollLockAbort = null;
   const SCROLL_ANCHOR_LOCK_ID = 'impeccable-scroll-anchor-lock';
+  const VARIANT_STATE_STYLE_ID = 'impeccable-variant-state';
 
   // Dedicated key for scroll position - SEPARATE from LS_KEY so that
   // saveSession's state updates don't clobber a carefully-captured scrollY.
@@ -3035,16 +3036,26 @@
   function applyParamValue(variantEl, param, value) {
     if (!variantEl) return;
     const attr = 'data-p-' + param.id;
-    if (param.kind === 'range') {
-      variantEl.style.setProperty('--p-' + param.id, String(value));
-    } else if (param.kind === 'toggle') {
+    if (param.kind === 'toggle') {
       const on = !!value;
-      variantEl.style.setProperty('--p-' + param.id, on ? '1' : '0');
       if (on) variantEl.setAttribute(attr, 'on');
       else variantEl.removeAttribute(attr);
     } else if (param.kind === 'steps') {
       variantEl.setAttribute(attr, String(value));
     }
+    // Svelte component variants are client-mounted into
+    // [data-impeccable-component-mount] with no [data-impeccable-variant="N"]
+    // wrapper for the state stylesheet to target, and the element is not SSR'd,
+    // so there is no React hydration to mismatch. Drive range/toggle --p-* inline
+    // on the mounted element so scoped preview CSS resolves them.
+    if (svelteComponentSession?.sessionId === currentSessionId) {
+      if (param.kind === 'range') variantEl.style.setProperty('--p-' + param.id, String(value));
+      else if (param.kind === 'toggle') variantEl.style.setProperty('--p-' + param.id, value ? '1' : '0');
+      return;
+    }
+    // range/toggle --p-* custom properties are driven through the injected
+    // variant-state stylesheet so we never mutate inline style on SSR'd divs.
+    updateVariantStateStylesheet(currentSessionId, visibleVariant);
   }
 
   function applyParamDefaults(variantEl, params) {
@@ -4714,6 +4725,7 @@
       paramsCurrentValues = {};
       tuneOpen = false;
       hideParamsPanel();
+      if (currentSessionId && visibleVariant) updateVariantStateStylesheet(currentSessionId, visibleVariant);
       return;
     }
     applyParamDefaults(variantEl, params);
@@ -4771,20 +4783,7 @@
 
   function isVariantShown(el) {
     if (!el) return false;
-    if (el.hidden) return false;
-    if (el.style?.display === 'none') return false;
-    return true;
-  }
-
-  function setVariantShown(el, shown) {
-    if (!el) return;
-    if (shown) {
-      el.removeAttribute('hidden');
-      el.style.display = '';
-    } else {
-      el.setAttribute('hidden', '');
-      el.style.display = 'none';
-    }
+    return getComputedStyle(el).display !== 'none';
   }
 
   function scheduleCyclingBarSync(sessionId, variantNum) {
@@ -4823,11 +4822,7 @@
     }
     const wrapper = document.querySelector('[data-impeccable-variants="' + sessionId + '"]');
     if (!wrapper) return false;
-    for (const child of wrapper.children) {
-      const v = child.dataset ? child.dataset.impeccableVariant : null;
-      if (!v) continue;
-      setVariantShown(child, v === String(num));
-    }
+    updateVariantStateStylesheet(sessionId, num);
     // Unconditional refresh - covers first-reveal (no-op if state isn't
     // CYCLING yet, the subsequent CYCLING transition triggers its own
     // refresh) and every cycle step.
@@ -5109,7 +5104,7 @@
   }
 
   function scopeCssToSveltePreview(css, sessionId) {
-    const prefix = '[data-impeccable-variants="' + String(sessionId).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"] ';
+    const prefix = '[data-impeccable-variants="' + String(sessionId).replace(/"/g, '\\"') + '"] ';
     return scopeCssBlock(String(css || ''), prefix).trim();
   }
 
@@ -5492,6 +5487,7 @@
     if (pendingSvelteComponentRetryObserver) { pendingSvelteComponentRetryObserver.disconnect(); pendingSvelteComponentRetryObserver = null; }
     if (pendingVariantAnchorRetryObserver) { pendingVariantAnchorRetryObserver.disconnect(); pendingVariantAnchorRetryObserver = null; }
     stopScrollLock();
+    removeVariantStateStylesheet();
     clearSession();
     clearHandled();
     resetSessionFileMeta();
@@ -5609,7 +5605,7 @@
     if (!/\.[cm]?[jt]sx$/i.test(String(filePath || ''))) return block;
     return String(block)
       .replace(
-        /<style\b([^>]*)>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style[^>]*>/g,
+        /<style\b([^>]*)>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style>/g,
         (_match, attrs, css) => '<style' + attrs + '>' + css + '</style>',
       )
       .replace(/\bclassName\s*=\s*\{\s*`([^`]*?)`\s*\}/g, (_match, value) => {
@@ -5640,7 +5636,7 @@
     let out = String(prop || '').trim().replace(/^["']|["']$/g, '');
     if (!out) return '';
     if (out.startsWith('--')) return out;
-    return out.replace(/[A-Z]/g, (ch) => '-' + ch.toLowerCase()).replace(/^ms-/, '-ms-');
+    return out.replace(/[A-Z]/g, (ch) => '-' + ch.toLowerCase()).replace(/^-ms-/, '-ms-');
   }
 
   function buildSvelteExpressionTextMap(sourceOriginal, liveOriginal) {
@@ -5804,6 +5800,68 @@
     }
     if (visual.length === 1) return visual[0];
     return variantDiv;
+  }
+
+  // Variant visibility and range/toggle params are expressed through ONE
+  // injected stylesheet, never inline attributes on the variant divs. Those
+  // divs are scaffolded into page source, so SSR frameworks (Next.js App
+  // Router) server-render them; toggling their `hidden` / inline `style` /
+  // `--p-*` client-side trips a React 19 hydration mismatch on the next
+  // Fast-Refresh re-render — the same failure mode the scroll-anchor (#276)
+  // and pick-cursor (#286) fixes address. A stylesheet rule has the same
+  // computed effect without mutating any hydrated element's attributes.
+  // (steps params keep driving `data-p-*` attributes, matching scoped CSS.)
+  const VARIANT_HIDE_DECL = 'display: none !important;';
+  const VARIANT_SHOW_DECL = 'display: block !important;';
+
+  // Build a direct-child variant selector for a session. With `num`, targets a
+  // single variant (`… > [data-impeccable-variant="N"]`); without it, targets
+  // every variant via the bare `[data-impeccable-variant]` attribute.
+  function variantStateSelector(sessionId, num) {
+    const wrapper = '[data-impeccable-variants="' + sessionId + '"]';
+    const variant = num == null
+      ? '[data-impeccable-variant]'
+      : '[data-impeccable-variant="' + num + '"]';
+    return wrapper + ' > ' + variant;
+  }
+
+  // Serialize the visible variant's knob values into `--p-<id>` custom-property
+  // declarations. Only range (number) and toggle (boolean) values become a
+  // custom property; steps params drive `data-p-*` attributes instead.
+  function variantParamDecls(values) {
+    return Object.entries(values || {})
+      .map(([id, val]) => {
+        if (typeof val === 'number') return ' --p-' + id + ': ' + val + ';';
+        if (typeof val === 'boolean') return ' --p-' + id + ': ' + (val ? '1' : '0') + ';';
+        return '';
+      })
+      .join('');
+  }
+
+  function updateVariantStateStylesheet(sessionId, num) {
+    if (!sessionId || num == null || num < 1) return;
+
+    let styleEl = document.getElementById(VARIANT_STATE_STYLE_ID);
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = VARIANT_STATE_STYLE_ID;
+      (document.head || document.documentElement).appendChild(styleEl);
+    }
+
+    // Hide every variant except the visible one (incl. the SSR'd "original").
+    const hideOthers = variantStateSelector(sessionId)
+      + ':not([data-impeccable-variant="' + num + '"]) { ' + VARIANT_HIDE_DECL + ' }';
+
+    // Force-show the visible variant (beats the source inline display:none on
+    // v2/v3) and apply its knob values as custom properties.
+    const showVisible = variantStateSelector(sessionId, num)
+      + ' { ' + VARIANT_SHOW_DECL + variantParamDecls(paramsCurrentValues) + ' }';
+
+    styleEl.textContent = hideOthers + '\n' + showVisible + '\n';
+  }
+
+  function removeVariantStateStylesheet() {
+    document.getElementById(VARIANT_STATE_STYLE_ID)?.remove();
   }
 
   // Hold window.scrollY at a fixed value across DOM mutations inside the
@@ -7636,6 +7694,7 @@ void main() {
     stopScrollTracking();
     if (variantObserver) { variantObserver.disconnect(); variantObserver = null; }
     stopScrollLock();
+    removeVariantStateStylesheet();
     clearScrollY();
     clearSession();
     resetSessionFileMeta();
@@ -7897,6 +7956,7 @@ void main() {
     if (variantObserver) { variantObserver.disconnect(); variantObserver = null; }
     if (pendingVariantAnchorRetryObserver) { pendingVariantAnchorRetryObserver.disconnect(); pendingVariantAnchorRetryObserver = null; }
     stopScrollLock();
+    removeVariantStateStylesheet();
     clearScrollY();
     finalizeInsertSession();
     clearSession();
@@ -7928,7 +7988,7 @@ void main() {
     const barTopFromBottom = barRect && barRect.height > 0
       ? Math.max(16, window.innerHeight - barRect.top + 12)
       : 16;
-    toastEl = el('div', {
+    const currentToast = el('div', {
       position: 'fixed', bottom: barTopFromBottom + 'px', left: '50%',
       transform: 'translateX(-50%) translateY(8px)',
       background: C.ink, color: C.white,
@@ -7938,19 +7998,24 @@ void main() {
       transition: 'opacity 0.25s ' + EASE + ', transform 0.25s ' + EASE,
       pointerEvents: 'none', maxWidth: '420px', textAlign: 'center',
     });
-    toastEl.id = PREFIX + '-toast';
-    toastEl.textContent = message;
-    uiAppend(toastEl);
+    toastEl = currentToast;
+    currentToast.id = PREFIX + '-toast';
+    currentToast.textContent = message;
+    uiAppend(currentToast);
     requestAnimationFrame(() => {
-      toastEl.style.opacity = '1';
-      toastEl.style.transform = 'translateX(-50%) translateY(0)';
+      if (toastEl !== currentToast) return;
+      currentToast.style.opacity = '1';
+      currentToast.style.transform = 'translateX(-50%) translateY(0)';
     });
     setTimeout(() => {
-      if (toastEl) {
-        toastEl.style.opacity = '0';
-        toastEl.style.transform = 'translateX(-50%) translateY(8px)';
-        setTimeout(() => { if (toastEl) { toastEl.remove(); toastEl = null; } }, 250);
-      }
+      if (toastEl !== currentToast) return;
+      currentToast.style.opacity = '0';
+      currentToast.style.transform = 'translateX(-50%) translateY(8px)';
+      setTimeout(() => {
+        if (toastEl !== currentToast) return;
+        currentToast.remove();
+        toastEl = null;
+      }, 250);
     }, duration);
   }
 
@@ -9984,6 +10049,7 @@ void main() {
     window.postMessage({ source: 'impeccable-command', action: 'remove' }, '*');
     setLiveState('IDLE');
     document.getElementById(PICK_CURSOR_STYLE_ID)?.remove();
+    removeVariantStateStylesheet();
     window.__IMPECCABLE_LIVE_INIT__ = false;
     console.log('[impeccable] Live mode exited.');
   }

--- a/packages/workflows/skills/impeccable/scripts/live-browser.js
+++ b/packages/workflows/skills/impeccable/scripts/live-browser.js
@@ -5076,7 +5076,7 @@
   }
 
   function extractSvelteComponentStyle(source) {
-    const match = String(source || '').match(/<style\b[^>]*>([\s\S]*?)<\/style\s*>/i);
+    const match = String(source || '').match(/<style\b[^>]*>([\s\S]*?)<\/style\b[^>]*>/i);
     return match ? match[1].trim() : '';
   }
 
@@ -5606,7 +5606,7 @@
     if (!/\.[cm]?[jt]sx$/i.test(String(filePath || ''))) return block;
     return String(block)
       .replace(
-        /<style\b([^>]*)>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style\s*>/g,
+        /<style\b([^>]*)>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style\b[^>]*>/g,
         (_match, attrs, css) => '<style' + attrs + '>' + css + '</style>',
       )
       .replace(/\bclassName\s*=\s*\{\s*`([^`]*?)`\s*\}/g, (_match, value) => {

--- a/packages/workflows/skills/impeccable/scripts/live-browser.js
+++ b/packages/workflows/skills/impeccable/scripts/live-browser.js
@@ -5104,7 +5104,8 @@
   }
 
   function scopeCssToSveltePreview(css, sessionId) {
-    const prefix = '[data-impeccable-variants="' + String(sessionId).replace(/"/g, '\\"') + '"] ';
+    const escapedSessionId = String(sessionId).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const prefix = '[data-impeccable-variants="' + escapedSessionId + '"] ';
     return scopeCssBlock(String(css || ''), prefix).trim();
   }
 
@@ -5605,7 +5606,7 @@
     if (!/\.[cm]?[jt]sx$/i.test(String(filePath || ''))) return block;
     return String(block)
       .replace(
-        /<style\b([^>]*)>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style>/g,
+        /<style\b([^>]*)>\s*\{\s*`([\s\S]*?)`\s*\}\s*<\/style\s*>/g,
         (_match, attrs, css) => '<style' + attrs + '>' + css + '</style>',
       )
       .replace(/\bclassName\s*=\s*\{\s*`([^`]*?)`\s*\}/g, (_match, value) => {
@@ -5636,7 +5637,7 @@
     let out = String(prop || '').trim().replace(/^["']|["']$/g, '');
     if (!out) return '';
     if (out.startsWith('--')) return out;
-    return out.replace(/[A-Z]/g, (ch) => '-' + ch.toLowerCase()).replace(/^-ms-/, '-ms-');
+    return out.replace(/[A-Z]/g, (ch) => '-' + ch.toLowerCase()).replace(/^ms-/, '-ms-');
   }
 
   function buildSvelteExpressionTextMap(sourceOriginal, liveOriginal) {

--- a/packages/workflows/skills/impeccable/scripts/live-wrap.mjs
+++ b/packages/workflows/skills/impeccable/scripts/live-wrap.mjs
@@ -310,6 +310,7 @@ The agent should insert variant HTML at insertLine.`);
   ];
 
   let outputFile = targetFile;
+  let outputLines;
   let outputStartLine = startLine + 1;
   let outputEndLine = startLine + wrapperLines.length + (originalLines.length - 1);
   let insertLine;
@@ -568,6 +569,14 @@ function buildSearchQueries(elementId, classes, tag, query) {
 
 function splitClassList(classes) {
   return String(classes).split(/[,\s]+/).map(c => c.trim()).filter(Boolean);
+}
+
+function attrEscapeDouble(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 function detectCommentSyntax(filePath) {

--- a/packages/workflows/skills/impeccable/scripts/live/svelte-component.mjs
+++ b/packages/workflows/skills/impeccable/scripts/live/svelte-component.mjs
@@ -97,7 +97,7 @@ export function substitutePropsWithExprs(markup, contract) {
 
 export function parseSvelteComponentFile(content) {
   const text = String(content || '');
-  const scriptMatch = text.match(/^([\s\S]*?)<script\b[^>]*>[\s\S]*?<\/script>/i);
+  const scriptMatch = text.match(/^([\s\S]*?)<script\b[^>]*>[\s\S]*?<\/script\s*>/i);
   const withoutScript = scriptMatch ? text.slice(scriptMatch[0].length) : text;
   const styleMatch = withoutScript.match(/<style\b[^>]*>[\s\S]*?<\/style\s*>/i);
   const styleBlock = styleMatch ? styleMatch[0] : '';
@@ -632,10 +632,16 @@ function inlineSvelteComponentInsertAccept({
 }
 
 function svelteMarkupHasVisibleContent(markup) {
-  const text = String(markup || '')
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?<\/style>/gi, '')
-    .replace(/<!--[\s\S]*?-->/g, '')
+  let stripped = String(markup || '');
+  let previous;
+  do {
+    previous = stripped;
+    stripped = stripped
+      .replace(/<script[\s\S]*?<\/script\s*>/gi, '')
+      .replace(/<style[\s\S]*?<\/style\s*>/gi, '')
+      .replace(/<!--[\s\S]*?-->/g, '');
+  } while (stripped !== previous);
+  const text = stripped
     .replace(/<[^>]+>/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();

--- a/packages/workflows/skills/impeccable/scripts/live/svelte-component.mjs
+++ b/packages/workflows/skills/impeccable/scripts/live/svelte-component.mjs
@@ -97,9 +97,9 @@ export function substitutePropsWithExprs(markup, contract) {
 
 export function parseSvelteComponentFile(content) {
   const text = String(content || '');
-  const scriptMatch = text.match(/^([\s\S]*?)<script\b[^>]*>[\s\S]*?<\/script\s*>/i);
+  const scriptMatch = text.match(/^([\s\S]*?)<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/i);
   const withoutScript = scriptMatch ? text.slice(scriptMatch[0].length) : text;
-  const styleMatch = withoutScript.match(/<style\b[^>]*>[\s\S]*?<\/style\s*>/i);
+  const styleMatch = withoutScript.match(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/i);
   const styleBlock = styleMatch ? styleMatch[0] : '';
   const markup = styleMatch
     ? withoutScript.slice(0, styleMatch.index).trim()
@@ -107,7 +107,7 @@ export function parseSvelteComponentFile(content) {
   const cssLines = styleBlock
     ? styleBlock
       .replace(/^<style\b[^>]*>/i, '')
-      .replace(/<\/style\s*>$/i, '')
+      .replace(/<\/style\b[^>]*>$/i, '')
       .split('\n')
       .map((line) => line.trimEnd())
     : [];
@@ -290,7 +290,7 @@ function appendCssToSvelteStyle(lines, cssLines) {
 
 function findLastStyleCloseLine(lines) {
   for (let i = lines.length - 1; i >= 0; i--) {
-    if (/<\/style\s*>/.test(lines[i])) return i;
+    if (/<\/style\b[^>]*>/.test(lines[i])) return i;
   }
   return -1;
 }
@@ -637,8 +637,8 @@ function svelteMarkupHasVisibleContent(markup) {
   do {
     previous = stripped;
     stripped = stripped
-      .replace(/<script[\s\S]*?<\/script\s*>/gi, '')
-      .replace(/<style[\s\S]*?<\/style\s*>/gi, '')
+      .replace(/<script[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style\b[^>]*>/gi, ' ')
       .replace(/<!--[\s\S]*?-->/g, '');
   } while (stripped !== previous);
   const text = stripped

--- a/packages/workflows/skills/impeccable/scripts/live/svelte-component.mjs
+++ b/packages/workflows/skills/impeccable/scripts/live/svelte-component.mjs
@@ -97,9 +97,9 @@ export function substitutePropsWithExprs(markup, contract) {
 
 export function parseSvelteComponentFile(content) {
   const text = String(content || '');
-  const scriptMatch = text.match(/^([\s\S]*?)<script\b[^>]*>[\s\S]*?<\/script[^>]*>/i);
+  const scriptMatch = text.match(/^([\s\S]*?)<script\b[^>]*>[\s\S]*?<\/script>/i);
   const withoutScript = scriptMatch ? text.slice(scriptMatch[0].length) : text;
-  const styleMatch = withoutScript.match(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/i);
+  const styleMatch = withoutScript.match(/<style\b[^>]*>[\s\S]*?<\/style\s*>/i);
   const styleBlock = styleMatch ? styleMatch[0] : '';
   const markup = styleMatch
     ? withoutScript.slice(0, styleMatch.index).trim()
@@ -632,24 +632,15 @@ function inlineSvelteComponentInsertAccept({
 }
 
 function svelteMarkupHasVisibleContent(markup) {
-  const raw = String(markup || '');
-  // Strip script/style/comment blocks to a fixpoint so partially-overlapping
-  // sequences cannot survive a single pass (CodeQL: complete sanitization).
-  let text = raw;
-  let prev;
-  do {
-    prev = text;
-    text = text
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, '')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, '')
-      .replace(/<!--[\s\S]*?-->/g, '');
-  } while (text !== prev);
-  text = text
+  const text = String(markup || '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<[^>]+>/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
   if (text.length > 0) return true;
-  return /<(img|svg|canvas|video|audio|picture|input|button|select|textarea)\b/i.test(raw);
+  return /<(img|svg|canvas|video|audio|picture|input|button|select|textarea)\b/i.test(markup || '');
 }
 
 function mergeOriginalTopLevelAttrs(markup, originalMarkup) {


### PR DESCRIPTION
## Summary

Refreshes Atomic's bundled `impeccable` skill from upstream `pbakaus/impeccable` version 3.8.0 to 3.9.1 (`fb6d3e9791c7abfe472f160bb20fc75dd802c033`), preserving the bundled workflow-skill packaging path under `packages/workflows/skills/impeccable`, then hardens the synced scripts against CodeQL findings.

Closes #1696

## Changes

### Sync to 3.9.1

- Synced `packages/workflows/skills/impeccable` to upstream 3.9.1, touching 36 files under `reference/` and `scripts/`.
- Added native platform reference docs (`adapt.native.md`, `android.md`, `ios.md`, `audit.native.md`) and a new `hooks.md` reference.
- Added hook management support: `scripts/hook-admin.mjs`, `scripts/hook-before-edit.mjs`, `scripts/hook-lib.mjs`, `scripts/hook.mjs`.
- Expanded the antipattern detector: new `design-system.mjs` and `registry/antipatterns.mjs` modules, font-detection support (`shared/fonts.mjs`), and updates to `checks.mjs`, `detect-text.mjs`, `detect-antipatterns-browser.js`, and `detector/cli/main.mjs`.
- Updated `SKILL.md`, `context.mjs`, `context-signals.mjs`, `live-browser.js`, `live-wrap.mjs`, `live/svelte-component.mjs`, and related reference docs (`bolder.md`, `critique.md`, `init.md`, `layout.md`, `typeset.md`) to match upstream.
- Updated the `impeccable` entry in `packages/coding-agent/docs/quickstart.md` to mention native/hooks support.

### CodeQL hardening (follow-up)

- Made HTML/CSS/comment block stripping (`<script>`, `<style>`, `<!-- -->`) loop until stable and tolerant of trailing whitespace before the closing tag (`is-generated.mjs`, `svelte-component.mjs`, `page.mjs`, `detect-text.mjs`, `checks.mjs`, `detect-antipatterns-browser.js`), preventing incomplete sanitization from nested/malformed markup.
- Replaced shell-interpolated `execSync` with argv-based `execFileSync` for `git check-ignore` in `is-generated.mjs` to avoid command injection via file paths.
- Fixed a broken regex replacement in `live-accept.mjs`'s HTML-entity decoder (`decodeHtmlAttr`) so all four entities are decoded via a single pass instead of chained, order-dependent replacements.
- Escaped backslashes (in addition to quotes) when scoping Svelte preview CSS selectors by session ID in `live-browser.js`, preventing selector escaping from being broken by a literal `\` in the session id.
- Fixed the `-ms-` vendor-prefix conversion in `live-browser.js`'s CSS property name inliner, which previously left `ms-` prefixed props unconverted.
- Further tightened `</script>`/`</style>` closing-tag regexes (`\s*>` → `\b[^>]*>`) across `detect-antipatterns-browser.js`, `detect-text.mjs`, `checks.mjs`, `live-accept.mjs`, `live-browser.js`, and `live/svelte-component.mjs` so CodeQL's bad-tag-filter check no longer flags them as bypassable (a closing tag with trailing attributes/garbage, e.g. `</style foo>`, previously wasn't matched).

Recorded both the sync (3.8.0 → 3.9.1) and the hardening pass in `packages/workflows/CHANGELOG.md` under `[Unreleased] > Changed` / `> Fixed`.

## Validation

- `AGENT=1 bun test test/unit/coding-agent-builtin-workflows.test.ts test/unit/package-metadata.test.ts test/unit/check-file-length.test.ts`
- `bun run check:file-length`
- `IMPECCABLE_NO_UPDATE_CHECK=1 bun packages/workflows/skills/impeccable/scripts/context.mjs --target packages/workflows`
- `bun packages/workflows/skills/impeccable/scripts/detect.mjs --json --no-config <clean sample>`
- `bun packages/workflows/skills/impeccable/scripts/hook-admin.mjs status`
- Pre-commit and pre-push hooks passed, including:
  - `bun run lint`
  - `bun run check:file-length`
  - `bun run test:unit`