### PR TITLE
fix(evals): provision auth for workflow model providers

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -11,6 +11,7 @@ Common options:
 - `--agent-kwarg version=next` installs `@bastani/atomic@next` inside the sandbox. Omit it for `@latest`, or pass a concrete npm version/tag without the leading `@` (for example `--agent-kwarg version=0.9.3-alpha.1`).
 - `--force-build` rebuilds the task image so the `npm install -g @bastani/atomic@...` layer re-runs. Without it, Docker layer caching reuses a previously installed Atomic even after a new version is published to the tag, so benchmark runs can silently test a stale build. All commands below include it.
 - `--agent-kwarg thinking=xhigh` configures Atomic's reasoning level for models that support it.
+- `--agent-kwarg disallowed_subscriptions=github-copilot` excludes matching providers from copied local subscription auth. The default is empty: every valid local entry remains eligible unless explicitly denied, with no known-provider allowlist. Pass multiple names as a comma-separated string or JSON list.
 - `--n-tasks` and `--include-task-name` control which Deep SWE tasks run.
 
 ## Timeouts
@@ -30,6 +31,7 @@ uv run pier run \
   --model MODEL_NAME \
   --agent-kwarg thinking=THINKING_LEVEL \
   --agent-kwarg version=VERSION \
+  --agent-kwarg disallowed_subscriptions=github-copilot \
   --agent-timeout-multiplier 16 \
   --job-name atomic-smoke \
   --n-tasks 1 \
@@ -63,6 +65,7 @@ uv run pier run \
   --model openai-codex/gpt-5.6-sol \
   --agent-kwarg thinking=xhigh \
   --agent-kwarg version=0.9.5 \
+  --agent-kwarg disallowed_subscriptions=github-copilot \
   --agent-timeout-multiplier 16 \
   --job-name atomic-deep-swe \
   --sample-seed 0 \
@@ -82,6 +85,7 @@ uv run pier run \
   --agent-import-path atomic_pier:Atomic \
   --model github-copilot/gpt-5.6-sol \
   --agent-kwarg thinking=xhigh \
+  --agent-kwarg disallowed_subscriptions=github-copilot \
   --agent-timeout-multiplier 16 \
   --job-name atomic-deep-swe \
   --sample-seed 0 \
@@ -110,6 +114,7 @@ uv run pier run \
   --agent-import-path atomic_pier:Atomic \
   --model github-copilot/gpt-5.6-sol \
   --agent-kwarg thinking=xhigh \
+  --agent-kwarg disallowed_subscriptions=github-copilot \
   --agent-timeout-multiplier 16 \
   --agent-env COPILOT_API_TARGET=api.githubcopilot.com \
   --job-name atomic-deep-swe \
@@ -133,6 +138,7 @@ uv run pier run \
   --agent-import-path atomic_pier:Atomic \
   --model anthropic/claude-fable-5 \
   --agent-kwarg thinking=high \
+  --agent-kwarg disallowed_subscriptions=github-copilot \
   --agent-timeout-multiplier 16 \
   --job-name atomic-deep-swe \
   --sample-seed 0 \
@@ -144,7 +150,7 @@ The native Anthropic provider uses dash-form model ids such as `claude-opus-4-8`
 
 ### OpenAI Codex subscription with OpenRouter fallback
 
-For `openai-codex/...` models, Atomic uses OAuth credentials stored in the agent auth file rather than an environment variable. Log in on the host so `~/.atomic/agent/auth.json` (or legacy `~/.pi/agent/auth.json`) contains an `openai-codex` entry. The Pier and Harbor adapters copy only that provider entry into the sandbox user's `~/.atomic/agent/auth.json` with `0600` permissions before launching Atomic. Export `OPENROUTER_API_KEY` if you want missing Codex subscription auth to fall back to the equivalent `openrouter/openai/...` model.
+For `openai-codex/...` models, Atomic uses OAuth credentials stored in the agent auth file rather than an environment variable. Log in on the host so `~/.atomic/agent/auth.json` (or legacy `~/.pi/agent/auth.json`) contains an `openai-codex` entry. The Pier and Harbor adapters merge valid local entries with Atomic taking precedence over legacy Pi, remove denied providers and providers shadowed by explicit environment credentials, then write the remainder to the sandbox user's `~/.atomic/agent/auth.json` with `0600` permissions. Export `OPENROUTER_API_KEY` if you want missing Codex subscription auth to fall back to the equivalent `openrouter/openai/...` model.
 
 ```bash
 export OPENROUTER_API_KEY="..."  # optional fallback
@@ -154,6 +160,7 @@ uv run pier run \
   --agent-import-path atomic_pier:Atomic \
   --model openai-codex/gpt-5.6-sol \
   --agent-kwarg thinking=xhigh \
+  --agent-kwarg disallowed_subscriptions=github-copilot \
   --agent-timeout-multiplier 16 \
   --job-name atomic-deep-swe \
   --sample-seed 0 \
@@ -161,7 +168,7 @@ uv run pier run \
   --force-build
 ```
 
-The adapters do not introduce Codex-specific auth environment variables and do not print the OAuth credential contents.
+The adapters do not introduce Codex-specific auth environment variables and do not print copied credential contents.
 
 ### OpenRouter
 
@@ -175,6 +182,7 @@ uv run pier run \
   --agent-import-path atomic_pier:Atomic \
   --model openrouter/openai/gpt-5.6-sol \
   --agent-kwarg thinking=xhigh \
+  --agent-kwarg disallowed_subscriptions=github-copilot \
   --agent-timeout-multiplier 16 \
   --job-name atomic-deep-swe \
   --sample-seed 0 \

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -4,7 +4,7 @@ import re
 import shlex
 import tempfile
 from pathlib import Path
-from typing import override
+from typing import cast, override
 
 from harbor.agents.installed.base import (
     BaseInstalledAgent,
@@ -53,6 +53,48 @@ class Atomic(BaseInstalledAgent):
             choices=["off", "minimal", "low", "medium", "high", "xhigh"],
         ),
     ]
