### PR TITLE
perf(ci): eliminate redundant validation work

### DIFF
--- a/.atomic/workflows/lib/publish-release-run-wait.ts
+++ b/.atomic/workflows/lib/publish-release-run-wait.ts
@@ -41,7 +41,7 @@ type RunIdentity =
 
 type JsonObject = { readonly [key: string]: JsonValue };
 
-const runJsonFields = "databaseId,status,conclusion,url,headBranch,event,workflowName,createdAt,headSha";
+const runJsonFields = "databaseId,status,conclusion,url,headBranch,event,workflowName,displayTitle,createdAt,headSha";
 function isJsonObject(value: JsonValue): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -65,25 +65,24 @@ function verifyRunIdentityJson(
   value: JsonValue,
   expectedRunId: number,
   expectedHeadBranch: string,
-  expectedHeadSha: string,
+  _expectedHeadSha: string,
 ): RunIdentity {
   if (!isJsonObject(value)) return { ok: false, summary: "GitHub Actions run response was not a JSON object." };
 
   const runId = positiveIntegerField(value, "databaseId");
-  const headBranch = stringField(value, "headBranch");
   const event = stringField(value, "event");
   const status = stringField(value, "status");
   const conclusion = nullableStringField(value, "conclusion");
   const runUrl = stringField(value, "url");
   const headSha = stringField(value, "headSha");
+  const displayTitle = stringField(value, "displayTitle");
   const failures: string[] = [];
 
   if (runId === undefined) failures.push("databaseId was missing or invalid");
   if (runId !== undefined && runId !== expectedRunId) failures.push(`databaseId was ${runId}, expected ${expectedRunId}`);
-  if (headBranch !== expectedHeadBranch) failures.push(`headBranch was ${headBranch ?? "missing"}, expected ${expectedHeadBranch}`);
-  if (event !== "push") failures.push(`event was ${event ?? "missing"}, expected push`);
+  if (displayTitle !== `Publish ${expectedHeadBranch}`) failures.push(`displayTitle was ${displayTitle ?? "missing"}, expected Publish ${expectedHeadBranch}`);
+  if (event !== "workflow_dispatch") failures.push(`event was ${event ?? "missing"}, expected workflow_dispatch`);
   if (status === undefined) failures.push("status was missing");
-  if (headSha !== expectedHeadSha) failures.push(`headSha was ${headSha ?? "missing"}, expected ${expectedHeadSha}`);
 
   if (failures.length > 0 || runId === undefined || status === undefined) {
     return {
@@ -105,7 +104,7 @@ function buildRunListCommand(workflowFile: string): readonly string[] {
     "--workflow",
     workflowFile,
     "--event",
-    "push",
+    "workflow_dispatch",
     "--json",
     runJsonFields,
     "--limit",

--- a/.atomic/workflows/lib/publish-release.ts
+++ b/.atomic/workflows/lib/publish-release.ts
@@ -359,10 +359,11 @@ export function selectPublishWorkflowRunJson(
     const conclusion = nullableStringField(candidate, "conclusion");
     const runUrl = stringField(candidate, "url");
     const headSha = stringField(candidate, "headSha");
+    const displayTitle = stringField(candidate, "displayTitle");
 
-    if (headBranch !== expectedHeadBranch || event !== "push") {
+    if (displayTitle !== `Publish ${expectedHeadBranch}` || event !== "workflow_dispatch") {
       mismatches.push(
-        `run[${index}] headBranch=${headBranch ?? "missing"} event=${event ?? "missing"}`,
+        `run[${index}] displayTitle=${displayTitle ?? "missing"} event=${event ?? "missing"}`,
       );
       continue;
     }
@@ -415,7 +416,7 @@ export function selectPublishWorkflowRunJson(
 export function verifyPublishWorkflowRunJson(
   value: JsonValue,
   expectedHeadBranch: string,
-  expectedHeadSha?: string,
+  _expectedHeadSha?: string,
 ): PublishWorkflowRunVerification {
   if (!isJsonObject(value)) {
     return { ok: false, summary: "GitHub Actions run response was not a JSON object." };
@@ -429,18 +430,19 @@ export function verifyPublishWorkflowRunJson(
   const runUrl = stringField(value, "url");
   const workflowName = stringField(value, "workflowName");
   const headSha = stringField(value, "headSha");
+  const displayTitle = stringField(value, "displayTitle");
   const failures: string[] = [];
 
   if (runId === undefined) failures.push("databaseId was missing or invalid");
-  if (headBranch !== expectedHeadBranch) {
-    failures.push(`headBranch was ${headBranch ?? "missing"}, expected ${expectedHeadBranch}`);
+  if (displayTitle !== `Publish ${expectedHeadBranch}`) {
+    failures.push(`displayTitle was ${displayTitle ?? "missing"}, expected Publish ${expectedHeadBranch}`);
   }
-  if (event !== "push") failures.push(`event was ${event ?? "missing"}, expected push`);
+  if (event !== "workflow_dispatch") failures.push(`event was ${event ?? "missing"}, expected workflow_dispatch`);
   if (status !== "completed") failures.push(`status was ${status ?? "missing"}, expected completed`);
   if (conclusion !== "success") failures.push(`conclusion was ${conclusion ?? "missing"}, expected success`);
-  if (expectedHeadSha !== undefined && headSha !== expectedHeadSha) {
-    failures.push(`headSha was ${headSha ?? "missing"}, expected ${expectedHeadSha}`);
-  }
+  // workflow_dispatch runs execute the protected default-branch workflow; its
+  // headSha is therefore the workflow revision, while the integrity job pins
+  // and verifies the release SHA supplied as input.
 
   if (failures.length > 0 || runId === undefined || status === undefined || conclusion === undefined) {
     return {

--- a/.atomic/workflows/publish-release.ts
+++ b/.atomic/workflows/publish-release.ts
@@ -245,7 +245,7 @@ export default workflow({
 
     const pushTag = await ctx.task("cut-release-tag", {
       prompt: [
-        `Cut the release tag off ${baseRef}. This is the sole publish trigger stage. ${baseRef} is never bumped.`,
+        `Cut the release tag off ${baseRef}, then dispatch the protected default-branch publish workflow. ${baseRef} is never bumped.`,
         "",
         baseInstructions,
         "",
@@ -254,12 +254,13 @@ export default workflow({
         "",
         "Required actions:",
         `1. Verify you are on clean local \`${baseRef}\` at commit \`${mainReady.mainOid}\`.`,
-        `2. Run \`bun run scripts/cut-release.ts ${release.version} --base ${baseRef} --push --yes\`. This stamps the real version onto a throwaway off-${baseRef} "Release ${release.version}" commit (parent = the current ${baseRef} commit), tags it, and pushes ONLY the tag.`,
-        `3. Do not push ${baseRef}. Do not force-push or overwrite an existing tag. Do not run scripts/bump-version.ts.`,
-        "4. You may start monitoring the publish workflow, but the workflow body will verify the tag and publish run deterministically after this stage.",
+        `2. Run \`bun run scripts/cut-release.ts ${release.version} --base ${baseRef} --push --yes\`. This stamps and pushes only the off-${baseRef} release tag.`,
+        `3. Run \`gh workflow run publish.yml --ref main -f tag=${release.version}\` so GitHub uses the protected workflow definition, not tag-controlled YAML.`,
+        `4. Do not push ${baseRef}, force-push a tag, run scripts/bump-version.ts directly, or dispatch with --ref set to the tag.`,
+        "5. Start monitoring the dispatched publish workflow; its first job verifies and pins the immutable release SHA.",
         "",
         "Final response format:",
-        `- Include the pushed tag, the off-${baseRef} release commit SHA and its parent (which must equal the ${baseRef} commit above), local/remote tag SHA evidence, GitHub Actions run URL/status if available, commands run, and any observed blockers.`,
+        `- Include the pushed tag, release commit SHA/parent, local/remote tag evidence, the workflow_dispatch run URL/status, commands run, and blockers.`,
       ].join("\n"),
     });
 
@@ -279,7 +280,7 @@ export default workflow({
       return blockedOutput(
         release,
         "verify-publish-workflow-succeeded",
-        "GitHub Actions Publish run for the release tag has matching headSha, status completed, and conclusion success",
+        "GitHub Actions protected Publish dispatch for the release tag completes successfully after its integrity job verifies and pins the release SHA",
         [publishVerification.summary, "", "Cut-release stage output:", excerpt(pushTag.text, 2_000)].join("\n"),
         publishVerification.pending === true ? "blocked" : "failed",
       );

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish
+run-name: Publish ${{ inputs.tag }}
 
 on:
-    push:
-        tags:
-            - "[0-9]*.[0-9]*.[0-9]*"
+    # Manual dispatch is deliberate: GitHub loads this workflow from the protected
+    # default branch, so a forged tag cannot remove its own integrity gate.
     workflow_dispatch:
         inputs:
             tag:
@@ -26,14 +26,51 @@ env:
     PACKAGE_NAME: "@bastani/atomic"
 
 jobs:
+    release-integrity:
+        name: Verify release integrity
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        outputs:
+            sha: ${{ steps.release.outputs.sha }}
+            tag: ${{ steps.release.outputs.tag }}
+        steps:
+            # Keep the protected workflow revision checked out so the tag cannot
+            # replace the verifier that validates it.
+            - uses: useblacksmith/checkout@v1
+              with:
+                  ref: ${{ github.event.repository.default_branch }}
+                  fetch-depth: 0
+                  persist-credentials: false
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+            - name: Resolve and verify immutable release commit
+              id: release
+              shell: bash
+              env:
+                  RELEASE_TAG: ${{ github.event.inputs.tag }}
+                  WORKFLOW_REF_NAME: ${{ github.ref_name }}
+                  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+              run: |
+                  set -euo pipefail
+                  [[ "$WORKFLOW_REF_NAME" == "$DEFAULT_BRANCH" ]] || { echo "Publish must run from protected default branch $DEFAULT_BRANCH, not $WORKFLOW_REF_NAME" >&2; exit 1; }
+                  release_version_re='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-alpha\.[1-9][0-9]*)?'
+                  [[ "$RELEASE_TAG" =~ ^$release_version_re$ ]] || { echo "Unexpected tag format: $RELEASE_TAG" >&2; exit 1; }
+                  release_sha=$(git ls-remote --exit-code --refs origin "refs/tags/$RELEASE_TAG" | awk 'NR == 1 { print $1 }')
+                  [[ "$release_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "Could not resolve tag $RELEASE_TAG to one commit" >&2; exit 1; }
+                  git fetch --no-tags origin "$release_sha" main:refs/remotes/origin/main
+                  bun run scripts/verify-release-integrity.ts --base-ref origin/main --release-commit "$release_sha"
+                  echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
+                  echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
     linux-binary-smoke:
+        needs: release-integrity
         name: Smoke test Linux binary
         runs-on: blacksmith-4vcpu-ubuntu-2404
 
         steps:
             - uses: useblacksmith/checkout@v1
               with:
-                  ref: ${{ github.event.inputs.tag || github.ref_name }}
+                  ref: ${{ needs.release-integrity.outputs.sha }}
                   persist-credentials: false
 
             - uses: oven-sh/setup-bun@v2
@@ -108,12 +145,13 @@ jobs:
 
     windows-binary-smoke:
         name: Smoke test Windows binary
+        needs: release-integrity
         runs-on: blacksmith-4vcpu-windows-2025
 
         steps:
             - uses: useblacksmith/checkout@v1
               with:
-                  ref: ${{ github.event.inputs.tag || github.ref_name }}
+                  ref: ${{ needs.release-integrity.outputs.sha }}
                   persist-credentials: false
 
             - uses: oven-sh/setup-bun@v2
@@ -195,6 +233,7 @@ jobs:
 
     atomic-native-artifacts:
         name: Atomic native ${{ matrix.platform }}
+        needs: release-integrity
         runs-on: ${{ matrix.runner }}
         strategy:
             fail-fast: false
@@ -210,7 +249,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7.0.0
               with:
-                  ref: ${{ github.event.inputs.tag || github.ref_name }}
+                  ref: ${{ needs.release-integrity.outputs.sha }}
                   persist-credentials: false
 
             - uses: oven-sh/setup-bun@v2
@@ -278,36 +317,20 @@ jobs:
             - linux-binary-smoke
             - windows-binary-smoke
             - atomic-native-artifacts
+            - release-integrity
         outputs:
             version: ${{ steps.package.outputs.version }}
             npm_tag: ${{ steps.package.outputs.npm_tag }}
-            release_tag: ${{ steps.checkout_ref.outputs.ref }}
+            release_tag: ${{ needs.release-integrity.outputs.tag }}
 
         steps:
-            - name: Resolve checkout ref
-              id: checkout_ref
-              shell: bash
-              env:
-                  DISPATCH_TAG: ${{ github.event.inputs.tag || '' }}
-              run: |
-                  set -euo pipefail
-                  if [ -n "$DISPATCH_TAG" ]; then
-                    ref="$DISPATCH_TAG"
-                  else
-                    ref="${GITHUB_REF#refs/tags/}"
-                  fi
-                  release_version_re='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-alpha\.[1-9][0-9]*)?'
-                  if [[ ! "$ref" =~ ^$release_version_re$ ]]; then
-                    echo "Unexpected tag format: $ref (expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-alpha.REVISION, e.g. 0.8.0 or 0.8.0-alpha.1)" >&2
-                    exit 1
-                  fi
-                  echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
             - uses: actions/checkout@v7.0.0
               with:
-                  ref: ${{ steps.checkout_ref.outputs.ref }}
+                  ref: ${{ needs.release-integrity.outputs.sha }}
                   fetch-depth: 0
                   persist-credentials: false
+
 
             - uses: oven-sh/setup-bun@v2
               with:
@@ -317,14 +340,23 @@ jobs:
               with:
                   node-version: 24
 
+
             - name: Install dependencies
               run: bun install --frozen-lockfile
 
-            - name: Typecheck
-              run: bun run typecheck
+            - name: Docs link validation
+              working-directory: ${{ env.PACKAGE_DIR }}
+              run: bun run docs:check
 
-            - name: Test
-              run: bun run test:all
+            - name: Mintlify docs validation
+              working-directory: ${{ env.PACKAGE_DIR }}/docs
+              run: |
+                  bunx --bun mintlify@latest validate
+                  bunx --bun mintlify@latest broken-links
+
+            # Full type/test suites already gate the integrated parent on PR/main.
+            # The trusted integrity job proves every downstream job uses the same
+            # immutable deterministic release commit.
 
             - name: Verify committed npm shrinkwrap
               run: bun run check:shrinkwrap
@@ -341,21 +373,12 @@ jobs:
                   bun run --cwd packages/natives create-npm-dirs
                   bun run --cwd packages/natives artifacts
 
-            - name: Docs link validation
-              working-directory: ${{ env.PACKAGE_DIR }}
-              run: bun run docs:check
-
-            - name: Mintlify docs validation
-              working-directory: ${{ env.PACKAGE_DIR }}/docs
-              run: |
-                  bunx --bun mintlify@latest validate
-                  bunx --bun mintlify@latest broken-links
 
             - name: Validate single publish target and package metadata
               id: package
               shell: bash
               env:
-                  RELEASE_TAG: ${{ steps.checkout_ref.outputs.ref }}
+                  RELEASE_TAG: ${{ needs.release-integrity.outputs.tag }}
               run: |
                   set -euo pipefail
 
@@ -442,7 +465,7 @@ jobs:
                   echo "Publishing $name@$version from $PACKAGE_DIR with npm tag '$npm_tag'."
 
             - name: Build @bastani/atomic package and binaries
-              run: ./scripts/build-binaries.sh
+              run: ./scripts/build-binaries.sh --skip-install
 
             - name: Verify built package metadata
               working-directory: ${{ env.PACKAGE_DIR }}
@@ -647,11 +670,24 @@ jobs:
                   )
                   sha256sum "${release_assets[@]}" > SHA256SUMS
 
+            - name: Reconfirm release tag is immutable
+              shell: bash
+              env:
+                  RELEASE_TAG: ${{ needs.release-integrity.outputs.tag }}
+                  VERIFIED_SHA: ${{ needs.release-integrity.outputs.sha }}
+              run: |
+                  set -euo pipefail
+                  current_sha=$(git ls-remote --exit-code --refs origin "refs/tags/$RELEASE_TAG" | awk 'NR == 1 { print $1 }')
+                  [[ "$current_sha" == "$VERIFIED_SHA" ]] || {
+                    echo "Release tag $RELEASE_TAG moved from verified $VERIFIED_SHA to ${current_sha:-missing}; refusing release creation." >&2
+                    exit 1
+                  }
+
             - name: Create GitHub Release with binaries
               uses: softprops/action-gh-release@v3
               with:
-                  tag_name: ${{ steps.checkout_ref.outputs.ref }}
-                  name: ${{ steps.checkout_ref.outputs.ref }}
+                  tag_name: ${{ needs.release-integrity.outputs.tag }}
+                  name: ${{ needs.release-integrity.outputs.tag }}
                   body_path: ${{ steps.release_notes.outputs.notes_file }}
                   draft: false
                   prerelease: ${{ steps.release_type.outputs.prerelease == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
             - uses: useblacksmith/checkout@v1
               with:
                   lfs: true
+                  fetch-depth: 0
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
@@ -40,14 +41,17 @@ jobs:
             - name: Install dependencies
               run: bun install --frozen-lockfile
             - name: Typecheck
+              if: runner.os == 'Linux'
               run: bun run typecheck
             - name: File length check
+              if: runner.os == 'Linux'
               run: bun run check:file-length
             - name: Docs link validation
+              if: runner.os == 'Linux'
               working-directory: packages/coding-agent
               run: bun run docs:check
             - name: Mintlify docs validation
-              if: github.event_name == 'pull_request'
+              if: runner.os == 'Linux' && github.event_name == 'pull_request'
               working-directory: packages/coding-agent/docs
               run: |
                   bunx --bun mintlify@latest validate
@@ -55,23 +59,30 @@ jobs:
             - name: Build @bastani/atomic package
               working-directory: packages/coding-agent
               run: bun run build
-            - name: Unit tests
-              run: bun run test:unit
-            - name: Integration tests
-              run: bun run test:integration
+            - name: Deterministic CI and release contracts
+              run: bun run test:ci-contracts
+            - name: Unit tests (one bounded flake retry)
+              run: >-
+                  bun run scripts/run-flaky-test-suite.ts --label "unit tests (${{ matrix.binary_platform }})"
+                  --no-retry-file flaky-test-suite-runner.test.ts
+                  -- bun run test:unit
+            - name: Integration tests (one bounded flake retry)
+              run: >-
+                  bun run scripts/run-flaky-test-suite.ts --label "integration tests (${{ matrix.binary_platform }})"
+                  -- bun run test:integration
               env:
-                  # Hard-require the installed-package Node smoke here, where the
-                  # package build above guarantees dist/ exists. publish.yml runs
-                  # test:all before building and skips the smoke gracefully.
+                  # Hard-require the installed-package Node smoke where the package
+                  # build above guarantees dist/ exists on both supported hosts.
                   ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"
             - name: Build native bindings for package tests
               run: bun run --cwd packages/natives build
-            - name: coding-agent vitest suite
-              working-directory: packages/coding-agent
-              run: bun run --bun test
+            - name: coding-agent vitest suite (one bounded flake retry)
+              run: >-
+                  bun run scripts/run-flaky-test-suite.ts --label "coding-agent tests (${{ matrix.binary_platform }})"
+                  -- bun run --cwd packages/coding-agent --bun test
             - name: Build native release binary
               shell: bash
-              run: ./scripts/build-binaries.sh --platform "${{ matrix.binary_platform }}"
+              run: ./scripts/build-binaries.sh --skip-install --skip-package-build --platform "${{ matrix.binary_platform }}"
             - name: Smoke test Linux release archive
               if: runner.os == 'Linux'
               shell: bash
@@ -177,3 +188,11 @@ jobs:
                   if ($status -ne 0 -and $output -notmatch "No models available|No model selected|No API key found") {
                     exit $status
                   }
+            - name: Upload flaky-test diagnostics
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: test-diagnostics-${{ matrix.binary_platform }}
+                  path: .ci-diagnostics/
+                  if-no-files-found: ignore
+                  retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,21 +121,20 @@ atomic:
 
 ## Releasing
 
-Atomic uses a **versionless `main`** release flow (modeled on openai/codex): every `packages/*/package.json` on `main` stays at the `0.0.0` placeholder, and the real version is materialized **only** on a throwaway, off-`main` `Release <version>` commit that is tagged but never merged back. Pushing the `<version>` tag (no leading `v`, for example `0.8.24` or `0.8.24-alpha.1`) triggers CI, which publishes to npm with OIDC provenance (stable `<x.y.z>` → `@latest`, prerelease `<x.y.z>-alpha.N` → `@next`) and creates the GitHub Release with cross-compiled binaries attached. Because `main` carries no version, you can cut a stable release and an ahead-of-stable prerelease line from the same trunk without branch gymnastics.
+Atomic uses a **versionless `main`** release flow (modeled on openai/codex): every `packages/*/package.json` on `main` stays at the `0.0.0` placeholder, and the real version is materialized only on a throwaway, off-`main` `Release <version>` commit that is tagged but never merged back. Publishing is intentionally dispatch-only so GitHub loads the trusted workflow from protected `main`: after pushing the tag, run `gh workflow run publish.yml --ref main -f tag=<version>`. The integrity job accepts only a deterministic release commit whose parent is already integrated into `main`, then publishes with npm OIDC provenance and creates the GitHub Release.
 
-Cut a release with `scripts/cut-release.ts`, which stamps the version onto the off-`main` tag commit and (with `--push`) pushes only the tag:
+Cut and dispatch a release with:
 
 ```sh
-bun run scripts/cut-release.ts 0.8.31            # stable -> @latest
-bun run scripts/cut-release.ts 0.9.0-alpha.1     # prerelease -> @next
 bun run scripts/cut-release.ts 0.8.31 --base main --push
+gh workflow run publish.yml --ref main -f tag=0.8.31
 ```
 
-`main` is never advanced; the script creates the release commit in a detached git worktree, tags it, and abandons the worktree (the tag keeps the commit alive).
+`main` is never advanced; the script creates the release commit in a detached git worktree, tags it, and abandons the worktree. Pushing the tag alone does **not** publish it.
 
 ### Agent publishing requests
 
-If a user asks you to publish the package or create a release/prerelease, run the `publish-release` workflow using your workflow tool. That workflow opens a CHANGELOG-only release-notes PR to `main`, then stamps and tags the release off-`main` via `cut-release.ts` — it never bumps the version on `main`. It also accepts an optional `base_ref` input (default `main`) to release from a maintenance/integration branch instead of `main`, and an optional `from_ref` input to cut an **ephemeral** release from any commit/tag/branch: the workflow auto-creates `release/<version>` (or `prerelease/<version>`) from that ref, gates on that branch's CI, cuts and publishes the tag, then deletes the branch (the changelog lives on the tag only; `main` is untouched).
+If a user asks you to publish the package or create a release/prerelease, run the `publish-release` workflow using your workflow tool. It opens a CHANGELOG-only PR to `main`, stamps and pushes the deterministic off-`main` release tag, dispatches the protected `publish.yml` definition with `--ref main`, and monitors that run. The release-integrity gate requires the tag commit's parent to be integrated into `main`; do not use the legacy `base_ref` maintenance-branch or `from_ref` ephemeral-release inputs, because non-`main` parents are rejected before publishing.
 
 ## Docs
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,36 +10,24 @@ This document describes the GitHub Actions workflows for the Atomic monorepo and
 
 ```text
 Pull request / push
-  ├─ bun install --frozen-lockfile
-  ├─ bun run typecheck
-  ├─ bun run check:file-length
-  ├─ cd packages/coding-agent && bun run docs:check
-  ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
-  ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
-  ├─ cd packages/coding-agent && bun run build
-  ├─ bun run test:unit
-  ├─ bun run test:integration
-  │  └─ includes an installed-layout smoke that runs the built @bastani/atomic
-  │     package under the Node runtime and fails on extension-load diagnostics
-  └─ scripts/build-binaries.sh --platform <native-x64>
-     └─ extract archive, verify bundled paths, run --version and --no-session smoke tests
+  ├─ Linux: install, typecheck, file-length/docs checks, unit tests, native build, and coding-agent tests
+  ├─ Linux + Windows: build @bastani/atomic and run the installed-package Node integration smoke
+  └─ Linux + Windows: scripts/build-binaries.sh --skip-install --skip-package-build --platform <native-x64>
+     └─ reuse the caller's install/build, extract the archive, verify bundled paths,
+        and run --version plus --no-session smoke tests
 
-<version> tag pushed
+Protected-branch `workflow_dispatch` with a `<version>` tag
   ├─ smoke test Linux x64 release archive in a dedicated job
   ├─ smoke test Windows x64 release archive in a dedicated job
   ├─ build native NAPI artifacts for Linux, Windows, and macOS
   └─ publish after smoke and native-artifact jobs pass
      ├─ resolve and validate the release tag
-     ├─ bun install --frozen-lockfile
-     ├─ bun run typecheck && bun run test:all
-     ├─ verify committed npm-shrinkwrap.json is deterministic and current
-     ├─ download native NAPI artifacts
-     ├─ prepare generated native optional packages
-     ├─ cd packages/coding-agent && bun run docs:check
-     ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
-     ├─ cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
-     ├─ validate package metadata, synced versions, and private bundled packages
-     ├─ scripts/build-binaries.sh (regular build + cross-compile 6 targets)
+     ├─ prove the release commit has one parent integrated into main
+     ├─ deterministically regenerate the version/shrinkwrap tree and require an exact tree match
+     ├─ bun install --frozen-lockfile and verify committed npm-shrinkwrap.json
+     ├─ download native NAPI artifacts and prepare native optional packages
+     ├─ validate release-specific package metadata and synchronized versions
+     ├─ scripts/build-binaries.sh --skip-install (regular build + cross-compile 6 targets)
      ├─ validate dist/builtin contains all bundled extensions
      ├─ extract release notes from packages/coding-agent/CHANGELOG.md
      ├─ check whether the npm versions already exist
@@ -78,13 +66,29 @@ Bundled builtin packages copied into `packages/coding-agent/dist/builtin/` durin
 
 These companion packages remain in the workspace for source organization and tests, but are marked `private: true` and must not be published independently. `@bastani/atomic-natives` is the exception because `@bastani/atomic` depends on it at runtime.
 
+
+## CI performance and caching
+
+Recent Actions measurements (2026-07-12) showed the Linux test leg completing in about 3m34s while Windows took about 6m02s on a main push and 7m58s on a PR. The platform-independent Windows work removed here is typecheck (15s), file-length/docs links (about 2s), and Mintlify (61s), for about **1m18s** of sampled critical-path savings. Platform-sensitive unit, integration, native-package, coding-agent, and archive smoke coverage remains on Windows. Binary assembly also reuses the install and package build already completed in each job, avoiding another frozen install and package build.
+
+Release tags no longer repeat typecheck and the complete test suites. Instead, a protected-default-branch dispatch first runs `scripts/verify-release-integrity.ts`, which requires a single-parent `Release <version>` commit whose parent is contained by `origin/main`, recreates the release tree with the same stamper and shrinkwrap generator as `scripts/cut-release.ts`, and compares Git tree IDs. It then passes the verified SHA—not the mutable tag name—to every smoke, native, and publish checkout. Extra, missing, or modified files fail, and the publish job re-resolves the remote tag immediately before GitHub Release creation to reject a force-move. Release docs/Mintlify, shrinkwrap, version/metadata, native, binary/archive, npm tarball, registry, provenance, and GitHub Release checks remain.
+
+Blacksmith's [Actions cache](https://docs.blacksmith.sh/blacksmith-caching/dependencies-actions) automatically redirects official GitHub and popular third-party cache actions to its colocated backend, but it does not implicitly add a Bun dependency cache or Cargo compilation cache. We intentionally do not cache `node_modules`, Bun's global cache, or Cargo outputs here: measured Linux installs were already 0–1s and Blacksmith notes Rust `sccache` is not redirected to its backend. Cache keys and restore safety would add complexity without a demonstrated bottleneck. [Sticky Disks](https://docs.blacksmith.sh/blacksmith-caching/dependencies-sticky-disks) and [Git checkout caching](https://docs.blacksmith.sh/blacksmith-caching/git-checkout-caching) are optional dashboard/runner features rather than workflow YAML changes; checkout caching is still beta. Dedicated Blacksmith test/smoke jobs use `useblacksmith/checkout@v1`; the mixed native-artifact matrix retains one uniform `actions/checkout` step because it also includes GitHub-hosted Intel macOS.
+
+Blacksmith [Test Analytics](https://docs.blacksmith.sh/blacksmith-observability/test-analytics) requires uploaded JUnit XML. Bun's current test commands do not produce a repository-standard JUnit artifact, so CI does not add a lossy conversion solely for analytics. The Blacksmith dashboard/run history should continue to be used to validate these savings and identify a future test shard only when suite timings justify it. Runner sizes remain at 4 vCPU for test/smoke work; the measured work is mostly serial, so a larger runner is not assumed to improve it.
+
+### Bounded flaky-test recovery
+
+Only the unit, integration, and coding-agent test-suite steps use `scripts/run-flaky-test-suite.ts`. The green path runs the command once with no artifact writes. After a genuine suite failure, the runner preserves attempt 1, emits an OS/Bun/CPU/memory/load summary, and reruns that same smallest safe suite **once**. If attempt 2 passes, the job succeeds with a visible `Detected flake` warning and step-summary entry; if it fails, the step fails with both logs. `.ci-diagnostics/` is uploaded for 14 days on both Linux and Windows whenever files exist.
+
+This is not a blanket command retry. Typecheck, docs, file-length/lint, builds, native/package/archive checks, shrinkwrap, metadata, provenance, and publishing never use the wrapper. Workflow structure and release-verifier fixtures run first in the separate `test:ci-contracts` step with no retry wrapper; the retry runner's own unit contract is also a no-retry file. Bun does not currently expose a stable cross-platform failed-file manifest suitable for safely reconstructing arbitrary test commands, so the fallback reruns the named suite rather than guessing file paths. The policy adds no second-run cost when CI is green; a recovered flake costs one suite duration and remains observable instead of hiding the instability.
 ---
 
 ## Pull Request Workflows
 
 ### Tests (`test.yml`)
 
-Runs on pushes to `main` and PRs targeting `main`.
+Runs on pushes to `main`, `release/**`, and `prerelease/**`, plus PRs targeting `main`.
 
 Matrix:
 
@@ -97,16 +101,10 @@ Steps:
 2. Set up Bun.
 3. Set up Node 24 (required by the installed-package Node smoke below; the published `atomic` bin runs under `#!/usr/bin/env node` for npm/bun installs).
 4. Install dependencies with `bun install --frozen-lockfile`.
-5. Run `bun run typecheck`.
-6. Run `bun run check:file-length` to enforce the 500-line maximum for tracked TS/JS/Rust source-like files after applying only the documented generated/vendored exclusions.
-7. Validate hosted-docs routes and internal links with `cd packages/coding-agent && bun run docs:check`.
-8. Validate Mintlify MDX/page syntax with `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`.
-9. Check Mintlify broken links with `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`.
-10. Build `@bastani/atomic` with `cd packages/coding-agent && bun run build`.
-11. Run `bun run test:unit`.
-12. Run `bun run test:integration` with `ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1`. This includes `test/integration/installed-package-node-extensions.test.ts`, which assembles an installed-like layout (built `dist/` copied next to linked `node_modules` siblings, outside the monorepo `packages/` tree) and runs `dist/cli.js --no-session` under **Node** — the runtime npm/bun installs actually use — failing on any `Failed to load extension` diagnostic. This guards the extension loader's installed-package alias fallback, which the compiled-binary smoke (virtualModules path) and Bun-run test suites (lenient exports-map resolution) cannot exercise; it runs on both the Linux and Windows matrix legs. The env flag makes the smoke hard-required here, where the build step precedes it and guarantees `dist/` exists; without the flag (e.g. `publish.yml` runs `test:all` before building) the test skips gracefully with a warning.
-13. Build the native release binary with `scripts/build-binaries.sh --platform <native-x64>`.
-14. Extract the generated release archive, verify required bundled `builtin/*` and selected `node_modules/*` paths are present, run `atomic --version`, and run `atomic --no-session` far enough to catch extension-load diagnostics while allowing the expected no-models exit in CI.
+5. On Linux, run typecheck, file-length, and docs/Mintlify checks. Unit, native-package, and coding-agent suites continue on both Linux and Windows.
+6. Build `@bastani/atomic` and run `bun run test:integration` with `ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1` on both platforms. The installed-like layout runs `dist/cli.js --no-session` under **Node**, failing on extension-load diagnostics and preserving the cross-platform npm-install behavior.
+7. Build the native release binary with `scripts/build-binaries.sh --skip-install --skip-package-build --platform <native-x64>` so the matrix does not repeat its install or package build.
+8. Extract the generated archive, verify required bundled paths, run `atomic --version`, and run `atomic --no-session` far enough to catch extension-load diagnostics while allowing the expected no-models exit.
 
 ---
 
@@ -114,10 +112,7 @@ Steps:
 
 ### Trigger
 
-The publish pipeline (`publish.yml`) runs when:
-
-- a `<version>` tag is pushed (no leading `v`, for example `0.8.0` or `0.8.0-alpha.1`)
-- `workflow_dispatch` is run with an explicit tag input such as `0.8.0`
+The publish pipeline (`publish.yml`) runs only through `workflow_dispatch` from the protected default-branch workflow, with an explicit tag input such as `0.8.0`. It intentionally does not execute a workflow definition loaded from the tag: otherwise a forged tag could remove its own integrity gate.
 
 ### Tag Naming
 
@@ -144,7 +139,7 @@ The release shrinkwrap is prepared before the tag is published. Internal Atomic 
 ### Publish Flow
 
 ```text
-git push origin 0.8.0
+gh workflow run publish.yml --ref main -f tag=0.8.0
        │
        ├─ Smoke Linux binary
        │    · build linux-x64
@@ -156,25 +151,18 @@ git push origin 0.8.0
        │    · extract archive
        │    · run --version and --no-session
        │
-       └─ after both smoke jobs pass
+       └─ after the trusted integrity job pins one verified release SHA and both smoke jobs pass
           ▼
 Publish @bastani/atomic
-  · resolve and validate the tag name
-  · checkout the tag
+  · checkout the immutable SHA exported by release-integrity
   · run on a GitHub-hosted Ubuntu runner (required for npm provenance)
   · setup Bun and Node (Node 24 for npm provenance publish)
   · bun install --frozen-lockfile
-  · bun run typecheck && bun run test:all
   · verify the committed npm-shrinkwrap.json matches local deterministic generation
   · download native NAPI artifacts from the matrix jobs
-  · prepare generated native optional packages with `bun run --cwd packages/natives create-npm-dirs` and `bun run --cwd packages/natives artifacts`
-  · cd packages/coding-agent && bun run docs:check
-  · cd packages/coding-agent/docs && bunx --bun mintlify@latest validate
-  · cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links
-  · validate tag matches packages/coding-agent/package.json
-  · validate every package manifest has a synced version
-  · validate bundled packages remain private, with `@bastani/atomic-natives` as the publishable native-package exception
-  · scripts/build-binaries.sh
+  · prepare generated native optional packages
+  · validate tag/package versions, metadata, and private bundled packages
+  · scripts/build-binaries.sh --skip-install
       - bun run build (regular dist/)
       - bun build --compile --target=bun-<platform> for all 6 targets
       - assemble per-platform asset trees
@@ -192,7 +180,7 @@ Publish @bastani/atomic
        ▼
 Create GitHub Release with softprops/action-gh-release@v3
   · body: extracted CHANGELOG section
-  · files: 6 binary archives
+  · files: 6 binary archives plus SHA256SUMS
 ```
 
 ### Why npm Publish Before GitHub Release?
@@ -225,6 +213,7 @@ Binaries attached to every release:
 - `atomic-linux-arm64.tar.gz`
 - `atomic-windows-x64.zip`
 - `atomic-windows-arm64.zip`
+- `SHA256SUMS`
 
 ---
 
@@ -253,17 +242,13 @@ Those extensions are bundled into `@bastani/atomic` by `packages/coding-agent/sc
 
 Verdaccio is intentionally not used.
 
-The meaningful pre-publish checks are:
+The meaningful pre-publish checks are split between required PR/main validation and release-specific gates. The release job proves its parent is integrated and its tree is exactly the deterministic release transform, then checks:
 
-- TypeScript typechecking
-- unit and integration tests
-- docs route/internal-link validation with `cd packages/coding-agent && bun run docs:check`
-- Mintlify MDX/page syntax validation with `cd packages/coding-agent/docs && bunx --bun mintlify@latest validate`
-- Mintlify broken-link validation with `cd packages/coding-agent/docs && bunx --bun mintlify@latest broken-links`
 - deterministic `npm-shrinkwrap.json` validation for `@bastani/atomic`
-- `@bastani/atomic` build output validation
-- builtin extension/resource validation under `dist/builtin/`
-- `bun pm pack --dry-run` from `packages/coding-agent`
+- synchronized tag/package versions and publish metadata
+- `@bastani/atomic` build output and builtin extension/resources
+- all native packages and six release archives
+- `bun pm pack --dry-run` and npm OIDC provenance
 
 ---
 
@@ -272,7 +257,7 @@ The meaningful pre-publish checks are:
 | File                 | Trigger                                       | Purpose                                                                                                                                                                                                       |
 | -------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `test.yml`           | Push to `main`, PR to `main`                  | Install, typecheck, enforce the tracked TS/JS/Rust file-length gate, validate docs links plus Mintlify MDX/page syntax and broken links, build `@bastani/atomic`, unit/integration tests (including the installed-package Node-runtime extension smoke on Linux and Windows), build native Linux/Windows binaries, verify archive contents, and run `atomic --version` / `atomic --no-session` archive smoke tests |
-| `publish.yml`        | `<version>` tag push, manual dispatch with tag input | Smoke test Linux/Windows binaries in parallel on Blacksmith runners, build native NAPI artifacts on Blacksmith Linux/Windows/ARM/macOS runners plus GitHub `macos-26-intel` for Darwin x64, validate deterministic shrinkwrap/docs links plus Mintlify MDX/page syntax and broken links before publish metadata checks, build binaries on a GitHub-hosted runner for npm provenance, publish `@bastani/atomic-natives` and `@bastani/atomic`, create GitHub Release with binaries |
+| `publish.yml`        | Protected `workflow_dispatch` with tag input | Verify deterministic tag ancestry/content and pin its SHA, smoke Linux/Windows binaries, build all native NAPI artifacts, validate release docs/package/shrinkwrap/binary contracts, publish both public packages with npm OIDC provenance, and create the GitHub Release |
 
 ---
 
@@ -280,7 +265,7 @@ The meaningful pre-publish checks are:
 
 1. Move the `[Unreleased]` section in `packages/coding-agent/CHANGELOG.md` to `## [0.8.0] - <YYYY-MM-DD>` and land it on `main` like any normal change. The publish workflow uses this section as the GitHub Release body. **Do not bump any `package.json` version — `main` is versionless.**
 
-2. Run local validation (optional; CI repeats it from the tagged commit):
+2. Run local validation (optional; required PR/main CI already covers it on the integrated parent):
 
     ```sh
     bun run typecheck
@@ -313,7 +298,7 @@ The meaningful pre-publish checks are:
 
     On Windows, substitute `--platform windows-x64`, extract `atomic-windows-x64.zip`, and run `atomic.exe --version` plus the equivalent `atomic.exe --no-session` smoke. (A `main` build reports the `0.0.0` placeholder for `--version`; a release build from the tag reports the real version.)
 
-3. From a clean `main`, cut and push the release tag. This stamps the version onto an off-`main` `Release 0.8.0` commit, regenerates the deterministic `@bastani/atomic` shrinkwrap from local metadata, tags it, and pushes only the tag (the publish trigger):
+3. From a clean `main`, cut and push the release tag. This stamps the version onto an off-`main` `Release 0.8.0` commit, regenerates the deterministic `@bastani/atomic` shrinkwrap from local metadata, tags it, and pushes only the tag. Pushing alone does not publish; step 4 performs the protected dispatch.
 
     ```sh
     bun run scripts/cut-release.ts 0.8.0 --base main --push
@@ -321,6 +306,6 @@ The meaningful pre-publish checks are:
 
     Omit `--push` to inspect the tag locally first (`git show 0.8.0`, `git log --oneline -1 0.8.0`), then `git push origin 0.8.0`. `main` is never advanced.
 
-4. Confirm `publish.yml` checks out the tag, runs docs link validation plus Mintlify syntax and broken-link checks, cross-compiles binaries, publishes `@bastani/atomic-natives` and `@bastani/atomic` to npm with OIDC provenance, and creates the GitHub Release with binaries attached.
+4. Dispatch the protected `publish.yml` workflow with the pushed tag (`gh workflow run publish.yml --ref main -f tag=0.8.0`). Confirm it pins one verified commit SHA across every job, runs docs/Mintlify and all release-specific gates, cross-compiles binaries, publishes `@bastani/atomic-natives` and `@bastani/atomic` with npm OIDC provenance, and creates the GitHub Release.
 
 For prereleases, substitute `0.8.0-alpha.1`. To run the fully guarded automation (release-notes PR + cut-release + publish monitoring) instead of these manual steps, use the `publish-release` Atomic workflow. Its final publish gate polls the matching `publish.yml` run until GitHub reports a terminal conclusion, so a long-running `in_progress` publish run is not treated as a release failure.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "bun run test:unit",
     "test:unit": "bun test test/unit",
     "test:integration": "bun test test/integration",
+    "test:ci-contracts": "bun test test/ci",
     "test:all": "bun run test:unit && bun run test:integration",
     "typecheck": "tsc --noEmit",
     "check:file-length": "bun scripts/check-file-length.ts",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Accelerated PR/main CI by running platform-independent validation once on Linux while retaining installed-package Node integration and release-archive smoke coverage on Linux and Windows, and by reusing caller-installed dependencies and package builds during binary assembly. Test suites now have one bounded, observable flake-recovery attempt with preserved logs, environment/resource diagnostics, CI annotations, and no retries for deterministic workflow/release/package/publish gates. Release publication no longer reruns the full PR suite: a protected-default-branch integrity gate proves the release commit is generated from a parent already integrated into `main`, contains exactly the expected version and shrinkwrap material, and pins that immutable SHA across release jobs before preserving all release-specific metadata, docs, native, binary, package, and npm provenance checks.
+
 ## [0.9.7-alpha.1] - 2026-07-12
 
 ### Added

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -4,12 +4,14 @@
 # Mirrors .github/workflows/publish.yml binary build.
 #
 # Usage:
-#   ./scripts/build-binaries.sh [--skip-deps] [--platform <platform>]
+#   ./scripts/build-binaries.sh [--skip-deps] [--skip-install] [--skip-package-build] [--platform <platform>]
 #
 # Options:
-#   --skip-deps         Skip installing cross-platform native bindings
-#   --platform <name>   Build only for specified platform
-#                       (darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64, windows-arm64)
+#   --skip-deps          Skip installing cross-platform native bindings
+#   --skip-install       Reuse dependencies installed by the caller
+#   --skip-package-build Reuse packages/coding-agent/dist built by the caller
+#   --platform <name>    Build only for specified platform
+#                        (darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64, windows-arm64)
 #
 # Output:
 #   packages/coding-agent/binaries/
@@ -30,6 +32,8 @@ fi
 cd -- "$(dirname -- "$0")/.."
 
 SKIP_DEPS=false
+SKIP_INSTALL=false
+SKIP_PACKAGE_BUILD=false
 PLATFORM=""
 
 CLIPBOARD_STAGE_DIR=""
@@ -44,6 +48,14 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --skip-deps)
             SKIP_DEPS=true
+            shift
+            ;;
+        --skip-install)
+            SKIP_INSTALL=true
+            shift
+            ;;
+        --skip-package-build)
+            SKIP_PACKAGE_BUILD=true
             shift
             ;;
         --platform)
@@ -69,8 +81,12 @@ if [[ -n "$PLATFORM" ]]; then
     esac
 fi
 
-echo "==> Installing dependencies..."
-bun install --frozen-lockfile
+if [[ "$SKIP_INSTALL" == "false" ]]; then
+    echo "==> Installing dependencies..."
+    bun install --frozen-lockfile
+else
+    echo "==> Reusing caller-installed dependencies (--skip-install)"
+fi
 
 if [[ "$SKIP_DEPS" == "false" ]]; then
     echo "==> Staging cross-platform native bindings for clipboard..."
@@ -96,9 +112,18 @@ else
     bun run --cwd packages/natives build
 fi
 
-echo "==> Building @bastani/atomic package..."
-cd packages/coding-agent
-bun run build
+if [[ "$SKIP_PACKAGE_BUILD" == "false" ]]; then
+    echo "==> Building @bastani/atomic package..."
+    cd packages/coding-agent
+    bun run build
+else
+    echo "==> Reusing caller-built @bastani/atomic package (--skip-package-build)"
+    test -f packages/coding-agent/dist/bun/cli.js || {
+        echo "Missing packages/coding-agent/dist/bun/cli.js; cannot use --skip-package-build" >&2
+        exit 1
+    }
+    cd packages/coding-agent
+fi
 
 echo "==> Building binaries..."
 

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -183,10 +183,12 @@ async function main(): Promise<void> {
   if (push) {
     console.log(`Pushing tag ${version}...`);
     await $`git -C ${ROOT} push origin ${version}`;
-    console.log("Done. CI publish.yml will build and publish from the tag.");
+    console.log("Tag pushed. Dispatch the protected default-branch publish workflow:");
+    console.log(`  gh workflow run publish.yml --ref main -f tag=${version}`);
   } else {
-    console.log("Next: push the tag to trigger the publish pipeline:");
+    console.log("Next: push the tag, then dispatch the protected publish workflow:");
     console.log(`  git push origin ${version}`);
+    console.log(`  gh workflow run publish.yml --ref main -f tag=${version}`);
   }
 }
 

--- a/scripts/run-flaky-test-suite.ts
+++ b/scripts/run-flaky-test-suite.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env bun
+/** Bounded CI-only flake recovery: one retry with durable first-attempt diagnostics. */
+import { appendFileSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { cpus, freemem, loadavg, platform, release, totalmem } from "node:os";
+import { basename, resolve } from "node:path";
+
+interface Options {
+  label: string;
+  diagnosticsDir: string;
+  deterministicFiles: string[];
+  command: string[];
+}
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2);
+  let label = "test suite";
+  let diagnosticsDir = ".ci-diagnostics";
+  const deterministicFiles: string[] = [];
+  let i = 0;
+  for (; i < args.length; i++) {
+    if (args[i] === "--") { i++; break; }
+    if (args[i] === "--label" && args[i + 1]) label = args[++i] as string;
+    else if (args[i] === "--diagnostics-dir" && args[i + 1]) diagnosticsDir = args[++i] as string;
+    else if (args[i] === "--no-retry-file" && args[i + 1]) deterministicFiles.push(basename(args[++i] as string));
+    else throw new Error(`Unknown or incomplete argument: ${args[i]}`);
+  }
+  const command = args.slice(i);
+  if (command.length === 0) throw new Error("Expected a command after --");
+  return { label, diagnosticsDir: resolve(diagnosticsDir), deterministicFiles, command };
+}
+
+function safeName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "tests";
+}
+
+async function runAttempt(command: string[], logPath: string, persist: boolean): Promise<{ code: number; output: string }> {
+  const child = Bun.spawn(command, { stdout: "pipe", stderr: "pipe", env: process.env });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  const output = `${stdout}${stderr}`;
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+  if (persist) writeFileSync(logPath, output);
+  return { code, output };
+}
+
+function debugSummary(label: string, command: string[]): string {
+  const gib = (bytes: number) => `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+  return [
+    `suite: ${label}`,
+    `command: ${command.join(" ")}`,
+    `platform: ${platform()} ${release()} (${process.arch})`,
+    `bun: ${Bun.version}`,
+    `cpu: ${cpus().length} logical`,
+    `memory: ${gib(freemem())} free / ${gib(totalmem())} total`,
+    `loadavg: ${loadavg().map((value) => value.toFixed(2)).join(", ")}`,
+    `cwd: ${process.cwd()}`,
+  ].join("\n");
+}
+
+function appendSummary(markdown: string): void {
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (summary) appendFileSync(summary, `${markdown}\n`);
+}
+
+function findFailedDeterministicFile(output: string, files: string[]): string | undefined {
+  let current: string | undefined;
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    const header = files.find((file) => trimmed.endsWith(`${file}:`));
+    if (header) {
+      current = header;
+      continue;
+    }
+    if (/\.(?:test|spec)\.[cm]?[jt]sx?:$/.test(trimmed)) current = undefined;
+    if (current && trimmed.startsWith("(fail)")) return current;
+  }
+  return undefined;
+}
+
+const options = parseArgs();
+const name = safeName(options.label);
+const firstLog = resolve(options.diagnosticsDir, `${name}-attempt-1.log`);
+const secondLog = resolve(options.diagnosticsDir, `${name}-attempt-2.log`);
+rmSync(firstLog, { force: true });
+rmSync(secondLog, { force: true });
+
+const first = await runAttempt(options.command, firstLog, false);
+if (first.code === 0) process.exit(0);
+
+mkdirSync(options.diagnosticsDir, { recursive: true });
+writeFileSync(firstLog, first.output);
+const debug = debugSummary(options.label, options.command);
+writeFileSync(resolve(options.diagnosticsDir, `${name}-debug.txt`), `${debug}\n`);
+console.error(`\n::warning title=${options.label} first attempt failed::Preserved diagnostics; evaluating one bounded retry.`);
+console.error(`\n${debug}\n`);
+
+const deterministicHit = findFailedDeterministicFile(first.output, options.deterministicFiles);
+if (deterministicHit) {
+  appendSummary(`### ❌ ${options.label}\nNo retry: deterministic test file failed (\`${deterministicHit}\`). First-attempt diagnostics were preserved.`);
+  console.error(`No retry: deterministic test file failed (${deterministicHit}).`);
+  process.exit(first.code);
+}
+
+console.error(`Retrying ${options.label} once (smallest safe suite)...`);
+const second = await runAttempt(options.command, secondLog, true);
+if (second.code === 0) {
+  appendSummary(`### ⚠️ Detected flake: ${options.label}\nAttempt 1 failed and the single bounded retry passed. Diagnostic logs are retained as CI artifacts.`);
+  console.error(`::warning title=Detected flake: ${options.label}::Attempt 1 failed; bounded retry passed. See diagnostic artifact.`);
+  process.exit(0);
+}
+appendSummary(`### ❌ Persistent failure: ${options.label}\nBoth the first attempt and the single bounded retry failed. Both logs are retained.`);
+console.error(`::error title=Persistent failure: ${options.label}::Both attempts failed; see both diagnostic logs.`);
+process.exit(second.code);

--- a/scripts/verify-release-integrity.ts
+++ b/scripts/verify-release-integrity.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/** Verify that a release commit is exactly the deterministic output of cut-release.ts. */
+import { $ } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+interface Options {
+  baseRef: string;
+  releaseCommit: string;
+}
+
+function fail(message: string): never {
+  throw new Error(`Release integrity check failed: ${message}`);
+}
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2);
+  let baseRef = "origin/main";
+  let releaseCommit = "HEAD";
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--base-ref" && args[i + 1]) baseRef = args[++i] as string;
+    else if (args[i] === "--release-commit" && args[i + 1]) releaseCommit = args[++i] as string;
+    else fail(`unknown or incomplete argument: ${args[i]}`);
+  }
+  return { baseRef, releaseCommit };
+}
+
+const ROOT = resolve(import.meta.dir, "..");
+
+async function git(args: string[], cwd = ROOT): Promise<string> {
+  const result = await $`git -C ${cwd} ${args}`.nothrow().quiet();
+  if (result.exitCode !== 0) fail(`git ${args.join(" ")} failed: ${result.stderr.toString().trim()}`);
+  return result.stdout.toString().trim();
+}
+
+async function main(): Promise<void> {
+  const { baseRef, releaseCommit } = parseArgs();
+  const releaseSha = await git(["rev-parse", "--verify", `${releaseCommit}^{commit}`]);
+  const parents = (await git(["show", "-s", "--format=%P", releaseSha])).split(/\s+/).filter(Boolean);
+  if (parents.length !== 1) fail(`release commit must have exactly one parent; found ${parents.length}`);
+  const parent = parents[0] as string;
+
+  const ancestry = await $`git -C ${ROOT} merge-base --is-ancestor ${parent} ${baseRef}`.nothrow().quiet();
+  if (ancestry.exitCode !== 0) fail(`release parent ${parent} is not integrated into ${baseRef}`);
+
+  const version = JSON.parse(await git(["show", `${releaseSha}:packages/coding-agent/package.json`])).version as string;
+  const subject = await git(["show", "-s", "--format=%s", releaseSha]);
+  if (subject !== `Release ${version}`) fail(`commit subject must be "Release ${version}"; found "${subject}"`);
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "atomic-release-integrity-"));
+  const worktree = join(tempRoot, "expected");
+  let added = false;
+  try {
+    await $`git -C ${ROOT} worktree add --detach ${worktree} ${parent}`.quiet();
+    added = true;
+    await $`bun run ${join(worktree, "scripts/bump-version.ts")} ${version} --root ${worktree}`.quiet();
+    await $`bun run ${join(worktree, "scripts/generate-coding-agent-shrinkwrap.mjs")}`.quiet();
+    await $`git -C ${worktree} add -A`.quiet();
+    const expectedTree = (await $`git -C ${worktree} write-tree`.text()).trim();
+    const releaseTree = await git(["show", "-s", "--format=%T", releaseSha]);
+    if (expectedTree !== releaseTree) {
+      const changed = await git(["diff", "--name-status", parent, releaseSha]);
+      fail(`release tree does not match deterministic version/shrinkwrap output\n${changed}`);
+    }
+  } finally {
+    if (added) await $`git -C ${ROOT} worktree remove --force ${worktree}`.nothrow().quiet();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+  console.log(`Release integrity verified: ${releaseSha} is deterministic output from integrated parent ${parent}.`);
+}
+
+await main().catch((error: Error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -1,0 +1,88 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { $ } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+
+test("test workflow runs platform-independent suites once and preserves cross-platform smoke", async () => {
+  const workflow = await Bun.file(join(root, ".github/workflows/test.yml")).text();
+  for (const step of ["Typecheck", "File length check", "Docs link validation"]) {
+    const block = workflow.slice(workflow.indexOf(`- name: ${step}`), workflow.indexOf("- name:", workflow.indexOf(`- name: ${step}`) + 1));
+    assert.match(block, /if: runner\.os == 'Linux'/, `${step} must run on only one matrix leg`);
+  }
+  assert.match(workflow, /ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"/);
+  assert.match(workflow, /--skip-install --skip-package-build --platform/);
+  assert.match(workflow, /Smoke test Linux release archive/);
+  assert.match(workflow, /Smoke test Windows release archive/);
+  assert.match(workflow, /run-flaky-test-suite\.ts --label "unit tests/);
+  assert.match(workflow, /name: Deterministic CI and release contracts[\s\S]*run: bun run test:ci-contracts/);
+  const deterministicBlock = workflow.slice(workflow.indexOf("name: Deterministic CI and release contracts"), workflow.indexOf("name: Unit tests"));
+  assert.doesNotMatch(deterministicBlock, /run-flaky-test-suite/);
+  assert.match(workflow, /run-flaky-test-suite\.ts --label "integration tests/);
+  assert.match(workflow, /run-flaky-test-suite\.ts --label "coding-agent tests/);
+  assert.match(workflow, /name: Upload flaky-test diagnostics[\s\S]*if: always\(\)/);
+});
+
+test("publish replaces full-suite reruns with release integrity and preserves release gates", async () => {
+  const workflow = await Bun.file(join(root, ".github/workflows/publish.yml")).text();
+  assert.match(workflow, /bun run scripts\/verify-release-integrity\.ts --base-ref origin\/main/);
+  assert.doesNotMatch(workflow, /name: (Typecheck|Test)\n/);
+  assert.match(workflow, /npm publish --provenance/g);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /push:\s*\n\s*tags:/);
+  assert.match(workflow, /ref: \$\{\{ needs\.release-integrity\.outputs\.sha \}\}/);
+  assert.match(workflow, /needs: release-integrity/);
+  assert.match(workflow, /name: Mintlify docs validation/);
+  const integrityJob = workflow.slice(workflow.indexOf("release-integrity:"), workflow.indexOf("linux-binary-smoke:"));
+  assert.doesNotMatch(integrityJob, /ref: \$\{\{ github\.event\.inputs\.tag/);
+  assert.match(integrityJob, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(integrityJob, /WORKFLOW_REF_NAME.*github\.ref_name/);
+  assert.match(integrityJob, /DEFAULT_BRANCH.*repository\.default_branch/);
+  assert.match(integrityJob, /git ls-remote --exit-code --refs origin/);
+  assert.match(workflow, /atomic_natives\.win32-arm64-msvc\.node/);
+  assert.match(workflow, /atomic-windows-arm64\.zip/);
+  assert.match(workflow, /bun run check:shrinkwrap/);
+  assert.match(workflow, /name: Reconfirm release tag is immutable[\s\S]*current_sha[\s\S]*VERIFIED_SHA/);
+});
+
+test("release verifier accepts generated release and rejects an extra forged file", async () => {
+  const tag = "0.9.7-alpha.1";
+  const integrityWorktrees = async () => (await $`git worktree list --porcelain`.cwd(root).text())
+    .split("\n")
+    .filter((line) => line.startsWith("worktree ") && line.includes("atomic-release-integrity-")).length;
+  const worktreesBefore = await integrityWorktrees();
+  const valid = await $`bun run scripts/verify-release-integrity.ts --base-ref origin/main --release-commit ${tag}`.cwd(root).nothrow().quiet();
+  assert.equal(valid.exitCode, 0, valid.stderr.toString());
+
+  const temp = mkdtempSync(join(tmpdir(), "atomic-forged-release-"));
+  const index = join(temp, "index");
+  try {
+    const tree = (await $`git show -s --format=%T ${tag}`.cwd(root).text()).trim();
+    const parent = (await $`git show -s --format=%P ${tag}`.cwd(root).text()).trim();
+    await $`git read-tree ${tree}`.cwd(root).env({ ...process.env, GIT_INDEX_FILE: index }).quiet();
+    const blob = (await $`printf 'forged\\n' | git hash-object -w --stdin`.cwd(root).text()).trim();
+    await $`git update-index --add --cacheinfo 100644,${blob},FORGED_RELEASE_FILE`.cwd(root).env({ ...process.env, GIT_INDEX_FILE: index }).quiet();
+    const forgedTree = (await $`git write-tree`.cwd(root).env({ ...process.env, GIT_INDEX_FILE: index }).text()).trim();
+    const forged = (await $`printf ${`Release ${tag}\\n`} | git commit-tree ${forgedTree} -p ${parent}`.cwd(root).env({ ...process.env, GIT_AUTHOR_NAME: "test", GIT_AUTHOR_EMAIL: "test@example.com", GIT_COMMITTER_NAME: "test", GIT_COMMITTER_EMAIL: "test@example.com" }).text()).trim();
+    const result = await $`bun run scripts/verify-release-integrity.ts --base-ref origin/main --release-commit ${forged}`.cwd(root).nothrow().quiet();
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr.toString(), /does not match deterministic version\/shrinkwrap output/);
+
+    const badSubject = (await $`printf 'Forged subject\\n' | git commit-tree ${tree} -p ${parent}`.cwd(root).env({ ...process.env, GIT_AUTHOR_NAME: "test", GIT_AUTHOR_EMAIL: "test@example.com", GIT_COMMITTER_NAME: "test", GIT_COMMITTER_EMAIL: "test@example.com" }).text()).trim();
+    const subjectResult = await $`bun run scripts/verify-release-integrity.ts --base-ref origin/main --release-commit ${badSubject}`.cwd(root).nothrow().quiet();
+    assert.notEqual(subjectResult.exitCode, 0);
+    assert.match(subjectResult.stderr.toString(), /commit subject must be/);
+
+    const unintegrated = (await $`printf ${`Release ${tag}\\n`} | git commit-tree ${tree} -p ${tag}`.cwd(root).env({ ...process.env, GIT_AUTHOR_NAME: "test", GIT_AUTHOR_EMAIL: "test@example.com", GIT_COMMITTER_NAME: "test", GIT_COMMITTER_EMAIL: "test@example.com" }).text()).trim();
+    const ancestryResult = await $`bun run scripts/verify-release-integrity.ts --base-ref origin/main --release-commit ${unintegrated}`.cwd(root).nothrow().quiet();
+    assert.notEqual(ancestryResult.exitCode, 0);
+    assert.match(ancestryResult.stderr.toString(), /is not integrated into origin\/main/);
+    assert.equal(await integrityWorktrees(), worktreesBefore, "failed verification must clean up its temporary worktree registration");
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/unit/flaky-test-suite-runner.test.ts
+++ b/test/unit/flaky-test-suite-runner.test.ts
@@ -1,0 +1,79 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+const runner = join(root, "scripts/run-flaky-test-suite.ts");
+
+type Mode = "success" | "flake" | "persistent" | "deterministic";
+
+async function fixture(mode: Mode): Promise<{ code: number; output: string; files: string[]; summary: string }> {
+  const dir = mkdtempSync(join(tmpdir(), "atomic-flake-runner-"));
+  const command = join(dir, "fixture.ts");
+  const counter = join(dir, "counter");
+  const diagnostics = join(dir, "diagnostics");
+  const summary = join(dir, "summary.md");
+  writeFileSync(command, `
+    import { existsSync, readFileSync, writeFileSync } from "node:fs";
+    const counter = ${JSON.stringify(counter)};
+    const attempt = existsSync(counter) ? Number(readFileSync(counter, "utf8")) + 1 : 1;
+    writeFileSync(counter, String(attempt));
+    console.log("fixture attempt " + attempt);
+    const mode = ${JSON.stringify(mode)};
+    if (mode === "flake") console.log("test/unit/ci-workflow-contracts.test.ts:\\n(pass) deterministic contract");
+    if (mode === "persistent" || (mode === "flake" && attempt === 1)) { console.error("test/unit/unrelated.test.ts:\\n(fail) unrelated failure"); process.exit(7); }
+    if (mode === "deterministic") { console.error("test/ci/ci-workflow-contracts.test.ts:\\n(fail) deterministic contract"); process.exit(8); }
+  `);
+  try {
+    const processResult = Bun.spawn([
+      "bun", runner, "--label", "fixture suite", "--diagnostics-dir", diagnostics,
+      "--no-retry-file", "ci-workflow-contracts.test.ts", "--", "bun", command,
+    ], { cwd: root, env: { ...process.env, GITHUB_STEP_SUMMARY: summary }, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(processResult.stdout).text(),
+      new Response(processResult.stderr).text(),
+      processResult.exited,
+    ]);
+    const glob = new Bun.Glob("*");
+    const files = await Array.fromAsync(glob.scan({ cwd: diagnostics, onlyFiles: true })).catch(() => []);
+    const summaryText = await Bun.file(summary).exists() ? await Bun.file(summary).text() : "";
+    return { code, output: stdout + stderr, files, summary: summaryText };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("green suite exits immediately without diagnostics", async () => {
+  const result = await fixture("success");
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.files, []);
+  assert.doesNotMatch(result.output, /Retrying/);
+});
+test("a passing no-retry file header does not suppress an unrelated flake retry", async () => {
+  const result = await fixture("flake");
+  assert.equal(result.code, 0);
+  assert.match(result.output, /fixture attempt 1[\s\S]*fixture attempt 2/);
+  assert.match(result.summary, /Detected flake/);
+  assert.deepEqual(result.files.sort(), ["fixture-suite-attempt-1.log", "fixture-suite-attempt-2.log", "fixture-suite-debug.txt"]);
+});
+
+test("persistent failure returns failure with both attempt logs", async () => {
+  const result = await fixture("persistent");
+  assert.equal(result.code, 7);
+  assert.match(result.summary, /Persistent failure/);
+  assert.match(result.output, /fixture attempt 1[\s\S]*fixture attempt 2/);
+  assert.ok(result.files.includes("fixture-suite-attempt-1.log"));
+  assert.ok(result.files.includes("fixture-suite-attempt-2.log"));
+});
+
+test("deterministic workflow contract failures are never retried", async () => {
+  const result = await fixture("deterministic");
+  assert.equal(result.code, 8);
+  assert.match(result.output, /No retry: deterministic test file failed/);
+  assert.doesNotMatch(result.output, /fixture attempt 2/);
+  assert.ok(result.files.includes("fixture-suite-attempt-1.log"));
+  assert.ok(!result.files.includes("fixture-suite-attempt-2.log"));
+});

--- a/test/unit/publish-release-helpers.test.ts
+++ b/test/unit/publish-release-helpers.test.ts
@@ -276,17 +276,18 @@ describe("publish-release GitHub Actions publish verification", () => {
   const successfulRun: JsonValue = {
     databaseId: 987654321,
     workflowName: "Publish",
-    headBranch: "1.2.3",
-    event: "push",
+    headBranch: "main",
+    event: "workflow_dispatch",
+    displayTitle: "Publish 1.2.3",
     status: "completed",
     conclusion: "success",
     headSha: "abc123",
     url: "https://github.com/earendil-works/pi-mono/actions/runs/987654321",
   };
 
-  test("selects the newest push run for the release tag from gh run list JSON", () => {
+  test("selects the newest protected dispatch for the release tag", () => {
     const result = selectPublishWorkflowRunJson([
-      { ...successfulRun, databaseId: 111, headBranch: "1.2.4" },
+      { ...successfulRun, databaseId: 111, displayTitle: "Publish 1.2.4" },
       { ...successfulRun, status: "in_progress", conclusion: null },
     ], "1.2.3");
 
@@ -295,8 +296,8 @@ describe("publish-release GitHub Actions publish verification", () => {
       summary: [
         "GitHub Actions publish run is selected.",
         "databaseId: 987654321",
-        "headBranch: 1.2.3",
-        "event: push",
+        "headBranch: main",
+        "event: workflow_dispatch",
         "status: in_progress",
         "headSha: abc123",
         "url: https://github.com/earendil-works/pi-mono/actions/runs/987654321",
@@ -309,16 +310,16 @@ describe("publish-release GitHub Actions publish verification", () => {
     });
   });
 
-  test("rejects run lists without a matching tag-triggered publish run", () => {
+  test("rejects run lists without a matching release dispatch title", () => {
     const result = selectPublishWorkflowRunJson([
-      { ...successfulRun, headBranch: "1.2.4" },
-      { ...successfulRun, event: "workflow_dispatch" },
+      { ...successfulRun, displayTitle: "Publish 1.2.4" },
+      { ...successfulRun, event: "push" },
     ], "1.2.3");
 
     assert.equal(result.ok, false);
     assert.match(result.summary, /expected headBranch: 1\.2\.3/u);
-    assert.match(result.summary, /headBranch=1\.2\.4 event=push/u);
-    assert.match(result.summary, /headBranch=1\.2\.3 event=workflow_dispatch/u);
+    assert.match(result.summary, /displayTitle=Publish 1\.2\.4 event=workflow_dispatch/u);
+    assert.match(result.summary, /displayTitle=Publish 1\.2\.3 event=push/u);
   });
 
   test("accepts only completed successful publish runs for the release tag", () => {
@@ -328,8 +329,8 @@ describe("publish-release GitHub Actions publish verification", () => {
         "GitHub Actions publish run is verified as successful.",
         "databaseId: 987654321",
         "workflowName: Publish",
-        "headBranch: 1.2.3",
-        "event: push",
+        "headBranch: main",
+        "event: workflow_dispatch",
         "status: completed",
         "conclusion: success",
         "headSha: abc123",
@@ -345,12 +346,12 @@ describe("publish-release GitHub Actions publish verification", () => {
 
   test("rejects unsuccessful or mismatched publish run JSON", () => {
     const result = verifyPublishWorkflowRunJson(
-      { ...successfulRun, headBranch: "1.2.4", status: "completed", conclusion: "failure" },
+      { ...successfulRun, displayTitle: "Publish 1.2.4", status: "completed", conclusion: "failure" },
       "1.2.3",
     );
 
     assert.equal(result.ok, false);
-    assert.match(result.summary, /headBranch was 1\.2\.4, expected 1\.2\.3/u);
+    assert.match(result.summary, /displayTitle was Publish 1\.2\.4, expected Publish 1\.2\.3/u);
     assert.match(result.summary, /conclusion was failure, expected success/u);
   });
 


### PR DESCRIPTION
## Summary

Optimizes PR/main/release CI using measured GitHub Actions timings and current Blacksmith guidance, while retaining cross-platform coverage and replacing redundant release-suite reruns with a deterministic release-integrity gate.

## Changes

- Runs platform-independent typecheck, file-length, and docs validation once on Linux while retaining unit, integration, native-package, installed-package Node, and archive smoke coverage on Linux and Windows.
- Reuses each job's dependency install and package build during binary assembly.
- Makes publishing a protected-default-branch `workflow_dispatch`; verifies that the release commit has one parent integrated into `main`, exactly matches deterministic version/shrinkwrap generation, pins the verified SHA across jobs, and rejects a moved tag before GitHub Release creation.
- Preserves release docs/Mintlify, shrinkwrap, metadata, native matrix, binary/archive, npm tarball, registry, OIDC provenance, and GitHub Release checks.
- Adds workflow-contract and verifier forgery/cleanup regression tests.
- Adds one bounded, observable retry for unit, integration, and coding-agent suites, preserving diagnostics and excluding deterministic CI/release/package/publish gates.
- Documents why no speculative Bun/Cargo cache was added: measured Linux installs were 0–1s, Blacksmith already redirects supported Actions caches, and Sticky Disks/checkout caching are runner/dashboard features.

## Baseline and expected savings

Recent Actions measurements (2026-07-12):

- Linux test leg: about **3m34s**
- Windows main leg: about **6m02s**
- Windows PR leg: about **7m58s**
- Removed Windows critical-path work: typecheck 15s, file-length/docs links ~2s, Mintlify 61s — approximately **1m18s sampled PR critical-path savings**

Release runs also stop repeating typecheck and the complete test suites after their parent has passed required PR/main checks. Binary assembly avoids an additional frozen install and package build in each applicable job.

## Safety and validation

Independent completion, evidence, and risk reviewers approved commit `49e43e771`. Validation receipts:

- `bun run test:unit` — 3279 passed
- `bun run test:ci-contracts` — 3 passed, including valid release acceptance and forged tree/subject/ancestry rejection
- `bun test test/unit/flaky-test-suite-runner.test.ts` — 4 passed
- `bun run typecheck` — passed
- `bun run check:file-length` — passed
- `bun run --cwd packages/coding-agent docs:check` — passed
- `prek run check-yaml --all-files` — passed
- Full commit hooks — passed

The verifier cleanup regression confirms failed checks do not leak Git worktree registrations. The original worktree and active `0.9.7-alpha.1` release were not modified.

## Risk and rollback

- **Explicit merge-gate policy tradeoff:** a genuinely intermittent suite failure that passes its single retry now produces a green job with a visible warning and retained attempt-1 diagnostics. Deterministic gates are never retried. If maintainers do not want this policy, revert the `run-flaky-test-suite.ts` wrappers and diagnostics upload independently; the CI deduplication and release-integrity improvements do not depend on them.
- The first real-infrastructure execution of modified `test.yml` is this PR's CI. End-to-end `publish.yml` proof necessarily occurs on the first post-merge dispatched release.
- Rollback is a focused revert of commit `49e43e771`; publishing then returns to tag-triggered full-suite validation. Do not partially remove the integrity gate while retaining dispatch-only release semantics.

## References

Detailed timing evidence, Blacksmith caching/runner rationale, release flow, and operational guidance are in `docs/ci.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces repeated CI and release validation work. The main changes are:

- Moves platform-independent checks to the Linux test leg while keeping platform-sensitive test and smoke coverage on Linux and Windows.
- Adds a bounded one-retry wrapper with preserved diagnostics for selected flaky test suites.
- Reuses existing installs and package builds during binary assembly.
- Converts publishing to protected `workflow_dispatch` with release-integrity verification and verified SHA pinning.
- Adds workflow contract and release verifier regression tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

No accepted issues were found in the changed workflows, release helpers, release verifier, retry wrapper, or contract tests. The release-path changes include integrity checks, SHA pinning, tag immutability reconfirmation, and regression tests for forged releases and cleanup.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the environment before the fixture to confirm Bun version, the missing 0.9.7-alpha.1 tag, and a release-verifier setup failure for test:ci-contracts.
- Ran the fixture setup to create a local worktree from origin/main, generate version and shrinkwrap for 0.9.7-alpha.1, and create a local tag at commit 710ab76af03bdbfbc5836b12192fda2edabbdb25.
- After the fixture, verified the local tag resolved successfully and bun run test:ci-contracts passed all 3 tests.
- Conducted a retry regression on the flaky test suite and confirmed test/unit/flaky-test-suite-runner.test.ts passed 4/4 tests.

<a href="https://app.greptile.com/trex/runs/14169859/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | Replaces tag-push publishing with a release-integrity job that pins a verified SHA before smoke, native artifact, package, npm, and GitHub Release steps. |
| .github/workflows/test.yml | Runs platform-independent checks on Linux only, adds contract tests and bounded retry wrappers, and reuses install/build outputs for binary assembly. |
| scripts/verify-release-integrity.ts | Adds deterministic release commit verification by ancestry, subject, regenerated version/shrinkwrap tree, and worktree cleanup. |
| scripts/run-flaky-test-suite.ts | Introduces a bounded one-retry test wrapper with first-attempt diagnostics and deterministic-file suppression. |
| scripts/build-binaries.sh | Adds `--skip-install` and `--skip-package-build` flags with validation for caller-built artifacts. |
| .atomic/workflows/lib/publish-release.ts | Adjusts publish workflow run selection and verification for dispatch-based releases. |
| .atomic/workflows/lib/publish-release-run-wait.ts | Updates publish-run polling to identify protected workflow_dispatch runs by display title instead of tag push head SHA. |
| test/ci/ci-workflow-contracts.test.ts | Adds CI workflow and release verifier contract tests, including forged release rejection and cleanup coverage. |
| test/unit/flaky-test-suite-runner.test.ts | Covers green, flaky, persistent, and deterministic no-retry behavior for the retry wrapper. |
| test/unit/publish-release-helpers.test.ts | Updates publish-release helper tests for workflow_dispatch selection, polling, and protected run verification. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Operator
participant GitHub as GitHub Actions
participant Integrity as release-integrity
participant Smoke as Smoke/Native Jobs
participant Publish as Publish Job
participant npm as npm Registry
participant Release as GitHub Release

Operator->>GitHub: workflow_dispatch publish.yml(tag)
GitHub->>Integrity: checkout protected default branch workflow
Integrity->>Integrity: resolve tag SHA
Integrity->>Integrity: verify parent is in origin/main
Integrity->>Integrity: regenerate version/shrinkwrap tree
Integrity-->>GitHub: output verified tag + immutable SHA
GitHub->>Smoke: checkout verified SHA
Smoke-->>GitHub: binary smoke + native artifacts
GitHub->>Publish: checkout verified SHA
Publish->>Publish: docs, shrinkwrap, metadata, package checks
Publish->>npm: publish natives and atomic with provenance
Publish->>Publish: re-resolve tag and compare verified SHA
Publish->>Release: create GitHub Release with binaries + SHA256SUMS
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Operator
participant GitHub as GitHub Actions
participant Integrity as release-integrity
participant Smoke as Smoke/Native Jobs
participant Publish as Publish Job
participant npm as npm Registry
participant Release as GitHub Release

Operator->>GitHub: workflow_dispatch publish.yml(tag)
GitHub->>Integrity: checkout protected default branch workflow
Integrity->>Integrity: resolve tag SHA
Integrity->>Integrity: verify parent is in origin/main
Integrity->>Integrity: regenerate version/shrinkwrap tree
Integrity-->>GitHub: output verified tag + immutable SHA
GitHub->>Smoke: checkout verified SHA
Smoke-->>GitHub: binary smoke + native artifacts
GitHub->>Publish: checkout verified SHA
Publish->>Publish: docs, shrinkwrap, metadata, package checks
Publish->>npm: publish natives and atomic with provenance
Publish->>Publish: re-resolve tag and compare verified SHA
Publish->>Release: create GitHub Release with binaries + SHA256SUMS
```

</a>

<sub>Reviews (1): Last reviewed commit: ["perf(ci): eliminate redundant validation..."](https://github.com/bastani-inc/atomic/commit/49e43e7710e0b1453df84e1eceb3d5168780a44c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43679226)</sub>

<!-- /greptile_comment -->