### PR TITLE
feat(subagents): raise parallel task limit to 50

### DIFF
--- a/packages/coding-agent/docs/subagents.md
+++ b/packages/coding-agent/docs/subagents.md
@@ -124,6 +124,8 @@ For adversarial review or research, prefer fresh context so the specialist inspe
 
 For parallel implementation work, `worktree: true` can give each child an isolated git worktree so concurrent edits do not clobber each other.
 
+Top-level parallel calls support up to 50 subagents after expanding each task's optional `count`. The extension's `parallel.maxTasks` setting defaults to 50 and can enforce a lower task limit; `parallel.concurrency` independently controls how many of those children run at once.
+
 When a subagent call, parallel task, chain step, or background run uses a `cwd`, Atomic validates that working directory before starting the child runtime. Missing or non-directory paths are reported as `cwd` problems instead of lower-level process-spawn errors, so failures point at the requested child workspace rather than at the runtime binary.
 
 ## Nested and fanout boundaries

--- a/packages/coding-agent/examples/extensions/subagent/README.md
+++ b/packages/coding-agent/examples/extensions/subagent/README.md
@@ -93,7 +93,7 @@ Use a chain: first have scout find the read tool, then have planner suggest impr
 | Mode | Parameter | Description |
 |------|-----------|-------------|
 | Single | `{ agent, task }` | One agent, one task |
-| Parallel | `{ tasks: [...] }` | Multiple agents run concurrently (max 8, 4 concurrent) |
+| Parallel | `{ tasks: [...] }` | Multiple agents run concurrently (max 50, 4 concurrent) |
 | Chain | `{ chain: [...] }` | Sequential with `{previous}` placeholder |
 
 ## Output Display
@@ -169,4 +169,4 @@ Project agents override user agents with the same name when `agentScope: "both"`
 
 - Output truncated to last 10 items in collapsed view (expand to see all)
 - Agents discovered fresh on each invocation (allows editing mid-session)
-- Parallel mode limited to 8 tasks, 4 concurrent
+- Parallel mode limited to 50 tasks, 4 concurrent

--- a/packages/coding-agent/examples/extensions/subagent/index.ts
+++ b/packages/coding-agent/examples/extensions/subagent/index.ts
@@ -20,11 +20,10 @@ import type { AgentScope } from "./agents.ts";
 import { discoverAgents } from "./agents.ts";
 import { getFinalOutput } from "./display.js";
 import { mapWithConcurrencyLimit, runSingleAgent } from "./runner.js";
-import { SubagentParams } from "./schemas.js";
+import { MAX_PARALLEL_TASKS, SubagentParams } from "./schemas.js";
 import type { SingleResult, SubagentDetails } from "./types.js";
 import { renderSubagentResult } from "./render.js";
 
