### PR TITLE
ci: add provider-wide publish runner fallback

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,14 @@ on:
                 description: "Tag to publish (e.g., 0.8.0 or 0.8.0-alpha.1)"
                 required: true
                 type: string
-            windows_runner:
-                description: "Windows smoke runner (use github-hosted only if Blacksmith is blocked)"
+            runner_provider:
+                description: "Runner provider for Blacksmith-backed jobs"
                 required: true
                 default: blacksmith
                 type: choice
                 options:
                     - blacksmith
-                    - github-hosted
+                    - github
 
 permissions:
     contents: write
@@ -36,10 +36,10 @@ env:
 jobs:
     linux-binary-smoke:
         name: Smoke test Linux binary
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ${{ inputs.runner_provider == 'github' && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}
 
         steps:
-            - uses: useblacksmith/checkout@v1
+            - uses: actions/checkout@v7.0.0
               with:
                   ref: ${{ github.event.inputs.tag || github.ref_name }}
                   persist-credentials: false
@@ -116,7 +116,7 @@ jobs:
 
     windows-binary-smoke:
         name: Smoke test Windows binary
-        runs-on: ${{ inputs.windows_runner == 'github-hosted' && 'windows-2025' || 'blacksmith-4vcpu-windows-2025' }}
+        runs-on: ${{ inputs.runner_provider == 'github' && 'windows-2025' || 'blacksmith-4vcpu-windows-2025' }}
 
         steps:
             - uses: actions/checkout@v7.0.0
@@ -208,12 +208,12 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - { runner: blacksmith-4vcpu-ubuntu-2404, platform: linux-x64, target: "" }
-                    - { runner: blacksmith-4vcpu-ubuntu-2404-arm, platform: linux-arm64, target: "" }
+                    - { runner: "${{ inputs.runner_provider == 'github' && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}", platform: linux-x64, target: "" }
+                    - { runner: "${{ inputs.runner_provider == 'github' && 'ubuntu-24.04-arm' || 'blacksmith-4vcpu-ubuntu-2404-arm' }}", platform: linux-arm64, target: "" }
                     - { runner: macos-26-intel, platform: darwin-x64, target: "" }
-                    - { runner: blacksmith-6vcpu-macos-26, platform: darwin-arm64, target: "" }
-                    - { runner: blacksmith-4vcpu-ubuntu-2404, platform: windows-x64, target: x86_64-pc-windows-msvc }
-                    - { runner: blacksmith-4vcpu-ubuntu-2404, platform: windows-arm64, target: aarch64-pc-windows-msvc }
+                    - { runner: "${{ inputs.runner_provider == 'github' && 'macos-26' || 'blacksmith-6vcpu-macos-26' }}", platform: darwin-arm64, target: "" }
+                    - { runner: "${{ inputs.runner_provider == 'github' && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}", platform: windows-x64, target: x86_64-pc-windows-msvc }
+                    - { runner: "${{ inputs.runner_provider == 'github' && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}", platform: windows-arm64, target: aarch64-pc-windows-msvc }
 
         steps:
             - uses: actions/checkout@v7.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,14 @@ on:
                 description: "Tag to publish (e.g., 0.8.0 or 0.8.0-alpha.1)"
                 required: true
                 type: string
+            windows_runner:
+                description: "Windows smoke runner (use github-hosted only if Blacksmith is blocked)"
+                required: true
+                default: blacksmith
+                type: choice
+                options:
+                    - blacksmith
+                    - github-hosted
 
 permissions:
     contents: write
@@ -108,10 +116,10 @@ jobs:
 
     windows-binary-smoke:
         name: Smoke test Windows binary
-        runs-on: blacksmith-4vcpu-windows-2025
+        runs-on: ${{ inputs.windows_runner == 'github-hosted' && 'windows-2025' || 'blacksmith-4vcpu-windows-2025' }}
 
         steps:
-            - uses: useblacksmith/checkout@v1
+            - uses: actions/checkout@v7.0.0
               with:
                   ref: ${{ github.event.inputs.tag || github.ref_name }}
                   persist-credentials: false

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -116,10 +116,10 @@ Steps:
 
 The publish pipeline (`publish.yml`) runs when:
 
-- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`); the Windows smoke job always uses the default Blacksmith runner
-- `workflow_dispatch` is run with an explicit `tag` input such as `0.8.0` and a `windows_runner` choice (`blacksmith` by default, or `github-hosted` for the capacity fallback)
+- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`); every Blacksmith-backed job uses its existing Blacksmith runner
+- `workflow_dispatch` is run with an explicit `tag` input such as `0.8.0` and a `runner_provider` choice (`blacksmith` by default, or `github` for the provider-wide fallback)
 
