### PR TITLE
test(workflows): isolate lazy startup durability

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Fixed workflow resource reload to build and atomically publish a fresh registry for additions, edits, renames, deletions, config paths, conventional/legacy directories, and package resources without restarting Atomic. Reloads now serialize and coalesce, reject stale session generations, retain the active registry on fatal failures, remain safe during in-flight runs, and return visible config/discovery diagnostics through both slash-command and tool surfaces while preserving valid siblings.
 - Fixed exact paused top-level live `/workflow resume <id>` targets to resume before enumerating retained completed durable history, preserving live-over-durable precedence and keeping headless command output responsive when the durable catalog is large, while exact nested child IDs remain excluded from the top-level resume namespace. Slash-dispatch tests now isolate durable state in memory and restore the backend after each test so they never read or populate a user's workflow history.
+- Isolated lazy-startup continuation tests with fresh in-memory durable backends and a completed-catalog regression guard, preventing test runs from enumerating or populating the user's real durable workflow history while preserving failed-run resource-loading coverage.
 
 ## [0.9.9-alpha.3] - 2026-07-14
 

--- a/test/unit/workflow-lazy-startup-continuation.test.ts
+++ b/test/unit/workflow-lazy-startup-continuation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, test } from "bun:test";
+import { afterEach, beforeEach, describe, test } from "bun:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -17,6 +17,8 @@ import { Type } from "typebox";
 import { createExtensionRuntime, type ExtensionRuntime } from "../../packages/workflows/src/extension/runtime.js";
 import { makeExecuteWorkflowTool } from "../../packages/workflows/src/extension/workflow-tool.js";
 import { WORKFLOW_STAGE_SUBAGENT_GUARD_ENV } from "@bastani/atomic";
