### PR TITLE
docs: route release requests through workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,18 +133,14 @@ The selected base is never advanced by the version stamp. The script resolves it
 
 ### Agent publishing requests
 
-If a user asks to publish a release or prerelease, execute the release process directly rather than launching an Atomic workflow:
+If a user asks to publish a release or prerelease, route the request through the named Atomic `publish-release` workflow. When that workflow is discoverable, it is the only authorized release execution path; never silently fall back to performing its steps inline. If discovery or input validation fails, report the configuration problem instead of manually duplicating the release process.
 
-1. Ask for the version only when it was not supplied. Stable releases use `MAJOR.MINOR.PATCH`; prereleases use `MAJOR.MINOR.PATCH-alpha.REVISION` with revision starting at 1.
-2. Infer release versus prerelease from a valid supplied version; ask only when it is ambiguous or invalid. Use the requested `base_ref`, defaulting to the short branch name `main` when omitted.
+1. Ask for the version only when it was not supplied. Stable releases use `MAJOR.MINOR.PATCH`; prereleases use `MAJOR.MINOR.PATCH-alpha.REVISION` with revision starting at 1. Infer `release_kind` (`release` or `prerelease`) from a valid supplied version; ask only when the version is ambiguous or invalid.
+2. Use the workflow discovery and inspection actions to confirm that `publish-release` is available and validate its current input contract before launch. Launch it with `target_version` set to the version without a leading `v`, the inferred `release_kind`, and the requested short `base_ref`, defaulting to `main` when omitted.
 3. For non-main bases, require the branch to be protected with the repository's required CI checks and configure its exact canonical `refs/heads/<base_ref>` in the repository variable `RELEASE_BASE_REFS`; entries are comma-separated with no spaces, aliases, globs, or partial matches.
-4. Create `[release|prerelease]/<version>` without a leading `v` from the selected base.
-5. Update every relevant `packages/*/CHANGELOG.md` according to the Changelog rules below. Keep the selected base versionless; do not run `scripts/bump-version.ts` on the branch.
-6. Run local validation, commit all intended release-notes changes, push the branch, and open a PR to the selected base.
-7. Inspect required CI checks once. Never use `--watch`, sleeps, polling loops, or another workflow as a waiter. If checks are pending, report the PR/run and wait for a lifecycle notice or user follow-up; if checks fail, ask what to do.
-8. After checks pass, merge the exact verified head commit, switch to the selected base, and pull `origin/<base_ref>`.
-9. Run `bun run scripts/cut-release.ts <version> --base <base_ref> --push --yes`. This stamps the real version only on the detached release commit, records canonical base metadata, and pushes the tag, which automatically starts protected publishing.
-10. Inspect the matching `Publish <version>` action once. If it is pending, report its URL and wait for a lifecycle notice or user follow-up rather than blocking. If it fails, report the failing job and ask what to do. If it succeeds, verify npm and GitHub Release state and summarize the release evidence.
+4. Launch the named workflow in the background, as required for model-launched named workflows. After the launch is accepted, report its run ID and end the turn; do not wait for release gates in the launching turn.
+5. The `publish-release` workflow owns release preparation, the release-notes PR and required-check gates, exact merge verification, release-tag creation, and publish verification. Do not manually dispatch GitHub's `publish.yml`; pushing the verified release tag is the workflow's sole publication signal.
+6. If a PR-check or publish gate is pending, wait for a workflow lifecycle notice or user follow-up, then resume the same workflow run by its existing run ID. Never poll, use `--watch` or sleep loops, launch a second release workflow, or manually duplicate any release action while the run is pending.
 
 ## Docs
 


### PR DESCRIPTION
## Summary

Route future stable and prerelease publishing requests through the named Atomic `publish-release` workflow instead of allowing agents to execute the release procedure inline.

## Changes

- Require discovery and input-contract validation before launching `publish-release` with `target_version`, inferred `release_kind`, and `base_ref` (default `main`).
- Require background launch, run-ID reporting, and same-run resume after lifecycle notices or user follow-up; prohibit polling, duplicate workflow launches, and inline fallback.
- Preserve version formats, protected non-main base and `RELEASE_BASE_REFS` requirements, and the prohibition on manually dispatching `publish.yml`.
- Assign release preparation, PR/check gates, exact merge verification, tag creation, and publish verification to the named workflow.
- Remove the obsolete inline ten-step release checklist.