-Both runner choices check out the exact `tag` input before building. The Windows job uses `actions/checkout`, which is supported on both providers; changing `windows_runner` does not change the release ref or any publish validation.
+Both provider choices check out the exact `tag` input with `actions/checkout` before building. Changing `runner_provider` does not change the release ref, publish validation, or jobs that are already GitHub-hosted.
 
 ### Tag Naming
 
@@ -130,21 +130,23 @@ Both runner choices check out the exact `tag` input before building. The Windows
 
 `main` is **versionless**: every `packages/*/package.json` on `main` sits at the `0.0.0` placeholder. The real version exists only on the tagged, off-`main` `Release <version>` commit produced by `scripts/cut-release.ts`, where the tag matches `packages/coding-agent/package.json` exactly (no leading `v`) and all `packages/*` versions are stamped in sync. publish.yml checks out that tagged commit, so its `validate tag matches package.json` gate sees the real version, not the placeholder. The pipeline also refuses to publish the `0.0.0` placeholder if it is ever tagged directly.
 
-### Windows runner fallback
+### Manual runner-provider fallback
 
-Normal tag pushes require no runner input: `windows-binary-smoke` runs on `blacksmith-4vcpu-windows-2025`. A normal manual retry uses the same provider:
-
-```sh
-gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f windows_runner=blacksmith
-```
-
-Use the fallback only when the Blacksmith Windows job is stuck waiting for capacity. A tag-push run and a manual dispatch use different concurrency keys, so the fallback dispatch can start concurrently with the stuck run. To prevent two live publish attempts for one tag, first cancel the stuck run in the GitHub Actions UI and wait until it is terminal. Then open **Actions → Publish → Run workflow**, select `main`, set **Tag to publish** to `0.9.7-alpha.1`, set **Windows smoke runner** (`windows_runner`) to **GitHub-hosted** (`github-hosted`), and run the workflow. The equivalent command is:
+Normal tag pushes require no runner input and preserve every existing Blacksmith default. A normal manual retry explicitly selects the same provider:
 
 ```sh
-gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f windows_runner=github-hosted
+gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f runner_provider=blacksmith
 ```
 
-The fallback changes only `windows-binary-smoke` to GitHub's `windows-2025` image. Linux smoke, native-artifact builds, the GitHub-hosted provenance publish job, checkout of `0.9.7-alpha.1`, and all tag/package validation remain unchanged. Do not use a branch name for `tag`; manual dispatch is a release/publish operation, not a smoke-only run.
+If Blacksmith is unavailable, the provider-wide fallback is:
+
+```sh
+gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f runner_provider=github
+```
+
+A tag-push run and a manual dispatch use different concurrency keys, so the fallback dispatch can start concurrently with a stuck run. To prevent two live publish attempts for one tag, first cancel the stuck run in the GitHub Actions UI and wait until it is terminal. Then run the fallback command above (or open **Actions → Publish → Run workflow**, select `main`, set **Tag to publish** to `0.9.7-alpha.1`, and set **Runner provider** to **github**). Do not use a branch name for `tag`; manual dispatch is a release/publish operation, not a smoke-only run.
+
+The GitHub fallback uses GitHub's published architecture-compatible labels: Linux x64 smoke and the Linux x64/cross-compile native entries use `ubuntu-24.04`; Linux arm64 uses `ubuntu-24.04-arm`; Windows x64 smoke uses `windows-2025`; and Darwin arm64 uses `macos-26`. The Darwin x64 native entry is the sole exception: it already requires GitHub's Intel `macos-26-intel` runner because Blacksmith has no Intel macOS runner, so it remains unchanged for both choices. The provenance-sensitive `publish` job likewise remains on its required GitHub-hosted `ubuntu-latest` runner. These labels are listed in GitHub's [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) and [`actions/runner-images` catalog](https://github.com/actions/runner-images).
 
 ### Cutting a release (versionless main)
 
