### PR TITLE
fix(subagents): isolate extension API lifecycle state

### DIFF
--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed Bun source-checkout subagent launches to reuse the current TypeScript Atomic CLI entrypoint instead of falling back to an unrelated `atomic` executable on `PATH`, while preserving JavaScript, compiled-runtime, and cross-platform spawn behavior.
+- Fixed direct async subagent completions disappearing after an in-process workflow stage loaded or shut down the extension. Runtime cleanup, watchers, event subscriptions, completion notification handlers and dedupe state, slash live snapshots, visible-control deduplication, fanout-child nested-control listeners/timers, and async widget animation state are now owned per `ExtensionAPI`, so concurrent parent/stage sessions cannot tear down, suppress, clear, or replace one another's parent-owned state even when they share a forwarded host UI and session identity. Native result watching also coalesces directory activity into a short rescan, so macOS/Bun atomic writes are consumed even when `fs.watch` reports only a hidden temporary rename rather than the final JSON filename. Same-API reloads remain deduplicated, partial registration failures clean up acquired resources, stale shutdown callbacks cannot stop a newer registration, and duplicate watcher activity still consumes a parent result file with exactly one `subagent-notify`.
 
 ## [0.9.5-alpha.9] - 2026-07-09
 

--- a/packages/subagents/src/extension/api-lifecycle.ts
+++ b/packages/subagents/src/extension/api-lifecycle.ts
@@ -1,0 +1,64 @@
+import type { ExtensionAPI } from "@bastani/atomic";
+
+interface ApiRegistration {
+	cleanup: () => void;
+	disposed: boolean;
+}
+
+export interface ApiLifecycle {
+	isCurrent(): boolean;
+	setCleanup(cleanup: () => void): void;
+	dispose(): void;
+}
+
+function getWeakMap<T>(key: string): WeakMap<ExtensionAPI, T> {
+	const store = globalThis as Record<string, unknown>;
+	const existing = store[key];
+	if (existing instanceof WeakMap) return existing as WeakMap<ExtensionAPI, T>;
+	const registry = new WeakMap<ExtensionAPI, T>();
+	store[key] = registry;
+	return registry;
+}
+
+export function beginApiLifecycle(pi: ExtensionAPI): ApiLifecycle {
+	const registry = getWeakMap<ApiRegistration>("__piSubagentRuntimeRegistrations");
+	try {
+		registry.get(pi)?.cleanup();
+	} catch {
+		// Reload cleanup is best effort; a stale resource must not block registration.
+	}
+
+	let ownedCleanup = () => {};
+	const registration: ApiRegistration = {
+		disposed: false,
+		cleanup: () => {
+			if (registration.disposed) return;
+			registration.disposed = true;
+			try {
+				ownedCleanup();
+			} finally {
+				if (registry.get(pi) === registration) registry.delete(pi);
+			}
+		},
+	};
+	registry.set(pi, registration);
+
+	return {
+		isCurrent: () => !registration.disposed && registry.get(pi) === registration,
+		setCleanup(cleanup) {
+			ownedCleanup = cleanup;
+		},
+		dispose() {
+			if (registry.get(pi) === registration) registration.cleanup();
+		},
+	};
+}
+
+export function getApiScopedSet(pi: ExtensionAPI, key: string): Set<string> {
+	const registry = getWeakMap<Set<string>>(key);
+	const existing = registry.get(pi);
+	if (existing) return existing;
+	const values = new Set<string>();
+	registry.set(pi, values);
+	return values;
+}

--- a/packages/subagents/src/extension/fanout-child.ts
+++ b/packages/subagents/src/extension/fanout-child.ts
@@ -8,13 +8,14 @@ import type { ExtensionAPI, ToolDefinition } from "@bastani/atomic";
 import { discoverAgents } from "../agents/agents.ts";
 import { resolveSubagentIntercomTarget } from "../intercom/intercom-bridge.ts";
 import { deliverSubagentIntercomMessageEvent } from "../intercom/result-intercom.ts";
-import { createSubagentExecutor } from "../runs/foreground/subagent-executor.ts";
+import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { readNestedControlRequests, resolveNestedRouteFromEnv, writeNestedControlResult, type NestedRoute } from "../runs/shared/nested-events.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
 import { getArtifactsDir } from "../shared/artifacts.ts";
 import { type Details, type SubagentState } from "../shared/types.ts";
 import { loadConfig } from "./config.ts";
 import { SubagentParams } from "./schemas.ts";
