### PR TITLE
Release 0.9.9-alpha.4

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
 ### Fixed
 
 - Fixed in-process workflow reload to atomically publish freshly rescanned project, user, legacy, configured, and package workflow resources across list/get/inputs/help/completion/invocation surfaces. Overlapping requests are serialized and coalesced, stale session generations cannot overwrite current state, fatal refresh failures retain the prior registry, and reload no longer blocks or changes workflows already in flight. `/workflow reload` and the workflow tool now include actionable per-resource diagnostics instead of reporting bare success when malformed or missing resources were skipped.

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the Cursor provider package; no functional Cursor provider changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the intercom extension; no functional intercom changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Fixed

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the MCP extension; no functional MCP changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the native transport package; no native transport changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the subagents extension; no functional subagent changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Fixed

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
+### Changed
+
+- Published a synchronized Atomic 0.9.9-alpha.4 prerelease for the web-access extension; no functional web-access changes were made after 0.9.9-alpha.3.
+
 ## [0.9.9-alpha.3] - 2026-07-14
 
 ### Changed

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.9-alpha.4] - 2026-07-15
+
 ### Fixed
 
 - Fixed workflow resource reload to build and atomically publish a fresh registry for additions, edits, renames, deletions, config paths, conventional/legacy directories, and package resources without restarting Atomic. Reloads now serialize and coalesce, reject stale session generations, retain the active registry on fatal failures, remain safe during in-flight runs, and return visible config/discovery diagnostics through both slash-command and tool surfaces while preserving valid siblings.


### PR DESCRIPTION
## Release

- **Kind:** Prerelease
- **Version:** `0.9.9-alpha.4`
- **Base:** `main`
- **Head:** `prerelease/0.9.9-alpha.4`
- **Head SHA:** `69a45168c4d4116dc0bd8c839b80c52e449263a4`

## Changelog and version summary

- Adds the `0.9.9-alpha.4` prerelease notes for `coding-agent`, `cursor`, `intercom`, `mcp`, `natives`, `subagents`, `web-access`, and `workflows`.
- This is a changelog-only PR; no `packages/*/package.json` versions are changed, and `main` remains at the versionless `0.0.0` placeholder.
- The real `0.9.9-alpha.4` version will be materialized only on the throwaway off-main tag commit produced by `scripts/cut-release.ts`; that commit will not be merged into `main`.

## Validation

Deterministic release preparation and local checks passed with:

```sh
git branch --show-current
git rev-parse HEAD
git status --short
git diff --name-only 69a45168c4d4116dc0bd8c839b80c52e449263a4..HEAD
bun run typecheck
bun run test:unit
```

Release publication checks run in this stage:

```sh
git push -u origin prerelease/0.9.9-alpha.4
gh auth status
gh repo view --json nameWithOwner,url,defaultBranchRef
gh pr list --head prerelease/0.9.9-alpha.4 --base main --state all --json number,title,url,state,baseRefName,headRefName,headRefOid
```

The push hooks also passed:

```sh
bun run lint
bun run check:file-length
bun run test:unit
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `0.9.9-alpha.4` prerelease changelog entries. The main changes are:

- New release notes for `coding-agent` and `workflows` workflow reload and resume fixes.
- Synchronized prerelease notes for `cursor`, `intercom`, `mcp`, `natives`, `subagents`, and `web-access`.
- No package manifest version changes on `main`, preserving the versionless release flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The PR only adds changelog entries and keeps the versionless-main release flow intact. No code, manifest, workflow, or security-sensitive behavior changed. No issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the release changelog validation run for the PR and used the evidence-capture helper script to record command-by-command outputs.
- Verified the validation log shows all steps’ stdout/stderr and exit codes, and confirmed the overall script exit code was 0.
- Prepared and uploaded the validation artifacts for reviewer access: the release-changelog validation log and the evidence-capture script.

<a href="https://app.greptile.com/trex/runs/14579364/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds 0.9.9-alpha.4 release notes for the coding-agent workflow reload fixes; no issues found. |
| packages/workflows/CHANGELOG.md | Adds 0.9.9-alpha.4 release notes for workflow reload/resume and test-isolation fixes; no issues found. |
| packages/cursor/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.4 prerelease note for the Cursor provider; no issues found. |
| packages/intercom/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.4 prerelease note for the intercom extension; no issues found. |
| packages/mcp/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.4 prerelease note for the MCP extension; no issues found. |
| packages/natives/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.4 prerelease note for the native transport package; no issues found. |
| packages/subagents/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.4 prerelease note for the subagents extension; no issues found. |
| packages/web-access/CHANGELOG.md | Adds a synchronized 0.9.9-alpha.4 prerelease note for the web-access extension; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Main as main branch
participant Changelogs as packages/*/CHANGELOG.md
participant Release as cut-release.ts off-main worktree
participant Tag as 0.9.9-alpha.4 tag
Main->>Changelogs: Merge changelog-only prerelease notes
Note over Main: package manifests remain 0.0.0 placeholders
Release->>Release: Materialize real 0.9.9-alpha.4 versions off main
Release->>Tag: Create throwaway tagged release commit
Tag->>Tag: Publish prerelease from protected release flow
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Main as main branch
participant Changelogs as packages/*/CHANGELOG.md
participant Release as cut-release.ts off-main worktree
participant Tag as 0.9.9-alpha.4 tag
Main->>Changelogs: Merge changelog-only prerelease notes
Note over Main: package manifests remain 0.0.0 placeholders
Release->>Release: Materialize real 0.9.9-alpha.4 versions off main
Release->>Tag: Create throwaway tagged release commit
Tag->>Tag: Publish prerelease from protected release flow
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: release notes for 0.9.9-alpha.4"](https://github.com/bastani-inc/atomic/commit/69a45168c4d4116dc0bd8c839b80c52e449263a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44536367)</sub>

<!-- /greptile_comment -->