### PR TITLE
Release 0.9.6-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
 ### Changed
 
 - Restored workflow-first Atomic guidance for non-trivial work with verifiable objectives and synchronized help/docs around rich inline TypeScript workflow authoring, including dynamic branching, fan-out, verification, candidate-selection, human-gate, child-workflow, and bounded-loop patterns.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
 ### Changed
 
 - Restored fully tool-driven Intercom connections: parent and bridged child sessions no longer import or connect to the broker merely because a subagent starts. The runtime now connects only when the model or user invokes an Intercom tool, command, shortcut, or relay.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the MCP extension; no functional MCP changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the native transport package; no native transport changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
 ### Changed
 
 - Aligned model-facing subagent guidance with workflow-first routing: subagents remain focused specialists inside workflow stages or bounded direct delegation, rather than becoming an ad hoc implementation/review/retry pipeline for workflow-fit work.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.6-alpha.1 prerelease for the web-access extension; no functional web-access changes were made after 0.9.5.
+
 ## [0.9.5] - 2026-07-11
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.6-alpha.1] - 2026-07-12
+
 ### Changed
 
 - Restored workflow-first model routing for non-trivial, structured, and verifiable work while retaining the newer ability to author task-specific TypeScript workflows inline. Prompt guidance now explicitly combines the documented classify/branch, fan-out/synthesis, adversarial verification, generate/filter, tournament, and bounded loop patterns instead of forcing every workflow-fit task into an installed workflow, direct shape, or builtin.


### PR DESCRIPTION
## Summary

Prepare release notes for the `0.9.6-alpha.1` prerelease from `main`.

- **Release kind:** prerelease
- **Version:** `0.9.6-alpha.1`
- **Base branch:** `main`
- **Head branch:** `prerelease/0.9.6-alpha.1`
- **Head SHA:** `b576a0fcd5d8b21bea5fafcbccc80260bae23f14`

## Changes

- Update the `## [Unreleased]` sections in eight package changelogs with the cumulative prerelease notes.
- Keep every package version at the versionless `0.0.0` placeholder on `main`.
- Do not include a package version bump in this PR. The real `0.9.6-alpha.1` version will be materialized only on the throwaway off-main tag commit produced by `scripts/cut-release.ts` after release gates pass.

## Validation

Deterministic release preparation and local checks passed:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only 0701b008d95d1a5f91b249e6fdcefa62c77a5e85..HEAD
bun run lint
bun run check:file-length
bun run test:unit
```

The lint, file-length, and unit-test checks also passed in the pre-push hooks for:

```sh
git push -u origin prerelease/0.9.6-alpha.1
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.6-alpha.1` prerelease notes across package changelogs. The main changes are:

- Added `0.9.6-alpha.1` changelog sections for eight packages.
- Documented restored workflow-first guidance, compositional workflow authoring, and tool-driven Intercom behavior where relevant.
- Recorded synchronized prerelease notes for packages with no functional changes since `0.9.5`.
- Kept the release flow aligned with versionless `main` by avoiding package version bumps.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The PR only changes changelog markdown and does not update runtime code, package manifests, or lockfiles. No correctness or security issues were found in the changed files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex completed the requested contract validation verification and noted that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds the `0.9.6-alpha.1` prerelease section with cumulative Atomic CLI guidance, workflow, and Intercom release notes. |
| packages/cursor/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` prerelease note documenting no functional Cursor provider changes since `0.9.5`. |
| packages/intercom/CHANGELOG.md | Adds the `0.9.6-alpha.1` prerelease section for restored tool-driven Intercom connection behavior. |
| packages/mcp/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` prerelease note documenting no functional MCP changes since `0.9.5`. |
| packages/natives/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` prerelease note documenting no native transport changes since `0.9.5`. |
| packages/subagents/CHANGELOG.md | Adds the `0.9.6-alpha.1` prerelease section for workflow-first subagent guidance and model-driven Intercom coordination. |
| packages/web-access/CHANGELOG.md | Adds a synchronized `0.9.6-alpha.1` prerelease note documenting no functional web-access changes since `0.9.5`. |
| packages/workflows/CHANGELOG.md | Adds the `0.9.6-alpha.1` prerelease section for restored workflow-first routing, Ralph prompt behavior, and compositional workflow guidance. |

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.6-alpha.1"](https://github.com/bastani-inc/atomic/commit/b576a0fcd5d8b21bea5fafcbccc80260bae23f14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43601601)</sub>

<!-- /greptile_comment -->