+
+    @override
+    def __init__(
+        self,
+        logs_dir: Path,
+        prompt_template_path: Path | str | None = None,
+        version: str | None = None,
+        extra_env: dict[str, str] | None = None,
+        *,
+        disallowed_subscriptions: str | list[str] | tuple[str, ...] | None = None,
+        **kwargs: object,
+    ) -> None:
+        self._disallowed_subscriptions: frozenset[str] = (
+            self._normalize_disallowed_subscriptions(disallowed_subscriptions)
+        )
+        super().__init__(
+            logs_dir=logs_dir,
+            prompt_template_path=prompt_template_path,
+            version=version,
+            extra_env=extra_env,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _normalize_disallowed_subscriptions(value: object) -> frozenset[str]:
+        if value is None:
+            return frozenset()
+        values = [value] if isinstance(value, str) else value
+        if not isinstance(values, list | tuple):
+            raise TypeError(
+                "disallowed_subscriptions must be a string or list of strings"
+            )
+        subscriptions: set[str] = set()
+        for item in values:
+            if not isinstance(item, str):
+                raise TypeError(
+                    "disallowed_subscriptions must contain only provider names"
+                )
+            subscriptions.update(
+                name.strip() for name in item.split(",") if name.strip()
+            )
+        return frozenset(subscriptions)
 
     @staticmethod
     @override
@@ -118,10 +160,10 @@ class Atomic(BaseInstalledAgent):
             if isinstance(data, dict):
                 merged.update(data)
         return {
-            provider: entry
+            provider: cast(dict[str, object], entry)
             for provider, entry in merged.items()
-            if isinstance(provider, str)
-            and provider
+            if provider
+            and provider not in self._disallowed_subscriptions
             and self._is_valid_provider_auth(entry)
         }
 
@@ -259,6 +301,7 @@ class Atomic(BaseInstalledAgent):
             "trap 'cleanup_atomic_sessions 143; exit 143' TERM; "
         )
 
+    @override
     @with_prompt_template
     async def run(
         self,

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -179,7 +179,11 @@ class Atomic(BaseInstalledAgent):
                 key: value for key in keys if (value := self._get_env(key))
             }
         else:
