### PR TITLE
fix(workflows): preserve disabled task output through schema validation

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fixed archived/read-only workflow transcript views to use the standard responsive footer and Ctrl+T copy-mode toggle/status, enabling normal terminal or tmux text selection while preserving Escape and Ctrl+D navigation ([#1706](https://github.com/bastani-inc/atomic/issues/1706)).
+- Fixed workflow tool validation coercing `output: false` into the literal file path `false`, so disabled output remains disabled across direct task, parallel task, and chain execution.
 
 ## [0.9.5-alpha.9] - 2026-07-09
 

--- a/packages/workflows/src/extension/workflow-schema.ts
+++ b/packages/workflows/src/extension/workflow-schema.ts
@@ -71,8 +71,21 @@ const StageSessionOptionProperties = {
   forkFromSessionFile: Type.Optional(Type.String()),
 };
 
+// Keep this union opaque to Value.Convert: branch ordering otherwise coerces
+// boolean false to "false", or the legitimate string path "false" to false.
+const WorkflowOutputSchema = Type.Unsafe<string | false>({
+  not: {
+    not: {
+      anyOf: [
+        { type: "string" },
+        { const: false },
+      ],
+    },
+  },
+});
+
 const WorkflowTaskOptionProperties = {
-  output: Type.Optional(Type.Union([Type.String(), Type.Literal(false)])),
+  output: Type.Optional(WorkflowOutputSchema),
   outputMode: Type.Optional(Type.Union([Type.Literal("inline"), Type.Literal("file-only")])),
   reads: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Literal(false)])),
   worktree: Type.Optional(Type.Boolean()),

--- a/test/unit/workflow-schema.test.ts
+++ b/test/unit/workflow-schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, test } from "bun:test";
+import { validateToolCall } from "@earendil-works/pi-ai/compat";
 import assert from "node:assert/strict";
 import { Value } from "typebox/value";
 import { WorkflowParametersSchema } from "../../packages/workflows/src/extension/workflow-schema.js";
@@ -190,6 +191,44 @@ describe("WorkflowParametersSchema stage options", () => {
       task: { name: "planner", prompt: "plan" },
       fallbackModels: [false],
     }), false);
+  });
+
+  test("validates output values without coercing false", () => {
+    const tools = [
+      {
+        name: "workflow",
+        description: "Run a workflow",
+        parameters: WorkflowParametersSchema,
+      },
+    ];
+    const validated = validateToolCall(tools, {
+      type: "toolCall",
+      id: "workflow-call",
+      name: "workflow",
+      arguments: {
+        output: false,
+        task: { name: "worker", task: "work", output: false },
+      },
+    }) as {
+      output?: string | false;
+      task?: { output?: string | false };
+    };
+    const validatedPath = validateToolCall(tools, {
+      type: "toolCall",
+      id: "workflow-path-call",
+      name: "workflow",
+      arguments: { output: "false" },
+    }) as { output?: string | false };
+
+    assert.equal(validated.output, false);
+    assert.equal(validated.task?.output, false);
+    assert.equal(validatedPath.output, "false");
+    assert.throws(() => validateToolCall(tools, {
+      type: "toolCall",
+      id: "workflow-invalid-output-call",
+      name: "workflow",
+      arguments: { output: true },
+    }));
   });
 
 });


### PR DESCRIPTION
## Summary

`Value.Convert`'s type coercion walked the `output` union (`string | Literal(false)`) in branch order and rewrote boolean `false` to the string `"false"` (or vice versa) during workflow tool-call validation, so setting `output: false` to disable a task's output file silently produced a file literally named `false` instead of suppressing output.

## Changes

- `packages/workflows/src/extension/workflow-schema.ts`: replace the `output` property's `Type.Union([Type.String(), Type.Literal(false)])` with an opaque `Type.Unsafe` schema (`WorkflowOutputSchema`) built from a double-negated `anyOf`, so TypeBox's `Value.Convert` cannot see into the union and coerce between the boolean and its string form. The legitimate string path `"false"` and the boolean `false` now both validate to their original type unchanged.
- `test/unit/workflow-schema.test.ts`: add regression coverage via `validateToolCall` confirming `output: false` stays `false` for both top-level and nested `task.output`, the string path `"false"` stays a string, and non-boolean/non-string values (e.g. `true`) are rejected.
- `packages/workflows/CHANGELOG.md`: document the fix under `[Unreleased] > Fixed`.

## Validation

- `AGENT=1 bun test test/unit/workflow-schema.test.ts` — 7 passed
- `bun run typecheck`
- `bun run check:file-length`
- `git diff --check`
- Commit and push hooks, including `bun run lint` and `bun run test:unit`
