### PR TITLE
feat: add configurable timeoutMs for remote MCP server calls

### DIFF
--- a/packages/mcp/server-manager.ts
+++ b/packages/mcp/server-manager.ts
@@ -71,7 +71,7 @@ export class McpServerManager {
     name: string,
     definition: ServerDefinition
   ): Promise<ServerConnection> {
-    const client = this.createClient(name);
+    const client = this.createClient(name, definition.timeoutMs);
     
     let transport: Transport;
     
@@ -148,10 +148,17 @@ export class McpServerManager {
     }
   }
   
-  private createClient(serverName: string): Client {
+  private createClient(serverName: string, timeoutMs?: number): Client {
+    const clientOptions: ConstructorParameters<typeof Client>[1] = {};
+    if (this.samplingConfig) {
+      clientOptions.capabilities = { sampling: {} };
+    }
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+      clientOptions.requestTimeout = timeoutMs;
+    }
     const client = new Client(
       { name: `pi-mcp-${serverName}`, version: "1.0.0" },
-      this.samplingConfig ? { capabilities: { sampling: {} } } : undefined,
+      Object.keys(clientOptions).length > 0 ? clientOptions : undefined,
     );
     if (this.samplingConfig) {
       registerSamplingHandler(client, { ...this.samplingConfig, serverName });

--- a/packages/mcp/timeout.test.ts
+++ b/packages/mcp/timeout.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "bun:test";
+import { ServerEntry } from "./types.ts";
+
+describe("ServerEntry timeoutMs", () => {
+  it("should accept timeoutMs as an optional number", () => {
+    const entry: ServerEntry = {
+      url: "https://example.com/mcp",
+      timeoutMs: 60000,
+    };
+    expect(entry.timeoutMs).toBe(60000);
+  });
+
+  it("should allow entries without timeoutMs", () => {
+    const entry: ServerEntry = {
+      command: "npx",
+      args: ["-y", "@some/mcp-server"],
+    };
+    expect(entry.timeoutMs).toBeUndefined();
+  });
+
+  it("should support the config shape from the issue", () => {
+    const config = {
+      mcpServers: {
+        github: {
+          type: "http" as const,
+          url: "https://api.githubcopilot.com/mcp",
+          timeoutMs: 60000,
+        },
+      },
+    };
+    const entry = config.mcpServers.github as ServerEntry;
+    expect(entry.timeoutMs).toBe(60000);
+    expect(entry.url).toBe("https://api.githubcopilot.com/mcp");
+  });
+});

--- a/packages/mcp/types.ts
+++ b/packages/mcp/types.ts
@@ -309,6 +309,13 @@ export interface ServerEntry {
   excludeTools?: string[];
   // Debug
   debug?: boolean;  // Show server stderr (default: false)
+  /**
+   * Request timeout in milliseconds for remote MCP server calls.
+   * If not set, the MCP SDK default is used.
+   * Applies to remote HTTP/SSE servers. For stdio servers, the
+   * SDK's default timeout applies.
+   */
+  timeoutMs?: number;
 }
 
 // Settings


### PR DESCRIPTION
## Summary

Add a `timeoutMs` optional field to `ServerEntry` that allows per-server request timeout configuration for remote MCP server calls.

Closes #1094

## Changes

- `packages/mcp/types.ts`: Add `timeoutMs?: number` to `ServerEntry` interface
- `packages/mcp/server-manager.ts`: Pass `timeoutMs` to the MCP SDK `Client` constructor as `requestTimeout`
- `packages/mcp/timeout.test.ts`: Type-level tests for the new field

## Config Example

```json
{
  "mcpServers": {
    "github": {
      "url": "https://api.githubcopilot.com/mcp",
      "timeoutMs": 60000
    }
  }
}
```

When `timeoutMs` is not set, the MCP SDK default timeout is used.

## Verification

- TypeScript type check passes (no errors from modified files)
- Test file verifies type acceptance and the config shape from the issue