### PR TITLE
Release 0.9.9-alpha.1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
 ### Breaking Changes
 
 - Replaced deletion-target context compaction with durable verbatim line compaction. Legacy `context_compaction` entries are now inert archival records, so content they previously hid may re-enter context when old sessions resume; start a new conversation or compact again to establish a new boundary.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.1 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.8.
+
 ## [0.9.8] - 2026-07-12
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.1 prerelease for the intercom extension; no functional intercom changes were made after 0.9.8.
+
 ## [0.9.8] - 2026-07-12
 
 ### Changed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.1 prerelease for the MCP extension; no functional MCP changes were made after 0.9.8.
+
 ## [0.9.8] - 2026-07-12
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.1 prerelease for the native transport package; no native transport changes were made after 0.9.8.
+
 ## [0.9.8] - 2026-07-12
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
 ### Fixed
 
 - Fixed first-party subagent transcripts launched inside workflow stages to inherit complete workflow ownership metadata in foreground and background execution, while fork-context children also inherit classification through the branched JSONL header.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.1 prerelease for the web-access extension; no functional web-access changes were made after 0.9.8.
+
 ## [0.9.8] - 2026-07-12
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.9-alpha.1] - 2026-07-14
+
 ### Changed
 
 - Hardened the shared builtin `goal`/`ralph` prompt contracts against over-implementation drift (observed in eval traces where near-perfect patches lost binary reward to a single invented strictness: returning a read-only mapping proxy where the contract said "dict", marking an optional schema field required, and rejecting duplicate aliases the task's hidden tests expected to be tolerated). The literal objective contract now states that the loud-error preference applies only to error conditions the contract enumerates and that the default for unenumerated behavior is permissive acceptance (never invent a validation error, required field, uniqueness constraint, or rejection the contract does not name); that contract-named types/shapes/formats must be produced exactly, with no defensive substitutes such as read-only proxies, frozen collections, or tuples-for-lists, because consumers may check type identity literally; and that unspecified behavior defaults to preserving input verbatim over normalizing, deduplicating, reordering, or rewriting it.


### PR DESCRIPTION
## Summary

Prepare the `0.9.9-alpha.1` prerelease release notes for merge into `main`.

- **Release kind:** prerelease
- **Version:** `0.9.9-alpha.1`

## Changes

- Update the `## [Unreleased]` sections in the changelogs for `coding-agent`, `cursor`, `intercom`, `mcp`, `natives`, `subagents`, `web-access`, and `workflows`.
- Keep all `packages/*/package.json` versions at the versionless-main `0.0.0` placeholder; this PR contains no package version bump.
- The real version will be materialized only in the throwaway off-main release-tag commit created by `scripts/cut-release.ts` after this PR is merged.

## Validation

Deterministic release preparation and local checks passed at commit `1ebd7cd8d280b90fd914645523ee02a0a20e729f`.

Commands run:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only 6667064e1c917057892192dbbfbe920332f8ff46..HEAD
git push -u origin prerelease/0.9.9-alpha.1
gh auth status
gh repo view --json nameWithOwner,url,defaultBranchRef
gh pr list --repo bastani-inc/atomic --head prerelease/0.9.9-alpha.1 --base main --state all --json number,title,url,state,isDraft,baseRefName,headRefName,headRefOid
```

The push hook also passed:

- `bun run lint`
- `bun run check:file-length`
- `bun run test:unit`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.9-alpha.1` prerelease changelog updates. The main changes are:

- Adds `0.9.9-alpha.1` release headings to the changed package changelogs.
- Moves accumulated `coding-agent`, `subagents`, and `workflows` release notes out of `Unreleased`.
- Adds synchronized prerelease notes for unchanged companion packages.
- Leaves package versions unchanged for the versionless-main release flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are limited to changelog release-note sections and match the documented versionless-main release flow.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- HEAD was captured for the changelog validation baseline as 1ebd7cd8d280b90fd914645523ee02a0a20e729f.
- A git diff was run to compare base and HEAD, and it listed eight changed changelog files in the changed files artifact.
- An after-state verification run exited with code 0 and reported version 0.0.0 for all eight changed packages.
- An optional file-length check confirmed the known missing-file blocker.

<a href="https://app.greptile.com/trex/runs/14445710/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds the 0.9.9-alpha.1 release heading above accumulated coding-agent breaking, added, changed, and fixed release notes. |
| packages/cursor/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.1 prerelease note for the Cursor provider package. |
| packages/intercom/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.1 prerelease note for the Intercom extension. |
| packages/mcp/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.1 prerelease note for the MCP extension. |
| packages/natives/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.1 prerelease note for the native transport package. |
| packages/subagents/CHANGELOG.md | Adds the 0.9.9-alpha.1 release heading above the subagents workflow-ownership fix note. |
| packages/web-access/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.1 prerelease note for the web-access extension. |
| packages/workflows/CHANGELOG.md | Adds the 0.9.9-alpha.1 release heading above workflows changed and fixed notes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Main as versionless main
participant Changelogs as packages/*/CHANGELOG.md
participant Release as cut-release.ts off-main worktree
participant Publish as publish.yml

Main->>Changelogs: merge 0.9.9-alpha.1 release notes
Main->>Main: keep package.json versions at 0.0.0
Release->>Release: materialize real 0.9.9-alpha.1 versions on tag commit
Release->>Publish: push tag and dispatch protected publish workflow
Publish->>Publish: verify release commit parent is integrated into main
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Main as versionless main
participant Changelogs as packages/*/CHANGELOG.md
participant Release as cut-release.ts off-main worktree
participant Publish as publish.yml

Main->>Changelogs: merge 0.9.9-alpha.1 release notes
Main->>Main: keep package.json versions at 0.0.0
Release->>Release: materialize real 0.9.9-alpha.1 versions on tag commit
Release->>Publish: push tag and dispatch protected publish workflow
Publish->>Publish: verify release commit parent is integrated into main
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.9-alpha.1"](https://github.com/bastani-inc/atomic/commit/1ebd7cd8d280b90fd914645523ee02a0a20e729f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44257553)</sub>

<!-- /greptile_comment -->