### PR TITLE
Release 0.9.6-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
 ### Changed
 
 - Restored workflow-first Atomic guidance for non-trivial work with verifiable objectives and synchronized help/docs around rich inline TypeScript workflow authoring, including dynamic branching, fan-out, verification, candidate-selection, human-gate, child-workflow, and bounded-loop patterns.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
 ### Changed
 
 - Restored fully tool-driven Intercom connections: parent and bridged child sessions no longer import or connect to the broker merely because a subagent starts. The runtime now connects only when the model or user invokes an Intercom tool, command, shortcut, or relay.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the MCP extension; no functional MCP changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the native transport package; no native transport changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
 ### Changed
 
 - Aligned model-facing subagent guidance with workflow-first routing: subagents remain focused specialists inside workflow stages or bounded direct delegation, rather than becoming an ad hoc implementation/review/retry pipeline for workflow-fit work.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the web-access extension; no functional web-access changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-11
+
 ### Changed
 
 - Restored workflow-first model routing for non-trivial, structured, and verifiable work while retaining the newer ability to author task-specific TypeScript workflows inline. Prompt guidance now explicitly combines the documented classify/branch, fan-out/synthesis, adversarial verification, generate/filter, tournament, and bounded loop patterns instead of forcing every workflow-fit task into an installed workflow, direct shape, or builtin.


### PR DESCRIPTION
## Summary

Prepare the release notes for the `0.9.6-alpha.1` prerelease from `main`.

- **Release kind:** prerelease
- **Version:** `0.9.6-alpha.1`
- **Base:** `main`
- **Release-notes branch:** `prerelease/0.9.6-alpha.1`

## Changes

- Update the `## [Unreleased]` sections in eight package changelogs with the cumulative release notes for this prerelease.
- Keep all package versions at the versionless `0.0.0` placeholder on `main`.
- Do not include a package version bump in this PR. The real version will be materialized only on the throwaway off-main tag commit produced by `scripts/cut-release.ts` after this PR is merged and release gates pass.

## Validation

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only c729ece9e74da48661acdf1c1fcd8f5f26821f31..HEAD
bun run lint
bun run check:file-length
bun run test:unit
```

Deterministic release preparation and local checks passed. The lint, file-length, and unit-test commands also passed in the pre-push hooks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.6-alpha.1` prerelease notes. The main changes are:

- Adds `0.9.6-alpha.1` changelog sections across eight packages.
- Records cumulative release notes for `coding-agent`, `workflows`, `subagents`, and `intercom`.
- Adds synchronized no-functional-change prerelease notes for `cursor`, `mcp`, `natives`, and `web-access`.
- Keeps package versions untouched for the versionless `main` release flow.

<h3>Confidence Score: 5/5</h3>

This changelog-only release preparation PR is safe to merge.

The changes only add release-note headings and entries. The update matches the repository's versionless `main` release guidance. No package manifests or executable code were changed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding in the review comment.
- T-Rex produced a proof for the second posted P1 finding in the review comment.
- T-Rex ran the requested general contract validation; the verification completed but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds the `0.9.6-alpha.1` release heading over existing cumulative Atomic CLI release notes; no issues found. |
| packages/cursor/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` Cursor provider changelog entry with no functional changes; no issues found. |
| packages/intercom/CHANGELOG.md | Adds the `0.9.6-alpha.1` Intercom release heading and release note; no issues found. |
| packages/mcp/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` MCP extension changelog entry with no functional changes; no issues found. |
| packages/natives/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` native transport changelog entry with no functional changes; no issues found. |
| packages/subagents/CHANGELOG.md | Adds the `0.9.6-alpha.1` subagents release heading and release notes; no issues found. |
| packages/web-access/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` web-access changelog entry with no functional changes; no issues found. |
| packages/workflows/CHANGELOG.md | Adds the `0.9.6-alpha.1` workflows release heading and release notes; no issues found. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Main as main branch
participant Changelogs as package CHANGELOG.md files
participant Release as cut-release.ts off-main tag commit
participant NPM as npm/GitHub Release

Main->>Changelogs: Add 0.9.6-alpha.1 release notes
Note over Main: package versions remain 0.0.0
Main->>Release: Merge release-notes PR, then run cut-release.ts
Release->>Release: Materialize 0.9.6-alpha.1 only on tag commit
Release->>NPM: "Push prerelease tag and publish @next"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Main as main branch
participant Changelogs as package CHANGELOG.md files
participant Release as cut-release.ts off-main tag commit
participant NPM as npm/GitHub Release

Main->>Changelogs: Add 0.9.6-alpha.1 release notes
Note over Main: package versions remain 0.0.0
Main->>Release: Merge release-notes PR, then run cut-release.ts
Release->>Release: Materialize 0.9.6-alpha.1 only on tag commit
Release->>NPM: "Push prerelease tag and publish @next"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **PR is not changelog-only: workflows README is changed**

   - **Bug**
     - The explicit diff validation command showed `packages/workflows/README.md` in addition to the eight expected package changelog files. This contradicts the stated changelog-only release-preparation hypothesis.
   - **Cause**
     - The head checkout contains a non-changelog file change relative to base `c729ece9e74da48661acdf1c1fcd8f5f26821f31`.
   - **Fix**
     - Remove the unintended `packages/workflows/README.md` change from the PR, or update the release validation scope/hypothesis to explicitly include and justify the README change.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Lint validation did not complete under explicit timeouts**

   - **Bug**
     - `bun run lint` did not produce a passing result. The first execution was terminated by `timeout 300` with exit code 124, and an extended retry was killed with exit code 137 while running `tsc --noEmit`. Because lint did not pass, file-length and unit-test validation were not attempted per the requested stop condition.
   - **Cause**
     - TypeScript lint/typecheck exceeded available validation time/resources in this environment and was terminated before completion.
   - **Fix**
     - Investigate why `tsc --noEmit` is hanging or exhausting resources in CI-like validation. If this is expected in the review environment, provide a narrower documented validation command for changelog-only release PRs; otherwise fix the typecheck performance/resource issue so `bun run lint` completes.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs: release notes for 0.9.6-alpha.1"](https://github.com/bastani-inc/atomic/commit/894e565e6c65465434990145ab383c0bc926e7f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43598957)</sub>

<!-- /greptile_comment -->