### PR TITLE
ci: add Windows publish runner fallback

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,14 @@ on:
                 description: "Tag to publish (e.g., 0.8.0 or 0.8.0-alpha.1)"
                 required: true
                 type: string
+            windows_runner:
+                description: "Windows smoke runner (use github-hosted only if Blacksmith is blocked)"
+                required: true
+                default: blacksmith
+                type: choice
+                options:
+                    - blacksmith
+                    - github-hosted
 
 permissions:
     contents: write
@@ -108,10 +116,10 @@ jobs:
 
     windows-binary-smoke:
         name: Smoke test Windows binary
-        runs-on: blacksmith-4vcpu-windows-2025
+        runs-on: ${{ inputs.windows_runner == 'github-hosted' && 'windows-2025' || 'blacksmith-4vcpu-windows-2025' }}
 
         steps:
-            - uses: useblacksmith/checkout@v1
+            - uses: actions/checkout@v7.0.0
               with:
                   ref: ${{ github.event.inputs.tag || github.ref_name }}
                   persist-credentials: false

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -116,8 +116,10 @@ Steps:
 
 The publish pipeline (`publish.yml`) runs when:
 
-- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`)
-- `workflow_dispatch` is run with an explicit tag input such as `0.8.0`
+- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`); the Windows smoke job always uses the default Blacksmith runner
+- `workflow_dispatch` is run with an explicit `tag` input such as `0.8.0` and a `windows_runner` choice (`blacksmith` by default, or `github-hosted` for the capacity fallback)
+
+Both runner choices check out the exact `tag` input before building. The Windows job uses `actions/checkout`, which is supported on both providers; changing `windows_runner` does not change the release ref or any publish validation.
 
 ### Tag Naming
 
@@ -127,6 +129,22 @@ The publish pipeline (`publish.yml`) runs when:
 | `<major>.<minor>.<patch>-<prerelease>` (e.g. `0.8.0-alpha.1`) | `next`   | prerelease, not marked latest |
 
 `main` is **versionless**: every `packages/*/package.json` on `main` sits at the `0.0.0` placeholder. The real version exists only on the tagged, off-`main` `Release <version>` commit produced by `scripts/cut-release.ts`, where the tag matches `packages/coding-agent/package.json` exactly (no leading `v`) and all `packages/*` versions are stamped in sync. publish.yml checks out that tagged commit, so its `validate tag matches package.json` gate sees the real version, not the placeholder. The pipeline also refuses to publish the `0.0.0` placeholder if it is ever tagged directly.
+
+### Windows runner fallback
+
+Normal tag pushes require no runner input: `windows-binary-smoke` runs on `blacksmith-4vcpu-windows-2025`. A normal manual retry uses the same provider:
+
+```sh
+gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f windows_runner=blacksmith
+```
+
+Use the fallback only when the Blacksmith Windows job is stuck waiting for capacity. A tag-push run and a manual dispatch use different concurrency keys, so the fallback dispatch can start concurrently with the stuck run. To prevent two live publish attempts for one tag, first cancel the stuck run in the GitHub Actions UI and wait until it is terminal. Then open **Actions → Publish → Run workflow**, select `main`, set **Tag to publish** to `0.9.7-alpha.1`, set **Windows smoke runner** (`windows_runner`) to **GitHub-hosted** (`github-hosted`), and run the workflow. The equivalent command is:
+
+```sh
+gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f windows_runner=github-hosted
+```
+
+The fallback changes only `windows-binary-smoke` to GitHub's `windows-2025` image. Linux smoke, native-artifact builds, the GitHub-hosted provenance publish job, checkout of `0.9.7-alpha.1`, and all tag/package validation remain unchanged. Do not use a branch name for `tag`; manual dispatch is a release/publish operation, not a smoke-only run.
 
 ### Cutting a release (versionless main)
 
@@ -199,7 +217,7 @@ Create GitHub Release with softprops/action-gh-release@v3
 
 npm versions are immutable. The workflow publishes to npm first so the GitHub Release is only created after the npm package is available.
 
-npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test and most native-artifact jobs can use Blacksmith runners. The native-artifact matrix follows Blacksmith's architecture-aware runner pattern: Linux x64 uses `blacksmith-4vcpu-ubuntu-2404`, Linux arm64 uses `blacksmith-4vcpu-ubuntu-2404-arm`, Darwin arm64 uses `blacksmith-6vcpu-macos-26`, and Darwin x64 uses GitHub's Intel macOS runner (`macos-26-intel`) because Blacksmith does not provide Intel macOS runners.
+npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test and most native-artifact jobs can use Blacksmith runners. The Windows smoke job normally uses `blacksmith-4vcpu-windows-2025`; a manual dispatch may set `windows_runner=github-hosted` to use GitHub's `windows-2025` image after a stuck same-tag attempt has been canceled. The native-artifact matrix follows Blacksmith's architecture-aware runner pattern: Linux x64 uses `blacksmith-4vcpu-ubuntu-2404`, Linux arm64 uses `blacksmith-4vcpu-ubuntu-2404-arm`, Darwin arm64 uses `blacksmith-6vcpu-macos-26`, and Darwin x64 uses GitHub's Intel macOS runner (`macos-26-intel`) because Blacksmith does not provide Intel macOS runners.
 
 ### GitHub Release Creation
 
@@ -272,7 +290,7 @@ The meaningful pre-publish checks are:
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, enforce the tracked TS/JS/Rust file-length gate, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests (including the installed-package Node-runtime extension smoke on Linux and Windows), build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
-| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
+| `publish.yml`        | `<version>` tag push, manual dispatch with `tag` and `windows_runner` inputs | Smoke test Linux/Windows binaries in parallel (Windows uses Blacksmith by default, with a manual `github-hosted` capacity fallback), build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
 
 ---
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a manual `publish.yml` Windows-runner fallback: tag pushes and ordinary dispatches keep Blacksmith by default, while operators can select GitHub's hosted Windows image when Blacksmith capacity is blocked without changing the requested release tag.
+
 ## [0.9.7-alpha.1] - 2026-07-12
 
 ### Added

--- a/test/unit/publish-workflow-runner-fallback.test.ts
+++ b/test/unit/publish-workflow-runner-fallback.test.ts
@@ -1,0 +1,73 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+
+interface ChoiceInput {
+  default: string;
+  options: string[];
+  required: boolean;
+  type: string;
+}
+
+interface Step {
+  uses?: string;
+  with?: { ref?: string };
+}
+
+interface PublishWorkflow {
+  on: {
+    workflow_dispatch: {
+      inputs: {
+        windows_runner: ChoiceInput;
+      };
+    };
+  };
+  jobs: {
+    "windows-binary-smoke": {
+      "runs-on": string;
+      steps: Step[];
+    };
+  };
+}
+
+const workflowPath = new URL("../../.github/workflows/publish.yml", import.meta.url);
+const docsPath = new URL("../../docs/ci.md", import.meta.url);
+
+async function loadWorkflow(): Promise<PublishWorkflow> {
+  const source = await Bun.file(workflowPath).text();
+  return Bun.YAML.parse(source) as PublishWorkflow;
+}
+
+test("publish workflow defaults Windows smoke to Blacksmith with a manual GitHub-hosted choice", async () => {
+  const workflow = await loadWorkflow();
+  const input = workflow.on.workflow_dispatch.inputs.windows_runner;
+
+  assert.deepEqual(input, {
+    description: "Windows smoke runner (use github-hosted only if Blacksmith is blocked)",
+    required: true,
+    default: "blacksmith",
+    type: "choice",
+    options: ["blacksmith", "github-hosted"],
+  });
+  assert.equal(
+    workflow.jobs["windows-binary-smoke"]["runs-on"],
+    "${{ inputs.windows_runner == 'github-hosted' && 'windows-2025' || 'blacksmith-4vcpu-windows-2025' }}",
+  );
+});
+
+test("Windows smoke uses a provider-neutral checkout of the requested tag", async () => {
+  const workflow = await loadWorkflow();
+  const checkout = workflow.jobs["windows-binary-smoke"].steps[0];
+
+  assert.equal(checkout?.uses, "actions/checkout@v7.0.0");
+  assert.equal(checkout?.with?.ref, "${{ github.event.inputs.tag || github.ref_name }}");
+});
+
+test("CI docs record exact normal and fallback dispatch inputs", async () => {
+  const docs = await Bun.file(docsPath).text();
+
+  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f windows_runner=blacksmith/u);
+  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f windows_runner=github-hosted/u);
+  assert.match(docs, /different concurrency keys.*start concurrently/u);
+  assert.match(docs, /first cancel the stuck run.*wait until it is terminal/u);
+  assert.doesNotMatch(docs, /runs for the same tag share a non-canceling concurrency group/u);
+});


### PR DESCRIPTION
## Summary

Add a safe, operator-selected GitHub-hosted Windows fallback for the Publish workflow when Blacksmith Windows capacity is stuck. Tag-push releases and ordinary manual dispatches continue to use Blacksmith by default, while the fallback preserves checkout and build of the requested release tag.

## Changes

