### PR TITLE
fix(evals): harden sandbox prerequisites

### DIFF
--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -13,7 +13,7 @@ from harbor.agents.installed.base import (
 )
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
-from skill_prerequisites import (
+from prerequisites import (
     agent_install_command,
     root_install_command,
     runtime_environment_command,

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -32,7 +32,7 @@ from pier.models.trajectories import (
 )
 from pier.models.trial.paths import EnvironmentPaths
 from pier.utils.trajectory_utils import format_trajectory_json
-from skill_prerequisites import (
+from prerequisites import (
     agent_install_command,
     root_install_command,
     runtime_environment_command,

--- a/evals/prerequisites.py
+++ b/evals/prerequisites.py
@@ -32,13 +32,12 @@ def root_install_command(*, harbor: bool = False) -> str:
         "apk add --no-cache bash ca-certificates curl fd git nodejs npm "
         "ripgrep tmux chromium"
     )
-    # Fedora provides these directly; RHEL-compatible images need EPEL. Avoid
-    # DNF-only flags/subcommands because some supported images expose real yum.
+    # Fedora provides these directly; RHEL-compatible images need EPEL.
     yum = (
         "yum install -y bash ca-certificates git tmux && "
         "(command -v curl >/dev/null 2>&1 || yum install -y curl) && "
-        "(yum install -y chromium ripgrep fd-find || "
-        "(yum install -y epel-release && yum install -y chromium ripgrep fd-find))"
+        "(yum install -y chromium fd-find ripgrep || "
+        "(yum install -y epel-release && yum install -y chromium fd-find ripgrep))"
     )
     return (
         "set -euo pipefail; "
@@ -71,9 +70,8 @@ def agent_install_command(version_spec: str) -> str:
         "{ echo 'Error: Alpine nodejs must be Node.js 18 or newer' >&2; exit 1; }; "
         'npm config set prefix "$HOME/.local"; export PATH="$HOME/.local/bin:$PATH"; '
         'else export NVM_DIR="$HOME/.nvm"; '
-        'if [ -d "$NVM_DIR/.git" ]; then git -C "$NVM_DIR" fetch --depth=1 origin master && '
-        'git -C "$NVM_DIR" reset --hard origin/master; else rm -rf "$NVM_DIR" && '
-        'git clone --depth=1 https://github.com/nvm-sh/nvm.git "$NVM_DIR"; fi; '
+        'if [ ! -s "$NVM_DIR/nvm.sh" ]; then '
+        "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash; fi; "
         '. "$NVM_DIR/nvm.sh"; '
         "command -v nvm >/dev/null 2>&1 || { echo 'Error: NVM failed to load' >&2; exit 1; }; "
         "nvm install 22; nvm alias default 22; fi"
@@ -85,9 +83,13 @@ def agent_install_command(version_spec: str) -> str:
         "'export PLAYWRIGHT_MCP_SANDBOX=false' > \"$env_tmp\"; "
         "if command -v apk >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then "
         "browser_path=$(command -v chromium || command -v chromium-browser); "
+        "else playwright-cli install-browser --only-shell chromium; "
+        'browser_path=$(find "$HOME/.cache/ms-playwright" -type f '
+        "\\( -name headless_shell -o -name chrome-headless-shell \\) "
+        "-perm -u+x -print -quit); fi; "
+        'test -n "$browser_path" && test -x "$browser_path"; '
         "printf '%s\\n' \"export PLAYWRIGHT_MCP_EXECUTABLE_PATH='$browser_path'\" "
         '>> "$env_tmp"; '
-        "else playwright-cli install-browser chromium; fi; "
         'mv -f "$env_tmp" "$HOME/.atomic-eval-env"; '
         f"{runtime_environment_command()}"
     )


### PR DESCRIPTION
## Summary

Hardens and simplifies Atomic eval sandbox provisioning while retaining the command-line tools Atomic prefers.

## Changes

- Rename the shared module from `skill_prerequisites.py` to `prerequisites.py` and update Pier/Harbor imports.
- Install NVM through its curl installer instead of maintaining a Git checkout.
- Install only Chromium's headless shell on Debian/Ubuntu and persist its executable path for `playwright-cli`.
- Retain `git`, `fd`, `ripgrep`, and `tmux` across supported package managers.

## Testing

- Python compilation and generated-command assertions.
- Clean Debian container smoke test verifying Atomic, Node.js, tmux, playwright-cli, browser launch, snapshot, and close.
- Repository commit and push hooks: lint, file-length checks, and 3,275 unit tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Atomic eval sandbox provisioning flow. The main changes are:

- Renames the shared prerequisite helper from `skill_prerequisites.py` to `prerequisites.py`.
- Updates the Pier and Harbor eval adapters to import the renamed helper.
- Switches non-Alpine Node setup to the NVM installer.
- Installs and persists a Playwright Chromium headless-shell path for Debian/Ubuntu runtime shells.
- Keeps preferred CLI tools such as `git`, `fd`, `ripgrep`, and `tmux` across supported package managers.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped to eval sandbox provisioning and import updates, with no verified correctness or security issues found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the Python prerequisites compilation for evals modules and verified EXIT\_CODE: 0.
- Reviewed the prereq\_command\_assertions.log to confirm prerequisites imports pass, noted the four unsafe version specifier rejections with ValueError, and recorded blockers for atomic\_harbor and atomic\_pier.
- Archived and uploaded artifacts documenting the prereq checks, including the py\_compile log, the prereq command assertions log, and the Python prerequisites sources.

<a href="https://app.greptile.com/trex/runs/14203120/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/atomic_harbor.py | Updates the Harbor eval adapter to import the renamed shared sandbox prerequisites module. |
| evals/atomic_pier.py | Updates the Pier eval adapter to import the renamed shared sandbox prerequisites module. |
| evals/prerequisites.py | Renames and hardens shared eval provisioning commands for NVM and Playwright Chromium setup. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Eval as Pier/Harbor eval adapter
participant Pre as evals/prerequisites.py
participant Root as Root install step
participant Agent as Agent install step
participant Runtime as Eval runtime shell

Eval->>Pre: root_install_command(...)
Pre-->>Eval: package-manager install command
Eval->>Root: install bash/curl/git/fd/rg/tmux/browser deps
Eval->>Pre: agent_install_command(version_spec)
Pre-->>Eval: Node, Atomic, playwright-cli, browser setup command
Eval->>Agent: install Node via distro/NVM and Atomic packages
Agent->>Agent: "persist PLAYWRIGHT_MCP_* env and executable path"
Eval->>Pre: runtime_environment_command()
Pre-->>Eval: source ~/.atomic-eval-env and PATH
Eval->>Runtime: run atomic with persisted sandbox environment
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Eval as Pier/Harbor eval adapter
participant Pre as evals/prerequisites.py
participant Root as Root install step
participant Agent as Agent install step
participant Runtime as Eval runtime shell

Eval->>Pre: root_install_command(...)
Pre-->>Eval: package-manager install command
Eval->>Root: install bash/curl/git/fd/rg/tmux/browser deps
Eval->>Pre: agent_install_command(version_spec)
Pre-->>Eval: Node, Atomic, playwright-cli, browser setup command
Eval->>Agent: install Node via distro/NVM and Atomic packages
Agent->>Agent: "persist PLAYWRIGHT_MCP_* env and executable path"
Eval->>Pre: runtime_environment_command()
Pre-->>Eval: source ~/.atomic-eval-env and PATH
Eval->>Runtime: run atomic with persisted sandbox environment
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): harden sandbox prerequisites"](https://github.com/bastani-inc/atomic/commit/ca5b6c2a1743e956a9d766dcb865112a456b1d2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43743131)</sub>

<!-- /greptile_comment -->