### PR TITLE
fix(evals): count workflow steps and preserve proxy log ownership

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -184,6 +184,6 @@ The adapter is self-contained; it does not require patching Pier or Harbor. It f
 2. Run the Atomic CLI in JSON mode.
 3. Keep Atomic's mutable agent state under the sandbox user's `~/.atomic/agent` directory by setting Atomic's existing agent-dir environment override, passing `--session-dir ~/.atomic/agent/atomic-sessions`, and exporting `ATOMIC_TODO_PATH=$HOME/.atomic/agent/todos` inside the sandbox so the default todo tool cannot create `.atomic/todos` in the benchmark repository.
 4. Tee Atomic's JSON stream to `/logs/agent/atomic.txt` and continuously mirror session transcripts to `/logs/agent/atomic-sessions/` during the run, with a final exit-trap sync to preserve transcripts on normal exits and SIGTERM-based timeouts.
-5. Collect usage and trajectory data from the logs.
+5. Collect usage and trajectory data from the main chat plus workflow-stage and nested child transcripts, de-duplicating copied parent context and reporting the combined agent-step count (`n_agent_steps` in Pier and Harbor context metadata).
 
 Like the built-in Pier agents, it does not auto-commit work. Deep SWE tasks rely on the agent following the task instruction to commit.

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -373,6 +373,7 @@ class Atomic(BaseInstalledAgent):
         total_cache_read_tokens = 0
         total_cache_write_tokens = 0
         total_cost = 0.0
+        total_agent_steps = 0
         seen_message_ids: set[str] = set()
         seen_message_fingerprints: set[str] = set()
 
@@ -380,12 +381,9 @@ class Atomic(BaseInstalledAgent):
             message: object,
             entry_id: object = None,
         ) -> None:
-            nonlocal total_input_tokens, total_output_tokens
+            nonlocal total_input_tokens, total_output_tokens, total_agent_steps
             nonlocal total_cache_read_tokens, total_cache_write_tokens, total_cost
             if not isinstance(message, dict) or message.get("role") != "assistant":
-                return
-            usage = message.get("usage")
-            if not isinstance(usage, dict):
                 return
             fingerprint = self._assistant_message_fingerprint(message)
             if isinstance(entry_id, str):
@@ -397,6 +395,10 @@ class Atomic(BaseInstalledAgent):
                 seen_message_ids.add(entry_id)
             if fingerprint:
                 seen_message_fingerprints.add(fingerprint)
+            total_agent_steps += 1
+            usage = message.get("usage")
+            if not isinstance(usage, dict):
+                return
             total_input_tokens += self._token_count(usage.get("input"))
             total_output_tokens += self._token_count(usage.get("output"))
             total_cache_read_tokens += self._token_count(usage.get("cacheRead"))
@@ -472,3 +474,7 @@ class Atomic(BaseInstalledAgent):
         context.n_output_tokens = total_output_tokens
         context.n_cache_tokens = total_cache_tokens
         context.cost_usd = total_cost if total_cost > 0 else None
+        context.metadata = {
+            **(context.metadata or {}),
+            "n_agent_steps": total_agent_steps,
+        }

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -829,7 +829,11 @@ class Atomic(BaseInstalledAgent):
         )
         context.peak_context_tokens = peak
         context.summarization_count = summarization_count or None
-        context.n_agent_steps = sum(1 for step in all_steps if step.source == "agent")
+        context.n_agent_steps = sum(
+            1
+            for step in all_steps
+            if step.source == "agent" and step.is_copied_context is not True
+        )
 
         trajectory_path = self.logs_dir / "trajectory.json"
         try:

