### PR TITLE
Release 0.9.7-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
 ### Added
 
 - Added a shared convergence contract to the bundled `goal` and `ralph` workflows: implementation starts from an observable acceptance/contract matrix derived from the literal objective/acceptance criteria (with explicit state/transition/invariant modeling for stateful work), reviewers independently derive adversarial checks from the literal contract before relying on worker receipts or worker-authored tests, reproduced findings require durable regression evidence before they count as resolved, and each review round persists a deduplicated cross-reviewer `consolidated_findings` batch that the next worker turn repairs together instead of one finding per turn. Literal-contract scope controls are preserved throughout, so nothing beyond the user's requirements is forced.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.7-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.6.
+
 ## [0.9.6] - 2026-07-12
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
 ### Fixed
 
 - Made blocking reply waits race-safe under concurrent tool calls. Waiter admission is now an atomic synchronous check-and-reserve shared by `intercom` `ask` and `contact_supervisor`: when several blocking requests race (parallel tool calls in one turn, same-tool or cross-tool), exactly one wins the reservation and every other call returns a normal structured "Already waiting for a reply" tool error. Previously the loser received an already-rejected promise that could sit unhandled while the winner's question was still being sent, crashing the whole agent process with an unhandled `Error: Already waiting for a reply` rejection.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.7-alpha.1 prerelease for the MCP extension; no functional MCP changes were made after 0.9.6.
+
 ## [0.9.6] - 2026-07-12
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.7-alpha.1 prerelease for the native transport package; no native transport changes were made after 0.9.6.
+
 ## [0.9.6] - 2026-07-12
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
 ### Fixed
 
 - Fixed subagent model fallback to classify provider usage-limit exhaustion (for example `Codex error: The usage limit has been reached`, plus `usage_limit`/`usage_limit_reached`/`usage_limit_exceeded`/`insufficient_quota` codes) as a retryable quota/rate-limit failure, so configured `fallbackModels` advance to the next candidate provider/model instead of failing the run. The message matcher tolerates the same space/underscore/hyphen/joined separators as the code path, so provider errors that flatten the token into free text (for example `usage_limit_reached` or `usage-limit`) also advance the chain. Nested cause/diagnostic and session-shaped errors classify the same way, while cancellations, safety refusals, task/tool failures, and unrelated errors remain non-retryable; the shared conformance corpus keeps this rule in lockstep with the workflows classifier.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.7-alpha.1 prerelease for the web-access extension; no functional web-access changes were made after 0.9.6.
+
 ## [0.9.6] - 2026-07-12
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.7-alpha.1] - 2026-07-12
+
 ### Added
 
 - Added a shared convergence contract for the builtin `goal` and `ralph` workflows (`builtin/shared-prompts.ts` + deterministic gates in `builtin/review-convergence.ts`): workers/orchestrators must derive an observable acceptance/contract matrix from the literal objective/acceptance criteria before implementing (one row per clause mapped to the concrete check that proves it) and must model states, transitions, and invariants explicitly for stateful work; reviewers must independently derive adversarial checks (boundary/edge/negative and state/transition/invariant probes) from the literal contract before relying on the worker receipt, implementation notes, or worker-authored tests; reproduced findings require durable regression evidence (a persisted test or exact re-runnable check) before they count as resolved; and the evidence-closure policy is stated to both roles so approval semantics are visible in-prompt. All contracts inherit the literal-contract scope controls, so no behavior beyond the objective/acceptance criteria is required.


### PR DESCRIPTION
## Summary

Prepare the **prerelease** release notes for version **0.9.7-alpha.1** from source commit `864c8f9122d5c5722fb2c324efd2374418bed190`.

## Changes

- Add `0.9.7-alpha.1` release notes under the existing `## [Unreleased]` sections for the coding-agent, cursor, intercom, MCP, natives, subagents, web-access, and workflows packages.
- Keep all previously released changelog sections unchanged.
- Keep `main` versionless: this PR contains no package-version bump, and all package manifests remain at the `0.0.0` placeholder.
- Defer real-version materialization to the throwaway off-main tag commit produced by `scripts/cut-release.ts` after this release-notes PR is merged.

## Release

- **Kind:** Prerelease
- **Version:** `0.9.7-alpha.1`
- **Base:** `main`
- **Head:** `prerelease/0.9.7-alpha.1`
- **Head SHA:** `6b0e69abf34eeb26095907dc3eb8f86897963359`