+import { beginApiLifecycle } from "./api-lifecycle.ts";
 
 function getSubagentSessionRoot(parentSessionFile: string | null): string {
 	if (parentSessionFile) {
@@ -192,55 +193,48 @@ export function startNestedControlInboxListener(pi: ExtensionAPI, state: Subagen
 export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): void {
 	if (getEnvValue(SUBAGENT_CHILD_ENV) !== "1" || getEnvValue(SUBAGENT_FANOUT_CHILD_ENV) !== "1") return;
 
-	const globalStore = globalThis as Record<string, unknown>;
-	const registeredKey = "__atomicSubagentFanoutChildRegisteredApis";
-	const cleanupKey = "__atomicSubagentFanoutChildRuntimeCleanup";
-	const registeredApis = globalStore[registeredKey] instanceof WeakSet
-		? globalStore[registeredKey] as WeakSet<ExtensionAPI>
-		: new WeakSet<ExtensionAPI>();
-	globalStore[registeredKey] = registeredApis;
-	if (registeredApis.has(pi)) return;
-	const previousRuntimeCleanup = globalStore[cleanupKey];
-	if (typeof previousRuntimeCleanup === "function") {
-		try {
-			previousRuntimeCleanup();
-		} catch {
-			// Best effort cleanup for stale fanout-child timers from an older reload.
-		}
+	const lifecycle = beginApiLifecycle(pi);
+
+	try {
+		const config = loadConfig();
+		const state = createChildSafeState();
+		lifecycle.setCleanup(() => {
+			for (const timer of state.cleanupTimers.values()) clearInterval(timer);
+			state.cleanupTimers.clear();
+		});
+		const executor = createSubagentExecutor({
+			pi,
+			state,
+			config,
+			asyncByDefault: config.asyncByDefault === true,
+			tempArtifactsDir: getArtifactsDir(null),
+			getSubagentSessionRoot,
+			expandTilde,
+			discoverAgents,
+			allowMutatingManagementActions: false,
+		});
+
+		const tool: ToolDefinition<typeof SubagentParams, Details> = {
+			name: "subagent",
+			label: "Subagent",
+			description: [
+				"Delegate to subagents from child-safe fanout mode.",
+				"Execution calls always start non-interactively.",
+				"Allowed management/control actions: list, get, status, interrupt, resume, doctor.",
+				"Agent config mutation actions create, update, and delete are blocked in this mode.",
+			].join("\n"),
+			parameters: SubagentParams,
+			execute(id, params, signal, onUpdate, ctx) {
+				const executionSignal = signal ?? ctx.signal ?? new AbortController().signal;
+				return executor.execute(id, params as SubagentParamsLike, executionSignal, onUpdate, ctx);
+			},
+		};
+
+		pi.registerTool(tool);
+		startNestedControlInboxListener(pi, state);
+		pi.on?.("session_shutdown", () => lifecycle.dispose());
+	} catch (error) {
+		lifecycle.dispose();
+		throw error;
 	}
-	registeredApis.add(pi);
-
-	const config = loadConfig();
-	const state = createChildSafeState();
-	const executor = createSubagentExecutor({
-		pi,
-		state,
-		config,
-		asyncByDefault: config.asyncByDefault === true,
-		tempArtifactsDir: getArtifactsDir(null),
-		getSubagentSessionRoot,
-		expandTilde,
-		discoverAgents,
-		allowMutatingManagementActions: false,
-	});
-
-	const tool: ToolDefinition<typeof SubagentParams, Details> = {
-		name: "subagent",
-		label: "Subagent",
-		description: [
-			"Delegate to subagents from child-safe fanout mode.",
-			"Execution calls always start non-interactively.",
-			"Allowed management/control actions: list, get, status, interrupt, resume, doctor.",
-			"Agent config mutation actions create, update, and delete are blocked in this mode.",
-		].join("\n"),
-		parameters: SubagentParams,
-		execute: executor.execute,
-	};
-
-	pi.registerTool(tool);
-	startNestedControlInboxListener(pi, state);
-	globalStore[cleanupKey] = () => {
-		for (const timer of state.cleanupTimers.values()) clearInterval(timer);
-		state.cleanupTimers.clear();
-	};
 }

--- a/packages/subagents/src/extension/index.ts
+++ b/packages/subagents/src/extension/index.ts
@@ -23,9 +23,10 @@ import registerFanoutChildSubagentExtension from "./fanout-child.ts";
 import { formatDuration, shortenPath } from "../shared/formatters.ts";
 import { loadConfig } from "./config.ts";
 import { DEFAULT_PROMPT_GUIDANCE } from "./prompt-guidance.ts";
-import { type Details, type SubagentState, ASYNC_DIR, DEFAULT_ARTIFACT_CONFIG, RESULTS_DIR, SLASH_RESULT_TYPE, SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_CONTROL_EVENT, WIDGET_KEY } from "../shared/types.ts";
+import { type Details, type SubagentState, ASYNC_DIR, DEFAULT_ARTIFACT_CONFIG, RESULTS_DIR, SLASH_RESULT_TYPE, SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_CONTROL_EVENT } from "../shared/types.ts";
 import { clearPendingForegroundControlNotices, formatSubagentControlNotice, handleSubagentControlNotice, SUBAGENT_CONTROL_MESSAGE_TYPE, type SubagentControlMessageDetails } from "./control-notices.ts";
 import { createSubagentStartupMaintenance } from "./startup-maintenance.ts";
+import { beginApiLifecycle, getApiScopedSet } from "./api-lifecycle.ts";
 export { loadConfig } from "./config.ts";
 function getSubagentSessionRoot(parentSessionFile: string | null): string {
 	if (parentSessionFile) {
@@ -59,9 +60,6 @@ function isSlashResultRunning(result: { details?: Details }): boolean {
 function isSlashResultError(result: { details?: Details }): boolean {
 	return result.details?.results.some((entry) => entry.exitCode !== 0 && entry.progress?.status !== "running") || false;
 }
-function isStaleExtensionContextError(error: unknown): boolean {
-	return error instanceof Error && error.message.includes("Extension context no longer active");
-}
 type SubagentToolRenderState = SubagentResultRenderState;
 function rebuildSlashResultContainer(
 	container: Container,
@@ -80,13 +78,14 @@ function createSlashResultComponent(
 	details: SlashMessageDetails,
 	options: { expanded: boolean },
 	theme: ExtensionContext["ui"]["theme"],
+	owner: ExtensionAPI,
 ): Container {
 	const container = new Container();
 	let lastVersion = -1;
 	let lastSnapshotNow = 0;
 	let pulseFrame = 0;
 	container.render = (width: number): string[] => {
-		const snapshot = getSlashRenderableSnapshot(details);
+		const snapshot = getSlashRenderableSnapshot(details, owner);
 		if (snapshot.version !== lastVersion) {
 			lastVersion = snapshot.version;
 			lastSnapshotNow = Date.now();
@@ -157,169 +156,162 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		if (getEnvValue(SUBAGENT_FANOUT_CHILD_ENV) === "1") registerFanoutChildSubagentExtension(pi);
 		return;
 	}
-	const globalStore = globalThis as Record<string, unknown>;
-	const runtimeCleanupStoreKey = "__piSubagentRuntimeCleanup";
-	const previousRuntimeCleanup = globalStore[runtimeCleanupStoreKey];
-	if (typeof previousRuntimeCleanup === "function") {
-		try {
-			previousRuntimeCleanup();
-		} catch {
-		}
-	}
-	ensureAccessibleDir(RESULTS_DIR);
-	ensureAccessibleDir(ASYNC_DIR);
-	const config = loadConfig();
-	const asyncByDefault = config.asyncByDefault === true;
-	const tempArtifactsDir = getArtifactsDir(null);
-	const state: SubagentState = {
-		baseCwd: "",
-		currentSessionId: null,
-		asyncJobs: new Map(),
-		subagentInProgress: false,
-		foregroundRuns: new Map(),
-		foregroundControls: new Map(),
-		lastForegroundControlId: null,
-		pendingForegroundControlNotices: new Map(),
-		cleanupTimers: new Map(),
-		lastUiContext: null,
-		poller: null,
-		completionSeen: new Map(),
-		watcher: null,
-		watcherRestartTimer: null,
-		resultFileCoalescer: {
-			schedule: () => false,
-			clear: () => {},
-		},
-	};
-	const maintenance = createSubagentStartupMaintenance(pi, state, {
-		resultsDir: RESULTS_DIR,
-		artifactCleanupDays: DEFAULT_ARTIFACT_CONFIG.cleanupDays,
-		resultTtlMs: 10 * 60 * 1000,
-	});
-	maintenance.scheduleStartupCleanup();
-	maintenance.startResultWatcherDeferred();
-	maintenance.primeExistingResultsDeferred();
-	const runtimeCleanup = () => {
-		maintenance.stop();
-		stopWidgetAnimation();
-		stopResultAnimations();
-		clearPendingForegroundControlNotices(state);
-		if (state.poller) {
-			clearInterval(state.poller);
-			state.poller = null;
-		}
-	};
-	globalStore[runtimeCleanupStoreKey] = runtimeCleanup;
-	const { ensurePoller, handleStarted, handleComplete, resetJobs, hydrateActiveJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR);
-	const executor = createSubagentExecutor({
-		pi,
-		state,
-		config,
-		asyncByDefault,
-		tempArtifactsDir,
-		getSubagentSessionRoot,
-		expandTilde,
-		discoverAgents,
-	});
-	pi.registerMessageRenderer<SlashMessageDetails>(SLASH_RESULT_TYPE, (message, options, theme) => {
-		const details = resolveSlashMessageDetails(message.details);
-		if (!details) return undefined;
-		return createSlashResultComponent(details, options, theme);
-	});
-	pi.registerMessageRenderer<SubagentNotifyDetails>("subagent-notify", (message, options, theme) => {
-		const content = typeof message.content === "string" ? message.content : "";
-		const details = (message.details as SubagentNotifyDetails | undefined) ?? parseSubagentNotifyContent(content);
-		if (!details) return new Text(content, 0, 0);
-		const icon = details.status === "completed"
-			? theme.fg("success", "✓")
-			: details.status === "paused"
-				? theme.fg("warning", "■")
-				: theme.fg("error", "✗");
-		const parts: string[] = [];
-		if (details.taskInfo) parts.push(details.taskInfo);
-		if (details.durationMs !== undefined) parts.push(formatDuration(details.durationMs));
-		let text = `${icon} ${theme.bold(details.agent)} ${theme.fg("dim", details.status)}`;
-		if (parts.length > 0) text += ` ${theme.fg("dim", "·")} ${parts.map((part) => theme.fg("dim", part)).join(` ${theme.fg("dim", "·")} `)}`;
-		const trimmedPreview = details.resultPreview.trim();
-		const previewLines = options.expanded
-			? trimmedPreview.split("\n").filter((line) => line.trim())
-			: [trimmedPreview.split("\n", 1)[0] ?? ""].filter((line) => line.trim());
-		for (const line of previewLines.length > 0 ? previewLines : ["(no output)"]) {
-			text += `\n  ${theme.fg("dim", `⎿  ${line}`)}`;
-		}
-		if (!options.expanded && trimmedPreview.includes("\n")) {
-			text += `\n  ${theme.fg("dim", "ctrl+o full notification")}`;
-		}
-		if (details.sessionLabel && details.sessionValue) {
-			text += `\n  ${theme.fg("muted", `${details.sessionLabel}: ${shortenPath(details.sessionValue)}`)}`;
-		}
-		return new Text(text, 0, 0);
-	});
-	pi.registerMessageRenderer<SubagentControlMessageDetails>(SUBAGENT_CONTROL_MESSAGE_TYPE, (message, _options, theme) => {
-		const details = message.details as SubagentControlMessageDetails | undefined;
-		if (!details?.event) return undefined;
-		const content = typeof message.content === "string" ? message.content : undefined;
-		return new SubagentControlNoticeComponent({ ...details, noticeText: formatSubagentControlNotice(details, content) }, theme);
-	});
-	const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {
-		if (ctx.hasUI) {
-			state.lastUiContext = ctx;
-			ctx.ui.setToolsExpanded(false);
-		}
-		return executor.execute(id, params, signal, onUpdate, ctx);
-	};
-	const slashBridge = registerSlashSubagentBridge({
-		events: pi.events,
-		getContext: () => state.lastUiContext,
-		execute: (id, params, signal, onUpdate, ctx) =>
-			executeSubagentCollapsed(id, params, signal, onUpdate, ctx),
-	});
-	const promptTemplateBridge = registerPromptTemplateDelegationBridge({
-		events: pi.events,
-		getContext: () => state.lastUiContext,
-		execute: async (requestId, request, signal, ctx, onUpdate) => {
-			if (request.tasks && request.tasks.length > 0) {
+	const lifecycle = beginApiLifecycle(pi);
+	const registrationFailureCleanups: Array<() => void> = [];
+	let runtimeCleanupInstalled = false;
+	try {
+		ensureAccessibleDir(RESULTS_DIR);
+		ensureAccessibleDir(ASYNC_DIR);
+		const config = loadConfig();
+		const asyncByDefault = config.asyncByDefault === true;
+		const tempArtifactsDir = getArtifactsDir(null);
+		const state: SubagentState = {
+			baseCwd: "",
+			currentSessionId: null,
+			asyncJobs: new Map(),
+			subagentInProgress: false,
+			foregroundRuns: new Map(),
+			foregroundControls: new Map(),
+			lastForegroundControlId: null,
+			pendingForegroundControlNotices: new Map(),
+			cleanupTimers: new Map(),
+			lastUiContext: null,
+			poller: null,
+			completionSeen: new Map(),
+			watcher: null,
+			watcherRestartTimer: null,
+			resultFileCoalescer: {
+				schedule: () => false,
+				clear: () => {},
+			},
+		};
+		const maintenance = createSubagentStartupMaintenance(pi, state, {
+			resultsDir: RESULTS_DIR,
+			artifactCleanupDays: DEFAULT_ARTIFACT_CONFIG.cleanupDays,
+			resultTtlMs: 10 * 60 * 1000,
+		});
+		maintenance.scheduleStartupCleanup();
+		registrationFailureCleanups.push(() => maintenance.stop());
+		maintenance.startResultWatcherDeferred();
+		maintenance.primeExistingResultsDeferred();
+		const { ensurePoller, handleStarted, handleComplete, resetJobs, hydrateActiveJobs } = createAsyncJobTracker(pi, state, ASYNC_DIR);
+		const executor = createSubagentExecutor({
+			pi,
+			state,
+			config,
+			asyncByDefault,
+			tempArtifactsDir,
+			getSubagentSessionRoot,
+			expandTilde,
+			discoverAgents,
+		});
+		pi.registerMessageRenderer<SlashMessageDetails>(SLASH_RESULT_TYPE, (message, options, theme) => {
+			const details = resolveSlashMessageDetails(message.details);
+			if (!details) return undefined;
+			return createSlashResultComponent(details, options, theme, pi);
+		});
+		pi.registerMessageRenderer<SubagentNotifyDetails>("subagent-notify", (message, options, theme) => {
+			const content = typeof message.content === "string" ? message.content : "";
+			const details = (message.details as SubagentNotifyDetails | undefined) ?? parseSubagentNotifyContent(content);
+			if (!details) return new Text(content, 0, 0);
+			const icon = details.status === "completed"
+				? theme.fg("success", "✓")
+				: details.status === "paused"
+					? theme.fg("warning", "■")
+					: theme.fg("error", "✗");
+			const parts: string[] = [];
+			if (details.taskInfo) parts.push(details.taskInfo);
+			if (details.durationMs !== undefined) parts.push(formatDuration(details.durationMs));
+			let text = `${icon} ${theme.bold(details.agent)} ${theme.fg("dim", details.status)}`;
+			if (parts.length > 0) text += ` ${theme.fg("dim", "·")} ${parts.map((part) => theme.fg("dim", part)).join(` ${theme.fg("dim", "·")} `)}`;
+			const trimmedPreview = details.resultPreview.trim();
+			const previewLines = options.expanded
+				? trimmedPreview.split("\n").filter((line) => line.trim())
+				: [trimmedPreview.split("\n", 1)[0] ?? ""].filter((line) => line.trim());
+			for (const line of previewLines.length > 0 ? previewLines : ["(no output)"]) {
+				text += `\n  ${theme.fg("dim", `⎿  ${line}`)}`;
+			}
+			if (!options.expanded && trimmedPreview.includes("\n")) {
+				text += `\n  ${theme.fg("dim", "ctrl+o full notification")}`;
+			}
+			if (details.sessionLabel && details.sessionValue) {
+				text += `\n  ${theme.fg("muted", `${details.sessionLabel}: ${shortenPath(details.sessionValue)}`)}`;
+			}
+			return new Text(text, 0, 0);
+		});
+		pi.registerMessageRenderer<SubagentControlMessageDetails>(SUBAGENT_CONTROL_MESSAGE_TYPE, (message, _options, theme) => {
+			const details = message.details as SubagentControlMessageDetails | undefined;
+			if (!details?.event) return undefined;
+			const content = typeof message.content === "string" ? message.content : undefined;
+			return new SubagentControlNoticeComponent({ ...details, noticeText: formatSubagentControlNotice(details, content) }, theme);
+		});
+		const executeSubagentCollapsed = (id: string, params: SubagentParamsLike, signal: AbortSignal, onUpdate: ((result: AgentToolResult<Details>) => void) | undefined, ctx: ExtensionContext) => {
+			if (ctx.hasUI) {
+				state.lastUiContext = ctx;
+				ctx.ui.setToolsExpanded(false);
+			}
+			return executor.execute(id, params, signal, onUpdate, ctx);
+		};
+		const slashBridge = registerSlashSubagentBridge({
+			events: pi.events,
+			getContext: () => state.lastUiContext,
+			execute: (id, params, signal, onUpdate, ctx) =>
+				executeSubagentCollapsed(id, params, signal, onUpdate, ctx),
+		});
+		registrationFailureCleanups.push(() => {
+			slashBridge.cancelAll();
+			slashBridge.dispose();
+		});
+		const promptTemplateBridge = registerPromptTemplateDelegationBridge({
+			events: pi.events,
+			getContext: () => state.lastUiContext,
+			execute: async (requestId, request, signal, ctx, onUpdate) => {
+				if (request.tasks && request.tasks.length > 0) {
+					return executeSubagentCollapsed(
+						requestId,
+						{
+							tasks: request.tasks,
+							context: request.context,
+							cwd: request.cwd,
+							worktree: request.worktree,
+							async: false,
+						},
+						signal,
+						onUpdate,
+						ctx,
+					);
+				}
 				return executeSubagentCollapsed(
 					requestId,
 					{
-						tasks: request.tasks,
+						agent: request.agent,
+						task: request.task,
 						context: request.context,
 						cwd: request.cwd,
-						worktree: request.worktree,
+						model: request.model,
 						async: false,
 					},
 					signal,
 					onUpdate,
 					ctx,
 				);
-			}
-			return executeSubagentCollapsed(
-				requestId,
-				{
-					agent: request.agent,
-					task: request.task,
-					context: request.context,
-					cwd: request.cwd,
-					model: request.model,
-					async: false,
-				},
-				signal,
-				onUpdate,
-				ctx,
-			);
-		},
-	});
-	function effectiveParallelTaskCount(tasks: Array<{ count?: unknown }> | undefined): number {
-		if (!tasks || tasks.length === 0) return 0;
-		return tasks.reduce((total, task) => {
-			const count = typeof task.count === "number" && Number.isInteger(task.count) && task.count >= 1 ? task.count : 1;
-			return total + count;
-		}, 0);
-	}
-	const tool: ToolDefinition<typeof SubagentParams, Details, SubagentToolRenderState> = {
-		name: "subagent",
-		label: "Subagent",
-		description: `Delegate to subagents or manage agent definitions.
+			},
+		});
+		registrationFailureCleanups.push(() => {
+			promptTemplateBridge.cancelAll();
+			promptTemplateBridge.dispose();
+		});
+		function effectiveParallelTaskCount(tasks: Array<{ count?: unknown }> | undefined): number {
+			if (!tasks || tasks.length === 0) return 0;
+			return tasks.reduce((total, task) => {
+				const count = typeof task.count === "number" && Number.isInteger(task.count) && task.count >= 1 ? task.count : 1;
+				return total + count;
+			}, 0);
+		}
+		const tool: ToolDefinition<typeof SubagentParams, Details, SubagentToolRenderState> = {
+			name: "subagent",
+			label: "Subagent",
+			description: `Delegate to subagents or manage agent definitions.
 EXECUTION (use exactly ONE mode):
 • Execution calls always start non-interactively.
 • Before executing, use { action: "list" } to inspect configured agents/chains. Only execute agents listed as executable/non-disabled.
@@ -345,133 +337,147 @@ CONTROL:
 • { action: "resume", id: "...", message: "...", index?: 0 } - follow up with a live async child or revive a completed async/foreground child from its session
 DIAGNOSTICS:
 • { action: "doctor" } - read-only report for runtime paths, discovery, sessions, and intercom`,
-		parameters: SubagentParams,
-		promptGuidelines: DEFAULT_PROMPT_GUIDANCE,
-		execute: executeSubagentCollapsed,
-		renderCall(args, theme) {
-			if (args.action) {
-				const target = args.agent || args.chainName || "";
+			parameters: SubagentParams,
+			promptGuidelines: DEFAULT_PROMPT_GUIDANCE,
+			execute(id, params, signal, onUpdate, ctx) {
+				const executionSignal = signal ?? ctx.signal ?? new AbortController().signal;
+				return executeSubagentCollapsed(id, params as SubagentParamsLike, executionSignal, onUpdate, ctx);
+			},
+			renderCall(args, theme) {
+				if (args.action) {
+					const target = args.agent || args.chainName || "";
+					return new Text(
+						`${theme.fg("toolTitle", theme.bold("subagent "))}${args.action}${target ? ` ${theme.fg("accent", target)}` : ""}`,
+						0, 0,
+					);
+				}
+				const isParallel = (args.tasks?.length ?? 0) > 0;
+				const parallelCount = effectiveParallelTaskCount(args.tasks as Array<{ count?: unknown }> | undefined);
+				const asyncLabel = args.async === true ? theme.fg("warning", " [async]") : "";
+				if (args.chain?.length)
+					return new Text(
+						`${theme.fg("toolTitle", theme.bold("subagent "))}chain (${args.chain.length})${asyncLabel}`,
+						0,
+						0,
+					);
+				if (isParallel)
+					return new Text(
+						`${theme.fg("toolTitle", theme.bold("subagent "))}parallel (${parallelCount})${asyncLabel}`,
+						0,
+						0,
+					);
 				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}${args.action}${target ? ` ${theme.fg("accent", target)}` : ""}`,
-					0, 0,
-				);
-			}
-			const isParallel = (args.tasks?.length ?? 0) > 0;
-			const parallelCount = effectiveParallelTaskCount(args.tasks as Array<{ count?: unknown }> | undefined);
-			const asyncLabel = args.async === true ? theme.fg("warning", " [async]") : "";
-			if (args.chain?.length)
-				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}chain (${args.chain.length})${asyncLabel}`,
+					`${theme.fg("toolTitle", theme.bold("subagent "))}${theme.fg("accent", args.agent || "?")}${asyncLabel}`,
 					0,
 					0,
 				);
-			if (isParallel)
-				return new Text(
-					`${theme.fg("toolTitle", theme.bold("subagent "))}parallel (${parallelCount})${asyncLabel}`,
-					0,
-					0,
-				);
-			return new Text(
-				`${theme.fg("toolTitle", theme.bold("subagent "))}${theme.fg("accent", args.agent || "?")}${asyncLabel}`,
-				0,
-				0,
-			);
-		},
-		renderResult(result, options, theme, context) {
-			return renderLiveSubagentResult(result, options, theme, context);
-		},
-	};
-	pi.registerTool(tool);
-	registerSlashCommands(pi, state);
-	const eventUnsubscribeStoreKey = "__piSubagentEventUnsubscribes";
-	const controlNoticeSeenStoreKey = "__piSubagentVisibleControlNotices";
-	const previousEventUnsubscribes = globalStore[eventUnsubscribeStoreKey];
-	if (Array.isArray(previousEventUnsubscribes)) {
-		for (const unsubscribe of previousEventUnsubscribes) {
-			if (typeof unsubscribe !== "function") continue;
-			try {
-				unsubscribe();
-			} catch {
-			}
+			},
+			renderResult(result, options, theme, context) {
+				return renderLiveSubagentResult(result, options, theme, context);
+			},
+		};
+		pi.registerTool(tool);
+		registerSlashCommands(pi, state);
+		const notifyCleanup = registerSubagentNotify(pi);
+		registrationFailureCleanups.push(notifyCleanup);
+		const visibleControlNotices = getApiScopedSet(pi, "__piSubagentVisibleControlNoticesByApi");
+		const startedEventHandler = (payload: unknown) => {
+			if (lifecycle.isCurrent()) handleStarted(payload);
+		};
+		const completeEventHandler = (payload: unknown) => {
+			if (lifecycle.isCurrent()) handleComplete(payload);
+		};
+		const controlEventHandler = (payload: unknown) => {
+			if (!lifecycle.isCurrent()) return;
+			handleSubagentControlNotice({
+				pi,
+				state,
+				visibleControlNotices,
+				details: payload as SubagentControlMessageDetails,
+			});
+		};
+		const eventUnsubscribes: Array<() => void> = [];
+		for (const [event, handler] of [
+			[SUBAGENT_ASYNC_STARTED_EVENT, startedEventHandler],
+			[SUBAGENT_ASYNC_COMPLETE_EVENT, completeEventHandler],
+			[SUBAGENT_CONTROL_EVENT, controlEventHandler],
+		] as const) {
+			const unsubscribe = pi.events.on(event, handler);
+			eventUnsubscribes.push(unsubscribe);
+			registrationFailureCleanups.push(unsubscribe);
 		}
-	}
-	registerSubagentNotify(pi);
-	const existingVisibleControlNotices = globalStore[controlNoticeSeenStoreKey];
-	const visibleControlNotices = existingVisibleControlNotices instanceof Set ? existingVisibleControlNotices as Set<string> : new Set<string>();
-	globalStore[controlNoticeSeenStoreKey] = visibleControlNotices;
-	const controlEventHandler = (payload: unknown) => {
-		handleSubagentControlNotice({
-			pi,
-			state,
-			visibleControlNotices,
-			details: payload as SubagentControlMessageDetails,
+		let cleaned = false;
+		const runtimeCleanup = () => {
+			if (cleaned) return;
+			cleaned = true;
+			const cleanupSteps: Array<() => void> = [
+				...eventUnsubscribes,
+				notifyCleanup,
+				() => maintenance.stop(),
+				() => stopWidgetAnimation(undefined, pi),
+				() => stopResultAnimations(),
+				() => {
+					if (state.poller) clearInterval(state.poller);
+					state.poller = null;
+				},
+				() => clearPendingForegroundControlNotices(state),
+				...Array.from(state.cleanupTimers.values(), (timer) => () => clearTimeout(timer)),
+				() => state.cleanupTimers.clear(),
+				() => state.asyncJobs.clear(),
+				() => clearSlashSnapshots(pi),
+				() => slashBridge.cancelAll(),
+				() => slashBridge.dispose(),
+				() => promptTemplateBridge.cancelAll(),
+				() => promptTemplateBridge.dispose(),
+			];
+			for (const cleanup of cleanupSteps) {
+				try {
+					cleanup();
+				} catch {
+					// Cleanup is exhaustive and best effort so later owned resources release.
+				}
+			}
+		};
+		lifecycle.setCleanup(runtimeCleanup);
+		runtimeCleanupInstalled = true;
+		pi.on("tool_result", (event, ctx) => {
+			if (!lifecycle.isCurrent() || event.toolName !== "subagent") return;
+			if (!ctx.hasUI) return;
+			state.lastUiContext = ctx;
+			hydrateActiveJobs(ctx);
+			if (state.asyncJobs.size > 0) ensurePoller();
 		});
-	};
-	const eventUnsubscribes = [
-		pi.events.on(SUBAGENT_ASYNC_STARTED_EVENT, handleStarted),
-		pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete),
-		pi.events.on(SUBAGENT_CONTROL_EVENT, controlEventHandler),
-	];
-	globalStore[eventUnsubscribeStoreKey] = eventUnsubscribes;
-	pi.on("tool_result", (event, ctx) => {
-		if (event.toolName !== "subagent") return;
-		if (!ctx.hasUI) return;
-		state.lastUiContext = ctx;
-		hydrateActiveJobs(ctx);
-		if (state.asyncJobs.size > 0) ensurePoller();
-	});
-	const cleanupSessionArtifacts = (ctx: ExtensionContext) => {
-		maintenance.cleanupSessionArtifactsDeferred(ctx);
-	};
-	const resetSessionState = (ctx: ExtensionContext) => {
-		state.baseCwd = ctx.cwd;
-		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
-		state.lastUiContext = ctx;
-		cleanupSessionArtifacts(ctx);
-		clearPendingForegroundControlNotices(state);
-		resetJobs(ctx);
-		hydrateActiveJobs(ctx);
-		restoreSlashFinalSnapshots(ctx.sessionManager.getEntries());
-		maintenance.primeExistingResultsDeferred();
-	};
-	pi.on("session_start", (_event, ctx) => {
-		resetSessionState(ctx);
-	});
-	pi.on("session_shutdown", () => {
-		for (const unsubscribe of eventUnsubscribes) {
-			try {
-				unsubscribe();
-			} catch {
+		const cleanupSessionArtifacts = (ctx: ExtensionContext) => {
+			maintenance.cleanupSessionArtifactsDeferred(ctx);
+		};
+		const resetSessionState = (ctx: ExtensionContext) => {
+			state.baseCwd = ctx.cwd;
+			state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
+			state.lastUiContext = ctx;
+			cleanupSessionArtifacts(ctx);
+			clearPendingForegroundControlNotices(state);
+			resetJobs(ctx);
+			hydrateActiveJobs(ctx);
+			restoreSlashFinalSnapshots(ctx.sessionManager.getEntries(), pi);
+			maintenance.primeExistingResultsDeferred();
+		};
+		pi.on("session_start", (_event, ctx) => {
+			if (lifecycle.isCurrent()) resetSessionState(ctx);
+		});
+		pi.on("session_shutdown", () => {
+			lifecycle.dispose();
+		});
+	} catch (error) {
+		if (!runtimeCleanupInstalled) {
+			for (const cleanup of registrationFailureCleanups.reverse()) {
+				try {
+					cleanup();
+				} catch {
+					// Continue releasing partial-registration resources.
+				}
 			}
 		}
-		if (globalStore[eventUnsubscribeStoreKey] === eventUnsubscribes) {
-			delete globalStore[eventUnsubscribeStoreKey];
-		}
-		maintenance.stop();
-		stopWidgetAnimation();
-		stopResultAnimations();
-		if (state.poller) clearInterval(state.poller);
-		state.poller = null;
-		clearPendingForegroundControlNotices(state);
-		for (const timer of state.cleanupTimers.values()) {
-			clearTimeout(timer);
-		}
-		state.cleanupTimers.clear();
-		state.asyncJobs.clear();
-		clearSlashSnapshots();
-		slashBridge.cancelAll();
-		slashBridge.dispose();
-		promptTemplateBridge.cancelAll();
-		promptTemplateBridge.dispose();
-		if (globalStore[runtimeCleanupStoreKey] === runtimeCleanup) {
-			delete globalStore[runtimeCleanupStoreKey];
-		}
-		try {
-			if (state.lastUiContext?.hasUI) {
-				state.lastUiContext.ui.setWidget(WIDGET_KEY, undefined);
-			}
-		} catch (error) {
-			if (!isStaleExtensionContextError(error)) throw error;
-		}
-	});
+		lifecycle.dispose();
+		throw error;
+	}
 }

--- a/packages/subagents/src/runs/background/async-job-tracker.ts
+++ b/packages/subagents/src/runs/background/async-job-tracker.ts
@@ -97,7 +97,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
 	const resultsDir = options.resultsDir ?? RESULTS_DIR;
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
-		renderWidget(ctx, jobs);
+		renderWidget(ctx, jobs, pi);
 	};
 	const cancelCleanup = (asyncId: string) => {
 		const existingTimer = state.cleanupTimers.get(asyncId);

--- a/packages/subagents/src/runs/background/notify.ts
+++ b/packages/subagents/src/runs/background/notify.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ExtensionAPI } from "@bastani/atomic";
-import { buildCompletionKey, getGlobalSeenMap, markSeenWithTtl } from "./completion-dedupe.ts";
+import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT } from "../../shared/types.ts";
 
 interface ChainStepResult {
@@ -40,22 +40,55 @@ interface SubagentResult {
 	totalTasks?: number;
 }
 
-export default function registerSubagentNotify(pi: ExtensionAPI): void {
-	const unsubscribeStoreKey = "__pi_subagents_notify_unsubscribe__";
-	const globalStore = globalThis as Record<string, unknown>;
-	const previousUnsubscribe = globalStore[unsubscribeStoreKey];
-	if (typeof previousUnsubscribe === "function") {
+interface NotifyRegistration {
+	unsubscribe: () => void;
+}
+
+function getNotifyRegistry(): WeakMap<ExtensionAPI, NotifyRegistration> {
+	const key = "__piSubagentsNotifyRegistrations";
+	const store = globalThis as Record<string, unknown>;
+	const existing = store[key];
+	if (existing instanceof WeakMap) return existing as WeakMap<ExtensionAPI, NotifyRegistration>;
+	const registry = new WeakMap<ExtensionAPI, NotifyRegistration>();
+	store[key] = registry;
+	return registry;
+}
+
+function getNotifySeenRegistry(): WeakMap<ExtensionAPI, Map<string, number>> {
+	const key = "__piSubagentsNotifySeenByApi";
+	const store = globalThis as Record<string, unknown>;
+	const existing = store[key];
+	if (existing instanceof WeakMap) return existing as WeakMap<ExtensionAPI, Map<string, number>>;
+	const registry = new WeakMap<ExtensionAPI, Map<string, number>>();
+	store[key] = registry;
+	return registry;
+}
+
+function getNotifySeen(pi: ExtensionAPI): Map<string, number> {
+	const registry = getNotifySeenRegistry();
+	const existing = registry.get(pi);
+	if (existing) return existing;
+	const seen = new Map<string, number>();
+	registry.set(pi, seen);
+	return seen;
+}
+
+export default function registerSubagentNotify(pi: ExtensionAPI): () => void {
+	const registry = getNotifyRegistry();
+	const previous = registry.get(pi);
+	if (previous) {
 		try {
-			previousUnsubscribe();
+			previous.unsubscribe();
 		} catch {
 			// Best effort cleanup for stale handlers from an older reload.
 		}
 	}
-
-	const seen = getGlobalSeenMap("__pi_subagents_notify_seen__");
+	const seen = getNotifySeen(pi);
 	const ttlMs = 10 * 60 * 1000;
 
+	let registration: NotifyRegistration;
 	const handleComplete = (data: unknown) => {
+		if (registry.get(pi) !== registration) return;
 		const result = data as SubagentResult;
 		const now = Date.now();
 		const key = buildCompletionKey(result, "notify");
@@ -104,5 +137,12 @@ export default function registerSubagentNotify(pi: ExtensionAPI): void {
 		);
 	};
 
-	globalStore[unsubscribeStoreKey] = pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete);
+	const unsubscribe = pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, handleComplete);
+	registration = { unsubscribe };
+	registry.set(pi, registration);
+	return () => {
+		if (registry.get(pi) !== registration) return;
+		registry.delete(pi);
+		unsubscribe();
+	};
 }

--- a/packages/subagents/src/runs/background/result-watcher.ts
+++ b/packages/subagents/src/runs/background/result-watcher.ts
@@ -21,6 +21,7 @@ import { projectNestedRegistryForRoot, sanitizeSummary } from "../shared/nested-
 
 const WATCHER_RESTART_DELAY_MS = 3000;
 const POLL_INTERVAL_MS = 3000;
+const DIRECTORY_RESCAN_DELAY_MS = 50;
 
 type ResultWatcherFs = Pick<typeof fs, "existsSync" | "readFileSync" | "unlinkSync" | "readdirSync" | "mkdirSync" | "watch"> & {
 	realpathSync?: typeof fs.realpathSync;
@@ -111,6 +112,7 @@ export function createResultWatcher(
 	const fsApi = deps.fs ?? fs;
 	const timers = deps.timers ?? { setTimeout, clearTimeout, setInterval, clearInterval };
 	const safeWatch = deps.safeWatch ?? watchWithErrorHandler;
+	let directoryRescanTimer: ReturnType<typeof setTimeout> | null = null;
 
 	const handleResult = async (file: string) => {
 		const resultPath = path.join(resultsDir, file);
@@ -231,6 +233,15 @@ export function createResultWatcher(
 		}
 	};
 
+	const scheduleDirectoryRescan = () => {
+		if (directoryRescanTimer) timers.clearTimeout(directoryRescanTimer);
+		directoryRescanTimer = timers.setTimeout(() => {
+			directoryRescanTimer = null;
+			primeExistingResults();
+		}, DIRECTORY_RESCAN_DELAY_MS);
+		directoryRescanTimer.unref?.();
+	};
+
 	const startPollingFallback = (reason: unknown) => {
 		state.watcher?.close();
 		state.watcher = null;
@@ -281,11 +292,16 @@ export function createResultWatcher(
 				state.watcher = null;
 				scheduleRestart();
 			};
-			state.watcher = safeWatch(resultsDir, (ev, file) => {
-				if (ev !== "rename" || !file) return;
-				const fileName = file.toString();
-				if (!fileName.endsWith(".json")) return;
-				state.resultFileCoalescer.schedule(fileName);
+			state.watcher = safeWatch(resultsDir, (_event, file) => {
+				// Atomic writes may surface only their hidden temporary rename on
+				// macOS/Bun. Treat every watcher event as directory activity and
+				// rescan shortly after the write settles instead of trusting the
+				// event type or filename. Keep the final-name fast path when present.
+				if (file) {
+					const fileName = file.toString();
+					if (fileName.endsWith(".json")) state.resultFileCoalescer.schedule(fileName);
+				}
+				scheduleDirectoryRescan();
 			}, handleWatcherError, {
 				watch: fsApi.watch,
 				realpathSyncNative: fsApi.realpathSync?.native,
@@ -310,6 +326,8 @@ export function createResultWatcher(
 			timers.clearInterval(state.watcherRestartTimer);
 		}
 		state.watcherRestartTimer = null;
+		if (directoryRescanTimer) timers.clearTimeout(directoryRescanTimer);
+		directoryRescanTimer = null;
 		state.resultFileCoalescer.clear();
 	};
 

--- a/packages/subagents/src/slash/slash-commands.ts
+++ b/packages/subagents/src/slash/slash-commands.ts
@@ -160,7 +160,7 @@ async function requestSlashRun(
 			if (done || !data || typeof data !== "object") return;
 			const update = data as SlashSubagentUpdate;
 			if (update.requestId !== requestId) return;
-			applySlashUpdate(requestId, update);
+			applySlashUpdate(requestId, update, pi);
 			if (!ctx.hasUI) return;
 			const tool = update.currentTool ? ` ${update.currentTool}` : "";
 			const count = update.toolCount ?? 0;
@@ -260,7 +260,7 @@ async function runSlashSubagent(
 ): Promise<void> {
 	if (ctx.hasUI) ctx.ui.setToolsExpanded(false);
 	const requestId = randomUUID();
-	const initialDetails = buildSlashInitialResult(requestId, params);
+	const initialDetails = buildSlashInitialResult(requestId, params, pi);
 	const initialText = extractSlashMessageText(initialDetails.result.content) || "Running subagent...";
 	pi.sendMessage({
 		customType: SLASH_RESULT_TYPE,
@@ -272,7 +272,7 @@ async function runSlashSubagent(
 
 	try {
 		const response = await requestSlashRun(pi, ctx, requestId, params);
-		const finalDetails = finalizeSlashResult(response);
+		const finalDetails = finalizeSlashResult(response, pi);
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: buildSlashExportText(response),
@@ -288,7 +288,7 @@ async function runSlashSubagent(
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		const failedDetails = failSlashResult(requestId, params, message);
+		const failedDetails = failSlashResult(requestId, params, message, pi);
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: `## Subagent result\n\n${message}`,

--- a/packages/subagents/src/slash/slash-live-state.ts
+++ b/packages/subagents/src/slash/slash-live-state.ts
@@ -14,6 +14,12 @@ interface SlashSnapshot {
 	version: number;
 }
 
+export interface SlashSnapshotStore {
+	liveSnapshots: Map<string, SlashSnapshot>;
+	finalSnapshots: Map<string, SlashSnapshot>;
+	versionCounter: number;
+}
+
 interface SequentialChainStepLike {
 	agent: string;
 	task?: string;
@@ -25,9 +31,26 @@ interface ParallelChainStepLike {
 
 type ChainStepLike = SequentialChainStepLike | ParallelChainStepLike;
 
-const liveSnapshots = new Map<string, SlashSnapshot>();
-const finalSnapshots = new Map<string, SlashSnapshot>();
-let versionCounter = 1;
+const defaultStoreOwner = {};
+
+function getStoreRegistry(): WeakMap<object, SlashSnapshotStore> {
+	const key = "__piSubagentSlashSnapshotStores";
+	const globalStore = globalThis as Record<string, unknown>;
+	const existing = globalStore[key];
+	if (existing instanceof WeakMap) return existing as WeakMap<object, SlashSnapshotStore>;
+	const registry = new WeakMap<object, SlashSnapshotStore>();
+	globalStore[key] = registry;
+	return registry;
+}
+
+export function getSlashSnapshotStore(owner: object = defaultStoreOwner): SlashSnapshotStore {
+	const registry = getStoreRegistry();
+	const existing = registry.get(owner);
+	if (existing) return existing;
+	const store = { liveSnapshots: new Map(), finalSnapshots: new Map(), versionCounter: 1 };
+	registry.set(owner, store);
+	return store;
+}
 
 const EMPTY_MESSAGES: Message[] = [];
 const EMPTY_USAGE: Usage = {
@@ -39,8 +62,8 @@ const EMPTY_USAGE: Usage = {
 	turns: 0,
 };
 
-function nextVersion(): number {
-	return versionCounter++;
+function nextVersion(store: SlashSnapshotStore): number {
+	return store.versionCounter++;
 }
 
 function cloneUsage(): Usage {
@@ -51,7 +74,7 @@ function createPlaceholderResult(
 	agent: string,
 	task: string,
 	status: "pending" | "running",
-	index: number,
+	index?: number,
 ): SingleResult {
 	return {
 		agent,
@@ -60,7 +83,7 @@ function createPlaceholderResult(
 		messages: EMPTY_MESSAGES,
 		usage: cloneUsage(),
 		progress: {
-			index,
+			index: index ?? 0,
 			agent,
 			status,
 			task,
@@ -162,7 +185,7 @@ function buildSingleInitialResult(params: SubagentParamsLike): AgentToolResult<D
 		details: {
 			mode: "single",
 			...(params.context ? { context: params.context } : {}),
-			results: [createPlaceholderResult(agent, task, "running", 0)],
+			results: [createPlaceholderResult(agent, task, "running")],
 			progress: [{
 				index: 0,
 				agent,
@@ -178,14 +201,15 @@ function buildSingleInitialResult(params: SubagentParamsLike): AgentToolResult<D
 	};
 }
 
-export function buildSlashInitialResult(requestId: string, params: SubagentParamsLike): SlashMessageDetails {
+export function buildSlashInitialResult(requestId: string, params: SubagentParamsLike, owner?: object): SlashMessageDetails {
+	const store = getSlashSnapshotStore(owner);
 	const result = (params.tasks?.length ?? 0) > 0
 		? buildParallelInitialResult(params)
 		: (params.chain?.length ?? 0) > 0
 			? buildChainInitialResult(params)
 			: buildSingleInitialResult(params);
-	liveSnapshots.set(requestId, { result, version: nextVersion() });
-	finalSnapshots.delete(requestId);
+	store.liveSnapshots.set(requestId, { result, version: nextVersion(store) });
+	store.finalSnapshots.delete(requestId);
 	return { requestId, result };
 }
 
@@ -201,8 +225,9 @@ function cloneResultsWithProgress(
 	});
 }
 
-export function applySlashUpdate(requestId: string, update: SlashSubagentUpdate): void {
-	const snapshot = liveSnapshots.get(requestId);
+export function applySlashUpdate(requestId: string, update: SlashSubagentUpdate, owner?: object): void {
+	const store = getSlashSnapshotStore(owner);
+	const snapshot = store.liveSnapshots.get(requestId);
 	if (!snapshot) return;
 	const progress = update.progress;
 	if (!progress || !snapshot.result.details) return;
@@ -213,30 +238,32 @@ export function applySlashUpdate(requestId: string, update: SlashSubagentUpdate)
 		results: cloneResultsWithProgress(snapshot.result.details.results, progress),
 		...(snapshot.result.details.mode === "chain" && currentStepIndex >= 0 ? { currentStepIndex } : {}),
 	};
-	liveSnapshots.set(requestId, {
+	store.liveSnapshots.set(requestId, {
 		result: {
 			...snapshot.result,
 			details: nextDetails,
 		},
-		version: nextVersion(),
+		version: nextVersion(store),
 	});
 }
 
-export function finalizeSlashResult(response: SlashSubagentResponse): SlashMessageDetails {
+export function finalizeSlashResult(response: SlashSubagentResponse, owner?: object): SlashMessageDetails {
+	const store = getSlashSnapshotStore(owner);
 	const snapshot = {
 		result: response.result,
-		version: nextVersion(),
+		version: nextVersion(store),
 	};
-	finalSnapshots.set(response.requestId, snapshot);
-	liveSnapshots.delete(response.requestId);
+	store.finalSnapshots.set(response.requestId, snapshot);
+	store.liveSnapshots.delete(response.requestId);
 	return {
 		requestId: response.requestId,
 		result: response.result,
 	};
 }
 
-export function failSlashResult(requestId: string, params: SubagentParamsLike, message: string): SlashMessageDetails {
-	const initial = buildSlashInitialResult(requestId, params).result;
+export function failSlashResult(requestId: string, params: SubagentParamsLike, message: string, owner?: object): SlashMessageDetails {
+	const store = getSlashSnapshotStore(owner);
+	const initial = buildSlashInitialResult(requestId, params, owner).result;
 	const failedResults = initial.details.results.map((result) => ({
 		...result,
 		exitCode: 1,
@@ -251,9 +278,9 @@ export function failSlashResult(requestId: string, params: SubagentParamsLike, m
 			progress: failedResults.map((entry) => entry.progress!).filter(Boolean),
 		},
 	};
-	const snapshot = { result, version: nextVersion() };
-	finalSnapshots.set(requestId, snapshot);
-	liveSnapshots.delete(requestId);
+	const snapshot = { result, version: nextVersion(store) };
+	store.finalSnapshots.set(requestId, snapshot);
+	store.liveSnapshots.delete(requestId);
 	return { requestId, result };
 }
 
@@ -269,25 +296,28 @@ export function resolveSlashMessageDetails(value: unknown): SlashMessageDetails 
 	return isSlashMessageDetails(value) ? value : undefined;
 }
 
-export function getSlashRenderableSnapshot(details: SlashMessageDetails): SlashSnapshot {
-	return finalSnapshots.get(details.requestId)
-		?? liveSnapshots.get(details.requestId)
+export function getSlashRenderableSnapshot(details: SlashMessageDetails, owner?: object): SlashSnapshot {
+	const store = getSlashSnapshotStore(owner);
+	return store.finalSnapshots.get(details.requestId)
+		?? store.liveSnapshots.get(details.requestId)
 		?? { result: details.result, version: 0 };
 }
 
-export function restoreSlashFinalSnapshots(entries: unknown[]): void {
-	liveSnapshots.clear();
-	finalSnapshots.clear();
+export function restoreSlashFinalSnapshots(entries: unknown[], owner?: object): void {
+	const store = getSlashSnapshotStore(owner);
+	store.liveSnapshots.clear();
+	store.finalSnapshots.clear();
 	for (const entry of entries) {
 		const e = entry as { type?: string; customType?: string; details?: unknown };
 		if (e?.type !== "custom_message" || e.customType !== SLASH_RESULT_TYPE) continue;
 		const details = resolveSlashMessageDetails(e.details);
 		if (!details) continue;
-		finalSnapshots.set(details.requestId, { result: details.result, version: nextVersion() });
+		store.finalSnapshots.set(details.requestId, { result: details.result, version: nextVersion(store) });
 	}
 }
 
-export function clearSlashSnapshots(): void {
-	liveSnapshots.clear();
-	finalSnapshots.clear();
+export function clearSlashSnapshots(owner?: object): void {
+	const store = getSlashSnapshotStore(owner);
+	store.liveSnapshots.clear();
+	store.finalSnapshots.clear();
 }

--- a/packages/subagents/src/tui/render-widget.ts
+++ b/packages/subagents/src/tui/render-widget.ts
@@ -60,53 +60,81 @@ interface RenderRequestingContext {
 	ui: ExtensionContext["ui"] & { requestRender?: () => void };
 }
 
-// There is only ever one async-agents widget per host process, so the mounted
-// component reads its driving context/jobs/pulse frame from module-level
-// singletons instead of remounting the widget for every visible update.
-let latestWidgetCtx: ExtensionContext | undefined;
-let latestWidgetJobs: AsyncJobState[] = [];
-let latestWidgetFrameNow = 0;
-let latestWidgetExpanded = false;
-let latestWidgetSnapshotKey: string | undefined;
-let latestWidgetPulseFrame: number | undefined;
-let mountedWidgetCtx: ExtensionContext | undefined;
-let mountedWidgetOwnerKey: string | undefined;
-let widgetMounted = false;
-
-function getLatestWidgetJobs(): AsyncJobState[] {
-	return latestWidgetJobs;
+interface WidgetAnimationState {
+	latestCtx?: ExtensionContext;
+	latestJobs: AsyncJobState[];
+	frameNow: number;
+	expanded: boolean;
+	snapshotKey?: string;
+	pulseFrame?: number;
+	mountedCtx?: ExtensionContext;
+	mountedOwnerKey?: string;
+	surfaceKey?: object;
+	mounted: boolean;
 }
 
-function getLatestWidgetFrameNow(): number {
-	return latestWidgetFrameNow;
+interface WidgetSurfaceState {
+	activeOwner?: object;
 }
 
-function getLatestWidgetPulseFrame(): number | undefined {
-	return latestWidgetPulseFrame;
+interface WidgetRegistry {
+	states: WeakMap<object, WidgetAnimationState>;
+	surfaces: WeakMap<object, WidgetSurfaceState>;
 }
 
-function getLatestWidgetExpanded(): boolean {
-	// LiveWidgetComponent re-renders outside a specific renderWidget() call, so
-	// remember the last expansion state observed from a live host UI. Workflow
-	// stage-node detach can briefly repaint the mounted singleton with a stale or
-	// no-UI context before the next subagent status update refreshes it; falling
-	// back to the cached value avoids a transient collapse while jobs keep running.
-	if (!latestWidgetCtx?.hasUI) return latestWidgetExpanded;
-	const expanded = latestWidgetCtx.ui.getToolsExpanded?.();
-	if (typeof expanded === "boolean") latestWidgetExpanded = expanded;
-	return latestWidgetExpanded;
+const defaultWidgetOwner = {};
+
+function getWidgetRegistry(): WidgetRegistry {
+	const key = "__piSubagentWidgetRegistry";
+	const globalStore = globalThis as Record<string, unknown>;
+	const existing = globalStore[key] as WidgetRegistry | undefined;
+	if (existing?.states instanceof WeakMap && existing.surfaces instanceof WeakMap) return existing;
+	const registry: WidgetRegistry = { states: new WeakMap(), surfaces: new WeakMap() };
+	globalStore[key] = registry;
+	return registry;
 }
 
-function clearLatestWidgetState(): void {
-	latestWidgetCtx = undefined;
-	latestWidgetJobs = [];
-	latestWidgetFrameNow = 0;
-	latestWidgetExpanded = false;
-	latestWidgetSnapshotKey = undefined;
-	latestWidgetPulseFrame = undefined;
-	mountedWidgetCtx = undefined;
-	mountedWidgetOwnerKey = undefined;
-	widgetMounted = false;
+function getWidgetState(owner: object): WidgetAnimationState {
+	const registry = getWidgetRegistry();
+	const existing = registry.states.get(owner);
+	if (existing) return existing;
+	const state: WidgetAnimationState = {
+		latestJobs: [],
+		frameNow: 0,
+		expanded: false,
+		mounted: false,
+	};
+	registry.states.set(owner, state);
+	return state;
+}
+
+function getSurfaceState(surfaceKey: object): WidgetSurfaceState {
+	const registry = getWidgetRegistry();
+	const existing = registry.surfaces.get(surfaceKey);
+	if (existing) return existing;
+	const surface = {};
+	registry.surfaces.set(surfaceKey, surface);
+	return surface;
+}
+
+function getExpanded(state: WidgetAnimationState): boolean {
+	if (!state.latestCtx?.hasUI) return state.expanded;
+	const expanded = state.latestCtx.ui.getToolsExpanded?.();
+	if (typeof expanded === "boolean") state.expanded = expanded;
+	return state.expanded;
+}
+
+function clearWidgetState(state: WidgetAnimationState): void {
+	state.latestCtx = undefined;
+	state.latestJobs = [];
+	state.frameNow = 0;
+	state.expanded = false;
+	state.snapshotKey = undefined;
+	state.pulseFrame = undefined;
+	state.mountedCtx = undefined;
+	state.mountedOwnerKey = undefined;
+	state.surfaceKey = undefined;
+	state.mounted = false;
 }
 
 function getWidgetOwnerKey(ctx: ExtensionContext): string {
@@ -183,19 +211,33 @@ function widgetSnapshotKey(jobs: AsyncJobState[]): string {
 	return jobs.map(widgetRenderKey).join("\n");
 }
 
-function refreshWidgetSnapshot(jobs: AsyncJobState[]): void {
+function refreshWidgetSnapshot(state: WidgetAnimationState, jobs: AsyncJobState[]): void {
 	const snapshotKey = widgetSnapshotKey(jobs);
-	if (snapshotKey === latestWidgetSnapshotKey) return;
-	latestWidgetSnapshotKey = snapshotKey;
-	latestWidgetFrameNow = Date.now();
-	latestWidgetPulseFrame = advanceResultPulseFrame(latestWidgetPulseFrame);
+	if (snapshotKey === state.snapshotKey) return;
+	state.snapshotKey = snapshotKey;
+	state.frameNow = Date.now();
+	state.pulseFrame = advanceResultPulseFrame(state.pulseFrame);
 }
 
-// Full teardown: clear the mounted widget if possible, and forget the driving
-// context/jobs entirely.
-export function stopWidgetAnimation(): void {
-	if (widgetMounted) unmountWidgetBestEffort(mountedWidgetCtx);
-	clearLatestWidgetState();
+function releaseMountedWidget(state: WidgetAnimationState, owner: object): void {
+	if (state.mounted) unmountWidgetBestEffort(state.mountedCtx);
+	if (state.surfaceKey) {
+		const surface = getSurfaceState(state.surfaceKey);
+		if (surface.activeOwner === owner) surface.activeOwner = undefined;
+	}
+	clearWidgetState(state);
+}
+
+// Full teardown. Explicit API ownership is authoritative; logical context
+// matching only protects context-driven teardown from stale session wrappers.
+export function stopWidgetAnimation(ownerCtx?: ExtensionContext, owner: object = defaultWidgetOwner): void {
+	const state = getWidgetState(owner);
+	if (ownerCtx && state.mounted && state.mountedOwnerKey !== getWidgetOwnerKey(ownerCtx)) return;
+	if (state.surfaceKey && getSurfaceState(state.surfaceKey).activeOwner !== owner) {
+		clearWidgetState(state);
+		return;
+	}
+	releaseMountedWidget(state, owner);
 }
 
 export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = getTermWidth(), expanded = false, now: number = Date.now(), pulseFrame?: number): string[] {
@@ -268,57 +310,54 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 	return lines;
 }
 
-/**
- * Render the async jobs widget
- */
-export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void {
+/** Render the async jobs widget for one ExtensionAPI owner. */
+export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[], owner: object = defaultWidgetOwner): void {
+	const state = getWidgetState(owner);
 	const ownerKey = getWidgetOwnerKey(ctx);
+	const requestedSurfaceKey = ctx.ui.setWidget;
+	const requestedSurface = getSurfaceState(requestedSurfaceKey);
 	if (jobs.length === 0) {
-		if (widgetMounted && mountedWidgetOwnerKey !== ownerKey) {
-			// With no visible job frame, stale-owner empty updates and newly-active
-			// empty owners are indistinguishable here. Preserve active-widget safety;
-			// host session disposal owns cross-owner empty-session teardown.
-			return;
-		}
+		if (requestedSurface.activeOwner && requestedSurface.activeOwner !== owner) return;
+		if (state.surfaceKey && getSurfaceState(state.surfaceKey).activeOwner !== owner) return;
+		if (state.mounted && state.mountedOwnerKey !== ownerKey) return;
 		if (ctx.hasUI) setWidgetStatus(ctx, []);
-		stopWidgetAnimation();
+		stopWidgetAnimation(ctx, owner);
 		return;
 	}
 	if (!ctx.hasUI) {
-		stopWidgetAnimation();
+		stopWidgetAnimation(ctx, owner);
 		return;
 	}
-	latestWidgetCtx = ctx;
-	latestWidgetJobs = [...jobs];
-	refreshWidgetSnapshot(jobs);
-	if (widgetMounted && mountedWidgetOwnerKey !== ownerKey) {
-		// Session rebinding can leave the previous host UI alive briefly; clear the
-		// old mount before installing the singleton widget on the new owner/context.
-		unmountWidgetBestEffort(mountedWidgetCtx);
-		mountedWidgetCtx = undefined;
-		mountedWidgetOwnerKey = undefined;
-		widgetMounted = false;
+	// Workflow stages forward the host's setWidget function, which identifies the
+	// shared widget surface. A stage cannot replace a parent already active there.
+	if (!state.mounted && requestedSurface.activeOwner && requestedSurface.activeOwner !== owner) return;
+	state.latestCtx = ctx;
+	state.latestJobs = [...jobs];
+	refreshWidgetSnapshot(state, jobs);
+	if (state.mounted && state.mountedOwnerKey !== ownerKey) {
+		releaseMountedWidget(state, owner);
+		state.latestCtx = ctx;
+		state.latestJobs = [...jobs];
+		refreshWidgetSnapshot(state, jobs);
 	}
 	setWidgetStatus(ctx, jobs);
-	if (!widgetMounted) {
-		// belowEditor keeps the live async widget pinned to the bottom viewport,
-		// matching the workflow companion widget's placement (#1109). The pulse frame
-		// is advanced only by semantic async status updates, not by a cosmetic timer.
-		ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(getLatestWidgetJobs, getLatestWidgetExpanded, getLatestWidgetFrameNow, getLatestWidgetPulseFrame), {
-			placement: "belowEditor",
-		});
-		mountedWidgetCtx = ctx;
-		mountedWidgetOwnerKey = ownerKey;
-		widgetMounted = true;
+	if (!state.mounted) {
+		const surface = getSurfaceState(requestedSurfaceKey);
+		if (surface.activeOwner && surface.activeOwner !== owner) return;
+		ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(
+			() => state.latestJobs,
+			() => getExpanded(state),
+			() => state.frameNow,
+			() => state.pulseFrame,
+		), { placement: "belowEditor" });
+		state.mountedCtx = ctx;
+		state.mountedOwnerKey = ownerKey;
+		state.surfaceKey = requestedSurfaceKey;
+		state.mounted = true;
+		surface.activeOwner = owner;
 	} else {
-		// The mounted widget reads latestWidgetJobs via getLatestWidgetJobs(), so a
-		// visible->visible update only needs to ask the host to render in place. Keep
-		// teardown pointed at the freshest same-owner wrapper because older wrappers
-		// can go stale after host session/context rebinding.
-		mountedWidgetCtx = ctx;
-		mountedWidgetOwnerKey = ownerKey;
+		state.mountedCtx = ctx;
+		state.mountedOwnerKey = ownerKey;
 		requestWidgetRender(ctx);
 	}
-	// The async pulse is update-driven like foreground subagent results, so no
-	// periodic cosmetic ticker is needed.
 }

--- a/test/unit/subagents-extension-api-lifecycle.test.ts
+++ b/test/unit/subagents-extension-api-lifecycle.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@bastani/atomic";
+import registerSubagentExtension from "../../packages/subagents/src/extension/index.js";
+import { beginApiLifecycle } from "../../packages/subagents/src/extension/api-lifecycle.js";
+import registerSubagentNotify from "../../packages/subagents/src/runs/background/notify.js";
+import { createResultWatcher } from "../../packages/subagents/src/runs/background/result-watcher.js";
+import { buildSlashInitialResult, getSlashRenderableSnapshot } from "../../packages/subagents/src/slash/slash-live-state.js";
+import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../../packages/subagents/src/runs/shared/pi-args.js";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "../../packages/subagents/src/shared/types.js";
+
+class TestEventBus {
+	private readonly handlers = new Map<string, Set<(payload: object) => void>>();
+
+	constructor(private readonly ineffectiveUnsubscribe = false) {}
+
+	on(event: string, handler: (payload: object) => void): () => void {
+		const handlers = this.handlers.get(event) ?? new Set<(payload: object) => void>();
+		handlers.add(handler);
+		this.handlers.set(event, handlers);
+		return () => {
+			if (!this.ineffectiveUnsubscribe) handlers.delete(handler);
+		};
+	}
+
+	emit(event: string, payload: object): void {
+		for (const handler of [...(this.handlers.get(event) ?? [])]) handler(payload);
+	}
+
+	count(event: string): number {
+		return this.handlers.get(event)?.size ?? 0;
+	}
+
+	totalCount(): number {
+		return [...this.handlers.values()].reduce((total, handlers) => total + handlers.size, 0);
+	}
+}
+
+interface TestApi {
+	pi: ExtensionAPI;
+	events: TestEventBus;
+	messages: Array<{ customType?: string; content: string }>;
+}
+
+function makeApi(ineffectiveUnsubscribe = false): TestApi {
+	const events = new TestEventBus(ineffectiveUnsubscribe);
+	const messages: TestApi["messages"] = [];
+	const pi = {
+		events,
+		sendMessage(message: { customType?: string; content: string }) {
+			messages.push(message);
+		},
+	} as unknown as ExtensionAPI;
+	return { pi, events, messages };
+}
+
+interface ExtensionHarness extends TestApi {
+	shutdownHandlers: Array<() => void>;
+}
+
+function makeExtensionHarness(): ExtensionHarness {
+	const base = makeApi();
+	const shutdownHandlers: Array<() => void> = [];
+	Object.assign(base.pi, {
+		registerTool: () => {},
+		registerCommand: () => {},
+		registerMessageRenderer: () => {},
+		on(event: string, handler: () => void) {
+			if (event === "session_shutdown") shutdownHandlers.push(handler);
+		},
+	});
+	return { ...base, shutdownHandlers };
+}
+
+function makeState(sessionId: string): SubagentState {
+	return {
+		baseCwd: "",
+		currentSessionId: sessionId,
+		asyncJobs: new Map(),
+		subagentInProgress: false,
+		foregroundRuns: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		pendingForegroundControlNotices: new Map(),
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
+const tempRoots: string[] = [];
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+
+test("full extension wiring keeps parent handlers alive across stage shutdown and reload", () => {
+	const priorChild = process.env[SUBAGENT_CHILD_ENV];
+	const priorFanout = process.env[SUBAGENT_FANOUT_CHILD_ENV];
+	delete process.env[SUBAGENT_CHILD_ENV];
+	delete process.env[SUBAGENT_FANOUT_CHILD_ENV];
+	try {
+		const parent = makeExtensionHarness();
+		const stage = makeExtensionHarness();
+		registerSubagentExtension(parent.pi);
+		registerSubagentExtension(stage.pi);
+		assert.equal(parent.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 2, "parent owns tracker and notify handlers");
+		assert.equal(stage.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 2, "stage owns independent handlers");
+		const parentSlash = buildSlashInitialResult("shared-request", { agent: "worker", task: "parent task" }, parent.pi);
+		buildSlashInitialResult("shared-request", { agent: "worker", task: "stage task" }, stage.pi);
+
+		stage.shutdownHandlers[0]?.();
+		assert.equal(stage.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 0);
+		assert.equal(parent.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 2, "stage shutdown must preserve parent handlers");
+		assert.equal(
+			getSlashRenderableSnapshot(parentSlash, parent.pi).result.details.results[0]?.task,
+			"parent task",
+			"stage shutdown must preserve the parent slash snapshot store",
+		);
+
+		registerSubagentExtension(parent.pi);
+		assert.equal(parent.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 2, "same-API reload replaces rather than duplicates handlers");
+		parent.shutdownHandlers[0]?.();
+		assert.equal(parent.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 2, "stale shutdown cannot tear down the replacement");
+		parent.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+			id: "full-extension-result",
+			agent: "worker",
+			success: true,
+			summary: "done",
+			timestamp: Date.now(),
+		});
+		assert.equal(parent.messages.length, 1);
+		parent.shutdownHandlers[1]?.();
+		assert.equal(parent.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 0);
+	} finally {
+		if (priorChild === undefined) delete process.env[SUBAGENT_CHILD_ENV];
+		else process.env[SUBAGENT_CHILD_ENV] = priorChild;
+		if (priorFanout === undefined) delete process.env[SUBAGENT_FANOUT_CHILD_ENV];
+		else process.env[SUBAGENT_FANOUT_CHILD_ENV] = priorFanout;
+	}
+});
+describe("subagent ExtensionAPI lifecycle ownership", () => {
+	test("concurrent stage shutdown preserves the parent watcher and notification path", async () => {
+		const parent = makeApi();
+		const stage = makeApi();
+		const parentRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-parent-results-"));
+		const stageRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-stage-results-"));
+		tempRoots.push(parentRoot, stageRoot);
+
+		let parentWatchListener: ((event: fs.WatchEventType, file: string | null) => void) | undefined;
+		let parentWatcherClosed = false;
+		let stageWatcherClosed = false;
+		const parentWatcher = createResultWatcher(parent.pi, makeState("parent-session"), parentRoot, 60_000, {
+			safeWatch: (_watchPath, listener) => {
+				parentWatchListener = listener;
+				return { close: () => { parentWatcherClosed = true; }, unref: () => {} } as fs.FSWatcher;
+			},
+		});
+		const stageWatcher = createResultWatcher(stage.pi, makeState("stage-session"), stageRoot, 60_000, {
+			safeWatch: () => ({ close: () => { stageWatcherClosed = true; }, unref: () => {} }) as fs.FSWatcher,
+		});
+		const parentLifecycle = beginApiLifecycle(parent.pi);
+		const stageLifecycle = beginApiLifecycle(stage.pi);
+		const parentNotifyCleanup = registerSubagentNotify(parent.pi);
+		const stageNotifyCleanup = registerSubagentNotify(stage.pi);
+		parentWatcher.startResultWatcher();
+		stageWatcher.startResultWatcher();
+		parentLifecycle.setCleanup(() => { parentWatcher.stopResultWatcher(); parentNotifyCleanup(); });
+		stageLifecycle.setCleanup(() => { stageWatcher.stopResultWatcher(); stageNotifyCleanup(); });
+
+		stageLifecycle.dispose();
+		assert.equal(stageWatcherClosed, true);
+		assert.equal(parentWatcherClosed, false, "stage shutdown must not stop the parent watcher");
+		assert.equal(parent.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 1);
+
+		const resultFile = "parent-result.json";
+		fs.writeFileSync(path.join(parentRoot, resultFile), JSON.stringify({
+			id: "parent-run-lifecycle",
+			sessionId: "parent-session",
+			agent: "worker",
+			success: true,
+			summary: "implemented the fix",
+			timestamp: Date.now(),
+		}));
+		parentWatchListener?.("rename", ".parent-result.json.atomic-write-123.tmp");
+		parentWatchListener?.("change", null);
+		parentWatchListener?.("rename", ".parent-result.json.atomic-write-123.tmp");
+		await Bun.sleep(150);
+
+		assert.equal(parent.messages.length, 1);
+		assert.equal(parent.messages[0]?.customType, "subagent-notify");
+		assert.equal(fs.existsSync(path.join(parentRoot, resultFile)), false, "consumed result must be removed");
+		parentLifecycle.dispose();
+	});
+	test("stopping a watcher cancels its pending directory rescan", async () => {
+		const api = makeApi();
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-stopped-results-"));
+		tempRoots.push(root);
+		let listener: ((event: fs.WatchEventType, file: string | null) => void) | undefined;
+		const watcher = createResultWatcher(api.pi, makeState("stopped-session"), root, 60_000, {
+			safeWatch: (_watchPath, nextListener) => {
+				listener = nextListener;
+				return { close: () => {}, unref: () => {} } as fs.FSWatcher;
+			},
+		});
+		const notifyCleanup = registerSubagentNotify(api.pi);
+		watcher.startResultWatcher();
+		const resultPath = path.join(root, "stopped-result.json");
+		fs.writeFileSync(resultPath, JSON.stringify({
+			id: "stopped-result",
+			sessionId: "stopped-session",
+			agent: "worker",
+			success: true,
+			summary: "must remain pending",
+			timestamp: Date.now(),
+		}));
+		listener?.("rename", ".stopped-result.json.atomic-write.tmp");
+		watcher.stopResultWatcher();
+		await Bun.sleep(100);
+
+		assert.equal(api.messages.length, 0);
+		assert.equal(fs.existsSync(resultPath), true, "stopped watcher must not rescan or consume results");
+		notifyCleanup();
+	});
+
+
+	test("notification dedupe is reload-stable per API rather than process-global", () => {
+		const parent = makeApi();
+		const stage = makeApi();
+		const parentCleanup = registerSubagentNotify(parent.pi);
+		const firstStageCleanup = registerSubagentNotify(stage.pi);
+		const result = {
+			id: "same-key-across-apis",
+			agent: "worker",
+			success: true,
+			summary: "done",
+			timestamp: Date.now(),
+		};
+		stage.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, result);
+		parent.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, result);
+		assert.equal(stage.messages.length, 1);
+		assert.equal(parent.messages.length, 1, "stage dedupe must not suppress parent notification");
+
+		const secondStageCleanup = registerSubagentNotify(stage.pi);
+		stage.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, result);
+		assert.equal(stage.messages.length, 1, "same-API reload must retain its dedupe history");
+		parentCleanup();
+		firstStageCleanup();
+		secondStageCleanup();
+	});
+
+	test("stale notify registrations stay inert when unsubscribe is ineffective", () => {
+		const api = makeApi(true);
+		registerSubagentNotify(api.pi);
+		const cleanup = registerSubagentNotify(api.pi);
+		api.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+			id: "ineffective-unsubscribe",
+			agent: "worker",
+			success: true,
+			summary: "done",
+			timestamp: Date.now(),
+		});
+		assert.equal(api.messages.length, 1, "only the current registration may notify");
+		cleanup();
+	});
+
+	test("failed extension registration disposes partial bridge subscriptions", () => {
+		const priorChild = process.env[SUBAGENT_CHILD_ENV];
+		const priorFanout = process.env[SUBAGENT_FANOUT_CHILD_ENV];
+		delete process.env[SUBAGENT_CHILD_ENV];
+		delete process.env[SUBAGENT_FANOUT_CHILD_ENV];
+		try {
+			const api = makeApi();
+			Object.assign(api.pi, {
+				registerCommand: () => {},
+				registerMessageRenderer: () => {},
+				registerTool: () => { throw new Error("injected registerTool failure"); },
+				on: () => {},
+			});
+			assert.throws(() => registerSubagentExtension(api.pi), /injected registerTool failure/);
+			assert.equal(api.events.totalCount(), 0, "partial bridge subscriptions must not leak");
+		} finally {
+			if (priorChild === undefined) delete process.env[SUBAGENT_CHILD_ENV];
+			else process.env[SUBAGENT_CHILD_ENV] = priorChild;
+			if (priorFanout === undefined) delete process.env[SUBAGENT_FANOUT_CHILD_ENV];
+			else process.env[SUBAGENT_FANOUT_CHILD_ENV] = priorFanout;
+		}
+	});
+
+	test("same-API registration is deduplicated and stale shutdown cannot stop the replacement", () => {
+		const api = makeApi();
+		let firstCleanups = 0;
+		let secondCleanups = 0;
+		const firstLifecycle = beginApiLifecycle(api.pi);
+		firstLifecycle.setCleanup(() => { firstCleanups++; });
+		const firstNotifyCleanup = registerSubagentNotify(api.pi);
+
+		const secondLifecycle = beginApiLifecycle(api.pi);
+		secondLifecycle.setCleanup(() => { secondCleanups++; });
+		const secondNotifyCleanup = registerSubagentNotify(api.pi);
+		assert.equal(firstCleanups, 1, "replacement cleans only the previous same-API runtime");
+		assert.equal(api.events.count(SUBAGENT_ASYNC_COMPLETE_EVENT), 1);
+
+		firstLifecycle.dispose();
+		firstNotifyCleanup();
+		api.events.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
+			id: "same-api-result",
+			agent: "worker",
+			success: true,
+			summary: "done",
+			timestamp: Date.now(),
+		});
+		assert.equal(api.messages.length, 1, "re-registration must emit exactly one notification");
+		assert.equal(secondCleanups, 0, "stale shutdown must not tear down the replacement runtime");
+
+		secondNotifyCleanup();
+		secondLifecycle.dispose();
+		assert.equal(secondCleanups, 1);
+	});
+});

--- a/test/unit/subagents-fanout-child-lifecycle.test.ts
+++ b/test/unit/subagents-fanout-child-lifecycle.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@bastani/atomic";
+import registerFanoutChildSubagentExtension from "../../packages/subagents/src/extension/fanout-child.js";
+import {
+	createNestedRoute,
+	readNestedControlResults,
+	writeNestedControlRequest,
+	type NestedRoute,
+} from "../../packages/subagents/src/runs/shared/nested-events.js";
+import {
+	SUBAGENT_CHILD_ENV,
+	SUBAGENT_FANOUT_CHILD_ENV,
+	SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV,
+	SUBAGENT_PARENT_CONTROL_INBOX_ENV,
+	SUBAGENT_PARENT_EVENT_SINK_ENV,
+	SUBAGENT_PARENT_ROOT_RUN_ID_ENV,
+} from "../../packages/subagents/src/runs/shared/pi-args.js";
+
+interface FanoutHarness {
+	pi: ExtensionAPI;
+	shutdownHandlers: Array<() => void>;
+}
+
+const envKeys = [
+	SUBAGENT_CHILD_ENV,
+	SUBAGENT_FANOUT_CHILD_ENV,
+	SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV,
+	SUBAGENT_PARENT_CONTROL_INBOX_ENV,
+	SUBAGENT_PARENT_EVENT_SINK_ENV,
+	SUBAGENT_PARENT_ROOT_RUN_ID_ENV,
+] as const;
+const originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+const routes: NestedRoute[] = [];
+const harnesses: FanoutHarness[] = [];
+
+function makeHarness(): FanoutHarness {
+	const shutdownHandlers: Array<() => void> = [];
+	const pi = {
+		events: { on: () => () => {}, emit: () => {} },
+		registerTool: () => {},
+		on(event: string, handler: () => void) {
+			if (event === "session_shutdown") shutdownHandlers.push(handler);
+		},
+	} as unknown as ExtensionAPI;
+	const harness = { pi, shutdownHandlers };
+	harnesses.push(harness);
+	return harness;
+}
+
+function safeId(prefix: string): string {
+	return `${prefix}${Date.now()}${Math.random().toString(16).slice(2)}`;
+}
+
+function activateRoute(prefix: string): NestedRoute {
+	const route = createNestedRoute(safeId(prefix));
+	routes.push(route);
+	process.env[SUBAGENT_CHILD_ENV] = "1";
+	process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
+	process.env[SUBAGENT_PARENT_ROOT_RUN_ID_ENV] = route.rootRunId;
+	process.env[SUBAGENT_PARENT_EVENT_SINK_ENV] = route.eventSink;
+	process.env[SUBAGENT_PARENT_CONTROL_INBOX_ENV] = route.controlInbox;
+	process.env[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV] = route.capabilityToken;
+	return route;
+}
+
+async function waitForControlResult(route: NestedRoute, requestId: string): Promise<void> {
+	for (let attempt = 0; attempt < 20; attempt++) {
+		if (readNestedControlResults(route).some((result) => result.requestId === requestId)) return;
+		await Bun.sleep(50);
+	}
+	assert.fail(`fanout listener did not process ${requestId}`);
+}
+
+afterEach(() => {
+	for (const harness of harnesses.splice(0)) {
+		for (const shutdown of harness.shutdownHandlers) shutdown();
+	}
+	for (const route of routes.splice(0)) {
+		fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+	}
+	for (const key of envKeys) {
+		const value = originalEnv.get(key);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+});
+
+describe("fanout-child ExtensionAPI lifecycle ownership", () => {
+	test("stage shutdown preserves the concurrent parent nested-control listener", async () => {
+		const parent = makeHarness();
+		const parentRoute = activateRoute("fanoutparent");
+		registerFanoutChildSubagentExtension(parent.pi);
+
+		const stage = makeHarness();
+		activateRoute("fanoutstage");
+		registerFanoutChildSubagentExtension(stage.pi);
+		stage.shutdownHandlers[0]?.();
+
+		const requestId = safeId("request");
+		writeNestedControlRequest(parentRoute, {
+			ts: Date.now(),
+			requestId,
+			targetRunId: "missing-run",
+			action: "interrupt",
+		});
+		await waitForControlResult(parentRoute, requestId);
+	});
+
+	test("same-API reload replaces its listener and stale shutdown cannot stop the replacement", async () => {
+		const api = makeHarness();
+		const retiredRoute = activateRoute("fanoutold");
+		registerFanoutChildSubagentExtension(api.pi);
+		const replacementRoute = activateRoute("fanoutreplacement");
+		registerFanoutChildSubagentExtension(api.pi);
+		assert.equal(api.shutdownHandlers.length, 2);
+
+		const retiredRequestId = safeId("retiredrequest");
+		writeNestedControlRequest(retiredRoute, {
+			ts: Date.now(),
+			requestId: retiredRequestId,
+			targetRunId: "missing-run",
+			action: "interrupt",
+		});
+		await Bun.sleep(300);
+		assert.equal(
+			readNestedControlResults(retiredRoute).some((result) => result.requestId === retiredRequestId),
+			false,
+			"same-API reload must stop the replaced listener",
+		);
+
+		api.shutdownHandlers[0]?.();
+		const requestId = safeId("replacementrequest");
+		writeNestedControlRequest(replacementRoute, {
+			ts: Date.now(),
+			requestId,
+			targetRunId: "missing-run",
+			action: "interrupt",
+		});
+		await waitForControlResult(replacementRoute, requestId);
+	});
+});

--- a/test/unit/subagents-render-widget-owner.test.ts
+++ b/test/unit/subagents-render-widget-owner.test.ts
@@ -17,6 +17,7 @@ interface WidgetCall {
 interface MakeCtxOptions {
 	statuses?: Map<string, string>;
 	setStatus?: (key: string, value: string | undefined) => void;
+	setWidget?: ExtensionContext["ui"]["setWidget"];
 }
 
 const tempRoots: string[] = [];
@@ -36,13 +37,14 @@ function makeCtx(cwd: string, sessionFile: string, options: MakeCtxOptions = {})
 			else options.statuses?.set(key, value);
 		}
 		: undefined);
+	const setWidget = options.setWidget ?? ((key: string, content: SetWidgetArgs[1], widgetOptions?: SetWidgetArgs[2]) => {
+		widgetCalls.push({ key, content, options: widgetOptions });
+	});
 	const ctx = {
 		hasUI: true,
 		cwd,
 		ui: {
-			setWidget: (key: string, content: SetWidgetArgs[1], options?: SetWidgetArgs[2]) => {
-				widgetCalls.push({ key, content, options });
-			},
+			setWidget,
 			setStatus,
 			getToolsExpanded: () => false,
 			setToolsExpanded: () => {},
@@ -200,6 +202,75 @@ describe("subagent render widget logical owner stability", () => {
 		assert.equal(undefinedCalls(active.widgetCalls), 0);
 		assert.equal(undefinedCalls(stale.widgetCalls), 0);
 		assert.equal(statuses.get(WIDGET_KEY), "Async agents: 1 running");
+	});
+
+	test("stale session teardown cannot unmount another owner's active widget", () => {
+		const cwd = makeTempRoot("atomic-widget-owner-cwd-");
+		const otherCwd = makeTempRoot("atomic-widget-owner-other-");
+		const active = makeCtx(cwd, path.join(cwd, "session.jsonl"));
+		const stale = makeCtx(otherCwd, path.join(otherCwd, "session.jsonl"));
+
+		renderWidget(active.ctx, [makeJob()]);
+		stopWidgetAnimation(stale.ctx);
+
+		assert.equal(undefinedCalls(active.widgetCalls), 0);
+		assert.equal(active.renderCount(), 0);
+	});
+
+	test("same-surface workflow-stage API cannot replace or stop the parent API widget", () => {
+		const cwd = makeTempRoot("atomic-widget-api-owner-");
+		const sessionFile = path.join(cwd, "session.jsonl");
+		const statuses = new Map<string, string>();
+		const parent = makeCtx(cwd, sessionFile, { statuses });
+		const stage = makeCtx(cwd, sessionFile, { statuses, setWidget: parent.ctx.ui.setWidget });
+		const parentApi = {};
+		const stageApi = {};
+
+		renderWidget(parent.ctx, [makeJob()], parentApi);
+		renderWidget(stage.ctx, [makeJob()], stageApi);
+		renderWidget(stage.ctx, [], stageApi);
+		assert.equal(statuses.get(WIDGET_KEY), "Async agents: 1 running", "stage empty updates must preserve parent status");
+		stopWidgetAnimation(undefined, stageApi);
+		renderWidget(parent.ctx, [makeJob("complete")], parentApi);
+
+		assert.equal(mountCalls(parent.widgetCalls), 1);
+		assert.equal(mountCalls(stage.widgetCalls), 0, "stage must not replace the parent mount");
+		assert.equal(undefinedCalls(parent.widgetCalls), 0, "stage teardown must not clear the parent mount");
+		assert.equal(parent.renderCount(), 1, "parent owner remains live after stage teardown");
+		stopWidgetAnimation(undefined, parentApi);
+	});
+
+	test("independent widget surfaces can mount and tear down concurrently", () => {
+		const cwd = makeTempRoot("atomic-widget-independent-parent-");
+		const otherCwd = makeTempRoot("atomic-widget-independent-stage-");
+		const parent = makeCtx(cwd, path.join(cwd, "session.jsonl"));
+		const stage = makeCtx(otherCwd, path.join(otherCwd, "session.jsonl"));
+		const parentApi = {};
+		const stageApi = {};
+
+		renderWidget(parent.ctx, [makeJob()], parentApi);
+		renderWidget(stage.ctx, [makeJob()], stageApi);
+		assert.equal(mountCalls(parent.widgetCalls), 1);
+		assert.equal(mountCalls(stage.widgetCalls), 1);
+
+		stopWidgetAnimation(undefined, stageApi);
+		assert.equal(undefinedCalls(stage.widgetCalls), 1);
+		assert.equal(undefinedCalls(parent.widgetCalls), 0);
+		stopWidgetAnimation(undefined, parentApi);
+		assert.equal(undefinedCalls(parent.widgetCalls), 1);
+	});
+
+	test("API teardown bypasses stale logical context matching", () => {
+		const cwd = makeTempRoot("atomic-widget-authoritative-teardown-");
+		const mounted = makeCtx(cwd, path.join(cwd, "mounted.jsonl"));
+		const stale = makeCtx(cwd, path.join(cwd, "stale.jsonl"), { setWidget: mounted.ctx.ui.setWidget });
+		const api = {};
+
+		renderWidget(mounted.ctx, [makeJob()], api);
+		stopWidgetAnimation(stale.ctx, api);
+		assert.equal(undefinedCalls(mounted.widgetCalls), 0, "context-driven stale teardown remains guarded");
+		stopWidgetAnimation(undefined, api);
+		assert.equal(undefinedCalls(mounted.widgetCalls), 1, "API shutdown authoritatively releases its mount");
 	});
 
 	test("status cleanup failures do not block widget teardown", () => {


### PR DESCRIPTION
## Summary

Fixes direct async subagent completion notifications disappearing from the originating parent chat after an in-process workflow stage registers or shuts down its own subagent extension. Lifecycle resources are now owned per `ExtensionAPI`, so concurrent parent and workflow-stage sessions can no longer tear down or suppress one another's state.

## Changes

- Add `packages/subagents/src/extension/api-lifecycle.ts`: a `WeakMap`-backed registry (`beginApiLifecycle`) that gives each `ExtensionAPI` its own cleanup handle, replaces same-API reload registrations instead of colliding with them, and guards against stale/duplicate disposal.
- Rework `packages/subagents/src/extension/index.ts` to scope result watchers, event subscriptions, notification handlers, dedupe state, and slash snapshots to the owning API via the new lifecycle helper, with exhaustive cleanup on partial registration failure.
- Update `packages/subagents/src/runs/background/notify.ts` and `result-watcher.ts` to coalesce result-directory activity into a short rescan, so macOS/Bun's atomic renames still deliver and consume completion results reliably, and to emit exactly one `subagent-notify` per completed run before cleaning up its result file.
- Scope fanout-child listeners (`packages/subagents/src/extension/fanout-child.ts`) and slash-command live state (`packages/subagents/src/slash/slash-live-state.ts`) per-API instead of relying on module-level singletons.
- Rework `packages/subagents/src/tui/render-widget.ts` to key widget animation and mount state off a per-owner registry, and protect shared widget surfaces so a workflow-stage API cannot replace or unmount the parent API's active widget.
- Add regression coverage: `test/unit/subagents-extension-api-lifecycle.test.ts` and `test/unit/subagents-fanout-child-lifecycle.test.ts` (new), plus expanded `test/unit/subagents-render-widget-owner.test.ts`, covering concurrent parent/stage APIs, stage shutdown preserving the parent path, exactly-one `subagent-notify` with result cleanup, same-API re-registration dedup, fanout listener ownership, and widget ownership.
- Document the fix under `packages/subagents/CHANGELOG.md`'s existing `[Unreleased]` section.

## Notes

Rebased onto current `main` after #1709's clarification-TUI removal, reconciling the overlapping extension changes before validation.

Validation on the rebased branch:

- `bun test test/unit/subagents-extension-api-lifecycle.test.ts test/unit/subagents-fanout-child-lifecycle.test.ts test/unit/subagents-render-widget-owner.test.ts` — 21 passed, 0 failed
- `bun test test/unit/subagents-*.test.ts` — 237 passed, 0 failed
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run check:file-length` — passed
- `git diff --check origin/main` — passed
- Commit and push hooks (`prek`) — passed, including the full unit-test hook

Goal-run E2E evidence also exercised the native TUI directly and concurrently with an in-process workflow: each scenario rendered exactly one direct-subagent completion notice in the parent chat and consumed the result file.