### PR TITLE
fix(evals): streamline sandbox prerequisite setup

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -185,32 +185,3 @@ uv run pier run \
 The Atomic Pier adapter reads `OPENROUTER_API_KEY` from the Pier process environment and passes it into the sandbox for Atomic. If your launcher does not inherit shell exports, pass it explicitly with `--agent-env OPENROUTER_API_KEY=...` instead.
 
 The Pier network allowlist automatically includes `openrouter.ai` when the model provider is `openrouter`. To use a custom OpenRouter-compatible endpoint, pass it with `--agent-env OPENROUTER_BASE_URL=...`.
-
-## Pre-provisioned shipped-skill prerequisites
-
-Pier and Harbor install Atomic's default shipped skills with their runtime prerequisites during the sandbox setup phase, while network access is available. `skill_prerequisites.py` is the shared inventory and command source consumed explicitly by both adapters during their install phases, before task runtime and restricted-network execution. Prerequisite installers select their current versions without explicit pins; Atomic itself still follows `--agent-kwarg version` and defaults to `@latest`.
-
-| Shipped skill | Provisioned prerequisite | Install command/source | Early verification |
-| --- | --- | --- | --- |
-| `liteparse` | Node.js; `lit`; LibreOffice; ImageMagick; `uv`; uv-managed Python with cached `bm25s`/`aiofiles` | Current NVM Node.js or distro Node.js; `npm install -g @llamaindex/liteparse`; distro packages; Astral's current-version installer; `uv python install` and a dependency-prefetch run | `node --version`, `lit --version`, `libreoffice --version`, `magick -version` or `convert -version`, `uv --version`, managed-Python lookup and imports |
-| `playwright-cli` | `@playwright/cli`, Playwright-managed Chromium and Chromium headless shell, and Linux runtime libraries | Unpinned `npm install -g @playwright/cli`, followed on Debian/Ubuntu by the supported `playwright-cli install-browser chromium` flow after root setup installs the Linux dependency set. Setup validates those packages and prints the browser plan with `--with-deps --dry-run`, then prints `--list` output after installation. Alpine/musl and yum-family RHEL-compatible images retain distro Chromium because Playwright's managed Linux dependency path is not supported there; their explicit executable, Chromium, headless, and sandbox settings are written idempotently to `~/.atomic-eval-env`, which both adapters source in non-login shells. | CLI version and Playwright-managed installed-browser listing or fallback executable check, followed by an actual headless `about:blank` open, snapshot, and close with browser downloads and npm network access disabled |
-| `tmux` | tmux-compatible CLI | Distro `tmux` package (`apk`, `apt-get`, or `yum` in Pier; Debian `apt-get` in Harbor). Alpine also receives edge `libc++`, needed by LiteParse's published musl native module. Yum-family images enable EPEL and CRB/PowerTools before installing Chromium, ImageMagick, ripgrep, and LibreOffice component packages. | `tmux -V` |
-| `impeccable` | Node.js for bundled `.mjs` scripts | Node.js as above | `node --version` |
-| `skill-creator` | Python 3 and PyYAML for bundled validation/packaging scripts | Distro `python3` and PyYAML package; after installing `uv`, setup first tests whether the active `python3` can import `yaml` and, when it cannot, installs PyYAML with `uv pip install --python <active-python3>` into that exact interpreter (covering task images whose `/usr/local` or virtualenv Python precedes the distro interpreter on `PATH` without modifying an already-working externally-managed distro Python) | `python3 -c "import yaml"` |
-| `create-spec`, `intercom`, `prompt-engineer`, `research-codebase`, `subagent`, `tdd` | No independently installed external runtime | Harness tools, bundled extensions, or target-project tooling | Not applicable |
-
-The inventory excludes repository-local `.agents` developer helpers such as Crabbox, prek, and GitHub commit/PR skills. Conditional examples are not promoted to universal dependencies: for example, Claude Code is needed only for `skill-creator`'s optional description-optimization path, a browser tool is conditional for Impeccable live mode, and `gh`/`curl` are conditional research paths. Conversely, Office/image support and the `liteparse` ranked-search helper are provisioned because they are declared capabilities of the shipped skill.
-
-The setup commands are noninteractive, repeatable, fail on unsupported package managers or unusable tools, and preload Chromium, Chromium headless shell, Linux browser libraries, and the uv/Python artifacts so skill use does not depend on downloading them after restricted-network task execution begins. The Playwright install uses the public `playwright-cli install-browser` command rather than a package-internal Node entrypoint. This increases eval image size and setup time, especially from LibreOffice and Chromium, in exchange for deterministic availability.
-
-## Adapter behavior
-
-The adapter is self-contained; it does not require patching Pier or Harbor. It follows the installed-agent pattern:
-
-1. Install Atomic and required local search tools (`rg` and `fd`) during setup.
-2. Run the Atomic CLI in JSON mode.
-3. Keep Atomic's mutable agent state under the sandbox user's `~/.atomic/agent` directory by setting Atomic's existing agent-dir environment override, passing `--session-dir ~/.atomic/agent/atomic-sessions`, and exporting `ATOMIC_TODO_PATH=$HOME/.atomic/agent/todos` inside the sandbox so the default todo tool cannot create `.atomic/todos` in the benchmark repository.
-4. Tee Atomic's JSON stream to `/logs/agent/atomic.txt` and continuously mirror session transcripts to `/logs/agent/atomic-sessions/` during the run, with a final exit-trap sync to preserve transcripts on normal exits and SIGTERM-based timeouts. Mirrored transcript permissions are normalized after every copy so job artifacts remain readable and removable by the host user even when the sandbox agent runs as root.
-5. Collect usage and trajectory data from the main chat plus workflow-stage and nested child transcripts, de-duplicating copied parent context and reporting the combined agent-step count (`n_agent_steps` in Pier and Harbor context metadata).
-
-Like the built-in Pier agents, it does not auto-commit work. Deep SWE tasks rely on the agent following the task instruction to commit.

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -36,7 +36,6 @@ from skill_prerequisites import (
     agent_install_command,
     root_install_command,
     runtime_environment_command,
-    verification_command,
 )
 
 