## Validation

- `bun run hooks:run`
- `bunx prek run --files AGENTS.md` (independent reviewer validation)
- `git diff --check origin/main`
- Cross-checked policy wording against `.atomic/workflows/publish-release.ts` and the documented named-workflow lifecycle.

No runtime code or package changelog is changed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites the "Agent publishing requests" section of `AGENTS.md` to route all release requests through the named Atomic `publish-release` workflow instead of executing a ten-step inline checklist. The change is documentation-only — no runtime code, package manifests, or changelogs are touched.

- The old ten-step inline procedure (branch creation, changelog edits, CI inspection, `cut-release.ts`, publish verification) is replaced by a six-step workflow-routing contract that forbids inline fallback, polling, and duplicate workflow launches.
- The new instructions correctly match the `publish-release.ts` workflow's input schema (`target_version`, `release_kind`, `base_ref`), its `blocked`/`failed` output states, and its resumable run-ID model; the cross-check against the workflow source confirms alignment throughout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only the agent-instruction prose in AGENTS.md changes; no runtime code, package manifests, or changelogs are modified.

The rewritten section accurately reflects the publish-release workflow's input schema, blocked/failed output states, and background launch model. The cross-check against .atomic/workflows/publish-release.ts confirms every claimed responsibility (release preparation, PR gating, merge verification, tag creation, publish verification) maps directly to a deterministic gate in the workflow.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Documentation-only rewrite of the Agent publishing requests section; content is well-aligned with the publish-release.ts workflow's input schema, output states, and resumable lifecycle model. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant Agent
  participant WF as publish-release workflow
  participant GH as GitHub Actions (publish.yml)

  User->>Agent: "publish release X.Y.Z"
  Agent->>Agent: Infer release_kind from version
  Agent->>WF: "Discover & inspect input contract"
  WF-->>Agent: Contract confirmed
  Agent->>WF: Launch (background) with target_version, release_kind, base_ref
  WF-->>Agent: Run ID accepted
  Agent->>User: Report run ID, end turn

  Note over WF: prepare-release-branch-and-metadata
  Note over WF: open-release-pr
  Note over WF: verifyReleasePrChecksPassed

  alt CI pending / gate blocked
    WF-->>Agent: "status=blocked (lifecycle notice)"
    Agent->>Agent: Wait for notice or user follow-up
    Agent->>WF: Resume existing run by run ID
  end

  Note over WF: merge-verified-release-pr
  Note over WF: sync-main-after-merge
  Note over WF: materialize-release-tag (cut-release.ts)
  WF->>GH: Tag push (sole publication signal)
  GH-->>WF: publish.yml triggered
  Note over WF: verifyPublishWorkflowSucceeded

  WF-->>Agent: "status=completed, summary"
  Agent->>User: Release evidence summary
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant Agent
  participant WF as publish-release workflow
  participant GH as GitHub Actions (publish.yml)

  User->>Agent: "publish release X.Y.Z"
  Agent->>Agent: Infer release_kind from version
  Agent->>WF: "Discover & inspect input contract"
  WF-->>Agent: Contract confirmed
  Agent->>WF: Launch (background) with target_version, release_kind, base_ref
  WF-->>Agent: Run ID accepted
  Agent->>User: Report run ID, end turn

  Note over WF: prepare-release-branch-and-metadata
  Note over WF: open-release-pr
  Note over WF: verifyReleasePrChecksPassed

  alt CI pending / gate blocked
    WF-->>Agent: "status=blocked (lifecycle notice)"
    Agent->>Agent: Wait for notice or user follow-up
    Agent->>WF: Resume existing run by run ID
  end

  Note over WF: merge-verified-release-pr
  Note over WF: sync-main-after-merge
  Note over WF: materialize-release-tag (cut-release.ts)
  WF->>GH: Tag push (sole publication signal)
  GH-->>WF: publish.yml triggered
  Note over WF: verifyPublishWorkflowSucceeded

  WF-->>Agent: "status=completed, summary"
  Agent->>User: Release evidence summary
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: route release requests through wor..."](https://github.com/bastani-inc/atomic/commit/849aa785316d2a46524c8d7b1a1cf8852727d811) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44904053)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/bastani-inc/github/bastani-inc/atomic/-/custom-context?memory=6b6bc6e3-dafb-4fa7-9d98-538aac70844a))

<!-- /greptile_comment -->