### PR TITLE
fix(workflows): refresh in-process workflow discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed in-process workflow reload to atomically publish freshly rescanned project, user, legacy, configured, and package workflow resources across list/get/inputs/help/completion/invocation surfaces. Overlapping requests are serialized and coalesced, stale session generations cannot overwrite current state, fatal refresh failures retain the prior registry, and reload no longer blocks or changes workflows already in flight. `/workflow reload` and the workflow tool now include actionable per-resource diagnostics instead of reporting bare success when malformed or missing resources were skipped.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Added

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -781,6 +781,14 @@ export const tableSelectorFactory: WorkflowCustomUiFactory<{ id: string; name: s
 
 Workflow files are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation.
 
+## Reloading workflow resources
+
+Run `/workflow reload` after adding, editing, renaming, or deleting workflow modules or changing workflow config. Reload rescans project and user conventional directories, legacy `.pi` locations, configured file/directory paths, and package resources without restarting Atomic. The workflow tool's `reload` action uses the same in-process path.
+
+Reload builds a complete replacement registry before publishing it. Concurrent requests are serialized and coalesced, stale discovery from an earlier session cannot overwrite newer state, and a fatal refresh failure retains the previous registry. Reload is safe while workflows are running: existing runs keep the definition and runtime snapshot they started with, while subsequent list/get/inputs/help/completion/invocation calls use the newly published registry.
+
+A successful rescan may still contain per-resource diagnostics. Both reload surfaces now show `CONFIG_INVALID`, `IMPORT_FAILED`, `INVALID_DEFINITION`, `PATH_NOT_FOUND`, and duplicate-name diagnostics instead of reporting bare success while silently skipping a resource. Valid sibling workflows remain available. Fix the reported source/path and reload again; no process restart is required.
+
 ## Workflow Configuration
 
 Configured workflow paths live in workflow extension config. Project config paths are relative to the project root. Global config paths are relative to `~/.atomic/agent`.

--- a/packages/coding-agent/test/resource-loader-01-01.suite.ts
+++ b/packages/coding-agent/test/resource-loader-01-01.suite.ts
@@ -63,6 +63,21 @@ describe("DefaultResourceLoader", () => {
 			writeManifest(["workflows/a.ts"]);
 			settingsManager.setPackages([pkgDir]);
 
+			const preservedSkillDir = join(agentDir, "skills", "preserved-skill");
+			const preservedPromptDir = join(agentDir, "prompts");
+			const preservedThemeDir = join(agentDir, "themes");
+			mkdirSync(preservedSkillDir, { recursive: true });
+			mkdirSync(preservedPromptDir, { recursive: true });
+			mkdirSync(preservedThemeDir, { recursive: true });
+			writeFileSync(
+				join(preservedSkillDir, "SKILL.md"),
+				"---\nname: preserved-skill\ndescription: Reload preservation fixture\n---\n",
+			);
+			writeFileSync(join(preservedPromptDir, "preserved.md"), "Preserved prompt");
+			const baseThemePath = fileURLToPath(new URL("../src/modes/interactive/theme/dark.json", import.meta.url));
+			const preservedTheme = JSON.parse(readFileSync(baseThemePath, "utf8")) as { name: string };
+			preservedTheme.name = "preserved-theme";
+			writeFileSync(join(preservedThemeDir, "preserved.json"), JSON.stringify(preservedTheme));
 			let factoryCalls = 0;
 			let apiGetWorkflowResources: (() => ResolvedResource[]) | undefined;
 			let apiRefreshWorkflowResources: (() => Promise<ResolvedResource[]>) | undefined;
@@ -89,6 +104,18 @@ describe("DefaultResourceLoader", () => {
 			expect(apiGetWorkflowResources().map((resource) => resource.path)).toEqual([workflowA]);
 			expect(loader.getWorkflowResources().map((resource) => resource.path)).toEqual([workflowA]);
 
+			const preservedResources = {
+				extensions: loader.getExtensions(),
+				skills: loader.getSkills(),
+				prompts: loader.getPrompts(),
+				themes: loader.getThemes(),
+				projectTrusted: settingsManager.isProjectTrusted(),
+				inheritance: loader.getInheritanceSnapshot(),
+			};
+			expect(preservedResources.skills.skills.map((skill) => skill.name)).toContain("preserved-skill");
+			expect(preservedResources.prompts.prompts.map((prompt) => prompt.name)).toContain("preserved");
+			expect(preservedResources.themes.themes.map((theme) => theme.name)).toContain("preserved-theme");
+
 			writeManifest(["workflows/a.ts", "workflows/b.ts"]);
 			const refreshed = await apiRefreshWorkflowResources();
 
@@ -96,6 +123,12 @@ describe("DefaultResourceLoader", () => {
 			expect(apiGetWorkflowResources().map((resource) => resource.path)).toEqual([workflowA, workflowB]);
 			expect(loader.getWorkflowResources().map((resource) => resource.path)).toEqual([workflowA, workflowB]);
 			expect(factoryCalls).toBe(1);
+			expect(loader.getExtensions()).toEqual(preservedResources.extensions);
+			expect(loader.getSkills()).toEqual(preservedResources.skills);
+			expect(loader.getPrompts()).toEqual(preservedResources.prompts);
+			expect(loader.getThemes()).toEqual(preservedResources.themes);
+			expect(settingsManager.isProjectTrusted()).toBe(preservedResources.projectTrusted);
+			expect(loader.getInheritanceSnapshot()).toEqual(preservedResources.inheritance);
 		});
 		it("should expose project-local workflows from additional extension paths", async () => {
 			const repoDir = join(tempDir, "borrowed-repo");

--- a/packages/subagents/src/extension/startup-maintenance.ts
+++ b/packages/subagents/src/extension/startup-maintenance.ts
@@ -39,6 +39,7 @@ export function createSubagentStartupMaintenance(
     resultsDir: string;
     artifactCleanupDays: number;
     resultTtlMs: number;
+    scheduleMacrotask?: (task: () => void) => () => void;
   },
 ): SubagentStartupMaintenance {
   const { startResultWatcher, primeExistingResults, stopResultWatcher } = createResultWatcher(
@@ -49,7 +50,7 @@ export function createSubagentStartupMaintenance(
   );
   const cancelTasks = new Set<() => void>();
   const schedule = (task: () => void): void => {
-    const cancel = scheduleMacrotask(() => {
+    const cancel = (options.scheduleMacrotask ?? scheduleMacrotask)(() => {
       cancelTasks.delete(cancel);
       task();
     });

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed workflow resource reload to build and atomically publish a fresh registry for additions, edits, renames, deletions, config paths, conventional/legacy directories, and package resources without restarting Atomic. Reloads now serialize and coalesce, reject stale session generations, retain the active registry on fatal failures, remain safe during in-flight runs, and return visible config/discovery diagnostics through both slash-command and tool surfaces while preserving valid siblings.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Fixed

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -29,6 +29,8 @@ Adding workflow files under `.atomic/workflows/` (project scope) or `~/.atomic/a
 }
 ```
 
+After Atomic is running, use `/workflow reload` or the workflow tool's `reload` action to rescan all workflow sources in process. Additions, edits, renames, deletions, config changes, and package-resource changes become visible immediately to list/get/inputs/help/completion/invocation surfaces. Reload requests are serialized/coalesced and publish a complete replacement registry; an in-flight workflow keeps its original definition while later calls use the new registry. Fatal refresh failures retain the prior registry, and skipped malformed or missing resources are reported with actionable diagnostics while valid siblings remain available.
+
 ### Workflow lifecycle notifications
 
 Workflow lifecycle notices are enabled by default. They send steer prompts into the main chat/model context when a run completes, fails, or ends blocked. Awaiting-input prompts are tracked for dedupe/restore, but they do not wake the main chat agent. Configure lifecycle tracking in the same extension config file:

--- a/packages/workflows/src/extension/extension-runtime-state.ts
+++ b/packages/workflows/src/extension/extension-runtime-state.ts
@@ -273,14 +273,18 @@ export function createWorkflowExtensionRuntimeState(
     };
   }
 
-  function failedReloadReport(error: unknown, coalescedRequests: number): WorkflowReloadReport {
+  function failedReloadReport(
+    error: unknown,
+    coalescedRequests: number,
+    configResult?: ConfigLoadResult,
+  ): WorkflowReloadReport {
     return {
       outcome: "failed",
       error: error instanceof Error ? error.message : String(error),
       generation: activeResourceGeneration,
       workflowCount: runtimeRef.current.registry.names().length,
       coalescedRequests,
-      diagnostics: [],
+      diagnostics: workflowReloadDiagnostics(configResult?.diagnostics ?? [], []),
     };
   }
 
@@ -310,33 +314,37 @@ export function createWorkflowExtensionRuntimeState(
     if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
       return supersededReloadReport(coalescedRequests, configResult);
     }
-    const hasGlobal = configResult.globalConfig != null;
-    const hasProject = configResult.projectConfig != null;
-    const discoveryConfig = hasGlobal || hasProject
-      ? toScopedDiscoveryConfig(configResult.globalConfig ?? null, configResult.projectConfig ?? null, { projectRoot: process.cwd() })
-      : undefined;
-    const packageWorkflowPaths = await loadPackageWorkflowPaths();
-    if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
-      return supersededReloadReport(coalescedRequests, configResult);
-    }
-    const result = await discoverWorkflows({ config: discoveryConfig, packageWorkflowPaths });
-    if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
-      return supersededReloadReport(coalescedRequests, configResult, result);
-    }
+    try {
+      const hasGlobal = configResult.globalConfig != null;
+      const hasProject = configResult.projectConfig != null;
+      const discoveryConfig = hasGlobal || hasProject
+        ? toScopedDiscoveryConfig(configResult.globalConfig ?? null, configResult.projectConfig ?? null, { projectRoot: process.cwd() })
+        : undefined;
+      const packageWorkflowPaths = await loadPackageWorkflowPaths();
+      if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
+        return supersededReloadReport(coalescedRequests, configResult);
+      }
+      const result = await discoverWorkflows({ config: discoveryConfig, packageWorkflowPaths });
+      if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
+        return supersededReloadReport(coalescedRequests, configResult, result);
+      }
 
-    // Commit config, diagnostics, and the replacement runtime synchronously,
-    // after every fallible/awaited discovery step has completed.
-    applyWorkflowConfig(configResult);
-    discoveryRef.current = result;
-    rebuildRuntime(result.registry);
-    activeResourceGeneration += 1;
-    return {
-      outcome: "applied",
-      generation: activeResourceGeneration,
-      workflowCount: result.registry.names().length,
-      coalescedRequests,
-      diagnostics: workflowReloadDiagnostics(configResult.diagnostics, result.errors),
-    };
+      // Commit config, diagnostics, and the replacement runtime synchronously,
+      // after every fallible/awaited discovery step has completed.
+      applyWorkflowConfig(configResult);
+      discoveryRef.current = result;
+      rebuildRuntime(result.registry);
+      activeResourceGeneration += 1;
+      return {
+        outcome: "applied",
+        generation: activeResourceGeneration,
+        workflowCount: result.registry.names().length,
+        coalescedRequests,
+        diagnostics: workflowReloadDiagnostics(configResult.diagnostics, result.errors),
+      };
+    } catch (error) {
+      return failedReloadReport(error, coalescedRequests, configResult);
+    }
   }
 
   const reloadCoordinator = createWorkflowReloadCoordinator(async (discoveryGeneration, coalescedRequests) => {

--- a/packages/workflows/src/extension/extension-runtime-state.ts
+++ b/packages/workflows/src/extension/extension-runtime-state.ts
@@ -36,7 +36,11 @@ import {
 } from "./hil-answer-notifications.js";
 import type { ExtensionAPI, PiModelContext } from "./public-types.js";
 import { makeMcpPort, makePersistencePort } from "./workflow-ports.js";
-import { inFlightRunCount, reloadBlockedMessage, WorkflowReloadBlockedError } from "./workflow-targets.js";
+import { createWorkflowReloadCoordinator } from "./workflow-reload-coordinator.js";
+import {
+  workflowReloadDiagnostics,
+  type WorkflowReloadReport,
+} from "./workflow-reload-report.js";
 
 export interface WorkflowExtensionRuntimeState {
   persistenceRef: { current: WorkflowPersistencePort | undefined };
@@ -49,8 +53,8 @@ export interface WorkflowExtensionRuntimeState {
   runtimeForContext(ctx?: PiModelContext): ExtensionRuntime;
   resetWorkflowDiscoveryForSession(): void;
   ensureWorkflowConfigLoaded(): Promise<void>;
-  ensureWorkflowResourcesLoaded(options?: { allowInFlight?: boolean }): Promise<void>;
-  reloadWorkflowResources(options?: { allowInFlight?: boolean }): Promise<void>;
+  ensureWorkflowResourcesLoaded(): Promise<void>;
+  reloadWorkflowResources(): Promise<WorkflowReloadReport>;
   startWorkflowDiscoveryWarmup(onSettled?: () => void): void;
   runWithLifecycleSuppressedForPolicy<T>(policy: WorkflowExecutionPolicy, fn: () => Promise<T>): Promise<T>;
   setNotificationsActive(active: boolean): void;
@@ -198,10 +202,9 @@ export function createWorkflowExtensionRuntimeState(
     });
   }
 
-  let workflowReloadQueue: Promise<void> = Promise.resolve();
-
-  let lazyDiscoveryPromise: Promise<void> | null = null;
+  let lazyDiscoveryPromise: Promise<WorkflowReloadReport> | null = null;
   let workflowDiscoveryGeneration = 0;
+  let activeResourceGeneration = 0;
   function deferToMacrotask(): Promise<void> {
     return new Promise((resolve) => setImmediate(resolve));
   }
@@ -245,7 +248,6 @@ export function createWorkflowExtensionRuntimeState(
     workflowDiscoveryGeneration += 1;
     discoveryRef.current = null;
     lazyDiscoveryPromise = null;
-    workflowReloadQueue = Promise.resolve();
     rebuildRuntime(startupDiscovery.registry);
   }
 
@@ -257,13 +259,32 @@ export function createWorkflowExtensionRuntimeState(
     rebuildRuntime();
   }
 
-  function queueWorkflowResourceReload(options: { allowInFlight?: boolean } | undefined, generation: number): Promise<void> {
-    const reload = workflowReloadQueue.then(() => reloadWorkflowResourcesNow(options, generation));
-    workflowReloadQueue = reload.catch(() => {});
-    return reload;
+  function supersededReloadReport(
+    coalescedRequests: number,
+    configResult?: ConfigLoadResult,
+    result?: DiscoveryResult,
+  ): WorkflowReloadReport {
+    return {
+      outcome: "superseded",
+      generation: activeResourceGeneration,
+      workflowCount: runtimeRef.current.registry.names().length,
+      coalescedRequests,
+      diagnostics: workflowReloadDiagnostics(configResult?.diagnostics ?? [], result?.errors ?? []),
+    };
   }
 
-  function trackLazyDiscovery(pending: Promise<void>): Promise<void> {
+  function failedReloadReport(error: unknown, coalescedRequests: number): WorkflowReloadReport {
+    return {
+      outcome: "failed",
+      error: error instanceof Error ? error.message : String(error),
+      generation: activeResourceGeneration,
+      workflowCount: runtimeRef.current.registry.names().length,
+      coalescedRequests,
+      diagnostics: [],
+    };
+  }
+
+  function trackLazyDiscovery(pending: Promise<WorkflowReloadReport>): Promise<WorkflowReloadReport> {
     lazyDiscoveryPromise = pending;
     void pending.finally(() => {
       if (lazyDiscoveryPromise === pending) lazyDiscoveryPromise = null;
@@ -271,49 +292,70 @@ export function createWorkflowExtensionRuntimeState(
     return pending;
   }
 
-  function reloadWorkflowResources(options?: { allowInFlight?: boolean }): Promise<void> {
-    const generation = workflowDiscoveryGeneration;
-    return trackLazyDiscovery(queueWorkflowResourceReload(options, generation));
+  function reloadWorkflowResources(): Promise<WorkflowReloadReport> {
+    return trackLazyDiscovery(reloadCoordinator.request(workflowDiscoveryGeneration));
   }
   async function loadPackageWorkflowPaths(): Promise<string[]> {
     const packageResources = (await pi.refreshWorkflowResources?.()) ?? pi.getWorkflowResources?.() ?? [];
     return packageResources.filter((resource) => resource.enabled !== false).map((resource) => resource.path);
   }
-  async function reloadWorkflowResourcesNow(options: { allowInFlight?: boolean } | undefined, generation: number): Promise<void> {
-    const activeRuns = inFlightRunCount();
-    if (options?.allowInFlight !== true && activeRuns > 0) {
-      throw new WorkflowReloadBlockedError(reloadBlockedMessage(activeRuns));
-    }
-    if (options?.allowInFlight === true && activeRuns > 0 && process.env.ATOMIC_WORKFLOW_DEBUG === "1") {
-      console.warn(`Workflow reload bypassed in-flight guard with ${activeRuns} active run(s).`);
+  async function reloadWorkflowResourcesNow(
+    discoveryGeneration: number,
+    coalescedRequests: number,
+  ): Promise<WorkflowReloadReport> {
+    if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
+      return supersededReloadReport(coalescedRequests);
     }
     const configResult = await loadWorkflowConfig();
-    if (!isWorkflowDiscoveryCurrent(generation)) return;
-    applyWorkflowConfig(configResult);
+    if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
+      return supersededReloadReport(coalescedRequests, configResult);
+    }
     const hasGlobal = configResult.globalConfig != null;
     const hasProject = configResult.projectConfig != null;
     const discoveryConfig = hasGlobal || hasProject
       ? toScopedDiscoveryConfig(configResult.globalConfig ?? null, configResult.projectConfig ?? null, { projectRoot: process.cwd() })
       : undefined;
     const packageWorkflowPaths = await loadPackageWorkflowPaths();
-    if (!isWorkflowDiscoveryCurrent(generation)) return;
+    if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
+      return supersededReloadReport(coalescedRequests, configResult);
+    }
     const result = await discoverWorkflows({ config: discoveryConfig, packageWorkflowPaths });
-    if (!isWorkflowDiscoveryCurrent(generation)) return;
+    if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) {
+      return supersededReloadReport(coalescedRequests, configResult, result);
+    }
+
+    // Commit config, diagnostics, and the replacement runtime synchronously,
+    // after every fallible/awaited discovery step has completed.
+    applyWorkflowConfig(configResult);
     discoveryRef.current = result;
     rebuildRuntime(result.registry);
+    activeResourceGeneration += 1;
+    return {
+      outcome: "applied",
+      generation: activeResourceGeneration,
+      workflowCount: result.registry.names().length,
+      coalescedRequests,
+      diagnostics: workflowReloadDiagnostics(configResult.diagnostics, result.errors),
+    };
   }
 
-  async function ensureWorkflowResourcesLoaded(options?: { allowInFlight?: boolean }): Promise<void> {
+  const reloadCoordinator = createWorkflowReloadCoordinator(async (discoveryGeneration, coalescedRequests) => {
+    try {
+      return await reloadWorkflowResourcesNow(discoveryGeneration, coalescedRequests);
+    } catch (error) {
+      return failedReloadReport(error, coalescedRequests);
+    }
+  });
+
+  async function ensureWorkflowResourcesLoaded(): Promise<void> {
     while (!pi.disableAsyncDiscovery && discoveryRef.current === null) {
-      const generation = workflowDiscoveryGeneration;
-      const pending = lazyDiscoveryPromise ?? trackLazyDiscovery(
-        queueWorkflowResourceReload({ allowInFlight: options?.allowInFlight ?? true }, generation),
-      );
-      await pending;
-      if (!isWorkflowDiscoveryCurrent(generation)) continue;
-      if (discoveryRef.current === null) {
-        lazyDiscoveryPromise = null;
-      }
+      const discoveryGeneration = workflowDiscoveryGeneration;
+      const pending = lazyDiscoveryPromise
+        ?? trackLazyDiscovery(reloadCoordinator.request(discoveryGeneration));
+      const report = await pending;
+      if (report.outcome === "failed") throw new Error(report.error);
+      if (!isWorkflowDiscoveryCurrent(discoveryGeneration)) continue;
+      if (discoveryRef.current === null) lazyDiscoveryPromise = null;
     }
   }
 
@@ -321,10 +363,14 @@ export function createWorkflowExtensionRuntimeState(
     if (pi.disableAsyncDiscovery || discoveryRef.current !== null || lazyDiscoveryPromise !== null) return;
     const notificationStart = notificationGeneration;
     const discoveryStart = workflowDiscoveryGeneration;
-    const pending = (async () => {
+    const pending = (async (): Promise<WorkflowReloadReport> => {
       await deferToMacrotask();
-      if (!isWorkflowDiscoveryCurrent(discoveryStart)) return;
-      await queueWorkflowResourceReload({ allowInFlight: true }, discoveryStart);
+      if (!isWorkflowDiscoveryCurrent(discoveryStart)) {
+        return supersededReloadReport(1);
+      }
+      const report = await reloadCoordinator.request(discoveryStart);
+      if (report.outcome === "failed") throw new Error(report.error);
+      return report;
     })();
     lazyDiscoveryPromise = pending;
     const isCurrentWarmup = (): boolean => lazyDiscoveryPromise === pending

--- a/packages/workflows/src/extension/render-result.ts
+++ b/packages/workflows/src/extension/render-result.ts
@@ -24,6 +24,7 @@ import { renderDispatchConfirm } from "../tui/dispatch-confirm.js";
 import type { WorkflowInputValues, WorkflowOutputValues } from "../shared/types.js";
 import { renderRoundedBox } from "../tui/chat-surface.js";
 import { truncateToWidth } from "../tui/text-helpers.js";
+import { wrapTextWithAnsi } from "@earendil-works/pi-tui";
 
 // ---------------------------------------------------------------------------
 // Result variants
@@ -202,6 +203,13 @@ function fitLine(line: string, width?: number): string {
   return truncateToWidth(line, width, "…");
 }
 
+function noticeBodyLines(message: string, width?: number): string[] {
+  return message.split(/\r?\n/).flatMap((line) => {
+    if (line.length === 0 || width === undefined || width <= 0) return [line];
+    return wrapTextWithAnsi(line, width);
+  }).map((line) => ` ${line} `);
+}
+
 function renderNotice(
   title: string,
   message: string,
@@ -213,7 +221,7 @@ function renderNotice(
   const contentWidth = width && width > 0 ? Math.max(1, width - 4) : undefined;
   return renderRoundedBox({
     title,
-    bodyLines: [` ${fitLine(message, contentWidth)} `],
+    bodyLines: noticeBodyLines(message, contentWidth),
     theme,
     width,
   });

--- a/packages/workflows/src/extension/render-result.ts
+++ b/packages/workflows/src/extension/render-result.ts
@@ -16,6 +16,7 @@ import type { WorkflowDetails } from "../shared/types.js";
 import type { RunDetail } from "../runs/background/status.js";
 import { renderInputsSchema } from "../shared/render-inputs-schema.js";
 import { renderStatusList } from "../tui/status-list.js";
+import type { WorkflowReloadReport } from "./workflow-reload-report.js";
 import { renderRunDetail } from "../tui/run-detail.js";
 import { renderWorkflowList } from "../tui/workflow-list.js";
 import { deriveGraphTheme } from "../tui/graph-theme.js";
@@ -138,7 +139,7 @@ type TranscriptResult = {
 };
 type SendResult = { action: "send"; runId: string; stageId: string; delivery: string; status: "ok" | "noop"; message: string };
 type PauseResult = { action: "pause"; runId: string; status: string; message: string };
-type ReloadResult = { action: "reload"; status: "ok" | "noop"; message: string };
+type ReloadResult = WorkflowReloadReport & { action: "reload"; status: "ok" | "noop"; message: string };
 type InterruptResult = { action: "interrupt"; runId: string; status: string; message: string };
 type KillResult = { action: "kill"; runId: string; status: string; message: string };
 type ResumeResult = { action: "resume"; runId: string; status: string; message: string };

--- a/packages/workflows/src/extension/workflow-command-registration.ts
+++ b/packages/workflows/src/extension/workflow-command-registration.ts
@@ -23,22 +23,25 @@ import {
   type WorkflowCommandHandler,
   type WorkflowCommandOutputDetails,
 } from "./workflow-command-utils.js";
-import { emitTerminalRunDetailSurface, formatWorkflowResourceLoadWarning } from "./workflow-command-surfaces.js";
+import {
+  emitTerminalRunDetailSurface,
+  formatWorkflowReloadReport,
+  formatWorkflowResourceLoadWarning,
+} from "./workflow-command-surfaces.js";
 import { handleRunControlCommand, type WorkflowRunControlDeps } from "./workflow-run-control-command.js";
 import { workflowPolicyFromContext } from "./workflow-policy.js";
 import {
-  inFlightRunCount,
-  reloadBlockedMessage,
   reloadFailureMessage,
   resolveRunIdPrefix,
   overlaySurfaceFromContext,
 } from "./workflow-targets.js";
+import { normalizeWorkflowReloadReport, type WorkflowReloadReport } from "./workflow-reload-report.js";
 
 export interface WorkflowSlashCommandDeps {
   runtimeProxy: ExtensionRuntime;
   runtimeForContext: (ctx?: PiCommandContext) => ExtensionRuntime;
   overlay: GraphOverlayPort;
-  reloadWorkflowResources: () => Promise<void> | void;
+  reloadWorkflowResources: () => Promise<WorkflowReloadReport | void> | void;
   ensureWorkflowResourcesLoaded: () => Promise<void> | void;
   runWithLifecycleSuppressedForPolicy: <T>(
     policy: WorkflowExecutionPolicy,
@@ -141,11 +144,11 @@ async function workflowSlashHandler(
     return;
   }
   if (subcommand === "reload") {
-    const activeRuns = inFlightRunCount();
-    if (activeRuns > 0) return fail(reloadBlockedMessage(activeRuns));
     try {
-      await deps.reloadWorkflowResources();
-      print("Reloaded workflow resources.");
+      const report = normalizeWorkflowReloadReport(await deps.reloadWorkflowResources());
+      const message = formatWorkflowReloadReport(report);
+      if (report.outcome === "applied") print(message);
+      else fail(message);
     } catch (error) {
       fail(reloadFailureMessage(error));
     }

--- a/packages/workflows/src/extension/workflow-command-surfaces.ts
+++ b/packages/workflows/src/extension/workflow-command-surfaces.ts
@@ -7,6 +7,7 @@ import type { DiscoveryResult } from "./discovery.js";
 import type { WorkflowToolResult } from "./render-result.js";
 import type { ExtensionAPI } from "./public-types.js";
 import { isRunStatus } from "./workflow-targets.js";
+import type { WorkflowReloadReport } from "./workflow-reload-report.js";
 
 function fallbackRunDetailFromResult(
   workflowName: string,
@@ -52,6 +53,31 @@ export function formatWorkflowResourceLoadWarning(error: unknown): string {
     "Workflow discovery diagnostics: workflow resources could not be fully refreshed.",
     `- [error DISCOVERY_FAILED] workflow discovery: ${message}`,
     "Using the currently loaded workflow registry; run `/workflow reload` after fixing the issue.",
+  ].join("\n");
+}
+
+export function formatWorkflowReloadReport(report: WorkflowReloadReport, reason?: string): string {
+  const reasonSuffix = reason?.trim() ? ` (${reason.trim()})` : "";
+  const legacySuccess = report.generation === 0 && report.workflowCount === 0 && report.diagnostics.length === 0;
+  const headline = report.outcome === "applied"
+    ? legacySuccess
+      ? `Reloaded workflow resources${reasonSuffix}.`
+      : `Reloaded workflow resources${reasonSuffix}. ${report.workflowCount} workflow(s), generation ${report.generation}.`
+    : report.outcome === "failed"
+      ? `Workflow resources could not be refreshed; the current registry was retained: ${report.error}`
+      : "Workflow reload was superseded by a newer session; no stale resources were applied.";
+  if (report.diagnostics.length === 0) return headline;
+
+  const maxVisible = 8;
+  const lines = report.diagnostics.slice(0, maxVisible).map((diagnostic) =>
+    `- [${diagnostic.level} ${diagnostic.code}] ${diagnostic.source ?? `workflow ${diagnostic.phase}`}: ${diagnostic.message}`
+  );
+  const remaining = report.diagnostics.length - lines.length;
+  return [
+    headline,
+    `Workflow discovery diagnostics (${report.diagnostics.length}): some resources were skipped or need attention.`,
+    ...lines,
+    ...(remaining > 0 ? [`- … ${remaining} more`] : []),
   ].join("\n");
 }
 export function formatStartupDiagnostics(

--- a/packages/workflows/src/extension/workflow-command-surfaces.ts
+++ b/packages/workflows/src/extension/workflow-command-surfaces.ts
@@ -68,16 +68,13 @@ export function formatWorkflowReloadReport(report: WorkflowReloadReport, reason?
       : "Workflow reload was superseded by a newer session; no stale resources were applied.";
   if (report.diagnostics.length === 0) return headline;
 
-  const maxVisible = 8;
-  const lines = report.diagnostics.slice(0, maxVisible).map((diagnostic) =>
+  const lines = report.diagnostics.map((diagnostic) =>
     `- [${diagnostic.level} ${diagnostic.code}] ${diagnostic.source ?? `workflow ${diagnostic.phase}`}: ${diagnostic.message}`
   );
-  const remaining = report.diagnostics.length - lines.length;
   return [
     headline,
     `Workflow discovery diagnostics (${report.diagnostics.length}): some resources were skipped or need attention.`,
     ...lines,
-    ...(remaining > 0 ? [`- … ${remaining} more`] : []),
   ].join("\n");
 }
 export function formatStartupDiagnostics(

--- a/packages/workflows/src/extension/workflow-reload-coordinator.ts
+++ b/packages/workflows/src/extension/workflow-reload-coordinator.ts
@@ -1,0 +1,66 @@
+import type { WorkflowReloadReport } from "./workflow-reload-report.js";
+
+type ReloadBatch = {
+  readonly discoveryGeneration: number;
+  requestCount: number;
+  readonly promise: Promise<WorkflowReloadReport>;
+  readonly resolve: (report: WorkflowReloadReport) => void;
+  readonly reject: (error: Error) => void;
+};
+
+export interface WorkflowReloadCoordinator {
+  request(discoveryGeneration: number): Promise<WorkflowReloadReport>;
+}
+
+function createBatch(discoveryGeneration: number): ReloadBatch {
+  let resolve: (report: WorkflowReloadReport) => void = () => undefined;
+  let reject: (error: Error) => void = () => undefined;
+  const promise = new Promise<WorkflowReloadReport>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = (error) => rejectPromise(error);
+  });
+  return { discoveryGeneration, requestCount: 0, promise, resolve, reject };
+}
+
+/**
+ * Runs one reload at a time. Requests coalesce only with the latest queued pass
+ * from the same session generation; generation boundaries remain ordered.
+ */
+export function createWorkflowReloadCoordinator(
+  reload: (discoveryGeneration: number, coalescedRequests: number) => Promise<WorkflowReloadReport>,
+): WorkflowReloadCoordinator {
+  const pending: ReloadBatch[] = [];
+  let draining = false;
+
+  const drain = async (): Promise<void> => {
+    if (draining) return;
+    draining = true;
+    try {
+      while (pending.length > 0) {
+        const batch = pending.shift()!;
+        try {
+          const report = await reload(batch.discoveryGeneration, batch.requestCount);
+          batch.resolve(report);
+        } catch (error) {
+          batch.reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+    } finally {
+      draining = false;
+      if (pending.length > 0) void drain();
+    }
+  };
+
+  return {
+    request(discoveryGeneration): Promise<WorkflowReloadReport> {
+      let batch = pending.at(-1);
+      if (batch?.discoveryGeneration !== discoveryGeneration) {
+        batch = createBatch(discoveryGeneration);
+        pending.push(batch);
+      }
+      batch.requestCount += 1;
+      queueMicrotask(() => void drain());
+      return batch.promise;
+    },
+  };
+}

--- a/packages/workflows/src/extension/workflow-reload-report.ts
+++ b/packages/workflows/src/extension/workflow-reload-report.ts
@@ -1,0 +1,39 @@
+import type { ConfigDiagnostic } from "./config-loader.js";
+import type { DiscoveryDiagnostic } from "./discovery.js";
+
+export type WorkflowReloadDiagnostic =
+  | (ConfigDiagnostic & { readonly phase: "config" })
+  | (DiscoveryDiagnostic & { readonly phase: "discovery" });
+
+type WorkflowReloadReportState = {
+  readonly generation: number;
+  readonly workflowCount: number;
+  readonly coalescedRequests: number;
+  readonly diagnostics: WorkflowReloadDiagnostic[];
+};
+
+export type WorkflowReloadReport = WorkflowReloadReportState & (
+  | { readonly outcome: "applied" }
+  | { readonly outcome: "failed"; readonly error: string }
+  | { readonly outcome: "superseded" }
+);
+
+export function normalizeWorkflowReloadReport(report: WorkflowReloadReport | void): WorkflowReloadReport {
+  return report ?? {
+    outcome: "applied",
+    generation: 0,
+    workflowCount: 0,
+    coalescedRequests: 1,
+    diagnostics: [],
+  };
+}
+
+export function workflowReloadDiagnostics(
+  configDiagnostics: readonly ConfigDiagnostic[],
+  discoveryDiagnostics: readonly DiscoveryDiagnostic[],
+): WorkflowReloadDiagnostic[] {
+  return [
+    ...configDiagnostics.map((diagnostic) => ({ ...diagnostic, phase: "config" as const })),
+    ...discoveryDiagnostics.map((diagnostic) => ({ ...diagnostic, phase: "discovery" as const })),
+  ];
+}

--- a/packages/workflows/src/extension/workflow-run-control-command.ts
+++ b/packages/workflows/src/extension/workflow-run-control-command.ts
@@ -288,6 +288,15 @@ export async function handleRunControlCommand(
     } else if (action === "resume") {
       const backend = getDurableBackend();
       const exactBeforePreparation = store.runs().find((run) => run.id === target);
+      const exactIsActivelyRunning = exactBeforePreparation !== undefined
+        && exactBeforePreparation.endedAt === undefined
+        && exactBeforePreparation.status === "running"
+        && !exactBeforePreparation.stages.some((stage) => stage.status === "paused")
+        && exactBeforePreparation.exitReason !== "quit";
+      if (exactIsActivelyRunning) {
+        fail(`Workflow ${exactBeforePreparation.id.slice(0, 8)} is already running in this session. Attach with \`/workflow connect ${exactBeforePreparation.id.slice(0, 8)}\` instead of resuming.`);
+        return true;
+      }
       let durable: readonly ResumableWorkflowEntry[] = [];
       let preparationError: string | undefined;
       const needsDurablePreparation = exactBeforePreparation === undefined

--- a/packages/workflows/src/extension/workflow-run-control-command.ts
+++ b/packages/workflows/src/extension/workflow-run-control-command.ts
@@ -288,10 +288,12 @@ export async function handleRunControlCommand(
     } else if (action === "resume") {
       const backend = getDurableBackend();
       const exactBeforePreparation = store.runs().find((run) => run.id === target);
+      const exactHasPausedState = exactBeforePreparation?.status === "paused"
+        || (exactBeforePreparation?.stages.some((stage) => stage.status === "paused") ?? false);
       const exactIsActivelyRunning = exactBeforePreparation !== undefined
         && exactBeforePreparation.endedAt === undefined
         && exactBeforePreparation.status === "running"
-        && !exactBeforePreparation.stages.some((stage) => stage.status === "paused")
+        && !exactHasPausedState
         && exactBeforePreparation.exitReason !== "quit";
       if (exactIsActivelyRunning) {
         fail(`Workflow ${exactBeforePreparation.id.slice(0, 8)} is already running in this session. Attach with \`/workflow connect ${exactBeforePreparation.id.slice(0, 8)}\` instead of resuming.`);
@@ -300,7 +302,8 @@ export async function handleRunControlCommand(
       let durable: readonly ResumableWorkflowEntry[] = [];
       let preparationError: string | undefined;
       const needsDurablePreparation = exactBeforePreparation === undefined
-        || !backend.isWorkflowLoadable(exactBeforePreparation.id);
+        || (!backend.isWorkflowLoadable(exactBeforePreparation.id)
+          && (!exactHasPausedState || backend.hydrateResumableWorkflows !== undefined));
       if (needsDurablePreparation) {
         await ensureWorkflowResourcesVisible();
         const runtime = deps.runtimeForContext(ctx);

--- a/packages/workflows/src/extension/workflow-targets.ts
+++ b/packages/workflows/src/extension/workflow-targets.ts
@@ -41,23 +41,13 @@ export function topLevelExpandedSnapshots() {
   }));
 }
 
-export function reloadBlockedMessage(count = inFlightRunCount()): string {
-  return `Reload skipped: ${count} workflow run(s) still in flight. Wait for them to finish, or pause/kill them before reloading workflow resources.`;
-}
 
 export function allStageConflictMessage(action: "pause" | "interrupt" | "kill"): string {
   return `Cannot ${action} --all with a stageId; omit stageId or target a single run.`;
 }
 
-export class WorkflowReloadBlockedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "WorkflowReloadBlockedError";
-  }
-}
 
 export function reloadFailureMessage(error: unknown): string {
-  if (error instanceof WorkflowReloadBlockedError) return error.message;
   return `Reload failed: ${error instanceof Error ? error.message : String(error)}`;
 }
 

--- a/packages/workflows/src/extension/workflow-tool-control.ts
+++ b/packages/workflows/src/extension/workflow-tool-control.ts
@@ -18,18 +18,17 @@ import {
   allStageConflictMessage,
   ambiguousRunMessage,
   formatAlreadyEndedRetainedMessage,
-  inFlightRunCount,
-  reloadBlockedMessage,
   reloadFailureMessage,
   resolveToolRunTarget,
   resolveToolStageTarget,
   stageFailureMessage,
 } from "./workflow-targets.js";
-import { formatWorkflowResourceLoadWarning } from "./workflow-command-surfaces.js";
+import { formatWorkflowReloadReport, formatWorkflowResourceLoadWarning } from "./workflow-command-surfaces.js";
+import { normalizeWorkflowReloadReport, type WorkflowReloadReport } from "./workflow-reload-report.js";
 
 export interface WorkflowControlActionDeps {
   getPersistence: () => WorkflowPersistencePort | undefined;
-  reloadWorkflowResources: () => Promise<void> | void;
+  reloadWorkflowResources: () => Promise<WorkflowReloadReport | void> | void;
   getRuntime: () => ExtensionRuntime;
   policy: WorkflowExecutionPolicy;
   ensureWorkflowResourcesLoaded: () => Promise<void> | void;
@@ -71,22 +70,27 @@ export async function workflowReloadAction(
   args: WorkflowToolArgs,
   deps: Pick<WorkflowControlActionDeps, "reloadWorkflowResources">,
 ): Promise<WorkflowToolResult> {
-  const activeRuns = inFlightRunCount();
-  if (activeRuns > 0) {
-    return { action: "reload", status: "noop", message: reloadBlockedMessage(activeRuns) };
-  }
   try {
-    await deps.reloadWorkflowResources();
+    const report = normalizeWorkflowReloadReport(await deps.reloadWorkflowResources());
+    return {
+      action: "reload",
+      status: report.outcome === "applied" ? "ok" : "noop",
+      message: formatWorkflowReloadReport(report, args.reason),
+      ...report,
+    };
   } catch (error) {
-    return { action: "reload", status: "noop", message: reloadFailureMessage(error) };
+    return {
+      action: "reload",
+      status: "noop",
+      message: reloadFailureMessage(error),
+      outcome: "failed",
+      error: error instanceof Error ? error.message : String(error),
+      generation: 0,
+      workflowCount: 0,
+      coalescedRequests: 1,
+      diagnostics: [],
+    };
   }
-  return {
-    action: "reload",
-    status: "ok",
-    message: args.reason?.trim()
-      ? `Reloaded workflow resources (${args.reason.trim()}).`
-      : "Reloaded workflow resources.",
-  };
 }
 
 export function workflowKillAction(

--- a/packages/workflows/src/extension/workflow-tool.ts
+++ b/packages/workflows/src/extension/workflow-tool.ts
@@ -32,11 +32,12 @@ import {
   topLevelExpandedSnapshots,
 } from "./workflow-targets.js";
 import { formatWorkflowResourceLoadWarning } from "./workflow-command-surfaces.js";
+import type { WorkflowReloadReport } from "./workflow-reload-report.js";
 
 export function makeExecuteWorkflowTool(
   runtime: ExtensionRuntime | ((ctx: PiExecuteContext) => ExtensionRuntime),
   getPersistence: () => WorkflowPersistencePort | undefined,
-  reloadWorkflowResources: () => Promise<void> | void,
+  reloadWorkflowResources: () => Promise<WorkflowReloadReport | void> | void,
   ensureWorkflowResourcesLoaded: () => Promise<void> | void = () => {},
 ): (args: WorkflowToolArgs, ctx: PiExecuteContext) => Promise<WorkflowToolResult> {
   return async function executeWorkflowTool(

--- a/test/unit/slash-dispatch-interrupt.ts
+++ b/test/unit/slash-dispatch-interrupt.ts
@@ -288,8 +288,8 @@ describe("/workflow interrupt chat command", () => {
         );
     });
 
-    test.serial("top-level /workflow reload is skipped while workflows are in flight", async () => {
-        const runId = `reload-slash-blocked-${Date.now()}`;
+    test.serial("top-level /workflow reload stays available while workflows are in flight", async () => {
+        const runId = `reload-slash-inflight-${Date.now()}`;
         store.recordRunStart(makeInflightRun(runId));
 
         const { pi, commands } = buildMockPi();
@@ -305,15 +305,12 @@ describe("/workflow interrupt chat command", () => {
         await workflowCmd.options.handler("reload", ctx);
 
         assert.equal(
-            messages.some((message) => message.includes("still in flight")),
-            true,
-        );
-        assert.equal(
             messages.some((message) =>
                 message.includes("Reloaded workflow resources"),
             ),
-            false,
+            true,
         );
+        assert.equal(store.runs().find((run) => run.id === runId)?.endedAt, undefined);
     });
 
     test.serial("top-level /workflow reload reports reload failures", async () => {
@@ -334,7 +331,7 @@ describe("/workflow interrupt chat command", () => {
 
         assert.equal(
             messages.some((message) =>
-                message.includes("Reload failed: package loader unavailable"),
+                message.includes("current registry was retained: package loader unavailable"),
             ),
             true,
         );

--- a/test/unit/slash-dispatch-resume.ts
+++ b/test/unit/slash-dispatch-resume.ts
@@ -73,6 +73,11 @@ describe("/workflow resume <runId> — active run is refused", () => {
         const openCalls: Array<{ overlay: boolean }> = [];
         const { pi, commands } = buildMockPi();
         addFactoryStubs(pi);
+        let refreshCalls = 0;
+        pi.refreshWorkflowResources = async () => {
+            refreshCalls += 1;
+            return [];
+        };
         const customFn: PiCustomOverlayFunction = (
             _factoryArg,
             options: PiCustomOverlayOptions,
@@ -107,6 +112,7 @@ describe("/workflow resume <runId> — active run is refused", () => {
         const joined = msgs.join("\n");
         assert.match(joined, /already running/);
         assert.match(joined, /\/workflow connect/);
+        assert.equal(refreshCalls, 0, "exact active runs must bypass durable preparation and discovery");
     });
 
     test.serial("active run resume output does NOT include 'still active — no resume needed'", async () => {

--- a/test/unit/slash-dispatch-tool-reload-resume.ts
+++ b/test/unit/slash-dispatch-tool-reload-resume.ts
@@ -246,7 +246,7 @@ describe("tool run-control actions", () => {
         assert.equal(reload.message, "Reloaded workflow resources.");
     });
 
-    test.serial("makeExecuteWorkflowTool reload is skipped while workflows are in flight", async () => {
+    test.serial("makeExecuteWorkflowTool reload stays available while workflows are in flight", async () => {
         const registry = createRegistry([]);
         const runtime = createExtensionRuntime({ registry });
         let reloads = 0;
@@ -257,7 +257,8 @@ describe("tool run-control actions", () => {
                 reloads += 1;
             },
         );
-        store.recordRunStart(makeInflightRun(`reload-blocked-${Date.now()}`));
+        const runId = `reload-inflight-${Date.now()}`;
+        store.recordRunStart(makeInflightRun(runId));
 
         const result = await handler(
             { action: "reload", reason: "test" },
@@ -270,9 +271,10 @@ describe("tool run-control actions", () => {
             status: string;
             message: string;
         };
-        assert.equal(reload.status, "noop");
-        assert.match(reload.message, /still in flight/);
-        assert.equal(reloads, 0);
+        assert.equal(reload.status, "ok");
+        assert.match(reload.message, /Reloaded workflow resources/);
+        assert.equal(reloads, 1);
+        assert.equal(store.runs().find((run) => run.id === runId)?.endedAt, undefined);
     });
 
     test.serial("makeExecuteWorkflowTool reload surfaces callback failures as noop", async () => {

--- a/test/unit/subagents-attempt-watchdog-helpers.ts
+++ b/test/unit/subagents-attempt-watchdog-helpers.ts
@@ -66,10 +66,13 @@ export async function withFakeCliEvent<T>(
   });
 }
 
-/** Runs `fn` with process.argv[1] pointed at a fake pi CLI script and short
- * watchdog timeouts (idle 250ms, wall 2000ms, kill grace 20ms); restores the
- * previous argv/env afterwards. */
-export async function withFakeCli<T>(script: string, fn: (dir: string) => Promise<T>): Promise<T> {
+/** Runs `fn` with process.argv[1] pointed at a fake pi CLI script and bounded
+ * watchdog timeouts; restores the previous argv/env afterwards. */
+export async function withFakeCli<T>(
+  script: string,
+  fn: (dir: string) => Promise<T>,
+  timeouts: { idleMs?: number; wallMs?: number } = {},
+): Promise<T> {
   const dir = mkdtempSync(join(tmpdir(), "atomic-subagent-watchdog-"));
   const scriptPath = join(dir, "fake-pi.js");
   const previousArgv1 = process.argv[1];
@@ -78,8 +81,8 @@ export async function withFakeCli<T>(script: string, fn: (dir: string) => Promis
   const previousKill = process.env.ATOMIC_SUBAGENT_ATTEMPT_KILL_GRACE_MS;
   writeFileSync(scriptPath, script, { mode: 0o700 });
   process.argv[1] = scriptPath;
-  process.env.ATOMIC_SUBAGENT_ATTEMPT_IDLE_TIMEOUT_MS = "250";
-  process.env.ATOMIC_SUBAGENT_ATTEMPT_TIMEOUT_MS = "2000";
+  process.env.ATOMIC_SUBAGENT_ATTEMPT_IDLE_TIMEOUT_MS = String(timeouts.idleMs ?? 250);
+  process.env.ATOMIC_SUBAGENT_ATTEMPT_TIMEOUT_MS = String(timeouts.wallMs ?? 2000);
   process.env.ATOMIC_SUBAGENT_ATTEMPT_KILL_GRACE_MS = "20";
   try {
     return await fn(dir);

--- a/test/unit/subagents-foreground-intercom-detach.test.ts
+++ b/test/unit/subagents-foreground-intercom-detach.test.ts
@@ -64,7 +64,7 @@ const timer = setInterval(() => {
       const metadata = JSON.parse(fs.readFileSync(actual.artifactPaths.metadataPath, "utf8")) as { exitCode: number; modelAttempts: Array<{ exitCode: number }> };
       assert.equal(metadata.exitCode, 0);
       assert.equal(metadata.modelAttempts.at(-1)?.exitCode, 0);
-    });
+    }, { idleMs: 4000, wallMs: 4000 });
   });
   test("a broker-routed handoff detaches the exact child even before tool-start observation", async () => {
     await withFakeCliEvent(successEvent("eventual result"), 100, async (dir) => {

--- a/test/unit/subagents-foreground-intercom-detach.test.ts
+++ b/test/unit/subagents-foreground-intercom-detach.test.ts
@@ -2,9 +2,10 @@ import { describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
+import { join } from "node:path";
 import { runSync } from "../../packages/subagents/src/runs/foreground/execution.js";
 import { INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT } from "../../packages/subagents/src/shared/types.js";
-import { agentConfig, successEvent, withFakeCliEvent } from "./subagents-attempt-watchdog-helpers.js";
+import { agentConfig, successEvent, withFakeCli, withFakeCliEvent } from "./subagents-attempt-watchdog-helpers.js";
 
 function eventBus(emitter: EventEmitter) {
   return {
@@ -23,13 +24,27 @@ const bridgedAgent = () => ({ ...agentConfig(), systemPrompt: "Intercom orchestr
 describe("foreground intercom detach routing", () => {
 
   test("reports the eventual result exactly once and finalizes artifacts after detach", async () => {
-    await withFakeCliEvent(successEvent("resumed result"), 100, async (dir) => {
+    const gateName = "release-detached-child";
+    const fakeScript = `import { existsSync } from "node:fs";
+import { join } from "node:path";
+const gate = join(process.cwd(), ${JSON.stringify(gateName)});
+const timer = setInterval(() => {
+  if (!existsSync(gate)) return;
+  clearInterval(timer);
+  console.log(${JSON.stringify(successEvent("resumed result"))});
+}, 5);`;
+    await withFakeCli(fakeScript, async (dir) => {
       const emitter = new EventEmitter();
       const recovered: Array<{ exitCode: number; finalOutput?: string; artifactPaths?: { outputPath: string; metadataPath: string }; modelAttempts?: Array<{ exitCode: number }> }> = [];
+      let resolveRecovery: () => void = () => undefined;
+      const recovery = new Promise<void>((resolve) => { resolveRecovery = resolve; });
       const pending = runSync(dir, [bridgedAgent()], "fake-worker", "A", {
         cwd: dir, runId: "recover", index: 0, intercomSessionName: "child-a", allowIntercomDetach: true,
         intercomEvents: eventBus(emitter), artifactsDir: dir,
-        onDetachedExit: (result) => recovered.push(result as typeof recovered[number]),
+        onDetachedExit: (result) => {
+          recovered.push(result as typeof recovered[number]);
+          resolveRecovery();
+        },
       });
       await Bun.sleep(25);
       await handoff(eventBus(emitter), { requestId: "q", childIntercomTarget: "child-a" });
@@ -37,7 +52,8 @@ describe("foreground intercom detach routing", () => {
       assert.equal(placeholder.exitCode, -2);
       assert.ok(placeholder.artifactPaths);
       assert.equal(fs.existsSync(placeholder.artifactPaths.outputPath), false);
-      await Bun.sleep(150);
+      fs.writeFileSync(join(dir, gateName), "release", "utf8");
+      await recovery;
       assert.equal(recovered.length, 1);
       const actual = recovered[0]!;
       assert.equal(actual.exitCode, 0);
@@ -54,8 +70,11 @@ describe("foreground intercom detach routing", () => {
     await withFakeCliEvent(successEvent("eventual result"), 100, async (dir) => {
       const emitter = new EventEmitter();
       const bus = eventBus(emitter);
+      let resolveFirstExit: () => void = () => undefined;
+      const firstExit = new Promise<void>((resolve) => { resolveFirstExit = resolve; });
       const first = runSync(dir, [bridgedAgent()], "fake-worker", "A", {
-        cwd: dir, runId: "run", index: 0, intercomSessionName: "child-a", allowIntercomDetach: true, intercomEvents: bus,
+        cwd: dir, runId: "run", index: 0, intercomSessionName: "child-a", allowIntercomDetach: true,
+        intercomEvents: bus, onDetachedExit: () => resolveFirstExit(),
       });
       const second = runSync(dir, [bridgedAgent()], "fake-worker", "B", {
         cwd: dir, runId: "run", index: 1, intercomSessionName: "child-b", allowIntercomDetach: true, intercomEvents: bus,
@@ -69,6 +88,7 @@ describe("foreground intercom detach routing", () => {
 		bus.emit(INTERCOM_DETACH_REQUEST_EVENT, { ...route, phase: "commit" });
 		const a = await first;
       const b = await second;
+      await firstExit;
       assert.equal(a.detached, true);
       assert.equal(a.exitCode, -2);
       assert.equal(b.detached, undefined);

--- a/test/unit/subagents-startup-maintenance.test.ts
+++ b/test/unit/subagents-startup-maintenance.test.ts
@@ -38,31 +38,37 @@ function pi(): ExtensionAPI {
   } as unknown as ExtensionAPI;
 }
 
-function nextImmediate(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
-}
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
 describe("subagent startup maintenance", () => {
-  test("watcher startup is scheduled on a macrotask instead of running synchronously", async () => {
+  test("watcher startup is scheduled on a macrotask instead of running synchronously", () => {
     const root = mkdtempSync(join(tmpdir(), "atomic-subagent-maintenance-"));
     roots.push(root);
     const state = makeState();
+    const scheduled: Array<() => void> = [];
     const maintenance = createSubagentStartupMaintenance(pi(), state, {
       resultsDir: root,
       artifactCleanupDays: 1,
       resultTtlMs: 1000,
+      scheduleMacrotask: (task) => {
+        scheduled.push(task);
+        return () => undefined;
+      },
     });
 
-    maintenance.startResultWatcherDeferred();
+    try {
+      maintenance.startResultWatcherDeferred();
 
-    assert.equal(state.watcher, null, "watcher should not start during extension registration/session_start");
-    await nextImmediate();
-    assert.notEqual(state.watcher, null, "watcher should start after a macrotask yield");
-    maintenance.stop();
+      assert.equal(state.watcher, null, "watcher should not start during extension registration/session_start");
+      assert.equal(scheduled.length, 1);
+      scheduled[0]!();
+      assert.notEqual(state.watcher, null, "watcher should start when the deferred task runs");
+    } finally {
+      maintenance.stop();
+    }
     assert.equal(state.watcher, null);
   });
 });

--- a/test/unit/workflow-lazy-startup-continuation.test.ts
+++ b/test/unit/workflow-lazy-startup-continuation.test.ts
@@ -387,10 +387,13 @@ describe("workflow lazy-startup continuation fixes", () => {
       await sessionStart({}, { ui: { notify: () => undefined } });
       await waitForRefresh(0);
       await sessionStart({}, { ui: { notify: () => undefined } });
-      await waitForRefresh(1);
 
-      assert.equal(refreshCalls, 2);
+      // The permanent reload coordinator serializes generations. Release the
+      // stale pass before waiting for the new session's trailing pass to start.
+      assert.equal(refreshCalls, 1);
       resolvers[0]?.([{ path: oldPath, enabled: true }]);
+      await waitForRefresh(1);
+      assert.equal(refreshCalls, 2);
       resolvers[1]?.([{ path: newPath, enabled: true }]);
 
       const workflowCmd = commands.find((command) => command.name === "workflow");

--- a/test/unit/workflow-reload-rediscovery.test.ts
+++ b/test/unit/workflow-reload-rediscovery.test.ts
@@ -1,0 +1,393 @@
+import { afterEach, describe, test } from "bun:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import factory, {
+  type ExtensionAPI,
+  type PiCommandOptions,
+  type PiExecuteContext,
+  type PiToolOpts,
+  type WorkflowToolArgs,
+} from "../../packages/workflows/src/extension/index.js";
+import type { WorkflowToolResult } from "../../packages/workflows/src/extension/render-result.js";
+import { store } from "../../packages/workflows/src/shared/store.js";
+import { cancellationRegistry } from "../../packages/workflows/src/runs/background/cancellation-registry.js";
+import { killAllRuns } from "../../packages/workflows/src/runs/background/status.js";
+import type { StageSessionRuntime } from "../../packages/workflows/src/runs/foreground/stage-runner-types.js";
+import { createWorkflowExtensionRuntimeState } from "../../packages/workflows/src/extension/extension-runtime-state.js";
+
+const originalCwd = process.cwd();
+const originalAgentDir = process.env.ATOMIC_CODING_AGENT_DIR;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const roots: string[] = [];
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  if (originalAgentDir === undefined) delete process.env.ATOMIC_CODING_AGENT_DIR;
+  else process.env.ATOMIC_CODING_AGENT_DIR = originalAgentDir;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  killAllRuns({ store, cancellation: cancellationRegistry });
+  store.clear();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+interface Harness {
+  readonly commands: Map<string, PiCommandOptions>;
+  readonly messages: string[];
+  execute(args: WorkflowToolArgs, ctx?: PiExecuteContext): Promise<WorkflowToolResult>;
+}
+
+function fakeSession(prompt?: (text: string) => Promise<string>): StageSessionRuntime {
+  let last: string | undefined;
+  return {
+    prompt: async (text: string) => {
+      last = await (prompt ?? (async (value: string) => `declared:${value}`))(text);
+      return last;
+    },
+    steer: async () => undefined,
+    followUp: async () => undefined,
+    subscribe: () => () => undefined,
+    sessionFile: undefined,
+    sessionId: "reload-matrix-stage",
+    setModel: async () => undefined,
+    setThinkingLevel: () => undefined,
+    cycleModel: async () => undefined,
+    cycleThinkingLevel: () => undefined,
+    agent: {} as StageSessionRuntime["agent"],
+    model: undefined,
+    thinkingLevel: "medium",
+    messages: [],
+    isStreaming: false,
+    navigateTree: async () => ({ cancelled: true }),
+    compact: async () => undefined as never,
+    abortCompaction: () => undefined,
+    abort: async () => undefined,
+    dispose: () => undefined,
+    getLastAssistantText: () => last,
+  };
+}
+
+function createHarness(overrides: Partial<ExtensionAPI> = {}): Harness {
+  const commands = new Map<string, PiCommandOptions>();
+  const messages: string[] = [];
+  let tool: PiToolOpts<WorkflowToolArgs, WorkflowToolResult> | undefined;
+  const pi: ExtensionAPI = {
+    registerCommand: (name, options) => commands.set(name, options),
+    registerTool: (options) => { tool = options as unknown as PiToolOpts<WorkflowToolArgs, WorkflowToolResult>; },
+    registerMessageRenderer: () => undefined,
+    registerFlag: () => undefined,
+    registerShortcut: () => undefined,
+    sendMessage: (message) => { if (message.content !== undefined) messages.push(message.content); },
+    on: () => undefined,
+    ui: { setWidget: () => undefined },
+    createAgentSession: async () => ({ session: fakeSession() }),
+    disableAsyncDiscovery: true,
+    ...overrides,
+  };
+  factory(pi);
+  assert.ok(tool);
+  return {
+    commands,
+    messages,
+    async execute(args, ctx = { hasUI: false } as PiExecuteContext) {
+      const result = await tool!.execute("reload-matrix-call", args, undefined, undefined, ctx);
+      return result.details;
+    },
+  };
+}
+
+async function writeJson(path: string, value: object): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(value), "utf8");
+}
+
+async function writeWorkflow(
+  path: string,
+  options: { name: string; description: string; named?: boolean; prompt?: string },
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const definition = `workflow({
+  name: ${JSON.stringify(options.name)},
+  description: ${JSON.stringify(options.description)},
+  inputs: { message: Type.String() },
+  outputs: { value: Type.String() },
+  run: async (ctx) => ({ value: await ctx.stage("emit").prompt(${JSON.stringify(options.prompt ?? options.name)} + ":" + ctx.inputs.message) }),
+})`;
+  await writeFile(path, [
+    `import { workflow } from "@bastani/workflows";`,
+    `import { Type } from "typebox";`,
+    options.named ? `export const namedWorkflow = ${definition};` : `export default ${definition};`,
+  ].join("\n"), "utf8");
+}
+
+function names(result: WorkflowToolResult): string[] {
+  assert.equal(result.action, "list");
+  return result.items.map((item) => item.name);
+}
+
+function reloadResult(result: WorkflowToolResult): Extract<WorkflowToolResult, { action: "reload" }> {
+  assert.equal(result.action, "reload");
+  return result;
+}
+
+async function makeIsolatedRoots(label: string): Promise<{ root: string; project: string; agent: string }> {
+  const root = await mkdtemp(join(tmpdir(), `atomic-${label}-`));
+  roots.push(root);
+  const project = join(root, "project");
+  const home = join(root, "home");
+  const agent = join(home, ".atomic", "agent");
+  await mkdir(project, { recursive: true });
+  await mkdir(agent, { recursive: true });
+  process.chdir(project);
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.ATOMIC_CODING_AGENT_DIR;
+  return { root, project, agent };
+}
+
+describe("workflow reload rediscovery matrix", () => {
+  test.serial("reload refreshes all discovery scopes and public list/get/inputs/help/completion/invocation surfaces", async () => {
+    const { root, project, agent } = await makeIsolatedRoots("workflow-reload-matrix");
+    const paths = {
+      projectAtomic: join(project, ".atomic/workflows/project-atomic.ts"),
+      projectLegacy: join(project, ".pi/workflows/project-legacy.ts"),
+      globalAtomic: join(agent, "workflows/global-atomic.ts"),
+      globalLegacy: join(root, "home/.pi/agent/workflows/global-legacy.ts"),
+      projectRelative: join(project, "configured/project-relative.ts"),
+      projectAbsoluteDir: join(root, "project-absolute-dir/project-absolute.ts"),
+      globalRelative: join(agent, "configured/global-relative.ts"),
+      globalAbsolute: join(root, "global-absolute.ts"),
+      globalRelativeDir: join(agent, "configured/global-dir/global-dir.ts"),
+      projectConflict: join(project, ".atomic/workflows/conflict.ts"),
+      globalConflict: join(agent, "workflows/conflict.ts"),
+    };
+    await Promise.all([
+      writeWorkflow(paths.projectAtomic, { name: "scope-project-atomic", description: "project atomic" }),
+      writeWorkflow(paths.projectLegacy, { name: "scope-project-legacy", description: "project legacy", named: true }),
+      writeWorkflow(paths.globalAtomic, { name: "scope-global-atomic", description: "global atomic" }),
+      writeWorkflow(paths.globalLegacy, { name: "scope-global-legacy", description: "global legacy", named: true }),
+      writeWorkflow(paths.projectRelative, { name: "scope-project-relative", description: "project relative" }),
+      writeWorkflow(paths.projectAbsoluteDir, { name: "scope-project-absolute", description: "project absolute", named: true }),
+      writeWorkflow(paths.globalRelative, { name: "scope-global-relative", description: "global relative" }),
+      writeWorkflow(paths.globalAbsolute, { name: "scope-global-absolute", description: "global absolute", named: true }),
+      writeWorkflow(paths.globalRelativeDir, { name: "scope-global-relative-dir", description: "global relative directory" }),
+      writeWorkflow(paths.projectConflict, { name: "scope-conflict", description: "project conflict wins" }),
+      writeWorkflow(paths.globalConflict, { name: "scope-conflict", description: "global conflict loses" }),
+    ]);
+    await writeJson(join(project, ".atomic/extensions/workflow/config.json"), {
+      workflows: {
+        projectRelative: { path: "configured/project-relative.ts" },
+        projectAbsoluteDir: { path: dirname(paths.projectAbsoluteDir) },
+      },
+    });
+    await writeJson(join(agent, "extensions/workflow/config.json"), {
+      workflows: {
+        globalRelative: { path: "configured/global-relative.ts" },
+        globalAbsolute: { path: paths.globalAbsolute },
+        globalRelativeDir: { path: "configured/global-dir" },
+      },
+    });
+
+    const harness = createHarness();
+    const reload = reloadResult(await harness.execute({ action: "reload" }));
+    assert.equal(reload.status, "ok");
+    assert.equal(reload.outcome, "applied");
+    assert.ok(reload.diagnostics.some((diagnostic) => diagnostic.code === "DUPLICATE_NAME"));
+    const listed = names(await harness.execute({ action: "list" }));
+    for (const expected of [
+      "scope-project-atomic", "scope-project-legacy", "scope-global-atomic", "scope-global-legacy",
+      "scope-project-relative", "scope-project-absolute", "scope-global-relative", "scope-global-absolute",
+      "scope-global-relative-dir", "scope-conflict",
+    ]) assert.ok(listed.includes(expected), expected);
+
+    const get = await harness.execute({ action: "get", workflow: "scope-project-atomic" });
+    assert.equal(get.action, "get");
+    assert.equal(get.details?.output?.description, "project atomic");
+    const conflict = await harness.execute({ action: "get", workflow: "scope-conflict" });
+    assert.equal(conflict.action, "get");
+    assert.equal(conflict.details?.output?.description, "project conflict wins");
+    const inputs = await harness.execute({ action: "inputs", workflow: "scope-project-atomic" });
+    assert.equal(inputs.action, "inputs");
+    assert.deepEqual(inputs.inputs.map((input) => input.name), ["message"]);
+    const workflowCommand = harness.commands.get("workflow");
+    assert.ok(workflowCommand?.getArgumentCompletions);
+    const completions = await workflowCommand.getArgumentCompletions("scope-project-at");
+    assert.ok(completions?.some((item) => item.label === "scope-project-atomic"));
+    const messageStart = harness.messages.length;
+    await workflowCommand.handler?.("scope-project-atomic --help", { hasUI: false, ui: { notify: () => undefined } });
+    assert.match(harness.messages.slice(messageStart).join("\n"), /message/);
+
+    const run = await harness.execute({ action: "run", workflow: "scope-project-atomic", inputs: { message: "hello" } });
+    assert.equal(run.action, "run");
+    assert.equal(run.status, "completed", JSON.stringify(run));
+    assert.deepEqual(run.result, { value: "declared:scope-project-atomic:hello" });
+  });
+
+  test.serial("add edit rename delete and malformed siblings replace metadata while preserving valid workflows", async () => {
+    const { project } = await makeIsolatedRoots("workflow-reload-mutations");
+    const dir = join(project, ".atomic/workflows");
+    const stable = join(dir, "stable.ts");
+    const changing = join(dir, "changing.ts");
+    await writeWorkflow(stable, { name: "reload-stable", description: "stable" });
+    const harness = createHarness();
+    await harness.execute({ action: "reload" });
+
+    await writeWorkflow(changing, { name: "reload-changing", description: "version one" });
+    await writeFile(join(dir, "invalid.ts"), "export default { broken: true };", "utf8");
+    const added = reloadResult(await harness.execute({ action: "reload" }));
+    assert.equal(added.status, "ok");
+    assert.ok(added.diagnostics.some((diagnostic) => diagnostic.code === "INVALID_DEFINITION"));
+    assert.ok(names(await harness.execute({ action: "list" })).includes("reload-stable"));
+    const slashMessageStart = harness.messages.length;
+    await harness.commands.get("workflow")?.handler?.("reload", { hasUI: false, ui: { notify: () => undefined } });
+    assert.match(harness.messages.slice(slashMessageStart).join("\n"), /INVALID_DEFINITION/);
+
+    await writeWorkflow(changing, { name: "reload-edited", description: "version two", named: true });
+    const edited = reloadResult(await harness.execute({ action: "reload" }));
+    assert.equal(edited.status, "ok");
+    const editedGet = await harness.execute({ action: "get", workflow: "reload-edited" });
+    assert.equal(editedGet.action, "get");
+    assert.equal(editedGet.details?.output?.description, "version two");
+    assert.ok(!names(await harness.execute({ action: "list" })).includes("reload-changing"));
+
+    const renamedPath = join(dir, "renamed.ts");
+    await rename(changing, renamedPath);
+    await writeWorkflow(renamedPath, { name: "reload-renamed", description: "renamed" });
+    await harness.execute({ action: "reload" });
+    assert.ok(names(await harness.execute({ action: "list" })).includes("reload-renamed"));
+    await unlink(renamedPath);
+    await harness.execute({ action: "reload" });
+    const finalNames = names(await harness.execute({ action: "list" }));
+    assert.ok(!finalNames.includes("reload-renamed"));
+    assert.ok(finalNames.includes("reload-stable"));
+  });
+
+  test.serial("fatal refresh failure retains the complete previously applied registry", async () => {
+    const { project } = await makeIsolatedRoots("workflow-reload-failure");
+    const workflowPath = join(project, ".atomic/workflows/retained.ts");
+    await writeWorkflow(workflowPath, { name: "reload-retained", description: "before failure" });
+    let failRefresh = false;
+    const harness = createHarness({
+      refreshWorkflowResources: async () => {
+        if (failRefresh) throw new Error("deterministic refresh failure");
+        return [];
+      },
+    });
+    const applied = reloadResult(await harness.execute({ action: "reload" }));
+    await writeWorkflow(workflowPath, { name: "reload-retained", description: "must not publish" });
+    failRefresh = true;
+    const failed = reloadResult(await harness.execute({ action: "reload" }));
+    assert.equal(failed.status, "noop");
+    assert.equal(failed.outcome, "failed");
+    assert.match(failed.message, /deterministic refresh failure/);
+    assert.equal(failed.generation, applied.generation);
+    assert.equal(failed.workflowCount, applied.workflowCount);
+    assert.equal(failed.error, "deterministic refresh failure");
+    const retained = await harness.execute({ action: "get", workflow: "reload-retained" });
+    assert.equal(retained.action, "get");
+    assert.equal(retained.details?.output?.description, "before failure");
+  });
+
+  test.serial("reload during an in-flight workflow publishes new metadata without changing the running definition", async () => {
+    const { project } = await makeIsolatedRoots("workflow-reload-inflight");
+    const workflowPath = join(project, ".atomic/workflows/inflight.ts");
+    await writeWorkflow(workflowPath, { name: "reload-inflight", description: "old metadata", prompt: "old prompt" });
+    let releasePrompt: (value: string) => void = () => undefined;
+    let markPromptStarted: () => void = () => undefined;
+    const promptStarted = new Promise<void>((resolve) => { markPromptStarted = resolve; });
+    const promptResult = new Promise<string>((resolve) => { releasePrompt = resolve; });
+    const harness = createHarness({
+      createAgentSession: async () => ({
+        session: fakeSession(async () => {
+          markPromptStarted();
+          return promptResult;
+        }),
+      }),
+    });
+    await harness.execute({ action: "reload" });
+    const running = harness.execute({ action: "run", workflow: "reload-inflight", inputs: { message: "value" } });
+    await promptStarted;
+    await writeWorkflow(workflowPath, { name: "reload-inflight", description: "new metadata", prompt: "new prompt" });
+    const reloaded = reloadResult(await harness.execute({ action: "reload" }));
+    assert.equal(reloaded.status, "ok");
+    const current = await harness.execute({ action: "get", workflow: "reload-inflight" });
+    assert.equal(current.action, "get");
+    assert.equal(current.details?.output?.description, "new metadata");
+    releasePrompt("held:old prompt:value");
+    const completed = await running;
+    assert.equal(completed.action, "run");
+    assert.equal(completed.status, "completed", JSON.stringify(completed));
+    assert.deepEqual(completed.result, { value: "held:old prompt:value" });
+  });
+
+  test.serial("overlapping reload requests serialize and coalesce one trailing generation", async () => {
+    await makeIsolatedRoots("workflow-reload-coalesce");
+    const gates: Array<() => void> = [];
+    const starts: Array<() => void> = [];
+    let refreshCalls = 0;
+    const started = (index: number): Promise<void> => new Promise((resolve) => { starts[index] = resolve; });
+    const start0 = started(0);
+    const start1 = started(1);
+    const harness = createHarness({
+      refreshWorkflowResources: async () => {
+        const index = refreshCalls++;
+        starts[index]?.();
+        await new Promise<void>((resolve) => { gates[index] = resolve; });
+        return [];
+      },
+    });
+
+    const first = harness.execute({ action: "reload" });
+    await start0;
+    const trailingA = harness.execute({ action: "reload" });
+    const trailingB = harness.execute({ action: "reload" });
+    assert.equal(refreshCalls, 1);
+    gates[0]?.();
+    await start1;
+    assert.equal(refreshCalls, 2);
+    gates[1]?.();
+    const [firstResult, secondResult, thirdResult] = await Promise.all([first, trailingA, trailingB]);
+    assert.equal(reloadResult(firstResult).coalescedRequests, 1);
+    assert.equal(reloadResult(secondResult).coalescedRequests, 2);
+    assert.equal(reloadResult(thirdResult).generation, reloadResult(secondResult).generation);
+  });
+
+  test.serial("queued old-session requests cannot coalesce with or publish into a new session", async () => {
+    await makeIsolatedRoots("workflow-reload-session-boundary");
+    const gates: Array<() => void> = [];
+    const starts: Array<() => void> = [];
+    let refreshCalls = 0;
+    const firstStarted = new Promise<void>((resolve) => { starts[0] = resolve; });
+    const freshStarted = new Promise<void>((resolve) => { starts[1] = resolve; });
+    const pi = {
+      refreshWorkflowResources: async () => {
+        const index = refreshCalls++;
+        starts[index]?.();
+        await new Promise<void>((resolve) => { gates[index] = resolve; });
+        return [];
+      },
+    } as ExtensionAPI;
+    const state = createWorkflowExtensionRuntimeState(pi, {} as never);
+
+    const activeOld = state.reloadWorkflowResources();
+    await firstStarted;
+    const queuedOld = state.reloadWorkflowResources();
+    state.resetWorkflowDiscoveryForSession();
+    const fresh = state.reloadWorkflowResources();
+    gates[0]?.();
+    await freshStarted;
+    assert.equal(refreshCalls, 2, "stale queued generation must be rejected before refresh");
+    gates[1]?.();
+
+    const [activeReport, queuedReport, freshReport] = await Promise.all([activeOld, queuedOld, fresh]);
+    assert.equal(activeReport.outcome, "superseded");
+    assert.equal(queuedReport.outcome, "superseded");
+    assert.equal(freshReport.outcome, "applied");
+    assert.ok(freshReport.generation > activeReport.generation);
+  });
+});

--- a/test/unit/workflow-reload-rediscovery.test.ts
+++ b/test/unit/workflow-reload-rediscovery.test.ts
@@ -372,7 +372,8 @@ describe("workflow reload rediscovery matrix", () => {
     const promptResult = new Promise<string>((resolve) => { releasePrompt = resolve; });
     const harness = createHarness({
       createAgentSession: async () => ({
-        session: fakeSession(async () => {
+        session: fakeSession(async (text) => {
+          if (text.endsWith(":resume")) return `resumed:${text}`;
           markPromptStarted();
           return promptResult;
         }),
@@ -381,8 +382,8 @@ describe("workflow reload rediscovery matrix", () => {
     const durableBackend = new InMemoryDurableBackend();
     durableBackend.registerWorkflow({
       workflowId: "durable-reload-retained",
-      name: "durable retained",
-      inputs: {},
+      name: "reload-inflight",
+      inputs: { message: "resume" },
       createdAt: 1,
       status: "paused",
       completedCheckpoints: 1,
@@ -390,12 +391,19 @@ describe("workflow reload rediscovery matrix", () => {
     setDurableBackend(durableBackend);
     const durableBefore = structuredClone(durableBackend.listResumableWorkflows());
     await harness.execute({ action: "reload" });
+    assert.deepEqual(durableBackend.listResumableWorkflows(), durableBefore);
+    const resumeMessageStart = harness.messages.length;
+    await harness.commands.get("workflow")?.handler?.("resume durable-reload-retained", {
+      hasUI: false,
+      ui: { notify: () => undefined },
+    });
+    assert.match(harness.messages.slice(resumeMessageStart).join("\n"), /Resuming durable workflow[\s\S]*checkpoints will be replayed/);
     const running = harness.execute({ action: "run", workflow: "reload-inflight", inputs: { message: "value" } });
     await promptStarted;
     await writeWorkflow(workflowPath, { name: "reload-inflight", description: "new metadata", prompt: "new prompt" });
     const reloaded = reloadResult(await harness.execute({ action: "reload" }));
     assert.equal(reloaded.status, "ok");
-    assert.deepEqual(durableBackend.listResumableWorkflows(), durableBefore);
+    assert.equal(durableBackend.isWorkflowLoadable("durable-reload-retained"), true);
     const current = await harness.execute({ action: "get", workflow: "reload-inflight" });
     assert.equal(current.action, "get");
     assert.equal(current.details?.output?.description, "new metadata");

--- a/test/unit/workflow-reload-rediscovery.test.ts
+++ b/test/unit/workflow-reload-rediscovery.test.ts
@@ -16,6 +16,8 @@ import { cancellationRegistry } from "../../packages/workflows/src/runs/backgrou
 import { killAllRuns } from "../../packages/workflows/src/runs/background/status.js";
 import type { StageSessionRuntime } from "../../packages/workflows/src/runs/foreground/stage-runner-types.js";
 import { createWorkflowExtensionRuntimeState } from "../../packages/workflows/src/extension/extension-runtime-state.js";
+import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
+import { setDurableBackend } from "../../packages/workflows/src/durable/factory.js";
 
 const originalCwd = process.cwd();
 const originalAgentDir = process.env.ATOMIC_CODING_AGENT_DIR;
@@ -33,6 +35,7 @@ afterEach(async () => {
   else process.env.USERPROFILE = originalUserProfile;
   killAllRuns({ store, cancellation: cancellationRegistry });
   store.clear();
+  setDurableBackend(undefined);
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
@@ -108,15 +111,24 @@ async function writeJson(path: string, value: object): Promise<void> {
 
 async function writeWorkflow(
   path: string,
-  options: { name: string; description: string; named?: boolean; prompt?: string },
+  options: {
+    name: string;
+    description: string;
+    named?: boolean;
+    prompt?: string;
+    inputName?: string;
+    outputName?: string;
+  },
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
+  const inputName = options.inputName ?? "message";
+  const outputName = options.outputName ?? "value";
   const definition = `workflow({
   name: ${JSON.stringify(options.name)},
   description: ${JSON.stringify(options.description)},
-  inputs: { message: Type.String() },
-  outputs: { value: Type.String() },
-  run: async (ctx) => ({ value: await ctx.stage("emit").prompt(${JSON.stringify(options.prompt ?? options.name)} + ":" + ctx.inputs.message) }),
+  inputs: { ${JSON.stringify(inputName)}: Type.String() },
+  outputs: { ${JSON.stringify(outputName)}: Type.String() },
+  run: async (ctx) => ({ ${JSON.stringify(outputName)}: await ctx.stage("emit").prompt(${JSON.stringify(options.prompt ?? options.name)} + ":" + ctx.inputs[${JSON.stringify(inputName)}]) }),
 })`;
   await writeFile(path, [
     `import { workflow } from "@bastani/workflows";`,
@@ -219,6 +231,7 @@ describe("workflow reload rediscovery matrix", () => {
     const completions = await workflowCommand.getArgumentCompletions("scope-project-at");
     assert.ok(completions?.some((item) => item.label === "scope-project-atomic"));
     const messageStart = harness.messages.length;
+
     await workflowCommand.handler?.("scope-project-atomic --help", { hasUI: false, ui: { notify: () => undefined } });
     assert.match(harness.messages.slice(messageStart).join("\n"), /message/);
 
@@ -226,6 +239,33 @@ describe("workflow reload rediscovery matrix", () => {
     assert.equal(run.action, "run");
     assert.equal(run.status, "completed", JSON.stringify(run));
     assert.deepEqual(run.result, { value: "declared:scope-project-atomic:hello" });
+  });
+
+  test.serial("post-start global and configured additions preserve the active registry", async () => {
+    const { root, project, agent } = await makeIsolatedRoots("workflow-reload-post-start");
+    const existing = join(project, ".atomic/workflows/existing.ts");
+    await writeWorkflow(existing, { name: "post-start-existing", description: "loaded first" });
+    const harness = createHarness();
+    await harness.execute({ action: "reload" });
+    const before = names(await harness.execute({ action: "list" }));
+    assert.deepEqual(before.filter((name) => name.startsWith("post-start-")), ["post-start-existing"]);
+    assert.ok(before.includes("goal"), "bundled workflows must survive reload");
+
+    const globalAdded = join(agent, "workflows/added.ts");
+    const configuredAdded = join(root, "configured-after-start/added.ts");
+    await writeWorkflow(globalAdded, { name: "post-start-global", description: "added globally" });
+    await writeWorkflow(configuredAdded, { name: "post-start-configured", description: "added by config" });
+    await writeJson(join(project, ".atomic/extensions/workflow/config.json"), {
+      workflows: { addedAfterStart: { path: configuredAdded } },
+    });
+
+    const report = reloadResult(await harness.execute({ action: "reload" }));
+    assert.equal(report.outcome, "applied");
+    const after = names(await harness.execute({ action: "list" }));
+    assert.ok(after.includes("post-start-existing"));
+    assert.ok(after.includes("post-start-global"));
+    assert.ok(after.includes("post-start-configured"));
+    assert.ok(after.includes("goal"), "bundled workflows must remain after rediscovery");
   });
 
   test.serial("add edit rename delete and malformed siblings replace metadata while preserving valid workflows", async () => {
@@ -239,21 +279,45 @@ describe("workflow reload rediscovery matrix", () => {
 
     await writeWorkflow(changing, { name: "reload-changing", description: "version one" });
     await writeFile(join(dir, "invalid.ts"), "export default { broken: true };", "utf8");
+    await writeFile(join(dir, "import-failed.ts"), "export default ;", "utf8");
     const added = reloadResult(await harness.execute({ action: "reload" }));
     assert.equal(added.status, "ok");
     assert.ok(added.diagnostics.some((diagnostic) => diagnostic.code === "INVALID_DEFINITION"));
+    assert.ok(added.diagnostics.some((diagnostic) => diagnostic.code === "IMPORT_FAILED"));
     assert.ok(names(await harness.execute({ action: "list" })).includes("reload-stable"));
+    const stableRun = await harness.execute({ action: "run", workflow: "reload-stable", inputs: { message: "still-valid" } });
+    assert.equal(stableRun.action, "run");
+    assert.equal(stableRun.status, "completed", JSON.stringify(stableRun));
+    assert.deepEqual(stableRun.result, { value: "declared:reload-stable:still-valid" });
     const slashMessageStart = harness.messages.length;
     await harness.commands.get("workflow")?.handler?.("reload", { hasUI: false, ui: { notify: () => undefined } });
-    assert.match(harness.messages.slice(slashMessageStart).join("\n"), /INVALID_DEFINITION/);
+    assert.match(harness.messages.slice(slashMessageStart).join("\n"), /INVALID_DEFINITION[\s\S]*IMPORT_FAILED|IMPORT_FAILED[\s\S]*INVALID_DEFINITION/);
 
-    await writeWorkflow(changing, { name: "reload-edited", description: "version two", named: true });
+    await writeWorkflow(changing, {
+      name: "reload-edited",
+      description: "version two",
+      named: true,
+      prompt: "edited",
+      inputName: "revisedInput",
+      outputName: "revisedValue",
+    });
     const edited = reloadResult(await harness.execute({ action: "reload" }));
     assert.equal(edited.status, "ok");
     const editedGet = await harness.execute({ action: "get", workflow: "reload-edited" });
     assert.equal(editedGet.action, "get");
     assert.equal(editedGet.details?.output?.description, "version two");
     assert.ok(!names(await harness.execute({ action: "list" })).includes("reload-changing"));
+    const editedInputs = await harness.execute({ action: "inputs", workflow: "reload-edited" });
+    assert.equal(editedInputs.action, "inputs");
+    assert.deepEqual(editedInputs.inputs.map((input) => input.name), ["revisedInput"]);
+    const editedRun = await harness.execute({
+      action: "run",
+      workflow: "reload-edited",
+      inputs: { revisedInput: "next" },
+    });
+    assert.equal(editedRun.action, "run");
+    assert.equal(editedRun.status, "completed", JSON.stringify(editedRun));
+    assert.deepEqual(editedRun.result, { revisedValue: "declared:edited:next" });
 
     const renamedPath = join(dir, "renamed.ts");
     await rename(changing, renamedPath);
@@ -280,6 +344,9 @@ describe("workflow reload rediscovery matrix", () => {
     });
     const applied = reloadResult(await harness.execute({ action: "reload" }));
     await writeWorkflow(workflowPath, { name: "reload-retained", description: "must not publish" });
+    const invalidConfig = join(project, ".atomic/extensions/workflow/config.json");
+    await mkdir(dirname(invalidConfig), { recursive: true });
+    await writeFile(invalidConfig, "{ invalid", "utf8");
     failRefresh = true;
     const failed = reloadResult(await harness.execute({ action: "reload" }));
     assert.equal(failed.status, "noop");
@@ -288,6 +355,8 @@ describe("workflow reload rediscovery matrix", () => {
     assert.equal(failed.generation, applied.generation);
     assert.equal(failed.workflowCount, applied.workflowCount);
     assert.equal(failed.error, "deterministic refresh failure");
+    assert.ok(failed.diagnostics.some((diagnostic) => diagnostic.code === "CONFIG_INVALID"));
+    assert.match(failed.message, /CONFIG_INVALID/);
     const retained = await harness.execute({ action: "get", workflow: "reload-retained" });
     assert.equal(retained.action, "get");
     assert.equal(retained.details?.output?.description, "before failure");
@@ -309,12 +378,24 @@ describe("workflow reload rediscovery matrix", () => {
         }),
       }),
     });
+    const durableBackend = new InMemoryDurableBackend();
+    durableBackend.registerWorkflow({
+      workflowId: "durable-reload-retained",
+      name: "durable retained",
+      inputs: {},
+      createdAt: 1,
+      status: "paused",
+      completedCheckpoints: 1,
+    });
+    setDurableBackend(durableBackend);
+    const durableBefore = structuredClone(durableBackend.listResumableWorkflows());
     await harness.execute({ action: "reload" });
     const running = harness.execute({ action: "run", workflow: "reload-inflight", inputs: { message: "value" } });
     await promptStarted;
     await writeWorkflow(workflowPath, { name: "reload-inflight", description: "new metadata", prompt: "new prompt" });
     const reloaded = reloadResult(await harness.execute({ action: "reload" }));
     assert.equal(reloaded.status, "ok");
+    assert.deepEqual(durableBackend.listResumableWorkflows(), durableBefore);
     const current = await harness.execute({ action: "get", workflow: "reload-inflight" });
     assert.equal(current.action, "get");
     assert.equal(current.details?.output?.description, "new metadata");
@@ -325,8 +406,8 @@ describe("workflow reload rediscovery matrix", () => {
     assert.deepEqual(completed.result, { value: "held:old prompt:value" });
   });
 
-  test.serial("overlapping reload requests serialize and coalesce one trailing generation", async () => {
-    await makeIsolatedRoots("workflow-reload-coalesce");
+  test.serial("overlapping reload recovers from an active failure and applies the coalesced trailing pass", async () => {
+    await makeIsolatedRoots("workflow-reload-coalesce-failure");
     const gates: Array<() => void> = [];
     const starts: Array<() => void> = [];
     let refreshCalls = 0;
@@ -338,6 +419,7 @@ describe("workflow reload rediscovery matrix", () => {
         const index = refreshCalls++;
         starts[index]?.();
         await new Promise<void>((resolve) => { gates[index] = resolve; });
+        if (index === 0) throw new Error("overlapping active failure");
         return [];
       },
     });
@@ -352,9 +434,14 @@ describe("workflow reload rediscovery matrix", () => {
     assert.equal(refreshCalls, 2);
     gates[1]?.();
     const [firstResult, secondResult, thirdResult] = await Promise.all([first, trailingA, trailingB]);
-    assert.equal(reloadResult(firstResult).coalescedRequests, 1);
-    assert.equal(reloadResult(secondResult).coalescedRequests, 2);
-    assert.equal(reloadResult(thirdResult).generation, reloadResult(secondResult).generation);
+    const failed = reloadResult(firstResult);
+    const applied = reloadResult(secondResult);
+    assert.equal(failed.outcome, "failed");
+    assert.equal(failed.error, "overlapping active failure");
+    assert.equal(applied.outcome, "applied");
+    assert.equal(applied.coalescedRequests, 2);
+    assert.equal(reloadResult(thirdResult).generation, applied.generation);
+    assert.ok(applied.generation > failed.generation);
   });
 
   test.serial("queued old-session requests cannot coalesce with or publish into a new session", async () => {

--- a/test/unit/workflow-reload-render.test.ts
+++ b/test/unit/workflow-reload-render.test.ts
@@ -1,0 +1,32 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { renderResult, type WorkflowToolResult } from "../../packages/workflows/src/extension/render-result.js";
+import { formatWorkflowReloadReport } from "../../packages/workflows/src/extension/workflow-command-surfaces.js";
+import type { WorkflowReloadReport } from "../../packages/workflows/src/extension/workflow-reload-report.js";
+
+test("reload result rendering wraps multiline diagnostics without losing actionable details", () => {
+  const report: WorkflowReloadReport = {
+    outcome: "applied",
+    generation: 2,
+    workflowCount: 8,
+    coalescedRequests: 1,
+    diagnostics: [{
+      phase: "discovery",
+      level: "error",
+      code: "IMPORT_FAILED",
+      source: "/a/very/long/workflow/source/path/that/would/otherwise/consume/the/notice/width.ts",
+      message: "module exploded while importing the newly added workflow",
+    }],
+  };
+  const result: WorkflowToolResult = {
+    action: "reload",
+    status: "ok",
+    message: formatWorkflowReloadReport(report),
+    ...report,
+  };
+
+  const rendered = renderResult(result, { width: 80, plain: true });
+  assert.match(rendered, /Reloaded workflow resources/);
+  assert.match(rendered, /IMPORT_FAILED/);
+  assert.match(rendered, /module exploded while importing/);
+});

--- a/test/unit/workflow-reload-render.test.ts
+++ b/test/unit/workflow-reload-render.test.ts
@@ -30,3 +30,27 @@ test("reload result rendering wraps multiline diagnostics without losing actiona
   assert.match(rendered, /IMPORT_FAILED/);
   assert.match(rendered, /module exploded while importing/);
 });
+
+test("explicit reload reports and renders every diagnostic beyond the former display cap", () => {
+  const diagnostics: WorkflowReloadReport["diagnostics"] = Array.from({ length: 9 }, (_, index) => ({
+    phase: "discovery" as const,
+    level: "error" as const,
+    code: "IMPORT_FAILED" as const,
+    source: `/workflows/malformed-${index + 1}.ts`,
+    message: `malformed workflow ${index + 1}`,
+  }));
+  const report: WorkflowReloadReport = {
+    outcome: "applied",
+    generation: 3,
+    workflowCount: 7,
+    coalescedRequests: 1,
+    diagnostics,
+  };
+  const message = formatWorkflowReloadReport(report);
+  const result: WorkflowToolResult = { action: "reload", status: "ok", message, ...report };
+  const rendered = renderResult(result, { width: 80, plain: true });
+
+  assert.match(message, /malformed-9\.ts: malformed workflow 9/);
+  assert.doesNotMatch(message, /… 1 more/);
+  assert.match(rendered, /malformed-9\.ts: malformed workflow 9/);
+});


### PR DESCRIPTION
## Summary

Fixes in-process workflow rediscovery so `/workflow reload` and the workflow tool reload action publish a fresh, generation-safe registry without restarting Atomic. Reload now exposes actionable diagnostics, remains safe while workflows are running, and preserves the last applied registry when refresh fails.

## Reproduction and root cause

The reported valid global conventional, project conventional/named-wrapper, and project configured-directory variants were replayed against the pre-change source and compiled runtimes after each process was already live. On the current `main` baseline, all three were discovered immediately after reload, so those exact variants did **not** reproduce; existing tracked workflows remained visible throughout.

The false-success failure mode did reproduce deterministically with a skipped module: discovery converted import/definition/path failures into diagnostics and a partial registry, but explicit reload surfaces discarded those diagnostics and always rendered bare success. The reload control flow also applied config before package refresh/discovery completed, reset its serialization queue at session boundaries, captured generations when work began rather than when requested, and blocked reload while runs were active. Together those boundaries allowed misleading success, split config/registry state on fatal failures, and insufficient fencing of queued work across session generations.

Concrete paths/symbols:

- `extension-runtime-state.ts`: `reloadWorkflowResourcesNow`, runtime/config/discovery refs, generation checks
- `workflow-command-registration.ts` and `workflow-tool-control.ts`: unconditional success and in-flight guards
- `workflow-command-surfaces.ts`: startup-only diagnostic formatting
- `workflow-reload-coordinator.ts`: new generation-keyed serialized/coalesced request coordinator
- `workflow-reload-report.ts`: exact applied/failed/superseded reports

## Changes

- Capture session generation at reload request time; serialize requests permanently and coalesce only same-generation trailing work.
- Reject queued stale generations before they read config or refresh package resources.
- Finish every awaited/fallible discovery step before synchronously committing config, diagnostics, and replacement runtime.
- Return discriminated applied/failed/superseded reports with retained generation/count state and visible diagnostics.
- Preserve every explicit reload diagnostic across slash-command and tool text/rendering, including reports with more than eight malformed resources.
- Keep the prior registry on fatal refresh failure while still applying usable partial discovery results with diagnostics.
- Allow reload during in-flight runs; active runs retain their captured definition/runtime while subsequent surfaces use the replacement registry.
- Preserve compatibility for extension-level reload callbacks that historically returned `void`.
- Document corrected reload semantics and update both Unreleased changelogs.

## Automated dummy-workflow matrix

Isolated temp HOME/project coverage includes:

- project `.atomic/workflows` and legacy `.pi/workflows`
- global `~/.atomic/agent/workflows` and legacy `~/.pi/agent/workflows`
- project/global config paths targeting files and directories with absolute and relative forms
- default and named exports, duplicate precedence, valid and malformed siblings
- additions, metadata/input/output edits, renames, deletions, repeated reloads
- list, get, inputs, help, completion, and declared-output invocation
- package-resource refresh
- concurrent/coalesced requests with deterministic barriers
- active-old + queued-old + reset + new-generation ordering
- fatal refresh retention and in-flight definition preservation

## Source and compiled TUI evidence

Driven through isolated tmux sessions with fixtures created only after editor readiness:

- Source command exactly: `bun packages/coding-agent/src/cli.ts`
- Compiled build: `./scripts/build-binaries.sh --skip-deps --skip-install --platform darwin-arm64`
- Compiled runtime: `packages/coding-agent/binaries/darwin-arm64/atomic`

Both processes demonstrated post-start conventional project/global and configured-path additions, `/workflow reload`, list, inputs/help, name completion, actual invocation completion, edits replacing stale metadata/input schema, rename/delete disappearance, and visible invalid-sibling diagnostics while valid workflows remained available. The final rebuilt compiled binary was smoke-tested again after the generation-boundary repair. Dummy workflows, auth copies, configs, tmux logs, binaries, native/target outputs, and scratch trees were deleted afterward.

## Validation

- Final exact `AGENT=1 bun run test:all`: **3471 unit passed; 249 integration passed; 1 expected built-dist skip; 0 failed**
- Final focused reload/render/durable/detach/slash set: **185/185 passed**
- Final commit and push hooks: full unit suite passed
- `bun run typecheck`
- `bun run lint`
- `bun run check:file-length`
- `git diff --check main`
- Coding-agent docs link validation
- Canonical darwin-arm64 standalone build
- Source and compiled tmux/PTY E2E, including post-start add/edit/rename/delete, config paths, completion/help, invocation, and malformed-sibling diagnostics
- Independent fresh-context reviewer quorum: **2/2 approved**, with separate evidence and risk reviewers reporting no remaining objective-relevant work

## Risks and rollback

The main behavioral change is that reload is now allowed while runs are active. This is safe because each run already captures its runtime/registry at dispatch; tests prove the running definition completes unchanged while new metadata is published for future calls. Reload remains workflow-resource-only and does not rebuild extensions, skills, prompts, themes, packages, durable state, or stage inheritance.

Rollback is a single revert of this PR. The previous behavior would restore in-flight blocking, queue reset semantics, and generic reload success messages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes in-process workflow reload so workflow changes can be rediscovered without restarting Atomic. The main changes are:

- Adds generation-aware reload serialization and same-generation request coalescing.
- Returns structured applied, failed, and superseded reload reports.
- Keeps the previous workflow registry when fatal refresh fails.
- Allows reload while workflows are running, with active runs keeping their captured definition.
- Surfaces config and discovery diagnostics through `/workflow reload` and the workflow tool.
- Updates documentation, changelogs, and unit coverage for rediscovery, diagnostics, and reload concurrency.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

No blocking correctness or security issues were identified in the changed reload, command/tool surface, documentation, or test updates. The core concurrency changes are narrowly scoped and covered by tests for failure retention, coalescing, generation fencing, and in-flight behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran bun test on workflow-reload-render.test.ts and workflow-reload-rediscovery.test.ts as part of the focused workflow reload suite, reporting 9 passing tests and 0 failures.
- Ran bun test on slash-dispatch-tool-reload-resume.ts and workflow-lazy-startup-continuation.test.ts as part of the continuation workflow reload suite, reporting 11 passing tests and 0 failures.
- Ran bun run typecheck and it completed with exit code 0, indicating no type errors.

<a href="https://app.greptile.com/trex/runs/14522950/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/workflows/src/extension/extension-runtime-state.ts | Reworks workflow resource reload to use generation-aware serialized/coalesced requests, retain prior state on failures, and publish config/registry synchronously after discovery. |
| packages/workflows/src/extension/workflow-reload-coordinator.ts | Introduces a generation-keyed reload coordinator that serializes reloads and coalesces only trailing same-generation requests. |
| packages/workflows/src/extension/workflow-reload-report.ts | Defines normalized reload report and diagnostic types for applied, failed, and superseded reload outcomes. |
| packages/workflows/src/extension/workflow-command-registration.ts | Changes `/workflow reload` to display structured applied/failed/superseded reload reports instead of unconditional success or in-flight blocking. |
| packages/workflows/src/extension/workflow-tool-control.ts | Updates workflow tool reload action to return structured reload reports and allow reload while runs are active. |
| test/unit/workflow-reload-rediscovery.test.ts | Adds comprehensive reload rediscovery coverage for discovery scopes, mutations, diagnostics, failure retention, in-flight behavior, coalescing, and session generation fencing. |
| packages/coding-agent/docs/workflows.md | Documents in-process workflow reload semantics, concurrency behavior, retention on fatal failures, and surfaced diagnostics. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Caller as Slash command / workflow tool
  participant State as Workflow runtime state
  participant Coord as Reload coordinator
  participant Config as Config loader
  participant Packages as Package resource refresh
  participant Discovery as Workflow discovery
  participant Runtime as Active registry/runtime

  Caller->>State: reloadWorkflowResources()
  State->>Coord: request(session generation)
  Coord->>Coord: serialize request and coalesce trailing same-generation calls
  Coord->>State: reloadWorkflowResourcesNow(generation, count)
  State->>State: reject if session generation is stale
  State->>Config: loadWorkflowConfig()
  State->>Packages: refreshWorkflowResources()
  State->>Discovery: discoverWorkflows(config, package paths)
  alt generation still current and discovery completes
    State->>Runtime: synchronously apply config + registry
    State-->>Caller: applied report with workflow count and diagnostics
  else fatal refresh/discovery failure
    State-->>Caller: failed report retaining current registry
  else stale generation
    State-->>Caller: superseded report without applying stale resources
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Caller as Slash command / workflow tool
  participant State as Workflow runtime state
  participant Coord as Reload coordinator
  participant Config as Config loader
  participant Packages as Package resource refresh
  participant Discovery as Workflow discovery
  participant Runtime as Active registry/runtime

  Caller->>State: reloadWorkflowResources()
  State->>Coord: request(session generation)
  Coord->>Coord: serialize request and coalesce trailing same-generation calls
  Coord->>State: reloadWorkflowResourcesNow(generation, count)
  State->>State: reject if session generation is stale
  State->>Config: loadWorkflowConfig()
  State->>Packages: refreshWorkflowResources()
  State->>Discovery: discoverWorkflows(config, package paths)
  alt generation still current and discovery completes
    State->>Runtime: synchronously apply config + registry
    State-->>Caller: applied report with workflow count and diagnostics
  else fatal refresh/discovery failure
    State-->>Caller: failed report retaining current registry
  else stale generation
    State-->>Caller: superseded report without applying stale resources
  end
```

</a>

<sub>Reviews (5): Last reviewed commit: ["fix(workflows): report every reload diag..."](https://github.com/bastani-inc/atomic/commit/f6d4fc633feeaddc2ee2d80885bbb551da37fda2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44398794)</sub>

<!-- /greptile_comment -->