@@ -151,7 +150,7 @@ class Atomic(BaseInstalledAgent):
                 ),
                 InstallStep(user="agent", run=agent_install_command(version_spec)),
             ],
-            verification_command=self.get_version_command() + "; " + verification_command(),
+            verification_command=self.get_version_command(),
         )
 
     def network_allowlist(self) -> NetworkAllowlist:

--- a/evals/skill_prerequisites.py
+++ b/evals/skill_prerequisites.py
@@ -1,124 +1,44 @@
-"""Shared sandbox provisioning for the runtime prerequisites of shipped Atomic skills."""
+"""Shared eval-sandbox provisioning for Atomic, tmux, and playwright-cli."""
 
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class SkillPrerequisite:
-    skill: str
-    prerequisite: str
-    install: str
-    verify: str
-    required_for: str = "all uses"
-
-
-SHIPPED_SKILLS = (
-    "create-spec",
-    "liteparse",
-    "impeccable",
-    "intercom",
-    "playwright-cli",
-    "prompt-engineer",
-    "research-codebase",
-    "skill-creator",
-    "subagent",
-    "tdd",
-    "tmux",
-)
-
-PREREQUISITES = (
-    SkillPrerequisite(
-        "liteparse",
-        "Node.js 18+",
-        "current NVM Node.js or distro nodejs",
-        "node --version",
-    ),
-    SkillPrerequisite(
-        "liteparse",
-        "@llamaindex/liteparse",
-        "npm install -g @llamaindex/liteparse",
-        "lit --version",
-    ),
-    SkillPrerequisite(
-        "liteparse",
-        "LibreOffice",
-        "install distro libreoffice package",
-        "libreoffice --version",
-        "Office documents",
-    ),
-    SkillPrerequisite(
-        "liteparse",
-        "ImageMagick",
-        "install distro imagemagick package",
-        "magick -version || convert -version",
-        "images",
-    ),
-    SkillPrerequisite(
-        "liteparse",
-        "uv and uv-managed Python",
-        "install uv; uv python install",
-        "uv --version; uv python find --managed-python",
-        "bundled ranked-search helper",
-    ),
-    SkillPrerequisite(
-        "playwright-cli",
-        "@playwright/cli",
-        "npm install -g @playwright/cli; playwright-cli install-browser chromium",
-        "playwright-cli --version; installed-browser listing; offline browser launch",
-    ),
-    SkillPrerequisite(
-        "tmux", "tmux-compatible CLI", "install distro tmux package", "tmux -V"
-    ),
-    SkillPrerequisite(
-        "impeccable", "Node.js", "current NVM Node.js or distro nodejs", "node --version"
-    ),
-    SkillPrerequisite(
-        "skill-creator",
-        "Python 3 and PyYAML",
-        "install distro python3 and PyYAML packages",
-        'python3 -c "import yaml"',
-    ),
-)
-
-NO_EXTERNAL_PREREQUISITES = (
-    "create-spec",
-    "intercom",
-    "prompt-engineer",
-    "research-codebase",
-    "subagent",
-    "tdd",
-)
 
 
 def root_install_command(*, harbor: bool = False) -> str:
-    """Return an idempotent, noninteractive system-package installation command."""
+    """Install Atomic runtime tools plus tmux and Playwright browser libraries."""
+    # Playwright-managed Chromium is reliable on Debian/Ubuntu, unlike Ubuntu's
+    # snap-backed distro Chromium. The t64 names are needed by newer Ubuntu
+    # images; apt-cache selects them without breaking older Debian images.
     apt = (
-        "apt-get update && apt-get install -y --no-install-recommends "
-        "bash ca-certificates curl fd-find git imagemagick libreoffice python3 python3-yaml ripgrep tmux "
-        "fonts-freefont-ttf fonts-ipafont-gothic fonts-liberation fonts-noto-color-emoji "
-        "fonts-tlwg-loma-otf fonts-unifont fonts-wqy-zenhei libasound2 "
-        "libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 libcairo2 libcups2 "
-        "libdbus-1-3 libdrm2 libfontconfig1 libfreetype6 libgbm1 libglib2.0-0 "
-        "libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 "
-        "libxdamage1 libxext6 libxfixes3 libxi6 libxkbcommon0 libxrandr2 xvfb && "
+        "apt-get update && "
+        "asound=$(if apt-cache show libasound2t64 >/dev/null 2>&1; then "
+        "echo libasound2t64; else echo libasound2; fi) && "
+        "atk=$(if apt-cache show libatk1.0-0t64 >/dev/null 2>&1; then "
+        "echo libatk1.0-0t64; else echo libatk1.0-0; fi) && "
+        "cups=$(if apt-cache show libcups2t64 >/dev/null 2>&1; then "
+        "echo libcups2t64; else echo libcups2; fi) && "
+        "apt-get install -y --no-install-recommends bash ca-certificates curl fd-find git "
+        "ripgrep tmux fonts-liberation \"$asound\" \"$atk\" libatk-bridge2.0-0 "
+        "libatspi2.0-0 libcairo2 \"$cups\" libdbus-1-3 libdrm2 libfontconfig1 "
+        "libfreetype6 libgbm1 libglib2.0-0 libnspr4 libnss3 libpango-1.0-0 "
+        "libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 "
+        "libxi6 libxkbcommon0 libxrandr2 && "
         "ln -sf /usr/bin/fdfind /usr/local/bin/fd && rm -rf /var/lib/apt/lists/*"
     )
     if harbor:
         return "set -euo pipefail; " + apt
     apk = (
-        "apk add --no-cache bash ca-certificates curl fd git imagemagick libreoffice nodejs npm "
-        "py3-yaml python3 ripgrep tmux chromium && "
-        "apk add --no-cache libc++ --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main"
+        "apk add --no-cache bash ca-certificates curl fd git nodejs npm "
+        "ripgrep tmux chromium"
     )