-            environment_keys = env
+            environment_keys = env.copy()
+        for credential_keys in self._PROVIDER_AUTH_ENV_KEYS.values():
+            for key in credential_keys:
+                if value := self._get_env(key):
+                    environment_keys[key] = value
         for auth_provider, credential_keys in self._PROVIDER_AUTH_ENV_KEYS.items():
             has_environment_auth = (
                 all(environment_keys.get(key) for key in credential_keys)

--- a/evals/atomic_harbor.py
+++ b/evals/atomic_harbor.py
@@ -27,6 +27,23 @@ class Atomic(BaseInstalledAgent):
     _LOG_SESSION_DIR = f"/logs/agent/{_SESSION_DIR_NAME}"
     _OPENAI_CODEX_PROVIDER = "openai-codex"
     _AUTH_UPLOAD_TARGET = "/tmp/atomic-subscription-auth.json"
+    _PROVIDER_AUTH_ENV_KEYS: dict[str, tuple[str, ...]] = {
+        "amazon-bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+        "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"),
+        "github-copilot": ("COPILOT_GITHUB_TOKEN",),
+        "google": (
+            "GEMINI_API_KEY",
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GOOGLE_API_KEY",
+        ),
+        "groq": ("GROQ_API_KEY",),
+        "huggingface": ("HF_TOKEN",),
+        "mistral": ("MISTRAL_API_KEY",),
+        "openai": ("OPENAI_API_KEY",),
+        "openrouter": ("OPENROUTER_API_KEY",),
+        "xai": ("XAI_API_KEY",),
+    }
 
     CLI_FLAGS = [
         CliFlag(
@@ -80,7 +97,18 @@ class Atomic(BaseInstalledAgent):
             Path.home() / ".pi" / "agent" / "auth.json",
         )
 
-    def _load_provider_auth(self, provider: str) -> dict[str, object] | None:
+    @staticmethod
+    def _is_valid_provider_auth(entry: object) -> bool:
+        if not isinstance(entry, dict):
+            return False
+        credential_type = entry.get("type")
+        if credential_type == "api_key":
+            return isinstance(entry.get("key"), str) and bool(entry["key"])
+        if credential_type == "oauth":
+            return isinstance(entry.get("access"), str) and bool(entry["access"])
+        return False
+
+    def _load_provider_auths(self) -> dict[str, dict[str, object]]:
         merged: dict[str, object] = {}
         for auth_path in reversed(self._auth_config_paths()):
             try:
@@ -89,13 +117,23 @@ class Atomic(BaseInstalledAgent):
                 continue
             if isinstance(data, dict):
                 merged.update(data)
-        entry = merged.get(provider)
-        return entry if isinstance(entry, dict) else None
+        return {
+            provider: entry
+            for provider, entry in merged.items()
+            if isinstance(provider, str)
+            and provider
+            and self._is_valid_provider_auth(entry)
+        }
+
+    def _load_provider_auth(self, provider: str) -> dict[str, object] | None:
+        return self._load_provider_auths().get(provider)
 
     def _has_subscription_auth(self, provider: str) -> bool:
         if provider == "anthropic":
-            return bool(self._get_env("ANTHROPIC_OAUTH_TOKEN")) or (
-                self._load_provider_auth(provider) is not None
+            return bool(
+                self._get_env("ANTHROPIC_API_KEY")
+                or self._get_env("ANTHROPIC_OAUTH_TOKEN")
+                or self._load_provider_auth(provider) is not None
             )
         if provider == self._OPENAI_CODEX_PROVIDER:
             return self._load_provider_auth(provider) is not None
@@ -126,24 +164,32 @@ class Atomic(BaseInstalledAgent):
                 return fallback
         return provider, model
 
-    def _should_provision_subscription_auth(self, provider: str) -> bool:
-        if provider == self._OPENAI_CODEX_PROVIDER:
-            return True
-        # Provision the local Claude Pro/Max OAuth entry only when no explicit
-        # env credential is supplied; ANTHROPIC_OAUTH_TOKEN keeps precedence.
-        return provider == "anthropic" and not self._get_env("ANTHROPIC_OAUTH_TOKEN")
-
     async def _provision_subscription_auth(
         self,
         environment: BaseEnvironment,
         provider: str,
+        env: dict[str, str] | None = None,
     ) -> None:
-        if not self._should_provision_subscription_auth(provider):
+        auth_data = self._load_provider_auths()
+        if env is None:
+            keys = list(self._PROVIDER_AUTH_ENV_KEYS.get(provider, ()))
+            if provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}:
+                keys.append("OPENROUTER_API_KEY")
+            environment_keys = {
+                key: value for key in keys if (value := self._get_env(key))
+            }
+        else:
+            environment_keys = env
+        for auth_provider, credential_keys in self._PROVIDER_AUTH_ENV_KEYS.items():
+            has_environment_auth = (
+                all(environment_keys.get(key) for key in credential_keys)
+                if auth_provider == "amazon-bedrock"
+                else any(environment_keys.get(key) for key in credential_keys)
+            )
+            if has_environment_auth:
+                auth_data.pop(auth_provider, None)
+        if not auth_data:
             return
-        entry = self._load_provider_auth(provider)
-        if entry is None:
-            return
-        auth_data = {provider: entry}
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             temp_path = Path(handle.name)
             json.dump(auth_data, handle, indent=2)
@@ -265,7 +311,7 @@ class Atomic(BaseInstalledAgent):
         skills_command = self._build_register_skills_command()
         if skills_command:
             await self.exec_as_agent(environment, command=skills_command)
-        await self._provision_subscription_auth(environment, requested_provider)
+        await self._provision_subscription_auth(environment, requested_provider, env)
 
         # Atomic state stays under the container user's ~/.atomic/agent; after
         # the run, transcripts are copied to /logs for Harbor artifact parsing.

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -76,6 +76,22 @@ class Atomic(BaseInstalledAgent):
         "openrouter": ("OPENROUTER_API_KEY",),
         "xai": ("XAI_API_KEY",),
     }
+    _PROVIDER_AUTH_ENV_KEYS: dict[str, tuple[str, ...]] = {
+        "amazon-bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+        "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"),
+        "github-copilot": ("COPILOT_GITHUB_TOKEN",),
+        "google": (
+            "GEMINI_API_KEY",
+            "GOOGLE_GENERATIVE_AI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GOOGLE_API_KEY",
+        ),
+        "groq": ("GROQ_API_KEY",),
+        "mistral": ("MISTRAL_API_KEY",),
+        "openai": ("OPENAI_API_KEY",),
+        "openrouter": ("OPENROUTER_API_KEY",),
+        "xai": ("XAI_API_KEY",),
+    }
     _BASE_URL_ENV_KEYS: tuple[str, ...] = (
         "ANTHROPIC_BASE_URL",
         "GEMINI_API_BASE",
@@ -188,7 +204,18 @@ class Atomic(BaseInstalledAgent):
             Path.home() / ".pi" / "agent" / "auth.json",
         )
 
-    def _load_provider_auth(self, provider: str) -> dict[str, object] | None:
+    @staticmethod
+    def _is_valid_provider_auth(entry: object) -> bool:
+        if not isinstance(entry, dict):
+            return False
+        credential_type = entry.get("type")
+        if credential_type == "api_key":
+            return isinstance(entry.get("key"), str) and bool(entry["key"])
+        if credential_type == "oauth":
+            return isinstance(entry.get("access"), str) and bool(entry["access"])
+        return False
+
+    def _load_provider_auths(self) -> dict[str, dict[str, object]]:
         merged: dict[str, object] = {}
         for auth_path in reversed(self._auth_config_paths()):
             try:
@@ -197,13 +224,23 @@ class Atomic(BaseInstalledAgent):
                 continue
             if isinstance(data, dict):
                 merged.update(data)
-        entry = merged.get(provider)
-        return entry if isinstance(entry, dict) else None
+        return {
+            provider: entry
+            for provider, entry in merged.items()
+            if isinstance(provider, str)
+            and provider
+            and self._is_valid_provider_auth(entry)
+        }
+
+    def _load_provider_auth(self, provider: str) -> dict[str, object] | None:
+        return self._load_provider_auths().get(provider)
 
     def _has_subscription_auth(self, provider: str) -> bool:
         if provider == "anthropic":
-            return bool(self._get_env("ANTHROPIC_OAUTH_TOKEN")) or (
-                self._load_provider_auth(provider) is not None
+            return bool(
+                self._get_env("ANTHROPIC_API_KEY")
+                or self._get_env("ANTHROPIC_OAUTH_TOKEN")
+                or self._load_provider_auth(provider) is not None
             )
         if provider == self._OPENAI_CODEX_PROVIDER:
             return self._load_provider_auth(provider) is not None
@@ -234,24 +271,32 @@ class Atomic(BaseInstalledAgent):
                 return fallback
         return provider, model
 
-    def _should_provision_subscription_auth(self, provider: str) -> bool:
-        if provider == self._OPENAI_CODEX_PROVIDER:
-            return True
-        # Provision the local Claude Pro/Max OAuth entry only when no explicit
-        # env credential is supplied; ANTHROPIC_OAUTH_TOKEN keeps precedence.
-        return provider == "anthropic" and not self._get_env("ANTHROPIC_OAUTH_TOKEN")
-
     async def _provision_subscription_auth(
         self,
         environment: BaseEnvironment,
         provider: str,
+        env: dict[str, str] | None = None,
     ) -> None:
-        if not self._should_provision_subscription_auth(provider):
+        auth_data = self._load_provider_auths()
+        if env is None:
+            keys = list(self._PROVIDER_AUTH_ENV_KEYS.get(provider, ()))
+            if provider in {"anthropic", self._OPENAI_CODEX_PROVIDER}:
+                keys.append("OPENROUTER_API_KEY")
+            environment_keys = {
+                key: value for key in keys if (value := self._get_env(key))
+            }
+        else:
+            environment_keys = env
+        for auth_provider, credential_keys in self._PROVIDER_AUTH_ENV_KEYS.items():
+            has_environment_auth = (
+                all(environment_keys.get(key) for key in credential_keys)
+                if auth_provider == "amazon-bedrock"
+                else any(environment_keys.get(key) for key in credential_keys)
+            )
+            if has_environment_auth:
+                auth_data.pop(auth_provider, None)
+        if not auth_data:
             return
-        entry = self._load_provider_auth(provider)
-        if entry is None:
-            return
-        auth_data = {provider: entry}
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             temp_path = Path(handle.name)
             json.dump(auth_data, handle, indent=2)
@@ -349,7 +394,7 @@ class Atomic(BaseInstalledAgent):
         skills_command = self._build_register_skills_command()
         if skills_command:
             await self.exec_as_agent(environment, command=skills_command)
-        await self._provision_subscription_auth(environment, requested_provider)
+        await self._provision_subscription_auth(environment, requested_provider, env)
 
         cli_flags = self.build_cli_flags()
         if cli_flags:

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -286,7 +286,11 @@ class Atomic(BaseInstalledAgent):
                 key: value for key in keys if (value := self._get_env(key))
             }
         else:
-            environment_keys = env
+            environment_keys = env.copy()
+        for credential_keys in self._PROVIDER_AUTH_ENV_KEYS.values():
+            for key in credential_keys:
+                if value := self._get_env(key):
+                    environment_keys[key] = value
         for auth_provider, credential_keys in self._PROVIDER_AUTH_ENV_KEYS.items():
             has_environment_auth = (
                 all(environment_keys.get(key) for key in credential_keys)

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -7,7 +7,7 @@ import shlex
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast, override
 from urllib.parse import urlparse
 
 from pier.agents.installed.base import (
@@ -143,16 +143,62 @@ class Atomic(BaseInstalledAgent):
         ),
     ]
 
+    @override
+    def __init__(
+        self,
+        logs_dir: Path,
+        prompt_template_path: Path | str | None = None,
+        version: str | None = None,
+        extra_env: dict[str, str] | None = None,
+        *,
+        disallowed_subscriptions: str | list[str] | tuple[str, ...] | None = None,
+        **kwargs: object,
+    ) -> None:
+        self._disallowed_subscriptions: frozenset[str] = (
+            self._normalize_disallowed_subscriptions(disallowed_subscriptions)
+        )
+        super().__init__(
+            logs_dir=logs_dir,
+            prompt_template_path=prompt_template_path,
+            version=version,
+            extra_env=extra_env,
+            **kwargs,
+        )
+
     @staticmethod
+    def _normalize_disallowed_subscriptions(value: object) -> frozenset[str]:
+        if value is None:
+            return frozenset()
+        values = [value] if isinstance(value, str) else value
+        if not isinstance(values, list | tuple):
+            raise TypeError(
+                "disallowed_subscriptions must be a string or list of strings"
+            )
+        subscriptions: set[str] = set()
+        for item in values:
+            if not isinstance(item, str):
+                raise TypeError(
+                    "disallowed_subscriptions must contain only provider names"
+                )
+            subscriptions.update(
+                name.strip() for name in item.split(",") if name.strip()
+            )
+        return frozenset(subscriptions)
+
+    @staticmethod
+    @override
     def name() -> str:
         return "atomic"
 
+    @override
     def get_version_command(self) -> str | None:
         return f"{runtime_environment_command()}; if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; atomic --version"
 
+    @override
     def parse_version(self, stdout: str) -> str:
         return stdout.strip().splitlines()[-1].strip()
 
+    @override
     def install_spec(self) -> AgentInstallSpec:
         version_spec = f"@{self._version}" if self._version else "@latest"
         return AgentInstallSpec(
@@ -169,6 +215,7 @@ class Atomic(BaseInstalledAgent):
             verification_command=self.get_version_command(),
         )
 
+    @override
     def network_allowlist(self) -> NetworkAllowlist:
         if not self.model_name or "/" not in self.model_name:
             return NetworkAllowlist()
@@ -225,10 +272,10 @@ class Atomic(BaseInstalledAgent):
             if isinstance(data, dict):
                 merged.update(data)
         return {
-            provider: entry
+            provider: cast(dict[str, object], entry)
             for provider, entry in merged.items()
-            if isinstance(provider, str)
-            and provider
+            if provider
+            and provider not in self._disallowed_subscriptions
             and self._is_valid_provider_auth(entry)
         }
 
@@ -366,6 +413,7 @@ class Atomic(BaseInstalledAgent):
             "trap 'cleanup_atomic_sessions 143; exit 143' TERM; "
         )
 