- Add the required `workflow_dispatch` choice input `windows_runner`, defaulting to `blacksmith` with `github-hosted` as the fallback.
- Select `windows-2025` only for `windows-binary-smoke` when the fallback is explicitly requested; tag pushes retain `blacksmith-4vcpu-windows-2025`.
- Use provider-neutral `actions/checkout@v7.0.0` while preserving `ref: ${{ github.event.inputs.tag || github.ref_name }}`.
- Document exact normal/fallback CLI and UI procedures, including cancel-first unblock guidance and concurrency behavior.
- Add regression coverage for runner selection, requested-tag checkout, and documented dispatch inputs, plus an Unreleased changelog entry.

## Validation

- `bun test test/unit/publish-workflow-runner-fallback.test.ts` — 3 passed
- `bun run typecheck` — passed
- `bunx prek run check-yaml --files .github/workflows/publish.yml` — passed
- `bun run docs:check` from `packages/coding-agent` — passed
- `git diff --check` — passed
- Commit and push hooks: lint, file-length, YAML, and full unit suite passed

## Operator note

For the requested fallback dispatch, use:

```text
tag=0.9.7-alpha.1
windows_runner=github-hosted
```

No release workflow was dispatched or published, and no existing Actions run was canceled while implementing or validating this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an operator-selected Windows runner fallback to the publish workflow. The main changes are:

- Adds a required `windows_runner` manual dispatch choice with Blacksmith as the default.
- Uses GitHub-hosted `windows-2025` only when `windows_runner=github-hosted` is selected.
- Switches the Windows smoke checkout to `actions/checkout@v7.0.0` while preserving the requested tag ref.
- Documents normal and fallback publish procedures, including cancel-first guidance.
- Adds tests for runner selection, tag checkout, and documented dispatch inputs.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is scoped to CI runner selection and preserves the requested release tag checkout. The docs and tests cover the new manual dispatch input and fallback behavior. No issues were identified in the changed files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the foreground Bun regression test for the publish workflow fallback and observed exit code 0.
- Verified the publish workflow YAML check completed with exit code 0.
- Verified the docs check completed with exit code 0.
- Captured a grep proof showing fallback values in the test/docs/workflow.
- Inspected the artifact directory listing to confirm artifacts are present.

<a href="https://app.greptile.com/trex/runs/14166421/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Adds the manual Windows runner choice and selects the GitHub-hosted fallback only when explicitly requested. |
| docs/ci.md | Documents normal and fallback publish dispatch procedures, including concurrency and cancel-first guidance. |
| packages/coding-agent/CHANGELOG.md | Adds an Unreleased changelog entry for the Windows runner fallback. |
| test/unit/publish-workflow-runner-fallback.test.ts | Adds tests for workflow input defaults, runner selection, requested-tag checkout, and docs coverage. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Operator
participant GitHubActions as GitHub Actions Publish
participant Blacksmith as Blacksmith Windows
participant GitHubHosted as GitHub-hosted Windows

Operator->>GitHubActions: "Push release tag or dispatch with windows_runner=blacksmith"
GitHubActions->>Blacksmith: Run windows-binary-smoke on blacksmith-4vcpu-windows-2025
GitHubActions->>GitHubActions: Checkout requested release tag
alt Blacksmith capacity is blocked
    Operator->>GitHubActions: Cancel stuck same-tag run
    Operator->>GitHubActions: "Dispatch tag with windows_runner=github-hosted"
    GitHubActions->>GitHubHosted: Run windows-binary-smoke on windows-2025
    GitHubActions->>GitHubActions: Checkout same requested release tag
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Operator
participant GitHubActions as GitHub Actions Publish
participant Blacksmith as Blacksmith Windows
participant GitHubHosted as GitHub-hosted Windows

Operator->>GitHubActions: "Push release tag or dispatch with windows_runner=blacksmith"
GitHubActions->>Blacksmith: Run windows-binary-smoke on blacksmith-4vcpu-windows-2025
GitHubActions->>GitHubActions: Checkout requested release tag
alt Blacksmith capacity is blocked
    Operator->>GitHubActions: Cancel stuck same-tag run
    Operator->>GitHubActions: "Dispatch tag with windows_runner=github-hosted"
    GitHubActions->>GitHubHosted: Run windows-binary-smoke on windows-2025
    GitHubActions->>GitHubActions: Checkout same requested release tag
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: add Windows publish runner fallback"](https://github.com/bastani-inc/atomic/commit/c89f7f6c770b0ae0f26ab57a1e5e8344f25fe0be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43672423)</sub>

<!-- /greptile_comment -->