+    # Fedora provides these directly; RHEL-compatible images need EPEL. Avoid
+    # DNF-only flags/subcommands because some supported images expose real yum.
     yum = (
-        "yum install -y --allowerasing bash ca-certificates curl git dnf-plugins-core epel-release && "
-        "(dnf config-manager --set-enabled crb || "
-        "dnf config-manager --set-enabled powertools || true) && yum makecache && "
-        "yum install -y --allowerasing ImageMagick chromium libreoffice-core libreoffice-writer "
-        "libreoffice-calc libreoffice-impress python3 python3-pyyaml ripgrep tmux"
+        "yum install -y bash ca-certificates git tmux && "
+        "(command -v curl >/dev/null 2>&1 || yum install -y curl) && "
+        "(yum install -y chromium ripgrep fd-find || "
+        "(yum install -y epel-release && yum install -y chromium ripgrep fd-find))"
     )
     return (
         "set -euo pipefail; "
@@ -143,7 +63,7 @@ def runtime_environment_command() -> str:
 
 
 def agent_install_command(version_spec: str) -> str:
-    """Install Atomic plus skill CLIs, browsers, and uv as the sandbox user."""
+    """Install Atomic and playwright-cli, then configure Chromium."""
     _validate_version_spec(version_spec)
     node_setup = (
         "if command -v apk >/dev/null 2>&1; then "
@@ -156,7 +76,7 @@ def agent_install_command(version_spec: str) -> str:
         'git clone --depth=1 https://github.com/nvm-sh/nvm.git "$NVM_DIR"; fi; '
         '. "$NVM_DIR/nvm.sh"; '
         "command -v nvm >/dev/null 2>&1 || { echo 'Error: NVM failed to load' >&2; exit 1; }; "
-        "nvm install node; nvm alias default node; fi"
+        "nvm install 22; nvm alias default 22; fi"
     )
     browser_setup = (
         'env_tmp="$HOME/.atomic-eval-env.tmp"; '
@@ -167,8 +87,7 @@ def agent_install_command(version_spec: str) -> str:
         "browser_path=$(command -v chromium || command -v chromium-browser); "
         "printf '%s\\n' \"export PLAYWRIGHT_MCP_EXECUTABLE_PATH='$browser_path'\" "
         '>> "$env_tmp"; '
-        "else playwright-cli install-browser chromium; "
-        "playwright-cli install-browser --list; fi; "
+        "else playwright-cli install-browser chromium; fi; "
         'mv -f "$env_tmp" "$HOME/.atomic-eval-env"; '
         f"{runtime_environment_command()}"
     )
@@ -176,32 +95,6 @@ def agent_install_command(version_spec: str) -> str:
         "set -euo pipefail; "
         f"{node_setup}; "
         'export PATH="$HOME/.local/bin:$PATH"; '
-        f"npm install -g @bastani/atomic{version_spec} "
-        "@playwright/cli @llamaindex/liteparse; "
-        "curl -fsSL https://astral.sh/uv/install.sh | "
-        'env UV_INSTALL_DIR="$HOME/.local/bin" sh; '
-        "uv python install; "
-        "python3 -c 'import yaml' 2>/dev/null || uv pip install "
-        "--python \"$(python3 -c 'import sys; print(sys.executable)')\" pyyaml; "
-        "uv run --managed-python --with bm25s --with aiofiles "
-        "python -c 'import aiofiles, bm25s'; "
-        f"{browser_setup}; " + verification_command()
-    )
-
-
-def verification_command() -> str:
-    """Fail fast unless every provisioned prerequisite is functional, including offline Chromium."""
-    return (
-        "atomic --version; node --version; npm --version; tmux -V; lit --version; "
-        "uv --version; uv python find --managed-python >/dev/null; "
-        "UV_OFFLINE=1 uv run --managed-python --with bm25s --with aiofiles "
-        "python -c 'import aiofiles, bm25s'; "
-        "python3 -c 'import yaml'; libreoffice --version; "
-        "(magick -version || convert -version); playwright-cli --version; "
-        "if [ -n \"${PLAYWRIGHT_MCP_EXECUTABLE_PATH:-}\" ]; then "
-        "test -x \"$PLAYWRIGHT_MCP_EXECUTABLE_PATH\"; "
-        "else playwright-cli install-browser --list; fi; "
-        "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_config_offline=true "
-        "PLAYWRIGHT_MCP_BROWSER=chromium playwright-cli open about:blank; "
-        "playwright-cli snapshot >/dev/null; playwright-cli close"
+        f"npm install -g @bastani/atomic{version_spec} @playwright/cli; "
+        f"{browser_setup}"
     )


### PR DESCRIPTION
## Summary

Streamline Pier and Harbor eval-sandbox setup by provisioning only Atomic's core runtime tools, tmux, and Playwright CLI/browser dependencies. This removes expensive, failure-prone pre-provisioning for optional shipped-skill runtimes that eval tasks may not use.

## Changes

- Trim distro and npm prerequisites to Atomic, tmux, Playwright CLI, and Chromium runtime dependencies.
- Standardize NVM-based installs on Node.js 22 and preserve distro Chromium fallbacks for Alpine and yum-based images.
- Handle `t64` library package names across newer Ubuntu and older Debian images.
- Scope Pier's install verification to the Atomic version command.
- Remove obsolete documentation for blanket shipped-skill prerequisite provisioning.