+    @override
     @with_prompt_template
     async def run(
         self,
@@ -873,6 +921,7 @@ class Atomic(BaseInstalledAgent):
         except OSError as exc:
             self.logger.debug("Failed to write Atomic trajectory: %s", exc)
 
+    @override
     def populate_context_post_run(self, context: AgentContext) -> None:
         output_file = self.logs_dir / self._OUTPUT_FILENAME
         if not output_file.exists():

--- a/evals/atomic_pier.py
+++ b/evals/atomic_pier.py
@@ -1,3 +1,5 @@
+# pyright: reportMissingTypeStubs=false
+
 from __future__ import annotations
 
 import json
@@ -7,7 +9,7 @@ import shlex
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast, override
+from typing import ClassVar, cast, override
 from urllib.parse import urlparse
 
 from pier.agents.installed.base import (
@@ -31,7 +33,9 @@ from pier.models.trajectories import (
     Trajectory,
 )
 from pier.models.trial.paths import EnvironmentPaths
-from pier.utils.trajectory_utils import format_trajectory_json
+from pier.utils.trajectory_utils import (
+    format_trajectory_json,  # pyright: ignore[reportUnknownVariableType]
+)
 from prerequisites import (
     agent_install_command,
     root_install_command,
@@ -39,18 +43,32 @@ from prerequisites import (
 )
 
 
+type JsonValue = str | int | float | bool | None | list[JsonValue] | JsonObject
+type JsonObject = dict[str, JsonValue]
+
+
+def _json_object(value: object) -> JsonObject | None:
+    if not isinstance(value, dict):
+        return None
+    return cast(JsonObject, value)
+
+
 class Atomic(BaseInstalledAgent):
     """Pier installed-agent adapter for the Atomic coding agent."""
 
     SUPPORTS_ATIF: bool = True
 
-    _OUTPUT_FILENAME = "atomic.txt"
-    _SESSION_DIR_NAME = "atomic-sessions"
-    _CONTAINER_AGENT_DIR = "$HOME/.atomic/agent"
-    _CONTAINER_SESSION_DIR = f"{_CONTAINER_AGENT_DIR}/{_SESSION_DIR_NAME}"
-    _LOG_SESSION_DIR = str(EnvironmentPaths.agent_dir / _SESSION_DIR_NAME)
-    _OPENAI_CODEX_PROVIDER = "openai-codex"
-    _AUTH_UPLOAD_TARGET = "/tmp/atomic-subscription-auth.json"
+    _OUTPUT_FILENAME: ClassVar[str] = "atomic.txt"
+    _SESSION_DIR_NAME: ClassVar[str] = "atomic-sessions"
+    _CONTAINER_AGENT_DIR: ClassVar[str] = "$HOME/.atomic/agent"
+    _CONTAINER_SESSION_DIR: ClassVar[str] = (
+        f"{_CONTAINER_AGENT_DIR}/{_SESSION_DIR_NAME}"
+    )
+    _LOG_SESSION_DIR: ClassVar[str] = str(
+        EnvironmentPaths.agent_dir / _SESSION_DIR_NAME
+    )
+    _OPENAI_CODEX_PROVIDER: ClassVar[str] = "openai-codex"
+    _AUTH_UPLOAD_TARGET: ClassVar[str] = "/tmp/atomic-subscription-auth.json"
 
     _PROVIDER_ENV_KEYS: dict[str, tuple[str, ...]] = {
         "amazon-bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"),
@@ -134,7 +152,7 @@ class Atomic(BaseInstalledAgent):
         "xai": ("api.x.ai",),
     }
 
-    CLI_FLAGS = [
+    CLI_FLAGS: ClassVar[list[CliFlag]] = [
         CliFlag(
             "thinking",
             cli="--thinking",
@@ -157,7 +175,7 @@ class Atomic(BaseInstalledAgent):
         self._disallowed_subscriptions: frozenset[str] = (
             self._normalize_disallowed_subscriptions(disallowed_subscriptions)
         )
-        super().__init__(
+        super().__init__(  # pyright: ignore[reportUnknownMemberType]
             logs_dir=logs_dir,
             prompt_template_path=prompt_template_path,
             version=version,
@@ -169,8 +187,11 @@ class Atomic(BaseInstalledAgent):
     def _normalize_disallowed_subscriptions(value: object) -> frozenset[str]:
         if value is None:
             return frozenset()
-        values = [value] if isinstance(value, str) else value
-        if not isinstance(values, list | tuple):
+        if isinstance(value, str):
+            values: list[object] | tuple[object, ...] = [value]
+        elif isinstance(value, list | tuple):
+            values = cast(list[object] | tuple[object, ...], value)
+        else:
             raise TypeError(
                 "disallowed_subscriptions must be a string or list of strings"
             )
@@ -192,7 +213,11 @@ class Atomic(BaseInstalledAgent):
 
     @override
     def get_version_command(self) -> str | None:
-        return f"{runtime_environment_command()}; if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; atomic --version"
+        return (
+            f"{runtime_environment_command()}; "
+            "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; "
+            "atomic --version"
+        )
 
     @override
     def parse_version(self, stdout: str) -> str:
@@ -253,33 +278,44 @@ class Atomic(BaseInstalledAgent):
 
     @staticmethod
     def _is_valid_provider_auth(entry: object) -> bool:
-        if not isinstance(entry, dict):
+        auth = _json_object(entry)
+        if auth is None:
             return False
-        credential_type = entry.get("type")
+        credential_type = auth.get("type")
         if credential_type == "api_key":
-            return isinstance(entry.get("key"), str) and bool(entry["key"])
+            key = auth.get("key")
+            return isinstance(key, str) and bool(key)
         if credential_type == "oauth":
-            return isinstance(entry.get("access"), str) and bool(entry["access"])
+            access = auth.get("access")
+            return isinstance(access, str) and bool(access)
         return False
 
-    def _load_provider_auths(self) -> dict[str, dict[str, object]]:
-        merged: dict[str, object] = {}
+    def _load_provider_auths(self) -> dict[str, JsonObject]:
+        merged: JsonObject = {}
         for auth_path in reversed(self._auth_config_paths()):
             try:
-                data = json.loads(auth_path.read_text(encoding="utf-8"))
+                data = cast(
+                    object,
+                    json.loads(auth_path.read_text(encoding="utf-8")),
+                )
             except (OSError, json.JSONDecodeError):
                 continue
-            if isinstance(data, dict):
-                merged.update(data)
-        return {
-            provider: cast(dict[str, object], entry)
-            for provider, entry in merged.items()
-            if provider
-            and provider not in self._disallowed_subscriptions
-            and self._is_valid_provider_auth(entry)
-        }
+            if data_object := _json_object(data):
+                merged.update(data_object)
 
-    def _load_provider_auth(self, provider: str) -> dict[str, object] | None:
+        auths: dict[str, JsonObject] = {}
+        for provider, entry in merged.items():
+            auth = _json_object(entry)
+            if (
+                provider
+                and provider not in self._disallowed_subscriptions
+                and auth is not None
+                and self._is_valid_provider_auth(auth)
+            ):
+                auths[provider] = auth
+        return auths
+
+    def _load_provider_auth(self, provider: str) -> JsonObject | None:
         return self._load_provider_auths().get(provider)
 
     def _has_subscription_auth(self, provider: str) -> bool:
@@ -345,13 +381,13 @@ class Atomic(BaseInstalledAgent):
                 else any(environment_keys.get(key) for key in credential_keys)
             )
             if has_environment_auth:
-                auth_data.pop(auth_provider, None)
+                _ = auth_data.pop(auth_provider, None)
         if not auth_data:
             return
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             temp_path = Path(handle.name)
             json.dump(auth_data, handle, indent=2)
-            handle.write("\n")
+            _ = handle.write("\n")
         try:
             os.chmod(temp_path, 0o600)
             await environment.upload_file(temp_path, self._AUTH_UPLOAD_TARGET)
@@ -409,12 +445,13 @@ class Atomic(BaseInstalledAgent):
             "wait \"$atomic_session_sync_pid\" 2>/dev/null || true; "
             "return \"$status\"; "
             "}; "
-            "trap 'status=$?; cleanup_atomic_sessions \"$status\"; exit \"$status\"' EXIT; "
+            "trap 'status=$?; cleanup_atomic_sessions \"$status\"; "
+            "exit \"$status\"' EXIT; "
             "trap 'cleanup_atomic_sessions 143; exit 143' TERM; "
         )
 
-    @override
-    @with_prompt_template
+    @override  # pyright: ignore[reportAny]
+    @with_prompt_template  # pyright: ignore[reportAny]
     async def run(
         self,
         instruction: str,
@@ -425,7 +462,10 @@ class Atomic(BaseInstalledAgent):
             raise ValueError("Model name must be in the format provider/model_name")
 
         requested_provider, requested_model = self.model_name.split("/", 1)
-        provider, model = self._select_provider_model(requested_provider, requested_model)
+        provider, model = self._select_provider_model(
+            requested_provider,
+            requested_model,
+        )
         env = {
             key: value
             for key in (
@@ -454,7 +494,9 @@ class Atomic(BaseInstalledAgent):
 
         session_dir = self._CONTAINER_SESSION_DIR
         log_session_dir = shlex.quote(self._LOG_SESSION_DIR)
-        output_file = shlex.quote(str(EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME))
+        output_file = shlex.quote(
+            str(EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME)
+        )
         copilot_config_command = self._copilot_models_config_command(copilot_base_url)
         command = (
             f"rm -rf {session_dir} {log_session_dir} && mkdir -p {session_dir} && "
@@ -473,7 +515,6 @@ class Atomic(BaseInstalledAgent):
         )
         await self.exec_as_agent(environment, command=command, env=env)
         self.populate_context_post_run(context)
-
 
     def _copilot_api_base_url(self) -> str:
         api_target = self._get_env("COPILOT_API_TARGET")
@@ -500,7 +541,8 @@ class Atomic(BaseInstalledAgent):
 
     @staticmethod
     def _copilot_api_base_url_from_server_url(server_url: str) -> str:
-        host = urlparse(server_url if "://" in server_url else f"https://{server_url}").hostname
+        parsed_url = server_url if "://" in server_url else f"https://{server_url}"
+        host = urlparse(parsed_url).hostname
         if not host or host == "github.com":
             return "https://api.githubcopilot.com"
         if host.endswith(".ghe.com"):
@@ -528,55 +570,57 @@ class Atomic(BaseInstalledAgent):
     def _cost_total(value: object) -> float:
         if isinstance(value, int | float):
             return float(value)
-        if not isinstance(value, dict):
+        cost = _json_object(value)
+        if cost is None:
             return 0.0
-        total = value.get("total")
+        total = cost.get("total")
         if isinstance(total, int | float):
             return float(total)
         return sum(
             float(part)
             for key in ("input", "output", "cacheRead", "cacheWrite")
-            if isinstance((part := value.get(key)), int | float)
+            if isinstance((part := cost.get(key)), int | float)
         )
 
     @staticmethod
     def _assistant_message_fingerprint(message: object) -> str | None:
-        if not isinstance(message, dict) or message.get("role") != "assistant":
+        message_object = _json_object(message)
+        if message_object is None or message_object.get("role") != "assistant":
             return None
-        timestamp = message.get("timestamp")
+        timestamp = message_object.get("timestamp")
         if timestamp is None:
             return None
-        usage = message.get("usage")
+        usage = _json_object(message_object.get("usage"))
         usage_fingerprint = ""
-        if isinstance(usage, dict):
+        if usage is not None:
             usage_fingerprint = ":".join(
                 str(usage.get(key, ""))
                 for key in ("input", "output", "cacheRead", "cacheWrite", "totalTokens")
             )
         message_fingerprint = ":".join(
-            str(message.get(key, ""))
+            str(message_object.get(key, ""))
             for key in ("timestamp", "provider", "model", "stopReason")
         )
         return f"{message_fingerprint}:{usage_fingerprint}"
 
     @staticmethod
-    def _read_jsonl(path: Path) -> list[dict[str, Any]]:
-        entries: list[dict[str, Any]] = []
+    def _read_jsonl(path: Path) -> list[JsonObject]:
+        entries: list[JsonObject] = []
         try:
             for line in path.read_text(encoding="utf-8").splitlines():
                 if not line.strip():
                     continue
                 try:
-                    entry = json.loads(line)
+                    entry = cast(object, json.loads(line))
                 except json.JSONDecodeError:
                     continue
-                if isinstance(entry, dict):
-                    entries.append(entry)
+                if entry_object := _json_object(entry):
+                    entries.append(entry_object)
         except OSError:
             return []
         return entries
 
-    def _read_session_header(self, session_file: Path) -> dict[str, Any] | None:
+    def _read_session_header(self, session_file: Path) -> JsonObject | None:
         for entry in self._read_jsonl(session_file):
             return entry if entry.get("type") == "session" else None
         return None
@@ -584,7 +628,7 @@ class Atomic(BaseInstalledAgent):
     def _should_count_session_file(
         self,
         session_file: Path,
-        header: dict[str, Any] | None,
+        header: JsonObject | None,
     ) -> bool:
         if not header:
             return False
@@ -602,7 +646,13 @@ class Atomic(BaseInstalledAgent):
             key=lambda path: (len(path.parts), str(path)),
         )
         return [
-            (path, self._should_count_session_file(path, self._read_session_header(path)))
+            (
+                path,
+                self._should_count_session_file(
+                    path,
+                    self._read_session_header(path),
+                ),
+            )
             for path in session_files
         ]
 
@@ -616,11 +666,14 @@ class Atomic(BaseInstalledAgent):
             return None
 
     @staticmethod
-    def _jsonable_arguments(value: object) -> dict[str, Any]:
-        return value if isinstance(value, dict) else {"value": value}
+    def _jsonable_arguments(value: object) -> dict[str, object]:
+        return cast(dict[str, object], value) if isinstance(value, dict) else {
+            "value": value
+        }
 
     def _split_message_content(
-        self, message: dict[str, Any]
+        self,
+        message: JsonObject,
     ) -> tuple[str, str | None, list[ToolCall] | None]:
         content = message.get("content")
         if isinstance(content, str):
@@ -632,24 +685,28 @@ class Atomic(BaseInstalledAgent):
         reasoning_parts: list[str] = []
         tool_calls: list[ToolCall] = []
         for block in content:
-            if not isinstance(block, dict):
+            block_object = _json_object(block)
+            if block_object is None:
                 continue
-            block_type = block.get("type")
-            if block_type == "text" and isinstance(block.get("text"), str):
-                text_parts.append(block["text"])
+            block_type = block_object.get("type")
+            text = block_object.get("text")
+            if block_type == "text" and isinstance(text, str):
+                text_parts.append(text)
             elif block_type in {"thinking", "redacted_thinking"}:
-                thinking = block.get("thinking") or block.get("text")
+                thinking = block_object.get("thinking") or text
                 if isinstance(thinking, str):
                     reasoning_parts.append(thinking)
             elif block_type == "toolCall":
-                tool_id = block.get("id")
-                name = block.get("name")
+                tool_id = block_object.get("id")
+                name = block_object.get("name")
                 if isinstance(tool_id, str) and isinstance(name, str):
                     tool_calls.append(
                         ToolCall(
                             tool_call_id=tool_id,
                             function_name=name,
-                            arguments=self._jsonable_arguments(block.get("arguments", {})),
+                            arguments=self._jsonable_arguments(
+                                block_object.get("arguments", {})
+                            ),
                         )
                     )
         return (
@@ -659,13 +716,14 @@ class Atomic(BaseInstalledAgent):
         )
 
     def _metrics_from_usage(self, usage: object) -> Metrics | None:
-        if not isinstance(usage, dict):
+        usage_object = _json_object(usage)
+        if usage_object is None:
             return None
-        input_tokens = self._token_count(usage.get("input"))
-        output_tokens = self._token_count(usage.get("output"))
-        cache_read = self._token_count(usage.get("cacheRead"))
-        cache_write = self._token_count(usage.get("cacheWrite"))
-        cost = self._cost_total(usage.get("cost"))
+        input_tokens = self._token_count(usage_object.get("input"))
+        output_tokens = self._token_count(usage_object.get("output"))
+        cache_read = self._token_count(usage_object.get("cacheRead"))
+        cache_write = self._token_count(usage_object.get("cacheWrite"))
+        cost = self._cost_total(usage_object.get("cost"))
         if not any((input_tokens, output_tokens, cache_read, cache_write, cost)):
             return None
         extra = {
@@ -683,7 +741,7 @@ class Atomic(BaseInstalledAgent):
     def _append_observation(
         self,
         steps: list[Step],
-        message: dict[str, Any],
+        message: JsonObject,
         timestamp: str | None,
     ) -> None:
         call_id = message.get("toolCallId")
@@ -725,7 +783,7 @@ class Atomic(BaseInstalledAgent):
 
     def _step_from_message(
         self,
-        message: dict[str, Any],
+        message: JsonObject,
         step_id: int,
         timestamp: str | None,
         entry_id: object,
@@ -744,11 +802,12 @@ class Atomic(BaseInstalledAgent):
             if fingerprint:
                 seen_fingerprints.add(fingerprint)
             metrics = None if copied else self._metrics_from_usage(message.get("usage"))
+            message_model = message.get("model")
             return Step(
                 step_id=step_id,
                 timestamp=timestamp,
                 source="agent",
-                model_name=message.get("model") if isinstance(message.get("model"), str) else None,
+                model_name=message_model if isinstance(message_model, str) else None,
                 message=text,
                 reasoning_content=reasoning,
                 tool_calls=tool_calls,
@@ -757,7 +816,12 @@ class Atomic(BaseInstalledAgent):
                 llm_call_count=1 if metrics else None,
             )
         if role == "user":
-            return Step(step_id=step_id, timestamp=timestamp, source="user", message=text)
+            return Step(
+                step_id=step_id,
+                timestamp=timestamp,
+                source="user",
+                message=text,
+            )
         if role == "bashExecution":
             command = message.get("command")
             output = message.get("output")
@@ -767,16 +831,25 @@ class Atomic(BaseInstalledAgent):
                 source="system",
                 message=f"bash: {command}" if isinstance(command, str) else "bash",
                 observation=Observation(
-                    results=[ObservationResult(content=output if isinstance(output, str) else None)]
+                    results=[
+                        ObservationResult(
+                            content=output if isinstance(output, str) else None
+                        )
+                    ]
                 ),
             )
         if role in {"custom", "branchSummary"}:
-            return Step(step_id=step_id, timestamp=timestamp, source="system", message=text)
+            return Step(
+                step_id=step_id,
+                timestamp=timestamp,
+                source="system",
+                message=text,
+            )
         return None
 
     def _trajectory_from_entries(
         self,
-        entries: list[dict[str, Any]],
+        entries: list[JsonObject],
         trajectory_id: str | None,
         seen_ids: set[str],
         seen_fingerprints: set[str],
@@ -794,8 +867,11 @@ class Atomic(BaseInstalledAgent):
             message = entry.get("message")
             if not isinstance(message, dict):
                 continue
-            timestamp = entry.get("timestamp") if isinstance(entry.get("timestamp"), str) else None
-            timestamp = timestamp or self._iso_from_message_timestamp(message.get("timestamp"))
+            entry_timestamp = entry.get("timestamp")
+            timestamp = entry_timestamp if isinstance(entry_timestamp, str) else None
+            timestamp = timestamp or self._iso_from_message_timestamp(
+                message.get("timestamp")
+            )
             if message.get("role") == "toolResult":
                 self._append_observation(steps, message, timestamp)
                 continue
@@ -811,8 +887,9 @@ class Atomic(BaseInstalledAgent):
                 steps.append(step)
         if not steps:
             return None, summarization_count
+        header_id = header.get("id")
         trajectory = Trajectory(
-            session_id=header.get("id") if isinstance(header.get("id"), str) else None,
+            session_id=header_id if isinstance(header_id, str) else None,
             trajectory_id=trajectory_id,
             agent=Agent(
                 name=self.name(),
@@ -833,13 +910,21 @@ class Atomic(BaseInstalledAgent):
         entries = [
             {"type": "message", "message": event.get("message")}
             for event in events
-            if event.get("type") == "message_end" and isinstance(event.get("message"), dict)
+            if event.get("type") == "message_end"
+            and _json_object(event.get("message")) is not None
         ]
-        trajectory, _ = self._trajectory_from_entries(entries, None, seen_ids, seen_fingerprints)
+        trajectory, _ = self._trajectory_from_entries(
+            entries,
+            None,
+            seen_ids,
+            seen_fingerprints,
+        )
         return trajectory
 
     @staticmethod
-    def _metric_totals(steps: list[Step]) -> tuple[int, int, int, float, int | None]:
+    def _metric_totals(
+        steps: list[Step],
+    ) -> tuple[int, int, int, float, int | None]:
         prompt = completion = cached = 0
         cost = 0.0
         peak: int | None = None
@@ -852,10 +937,18 @@ class Atomic(BaseInstalledAgent):
             cached += metrics.cached_tokens or 0
             cost += metrics.cost_usd or 0.0
             if metrics.prompt_tokens is not None:
-                peak = metrics.prompt_tokens if peak is None else max(peak, metrics.prompt_tokens)
+                peak = (
+                    metrics.prompt_tokens
+                    if peak is None
+                    else max(peak, metrics.prompt_tokens)
+                )
         return prompt, completion, cached, cost, peak
 
-    def _write_trajectory(self, context: AgentContext, classified: list[tuple[Path, bool]]) -> None:
+    def _write_trajectory(
+        self,
+        context: AgentContext,
+        classified: list[tuple[Path, bool]],
+    ) -> None:
         seen_ids: set[str] = set()
         seen_fingerprints: set[str] = set()
         main_files = [path for path, should_count in classified if not should_count]
@@ -915,7 +1008,7 @@ class Atomic(BaseInstalledAgent):
 
         trajectory_path = self.logs_dir / "trajectory.json"
         try:
-            trajectory_path.write_text(
+            _ = trajectory_path.write_text(
                 format_trajectory_json(root.to_json_dict()), encoding="utf-8"
             )
         except OSError as exc:
@@ -935,15 +1028,19 @@ class Atomic(BaseInstalledAgent):
         seen_message_ids: set[str] = set()
         seen_message_fingerprints: set[str] = set()
 
-        def add_assistant_message_usage(message: object, entry_id: object = None) -> None:
+        def add_assistant_message_usage(
+            message: object,
+            entry_id: object = None,
+        ) -> None:
             nonlocal total_input_tokens, total_output_tokens
             nonlocal total_cache_read_tokens, total_cache_write_tokens, total_cost
-            if not isinstance(message, dict) or message.get("role") != "assistant":
+            message_object = _json_object(message)
+            if message_object is None or message_object.get("role") != "assistant":
                 return
-            usage = message.get("usage")
-            if not isinstance(usage, dict):
+            usage = _json_object(message_object.get("usage"))
+            if usage is None:
                 return
-            fingerprint = self._assistant_message_fingerprint(message)
+            fingerprint = self._assistant_message_fingerprint(message_object)
             if isinstance(entry_id, str):
                 if entry_id in seen_message_ids:
                     return
@@ -959,12 +1056,16 @@ class Atomic(BaseInstalledAgent):
             total_cache_write_tokens += self._token_count(usage.get("cacheWrite"))
             total_cost += self._cost_total(usage.get("cost"))
 
-        def mark_assistant_message_seen(message: object, entry_id: object = None) -> None:
-            if not isinstance(message, dict) or message.get("role") != "assistant":
+        def mark_assistant_message_seen(
+            message: object,
+            entry_id: object = None,
+        ) -> None:
+            message_object = _json_object(message)
+            if message_object is None or message_object.get("role") != "assistant":
                 return
             if isinstance(entry_id, str):
                 seen_message_ids.add(entry_id)
-            fingerprint = self._assistant_message_fingerprint(message)
+            fingerprint = self._assistant_message_fingerprint(message_object)
             if fingerprint:
                 seen_message_fingerprints.add(fingerprint)
 

--- a/evals/pyproject.toml
+++ b/evals/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
 
 [tool.uv.sources]
 datacurve-pier = { path = "vendor/pier", editable = true }
+
+[dependency-groups]
+dev = [
+    "basedpyright>=1.39.9",
+]

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -166,6 +166,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.39.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/4b/c1f4e211e50389304d6af32b9280e026a7133e3ad59bbdf8f7a3250f8bee/basedpyright-1.39.9.tar.gz", hash = "sha256:32cbea5fc8273e89df3db20daea56cb7286e419ccdfdc479c64759d2dc071901", size = 24412216, upload-time = "2026-06-27T02:19:49.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d4/e1fa108710d0498a18c77b1e13897f31eab47c69aa8cfe2d2a4df746541e/basedpyright-1.39.9-py3-none-any.whl", hash = "sha256:6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c", size = 13374276, upload-time = "2026-06-27T02:19:54.431Z" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
@@ -624,8 +636,16 @@ dependencies = [
     { name = "datacurve-pier" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "basedpyright" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "datacurve-pier", editable = "vendor/pier" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "basedpyright", specifier = ">=1.39.9" }]
 
 [[package]]
 name = "fastapi"
@@ -1224,6 +1244,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
     { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
     { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/22/2a5beb4e21417c73233d9f65cf6f3e96e891b80d2f550a8f630ebc6b88c6/nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37", size = 8056, upload-time = "2026-05-30T16:52:09.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d1/68b43b53cd0fa83ae6fd406705023ca988d9e0ca41c724d82e66fbeb2ef6/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c", size = 55666374, upload-time = "2026-05-30T16:51:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51", size = 55838487, upload-time = "2026-05-30T16:51:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/cd42174fb5ff6faff7fa8d326a18914d8f232098ab5de055b57c16fa13ca/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342", size = 60179540, upload-time = "2026-05-30T16:51:47.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/c8a1f9ae140aa28df8744d984d01d4b3af7cdd6555af12127f40ceb45a7d/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd", size = 60716262, upload-time = "2026-05-30T16:51:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/7c35b3737f59e36d0249c265397b7bff570519b95301d6e16ea361e904ad/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502", size = 62230592, upload-time = "2026-05-30T16:51:55Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Provision valid stored credentials for every workflow model provider inside Pier and Harbor eval sandboxes, so primary and fallback models can authenticate independently without leaking or overriding explicit environment credentials.

## Changes

- Merge valid provider entries from Atomic and legacy Pi auth files, with Atomic entries taking precedence.
- Upload the merged auth map to the sandbox for workflow primary and fallback providers.
- Omit stored provider credentials when explicit environment authentication is configured, including complete AWS credential pairs.
- Recognize Anthropic API-key authentication when deciding whether subscription fallback is needed.

## Validation

- `python3 -m py_compile evals/atomic_pier.py evals/atomic_harbor.py`
- `uvx --offline ruff check evals/atomic_pier.py evals/atomic_harbor.py`
- `bun run check:file-length`
- `git diff --check`
- Configured pre-commit hooks via `prek` (including lint, file-length, and unit tests)
- Configured pre-push hooks during `git push`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates eval sandbox auth provisioning for workflow model providers. The main changes are:

- Merges valid Atomic and legacy Pi auth entries, with Atomic entries taking precedence.
- Uploads the merged auth map into Pier and Harbor sandboxes for workflow providers.
- Removes stored provider auth when explicit environment credentials are configured.
- Adds `disallowed_subscriptions` docs and a `basedpyright` dev dependency for evals.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing one provider-specific auth issue.

The main auth provisioning flow is contained, but Pier misses `huggingface` in the env-shadow pruning map, which can leave explicit `HF_TOKEN` workflow auth misapplied.

`evals/atomic_pier.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a Python harness that loads the real AtomicPier code and exercises the subscription-auth provisioning path to reproduce the behavior on a fake environment.
- The reproduction showed that a stale HuggingFace auth entry persisted in the upload while the OpenAI control entry was pruned, indicating HF\_TOKEN did not suppress stored HuggingFace credentials.
- As part of preparing the environment, CPython 3.14 provisioning was compiled for evals/atomic\_pier.py and related files, and the compile step completed successfully.
- A separate Python 3.11 system-compile check failed with a SyntaxError at type JsonValue, matching the known blocker.
- Diff checks passed, but Ruff offline and a file-length check were blocked due to offline-cache availability and a missing TypeScript reference file.

<a href="https://app.greptile.com/trex/runs/14289416/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| evals/README.md | Documents the new subscription-auth provisioning behavior and `disallowed_subscriptions` option. |
| evals/atomic_harbor.py | Adds merged subscription auth loading, denylist normalization, env-shadow pruning, and sandbox auth upload for Harbor. |
| evals/atomic_pier.py | Adds the same Pier subscription auth provisioning flow, but omits `huggingface` from env-shadow pruning so explicit `HF_TOKEN` cannot suppress stored auth. |
| evals/pyproject.toml | Adds `basedpyright` to the evals development dependency group. |
| evals/uv.lock | Locks the new `basedpyright` dev dependency and its `nodejs-wheel-binaries` dependency. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Adapter as Pier/Harbor adapter
participant Host as Host env/auth files
participant Sandbox as Eval sandbox
participant Atomic as Atomic workflow

Adapter->>Host: Read explicit provider env keys
Adapter->>Host: Load ~/.atomic and legacy ~/.pi auth.json
Adapter->>Adapter: Merge auth, apply disallowed_subscriptions
Adapter->>Adapter: Remove providers shadowed by explicit env auth
alt merged auth remains
    Adapter->>Sandbox: Upload temporary auth JSON
    Sandbox->>Sandbox: Install as ~/.atomic/agent/auth.json (0600)
end
Adapter->>Sandbox: Launch Atomic with selected env
Sandbox->>Atomic: Workflow primary/fallback providers authenticate
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Adapter as Pier/Harbor adapter
participant Host as Host env/auth files
participant Sandbox as Eval sandbox
participant Atomic as Atomic workflow

Adapter->>Host: Read explicit provider env keys
Adapter->>Host: Load ~/.atomic and legacy ~/.pi auth.json
Adapter->>Adapter: Merge auth, apply disallowed_subscriptions
Adapter->>Adapter: Remove providers shadowed by explicit env auth
alt merged auth remains
    Adapter->>Sandbox: Upload temporary auth JSON
    Sandbox->>Sandbox: Install as ~/.atomic/agent/auth.json (0600)
end
Adapter->>Sandbox: Launch Atomic with selected env
Sandbox->>Atomic: Workflow primary/fallback providers authenticate
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
evals/atomic_pier.py:97-112
**Hugging Face env skipped**
`_provision_subscription_auth` only prunes stored auth for providers listed in `_PROVIDER_AUTH_ENV_KEYS`, but Pier omits `huggingface` while Harbor includes `HF_TOKEN`. With an explicit host `HF_TOKEN` for a workflow fallback and a stale local `huggingface` auth entry, line 373 never imports `HF_TOKEN` and lines 377-384 never remove that stored entry, so the sandbox still receives the wrong credential despite explicit environment auth being configured.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(evals): satisfy strict typing in Pie..."](https://github.com/bastani-inc/atomic/commit/c5158ec12469693adb864abe5b3d5abf23183a9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43900466)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->