--- a/evals/test_atomic_adapters.py
+++ b/evals/test_atomic_adapters.py
@@ -1,0 +1,88 @@
+import json
+import logging
+from pathlib import Path
+
+from harbor.models.agent.context import AgentContext as HarborAgentContext
+from pier.models.agent.context import AgentContext as PierAgentContext
+
+from atomic_harbor import Atomic as HarborAtomic
+from atomic_pier import Atomic as PierAtomic
+
+
+def _assistant(timestamp: int, *, input_tokens: int = 10) -> dict[str, object]:
+    return {
+        "role": "assistant",
+        "timestamp": timestamp,
+        "provider": "test",
+        "model": "test-model",
+        "stopReason": "stop",
+        "content": [{"type": "text", "text": f"response-{timestamp}"}],
+        "usage": {
+            "input": input_tokens,
+            "output": 2,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "totalTokens": input_tokens + 2,
+            "cost": {"total": 0.01},
+        },
+    }
+
+
+def _write_jsonl(path: Path, entries: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{json.dumps(entry)}\n" for entry in entries))
+
+
+def _write_atomic_logs(logs_dir: Path) -> None:
+    main_message = _assistant(1_000)
+    workflow_message = _assistant(2_000, input_tokens=20)
+    _write_jsonl(
+        logs_dir / "atomic.txt",
+        [{"type": "message_end", "message": main_message}],
+    )
+    _write_jsonl(
+        logs_dir / "atomic-sessions" / "main.jsonl",
+        [
+            {"type": "session", "id": "main"},
+            {"type": "message", "id": "main-turn", "message": main_message},
+        ],
+    )
+    _write_jsonl(
+        logs_dir / "atomic-sessions" / "workflow" / "stage.jsonl",
+        [
+            {"type": "session", "id": "stage", "internal": True},
+            # Forked workflow transcripts contain copied parent context. It must
+            # be de-duplicated rather than reported as another agent turn.
+            {"type": "message", "id": "main-turn", "message": main_message},
+            {"type": "message", "id": "workflow-turn", "message": workflow_message},
+        ],
+    )
+
+
+def test_pier_counts_unique_main_and_workflow_agent_steps(tmp_path: Path) -> None:
+    _write_atomic_logs(tmp_path)
+    agent = PierAtomic.__new__(PierAtomic)
+    agent.logs_dir = tmp_path
+    agent._version = "test"
+    agent.model_name = "test/test-model"
+    agent.logger = logging.getLogger("test-atomic-pier")
+    context = PierAgentContext()
+
+    agent.populate_context_post_run(context)
+
+    assert context.n_agent_steps == 2
+    trajectory = json.loads((tmp_path / "trajectory.json").read_text())
+    assert len(trajectory["subagent_trajectories"]) == 1
+    assert trajectory["final_metrics"]["total_prompt_tokens"] == 30
+
+
+def test_harbor_reports_unique_main_and_workflow_agent_steps(tmp_path: Path) -> None:
+    _write_atomic_logs(tmp_path)
+    agent = HarborAtomic.__new__(HarborAtomic)
+    agent.logs_dir = tmp_path
+    context = HarborAgentContext()
+
+    agent.populate_context_post_run(context)
+
+    assert context.metadata == {"n_agent_steps": 2}
+    assert context.n_input_tokens == 30


### PR DESCRIPTION
## Summary

Correct Atomic eval accounting so workflow and nested-agent turns contribute to the reported agent-step count without double-counting copied parent context. Preserve host ownership of Docker egress-proxy logs so Linux users can remove trial artifacts without `sudo`.

## Changes

- Exclude Pier trajectory steps marked as copied context from `n_agent_steps` while retaining unique workflow-stage and nested-agent turns.
- Report the equivalent Harbor count through `AgentContext.metadata.n_agent_steps`, since Harbor has no first-class step-count field.
- Add regression coverage for main-session de-duplication and workflow transcript accounting.
- Update the Pier submodule to pre-create proxy log files on the host and grant Squid only the required file permissions instead of recursively changing the bind mount to `proxy:proxy`.
- Document combined workflow step accounting in the eval adapter guide.

## Notes

- Pier submodule commit: [`a17ee0b`](https://github.com/lavaman131/pier/commit/a17ee0b613d4b2dad2d8e1f0bc6717d703843285)
- Validation: `uv run --with pytest pytest -q test_atomic_adapters.py vendor/pier/tests/test_filtered_egress_env.py` (10 passed)
- Validation: Ruff checks passed for all changed Python files.
- Validation: `bun run hooks:run` passed, including lint, file-length checks, unit tests, Cargo formatting, and Clippy.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Atomic eval accounting across Pier and Harbor adapters. The main changes are:

- Counts main chat, workflow-stage, and nested child transcript turns together.
- De-duplicates copied parent context so it is not counted as another agent step.
- Reports Harbor agent-step totals through `AgentContext.metadata.n_agent_steps`.
- Updates the Pier submodule for Docker egress-proxy log ownership handling.
- Adds adapter tests and README notes for combined workflow step accounting.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The adapter changes are narrowly scoped and follow the existing transcript de-duplication flow. Tests cover the main accounting behavior changed by this PR. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the evals pytest suite to exercise the code-execution proof-of-work workflow.
- Verified the pytest run completed successfully with 10 tests passing in 0.97 seconds and exit code 0.

<a href="https://app.greptile.com/trex/runs/14126679/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/README.md | Documents combined main/workflow/nested transcript accounting and Harbor metadata step reporting. |
| evals/atomic_harbor.py | Adds unique assistant-turn counting across Harbor main output and counted session transcripts, preserving existing token/cost de-duplication. |
| evals/atomic_pier.py | Updates Pier trajectory-derived step accounting to exclude copied parent-context assistant steps while retaining workflow and nested-agent turns. |
| evals/test_atomic_adapters.py | Adds tests covering de-duplication of copied main-session context and inclusion of workflow turns for both Pier and Harbor adapters. |
| evals/vendor/pier | Updates the Pier submodule to the PR-described proxy-log ownership fix; only the gitlink changed in this repository. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Output as atomic.txt message_end stream
participant Main as atomic-sessions/main.jsonl
participant Child as Workflow/nested session jsonl
participant Adapter as Pier/Harbor adapter
participant Context as Eval AgentContext

Adapter->>Output: Read assistant completions
Output-->>Adapter: Count usage and unique agent steps
Adapter->>Main: Read main session for de-duplication
Main-->>Adapter: Mark copied parent context as seen
Adapter->>Child: Read workflow/nested transcripts
Child-->>Adapter: Count unseen assistant turns and skip copied context
Adapter->>Context: Write token totals and combined agent-step count
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Output as atomic.txt message_end stream
participant Main as atomic-sessions/main.jsonl
participant Child as Workflow/nested session jsonl
participant Adapter as Pier/Harbor adapter
participant Context as Eval AgentContext

Adapter->>Output: Read assistant completions
Output-->>Adapter: Count usage and unique agent steps
Adapter->>Main: Read main session for de-duplication
Main-->>Adapter: Mark copied parent context as seen
Adapter->>Child: Read workflow/nested transcripts
Child-->>Adapter: Count unseen assistant turns and skip copied context
Adapter->>Context: Write token totals and combined agent-step count
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): preserve proxy log ownership"](https://github.com/bastani-inc/atomic/commit/7272cb6720d8d31689b0b71775ecde77194994b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43584125)</sub>

<!-- /greptile_comment -->