### PR TITLE
Release 0.9.6

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Restored workflow-first Atomic guidance for non-trivial work with verifiable objectives and synchronized help/docs around rich inline TypeScript workflow authoring, including dynamic branching, fan-out, verification, candidate-selection, human-gate, child-workflow, and bounded-loop patterns.
+- Documented compositional workflow authoring in model prompts and onboarding/help surfaces, including importing bundled workflows from `@bastani/workflows/builtin`, nesting definitions with `ctx.workflow(...)`, and building deeper reusable workflow graphs within `maxDepth`.
+- Restored tool-driven bundled Intercom startup so foreground subagent launches and bridged child session startup no longer connect either session automatically; the model or user must invoke Intercom when coordination is needed.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Published the stable Atomic 0.9.6 release for the Cursor provider package; no functional Cursor provider changes were made after 0.9.5.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Restored fully tool-driven Intercom connections: parent and bridged child sessions no longer import or connect to the broker merely because a subagent starts. The runtime now connects only when the model or user invokes an Intercom tool, command, shortcut, or relay.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Published the stable Atomic 0.9.6 release for the MCP extension; no functional MCP changes were made after 0.9.5.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Published the stable Atomic 0.9.6 release for the native transport package; no native transport changes were made after 0.9.5.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Aligned model-facing subagent guidance with workflow-first routing: subagents remain focused specialists inside workflow stages or bounded direct delegation, rather than becoming an ad hoc implementation/review/retry pipeline for workflow-fit work.
+- Changed bundled Intercom coordination back to model-driven connection: launching foreground or background children no longer connects the parent or child session automatically; an Intercom tool or UI action must establish each session's broker connection.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Published the stable Atomic 0.9.6 release for the web-access extension; no functional web-access changes were made after 0.9.5.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-07-12
+
+### Changed
+
+- Restored workflow-first model routing for non-trivial, structured, and verifiable work while retaining the newer ability to author task-specific TypeScript workflows inline. Prompt guidance now explicitly combines the documented classify/branch, fan-out/synthesis, adversarial verification, generate/filter, tournament, and bounded loop patterns instead of forcing every workflow-fit task into an installed workflow, direct shape, or builtin.
+- Restored Ralph's builtin implementation-stage prompts to require subagent-led investigation, editing, and validation, reversing the selective direct-implementation wording introduced with intent-first routing.
+- Expanded model-facing workflow guidance to treat composition as a first-class design option: custom parents can import reusable project/package workflows or bundled builtin definitions, invoke them through `ctx.workflow(...)`, and nest further child workflows within `maxDepth` while preserving expanded graph visibility, HIL, durability, controls, and declared output contracts.
+
 ## [0.9.6-alpha.1] - 2026-07-12
 
 ### Changed


### PR DESCRIPTION
## Summary

Prepare the **release** of Atomic **0.9.6** by promoting the accumulated unreleased changelog entries into release notes.

## Changes

- Update the `## [Unreleased]` release notes across the coding-agent, cursor, intercom, MCP, natives, subagents, web-access, and workflows packages.
- Keep `main` versionless: package manifests remain at the `0.0.0` placeholder.
- Do not perform a version bump in this PR. Version `0.9.6` will be materialized only on the throwaway off-main tag commit created by `scripts/cut-release.ts`.

## Release Details

- Release kind: `release`
- Version/tag: `0.9.6` (no leading `v`)
- Base: `main`
- Head: `release/0.9.6`

## Validation

The deterministic release preparation checks passed, and the push hooks ran:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only f208d787787f57b73de3814f7c49962409d87d14..HEAD
bun run lint
bun run check:file-length
bun run test:unit
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the Atomic 0.9.6 release notes across the package changelogs. The main changes are:

- Adds stable `0.9.6` sections for the coding-agent, workflows, intercom, and subagents packages.
- Adds stable `0.9.6` publication notes for cursor, MCP, natives, and web-access.
- Keeps the release flow documentation-only with no package manifest version bump on `main`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are limited to changelog release-note additions and do not modify executable code or package manifests.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The current HEAD was captured as ac2f7cb2b7fdc178b9197155415c96c67beb372e.
- A diff-name proof shows changes are limited to the changelog files in the listed packages.
- Git status --short reported pre-existing deleted files and an untracked tool/artifact directory, documenting the surrounding repository state.
- The main release changelog validation log and the supporting helper script were identified as core artifacts of the validation workflow.

<a href="https://app.greptile.com/trex/runs/14136551/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Promotes the 0.9.6-alpha.1 coding-agent release notes into a stable 0.9.6 section while leaving Unreleased empty. |
| packages/cursor/CHANGELOG.md | Adds the stable 0.9.6 Cursor package release note with no functional changes after 0.9.5. |
| packages/intercom/CHANGELOG.md | Adds the stable 0.9.6 Intercom release note describing the restored tool-driven connection behavior. |
| packages/mcp/CHANGELOG.md | Adds the stable 0.9.6 MCP release note with no functional changes after 0.9.5. |
| packages/natives/CHANGELOG.md | Adds the stable 0.9.6 native transport release note with no functional changes after 0.9.5. |
| packages/subagents/CHANGELOG.md | Adds the stable 0.9.6 subagents release notes for workflow-first guidance and model-driven Intercom connection behavior. |
| packages/web-access/CHANGELOG.md | Adds the stable 0.9.6 web-access release note with no functional changes after 0.9.5. |
| packages/workflows/CHANGELOG.md | Promotes the 0.9.6 workflow guidance release notes into a stable 0.9.6 section. |

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.6"](https://github.com/bastani-inc/atomic/commit/ac2f7cb2b7fdc178b9197155415c96c67beb372e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43606385)</sub>

<!-- /greptile_comment -->