### PR TITLE
test(workflows): isolate durable resume follow-up

### DIFF
--- a/test/unit/workflow-lazy-startup-review-followup.test.ts
+++ b/test/unit/workflow-lazy-startup-review-followup.test.ts
@@ -67,6 +67,7 @@ function registerFactory(piOverrides: Partial<ExtensionAPI> = {}): Array<{ name:
 
 beforeEach(() => {
   delete process.env[WORKFLOW_STAGE_SUBAGENT_GUARD_ENV];
+  setDurableBackend(new InMemoryDurableBackend());
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Isolate the lazy-startup durable-shadow resume test from the user's persistent workflow store. Each test now starts with a fresh in-memory durable backend, preventing deterministic timeouts caused by scanning `$HOME/.atomic/workflow-durable` while leaving production behavior unchanged.

## Changes

- Set a new `InMemoryDurableBackend` in the test suite's existing `beforeEach` setup.
- Retain the existing `afterEach` reset so backend state does not leak between tests.
- Limit the patch to one test-only insertion; no production files are changed.

## Validation

- RED: with the `main` version restored and `ATOMIC_WORKFLOW_DURABLE` unset, the durable-shadow resume test timed out at 5000 ms.
- GREEN: `env -u ATOMIC_WORKFLOW_DURABLE bun test test/unit/workflow-lazy-startup-review-followup.test.ts --test-name-pattern "workflow resume routes quit durable shadows through durable resume"`
- `env -u ATOMIC_WORKFLOW_DURABLE bun test test/unit/workflow-lazy-startup-review-followup.test.ts test/unit/durable-resume-runtime.test.ts test/unit/durable-format-compatibility.test.ts` — 53 passed
- `env -u ATOMIC_WORKFLOW_DURABLE bun run test:unit` — 3430 passed, 0 failed across 390 files
- `bun run typecheck`
- `bun run check:file-length`
- `git diff --check`

## Notes

This is a test-isolation fix only. The existing teardown restores default durable-backend resolution, and production behavior is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR isolates workflow lazy-startup tests from the persistent durable workflow store. The main changes are:

- Adds a fresh `InMemoryDurableBackend` in the suite `beforeEach`.
- Keeps the existing `afterEach` reset to restore default durable backend resolution.
- Limits the update to the test file only.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge with minimal risk.

The change is a single test-only setup insertion paired with the existing `afterEach` reset. It matches the isolation goal and does not affect production code paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused durable-resume test for workflow-lazy-startup-review-followup.test.ts with the specified test-name pattern, and it completed with 1 pass and 0 failures (EXIT\_CODE: 0).
- Executed the broader related durable tests, including workflow-lazy-startup-review-followup.test.ts and durable-resume-runtime and durable-format-compatibility tests, which finished with 53 pass and 0 fail (EXIT\_CODE: 0).
- Reviewed the compatibility diagnostics about unavailable delete operations reported in the related run and confirmed they were expected and did not block completion.

<a href="https://app.greptile.com/trex/runs/14477033/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/unit/workflow-lazy-startup-review-followup.test.ts | Adds per-test `InMemoryDurableBackend` setup to isolate workflow lazy-startup tests from the user's persistent durable store; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant TestRunner as bun:test
participant BeforeEach as beforeEach
participant Backend as InMemoryDurableBackend
participant Test as Workflow resume tests
participant AfterEach as afterEach

TestRunner->>BeforeEach: start each test
BeforeEach->>BeforeEach: delete stage guard env
BeforeEach->>Backend: new InMemoryDurableBackend()
BeforeEach->>Test: setDurableBackend(backend)
Test->>Test: exercise workflow resume behavior
TestRunner->>AfterEach: finish test
AfterEach->>Test: store.clear()
AfterEach->>Test: setDurableBackend(undefined)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant TestRunner as bun:test
participant BeforeEach as beforeEach
participant Backend as InMemoryDurableBackend
participant Test as Workflow resume tests
participant AfterEach as afterEach

TestRunner->>BeforeEach: start each test
BeforeEach->>BeforeEach: delete stage guard env
BeforeEach->>Backend: new InMemoryDurableBackend()
BeforeEach->>Test: setDurableBackend(backend)
Test->>Test: exercise workflow resume behavior
TestRunner->>AfterEach: finish test
AfterEach->>Test: store.clear()
AfterEach->>Test: setDurableBackend(undefined)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(workflows): isolate durable resume ..."](https://github.com/bastani-inc/atomic/commit/100252984793a407c09dc6dd1cb8810266f93a3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44324267)</sub>

<!-- /greptile_comment -->