### PR TITLE
Release 0.9.9-alpha.4

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
 ### Fixed
 
 - Fixed in-process workflow reload to atomically publish freshly rescanned project, user, legacy, configured, and package workflow resources across list/get/inputs/help/completion/invocation surfaces. Overlapping requests are serialized and coalesced, stale session generations cannot overwrite current state, fatal refresh failures retain the prior registry, and reload no longer blocks or changes workflows already in flight. `/workflow reload` and the workflow tool now include actionable per-resource diagnostics instead of reporting bare success when malformed or missing resources were skipped.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the intercom extension; no functional intercom changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Fixed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the MCP extension; no functional MCP changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the native transport package; no native transport changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the subagents extension; no functional subagent changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Fixed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the web-access extension; no functional web-access changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
 ### Fixed
 
 - Fixed workflow resource reload to build and atomically publish a fresh registry for additions, edits, renames, deletions, config paths, conventional/legacy directories, and package resources without restarting Atomic. Reloads now serialize and coalesce, reject stale session generations, retain the active registry on fatal failures, remain safe during in-flight runs, and return visible config/discovery diagnostics through both slash-command and tool surfaces while preserving valid siblings.


### PR DESCRIPTION
## Release

- **Kind:** Prerelease
- **Version:** `0.9.9-alpha.4`
- **Source HEAD:** `5a8236ccf76042e568617ed7157f706e00e4837a`
- **Release-notes commit:** `5d886442c4faffa1a426ce8718e9a334266bda5b`

## Changelog and version summary

- Updates the `## [Unreleased]` release notes for `coding-agent`, `cursor`, `intercom`, `mcp`, `natives`, `subagents`, `web-access`, and `workflows`.
- This is a changelog-only PR: no `packages/*/package.json` versions are changed, and `main` remains at the versionless `0.0.0` placeholder.
- The real `0.9.9-alpha.4` version will be materialized only on the throwaway off-main tag commit produced by `scripts/cut-release.ts`; that commit is not merged into `main`.

## Validation

Deterministic release preparation and local checks passed. Commands run:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only 5a8236ccf76042e568617ed7157f706e00e4837a..HEAD
git diff --name-only 5a8236ccf76042e568617ed7157f706e00e4837a..HEAD -- 'packages/*/package.json'
git show --no-ext-diff --format=fuller --stat --oneline HEAD
git push -u origin prerelease/0.9.9-alpha.4
gh auth status
gh repo view --json nameWithOwner,url,defaultBranchRef
gh pr list --state all --head prerelease/0.9.9-alpha.4 --base main --json number,title,url,state,baseRefName,headRefName,headRefOid
```

The push hooks also passed:

```sh
bun run lint
bun run check:file-length
bun run test:unit
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `0.9.9-alpha.4` prerelease notes across the affected package changelogs. The main changes are:

- Release notes for the coding-agent and workflows reload/resume fixes.
- Synchronized prerelease notes for cursor, intercom, MCP, natives, subagents, and web-access.
- No package manifest or runtime code changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are limited to changelog entries and follow the versionless-main release flow.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The diff across the commit range shows eight changelog files changed, as requested.
- The diff restricting to packages/\*/package.json produced no changes, with exit code 0.
- The bun run lint step executed tsc --noEmit and completed with exit code 0, confirming TypeScript checks passed.
- After restoring missing tracked setup files, the check:file-length step passed, validating 2079 files.

<a href="https://app.greptile.com/trex/runs/14571308/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds the 0.9.9-alpha.4 release notes for the coding-agent workflow reload fix; no issues found. |
| packages/cursor/CHANGELOG.md | Adds synchronized 0.9.9-alpha.4 prerelease notes indicating no functional Cursor provider changes; no issues found. |
| packages/intercom/CHANGELOG.md | Adds synchronized 0.9.9-alpha.4 prerelease notes indicating no functional intercom changes; no issues found. |
| packages/mcp/CHANGELOG.md | Adds synchronized 0.9.9-alpha.4 prerelease notes indicating no functional MCP changes; no issues found. |
| packages/natives/CHANGELOG.md | Adds synchronized 0.9.9-alpha.4 prerelease notes indicating no functional native transport changes; no issues found. |
| packages/subagents/CHANGELOG.md | Adds synchronized 0.9.9-alpha.4 prerelease notes indicating no functional subagent changes; no issues found. |
| packages/web-access/CHANGELOG.md | Adds synchronized 0.9.9-alpha.4 prerelease notes indicating no functional web-access changes; no issues found. |
| packages/workflows/CHANGELOG.md | Adds the 0.9.9-alpha.4 release notes for workflow reload and resume fixes; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Release as 0.9.9-alpha.4 prerelease PR
participant Unreleased as Changelog [Unreleased]
participant Version as New 0.9.9-alpha.4 sections
participant Packages as Affected package changelogs

Release->>Unreleased: Move documented release notes out of Unreleased
Unreleased->>Version: Insert dated 0.9.9-alpha.4 heading
Version->>Packages: Record workflow fixes and synchronized prerelease notes
Note over Packages: No package.json version changes or runtime code changes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Release as 0.9.9-alpha.4 prerelease PR
participant Unreleased as Changelog [Unreleased]
participant Version as New 0.9.9-alpha.4 sections
participant Packages as Affected package changelogs

Release->>Unreleased: Move documented release notes out of Unreleased
Unreleased->>Version: Insert dated 0.9.9-alpha.4 heading
Version->>Packages: Record workflow fixes and synchronized prerelease notes
Note over Packages: No package.json version changes or runtime code changes
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.9-alpha.4"](https://github.com/bastani-inc/atomic/commit/5d886442c4faffa1a426ce8718e9a334266bda5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44521316)</sub>

<!-- /greptile_comment -->