## Testing

- `python3 -m py_compile evals/atomic_pier.py evals/atomic_harbor.py evals/skill_prerequisites.py`
- Generated root/agent shell commands validated with `bash -n`
- Pre-commit and pre-push hooks passed, including lint, file-length checks, and 3,275 unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR streamlines the eval sandbox prerequisite setup. The main changes are:

- Removes blanket shipped-skill runtime provisioning from the eval docs.
- Installs only Atomic core runtime tools, `tmux`, Node 22, `@playwright/cli`, and Chromium support.
- Narrows Pier install verification to Atomic's version command.
- Keeps distro Chromium fallbacks for Alpine and yum-based images.

<h3>Confidence Score: 4/5</h3>

This PR needs a targeted fix before apt-based browser evals are safe.

One contained setup bug remains: Debian/Ubuntu images no longer install the full Chromium runtime dependency set needed by Playwright browser launches. The remaining changes are focused and match the stated goal of reducing sandbox setup work.

`evals/skill_prerequisites.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the browser dependency verification by running the Python harness that imports evals.skill\_prerequisites.root\_install\_command(harbor=True) and extracts the generated apt install package list, which failed because four Chromium runtime packages were missing, with the harness showing libx11-6, libxcb1, and libxrandr2 present while libgtk-3-0, libx11-xcb1, libxss1, and libxcursor1 were omitted.
- I validated the sandbox issue by running a Node harness to attempt a local Playwright Chromium launch against the provisioned host, which succeeded, indicating the fresh apt sandbox failure arises from the missing packages rather than host mutation.
- I reviewed the prereq validation log, which records the exact commands, working directory, stdout/stderr, and exit codes used during prereq checks.
- I noted that the prereq artifacts include generation of three install scripts for sandbox provisioning.
- I confirmed that all commands listed in the prereq validation exited with code 0 according to the validation report.

<a href="https://app.greptile.com/trex/runs/14201255/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/README.md | Removes obsolete documentation for blanket shipped-skill prerequisite provisioning. |
| evals/atomic_pier.py | Narrows Pier install verification to Atomic's version command. |
| evals/skill_prerequisites.py | Streamlines sandbox installs, but the apt browser dependency set now omits required Chromium runtime libraries. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Adapter as Pier/Harbor adapter
participant Root as root_install_command
participant Agent as agent_install_command
participant Runtime as eval runtime shell
Adapter->>Root: Install core packages, tmux, rg/fd, Chromium deps
Root-->>Adapter: System tools available
Adapter->>Agent: Install Node 22, Atomic, playwright-cli
Agent->>Agent: Install managed Chromium or record distro Chromium path
Agent-->>Runtime: Persist .atomic-eval-env
Runtime->>Runtime: Source runtime_environment_command()
Runtime->>Agent: Run atomic with browser env when needed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Adapter as Pier/Harbor adapter
participant Root as root_install_command
participant Agent as agent_install_command
participant Runtime as eval runtime shell
Adapter->>Root: Install core packages, tmux, rg/fd, Chromium deps
Root-->>Adapter: System tools available
Adapter->>Agent: Install Node 22, Atomic, playwright-cli
Agent->>Agent: Install managed Chromium or record distro Chromium path
Agent-->>Runtime: Persist .atomic-eval-env
Runtime->>Runtime: Source runtime_environment_command()
Runtime->>Agent: Run atomic with browser env when needed
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
evals/skill_prerequisites.py:21-26
**Restore browser dependencies**
The Debian/Ubuntu install set no longer includes required Chromium runtime libraries such as `libgtk-3-0`, `libx11-xcb1`, `libxss1`, and `libxcursor1`. Playwright’s documented `install --with-deps chromium` flow installs these system dependencies, so a fresh apt-based sandbox can complete setup but fail when `playwright-cli` launches Chromium during eval runtime, especially now that the offline launch verification was removed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): streamline sandbox prerequis..."](https://github.com/bastani-inc/atomic/commit/2d5bfc2a3a8adb502c8b4e627da00b53ba4b3622) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43739487)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/bastani-inc/github/bastani-inc/atomic/-/custom-context?memory=6b6bc6e3-dafb-4fa7-9d98-538aac70844a))

<!-- /greptile_comment -->