### PR TITLE
fix(evals): avoid failing Playwright dependency dry run

### DIFF
--- a/evals/skill_prerequisites.py
+++ b/evals/skill_prerequisites.py
@@ -167,8 +167,7 @@ def agent_install_command(version_spec: str) -> str:
         "browser_path=$(command -v chromium || command -v chromium-browser); "
         "printf '%s\\n' \"export PLAYWRIGHT_MCP_EXECUTABLE_PATH='$browser_path'\" "
         '>> "$env_tmp"; '
-        "else playwright-cli install-browser chromium --with-deps --dry-run; "
-        "playwright-cli install-browser chromium; "
+        "else playwright-cli install-browser chromium; "
         "playwright-cli install-browser --list; fi; "
         'mv -f "$env_tmp" "$HOME/.atomic-eval-env"; '
         f"{runtime_environment_command()}"


### PR DESCRIPTION
## Summary

Avoid eval job setup failures caused by Playwright dependency simulation on container images whose package metadata cannot satisfy the dry run.

## Changes

- Remove the redundant `playwright-cli install-browser chromium --with-deps --dry-run` invocation.
- Retain the actual Chromium installation and browser verification.

## Notes

- Python compilation passed.
- `git diff --check` passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates eval sandbox provisioning for Playwright Chromium setup. The main changes are:

- Removes the `playwright-cli install-browser chromium --with-deps --dry-run` step.
- Keeps the actual Chromium installation for non-`apk` and non-`yum` environments.
- Keeps browser listing, persisted Playwright environment settings, and runtime verification.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow and leaves the actual install and verification path intact. No runtime, workflow, or security issues were identified in the changed file.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Python harness was run to validate the skill prereq command checks, and both py\_compile and the harness completed with exit code 0.
- The evidence log skill\_prereq\_command\_check.log was opened and inspected, confirming py\_compile exit code 0 and harness exit code 0.
- The log content shows an absence check for playwright-cli install-browser chromium --with-deps --dry-run and outlines the agent real chromium install steps.
- The log includes verification snippets for version, listing fallback, open, snapshot, and close commands.

<a href="https://app.greptile.com/trex/runs/14190485/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/skill_prerequisites.py | Removes the Playwright Chromium dependency dry-run while preserving actual browser installation, environment persistence, listing, and runtime verification. |

<sub>Reviews (1): Last reviewed commit: ["fix(evals): avoid failing Playwright dep..."](https://github.com/bastani-inc/atomic/commit/442caacaf5c4f40e7fa558773af86f915c757cd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43719282)</sub>

<!-- /greptile_comment -->