### PR TITLE
fix(workflows): surface resumable runs on session restore

### DIFF
--- a/packages/workflows/src/extension/extension-lifecycle.ts
+++ b/packages/workflows/src/extension/extension-lifecycle.ts
@@ -4,6 +4,7 @@ import { cancellationRegistry } from "../runs/background/cancellation-registry.j
 import { stageControlRegistry } from "../runs/foreground/stage-control-registry.js";
 import { store } from "../shared/store.js";
 import { restoreOnSessionStart } from "../shared/persistence-restore.js";
+import { findResumableWorkflowNotices } from "../shared/resumable-workflow-notices.js";
 import { installCompactionHook } from "../shared/persistence-compaction-policy.js";
 import { clearForms } from "../tui/inline-form-store.js";
 import { installStoreWidget } from "../tui/store-widget-installer.js";
@@ -57,7 +58,7 @@ export function registerWorkflowLifecycleHandlers(
     return { cancel: true };
   });
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", async (event, ctx) => {
     runtimeState.resetWorkflowDiscoveryForSession();
     deAdvertiseAskUserQuestionWhenHeadless(pi, ctx?.hasUI);
     await runtimeState.ensureWorkflowConfigLoaded();
@@ -95,6 +96,21 @@ export function registerWorkflowLifecycleHandlers(
         );
         seedWorkflowLifecycleNotificationState(runtimeState.lifecycleNotificationState, store.snapshot());
       });
+      const reason = typeof event === "object" && event !== null && "reason" in event
+        ? (event as { readonly reason?: string }).reason
+        : undefined;
+      if (reason === "startup" || reason === "resume") {
+        const getEntries = sessionManager.getEntries;
+        if (typeof getEntries === "function") {
+          const resumable = findResumableWorkflowNotices(getEntries.call(sessionManager));
+          if (resumable.length > 0) {
+            const commands = resumable
+              .map((workflow) => `\`${workflow.name}\` (${workflow.workflowId.slice(0, 8)}): /workflow resume ${workflow.workflowId}`)
+              .join("\n");
+            ctx?.ui?.notify?.(`This session has resumable workflows:\n${commands}`, "info");
+          }
+        }
+      }
     }
   });
 

--- a/packages/workflows/src/shared/resumable-workflow-notices.ts
+++ b/packages/workflows/src/shared/resumable-workflow-notices.ts
@@ -1,0 +1,42 @@
+import type { WorkflowSerializableValue } from "./types.js";
+
+export interface ResumableWorkflowNotice {
+  readonly workflowId: string;
+  readonly name: string;
+}
+
+function recordOrUndefined(value: unknown): Record<string, WorkflowSerializableValue> | undefined {
+  return typeof value === "object" && value !== null
+    ? value as Record<string, WorkflowSerializableValue>
+    : undefined;
+}
+
+/** Return the latest resumable durable workflow references cached in a session. */
+export function findResumableWorkflowNotices(entries: readonly unknown[]): ResumableWorkflowNotice[] {
+  const latestByWorkflow = new Map<string, Record<string, WorkflowSerializableValue>>();
+  for (const value of entries) {
+    const entry = recordOrUndefined(value);
+    if (entry === undefined) continue;
+    const payload = entry["type"] === "custom" && entry["customType"] === "workflow.durable.checkpoint"
+      ? recordOrUndefined(entry["data"])
+      : entry["type"] === "workflow.durable.checkpoint"
+        ? recordOrUndefined(entry["payload"])
+        : undefined;
+    const workflowId = payload?.["workflowId"];
+    if (typeof workflowId === "string" && payload !== undefined) latestByWorkflow.set(workflowId, payload);
+  }
+
+  const notices: ResumableWorkflowNotice[] = [];
+  for (const payload of latestByWorkflow.values()) {
+    const workflowId = payload["workflowId"];
+    const name = payload["name"];
+    const status = payload["status"];
+    const resumable = payload["resumable"];
+    const canResume = status === "running" || status === "paused" || status === "blocked"
+      || (status === "failed" && resumable === true);
+    if (typeof workflowId === "string" && typeof name === "string" && canResume && resumable !== false) {
+      notices.push({ workflowId, name });
+    }
+  }
+  return notices;
+}

--- a/test/unit/resumable-workflow-notices.test.ts
+++ b/test/unit/resumable-workflow-notices.test.ts
@@ -1,0 +1,25 @@
+import { describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { findResumableWorkflowNotices } from "../../packages/workflows/src/shared/resumable-workflow-notices.js";
+
+describe("findResumableWorkflowNotices", () => {
+  test("returns only the latest resumable durable workflow metadata", () => {
+    const entries = [
+      { type: "custom", customType: "workflow.durable.checkpoint", data: { workflowId: "run-1", name: "ralph", status: "running", resumable: true } },
+      { type: "custom", customType: "workflow.durable.checkpoint", data: { workflowId: "run-2", name: "done", status: "completed", resumable: true } },
+      { type: "custom", customType: "workflow.durable.checkpoint", data: { workflowId: "run-1", name: "ralph", status: "paused", resumable: true } },
+      { type: "custom", customType: "workflow.durable.checkpoint", data: { workflowId: "run-3", name: "failed", status: "failed", resumable: false } },
+    ];
+
+    assert.deepEqual(findResumableWorkflowNotices(entries), [{ workflowId: "run-1", name: "ralph" }]);
+  });
+
+  test("accepts legacy direct workflow entries", () => {
+    const entries = [{
+      type: "workflow.durable.checkpoint",
+      payload: { workflowId: "run-4", name: "research", status: "blocked", resumable: true },
+    }];
+
+    assert.deepEqual(findResumableWorkflowNotices(entries), [{ workflowId: "run-4", name: "research" }]);
+  });
+});


### PR DESCRIPTION
## Summary

- detect resumable durable workflow references when an existing Atomic session starts or is resumed
- show each workflow name, short ID, and exact `/workflow resume <id>` command
- ignore completed, cancelled, and explicitly non-resumable workflows, using the latest cached state for each workflow

## Validation

- `/tmp/bun-runtime/bun-linux-x64/bun test test/unit/resumable-workflow-notices.test.ts` (2 passed)
- `git diff --check`

The full workspace typecheck and test suite were not run locally because this runner did not have the repository dependencies installed and had insufficient disk space for a full `bun install`.

Fixes #1722
