### PR TITLE
fix(web-access): retry failed lazy initialization

### DIFF
--- a/packages/coding-agent/test/suite/regressions/1223-startup-lazy-builtins.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1223-startup-lazy-builtins.test.ts
@@ -55,6 +55,56 @@ await new Promise((resolve) => setTimeout(resolve, 250));
 	}
 }
 
+function assertWebAccessRetriesFailedHeavyInitialization(): void {
+	const tempDir = mkdtempSync(join(tmpdir(), "atomic-web-access-retry-"));
+	try {
+		writeFileSync(join(tempDir, "package.json"), JSON.stringify({ type: "module" }));
+		writeFileSync(join(tempDir, "index.ts"), readRepoFile("packages/web-access/index.ts"));
+		writeFileSync(join(tempDir, "result-renderers.ts"), "export function renderWebAccessToolResult() { return undefined; }\n");
+		writeFileSync(join(tempDir, "index-heavy.ts"), `
+let attempts = 0;
+export default async function webAccessHeavy(pi) {
+	attempts += 1;
+	if (attempts === 1) throw new Error("simulated heavy startup failure");
+	pi.registerTool({ name: "web_search", execute: async () => ({ ok: true, attempts }) });
+}
+`);
+		const extensionUrl = pathToFileURL(join(tempDir, "index.ts")).href;
+		const script = `
+const { default: webAccess } = await import(${JSON.stringify(extensionUrl)});
+const tools = [];
+const pi = {
+  registerTool(tool) { tools.push(tool); },
+  registerCommand() {},
+  registerShortcut() {},
+  registerMessageRenderer() {},
+  on() {},
+};
+webAccess(pi);
+const webSearch = tools.find((tool) => tool.name === "web_search");
+if (!webSearch) throw new Error("web_search was not registered");
+try {
+  await webSearch.execute({ query: "first" });
+  throw new Error("first execution unexpectedly succeeded");
+} catch (error) {
+  if (!String(error?.message ?? error).includes("simulated heavy startup failure")) throw error;
+}
+const result = await webSearch.execute({ query: "retry" });
+console.log(JSON.stringify(result));
+`;
+		const result = spawnSync("bun", ["--eval", script], {
+			cwd: repoRoot,
+			env: process.env,
+			encoding: "utf-8",
+		});
+		expect(result.status, result.stderr || result.stdout).toBe(0);
+		expect(JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}"))
+			.toEqual({ ok: true, attempts: 2 });
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
 function assertMcpColdStartupTools(options: { withCache: boolean; expectedTools: string[] }): void {
 	const tempDir = mkdtempSync(join(tmpdir(), "atomic-mcp-startup-"));
 	const agentDir = join(tempDir, "agent");
@@ -198,6 +248,10 @@ describe("regression #1223 lazy built-in startup imports", () => {
 
 		assertColdRegistrationDoesNotImportHeavy("packages/web-access/index.ts");
 		assertColdRegistrationDoesNotImportHeavy("packages/intercom/index.ts");
+	});
+
+	it("allows web-access lazy heavy imports to retry after initialization failure", () => {
+		assertWebAccessRetriesFailedHeavyInitialization();
 	});
 
 	it("keeps the MCP proxy fallback until cached direct tools are available", () => {

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Aligned the web-access extension peer dependency with upstream `pi-tui` `^0.80.5` as part of the consolidated dependency refresh; no web-access source changes were needed.
 
+### Fixed
+
+- Reset failed lazy web-access initialization attempts so a later `web_search`/`fetch_content` invocation can retry loading the heavy provider module instead of reusing a rejected startup promise ([#1704](https://github.com/bastani-inc/atomic/issues/1704)).
+
 ## [0.9.4] - 2026-07-03
 
 ### Changed

--- a/packages/web-access/index.ts
+++ b/packages/web-access/index.ts
@@ -128,7 +128,11 @@ export default function webAccess(pi: ExtensionAPI) {
 				loadedHeavy = captured;
 				await replayCurrentSession(captured);
 				return captured;
-			})();
+			})().catch((error) => {
+				heavyPromise = null;
+				loadedHeavy = null;
+				throw error;
+			});
 		}
 		return heavyPromise;
 	}


### PR DESCRIPTION
## Summary

- Reset the web-access lazy `heavyPromise` when heavy provider initialization rejects.
- Clear `loadedHeavy` on the same failure path so a later `web_search`/`fetch_content` invocation starts from a clean initialization attempt.
- Add a regression test that simulates a failed first heavy initialization and verifies the next tool call retries and succeeds.
- Add an Unreleased changelog entry for the web-access fix.

Fixes #1704

## Verification

- `bun run --cwd packages/coding-agent vitest --run test/suite/regressions/1223-startup-lazy-builtins.test.ts`
- `bun run typecheck`
- `bun run check:file-length`
- `git diff --check`
- pre-push hook: `bun run lint`, `bun run check:file-length`, `bun run test:unit`
