### PR TITLE
Release 0.9.5-alpha.10

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
 ### Added
 
 - Added model-capability-aware `max` thinking support across the CLI, settings, SDK/RPC/extension surfaces, Cursor model mapping, workflow stages, and bundled subagents; models still expose only the levels in their own capability maps ([#1703](https://github.com/bastani-inc/atomic/issues/1703)).

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
 ### Changed
 
 - Aligned the Cursor provider dependency with upstream `pi-ai` `^0.80.6` and mapped the new `max` thinking level to Cursor's advertised effort variants while preserving per-model capability filtering ([#1703](https://github.com/bastani-inc/atomic/issues/1703)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
 ### Changed
 
 - Aligned the intercom extension peer dependency with upstream `pi-tui` `^0.80.6` as part of the consolidated Pi sync; no intercom source behavior changed ([#1703](https://github.com/bastani-inc/atomic/issues/1703)).

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
 ### Changed
 
 - Aligned the MCP extension peer dependencies with upstream `pi-ai`/`pi-tui` `^0.80.6` as part of the consolidated Pi sync; no MCP source behavior changed ([#1703](https://github.com/bastani-inc/atomic/issues/1703)).

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
+### Changed
+
+- Published a synchronized Atomic 0.9.5-alpha.10 prerelease for the native transport package; no native transport changes were made after 0.9.4.
+
 ## [0.9.4] - 2026-07-03
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
 ### Added
 
 - Added model-capability-aware `max` reasoning suffix support to subagent model/fallback parsing and child CLI forwarding ([#1703](https://github.com/bastani-inc/atomic/issues/1703)).

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
 ### Changed
 
 - Aligned the web-access extension peer dependency with upstream `pi-tui` `^0.80.6` as part of the consolidated Pi sync; no web-access source behavior changed ([#1703](https://github.com/bastani-inc/atomic/issues/1703)).

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.5-alpha.10] - 2026-07-11
+
 ### Added
 
 - Added model-capability-aware `max` reasoning suffix support throughout workflow stage schemas, fallback candidates, authoring contracts, and TUI status labels ([#1703](https://github.com/bastani-inc/atomic/issues/1703)).


### PR DESCRIPTION
## Summary

Prepares the release notes for prerelease `0.9.5-alpha.10` from `main`.

## Changes

- Updates the `[Unreleased]` changelog sections for coding-agent, cursor, intercom, mcp, natives, subagents, web-access, and workflows.
- Leaves all package versions at the versionless `0.0.0` placeholder; this PR contains no package version bump.
- The real `0.9.5-alpha.10` version will be materialized only on the throwaway off-main tag commit created by `scripts/cut-release.ts` after this release-notes PR is merged.

## Release

- **Kind:** Prerelease
- **Version:** `0.9.5-alpha.10`
- **Tag base:** `main`
- **Tag:** `0.9.5-alpha.10` (no leading `v`)

## Validation

Deterministic release preparation and local release checks passed. Verified with:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only 9d95dd0d23bf79a44ef5bdb60bfeba21bb143026..HEAD
gh auth status
gh repo view --json nameWithOwner,url,defaultBranchRef
git push -u origin prerelease/0.9.5-alpha.10
```

The push hooks also passed:

- `bun run lint`
- `bun run check:file-length`
- `bun run test:unit`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares release notes for `0.9.5-alpha.10`. The main changes are:

- Adds `0.9.5-alpha.10` headings across the affected package changelogs.
- Keeps package versions at the versionless `0.0.0` placeholder on `main`.
- Adds a synchronized native transport prerelease note with no native source changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The diff is limited to changelog release-note updates. No runtime code, dependency manifests, lockfiles, or package versions changed. The versionless `main` release flow matches the repository guidance.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification and reported that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds the `0.9.5-alpha.10` release heading above the existing coding-agent release-note entries. |
| packages/cursor/CHANGELOG.md | Adds the `0.9.5-alpha.10` release heading for Cursor dependency and thinking-level notes. |
| packages/intercom/CHANGELOG.md | Adds the `0.9.5-alpha.10` release heading for Intercom dependency and lifecycle notes. |
| packages/mcp/CHANGELOG.md | Adds the `0.9.5-alpha.10` release heading for MCP dependency, readiness, and cancellation notes. |
| packages/natives/CHANGELOG.md | Adds a synchronized `0.9.5-alpha.10` native transport changelog entry noting no native changes after `0.9.4`. |
| packages/subagents/CHANGELOG.md | Adds the `0.9.5-alpha.10` release heading for subagent reasoning, progress, routing, and lifecycle notes. |
| packages/web-access/CHANGELOG.md | Adds the `0.9.5-alpha.10` release heading for web-access dependency and lazy lifecycle notes. |
| packages/workflows/CHANGELOG.md | Adds the `0.9.5-alpha.10` release heading for workflow reasoning, routing, resume, and fix notes. |

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.5-alpha.10"](https://github.com/bastani-inc/atomic/commit/4b05f600c4fb4463bc06742a4508a481dd5c435a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43576656)</sub>

<!-- /greptile_comment -->