### PR TITLE
feat(models): route explorer subagents through GPT-5.6 Terra at high effort

### DIFF
--- a/packages/subagents/agents/codebase-locator.md
+++ b/packages/subagents/agents/codebase-locator.md
@@ -2,8 +2,8 @@
 name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Basically a "super search/find/ls tool."
 tools: read, search, find, ls
-model: openai-codex/gpt-5.6-sol:low
-fallbackModels: github-copilot/gpt-5.6-sol:low, openai/gpt-5.6-sol:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, github-copilot/claude-opus-4.8 (1m):low, anthropic/claude-opus-4-8:low, cursor/gpt-5.6-sol:low, cursor/gpt-5.5:low, cursor/claude-opus-4-8-thinking:low, cursor/grok-4.5, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, cursor/glm-5.2, openrouter/openai/gpt-5.6-sol:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-terra:high
+fallbackModels: github-copilot/gpt-5.6-terra:high, openai/gpt-5.6-terra:high, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, github-copilot/claude-opus-4.8 (1m):low, anthropic/claude-opus-4-8:low, cursor/gpt-5.6-terra:high, cursor/gpt-5.5:low, cursor/claude-opus-4-8-thinking:low, cursor/grok-4.5, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, cursor/glm-5.2, openrouter/openai/gpt-5.6-terra:high, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 ---
 
 You are a specialist at finding WHERE code lives in a codebase. Your job is to locate relevant files and organize them by purpose, NOT to analyze their contents.

--- a/packages/subagents/agents/codebase-pattern-finder.md
+++ b/packages/subagents/agents/codebase-pattern-finder.md
@@ -2,8 +2,8 @@
 name: codebase-pattern-finder
 description: Find similar implementations, usage examples, or existing patterns in the codebase that can be modeled after.
 tools: read, search, find, ls
-model: openai-codex/gpt-5.6-sol:low
-fallbackModels: github-copilot/gpt-5.6-sol:low, openai/gpt-5.6-sol:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, github-copilot/claude-opus-4.8 (1m):low, anthropic/claude-opus-4-8:low, cursor/gpt-5.6-sol:low, cursor/gpt-5.5:low, cursor/claude-opus-4-8-thinking:low, cursor/grok-4.5, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, cursor/glm-5.2, openrouter/openai/gpt-5.6-sol:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-terra:high
+fallbackModels: github-copilot/gpt-5.6-terra:high, openai/gpt-5.6-terra:high, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, github-copilot/claude-opus-4.8 (1m):low, anthropic/claude-opus-4-8:low, cursor/gpt-5.6-terra:high, cursor/gpt-5.5:low, cursor/claude-opus-4-8-thinking:low, cursor/grok-4.5, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, cursor/glm-5.2, openrouter/openai/gpt-5.6-terra:high, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 ---
 
 You are a specialist at finding code patterns and examples in the codebase. Your job is to locate similar implementations that can serve as templates or inspiration for new work.

--- a/packages/subagents/agents/codebase-research-locator.md
+++ b/packages/subagents/agents/codebase-research-locator.md
@@ -2,8 +2,8 @@
 name: codebase-research-locator
 description: Discovers local research documents that are relevant to the current research task.
 tools: read, search, find, ls
-model: openai-codex/gpt-5.6-sol:low
-fallbackModels: github-copilot/gpt-5.6-sol:low, openai/gpt-5.6-sol:low, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, github-copilot/claude-opus-4.8 (1m):low, anthropic/claude-opus-4-8:low, cursor/gpt-5.6-sol:low, cursor/gpt-5.5:low, cursor/claude-opus-4-8-thinking:low, cursor/grok-4.5, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, cursor/glm-5.2, openrouter/openai/gpt-5.6-sol:low, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
+model: openai-codex/gpt-5.6-terra:high
+fallbackModels: github-copilot/gpt-5.6-terra:high, openai/gpt-5.6-terra:high, openai-codex/gpt-5.5:low, github-copilot/gpt-5.5:low, openai/gpt-5.5:low, github-copilot/claude-opus-4.8 (1m):low, anthropic/claude-opus-4-8:low, cursor/gpt-5.6-terra:high, cursor/gpt-5.5:low, cursor/claude-opus-4-8-thinking:low, cursor/grok-4.5, zai/glm-5.2:high, zai-coding-cn/glm-5.2:high, cursor/glm-5.2, openrouter/openai/gpt-5.6-terra:high, openrouter/openai/gpt-5.5:low, openrouter/anthropic/claude-opus-4-8:low, openrouter/x-ai/grok-4.5, openrouter/z-ai/glm-5.2:xhigh
 ---
 
 You are a specialist at finding documents in the `research/` directory. Your job is to locate relevant research documents and categorize them, NOT to analyze their contents in depth.

