### PR TITLE
Release 0.9.9-alpha.2

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Updated the Pi runtime dependency set (`@earendil-works/pi-agent-core`, `pi-ai`, and `pi-tui`) from `^0.80.6` to `^0.80.7` across Atomic and its bundled packages, with matching Bun and npm lock metadata. This inherits the upstream provider authentication, session-affinity, reasoning replay, tool-choice, model-catalog, terminal input, and prompt-cache fixes from [Pi v0.80.7](https://github.com/earendil-works/pi/releases/tag/v0.80.7) while preserving versionless `0.0.0` workspace manifests.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Aligned the Cursor provider dependency with `@earendil-works/pi-ai` `^0.80.7` as part of the consolidated Pi v0.80.7 dependency update; no Cursor provider source changes were needed.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Aligned the intercom extension peer dependency with `@earendil-works/pi-tui` `^0.80.7` as part of the consolidated Pi v0.80.7 dependency update; no intercom source changes were needed.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Aligned the MCP extension peer dependencies with `@earendil-works/pi-ai` and `@earendil-works/pi-tui` `^0.80.7` as part of the consolidated Pi v0.80.7 dependency update; no MCP source changes were needed.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Refreshed the native Rust lockfile to `rustls` 0.23.42, `bytes` 1.12.1, Rust `ignore` 0.4.28, `napi-derive` 3.5.10 (with `napi-derive-backend` 5.1.2), and `tree-sitter` 0.26.11; no native API or source changes were required.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Aligned the subagents extension peer dependencies with the `@earendil-works/pi-agent-core`, `pi-ai`, and `pi-tui` `^0.80.7` runtime set as part of the consolidated Pi v0.80.7 dependency update; no subagent source changes were needed.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Aligned the web-access extension peer dependency with `@earendil-works/pi-tui` `^0.80.7` as part of the consolidated Pi v0.80.7 dependency update; no web-access source changes were needed.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.9-alpha.2] - 2026-07-14
+
 ### Changed
 
 - Aligned the workflows extension peer dependency with `@earendil-works/pi-tui` `^0.80.7` as part of the consolidated Pi v0.80.7 dependency update; no workflow source changes were needed.


### PR DESCRIPTION
## Summary

Prepare the **prerelease** release notes for version **0.9.9-alpha.2**.

## Changes

- Stamp the `0.9.9-alpha.2` release heading in the changelogs for `coding-agent`, `cursor`, `intercom`, `mcp`, `natives`, `subagents`, `web-access`, and `workflows`.
- Keep `main` versionless: no package manifests or dependency versions are bumped, and all `packages/*/package.json` versions remain at `0.0.0`.
- Leave real-version materialization to the throwaway off-main tag commit created by `scripts/cut-release.ts` after this PR is merged.

## Validation

- `bun run typecheck`
- `bun run test:unit`
- Pre-push hooks: `bun run lint`, `bun run check:file-length`, and `bun run test:unit`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.9-alpha.2` prerelease changelog entries. The main changes are:

- Stamped `0.9.9-alpha.2` headings across eight package changelogs.
- Kept `main` versionless with no package manifest or dependency version bumps.
- Left release version materialization to the off-main release tag flow.

<h3>Confidence Score: 5/5</h3>

This changelog-only PR is safe to merge.

The changes are limited to release-note headings in the expected package changelogs and follow the repository's versionless-main release guidance.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The TypeScript typecheck step was run and completed without errors.
- The unit test suite executed with 3430 tests across 390 files and finished with no failures.
- The lint check completed successfully with exit code 0.
- The file-length check ran and failed due to a missing pre-existing deleted reference to a TypeScript utility types file.
- The manifest/version checks reported no changes to the package manifest.

<a href="https://app.greptile.com/trex/runs/14478718/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Stamped `0.9.9-alpha.2` above existing unreleased coding-agent release notes; no issues found. |
| packages/cursor/CHANGELOG.md | Stamped `0.9.9-alpha.2` for Cursor dependency-alignment release notes; no issues found. |
| packages/intercom/CHANGELOG.md | Stamped `0.9.9-alpha.2` for Intercom dependency/typebox release notes; no issues found. |
| packages/mcp/CHANGELOG.md | Stamped `0.9.9-alpha.2` for MCP peer dependency and typebox release notes; no issues found. |
| packages/natives/CHANGELOG.md | Stamped `0.9.9-alpha.2` for native lockfile refresh release notes; no issues found. |
| packages/subagents/CHANGELOG.md | Stamped `0.9.9-alpha.2` for subagents dependency/typebox release notes; no issues found. |
| packages/web-access/CHANGELOG.md | Stamped `0.9.9-alpha.2` for web-access dependency/linkedom release notes; no issues found. |
| packages/workflows/CHANGELOG.md | Stamped `0.9.9-alpha.2` for workflows dependency/typebox release notes; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.9-alpha.2"](https://github.com/bastani-inc/atomic/commit/a5c087f2d6fc580c4c65e0328360201718bb18b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44327265)</sub>

<!-- /greptile_comment -->