@@ -217,7 +219,7 @@ Create GitHub Release with softprops/action-gh-release@v3
 
 npm versions are immutable. The workflow publishes to npm first so the GitHub Release is only created after the npm package is available.
 
-npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test and most native-artifact jobs can use Blacksmith runners. The Windows smoke job normally uses `blacksmith-4vcpu-windows-2025`; a manual dispatch may set `windows_runner=github-hosted` to use GitHub's `windows-2025` image after a stuck same-tag attempt has been canceled. The native-artifact matrix follows Blacksmith's architecture-aware runner pattern: Linux x64 uses `blacksmith-4vcpu-ubuntu-2404`, Linux arm64 uses `blacksmith-4vcpu-ubuntu-2404-arm`, Darwin arm64 uses `blacksmith-6vcpu-macos-26`, and Darwin x64 uses GitHub's Intel macOS runner (`macos-26-intel`) because Blacksmith does not provide Intel macOS runners.
+npm provenance currently supports GitHub-hosted runners only, so the final publish job remains on `ubuntu-latest`. Tag pushes and normal manual dispatches use the existing Blacksmith mappings. A manual dispatch with `runner_provider=github` switches all Blacksmith-backed jobs to GitHub's architecture-compatible images: `ubuntu-24.04` for Linux x64 and Linux-hosted Windows cross-compiles, `ubuntu-24.04-arm` for Linux arm64, `windows-2025` for Windows x64 smoke, and `macos-26` for Darwin arm64. The existing `macos-26-intel` Darwin x64 entry and `ubuntu-latest` publish job are already required to be GitHub-hosted and remain unchanged.
 
 ### GitHub Release Creation
 
@@ -290,7 +292,7 @@ The meaningful pre-publish checks are:
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, enforce the tracked TS/JS/Rust file-length gate, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests (including the installed-package Node-runtime extension smoke on Linux and Windows), build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
-| `publish.yml`        | `<version>` tag push, manual dispatch with `tag` and `windows_runner` inputs | Smoke test Linux/Windows binaries in parallel (Windows uses Blacksmith by default, with a manual `github-hosted` capacity fallback), build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
+| `publish.yml`        | `<version>` tag push, manual dispatch with `tag` and `runner_provider` inputs | Smoke test Linux/Windows binaries in parallel, build native NAPI artifacts across architecture-compatible runners, and retain Blacksmith defaults for tag pushes while allowing a provider-wide GitHub-hosted manual fallback; keep the required GitHub-hosted Darwin x64 and provenance publish jobs unchanged; validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks; publish `@bastani/atomic-natives` and `@bastani/atomic`; create the GitHub Release with binaries |
 
 ---
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -116,8 +116,10 @@ Steps:
 
 The publish pipeline (`publish.yml`) runs when:
 
-- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`)
-- `workflow_dispatch` is run with an explicit tag input such as `0.8.0`
+- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`); the Windows smoke job always uses the default Blacksmith runner
+- `workflow_dispatch` is run with an explicit `tag` input such as `0.8.0` and a `windows_runner` choice (`blacksmith` by default, or `github-hosted` for the capacity fallback)
+
+Both runner choices check out the exact `tag` input before building. The Windows job uses `actions/checkout`, which is supported on both providers; changing `windows_runner` does not change the release ref or any publish validation.
 
 ### Tag Naming
 