## Validation

Deterministic release preparation and local checks passed. Commands run include:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only 864c8f9122d5c5722fb2c324efd2374418bed190..HEAD
git push -u origin prerelease/0.9.7-alpha.1
gh auth status
gh repo view --json nameWithOwner,url,defaultBranchRef
```

The push hooks also passed:

```sh
bun run lint
bun run check:file-length
bun run test:unit
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.7-alpha.1` prerelease changelog notes. The main changes are:

- Adds new prerelease sections across eight package changelogs.
- Documents functional release notes for coding-agent, workflows, intercom, and subagents.
- Marks cursor, MCP, natives, and web-access as synchronized prerelease entries with no functional changes.
- Keeps `main` versionless with no package manifest changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge as a changelog-only prerelease notes update.

Changes are limited to new changelog sections and preserve the versionless `main` release flow. No package manifests or runtime code were changed. No issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the git identity and file-diff snapshot for changelog release 01, confirming HEAD is 6b0e69abf34eeb26095907dc3eb8f86897963359 and that the diff base..HEAD lists exactly the eight expected changelog files.
- Validated the changelog structure and manifests for release 02, with the validation harness exiting 0 and verifying the eight changelogs include 0.9.7-alpha.1 insertion while manifest versions stay at 0.0.0.
- Documented why the targeted-filelength check for release 03 could not proceed, showing an Unknown argument error and explaining the built-in narrow check cannot be applied to specific files.
- Validated the fallback Markdown line-count check for release 04, which exited 0 and reported per-file counts for the changed changelogs.

<a href="https://app.greptile.com/trex/runs/14164553/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds the 0.9.7-alpha.1 prerelease section with user-facing coding-agent notes for bundled workflow convergence, workflow docs, prompt guidance, evidence closure, and retryable usage-limit fallback. |
| packages/cursor/CHANGELOG.md | Adds a synchronized 0.9.7-alpha.1 prerelease note indicating no functional Cursor provider changes after 0.9.6. |
| packages/intercom/CHANGELOG.md | Adds the 0.9.7-alpha.1 prerelease section documenting concurrent blocking-reply race fixes and lazy runtime relay behavior fixes. |
| packages/mcp/CHANGELOG.md | Adds a synchronized 0.9.7-alpha.1 prerelease note indicating no functional MCP extension changes after 0.9.6. |
| packages/natives/CHANGELOG.md | Adds a synchronized 0.9.7-alpha.1 prerelease note indicating no functional native transport changes after 0.9.6. |
| packages/subagents/CHANGELOG.md | Adds the 0.9.7-alpha.1 prerelease section documenting retryable provider usage-limit fallback classification for subagents. |
| packages/web-access/CHANGELOG.md | Adds a synchronized 0.9.7-alpha.1 prerelease note indicating no functional web-access extension changes after 0.9.6. |
| packages/workflows/CHANGELOG.md | Adds the 0.9.7-alpha.1 prerelease section documenting Goal/Ralph convergence contracts, consolidated findings, reviewer defaults, evidence closure, prompt slimming, and related fixes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Main as versionless main
participant Changelogs as package CHANGELOG.md files
participant ReleaseScript as scripts/cut-release.ts
participant Tag as off-main release tag

Main->>Changelogs: Add 0.9.7-alpha.1 notes under Unreleased
Changelogs-->>Main: Keep manifests at 0.0.0
Main->>ReleaseScript: Merge release-notes PR
ReleaseScript->>Tag: Materialize real version on throwaway commit
Tag-->>Main: Publish/tag without advancing main
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Main as versionless main
participant Changelogs as package CHANGELOG.md files
participant ReleaseScript as scripts/cut-release.ts
participant Tag as off-main release tag

Main->>Changelogs: Add 0.9.7-alpha.1 notes under Unreleased
Changelogs-->>Main: Keep manifests at 0.0.0
Main->>ReleaseScript: Merge release-notes PR
ReleaseScript->>Tag: Materialize real version on throwaway commit
Tag-->>Main: Publish/tag without advancing main
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.7-alpha.1"](https://github.com/bastani-inc/atomic/commit/6b0e69abf34eeb26095907dc3eb8f86897963359) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43668761)</sub>

<!-- /greptile_comment -->