### PR TITLE
docs: clarify workflow graph execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 <p align="center">
   <b>The verifiable runtime for coding agents.</b><br>
   <b>Run verifiable engineering loops with control, alignment, and confidence. Build your own software factory with verification built in.</b><br>
-  <i>Define the work as stages, checks, gates, tools, artifacts, and approvals. Atomic runs the process so agent work is verifiable by design. Leverage Atomic to start building your software factory.</i>
+  <i>Define work as an execution graph of bounded stages and gates, with scoped tools, enforced checks, auditable artifacts, and human approvals. Atomic runs and records that graph so agent work is verifiable by design.</i>
 </p>
 
 <p align="center">
-  Atomic enforces controlled, instruction-following agent runs you can trust: instructions are explicit, stages are bounded, checks are enforced, approvals can block progress, and every run leaves auditable artifacts.
+  Atomic turns agent work into controlled, directed acyclic workflow graphs you can trust: instructions are explicit, dependencies are visible, stages are bounded, checks are enforced, approvals can block progress, and every run leaves auditable artifacts.
 </p>
 
 <p align="center">
@@ -312,7 +312,7 @@ The docs are open source in this repository under [`packages/coding-agent/docs`]
 
 ## What happens during a run?
 
-An Atomic run is one execution of a loop on the Atomic runtime:
+An Atomic workflow run is a directed acyclic execution graph. Stages become nodes, dependencies become edges, parallel work becomes branches, and checks and approvals control what may proceed.
 
 ```text
 issue or goal -> research -> plan -> agent stages -> artifacts -> checks -> review gate -> final output
@@ -320,7 +320,7 @@ issue or goal -> research -> plan -> agent stages -> artifacts -> checks -> revi
 
 Each stage can prompt an agent, run tools, call MCP servers, save artifacts, pass selected output forward, branch, retry, run in parallel, or pause for approval.
 
-The loop structure is deterministic and inspectable. Model output can vary; the stage order, inputs, handoffs, checks, gates, and artifacts are explicit.
+The graph structure is deterministic and inspectable. Model output can vary; the stage order, inputs, handoffs, checks, gates, and artifacts are explicit.
 
 ---
 


### PR DESCRIPTION
## Summary

Clarify that Atomic workflow runs execute as directed acyclic graphs and connect that model to verifiable agent work.

## Changes

- Describe bounded stages and gates as an execution graph in the README hero
- Explain nodes, dependencies, parallel branches, checks, and approvals
- Use the full term \"directed acyclic\" instead of the acronym

## Notes

- Documentation-only change limited to `README.md`
- Pre-commit and pre-push checks passed: lint, file-length validation, and unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clarifies how Atomic workflow runs execute. The main changes are:

- Describes runs as directed acyclic execution graphs.
- Connects stages, dependencies, branches, checks, approvals, and artifacts to graph concepts.
- Updates README hero and run lifecycle wording from loop-focused language to graph-focused language.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The change is limited to README wording and aligns with the repository's workflow graph terminology.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the README docs validation lint step; the lint command completed with exit code 0 and a TypeScript check (tsc --noEmit) was executed.
- Executed the README docs validation file-length check; the run exited with code 1 due to ENOENT for .agents/skills/typescript-expert/references/utility-types.ts, a failure unrelated to the README change.

<a href="https://app.greptile.com/trex/runs/14934064/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Clarifies Atomic workflow runs as directed acyclic execution graphs in the README hero and run lifecycle section; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["docs: clarify workflow graph execution"](https://github.com/bastani-inc/atomic/commit/48683f54c7caddfdc03c86d1b3c2fa96e1dcf11b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45282636)</sub>

<!-- /greptile_comment -->