### PR TITLE
docs: expand verifiability bullet points in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,12 +199,13 @@ Atomic defines what runs, what context each stage receives, what it must produce
 
 Atomic verifiability comes from:
 
-- **Explicit stages** instead of one oversized autonomous prompt.
-- **Scoped instructions and context** for research, implementation, review, and verification.
-- **Tool boundaries and MCP access** for repo edits, shell commands, external systems, and team tools.
-- **Required artifacts** such as research docs, specs, transcripts, logs, diffs, reviewer notes, and check output.
-- **Verification checks, review gates, and approvals** before risky or externally visible steps.
-- **Checkpoints, resumability, and subagents** for long-running or parallel work.
+- **Workflow-shaped execution** through staged, bounded runs with scoped context, tools, handoffs, and done criteria.
+- **Evidence artifacts and receipts** for persistent proof of claims, diffs, commands, outputs, blockers, and remaining risk.
+- **Structured output contracts** for schema-validated handoffs, decisions, and failure states.
+- **Adversarial review** through fresh-context verifier passes that inspect the actual work against the contract.
+- **Reducer-enforced gates** for deterministic approve, retry, block, or human-escalation decisions.
+- **Executable validation before approval** through runtime checks, external tools, and human gates before risky steps.
+- **Checkpoints and resumability** for long-running or parallel work.
 
 The selected model still generates text and code. Confidence comes from runtime-enforced structure, evidence, and review.
 


### PR DESCRIPTION
## Summary

Expands the "What makes a run verifiable?" section in the README with more specific and detailed points about how Atomic enforces verifiability, replacing several general bullets with more precise descriptions of the underlying mechanisms.

## Key changes

- Reworded "Explicit stages" to **Workflow-shaped execution**, emphasizing staged, bounded runs with scoped context, tools, handoffs, and done criteria.
- Split "Required artifacts" into **Evidence artifacts and receipts** (proof of claims, diffs, commands, outputs, blockers, risk) and **Structured output contracts** (schema-validated handoffs, decisions, failure states).
- Reworded "Verification checks, review gates, and approvals" into two more specific bullets: **Adversarial review** (fresh-context verifier passes against the contract) and **Reducer-enforced gates** (deterministic approve/retry/block/escalate decisions).
- Added **Executable validation before approval**, covering runtime checks, external tools, and human gates before risky steps.
- Kept **Checkpoints and resumability** for long-running or parallel work.

## Notes

Documentation-only change; no code or behavior is affected.