### PR TITLE
Release 0.9.9-alpha.3

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
 ### Added
 
 - Added `pi.sendMessages()` for atomic, array-ordered custom-message admission without waiting for the resulting model turn, allowing companion extensions to keep related preludes and terminal notices contiguous without globally serializing unrelated work.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.3 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.9-alpha.2.
+
 ## [0.9.9-alpha.2] - 2026-07-14
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
 ### Fixed
 
 - Preserved per-child chronology between busy-parent Intercom messages and terminal async subagent notifications: paused, completed, and failed paths now claim pre-terminal ordinary messages from the exact child session/run in FIFO order and atomically admit the prelude plus terminal notice through the custom-message batch API. A process-local bridge complements extension-bus delivery for lazily activated companions; terminal identity deduplicates both paths even when the successful terminal dispatch has an empty prelude, while failed dispatches remain retryable and distinct resumed-run lifecycle terminals remain independent. Idle flushes use the same ordered batch admission, unrelated children remain independent, and ask/reply correlation is unchanged ([#1802](https://github.com/bastani-inc/atomic/issues/1802)).

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.3 prerelease for the MCP extension; no functional MCP changes were made after 0.9.9-alpha.2.
+
 ## [0.9.9-alpha.2] - 2026-07-14
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.3 prerelease for the native transport package; no native transport changes were made after 0.9.9-alpha.2.
+
 ## [0.9.9-alpha.2] - 2026-07-14
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
+### Fixed
+
+- Preserved background async-child completion chronology with Intercom by emitting a terminal-ordering barrier and atomically batching claimed same-child messages before the completion notice, with a compatibility fallback for hosts without batched message admission.
+
 ## [0.9.9-alpha.2] - 2026-07-14
 
 ### Changed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.3 prerelease for the web-access extension; no functional web-access changes were made after 0.9.9-alpha.2.
+
 ## [0.9.9-alpha.2] - 2026-07-14
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.9-alpha.3] - 2026-07-14
+
 ### Fixed
 
 - Made `workflow({ action: "status", runId })` apply the same exact-or-unique-prefix contract as the other run actions. A prefix shared by multiple retained runs now returns the standard ambiguity diagnostic instead of silently inspecting the first match, so abbreviated run IDs printed by status surfaces remain safe and actionable.


### PR DESCRIPTION
## Release

- **Kind:** prerelease
- **Version:** `0.9.9-alpha.3`
- **Base:** `main`
- **Head:** `prerelease/0.9.9-alpha.3`

## Summary

- Finalizes the `0.9.9-alpha.3` changelog sections across the coding-agent, cursor, intercom, MCP, natives, subagents, web-access, and workflows packages.
- Captures the new atomic custom-message batch API, Intercom/subagent chronology fixes, workflow status prefix handling, and synchronized prerelease notes for packages without functional changes since `0.9.9-alpha.2`.
- Does **not** bump package manifests: `main` remains versionless with `0.0.0` placeholders. The real version will be materialized only on the throwaway off-main tag commit produced by `scripts/cut-release.ts` after this PR is merged.

## Validation

Deterministic preparation was verified from source commit `d83dc30ceffda036bbe3b0e1500569e04249feae` to release commit `befe28963e127ee1e490dcaaca19c38f338f37f4`.

Commands run:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only d83dc30ceffda036bbe3b0e1500569e04249feae..HEAD
git push -u origin prerelease/0.9.9-alpha.3
gh auth status
gh repo view --json nameWithOwner,url,defaultBranchRef
gh pr list --state all --head prerelease/0.9.9-alpha.3 --base main --json number,title,url,state,baseRefName,headRefName,headRefOid
```

The push hooks also passed:

```sh
bun run lint
bun run check:file-length
bun run test:unit
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR finalizes the `0.9.9-alpha.3` prerelease changelog across all eight packages by inserting the version header `## [0.9.9-alpha.3] - 2026-07-14` above content that was already staged under `## [Unreleased]`. No package manifests are bumped; `main` stays at the `0.0.0` placeholder, consistent with the repo's versionless-main release flow.

- **Packages with functional entries** (`coding-agent`, `intercom`, `subagents`, `workflows`): version headers gate meaningful `### Added` or `### Fixed` items covering the new `pi.sendMessages()` batch API, Intercom/subagent chronology fixes, and the `workflow status` prefix contract.
- **Synchronized-only packages** (`cursor`, `mcp`, `natives`, `web-access`): new `### Changed` entries correctly state no functional changes occurred since alpha.2, following the established pattern for no-op prerelease syncs.
- All previously released version sections are left untouched, satisfying the immutability rule in the project's changelog conventions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is changelog text only; no source code, package manifests, or configuration files are touched.

Every file changed is a CHANGELOG.md. The version headers are inserted correctly between ## [Unreleased] and the existing subsections, no previously released sections are modified, the meaningful entries in coding-agent, intercom, subagents, and workflows are substantive and accurate, and the no-op sync entries for cursor, mcp, natives, and web-access follow the established project pattern. Package versions remain at 0.0.0 on main as the versionless-main flow requires.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds ## [0.9.9-alpha.3] - 2026-07-14 header above the existing ### Added and ### Fixed unreleased content, correctly stamping the new pi.sendMessages() batch API and Intercom chronology fix under the prerelease version. |
| packages/intercom/CHANGELOG.md | Adds ## [0.9.9-alpha.3] - 2026-07-14 header above two existing ### Fixed entries covering per-child Intercom chronology (#1802) and intercom list short-ID actionability; no previously released sections modified. |
| packages/subagents/CHANGELOG.md | Adds ## [0.9.9-alpha.3] - 2026-07-14 with a ### Fixed entry describing the terminal-ordering barrier and batch-admission compatibility fallback for async-child completion chronology. |
| packages/workflows/CHANGELOG.md | Adds ## [0.9.9-alpha.3] - 2026-07-14 header above the existing ### Fixed entry for the workflow status exact-or-unique-prefix contract; no previously released sections modified. |
| packages/cursor/CHANGELOG.md | Adds a synchronized ## [0.9.9-alpha.3] prerelease entry with a ### Changed note that no functional Cursor provider changes were made since alpha.2. |
| packages/mcp/CHANGELOG.md | Adds a synchronized ## [0.9.9-alpha.3] prerelease entry with a ### Changed note that no functional MCP changes were made since alpha.2. |
| packages/natives/CHANGELOG.md | Adds a synchronized ## [0.9.9-alpha.3] prerelease entry with a ### Changed note that no native transport changes were made since alpha.2. |
| packages/web-access/CHANGELOG.md | Adds a synchronized ## [0.9.9-alpha.3] prerelease entry with a ### Changed note that no functional web-access changes were made since alpha.2. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant Main as main branch
    participant Script as cut-release.ts
    participant Tag as Git Tag (0.9.9-alpha.3)
    participant CI as publish.yml (CI)

    Dev->>Main: "Merge changelog-only PR #1815"
    Note over Main: package.json stays at 0.0.0
    Dev->>Script: bun run scripts/cut-release.ts 0.9.9-alpha.3 --base main --push
    Script->>Tag: Stamp real version, create throwaway off-main tag commit
    Note over Tag: Parent is already in main (integrity gate)
    Dev->>CI: "gh workflow run publish.yml --ref main -f tag=0.9.9-alpha.3"
    CI->>Tag: Verify deterministic release commit
    CI->>CI: npm publish --provenance (OIDC, no token)
    CI->>CI: Create GitHub Release
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant Main as main branch
    participant Script as cut-release.ts
    participant Tag as Git Tag (0.9.9-alpha.3)
    participant CI as publish.yml (CI)

    Dev->>Main: "Merge changelog-only PR #1815"
    Note over Main: package.json stays at 0.0.0
    Dev->>Script: bun run scripts/cut-release.ts 0.9.9-alpha.3 --base main --push
    Script->>Tag: Stamp real version, create throwaway off-main tag commit
    Note over Tag: Parent is already in main (integrity gate)
    Dev->>CI: "gh workflow run publish.yml --ref main -f tag=0.9.9-alpha.3"
    CI->>Tag: Verify deterministic release commit
    CI->>CI: npm publish --provenance (OIDC, no token)
    CI->>CI: Create GitHub Release
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.9-alpha.3"](https://github.com/bastani-inc/atomic/commit/befe28963e127ee1e490dcaaca19c38f338f37f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44382080)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/bastani-inc/github/bastani-inc/atomic/-/custom-context?memory=6b6bc6e3-dafb-4fa7-9d98-538aac70844a))

<!-- /greptile_comment -->