### PR TITLE
fix(ci): resolve lazy fixture dependencies on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.atomic-test-fixtures/
 dist/
 target/
 packages/natives/*.node

--- a/packages/coding-agent/test/suite/regressions/1223-startup-lazy-builtins.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1223-startup-lazy-builtins.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
+import { createRepositoryFixtureDir } from "./lazy-tool-fixtures.js";
 
 const repoRoot = resolve(__dirname, "../../../../..");
 const subprocessTimeoutMs = 10_000;
@@ -58,7 +59,7 @@ await new Promise((resolve) => setTimeout(resolve, 250));
 }
 
 function assertWebAccessRetriesRejectedInitializer(): void {
-	const tempDir = mkdtempSync(join(tmpdir(), "atomic-web-access-retry-"));
+	const tempDir = createRepositoryFixtureDir("web-access-retry");
 	try {
 		writeFileSync(join(tempDir, "package.json"), JSON.stringify({ type: "module" }));
 		writeFileSync(join(tempDir, "index.ts"), readRepoFile("packages/web-access/index.ts"));

--- a/packages/coding-agent/test/suite/regressions/1704-lazy-tool-initialization.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1704-lazy-tool-initialization.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
 import { buildSearchReturn } from "../../../../web-access/web-search-return.js";
 
-import { repoRoot, runIntercomFixture, runWebFixture } from "./lazy-tool-fixtures.js";
+import { createRepositoryFixtureDir, repoRoot, runIntercomFixture, runWebFixture } from "./lazy-tool-fixtures.js";
 
 interface FetchClassificationFixtureResult {
 	failed: { details: { outcome: string; stage: string; failedUrls: number; successful: number } };
@@ -14,7 +13,7 @@ interface FetchClassificationFixtureResult {
 }
 
 function runFetchClassificationFixture(): FetchClassificationFixtureResult {
-	const tempDir = mkdtempSync(join(tmpdir(), "atomic-fetch-classification-"));
+	const tempDir = createRepositoryFixtureDir("fetch-classification");
 	try {
 		writeFileSync(join(tempDir, "package.json"), JSON.stringify({ type: "module" }));
 		writeFileSync(join(tempDir, "content-tools.ts"), readFileSync(resolve(repoRoot, "packages/web-access/content-tools.ts"), "utf-8"));

--- a/packages/coding-agent/test/suite/regressions/lazy-tool-fixtures.ts
+++ b/packages/coding-agent/test/suite/regressions/lazy-tool-fixtures.ts
@@ -1,5 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -26,8 +25,14 @@ function parseFixtureResult<T>(result: ReturnType<typeof spawnSync>): T {
 	return JSON.parse(String(result.stdout).trim().split(/\r?\n/).at(-1) ?? "{}") as T;
 }
 
+export function createRepositoryFixtureDir(name: string): string {
+	const fixtureRoot = resolve(repoRoot, ".atomic-test-fixtures");
+	mkdirSync(fixtureRoot, { recursive: true });
+	return mkdtempSync(join(fixtureRoot, `${name}-`));
+}
+
 export function runWebFixture<T>(heavySource: string, scriptBody: string): T {
-	const tempDir = mkdtempSync(join(tmpdir(), "atomic-web-lazy-hardening-"));
+	const tempDir = createRepositoryFixtureDir("web-lazy-hardening");
 	try {
 		writeFileSync(join(tempDir, "package.json"), JSON.stringify({ type: "module" }));
 		writeFileSync(join(tempDir, "index.ts"), readFileSync(resolve(repoRoot, "packages/web-access/index.ts"), "utf-8"));
@@ -59,7 +64,7 @@ ${scriptBody}
 }
 
 export function runIntercomFixture<T>(heavySource: string, scriptBody: string, eager = false): T {
-	const tempDir = mkdtempSync(join(tmpdir(), "atomic-intercom-lazy-hardening-"));
+	const tempDir = createRepositoryFixtureDir("intercom-lazy-hardening");
 	try {
 		writeFileSync(join(tempDir, "package.json"), JSON.stringify({ type: "module" }));
 		writeFileSync(join(tempDir, "index.ts"), readFileSync(resolve(repoRoot, "packages/intercom/index.ts"), "utf-8"));

--- a/packages/web-access/content-tools.ts
+++ b/packages/web-access/content-tools.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@bastani/atomic";
-import { Text } from "@mariozechner/pi-tui";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import {
 	renderCodeSearchResult,

--- a/packages/web-access/index.ts
+++ b/packages/web-access/index.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext, HandlerFn, MessageRenderer, Regist
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { Text } from "@mariozechner/pi-tui";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { renderWebAccessToolResult } from "./result-renderers.js";
 import { assertCurrentLifecycleLease, createLifecycleLease, retainSettledLifecycleCleanup, retireLifecycleLease, type LifecycleLease } from "./lifecycle-lease.js";

--- a/packages/web-access/result-renderers.ts
+++ b/packages/web-access/result-renderers.ts
@@ -1,5 +1,5 @@
 import type { ToolDefinition } from "@bastani/atomic";
-import { Box, Text } from "@mariozechner/pi-tui";
+import { Box, Text } from "@earendil-works/pi-tui";
 import { formatSeconds } from "./utils.js";
 
 type ToolResultRenderer = NonNullable<ToolDefinition["renderResult"]>;

--- a/packages/web-access/web-search-activity.ts
+++ b/packages/web-access/web-search-activity.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "@bastani/atomic";
-import { Text, truncateToWidth } from "@mariozechner/pi-tui";
+import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { activityMonitor, type ActivityEntry } from "./activity.js";
 
 export interface ActivityWidgetState {

--- a/packages/web-access/web-search-tool.ts
+++ b/packages/web-access/web-search-tool.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@bastani/atomic";
-import { Text } from "@mariozechner/pi-tui";
+import { Text } from "@earendil-works/pi-tui";
 import { StringEnum } from "@mariozechner/pi-ai/compat";
 import { Type } from "typebox";
 import { renderWebSearchResult } from "./result-renderers.js";


### PR DESCRIPTION
## Summary

Fix the Windows CI failures from [run 29119461790, job 86450872293](https://github.com/bastani-inc/atomic/actions/runs/29119461790/job/86450872293) by creating copied lazy-tool TypeScript fixtures beneath the repository instead of the operating-system temp directory. This keeps the fixtures within Bun's workspace dependency-resolution ancestry on every platform. Also included is a small follow-up fix that points `@bastani/web-access` at the installed `pi-tui` package.

## Changes

### CI: Windows lazy-fixture resolution
- Add `createRepositoryFixtureDir()` in `lazy-tool-fixtures.ts`, a shared helper that creates isolated fixture directories under `.atomic-test-fixtures/` at the repository root instead of `os.tmpdir()`.
- Route `runWebFixture`, `runIntercomFixture`, the fetch-classification fixture (`1704-lazy-tool-initialization.test.ts`), and the startup retry fixture (`1223-startup-lazy-builtins.test.ts`) through the new helper.
- Ignore the ephemeral `.atomic-test-fixtures/` root in `.gitignore` while retaining existing per-test cleanup (`rmSync`).

### web-access: use installed `pi-tui` package
- Update `packages/web-access/{content-tools,index,result-renderers,web-search-activity,web-search-tool}.ts` to import `Text`/`Box`/`truncateToWidth` from `@earendil-works/pi-tui` instead of `@mariozechner/pi-tui`, matching the package actually installed in the workspace.

## Notes

Validation performed locally:

- `bunx vitest run packages/coding-agent/test/suite/regressions/1223-startup-lazy-builtins.test.ts packages/coding-agent/test/suite/regressions/1704-lazy-tool-initialization.test.ts` (19 tests passed)
- `bun run typecheck`
- `bun run check:file-length`
- Commit and push hooks: lint, file-length, and unit tests passed

Remote Windows CI will provide final platform validation.