### PR TITLE
fix: disable terminal autowrap while graph overlay is visible on Windows

### DIFF
--- a/packages/workflows/src/tui/overlay-adapter.ts
+++ b/packages/workflows/src/tui/overlay-adapter.ts
@@ -103,12 +103,25 @@ const FULLSCREEN_OVERLAY_OPTIONS: PiOverlayOptions = {
 
 const MOUSE_SCROLL_TRACKING_ON = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
 const MOUSE_SCROLL_TRACKING_OFF = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+const TERMINAL_AUTOWRAP_ON = "\x1b[?7h";
+const TERMINAL_AUTOWRAP_OFF = "\x1b[?7l";
 const MAIN_CHAT_INPUT_STATUS_KEY = `${WORKFLOW_STATUS_KEY}:main-chat-input`;
 const MAIN_CHAT_INPUT_STATUS = "Main chat needs input — exit graph to answer.";
 
-function setMouseScrollTracking(enabled: boolean): void {
-  if (!process.stdout.isTTY) return;
-  process.stdout.write(enabled ? MOUSE_SCROLL_TRACKING_ON : MOUSE_SCROLL_TRACKING_OFF);
+export interface OverlayTerminalOutput {
+  platform: NodeJS.Platform;
+  isTTY: boolean | undefined;
+  write(data: string): void;
+}
+
+function setMouseScrollTracking(enabled: boolean, output: OverlayTerminalOutput): void {
+  if (!output.isTTY) return;
+  output.write(enabled ? MOUSE_SCROLL_TRACKING_ON : MOUSE_SCROLL_TRACKING_OFF);
+}
+
+function setTerminalAutowrap(enabled: boolean, output: OverlayTerminalOutput): void {
+  if (output.platform !== "win32" || !output.isTTY) return;
+  output.write(enabled ? TERMINAL_AUTOWRAP_ON : TERMINAL_AUTOWRAP_OFF);
 }
 
 export interface BuildGraphOverlayAdapterOpts {
@@ -126,6 +139,8 @@ export interface BuildGraphOverlayAdapterOpts {
   onQuitRun?: (runId: string) => void;
   /** Optional clock injection for deterministic attach-pane transition tests. */
   now?: () => number;
+  /** Terminal output seam used to test raw overlay control sequences. */
+  terminalOutput?: OverlayTerminalOutput;
 }
 
 export function buildGraphOverlayAdapter(
@@ -135,6 +150,16 @@ export function buildGraphOverlayAdapter(
 ): GraphOverlayPort {
   const registry = buildOpts.stageControlRegistry ?? defaultStageControlRegistry;
   const stageUiBroker = buildOpts.stageUiBroker;
+  const terminalOutput = buildOpts.terminalOutput ?? {
+    platform: process.platform,
+    isTTY: process.stdout.isTTY,
+    write: (data: string): void => {
+      process.stdout.write(data);
+    },
+  };
+  const updateMouseScrollTracking = (enabled: boolean): void => {
+    setMouseScrollTracking(enabled, terminalOutput);
+  };
   const quitRun = buildOpts.onQuitRun ?? ((id: string): void => {
     defaultQuitRun(id, { store, stageControlRegistry: registry });
   });
@@ -149,6 +174,13 @@ export function buildGraphOverlayAdapter(
   let observedUi: OverlayUISurface | undefined;
   let unsubscribeHostCustomUi: (() => void) | null = null;
   let hostInlineCustomUiActive = false;
+  let overlayVisible = false;
+
+  function updateTerminalAutowrap(visible: boolean): void {
+    if (overlayVisible === visible) return;
+    overlayVisible = visible;
+    setTerminalAutowrap(!visible, terminalOutput);
+  }
 
   function readHostCustomUiActive(ui: OverlayUISurface | undefined = observedUi): boolean {
     const state = ui?.getHostCustomUiState?.();
@@ -188,8 +220,9 @@ export function buildGraphOverlayAdapter(
   }
 
   function close(): void {
-    setMouseScrollTracking(false);
+    updateMouseScrollTracking(false);
     currentHandle?.hide();
+    updateTerminalAutowrap(false);
     finishMounted?.();
     observedUi?.setStatus?.(WORKFLOW_STATUS_KEY, undefined);
     observedUi?.setStatus?.(MAIN_CHAT_INPUT_STATUS_KEY, undefined);
@@ -218,11 +251,12 @@ export function buildGraphOverlayAdapter(
    * running and can be re-attached.
    */
   function hideMounted(): void {
-    setMouseScrollTracking(false);
+    updateMouseScrollTracking(false);
     observedUi?.setStatus?.(MAIN_CHAT_INPUT_STATUS_KEY, undefined);
     if (currentHandle) {
       currentView?.setVisible(false);
       currentHandle.setHidden(true);
+      updateTerminalAutowrap(false);
       currentHandle.unfocus();
       return;
     }
@@ -230,6 +264,7 @@ export function buildGraphOverlayAdapter(
       finishMounted();
       return;
     }
+    updateTerminalAutowrap(false);
   }
 
   function refocusVisibleOverlayForAwaitingInput(snapshot: StoreSnapshot): void {
@@ -258,7 +293,8 @@ export function buildGraphOverlayAdapter(
       },
       invalidate: () => tui.requestRender?.(),
       dispose: () => {
-        setMouseScrollTracking(false);
+        updateTerminalAutowrap(false);
+        updateMouseScrollTracking(false);
         unsubscribe();
         view.dispose();
       },
@@ -277,14 +313,16 @@ export function buildGraphOverlayAdapter(
     if (mounted && currentHandle?.isHidden()) {
       currentView?.retarget(runId, stageId);
       currentView?.setVisible(true);
-      setMouseScrollTracking(currentView?.wantsMouseScrollTracking() ?? true);
+      updateTerminalAutowrap(true);
+      updateMouseScrollTracking(currentView?.wantsMouseScrollTracking() ?? true);
       currentHandle.setHidden(false);
       currentHandle.focus();
       return;
     }
     if (mounted) {
       currentView?.retarget(runId, stageId);
-      setMouseScrollTracking(currentView?.wantsMouseScrollTracking() ?? true);
+      updateTerminalAutowrap(true);
+      updateMouseScrollTracking(currentView?.wantsMouseScrollTracking() ?? true);
       // Restore keyboard focus to the visible overlay after retargeting.
       // pi-tui dispatches key events only to the focused component, so a
       // mounted-but-visible overlay that is retargeted (e.g. to a stage-scoped
@@ -309,7 +347,7 @@ export function buildGraphOverlayAdapter(
       const finish = (): void => {
         if (settled) return;
         settled = true;
-        setMouseScrollTracking(false);
+        updateMouseScrollTracking(false);
         observedUi?.setStatus?.(WORKFLOW_STATUS_KEY, undefined);
         observedUi?.setStatus?.(MAIN_CHAT_INPUT_STATUS_KEY, undefined);
         currentView?.dispose();
@@ -318,7 +356,11 @@ export function buildGraphOverlayAdapter(
         finishMounted = null;
         mounted = false;
         clearHostCustomUiObservation();
-        done(undefined);
+        try {
+          done(undefined);
+        } finally {
+          updateTerminalAutowrap(false);
+        }
       };
       const view = new WorkflowAttachPane({
         store,
@@ -369,7 +411,7 @@ export function buildGraphOverlayAdapter(
           if (currentHandle?.isFocused() === true) return;
           currentHandle?.focus();
         },
-        setMouseScrollTracking,
+        setMouseScrollTracking: updateMouseScrollTracking,
         now: buildOpts.now,
       } as ConstructorParameters<typeof WorkflowAttachPane>[0] & {
         piTui?: PiCustomOverlayFactoryTui;
@@ -379,7 +421,8 @@ export function buildGraphOverlayAdapter(
       currentView = view;
       finishMounted = finish;
       mounted = true;
-      setMouseScrollTracking(view.wantsMouseScrollTracking());
+      updateTerminalAutowrap(true);
+      updateMouseScrollTracking(view.wantsMouseScrollTracking());
       updateMainChatInputHint(readHostCustomUiActive(ui));
       return makeComponent(view, tui);
     };
@@ -403,11 +446,13 @@ export function buildGraphOverlayAdapter(
     if (mounted && currentHandle) {
       const nowHidden = !currentHandle.isHidden();
       currentView?.setVisible(!nowHidden);
-      setMouseScrollTracking(
+      if (!nowHidden) updateTerminalAutowrap(true);
+      updateMouseScrollTracking(
         nowHidden ? false : currentView?.wantsMouseScrollTracking() ?? true,
       );
       currentHandle.setHidden(nowHidden);
-      if (!nowHidden) currentHandle.focus();
+      if (nowHidden) updateTerminalAutowrap(false);
+      else currentHandle.focus();
       return;
     }
     if (mounted) {

--- a/test/unit/overlay-adapter-autowrap.test.ts
+++ b/test/unit/overlay-adapter-autowrap.test.ts
@@ -1,0 +1,190 @@
+import { describe, mock, test } from "bun:test";
+import assert from "node:assert/strict";
+import { createStore } from "../../packages/workflows/src/shared/store.js";
+import type {
+  GraphOverlayPort,
+  OverlayPiSurface,
+} from "../../packages/workflows/src/tui/overlay-adapter.js";
+import type {
+  PiCustomOverlayFactoryTui,
+  PiOverlayHandle,
+} from "../../packages/workflows/src/extension/wiring.js";
+
+class TestComponent {
+  constructor(..._args: never[]) {}
+}
+
+mock.module("@earendil-works/pi-tui", () => ({
+  Box: TestComponent,
+  Editor: TestComponent,
+  SelectList: TestComponent,
+  Text: TestComponent,
+  Key: {
+    backspace: "\x7f",
+    down: "\x1b[B",
+    enter: "\r",
+    escape: "\x1b",
+    left: "\x1b[D",
+    right: "\x1b[C",
+    up: "\x1b[A",
+    ctrl: (key: string) => key,
+  },
+  decodeKittyPrintable: () => undefined,
+  matchesKey: (data: string, key: string) => data === key,
+  truncateToWidth: (text: string, width: number) => text.slice(0, width),
+  visibleWidth: (text: string) => text.length,
+  wrapTextWithAnsi: (text: string) => [text],
+}));
+
+mock.module("@bastani/atomic", () => ({
+  ChatSessionHost: TestComponent,
+  keyHint: (key: string) => key,
+  keyText: (key: string) => key,
+  rawKeyHint: (key: string) => key,
+}));
+
+const { buildGraphOverlayAdapter } = await import(
+  "../../packages/workflows/src/tui/overlay-adapter.js"
+);
+
+const MOUSE_SCROLL_TRACKING_ON = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+const MOUSE_SCROLL_TRACKING_OFF = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+const TERMINAL_AUTOWRAP_ON = "\x1b[?7h";
+const TERMINAL_AUTOWRAP_OFF = "\x1b[?7l";
+
+interface AdapterHarness {
+  adapter: GraphOverlayPort;
+  writes: string[];
+}
+
+function buildHarness(
+  platform: NodeJS.Platform = "win32",
+  isTTY = true,
+): AdapterHarness {
+  const writes: string[] = [];
+  let hidden = false;
+  let focused = true;
+  const handle: PiOverlayHandle = {
+    hide: () => {
+      hidden = true;
+    },
+    setHidden: (value) => {
+      hidden = value;
+    },
+    isHidden: () => hidden,
+    focus: () => {
+      focused = true;
+    },
+    unfocus: () => {
+      focused = false;
+    },
+    isFocused: () => focused,
+  };
+  const pi: OverlayPiSurface = {
+    ui: {
+      custom: (factory, options) => {
+        options.onHandle?.(handle);
+        const tui: PiCustomOverlayFactoryTui = {
+          requestRender: () => undefined,
+          terminal: { rows: 24, columns: 80 },
+        };
+        const component = factory(tui, {}, {}, () => undefined);
+        if (component instanceof Promise) {
+          throw new Error("overlay adapter factory should mount synchronously");
+        }
+        return undefined;
+      },
+    },
+  };
+  const adapter = buildGraphOverlayAdapter(pi, createStore(), {
+    terminalOutput: {
+      platform,
+      isTTY,
+      write: (data) => writes.push(data),
+    },
+  });
+  return { adapter, writes };
+}
+
+function autowrapWrites(writes: string[]): string[] {
+  return writes.filter(
+    (data) => data === TERMINAL_AUTOWRAP_ON || data === TERMINAL_AUTOWRAP_OFF,
+  );
+}
+
+describe("workflow overlay terminal autowrap", () => {
+  test("disables autowrap when opened on a Windows TTY", () => {
+    const { adapter, writes } = buildHarness();
+
+    adapter.open(null);
+
+    assert.deepEqual(autowrapWrites(writes), [TERMINAL_AUTOWRAP_OFF]);
+    assert.equal(writes.includes(MOUSE_SCROLL_TRACKING_ON), true);
+  });
+
+  test("restores autowrap once when hidden and does not duplicate on close", () => {
+    const { adapter, writes } = buildHarness();
+
+    adapter.open(null);
+    adapter.toggle(null);
+    adapter.close();
+    adapter.close();
+
+    assert.deepEqual(autowrapWrites(writes), [
+      TERMINAL_AUTOWRAP_OFF,
+      TERMINAL_AUTOWRAP_ON,
+    ]);
+  });
+
+  test("restores autowrap once when a visible overlay closes", () => {
+    const { adapter, writes } = buildHarness();
+
+    adapter.open(null);
+    adapter.close();
+    adapter.close();
+
+    assert.deepEqual(autowrapWrites(writes), [
+      TERMINAL_AUTOWRAP_OFF,
+      TERMINAL_AUTOWRAP_ON,
+    ]);
+  });
+
+  test("rapid visibility toggles leave autowrap matching the final state", () => {
+    const { adapter, writes } = buildHarness();
+
+    adapter.open(null);
+    adapter.toggle(null);
+    adapter.toggle(null);
+    adapter.toggle(null);
+
+    assert.deepEqual(autowrapWrites(writes), [
+      TERMINAL_AUTOWRAP_OFF,
+      TERMINAL_AUTOWRAP_ON,
+      TERMINAL_AUTOWRAP_OFF,
+      TERMINAL_AUTOWRAP_ON,
+    ]);
+  });
+
+  test("keeps the existing terminal byte stream on non-Windows platforms", () => {
+    const { adapter, writes } = buildHarness("darwin");
+
+    adapter.open(null);
+    adapter.toggle(null);
+
+    assert.deepEqual(writes, [
+      MOUSE_SCROLL_TRACKING_ON,
+      MOUSE_SCROLL_TRACKING_ON,
+      MOUSE_SCROLL_TRACKING_OFF,
+    ]);
+  });
+
+  test("writes no terminal controls when stdout is not a TTY", () => {
+    const { adapter, writes } = buildHarness("win32", false);
+
+    adapter.open(null);
+    adapter.toggle(null);
+    adapter.close();
+
+    assert.deepEqual(writes, []);
+  });
+});

--- a/test/unit/overlay-adapter-autowrap.test.ts
+++ b/test/unit/overlay-adapter-autowrap.test.ts
@@ -1,6 +1,7 @@
 import { describe, mock, test } from "bun:test";
 import assert from "node:assert/strict";
-import { createStore } from "../../packages/workflows/src/shared/store.js";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import type {
   GraphOverlayPort,
   OverlayPiSurface,
@@ -10,181 +11,202 @@ import type {
   PiOverlayHandle,
 } from "../../packages/workflows/src/extension/wiring.js";
 
-class TestComponent {
-  constructor(..._args: never[]) {}
-}
+const ISOLATED_PROCESS_ENV = "ATOMIC_OVERLAY_AUTOWRAP_ISOLATED";
 
-mock.module("@earendil-works/pi-tui", () => ({
-  Box: TestComponent,
-  Editor: TestComponent,
-  SelectList: TestComponent,
-  Text: TestComponent,
-  Key: {
-    backspace: "\x7f",
-    down: "\x1b[B",
-    enter: "\r",
-    escape: "\x1b",
-    left: "\x1b[D",
-    right: "\x1b[C",
-    up: "\x1b[A",
-    ctrl: (key: string) => key,
-  },
-  decodeKittyPrintable: () => undefined,
-  matchesKey: (data: string, key: string) => data === key,
-  truncateToWidth: (text: string, width: number) => text.slice(0, width),
-  visibleWidth: (text: string) => text.length,
-  wrapTextWithAnsi: (text: string) => [text],
-}));
+async function registerIsolatedTests(): Promise<void> {
+  class TestComponent {
+    constructor(..._args: never[]) {}
+  }
 
-mock.module("@bastani/atomic", () => ({
-  ChatSessionHost: TestComponent,
-  keyHint: (key: string) => key,
-  keyText: (key: string) => key,
-  rawKeyHint: (key: string) => key,
-}));
-
-const { buildGraphOverlayAdapter } = await import(
-  "../../packages/workflows/src/tui/overlay-adapter.js"
-);
-
-const MOUSE_SCROLL_TRACKING_ON = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
-const MOUSE_SCROLL_TRACKING_OFF = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
-const TERMINAL_AUTOWRAP_ON = "\x1b[?7h";
-const TERMINAL_AUTOWRAP_OFF = "\x1b[?7l";
-
-interface AdapterHarness {
-  adapter: GraphOverlayPort;
-  writes: string[];
-}
-
-function buildHarness(
-  platform: NodeJS.Platform = "win32",
-  isTTY = true,
-): AdapterHarness {
-  const writes: string[] = [];
-  let hidden = false;
-  let focused = true;
-  const handle: PiOverlayHandle = {
-    hide: () => {
-      hidden = true;
+  mock.module("@earendil-works/pi-tui", () => ({
+    Box: TestComponent,
+    Editor: TestComponent,
+    SelectList: TestComponent,
+    Text: TestComponent,
+    Key: {
+      backspace: "\x7f",
+      down: "\x1b[B",
+      enter: "\r",
+      escape: "\x1b",
+      left: "\x1b[D",
+      right: "\x1b[C",
+      up: "\x1b[A",
+      ctrl: (key: string) => key,
     },
-    setHidden: (value) => {
-      hidden = value;
-    },
-    isHidden: () => hidden,
-    focus: () => {
-      focused = true;
-    },
-    unfocus: () => {
-      focused = false;
-    },
-    isFocused: () => focused,
-  };
-  const pi: OverlayPiSurface = {
-    ui: {
-      custom: (factory, options) => {
-        options.onHandle?.(handle);
-        const tui: PiCustomOverlayFactoryTui = {
-          requestRender: () => undefined,
-          terminal: { rows: 24, columns: 80 },
-        };
-        const component = factory(tui, {}, {}, () => undefined);
-        if (component instanceof Promise) {
-          throw new Error("overlay adapter factory should mount synchronously");
-        }
-        return undefined;
+    decodeKittyPrintable: () => undefined,
+    matchesKey: (data: string, key: string) => data === key,
+    truncateToWidth: (text: string, width: number) => text.slice(0, width),
+    visibleWidth: (text: string) => text.length,
+    wrapTextWithAnsi: (text: string) => [text],
+  }));
+
+  mock.module("@bastani/atomic", () => ({
+    ChatSessionHost: TestComponent,
+    keyHint: (key: string) => key,
+    keyText: (key: string) => key,
+    rawKeyHint: (key: string) => key,
+  }));
+
+  const [{ buildGraphOverlayAdapter }, { createStore }] = await Promise.all([
+    import("../../packages/workflows/src/tui/overlay-adapter.js"),
+    import("../../packages/workflows/src/shared/store.js"),
+  ]);
+
+  const MOUSE_SCROLL_TRACKING_ON = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+  const MOUSE_SCROLL_TRACKING_OFF = "\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+  const TERMINAL_AUTOWRAP_ON = "\x1b[?7h";
+  const TERMINAL_AUTOWRAP_OFF = "\x1b[?7l";
+
+  interface AdapterHarness {
+    adapter: GraphOverlayPort;
+    writes: string[];
+  }
+
+  function buildHarness(
+    platform: NodeJS.Platform = "win32",
+    isTTY = true,
+  ): AdapterHarness {
+    const writes: string[] = [];
+    let hidden = false;
+    let focused = true;
+    const handle: PiOverlayHandle = {
+      hide: () => {
+        hidden = true;
       },
-    },
-  };
-  const adapter = buildGraphOverlayAdapter(pi, createStore(), {
-    terminalOutput: {
-      platform,
-      isTTY,
-      write: (data) => writes.push(data),
-    },
+      setHidden: (value) => {
+        hidden = value;
+      },
+      isHidden: () => hidden,
+      focus: () => {
+        focused = true;
+      },
+      unfocus: () => {
+        focused = false;
+      },
+      isFocused: () => focused,
+    };
+    const pi: OverlayPiSurface = {
+      ui: {
+        custom: (factory, options) => {
+          options.onHandle?.(handle);
+          const tui: PiCustomOverlayFactoryTui = {
+            requestRender: () => undefined,
+            terminal: { rows: 24, columns: 80 },
+          };
+          const component = factory(tui, {}, {}, () => undefined);
+          if (component instanceof Promise) {
+            throw new Error("overlay adapter factory should mount synchronously");
+          }
+          return undefined;
+        },
+      },
+    };
+    const adapter = buildGraphOverlayAdapter(pi, createStore(), {
+      terminalOutput: {
+        platform,
+        isTTY,
+        write: (data) => writes.push(data),
+      },
+    });
+    return { adapter, writes };
+  }
+
+  function autowrapWrites(writes: string[]): string[] {
+    return writes.filter(
+      (data) => data === TERMINAL_AUTOWRAP_ON || data === TERMINAL_AUTOWRAP_OFF,
+    );
+  }
+
+  describe("workflow overlay terminal autowrap", () => {
+    test("disables autowrap when opened on a Windows TTY", () => {
+      const { adapter, writes } = buildHarness();
+
+      adapter.open(null);
+
+      assert.deepEqual(autowrapWrites(writes), [TERMINAL_AUTOWRAP_OFF]);
+      assert.equal(writes.includes(MOUSE_SCROLL_TRACKING_ON), true);
+    });
+
+    test("restores autowrap once when hidden and does not duplicate on close", () => {
+      const { adapter, writes } = buildHarness();
+
+      adapter.open(null);
+      adapter.toggle(null);
+      adapter.close();
+      adapter.close();
+
+      assert.deepEqual(autowrapWrites(writes), [
+        TERMINAL_AUTOWRAP_OFF,
+        TERMINAL_AUTOWRAP_ON,
+      ]);
+    });
+
+    test("restores autowrap once when a visible overlay closes", () => {
+      const { adapter, writes } = buildHarness();
+
+      adapter.open(null);
+      adapter.close();
+      adapter.close();
+
+      assert.deepEqual(autowrapWrites(writes), [
+        TERMINAL_AUTOWRAP_OFF,
+        TERMINAL_AUTOWRAP_ON,
+      ]);
+    });
+
+    test("rapid visibility toggles leave autowrap matching the final state", () => {
+      const { adapter, writes } = buildHarness();
+
+      adapter.open(null);
+      adapter.toggle(null);
+      adapter.toggle(null);
+      adapter.toggle(null);
+
+      assert.deepEqual(autowrapWrites(writes), [
+        TERMINAL_AUTOWRAP_OFF,
+        TERMINAL_AUTOWRAP_ON,
+        TERMINAL_AUTOWRAP_OFF,
+        TERMINAL_AUTOWRAP_ON,
+      ]);
+    });
+
+    test("keeps the existing terminal byte stream on non-Windows platforms", () => {
+      const { adapter, writes } = buildHarness("darwin");
+
+      adapter.open(null);
+      adapter.toggle(null);
+
+      assert.deepEqual(writes, [
+        MOUSE_SCROLL_TRACKING_ON,
+        MOUSE_SCROLL_TRACKING_ON,
+        MOUSE_SCROLL_TRACKING_OFF,
+      ]);
+    });
+
+    test("writes no terminal controls when stdout is not a TTY", () => {
+      const { adapter, writes } = buildHarness("win32", false);
+
+      adapter.open(null);
+      adapter.toggle(null);
+      adapter.close();
+
+      assert.deepEqual(writes, []);
+    });
   });
-  return { adapter, writes };
 }
 
-function autowrapWrites(writes: string[]): string[] {
-  return writes.filter(
-    (data) => data === TERMINAL_AUTOWRAP_ON || data === TERMINAL_AUTOWRAP_OFF,
-  );
+if (process.env[ISOLATED_PROCESS_ENV] === "1") {
+  await registerIsolatedTests();
+} else {
+  test("runs terminal autowrap checks without leaking module mocks", () => {
+    const testPath = fileURLToPath(import.meta.url);
+    const result = spawnSync(process.execPath, ["test", testPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, [ISOLATED_PROCESS_ENV]: "1" },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  });
 }
-
-describe("workflow overlay terminal autowrap", () => {
-  test("disables autowrap when opened on a Windows TTY", () => {
-    const { adapter, writes } = buildHarness();
-
-    adapter.open(null);
-
-    assert.deepEqual(autowrapWrites(writes), [TERMINAL_AUTOWRAP_OFF]);
-    assert.equal(writes.includes(MOUSE_SCROLL_TRACKING_ON), true);
-  });
-
-  test("restores autowrap once when hidden and does not duplicate on close", () => {
-    const { adapter, writes } = buildHarness();
-
-    adapter.open(null);
-    adapter.toggle(null);
-    adapter.close();
-    adapter.close();
-
-    assert.deepEqual(autowrapWrites(writes), [
-      TERMINAL_AUTOWRAP_OFF,
-      TERMINAL_AUTOWRAP_ON,
-    ]);
-  });
-
-  test("restores autowrap once when a visible overlay closes", () => {
-    const { adapter, writes } = buildHarness();
-
-    adapter.open(null);
-    adapter.close();
-    adapter.close();
-
-    assert.deepEqual(autowrapWrites(writes), [
-      TERMINAL_AUTOWRAP_OFF,
-      TERMINAL_AUTOWRAP_ON,
-    ]);
-  });
-
-  test("rapid visibility toggles leave autowrap matching the final state", () => {
-    const { adapter, writes } = buildHarness();
-
-    adapter.open(null);
-    adapter.toggle(null);
-    adapter.toggle(null);
-    adapter.toggle(null);
-
-    assert.deepEqual(autowrapWrites(writes), [
-      TERMINAL_AUTOWRAP_OFF,
-      TERMINAL_AUTOWRAP_ON,
-      TERMINAL_AUTOWRAP_OFF,
-      TERMINAL_AUTOWRAP_ON,
-    ]);
-  });
-
-  test("keeps the existing terminal byte stream on non-Windows platforms", () => {
-    const { adapter, writes } = buildHarness("darwin");
-
-    adapter.open(null);
-    adapter.toggle(null);
-
-    assert.deepEqual(writes, [
-      MOUSE_SCROLL_TRACKING_ON,
-      MOUSE_SCROLL_TRACKING_ON,
-      MOUSE_SCROLL_TRACKING_OFF,
-    ]);
-  });
-
-  test("writes no terminal controls when stdout is not a TTY", () => {
-    const { adapter, writes } = buildHarness("win32", false);
-
-    adapter.open(null);
-    adapter.toggle(null);
-    adapter.close();
-
-    assert.deepEqual(writes, []);
-  });
-});


### PR DESCRIPTION
## Summary

The workflow graph overlay no longer leaves garbled, auto-wrapped chat text behind on Windows terminals. The overlay adapter now disables terminal autowrap (`ESC[?7l`) whenever the graph overlay becomes visible and restores it (`ESC[?7h`) when the overlay is hidden or closed, using the exact same show/hide/close call sites that already toggle mouse-scroll tracking in `packages/workflows/src/tui/overlay-adapter.ts`. The toggle is gated to `process.platform === "win32"` so macOS and Linux byte streams are unchanged; if you would rather make it unconditional (matching the pi-tui `Terminal.start()/stop()` suggestion from the issue thread), the gate is a one-line change and I'm happy to drop it.

## Why this matters

The reporter in #1663 saw main-chat lines re-wrap and interleave with overlay rows on Windows because conhost/Windows Terminal auto-wraps the overlay's absolute-positioned writes at the right edge, while the overlay renderer assumes clipping. The preferred fix named in the thread lives at the pi-tui layer, but that code is in the external `@earendil-works/pi-tui` dependency and can't be patched from this repository — the overlay boundary here is the same seam and already owns raw control-sequence writes (mouse tracking), so autowrap belongs beside it.

## Testing

The write sink and platform are injectable via a small `OverlayTerminalOutput` seam (mirroring how the existing mouse-tracking sequences are tested), and `test/unit/overlay-adapter-autowrap.test.ts` covers: autowrap disabled on overlay show, restored on hide and on close, no writes on non-Windows platforms, and no writes when stdout is not a TTY. `bun test test/unit/overlay-adapter-autowrap.test.ts`: 6 pass, 0 fail.

Closes #1663

AI was used for assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the workflow graph overlay terminal handling on Windows. The main changes are:

- Disables terminal autowrap while the graph overlay is visible on Windows TTYs.
- Restores terminal autowrap when the overlay is hidden, closed, or disposed.
- Adds an injectable terminal output seam for testing raw control sequences.
- Adds Bun unit tests for Windows, non-Windows, visibility toggles, and non-TTY output.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, Windows-gated, TTY-gated, and covered by focused tests for the affected state transitions.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The requested narrow unit test was executed and completed with exit code 0, with the full run details captured in the test log.
- The optional workflows typecheck was run and completed with exit code 0, as recorded in the typecheck log.
- A notes file was generated to summarize the PR test plan bullets and environment caveats, as shown by the notes command log.

<a href="https://app.greptile.com/trex/runs/14179859/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/workflows/src/tui/overlay-adapter.ts | Adds an injectable terminal-output seam and Windows-only autowrap toggling around overlay show, hide, close, and dispose paths. |
| test/unit/overlay-adapter-autowrap.test.ts | Adds isolated Bun coverage for autowrap control sequences, platform gating, and non-TTY behavior. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Adapter as GraphOverlayAdapter
participant Overlay as Pi Overlay Handle/View
participant Terminal as Terminal Output

User->>Adapter: open(runId)
Adapter->>Terminal: ESC[?7l (Windows TTY only)
Adapter->>Terminal: enable mouse tracking
Adapter->>Overlay: mount/show + focus

User->>Adapter: toggle()/hideMounted()
Adapter->>Terminal: disable mouse tracking
Adapter->>Overlay: setHidden(true) / hide
Adapter->>Terminal: ESC[?7h (Windows TTY only)

User->>Adapter: toggle()/open again
Adapter->>Terminal: ESC[?7l (Windows TTY only)
Adapter->>Terminal: enable mouse tracking if needed
Adapter->>Overlay: setHidden(false) + focus

User->>Adapter: close()/dispose
Adapter->>Terminal: disable mouse tracking
Adapter->>Overlay: dispose
Adapter->>Terminal: ESC[?7h (Windows TTY only)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Adapter as GraphOverlayAdapter
participant Overlay as Pi Overlay Handle/View
participant Terminal as Terminal Output

User->>Adapter: open(runId)
Adapter->>Terminal: ESC[?7l (Windows TTY only)
Adapter->>Terminal: enable mouse tracking
Adapter->>Overlay: mount/show + focus

User->>Adapter: toggle()/hideMounted()
Adapter->>Terminal: disable mouse tracking
Adapter->>Overlay: setHidden(true) / hide
Adapter->>Terminal: ESC[?7h (Windows TTY only)

User->>Adapter: toggle()/open again
Adapter->>Terminal: ESC[?7l (Windows TTY only)
Adapter->>Terminal: enable mouse tracking if needed
Adapter->>Overlay: setHidden(false) + focus

User->>Adapter: close()/dispose
Adapter->>Terminal: disable mouse tracking
Adapter->>Overlay: dispose
Adapter->>Terminal: ESC[?7h (Windows TTY only)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test: isolate overlay-adapter autowrap m..."](https://github.com/bastani-inc/atomic/commit/e50c79e1db055fcdc3878d245932fd3f0c6147c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43625665)</sub>

<!-- /greptile_comment -->