### PR TITLE
docs: release notes for 0.9.5-alpha.9

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.9] - 2026-07-09
+
 ### Changed
 
 - Improved interactive startup responsiveness by keeping footer git watcher setup out of first paint and deferring it until the first input handler is ready, while preserving lazy footer branch reads and post-frame branch-change re-rendering. Deferred extension/resource loading no longer starts on a blind post-paint timer that can freeze live typing; instead, Atomic starts it in the background once input is ready and uses a readiness gate before the first normal prompt/model turn if the background load has not settled. This keeps first-paint/typeahead responsive while ensuring the first interactive prompt sees extension tools, skills, prompt templates, resources, and extension-registered provider/model updates. Built-in slash commands stay available immediately, and bundled extension slash commands expose lightweight metadata for autocomplete before their heavy implementations load; explicitly submitted extension slash commands load the implementation on demand and then route the same command. Explicit provider/model selections stay on the synchronous startup path because they must resolve against extension-registered providers before the session is created. Changelog and first-run notice materialization now happen after the first frame, and startup/input timing probes cover raw-mode enablement, first captured raw key, first frame, input-handler callback installation, and first submit for benchmark/probe runs.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5-alpha.9] - 2026-07-09
+
 ### Changed
 
 - Improved startup responsiveness by keeping first-run/default lazy MCP metadata bootstrap out of `initializeMcp()`'s synchronous path. Cached direct tools and the MCP proxy still register immediately, explicit `eager`/`keep-alive` servers still connect during initialization, missing configured or `MCP_DIRECT_TOOLS`-selected direct-tool metadata is warmed in the background, and explicit proxy `search`, `describe`, and server-list requests hydrate cold-cache lazy server metadata on demand instead of broadening startup warmup. Warmed direct tools are registered live in the current session after metadata refresh rather than requiring restart. Cold-cache `describe` first narrows hydration to prefix-matched or explicitly requested servers, treats hyphen/underscore prefixes as aliases, and does not fan out to unrelated lazy servers after a prefix-directed miss; cold-cache proxy `search` intentionally hydrates all matching lazy servers so unscoped searches can see every configured tool.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.9] - 2026-07-09
+
 ### Changed
 
 - Improved subagent extension startup by deferring old-run cleanup scans, result watcher startup, and existing-result priming to macrotasks while preserving immediate `subagent` tool and slash-command registration.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.9] - 2026-07-09
+
 ### Changed
 
 - Improved workflow extension startup by seeding only the bundled startup registry during extension registration/session start, then loading user, project, and package workflow modules in the background or when `/workflow` commands and workflow tool actions need the full registry.


### PR DESCRIPTION
## Summary

Seals the `[Unreleased]` changelog sections into a `[0.9.5-alpha.9] - 2026-07-09` release header across four packages ahead of cutting the `0.9.5-alpha.9` prerelease tag. No source or version changes — `main` remains versionless with `0.0.0` package placeholders, per the [versionless-main release flow](../blob/main/CLAUDE.md#releasing).

## Key changes

- `packages/coding-agent/CHANGELOG.md`: stamps `[0.9.5-alpha.9]` covering interactive startup responsiveness improvements (deferred footer git watcher setup, background extension/resource loading with a readiness gate, lazy slash-command metadata for autocomplete, and startup/input timing probes).
- `packages/mcp/CHANGELOG.md`: stamps `[0.9.5-alpha.9]` covering deferred lazy MCP metadata bootstrap, background warm-up of missing direct-tool metadata, live registration of warmed tools, and prefix-scoped cold-cache `describe`/`search` hydration behavior.
- `packages/subagents/CHANGELOG.md`: stamps `[0.9.5-alpha.9]` covering deferred old-run cleanup scans, result watcher startup, and result priming to macrotasks while keeping tool/slash-command registration immediate.
- `packages/workflows/CHANGELOG.md`: stamps `[0.9.5-alpha.9]` covering seeding only the bundled startup workflow registry at session start, with user/project/package modules loaded in the background or on demand.

## Validation

- `git diff origin/main...HEAD --stat` -> changelog files only, 4 files changed, 8 insertions
- `bun run typecheck` -> passed
- `bun run test:unit` -> passed
- Push hooks ran `bun run lint`, `bun run check:file-length`, and `bun run test:unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)