-const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
 
 export default function (pi: ExtensionAPI) {

--- a/packages/coding-agent/examples/extensions/subagent/schemas.ts
+++ b/packages/coding-agent/examples/extensions/subagent/schemas.ts
@@ -1,6 +1,8 @@
 import { StringEnum } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 
+export const MAX_PARALLEL_TASKS = 50;
+
 const TaskItem = Type.Object({
   agent: Type.String({ description: "Name of the agent to invoke" }),
   task: Type.String({ description: "Task to delegate to the agent" }),
@@ -36,7 +38,8 @@ export const SubagentParams = Type.Object({
   ),
   tasks: Type.Optional(
     Type.Array(TaskItem, {
-      description: "Array of {agent, task} for parallel execution",
+      description: `Array of {agent, task} for parallel execution (max ${MAX_PARALLEL_TASKS})`,
+      maxItems: MAX_PARALLEL_TASKS,
     }),
   ),
   chain: Type.Optional(

--- a/packages/coding-agent/test/subagent-example-schema.test.ts
+++ b/packages/coding-agent/test/subagent-example-schema.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+import {
+	MAX_PARALLEL_TASKS,
+	SubagentParams,
+} from "../examples/extensions/subagent/schemas.js";
+
+function makeTasks(count: number) {
+	return Array.from({ length: count }, (_, index) => ({
+		agent: "worker",
+		task: `Task ${index + 1}`,
+	}));
+}
+
+describe("subagent example parallel task limit", () => {
+	test("accepts 50 parallel tasks and rejects 51", () => {
+		expect(MAX_PARALLEL_TASKS).toBe(50);
+		expect(
+			Value.Check(SubagentParams, { tasks: makeTasks(MAX_PARALLEL_TASKS) }),
+		).toBe(true);
+		expect(
+			Value.Check(SubagentParams, {
+				tasks: makeTasks(MAX_PARALLEL_TASKS + 1),
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Aligned the subagents extension peer dependencies with upstream Pi `^0.80.5` runtime packages as part of the consolidated dependency refresh.
+- Increased the top-level parallel subagent task limit from 8 to 50, including repeated tasks expanded through `count`; `parallel.maxTasks` can still configure a lower limit while concurrency remains independently configurable.
 
 ### Removed
 

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -880,7 +880,7 @@ Forces depth-0 single, parallel, and chain runs into background mode. Calls rema
 }
 ```
 
-`maxTasks` defaults to `8`; `concurrency` defaults to `4`. Per-call `concurrency` takes precedence.
+`maxTasks` defaults to `50`; `concurrency` defaults to `4`. `maxTasks` can set a lower per-call task limit but cannot exceed the hard maximum of `50`. Per-call `concurrency` takes precedence.
 
 ### `defaultSessionDir`
 

--- a/packages/subagents/src/extension/schemas.ts
+++ b/packages/subagents/src/extension/schemas.ts
@@ -3,7 +3,7 @@
  */
 
 import { Type } from "typebox";
-import { MAX_SUBAGENT_NESTING_DEPTH, SUBAGENT_ACTIONS } from "../shared/types.ts";
+import { MAX_PARALLEL_TASKS, MAX_SUBAGENT_NESTING_DEPTH, SUBAGENT_ACTIONS } from "../shared/types.ts";
 
 const SkillOverride = Type.Unsafe({
 	anyOf: [
@@ -190,7 +190,10 @@ export const SubagentParams = Type.Object({
 		],
 		description: `Agent or chain config for create/update. Agent: name, package (optional namespace; runtime name becomes package.name), description, scope ('user'|'project', default 'user'), systemPrompt, systemPromptMode, inheritProjectContext, inheritSkills, defaultContext ('fresh'|'fork'), model, tools (comma-separated), extensions (comma-separated), skills (comma-separated), thinking, output, reads, progress, maxSubagentDepth (integer >= 0, clamped to ${MAX_SUBAGENT_NESTING_DEPTH}). Chain: name, package, description, scope, steps (array of {agent, task?, output?, outputMode?, reads?, model?, skill?, progress?}). Presence of 'steps' creates a chain instead of an agent. String values must be valid JSON.`
 	})),
-	tasks: Type.Optional(Type.Array(TaskItem, { description: "PARALLEL mode: [{agent, task, count?, output?, outputMode?, reads?, progress?}, ...]" })),
+	tasks: Type.Optional(Type.Array(TaskItem, {
+		maxItems: MAX_PARALLEL_TASKS,
+		description: `PARALLEL mode: [{agent, task, count?, output?, outputMode?, reads?, progress?}, ...]. Maximum ${MAX_PARALLEL_TASKS} tasks after count expansion.`,
+	})),
 	concurrency: Type.Optional(Type.Integer({ minimum: 1, description: "Top-level PARALLEL mode only: max concurrent tasks. Defaults to config.parallel.concurrency or 4." })),
 	worktree: Type.Optional(Type.Boolean({
 		description: "Create isolated git worktrees for each parallel task. " +

--- a/packages/subagents/src/shared/types-runtime.ts
+++ b/packages/subagents/src/shared/types-runtime.ts
@@ -77,7 +77,7 @@ export function resolveTempScopeId(options?: {
 	return "shared";
 }
 
-const MAX_PARALLEL = 8;
+export const MAX_PARALLEL_TASKS = 50;
 export const MAX_CONCURRENCY = 4;
 export const TEMP_ROOT_DIR = path.join(os.tmpdir(), `${APP_NAME}-subagents-${resolveTempScopeId()}`);
 export const RESULTS_DIR = path.join(TEMP_ROOT_DIR, "async-subagent-results");
@@ -110,7 +110,8 @@ function normalizeTopLevelParallelValue(value: unknown): number | undefined {
 }
 
 export function resolveTopLevelParallelMaxTasks(value: unknown): number {
-	return normalizeTopLevelParallelValue(value) ?? MAX_PARALLEL;
+	const configuredMax = normalizeTopLevelParallelValue(value);
+	return configuredMax === undefined ? MAX_PARALLEL_TASKS : Math.min(configuredMax, MAX_PARALLEL_TASKS);
 }
 
 export function resolveTopLevelParallelConcurrency(

--- a/test/unit/subagents-foreground-guard-propagation.test.ts
+++ b/test/unit/subagents-foreground-guard-propagation.test.ts
@@ -191,7 +191,7 @@ function makeExecutor(_cwd: string, agents: MinimalAgentConfig[]) {
 	const deps = {
 		pi: makePi(),
 		state: makeState(),
-		config: { maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 8 } },
+		config: { maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 50 } },
 		asyncByDefault: false,
 		tempArtifactsDir: path.join(tempRoot, "artifacts"),
 		getSubagentSessionRoot: () => path.join(tempRoot, "sessions"),

--- a/test/unit/subagents-noninteractive-tool-boundary.test.ts
+++ b/test/unit/subagents-noninteractive-tool-boundary.test.ts
@@ -106,7 +106,7 @@ function makeExecutor(
 	return createSubagentExecutor({
 		pi: { events: { on: () => () => {}, emit: () => {} }, getSessionName: () => "parent" } as unknown as ExecutorDeps["pi"],
 		state,
-		config: { asyncByDefault, maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 8 } },
+		config: { asyncByDefault, maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 50 } },
 		asyncByDefault,
 		tempArtifactsDir: join(cwd, "artifacts"),
 		getSubagentSessionRoot: () => join(cwd, "sessions"),
@@ -187,6 +187,33 @@ describe("programmatic subagent tool boundary", () => {
 			assert.deepEqual(backgroundCalls, [{ agent: "worker", task: "fix it" }]);
 			assert.equal(foregroundCalls, 0);
 			assert.equal(customCalls, 0);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("async parallel execution rejects more than 50 expanded tasks before dispatch", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "atomic-subagent-tool-async-limit-"));
+		try {
+			let dispatchCalls = 0;
+			const executor = makeExecutor(cwd, [makeAgent("worker")], {
+				isAsyncAvailable: () => true,
+				executeAsyncChain: () => {
+					dispatchCalls += 1;
+					return { content: [{ type: "text", text: "background started" }], details: { mode: "parallel", results: [] } };
+				},
+			});
+			const result = await executor.execute(
+				"async-parallel-limit",
+				{ tasks: [{ agent: "worker", task: "repeat", count: 51 }], async: true },
+				new AbortController().signal,
+				undefined,
+				makeContext(cwd, () => { throw new Error("unexpected UI prompt"); }),
+			);
+
+			assert.equal(result.isError, true);
+			assert.equal(result.content[0]?.type === "text" ? result.content[0].text : "", "Max 50 tasks");
+			assert.equal(dispatchCalls, 0);
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}

--- a/test/unit/subagents-upstream-sync.test.ts
+++ b/test/unit/subagents-upstream-sync.test.ts
@@ -1,4 +1,5 @@
 import { describe, test } from "bun:test";
+import { Value } from "typebox/value";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,6 +17,7 @@ import {
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AgentConfig } from "../../packages/subagents/src/agents/agent-types.js";
 import type { ExecutorDeps, SubagentExecutorRuntimeDeps } from "../../packages/subagents/src/runs/foreground/subagent-executor-types.js";
+import { resolveTopLevelParallelMaxTasks } from "../../packages/subagents/src/shared/types.js";
 import type { SingleResult, Usage } from "../../packages/subagents/src/shared/types.js";
 import type { ExtensionContext } from "../../packages/coding-agent/src/index.js";
 
@@ -124,7 +126,7 @@ function makeExecutor(input: {
 			getSessionName: () => "parent-session-name",
 		} as unknown as ExecutorDeps["pi"],
 		state: makeState(),
-		config: { maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 8 } } as ExecutorDeps["config"],
+		config: { maxSubagentDepth: 2, parallel: { concurrency: 4, maxTasks: 50 } } as ExecutorDeps["config"],
 		asyncByDefault: false,
 		tempArtifactsDir: join(input.cwd, "artifacts"),
 		getSubagentSessionRoot: () => join(input.cwd, "sessions"),
@@ -215,6 +217,48 @@ describe("recent upstream subagent syncs", () => {
 		const serialized = JSON.stringify(SubagentParams);
 		for (const keyword of ["allOf", "const", "if", "then", "not"]) {
 			assert.equal(serialized.includes(`\"${keyword}\"`), false, `schema should omit ${keyword}`);
+		}
+	});
+
+	test("defaults the top-level parallel task maximum to 50 and only allows config to lower it", () => {
+		assert.equal(resolveTopLevelParallelMaxTasks(undefined), 50);
+		assert.equal(resolveTopLevelParallelMaxTasks(12), 12);
+		assert.equal(resolveTopLevelParallelMaxTasks(51), 50);
+	});
+
+	test("accepts 50 top-level parallel tasks in the tool schema and rejects 51", () => {
+		const makeTasks = (count: number) => Array.from({ length: count }, (_, index) => ({
+			agent: "worker",
+			task: `Task ${index + 1}`,
+		}));
+
+		assert.equal(Value.Check(SubagentParams, { tasks: makeTasks(50) }), true);
+		assert.equal(Value.Check(SubagentParams, { tasks: makeTasks(51) }), false);
+	});
+
+	test("rejects more than 50 expanded top-level parallel tasks at runtime", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "atomic-subagent-parallel-limit-"));
+		try {
+			let runCount = 0;
+			const executor = makeExecutor({
+				cwd,
+				agents: [makeAgent("worker")],
+				runSync: async (_parentCwd, _agents, agentName, task) => {
+					runCount += 1;
+					return result(agentName, task);
+				},
+			});
+
+			const output = await executor.execute("parallel-limit", {
+				tasks: [{ agent: "worker", task: "Repeated task", count: 51 }],
+			}, new AbortController().signal, undefined, makeContext(cwd));
+			const text = output.content[0]?.type === "text" ? output.content[0].text : "";
+
+			assert.equal(output.isError, true);
+			assert.equal(text, "Max 50 tasks");
+			assert.equal(runCount, 0);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
## Summary

Raise the maximum number of top-level parallel subagent tasks from 8 to 50 across runtime enforcement, tool schemas, examples, tests, and user-facing documentation. This enables larger parallel task batches while preserving lower configured limits and the independent concurrency default of 4.

## Changes

- `packages/subagents/src/shared/types-runtime.ts`: export `MAX_PARALLEL_TASKS = 50` (renamed from the internal `MAX_PARALLEL = 8`) as the shared hard maximum, and clamp `resolveTopLevelParallelMaxTasks` so configured values above 50 are capped while lower configured values are still honored.
- `packages/subagents/src/extension/schemas.ts`: add `maxItems: MAX_PARALLEL_TASKS` to the `tasks` schema and document that the limit applies after `count` expansion.
- `packages/coding-agent/examples/extensions/subagent/schemas.ts` and `index.ts`: introduce and use an exported `MAX_PARALLEL_TASKS = 50` constant (previously a local `MAX_PARALLEL_TASKS = 8`), with a matching `maxItems` schema limit.
- Docs: update `packages/coding-agent/docs/subagents.md`, `packages/subagents/README.md`, and the example extension's `README.md` to describe the new 50-task ceiling and clarify that `parallel.maxTasks` can only lower it, not raise it above the hard max.
- Changelog: add an `[Unreleased]` entry to `packages/subagents/CHANGELOG.md`.
- Tests:
  - New `packages/coding-agent/test/subagent-example-schema.test.ts` verifies the example schema accepts 50 tasks and rejects 51.
  - `test/unit/subagents-upstream-sync.test.ts` adds coverage for `resolveTopLevelParallelMaxTasks` clamping behavior, schema-level accept/reject at 50/51, and runtime rejection of 51 `count`-expanded tasks before any task executes.
  - `test/unit/subagents-noninteractive-tool-boundary.test.ts` adds coverage that asynchronous parallel dispatch also rejects 51 `count`-expanded tasks before dispatching any work.
  - Existing executor tests (`subagents-foreground-guard-propagation.test.ts`, `subagents-noninteractive-tool-boundary.test.ts`, `subagents-upstream-sync.test.ts`) updated to configure `maxTasks: 50` instead of `8`.

## Testing

- Focused root Bun tests: **23 passed, 0 failed**
- Coding-agent example schema test: **1 passed, 0 failed**
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run check:file-length` — passed
- `git diff --check` — passed

## Notes

- This changes the task-count ceiling only; parallel concurrency remains independently configurable and defaults to 4.
- Existing configurations below 50 continue to impose their lower task limit; values above 50 are clamped to the hard maximum.
- No UI/E2E video is applicable for this runtime/schema limit change. Executor-level tests cover the user-visible rejection behavior in foreground and async dispatch paths.