### PR TITLE
docs(workflows): sync workflow tool description

### DIFF
--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -552,12 +552,12 @@ Prompt answer replay is live-memory only. `StageSnapshot.promptAnswerState` repo
 
 ### `workflow` tool (LLM-callable)
 
-<!-- Keep the description below in sync with WORKFLOW_TOOL_DESCRIPTION in packages/workflows/src/extension/index.ts; integration tests assert this. -->
+<!-- Keep the description below in sync with WORKFLOW_TOOL_DESCRIPTION in packages/workflows/src/extension/workflow-prompts.ts; integration tests assert this. -->
 
 ```json
 {
   "name": "workflow",
-  "description": "Run named builtin, project, user, or package workflows, or direct one-off task/tasks/chain workflows; when workflow execution fits but another shape would better achieve the task, author a custom TypeScript workflow({...}) inline with normal coding tools, reload it, and run it; discover with list/get/inputs, inspect status/stages/stage details, send prompt answers or steering, pause/resume/interrupt/kill runs, and reload workflow resources. For large stage handoffs, write context to files/artifacts, pass paths via reads, and prompt downstream agents to 'Read the file at <path>...' instead of injecting large previous text. For transcripts, prefer status/stages/stage to get sessionFile/transcriptPath, quote the exact path without rewriting separators (Windows backslashes are valid), then search it with rg/grep and read small ranges; transcript is path-only by default when sessionFile/transcriptPath exists, explicit tail/limit returns bounded previews, and missing transcript paths fall back to a small preview.",
+  "description": "Run named builtin, project, user, or package workflows, or direct one-off task/tasks/chain workflows; custom definitions may import reusable project/package workflows or builtin definitions from @bastani/workflows/builtin and nest them with ctx.workflow(...), including deeper composition within the configured maxDepth; when workflow execution fits but another shape would better achieve the task, author a custom TypeScript workflow({...}) inline with normal coding tools, reload it, and run it; discover with list/get/inputs, inspect status/stages/stage details, send prompt answers or steering, pause/resume/interrupt/kill runs, and reload workflow resources. For large stage handoffs, write context to files/artifacts, pass paths via reads, and prompt downstream agents to 'Read the file at <path>...' instead of injecting large previous text. For transcripts, prefer status/stages/stage to get sessionFile/transcriptPath, quote the exact path without rewriting separators (Windows backslashes are valid), then search it with rg/grep and read small ranges; transcript is path-only by default when sessionFile/transcriptPath exists, explicit tail/limit returns bounded previews, and missing transcript paths fall back to a small preview.",
   "parameters": {
     "workflow": "string (optional) — workflow ID or normalized name",
     "inputs": "object (optional) — key/value map of workflow inputs",


### PR DESCRIPTION
## Summary

Synchronize the workflows README JSON example with the canonical `WORKFLOW_TOOL_DESCRIPTION` so the README contract test passes on `main`.

## Changes

- Update the README workflow tool description to include reusable and nested workflow composition guidance.
- Point the synchronization comment at `packages/workflows/src/extension/workflow-prompts.ts`, where the canonical constant is defined.

## Validation

- `bun test test/integration/mock-extension-api-tool-registration.test.ts` — 30 passed
- `bun run test:integration` — 248 passed, 1 skipped
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run check:file-length` — passed
- Pre-commit and pre-push hooks, including unit tests — passed

## Notes

- This is a separate PR targeting `main` and does not modify, close, or merge prerelease PR #1752.
- No changelog entry is included because this only restores README/source synchronization and does not change package behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs the workflow tool documentation with the canonical prompt text. The main changes are:

- Updates the README JSON example for the `workflow` tool description.
- Adds guidance for reusable and nested workflow composition.
- Points the synchronization comment to `packages/workflows/src/extension/workflow-prompts.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to README text and matches the canonical `WORKFLOW_TOOL_DESCRIPTION` source.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The primary passing Bun test was executed and its results were saved in the official log, including the exact command, working directory, full Bun output, pass/fail counts, and exit code.
- An earlier shell-wrapper attempt ran the same Bun test but exited nonzero because /bin/sh does not support ${PIPESTATUS\[0\]}, as captured in the separate log.
- The corrected Bash wrapper run is identified as the authoritative proof validating the test outcome.

<a href="https://app.greptile.com/trex/runs/14134475/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/workflows/README.md | Updates the documented LLM-callable workflow tool description and sync comment to match the canonical `WORKFLOW_TOOL_DESCRIPTION` constant; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["docs(workflows): sync workflow tool desc..."](https://github.com/bastani-inc/atomic/commit/bca2fca02b7f6150f3e55d94c7b93fe715c17191) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43599575)</sub>

<!-- /greptile_comment -->