### PR TITLE
Release 0.9.8-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
+### Changed
+
+- Changed builtin `goal` and `ralph` reviewer approval to be deterministic on the reviewer's self-reported `stop_review_loop` boolean: a reviewer approves exactly when it returns `stop_review_loop=true` with no `reviewer_error`, parse failures still count as non-approval, and Goal's reducer completes on quorum of those booleans without recomputing approval from findings arrays, priorities, or `requirements_traceability` statuses. Recomputing approval from those arrays could deadlock runs whose acceptance criteria referenced the review process itself (for example "three reviewers approve" or "an unmerged PR is created"): no individual reviewer can prove such clauses, so traceability never became fully `proven` even when every reviewer explicitly approved, and the loop burned worker/review turns until `needs_human`. Reviewer prompts now state that the boolean is the single authoritative convergence signal, spell out how to derive it (blocking P0/P1/P2 findings and `required_by_objective` findings at any priority mean `false`; in-scope P3 nice-to-haves, `beyond_objective`/`contradicts_objective` observations, the reviewer-quorum process itself, and the authorized post-approval PR/MR/review final action must never hold it at `false`), and keep findings/traceability as required audit evidence.
+- Synchronized the builtin `playwright-cli` skill with microsoft/playwright-cli at `793cfb32572733cbcb401e6f28d05a7a914ce408`, including current installation, snapshot search, mobile emulation, and test generation guidance.
+- Renamed the builtin `effective-liteparse` skill to `liteparse` and synchronized it with run-llama/llamaparse-agent-skills at `2dcef7c62417bd2ec4671fce4621bb1e8cce48d0`; existing `/skill:effective-liteparse` references must migrate to `/skill:liteparse`.
+- Synchronized the complete builtin `impeccable` skill tree with pbakaus/impeccable at `630fc2682a5bd39b25a8e61f74b6b3f14f2b1e21`, including its latest references, detector libraries, live-review scripts, and provider integrations.
+
+### Fixed
+
+- Disabled terminal autowrap while the fullscreen workflow graph overlay is visible on Windows and restored the previous terminal mode when the overlay closes, preventing wrapped graph rows and stale terminal state ([#1760](https://github.com/bastani-inc/atomic/issues/1760)).
+- Hardened synced Impeccable HTML filtering and preview selector escaping against nested sanitizer inputs, permissive script/style closing tags, HTML comment end-bang syntax, and backslash-containing session identifiers; also removed an ineffective CSS property replacement flagged by CodeQL.
+
 ## [0.9.7] - 2026-07-12
 
 ### Added

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.8-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.7.
+
 ## [0.9.7] - 2026-07-12
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.8-alpha.1 prerelease for the intercom extension; no functional intercom changes were made after 0.9.7.
+
 ## [0.9.7] - 2026-07-12
 
 ### Fixed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.8-alpha.1 prerelease for the MCP extension; no functional MCP changes were made after 0.9.7.
+
 ## [0.9.7] - 2026-07-12
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.8-alpha.1 prerelease for the native transport package; no native transport changes were made after 0.9.7.
+
 ## [0.9.7] - 2026-07-12
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
 ### Changed
 
 - Synchronized the builtin `playwright-cli` skill with microsoft/playwright-cli at `793cfb32572733cbcb401e6f28d05a7a914ce408`, including current installation, snapshot search, mobile emulation, and test generation guidance.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
+### Changed
+
+- Published a synchronized Atomic 0.9.8-alpha.1 prerelease for the web-access extension; no functional web-access changes were made after 0.9.7.
+
 ## [0.9.7] - 2026-07-12
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.8-alpha.1] - 2026-07-12
+
 ### Changed
 
 - Changed builtin `goal` and `ralph` reviewer approval to be deterministic on the reviewer's self-reported `stop_review_loop` boolean: a reviewer approves exactly when it returns `stop_review_loop=true` with no `reviewer_error`, parse failures still count as non-approval, and Goal's reducer completes on quorum of those booleans without recomputing approval from findings arrays, priorities, or `requirements_traceability` statuses. Recomputing approval from those arrays could deadlock runs whose acceptance criteria referenced the review process itself (for example "three reviewers approve" or "an unmerged PR is created"): no individual reviewer can prove such clauses, so traceability never became fully `proven` even when every reviewer explicitly approved, and the loop burned worker/review turns until `needs_human`. Reviewer prompts now state that the boolean is the single authoritative convergence signal, spell out how to derive it (blocking P0/P1/P2 findings and `required_by_objective` findings at any priority mean `false`; in-scope P3 nice-to-haves, `beyond_objective`/`contradicts_objective` observations, the reviewer-quorum process itself, and the authorized post-approval PR/MR/review final action must never hold it at `false`), and keep findings/traceability as required audit evidence. `findingBlocksClosure`/`isBlockingFinding` still classify findings for prompts and consolidated repair batches.
@@ -13,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Disabled terminal autowrap while the fullscreen workflow graph overlay is visible on Windows and restored the previous terminal mode when the overlay closes, preventing wrapped graph rows and stale terminal state ([#1760](https://github.com/bastani-inc/atomic/issues/1760)).
 - Hardened synced Impeccable HTML filtering and preview selector escaping against nested sanitizer inputs, permissive script/style closing tags, HTML comment end-bang syntax, and backslash-containing session identifiers; also removed an ineffective CSS property replacement flagged by CodeQL.
 
 ## [0.9.7] - 2026-07-12


### PR DESCRIPTION
## Summary

Prepare the **prerelease** release notes for version **0.9.8-alpha.1**.

## Changes

- Added the `0.9.8-alpha.1` changelog sections across the workspace packages.
- Documented the deterministic reviewer convergence changes, synchronized builtin skill updates, Windows workflow graph terminal fix, and Impeccable hardening.
- Added synchronized prerelease notes for packages without functional changes since 0.9.7.
- Did **not** bump package versions: all `packages/*/package.json` files remain at the versionless `0.0.0` placeholder. The real version will be materialized only in the throwaway off-main tag commit created by `scripts/cut-release.ts`.

## Release Details

- Release kind: prerelease
- Version/tag: `0.9.8-alpha.1`
- Base branch: `main`
- Release-notes branch: `prerelease/0.9.8-alpha.1`
- Head SHA: `df6c85a4e727ef77e18dad11d576478e03d50526`

## Validation

- `git branch --show-current`
- `git rev-parse HEAD`
- `git status --short`
- `bun run typecheck`
- `bun run test:unit`
- Push hooks: `bun run lint`, `bun run check:file-length`, and `bun run test:unit`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.8-alpha.1` prerelease changelog notes across workspace packages. The main changes are:

- Added detailed `0.9.8-alpha.1` notes for the Atomic CLI aggregate package.
- Added workflow release notes for deterministic reviewer convergence, Impeccable sync, and the Windows workflow graph terminal fix.
- Added subagent release notes for builtin skill synchronization and the `effective-liteparse` to `liteparse` rename.
- Added synchronized prerelease entries for packages with no functional changes since `0.9.7`.

<h3>Confidence Score: 5/5</h3>

Safe to merge as a documentation-only prerelease changelog update.

No functional code changes or package version bumps were introduced. The changelog entries match the repository's versionless-main release flow.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated release notes validation by verifying the git checkout at head df6c85a4e727ef77e18dad11d576478e03d50526 and confirming the git proof reports exit code 0, plus the typecheck run details including a SIGKILL termination with exit 137 and the overall validation summary of run statuses and log paths.
- Unit validation initially failed due to /bin/sh not supporting set -o pipefail, was retried with bash -lc, and the final transcript shows 3275 pass, 0 fail, exit 0, with a summary that records command, cwd, exit status, duration, and log path.

<a href="https://app.greptile.com/trex/runs/14186464/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds comprehensive `0.9.8-alpha.1` prerelease notes for the aggregate Atomic CLI package. |
| packages/workflows/CHANGELOG.md | Adds `0.9.8-alpha.1` notes for deterministic reviewer convergence, Impeccable synchronization, and Windows workflow graph terminal fixes. |
| packages/subagents/CHANGELOG.md | Adds `0.9.8-alpha.1` notes for builtin subagent skill synchronization and the `liteparse` rename. |
| packages/cursor/CHANGELOG.md | Adds a synchronized `0.9.8-alpha.1` prerelease entry noting no Cursor provider functional changes. |
| packages/intercom/CHANGELOG.md | Adds a synchronized `0.9.8-alpha.1` prerelease entry noting no Intercom functional changes. |
| packages/mcp/CHANGELOG.md | Adds a synchronized `0.9.8-alpha.1` prerelease entry noting no MCP functional changes. |
| packages/natives/CHANGELOG.md | Adds a synchronized `0.9.8-alpha.1` prerelease entry noting no native transport functional changes. |
| packages/web-access/CHANGELOG.md | Adds a synchronized `0.9.8-alpha.1` prerelease entry noting no web-access functional changes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Main as versionless main
participant Changelogs as packages/*/CHANGELOG.md
participant Cut as scripts/cut-release.ts
participant Tag as off-main 0.9.8-alpha.1 tag
participant Publish as publish.yml

Main->>Changelogs: Add 0.9.8-alpha.1 release notes
Note over Main,Changelogs: package.json versions remain 0.0.0
Main->>Cut: Cut release from integrated parent
Cut->>Tag: Materialize real prerelease version in throwaway commit
Tag->>Publish: Dispatch protected publish workflow with tag
Publish-->>Tag: Publish prerelease artifacts
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Main as versionless main
participant Changelogs as packages/*/CHANGELOG.md
participant Cut as scripts/cut-release.ts
participant Tag as off-main 0.9.8-alpha.1 tag
participant Publish as publish.yml

Main->>Changelogs: Add 0.9.8-alpha.1 release notes
Note over Main,Changelogs: package.json versions remain 0.0.0
Main->>Cut: Cut release from integrated parent
Cut->>Tag: Materialize real prerelease version in throwaway commit
Tag->>Publish: Dispatch protected publish workflow with tag
Publish-->>Tag: Publish prerelease artifacts
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.8-alpha.1"](https://github.com/bastani-inc/atomic/commit/df6c85a4e727ef77e18dad11d576478e03d50526) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43711075)</sub>

<!-- /greptile_comment -->