@@ -127,6 +129,22 @@ The publish pipeline (`publish.yml`) runs when:
 | `<major>.<minor>.<patch>-<prerelease>` (e.g. `0.8.0-alpha.1`) | `next`   | prerelease, not marked latest |
 
 `main` is **versionless**: every `packages/*/package.json` on `main` sits at the `0.0.0` placeholder. The real version exists only on the tagged, off-`main` `Release <version>` commit produced by `scripts/cut-release.ts`, where the tag matches `packages/coding-agent/package.json` exactly (no leading `v`) and all `packages/*` versions are stamped in sync. publish.yml checks out that tagged commit, so its `validate tag matches package.json` gate sees the real version, not the placeholder. The pipeline also refuses to publish the `0.0.0` placeholder if it is ever tagged directly.
+
+### Windows runner fallback
+
+Normal tag pushes require no runner input: `windows-binary-smoke` runs on `blacksmith-4vcpu-windows-2025`. A normal manual retry uses the same provider:
+
+```sh
+gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f windows_runner=blacksmith
+```
+
+Use the fallback only when the Blacksmith Windows job is stuck waiting for capacity. A tag-push run and a manual dispatch use different concurrency keys, so the fallback dispatch can start concurrently with the stuck run. To prevent two live publish attempts for one tag, first cancel the stuck run in the GitHub Actions UI and wait until it is terminal. Then open **Actions → Publish → Run workflow**, select `main`, set **Tag to publish** to `0.9.7-alpha.1`, set **Windows smoke runner** (`windows_runner`) to **GitHub-hosted** (`github-hosted`), and run the workflow. The equivalent command is:
+
+```sh
+gh workflow run publish.yml --ref main -f tag=0.9.7-alpha.1 -f windows_runner=github-hosted
+```
+
+The fallback changes only `windows-binary-smoke` to GitHub's `windows-2025` image. Linux smoke, native-artifact builds, the GitHub-hosted provenance publish job, checkout of `0.9.7-alpha.1`, and all tag/package validation remain unchanged. Do not use a branch name for `tag`; manual dispatch is a release/publish operation, not a smoke-only run.
 
 ### Cutting a release (versionless main)
 
@@ -199,7 +217,7 @@ Create GitHub Release with softprops/action-gh-release@v3
 
 npm versions are immutable. The workflow publishes to npm first so the GitHub Release is only created after the npm package is available.
 
-npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test and most native-artifact jobs can use Blacksmith runners. The native-artifact matrix follows Blacksmith's architecture-aware runner pattern: Linux x64 uses `blacksmith-4vcpu-ubuntu-2404`, Linux arm64 uses `blacksmith-4vcpu-ubuntu-2404-arm`, Darwin arm64 uses `blacksmith-6vcpu-macos-26`, and Darwin x64 uses GitHub's Intel macOS runner (`macos-26-intel`) because Blacksmith does not provide Intel macOS runners.
+npm provenance currently supports GitHub-hosted runners only, so the final publish job runs on `ubuntu-latest` even though the binary smoke-test and most native-artifact jobs can use Blacksmith runners. The Windows smoke job normally uses `blacksmith-4vcpu-windows-2025`; a manual dispatch may set `windows_runner=github-hosted` to use GitHub's `windows-2025` image after a stuck same-tag attempt has been canceled. The native-artifact matrix follows Blacksmith's architecture-aware runner pattern: Linux x64 uses `blacksmith-4vcpu-ubuntu-2404`, Linux arm64 uses `blacksmith-4vcpu-ubuntu-2404-arm`, Darwin arm64 uses `blacksmith-6vcpu-macos-26`, and Darwin x64 uses GitHub's Intel macOS runner (`macos-26-intel`) because Blacksmith does not provide Intel macOS runners.
 
 ### GitHub Release Creation
 