+import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
+import { setDurableBackend } from "../../packages/workflows/src/durable/factory.js";
 
 interface SentMessage {
   customType?: string;
@@ -32,12 +34,17 @@ async function cleanupJobs(): Promise<void> {
   await Promise.all(jobTracker.runIds().map((runId) => jobTracker.get(runId)?.promise));
 }
 
+beforeEach(() => {
+  setDurableBackend(new InMemoryDurableBackend());
+});
+
 afterEach(async () => {
   delete process.env[WORKFLOW_STAGE_SUBAGENT_GUARD_ENV];
   process.chdir(originalCwd);
   killAllRuns({ store, cancellation: cancellationRegistry });
   await cleanupJobs();
   store.clear();
+  setDurableBackend(undefined);
 });
 
 function workflowConfigDir(root: string): string {
@@ -297,12 +304,23 @@ describe("workflow lazy-startup continuation fixes", () => {
   });
 
   test("/workflow resume lazy-loads resources before failed-run registry lookup", async () => {
+    class CatalogCountingBackend extends InMemoryDurableBackend {
+      completedCatalogCalls = 0;
+
+      override listCompletedWorkflows() {
+        this.completedCatalogCalls += 1;
+        return super.listCompletedWorkflows();
+      }
+    }
+
+    const backend = new CatalogCountingBackend();
+    setDurableBackend(backend);
     const dir = await mkdtemp(join(tmpdir(), "atomic-workflow-slash-resume-lazy-"));
     try {
       const workflowPath = join(dir, "slash-resume-lazy.ts");
       await writePromptWorkflowFixture(workflowPath, "slash-resume-lazy");
       let refreshCalls = 0;
-      const { commands } = registerFactory({
+      const { commands, sent } = registerFactory({
         refreshWorkflowResources: async () => {
           refreshCalls += 1;
           return [{ path: workflowPath, enabled: true }];
@@ -313,10 +331,15 @@ describe("workflow lazy-startup continuation fixes", () => {
       store.recordStageStart(sourceRunId, { id: "retry-old", name: "retry", status: "failed", parentIds: [], toolEvents: [], error: "boom" });
       store.recordStageEnd(sourceRunId, { id: "retry-old", name: "retry", status: "failed", parentIds: [], toolEvents: [], error: "boom" });
       store.recordRunEnd(sourceRunId, "failed", undefined, "boom", { resumable: true, failedStageId: "retry-old" });
+      backend.registerWorkflow({ workflowId: sourceRunId, name: "slash-resume-lazy", inputs: {}, createdAt: Date.now(), status: "failed", resumable: true });
       const workflowCmd = commands.find((command) => command.name === "workflow");
       assert.ok(workflowCmd);
       await workflowCmd.options.handler?.(`resume ${sourceRunId}`, { hasUI: false, ui: { notify: () => undefined } });
       assert.equal(refreshCalls, 1);
+      assert.equal(backend.completedCatalogCalls, 1);
+      const output = sent.map((entry) => entry.content ?? "").join("\n");
+      assert.match(output, /Resum/);
+      assert.doesNotMatch(output, /Run not found/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Make the workflow lazy-startup continuation unit suite hermetic so `/workflow resume` coverage never reads or populates the user's real durable workflow catalog. This removes the release-blocking dependency on large `~/.atomic/workflow-durable` histories while preserving the lazy resource-loading and failed-run continuation contract.

## Changes

- Install a fresh `InMemoryDurableBackend` before each lazy-startup continuation test and reset the global backend during teardown, following the established slash-dispatch isolation pattern.
- Add a counting in-memory catalog guard to the failed-run resume test and register its synthetic failed workflow exclusively in that backend.
- Preserve the resource refresh assertion and strengthen the continuation checks to require resumptive output and reject `Run not found`.
- Document the test-isolation fix in `packages/workflows/CHANGELOG.md` under `Unreleased`.

## Validation

- Focused suite repeated five times: 11/11 passed each run
- Focused suite with a poisoned/sentinel user durable-catalog path: 11/11 passed; the real catalog path was not accessed
- Affected workflow tests: 160/160 passed
- `AGENT=1 bun run test:unit`: 3473/3473 passed across 394 files
- `bun run typecheck`: passed
- `bun run lint`: passed
- `bun run check:file-length`: passed
- Push hooks, including the full unit suite: passed

## Notes

This is test-only isolation; it does not change runtime durability behavior, disable durability, increase timeouts, mutate user history, or weaken assertions. No user-facing workflow documentation update is needed because behavior is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR isolates workflow lazy-startup continuation tests from the user's durable workflow catalog. The main changes are:

- Installs a fresh `InMemoryDurableBackend` before each lazy-startup continuation test.
- Resets the global durable backend during test teardown.
- Adds a counting in-memory catalog guard for the failed-run `/workflow resume` regression test.
- Strengthens resume assertions to require resumptive output and reject `Run not found`.
- Documents the test-isolation fix in `packages/workflows/CHANGELOG.md`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are test-only, narrowly scoped, and correctly restore the global durable backend after each test.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- \`trex-artifacts/workflow-lazy-startup-continuation-01-before.log\` shows initial sentinel catalog state with only \`SENTINEL\_MARKER\` and SHA \`aa4fda23581121e061a348bf1c3be0e9e58aab7d7262efb18cf428cb092647db\`.
- \`trex-artifacts/workflow-lazy-startup-continuation-02-after.log\` shows the focused suite passed: \`11 pass\`, \`0 fail\`, exit code 0.
- \`trex-artifacts/workflow-lazy-startup-continuation-sentinel-after.log\` shows the catalog still contained only the marker, path count remained 4, and marker SHA stayed unchanged.
- \`trex-artifacts/workflow-lazy-startup-continuation-repeat.log\` shows two further focused iterations passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/14576312/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/unit/workflow-lazy-startup-continuation.test.ts | Adds per-test in-memory durable backend isolation and stronger failed-run `/workflow resume` lazy-loading regression assertions. |
| packages/workflows/CHANGELOG.md | Documents the lazy-startup continuation test isolation fix under the existing Unreleased Fixed section. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Test as Lazy startup test
participant Factory as Durable factory
participant Backend as InMemoryDurableBackend
participant Command as /workflow resume
participant Store as Test workflow store

Test->>Factory: beforeEach setDurableBackend(new InMemoryDurableBackend())
Test->>Store: Seed failed resumable run
Test->>Backend: Register synthetic failed workflow
Test->>Command: "resume <runId>"
Command->>Backend: listCompletedWorkflows()
Command->>Store: Resolve failed resumable run
Command-->>Test: Resumptive output, not "Run not found"
Test->>Factory: afterEach setDurableBackend(undefined)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Test as Lazy startup test
participant Factory as Durable factory
participant Backend as InMemoryDurableBackend
participant Command as /workflow resume
participant Store as Test workflow store

Test->>Factory: beforeEach setDurableBackend(new InMemoryDurableBackend())
Test->>Store: Seed failed resumable run
Test->>Backend: Register synthetic failed workflow
Test->>Command: "resume <runId>"
Command->>Backend: listCompletedWorkflows()
Command->>Store: Resolve failed resumable run
Command-->>Test: Resumptive output, not "Run not found"
Test->>Factory: afterEach setDurableBackend(undefined)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(workflows): isolate lazy startup du..."](https://github.com/bastani-inc/atomic/commit/f6b8af4dbc8ca61e8ce933267938d2c63167596e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44530709)</sub>

<!-- /greptile_comment -->