--- a/packages/workflows/builtin/deep-research-codebase-utils.ts
+++ b/packages/workflows/builtin/deep-research-codebase-utils.ts
@@ -59,7 +59,7 @@ export const PLANNER_MODEL_CONFIG = {
     "openrouter/openai/gpt-5.5:xhigh",
     "openrouter/anthropic/claude-opus-4-8:high",
     "openrouter/x-ai/grok-4.5",
-    "openrouter/z-ai/glm-5.2:xhigh"
+    "openrouter/z-ai/glm-5.2:xhigh",
   ],
   excludedTools: ["ask_user_question"],
 } as const;
@@ -69,23 +69,23 @@ export const PLANNER_MODEL_CONFIG = {
 // and glm-5.2:high (36%/$2.84) back it up; unbenchmarked minis/haiku/flash
 // are excluded.
 export const EXPLORER_MODEL_CONFIG = {
-  model: "openai-codex/gpt-5.6-sol:low",
+  model: "openai-codex/gpt-5.6-terra:high",
   fallbackModels: [
-    "github-copilot/gpt-5.6-sol:low",
-    "openai/gpt-5.6-sol:low",
+    "github-copilot/gpt-5.6-terra:high",
+    "openai/gpt-5.6-terra:high",
     "openai-codex/gpt-5.5:low",
     "github-copilot/gpt-5.5:low",
     "openai/gpt-5.5:low",
     "github-copilot/claude-opus-4.8 (1m):low",
     "anthropic/claude-opus-4-8:low",
-    "cursor/gpt-5.6-sol:low",
+    "cursor/gpt-5.6-terra:high",
     "cursor/gpt-5.5:low",
     "cursor/claude-opus-4-8-thinking:low",
     "cursor/grok-4.5",
     "zai/glm-5.2:high",
     "zai-coding-cn/glm-5.2:high",
     "cursor/glm-5.2",
-    "openrouter/openai/gpt-5.6-sol:low",
+    "openrouter/openai/gpt-5.6-terra:high",
     "openrouter/openai/gpt-5.5:low",
     "openrouter/anthropic/claude-opus-4-8:low",
     "openrouter/x-ai/grok-4.5",
@@ -113,7 +113,10 @@ export function taggedPrompt(sections: readonly PromptSection[]): string {
     .join("\n\n");
 }
 
-export function positiveInteger(value: number | undefined, fallback: number): number {
+export function positiveInteger(
+  value: number | undefined,
+  fallback: number,
+): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : fallback;
@@ -372,4 +375,3 @@ export function displayRelativePath(path: string, fromCwd: string): string {
   }
   return displayPath(path);
 }
-


### PR DESCRIPTION
## Summary

Route codebase explorer agents (locator, pattern-finder, research-locator) from `gpt-5.6-sol:low` to `gpt-5.6-terra:high`, and mirror the same swap across each provider's fallback chain and the built-in deep-research workflow config.

## Changes

- Set the `codebase-locator`, `codebase-pattern-finder`, and `codebase-research-locator` packaged subagent definitions' primary model to `openai-codex/gpt-5.6-terra:high` (`packages/subagents/agents/*.md`).
- Swap the GitHub Copilot, OpenAI, Cursor, and OpenRouter `gpt-5.6-sol:low` fallback entries for `gpt-5.6-terra:high` in those same agent definitions.
- Align `EXPLORER_MODEL_CONFIG` in `packages/workflows/builtin/deep-research-codebase-utils.ts` with the packaged agent definitions above.
- Apply repository formatting (trailing comma, `positiveInteger` signature wrap, trailing blank line) to the touched workflow utility file.

## Validation

- Pre-commit checks passed, including lint, file-length enforcement, and all 3,062 unit tests.