@@ -272,7 +290,7 @@ The meaningful pre-publish checks are:
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, enforce the tracked TS/JS/Rust file-length gate, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests (including the installed-package Node-runtime extension smoke on Linux and Windows), build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
-| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
+| `publish.yml`        | `<version>` tag push, manual dispatch with `tag` and `windows_runner` inputs | Smoke test Linux/Windows binaries in parallel (Windows uses Blacksmith by default, with a manual `github-hosted` capacity fallback), build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
 
 ---
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added a manual `publish.yml` Windows-runner fallback: tag pushes and ordinary dispatches keep Blacksmith by default, while operators can select GitHub's hosted Windows image when Blacksmith capacity is blocked without changing the requested release tag.
+- Added a provider-wide manual `publish.yml` runner fallback: tag pushes and ordinary dispatches retain architecture-aware Blacksmith defaults, while operators can switch every Blacksmith-backed smoke and native-artifact job to verified GitHub-hosted Linux x64, Linux arm64, Windows x64, and Darwin arm64 runners without changing the release tag; the already-required GitHub-hosted Darwin x64 and provenance publish jobs remain unchanged.
 
 ## [0.9.7-alpha.1] - 2026-07-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a manual `publish.yml` Windows-runner fallback: tag pushes and ordinary dispatches keep Blacksmith by default, while operators can select GitHub's hosted Windows image when Blacksmith capacity is blocked without changing the requested release tag.
+
 ## [0.9.7-alpha.1] - 2026-07-12
 
 ### Added

--- a/test/unit/publish-workflow-runner-fallback.test.ts
+++ b/test/unit/publish-workflow-runner-fallback.test.ts
@@ -13,19 +13,27 @@ interface Step {
   with?: { ref?: string };
 }
 
+interface MatrixEntry {
+  platform: string;
+  runner: string;
+  target: string;
+}
+
 interface PublishWorkflow {
   on: {
     workflow_dispatch: {
-      inputs: {
-        windows_runner: ChoiceInput;
-      };
+      inputs: Record<string, ChoiceInput>;
     };
   };
   jobs: {
-    "windows-binary-smoke": {
+    "linux-binary-smoke": { "runs-on": string; steps: Step[] };
+    "windows-binary-smoke": { "runs-on": string; steps: Step[] };
+    "atomic-native-artifacts": {
       "runs-on": string;
       steps: Step[];
+      strategy: { matrix: { include: MatrixEntry[] } };
     };
+    publish: { "runs-on": string; steps: Step[] };
   };
 }
 
@@ -33,41 +41,95 @@ const workflowPath = new URL("../../.github/workflows/publish.yml", import.meta.
 const docsPath = new URL("../../docs/ci.md", import.meta.url);
 
 async function loadWorkflow(): Promise<PublishWorkflow> {
-  const source = await Bun.file(workflowPath).text();
-  return Bun.YAML.parse(source) as PublishWorkflow;
+  return Bun.YAML.parse(await Bun.file(workflowPath).text()) as PublishWorkflow;
 }
 
-test("publish workflow defaults Windows smoke to Blacksmith with a manual GitHub-hosted choice", async () => {
-  const workflow = await loadWorkflow();
-  const input = workflow.on.workflow_dispatch.inputs.windows_runner;
+const providerExpression = (github: string, blacksmith: string): string =>
+  `\${{ inputs.runner_provider == 'github' && '${github}' || '${blacksmith}' }}`;
 
-  assert.deepEqual(input, {
-    description: "Windows smoke runner (use github-hosted only if Blacksmith is blocked)",
+test("publish workflow exposes one Blacksmith-default provider choice", async () => {
+  const inputs = (await loadWorkflow()).on.workflow_dispatch.inputs;
+
+  assert.deepEqual(Object.keys(inputs).sort(), ["runner_provider", "tag"]);
+  assert.deepEqual(inputs.runner_provider, {
+    description: "Runner provider for Blacksmith-backed jobs",
     required: true,
     default: "blacksmith",
     type: "choice",
-    options: ["blacksmith", "github-hosted"],
+    options: ["blacksmith", "github"],
   });
+  assert.equal("windows_runner" in inputs, false);
+});
+
+test("smoke jobs retain Blacksmith for tag pushes and map manual GitHub fallback by architecture", async () => {
+  const jobs = (await loadWorkflow()).jobs;
+
   assert.equal(
-    workflow.jobs["windows-binary-smoke"]["runs-on"],
-    "${{ inputs.windows_runner == 'github-hosted' && 'windows-2025' || 'blacksmith-4vcpu-windows-2025' }}",
+    jobs["linux-binary-smoke"]["runs-on"],
+    providerExpression("ubuntu-24.04", "blacksmith-4vcpu-ubuntu-2404"),
+  );
+  assert.equal(
+    jobs["windows-binary-smoke"]["runs-on"],
+    providerExpression("windows-2025", "blacksmith-4vcpu-windows-2025"),
   );
 });
 
-test("Windows smoke uses a provider-neutral checkout of the requested tag", async () => {
+test("every native matrix entry preserves its architecture across providers", async () => {
   const workflow = await loadWorkflow();
-  const checkout = workflow.jobs["windows-binary-smoke"].steps[0];
+  const entries = Object.fromEntries(
+    workflow.jobs["atomic-native-artifacts"].strategy.matrix.include.map((entry) => [entry.platform, entry]),
+  );
 
-  assert.equal(checkout?.uses, "actions/checkout@v7.0.0");
-  assert.equal(checkout?.with?.ref, "${{ github.event.inputs.tag || github.ref_name }}");
+  assert.deepEqual(entries, {
+    "linux-x64": {
+      runner: providerExpression("ubuntu-24.04", "blacksmith-4vcpu-ubuntu-2404"),
+      platform: "linux-x64",
+      target: "",
+    },
+    "linux-arm64": {
+      runner: providerExpression("ubuntu-24.04-arm", "blacksmith-4vcpu-ubuntu-2404-arm"),
+      platform: "linux-arm64",
+      target: "",
+    },
+    "darwin-x64": { runner: "macos-26-intel", platform: "darwin-x64", target: "" },
+    "darwin-arm64": {
+      runner: providerExpression("macos-26", "blacksmith-6vcpu-macos-26"),
+      platform: "darwin-arm64",
+      target: "",
+    },
+    "windows-x64": {
+      runner: providerExpression("ubuntu-24.04", "blacksmith-4vcpu-ubuntu-2404"),
+      platform: "windows-x64",
+      target: "x86_64-pc-windows-msvc",
+    },
+    "windows-arm64": {
+      runner: providerExpression("ubuntu-24.04", "blacksmith-4vcpu-ubuntu-2404"),
+      platform: "windows-arm64",
+      target: "aarch64-pc-windows-msvc",
+    },
+  });
+  assert.equal(workflow.jobs["atomic-native-artifacts"]["runs-on"], "${{ matrix.runner }}");
 });
 
-test("CI docs record exact normal and fallback dispatch inputs", async () => {
+test("all jobs use provider-portable checkout while GitHub-required jobs stay unchanged", async () => {
+  const jobs = (await loadWorkflow()).jobs;
+
+  for (const name of ["linux-binary-smoke", "windows-binary-smoke", "atomic-native-artifacts", "publish"] as const) {
+    const checkout = jobs[name].steps.find((step) => step.uses?.includes("checkout"));
+    assert.equal(checkout?.uses, "actions/checkout@v7.0.0", `${name} checkout`);
+  }
+  assert.equal(jobs.publish["runs-on"], "ubuntu-latest");
+});
+
+test("CI docs record exact provider dispatches, labels, exception, and cancellation guidance", async () => {
   const docs = await Bun.file(docsPath).text();
 
-  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f windows_runner=blacksmith/u);
-  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f windows_runner=github-hosted/u);
+  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f runner_provider=blacksmith/u);
+  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f runner_provider=github/u);
+  for (const label of ["ubuntu-24.04", "ubuntu-24.04-arm", "windows-2025", "macos-26", "macos-26-intel"]) {
+    assert.match(docs, new RegExp(`\\b${label}\\b`, "u"));
+  }
+  assert.match(docs, /macos-26-intel.*unchanged/u);
   assert.match(docs, /different concurrency keys.*start concurrently/u);
   assert.match(docs, /first cancel the stuck run.*wait until it is terminal/u);
-  assert.doesNotMatch(docs, /runs for the same tag share a non-canceling concurrency group/u);
 });

--- a/test/unit/publish-workflow-runner-fallback.test.ts
+++ b/test/unit/publish-workflow-runner-fallback.test.ts
@@ -1,0 +1,73 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+
+interface ChoiceInput {
+  default: string;
+  options: string[];
+  required: boolean;
+  type: string;
+}
+
+interface Step {
+  uses?: string;
+  with?: { ref?: string };
+}
+
+interface PublishWorkflow {
+  on: {
+    workflow_dispatch: {
+      inputs: {
+        windows_runner: ChoiceInput;
+      };
+    };
+  };
+  jobs: {
+    "windows-binary-smoke": {
+      "runs-on": string;
+      steps: Step[];
+    };
+  };
+}
+
+const workflowPath = new URL("../../.github/workflows/publish.yml", import.meta.url);
+const docsPath = new URL("../../docs/ci.md", import.meta.url);
+
+async function loadWorkflow(): Promise<PublishWorkflow> {
+  const source = await Bun.file(workflowPath).text();
+  return Bun.YAML.parse(source) as PublishWorkflow;
+}
+
+test("publish workflow defaults Windows smoke to Blacksmith with a manual GitHub-hosted choice", async () => {
+  const workflow = await loadWorkflow();
+  const input = workflow.on.workflow_dispatch.inputs.windows_runner;
+
+  assert.deepEqual(input, {
+    description: "Windows smoke runner (use github-hosted only if Blacksmith is blocked)",
+    required: true,
+    default: "blacksmith",
+    type: "choice",
+    options: ["blacksmith", "github-hosted"],
+  });
+  assert.equal(
+    workflow.jobs["windows-binary-smoke"]["runs-on"],
+    "${{ inputs.windows_runner == 'github-hosted' && 'windows-2025' || 'blacksmith-4vcpu-windows-2025' }}",
+  );
+});
+
+test("Windows smoke uses a provider-neutral checkout of the requested tag", async () => {
+  const workflow = await loadWorkflow();
+  const checkout = workflow.jobs["windows-binary-smoke"].steps[0];
+
+  assert.equal(checkout?.uses, "actions/checkout@v7.0.0");
+  assert.equal(checkout?.with?.ref, "${{ github.event.inputs.tag || github.ref_name }}");
+});
+
+test("CI docs record exact normal and fallback dispatch inputs", async () => {
+  const docs = await Bun.file(docsPath).text();
+
+  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f windows_runner=blacksmith/u);
+  assert.match(docs, /-f tag=0\.9\.7-alpha\.1 -f windows_runner=github-hosted/u);
+  assert.match(docs, /different concurrency keys.*start concurrently/u);
+  assert.match(docs, /first cancel the stuck run.*wait until it is terminal/u);
+  assert.doesNotMatch(docs, /runs for the same tag share a non-canceling concurrency group/u);
+});


### PR DESCRIPTION
## Summary

Replace the superseded Windows-only publish fallback with a provider-wide manual runner fallback while preserving Blacksmith defaults for tag-push releases. This supersedes closed PR #1768.

## Changes

- Add the required `runner_provider` workflow-dispatch choice (`blacksmith`/`github`, default `blacksmith`).
- Map every Blacksmith-backed smoke and native-artifact entry to an architecture-compatible GitHub-hosted runner for manual fallback dispatches.
- Keep the required GitHub-hosted `macos-26-intel` Darwin x64 and `ubuntu-latest` provenance jobs unchanged.
- Use `actions/checkout@v7.0.0` across publish jobs.
- Document exact normal/fallback commands for `0.9.7-alpha.1`, runner mappings, exceptions, and cancel-before-retry guidance.
- Add workflow-parsing regression tests covering the input contract, every affected job/matrix entry, portable checkout, and documentation.

## Validation

- Focused regression tests: 5 passed
- Bun YAML parsing: passed
- `bun run typecheck`: passed
- `bun run check:file-length`: passed
- `bun run docs:check`: passed, including Mintlify and broken-link validation
- `bun run hooks:run`: passed
- `git diff --check`: passed

`actionlint` was unavailable; Bun YAML parsing and prek's YAML hook passed. No release workflow was dispatched, no tag was pushed, and no package was published.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a manual runner-provider fallback for the publish workflow. The main changes are:

- Adds a required `runner_provider` workflow-dispatch choice with `blacksmith` as the default.
- Maps Blacksmith-backed smoke and native-artifact jobs to GitHub-hosted fallback runners when `runner_provider=github`.
- Keeps the required GitHub-hosted Darwin x64 and npm provenance publish jobs unchanged.
- Updates publish CI docs, the changelog, and workflow regression tests for the new fallback behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are scoped to CI runner selection, documentation, changelog, and focused tests. The default publish path remains on Blacksmith-backed runners, while existing GitHub-hosted provenance and Darwin x64 jobs stay unchanged. No correctness or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused regression test was executed with Bun v1.3.10 and completed with 5 pass, 0 fail, and EXIT\_CODE: 0.
- The publish workflow YAML was parsed successfully, and it shows the runner\_provider choice plus GitHub/Blacksmith runner expressions for smoke jobs and matrix entries.

<a href="https://app.greptile.com/trex/runs/14166996/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Adds `runner_provider`, switches Blacksmith-backed smoke/native jobs through GitHub-hosted fallback labels, and standardizes publish checkouts on `actions/checkout@v7.0.0`. |
| docs/ci.md | Documents the normal Blacksmith dispatch, GitHub fallback command, runner-label mappings, unchanged GitHub-hosted exceptions, and cancellation guidance. |
| test/unit/publish-workflow-runner-fallback.test.ts | Adds tests for the dispatch input contract, runner mappings, checkout action usage, and fallback documentation. |
| packages/coding-agent/CHANGELOG.md | Adds an Unreleased changelog entry for the provider-wide manual publish runner fallback. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
actor Operator
participant GH as GitHub Actions
participant Smoke as Smoke jobs
participant Native as Native artifact matrix
participant Publish as Publish job

Operator->>GH: Push version tag or dispatch publish.yml(tag, runner_provider)
alt "runner_provider == github"
    GH->>Smoke: Run Linux/Windows smoke on GitHub-hosted fallback labels
    GH->>Native: Run Blacksmith-backed native entries on GitHub-hosted fallback labels
else "tag push or runner_provider == blacksmith"
    GH->>Smoke: Run smoke jobs on Blacksmith defaults
    GH->>Native: Run native entries on Blacksmith defaults where applicable
end
GH->>Native: Always keep darwin-x64 on macos-26-intel
Smoke-->>Publish: Smoke jobs pass
Native-->>Publish: Native artifacts uploaded
Publish->>Publish: Run on ubuntu-latest for npm provenance
Publish->>GH: Publish npm packages and create GitHub Release
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
actor Operator
participant GH as GitHub Actions
participant Smoke as Smoke jobs
participant Native as Native artifact matrix
participant Publish as Publish job

Operator->>GH: Push version tag or dispatch publish.yml(tag, runner_provider)
alt "runner_provider == github"
    GH->>Smoke: Run Linux/Windows smoke on GitHub-hosted fallback labels
    GH->>Native: Run Blacksmith-backed native entries on GitHub-hosted fallback labels
else "tag push or runner_provider == blacksmith"
    GH->>Smoke: Run smoke jobs on Blacksmith defaults
    GH->>Native: Run native entries on Blacksmith defaults where applicable
end
GH->>Native: Always keep darwin-x64 on macos-26-intel
Smoke-->>Publish: Smoke jobs pass
Native-->>Publish: Native artifacts uploaded
Publish->>Publish: Run on ubuntu-latest for npm provenance
Publish->>GH: Publish npm packages and create GitHub Release
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: add provider-wide publish runner fal..."](https://github.com/bastani-inc/atomic/commit/bc945c794c1f71b1c08ea14baddcde8fc03ae7ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43673761)</sub>

<!-- /greptile_comment -->